### PR TITLE
fix(web): restore Behavior settings on session-less factory routes

### DIFF
--- a/mastracode/web/src/web/ui/__tests__/SettingsBehaviorPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/SettingsBehaviorPage.msw.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * BDD coverage for the factory Behavior settings page
+ * (`/factories/:factoryId/settings/behavior`). The page lives outside any
+ * workspace route, so it must address the factory-level session (the
+ * `resourceId` returned by the sandbox `/ensure` route) — a regression here
+ * leaves every toggle permanently disabled because no session settings or
+ * permissions can load.
+ */
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../e2e/web-ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../e2e/web-ui/render';
+import { createAppRoutes } from '../router';
+
+const API = `${TEST_BASE_URL}/api/agent-controller/code`;
+const FACTORY_ID = 'fp-1';
+const REPO_ID = 'repo-1';
+/** The factory-level session address returned by the /ensure route. */
+const FACTORY_RESOURCE_ID = 'fp-1';
+
+function renderBehaviorSettings() {
+  const router = createMemoryRouter(createAppRoutes(), {
+    initialEntries: [`/factories/${FACTORY_ID}/settings/behavior`],
+  });
+  renderWithProviders(<RouterProvider router={router} />);
+  return router;
+}
+
+function stubBehaviorPage() {
+  const settings = { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true };
+  const permissions = { categories: { read: 'ask', edit: 'ask', execute: 'ask', mcp: 'ask', other: 'ask' }, tools: {} };
+  const seen = {
+    settingsResourceIds: [] as string[],
+    permissionResourceIds: [] as string[],
+    stateWrites: [] as { resourceId: string; body: unknown }[],
+    permissionWrites: [] as { resourceId: string; body: unknown }[],
+  };
+
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Mastra' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'conn-1',
+            installationId: 'inst-1',
+            repositories: [
+              {
+                id: REPO_ID,
+                branch: 'main',
+                sandboxWorkdir: '/workspace/mastra',
+                repository: { slug: 'org/mastra', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () =>
+      HttpResponse.json({
+        resourceId: FACTORY_RESOURCE_ID,
+        factoryProjectId: FACTORY_ID,
+        projectRepositoryId: REPO_ID,
+        sandboxId: 'sb-1',
+        sandboxWorkdir: '/workspace/mastra',
+      }),
+    ),
+    http.post(`${API}/sessions`, async ({ request }) => {
+      const { resourceId } = (await request.json()) as { resourceId: string };
+      return HttpResponse.json({ controllerId: 'code', resourceId, threadId: 'thread-1' });
+    }),
+    http.get(`${API}/sessions/:resourceId`, ({ params }) => {
+      seen.settingsResourceIds.push(String(params.resourceId));
+      return HttpResponse.json({
+        controllerId: 'code',
+        resourceId: params.resourceId,
+        modeId: 'build',
+        modelId: 'openai/gpt-4o-mini',
+        threadId: 'thread-1',
+        settings,
+      });
+    }),
+    http.put(`${API}/sessions/:resourceId/state`, async ({ params, request }) => {
+      const body = (await request.json()) as { state?: Record<string, unknown> };
+      seen.stateWrites.push({ resourceId: String(params.resourceId), body });
+      Object.assign(settings, body.state);
+      return HttpResponse.json({});
+    }),
+    http.get(`${API}/sessions/:resourceId/permissions`, ({ params }) => {
+      seen.permissionResourceIds.push(String(params.resourceId));
+      return HttpResponse.json(permissions);
+    }),
+    http.put(`${API}/sessions/:resourceId/permissions/category`, async ({ params, request }) => {
+      const body = (await request.json()) as { category: string; policy: string };
+      seen.permissionWrites.push({ resourceId: String(params.resourceId), body });
+      permissions.categories[body.category as keyof typeof permissions.categories] = body.policy;
+      return HttpResponse.json(permissions);
+    }),
+  );
+  return seen;
+}
+
+describe('Behavior settings page (factory scope)', () => {
+  it('loads factory-level session settings so the behavior toggles are interactive', async () => {
+    const seen = stubBehaviorPage();
+
+    renderBehaviorSettings();
+
+    const yolo = await screen.findByRole('switch', { name: 'Auto-approve tools' });
+    await waitFor(() => expect(yolo).toBeEnabled());
+    expect(screen.getByRole('switch', { name: 'Smart editing' })).toBeEnabled();
+    expect(seen.settingsResourceIds).toContain(FACTORY_RESOURCE_ID);
+    // Never address a session with an empty resourceId.
+    expect(seen.settingsResourceIds).not.toContain('');
+  });
+
+  it('persists a toggle change to the factory-level session', async () => {
+    const seen = stubBehaviorPage();
+    const user = userEvent.setup();
+
+    renderBehaviorSettings();
+
+    const yolo = await screen.findByRole('switch', { name: 'Auto-approve tools' });
+    await waitFor(() => expect(yolo).toBeEnabled());
+    await user.click(yolo);
+
+    await waitFor(() => expect(seen.stateWrites).toHaveLength(1));
+    expect(seen.stateWrites[0]).toEqual({
+      resourceId: FACTORY_RESOURCE_ID,
+      body: { state: { yolo: true } },
+    });
+    await waitFor(() => expect(yolo).toBeChecked());
+  });
+
+  it('loads and updates tool permissions for the factory-level session', async () => {
+    const seen = stubBehaviorPage();
+    const user = userEvent.setup();
+
+    renderBehaviorSettings();
+
+    const readGroup = await screen.findByRole('group', { name: 'Read permission' });
+    const readAllow = within(readGroup).getByRole('button', { name: 'Allow' });
+    await waitFor(() => expect(readAllow).toBeEnabled());
+    expect(seen.permissionResourceIds).toContain(FACTORY_RESOURCE_ID);
+
+    await user.click(readAllow);
+
+    await waitFor(() => expect(seen.permissionWrites).toHaveLength(1));
+    expect(seen.permissionWrites[0]).toEqual({
+      resourceId: FACTORY_RESOURCE_ID,
+      body: { category: 'read', policy: 'allow' },
+    });
+  });
+});

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatPermissionsProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatPermissionsProvider.tsx
@@ -14,14 +14,17 @@ interface ChatPermissionsProviderProps {
 }
 
 export function ChatPermissionsProvider({ children }: ChatPermissionsProviderProps) {
-  const { resourceId, projectPath, baseUrl, sessionEnabled } = useChatSessionContext();
+  const { resourceId, projectPath, baseUrl, sessionEnabled, resourceEnabled } = useChatSessionContext();
   const [pendingPermissionCategory, setPendingPermissionCategory] = useState<ToolCategory | null>(null);
   const hookArgs = {
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
     scope: projectPath,
     baseUrl,
-    enabled: sessionEnabled,
+    // Workspace routes wait for their stored session; session-less factory
+    // surfaces (the routed Settings pages) address the factory-level session
+    // so tool permissions stay editable there.
+    enabled: sessionEnabled || (resourceEnabled && Boolean(resourceId)),
   };
   const permissionsQuery = useAgentControllerPermissions(hookArgs);
   const setPermissionForCategoryMutation = useSetPermissionForCategoryMutation(hookArgs);

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -53,8 +53,11 @@ export function ChatSessionConfigProvider({
   // memory resourceId and no scope (see FactoryStartCoordinator.prepare and
   // UserSessionsSection), so the chat surface must address the same
   // (resourceId, no scope) session to read threads and share the live run.
-  // On user routes the :threadId param IS the sessionId.
-  const resourceId = userScoped ? threadId : (storedSession?.sessionId ?? sessionId);
+  // On user routes the :threadId param IS the sessionId. Factory routes with
+  // no workspace session (e.g. /settings/*) fall back to the factory-level
+  // session address returned by the /ensure route so resource-scoped surfaces
+  // (behavior settings, tool permissions) stay functional.
+  const resourceId = userScoped ? threadId : (storedSession?.sessionId ?? sessionId ?? ensureQuery.data?.resourceId);
   const projectPath = undefined;
   const sessionEnabled = userScoped
     ? Boolean(storedSession) && !resolvingSession


### PR DESCRIPTION
## Summary

The Behavior page (`/factories/:factoryId/settings/behavior`) rendered with every toggle, thinking-level segment, and tool-permission control permanently disabled. Manual testing on a local factory confirmed the page was unusable.

**Root cause:** the per-session addressing migration (#20023/#20026) changed the chat session context to derive its `resourceId` from the workspace `:sessionId` route param or the stored session. Settings routes have neither, so:

- the session settings query fired `GET /api/agent-controller/code/sessions/` with an **empty resourceId** and never resolved, and controls render `disabled` while settings are missing
- the permissions query is gated on an active workspace session, so tool-permission rows never loaded either

**Fix:**

- `ChatSessionProvider` falls back to the factory-level session address returned by the sandbox `/ensure` route when no workspace session exists (the pre-migration address for these surfaces; the server get-or-creates that session)
- `ChatPermissionsProvider` also enables the permissions query on those session-less, resource-scoped surfaces

## Test plan

- New full-router MSW test (`SettingsBehaviorPage.msw.test.tsx`) that reproduced the regression (red before the fix, including the empty-resourceId request) and now verifies:
  - behavior toggles load enabled from the factory-level session
  - a toggle change persists via `PUT /sessions/:resourceId/state` with the factory-level id
  - tool permissions load and update against the factory-level session
- Full web-ui suite: 273 passed; unit suite: 75 passed; `pnpm run check` clean
- Manually verified the Behavior page controls load and persist on a local factory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Behavior settings page could not load or save settings because it did not know which factory session to use. This change lets it use the factory’s session and adds tests proving settings and permissions work correctly.

## Changes

- Fall back to the factory-level session returned by the sandbox when no workspace session exists.
- Enable permission queries and updates on factory-scoped routes.
- Add MSW router tests covering:
  - Loading behavior settings with a valid factory resource ID.
  - Saving behavior toggle changes.
  - Loading and updating tool permissions.
- Confirm web and unit tests pass and `pnpm run check` is clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->