### PR TITLE
fix(web): align workspace row interactions

### DIFF
--- a/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -270,7 +270,7 @@ export function WorkspaceRow({
 }) {
   const name = label ?? workspace.branch;
   return (
-    <div className={`group relative rounded-md ${active ? 'bg-surface4' : 'hover:bg-surface3'}`}>
+    <div className={`group relative rounded-md ${active ? 'bg-sidebar-nav-active' : 'hover:bg-sidebar-nav-hover'}`}>
       <button
         type="button"
         aria-current={active ? 'true' : undefined}
@@ -278,7 +278,7 @@ export function WorkspaceRow({
         disabled={disabled}
         onClick={onSelect}
         title={workspace.branch}
-        className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition ${active ? 'text-icon6' : 'text-icon3 hover:text-icon5'} disabled:cursor-default disabled:opacity-70`}
+        className={`flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition ${active ? 'text-icon6' : 'text-icon3 hover:text-icon5'} disabled:cursor-default disabled:opacity-70`}
       >
         <GitBranch size={13} />
         <span className="min-w-0 flex-1 truncate">{name}</span>
@@ -305,7 +305,7 @@ export function WorkspaceRow({
               <Button
                 type="button"
                 variant="ghost"
-                size="icon-sm"
+                size="icon-xs"
                 aria-label="Workspace actions"
                 disabled={disabled}
                 className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 data-[popup-open]:opacity-100"


### PR DESCRIPTION
Workspace session rows used generic surface hover tokens, which made them look different from sidebar navigation.

Rows now use `hover:bg-sidebar-nav-hover` instead of `hover:bg-surface3`, active rows use the matching sidebar token, and the action button uses `icon-xs` instead of `icon-sm`. The row also exposes a pointer cursor.

Verified by hovering the actual WorkspaceRow in Vite and matching its computed background to the sidebar token. `pnpm check:ui` and React Doctor also pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Workspace rows now look and behave more like sidebar items, making hover and active states feel consistent and easier to click.

## Changes

- Applied sidebar hover and active background styles.
- Added pointer cursor to workspace rows.
- Reduced the actions button size from `icon-sm` to `icon-xs`.
- Verified with Vite, `pnpm check:ui`, and React Doctor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->