### PR TITLE
fix(create-factory): handle release tag transitions

### DIFF
--- a/.changeset/silly-boxes-film.md
+++ b/.changeset/silly-boxes-film.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Fixed Factory template generation during release transitions by selecting exact published package versions that match the local source release and configuring npm for compatible prerelease installs.

--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -11,9 +11,9 @@
  *   - .env.schema            -> also emitted as .env.example (decorators stripped)
  *
  * Versions: every `link:` dep is resolved from npm and written as an exact
- * version. Packages on the local alpha release train resolve from the `alpha`
- * tag; stable packages resolve from `latest`. This keeps the generated source
- * aligned with its published package release channel.
+ * version. The sync selects `latest` or `alpha`, whichever has the same base
+ * version as the local source package, so release transitions cannot pair new
+ * source with an older stable package.
  *
  * Usage:
  *   node scripts/sync-template.mjs [--out <dir>]
@@ -171,6 +171,28 @@ function resolveTaggedVersion(name, tag) {
   }
 }
 
+function baseVersion(version) {
+  return version.split('-')[0];
+}
+
+function resolveLinkedVersion(name, localVersion) {
+  const localBase = baseVersion(localVersion);
+
+  if (!localVersion.includes('-alpha.')) {
+    const latestVersion = resolveTaggedVersion(name, 'latest');
+    if (baseVersion(latestVersion) === localBase) {
+      return { version: latestVersion, tag: 'latest' };
+    }
+  }
+
+  const alphaVersion = resolveTaggedVersion(name, 'alpha');
+  if (baseVersion(alphaVersion) === localBase) {
+    return { version: alphaVersion, tag: 'alpha' };
+  }
+
+  throw new Error(`sync-template: no published ${name} version matches local release ${localBase}.`);
+}
+
 function transformPackageJson() {
   const manifest = JSON.parse(fs.readFileSync(path.join(webRoot, 'package.json'), 'utf8'));
 
@@ -193,9 +215,10 @@ function transformPackageJson() {
     deploy: 'mastra deploy',
   };
 
-  // Resolve each linked package from the release channel used by its local
-  // source version. Current alpha sources need alpha packages; resolving their
-  // stable `latest` tags can select packages that predate required exports.
+  // Resolve each linked package from a published release with the same base
+  // version as its local source. Immediately after exiting prerelease mode,
+  // `latest` can still point at the previous stable release while `alpha`
+  // contains the package matching the newly-stable local source version.
   console.log('sync-template: resolving published versions for link: deps...');
   for (const section of ['dependencies', 'devDependencies']) {
     const deps = manifest[section];
@@ -203,8 +226,7 @@ function transformPackageJson() {
     for (const [name, spec] of Object.entries(deps)) {
       if (!spec.startsWith('link:')) continue;
       const localVersion = linkedPackageVersion(name, linkSpecToRelPath(spec));
-      const tag = localVersion.includes('-alpha.') ? 'alpha' : 'latest';
-      const version = resolveTaggedVersion(name, tag);
+      const { version, tag } = resolveLinkedVersion(name, localVersion);
       deps[name] = version;
       console.log(`  ✓ ${name}@${version} (${tag})`);
     }

--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -3,16 +3,17 @@
  * Produces the Mastra Factory template tree from `mastracode/web`.
  *
  * The template is the web project minus monorepo coupling:
- *   - `link:` deps           -> exact versions resolved from npm's `latest` tag
+ *   - `link:` deps           -> exact versions resolved from npm
  *   - monorepo tsconfig      -> standalone tsconfig
  *   - contributor README     -> checked-in template/README.md
  *   - e2e/tests/test deps    -> stripped
  *   - monorepo-only scripts  -> user-facing scripts (dev/build/start/deploy)
  *   - .env.schema            -> also emitted as .env.example (decorators stripped)
  *
- * Versions: every `link:` dep is resolved from npm's `latest` dist-tag and
- * written as an exact version. This prevents a later install from resolving
- * different package versions than the set used when the template was synced.
+ * Versions: every `link:` dep is resolved from npm and written as an exact
+ * version. Packages on the local alpha release train resolve from the `alpha`
+ * tag; stable packages resolve from `latest`. This keeps the generated source
+ * aligned with its published package release channel.
  *
  * Usage:
  *   node scripts/sync-template.mjs [--out <dir>]
@@ -140,27 +141,33 @@ function copyTree(srcDir, destDir, relBase = '') {
   }
 }
 
-/** Verify the linked package exists and its manifest name matches the dependency key. */
-function assertLinkedPackage(name, relPath) {
+/** Verify the linked package exists and return its local version. */
+function linkedPackageVersion(name, relPath) {
   const pkgJsonPath = path.join(monorepoRoot, relPath, 'package.json');
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
   if (pkg.name !== name) {
     throw new Error(`sync-template: ${pkgJsonPath} is named ${pkg.name}, expected ${name}`);
   }
+  return pkg.version;
 }
 
-const latestVersions = new Map();
-function resolveLatestVersion(name) {
-  const cached = latestVersions.get(name);
+const resolvedVersions = new Map();
+let usesPrereleaseVersions = false;
+function resolveTaggedVersion(name, tag) {
+  const key = `${name}@${tag}`;
+  const cached = resolvedVersions.get(key);
   if (cached) return cached;
 
   try {
-    const version = execFileSync('npm', ['view', name, 'dist-tags.latest'], { stdio: 'pipe' }).toString().trim();
+    const version = execFileSync('npm', ['view', name, `dist-tags.${tag}`], { stdio: 'pipe' })
+      .toString()
+      .trim();
     if (!version) throw new Error('empty version');
-    latestVersions.set(name, version);
+    if (version.includes('-')) usesPrereleaseVersions = true;
+    resolvedVersions.set(key, version);
     return version;
   } catch {
-    throw new Error(`sync-template: could not resolve ${name}@latest on npm.`);
+    throw new Error(`sync-template: could not resolve ${name}@${tag} on npm.`);
   }
 }
 
@@ -186,19 +193,20 @@ function transformPackageJson() {
     deploy: 'mastra deploy',
   };
 
-  // Resolve every `link:` dep's `latest` dist-tag now so the generated
-  // template installs the exact package set selected at sync time. We still
-  // resolve the link target so an invalid `link:` spec fails loudly.
-  console.log('sync-template: resolving latest versions for link: deps...');
+  // Resolve each linked package from the release channel used by its local
+  // source version. Current alpha sources need alpha packages; resolving their
+  // stable `latest` tags can select packages that predate required exports.
+  console.log('sync-template: resolving published versions for link: deps...');
   for (const section of ['dependencies', 'devDependencies']) {
     const deps = manifest[section];
     if (!deps) continue;
     for (const [name, spec] of Object.entries(deps)) {
       if (!spec.startsWith('link:')) continue;
-      assertLinkedPackage(name, linkSpecToRelPath(spec));
-      const version = resolveLatestVersion(name);
+      const localVersion = linkedPackageVersion(name, linkSpecToRelPath(spec));
+      const tag = localVersion.includes('-alpha.') ? 'alpha' : 'latest';
+      const version = resolveTaggedVersion(name, tag);
       deps[name] = version;
-      console.log(`  ✓ ${name}@${version}`);
+      console.log(`  ✓ ${name}@${version} (${tag})`);
     }
   }
 
@@ -218,7 +226,7 @@ function transformPackageJson() {
   // Transitive runtime peers that must be declared as direct deps so npm
   // resolves them without needing pnpm's auto-install-peers behavior.
   // (In the monorepo dev setup pnpm provides them automatically.)
-  manifest.dependencies['@mastra/memory'] = resolveLatestVersion('@mastra/memory'); // peer of @mastra/playground-ui
+  manifest.dependencies['@mastra/memory'] = resolveTaggedVersion('@mastra/memory', 'latest'); // peer of @mastra/playground-ui
   manifest.dependencies['react-is'] = '^19.0.0'; // peer of recharts (via @mastra/playground-ui)
 
   // Downgrade `typescript` from tsgo (v7) to classic (v5). The Mastra Factory
@@ -335,6 +343,16 @@ src/mastra/public/factory/
 }
 
 /**
+ * Relax npm's peer resolver when the generated package set includes
+ * prereleases. npm does not match prerelease versions against otherwise
+ * compatible peer ranges unless the range names that prerelease explicitly.
+ */
+function writeNpmrc() {
+  if (!usesPrereleaseVersions) return;
+  fs.writeFileSync(path.join(outDir, '.npmrc'), 'legacy-peer-deps=true\n');
+}
+
+/**
  * Emit `pnpm-workspace.yaml` with `allowBuilds`.
  *
  * pnpm v10+ blocks install scripts by default and exits with
@@ -398,6 +416,7 @@ writeTsconfig();
 stripTestingTypesFromUiTsconfig();
 writeEnvExample();
 writeGitignore();
+writeNpmrc();
 writePnpmWorkspace();
 writeReadme();
 

--- a/mastracode/mastra-factory/src/sync-template.test.ts
+++ b/mastracode/mastra-factory/src/sync-template.test.ts
@@ -8,7 +8,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 /**
  * Validates the output of scripts/sync-template.mjs — the artifact users
  * actually receive. Runs the real script offline: a fake `npm` on PATH
- * answers the latest-version lookups so no network is needed.
+ * answers the dist-tag lookups so no network is needed.
  */
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -38,10 +38,14 @@ beforeAll(() => {
   workDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'sf-sync-test-')));
   outDir = path.join(workDir, 'out');
 
-  // Fake npm: resolves every `latest` dist-tag to a deterministic version.
+  // Fake npm: resolves stable and alpha dist-tags to deterministic versions.
   fakeBinDir = path.join(workDir, 'bin');
   fs.mkdirSync(fakeBinDir);
-  fs.writeFileSync(path.join(fakeBinDir, 'npm'), '#!/bin/sh\necho "9.9.9"\n', { mode: 0o755 });
+  fs.writeFileSync(
+    path.join(fakeBinDir, 'npm'),
+    '#!/bin/sh\ncase "$3" in\n  dist-tags.alpha) echo "9.9.9-alpha.0" ;;\n  dist-tags.latest) echo "9.9.9" ;;\n  *) exit 1 ;;\nesac\n',
+    { mode: 0o755 },
+  );
 
   // Sentinel env file in the source tree — must never reach the template.
   sentinel = path.join(webRoot, '.env.test-sentinel');
@@ -94,20 +98,26 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     const envExample = fs.readFileSync(path.join(outDir, '.env.example'), 'utf8');
     expect(envExample).not.toMatch(/^[A-Z][A-Z0-9_]*=\s*$/m);
 
-    // package.json: monorepo coupling removed; every Mastra dep uses the exact
-    // version resolved from npm's `latest` dist-tag.
+    // package.json: monorepo coupling removed; every Mastra dep uses an exact
+    // version from the release channel matching its local source package.
     const pkg = JSON.parse(fs.readFileSync(path.join(outDir, 'package.json'), 'utf8'));
     const allDeps: Record<string, string> = { ...pkg.dependencies, ...pkg.devDependencies };
     for (const [name, spec] of Object.entries(allDeps)) {
       expect(spec, `${name} must not use a link:/workspace: spec`).not.toMatch(/^(link|workspace|catalog|file):/);
       if (name === 'mastra' || name.startsWith('@mastra/')) {
-        expect(spec, `${name} must use the resolved latest version`).toBe('9.9.9');
+        expect(spec, `${name} must use an exact resolved version`).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
       }
     }
+    expect(pkg.dependencies['@mastra/factory']).toBe('9.9.9-alpha.0');
+    expect(pkg.dependencies['@mastra/code-sdk']).toBe('9.9.9-alpha.0');
+    expect(pkg.dependencies['@mastra/core']).toBe('9.9.9-alpha.0');
+    expect(pkg.dependencies['@mastra/playground-ui']).toBe('9.9.9-alpha.0');
+    expect(pkg.dependencies['@mastra/auth-studio']).toBe('9.9.9');
+    expect(pkg.dependencies['@mastra/libsql']).toBe('9.9.9');
     expect(pkg.dependencies['@mastra/memory']).toBe('9.9.9');
-    // No `.npmrc` ships — the template installs cleanly on npm with the
-    // published `latest` set, same as every other create-mastra template.
-    expect(fs.existsSync(path.join(outDir, '.npmrc'))).toBe(false);
+    // npm needs relaxed peer resolution for prerelease packages because its
+    // semver matching excludes prereleases from otherwise compatible ranges.
+    expect(fs.readFileSync(path.join(outDir, '.npmrc'), 'utf8')).toBe('legacy-peer-deps=true\n');
 
     // `typescript` is downgraded from tsgo (v7) to the classic compiler (v5)
     // because `mastra build` transitively loads TypeScript via

--- a/mastracode/mastra-factory/src/sync-template.test.ts
+++ b/mastracode/mastra-factory/src/sync-template.test.ts
@@ -15,11 +15,22 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const pkgRoot = path.resolve(here, '..');
 const webRoot = path.resolve(pkgRoot, '../web');
 const script = path.join(pkgRoot, 'scripts', 'sync-template.mjs');
+const ALPHA_FALLBACK_PACKAGES = new Set([
+  '@mastra/client-js',
+  '@mastra/code-sdk',
+  '@mastra/core',
+  '@mastra/factory',
+  '@mastra/hono',
+  '@mastra/playground-ui',
+  '@mastra/react',
+  'mastra',
+]);
 
 let workDir: string;
 let outDir: string;
 let fakeBinDir: string;
 let sentinel: string;
+let linkedLocalVersions: Record<string, string>;
 
 function runSync(args: string[]): { status: number; stderr: string } {
   try {
@@ -38,12 +49,43 @@ beforeAll(() => {
   workDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'sf-sync-test-')));
   outDir = path.join(workDir, 'out');
 
-  // Fake npm: resolves stable and alpha dist-tags to deterministic versions.
+  // Fake npm: model stable packages whose latest tag matches local source and
+  // release-train packages whose matching base version is still on alpha.
+  const webManifest = JSON.parse(fs.readFileSync(path.join(webRoot, 'package.json'), 'utf8'));
+  linkedLocalVersions = {};
+  const registryVersions: Record<string, Record<string, string>> = {};
+  for (const [name, spec] of Object.entries<string>({
+    ...webManifest.dependencies,
+    ...webManifest.devDependencies,
+  })) {
+    if (!spec.startsWith('link:')) continue;
+    const linkedManifest = JSON.parse(
+      fs.readFileSync(path.resolve(webRoot, spec.slice('link:'.length), 'package.json'), 'utf8'),
+    );
+    const localVersion = linkedManifest.version as string;
+    const baseVersion = localVersion.split('-')[0]!;
+    linkedLocalVersions[name] = localVersion;
+    registryVersions[name] = {
+      latest: ALPHA_FALLBACK_PACKAGES.has(name) ? '0.0.1' : baseVersion,
+      alpha: `${baseVersion}-alpha.0`,
+    };
+  }
+  registryVersions['@mastra/memory'] = { latest: '9.9.9', alpha: '9.9.9-alpha.0' };
+
   fakeBinDir = path.join(workDir, 'bin');
   fs.mkdirSync(fakeBinDir);
+  const registryVersionsPath = path.join(workDir, 'registry-versions.json');
+  fs.writeFileSync(registryVersionsPath, JSON.stringify(registryVersions));
   fs.writeFileSync(
     path.join(fakeBinDir, 'npm'),
-    '#!/bin/sh\ncase "$3" in\n  dist-tags.alpha) echo "9.9.9-alpha.0" ;;\n  dist-tags.latest) echo "9.9.9" ;;\n  *) exit 1 ;;\nesac\n',
+    `#!/usr/bin/env node
+const versions = require(${JSON.stringify(registryVersionsPath)});
+const [, , command, name, field] = process.argv;
+const tag = field?.replace('dist-tags.', '');
+const version = command === 'view' ? versions[name]?.[tag] : undefined;
+if (!version) process.exit(1);
+console.log(version);
+`,
     { mode: 0o755 },
   );
 
@@ -108,12 +150,12 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
         expect(spec, `${name} must use an exact resolved version`).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
       }
     }
-    expect(pkg.dependencies['@mastra/factory']).toBe('9.9.9-alpha.0');
-    expect(pkg.dependencies['@mastra/code-sdk']).toBe('9.9.9-alpha.0');
-    expect(pkg.dependencies['@mastra/core']).toBe('9.9.9-alpha.0');
-    expect(pkg.dependencies['@mastra/playground-ui']).toBe('9.9.9-alpha.0');
-    expect(pkg.dependencies['@mastra/auth-studio']).toBe('9.9.9');
-    expect(pkg.dependencies['@mastra/libsql']).toBe('9.9.9');
+    for (const [name, localVersion] of Object.entries(linkedLocalVersions)) {
+      const baseVersion = localVersion.split('-')[0]!;
+      const expectedVersion =
+        localVersion.includes('-alpha.') || ALPHA_FALLBACK_PACKAGES.has(name) ? `${baseVersion}-alpha.0` : baseVersion;
+      expect(allDeps[name], `${name} must match its local source release`).toBe(expectedVersion);
+    }
     expect(pkg.dependencies['@mastra/memory']).toBe('9.9.9');
     // npm needs relaxed peer resolution for prerelease packages because its
     // semver matching excludes prereleases from otherwise compatible ranges.


### PR DESCRIPTION
Follow-up to #20093. The template validation ran while the newly stable package versions were still published only under `alpha`, so resolving `latest` selected an older `@mastra/factory` package that did not export `ProviderOMDefaultsResponse`.

The sync now compares each local package’s base version with npm’s tags and selects the exact `latest` or `alpha` version that matches it. If prereleases are selected, the generated template includes npm peer-resolution configuration required for that package set.

A clean generated template now completes `npm install`, `npm run check`, and `npm run build`. The create-factory tests, lint, and typecheck also pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This keeps generated templates on the same release track as their source packages, choosing stable or alpha versions correctly. It also adds the npm setting needed for alpha packages to install successfully.

## Summary

- Match linked package versions to the local package’s base version across npm `latest` and `alpha` dist-tags.
- Generate `.npmrc` with `legacy-peer-deps=true` when prerelease dependencies are included.
- Expand synchronization tests with realistic per-package npm responses and exact version assertions.
- Add a patch Changesets entry for `create-factory`.
- Verified template installation, checks, builds, tests, lint, and typechecking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->