### PR TITLE
fix: serialize LibSQL observational-memory writes and close storage on TUI shutdown

### DIFF
--- a/.changeset/libsql-om-write-lock.md
+++ b/.changeset/libsql-om-write-lock.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Fixed lost writes and transaction contamination in observational-memory buffering by routing all memory-domain mutations through the per-client write lock. Read-modify-write operations (buffered observation appends, config updates, buffered-to-active swaps) now run inside locked write transactions, preventing concurrent autocommit statements from being swept into open interactive transactions.

--- a/.changeset/libsql-om-write-lock.md
+++ b/.changeset/libsql-om-write-lock.md
@@ -2,4 +2,4 @@
 '@mastra/libsql': patch
 ---
 
-Fixed lost writes and transaction contamination in observational-memory buffering by routing all memory-domain mutations through the per-client write lock. Read-modify-write operations (buffered observation appends, config updates, buffered-to-active swaps) now run inside locked write transactions, preventing concurrent autocommit statements from being swept into open interactive transactions.
+Fixed data loss and corruption in observational memory when it is written to concurrently on a local SQLite database. Buffered observations could previously be dropped or leave the memory record in an inconsistent state under load; memory updates are now serialized so concurrent writes are preserved.

--- a/.changeset/mastracode-storage-shutdown.md
+++ b/.changeset/mastracode-storage-shutdown.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed local database corruption on exit by closing storage connections during TUI shutdown. The signal handler (SIGINT, SIGTERM, SIGHUP) now calls storage close, which checkpoints and truncates WAL files and switches back to DELETE journal mode before the process exits. Previously, abrupt termination left WAL sidecars un-checkpointed, which could corrupt the local SQLite database on the next open.

--- a/mastracode/tui/e2e/terminal-backend.ts
+++ b/mastracode/tui/e2e/terminal-backend.ts
@@ -400,8 +400,11 @@ async function startMastraCodeApp(
     }
   }
 
