### PR TITLE
fix(factory): improve Platform event intake workers

### DIFF
--- a/.changeset/busy-pens-refuse.md
+++ b/.changeset/busy-pens-refuse.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Improved Platform GitHub event intake latency and restored closed issue and pull request ingestion for Factory rules.
+Improved Platform GitHub event intake latency, restored closed issue and pull request ingestion for Factory rules, and added background ingestion for selected Platform Linear projects.

--- a/.changeset/busy-pens-refuse.md
+++ b/.changeset/busy-pens-refuse.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Improved Platform GitHub event intake latency, restored closed issue and pull request ingestion for Factory rules, and added background ingestion for selected Platform Linear projects.
+Improved Platform event intake workers, restored closed GitHub issue and pull request ingestion, added background ingestion for selected Linear projects, and prevented unrelated GitHub or Linear issues from sharing Factory work items.

--- a/.changeset/busy-pens-refuse.md
+++ b/.changeset/busy-pens-refuse.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved Platform GitHub event intake latency and restored closed issue and pull request ingestion for Factory rules.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -52,6 +52,7 @@ import {
 } from './routes/tenant-credentials.js';
 import { builtInFactoryRules } from './rules/defaults.js';
 import { FactoryDecisionDispatcher } from './rules/dispatcher.js';
+import { FactoryGithubEventService } from './rules/github-service.js';
 import { FactoryPhaseStateProcessor } from './rules/processor.js';
 import { createFactoryTransitionTools } from './rules/tools.js';
 import { FactoryTransitionService } from './rules/transition-service.js';
