### PR TITLE
fix(platform-workspace): recover stale sandbox reattach IDs on start

### DIFF
--- a/.changeset/common-turtles-cheer.md
+++ b/.changeset/common-turtles-cheer.md
@@ -2,4 +2,4 @@
 '@mastra/platform-workspace': patch
 ---
 
-Fixed PlatformSandbox exec requests so reattached sandboxes include environment details needed for automatic sandbox recovery.
+Fixed PlatformSandbox reattach so stale sandbox IDs are recreated before commands run.

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -34,10 +34,10 @@ describe('PlatformSandbox', () => {
     const execBody = JSON.parse(fetchMock.mock.calls[1]![1].body as string);
     expect(execBody).toMatchObject({
       command: 'echo ok',
-      environmentId: 'env_123',
       cwd: '/workspace',
       env: { A: '1' },
     });
+    expect(execBody.environmentId).toBeUndefined();
   });
 
   it('does not send a template field on the create wire body', async () => {
@@ -76,8 +76,11 @@ describe('PlatformSandbox', () => {
   });
 
   it('reattaches when constructed with a sandbox id', async () => {
-    vi.stubEnv('MASTRA_ENVIRONMENT_ID', 'env_from_process');
-    const fetchMock = vi.fn().mockResolvedValue(json({ exitCode: 0, stdout: 'ok', stderr: '' }));
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(json({ id: 'sbx_existing', createdAt: '2026-06-26T00:00:00.000Z' }))
+      .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '' }));
     const sandbox = new PlatformSandbox({
       accessToken: 'sk_test',
       projectId: 'proj_123',
@@ -88,10 +91,40 @@ describe('PlatformSandbox', () => {
     await sandbox._start();
     await sandbox.executeCommand('pwd');
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(String(fetchMock.mock.calls[0]![0])).toContain('/sandbox/sbx_existing/exec');
-    const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
-    expect(body).toMatchObject({ command: 'pwd', environmentId: 'env_from_process' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing');
+    expect(String(fetchMock.mock.calls[1]![0])).toBe(
+      'https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing/exec',
+    );
+  });
+
+  it('creates a fresh sandbox when the reattached sandbox no longer exists', async () => {
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    vi.stubEnv('MASTRA_ENVIRONMENT_ID', 'env_from_process');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(json({ error: { message: 'Sandbox not found', type: 'not_found' } }, { status: 404 }))
+      .mockResolvedValueOnce(json({ id: 'sbx_recreated', createdAt: '2026-06-26T00:00:00.000Z' }))
+      .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '' }));
+    const sandbox = new PlatformSandbox({
+      accessToken: 'sk_test',
+      projectId: 'proj_123',
+      sandboxId: 'sbx_stale',
+      fetch: fetchMock,
+    });
+
+    await sandbox._start();
+    await sandbox.executeCommand('pwd');
+
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_stale');
+    expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox');
+    expect(JSON.parse(fetchMock.mock.calls[1]![1].body as string)).toMatchObject({
+      id: sandbox.id,
+      environmentId: 'env_from_process',
+    });
+    expect(String(fetchMock.mock.calls[2]![0])).toBe(
+      'https://proxy.test/v1/projects/proj_123/sandbox/sbx_recreated/exec',
+    );
   });
 
   it('clears sandbox state on destroy so stale IDs cannot leak to later calls', async () => {
@@ -222,7 +255,11 @@ describe('PlatformSandbox', () => {
     });
 
     it('reattaches to a provider sandbox when sandboxId is passed', async () => {
-      const fetchMock = vi.fn().mockResolvedValue(json({ exitCode: 0, stdout: 'ok', stderr: '' }));
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_existing', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '' }));
       const template = new PlatformSandbox({
         accessToken: 'sk_test',
         projectId: 'proj_123',
@@ -234,8 +271,10 @@ describe('PlatformSandbox', () => {
       await child._start();
       await child.executeCommand!('echo hello');
 
-      // First (and only) fetch call should be exec — no create POST.
-      expect(String(fetchMock.mock.calls[0]![0])).toContain('/sandbox/sbx_existing/exec');
+      expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing');
+      expect(String(fetchMock.mock.calls[1]![0])).toBe(
+        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing/exec',
+      );
       const createCalls = fetchMock.mock.calls.filter(call => {
         const url = String(call[0]);
         return url.endsWith('/sandbox') && (call[1] as RequestInit | undefined)?.method === 'POST';

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -12,7 +12,7 @@ import type {
 } from '@mastra/core/workspace';
 import { MastraSandbox, ProcessHandle, SandboxNotReadyError, SandboxProcessManager } from '@mastra/core/workspace';
 import type { PlatformClientOptions } from './client.js';
-import { PlatformClient } from './client.js';
+import { PlatformApiError, PlatformClient } from './client.js';
 
 export type PlatformSandboxNetworkIsolation = 'ISOLATED' | 'PRIVATE';
 
@@ -196,9 +196,18 @@ export class PlatformSandbox extends MastraSandbox {
 
   async start(): Promise<void> {
     if (this._sandboxId) {
-      this._createdAt = new Date();
-      return;
+      try {
+        const response = await this._client.request(`/sandbox/${encodeURIComponent(this._sandboxId)}`);
+        const json = (await response.json()) as CreateSandboxResponse;
+        this._createdAt = json.createdAt ? new Date(json.createdAt) : new Date();
+        return;
+      } catch (error) {
+        if (!(error instanceof PlatformApiError) || error.status !== 404) throw error;
+        this._sandboxId = undefined;
+      }
     }
+
+    if (!this._environmentId) throw new Error('environmentId is required');
 
     const response = await this._client.request('/sandbox', {
       method: 'POST',
@@ -270,9 +279,6 @@ export class PlatformSandbox extends MastraSandbox {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         command: fullCommand,
-        environmentId: this._environmentId,
-        idleTimeoutMinutes: this._idleTimeoutMinutes,
-        networkIsolation: this._networkIsolation,
         timeoutSec,
         cwd: options?.cwd,
         env: options?.env,


### PR DESCRIPTION
## Summary
- Validate reattached `PlatformSandbox` ids with `GET /sandbox/:id` during `start()`.
- If the proxy returns 404, clear the stale id and create a fresh sandbox before commands run.
- Remove the exec-time environment/provisioning fields added by the previous PR; recovery now happens in the normal start lifecycle.
- Update regression coverage and the unreleased changeset text.

## Why
The previous PR taught exec requests to carry enough environment context for proxy-side lazy recovery, but Factory already has a create-before-exec lifecycle. The problem is that `PlatformSandbox.start()` treated any stored `sandboxId` as valid without checking the proxy. This PR makes stale reattach recovery happen at start time instead, so first command execution uses a live sandbox id.

## Test plan
- [x] `pnpm --filter @mastra/platform-workspace exec vitest run src/sandbox.test.ts --reporter=dot`
- [x] `pnpm --filter @mastra/platform-workspace lint`
- [x] `pnpm exec prettier --check workspaces/platform-workspace/src/sandbox.ts workspaces/platform-workspace/src/sandbox.test.ts .changeset/common-turtles-cheer.md`
- [x] `git diff --check`

## Notes
- `pnpm --filter @mastra/platform-workspace build` is currently blocked by current-main TS/typegen issues involving `RequestContext` imports in `workspaces/platform-workspace/src/filesystem.ts` and `src/sandbox.ts`; focused runtime tests/lint pass.