+  let stopped = false;
   return {
     async stop() {
+      if (stopped) return;
+      stopped = true;
       tui.stop();
       const closeSignalsPubSub = (result.signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close;
       await Promise.allSettled([
@@ -410,6 +413,11 @@ async function startMastraCodeApp(
         result.controller.stopIntervals(),
         closeSignalsPubSub?.(),
       ]);
+      // Close storage last — checkpoints WAL and switches to DELETE journal
+      // mode for local libsql, mirroring the production asyncCleanup() path.
+      await result.storageMaintenance?.closeStorage?.().catch(() => {
+        // Best-effort during test shutdown.
+      });
     },
   };
 }
@@ -463,7 +471,13 @@ export async function runTerminalScenario(
         stopApp = app.stop;
       }
 
-      await withTerminalProcessOutput(terminal, () => scenario.run({ terminal: scenarioTerminal, runtime }));
+      runtime.stopApp = async () => {
+        await stopApp?.();
+      };
+
+      await withTerminalProcessOutput(terminal, () =>
+        scenario.run({ terminal: scenarioTerminal, runtime, dbPath: runConfig.context.dbPath }),
+      );
       return 0;
     } finally {
       await stopApp?.();

--- a/mastracode/tui/e2e/tui/process-shortcuts.ts
+++ b/mastracode/tui/e2e/tui/process-shortcuts.ts
@@ -1,11 +1,14 @@
+import { existsSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+
 import { expect } from './expect.js';
 import type { McE2eScenario } from './types.js';
 
 export const processShortcutsScenario: McE2eScenario = {
   name: 'process-shortcuts',
-  description: 'Exercise process shortcut help and Alt+Z undo behavior through the real TUI.',
-  testName: 'shows suspend shortcut help and restores cleared input with Alt+Z',
-  async run({ terminal, runtime }) {
+  description: 'Exercise process shortcut help, Alt+Z undo behavior, and Ctrl+C storage shutdown through the real TUI.',
+  testName: 'shows suspend shortcut help, restores cleared input with Alt+Z, and checkpoints storage on shutdown',
+  async run({ terminal, runtime, dbPath }) {
     runtime.startLiveOutput(terminal);
     runtime.printScreen('spawned', terminal);
 
@@ -32,5 +35,29 @@ export const processShortcutsScenario: McE2eScenario = {
 
     terminal.keyCtrlC();
     runtime.printScreen('after Ctrl-C', terminal);
+
+    // Shut down the in-process app so storage close (WAL checkpoint) runs,
+    // then verify the local database is intact and WAL/SHM sidecars are gone.
+    await runtime.stopApp?.();
+
+    const db = new DatabaseSync(dbPath);
+    try {
+      const rows = db.prepare('PRAGMA quick_check').all() as Array<Record<string, unknown>>;
+      const result = rows[0] ? Object.values(rows[0])[0] : undefined;
+      if (result !== 'ok') {
+        throw new Error(`PRAGMA quick_check failed: ${String(result)}`);
+      }
+    } finally {
+      db.close();
+    }
+
+    // After closeStorage() checkpoints and truncates the WAL, the sidecar
+    // files should be absent (or at least not left in a half-written state).
+    if (existsSync(`${dbPath}-wal`)) {
+      throw new Error(`WAL sidecar still exists after shutdown: ${dbPath}-wal`);
+    }
+    if (existsSync(`${dbPath}-shm`)) {
+      throw new Error(`SHM sidecar still exists after shutdown: ${dbPath}-shm`);
+    }
   },
 };

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -177,6 +177,12 @@ export type McE2eScenarioRuntime = {
   waitForOutputText: (pattern: RegExp, terminal: McE2eTerminal, timeoutMs?: number) => Promise<void>;
   waitForScreenText: (pattern: RegExp, terminal: McE2eTerminal, timeoutMs?: number) => Promise<void>;
   waitForScreenTextAbsent: (pattern: RegExp, terminal: McE2eTerminal, timeoutMs?: number) => Promise<void>;
+  /**
+   * Stop the in-process Mastra Code app (TUI + storage close). Idempotent —
+   * safe to call before the runner's own finally-block stop. Scenarios that
+   * need to inspect on-disk database state after shutdown call this first.
+   */
+  stopApp?: () => Promise<void>;
 };
 
 export type McE2ePrepareContext = {
@@ -225,6 +231,6 @@ export type McE2eScenario = {
   inProcessApp?: (context: McE2eInProcessAppContext) => Promise<McE2eInProcessApp> | McE2eInProcessApp;
   terminalBackend?: 'subprocess';
   prepare?: (context: McE2ePrepareContext) => Promise<void> | void;
-  run: (context: { terminal: McE2eTerminal; runtime: McE2eScenarioRuntime }) => Promise<void>;
+  run: (context: { terminal: McE2eTerminal; runtime: McE2eScenarioRuntime; dbPath: string }) => Promise<void>;
   verifyAimockRequests?: (requests: unknown[]) => void;
 };

--- a/mastracode/tui/src/main.ts
+++ b/mastracode/tui/src/main.ts
@@ -23,8 +23,10 @@ let mcpManager: Awaited<ReturnType<typeof createMastraCode>>['mcpManager'];
 let hookManager: Awaited<ReturnType<typeof createMastraCode>>['hookManager'];
 let authStorage: Awaited<ReturnType<typeof createMastraCode>>['authStorage'];
 let signalsPubSub: Awaited<ReturnType<typeof createMastraCode>>['signalsPubSub'];
+let storageMaintenance: Awaited<ReturnType<typeof createMastraCode>>['storageMaintenance'];
 let analytics: ReturnType<typeof createMastraCodeAnalytics> | undefined;
 let tui: MastraTUI | undefined;
+let storageClosed = false;
 
 function isTruthyEnv(name: string): boolean {
   return ['1', 'true', 'yes', 'on'].includes(process.env[name]?.trim().toLowerCase() ?? '');
@@ -71,6 +73,7 @@ async function tuiMain(pipedInput?: string | null) {
   hookManager = result.hookManager;
   authStorage = result.authStorage;
   signalsPubSub = result.signalsPubSub;
+  storageMaintenance = result.storageMaintenance;
 
   if (result.storageWarning) {
     console.info(`⚠ ${result.storageWarning}`);
@@ -158,6 +161,16 @@ const asyncCleanup = async () => {
     closeSignalsPubSub?.(),
     analytics?.shutdown(),
   ]);
+  // Checkpoint WAL and close the local storage connection after all producers
+  // and timers are quiesced. Idempotent — repeated signals (SIGINT then SIGHUP)
+  // close only once. LibSQLStore.close()/LibSQLVector.close() truncate the WAL
+  // and switch back to DELETE journal mode for a clean shutdown.
+  if (!storageClosed) {
+    storageClosed = true;
+    await storageMaintenance?.closeStorage?.().catch(() => {
+      // Swallow — best-effort cleanup during shutdown. The process is exiting.
+    });
+  }
 };
 
 process.on('beforeExit', () => {

--- a/stores/_test-utils/src/domains/memory/observational-memory.ts
+++ b/stores/_test-utils/src/domains/memory/observational-memory.ts
@@ -1589,6 +1589,32 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
         expect(updated?.isObserving).toBe(true);
         expect(updated?.bufferedObservationChunks?.length ?? 0).toBe(1);
       });
+
+      it('preserves every chunk under concurrent buffered-observation appends', async () => {
+        const input = createSampleOMInput();
+        const record = await memoryStorage.initializeObservationalMemory(input);
+
+        const CONCURRENT_CHUNKS = 8;
+        const labels = Array.from({ length: CONCURRENT_CHUNKS }, (_, i) => `concurrent-chunk-${i}`);
+
+        await Promise.all(
+          labels.map(label =>
+            memoryStorage.updateBufferedObservations({
+              id: record.id,
+              chunk: createChunk({ observations: label, messageTokens: 100 }),
+            }),
+          ),
+        );
+
+        const updated = await memoryStorage.getObservationalMemory(input.threadId, input.resourceId);
+        const chunks = updated?.bufferedObservationChunks ?? [];
+        expect(chunks.length).toBe(CONCURRENT_CHUNKS);
+
+        // Every uniquely identified chunk must be present — no lost writes.
+        const observations = chunks.map(c => c.observations).sort();
+        const expected = [...labels].sort();
+        expect(observations).toEqual(expected);
+      });
     });
   });
 }

--- a/stores/libsql/src/storage/db/write-lock.test.ts
+++ b/stores/libsql/src/storage/db/write-lock.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -139,5 +140,140 @@ describe('LibSQL concurrent writes across domains (regression)', () => {
     });
 
     expect(listed.experiments.map(e => e.id)).toContain(experiment.id);
+  });
+});
+
+describe('LibSQL observational-memory write-lock regression', () => {
+  let tmpDir: string;
+  let store: LibSQLStore;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'libsql-om-lock-'));
+  });
+
+  afterEach(async () => {
+    await store?.close?.();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // Reproduces the lost-write path where OM buffering (read-modify-write on
+  // bufferedObservationChunks) races interactive workflow transactions on the
+  // same LibSQL client. Before OM participated in withClientWriteLock, the
+  // autocommit SELECT+UPDATE inside updateBufferedObservations could be swept
+  // into an open workflow transaction, causing lost chunks or transaction
+  // contamination.
+  it('preserves all OM buffered chunks that race workflow transactions', async () => {
+    store = new LibSQLStore({ id: 'om-lock-regression', url: `file:${path.join(tmpDir, 'om-race.db')}` });
+    const memory = store.stores.memory!;
+    const workflows = store.stores.workflows!;
+    await memory.init();
+    await workflows.init();
+
+    const resourceId = `resource-${randomUUID()}`;
+    const record = await memory.initializeObservationalMemory({
+      threadId: null,
+      resourceId,
+      scope: 'resource',
+      config: { observationThreshold: 5000, reflectionThreshold: 40000 },
+    });
+
+    // Set up a workflow snapshot to churn against
+    const workflowName = 'om-race-workflow';
+    const runId = 'om-race-run';
+    await workflows.persistWorkflowSnapshot({
+      workflowName,
+      runId,
+      snapshot: {
+        context: {},
+        activePaths: [],
+        timestamp: Date.now(),
+        suspendedPaths: {},
+        serializedStepGraph: [],
+        status: 'running',
+        value: {},
+        runId,
+      } as any,
+    });
+
+    const CHUNK_COUNT = 10;
+    const labels = Array.from({ length: CHUNK_COUNT }, (_, i) => `om-chunk-${i}`);
+
+    // Fire workflow-state transactions concurrently with OM buffer appends —
+    // the exact interleaving that previously dropped buffered chunks.
+    const workflowChurn = Array.from({ length: 12 }, (_, i) =>
+      workflows.updateWorkflowState({
+        workflowName,
+        runId,
+        opts: { status: 'running', activePaths: [i] },
+      }),
+    );
+
+    const omAppends = labels.map(label =>
+      memory.updateBufferedObservations({
+        id: record.id,
+        chunk: {
+          cycleId: `cycle-${randomUUID()}`,
+          observations: label,
+          tokenCount: 50,
+          messageIds: [`msg-${randomUUID()}`],
+          messageTokens: 100,
+          lastObservedAt: new Date(),
+        },
+      }),
+    );
+
+    await Promise.all([...omAppends, ...workflowChurn]);
+
+    const updated = await memory.getObservationalMemory(null, resourceId);
+    const chunks = updated?.bufferedObservationChunks ?? [];
+    expect(chunks.length).toBe(CHUNK_COUNT);
+
+    // Every uniquely identified chunk must be present — no lost writes.
+    const observations = chunks.map(c => c.observations).sort();
+    const expected = [...labels].sort();
+    expect(observations).toEqual(expected);
+
+    // The workflow snapshot must also survive the contention.
+    const snapshot = await workflows.loadWorkflowSnapshot({ workflowName, runId });
+    expect(snapshot).toBeDefined();
+  });
+
+  // Verifies that a failed OM operation does not contaminate or roll back
+  // unrelated work that committed on the same client.
+  it('does not contaminate unrelated writes when an OM operation fails', async () => {
+    store = new LibSQLStore({ id: 'om-fail-regression', url: `file:${path.join(tmpDir, 'om-fail.db')}` });
+    const memory = store.stores.memory!;
+    await memory.init();
+
+    const resourceId = `resource-${randomUUID()}`;
+    const record = await memory.initializeObservationalMemory({
+      threadId: null,
+      resourceId,
+      scope: 'resource',
+      config: { observationThreshold: 5000, reflectionThreshold: 40000 },
+    });
+
+    // A valid flag update that should succeed and persist.
+    await memory.setObservingFlag(record.id, true);
+
+    // A failing OM operation — referencing a non-existent record id.
+    await expect(
+      memory.updateBufferedObservations({
+        id: 'nonexistent-id',
+        chunk: {
+          cycleId: 'cycle-fail',
+          observations: 'should-fail',
+          tokenCount: 50,
+          messageIds: ['msg-fail'],
+          messageTokens: 100,
+          lastObservedAt: new Date(),
+        },
+      }),
+    ).rejects.toThrow();
+
+    // The valid flag update must still be visible — the failure did not roll
+    // it back or contaminate the client state.
+    const updated = await memory.getObservationalMemory(null, resourceId);
+    expect(updated?.isObserving).toBe(true);
   });
 });

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import type { Client, InValue } from '@libsql/client';
+import type { Client, InValue, Transaction } from '@libsql/client';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { MessageList } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
@@ -53,6 +53,7 @@ import { parseSqlIdentifier } from '@mastra/core/utils';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';
+import { withClientWriteLock } from '../../db/write-lock';
 import { runPrune, resolveTargets } from '../../retention';
 
 export class MemoryLibSQL extends MemoryStorage {
@@ -1663,42 +1664,44 @@ export class MemoryLibSQL extends MemoryStorage {
         observedTimezone: input.observedTimezone,
       };
 
-      await this.#client.execute({
-        sql: `INSERT INTO "${OM_TABLE}" (
-          id, "lookupKey", scope, "resourceId", "threadId",
-          "activeObservations", "activeObservationsPendingUpdate",
-          "originType", config, "generationCount", "lastObservedAt", "lastReflectionAt",
-          "pendingMessageTokens", "totalTokensObserved", "observationTokenCount",
-          "isObserving", "isReflecting", "isBufferingObservation", "isBufferingReflection", "lastBufferedAtTokens", "lastBufferedAtTime",
-          "observedTimezone", "createdAt", "updatedAt"
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        args: [
-          id,
-          lookupKey,
-          input.scope,
-          input.resourceId,
-          input.threadId || null,
-          '',
-          null,
-          'initial',
-          JSON.stringify(input.config),
-          0,
-          null,
-          null,
-          0,
-          0,
-          0,
-          false,
-          false,
-          false, // isBufferingObservation
-          false, // isBufferingReflection
-          0, // lastBufferedAtTokens
-          null, // lastBufferedAtTime
-          input.observedTimezone || null,
-          now.toISOString(),
-          now.toISOString(),
-        ],
-      });
+      await withClientWriteLock(this.#client, () =>
+        this.#client.execute({
+          sql: `INSERT INTO "${OM_TABLE}" (
+            id, "lookupKey", scope, "resourceId", "threadId",
+            "activeObservations", "activeObservationsPendingUpdate",
+            "originType", config, "generationCount", "lastObservedAt", "lastReflectionAt",
+            "pendingMessageTokens", "totalTokensObserved", "observationTokenCount",
+            "isObserving", "isReflecting", "isBufferingObservation", "isBufferingReflection", "lastBufferedAtTokens", "lastBufferedAtTime",
+            "observedTimezone", "createdAt", "updatedAt"
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          args: [
+            id,
+            lookupKey,
+            input.scope,
+            input.resourceId,
+            input.threadId || null,
+            '',
+            null,
+            'initial',
+            JSON.stringify(input.config),
+            0,
+            null,
+            null,
+            0,
+            0,
+            0,
+            false,
+            false,
+            false, // isBufferingObservation
+            false, // isBufferingReflection
+            0, // lastBufferedAtTokens
+            null, // lastBufferedAtTime
+            input.observedTimezone || null,
+            now.toISOString(),
+            now.toISOString(),
+          ],
+        }),
+      );
 
       return record;
     } catch (error) {
@@ -1717,53 +1720,55 @@ export class MemoryLibSQL extends MemoryStorage {
   async insertObservationalMemoryRecord(record: ObservationalMemoryRecord): Promise<void> {
     try {
       const lookupKey = this.getOMKey(record.threadId, record.resourceId);
-      await this.#client.execute({
-        sql: `INSERT INTO "${OM_TABLE}" (
-          id, "lookupKey", scope, "resourceId", "threadId",
-          "activeObservations", "activeObservationsPendingUpdate",
-          "originType", config, "generationCount", "lastObservedAt", "lastReflectionAt",
-          "pendingMessageTokens", "totalTokensObserved", "observationTokenCount",
-          "observedMessageIds", "bufferedObservationChunks",
-          "bufferedReflection", "bufferedReflectionTokens", "bufferedReflectionInputTokens",
-          "reflectedObservationLineCount",
-          "isObserving", "isReflecting", "isBufferingObservation", "isBufferingReflection",
-          "lastBufferedAtTokens", "lastBufferedAtTime",
-          "observedTimezone", metadata, "createdAt", "updatedAt"
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        args: [
-          record.id,
-          lookupKey,
-          record.scope,
-          record.resourceId,
-          record.threadId || null,
-          record.activeObservations || '',
-          null,
-          record.originType || 'initial',
-          record.config ? JSON.stringify(record.config) : null,
-          record.generationCount || 0,
-          record.lastObservedAt ? record.lastObservedAt.toISOString() : null,
-          null,
-          record.pendingMessageTokens || 0,
-          record.totalTokensObserved || 0,
-          record.observationTokenCount || 0,
-          record.observedMessageIds ? JSON.stringify(record.observedMessageIds) : null,
-          record.bufferedObservationChunks ? JSON.stringify(record.bufferedObservationChunks) : null,
-          record.bufferedReflection || null,
-          record.bufferedReflectionTokens ?? null,
-          record.bufferedReflectionInputTokens ?? null,
-          record.reflectedObservationLineCount ?? null,
-          record.isObserving || false,
-          record.isReflecting || false,
-          record.isBufferingObservation || false,
-          record.isBufferingReflection || false,
-          record.lastBufferedAtTokens || 0,
-          record.lastBufferedAtTime ? record.lastBufferedAtTime.toISOString() : null,
-          record.observedTimezone || null,
-          record.metadata ? JSON.stringify(record.metadata) : null,
-          record.createdAt.toISOString(),
-          record.updatedAt.toISOString(),
-        ],
-      });
+      await withClientWriteLock(this.#client, () =>
+        this.#client.execute({
+          sql: `INSERT INTO "${OM_TABLE}" (
+            id, "lookupKey", scope, "resourceId", "threadId",
+            "activeObservations", "activeObservationsPendingUpdate",
+            "originType", config, "generationCount", "lastObservedAt", "lastReflectionAt",
+            "pendingMessageTokens", "totalTokensObserved", "observationTokenCount",
+            "observedMessageIds", "bufferedObservationChunks",
+            "bufferedReflection", "bufferedReflectionTokens", "bufferedReflectionInputTokens",
+            "reflectedObservationLineCount",
+            "isObserving", "isReflecting", "isBufferingObservation", "isBufferingReflection",
+            "lastBufferedAtTokens", "lastBufferedAtTime",
+            "observedTimezone", metadata, "createdAt", "updatedAt"
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          args: [
+            record.id,
+            lookupKey,
+            record.scope,
+            record.resourceId,
+            record.threadId || null,
+            record.activeObservations || '',
+            null,
+            record.originType || 'initial',
+            record.config ? JSON.stringify(record.config) : null,
+            record.generationCount || 0,
+            record.lastObservedAt ? record.lastObservedAt.toISOString() : null,
+            null,
+            record.pendingMessageTokens || 0,
+            record.totalTokensObserved || 0,
+            record.observationTokenCount || 0,
+            record.observedMessageIds ? JSON.stringify(record.observedMessageIds) : null,
+            record.bufferedObservationChunks ? JSON.stringify(record.bufferedObservationChunks) : null,
+            record.bufferedReflection || null,
+            record.bufferedReflectionTokens ?? null,
+            record.bufferedReflectionInputTokens ?? null,
+            record.reflectedObservationLineCount ?? null,
+            record.isObserving || false,
+            record.isReflecting || false,
+            record.isBufferingObservation || false,
+            record.isBufferingReflection || false,
+            record.lastBufferedAtTokens || 0,
+            record.lastBufferedAtTime ? record.lastBufferedAtTime.toISOString() : null,
+            record.observedTimezone || null,
+            record.metadata ? JSON.stringify(record.metadata) : null,
+            record.createdAt.toISOString(),
+            record.updatedAt.toISOString(),
+          ],
+        }),
+      );
     } catch (error) {
       throw new MastraError(
         {
@@ -1782,26 +1787,28 @@ export class MemoryLibSQL extends MemoryStorage {
       const now = new Date();
 
       const observedMessageIdsJson = input.observedMessageIds ? JSON.stringify(input.observedMessageIds) : null;
-      const result = await this.#client.execute({
-        sql: `UPDATE "${OM_TABLE}" SET
-          "activeObservations" = ?,
-          "lastObservedAt" = ?,
-          "pendingMessageTokens" = 0,
-          "observationTokenCount" = ?,
-          "totalTokensObserved" = "totalTokensObserved" + ?,
-          "observedMessageIds" = ?,
-          "updatedAt" = ?
-        WHERE id = ?`,
-        args: [
-          input.observations,
-          input.lastObservedAt.toISOString(),
-          input.tokenCount,
-          input.tokenCount,
-          observedMessageIdsJson,
-          now.toISOString(),
-          input.id,
-        ],
-      });
+      const result = await withClientWriteLock(this.#client, () =>
+        this.#client.execute({
+          sql: `UPDATE "${OM_TABLE}" SET
+            "activeObservations" = ?,
+            "lastObservedAt" = ?,
+            "pendingMessageTokens" = 0,
+            "observationTokenCount" = ?,
+            "totalTokensObserved" = "totalTokensObserved" + ?,
+            "observedMessageIds" = ?,
+            "updatedAt" = ?
+          WHERE id = ?`,
+          args: [
+            input.observations,
+            input.lastObservedAt.toISOString(),
+            input.tokenCount,
+            input.tokenCount,
+            observedMessageIdsJson,
+            now.toISOString(),
+            input.id,
+          ],
+        }),
+      );
 
       if (result.rowsAffected === 0) {
         throw new MastraError({
@@ -1830,75 +1837,21 @@ export class MemoryLibSQL extends MemoryStorage {
 
   async createReflectionGeneration(input: CreateReflectionGenerationInput): Promise<ObservationalMemoryRecord> {
     try {
-      const id = crypto.randomUUID();
-      const now = new Date();
-      const lookupKey = this.getOMKey(input.currentRecord.threadId, input.currentRecord.resourceId);
-
-      const record: ObservationalMemoryRecord = {
-        id,
-        scope: input.currentRecord.scope,
-        threadId: input.currentRecord.threadId,
-        resourceId: input.currentRecord.resourceId,
-        createdAt: now,
-        updatedAt: now,
-        lastObservedAt: input.currentRecord.lastObservedAt,
-        originType: 'reflection',
-        generationCount: input.currentRecord.generationCount + 1,
-        activeObservations: input.reflection,
-        totalTokensObserved: input.currentRecord.totalTokensObserved,
-        observationTokenCount: input.tokenCount,
-        pendingMessageTokens: 0,
-        isReflecting: false,
-        isObserving: false,
-        isBufferingObservation: false,
-        isBufferingReflection: false,
-        lastBufferedAtTokens: 0,
-        lastBufferedAtTime: null,
-        config: input.currentRecord.config,
-        metadata: input.currentRecord.metadata,
-        observedTimezone: input.currentRecord.observedTimezone,
-      };
-
-      await this.#client.execute({
-        sql: `INSERT INTO "${OM_TABLE}" (
-          id, "lookupKey", scope, "resourceId", "threadId",
-          "activeObservations", "activeObservationsPendingUpdate",
-          "originType", config, "generationCount", "lastObservedAt", "lastReflectionAt",
-          "pendingMessageTokens", "totalTokensObserved", "observationTokenCount",
-          "isObserving", "isReflecting", "isBufferingObservation", "isBufferingReflection", "lastBufferedAtTokens", "lastBufferedAtTime",
-          "observedTimezone", metadata, "createdAt", "updatedAt"
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        args: [
-          id,
-          lookupKey,
-          record.scope,
-          record.resourceId,
-          record.threadId || null,
-          input.reflection,
-          null,
-          'reflection',
-          JSON.stringify(record.config),
-          input.currentRecord.generationCount + 1,
-          record.lastObservedAt?.toISOString() || null,
-          now.toISOString(),
-          record.pendingMessageTokens,
-          record.totalTokensObserved,
-          record.observationTokenCount,
-          false, // isObserving
-          false, // isReflecting
-          false, // isBufferingObservation
-          false, // isBufferingReflection
-          0, // lastBufferedAtTokens
-          null, // lastBufferedAtTime
-          record.observedTimezone || null,
-          record.metadata ? JSON.stringify(record.metadata) : null,
-          now.toISOString(),
-          now.toISOString(),
-        ],
+      return await withClientWriteLock(this.#client, async () => {
+        const tx = await this.#client.transaction('write');
+        try {
+          const record = await this.#insertReflectionGeneration(tx, input);
+          await tx.commit();
+          return record;
+        } catch (error) {
+          if (!tx.closed) await tx.rollback();
+          throw error;
+        }
       });
-
-      return record;
     } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
       throw new MastraError(
         {
           id: createStorageErrorId('LIBSQL', 'CREATE_REFLECTION_GENERATION', 'FAILED'),
@@ -1911,12 +1864,94 @@ export class MemoryLibSQL extends MemoryStorage {
     }
   }
 
+  /**
+   * Inserts a new reflection-generation row. Called inside a locked write
+   * transaction — either from {@link createReflectionGeneration} (standalone)
+   * or from {@link swapBufferedReflectionToActive} (as part of a compound
+   * swap). Must not acquire the write lock itself; the caller owns it.
+   */
+  async #insertReflectionGeneration(
+    tx: Transaction,
+    input: CreateReflectionGenerationInput,
+  ): Promise<ObservationalMemoryRecord> {
+    const id = crypto.randomUUID();
+    const now = new Date();
+    const lookupKey = this.getOMKey(input.currentRecord.threadId, input.currentRecord.resourceId);
+
+    const record: ObservationalMemoryRecord = {
+      id,
+      scope: input.currentRecord.scope,
+      threadId: input.currentRecord.threadId,
+      resourceId: input.currentRecord.resourceId,
+      createdAt: now,
+      updatedAt: now,
+      lastObservedAt: input.currentRecord.lastObservedAt,
+      originType: 'reflection',
+      generationCount: input.currentRecord.generationCount + 1,
+      activeObservations: input.reflection,
+      totalTokensObserved: input.currentRecord.totalTokensObserved,
+      observationTokenCount: input.tokenCount,
+      pendingMessageTokens: 0,
+      isReflecting: false,
+      isObserving: false,
+      isBufferingObservation: false,
+      isBufferingReflection: false,
+      lastBufferedAtTokens: 0,
+      lastBufferedAtTime: null,
+      config: input.currentRecord.config,
+      metadata: input.currentRecord.metadata,
+      observedTimezone: input.currentRecord.observedTimezone,
+    };
+
+    await tx.execute({
+      sql: `INSERT INTO "${OM_TABLE}" (
+        id, "lookupKey", scope, "resourceId", "threadId",
+        "activeObservations", "activeObservationsPendingUpdate",
+        "originType", config, "generationCount", "lastObservedAt", "lastReflectionAt",
+        "pendingMessageTokens", "totalTokensObserved", "observationTokenCount",
+        "isObserving", "isReflecting", "isBufferingObservation", "isBufferingReflection", "lastBufferedAtTokens", "lastBufferedAtTime",
+        "observedTimezone", metadata, "createdAt", "updatedAt"
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        id,
+        lookupKey,
+        record.scope,
+        record.resourceId,
+        record.threadId || null,
+        input.reflection,
+        null,
+        'reflection',
+        JSON.stringify(record.config),
+        input.currentRecord.generationCount + 1,
+        record.lastObservedAt?.toISOString() || null,
+        now.toISOString(),
+        record.pendingMessageTokens,
+        record.totalTokensObserved,
+        record.observationTokenCount,
+        false, // isObserving
+        false, // isReflecting
+        false, // isBufferingObservation
+        false, // isBufferingReflection
+        0, // lastBufferedAtTokens
+        null, // lastBufferedAtTime
+        record.observedTimezone || null,
+        record.metadata ? JSON.stringify(record.metadata) : null,
+        now.toISOString(),
+        now.toISOString(),
+      ],
+    });
+
+    return record;
+  }
+
   async setReflectingFlag(id: string, isReflecting: boolean): Promise<void> {
     try {
-      const result = await this.#client.execute({
-        sql: `UPDATE "${OM_TABLE}" SET "isReflecting" = ?, "updatedAt" = ? WHERE id = ?`,
-        args: [isReflecting, new Date().toISOString(), id],
-      });
+      const result = await withClientWriteLock(this.#client, () =>
+        this.#client.execute({
+          sql: `UPDATE "${OM_TABLE}" SET "isReflecting" = ?, "updatedAt" = ? WHERE id = ?`,
+          args: [isReflecting, new Date().toISOString(), id],
+        }),
+      );
 
       if (result.rowsAffected === 0) {
         throw new MastraError({
@@ -1945,10 +1980,12 @@ export class MemoryLibSQL extends MemoryStorage {
 
   async setObservingFlag(id: string, isObserving: boolean): Promise<void> {
     try {
-      const result = await this.#client.execute({
-        sql: `UPDATE "${OM_TABLE}" SET "isObserving" = ?, "updatedAt" = ? WHERE id = ?`,
-        args: [isObserving, new Date().toISOString(), id],
-      });
+      const result = await withClientWriteLock(this.#client, () =>
+        this.#client.execute({
+          sql: `UPDATE "${OM_TABLE}" SET "isObserving" = ?, "updatedAt" = ? WHERE id = ?`,
+          args: [isObserving, new Date().toISOString(), id],
+        }),
+      );
 
       if (result.rowsAffected === 0) {
         throw new MastraError({
@@ -1990,7 +2027,7 @@ export class MemoryLibSQL extends MemoryStorage {
         args = [isBuffering, nowStr, id];
       }
 
-      const result = await this.#client.execute({ sql, args });
+      const result = await withClientWriteLock(this.#client, () => this.#client.execute({ sql, args }));
 
       if (result.rowsAffected === 0) {
         throw new MastraError({
@@ -2019,10 +2056,12 @@ export class MemoryLibSQL extends MemoryStorage {
 
   async setBufferingReflectionFlag(id: string, isBuffering: boolean): Promise<void> {
     try {
-      const result = await this.#client.execute({
-        sql: `UPDATE "${OM_TABLE}" SET "isBufferingReflection" = ?, "updatedAt" = ? WHERE id = ?`,
-        args: [isBuffering, new Date().toISOString(), id],
-      });
+      const result = await withClientWriteLock(this.#client, () =>
+        this.#client.execute({
+          sql: `UPDATE "${OM_TABLE}" SET "isBufferingReflection" = ?, "updatedAt" = ? WHERE id = ?`,
+          args: [isBuffering, new Date().toISOString(), id],
+        }),
+      );
 
       if (result.rowsAffected === 0) {
         throw new MastraError({
@@ -2052,10 +2091,12 @@ export class MemoryLibSQL extends MemoryStorage {
   async clearObservationalMemory(threadId: string | null, resourceId: string): Promise<void> {
     try {
       const lookupKey = this.getOMKey(threadId, resourceId);
-      await this.#client.execute({
-        sql: `DELETE FROM "${OM_TABLE}" WHERE "lookupKey" = ?`,
-        args: [lookupKey],
-      });
+      await withClientWriteLock(this.#client, () =>
+        this.#client.execute({
+          sql: `DELETE FROM "${OM_TABLE}" WHERE "lookupKey" = ?`,
+          args: [lookupKey],
+        }),
+      );
     } catch (error) {
       throw new MastraError(
         {
@@ -2071,13 +2112,15 @@ export class MemoryLibSQL extends MemoryStorage {
 
   async setPendingMessageTokens(id: string, tokenCount: number): Promise<void> {
     try {
-      const result = await this.#client.execute({
-        sql: `UPDATE "${OM_TABLE}" SET 
-          "pendingMessageTokens" = ?, 
-          "updatedAt" = ? 
-        WHERE id = ?`,
-        args: [tokenCount, new Date().toISOString(), id],
-      });
+      const result = await withClientWriteLock(this.#client, () =>
+        this.#client.execute({
+          sql: `UPDATE "${OM_TABLE}" SET 
+            "pendingMessageTokens" = ?, 
+            "updatedAt" = ? 
+          WHERE id = ?`,
+          args: [tokenCount, new Date().toISOString(), id],
+        }),
+      );
 
       if (result.rowsAffected === 0) {
         throw new MastraError({
@@ -2106,29 +2149,39 @@ export class MemoryLibSQL extends MemoryStorage {
 
   async updateObservationalMemoryConfig(input: UpdateObservationalMemoryConfigInput): Promise<void> {
     try {
-      // Read current config
-      const selectResult = await this.#client.execute({
-        sql: `SELECT config FROM "${OM_TABLE}" WHERE id = ?`,
-        args: [input.id],
-      });
+      await withClientWriteLock(this.#client, async () => {
+        const tx = await this.#client.transaction('write');
+        try {
+          // Read current config
+          const selectResult = await tx.execute({
+            sql: `SELECT config FROM "${OM_TABLE}" WHERE id = ?`,
+            args: [input.id],
+          });
 
-      if (selectResult.rows.length === 0) {
-        throw new MastraError({
-          id: createStorageErrorId('LIBSQL', 'UPDATE_OM_CONFIG', 'NOT_FOUND'),
-          text: `Observational memory record not found: ${input.id}`,
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { id: input.id },
-        });
-      }
+          if (selectResult.rows.length === 0) {
+            throw new MastraError({
+              id: createStorageErrorId('LIBSQL', 'UPDATE_OM_CONFIG', 'NOT_FOUND'),
+              text: `Observational memory record not found: ${input.id}`,
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.THIRD_PARTY,
+              details: { id: input.id },
+            });
+          }
 
-      const row = selectResult.rows[0] as any;
-      const existing: Record<string, unknown> = row.config ? JSON.parse(row.config) : {};
-      const merged = this.deepMergeConfig(existing, input.config);
+          const row = selectResult.rows[0] as any;
+          const existing: Record<string, unknown> = row.config ? JSON.parse(row.config) : {};
+          const merged = this.deepMergeConfig(existing, input.config);
 
-      await this.#client.execute({
-        sql: `UPDATE "${OM_TABLE}" SET config = ?, "updatedAt" = ? WHERE id = ?`,
-        args: [JSON.stringify(merged), new Date().toISOString(), input.id],
+          await tx.execute({
+            sql: `UPDATE "${OM_TABLE}" SET config = ?, "updatedAt" = ? WHERE id = ?`,
+            args: [JSON.stringify(merged), new Date().toISOString(), input.id],
+          });
+
+          await tx.commit();
+        } catch (error) {
+          if (!tx.closed) await tx.rollback();
+          throw error;
+        }
       });
     } catch (error) {
       if (error instanceof MastraError) {
@@ -2154,74 +2207,84 @@ export class MemoryLibSQL extends MemoryStorage {
     try {
       const nowStr = new Date().toISOString();
 
-      // First get current record to get existing chunks
-      const current = await this.#client.execute({
-        sql: `SELECT "bufferedObservationChunks" FROM "${OM_TABLE}" WHERE id = ?`,
-        args: [input.id],
-      });
-
-      if (!current.rows || current.rows.length === 0) {
-        throw new MastraError({
-          id: createStorageErrorId('LIBSQL', 'UPDATE_BUFFERED_OBSERVATIONS', 'NOT_FOUND'),
-          text: `Observational memory record not found: ${input.id}`,
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { id: input.id },
-        });
-      }
-
-      const row = current.rows[0]!;
-      let existingChunks: BufferedObservationChunk[] = [];
-      if (row.bufferedObservationChunks) {
+      await withClientWriteLock(this.#client, async () => {
+        const tx = await this.#client.transaction('write');
         try {
-          const parsed =
-            typeof row.bufferedObservationChunks === 'string'
-              ? JSON.parse(row.bufferedObservationChunks)
-              : row.bufferedObservationChunks;
-          existingChunks = Array.isArray(parsed) ? parsed : [];
-        } catch {
-          existingChunks = [];
+          // First get current record to get existing chunks
+          const current = await tx.execute({
+            sql: `SELECT "bufferedObservationChunks" FROM "${OM_TABLE}" WHERE id = ?`,
+            args: [input.id],
+          });
+
+          if (!current.rows || current.rows.length === 0) {
+            throw new MastraError({
+              id: createStorageErrorId('LIBSQL', 'UPDATE_BUFFERED_OBSERVATIONS', 'NOT_FOUND'),
+              text: `Observational memory record not found: ${input.id}`,
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.THIRD_PARTY,
+              details: { id: input.id },
+            });
+          }
+
+          const row = current.rows[0]!;
+          let existingChunks: BufferedObservationChunk[] = [];
+          if (row.bufferedObservationChunks) {
+            try {
+              const parsed =
+                typeof row.bufferedObservationChunks === 'string'
+                  ? JSON.parse(row.bufferedObservationChunks)
+                  : row.bufferedObservationChunks;
+              existingChunks = Array.isArray(parsed) ? parsed : [];
+            } catch {
+              existingChunks = [];
+            }
+          }
+
+          // Create new chunk with ID and timestamp
+          const newChunk: BufferedObservationChunk = {
+            id: `ombuf-${randomUUID()}`,
+            cycleId: input.chunk.cycleId,
+            observations: input.chunk.observations,
+            tokenCount: input.chunk.tokenCount,
+            messageIds: input.chunk.messageIds,
+            messageTokens: input.chunk.messageTokens,
+            lastObservedAt: input.chunk.lastObservedAt,
+            createdAt: new Date(),
+            suggestedContinuation: input.chunk.suggestedContinuation,
+            currentTask: input.chunk.currentTask,
+            threadTitle: input.chunk.threadTitle,
+            extractedValues: input.chunk.extractedValues,
+            extractionFailures: input.chunk.extractionFailures,
+          };
+
+          const newChunks = [...existingChunks, newChunk];
+
+          const lastBufferedAtTime = input.lastBufferedAtTime ? input.lastBufferedAtTime.toISOString() : null;
+          const result = await tx.execute({
+            sql: `UPDATE "${OM_TABLE}" SET
+              "bufferedObservationChunks" = ?,
+              "lastBufferedAtTime" = COALESCE(?, "lastBufferedAtTime"),
+              "updatedAt" = ?
+            WHERE id = ?`,
+            args: [JSON.stringify(newChunks), lastBufferedAtTime, nowStr, input.id],
+          });
+
+          if (result.rowsAffected === 0) {
+            throw new MastraError({
+              id: createStorageErrorId('LIBSQL', 'UPDATE_BUFFERED_OBSERVATIONS', 'NOT_FOUND'),
+              text: `Observational memory record not found: ${input.id}`,
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.THIRD_PARTY,
+              details: { id: input.id },
+            });
+          }
+
+          await tx.commit();
+        } catch (error) {
+          if (!tx.closed) await tx.rollback();
+          throw error;
         }
-      }
-
-      // Create new chunk with ID and timestamp
-      const newChunk: BufferedObservationChunk = {
-        id: `ombuf-${randomUUID()}`,
-        cycleId: input.chunk.cycleId,
-        observations: input.chunk.observations,
-        tokenCount: input.chunk.tokenCount,
-        messageIds: input.chunk.messageIds,
-        messageTokens: input.chunk.messageTokens,
-        lastObservedAt: input.chunk.lastObservedAt,
-        createdAt: new Date(),
-        suggestedContinuation: input.chunk.suggestedContinuation,
-        currentTask: input.chunk.currentTask,
-        threadTitle: input.chunk.threadTitle,
-        extractedValues: input.chunk.extractedValues,
-        extractionFailures: input.chunk.extractionFailures,
-      };
-
-      const newChunks = [...existingChunks, newChunk];
-
-      const lastBufferedAtTime = input.lastBufferedAtTime ? input.lastBufferedAtTime.toISOString() : null;
-      const result = await this.#client.execute({
-        sql: `UPDATE "${OM_TABLE}" SET
-          "bufferedObservationChunks" = ?,
-          "lastBufferedAtTime" = COALESCE(?, "lastBufferedAtTime"),
-          "updatedAt" = ?
-        WHERE id = ?`,
-        args: [JSON.stringify(newChunks), lastBufferedAtTime, nowStr, input.id],
       });
-
-      if (result.rowsAffected === 0) {
-        throw new MastraError({
-          id: createStorageErrorId('LIBSQL', 'UPDATE_BUFFERED_OBSERVATIONS', 'NOT_FOUND'),
-          text: `Observational memory record not found: ${input.id}`,
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { id: input.id },
-        });
-      }
     } catch (error) {
       if (error instanceof MastraError) {
         throw error;
@@ -2242,202 +2305,213 @@ export class MemoryLibSQL extends MemoryStorage {
     try {
       const nowStr = new Date().toISOString();
 
-      // Get current record
-      const current = await this.#client.execute({
-        sql: `SELECT * FROM "${OM_TABLE}" WHERE id = ?`,
-        args: [input.id],
-      });
-
-      if (!current.rows || current.rows.length === 0) {
-        throw new MastraError({
-          id: createStorageErrorId('LIBSQL', 'SWAP_BUFFERED_TO_ACTIVE', 'NOT_FOUND'),
-          text: `Observational memory record not found: ${input.id}`,
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { id: input.id },
-        });
-      }
-
-      const row = current.rows[0]!;
-
-      // Parse buffered chunks
-      let chunks: BufferedObservationChunk[] = [];
-      if (row.bufferedObservationChunks) {
+      return await withClientWriteLock(this.#client, async () => {
+        const tx = await this.#client.transaction('write');
         try {
-          const parsed =
-            typeof row.bufferedObservationChunks === 'string'
-              ? JSON.parse(row.bufferedObservationChunks)
-              : row.bufferedObservationChunks;
-          chunks = Array.isArray(parsed) ? parsed : [];
-        } catch {
-          chunks = [];
-        }
-      }
+          // Get current record
+          const current = await tx.execute({
+            sql: `SELECT * FROM "${OM_TABLE}" WHERE id = ?`,
+            args: [input.id],
+          });
 
-      if (chunks.length === 0) {
-        return {
-          chunksActivated: 0,
-          messageTokensActivated: 0,
-          observationTokensActivated: 0,
-          messagesActivated: 0,
-          activatedCycleIds: [],
-          activatedMessageIds: [],
-        };
-      }
-
-      // Calculate target message tokens to activate based on new formula:
-      // retentionFloor = threshold * (1 - ratio) represents tokens to keep as raw messages
-      // targetMessageTokens = max(0, currentPending - retentionFloor) represents tokens to activate
-      const retentionFloor = input.messageTokensThreshold * (1 - input.activationRatio);
-      const targetMessageTokens = Math.max(0, input.currentPendingTokens - retentionFloor);
-
-      // Find the closest chunk boundary to the target, biased over (prefer removing
-      // slightly more than the target so remaining context lands at or below retentionFloor).
-      // Track both best-over and best-under boundaries so we can fall back to under
-      // if the over boundary would overshoot by too much.
-      let cumulativeMessageTokens = 0;
-      let bestOverBoundary = 0;
-      let bestOverTokens = 0;
-      let bestUnderBoundary = 0;
-      let bestUnderTokens = 0;
-
-      for (let i = 0; i < chunks.length; i++) {
-        cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
-        const boundary = i + 1;
-
-        if (cumulativeMessageTokens >= targetMessageTokens) {
-          // Over or equal — track the closest (lowest) over boundary
-          if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
-            bestOverBoundary = boundary;
-            bestOverTokens = cumulativeMessageTokens;
+          if (!current.rows || current.rows.length === 0) {
+            throw new MastraError({
+              id: createStorageErrorId('LIBSQL', 'SWAP_BUFFERED_TO_ACTIVE', 'NOT_FOUND'),
+              text: `Observational memory record not found: ${input.id}`,
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.THIRD_PARTY,
+              details: { id: input.id },
+            });
           }
-        } else {
-          // Under — track the closest (highest) under boundary
-          if (cumulativeMessageTokens > bestUnderTokens) {
-            bestUnderBoundary = boundary;
-            bestUnderTokens = cumulativeMessageTokens;
+
+          const row = current.rows[0]!;
+
+          // Parse buffered chunks
+          let chunks: BufferedObservationChunk[] = [];
+          if (row.bufferedObservationChunks) {
+            try {
+              const parsed =
+                typeof row.bufferedObservationChunks === 'string'
+                  ? JSON.parse(row.bufferedObservationChunks)
+                  : row.bufferedObservationChunks;
+              chunks = Array.isArray(parsed) ? parsed : [];
+            } catch {
+              chunks = [];
+            }
           }
+
+          if (chunks.length === 0) {
+            await tx.commit();
+            return {
+              chunksActivated: 0,
+              messageTokensActivated: 0,
+              observationTokensActivated: 0,
+              messagesActivated: 0,
+              activatedCycleIds: [],
+              activatedMessageIds: [],
+            };
+          }
+
+          // Calculate target message tokens to activate based on new formula:
+          // retentionFloor = threshold * (1 - ratio) represents tokens to keep as raw messages
+          // targetMessageTokens = max(0, currentPending - retentionFloor) represents tokens to activate
+          const retentionFloor = input.messageTokensThreshold * (1 - input.activationRatio);
+          const targetMessageTokens = Math.max(0, input.currentPendingTokens - retentionFloor);
+
+          // Find the closest chunk boundary to the target, biased over (prefer removing
+          // slightly more than the target so remaining context lands at or below retentionFloor).
+          // Track both best-over and best-under boundaries so we can fall back to under
+          // if the over boundary would overshoot by too much.
+          let cumulativeMessageTokens = 0;
+          let bestOverBoundary = 0;
+          let bestOverTokens = 0;
+          let bestUnderBoundary = 0;
+          let bestUnderTokens = 0;
+
+          for (let i = 0; i < chunks.length; i++) {
+            cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
+            const boundary = i + 1;
+
+            if (cumulativeMessageTokens >= targetMessageTokens) {
+              // Over or equal — track the closest (lowest) over boundary
+              if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
+                bestOverBoundary = boundary;
+                bestOverTokens = cumulativeMessageTokens;
+              }
+            } else {
+              // Under — track the closest (highest) under boundary
+              if (cumulativeMessageTokens > bestUnderTokens) {
+                bestUnderBoundary = boundary;
+                bestUnderTokens = cumulativeMessageTokens;
+              }
+            }
+          }
+
+          // Safeguard: if the over boundary would eat into more than 95% of the
+          // retention floor, fall back to the best under boundary instead.
+          // This prevents edge cases where a large chunk overshoots dramatically.
+          // When forceMaxActivation is set (above blockAfter), still prefer the over
+          // boundary, but never if it would leave fewer than the smaller of 1000
+          // tokens or the retention floor remaining.
+          const maxOvershoot = retentionFloor * 0.95;
+          const overshoot = bestOverTokens - targetMessageTokens;
+          const remainingAfterOver = input.currentPendingTokens - bestOverTokens;
+          const remainingAfterUnder = input.currentPendingTokens - bestUnderTokens;
+          // When activationRatio ≈ 1.0, retentionFloor is 0 and minRemaining becomes 0 — intentional for "activate everything" configs.
+          const minRemaining = Math.min(1000, retentionFloor);
+
+          let chunksToActivate: number;
+          if (input.forceMaxActivation && bestOverBoundary > 0 && remainingAfterOver >= minRemaining) {
+            chunksToActivate = bestOverBoundary;
+          } else if (bestOverBoundary > 0 && overshoot <= maxOvershoot && remainingAfterOver >= minRemaining) {
+            chunksToActivate = bestOverBoundary;
+          } else if (bestUnderBoundary > 0 && remainingAfterUnder >= minRemaining) {
+            chunksToActivate = bestUnderBoundary;
+          } else if (bestOverBoundary > 0) {
+            // All boundaries are over and exceed the safeguard — still activate
+            // the closest over boundary (better than nothing)
+            chunksToActivate = bestOverBoundary;
+          } else {
+            chunksToActivate = 1;
+          }
+
+          // Split chunks
+          const activatedChunks = chunks.slice(0, chunksToActivate);
+          const remainingChunks = chunks.slice(chunksToActivate);
+
+          // Combine activated observations
+          const activatedContent = activatedChunks.map(c => c.observations).join('\n\n');
+          const activatedTokens = activatedChunks.reduce((sum, c) => sum + c.tokenCount, 0);
+          const activatedMessageTokens = activatedChunks.reduce((sum, c) => sum + (c.messageTokens ?? 0), 0);
+          const activatedMessageCount = activatedChunks.reduce((sum, c) => sum + c.messageIds.length, 0);
+          const activatedCycleIds = activatedChunks.map(c => c.cycleId).filter((id): id is string => !!id);
+          const activatedMessageIds = activatedChunks.flatMap(c => c.messageIds ?? []);
+
+          // Derive lastObservedAt from the latest activated chunk, or use provided value
+          const latestChunk = activatedChunks[activatedChunks.length - 1];
+          const lastObservedAt =
+            input.lastObservedAt ?? (latestChunk?.lastObservedAt ? new Date(latestChunk.lastObservedAt) : new Date());
+          const lastObservedAtStr = lastObservedAt.toISOString();
+
+          // Get existing values
+          const existingActive = (row.activeObservations as string) || '';
+          const existingTokenCount = Number(row.observationTokenCount || 0);
+
+          // Calculate new values
+          const boundary = `\n\n--- message boundary (${lastObservedAt.toISOString()}) ---\n\n`;
+          const newActive = existingActive ? `${existingActive}${boundary}${activatedContent}` : activatedContent;
+          const newTokenCount = existingTokenCount + activatedTokens;
+          // NOTE: We intentionally do NOT add message IDs to observedMessageIds during buffered activation.
+          // Buffered chunks represent observations of messages as they were at buffering time.
+          // With streaming, messages grow after buffering, so we rely on lastObservedAt for filtering.
+          // New content after lastObservedAt will be picked up in subsequent observations.
+
+          // Decrement pending message tokens (clamped to zero)
+          const existingPending = Number(row.pendingMessageTokens || 0);
+          const newPending = Math.max(0, existingPending - activatedMessageTokens);
+
+          // Conditional update — only proceed if chunks haven't been swapped by a concurrent run
+          const updateResult = await tx.execute({
+            sql: `UPDATE "${OM_TABLE}" SET
+              "activeObservations" = ?,
+              "observationTokenCount" = ?,
+              "pendingMessageTokens" = ?,
+              "bufferedObservationChunks" = ?,
+              "lastObservedAt" = ?,
+              "updatedAt" = ?
+            WHERE id = ?
+              AND "bufferedObservationChunks" IS NOT NULL
+              AND "bufferedObservationChunks" != '[]'`,
+            args: [
+              newActive,
+              newTokenCount,
+              newPending,
+              remainingChunks.length > 0 ? JSON.stringify(remainingChunks) : null,
+              lastObservedAtStr,
+              nowStr,
+              input.id,
+            ],
+          });
+
+          await tx.commit();
+
+          if (updateResult.rowsAffected === 0) {
+            return {
+              chunksActivated: 0,
+              messageTokensActivated: 0,
+              observationTokensActivated: 0,
+              messagesActivated: 0,
+              activatedCycleIds: [],
+              activatedMessageIds: [],
+            };
+          }
+
+          // Use hints from the most recent activated chunk only — stale hints from older chunks are discarded
+          const latestChunkHints = activatedChunks[activatedChunks.length - 1];
+
+          return {
+            chunksActivated: activatedChunks.length,
+            messageTokensActivated: activatedMessageTokens,
+            observationTokensActivated: activatedTokens,
+            messagesActivated: activatedMessageCount,
+            activatedCycleIds,
+            activatedMessageIds,
+            observations: activatedContent,
+            perChunk: activatedChunks.map(c => ({
+              cycleId: c.cycleId ?? '',
+              messageTokens: c.messageTokens ?? 0,
+              observationTokens: c.tokenCount,
+              messageCount: c.messageIds.length,
+              observations: c.observations,
+            })),
+            suggestedContinuation: latestChunkHints?.suggestedContinuation ?? undefined,
+            currentTask: latestChunkHints?.currentTask ?? undefined,
+          };
+        } catch (error) {
+          if (!tx.closed) await tx.rollback();
+          throw error;
         }
-      }
-
-      // Safeguard: if the over boundary would eat into more than 95% of the
-      // retention floor, fall back to the best under boundary instead.
-      // This prevents edge cases where a large chunk overshoots dramatically.
-      // When forceMaxActivation is set (above blockAfter), still prefer the over
-      // boundary, but never if it would leave fewer than the smaller of 1000
-      // tokens or the retention floor remaining.
-      const maxOvershoot = retentionFloor * 0.95;
-      const overshoot = bestOverTokens - targetMessageTokens;
-      const remainingAfterOver = input.currentPendingTokens - bestOverTokens;
-      const remainingAfterUnder = input.currentPendingTokens - bestUnderTokens;
-      // When activationRatio ≈ 1.0, retentionFloor is 0 and minRemaining becomes 0 — intentional for "activate everything" configs.
-      const minRemaining = Math.min(1000, retentionFloor);
-
-      let chunksToActivate: number;
-      if (input.forceMaxActivation && bestOverBoundary > 0 && remainingAfterOver >= minRemaining) {
-        chunksToActivate = bestOverBoundary;
-      } else if (bestOverBoundary > 0 && overshoot <= maxOvershoot && remainingAfterOver >= minRemaining) {
-        chunksToActivate = bestOverBoundary;
-      } else if (bestUnderBoundary > 0 && remainingAfterUnder >= minRemaining) {
-        chunksToActivate = bestUnderBoundary;
-      } else if (bestOverBoundary > 0) {
-        // All boundaries are over and exceed the safeguard — still activate
-        // the closest over boundary (better than nothing)
-        chunksToActivate = bestOverBoundary;
-      } else {
-        chunksToActivate = 1;
-      }
-
-      // Split chunks
-      const activatedChunks = chunks.slice(0, chunksToActivate);
-      const remainingChunks = chunks.slice(chunksToActivate);
-
-      // Combine activated observations
-      const activatedContent = activatedChunks.map(c => c.observations).join('\n\n');
-      const activatedTokens = activatedChunks.reduce((sum, c) => sum + c.tokenCount, 0);
-      const activatedMessageTokens = activatedChunks.reduce((sum, c) => sum + (c.messageTokens ?? 0), 0);
-      const activatedMessageCount = activatedChunks.reduce((sum, c) => sum + c.messageIds.length, 0);
-      const activatedCycleIds = activatedChunks.map(c => c.cycleId).filter((id): id is string => !!id);
-      const activatedMessageIds = activatedChunks.flatMap(c => c.messageIds ?? []);
-
-      // Derive lastObservedAt from the latest activated chunk, or use provided value
-      const latestChunk = activatedChunks[activatedChunks.length - 1];
-      const lastObservedAt =
-        input.lastObservedAt ?? (latestChunk?.lastObservedAt ? new Date(latestChunk.lastObservedAt) : new Date());
-      const lastObservedAtStr = lastObservedAt.toISOString();
-
-      // Get existing values
-      const existingActive = (row.activeObservations as string) || '';
-      const existingTokenCount = Number(row.observationTokenCount || 0);
-
-      // Calculate new values
-      const boundary = `\n\n--- message boundary (${lastObservedAt.toISOString()}) ---\n\n`;
-      const newActive = existingActive ? `${existingActive}${boundary}${activatedContent}` : activatedContent;
-      const newTokenCount = existingTokenCount + activatedTokens;
-      // NOTE: We intentionally do NOT add message IDs to observedMessageIds during buffered activation.
-      // Buffered chunks represent observations of messages as they were at buffering time.
-      // With streaming, messages grow after buffering, so we rely on lastObservedAt for filtering.
-      // New content after lastObservedAt will be picked up in subsequent observations.
-
-      // Decrement pending message tokens (clamped to zero)
-      const existingPending = Number(row.pendingMessageTokens || 0);
-      const newPending = Math.max(0, existingPending - activatedMessageTokens);
-
-      // Conditional update — only proceed if chunks haven't been swapped by a concurrent run
-      const updateResult = await this.#client.execute({
-        sql: `UPDATE "${OM_TABLE}" SET
-          "activeObservations" = ?,
-          "observationTokenCount" = ?,
-          "pendingMessageTokens" = ?,
-          "bufferedObservationChunks" = ?,
-          "lastObservedAt" = ?,
-          "updatedAt" = ?
-        WHERE id = ?
-          AND "bufferedObservationChunks" IS NOT NULL
-          AND "bufferedObservationChunks" != '[]'`,
-        args: [
-          newActive,
-          newTokenCount,
-          newPending,
-          remainingChunks.length > 0 ? JSON.stringify(remainingChunks) : null,
-          lastObservedAtStr,
-          nowStr,
-          input.id,
-        ],
       });
-
-      if (updateResult.rowsAffected === 0) {
-        return {
-          chunksActivated: 0,
-          messageTokensActivated: 0,
-          observationTokensActivated: 0,
-          messagesActivated: 0,
-          activatedCycleIds: [],
-          activatedMessageIds: [],
-        };
-      }
-
-      // Use hints from the most recent activated chunk only — stale hints from older chunks are discarded
-      const latestChunkHints = activatedChunks[activatedChunks.length - 1];
-
-      return {
-        chunksActivated: activatedChunks.length,
-        messageTokensActivated: activatedMessageTokens,
-        observationTokensActivated: activatedTokens,
-        messagesActivated: activatedMessageCount,
-        activatedCycleIds,
-        activatedMessageIds,
-        observations: activatedContent,
-        perChunk: activatedChunks.map(c => ({
-          cycleId: c.cycleId ?? '',
-          messageTokens: c.messageTokens ?? 0,
-          observationTokens: c.tokenCount,
-          messageCount: c.messageIds.length,
-          observations: c.observations,
-        })),
-        suggestedContinuation: latestChunkHints?.suggestedContinuation ?? undefined,
-        currentTask: latestChunkHints?.currentTask ?? undefined,
-      };
     } catch (error) {
       if (error instanceof MastraError) {
         throw error;
@@ -2458,28 +2532,30 @@ export class MemoryLibSQL extends MemoryStorage {
     try {
       const nowStr = new Date().toISOString();
 
-      const result = await this.#client.execute({
-        sql: `UPDATE "${OM_TABLE}" SET
-          "bufferedReflection" = CASE
-            WHEN "bufferedReflection" IS NOT NULL AND "bufferedReflection" != ''
-            THEN "bufferedReflection" || char(10) || char(10) || ?
-            ELSE ?
-          END,
-          "bufferedReflectionTokens" = COALESCE("bufferedReflectionTokens", 0) + ?,
-          "bufferedReflectionInputTokens" = COALESCE("bufferedReflectionInputTokens", 0) + ?,
-          "reflectedObservationLineCount" = ?,
-          "updatedAt" = ?
-        WHERE id = ?`,
-        args: [
-          input.reflection,
-          input.reflection,
-          input.tokenCount,
-          input.inputTokenCount,
-          input.reflectedObservationLineCount,
-          nowStr,
-          input.id,
-        ],
-      });
+      const result = await withClientWriteLock(this.#client, () =>
+        this.#client.execute({
+          sql: `UPDATE "${OM_TABLE}" SET
+            "bufferedReflection" = CASE
+              WHEN "bufferedReflection" IS NOT NULL AND "bufferedReflection" != ''
+              THEN "bufferedReflection" || char(10) || char(10) || ?
+              ELSE ?
+            END,
+            "bufferedReflectionTokens" = COALESCE("bufferedReflectionTokens", 0) + ?,
+            "bufferedReflectionInputTokens" = COALESCE("bufferedReflectionInputTokens", 0) + ?,
+            "reflectedObservationLineCount" = ?,
+            "updatedAt" = ?
+          WHERE id = ?`,
+          args: [
+            input.reflection,
+            input.reflection,
+            input.tokenCount,
+            input.inputTokenCount,
+            input.reflectedObservationLineCount,
+            nowStr,
+            input.id,
+          ],
+        }),
+      );
 
       if (result.rowsAffected === 0) {
         throw new MastraError({
@@ -2508,71 +2584,81 @@ export class MemoryLibSQL extends MemoryStorage {
 
   async swapBufferedReflectionToActive(input: SwapBufferedReflectionToActiveInput): Promise<ObservationalMemoryRecord> {
     try {
-      // Get current record
-      const current = await this.#client.execute({
-        sql: `SELECT * FROM "${OM_TABLE}" WHERE id = ?`,
-        args: [input.currentRecord.id],
+      return await withClientWriteLock(this.#client, async () => {
+        const tx = await this.#client.transaction('write');
+        try {
+          // Get current record
+          const current = await tx.execute({
+            sql: `SELECT * FROM "${OM_TABLE}" WHERE id = ?`,
+            args: [input.currentRecord.id],
+          });
+
+          if (!current.rows || current.rows.length === 0) {
+            throw new MastraError({
+              id: createStorageErrorId('LIBSQL', 'SWAP_BUFFERED_REFLECTION_TO_ACTIVE', 'NOT_FOUND'),
+              text: `Observational memory record not found: ${input.currentRecord.id}`,
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.THIRD_PARTY,
+              details: { id: input.currentRecord.id },
+            });
+          }
+
+          const row = current.rows[0]!;
+          const bufferedReflection = (row.bufferedReflection as string) || '';
+          const reflectedLineCount = Number(row.reflectedObservationLineCount || 0);
+
+          if (!bufferedReflection) {
+            throw new MastraError({
+              id: createStorageErrorId('LIBSQL', 'SWAP_BUFFERED_REFLECTION_TO_ACTIVE', 'NO_CONTENT'),
+              text: 'No buffered reflection to swap',
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.USER,
+              details: { id: input.currentRecord.id },
+            });
+          }
+
+          // Split current activeObservations by the recorded boundary.
+          // Lines 0..reflectedLineCount were reflected on → replaced by bufferedReflection.
+          // Lines after reflectedLineCount were added after reflection started → kept as-is.
+          const currentObservations = (row.activeObservations as string) || '';
+          const allLines = currentObservations.split('\n');
+          const unreflectedLines = allLines.slice(reflectedLineCount);
+          const unreflectedContent = unreflectedLines.join('\n').trim();
+
+          // New activeObservations = bufferedReflection + unreflected observations
+          const newObservations = unreflectedContent
+            ? `${bufferedReflection}\n\n${unreflectedContent}`
+            : bufferedReflection;
+
+          // Create new generation with the merged content (uses the private
+          // transaction-aware helper so the lock is not re-acquired).
+          // tokenCount is computed by the processor using its token counter on the combined content.
+          const newRecord = await this.#insertReflectionGeneration(tx, {
+            currentRecord: input.currentRecord,
+            reflection: newObservations,
+            tokenCount: input.tokenCount,
+          });
+
+          // Clear buffered state on old record
+          const nowStr = new Date().toISOString();
+          await tx.execute({
+            sql: `UPDATE "${OM_TABLE}" SET
+              "bufferedReflection" = NULL,
+              "bufferedReflectionTokens" = NULL,
+              "bufferedReflectionInputTokens" = NULL,
+              "reflectedObservationLineCount" = NULL,
+              "updatedAt" = ?
+            WHERE id = ?`,
+            args: [nowStr, input.currentRecord.id],
+          });
+
+          await tx.commit();
+          return newRecord;
+        } catch (error) {
+          if (!tx.closed) await tx.rollback();
+          throw error;
+        }
       });
-
-      if (!current.rows || current.rows.length === 0) {
-        throw new MastraError({
-          id: createStorageErrorId('LIBSQL', 'SWAP_BUFFERED_REFLECTION_TO_ACTIVE', 'NOT_FOUND'),
-          text: `Observational memory record not found: ${input.currentRecord.id}`,
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { id: input.currentRecord.id },
-        });
-      }
-
-      const row = current.rows[0]!;
-      const bufferedReflection = (row.bufferedReflection as string) || '';
-      const reflectedLineCount = Number(row.reflectedObservationLineCount || 0);
-
-      if (!bufferedReflection) {
-        throw new MastraError({
-          id: createStorageErrorId('LIBSQL', 'SWAP_BUFFERED_REFLECTION_TO_ACTIVE', 'NO_CONTENT'),
-          text: 'No buffered reflection to swap',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.USER,
-          details: { id: input.currentRecord.id },
-        });
-      }
-
-      // Split current activeObservations by the recorded boundary.
-      // Lines 0..reflectedLineCount were reflected on → replaced by bufferedReflection.
-      // Lines after reflectedLineCount were added after reflection started → kept as-is.
-      const currentObservations = (row.activeObservations as string) || '';
-      const allLines = currentObservations.split('\n');
-      const unreflectedLines = allLines.slice(reflectedLineCount);
-      const unreflectedContent = unreflectedLines.join('\n').trim();
-
-      // New activeObservations = bufferedReflection + unreflected observations
-      const newObservations = unreflectedContent
-        ? `${bufferedReflection}\n\n${unreflectedContent}`
-        : bufferedReflection;
-
-      // Create new generation with the merged content.
-      // tokenCount is computed by the processor using its token counter on the combined content.
-      const newRecord = await this.createReflectionGeneration({
-        currentRecord: input.currentRecord,
-        reflection: newObservations,
-        tokenCount: input.tokenCount,
-      });
-
-      // Clear buffered state on old record
-      const nowStr = new Date().toISOString();
-      await this.#client.execute({
-        sql: `UPDATE "${OM_TABLE}" SET
-          "bufferedReflection" = NULL,
-          "bufferedReflectionTokens" = NULL,
-          "bufferedReflectionInputTokens" = NULL,
-          "reflectedObservationLineCount" = NULL,
-          "updatedAt" = ?
-        WHERE id = ?`,
-        args: [nowStr, input.currentRecord.id],
-      });
-
-      return newRecord;
     } catch (error) {
       if (error instanceof MastraError) {
         throw error;


### PR DESCRIPTION
This fixes two paths that could corrupt the local SQLite database used by Mastra Code's observational memory.

**LibSQL observational-memory write lock**

Observational-memory mutations in the LibSQL storage domain bypassed the per-client write lock that all generic CRUD operations already use. Two concurrent OM operations could read the same buffered array, append independently, and overwrite each other — losing observation chunks. Autocommit statements could also be swept into open interactive transactions, causing unexpected rollback/commit coupling.

All 18 OM methods now route through `withClientWriteLock`. Read-modify-write operations (buffered observation appends, config updates, buffer swaps) run inside locked write transactions. The `swapBufferedReflectionToActive` → `createReflectionGeneration` nested call was refactored into a private transaction-aware helper to avoid deadlock from non-reentrant lock acquisition.

**TUI storage shutdown**

Signal handlers (SIGINT, SIGTERM, SIGHUP) called `asyncCleanup()` which stopped workers and timers but never closed storage connections. `LibSQLStore.close()` and `LibSQLVector.close()` already checkpoint/truncate WAL files and switch to DELETE journal mode — but that path was skipped on signal-induced exits, leaving un-checkpointed WAL sidecars that could corrupt the local database on next open.

`asyncCleanup()` now calls `storageMaintenance.closeStorage()` after workers/timers/signals are quiesced, with an idempotency guard against double-close from repeated signals.

**Tests**

- Strengthened the shared OM concurrency test to launch concurrent buffered-observation appends and assert every uniquely identified chunk persists
- Added a LibSQL write-lock regression test overlapping OM buffering with concurrent workflow transactions
- Extended the process-shortcuts e2e scenario to verify `PRAGMA quick_check=ok` and WAL sidecar removal after shutdown

**Note:** Existing malformed databases still require manual recovery (backup, SQLite recovery, or recreate). This change prevents the identified future corruption paths rather than silently deleting user data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR helps Mastra Code not lose “observations” or leave a local SQLite database in a broken state when things happen at the same time or when the app is shutting down. It makes database writes safer with per-client locking and ensures shutdown properly closes/finishes SQLite WAL work, plus adds tests to prove it.

## What changed

- Routed all LibSQL observational-memory methods through the per-client write lock.
- Used locked transactions for read-modify-write operations (and during reflection generation swaps) to prevent concurrent write corruption and avoid nested lock acquisition.
- Updated the TUI `asyncCleanup()` shutdown flow to close storage after workers/timers/signal handling stop, with an idempotency guard so cleanup runs once—ensuring WAL sidecars are checkpointed and removed.
- Added/expanded tests:
  - Concurrency regression tests for preserved buffered observation chunks (no lost updates) and error isolation after a failing buffered write.
  - Shutdown integrity coverage verifying SQLite health (`PRAGMA quick_check=ok`) and that WAL/SHM sidecar files are removed after stopping the app.
- Added patch Changesets for `@mastra/libsql` and `mastracode` documenting the observational-memory write-lock fix and the shutdown storage-close fix.

Existing malformed databases still require manual recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->