@@ -495,6 +496,18 @@ export class MastraFactory {
     const githubIntegration = integrations.find(integration => integration.id === 'github') as
       GithubIntegration | undefined;
     const workItemsReady = storage.isDomainReady('work-items');
+    const githubEventService =
+      githubIntegration && factoryReady
+        ? new FactoryGithubEventService({
+            github: githubIntegration,
+            sourceControl: sourceControlStorage.forIntegration('github'),
+            integrationStorage: integrationStorage.forIntegration('github'),
+            projects: factoryProjectsStorage,
+            storage: workItemsStorage,
+            rules,
+          })
+        : undefined;
+    const ingestGithubEvent = githubEventService ? githubEventService.ingest.bind(githubEventService) : undefined;
     const transitionService = workItemsReady
       ? new FactoryTransitionService({ rules, storage: workItemsStorage })
       : undefined;
@@ -662,6 +675,7 @@ export class MastraFactory {
           factoryReady,
           rules,
           factoryTransitionService: transitionService,
+          ingestGithubEvent,
           onFactoryRuntime: ({ transitionService: runtimeTransitionService, prepareBinding }) => {
             this.#dispatcher ??= new FactoryDecisionDispatcher({
               controller,
@@ -753,6 +767,7 @@ export class MastraFactory {
               integrationStorage,
               sourceControlStorage,
               domains,
+              ...(integration.id === 'github' && ingestGithubEvent ? { ingestGithubEvent } : {}),
             },
             integration.id,
           ),

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -53,6 +53,7 @@ import {
 import { builtInFactoryRules } from './rules/defaults.js';
 import { FactoryDecisionDispatcher } from './rules/dispatcher.js';
 import { FactoryGithubEventService } from './rules/github-service.js';
+import { FactoryLinearIssueService } from './rules/linear-service.js';
 import { FactoryPhaseStateProcessor } from './rules/processor.js';
 import { createFactoryTransitionTools } from './rules/tools.js';
 import { FactoryTransitionService } from './rules/transition-service.js';
@@ -508,6 +509,15 @@ export class MastraFactory {
           })
         : undefined;
     const ingestGithubEvent = githubEventService ? githubEventService.ingest.bind(githubEventService) : undefined;
+    const linearIssueService =
+      integrations.some(integration => integration.id === 'linear') && intakeReady && factoryReady
+        ? new FactoryLinearIssueService({
+            projects: factoryProjectsStorage,
+            storage: workItemsStorage,
+            rules,
+          })
+        : undefined;
+    const ingestLinearIssues = linearIssueService ? linearIssueService.ingest.bind(linearIssueService) : undefined;
     const transitionService = workItemsReady
       ? new FactoryTransitionService({ rules, storage: workItemsStorage })
       : undefined;
@@ -676,6 +686,7 @@ export class MastraFactory {
           rules,
           factoryTransitionService: transitionService,
           ingestGithubEvent,
+          ingestLinearIssues,
           onFactoryRuntime: ({ transitionService: runtimeTransitionService, prepareBinding }) => {
             this.#dispatcher ??= new FactoryDecisionDispatcher({
               controller,
@@ -768,6 +779,7 @@ export class MastraFactory {
               sourceControlStorage,
               domains,
               ...(integration.id === 'github' && ingestGithubEvent ? { ingestGithubEvent } : {}),
+              ...(integration.id === 'linear' && ingestLinearIssues ? { ingestLinearIssues } : {}),
             },
             integration.id,
           ),

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -52,8 +52,6 @@ import {
 } from './routes/tenant-credentials.js';
 import { builtInFactoryRules } from './rules/defaults.js';
 import { FactoryDecisionDispatcher } from './rules/dispatcher.js';
-import { FactoryGithubEventService } from './rules/github-service.js';
-import { FactoryLinearIssueService } from './rules/linear-service.js';
 import { FactoryPhaseStateProcessor } from './rules/processor.js';
 import { createFactoryTransitionTools } from './rules/tools.js';
 import { FactoryTransitionService } from './rules/transition-service.js';
@@ -497,27 +495,6 @@ export class MastraFactory {
     const githubIntegration = integrations.find(integration => integration.id === 'github') as
       GithubIntegration | undefined;
     const workItemsReady = storage.isDomainReady('work-items');
-    const githubEventService =
-      githubIntegration && factoryReady
-        ? new FactoryGithubEventService({
-            github: githubIntegration,
-            sourceControl: sourceControlStorage.forIntegration('github'),
-            integrationStorage: integrationStorage.forIntegration('github'),
-            projects: factoryProjectsStorage,
-            storage: workItemsStorage,
-            rules,
-          })
-        : undefined;
-    const ingestGithubEvent = githubEventService ? githubEventService.ingest.bind(githubEventService) : undefined;
-    const linearIssueService =
-      integrations.some(integration => integration.id === 'linear') && intakeReady && factoryReady
-        ? new FactoryLinearIssueService({
-            projects: factoryProjectsStorage,
-            storage: workItemsStorage,
-            rules,
-          })
-        : undefined;
-    const ingestLinearIssues = linearIssueService ? linearIssueService.ingest.bind(linearIssueService) : undefined;
     const transitionService = workItemsReady
       ? new FactoryTransitionService({ rules, storage: workItemsStorage })
       : undefined;
@@ -685,8 +662,6 @@ export class MastraFactory {
           factoryReady,
           rules,
           factoryTransitionService: transitionService,
-          ingestGithubEvent,
-          ingestLinearIssues,
           onFactoryRuntime: ({ transitionService: runtimeTransitionService, prepareBinding }) => {
             this.#dispatcher ??= new FactoryDecisionDispatcher({
               controller,
@@ -778,8 +753,8 @@ export class MastraFactory {
               integrationStorage,
               sourceControlStorage,
               domains,
-              ...(integration.id === 'github' && ingestGithubEvent ? { ingestGithubEvent } : {}),
-              ...(integration.id === 'linear' && ingestLinearIssues ? { ingestLinearIssues } : {}),
+              factoryReady,
+              rules,
             },
             integration.id,
           ),

--- a/mastracode/factory/src/integrations/base.ts
+++ b/mastracode/factory/src/integrations/base.ts
@@ -26,6 +26,7 @@ import type { MastraWorker } from '@mastra/core/worker';
 import type { Intake } from '../capabilities/intake.js';
 import type { VersionControl } from '../capabilities/version-control.js';
 import type { RouteAuth } from '../routes/route.js';
+import type { FactoryRules } from '../rules/types.js';
 import type { SandboxFleet } from '../sandbox/fleet.js';
 import type { StateSigner } from '../state-signing.js';
 import type { AuditEventRow } from '../storage/domains/audit/base.js';
@@ -34,7 +35,7 @@ import type { IntakeStorage } from '../storage/domains/intake/base.js';
 import type { IntegrationStorageHandle } from '../storage/domains/integrations/base.js';
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
-import type { ParsedGithubWebhook } from './github/webhook.js';
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 
 export interface LinearIssueIngress {
   id: string;
@@ -54,13 +55,6 @@ export interface LinearIssueIngress {
 /** Factory-owned hooks integrations may invoke. */
 export interface IntegrationHooks {
   emitAudit?: AuditEmitter['emit'];
-  ingestGithubEvent?: (event: ParsedGithubWebhook) => Promise<unknown>;
-  ingestLinearIssues?: (input: {
-    orgId: string;
-    userId: string;
-    factoryProjectId: string;
-    issues: LinearIssueIngress[];
-  }) => Promise<unknown>;
 }
 
 /**
@@ -114,6 +108,11 @@ export interface IntegrationContext {
     projects: FactoryProjectsStorage;
     /** Cross-integration intake selection (which sources are synced). */
     intake: IntakeStorage;
+  };
+  /** Factory rule runtime used by integrations that own event-ingestion workers. */
+  factory?: {
+    rules: FactoryRules;
+    workItems: WorkItemsStorage;
   };
   /** System hooks integrations may invoke. */
   hooks?: IntegrationHooks;

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -44,6 +44,8 @@ import type {
   ReviewComment,
   VersionControl,
 } from '../../capabilities/version-control.js';
+import { FactoryGithubEventService } from '../../rules/github-service.js';
+import type { FactoryGithubEventServiceOptions } from '../../rules/github-service.js';
 import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '../base.js';
 import { runGithubIssueTriage } from './issue-triage.js';
 import { buildGithubRoutes } from './routes.js';
@@ -986,6 +988,16 @@ export class GithubIntegration implements FactoryIntegration {
    */
   routes(ctx: IntegrationContext): ApiRoute[] {
     this.#storage = ctx.storage;
+    const factoryEvents = ctx.factory
+      ? new FactoryGithubEventService({
+          github: this,
+          sourceControl: ctx.storage.sourceControl,
+          integrationStorage: ctx.storage.generic as unknown as FactoryGithubEventServiceOptions['integrationStorage'],
+          projects: ctx.storage.projects,
+          storage: ctx.factory.workItems,
+          rules: ctx.factory.rules,
+        })
+      : undefined;
     return buildGithubRoutes({
       github: this,
       auth: ctx.auth,
@@ -999,7 +1011,7 @@ export class GithubIntegration implements FactoryIntegration {
         : undefined,
       emitAudit: ctx.hooks?.emitAudit,
       projects: ctx.storage.projects,
-      ingestFactoryEvent: ctx.hooks?.ingestGithubEvent,
+      ingestFactoryEvent: factoryEvents?.ingest.bind(factoryEvents),
     });
   }
 

--- a/mastracode/factory/src/integrations/linear/integration.ts
+++ b/mastracode/factory/src/integrations/linear/integration.ts
@@ -32,6 +32,7 @@ import type {
   ListIntakeIssuesInput,
 } from '../../capabilities/intake.js';
 import type { RouteAuth } from '../../routes/route.js';
+import { FactoryLinearIssueService } from '../../rules/linear-service.js';
 import type { IntegrationStorageHandle } from '../../storage/domains/integrations/base.js';
 import type { FactoryProjectsStorage } from '../../storage/domains/projects/base.js';
 import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '../base.js';
@@ -895,13 +896,20 @@ export class LinearIntegration implements FactoryIntegration {
    * Intake). Handlers operate on this instance.
    */
   routes(ctx: IntegrationContext): ApiRoute[] {
+    const factoryIssues = ctx.factory
+      ? new FactoryLinearIssueService({
+          projects: ctx.storage.projects,
+          storage: ctx.factory.workItems,
+          rules: ctx.factory.rules,
+        })
+      : undefined;
     return buildLinearRoutes({
       linear: this,
       auth: ctx.auth,
       stateSigner: ctx.stateSigner,
       baseUrl: ctx.baseUrl,
       intake: ctx.storage.intake,
-      hooks: ctx.hooks,
+      ingestLinearIssues: factoryIssues?.ingest.bind(factoryIssues),
     });
   }
 

--- a/mastracode/factory/src/integrations/linear/routes.test.ts
+++ b/mastracode/factory/src/integrations/linear/routes.test.ts
@@ -6,7 +6,7 @@ import type { TestAuthUser } from '../../routes/test-utils.js';
 import type { StateSigner } from '../../state-signing.js';
 import { createFactoryStorageForTests } from '../../storage/test-utils.js';
 import type { FactoryStorageTestSeed } from '../../storage/test-utils.js';
-import type { IntegrationHooks } from '../base.js';
+import type { LinearIssueIngress } from '../base.js';
 import { LinearIntegration } from './integration.js';
 import { buildLinearRoutes } from './routes.js';
 
@@ -68,7 +68,16 @@ const stateSigner: StateSigner = {
 // ── Test harness ─────────────────────────────────────────────────────────
 function buildApp(
   user: TestAuthUser | null,
-  options: { signer?: StateSigner | null; authEnabled?: boolean; hooks?: IntegrationHooks } = {},
+  options: {
+    signer?: StateSigner | null;
+    authEnabled?: boolean;
+    ingestLinearIssues?: (input: {
+      orgId: string;
+      userId: string;
+      factoryProjectId: string;
+      issues: LinearIssueIngress[];
+    }) => Promise<unknown>;
+  } = {},
 ) {
   const app = new Hono();
   app.use('*', async (c, next) => {
@@ -83,7 +92,7 @@ function buildApp(
       auth: fakeRouteAuth({ enabled: options.authEnabled ?? true }),
       stateSigner: options.signer === undefined ? stateSigner : (options.signer ?? undefined),
       intake: seed.intake,
-      hooks: options.hooks,
+      ingestLinearIssues: options.ingestLinearIssues,
     }),
   );
   return app;
@@ -253,7 +262,7 @@ describe('issues route', () => {
     await connect();
     const ingestLinearIssues = vi.fn(async () => ({ status: 'committed', ingested: 1 }));
     const factoryProjectId = '11111111-1111-4111-8111-111111111111';
-    const res = await buildApp(org1(), { hooks: { ingestLinearIssues } }).request(
+    const res = await buildApp(org1(), { ingestLinearIssues }).request(
       `/web/linear/issues?factoryProjectId=${factoryProjectId}`,
     );
 
@@ -269,7 +278,7 @@ describe('issues route', () => {
   it('rejects malformed Factory project identifiers before fetching issues', async () => {
     await connect();
     const ingestLinearIssues = vi.fn();
-    const res = await buildApp(org1(), { hooks: { ingestLinearIssues } }).request(
+    const res = await buildApp(org1(), { ingestLinearIssues }).request(
       '/web/linear/issues?factoryProjectId=not-a-uuid',
     );
 

--- a/mastracode/factory/src/integrations/linear/routes.ts
+++ b/mastracode/factory/src/integrations/linear/routes.ts
@@ -18,7 +18,7 @@ import type { Context } from 'hono';
 import type { RouteAuth } from '../../routes/route.js';
 import type { StateSigner } from '../../state-signing.js';
 import type { IntakeStorage } from '../../storage/domains/intake/base.js';
-import type { IntegrationHooks } from '../base.js';
+import type { LinearIssueIngress } from '../base.js';
 import type { LinearIntegration } from './integration.js';
 import { LinearReauthRequiredError } from './integration.js';
 
@@ -67,7 +67,12 @@ export interface MountLinearRoutesOptions {
    * project filter; when absent, only the disabled `status` route is served.
    */
   intake?: IntakeStorage;
-  hooks?: IntegrationHooks;
+  ingestLinearIssues?: (input: {
+    orgId: string;
+    userId: string;
+    factoryProjectId: string;
+    issues: LinearIssueIngress[];
+  }) => Promise<unknown>;
 }
 
 /**
@@ -327,8 +332,8 @@ export function buildLinearRoutes(options: MountLinearRoutesOptions): ApiRoute[]
             createdAt: issue.createdAt,
             updatedAt: issue.updatedAt,
           }));
-          if (factoryProjectId && options.hooks?.ingestLinearIssues) {
-            await options.hooks.ingestLinearIssues({
+          if (factoryProjectId && options.ingestLinearIssues) {
+            await options.ingestLinearIssues({
               orgId: resolved.tenant.orgId,
               userId: resolved.tenant.userId,
               factoryProjectId,

--- a/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
@@ -3,6 +3,7 @@ import { Mastra } from '@mastra/core/mastra';
 import { LibSQLFactoryStorage } from '@mastra/libsql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MastraFactory } from '../../../factory.js';
+import { FactoryGithubEventService } from '../../../rules/github-service.js';
 import { subscribeToPullRequest } from '../../github/subscriptions.js';
 
 import { PlatformGithubIntegration } from './integration.js';
@@ -80,9 +81,12 @@ afterEach(() => {
 });
 
 describe('Platform GitHub event worker factory lifecycle', () => {
-  it('prepares, starts, delivers once, and releases its timer and lease on stop', async () => {
+  it('prepares, starts, ingests and delivers once, and releases its timer and lease on stop', async () => {
     const storage = new LibSQLFactoryStorage({ url: ':memory:', id: 'platform-worker-lifecycle' });
     const pubsub = new EventEmitterPubSub();
+    const ingestFactoryEvent = vi.spyOn(FactoryGithubEventService.prototype, 'ingest').mockResolvedValue({
+      status: 'committed',
+    });
     const releaseLease = vi.spyOn(pubsub, 'releaseLease');
     const fetchImpl = vi.fn<typeof fetch>(async input => {
       const url = new URL(String(input));
@@ -101,7 +105,7 @@ describe('Platform GitHub event worker factory lifecycle', () => {
                 deliveryId: 'delivery-1',
                 event: 'pull_request',
                 payload: {
-                  action: 'synchronize',
+                  action: 'closed',
                   installation: { id: 7 },
                   repository: { id: 99, full_name: 'octo/hello' },
                   sender: { login: 'ada' },
@@ -152,6 +156,14 @@ describe('Platform GitHub event worker factory lifecycle', () => {
       expect(worker?.isRunning).toBe(true);
 
       await vi.waitFor(() => expect(harness.sendNotificationSignal).toHaveBeenCalledOnce());
+      expect(ingestFactoryEvent).toHaveBeenCalledOnce();
+      expect(ingestFactoryEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'pull_request',
+          deliveryId: 'delivery-1',
+          payload: expect.objectContaining({ action: 'closed' }),
+        }),
+      );
       expect(await pubsub.getLeaseOwner('platform-github-events:github')).toEqual(expect.any(String));
 
       await mastra.stopWorkers();

--- a/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
@@ -70,6 +70,7 @@ beforeEach(() => {
   vi.stubEnv('MASTRA_SHARED_API_URL', 'https://platform.example.com/v1');
   vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'platform-token');
   vi.stubEnv('MASTRA_PLATFORM_GITHUB_POLLING_INTERVAL_MS', '60000');
+  vi.stubEnv('MASTRA_PLATFORM_LINEAR_POLLING_ENABLED', 'false');
   harness.reset();
 });
 

--- a/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
@@ -120,6 +120,7 @@ describe('PlatformGithubEventWorker', () => {
                 id: '1001-0',
                 deliveryId: 'delivery-1',
                 event: 'pull_request',
+                timestamp: Date.now() - 2_500,
                 payload: { action: 'closed' },
               },
             ],
@@ -138,7 +139,8 @@ describe('PlatformGithubEventWorker', () => {
       ingestFactoryEvent,
     });
 
-    await worker.init(createDeps());
+    const deps = createDeps();
+    await worker.init(deps);
     await worker.start();
     await vi.advanceTimersByTimeAsync(0);
 
@@ -155,6 +157,17 @@ describe('PlatformGithubEventWorker', () => {
     });
     expect(ingestFactoryEvent).toHaveBeenCalledOnce();
     expect(ingestFactoryEvent).toHaveBeenCalledWith(parsedEvent);
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      'Platform GitHub event received from the Platform event log',
+      expect.objectContaining({
+        event: 'platform_github_event_received',
+        repositoryId: 101,
+        eventId: '1001-0',
+        deliveryId: 'delivery-1',
+        githubEvent: 'pull_request',
+        eventAgeMs: 2_500,
+      }),
+    );
     expect(dispatch).toHaveBeenCalledTimes(2);
     expect(dispatch).toHaveBeenNthCalledWith(
       1,
@@ -185,7 +198,7 @@ describe('PlatformGithubEventWorker', () => {
     await resumed.stop();
   });
 
-  it('does not advance the cursor when delivery fails and replays the page on the next cycle', async () => {
+  it('advances the cursor when delivery fails so one subscription cannot block newer events', async () => {
     const settings = createSettingsStorage();
     const dispatch = vi
       .fn<typeof dispatchGithubWebhook>()
@@ -207,10 +220,16 @@ describe('PlatformGithubEventWorker', () => {
               id: '1001-0',
               deliveryId: 'delivery-1',
               event: 'pull_request',
+              payload: { action: 'synchronize' },
+            },
+            {
+              id: '1002-0',
+              deliveryId: 'delivery-2',
+              event: 'pull_request',
               payload: { action: 'closed' },
             },
           ],
-          nextCursor: '1001-0',
+          nextCursor: '1002-0',
         });
       }
       throw new Error(`Unexpected request: ${url}`);
@@ -221,19 +240,17 @@ describe('PlatformGithubEventWorker', () => {
     await worker.start();
     await vi.advanceTimersByTimeAsync(0);
 
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(eventCursors[0]).toContain('afterTimestamp=');
     expect(settings.read()).toEqual({
       version: 1,
-      repositories: { '101': expect.objectContaining({ afterTimestamp: expect.any(Number) }) },
+      repositories: { '101': { afterEventId: '1002-0' } },
     });
+
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(dispatch).toHaveBeenCalledTimes(2);
-    expect(eventCursors[0]).toContain('afterTimestamp=');
-    expect(eventCursors[1]).toContain('afterTimestamp=');
-    expect(settings.read()).toEqual({
-      version: 1,
-      repositories: { '101': { afterEventId: '1001-0' } },
-    });
+    expect(eventCursors[1]).toContain('afterEventId=1002-0');
     await worker.stop();
   });
 
@@ -303,7 +320,85 @@ describe('PlatformGithubEventWorker', () => {
     await worker.stop();
   });
 
-  it('honors retry-after backoff and never overlaps polling cycles', async () => {
+  it('bounds concurrent installation repository discovery', async () => {
+    const settings = createSettingsStorage();
+    const discoveryRequests: number[] = [];
+    const releases = new Map<number, (response: Response) => void>();
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/installations')) {
+        return json({
+          installations: Array.from({ length: 12 }, (_, index) => ({
+            installationId: index + 1,
+            usable: true,
+            suspendedAt: null,
+          })),
+        });
+      }
+      const installationMatch = url.pathname.match(/\/installations\/(\d+)\/repositories$/);
+      if (installationMatch?.[1]) {
+        const installationId = Number(installationMatch[1]);
+        discoveryRequests.push(installationId);
+        return new Promise<Response>(resolve => releases.set(installationId, resolve));
+      }
+      if (url.pathname.match(/\/repositories\/(\d+)\/events$/)) {
+        return json({ events: [], nextCursor: null });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const worker = createWorker({ fetchImpl, storage: settings.storage, intervalMs: 1_000 });
+
+    await worker.init(createDeps());
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(discoveryRequests).toEqual(Array.from({ length: 10 }, (_, index) => index + 1));
+    for (const release of releases.values()) release(json({ repositories: [] }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(discoveryRequests).toEqual(Array.from({ length: 12 }, (_, index) => index + 1));
+    releases.get(11)?.(json({ repositories: [] }));
+    releases.get(12)?.(json({ repositories: [] }));
+    await vi.advanceTimersByTimeAsync(0);
+    await worker.stop();
+  });
+
+  it('polls repositories concurrently instead of serializing event-log requests', async () => {
+    const settings = createSettingsStorage();
+    const eventRequests: number[] = [];
+    const releases = new Map<number, (response: Response) => void>();
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/installations')) {
+        return json({ installations: [{ installationId: 7, usable: true, suspendedAt: null }] });
+      }
+      if (url.pathname.endsWith('/installations/7/repositories')) {
+        return json({ repositories: Array.from({ length: 12 }, (_, index) => ({ id: 101 + index })) });
+      }
+      const match = url.pathname.match(/\/repositories\/(\d+)\/events$/);
+      if (match?.[1]) {
+        const repositoryId = Number(match[1]);
+        eventRequests.push(repositoryId);
+        return new Promise<Response>(resolve => releases.set(repositoryId, resolve));
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const worker = createWorker({ fetchImpl, storage: settings.storage, intervalMs: 1_000 });
+
+    await worker.init(createDeps());
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(eventRequests).toEqual(Array.from({ length: 10 }, (_, index) => 101 + index));
+    for (const release of releases.values()) release(json({ events: [], nextCursor: null }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(eventRequests).toEqual(Array.from({ length: 12 }, (_, index) => 101 + index));
+    releases.get(111)?.(json({ events: [], nextCursor: null }));
+    releases.get(112)?.(json({ events: [], nextCursor: null }));
+    await vi.advanceTimersByTimeAsync(0);
+    await worker.stop();
+  });
+
+  it('honors retry-after backoff, keeps a start-to-start cadence, and never overlaps polling cycles', async () => {
     const settings = createSettingsStorage();
     let releaseEvents!: (response: Response) => void;
     const stalledEvents = new Promise<Response>(resolve => {
@@ -334,7 +429,6 @@ describe('PlatformGithubEventWorker', () => {
 
     releaseEvents(json({ events: [], nextCursor: null }));
     await vi.advanceTimersByTimeAsync(0);
-    await vi.advanceTimersByTimeAsync(1_000);
     expect(eventCalls).toBe(2);
     await vi.advanceTimersByTimeAsync(8_999);
     expect(eventCalls).toBe(2);

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -18,6 +18,7 @@ import { PlatformApiError } from '../api-client.js';
 const API_PREFIX = '/v1/server/github-app';
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
 const EVENT_PAGE_SIZE = 500;
+const REPOSITORY_POLL_CONCURRENCY = 10;
 const MIN_LEASE_TTL_MS = 30_000;
 const CURSOR_ORG_ID = '__platform_github_event_worker__';
 const CURSOR_USER_ID = 'worker';
@@ -54,6 +55,7 @@ type EventLogEntry = {
   id: string;
   deliveryId: string;
   event: string;
+  timestamp?: number;
   payload: unknown;
 };
 
@@ -102,6 +104,7 @@ export class PlatformGithubEventWorker extends MastraWorker {
   #hasLease = false;
   #startedAt = 0;
   #settings: PlatformGithubEventWorkerSettings = { version: 1, repositories: {} };
+  #settingsSaveQueue: Promise<void> = Promise.resolve();
 
   constructor(config: PlatformGithubEventWorkerConfig) {
     super();
@@ -169,18 +172,31 @@ export class PlatformGithubEventWorker extends MastraWorker {
   }
 
   async #tick(): Promise<void> {
+    const cycleStartedAt = Date.now();
     let nextDelay = this.#intervalMs;
+    let fixedCadence = true;
     try {
       if (!(await this.#ensureLease())) return;
-      nextDelay = await this.#poll();
+      const result = await this.#poll();
+      nextDelay = result.retryInMs;
+      fixedCadence = !result.backoff;
     } catch (error) {
       nextDelay = retryDelay(error, this.#intervalMs);
+      fixedCadence = false;
       this.deps?.logger.error('Platform GitHub event polling cycle failed', {
         error: error instanceof Error ? error.message : String(error),
         retryInMs: nextDelay,
       });
     } finally {
-      this.#schedule(nextDelay);
+      const durationMs = Math.max(0, Date.now() - cycleStartedAt);
+      if (durationMs >= this.#intervalMs) {
+        this.deps?.logger.warn('Platform GitHub event polling cycle exceeded its interval', {
+          event: 'platform_github_event_poll_cycle_slow',
+          durationMs,
+          intervalMs: this.#intervalMs,
+        });
+      }
+      this.#schedule(fixedCadence ? Math.max(0, nextDelay - durationMs) : nextDelay);
     }
   }
 
@@ -222,27 +238,39 @@ export class PlatformGithubEventWorker extends MastraWorker {
     this.#leaseRenewalTimer = undefined;
   }
 
-  async #poll(): Promise<number> {
+  async #poll(): Promise<{ retryInMs: number; backoff: boolean }> {
     const repositories = await this.#discoverRepositories();
     let retryInMs = this.#intervalMs;
+    let backoff = false;
+    let rateLimited = false;
+    let settingsChanged = false;
 
     for (const repository of repositories) {
-      if (!this.#running || !this.#hasLease) break;
+      const key = String(repository.id);
+      if (this.#settings.repositories[key]) continue;
+      this.#settings.repositories[key] = { afterTimestamp: this.#startedAt };
+      settingsChanged = true;
+    }
+    if (settingsChanged) await this.#saveSettings();
+
+    await forEachConcurrent(repositories, REPOSITORY_POLL_CONCURRENCY, async repository => {
+      if (!this.#running || !this.#hasLease || rateLimited) return;
       try {
         await this.#pollRepository(repository.id);
       } catch (error) {
         const delay = retryDelay(error, this.#intervalMs);
         retryInMs = Math.max(retryInMs, delay);
+        backoff = true;
         this.deps?.logger.error('Platform GitHub repository event polling failed', {
           repositoryId: repository.id,
           error: error instanceof Error ? error.message : String(error),
           retryInMs: delay,
         });
-        if (error instanceof PlatformApiError && error.status === 429) break;
+        if (error instanceof PlatformApiError && error.status === 429) rateLimited = true;
       }
-    }
+    });
 
-    return retryInMs;
+    return { retryInMs, backoff };
   }
 
   async #discoverRepositories(): Promise<Repository[]> {
@@ -253,26 +281,20 @@ export class PlatformGithubEventWorker extends MastraWorker {
         suspendedAt: string | null;
       }>;
     }>('GET', `${API_PREFIX}/installations`);
+    const installations = result.installations.filter(installation => installation.usable && !installation.suspendedAt);
     const repositories = new Map<number, Repository>();
-
-    for (const installation of result.installations) {
-      if (!installation.usable || installation.suspendedAt) continue;
+    await forEachConcurrent(installations, REPOSITORY_POLL_CONCURRENCY, async installation => {
       const page = await this.#client.request<{ repositories: Repository[] }>(
         'GET',
         `${API_PREFIX}/installations/${installation.installationId}/repositories`,
       );
       for (const repository of page.repositories) repositories.set(repository.id, repository);
-    }
-
+    });
     return [...repositories.values()];
   }
 
   async #pollRepository(repositoryId: number): Promise<void> {
     const key = String(repositoryId);
-    if (!this.#settings.repositories[key]) {
-      this.#settings.repositories[key] = { afterTimestamp: this.#startedAt };
-      await this.#saveSettings();
-    }
 
     while (this.#running && this.#hasLease) {
       const cursor: EventCursor = this.#settings.repositories[key]!;
@@ -296,10 +318,20 @@ export class PlatformGithubEventWorker extends MastraWorker {
           });
           continue;
         }
+        this.deps?.logger.info('Platform GitHub event received from the Platform event log', {
+          event: 'platform_github_event_received',
+          repositoryId,
+          eventId: event.id,
+          deliveryId: event.deliveryId,
+          githubEvent: event.event,
+          ...(typeof event.timestamp === 'number' && Number.isFinite(event.timestamp)
+            ? { eventAgeMs: Math.max(0, Date.now() - event.timestamp) }
+            : {}),
+        });
         if (isFactoryClosureEvent(parsed)) {
           await this.#ingestFactoryEvent?.(parsed);
         }
-        const result = await this.#dispatch(parsed, {
+        await this.#dispatch(parsed, {
           controller: this.#controller,
           listSubscriptions: (target, options) =>
             listPullRequestSubscriptionsForWebhook(target, options, this.#github.integrationStorage),
@@ -315,11 +347,6 @@ export class PlatformGithubEventWorker extends MastraWorker {
             });
           },
         });
-        if (result.failed > 0) {
-          throw new Error(
-            `Platform GitHub event ${event.deliveryId} failed for ${result.failed} subscribed target(s).`,
-          );
-        }
       }
 
       if (page.nextCursor === ('afterEventId' in cursor ? cursor.afterEventId : undefined)) return;
@@ -353,12 +380,29 @@ export class PlatformGithubEventWorker extends MastraWorker {
   }
 
   async #saveSettings(): Promise<void> {
-    await this.#storage.settings.save(CURSOR_ORG_ID, CURSOR_USER_ID, this.#settings);
+    const snapshot = structuredClone(this.#settings);
+    const save = this.#settingsSaveQueue.then(() =>
+      this.#storage.settings.save(CURSOR_ORG_ID, CURSOR_USER_ID, snapshot),
+    );
+    this.#settingsSaveQueue = save.catch(() => undefined);
+    await save;
   }
 
   #leaseKey(): string {
     return `${this.name}:${this.#storage.integrationId}`;
   }
+}
+
+async function forEachConcurrent<T>(items: T[], concurrency: number, run: (item: T) => Promise<void>): Promise<void> {
+  let nextIndex = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+      while (nextIndex < items.length) {
+        const item = items[nextIndex++];
+        if (item !== undefined) await run(item);
+      }
+    }),
+  );
 }
 
 function getLeaseProvider(pubsub: PubSub): LeaseProvider {

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -2,6 +2,7 @@ import { RequestContext } from '@mastra/core/request-context';
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { FactoryGithubEventService } from '../../../rules/github-service.js';
 import type { IntegrationContext } from '../../base.js';
 
 import { createPlatformStorageForTests, mountApiRoutes } from '../test-utils.js';
@@ -616,7 +617,9 @@ describe('PlatformGithubIntegration', () => {
       sandboxProvider: 'local',
       sandboxWorkdir: '/tmp/app',
     });
-    const ingestGithubEvent = vi.fn(async () => ({ status: 'committed' as const }));
+    const ingestGithubEvent = vi.spyOn(FactoryGithubEventService.prototype, 'ingest').mockResolvedValue({
+      status: 'committed',
+    });
     const context = {
       auth: fakeAuth(),
       fleet: { enabled: false },
@@ -628,7 +631,7 @@ describe('PlatformGithubIntegration', () => {
       },
       controller: {},
       stateSigner: {},
-      hooks: { ingestGithubEvent },
+      factory: { rules: {}, workItems: {} },
     } as unknown as IntegrationContext;
     integration.initialize?.({ storage: context.storage.generic });
     integration.versionControl.initialize({ storage: sourceControl });

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -30,6 +30,8 @@ import type {
   UpdateReviewersInput,
   VersionControl,
 } from '../../../capabilities/version-control.js';
+import { FactoryGithubEventService } from '../../../rules/github-service.js';
+import type { FactoryGithubEventServiceOptions } from '../../../rules/github-service.js';
 import type { IntegrationStorageHandle } from '../../../storage/domains/integrations/base.js';
 import type {
   SourceControlInstallation,
@@ -376,7 +378,20 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     });
   }
 
+  #createFactoryEventService(ctx: IntegrationContext): FactoryGithubEventService | undefined {
+    if (!ctx.factory) return undefined;
+    return new FactoryGithubEventService({
+      github: this as unknown as GithubIntegration,
+      sourceControl: ctx.storage.sourceControl,
+      integrationStorage: ctx.storage.generic as unknown as FactoryGithubEventServiceOptions['integrationStorage'],
+      projects: ctx.storage.projects,
+      storage: ctx.factory.workItems,
+      rules: ctx.factory.rules,
+    });
+  }
+
   routes(ctx: IntegrationContext): ApiRoute[] {
+    const factoryEvents = this.#createFactoryEventService(ctx);
     return [
       this.#statusRoute(ctx),
       this.#connectRoute(ctx),
@@ -391,7 +406,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         controller: ctx.controller,
         projects: ctx.storage.projects,
         emitAudit: ctx.hooks?.emitAudit,
-        ingestFactoryEvent: ctx.hooks?.ingestGithubEvent,
+        ingestFactoryEvent: factoryEvents?.ingest.bind(factoryEvents),
       }).filter(
         route =>
           route.path !== '/web/github/status' &&
@@ -555,13 +570,14 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     if (!ctx.controller) {
       throw new Error('Platform GitHub event polling requires the mounted Mastra Code controller.');
     }
+    const factoryEvents = this.#createFactoryEventService(ctx);
     return [
       new PlatformGithubEventWorker({
         client: this.#client,
         controller: ctx.controller,
         github: this,
         storage: ctx.storage.generic as unknown as PlatformGithubEventStorage,
-        ingestFactoryEvent: ctx.hooks?.ingestGithubEvent,
+        ingestFactoryEvent: factoryEvents?.ingest.bind(factoryEvents),
         intervalMs: this.#pollingIntervalMs,
       }),
     ];

--- a/mastracode/factory/src/integrations/platform/linear/event-worker.lifecycle.test.ts
+++ b/mastracode/factory/src/integrations/platform/linear/event-worker.lifecycle.test.ts
@@ -1,0 +1,181 @@
+import { EventEmitterPubSub } from '@mastra/core/events';
+import { Mastra } from '@mastra/core/mastra';
+import { LibSQLFactoryStorage } from '@mastra/libsql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MastraFactory } from '../../../factory.js';
+import { FactoryLinearIssueService } from '../../../rules/linear-service.js';
+import type { IntakeStorage } from '../../../storage/domains/intake/base.js';
+import type { FactoryProjectsStorage } from '../../../storage/domains/projects/base.js';
+import { PlatformLinearIntegration } from './integration.js';
+import { encodeSourceId } from './source-id.js';
+
+const harness = vi.hoisted(() => {
+  let mastra: Mastra | undefined;
+  const controller = {
+    id: 'code',
+    init: vi.fn(async () => undefined),
+    __registerMastra: vi.fn((instance: Mastra) => {
+      mastra = instance;
+    }),
+    getMastra: vi.fn(() => mastra),
+  };
+
+  return {
+    controller,
+    reset() {
+      mastra = undefined;
+      vi.clearAllMocks();
+    },
+  };
+});
+
+vi.mock('@mastra/code-sdk', () => ({
+  prepareAgentControllerMount: vi.fn(async (config: Record<string, unknown>) => {
+    const controllerId = String(config.controllerId ?? 'code');
+    const controller = harness.controller;
+    return {
+      base: { controller, authStorage: {} },
+      mastraArgs: {
+        agentControllers: { [controllerId]: controller },
+        storage: config.storage,
+        ...(config.pubsub ? { pubsub: config.pubsub } : {}),
+      },
+      finalize: async () => {
+        await controller.init();
+        await controller.getMastra()?.startWorkers();
+      },
+    };
+  }),
+}));
+
+function json(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubEnv('MASTRA_SHARED_API_URL', 'https://platform.example.com/v1');
+  vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'platform-token');
+  vi.stubEnv('MASTRA_PLATFORM_GITHUB_POLLING_ENABLED', 'false');
+  vi.stubEnv('MASTRA_PLATFORM_LINEAR_POLLING_INTERVAL_MS', '60000');
+  harness.reset();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe('Platform Linear event worker factory lifecycle', () => {
+  it('starts through MastraFactory and sends a selected workspace issue to every Factory project', async () => {
+    const storage = new LibSQLFactoryStorage({ url: ':memory:', id: 'platform-linear-worker-lifecycle' });
+    const pubsub = new EventEmitterPubSub();
+    const ingestLinearIssues = vi.spyOn(FactoryLinearIssueService.prototype, 'ingest').mockResolvedValue({
+      status: 'committed',
+      ingested: 1,
+    });
+    const releaseLease = vi.spyOn(pubsub, 'releaseLease');
+    const issue = {
+      id: 'issue-1',
+      identifier: 'ENG-42',
+      number: 42,
+      title: 'Fix intake',
+      description: 'Issue body',
+      url: 'https://linear.app/acme/issue/ENG-42',
+      priority: 2,
+      priorityLabel: 'High',
+      labels: [{ id: 'label-1', name: 'bug' }],
+      state: { id: 'state-1', name: 'Todo', type: 'unstarted' },
+      team: { id: 'team-1', key: 'ENG', name: 'Engineering' },
+      assignee: null,
+      creator: null,
+      createdAt: '2026-07-01T00:00:00Z',
+      updatedAt: '2026-07-02T00:00:00Z',
+      archivedAt: null,
+    };
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/linear/workspaces/workspace-1/events')) {
+        return json({
+          events: [
+            {
+              id: '1001-0',
+              timestamp: Date.now(),
+              envelope: {
+                type: 'Issue',
+                action: 'update',
+                data: { id: issue.id, projectId: 'linear-project-1' },
+              },
+            },
+          ],
+        });
+      }
+      if (url.pathname.endsWith('/linear/workspaces/workspace-1/issues/issue-1')) return json(issue);
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const linear = new PlatformLinearIntegration();
+    const factory = new MastraFactory({ storage, pubsub, integrations: [linear] });
+
+    try {
+      const args = await factory.prepare();
+      const worker = Array.isArray(args.workers)
+        ? args.workers.find(candidate => candidate.name === 'platform-linear-events')
+        : undefined;
+      expect(worker?.name).toBe('platform-linear-events');
+      expect(worker?.isRunning).toBe(false);
+
+      const intake = storage.getDomain<IntakeStorage>('intake');
+      await intake.saveConfig({
+        orgId: 'org-1',
+        userId: 'user-1',
+        config: { linear: { enabled: true, sourceIds: [encodeSourceId('workspace-1', 'linear-project-1')] } },
+      });
+      const projects = storage.getDomain<FactoryProjectsStorage>('projects');
+      const first = await projects.create({ orgId: 'org-1', userId: 'owner-1', input: { name: 'First' } });
+      const second = await projects.create({ orgId: 'org-1', userId: 'owner-2', input: { name: 'Second' } });
+
+      const mastra = new Mastra(args);
+      await factory.finalize();
+      expect(worker?.isRunning).toBe(true);
+
+      await vi.waitFor(() => expect(ingestLinearIssues).toHaveBeenCalledTimes(2));
+      expect(ingestLinearIssues).toHaveBeenCalledWith({
+        orgId: 'org-1',
+        userId: 'owner-1',
+        factoryProjectId: first.id,
+        issues: [
+          expect.objectContaining({
+            id: issue.id,
+            identifier: issue.identifier,
+            team: 'ENG',
+            priorityLabel: 'High',
+          }),
+        ],
+      });
+      expect(ingestLinearIssues).toHaveBeenCalledWith({
+        orgId: 'org-1',
+        userId: 'owner-2',
+        factoryProjectId: second.id,
+        issues: [expect.objectContaining({ id: issue.id })],
+      });
+      expect(await pubsub.getLeaseOwner('platform-linear-events:linear')).toEqual(expect.any(String));
+
+      await mastra.stopWorkers();
+
+      expect(worker?.isRunning).toBe(false);
+      expect(releaseLease).toHaveBeenCalledOnce();
+      expect(await pubsub.getLeaseOwner('platform-linear-events:linear')).toBeUndefined();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await harness.controller.getMastra()?.stopWorkers();
+      await storage.close();
+    }
+  });
+});

--- a/mastracode/factory/src/integrations/platform/linear/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/linear/event-worker.test.ts
@@ -1,0 +1,254 @@
+import type { WorkerDeps } from '@mastra/core/worker';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { IntakeStorage } from '../../../storage/domains/intake/base.js';
+import type { FactoryProjectsStorage } from '../../../storage/domains/projects/base.js';
+import type { LinearIssueIngress } from '../../base.js';
+import { PlatformApiClient } from '../api-client.js';
+import { PlatformLinearEventWorker } from './event-worker.js';
+import type { PlatformLinearEventStorage } from './event-worker.js';
+import { encodeSourceId } from './source-id.js';
+
+const baseUrl = 'https://platform.example.com';
+const accessToken = 'platform-token';
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function createSettingsStorage(initial: unknown = null) {
+  let value = initial;
+  const get = vi.fn(async () => value);
+  const save = vi.fn(async (_orgId: string, _userId: string, next: unknown) => {
+    value = structuredClone(next);
+  });
+  return {
+    storage: {
+      integrationId: 'linear',
+      settings: { get, save },
+    } as unknown as PlatformLinearEventStorage,
+    read: () => value,
+  };
+}
+
+function createDeps(): WorkerDeps {
+  return {
+    pubsub: {} as WorkerDeps['pubsub'],
+    storage: {} as WorkerDeps['storage'],
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as WorkerDeps['logger'],
+  };
+}
+
+const issue: LinearIssueIngress = {
+  id: 'issue-1',
+  identifier: 'ENG-42',
+  title: 'Fix intake',
+  url: 'https://linear.app/acme/issue/ENG-42',
+  state: 'Todo',
+  stateType: 'unstarted',
+  priorityLabel: 'High',
+  assignee: null,
+  team: 'ENG',
+  labels: ['bug'],
+  createdAt: '2026-07-01T00:00:00Z',
+  updatedAt: '2026-07-02T00:00:00Z',
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe('PlatformLinearEventWorker', () => {
+  it('polls selected workspaces, sends matching issues to every Factory project, and resumes from its cursor', async () => {
+    const settings = createSettingsStorage();
+    const intake = {
+      listEnabledSourceSelections: vi.fn(async () => [
+        { orgId: 'org-1', userId: 'user-1', sourceIds: [encodeSourceId('workspace-1', 'linear-project-1')] },
+        { orgId: 'org-1', userId: 'user-2', sourceIds: [encodeSourceId('workspace-1', 'linear-project-1')] },
+      ]),
+    } as unknown as IntakeStorage;
+    const projects = {
+      list: vi.fn(async () => [
+        { id: 'factory-1', orgId: 'org-1', createdBy: 'owner-1' },
+        { id: 'factory-2', orgId: 'org-1', createdBy: 'owner-2' },
+      ]),
+    } as unknown as FactoryProjectsStorage;
+    const loadIssue = vi.fn(async () => issue);
+    const ingestLinearIssues = vi.fn(async () => ({ status: 'committed' }));
+    const eventRequests: URL[] = [];
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/linear/workspaces/workspace-1/events')) {
+        eventRequests.push(url);
+        if (url.searchParams.has('after')) {
+          return json({
+            events: [
+              {
+                id: '1000-0',
+                timestamp: Date.now() - 2_500,
+                envelope: {
+                  type: 'Issue',
+                  action: 'update',
+                  data: { id: 'issue-1', projectId: 'linear-project-1' },
+                },
+              },
+              {
+                id: '1001-0',
+                timestamp: Date.now() - 1_000,
+                envelope: {
+                  type: 'Issue',
+                  action: 'update',
+                  data: { id: 'issue-2', projectId: 'unselected-project' },
+                },
+              },
+            ],
+          });
+        }
+        return json({ events: [] });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const worker = new PlatformLinearEventWorker({
+      client: new PlatformApiClient({ baseUrl, accessToken, fetchImpl }),
+      intake,
+      projects,
+      storage: settings.storage,
+      loadIssue,
+      ingestLinearIssues,
+      intervalMs: 1_000,
+      now: () => 10_000,
+    });
+    const deps = createDeps();
+
+    await worker.init(deps);
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(eventRequests[0]?.searchParams.get('after')).toBe('9999');
+    expect(loadIssue).toHaveBeenCalledOnce();
+    expect(loadIssue).toHaveBeenCalledWith('workspace-1', 'issue-1');
+    expect(ingestLinearIssues).toHaveBeenCalledTimes(2);
+    expect(ingestLinearIssues).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      userId: 'owner-1',
+      factoryProjectId: 'factory-1',
+      issues: [issue],
+    });
+    expect(ingestLinearIssues).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      userId: 'owner-2',
+      factoryProjectId: 'factory-2',
+      issues: [issue],
+    });
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      'Platform Linear event received from the Platform event log',
+      expect.objectContaining({
+        event: 'platform_linear_event_received',
+        organizationId: 'org-1',
+        workspaceId: 'workspace-1',
+        eventId: '1000-0',
+        linearEvent: 'Issue',
+        action: 'update',
+        eventAgeMs: 2_500,
+      }),
+    );
+    expect(settings.read()).toEqual({
+      version: 1,
+      workspaces: { 'org-1:workspace-1': { afterEventId: '1001-0' } },
+    });
+    await worker.stop();
+
+    eventRequests.length = 0;
+    const resumed = new PlatformLinearEventWorker({
+      client: new PlatformApiClient({ baseUrl, accessToken, fetchImpl }),
+      intake,
+      projects,
+      storage: settings.storage,
+      loadIssue,
+      ingestLinearIssues,
+      intervalMs: 1_000,
+      now: () => 20_000,
+    });
+    await resumed.init(createDeps());
+    await resumed.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(eventRequests[0]?.searchParams.get('afterEventId')).toBe('1001-0');
+    expect(eventRequests[0]?.searchParams.has('after')).toBe(false);
+    await resumed.stop();
+  });
+
+  it('advances the cursor when one Factory project rejects an event', async () => {
+    const settings = createSettingsStorage();
+    const intake = {
+      listEnabledSourceSelections: vi.fn(async () => [
+        { orgId: 'org-1', userId: 'user-1', sourceIds: [encodeSourceId('workspace-1', 'linear-project-1')] },
+      ]),
+    } as unknown as IntakeStorage;
+    const projects = {
+      list: vi.fn(async () => [
+        { id: 'factory-1', orgId: 'org-1', createdBy: 'owner-1' },
+        { id: 'factory-2', orgId: 'org-1', createdBy: 'owner-2' },
+      ]),
+    } as unknown as FactoryProjectsStorage;
+    const ingestLinearIssues = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('target unavailable'))
+      .mockResolvedValue({ status: 'committed' });
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.searchParams.has('after')) {
+        return json({
+          events: [
+            {
+              id: '1000-0',
+              timestamp: Date.now(),
+              envelope: {
+                type: 'Issue',
+                action: 'create',
+                data: { id: 'issue-1', projectId: 'linear-project-1' },
+              },
+            },
+          ],
+        });
+      }
+      return json({ events: [] });
+    });
+    const worker = new PlatformLinearEventWorker({
+      client: new PlatformApiClient({ baseUrl, accessToken, fetchImpl }),
+      intake,
+      projects,
+      storage: settings.storage,
+      loadIssue: async () => issue,
+      ingestLinearIssues,
+      intervalMs: 1_000,
+      now: () => 10_000,
+    });
+    const deps = createDeps();
+
+    await worker.init(deps);
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(ingestLinearIssues).toHaveBeenCalledTimes(2);
+    expect(settings.read()).toEqual({
+      version: 1,
+      workspaces: { 'org-1:workspace-1': { afterEventId: '1000-0' } },
+    });
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'Platform Linear event ingestion failed for a Factory project',
+      expect.objectContaining({ factoryProjectId: 'factory-1', eventId: '1000-0' }),
+    );
+    await worker.stop();
+  });
+});

--- a/mastracode/factory/src/integrations/platform/linear/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/linear/event-worker.ts
@@ -1,0 +1,418 @@
+import { randomUUID } from 'node:crypto';
+
+import { isLeaseProvider, NoopLeaseProvider } from '@mastra/core/events';
+import type { LeaseProvider, PubSub } from '@mastra/core/events';
+import { MastraWorker } from '@mastra/core/worker';
+import type { WorkerDeps } from '@mastra/core/worker';
+
+import type { IntakeStorage } from '../../../storage/domains/intake/base.js';
+import type { IntegrationStorageHandle } from '../../../storage/domains/integrations/base.js';
+import type { FactoryProject, FactoryProjectsStorage } from '../../../storage/domains/projects/base.js';
+import type { LinearIssueIngress } from '../../base.js';
+import type { PlatformApiClient } from '../api-client.js';
+import { PlatformApiError } from '../api-client.js';
+import { decodeSourceId } from './source-id.js';
+
+const API_PREFIX = '/v1/server/linear';
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const EVENT_PAGE_SIZE = 500;
+const WORKSPACE_POLL_CONCURRENCY = 10;
+const PROJECT_INGEST_CONCURRENCY = 10;
+const MIN_LEASE_TTL_MS = 30_000;
+const CURSOR_ORG_ID = '__platform_linear_event_worker__';
+const CURSOR_USER_ID = 'worker';
+
+type EventCursor = { afterEventId: string } | { afterTimestamp: number };
+type PlatformLinearEventWorkerSettings = {
+  version: 1;
+  workspaces: Record<string, EventCursor>;
+};
+
+export type PlatformLinearEventStorage = IntegrationStorageHandle<
+  Record<string, unknown>,
+  PlatformLinearEventWorkerSettings,
+  Record<string, unknown>
+>;
+
+type LinearEventLogEntry = {
+  id: string;
+  timestamp?: number;
+  envelope: {
+    type: string;
+    action?: string | null;
+    data?: unknown;
+  };
+};
+
+type WorkspaceTarget = {
+  key: string;
+  orgId: string;
+  workspaceId: string;
+  projectIds: Set<string>;
+};
+
+type LinearIssueEvent = {
+  issueId: string;
+  projectId: string;
+};
+
+export interface PlatformLinearEventWorkerConfig {
+  client: PlatformApiClient;
+  intake: IntakeStorage;
+  projects: FactoryProjectsStorage;
+  storage: PlatformLinearEventStorage;
+  loadIssue(workspaceId: string, issueId: string): Promise<LinearIssueIngress | null>;
+  ingestLinearIssues(input: {
+    orgId: string;
+    userId: string;
+    factoryProjectId: string;
+    issues: LinearIssueIngress[];
+  }): Promise<unknown>;
+  intervalMs?: number;
+  now?: () => number;
+}
+
+export class PlatformLinearEventWorker extends MastraWorker {
+  readonly name = 'platform-linear-events';
+
+  readonly #client: PlatformApiClient;
+  readonly #intake: IntakeStorage;
+  readonly #projects: FactoryProjectsStorage;
+  readonly #storage: PlatformLinearEventStorage;
+  readonly #loadIssue: PlatformLinearEventWorkerConfig['loadIssue'];
+  readonly #ingestLinearIssues: PlatformLinearEventWorkerConfig['ingestLinearIssues'];
+  readonly #intervalMs: number;
+  readonly #now: () => number;
+  readonly #leaseOwner = randomUUID();
+
+  #running = false;
+  #timer: ReturnType<typeof setTimeout> | undefined;
+  #leaseRenewalTimer: ReturnType<typeof setInterval> | undefined;
+  #inFlight: Promise<void> | undefined;
+  #leaseProvider: LeaseProvider = NoopLeaseProvider;
+  #leaseTtlMs: number;
+  #hasLease = false;
+  #startedAt = 0;
+  #settings: PlatformLinearEventWorkerSettings = { version: 1, workspaces: {} };
+  #settingsSaveQueue: Promise<void> = Promise.resolve();
+
+  constructor(config: PlatformLinearEventWorkerConfig) {
+    super();
+    this.#client = config.client;
+    this.#intake = config.intake;
+    this.#projects = config.projects;
+    this.#storage = config.storage;
+    this.#loadIssue = config.loadIssue;
+    this.#ingestLinearIssues = config.ingestLinearIssues;
+    this.#intervalMs = config.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    if (!Number.isFinite(this.#intervalMs) || this.#intervalMs <= 0) {
+      throw new Error('Platform Linear event polling interval must be a positive number.');
+    }
+    this.#leaseTtlMs = Math.max(MIN_LEASE_TTL_MS, this.#intervalMs * 3);
+    this.#now = config.now ?? Date.now;
+  }
+
+  async init(deps: WorkerDeps): Promise<void> {
+    await super.init(deps);
+    this.#leaseProvider = getLeaseProvider(deps.pubsub);
+  }
+
+  async start(): Promise<void> {
+    if (this.#running) return;
+    if (!this.deps) throw new Error('PlatformLinearEventWorker: call init() before start()');
+
+    this.#startedAt = this.#now() - 1;
+    this.#settings = normalizeSettings(await this.#storage.settings.get(CURSOR_ORG_ID, CURSOR_USER_ID));
+    this.#running = true;
+    this.deps.logger.info('Platform Linear event polling started', {
+      intervalMs: this.#intervalMs,
+      leaseTtlMs: this.#leaseTtlMs,
+    });
+    this.#schedule(0);
+  }
+
+  async stop(): Promise<void> {
+    if (!this.#running) return;
+    this.#running = false;
+    if (this.#timer) clearTimeout(this.#timer);
+    this.#timer = undefined;
+    this.#stopLeaseRenewal();
+    await this.#inFlight;
+    if (this.#hasLease) {
+      await this.#leaseProvider.releaseLease(this.#leaseKey(), this.#leaseOwner).catch(() => undefined);
+      this.#hasLease = false;
+    }
+  }
+
+  get isRunning(): boolean {
+    return this.#running;
+  }
+
+  #schedule(delayMs: number): void {
+    if (!this.#running) return;
+    this.#timer = setTimeout(() => {
+      this.#timer = undefined;
+      const run = this.#tick();
+      this.#inFlight = run;
+      void run.finally(() => {
+        if (this.#inFlight === run) this.#inFlight = undefined;
+      });
+    }, delayMs);
+    this.#timer.unref?.();
+  }
+
+  async #tick(): Promise<void> {
+    const cycleStartedAt = Date.now();
+    let nextDelay = this.#intervalMs;
+    let fixedCadence = true;
+    try {
+      if (!(await this.#ensureLease())) return;
+      const result = await this.#poll();
+      nextDelay = result.retryInMs;
+      fixedCadence = !result.backoff;
+    } catch (error) {
+      nextDelay = retryDelay(error, this.#intervalMs);
+      fixedCadence = false;
+      this.deps?.logger.error('Platform Linear event polling cycle failed', {
+        error: error instanceof Error ? error.message : String(error),
+        retryInMs: nextDelay,
+      });
+    } finally {
+      const durationMs = Math.max(0, Date.now() - cycleStartedAt);
+      if (durationMs >= this.#intervalMs) {
+        this.deps?.logger.warn('Platform Linear event polling cycle exceeded its interval', {
+          event: 'platform_linear_event_poll_cycle_slow',
+          durationMs,
+          intervalMs: this.#intervalMs,
+        });
+      }
+      this.#schedule(fixedCadence ? Math.max(0, nextDelay - durationMs) : nextDelay);
+    }
+  }
+
+  async #ensureLease(): Promise<boolean> {
+    if (this.#hasLease) return true;
+    const result = await this.#leaseProvider.acquireLease(this.#leaseKey(), this.#leaseOwner, this.#leaseTtlMs);
+    this.#hasLease = result.acquired;
+    if (this.#hasLease) this.#startLeaseRenewal();
+    return this.#hasLease;
+  }
+
+  #startLeaseRenewal(): void {
+    if (this.#leaseRenewalTimer) return;
+    this.#leaseRenewalTimer = setInterval(
+      () => {
+        void this.#leaseProvider
+          .renewLease(this.#leaseKey(), this.#leaseOwner, this.#leaseTtlMs)
+          .then(renewed => {
+            if (!renewed) {
+              this.#hasLease = false;
+              this.#stopLeaseRenewal();
+            }
+          })
+          .catch(error => {
+            this.#hasLease = false;
+            this.#stopLeaseRenewal();
+            this.deps?.logger.warn('Platform Linear event polling lease renewal failed', {
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
+      },
+      Math.floor(this.#leaseTtlMs / 3),
+    );
+    this.#leaseRenewalTimer.unref?.();
+  }
+
+  #stopLeaseRenewal(): void {
+    if (this.#leaseRenewalTimer) clearInterval(this.#leaseRenewalTimer);
+    this.#leaseRenewalTimer = undefined;
+  }
+
+  async #poll(): Promise<{ retryInMs: number; backoff: boolean }> {
+    const targets = await this.#discoverTargets();
+    let retryInMs = this.#intervalMs;
+    let backoff = false;
+    let rateLimited = false;
+    let settingsChanged = false;
+
+    for (const target of targets) {
+      if (this.#settings.workspaces[target.key]) continue;
+      this.#settings.workspaces[target.key] = { afterTimestamp: this.#startedAt };
+      settingsChanged = true;
+    }
+    if (settingsChanged) await this.#saveSettings();
+
+    const projectsByOrg = new Map<string, Promise<FactoryProject[]>>();
+    await forEachConcurrent(targets, WORKSPACE_POLL_CONCURRENCY, async target => {
+      if (!this.#running || !this.#hasLease || rateLimited) return;
+      try {
+        let organizationProjects = projectsByOrg.get(target.orgId);
+        if (!organizationProjects) {
+          organizationProjects = this.#projects.list({ orgId: target.orgId });
+          projectsByOrg.set(target.orgId, organizationProjects);
+        }
+        await this.#pollWorkspace(target, await organizationProjects);
+      } catch (error) {
+        const delay = retryDelay(error, this.#intervalMs);
+        retryInMs = Math.max(retryInMs, delay);
+        backoff = true;
+        this.deps?.logger.error('Platform Linear workspace event polling failed', {
+          organizationId: target.orgId,
+          workspaceId: target.workspaceId,
+          error: error instanceof Error ? error.message : String(error),
+          retryInMs: delay,
+        });
+        if (error instanceof PlatformApiError && error.status === 429) rateLimited = true;
+      }
+    });
+
+    return { retryInMs, backoff };
+  }
+
+  async #discoverTargets(): Promise<WorkspaceTarget[]> {
+    const selections = await this.#intake.listEnabledSourceSelections('linear');
+    const targets = new Map<string, WorkspaceTarget>();
+    for (const selection of selections) {
+      for (const sourceId of selection.sourceIds) {
+        try {
+          const source = decodeSourceId(sourceId);
+          const key = workspaceKey(selection.orgId, source.workspaceId);
+          const target = targets.get(key) ?? {
+            key,
+            orgId: selection.orgId,
+            workspaceId: source.workspaceId,
+            projectIds: new Set<string>(),
+          };
+          target.projectIds.add(source.projectId);
+          targets.set(key, target);
+        } catch (error) {
+          this.deps?.logger.warn('Platform Linear intake selection contains an invalid source id', {
+            organizationId: selection.orgId,
+            sourceId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+    return [...targets.values()];
+  }
+
+  async #pollWorkspace(target: WorkspaceTarget, factoryProjects: FactoryProject[]): Promise<void> {
+    while (this.#running && this.#hasLease) {
+      const cursor = this.#settings.workspaces[target.key]!;
+      const query = new URLSearchParams({ limit: String(EVENT_PAGE_SIZE) });
+      if ('afterEventId' in cursor) query.set('afterEventId', cursor.afterEventId);
+      else query.set('after', String(cursor.afterTimestamp));
+
+      const page = await this.#client.request<{ events: LinearEventLogEntry[] }>(
+        'GET',
+        `${API_PREFIX}/workspaces/${encodeURIComponent(target.workspaceId)}/events?${query}`,
+      );
+      if (page.events.length === 0) return;
+
+      for (const event of page.events) {
+        if (!this.#running || !this.#hasLease) return;
+        const issueEvent = parseIssueEvent(event);
+        if (!issueEvent || !target.projectIds.has(issueEvent.projectId)) continue;
+
+        this.deps?.logger.info('Platform Linear event received from the Platform event log', {
+          event: 'platform_linear_event_received',
+          organizationId: target.orgId,
+          workspaceId: target.workspaceId,
+          eventId: event.id,
+          linearEvent: event.envelope.type,
+          action: event.envelope.action ?? null,
+          ...(typeof event.timestamp === 'number' && Number.isFinite(event.timestamp)
+            ? { eventAgeMs: Math.max(0, Date.now() - event.timestamp) }
+            : {}),
+        });
+        const issue = await this.#loadIssue(target.workspaceId, issueEvent.issueId);
+        if (!issue) continue;
+
+        await forEachConcurrent(factoryProjects, PROJECT_INGEST_CONCURRENCY, async project => {
+          try {
+            await this.#ingestLinearIssues({
+              orgId: target.orgId,
+              userId: project.createdBy,
+              factoryProjectId: project.id,
+              issues: [issue],
+            });
+          } catch (error) {
+            this.deps?.logger.error('Platform Linear event ingestion failed for a Factory project', {
+              organizationId: target.orgId,
+              workspaceId: target.workspaceId,
+              factoryProjectId: project.id,
+              eventId: event.id,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        });
+      }
+
+      const nextCursor = page.events.at(-1)?.id;
+      if (!nextCursor || nextCursor === ('afterEventId' in cursor ? cursor.afterEventId : undefined)) return;
+      this.#settings.workspaces[target.key] = { afterEventId: nextCursor };
+      await this.#saveSettings();
+      if (page.events.length < EVENT_PAGE_SIZE) return;
+    }
+  }
+
+  async #saveSettings(): Promise<void> {
+    const snapshot = structuredClone(this.#settings);
+    const save = this.#settingsSaveQueue.then(() =>
+      this.#storage.settings.save(CURSOR_ORG_ID, CURSOR_USER_ID, snapshot),
+    );
+    this.#settingsSaveQueue = save.catch(() => undefined);
+    await save;
+  }
+
+  #leaseKey(): string {
+    return `${this.name}:${this.#storage.integrationId}`;
+  }
+}
+
+function parseIssueEvent(event: LinearEventLogEntry): LinearIssueEvent | null {
+  if (!event.id || event.envelope.type !== 'Issue') return null;
+  const data = event.envelope.data;
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null;
+  const issueId = Reflect.get(data, 'id');
+  const projectId = Reflect.get(data, 'projectId');
+  if (typeof issueId !== 'string' || !issueId || typeof projectId !== 'string' || !projectId) return null;
+  return { issueId, projectId };
+}
+
+function workspaceKey(orgId: string, workspaceId: string): string {
+  return `${orgId}:${workspaceId}`;
+}
+
+async function forEachConcurrent<T>(items: T[], concurrency: number, run: (item: T) => Promise<void>): Promise<void> {
+  let nextIndex = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+      while (nextIndex < items.length) {
+        const item = items[nextIndex++];
+        if (item !== undefined) await run(item);
+      }
+    }),
+  );
+}
+
+function getLeaseProvider(pubsub: PubSub): LeaseProvider {
+  const getProvider = (pubsub as PubSub & { getLeaseProvider?: () => LeaseProvider | undefined }).getLeaseProvider;
+  if (typeof getProvider === 'function') return getProvider.call(pubsub) ?? NoopLeaseProvider;
+  return isLeaseProvider(pubsub) ? pubsub : NoopLeaseProvider;
+}
+
+function normalizeSettings(value: PlatformLinearEventWorkerSettings | null): PlatformLinearEventWorkerSettings {
+  if (!value || value.version !== 1 || !value.workspaces || typeof value.workspaces !== 'object') {
+    return { version: 1, workspaces: {} };
+  }
+  return { version: 1, workspaces: { ...value.workspaces } };
+}
+
+function retryDelay(error: unknown, fallbackMs: number): number {
+  if (error instanceof PlatformApiError && error.status === 429 && error.retryAfterSeconds !== null) {
+    return Math.max(fallbackMs, error.retryAfterSeconds * 1_000);
+  }
+  return fallbackMs;
+}

--- a/mastracode/factory/src/integrations/platform/linear/integration.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.ts
@@ -7,12 +7,15 @@ import type { IntegrationConnection } from '../../../capabilities/connection.js'
 import type { Intake, IntakeIssue, IntakeIssueDetail } from '../../../capabilities/intake.js';
 import type { RouteAuth } from '../../../routes/route.js';
 import type { FactoryProjectsStorage } from '../../../storage/domains/projects/base.js';
-import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '../../base.js';
+import type { FactoryIntegration, IntegrationContext, IntegrationTools, LinearIssueIngress } from '../../base.js';
 import { buildLinearAgentTools } from '../../linear/agent-tools.js';
 import type { LinearConnectionCheck, LinearIntegration } from '../../linear/integration.js';
 import { buildLinearRoutes } from '../../linear/routes.js';
 import type { LinearConnectionData, LinearConnectionRow, LinearStorageHandle } from '../../linear/storage.js';
 import { logPlatformInfo, PlatformApiClient, PlatformApiError, platformApiClientConfigFromEnv } from '../api-client.js';
+import { PlatformLinearEventWorker } from './event-worker.js';
+import type { PlatformLinearEventStorage } from './event-worker.js';
+import { decodeSourceId, encodeSourceId } from './source-id.js';
 
 type PageInfo = { hasNextPage: boolean; endCursor: string | null };
 type LinearUser = {
@@ -82,6 +85,8 @@ export class PlatformLinearIntegration implements FactoryIntegration {
   readonly id = 'linear';
   readonly #client: PlatformApiClient;
   readonly #endpointHost: string;
+  readonly #pollingEnabled: boolean;
+  readonly #pollingIntervalMs: number | undefined;
   #projects: FactoryProjectsStorage | undefined;
   #auth: RouteAuth | undefined;
 
@@ -163,6 +168,8 @@ export class PlatformLinearIntegration implements FactoryIntegration {
     const config = platformApiClientConfigFromEnv();
     this.#client = new PlatformApiClient(config);
     this.#endpointHost = new URL(config.baseUrl).host;
+    this.#pollingEnabled = process.env.MASTRA_PLATFORM_LINEAR_POLLING_ENABLED?.trim().toLowerCase() !== 'false';
+    this.#pollingIntervalMs = optionalPositiveIntegerEnv('MASTRA_PLATFORM_LINEAR_POLLING_INTERVAL_MS');
   }
 
   get storage(): LinearStorageHandle {
@@ -287,6 +294,21 @@ export class PlatformLinearIntegration implements FactoryIntegration {
     });
   }
 
+  workers(ctx: IntegrationContext): PlatformLinearEventWorker[] {
+    if (!this.#pollingEnabled || !ctx.hooks?.ingestLinearIssues) return [];
+    return [
+      new PlatformLinearEventWorker({
+        client: this.#client,
+        intake: ctx.storage.intake,
+        projects: ctx.storage.projects,
+        storage: ctx.storage.generic as unknown as PlatformLinearEventStorage,
+        loadIssue: (workspaceId, issueId) => this.#loadIssueForEvent(workspaceId, issueId),
+        ingestLinearIssues: ctx.hooks.ingestLinearIssues,
+        intervalMs: this.#pollingIntervalMs,
+      }),
+    ];
+  }
+
   async agentTools({ requestContext }: { requestContext: RequestContext }): Promise<IntegrationTools> {
     return buildLinearAgentTools({ requestContext, linear: this as unknown as LinearIntegration });
   }
@@ -301,6 +323,19 @@ export class PlatformLinearIntegration implements FactoryIntegration {
       id: encodeSourceId(workspace.linearWorkspaceId, project.id),
       workspaceId: workspace.linearWorkspaceId,
     }));
+  }
+
+  async #loadIssueForEvent(workspaceId: string, issueId: string): Promise<LinearIssueIngress | null> {
+    try {
+      const issue = await this.#client.request<LinearIssue>(
+        'GET',
+        `${API_PREFIX}/workspaces/${encodeURIComponent(workspaceId)}/issues/${encodeURIComponent(issueId)}`,
+      );
+      return parseIssueIngress(issue);
+    } catch (error) {
+      if (isNotFound(error)) return null;
+      throw error;
+    }
   }
 
   async #listProjectSources(): Promise<ProjectSource[]> {
@@ -466,6 +501,23 @@ function parseIssue(issue: LinearIssue): IntakeIssue {
   };
 }
 
+function parseIssueIngress(issue: LinearIssue): LinearIssueIngress {
+  return {
+    id: issue.id,
+    identifier: issue.identifier,
+    title: issue.title,
+    url: issue.url,
+    state: issue.state.name,
+    stateType: issue.state.type,
+    priorityLabel: issue.priorityLabel,
+    assignee: issue.assignee?.displayName ?? issue.assignee?.name ?? null,
+    team: issue.team.key,
+    labels: issue.labels.map(label => label.name),
+    createdAt: issue.createdAt,
+    updatedAt: issue.updatedAt,
+  };
+}
+
 function parseIssueDetail(issue: LinearIssue, comments: LinearComment[]): IntakeIssueDetail {
   return {
     ...parseIssue(issue),
@@ -477,25 +529,6 @@ function parseIssueDetail(issue: LinearIssue, comments: LinearComment[]): Intake
       createdAt: comment.createdAt,
     })),
   };
-}
-
-function encodeSourceId(workspaceId: string, projectId: string): string {
-  return `linear-project:${Buffer.from(JSON.stringify({ workspaceId, projectId })).toString('base64url')}`;
-}
-
-function decodeSourceId(sourceId: string): { workspaceId: string; projectId: string } {
-  if (!sourceId.startsWith('linear-project:')) throw new Error('Linear project source id is invalid.');
-  try {
-    const parsed = JSON.parse(Buffer.from(sourceId.slice('linear-project:'.length), 'base64url').toString('utf8')) as {
-      workspaceId?: unknown;
-      projectId?: unknown;
-    };
-    if (typeof parsed.workspaceId !== 'string' || !parsed.workspaceId) throw new Error();
-    if (typeof parsed.projectId !== 'string' || !parsed.projectId) throw new Error();
-    return { workspaceId: parsed.workspaceId, projectId: parsed.projectId };
-  } catch {
-    throw new Error('Linear project source id is invalid.');
-  }
 }
 
 function normalizeLabels(labels: string[] | undefined): string[] {
@@ -527,4 +560,13 @@ function requireLinearConnection(connection: IntegrationConnection): void {
 
 function isNotFound(error: unknown): boolean {
   return error instanceof PlatformApiError && error.status === 404;
+}
+
+function optionalPositiveIntegerEnv(name: 'MASTRA_PLATFORM_LINEAR_POLLING_INTERVAL_MS'): number | undefined {
+  const value = process.env[name]?.trim();
+  if (!value) return undefined;
+  if (!/^\d+$/.test(value)) throw new Error(`${name} must be a positive integer.`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer.`);
+  return parsed;
 }

--- a/mastracode/factory/src/integrations/platform/linear/integration.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.ts
@@ -6,6 +6,7 @@ import type { Context } from 'hono';
 import type { IntegrationConnection } from '../../../capabilities/connection.js';
 import type { Intake, IntakeIssue, IntakeIssueDetail } from '../../../capabilities/intake.js';
 import type { RouteAuth } from '../../../routes/route.js';
+import { FactoryLinearIssueService } from '../../../rules/linear-service.js';
 import type { FactoryProjectsStorage } from '../../../storage/domains/projects/base.js';
 import type { FactoryIntegration, IntegrationContext, IntegrationTools, LinearIssueIngress } from '../../base.js';
 import { buildLinearAgentTools } from '../../linear/agent-tools.js';
@@ -258,7 +259,17 @@ export class PlatformLinearIntegration implements FactoryIntegration {
     };
   }
 
+  #createFactoryIssueService(ctx: IntegrationContext): FactoryLinearIssueService | undefined {
+    if (!ctx.factory) return undefined;
+    return new FactoryLinearIssueService({
+      projects: ctx.storage.projects,
+      storage: ctx.factory.workItems,
+      rules: ctx.factory.rules,
+    });
+  }
+
   routes(ctx: IntegrationContext): ApiRoute[] {
+    const factoryIssues = this.#createFactoryIssueService(ctx);
     return [
       this.#connectRoute(ctx),
       ...buildLinearRoutes({
@@ -267,6 +278,7 @@ export class PlatformLinearIntegration implements FactoryIntegration {
         stateSigner: ctx.stateSigner,
         baseUrl: ctx.baseUrl,
         intake: ctx.storage.intake,
+        ingestLinearIssues: factoryIssues?.ingest.bind(factoryIssues),
       }).filter(route => !route.path.startsWith('/auth/linear/')),
     ];
   }
@@ -295,7 +307,9 @@ export class PlatformLinearIntegration implements FactoryIntegration {
   }
 
   workers(ctx: IntegrationContext): PlatformLinearEventWorker[] {
-    if (!this.#pollingEnabled || !ctx.hooks?.ingestLinearIssues) return [];
+    if (!this.#pollingEnabled) return [];
+    const factoryIssues = this.#createFactoryIssueService(ctx);
+    if (!factoryIssues) return [];
     return [
       new PlatformLinearEventWorker({
         client: this.#client,
@@ -303,7 +317,7 @@ export class PlatformLinearIntegration implements FactoryIntegration {
         projects: ctx.storage.projects,
         storage: ctx.storage.generic as unknown as PlatformLinearEventStorage,
         loadIssue: (workspaceId, issueId) => this.#loadIssueForEvent(workspaceId, issueId),
-        ingestLinearIssues: ctx.hooks.ingestLinearIssues,
+        ingestLinearIssues: factoryIssues.ingest.bind(factoryIssues),
         intervalMs: this.#pollingIntervalMs,
       }),
     ];

--- a/mastracode/factory/src/integrations/platform/linear/source-id.ts
+++ b/mastracode/factory/src/integrations/platform/linear/source-id.ts
@@ -1,0 +1,18 @@
+export function encodeSourceId(workspaceId: string, projectId: string): string {
+  return `linear-project:${Buffer.from(JSON.stringify({ workspaceId, projectId })).toString('base64url')}`;
+}
+
+export function decodeSourceId(sourceId: string): { workspaceId: string; projectId: string } {
+  if (!sourceId.startsWith('linear-project:')) throw new Error('Linear project source id is invalid.');
+  try {
+    const parsed = JSON.parse(Buffer.from(sourceId.slice('linear-project:'.length), 'base64url').toString('utf8')) as {
+      workspaceId?: unknown;
+      projectId?: unknown;
+    };
+    if (typeof parsed.workspaceId !== 'string' || !parsed.workspaceId) throw new Error();
+    if (typeof parsed.projectId !== 'string' || !parsed.projectId) throw new Error();
+    return { workspaceId: parsed.workspaceId, projectId: parsed.projectId };
+  } catch {
+    throw new Error('Linear project source id is invalid.');
+  }
+}

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -11,7 +11,7 @@ import { ensureFactoryRuleSession } from '../integrations/github/factory-session
 import type { GithubIntegration } from '../integrations/github/integration.js';
 import type { FactoryBindingPreparationInput } from '../rules/dispatcher.js';
 import type { FactoryGithubEventService } from '../rules/github-service.js';
-import { FactoryLinearIssueService } from '../rules/linear-service.js';
+import type { FactoryLinearIssueService } from '../rules/linear-service.js';
 import { FactoryStartCoordinator } from '../rules/start-coordinator.js';
 import { FactoryTransitionService } from '../rules/transition-service.js';
 import type { FactoryRules } from '../rules/types.js';
@@ -78,6 +78,7 @@ export interface FactoryApiRoutesDeps {
   rules: FactoryRules;
   factoryTransitionService?: FactoryTransitionService;
   ingestGithubEvent?: FactoryGithubEventService['ingest'];
+  ingestLinearIssues?: FactoryLinearIssueService['ingest'];
   onFactoryRuntime?: (runtime: {
     transitionService: FactoryTransitionService;
     prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
@@ -207,6 +208,7 @@ export function buildIntegrationContext(
     stateSigner: StateSigner;
     emitAudit?: AuditEmitter['emit'];
     ingestGithubEvent?: FactoryGithubEventService['ingest'];
+    ingestLinearIssues?: FactoryLinearIssueService['ingest'];
     domains: Pick<FactoryApiRoutesDeps['domains'], 'projects' | 'intake'>;
   },
   integrationId: string,
@@ -224,11 +226,12 @@ export function buildIntegrationContext(
       projects: deps.domains.projects,
       intake: deps.domains.intake,
     },
-    ...(deps.emitAudit || deps.ingestGithubEvent
+    ...(deps.emitAudit || deps.ingestGithubEvent || deps.ingestLinearIssues
       ? {
           hooks: {
             ...(deps.emitAudit ? { emitAudit: deps.emitAudit } : {}),
             ...(deps.ingestGithubEvent ? { ingestGithubEvent: deps.ingestGithubEvent } : {}),
+            ...(deps.ingestLinearIssues ? { ingestLinearIssues: deps.ingestLinearIssues } : {}),
           },
         }
       : {}),
@@ -298,18 +301,8 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
   const emitAudit: AuditEmitter['emit'] = args => deps.audit.emit(args);
   const registrations = deps.integrations ?? [];
   const githubRegistration = registrations.find(({ integration }) => integration.id === 'github');
-  const linearRegistration = registrations.find(({ integration }) => integration.id === 'linear');
   const githubStorage = githubRegistration ? deps.sourceControlStorage.forIntegration('github') : undefined;
   const githubIntegration = githubRegistration?.integration as GithubIntegration | undefined;
-  const workItems = deps.factoryReady ? deps.domains.workItems : undefined;
-  const linearIssueService =
-    linearRegistration && workItems
-      ? new FactoryLinearIssueService({
-          projects: deps.domains.projects,
-          storage: workItems,
-          rules: deps.rules,
-        })
-      : undefined;
 
   const integrationRoutes = registrations.flatMap(registration => {
     const { integration } = registration;
@@ -320,12 +313,12 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
         stateSigner: deps.stateSigner,
         emitAudit,
         ...(integration.id === 'github' && deps.ingestGithubEvent ? { ingestGithubEvent: deps.ingestGithubEvent } : {}),
+        ...(integration.id === 'linear' && deps.ingestLinearIssues
+          ? { ingestLinearIssues: deps.ingestLinearIssues }
+          : {}),
       },
       integration.id,
     );
-    if (integration.id === 'linear' && linearIssueService) {
-      context.hooks = { ...context.hooks, ingestLinearIssues: input => linearIssueService.ingest(input) };
-    }
     return guardIntegrationRoutes({ ...registration, routes: integration.routes(context) });
   });
   // Absent known integrations still get their disabled-status stub.

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -10,8 +10,6 @@ import { getGithubFeatureDiagnostics } from '../integrations/github/config.js';
 import { ensureFactoryRuleSession } from '../integrations/github/factory-session.js';
 import type { GithubIntegration } from '../integrations/github/integration.js';
 import type { FactoryBindingPreparationInput } from '../rules/dispatcher.js';
-import type { FactoryGithubEventService } from '../rules/github-service.js';
-import type { FactoryLinearIssueService } from '../rules/linear-service.js';
 import { FactoryStartCoordinator } from '../rules/start-coordinator.js';
 import { FactoryTransitionService } from '../rules/transition-service.js';
 import type { FactoryRules } from '../rules/types.js';
@@ -77,8 +75,6 @@ export interface FactoryApiRoutesDeps {
   /** Resolved Factory rule set, threaded from the host (no service locator). */
   rules: FactoryRules;
   factoryTransitionService?: FactoryTransitionService;
-  ingestGithubEvent?: FactoryGithubEventService['ingest'];
-  ingestLinearIssues?: FactoryLinearIssueService['ingest'];
   onFactoryRuntime?: (runtime: {
     transitionService: FactoryTransitionService;
     prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
@@ -203,13 +199,19 @@ async function prepareFactoryRuleBinding(
 export function buildIntegrationContext(
   deps: Pick<
     FactoryApiRoutesDeps,
-    'controller' | 'publicOrigin' | 'auth' | 'fleet' | 'factoryStorage' | 'integrationStorage' | 'sourceControlStorage'
+    | 'controller'
+    | 'publicOrigin'
+    | 'auth'
+    | 'fleet'
+    | 'factoryStorage'
+    | 'integrationStorage'
+    | 'sourceControlStorage'
+    | 'factoryReady'
+    | 'rules'
   > & {
     stateSigner: StateSigner;
     emitAudit?: AuditEmitter['emit'];
-    ingestGithubEvent?: FactoryGithubEventService['ingest'];
-    ingestLinearIssues?: FactoryLinearIssueService['ingest'];
-    domains: Pick<FactoryApiRoutesDeps['domains'], 'projects' | 'intake'>;
+    domains: Pick<FactoryApiRoutesDeps['domains'], 'projects' | 'intake' | 'workItems'>;
   },
   integrationId: string,
 ): IntegrationContext {
@@ -226,15 +228,8 @@ export function buildIntegrationContext(
       projects: deps.domains.projects,
       intake: deps.domains.intake,
     },
-    ...(deps.emitAudit || deps.ingestGithubEvent || deps.ingestLinearIssues
-      ? {
-          hooks: {
-            ...(deps.emitAudit ? { emitAudit: deps.emitAudit } : {}),
-            ...(deps.ingestGithubEvent ? { ingestGithubEvent: deps.ingestGithubEvent } : {}),
-            ...(deps.ingestLinearIssues ? { ingestLinearIssues: deps.ingestLinearIssues } : {}),
-          },
-        }
-      : {}),
+    ...(deps.factoryReady ? { factory: { rules: deps.rules, workItems: deps.domains.workItems } } : {}),
+    ...(deps.emitAudit ? { hooks: { emitAudit: deps.emitAudit } } : {}),
   };
 }
 
@@ -312,10 +307,6 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
         ...deps,
         stateSigner: deps.stateSigner,
         emitAudit,
-        ...(integration.id === 'github' && deps.ingestGithubEvent ? { ingestGithubEvent: deps.ingestGithubEvent } : {}),
-        ...(integration.id === 'linear' && deps.ingestLinearIssues
-          ? { ingestLinearIssues: deps.ingestLinearIssues }
-          : {}),
       },
       integration.id,
     );

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -10,7 +10,7 @@ import { getGithubFeatureDiagnostics } from '../integrations/github/config.js';
 import { ensureFactoryRuleSession } from '../integrations/github/factory-session.js';
 import type { GithubIntegration } from '../integrations/github/integration.js';
 import type { FactoryBindingPreparationInput } from '../rules/dispatcher.js';
-import { FactoryGithubEventService } from '../rules/github-service.js';
+import type { FactoryGithubEventService } from '../rules/github-service.js';
 import { FactoryLinearIssueService } from '../rules/linear-service.js';
 import { FactoryStartCoordinator } from '../rules/start-coordinator.js';
 import { FactoryTransitionService } from '../rules/transition-service.js';
@@ -77,6 +77,7 @@ export interface FactoryApiRoutesDeps {
   /** Resolved Factory rule set, threaded from the host (no service locator). */
   rules: FactoryRules;
   factoryTransitionService?: FactoryTransitionService;
+  ingestGithubEvent?: FactoryGithubEventService['ingest'];
   onFactoryRuntime?: (runtime: {
     transitionService: FactoryTransitionService;
     prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
@@ -205,6 +206,7 @@ export function buildIntegrationContext(
   > & {
     stateSigner: StateSigner;
     emitAudit?: AuditEmitter['emit'];
+    ingestGithubEvent?: FactoryGithubEventService['ingest'];
     domains: Pick<FactoryApiRoutesDeps['domains'], 'projects' | 'intake'>;
   },
   integrationId: string,
@@ -222,7 +224,14 @@ export function buildIntegrationContext(
       projects: deps.domains.projects,
       intake: deps.domains.intake,
     },
-    ...(deps.emitAudit ? { hooks: { emitAudit: deps.emitAudit } } : {}),
+    ...(deps.emitAudit || deps.ingestGithubEvent
+      ? {
+          hooks: {
+            ...(deps.emitAudit ? { emitAudit: deps.emitAudit } : {}),
+            ...(deps.ingestGithubEvent ? { ingestGithubEvent: deps.ingestGithubEvent } : {}),
+          },
+        }
+      : {}),
   };
 }
 
@@ -293,17 +302,6 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
   const githubStorage = githubRegistration ? deps.sourceControlStorage.forIntegration('github') : undefined;
   const githubIntegration = githubRegistration?.integration as GithubIntegration | undefined;
   const workItems = deps.factoryReady ? deps.domains.workItems : undefined;
-  const githubEventService =
-    githubIntegration && githubStorage && workItems
-      ? new FactoryGithubEventService({
-          github: githubIntegration,
-          sourceControl: githubStorage,
-          integrationStorage: deps.integrationStorage.forIntegration('github'),
-          projects: deps.domains.projects,
-          storage: workItems,
-          rules: deps.rules,
-        })
-      : undefined;
   const linearIssueService =
     linearRegistration && workItems
       ? new FactoryLinearIssueService({
@@ -316,13 +314,15 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
   const integrationRoutes = registrations.flatMap(registration => {
     const { integration } = registration;
     if (!deps.stateSigner) return disabledIntegrationStatusRoutes(deps, integration.id, true);
-    const context = buildIntegrationContext({ ...deps, stateSigner: deps.stateSigner, emitAudit }, integration.id);
-    if (integration.id === 'github') {
-      context.hooks = {
-        ...context.hooks,
-        ...(githubEventService ? { ingestGithubEvent: event => githubEventService.ingest(event) } : {}),
-      };
-    }
+    const context = buildIntegrationContext(
+      {
+        ...deps,
+        stateSigner: deps.stateSigner,
+        emitAudit,
+        ...(integration.id === 'github' && deps.ingestGithubEvent ? { ingestGithubEvent: deps.ingestGithubEvent } : {}),
+      },
+      integration.id,
+    );
     if (integration.id === 'linear' && linearIssueService) {
       context.hooks = { ...context.hooks, ingestLinearIssues: input => linearIssueService.ingest(input) };
     }

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -145,7 +145,7 @@ describe('defaultFactoryRules', () => {
     expect(await rule?.(linearContext())).toMatchObject({
       type: 'upsertLinkedWorkItem',
       source: 'linear-issue',
-      sourceKey: 'linear:ENG-42',
+      sourceKey: 'linear:issue-1',
       title: 'ENG-42: Fix intake sync',
       stage: 'triage',
       metadata: { linearIssueId: 'issue-1', linearIssueIdentifier: 'ENG-42' },
@@ -161,7 +161,7 @@ describe('defaultFactoryRules', () => {
         item: {
           ...item,
           source: 'linear-issue',
-          sourceKey: 'linear:ENG-42',
+          sourceKey: 'linear:issue-1',
           stages: ['execute'],
         },
         board: 'work',
@@ -177,7 +177,7 @@ describe('defaultFactoryRules', () => {
       item: {
         ...item,
         source: 'linear-issue',
-        sourceKey: 'linear:ENG-42',
+        sourceKey: 'linear:issue-1',
         title: 'ENG-42: Fix intake sync',
         url: 'https://linear.app/acme/issue/ENG-42',
       },
@@ -338,11 +338,11 @@ describe('defaultFactoryRules', () => {
     const rules = defaultFactoryRules({ version: 'deployment-7' });
     expect(await rules.github.issueOpened?.onEvent?.(githubContext('issueOpened'))).toMatchObject({
       source: 'github-issue',
-      sourceKey: 'github-issue:42',
+      sourceKey: 'github-issue:10:42',
     });
     expect(await rules.github.pullRequestOpened?.onEvent?.(githubContext('pullRequestOpened'))).toMatchObject({
       source: 'github-pr',
-      sourceKey: 'github-pr:17',
+      sourceKey: 'github-pr:10:17',
     });
   });
 

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -1,3 +1,4 @@
+import { githubIssueSourceKey, githubPullRequestSourceKey, linearIssueSourceKey } from './source-keys.js';
 import type {
   FactoryBoardRuleLeaf,
   FactoryBoardRules,
@@ -38,9 +39,7 @@ function investigateTriagedIssue(context: FactoryStageRuleContext) {
 }
 
 function investigateTriagedLinearIssue(context: FactoryStageRuleContext) {
-  const identifier = context.item.sourceKey?.startsWith('linear:')
-    ? context.item.sourceKey.slice('linear:'.length)
-    : context.item.title;
+  const identifier = context.item.title.split(': ', 1)[0] || context.item.title;
   return {
     type: 'invokeSkill',
     idempotencyKey: `${context.ingress.id}:factory-triage-linear`,
@@ -113,7 +112,10 @@ function issueOpened(context: FactoryGithubRuleContext) {
     idempotencyKey: `${context.ingress.id}:issue-intake`,
     board: 'work',
     source: 'github-issue',
-    sourceKey: `github-issue:${context.issue.number}`,
+    sourceKey:
+      context.item?.source === 'github-issue' && context.item.sourceKey
+        ? context.item.sourceKey
+        : githubIssueSourceKey(context.repository.id, context.issue.number),
     title: context.issue.title,
     url: context.issue.url,
     stage:
@@ -134,7 +136,10 @@ function pullRequestOpened(context: FactoryGithubRuleContext) {
     idempotencyKey: `${context.ingress.id}:pull-request-intake`,
     board: 'review',
     source: 'github-pr',
-    sourceKey: `github-pr:${context.pullRequest.number}`,
+    sourceKey:
+      context.item?.source === 'github-pr' && context.item.sourceKey
+        ? context.item.sourceKey
+        : githubPullRequestSourceKey(context.repository.id, context.pullRequest.number),
     title: context.pullRequest.title,
     url: context.pullRequest.url,
     stage:
@@ -170,7 +175,7 @@ function linearIssueObserved(context: FactoryLinearRuleContext) {
     idempotencyKey: `${context.ingress.id}:issue-triage`,
     board: 'work',
     source: 'linear-issue',
-    sourceKey: `linear:${context.issue.identifier}`,
+    sourceKey: linearIssueSourceKey(context.issue.id),
     title: `${context.issue.identifier}: ${context.issue.title}`,
     url: context.issue.url,
     stage: 'triage',

--- a/mastracode/factory/src/rules/github-service.test.ts
+++ b/mastracode/factory/src/rules/github-service.test.ts
@@ -53,24 +53,29 @@ async function setup(permission: string | undefined) {
     workItems,
     projects: seeded.projects,
     project,
+    installation,
     projectRepository,
     github,
   };
 }
 
-function issueOpened(deliveryId = 'delivery-1', createdAt = '2030-01-01T00:00:00Z') {
+function issueOpened(
+  deliveryId = 'delivery-1',
+  createdAt = '2030-01-01T00:00:00Z',
+  repository = { id: 10, fullName: 'acme/repo' },
+) {
   return {
     event: 'issues',
     deliveryId,
     payload: {
       action: 'opened',
       installation: { id: 7 },
-      repository: { id: 10, full_name: 'acme/repo' },
+      repository: { id: repository.id, full_name: repository.fullName },
       sender: { login: 'maintainer' },
       issue: {
         number: 42,
         title: 'Issue 42',
-        html_url: 'https://github.com/acme/repo/issues/42',
+        html_url: `https://github.com/${repository.fullName}/issues/42`,
         created_at: createdAt,
       },
     },
@@ -82,6 +87,7 @@ function pullRequest(
   deliveryId: string,
   merged = false,
   createdAt = '2030-01-01T00:00:00Z',
+  repository = { id: 10, fullName: 'acme/repo' },
 ) {
   return {
     event: 'pull_request',
@@ -89,12 +95,12 @@ function pullRequest(
     payload: {
       action: event,
       installation: { id: 7 },
-      repository: { id: 10, full_name: 'acme/repo' },
+      repository: { id: repository.id, full_name: repository.fullName },
       sender: { login: 'contributor' },
       pull_request: {
         number: 17,
         title: 'PR 17',
-        html_url: 'https://github.com/acme/repo/pull/17',
+        html_url: `https://github.com/${repository.fullName}/pull/17`,
         created_at: createdAt,
         state: merged ? 'closed' : 'open',
         merged,
@@ -123,6 +129,58 @@ describe('FactoryGithubEventService', () => {
     expect(decisions).toHaveLength(1);
     expect(decisions[0]?.actor).toMatchObject({ type: 'github', login: 'maintainer', trusted: true });
     expect(decisions[0]?.decision).toMatchObject({ type: 'upsertLinkedWorkItem', source: 'github-issue' });
+  });
+
+  it('scopes issue and pull request source keys to their GitHub repository', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project, installation, projectRepository } =
+      await setup('write');
+    const secondRepository = await sourceControl.repositories.upsert({
+      orgId: 'org-1',
+      input: {
+        installationId: installation.id,
+        externalId: '20',
+        slug: 'acme/other-repo',
+        defaultBranch: 'main',
+      },
+    });
+    await sourceControl.projectRepositories.link({
+      orgId: 'org-1',
+      connectionId: projectRepository.connectionId,
+      repositoryId: secondRepository.id,
+      createdByUserId: 'user-1',
+      sandboxProvider: 'local',
+      sandboxWorkdir: '/workspace',
+    });
+    const service = new FactoryGithubEventService({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await service.ingest(issueOpened('delivery-repo-10'));
+    await service.ingest(
+      issueOpened('delivery-repo-20', '2030-01-01T00:00:00Z', { id: 20, fullName: 'acme/other-repo' }),
+    );
+    await service.ingest(pullRequest('opened', 'delivery-pr-repo-10'));
+    await service.ingest(
+      pullRequest('opened', 'delivery-pr-repo-20', false, '2030-01-01T00:00:00Z', {
+        id: 20,
+        fullName: 'acme/other-repo',
+      }),
+    );
+
+    const decisions = await workItems.listDeferredDecisions('org-1', project.id);
+    expect(decisions.map(record => record.decision)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceKey: 'github-issue:10:42' }),
+        expect.objectContaining({ sourceKey: 'github-issue:20:42' }),
+        expect.objectContaining({ sourceKey: 'github-pr:10:17' }),
+        expect.objectContaining({ sourceKey: 'github-pr:20:17' }),
+      ]),
+    );
   });
 
   it('keeps trusted issues created before the Factory in Intake', async () => {
@@ -239,7 +297,7 @@ describe('FactoryGithubEventService', () => {
 
     const [item] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
     expect(item).toMatchObject({
-      externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:42' },
+      externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:10:42' },
       stages: ['triage'],
       sessions: {
         triage: {
@@ -274,7 +332,7 @@ describe('FactoryGithubEventService', () => {
 
     const [rematerialized] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
     expect(rematerialized).toMatchObject({
-      externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:42' },
+      externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:10:42' },
       stages: ['triage'],
     });
     expect(rematerialized?.id).not.toBe(item?.id);
@@ -368,14 +426,74 @@ describe('FactoryGithubEventService', () => {
       expect.arrayContaining([
         expect.objectContaining({
           workItemId: issue.item.id,
-          decision: expect.objectContaining({ source: 'github-issue' }),
+          decision: expect.objectContaining({ source: 'github-issue', sourceKey: 'github-issue:42' }),
         }),
         expect.objectContaining({
           workItemId: review.item.id,
-          decision: expect.objectContaining({ source: 'github-pr' }),
+          decision: expect.objectContaining({ source: 'github-pr', sourceKey: 'github-pr:17' }),
         }),
       ]),
     );
+  });
+
+  it('does not match an unscoped legacy source key from another repository', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project, installation, projectRepository } =
+      await setup('write');
+    await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue',
+          externalId: 'github-issue:42',
+          url: 'https://github.com/acme/repo/issues/42',
+        },
+        title: 'Issue 42',
+        stages: ['intake'],
+        sessions: {},
+        metadata: { githubRepositoryId: 10, number: 42 },
+      },
+    });
+    const secondRepository = await sourceControl.repositories.upsert({
+      orgId: 'org-1',
+      input: {
+        installationId: installation.id,
+        externalId: '20',
+        slug: 'acme/other-repo',
+        defaultBranch: 'main',
+      },
+    });
+    await sourceControl.projectRepositories.link({
+      orgId: 'org-1',
+      connectionId: projectRepository.connectionId,
+      repositoryId: secondRepository.id,
+      createdByUserId: 'user-1',
+      sandboxProvider: 'local',
+      sandboxWorkdir: '/workspace',
+    });
+    const service = new FactoryGithubEventService({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await service.ingest(
+      issueOpened('delivery-other-repository', '2030-01-01T00:00:00Z', {
+        id: 20,
+        fullName: 'acme/other-repo',
+      }),
+    );
+
+    const [decision] = await workItems.listDeferredDecisions('org-1', project.id);
+    expect(decision).toMatchObject({
+      workItemId: null,
+      decision: { sourceKey: 'github-issue:20:42' },
+    });
   });
 
   it.each(['maintain', 'triage', 'read', undefined])('fails closed for GitHub permission %s', async permission => {

--- a/mastracode/factory/src/rules/github-service.ts
+++ b/mastracode/factory/src/rules/github-service.ts
@@ -8,6 +8,7 @@ import type {
 } from '../storage/domains/source-control/base.js';
 import type { WorkItemRow, WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { resolveFactoryGithubRule } from './resolve.js';
+import { githubIssueSourceKey, githubPullRequestSourceKey } from './source-keys.js';
 import type {
   FactoryGithubEventName,
   FactoryGithubRuleContext,
@@ -62,12 +63,26 @@ function eventName(parsed: ParsedGithubWebhook): FactoryGithubEventName | undefi
   return undefined;
 }
 
-function canonicalSourceKey(kind: 'issue' | 'pull-request', itemNumber: number): string {
+function scopedSourceKey(repositoryId: number, kind: 'issue' | 'pull-request', itemNumber: number): string {
+  return kind === 'issue'
+    ? githubIssueSourceKey(repositoryId, itemNumber)
+    : githubPullRequestSourceKey(repositoryId, itemNumber);
+}
+
+function unscopedSourceKey(kind: 'issue' | 'pull-request', itemNumber: number): string {
   return kind === 'issue' ? `github-issue:${itemNumber}` : `github-pr:${itemNumber}`;
 }
 
 function legacySourceKey(repositoryId: number, kind: 'issue' | 'pull-request', itemNumber: number): string {
   return `github:${repositoryId}:${kind}:${itemNumber}`;
+}
+
+function matchesLegacyUnscopedItem(item: WorkItemRow, repositoryId: number, sourceUrl: string): boolean {
+  const metadataRepositoryId = item.metadata?.githubRepositoryId;
+  return (
+    (metadataRepositoryId !== undefined && String(metadataRepositoryId) === String(repositoryId)) ||
+    item.externalSource?.url === sourceUrl
+  );
 }
 
 function provenanceTarget(repositoryId: number, pullRequestNumber: number): string {
@@ -179,6 +194,7 @@ export class FactoryGithubEventService {
       repositoryId,
       issueNumber,
       pullRequestNumber,
+      issueNumber ? string(issue?.html_url) : string(pullRequest?.html_url),
       string(object(pullRequest?.head)?.ref),
       provenance,
     );
@@ -295,6 +311,7 @@ export class FactoryGithubEventService {
     repositoryId: number,
     issueNumber: number | undefined,
     pullRequestNumber: number | undefined,
+    sourceUrl: string | undefined,
     pullRequestHeadBranch: string | undefined,
     provenance: FactoryPullRequestProvenanceData | null,
   ): Promise<WorkItemRow | undefined> {
@@ -302,13 +319,25 @@ export class FactoryGithubEventService {
     if (provenance) return items.find(item => item.id === provenance.workItemId);
     if (issueNumber) {
       return (
-        items.find(item => item.externalSource?.externalId === canonicalSourceKey('issue', issueNumber)) ??
+        items.find(item => item.externalSource?.externalId === scopedSourceKey(repositoryId, 'issue', issueNumber)) ??
+        items.find(
+          item =>
+            item.externalSource?.externalId === unscopedSourceKey('issue', issueNumber) &&
+            matchesLegacyUnscopedItem(item, repositoryId, sourceUrl ?? ''),
+        ) ??
         items.find(item => item.externalSource?.externalId === legacySourceKey(repositoryId, 'issue', issueNumber))
       );
     }
     if (pullRequestNumber) {
       return (
-        items.find(item => item.externalSource?.externalId === canonicalSourceKey('pull-request', pullRequestNumber)) ??
+        items.find(
+          item => item.externalSource?.externalId === scopedSourceKey(repositoryId, 'pull-request', pullRequestNumber),
+        ) ??
+        items.find(
+          item =>
+            item.externalSource?.externalId === unscopedSourceKey('pull-request', pullRequestNumber) &&
+            matchesLegacyUnscopedItem(item, repositoryId, sourceUrl ?? ''),
+        ) ??
         items.find(
           item => item.externalSource?.externalId === legacySourceKey(repositoryId, 'pull-request', pullRequestNumber),
         ) ??

--- a/mastracode/factory/src/rules/linear-service.test.ts
+++ b/mastracode/factory/src/rules/linear-service.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
-import { builtInFactoryRules } from './defaults.js';
+import { builtInFactoryRules, defaultFactoryRules } from './defaults.js';
 import { FactoryLinearIssueService } from './linear-service.js';
 
 const issue = {
@@ -18,7 +18,7 @@ const issue = {
   updatedAt: '2026-07-02T00:00:00Z',
 };
 
-async function setup() {
+async function setup(rules = builtInFactoryRules()) {
   const seeded = await createFactoryStorageForTests();
   const project = await seeded.projects.create({
     orgId: 'org-1',
@@ -28,7 +28,7 @@ async function setup() {
   const service = new FactoryLinearIssueService({
     projects: seeded.projects,
     storage: seeded.workItems,
-    rules: builtInFactoryRules(),
+    rules,
   });
   return { project, service, workItems: seeded.workItems };
 }
@@ -48,10 +48,103 @@ describe('FactoryLinearIssueService', () => {
       decision: {
         type: 'upsertLinkedWorkItem',
         source: 'linear-issue',
-        sourceKey: 'linear:ENG-42',
+        sourceKey: 'linear:issue-1',
         stage: 'triage',
       },
     });
+  });
+
+  it('keeps distinct Linear issues with the same identifier separate', async () => {
+    const { project, service, workItems } = await setup();
+
+    await service.ingest({
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      userId: 'user-1',
+      issues: [
+        issue,
+        {
+          ...issue,
+          id: 'issue-2',
+          url: 'https://linear.app/other/issue/ENG-42',
+        },
+      ],
+    });
+
+    const decisions = await workItems.listDeferredDecisions('org-1', project.id);
+    expect(decisions.map(record => record.decision)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceKey: 'linear:issue-1' }),
+        expect.objectContaining({ sourceKey: 'linear:issue-2' }),
+      ]),
+    );
+  });
+
+  it('recognizes legacy identifier-based source keys only for the same Linear issue', async () => {
+    const seen = vi.fn(() => undefined);
+    const rules = defaultFactoryRules({
+      version: 'test-legacy-linear-source-key',
+      overrides: { linear: { issueObserved: { onEvent: seen } } },
+    });
+    const { project, service, workItems } = await setup(rules);
+    const legacy = await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'linear',
+          type: 'issue',
+          externalId: 'linear:ENG-42',
+          url: issue.url,
+        },
+        title: 'ENG-42: Fix intake sync',
+        stages: ['triage'],
+        sessions: {},
+        metadata: { linearIssueId: issue.id, linearIssueIdentifier: issue.identifier },
+      },
+    });
+
+    await service.ingest({
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      userId: 'user-1',
+      issues: [{ ...issue, identifier: 'OPS-42', url: 'https://linear.app/acme/issue/OPS-42' }],
+    });
+
+    expect(seen).toHaveBeenCalledWith(
+      expect.objectContaining({ item: expect.objectContaining({ id: legacy.item.id }) }),
+    );
+  });
+
+  it('does not match a legacy identifier key that belongs to another Linear issue', async () => {
+    const seen = vi.fn(() => undefined);
+    const rules = defaultFactoryRules({
+      version: 'test-ambiguous-linear-source-key',
+      overrides: { linear: { issueObserved: { onEvent: seen } } },
+    });
+    const { project, service, workItems } = await setup(rules);
+    await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'linear',
+          type: 'issue',
+          externalId: 'linear:ENG-42',
+          url: 'https://linear.app/other/issue/ENG-42',
+        },
+        title: 'ENG-42: Another issue',
+        stages: ['triage'],
+        sessions: {},
+        metadata: { linearIssueId: 'issue-other', linearIssueIdentifier: issue.identifier },
+      },
+    });
+
+    await service.ingest({ orgId: 'org-1', factoryProjectId: project.id, userId: 'user-1', issues: [issue] });
+
+    expect(seen).toHaveBeenCalledWith(expect.not.objectContaining({ item: expect.anything() }));
   });
 
   it('fails closed when the active Factory project belongs to another organization', async () => {
@@ -82,5 +175,9 @@ describe('FactoryLinearIssueService', () => {
 
     const decisions = await workItems.listDeferredDecisions('org-1', project.id);
     expect(decisions).toHaveLength(2);
+    expect(decisions.map(record => record.decision)).toEqual([
+      expect.objectContaining({ sourceKey: 'linear:issue-1' }),
+      expect.objectContaining({ sourceKey: 'linear:issue-1' }),
+    ]);
   });
 });

--- a/mastracode/factory/src/rules/linear-service.ts
+++ b/mastracode/factory/src/rules/linear-service.ts
@@ -2,6 +2,7 @@ import type { LinearIssueIngress } from '../integrations/base.js';
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type { WorkItemRow, WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { resolveFactoryLinearRule } from './resolve.js';
+import { linearIssueSourceKey } from './source-keys.js';
 import type { FactoryLinearRuleContext, FactoryRuleDecision, FactoryRules } from './types.js';
 import { validateFactoryRuleDecisions } from './validation.js';
 
@@ -36,6 +37,16 @@ export interface FactoryLinearIssueIngress {
 
 type IngressStatus = 'committed' | 'replayed' | 'missing';
 
+function relatedLinearItem(items: WorkItemRow[], issue: LinearIssueIngress): WorkItemRow | undefined {
+  const scopedKey = linearIssueSourceKey(issue.id);
+  const legacyKey = `linear:${issue.identifier}`;
+  return (
+    items.find(item => item.externalSource?.externalId === scopedKey) ??
+    items.find(item => item.externalSource?.integrationId === 'linear' && item.metadata?.linearIssueId === issue.id) ??
+    items.find(item => item.externalSource?.externalId === legacyKey && item.externalSource.url === issue.url)
+  );
+}
+
 export class FactoryLinearIssueService {
   constructor(private readonly options: FactoryLinearIssueServiceOptions) {}
 
@@ -44,10 +55,9 @@ export class FactoryLinearIssueService {
     if (!project) return { status: 'missing', ingested: 0 };
 
     const items = await this.options.storage.list({ orgId: input.orgId, factoryProjectId: input.factoryProjectId });
-    const itemsBySourceKey = new Map(items.map(item => [item.externalSource?.externalId, item]));
     const statuses: IngressStatus[] = [];
     for (const issue of input.issues) {
-      statuses.push(await this.#ingestIssue(input, issue, itemsBySourceKey.get(`linear:${issue.identifier}`)));
+      statuses.push(await this.#ingestIssue(input, issue, relatedLinearItem(items, issue)));
     }
     if (statuses.some(status => status === 'committed')) return { status: 'committed', ingested: statuses.length };
     if (statuses.some(status => status === 'replayed')) return { status: 'replayed', ingested: statuses.length };

--- a/mastracode/factory/src/rules/source-keys.ts
+++ b/mastracode/factory/src/rules/source-keys.ts
@@ -1,0 +1,11 @@
+export function githubIssueSourceKey(repositoryId: number, issueNumber: number): string {
+  return `github-issue:${repositoryId}:${issueNumber}`;
+}
+
+export function githubPullRequestSourceKey(repositoryId: number, pullRequestNumber: number): string {
+  return `github-pr:${repositoryId}:${pullRequestNumber}`;
+}
+
+export function linearIssueSourceKey(issueId: string): string {
+  return `linear:${issueId}`;
+}

--- a/mastracode/factory/src/storage/domains/intake/base.test.ts
+++ b/mastracode/factory/src/storage/domains/intake/base.test.ts
@@ -38,6 +38,36 @@ describe('IntakeStorage', () => {
     expect(await storage.getConfig({ orgId: 'org1', userId: 'user1' })).toEqual(updated);
   });
 
+  it('lists enabled source selections across tenants for background workers', async () => {
+    const storage = await makeStorage();
+    await Promise.all([
+      storage.saveConfig({
+        orgId: 'org1',
+        userId: 'user1',
+        config: { linear: { enabled: true, sourceIds: ['linear-project:a'] } },
+      }),
+      storage.saveConfig({
+        orgId: 'org1',
+        userId: 'user2',
+        config: { linear: { enabled: false, sourceIds: ['linear-project:b'] } },
+      }),
+      storage.saveConfig({
+        orgId: 'org2',
+        userId: 'user3',
+        config: { linear: { enabled: true, sourceIds: null } },
+      }),
+      storage.saveConfig({
+        orgId: 'org3',
+        userId: 'user4',
+        config: { github: { enabled: true, sourceIds: ['repo-1'] } },
+      }),
+    ]);
+
+    await expect(storage.listEnabledSourceSelections('linear')).resolves.toEqual([
+      { orgId: 'org1', userId: 'user1', sourceIds: ['linear-project:a'] },
+    ]);
+  });
+
   it('converges concurrent first saves onto one row', async () => {
     const storage = await makeStorage();
     const a = { github: { enabled: true, sourceIds: ['a'] } };

--- a/mastracode/factory/src/storage/domains/intake/base.ts
+++ b/mastracode/factory/src/storage/domains/intake/base.ts
@@ -17,6 +17,12 @@ export interface IntakeSelection {
 
 export type IntakeConfig = Record<string, IntakeSelection>;
 
+export interface EnabledIntakeSourceSelection {
+  orgId: string;
+  userId: string;
+  sourceIds: string[];
+}
+
 export const DEFAULT_INTAKE_CONFIG: IntakeConfig = {};
 
 export const INTAKE_SETTINGS_SCHEMA: CollectionSchema = {
@@ -71,6 +77,24 @@ export class IntakeStorage extends FactoryStorageDomain {
     return Object.fromEntries(
       integrationIds.map(integrationId => [integrationId, saved[integrationId] ?? { enabled: true, sourceIds: null }]),
     );
+  }
+
+  async listEnabledSourceSelections(integrationId: string): Promise<EnabledIntakeSourceSelection[]> {
+    const rows = await this.#db.findMany<{ org_id: string; user_id: string; config: IntakeConfig }>(
+      'intake_settings',
+      {},
+      {
+        orderBy: [
+          ['org_id', 'asc'],
+          ['user_id', 'asc'],
+        ],
+      },
+    );
+    return rows.flatMap(row => {
+      const selection = row.config[integrationId];
+      if (!selection?.enabled || !selection.sourceIds?.length) return [];
+      return [{ orgId: row.org_id, userId: row.user_id, sourceIds: [...selection.sourceIds] }];
+    });
   }
 
   async saveConfig({ orgId, userId, config }: { orgId: string; userId: string; config: IntakeConfig }): Promise<void> {


### PR DESCRIPTION
## Summary

- restore Factory governance ingestion for closed GitHub issues and pull requests
- reduce GitHub polling latency with bounded concurrency, fixed-cadence scheduling, and failure-isolated cursor advancement
- add a background Platform Linear worker that polls intake-selected projects and sends matching issue updates to every Factory project in the organization
- let the GitHub and Linear integrations own their ingestion services and background workers, while MastraFactory supplies only shared runtime dependencies
- scope GitHub work-item identities by repository and Linear identities by immutable issue ID, while safely recognizing existing legacy work items

## Test plan

- `pnpm exec vitest run src/integrations/platform/github/event-worker.lifecycle.test.ts src/integrations/platform/linear/event-worker.test.ts src/integrations/platform/linear/event-worker.lifecycle.test.ts src/integrations/platform/linear/integration.test.ts src/integrations/linear/routes.test.ts src/storage/domains/intake/base.test.ts --reporter=dot --bail=1` — 6 files, 46 tests
- `pnpm exec vitest run src/rules/defaults.test.ts src/rules/github-service.test.ts src/rules/linear-service.test.ts --reporter=dot --bail=1` — 3 files, 41 tests
- `pnpm test -- --reporter=dot` — 71 files, 995 tests
- `pnpm check`
- `pnpm lint`
- `pnpm build:lib`
- Prettier check for changed files
- `git diff --check`
