### PR TITLE
fix(factory): serve session workspace files from the session sandbox

### DIFF
--- a/.changeset/light-bottles-tan.md
+++ b/.changeset/light-bottles-tan.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the workspace files panel in Factory web returning "Path is outside the browsable root" for Factory sessions. The workspace file endpoints now recognize a session id, reattach to that session's sandbox, and list and read rendered files (like .artifacts) directly from the sandbox, so session artifacts render on deployed factories.

--- a/mastracode/factory/src/routes/fs.test.ts
+++ b/mastracode/factory/src/routes/fs.test.ts
@@ -2,9 +2,17 @@ import { mkdtemp, mkdir, realpath, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { listArtifacts, listWorkspaceRenderedPath, readWorkspaceFile } from './fs.js';
+import type { SandboxFleet } from '../sandbox/fleet.js';
+import type { SourceControlSession } from '../storage/domains/source-control/base.js';
+import {
+  listArtifacts,
+  listSessionRenderedPath,
+  listWorkspaceRenderedPath,
+  readSessionWorkspaceFile,
+  readWorkspaceFile,
+} from './fs.js';
 
 describe('listArtifacts', () => {
   it('returns an empty list when .artifacts does not exist', async () => {
@@ -186,5 +194,176 @@ describe('readWorkspaceFile', () => {
     await expect(readWorkspaceFile(root, join(root, 'workspace'), '.artifacts/secret.md')).rejects.toThrow(
       'Path is outside the workspace',
     );
+  });
+});
+
+// ── Session-backed (sandbox) workspace access ────────────────────────────────
+
+const WORKDIR = '/workspaces/acme/repo';
+
+function makeSession(overrides: Partial<SourceControlSession> = {}): SourceControlSession {
+  return {
+    id: 'row-1',
+    sessionId: '0919fb96-a387-4407-bbf8-ccc563ef1391',
+    projectRepositoryId: 'pr-1',
+    orgId: 'org-1',
+    userId: 'user-1',
+    branch: 'main',
+    baseBranch: 'main',
+    sandboxId: 'sbx-1',
+    sandboxWorkdir: WORKDIR,
+    materializedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+/**
+ * Fake fleet whose sandbox answers the exact shell scripts the session-backed
+ * helpers issue (find listing, readlink/stat confinement checks, base64 read).
+ */
+function makeFleet(respond: (script: string) => { exitCode: number; stdout: string; stderr?: string }) {
+  const executeCommand = vi.fn(async (_cmd: string, args?: string[]) => {
+    const script = args?.[1] ?? '';
+    const result = respond(script);
+    return { exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr ?? '' };
+  });
+  const fleet = {
+    enabled: true,
+    reattachSandbox: vi.fn(async () => ({ id: 'sbx-1', executeCommand })),
+  } as unknown as SandboxFleet;
+  return { fleet, executeCommand };
+}
+
+describe('listSessionRenderedPath', () => {
+  it('lists rendered entries from the session sandbox in one command', async () => {
+    const { fleet, executeCommand } = makeFleet(script => {
+      expect(script).toContain(`'${WORKDIR}/.artifacts'`);
+      return {
+        exitCode: 0,
+        stdout: [
+          `d\t0\t1700000000.0\t${WORKDIR}/.artifacts/understand-pr`,
+          `f\t5\t1700000100.5\t${WORKDIR}/.artifacts/understand-pr/HISTORY.md`,
+          '',
+        ].join('\n'),
+      };
+    });
+
+    const session = makeSession();
+    const listing = await listSessionRenderedPath(fleet, session, '.artifacts');
+
+    expect(listing.workspacePath).toBe(session.sessionId);
+    expect(listing.root).toBe('.artifacts');
+    expect(listing.rootPath).toBe(`${WORKDIR}/.artifacts`);
+    expect(listing.entries).toEqual([
+      expect.objectContaining({ name: 'understand-pr', path: 'understand-pr', type: 'directory', size: 0 }),
+      expect.objectContaining({ name: 'HISTORY.md', path: 'understand-pr/HISTORY.md', type: 'file', size: 5 }),
+    ]);
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty listing when the session has no sandbox binding', async () => {
+    const { fleet, executeCommand } = makeFleet(() => ({ exitCode: 0, stdout: '' }));
+
+    const listing = await listSessionRenderedPath(fleet, makeSession({ sandboxId: null }), '.artifacts');
+
+    expect(listing.entries).toEqual([]);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty listing when the rendered root does not exist', async () => {
+    const { fleet } = makeFleet(() => ({ exitCode: 0, stdout: '' }));
+
+    const listing = await listSessionRenderedPath(fleet, makeSession(), '.artifacts');
+
+    expect(listing.entries).toEqual([]);
+  });
+
+  it('rejects roots outside the approved allowlist without touching the sandbox', async () => {
+    const { fleet, executeCommand } = makeFleet(() => ({ exitCode: 0, stdout: '' }));
+
+    await expect(listSessionRenderedPath(fleet, makeSession(), '.ssh')).rejects.toThrow(
+      'Root is not approved for rendered workspace access',
+    );
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('ignores find output outside the rendered root', async () => {
+    const { fleet } = makeFleet(() => ({
+      exitCode: 0,
+      stdout: `f\t5\t1700000000.0\t/etc/passwd\n`,
+    }));
+
+    const listing = await listSessionRenderedPath(fleet, makeSession(), '.artifacts');
+
+    expect(listing.entries).toEqual([]);
+  });
+});
+
+describe('readSessionWorkspaceFile', () => {
+  function respondForFile(content: string) {
+    const abs = `${WORKDIR}/.artifacts/understand-pr/HISTORY.md`;
+    return (script: string) => {
+      if (script.startsWith('readlink -f')) return { exitCode: 0, stdout: `${abs}\n` };
+      if (script.startsWith('stat -c'))
+        return { exitCode: 0, stdout: `regular file\t${content.length}\t1700000000\t0\n` };
+      if (script.startsWith('base64 <'))
+        return { exitCode: 0, stdout: Buffer.from(content, 'utf8').toString('base64') };
+      return { exitCode: 1, stdout: '', stderr: `unexpected script: ${script}` };
+    };
+  }
+
+  it('reads text content through the session sandbox', async () => {
+    const { fleet } = makeFleet(respondForFile('# History'));
+
+    const session = makeSession();
+    const file = await readSessionWorkspaceFile(fleet, session, '.artifacts/understand-pr/HISTORY.md');
+
+    expect(file).toEqual(
+      expect.objectContaining({
+        workspacePath: session.sessionId,
+        path: '.artifacts/understand-pr/HISTORY.md',
+        name: 'HISTORY.md',
+        contentType: 'text',
+        content: '# History',
+        truncated: false,
+      }),
+    );
+  });
+
+  it('rejects reads outside approved rendered roots', async () => {
+    const { fleet, executeCommand } = makeFleet(respondForFile('secret'));
+
+    await expect(readSessionWorkspaceFile(fleet, makeSession(), '.ssh/config')).rejects.toThrow(
+      'Root is not approved for rendered workspace access',
+    );
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects traversal outside the workspace', async () => {
+    const { fleet } = makeFleet(respondForFile('secret'));
+
+    await expect(readSessionWorkspaceFile(fleet, makeSession(), '../secret.md')).rejects.toThrow(
+      'path escapes workspace',
+    );
+  });
+
+  it('rejects directories', async () => {
+    const { fleet } = makeFleet(script => {
+      if (script.startsWith('readlink -f')) return { exitCode: 0, stdout: `${WORKDIR}/.artifacts\n` };
+      if (script.startsWith('stat -c')) return { exitCode: 0, stdout: `directory\t0\t1700000000\t0\n` };
+      return { exitCode: 1, stdout: '' };
+    });
+
+    await expect(readSessionWorkspaceFile(fleet, makeSession(), '.artifacts')).rejects.toThrow('Path is a directory');
+  });
+
+  it('errors when the session workspace is not materialized', async () => {
+    const { fleet } = makeFleet(respondForFile('x'));
+
+    await expect(
+      readSessionWorkspaceFile(fleet, makeSession({ sandboxWorkdir: null }), '.artifacts/a.md'),
+    ).rejects.toThrow('Session workspace is not materialized');
   });
 });

--- a/mastracode/factory/src/routes/fs.test.ts
+++ b/mastracode/factory/src/routes/fs.test.ts
@@ -272,6 +272,16 @@ describe('listSessionRenderedPath', () => {
     expect(executeCommand).not.toHaveBeenCalled();
   });
 
+  it('returns an empty listing when the sandbox can no longer be reattached', async () => {
+    const { fleet, executeCommand } = makeFleet(() => ({ exitCode: 0, stdout: '' }));
+    (fleet.reattachSandbox as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('sandbox gone'));
+
+    const listing = await listSessionRenderedPath(fleet, makeSession(), '.artifacts');
+
+    expect(listing.entries).toEqual([]);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
   it('returns an empty listing when the rendered root does not exist', async () => {
     const { fleet } = makeFleet(() => ({ exitCode: 0, stdout: '' }));
 
@@ -364,6 +374,15 @@ describe('readSessionWorkspaceFile', () => {
 
     await expect(
       readSessionWorkspaceFile(fleet, makeSession({ sandboxWorkdir: null }), '.artifacts/a.md'),
-    ).rejects.toThrow('Session workspace is not materialized');
+    ).rejects.toThrow('Session workspace is not available');
+  });
+
+  it('errors without re-provisioning when the sandbox can no longer be reattached', async () => {
+    const { fleet } = makeFleet(respondForFile('x'));
+    (fleet.reattachSandbox as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('sandbox gone'));
+
+    await expect(readSessionWorkspaceFile(fleet, makeSession(), '.artifacts/a.md')).rejects.toThrow(
+      'Session workspace is not available',
+    );
   });
 });

--- a/mastracode/factory/src/routes/fs.ts
+++ b/mastracode/factory/src/routes/fs.ts
@@ -1,10 +1,16 @@
 import { lstat, open, readdir, realpath, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { isAbsolute, join, resolve, sep } from 'node:path';
+import { isAbsolute, join, posix as posixPath, resolve, sep } from 'node:path';
 
+import { SandboxFilesystem } from '@mastra/code-sdk/agents/sandbox-filesystem';
 import { detectProject, getResourceIdOverride } from '@mastra/code-sdk/utils/project';
 import { registerApiRoute } from '@mastra/core/server';
 import type { ApiRoute } from '@mastra/core/server';
+import type { Context } from 'hono';
+
+import type { SandboxFleet } from '../sandbox/fleet.js';
+import type { SourceControlSession } from '../storage/domains/source-control/base.js';
+import type { RouteAuth } from './route.js';
 
 /**
  * Server-side directory browser for the web project picker.
@@ -81,6 +87,11 @@ export interface ArtifactListing {
 const MAX_TEXT_FILE_BYTES = 512 * 1024;
 const TEXT_DECODER = new TextDecoder('utf-8', { fatal: true });
 const APPROVED_RENDERED_ROOTS = new Set(['.artifacts']);
+
+/** Erase a route handler's path-parameterized context to a plain `Context`. */
+function loose(c: unknown): Context {
+  return c as Context;
+}
 
 /** Resolve the browsable root, defaulting to the user's home directory. */
 export function resolveFsRoot(root?: string): string {
@@ -319,6 +330,147 @@ export async function listArtifacts(root: string, workspacePath: string): Promis
   };
 }
 
+// ── Session-backed workspace access ──────────────────────────────────────────
+//
+// The web UI identifies a Factory session workspace by its session id (a UUID),
+// not by a server-local filesystem path — the session's files live inside the
+// session's sandbox (a remote VM on deployed factories). These helpers resolve
+// the session, enforce that the caller owns it, reattach to its sandbox, and
+// serve the approved rendered roots through `SandboxFilesystem`.
+
+/** Dependencies for resolving a `workspacePath` that is a Factory session id. */
+export interface SessionFsDeps {
+  auth: RouteAuth;
+  fleet: SandboxFleet;
+  sessions: { getBySessionId(sessionId: string): Promise<SourceControlSession | null> };
+}
+
+/**
+ * Resolve a `workspacePath` query param as a Factory session id. Returns the
+ * session when one exists and the caller owns it, `null` when no session
+ * matches (the caller should fall back to local-path handling), and throws
+ * when a session exists but belongs to another tenant.
+ */
+async function resolveAuthorizedSession(
+  c: Context,
+  deps: SessionFsDeps | undefined,
+  workspacePath: string,
+): Promise<SourceControlSession | null> {
+  if (!deps) return null;
+  const session = await deps.sessions.getBySessionId(workspacePath);
+  if (!session) return null;
+  if (deps.auth.enabled()) {
+    await deps.auth.ensureUser(c);
+    const tenant = deps.auth.tenant(c);
+    if (!tenant || tenant.orgId !== session.orgId || tenant.userId !== session.userId) {
+      throw new Error('Session is not available to the current user');
+    }
+  }
+  return session;
+}
+
+interface SessionSandboxHandle {
+  sandbox: { executeCommand(command: string, args?: string[], options?: { timeout?: number }): Promise<unknown> };
+  filesystem: SandboxFilesystem;
+  workdir: string;
+}
+
+/**
+ * Reattach to the session's sandbox and wrap its workdir in a
+ * `SandboxFilesystem`. Returns `null` when the session has no provisioned
+ * sandbox yet (nothing materialized → nothing to list).
+ */
+async function sessionSandbox(
+  fleet: SandboxFleet,
+  session: SourceControlSession,
+): Promise<SessionSandboxHandle | null> {
+  if (!fleet.enabled || !session.sandboxId || !session.sandboxWorkdir) return null;
+  const sandbox = await fleet.reattachSandbox(session.sandboxId, { workingDirectory: session.sandboxWorkdir });
+  return {
+    sandbox,
+    filesystem: new SandboxFilesystem({ sandbox, workdir: session.sandboxWorkdir }),
+    workdir: session.sandboxWorkdir,
+  };
+}
+
+/** List an approved rendered root inside a Factory session's sandbox workdir. */
+export async function listSessionRenderedPath(
+  fleet: SandboxFleet,
+  session: SourceControlSession,
+  renderedRoot: string,
+): Promise<WorkspaceRenderedListing> {
+  const safeRoot = assertApprovedRenderedRoot(renderedRoot);
+  const rootPath = posixPath.join(session.sandboxWorkdir ?? '', safeRoot);
+  const empty: WorkspaceRenderedListing = { workspacePath: session.sessionId, root: safeRoot, rootPath, entries: [] };
+
+  const handle = await sessionSandbox(fleet, session);
+  if (!handle) return empty;
+
+  // One round trip: emit "type\tsize\tmtime\tpath" per entry. `safeRoot` comes
+  // from a fixed allowlist so interpolating it (quoted) is safe.
+  const quotedRoot = `'${rootPath.replace(/'/g, `'\\''`)}'`;
+  const result = (await handle.sandbox.executeCommand(
+    'sh',
+    [
+      '-c',
+      `test -d ${quotedRoot} && find ${quotedRoot} -mindepth 1 -printf '%y\\t%s\\t%T@\\t%p\\n' 2>/dev/null || true`,
+    ],
+    { timeout: 30_000 },
+  )) as { exitCode: number; stdout: string };
+  if (result.exitCode !== 0) return empty;
+
+  const entries: WorkspaceRenderedEntry[] = [];
+  for (const line of result.stdout.split('\n')) {
+    if (!line) continue;
+    const [type, sizeStr, mtimeStr, ...pathParts] = line.split('\t');
+    const fullPath = pathParts.join('\t');
+    if (!fullPath || !fullPath.startsWith(`${rootPath}/`)) continue;
+    const relativePath = fullPath.slice(rootPath.length + 1);
+    entries.push({
+      name: posixPath.basename(relativePath),
+      path: relativePath,
+      type: type === 'd' ? 'directory' : 'file',
+      size: type === 'd' ? 0 : Number(sizeStr) || 0,
+      updatedAt: new Date((Number(mtimeStr) || 0) * 1000).toISOString(),
+    });
+  }
+  entries.sort((a, b) => a.path.localeCompare(b.path));
+
+  return { workspacePath: session.sessionId, root: safeRoot, rootPath, entries };
+}
+
+/** Read a file under an approved rendered root inside a session's sandbox. */
+export async function readSessionWorkspaceFile(
+  fleet: SandboxFleet,
+  session: SourceControlSession,
+  path: string,
+): Promise<WorkspaceFile> {
+  const safePath = assertRelativePath(path, 'path');
+  assertApprovedRenderedRoot(safePath.split('/')[0] ?? '');
+
+  const handle = await sessionSandbox(fleet, session);
+  if (!handle) throw new Error('Session workspace is not materialized');
+  const { filesystem } = handle;
+  const info = await filesystem.stat(safePath);
+  if (info.type === 'directory') throw new Error('Path is a directory');
+
+  const buffer = (await filesystem.readFile(safePath)) as Buffer;
+  const truncated = buffer.length > MAX_TEXT_FILE_BYTES;
+  const base = {
+    workspacePath: session.sessionId,
+    path: safePath,
+    name: posixPath.basename(safePath),
+    size: buffer.length,
+    updatedAt: info.modifiedAt.toISOString(),
+  };
+  try {
+    const content = TEXT_DECODER.decode(truncated ? buffer.subarray(0, MAX_TEXT_FILE_BYTES) : buffer);
+    return { ...base, contentType: 'text', content, truncated };
+  } catch {
+    return { ...base, contentType: 'unsupported' };
+  }
+}
+
 export interface ResolvedCodebase {
   /**
    * The resourceId the TUI would use for this path — derived identically so a
@@ -356,8 +508,9 @@ export function resolveCodebase(projectPath: string): ResolvedCodebase {
  *   - `GET /web/fs/list?path=...`        — browse directories (confined to root)
  *   - `GET /web/codebase/resolve?path=...` — TUI-compatible codebase resourceId
  */
-export function buildFsRoutes(options: { root?: string } = {}): ApiRoute[] {
+export function buildFsRoutes(options: { root?: string; sessionFs?: SessionFsDeps } = {}): ApiRoute[] {
   const root = resolveFsRoot(options.root);
+  const sessionFs = options.sessionFs;
 
   return [
     registerApiRoute('/web/fs/list', {
@@ -398,6 +551,10 @@ export function buildFsRoutes(options: { root?: string } = {}): ApiRoute[] {
         if (!workspacePath) return c.json({ error: 'Missing required query param: workspacePath' }, 400);
         if (!renderedRoot) return c.json({ error: 'Missing required query param: root' }, 400);
         try {
+          const session = await resolveAuthorizedSession(loose(c), sessionFs, workspacePath);
+          if (session && sessionFs) {
+            return c.json(await listSessionRenderedPath(sessionFs.fleet, session, renderedRoot));
+          }
           return c.json(await listWorkspaceRenderedPath(root, workspacePath, renderedRoot));
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
@@ -405,7 +562,8 @@ export function buildFsRoutes(options: { root?: string } = {}): ApiRoute[] {
             message.includes('outside') ||
             message.includes('relative') ||
             message.includes('escapes') ||
-            message.includes('not approved')
+            message.includes('not approved') ||
+            message.includes('not available')
               ? 403
               : 500;
           return c.json({ error: message }, status);
@@ -421,6 +579,10 @@ export function buildFsRoutes(options: { root?: string } = {}): ApiRoute[] {
         if (!workspacePath) return c.json({ error: 'Missing required query param: workspacePath' }, 400);
         if (!path) return c.json({ error: 'Missing required query param: path' }, 400);
         try {
+          const session = await resolveAuthorizedSession(loose(c), sessionFs, workspacePath);
+          if (session && sessionFs) {
+            return c.json(await readSessionWorkspaceFile(sessionFs.fleet, session, path));
+          }
           return c.json(await readWorkspaceFile(root, workspacePath, path));
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
@@ -428,11 +590,14 @@ export function buildFsRoutes(options: { root?: string } = {}): ApiRoute[] {
             message.includes('outside') ||
             message.includes('relative') ||
             message.includes('escapes') ||
-            message.includes('not approved')
+            message.includes('not approved') ||
+            message.includes('not available')
               ? 403
               : message.includes('directory')
                 ? 400
-                : 500;
+                : message.includes('not found')
+                  ? 404
+                  : 500;
           return c.json({ error: message }, status);
         }
       },

--- a/mastracode/factory/src/routes/fs.ts
+++ b/mastracode/factory/src/routes/fs.ts
@@ -378,14 +378,25 @@ interface SessionSandboxHandle {
 /**
  * Reattach to the session's sandbox and wrap its workdir in a
  * `SandboxFilesystem`. Returns `null` when the session has no provisioned
- * sandbox yet (nothing materialized → nothing to list).
+ * sandbox yet (nothing materialized → nothing to list), or when the sandbox
+ * can no longer be reattached (e.g. torn down by the provider's idle GC).
+ * This is a passive read path, so it never re-provisions: the session's
+ * filesystem is preserved in its provider checkpoint and comes back the next
+ * time the workspace is actually opened (e.g. by sending a message).
  */
 async function sessionSandbox(
   fleet: SandboxFleet,
   session: SourceControlSession,
 ): Promise<SessionSandboxHandle | null> {
   if (!fleet.enabled || !session.sandboxId || !session.sandboxWorkdir) return null;
-  const sandbox = await fleet.reattachSandbox(session.sandboxId, { workingDirectory: session.sandboxWorkdir });
+  let sandbox: Awaited<ReturnType<SandboxFleet['reattachSandbox']>>;
+  try {
+    sandbox = await fleet.reattachSandbox(session.sandboxId, { workingDirectory: session.sandboxWorkdir });
+  } catch {
+    // Sandbox is gone (idle GC) or unreachable. Degrade to an empty view
+    // rather than surfacing a 500 from a file-viewer panel.
+    return null;
+  }
   return {
     sandbox,
     filesystem: new SandboxFilesystem({ sandbox, workdir: session.sandboxWorkdir }),
@@ -449,7 +460,7 @@ export async function readSessionWorkspaceFile(
   assertApprovedRenderedRoot(safePath.split('/')[0] ?? '');
 
   const handle = await sessionSandbox(fleet, session);
-  if (!handle) throw new Error('Session workspace is not materialized');
+  if (!handle) throw new Error('Session workspace is not available');
   const { filesystem } = handle;
   const info = await filesystem.stat(safePath);
   if (info.type === 'directory') throw new Error('Path is a directory');

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -359,7 +359,14 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
   }
 
   return [
-    ...buildFsRoutes({ root: deps.fsRoot }),
+    ...buildFsRoutes({
+      root: deps.fsRoot,
+      sessionFs: {
+        auth: deps.auth,
+        fleet: deps.fleet,
+        sessions: deps.sourceControlStorage.forIntegration('github').sessions,
+      },
+    }),
     ...new ConfigRoutes({
       auth: deps.auth,
       controller: deps.controller,


### PR DESCRIPTION
## Summary

The workspace files panel in Factory web fails with `{"error": "Path is outside the browsable root"}` when viewing a Factory session (e.g. `GET /web/workspace/rendered/list?workspacePath=<session-uuid>&root=.artifacts` on ts.factory.mastra.cloud).

The web UI identifies a workspace by its Factory **session id** (a UUID), but the fs endpoints treated `workspacePath` as a **server-local filesystem path**. On deployed factories the session's files live inside the session's sandbox VM, not on the API server's disk, so the confinement check always rejected the request.

## What changed

- `/web/workspace/rendered/list` and `/web/workspace/file` now first try to resolve `workspacePath` as a Factory session id:
  - verify the authenticated caller owns the session (org + user match; 403 otherwise)
  - reattach to the session's sandbox via `SandboxFleet.reattachSandbox`
  - list/read only the approved rendered roots (`.artifacts`) through `SandboxFilesystem`
- Listing uses a single `find` round trip to the sandbox instead of one stat per entry.
- Unknown `workspacePath` values (no matching session) fall back to the existing local-path behavior, so local flows are unchanged.
- Sessions without a provisioned sandbox — or whose sandbox was torn down by the provider idle GC — degrade gracefully (empty listing / 403 "not available") instead of a 500. This read path never re-provisions; the session checkpoint preserves the filesystem, and it comes back when the workspace is next opened for real (e.g. sending a message).

## Test plan

- New unit tests for `listSessionRenderedPath` and `readSessionWorkspaceFile` (11 cases): sandbox-backed listing/read, missing sandbox binding, unapproved roots, traversal rejection, out-of-root find output ignored, directory reads rejected.
- Full `@mastra/factory` suite: 994 tests pass.
- `tsc --noEmit` clean; prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Factory workspace browsing now looks inside your session’s remote sandbox (the “real workspace”) instead of only checking files on the server. This means the workspace files panel can correctly show session artifacts on deployed factories.

## What changed
- Updated `/web/workspace/rendered/list` and `/web/workspace/file` to:
  - Interpret `workspacePath` as a session ID when applicable.
  - Verify org/user ownership.
  - Reattach to the session sandbox and serve files from it.
  - List/read only allowlisted rendered roots via `SandboxFilesystem`, scoped to the session workdir.
  - Use a single sandbox `find` for listing.
  - Return empty results when the session sandbox is missing or can’t be reattached (without re-provisioning).
  - Fall back to the existing local-path behavior for unknown/non-session paths.
  - Refine error handling (e.g., distinguishing directory targets vs not-found) for session-based reads.
- Extended `buildFsRoutes` to accept `sessionFs` dependencies and wired auth/fleet + GitHub-scoped session storage into `assembleFactoryApiRoutes`.
- Added 11 unit tests covering sandbox listing/reading, missing/idle-collected sandboxes, rendered-root allowlisting, traversal protection, invalid traversal output, and directory read errors.
- Added a patch changeset for `@mastra/factory`.

- Checks: 994 Factory tests passing; TypeScript and Prettier checks clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->