### PR TITLE
feat(factory): dispatch external source decisions

### DIFF
--- a/.changeset/neat-signs-tan.md
+++ b/.changeset/neat-signs-tan.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Added an updateIssue capability to the Intake surface so Factory can change the state of external issues (open/closed on GitHub, workflow state on Linear) as a side effect of stage transitions. Adapters cover the direct GitHub, direct Linear, platform GitHub, and platform Linear integrations. GitHub adapters reject pull-request targets. Linear adapters resolve the target workflow state per team and skip when the issue is already in the desired state. The platform Linear adapter degrades to a no-op (returns null) when the platform workflow-states endpoint is not yet deployed, so this change is safe to ship ahead of the platform companion route. This is a plumbing change: no rule currently emits the new decision, so behavior is unchanged.

--- a/.changeset/shaky-hands-turn.md
+++ b/.changeset/shaky-hands-turn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Added external tracker sync for Factory work item transitions. When a Factory rule emits an updateExternalSource or commentExternalSource decision, the decision dispatcher now updates the linked GitHub or Linear issue state or posts a comment on it, using the integration that owns the work item's external source. Sync failures are retried in the background and never block the internal transition.

--- a/mastracode/factory/src/capabilities/intake.ts
+++ b/mastracode/factory/src/capabilities/intake.ts
@@ -115,8 +115,25 @@ export interface UpdateIntakeIssueInput extends GetIntakeIssueInput {
   actingUserId?: string;
 }
 
+export interface ResolveIntakeDispatchInput {
+  orgId: string;
+  externalSource: { type: string; externalId: string };
+  metadata?: Record<string, unknown>;
+}
+
+export interface ResolvedIntakeDispatch {
+  connection: IntegrationConnection;
+  sourceId?: string;
+  issueId: string;
+}
+
 /** Fixed issue-oriented contract implemented by GitHub, Linear, and future sources. */
 export interface Intake {
+  /**
+   * Resolve the connection and provider-specific identifiers needed to call
+   * this capability from a background dispatch context.
+   */
+  resolveIntakeDispatch?(input: ResolveIntakeDispatchInput): Promise<ResolvedIntakeDispatch | null>;
   listSources(input: ListIntakeSourcesInput): Promise<IntakeSource[]>;
   listItems(input: ListIntakeItemsInput): Promise<IntakeItemPage>;
   listIssues(input: ListIntakeIssuesInput): Promise<IntakeIssuePage>;

--- a/mastracode/factory/src/capabilities/intake.ts
+++ b/mastracode/factory/src/capabilities/intake.ts
@@ -118,7 +118,6 @@ export interface UpdateIntakeIssueInput extends GetIntakeIssueInput {
 export interface ResolveIntakeDispatchInput {
   orgId: string;
   externalSource: { type: string; externalId: string };
-  metadata?: Record<string, unknown>;
 }
 
 export interface ResolvedIntakeDispatch {

--- a/mastracode/factory/src/capabilities/intake.ts
+++ b/mastracode/factory/src/capabilities/intake.ts
@@ -98,6 +98,23 @@ export interface CreatedIntakeComment {
   url: string;
 }
 
+/**
+ * Provider-neutral target state for `Intake.updateIssue`.
+ *
+ * `byType` uses the workflow-state family so callers don't have to know per-team
+ * state names; `byName` is escape hatch for teams that need a specific state.
+ * Adapters that don't support custom states (GitHub) ignore `byName` with a
+ * warn log.
+ */
+export type IntakeIssueTargetState =
+  { kind: 'byType'; stateType: 'unstarted' | 'started' | 'completed' | 'canceled' } | { kind: 'byName'; name: string };
+
+export interface UpdateIntakeIssueInput extends GetIntakeIssueInput {
+  state: IntakeIssueTargetState;
+  /** End user the state change should be attributed to, when the provider supports acting on a user's behalf. */
+  actingUserId?: string;
+}
+
 /** Fixed issue-oriented contract implemented by GitHub, Linear, and future sources. */
 export interface Intake {
   listSources(input: ListIntakeSourcesInput): Promise<IntakeSource[]>;
@@ -105,4 +122,12 @@ export interface Intake {
   listIssues(input: ListIntakeIssuesInput): Promise<IntakeIssuePage>;
   getIssue(input: GetIntakeIssueInput): Promise<IntakeIssueDetail | null>;
   createComment(input: CreateIntakeCommentInput): Promise<CreatedIntakeComment | null>;
+  /**
+   * Move an issue to a target state. Returns the refreshed `IntakeIssue` on
+   * success, or `null` when the target is not applicable (e.g., a GitHub PR,
+   * or no matching workflow state). Adapters MUST NOT throw for policy misses
+   * — only for infrastructure errors (network, auth). This distinction lets
+   * the executor idempotency guard treat `null` as "done, nothing to do".
+   */
+  updateIssue(input: UpdateIntakeIssueInput): Promise<IntakeIssue | null>;
 }

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -679,16 +679,16 @@ export class MastraFactory {
                 const registration = integrationRegistrations.find(
                   candidate => candidate.integration.id === externalSource.integrationId,
                 );
-                const integration = registration?.integration;
-                if (!integration?.intake || !integration.resolveIntakeDispatch) return null;
+                const intake = registration?.integration.intake;
+                if (!intake?.resolveIntakeDispatch) return null;
                 if (registration && !registration.ready) await registration.ensureReady();
-                const resolved = await integration.resolveIntakeDispatch({
+                const resolved = await intake.resolveIntakeDispatch({
                   orgId,
                   externalSource,
                   ...(workItem.metadata ? { metadata: workItem.metadata } : {}),
                 });
                 if (!resolved) return null;
-                return { intake: integration.intake, ...resolved };
+                return { intake, ...resolved };
               },
             });
           },

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -670,6 +670,26 @@ export class MastraFactory {
               reconcileToolResults: () => factoryProcessor?.reconcileAllBoundThreads() ?? Promise.resolve(),
               prepareBinding,
               primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
+              // External-source fan-out (`updateExternalSource` /
+              // `commentExternalSource`): the owning integration derives the
+              // connection + provider target from the item's external source.
+              intake: async ({ orgId, workItem }) => {
+                const externalSource = workItem.externalSource;
+                if (!externalSource) return null;
+                const registration = integrationRegistrations.find(
+                  candidate => candidate.integration.id === externalSource.integrationId,
+                );
+                const integration = registration?.integration;
+                if (!integration?.intake || !integration.resolveIntakeDispatch) return null;
+                if (registration && !registration.ready) await registration.ensureReady();
+                const resolved = await integration.resolveIntakeDispatch({
+                  orgId,
+                  externalSource,
+                  ...(workItem.metadata ? { metadata: workItem.metadata } : {}),
+                });
+                if (!resolved) return null;
+                return { intake: integration.intake, ...resolved };
+              },
             });
           },
         }),

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -682,11 +682,7 @@ export class MastraFactory {
                 const intake = registration?.integration.intake;
                 if (!intake?.resolveIntakeDispatch) return null;
                 if (registration && !registration.ready) await registration.ensureReady();
-                const resolved = await intake.resolveIntakeDispatch({
-                  orgId,
-                  externalSource,
-                  ...(workItem.metadata ? { metadata: workItem.metadata } : {}),
-                });
+                const resolved = await intake.resolveIntakeDispatch({ orgId, externalSource });
                 if (!resolved) return null;
                 return { intake, ...resolved };
               },

--- a/mastracode/factory/src/integrations/base.ts
+++ b/mastracode/factory/src/integrations/base.ts
@@ -23,7 +23,6 @@ import type { ApiRoute } from '@mastra/core/server';
 import type { FactoryStorage } from '@mastra/core/storage';
 import type { MastraWorker } from '@mastra/core/worker';
 
-import type { IntegrationConnection } from '../capabilities/connection.js';
 import type { Intake } from '../capabilities/intake.js';
 import type { VersionControl } from '../capabilities/version-control.js';
 import type { RouteAuth } from '../routes/route.js';
@@ -131,22 +130,6 @@ export interface FactoryIntegration {
   readonly intake?: Intake;
   /** Repository, installation, and pull-request capability. */
   readonly versionControl?: VersionControl;
-  /**
-   * Resolve everything the `intake` capability needs to reach the external
-   * source of a work item from a background context (no HTTP request): the
-   * org-scoped `IntegrationConnection` (OAuth token for Linear, app
-   * installation for GitHub) plus the provider-specific `sourceId`/`issueId`
-   * derived from the work item's `externalSource` and metadata. Returns
-   * `null` when the org has no usable connection or the target can't be
-   * derived — callers treat that as a policy skip, not an error. Optional
-   * capability: integrations without it cannot service background
-   * external-source dispatch (e.g. rule-driven state/comment sync).
-   */
-  resolveIntakeDispatch?(input: {
-    orgId: string;
-    externalSource: { type: string; externalId: string };
-    metadata?: Record<string, unknown>;
-  }): Promise<{ connection: IntegrationConnection; sourceId?: string; issueId: string } | null>;
   /**
    * Bind the integration's generic persistence handle. Called once by the
    * factory during `prepare()` (before routes/tools/workers are collected),

--- a/mastracode/factory/src/integrations/base.ts
+++ b/mastracode/factory/src/integrations/base.ts
@@ -23,6 +23,7 @@ import type { ApiRoute } from '@mastra/core/server';
 import type { FactoryStorage } from '@mastra/core/storage';
 import type { MastraWorker } from '@mastra/core/worker';
 
+import type { IntegrationConnection } from '../capabilities/connection.js';
 import type { Intake } from '../capabilities/intake.js';
 import type { VersionControl } from '../capabilities/version-control.js';
 import type { RouteAuth } from '../routes/route.js';
@@ -130,6 +131,22 @@ export interface FactoryIntegration {
   readonly intake?: Intake;
   /** Repository, installation, and pull-request capability. */
   readonly versionControl?: VersionControl;
+  /**
+   * Resolve everything the `intake` capability needs to reach the external
+   * source of a work item from a background context (no HTTP request): the
+   * org-scoped `IntegrationConnection` (OAuth token for Linear, app
+   * installation for GitHub) plus the provider-specific `sourceId`/`issueId`
+   * derived from the work item's `externalSource` and metadata. Returns
+   * `null` when the org has no usable connection or the target can't be
+   * derived — callers treat that as a policy skip, not an error. Optional
+   * capability: integrations without it cannot service background
+   * external-source dispatch (e.g. rule-driven state/comment sync).
+   */
+  resolveIntakeDispatch?(input: {
+    orgId: string;
+    externalSource: { type: string; externalId: string };
+    metadata?: Record<string, unknown>;
+  }): Promise<{ connection: IntegrationConnection; sourceId?: string; issueId: string } | null>;
   /**
    * Bind the integration's generic persistence handle. Called once by the
    * factory during `prepare()` (before routes/tools/workers are collected),

--- a/mastracode/factory/src/integrations/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/github/integration.test.ts
@@ -517,7 +517,7 @@ describe('GithubIntegration FactoryIntegration surface', () => {
     it('derives the target from canonical externalIds plus the repository-id metadata', async () => {
       const github = await createGithubWithRepo();
       await expect(
-        github.resolveIntakeDispatch({
+        github.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
           externalSource: { type: 'issue', externalId: 'github-issue:7' },
           metadata: { githubRepositoryId: 101 },
@@ -532,7 +532,7 @@ describe('GithubIntegration FactoryIntegration surface', () => {
     it('prefers repository slug and issue number from metadata', async () => {
       const github = await createGithubWithRepo();
       await expect(
-        github.resolveIntakeDispatch({
+        github.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
           externalSource: { type: 'pull-request', externalId: 'github-pr:3' },
           metadata: { repository: 'octo/widgets', githubPullRequestNumber: 9 },
@@ -547,13 +547,13 @@ describe('GithubIntegration FactoryIntegration surface', () => {
     it('derives the target from legacy and intake externalId formats', async () => {
       const github = await createGithubWithRepo();
       await expect(
-        github.resolveIntakeDispatch({
+        github.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
           externalSource: { type: 'issue', externalId: 'github:101:issue:11' },
         }),
       ).resolves.toMatchObject({ sourceId: 'octo/widgets', issueId: '11' });
       await expect(
-        github.resolveIntakeDispatch({
+        github.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
           externalSource: { type: 'issue', externalId: '101:13' },
         }),
@@ -563,14 +563,14 @@ describe('GithubIntegration FactoryIntegration surface', () => {
     it('returns null when the repository or issue number cannot be derived', async () => {
       const github = await createGithubWithRepo();
       await expect(
-        github.resolveIntakeDispatch({
+        github.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
           externalSource: { type: 'issue', externalId: 'github-issue:7' },
           metadata: { githubRepositoryId: 999 },
         }),
       ).resolves.toBeNull();
       await expect(
-        github.resolveIntakeDispatch({
+        github.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
           externalSource: { type: 'issue', externalId: 'not-a-known-format' },
           metadata: { repository: 'octo/widgets' },

--- a/mastracode/factory/src/integrations/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/github/integration.test.ts
@@ -181,6 +181,100 @@ describe('GithubIntegration capability surface', () => {
     ).resolves.toEqual({ id: '99', url: 'https://github.com/acme/app/issues/12#issuecomment-99' });
   });
 
+  it('maps byType stateTypes to open/closed and updates the GitHub issue', async () => {
+    const github = new GithubIntegration(validConfig());
+    const get = vi.fn(async () => ({ data: { number: 12, pull_request: null } }));
+    const update = vi.fn(async () => ({
+      data: {
+        number: 12,
+        title: 'Fix intake',
+        html_url: 'https://github.com/acme/app/issues/12',
+        user: { login: 'ada' },
+        state: 'closed',
+        assignee: null,
+        labels: [] as string[],
+        comments: 0,
+        created_at: '2026-07-01T00:00:00Z',
+        updated_at: '2026-07-02T00:00:00Z',
+      },
+    }));
+    vi.spyOn(github, 'getInstallationOctokit').mockReturnValue({ issues: { get, update } } as any);
+    const connection = { type: 'app-installation' as const, installationId: 7 };
+
+    await expect(
+      github.intake.updateIssue({
+        connection,
+        sourceId: 'acme/app',
+        issueId: '12',
+        state: { kind: 'byType', stateType: 'completed' },
+      }),
+    ).resolves.toMatchObject({ id: '12', state: 'closed' });
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'closed', state_reason: 'completed', issue_number: 12 }),
+    );
+  });
+
+  it('sets state_reason=not_planned when the target is canceled', async () => {
+    const github = new GithubIntegration(validConfig());
+    const get = vi.fn(async () => ({ data: { number: 12, pull_request: null } }));
+    const update = vi.fn(async () => ({
+      data: {
+        number: 12,
+        title: 'x',
+        html_url: 'u',
+        user: null,
+        state: 'closed',
+        assignee: null,
+        labels: [] as string[],
+        comments: 0,
+        created_at: 'a',
+        updated_at: 'b',
+      },
+    }));
+    vi.spyOn(github, 'getInstallationOctokit').mockReturnValue({ issues: { get, update } } as any);
+
+    await github.intake.updateIssue({
+      connection: { type: 'app-installation', installationId: 7 },
+      sourceId: 'acme/app',
+      issueId: '12',
+      state: { kind: 'byType', stateType: 'canceled' },
+    });
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({ state: 'closed', state_reason: 'not_planned' }));
+  });
+
+  it('refuses to close a pull request through updateIssue', async () => {
+    const github = new GithubIntegration(validConfig());
+    const get = vi.fn(async () => ({ data: { number: 34, pull_request: { url: 'x' } } }));
+    const update = vi.fn();
+    vi.spyOn(github, 'getInstallationOctokit').mockReturnValue({ issues: { get, update } } as any);
+
+    await expect(
+      github.intake.updateIssue({
+        connection: { type: 'app-installation', installationId: 7 },
+        sourceId: 'acme/app',
+        issueId: '34',
+        state: { kind: 'byType', stateType: 'completed' },
+      }),
+    ).resolves.toBeNull();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('ignores byName targets (GitHub has no custom states)', async () => {
+    const github = new GithubIntegration(validConfig());
+    const update = vi.fn();
+    vi.spyOn(github, 'getInstallationOctokit').mockReturnValue({ issues: { get: vi.fn(), update } } as any);
+
+    await expect(
+      github.intake.updateIssue({
+        connection: { type: 'app-installation', installationId: 7 },
+        sourceId: 'acme/app',
+        issueId: '12',
+        state: { kind: 'byName', name: 'In Review' },
+      }),
+    ).resolves.toBeNull();
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it('normalizes pull requests through the shared VersionControl contract', async () => {
     const github = new GithubIntegration(validConfig());
     const list = vi.fn(async () => ({ data: [pullRequestData()] }));
@@ -400,5 +494,88 @@ describe('GithubIntegration FactoryIntegration surface', () => {
   it('diagnostics() exposes only non-secret config', () => {
     const github = new GithubIntegration(validConfig());
     expect(github.diagnostics()).toEqual({ slug: 'test-app', webhookSecretConfigured: true });
+  });
+
+  describe('resolveIntakeDispatch', () => {
+    async function createGithubWithRepo() {
+      const { sourceControl } = await createFactoryStorageForTests();
+      const github = new GithubIntegration(validConfig());
+      github.versionControl.initialize({ storage: sourceControl.forIntegration(github.id) });
+      const installation = await github.versionControl.registerInstallation({
+        orgId: 'org-1',
+        userId: 'user-1',
+        installation: { externalId: '42', accountName: 'octo', accountType: 'Organization' },
+      });
+      await github.versionControl.registerRepositories({
+        orgId: 'org-1',
+        installationId: installation.id,
+        repositories: [{ externalId: '101', slug: 'octo/widgets', defaultBranch: 'main' }],
+      });
+      return github;
+    }
+
+    it('derives the target from canonical externalIds plus the repository-id metadata', async () => {
+      const github = await createGithubWithRepo();
+      await expect(
+        github.resolveIntakeDispatch({
+          orgId: 'org-1',
+          externalSource: { type: 'issue', externalId: 'github-issue:7' },
+          metadata: { githubRepositoryId: 101 },
+        }),
+      ).resolves.toEqual({
+        connection: { type: 'app-installation', installationId: 42 },
+        sourceId: 'octo/widgets',
+        issueId: '7',
+      });
+    });
+
+    it('prefers repository slug and issue number from metadata', async () => {
+      const github = await createGithubWithRepo();
+      await expect(
+        github.resolveIntakeDispatch({
+          orgId: 'org-1',
+          externalSource: { type: 'pull-request', externalId: 'github-pr:3' },
+          metadata: { repository: 'octo/widgets', githubPullRequestNumber: 9 },
+        }),
+      ).resolves.toEqual({
+        connection: { type: 'app-installation', installationId: 42 },
+        sourceId: 'octo/widgets',
+        issueId: '9',
+      });
+    });
+
+    it('derives the target from legacy and intake externalId formats', async () => {
+      const github = await createGithubWithRepo();
+      await expect(
+        github.resolveIntakeDispatch({
+          orgId: 'org-1',
+          externalSource: { type: 'issue', externalId: 'github:101:issue:11' },
+        }),
+      ).resolves.toMatchObject({ sourceId: 'octo/widgets', issueId: '11' });
+      await expect(
+        github.resolveIntakeDispatch({
+          orgId: 'org-1',
+          externalSource: { type: 'issue', externalId: '101:13' },
+        }),
+      ).resolves.toMatchObject({ sourceId: 'octo/widgets', issueId: '13' });
+    });
+
+    it('returns null when the repository or issue number cannot be derived', async () => {
+      const github = await createGithubWithRepo();
+      await expect(
+        github.resolveIntakeDispatch({
+          orgId: 'org-1',
+          externalSource: { type: 'issue', externalId: 'github-issue:7' },
+          metadata: { githubRepositoryId: 999 },
+        }),
+      ).resolves.toBeNull();
+      await expect(
+        github.resolveIntakeDispatch({
+          orgId: 'org-1',
+          externalSource: { type: 'issue', externalId: 'not-a-known-format' },
+          metadata: { repository: 'octo/widgets' },
+        }),
+      ).resolves.toBeNull();
+    });
   });
 });

--- a/mastracode/factory/src/integrations/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/github/integration.test.ts
@@ -514,13 +514,12 @@ describe('GithubIntegration FactoryIntegration surface', () => {
       return github;
     }
 
-    it('derives the target from canonical externalIds plus the repository-id metadata', async () => {
+    it('derives the target from the stored external source locator', async () => {
       const github = await createGithubWithRepo();
       await expect(
         github.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
-          externalSource: { type: 'issue', externalId: 'github-issue:7' },
-          metadata: { githubRepositoryId: 101 },
+          externalSource: { type: 'issue', externalId: '101:7' },
         }),
       ).resolves.toEqual({
         connection: { type: 'app-installation', installationId: 42 },
@@ -529,22 +528,7 @@ describe('GithubIntegration FactoryIntegration surface', () => {
       });
     });
 
-    it('prefers repository slug and issue number from metadata', async () => {
-      const github = await createGithubWithRepo();
-      await expect(
-        github.intake.resolveIntakeDispatch!({
-          orgId: 'org-1',
-          externalSource: { type: 'pull-request', externalId: 'github-pr:3' },
-          metadata: { repository: 'octo/widgets', githubPullRequestNumber: 9 },
-        }),
-      ).resolves.toEqual({
-        connection: { type: 'app-installation', installationId: 42 },
-        sourceId: 'octo/widgets',
-        issueId: '9',
-      });
-    });
-
-    it('derives the target from legacy and intake externalId formats', async () => {
+    it('supports legacy locators that still identify the repository and issue', async () => {
       const github = await createGithubWithRepo();
       await expect(
         github.intake.resolveIntakeDispatch!({
@@ -565,15 +549,13 @@ describe('GithubIntegration FactoryIntegration surface', () => {
       await expect(
         github.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
-          externalSource: { type: 'issue', externalId: 'github-issue:7' },
-          metadata: { githubRepositoryId: 999 },
+          externalSource: { type: 'issue', externalId: '999:7' },
         }),
       ).resolves.toBeNull();
       await expect(
         github.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
           externalSource: { type: 'issue', externalId: 'not-a-known-format' },
-          metadata: { repository: 'octo/widgets' },
         }),
       ).resolves.toBeNull();
     });

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -352,44 +352,30 @@ export class GithubIntegration implements FactoryIntegration {
     return this.#storage.generic as unknown as GithubSubscriptionStorage;
   }
 
-  /**
-   * Background-dispatch context for a work item's external source: derive the
-   * repository slug + issue/PR number from the item's metadata/externalId and
-   * resolve the installation connection that reaches the repository.
-   */
+  /** Resolve a stored GitHub locator without scanning installations or repositories. */
   async #resolveIntakeDispatch({
     orgId,
     externalSource,
-    metadata = {},
   }: {
     orgId: string;
     externalSource: { type: string; externalId: string };
-    metadata?: Record<string, unknown>;
   }): Promise<{ connection: IntegrationConnection; sourceId: string; issueId: string } | null> {
-    const issueNumber = deriveGithubIssueNumber(externalSource.externalId, metadata);
-    if (issueNumber === null) return null;
-    const repositoryId = deriveGithubRepositoryId(externalSource.externalId, metadata);
-    const metadataSlug = typeof metadata.repository === 'string' ? metadata.repository : null;
-    if (!metadataSlug && repositoryId === null) return null;
-    const installations = await this.sourceControlStorage.installations.list({ orgId });
-    for (const installation of installations) {
-      const repositories = await this.sourceControlStorage.repositories.list({
-        orgId,
-        installationId: installation.id,
-      });
-      const repository = repositories.find(candidate =>
-        metadataSlug ? candidate.slug === metadataSlug : candidate.externalId === String(repositoryId),
-      );
-      if (!repository) continue;
-      const installationId = Number.parseInt(installation.externalId, 10);
-      if (!Number.isSafeInteger(installationId)) continue;
-      return {
-        connection: { type: 'app-installation', installationId },
-        sourceId: repository.slug,
-        issueId: String(issueNumber),
-      };
-    }
-    return null;
+    const target = parseGithubExternalTarget(externalSource.externalId);
+    if (!target) return null;
+    const repository = await this.sourceControlStorage.repositories.findByExternalId({
+      orgId,
+      externalId: target.repositoryId,
+    });
+    if (!repository) return null;
+    const installation = await this.sourceControlStorage.installations.get({ orgId, id: repository.installationId });
+    if (!installation) return null;
+    const installationId = Number.parseInt(installation.externalId, 10);
+    if (!Number.isSafeInteger(installationId)) return null;
+    return {
+      connection: { type: 'app-installation', installationId },
+      sourceId: repository.slug,
+      issueId: target.issueId,
+    };
   }
 
   /** Secret GitHub uses to sign webhook deliveries, when configured. */
@@ -1313,28 +1299,10 @@ function splitRepoFullName(repoFullName: string): { owner: string; repo: string 
   return { owner: repoFullName.slice(0, slash), repo: repoFullName.slice(slash + 1) };
 }
 
-/**
- * Derive a GitHub issue/PR number from work-item metadata or the stored
- * `externalId`. Supports every key format Factory has written: canonical
- * (`github-issue:42` / `github-pr:42`), legacy (`github:<repoId>:issue:42`),
- * and intake (`<repoExternalId>:42`).
- */
-function deriveGithubIssueNumber(externalId: string, metadata: Record<string, unknown>): number | null {
-  for (const key of ['githubIssueNumber', 'githubPullRequestNumber', 'number'] as const) {
-    const value = metadata[key];
-    if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return value;
-  }
-  const match =
-    externalId.match(/^github-(?:issue|pr):(\d+)$/) ??
-    externalId.match(/^github:\d+:(?:issue|pull-request):(\d+)$/) ??
-    externalId.match(/^\d+:(\d+)$/);
-  return match?.[1] ? parsePositiveInteger(match[1]) : null;
-}
-
-/** Derive the GitHub repository id from work-item metadata or the stored `externalId`. */
-function deriveGithubRepositoryId(externalId: string, metadata: Record<string, unknown>): number | null {
-  const value = metadata.githubRepositoryId;
-  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return value;
-  const match = externalId.match(/^github:(\d+):/) ?? externalId.match(/^(\d+):\d+$/);
-  return match?.[1] ? parsePositiveInteger(match[1]) : null;
+function parseGithubExternalTarget(externalId: string): { repositoryId: string; issueId: string } | null {
+  const match = externalId.match(/^github:(\d+):(?:issue|pull-request):(\d+)$/) ?? externalId.match(/^(\d+):(\d+)$/);
+  if (!match?.[1] || !match[2]) return null;
+  const repositoryId = parsePositiveInteger(match[1]);
+  const issueId = parsePositiveInteger(match[2]);
+  return repositoryId && issueId ? { repositoryId: String(repositoryId), issueId: String(issueId) } : null;
 }

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -36,6 +36,7 @@ import type {
   IntakeIssue,
   IntakeIssueDetail,
   ListIntakeIssuesInput,
+  UpdateIntakeIssueInput,
 } from '../../capabilities/intake.js';
 import type {
   PullRequest,
@@ -227,6 +228,7 @@ export class GithubIntegration implements FactoryIntegration {
     listIssues: input => this.#listIntakeIssues(input),
     getIssue: input => this.#getIntakeIssue(input),
     createComment: input => this.#createIntakeComment(input),
+    updateIssue: input => this.#updateIntakeIssue(input),
   };
   readonly versionControl: VersionControl = {
     initialize: ({ storage }) => {
@@ -347,6 +349,46 @@ export class GithubIntegration implements FactoryIntegration {
   get integrationStorage(): GithubSubscriptionStorage {
     if (!this.#storage) throw new Error('GithubIntegration storage has not been initialized.');
     return this.#storage.generic as unknown as GithubSubscriptionStorage;
+  }
+
+  /**
+   * Background-dispatch context for a work item's external source: derive the
+   * repository slug + issue/PR number from the item's metadata/externalId and
+   * resolve the installation connection that reaches the repository.
+   */
+  async resolveIntakeDispatch({
+    orgId,
+    externalSource,
+    metadata = {},
+  }: {
+    orgId: string;
+    externalSource: { type: string; externalId: string };
+    metadata?: Record<string, unknown>;
+  }): Promise<{ connection: IntegrationConnection; sourceId: string; issueId: string } | null> {
+    const issueNumber = deriveGithubIssueNumber(externalSource.externalId, metadata);
+    if (issueNumber === null) return null;
+    const repositoryId = deriveGithubRepositoryId(externalSource.externalId, metadata);
+    const metadataSlug = typeof metadata.repository === 'string' ? metadata.repository : null;
+    if (!metadataSlug && repositoryId === null) return null;
+    const installations = await this.sourceControlStorage.installations.list({ orgId });
+    for (const installation of installations) {
+      const repositories = await this.sourceControlStorage.repositories.list({
+        orgId,
+        installationId: installation.id,
+      });
+      const repository = repositories.find(candidate =>
+        metadataSlug ? candidate.slug === metadataSlug : candidate.externalId === String(repositoryId),
+      );
+      if (!repository) continue;
+      const installationId = Number.parseInt(installation.externalId, 10);
+      if (!Number.isSafeInteger(installationId)) continue;
+      return {
+        connection: { type: 'app-installation', installationId },
+        sourceId: repository.slug,
+        issueId: String(issueNumber),
+      };
+    }
+    return null;
   }
 
   /** Secret GitHub uses to sign webhook deliveries, when configured. */
@@ -545,6 +587,66 @@ export class GithubIntegration implements FactoryIntegration {
           body: comment.body ?? '',
           createdAt: comment.created_at,
         })),
+      };
+    } catch (err) {
+      if (isNotFoundError(err)) return null;
+      throw err;
+    }
+  }
+
+  async #updateIntakeIssue(input: UpdateIntakeIssueInput): Promise<IntakeIssue | null> {
+    const installationId = getGithubInstallationId(input.connection);
+    const repoFullName = requireSourceId(input.sourceId, 'GitHub Intake requires a repository source.');
+    const parts = splitRepoFullName(repoFullName);
+    const issueNumber = parsePositiveInteger(input.issueId);
+    if (!parts || issueNumber === null) return null;
+    // GitHub has no custom workflow states; only open/closed. `byName` is a
+    // no-op with a warn log.
+    if (input.state.kind === 'byName') {
+      console.warn(`GitHub integration: updateIssue byName is not supported (name=${input.state.name}); ignoring.`);
+      return null;
+    }
+    const targetState: 'open' | 'closed' =
+      input.state.stateType === 'unstarted' || input.state.stateType === 'started' ? 'open' : 'closed';
+    const stateReason: 'completed' | 'not_planned' | null =
+      targetState === 'closed' ? (input.state.stateType === 'canceled' ? 'not_planned' : 'completed') : null;
+    const octokit = this.getInstallationOctokit(installationId);
+    try {
+      // Pre-flight: Factory does not close pull requests via `updateIssue`.
+      // PR merges/closes belong to the version-control pipeline.
+      const { data: current } = await octokit.issues.get({
+        owner: parts.owner,
+        repo: parts.repo,
+        issue_number: issueNumber,
+      });
+      if (current.pull_request) {
+        console.warn(
+          `GitHub integration: updateIssue rejected — target ${repoFullName}#${issueNumber} is a pull request.`,
+        );
+        return null;
+      }
+      const { data: issue } = await octokit.issues.update({
+        owner: parts.owner,
+        repo: parts.repo,
+        issue_number: issueNumber,
+        state: targetState,
+        ...(stateReason ? { state_reason: stateReason } : {}),
+      });
+      return {
+        id: String(issue.number),
+        identifier: `#${issue.number}`,
+        title: issue.title,
+        url: issue.html_url,
+        author: issue.user?.login ?? null,
+        state: issue.state,
+        stateType: issue.state,
+        priority: null,
+        assignee: issue.assignee?.login ?? null,
+        source: repoFullName,
+        labels: issue.labels.map(label => (typeof label === 'string' ? label : (label.name ?? ''))).filter(Boolean),
+        commentCount: issue.comments,
+        createdAt: issue.created_at,
+        updatedAt: issue.updated_at,
       };
     } catch (err) {
       if (isNotFoundError(err)) return null;
@@ -1208,4 +1310,30 @@ function splitRepoFullName(repoFullName: string): { owner: string; repo: string 
   const slash = repoFullName.indexOf('/');
   if (slash <= 0 || slash === repoFullName.length - 1) return null;
   return { owner: repoFullName.slice(0, slash), repo: repoFullName.slice(slash + 1) };
+}
+
+/**
+ * Derive a GitHub issue/PR number from work-item metadata or the stored
+ * `externalId`. Supports every key format Factory has written: canonical
+ * (`github-issue:42` / `github-pr:42`), legacy (`github:<repoId>:issue:42`),
+ * and intake (`<repoExternalId>:42`).
+ */
+function deriveGithubIssueNumber(externalId: string, metadata: Record<string, unknown>): number | null {
+  for (const key of ['githubIssueNumber', 'githubPullRequestNumber', 'number'] as const) {
+    const value = metadata[key];
+    if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return value;
+  }
+  const match =
+    externalId.match(/^github-(?:issue|pr):(\d+)$/) ??
+    externalId.match(/^github:\d+:(?:issue|pull-request):(\d+)$/) ??
+    externalId.match(/^\d+:(\d+)$/);
+  return match?.[1] ? parsePositiveInteger(match[1]) : null;
+}
+
+/** Derive the GitHub repository id from work-item metadata or the stored `externalId`. */
+function deriveGithubRepositoryId(externalId: string, metadata: Record<string, unknown>): number | null {
+  const value = metadata.githubRepositoryId;
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return value;
+  const match = externalId.match(/^github:(\d+):/) ?? externalId.match(/^(\d+):\d+$/);
+  return match?.[1] ? parsePositiveInteger(match[1]) : null;
 }

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -147,6 +147,7 @@ export class GithubIntegration implements FactoryIntegration {
   /** Stable integration identifier (see `../factory-integration.ts`). */
   readonly id = 'github';
   readonly intake: Intake = {
+    resolveIntakeDispatch: input => this.#resolveIntakeDispatch(input),
     listSources: async ({ orgId }) => {
       const installations = await this.sourceControlStorage.installations.list({ orgId });
       const repositories = await Promise.all(
@@ -356,7 +357,7 @@ export class GithubIntegration implements FactoryIntegration {
    * repository slug + issue/PR number from the item's metadata/externalId and
    * resolve the installation connection that reaches the repository.
    */
-  async resolveIntakeDispatch({
+  async #resolveIntakeDispatch({
     orgId,
     externalSource,
     metadata = {},

--- a/mastracode/factory/src/integrations/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/linear/integration.test.ts
@@ -217,7 +217,7 @@ describe('LinearIntegration capability surface', () => {
     vi.spyOn(linear, 'getFreshAccessToken').mockResolvedValue('fresh-token');
 
     await expect(
-      linear.resolveIntakeDispatch({
+      linear.intake.resolveIntakeDispatch!({
         orgId: 'org-1',
         externalSource: { type: 'issue', externalId: 'issue-uuid-1' },
       }),
@@ -232,7 +232,7 @@ describe('LinearIntegration capability surface', () => {
     const loadConnection = vi.spyOn(linear, 'loadConnection').mockResolvedValue(null);
 
     await expect(
-      linear.resolveIntakeDispatch({
+      linear.intake.resolveIntakeDispatch!({
         orgId: 'org-1',
         externalSource: { type: 'pull-request', externalId: 'x' },
       }),
@@ -240,7 +240,7 @@ describe('LinearIntegration capability surface', () => {
     expect(loadConnection).not.toHaveBeenCalled();
 
     await expect(
-      linear.resolveIntakeDispatch({
+      linear.intake.resolveIntakeDispatch!({
         orgId: 'org-1',
         externalSource: { type: 'issue', externalId: 'issue-uuid-1' },
       }),

--- a/mastracode/factory/src/integrations/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/linear/integration.test.ts
@@ -103,6 +103,104 @@ describe('LinearIntegration capability surface', () => {
     });
   });
 
+  it('resolves a byType target to a workflow state and issues a Linear mutation', async () => {
+    const linear = integration();
+    const detail: LinearIssueDetail = {
+      ...issue,
+      description: null,
+      comments: [],
+    };
+    vi.spyOn(linear, 'fetchIssueDetail').mockResolvedValue(detail);
+    const graphql = vi.fn(async (_url: string, init: RequestInit | undefined) => {
+      const body = JSON.parse(String(init?.body)) as { query: string; variables?: Record<string, unknown> };
+      if (body.query.includes('TeamStates')) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              team: {
+                states: {
+                  nodes: [
+                    { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+                    { id: 'state-done', name: 'Done', type: 'completed' },
+                  ],
+                },
+              },
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify({ data: { issueUpdate: { success: true } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', graphql);
+
+    await linear.intake.updateIssue({
+      connection,
+      issueId: 'issue-1',
+      state: { kind: 'byType', stateType: 'completed' },
+    });
+
+    const updateCall = graphql.mock.calls.find(call =>
+      String((call[1] as RequestInit).body).includes('UpdateIssueState'),
+    );
+    expect(updateCall).toBeDefined();
+    const updatePayload = JSON.parse(String((updateCall![1] as RequestInit).body)) as {
+      variables: { id: string; stateId: string };
+    };
+    expect(updatePayload.variables).toEqual({ id: 'issue-1', stateId: 'state-done' });
+  });
+
+  it('skips the mutation when the current state already matches the target', async () => {
+    const linear = integration();
+    const detail: LinearIssueDetail = { ...issue, description: null, comments: [] };
+    vi.spyOn(linear, 'fetchIssueDetail').mockResolvedValue(detail);
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: { team: { states: { nodes: [{ id: 'state-todo', name: 'Todo', type: 'unstarted' }] } } },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await linear.intake.updateIssue({
+      connection,
+      issueId: 'issue-1',
+      state: { kind: 'byName', name: 'Todo' },
+    });
+    expect(result).toMatchObject({ state: 'Todo' });
+    // Only the team-states query was made — no mutation.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when no workflow state matches the target', async () => {
+    const linear = integration();
+    const detail: LinearIssueDetail = { ...issue, description: null, comments: [] };
+    vi.spyOn(linear, 'fetchIssueDetail').mockResolvedValue(detail);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ data: { team: { states: { nodes: [] } } } }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      ),
+    );
+    await expect(
+      linear.intake.updateIssue({
+        connection,
+        issueId: 'issue-1',
+        state: { kind: 'byType', stateType: 'completed' },
+      }),
+    ).resolves.toBeNull();
+  });
+
   it('rejects an installation connection instead of silently misusing it', async () => {
     const linear = integration();
     await expect(
@@ -111,6 +209,43 @@ describe('LinearIntegration capability surface', () => {
         sourceIds: [],
       }),
     ).rejects.toThrow('Linear capabilities require an OAuth connection.');
+  });
+
+  it('resolves dispatch context from the org OAuth connection with a fresh token', async () => {
+    const linear = integration();
+    vi.spyOn(linear, 'loadConnection').mockResolvedValue({ id: 'conn-1' } as never);
+    vi.spyOn(linear, 'getFreshAccessToken').mockResolvedValue('fresh-token');
+
+    await expect(
+      linear.resolveIntakeDispatch({
+        orgId: 'org-1',
+        externalSource: { type: 'issue', externalId: 'issue-uuid-1' },
+      }),
+    ).resolves.toEqual({
+      connection: { type: 'oauth', accessToken: 'fresh-token' },
+      issueId: 'issue-uuid-1',
+    });
+  });
+
+  it('returns null dispatch context for non-issue sources or missing connections', async () => {
+    const linear = integration();
+    const loadConnection = vi.spyOn(linear, 'loadConnection').mockResolvedValue(null);
+
+    await expect(
+      linear.resolveIntakeDispatch({
+        orgId: 'org-1',
+        externalSource: { type: 'pull-request', externalId: 'x' },
+      }),
+    ).resolves.toBeNull();
+    expect(loadConnection).not.toHaveBeenCalled();
+
+    await expect(
+      linear.resolveIntakeDispatch({
+        orgId: 'org-1',
+        externalSource: { type: 'issue', externalId: 'issue-uuid-1' },
+      }),
+    ).resolves.toBeNull();
+    expect(loadConnection).toHaveBeenCalledWith('org-1');
   });
 
   it('provides intake without claiming source-control support', () => {

--- a/mastracode/factory/src/integrations/linear/integration.ts
+++ b/mastracode/factory/src/integrations/linear/integration.ts
@@ -30,6 +30,7 @@ import type {
   IntakeIssue,
   IntakeIssueDetail,
   ListIntakeIssuesInput,
+  UpdateIntakeIssueInput,
 } from '../../capabilities/intake.js';
 import type { RouteAuth } from '../../routes/route.js';
 import type { IntegrationStorageHandle } from '../../storage/domains/integrations/base.js';
@@ -534,7 +535,26 @@ export class LinearIntegration implements FactoryIntegration {
     listIssues: input => this.#listIntakeIssues(input),
     getIssue: input => this.#getIntakeIssue(input),
     createComment: input => this.#createIntakeComment(input),
+    updateIssue: input => this.#updateIntakeIssue(input),
   };
+
+  /**
+   * Background-dispatch context: the org's OAuth connection with a fresh
+   * token. Linear work items store the issue UUID directly as `externalId`.
+   */
+  async resolveIntakeDispatch({
+    orgId,
+    externalSource,
+  }: {
+    orgId: string;
+    externalSource: { type: string; externalId: string };
+  }): Promise<{ connection: IntegrationConnection; issueId: string } | null> {
+    if (externalSource.type !== 'issue') return null;
+    const connection = await this.loadConnection(orgId);
+    if (!connection) return null;
+    const accessToken = await this.getFreshAccessToken(connection);
+    return { connection: { type: 'oauth', accessToken }, issueId: externalSource.externalId };
+  }
   /**
    * The OAuth connect/callback flow round-trips a signed `state` through
    * Linear, so a multi-replica deploy needs a deployment-stable state secret.
@@ -657,6 +677,56 @@ export class LinearIntegration implements FactoryIntegration {
   async #createIntakeComment(input: CreateIntakeCommentInput): Promise<{ id: string; url: string } | null> {
     const accessToken = getLinearAccessToken(input.connection);
     return this.createIssueComment(accessToken, input.issueId, input.body);
+  }
+
+  async #updateIntakeIssue(input: UpdateIntakeIssueInput): Promise<IntakeIssue | null> {
+    const accessToken = getLinearAccessToken(input.connection);
+    const issue = await this.fetchIssueDetail(accessToken, input.issueId);
+    if (!issue) return null;
+    const teamKey = issue.team;
+    if (!teamKey) return null;
+    const states = await this.#listTeamWorkflowStates(accessToken, teamKey);
+    let targetState: { id: string; name: string; type: string } | null = null;
+    if (input.state.kind === 'byType') {
+      const wantedType = input.state.stateType;
+      targetState = states.find(state => state.type === wantedType) ?? null;
+    } else {
+      const wanted = input.state.name.toLowerCase();
+      targetState = states.find(state => state.name.toLowerCase() === wanted) ?? null;
+    }
+    if (!targetState) return null;
+    if (targetState.name === issue.state) {
+      return linearIssueToIntakeIssue(issue);
+    }
+    const data = await linearGraphql<{ issueUpdate: { success: boolean } }>(
+      accessToken,
+      `mutation UpdateIssueState($id: String!, $stateId: String!) {
+        issueUpdate(id: $id, input: { stateId: $stateId }) { success }
+      }`,
+      { id: issue.id, stateId: targetState.id },
+    );
+    if (!data.issueUpdate.success) {
+      throw new Error('Linear did not accept the issue update.');
+    }
+    const fresh = await this.fetchIssueDetail(accessToken, issue.id);
+    if (!fresh) return null;
+    return linearIssueToIntakeIssue(fresh);
+  }
+
+  async #listTeamWorkflowStates(
+    accessToken: string,
+    teamKey: string,
+  ): Promise<Array<{ id: string; name: string; type: string }>> {
+    const data = await linearGraphql<{
+      team: { states: { nodes: Array<{ id: string; name: string; type: string }> } } | null;
+    }>(
+      accessToken,
+      `query TeamStates($key: String!) {
+        team(id: $key) { states(first: 100) { nodes { id name type } } }
+      }`,
+      { key: teamKey },
+    );
+    return data.team?.states.nodes ?? [];
   }
 
   /** List the workspace's projects (for the Settings intake-source picker). */

--- a/mastracode/factory/src/integrations/linear/integration.ts
+++ b/mastracode/factory/src/integrations/linear/integration.ts
@@ -495,6 +495,7 @@ export class LinearIntegration implements FactoryIntegration {
   }
 
   readonly intake: Intake = {
+    resolveIntakeDispatch: input => this.#resolveIntakeDispatch(input),
     listSources: async ({ orgId }) => {
       const connection = await this.loadConnection(orgId);
       if (!connection) return [];
@@ -542,7 +543,7 @@ export class LinearIntegration implements FactoryIntegration {
    * Background-dispatch context: the org's OAuth connection with a fresh
    * token. Linear work items store the issue UUID directly as `externalId`.
    */
-  async resolveIntakeDispatch({
+  async #resolveIntakeDispatch({
     orgId,
     externalSource,
   }: {

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -950,22 +950,7 @@ describe('PlatformGithubIntegration', () => {
       });
     });
 
-    it('prefers metadata repository and issue number over externalId parsing', async () => {
-      const integration = createIntegration();
-      await expect(
-        integration.intake.resolveIntakeDispatch!({
-          orgId: 'org-1',
-          externalSource: { type: 'issue', externalId: 'github-issue:7' },
-          metadata: { repository: 'acme/app', githubIssueNumber: 7 },
-        }),
-      ).resolves.toEqual({
-        connection: { type: 'app-installation', installationId: 1 },
-        sourceId: 'acme/app',
-        issueId: '7',
-      });
-    });
-
-    it('falls back to stored repositories for numeric repository ids', async () => {
+    it('resolves numeric repository locators with one direct storage lookup', async () => {
       const { sourceControl } = await createPlatformStorageForTests();
       const integration = createIntegration();
       const storage = sourceControl.forIntegration('github');

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -939,7 +939,7 @@ describe('PlatformGithubIntegration', () => {
     it('derives repository + issue number from the intake externalId format', async () => {
       const integration = createIntegration();
       await expect(
-        integration.resolveIntakeDispatch({
+        integration.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
           externalSource: { type: 'issue', externalId: 'acme/app:34' },
         }),
@@ -953,7 +953,7 @@ describe('PlatformGithubIntegration', () => {
     it('prefers metadata repository and issue number over externalId parsing', async () => {
       const integration = createIntegration();
       await expect(
-        integration.resolveIntakeDispatch({
+        integration.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
           externalSource: { type: 'issue', externalId: 'github-issue:7' },
           metadata: { repository: 'acme/app', githubIssueNumber: 7 },
@@ -982,7 +982,7 @@ describe('PlatformGithubIntegration', () => {
       });
 
       await expect(
-        integration.resolveIntakeDispatch({
+        integration.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
           externalSource: { type: 'issue', externalId: 'github:101:issue:12' },
         }),
@@ -992,7 +992,7 @@ describe('PlatformGithubIntegration', () => {
     it('returns null when the target cannot be derived', async () => {
       const integration = createIntegration();
       await expect(
-        integration.resolveIntakeDispatch({
+        integration.intake.resolveIntakeDispatch!({
           orgId: 'org-1',
           externalSource: { type: 'issue', externalId: 'github-issue:7' },
         }),

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -213,6 +213,69 @@ describe('PlatformGithubIntegration', () => {
     await expect(integration.intake.getIssue({ connection, sourceId: 'acme/app', issueId: '99' })).resolves.toBeNull();
   });
 
+  it('updates issue state via PATCH after probing the pulls endpoint', async () => {
+    const closedIssue = { ...issue, state: 'closed' as const };
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      // Pulls probe → 404 (it's an issue, not a PR)
+      .mockResolvedValueOnce(json({ detail: 'Not found' }, 404))
+      // PATCH issue → returns closed issue
+      .mockResolvedValueOnce(json(closedIssue));
+    const integration = createIntegration(fetchImpl);
+
+    await expect(
+      integration.intake.updateIssue({
+        connection: { type: 'app-installation', installationId: 7 },
+        sourceId: 'acme/app',
+        issueId: '12',
+        state: { kind: 'byType', stateType: 'completed' },
+      }),
+    ).resolves.toMatchObject({ id: '12', state: 'closed' });
+
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toContain('/repos/acme/app/pulls/12');
+    expect((fetchImpl.mock.calls[1]?.[1] as RequestInit).method).toBe('PATCH');
+    const patchBody = JSON.parse(String((fetchImpl.mock.calls[1]?.[1] as RequestInit).body)) as {
+      state: string;
+      state_reason: string;
+    };
+    expect(patchBody).toEqual({ state: 'closed', state_reason: 'completed' });
+  });
+
+  it('refuses to update a pull request through updateIssue', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      // Pulls probe → 200 (target IS a PR)
+      .mockResolvedValueOnce(json(pullRequest));
+    const integration = createIntegration(fetchImpl);
+
+    await expect(
+      integration.intake.updateIssue({
+        connection: { type: 'app-installation', installationId: 7 },
+        sourceId: 'acme/app',
+        issueId: '34',
+        state: { kind: 'byType', stateType: 'completed' },
+      }),
+    ).resolves.toBeNull();
+
+    // Only the pulls probe was made — no PATCH.
+    expect(fetchImpl.mock.calls).toHaveLength(1);
+  });
+
+  it('ignores byName targets on updateIssue (GitHub has no custom states)', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const integration = createIntegration(fetchImpl);
+
+    await expect(
+      integration.intake.updateIssue({
+        connection: { type: 'app-installation', installationId: 7 },
+        sourceId: 'acme/app',
+        issueId: '12',
+        state: { kind: 'byName', name: 'In Review' },
+      }),
+    ).resolves.toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it('propagates platform rate limits through GitHub capabilities', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(JSON.stringify({ detail: 'Rate limited' }), {
@@ -869,6 +932,71 @@ describe('PlatformGithubIntegration', () => {
       mode: 'platform',
       endpointHost: 'platform.example.com',
       polling: { enabled: false, intervalMs: 9_000 },
+    });
+  });
+
+  describe('resolveIntakeDispatch', () => {
+    it('derives repository + issue number from the intake externalId format', async () => {
+      const integration = createIntegration();
+      await expect(
+        integration.resolveIntakeDispatch({
+          orgId: 'org-1',
+          externalSource: { type: 'issue', externalId: 'acme/app:34' },
+        }),
+      ).resolves.toEqual({
+        connection: { type: 'app-installation', installationId: 1 },
+        sourceId: 'acme/app',
+        issueId: '34',
+      });
+    });
+
+    it('prefers metadata repository and issue number over externalId parsing', async () => {
+      const integration = createIntegration();
+      await expect(
+        integration.resolveIntakeDispatch({
+          orgId: 'org-1',
+          externalSource: { type: 'issue', externalId: 'github-issue:7' },
+          metadata: { repository: 'acme/app', githubIssueNumber: 7 },
+        }),
+      ).resolves.toEqual({
+        connection: { type: 'app-installation', installationId: 1 },
+        sourceId: 'acme/app',
+        issueId: '7',
+      });
+    });
+
+    it('falls back to stored repositories for numeric repository ids', async () => {
+      const { sourceControl } = await createPlatformStorageForTests();
+      const integration = createIntegration();
+      const storage = sourceControl.forIntegration('github');
+      integration.versionControl.initialize({ storage });
+      const installation = await integration.versionControl.registerInstallation({
+        orgId: 'org-1',
+        userId: 'user-1',
+        installation: { externalId: '7', accountName: 'acme', accountType: 'Organization' },
+      });
+      await integration.versionControl.registerRepositories({
+        orgId: 'org-1',
+        installationId: installation.id,
+        repositories: [{ externalId: '101', slug: 'acme/app', defaultBranch: 'main' }],
+      });
+
+      await expect(
+        integration.resolveIntakeDispatch({
+          orgId: 'org-1',
+          externalSource: { type: 'issue', externalId: 'github:101:issue:12' },
+        }),
+      ).resolves.toMatchObject({ sourceId: 'acme/app', issueId: '12' });
+    });
+
+    it('returns null when the target cannot be derived', async () => {
+      const integration = createIntegration();
+      await expect(
+        integration.resolveIntakeDispatch({
+          orgId: 'org-1',
+          externalSource: { type: 'issue', externalId: 'github-issue:7' },
+        }),
+      ).resolves.toBeNull();
     });
   });
 });

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -4,7 +4,13 @@ import { registerApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
 
 import type { IntegrationConnection } from '../../../capabilities/connection.js';
-import type { CreateIntakeCommentInput, Intake, IntakeIssue, IntakeIssueDetail } from '../../../capabilities/intake.js';
+import type {
+  CreateIntakeCommentInput,
+  Intake,
+  IntakeIssue,
+  IntakeIssueDetail,
+  UpdateIntakeIssueInput,
+} from '../../../capabilities/intake.js';
 import type {
   CreatePullRequestCommentInput,
   CreatePullRequestInput,
@@ -268,6 +274,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     },
     getIssue: input => this.#getIssue(input.connection, input.sourceId, input.issueId),
     createComment: input => this.#createIssueComment(input),
+    updateIssue: input => this.#updateIntakeIssue(input),
   };
 
   readonly versionControl: VersionControl = {
@@ -365,6 +372,76 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       throw new Error('PlatformGithubIntegration generic storage has not been initialized.');
     }
     return this.#integrationStorage;
+  }
+
+  /**
+   * Background-dispatch context for a work item's external source: derive the
+   * repository full name + issue/PR number from the item's metadata or stored
+   * `externalId`. The platform client authenticates via the platform API, so
+   * the connection carries a nominal installation id (mirrors `listItems`).
+   */
+  async resolveIntakeDispatch({
+    orgId,
+    externalSource,
+    metadata = {},
+  }: {
+    orgId: string;
+    externalSource: { type: string; externalId: string };
+    metadata?: Record<string, unknown>;
+  }): Promise<{ connection: IntegrationConnection; sourceId: string; issueId: string } | null> {
+    const externalId = externalSource.externalId;
+    let issueNumber: number | null = null;
+    for (const key of ['githubIssueNumber', 'githubPullRequestNumber', 'number'] as const) {
+      const value = metadata[key];
+      if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) {
+        issueNumber = value;
+        break;
+      }
+    }
+    let repository =
+      typeof metadata.repository === 'string' && metadata.repository.length > 0 ? metadata.repository : null;
+    // Intake-format key: `<owner/name>:<number>` — split on the last colon.
+    const intakeMatch = externalId.match(/^(.+):(\d+)$/);
+    if (intakeMatch?.[1]?.includes('/')) {
+      repository ??= intakeMatch[1];
+      issueNumber ??= Number.parseInt(intakeMatch[2]!, 10);
+    }
+    if (issueNumber === null) {
+      const match =
+        externalId.match(/^github-(?:issue|pr):(\d+)$/) ??
+        externalId.match(/^github:\d+:(?:issue|pull-request):(\d+)$/);
+      issueNumber = match?.[1] ? Number.parseInt(match[1], 10) : null;
+    }
+    if (repository === null) {
+      // Fall back to the numeric repository id recorded by webhook rules.
+      const repositoryIdValue = metadata.githubRepositoryId;
+      const repositoryId =
+        typeof repositoryIdValue === 'number' && Number.isSafeInteger(repositoryIdValue)
+          ? repositoryIdValue
+          : (() => {
+              const match = externalId.match(/^github:(\d+):/);
+              return match?.[1] ? Number.parseInt(match[1], 10) : null;
+            })();
+      if (repositoryId !== null) {
+        const installations = await this.storage.installations.list({ orgId });
+        for (const installation of installations) {
+          const repositories = await this.storage.repositories.list({ orgId, installationId: installation.id });
+          const row = repositories.find(candidate => candidate.externalId === String(repositoryId));
+          if (row) {
+            repository = row.slug;
+            break;
+          }
+        }
+      }
+    }
+    if (repository === null || issueNumber === null || !Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+      return null;
+    }
+    return {
+      connection: { type: 'app-installation', installationId: 1 },
+      sourceId: repository,
+      issueId: String(issueNumber),
+    };
   }
 
   initialize({ storage }: { storage: IntegrationStorageHandle }): void {
@@ -702,6 +779,46 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         ),
       ]);
       return parseIntakeIssueDetail(repository, issue, comments.comments);
+    } catch (error) {
+      if (isNotFound(error)) return null;
+      throw error;
+    }
+  }
+
+  async #updateIntakeIssue(input: UpdateIntakeIssueInput): Promise<IntakeIssue | null> {
+    requireGithubConnection(input.connection);
+    const repository = requireSource(input.sourceId, 'GitHub Intake requires a repository source.');
+    const issueNumber = requirePositiveId(input.issueId, 'issue');
+    if (input.state.kind === 'byName') {
+      logPlatformWarn(`Platform GitHub: updateIssue byName is not supported (name=${input.state.name}); ignoring.`);
+      return null;
+    }
+    const targetState: 'open' | 'closed' =
+      input.state.stateType === 'unstarted' || input.state.stateType === 'started' ? 'open' : 'closed';
+    const stateReason: 'completed' | 'not_planned' | null =
+      targetState === 'closed' ? (input.state.stateType === 'canceled' ? 'not_planned' : 'completed') : null;
+    // Reject PR targets: probe the pulls endpoint. A 200 means the number is a
+    // pull request, not an issue. Factory does not close PRs via updateIssue —
+    // PR merges/closes go through the version-control pipeline.
+    try {
+      await this.#client.request<GithubPullRequest>('GET', repositoryPath(repository, `pulls/${issueNumber}`));
+      logPlatformWarn(`Platform GitHub: updateIssue rejected — target ${repository}#${issueNumber} is a pull request.`);
+      return null;
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      // 404 on pulls means it's an issue (or nothing) — fall through to PATCH.
+    }
+    try {
+      const issue = await this.#client.request<GithubIssue>(
+        'PATCH',
+        repositoryPath(repository, `issues/${issueNumber}`),
+        {
+          state: targetState,
+          ...(stateReason ? { state_reason: stateReason } : {}),
+        },
+        { actingUserId: input.actingUserId },
+      );
+      return parseIntakeIssue(repository, issue);
     } catch (error) {
       if (isNotFound(error)) return null;
       throw error;

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -375,73 +375,24 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     return this.#integrationStorage;
   }
 
-  /**
-   * Background-dispatch context for a work item's external source: derive the
-   * repository full name + issue/PR number from the item's metadata or stored
-   * `externalId`. The platform client authenticates via the platform API, so
-   * the connection carries a nominal installation id (mirrors `listItems`).
-   */
+  /** Resolve a stored GitHub locator without scanning installations or repositories. */
   async #resolveIntakeDispatch({
     orgId,
     externalSource,
-    metadata = {},
   }: {
     orgId: string;
     externalSource: { type: string; externalId: string };
-    metadata?: Record<string, unknown>;
   }): Promise<{ connection: IntegrationConnection; sourceId: string; issueId: string } | null> {
-    const externalId = externalSource.externalId;
-    let issueNumber: number | null = null;
-    for (const key of ['githubIssueNumber', 'githubPullRequestNumber', 'number'] as const) {
-      const value = metadata[key];
-      if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) {
-        issueNumber = value;
-        break;
-      }
-    }
-    let repository =
-      typeof metadata.repository === 'string' && metadata.repository.length > 0 ? metadata.repository : null;
-    // Intake-format key: `<owner/name>:<number>` — split on the last colon.
-    const intakeMatch = externalId.match(/^(.+):(\d+)$/);
-    if (intakeMatch?.[1]?.includes('/')) {
-      repository ??= intakeMatch[1];
-      issueNumber ??= Number.parseInt(intakeMatch[2]!, 10);
-    }
-    if (issueNumber === null) {
-      const match =
-        externalId.match(/^github-(?:issue|pr):(\d+)$/) ??
-        externalId.match(/^github:\d+:(?:issue|pull-request):(\d+)$/);
-      issueNumber = match?.[1] ? Number.parseInt(match[1], 10) : null;
-    }
-    if (repository === null) {
-      // Fall back to the numeric repository id recorded by webhook rules.
-      const repositoryIdValue = metadata.githubRepositoryId;
-      const repositoryId =
-        typeof repositoryIdValue === 'number' && Number.isSafeInteger(repositoryIdValue)
-          ? repositoryIdValue
-          : (() => {
-              const match = externalId.match(/^github:(\d+):/);
-              return match?.[1] ? Number.parseInt(match[1], 10) : null;
-            })();
-      if (repositoryId !== null) {
-        const installations = await this.storage.installations.list({ orgId });
-        for (const installation of installations) {
-          const repositories = await this.storage.repositories.list({ orgId, installationId: installation.id });
-          const row = repositories.find(candidate => candidate.externalId === String(repositoryId));
-          if (row) {
-            repository = row.slug;
-            break;
-          }
-        }
-      }
-    }
-    if (repository === null || issueNumber === null || !Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
-      return null;
-    }
+    const target = parseGithubExternalTarget(externalSource.externalId);
+    if (!target) return null;
+    const repository = target.repository.includes('/')
+      ? target.repository
+      : (await this.storage.repositories.findByExternalId({ orgId, externalId: target.repository }))?.slug;
+    if (!repository) return null;
     return {
       connection: { type: 'app-installation', installationId: 1 },
       sourceId: repository,
-      issueId: String(issueNumber),
+      issueId: target.issueId,
     };
   }
 
@@ -1250,6 +1201,15 @@ function parsePositiveInteger(value: string): number | null {
   if (!/^\d+$/.test(value)) return null;
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseGithubExternalTarget(externalId: string): { repository: string; issueId: string } | null {
+  const match =
+    externalId.match(/^(.+\/.+):(\d+)$/) ??
+    externalId.match(/^github:(\d+):(?:issue|pull-request):(\d+)$/) ??
+    externalId.match(/^(\d+):(\d+)$/);
+  if (!match?.[1] || !match[2] || parsePositiveInteger(match[2]) === null) return null;
+  return { repository: match[1], issueId: match[2] };
 }
 
 function optionalPositiveIntegerEnv(name: 'MASTRA_PLATFORM_GITHUB_POLLING_INTERVAL_MS'): number | undefined {

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -159,6 +159,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
   #integrationStorage: GithubSubscriptionStorage | undefined;
 
   readonly intake: Intake = {
+    resolveIntakeDispatch: input => this.#resolveIntakeDispatch(input),
     listSources: async ({ orgId, userId }) => {
       const installations = await this.#client.request<{
         installations: Array<{
@@ -380,7 +381,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
    * `externalId`. The platform client authenticates via the platform API, so
    * the connection carries a nominal installation id (mirrors `listItems`).
    */
-  async resolveIntakeDispatch({
+  async #resolveIntakeDispatch({
     orgId,
     externalSource,
     metadata = {},

--- a/mastracode/factory/src/integrations/platform/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.test.ts
@@ -100,7 +100,7 @@ describe('PlatformLinearIntegration', () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(json({ workspaces: [workspace] }));
     const integration = createIntegration(fetchImpl);
 
-    const resolved = await integration.resolveIntakeDispatch({
+    const resolved = await integration.intake.resolveIntakeDispatch!({
       orgId: 'org-1',
       externalSource: { type: 'issue', externalId: 'issue-1' },
     });
@@ -113,13 +113,13 @@ describe('PlatformLinearIntegration', () => {
     const integration = createIntegration(fetchImpl);
 
     await expect(
-      integration.resolveIntakeDispatch({
+      integration.intake.resolveIntakeDispatch!({
         orgId: 'org-1',
         externalSource: { type: 'issue', externalId: 'issue-1' },
       }),
     ).resolves.toBeNull();
     await expect(
-      integration.resolveIntakeDispatch({
+      integration.intake.resolveIntakeDispatch!({
         orgId: 'org-1',
         externalSource: { type: 'pull-request', externalId: 'x' },
       }),

--- a/mastracode/factory/src/integrations/platform/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.test.ts
@@ -96,6 +96,36 @@ describe('PlatformLinearIntegration', () => {
     await expect(integration.getFreshAccessToken(loadedConnection)).resolves.not.toBe(config.accessToken);
   });
 
+  it('resolves dispatch context with the platform-managed token when a workspace is connected', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(json({ workspaces: [workspace] }));
+    const integration = createIntegration(fetchImpl);
+
+    const resolved = await integration.resolveIntakeDispatch({
+      orgId: 'org-1',
+      externalSource: { type: 'issue', externalId: 'issue-1' },
+    });
+    expect(resolved).toMatchObject({ connection: { type: 'oauth' }, issueId: 'issue-1' });
+    expect((resolved?.connection as { accessToken?: string }).accessToken).not.toBe(config.accessToken);
+  });
+
+  it('returns null dispatch context without a connected workspace or for non-issue sources', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(json({ workspaces: [] }));
+    const integration = createIntegration(fetchImpl);
+
+    await expect(
+      integration.resolveIntakeDispatch({
+        orgId: 'org-1',
+        externalSource: { type: 'issue', externalId: 'issue-1' },
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      integration.resolveIntakeDispatch({
+        orgId: 'org-1',
+        externalSource: { type: 'pull-request', externalId: 'x' },
+      }),
+    ).resolves.toBeNull();
+  });
+
   it('lists connected workspace projects as Intake sources', async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()
@@ -198,6 +228,106 @@ describe('PlatformLinearIntegration', () => {
     expect(fetchImpl.mock.calls[1]?.[1]).toEqual(
       expect.objectContaining({ method: 'POST', body: JSON.stringify({ body: 'Done' }) }),
     );
+  });
+
+  it('resolves a byType target to a workflow state and PATCHes the Linear issue', async () => {
+    const workflowStates = [
+      { id: 'state-todo', name: 'Todo', type: 'unstarted', position: 1, teamId: 'team-1' },
+      { id: 'state-done', name: 'Done', type: 'completed', position: 3, teamId: 'team-1' },
+    ];
+    const updatedIssue = { ...issue, state: { id: 'state-done', name: 'Done', type: 'completed' } };
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = String(input);
+      if (url.includes('/workflow-states'))
+        return json({ workflowStates, pageInfo: { hasNextPage: false, endCursor: null } });
+      if (url.includes(`/issues/${encodeURIComponent('issue-1')}?include=comments`)) {
+        // Two calls: initial locate + refreshed fetch after PATCH.
+        return fetchImpl.mock.calls.filter(c => String(c[0]).includes('?include=comments')).length > 1
+          ? json({ ...updatedIssue, comments: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } })
+          : json({ ...issue, comments: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } });
+      }
+      return json({});
+    });
+    const integration = createIntegration(fetchImpl);
+
+    const result = await integration.intake.updateIssue({
+      connection: { type: 'oauth', accessToken: 'unused-provider-token' },
+      sourceId: project1SourceId,
+      issueId: 'issue-1',
+      state: { kind: 'byType', stateType: 'completed' },
+    });
+    expect(result).toMatchObject({ id: 'issue-1', state: 'Done', stateType: 'completed' });
+
+    const patchCall = fetchImpl.mock.calls.find(call => (call[1] as RequestInit).method === 'PATCH');
+    expect(patchCall).toBeDefined();
+    expect(String(patchCall![0])).toContain(`/workspaces/workspace-1/issues/${encodeURIComponent('issue-1')}`);
+    expect(JSON.parse(String((patchCall![1] as RequestInit).body))).toEqual({ stateId: 'state-done' });
+  });
+
+  it('skips the PATCH when the current byType state already matches', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = String(input);
+      if (url.includes(`/issues/${encodeURIComponent('issue-1')}?include=comments`)) {
+        return json({ ...issue, comments: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } });
+      }
+      return json({});
+    });
+    const integration = createIntegration(fetchImpl);
+
+    const result = await integration.intake.updateIssue({
+      connection: { type: 'oauth', accessToken: 'unused-provider-token' },
+      sourceId: project1SourceId,
+      issueId: 'issue-1',
+      state: { kind: 'byType', stateType: 'unstarted' },
+    });
+    expect(result).toMatchObject({ stateType: 'unstarted' });
+    expect(fetchImpl.mock.calls.some(c => (c[1] as RequestInit).method === 'PATCH')).toBe(false);
+  });
+
+  it('returns null when no workflow state matches the byType target', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = String(input);
+      if (url.includes('/workflow-states')) {
+        return json({
+          workflowStates: [{ id: 'state-todo', name: 'Todo', type: 'unstarted', position: 1, teamId: 'team-1' }],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        });
+      }
+      if (url.includes(`/issues/${encodeURIComponent('issue-1')}?include=comments`)) {
+        return json({ ...issue, comments: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } });
+      }
+      return json({});
+    });
+    const integration = createIntegration(fetchImpl);
+    await expect(
+      integration.intake.updateIssue({
+        connection: { type: 'oauth', accessToken: 'unused-provider-token' },
+        sourceId: project1SourceId,
+        issueId: 'issue-1',
+        state: { kind: 'byType', stateType: 'completed' },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('degrades to null when the workflow-states endpoint is not deployed on the platform', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = String(input);
+      if (url.includes('/workflow-states')) return json({ detail: 'Not found' }, 404);
+      if (url.includes(`/issues/${encodeURIComponent('issue-1')}?include=comments`)) {
+        return json({ ...issue, comments: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } });
+      }
+      return json({});
+    });
+    const integration = createIntegration(fetchImpl);
+    await expect(
+      integration.intake.updateIssue({
+        connection: { type: 'oauth', accessToken: 'unused-provider-token' },
+        sourceId: project1SourceId,
+        issueId: 'issue-1',
+        state: { kind: 'byType', stateType: 'completed' },
+      }),
+    ).resolves.toBeNull();
+    expect(fetchImpl.mock.calls.some(c => (c[1] as RequestInit).method === 'PATCH')).toBe(false);
   });
 
   it('searches connected workspaces when issue operations have no source id and returns null on 404', async () => {

--- a/mastracode/factory/src/integrations/platform/linear/integration.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.ts
@@ -105,6 +105,7 @@ export class PlatformLinearIntegration implements FactoryIntegration {
   readonly #workflowStatesByTeam = new Map<string, LinearWorkflowState[]>();
 
   readonly intake: Intake = {
+    resolveIntakeDispatch: input => this.#resolveIntakeDispatch(input),
     listSources: async () => {
       const sources = await this.#listProjectSources();
       return sources.map(({ workspace, project }) => ({
@@ -324,7 +325,7 @@ export class PlatformLinearIntegration implements FactoryIntegration {
    * org has a connected workspace. Linear work items store the issue UUID
    * directly as `externalId`.
    */
-  async resolveIntakeDispatch({
+  async #resolveIntakeDispatch({
     orgId,
     externalSource,
   }: {

--- a/mastracode/factory/src/integrations/platform/linear/integration.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.ts
@@ -4,7 +4,7 @@ import { registerApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
 
 import type { IntegrationConnection } from '../../../capabilities/connection.js';
-import type { Intake, IntakeIssue, IntakeIssueDetail } from '../../../capabilities/intake.js';
+import type { Intake, IntakeIssue, IntakeIssueDetail, UpdateIntakeIssueInput } from '../../../capabilities/intake.js';
 import type { RouteAuth } from '../../../routes/route.js';
 import type { FactoryProjectsStorage } from '../../../storage/domains/projects/base.js';
 import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '../../base.js';
@@ -12,7 +12,13 @@ import { buildLinearAgentTools } from '../../linear/agent-tools.js';
 import type { LinearConnectionCheck, LinearIntegration } from '../../linear/integration.js';
 import { buildLinearRoutes } from '../../linear/routes.js';
 import type { LinearConnectionData, LinearConnectionRow, LinearStorageHandle } from '../../linear/storage.js';
-import { logPlatformInfo, PlatformApiClient, PlatformApiError, platformApiClientConfigFromEnv } from '../api-client.js';
+import {
+  logPlatformInfo,
+  logPlatformWarn,
+  PlatformApiClient,
+  PlatformApiError,
+  platformApiClientConfigFromEnv,
+} from '../api-client.js';
 
 type PageInfo = { hasNextPage: boolean; endCursor: string | null };
 type LinearUser = {
@@ -63,6 +69,13 @@ type LinearProject = {
   teams: Array<{ id: string; key: string; name: string }>;
 };
 type ProjectSource = { workspace: LinearWorkspace; project: LinearProject };
+type LinearWorkflowState = {
+  id: string;
+  name: string;
+  type: string;
+  position: number;
+  teamId: string;
+};
 
 const API_PREFIX = '/v1/server/linear';
 const PAGE_SIZE = 30;
@@ -84,6 +97,12 @@ export class PlatformLinearIntegration implements FactoryIntegration {
   readonly #endpointHost: string;
   #projects: FactoryProjectsStorage | undefined;
   #auth: RouteAuth | undefined;
+  /**
+   * Per-instance workflow-state cache keyed by `${workspaceId}:${teamId}`. Scoped to the process
+   * lifetime; not shared across requests intentionally to keep failure modes simple (stale states
+   * clear on process restart). Populated lazily on first `updateIssue` per team.
+   */
+  readonly #workflowStatesByTeam = new Map<string, LinearWorkflowState[]>();
 
   readonly intake: Intake = {
     listSources: async () => {
@@ -156,6 +175,69 @@ export class PlatformLinearIntegration implements FactoryIntegration {
         if (isNotFound(error)) return null;
         throw error;
       }
+    },
+    updateIssue: async (input: UpdateIntakeIssueInput): Promise<IntakeIssue | null> => {
+      requireLinearConnection(input.connection);
+      const located = await this.#findIssue(input.sourceId, input.issueId);
+      if (!located) return null;
+      const { workspaceId, issue } = located;
+
+      const target = input.state;
+      // Idempotency: skip the write entirely if the issue is already at the target state.
+      if (target.kind === 'byType' && issue.state.type === target.stateType) {
+        return parseIssue(issue);
+      }
+      if (target.kind === 'byName' && issue.state.name.toLowerCase() === target.name.toLowerCase()) {
+        return parseIssue(issue);
+      }
+
+      let states: LinearWorkflowState[];
+      try {
+        states = await this.#listWorkflowStates(workspaceId, issue.team.id);
+      } catch (error) {
+        if (isNotFound(error)) {
+          // Platform companion endpoint not deployed yet — degrade to policy skip so PR 1
+          // is standalone-mergeable ahead of the platform-side workflow-states route landing.
+          logPlatformWarn('Platform Linear: workflow-states endpoint not available; skipping updateIssue.', {
+            workspaceId,
+            teamId: issue.team.id,
+          });
+          return null;
+        }
+        throw error;
+      }
+      let matched: LinearWorkflowState | undefined;
+      if (target.kind === 'byType') {
+        matched = states
+          .slice()
+          .sort((a, b) => a.position - b.position)
+          .find(s => s.type === target.stateType);
+      } else {
+        const wanted = target.name.toLowerCase();
+        matched = states.find(s => s.name.toLowerCase() === wanted);
+      }
+      if (!matched) {
+        logPlatformWarn('Platform Linear: no workflow state matched target; skipping updateIssue.', {
+          workspaceId,
+          teamId: issue.team.id,
+          target,
+        });
+        return null;
+      }
+
+      try {
+        await this.#client.request<LinearIssue>(
+          'PATCH',
+          `${API_PREFIX}/workspaces/${encodeURIComponent(workspaceId)}/issues/${encodeURIComponent(input.issueId)}`,
+          { stateId: matched.id },
+        );
+      } catch (error) {
+        if (isNotFound(error)) return null;
+        throw error;
+      }
+
+      const refreshed = await this.#findIssue(input.sourceId, input.issueId);
+      return refreshed ? parseIssue(refreshed.issue) : null;
     },
   };
 
@@ -235,6 +317,27 @@ export class PlatformLinearIntegration implements FactoryIntegration {
 
   async getFreshAccessToken(_connection: LinearConnectionRow): Promise<string> {
     return PLATFORM_MANAGED_CONNECTION_TOKEN;
+  }
+
+  /**
+   * Background-dispatch context: platform-managed connection token when the
+   * org has a connected workspace. Linear work items store the issue UUID
+   * directly as `externalId`.
+   */
+  async resolveIntakeDispatch({
+    orgId,
+    externalSource,
+  }: {
+    orgId: string;
+    externalSource: { type: string; externalId: string };
+  }): Promise<{ connection: IntegrationConnection; issueId: string } | null> {
+    if (externalSource.type !== 'issue') return null;
+    const connection = await this.loadConnection(orgId);
+    if (!connection) return null;
+    return {
+      connection: { type: 'oauth', accessToken: PLATFORM_MANAGED_CONNECTION_TOKEN },
+      issueId: externalSource.externalId,
+    };
   }
 
   canPostComments(connection: LinearConnectionRow): boolean {
@@ -419,6 +522,18 @@ export class PlatformLinearIntegration implements FactoryIntegration {
       }
     }
     return null;
+  }
+
+  async #listWorkflowStates(workspaceId: string, teamId: string): Promise<LinearWorkflowState[]> {
+    const cacheKey = `${workspaceId}:${teamId}`;
+    const cached = this.#workflowStatesByTeam.get(cacheKey);
+    if (cached) return cached;
+    const result = await this.#client.request<{ workflowStates: LinearWorkflowState[]; pageInfo: PageInfo }>(
+      'GET',
+      `${API_PREFIX}/workspaces/${encodeURIComponent(workspaceId)}/workflow-states?teamId=${encodeURIComponent(teamId)}&first=100`,
+    );
+    this.#workflowStatesByTeam.set(cacheKey, result.workflowStates);
+    return result.workflowStates;
   }
 
   async #candidateWorkspaceIds(sourceId: string | undefined): Promise<string[]> {

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -969,6 +969,179 @@ describe('FactoryDecisionDispatcher', () => {
     expect((await storage.listPendingStarts('org-1', PROJECT_ID))[0]?.status).toBe('sent');
   });
 
+  it('fans out updateExternalSource decisions through the resolved Intake and skips when already in target state', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { transitionService } = await queueDecision(storage, {
+      type: 'updateExternalSource',
+      idempotencyKey: 'ext-state-1',
+      state: { kind: 'byType', stateType: 'started' },
+    });
+    const { controller } = createSession();
+
+    const getIssue = vi.fn().mockResolvedValueOnce({
+      id: 'issue-1',
+      identifier: 'ORG-1',
+      title: 'Fix issue',
+      url: 'https://example.com',
+      author: null,
+      state: 'Todo',
+      stateType: 'unstarted',
+      priority: null,
+      assignee: null,
+      source: null,
+      labels: [],
+      commentCount: 0,
+      createdAt: '2030-01-01T00:00:00Z',
+      updatedAt: '2030-01-01T00:00:00Z',
+    });
+    const updateIssue = vi.fn().mockResolvedValue(null);
+    const intake = { getIssue, updateIssue };
+
+    const connection = { type: 'oauth' as const, accessToken: 'token-1' };
+    const resolveIntake = vi.fn(async () => ({
+      intake: intake as never,
+      connection,
+      issueId: 'issue-1',
+    }));
+
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-ext',
+      intake: resolveIntake,
+    });
+    await dispatcher.runOnce();
+
+    expect(resolveIntake).toHaveBeenCalledTimes(1);
+    expect(getIssue).toHaveBeenCalledTimes(1);
+    expect(updateIssue).toHaveBeenCalledTimes(1);
+    expect(updateIssue).toHaveBeenCalledWith({
+      connection,
+      issueId: 'issue-1',
+      state: { kind: 'byType', stateType: 'started' },
+      actingUserId: 'user-1',
+    });
+
+    const first = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(first[0]?.status).toBe('succeeded');
+
+    // Idempotency: replay with current state already 'started' skips updateIssue
+    getIssue.mockResolvedValueOnce({
+      id: 'issue-1',
+      identifier: 'ORG-1',
+      title: 'Fix issue',
+      url: 'https://example.com',
+      author: null,
+      state: 'In Progress',
+      stateType: 'started',
+      priority: null,
+      assignee: null,
+      source: null,
+      labels: [],
+      commentCount: 0,
+      createdAt: '2030-01-01T00:00:00Z',
+      updatedAt: '2030-01-01T00:00:00Z',
+    });
+    const { transitionService: transitionService2 } = await queueDecision(storage, {
+      type: 'updateExternalSource',
+      idempotencyKey: 'ext-state-2',
+      state: { kind: 'byType', stateType: 'started' },
+    });
+    const dispatcher2 = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService: transitionService2,
+      storage,
+      ownerId: 'worker-ext-2',
+      intake: resolveIntake,
+    });
+    // reset call counts to isolate the second dispatch
+    updateIssue.mockClear();
+    await dispatcher2.runOnce();
+    expect(updateIssue).not.toHaveBeenCalled();
+  });
+
+  it('fans out commentExternalSource decisions through the resolved Intake', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { transitionService } = await queueDecision(storage, {
+      type: 'commentExternalSource',
+      idempotencyKey: 'ext-comment-1',
+      body: 'Factory picked this up.',
+    });
+    const { controller } = createSession();
+
+    const createComment = vi.fn().mockResolvedValue({ id: 'comment-1', url: 'https://example.com/1' });
+    const intake = { getIssue: vi.fn(), updateIssue: vi.fn(), createComment };
+    const connection = { type: 'oauth' as const, accessToken: 'token-1' };
+    const resolveIntake = vi.fn(async () => ({
+      intake: intake as never,
+      connection,
+      issueId: 'issue-1',
+    }));
+
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-comment',
+      intake: resolveIntake,
+    });
+    await dispatcher.runOnce();
+
+    expect(createComment).toHaveBeenCalledWith({
+      connection,
+      issueId: 'issue-1',
+      body: 'Factory picked this up.',
+      actingUserId: 'user-1',
+    });
+    const [record] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(record?.status).toBe('succeeded');
+  });
+
+  it('completes silently when the intake resolver returns null (manual/skip)', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { transitionService } = await queueDecision(storage, {
+      type: 'commentExternalSource',
+      idempotencyKey: 'ext-comment-skip',
+      body: 'Would comment.',
+    });
+    const { controller } = createSession();
+    const resolveIntake = vi.fn(async () => null);
+
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-null',
+      intake: resolveIntake,
+    });
+    await dispatcher.runOnce();
+
+    const [record] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(record?.status).toBe('succeeded');
+  });
+
+  it('fails terminally when no intake resolver is configured', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { transitionService } = await queueDecision(storage, {
+      type: 'commentExternalSource',
+      idempotencyKey: 'ext-comment-noresolver',
+      body: 'Would comment.',
+    });
+    const { controller } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-noresolver',
+    });
+    await dispatcher.runOnce();
+
+    const [record] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(record?.status).toBe('failed');
+    expect(record?.lastError).toMatch(/external-source dispatch is not configured/i);
+  });
+
   it('starts one polling loop and stops claiming before shutdown returns', async () => {
     vi.useFakeTimers();
     try {

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -1020,7 +1020,6 @@ describe('FactoryDecisionDispatcher', () => {
       connection,
       issueId: 'issue-1',
       state: { kind: 'byType', stateType: 'started' },
-      actingUserId: 'user-1',
     });
 
     const first = await storage.listDeferredDecisions('org-1', PROJECT_ID);
@@ -1092,7 +1091,6 @@ describe('FactoryDecisionDispatcher', () => {
       connection,
       issueId: 'issue-1',
       body: 'Factory picked this up.',
-      actingUserId: 'user-1',
     });
     const [record] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
     expect(record?.status).toBe('succeeded');

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -109,15 +109,36 @@ function retryAt(now: Date, attempts: number): Date {
 }
 
 function externalSourceForDecision(decision: Extract<FactoryCommitDecision, { type: 'upsertLinkedWorkItem' }>) {
-  const [integrationId, type] =
-    decision.source === 'github-pr'
-      ? ['github', 'pull-request']
-      : decision.source === 'github-issue'
-        ? ['github', 'issue']
-        : decision.source === 'linear-issue'
-          ? ['linear', 'issue']
-          : ['factory', 'manual'];
-  return { integrationId, type, externalId: decision.sourceKey, url: decision.url ?? undefined };
+  const metadata = decision.metadata ?? {};
+  if (decision.source === 'github-issue' || decision.source === 'github-pr') {
+    const repositoryId = metadata.githubRepositoryId;
+    const issueNumber =
+      decision.source === 'github-issue' ? metadata.githubIssueNumber : metadata.githubPullRequestNumber;
+    const externalId =
+      typeof repositoryId === 'number' && typeof issueNumber === 'number'
+        ? `${repositoryId}:${issueNumber}`
+        : decision.sourceKey;
+    return {
+      integrationId: 'github',
+      type: decision.source === 'github-pr' ? 'pull-request' : 'issue',
+      externalId,
+      url: decision.url ?? undefined,
+    };
+  }
+  if (decision.source === 'linear-issue') {
+    return {
+      integrationId: 'linear',
+      type: 'issue',
+      externalId: typeof metadata.linearIssueId === 'string' ? metadata.linearIssueId : decision.sourceKey,
+      url: decision.url ?? undefined,
+    };
+  }
+  return {
+    integrationId: 'factory',
+    type: 'manual',
+    externalId: decision.sourceKey,
+    url: decision.url ?? undefined,
+  };
 }
 
 function deferredActor(record: FactoryDeferredDecisionRecord): FactoryRuleActor {

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -4,6 +4,8 @@ import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentController } from '@mastra/core/agent-controller';
 import { RequestContext } from '@mastra/core/request-context';
 
+import type { IntegrationConnection } from '../capabilities/connection.js';
+import type { Intake } from '../capabilities/intake.js';
 import { resolveSkillInvocation } from '../skills/service.js';
 import type { SkillSession } from '../skills/service.js';
 import type {
@@ -44,6 +46,40 @@ export interface FactoryBindingPreparationInput {
   role: string;
 }
 
+/**
+ * Result of resolving the `Intake` and connection to reach the external source
+ * of a work item, used by the dispatcher when it fans out
+ * `updateExternalSource` and `commentExternalSource` decisions.
+ */
+export interface FactoryIntakeResolution {
+  intake: Intake;
+  connection: IntegrationConnection;
+  /** Provider-defined source id (e.g., GitHub `owner/repo`). Undefined when the provider doesn't need one. */
+  sourceId?: string;
+  /** Provider-defined issue id used by `Intake.getIssue` / `updateIssue` / `createComment`. */
+  issueId: string;
+  /**
+   * End user to attribute the action to when the provider supports it (GitHub
+   * App on-behalf-of, Linear `createAsUser`). Optional.
+   */
+  actingUserId?: string;
+}
+
+export interface FactoryIntakeResolverInput {
+  orgId: string;
+  factoryProjectId: string;
+  workItem: WorkItemRow;
+}
+
+/**
+ * Resolve the external-source dispatch context for a work item, or `null` when
+ * the work item has no external source we can act on (manual items, missing
+ * integration, no connection). `null` is treated as a policy skip — the
+ * decision completes silently. Infrastructure errors propagate so the
+ * dispatcher's retry loop can back off.
+ */
+export type FactoryIntakeResolver = (input: FactoryIntakeResolverInput) => Promise<FactoryIntakeResolution | null>;
+
 export interface FactoryDecisionDispatcherOptions {
   controller: FactoryController;
   transitionService: Pick<FactoryTransitionService, 'transition'>;
@@ -52,6 +88,13 @@ export interface FactoryDecisionDispatcherOptions {
   reconcileToolResults?: () => Promise<void>;
   prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
   primeCredentials?: (tenant: { orgId: string; userId: string }) => Promise<void>;
+  /**
+   * Resolves `Intake` + `IntegrationConnection` for external-source decisions
+   * (`updateExternalSource`, `commentExternalSource`). When omitted, those
+   * decisions fail terminally on first attempt — the resolver must be wired
+   * in production to make those decision types functional.
+   */
+  intake?: FactoryIntakeResolver;
 }
 
 function sanitizeDispatchError(error: unknown): string {
@@ -130,6 +173,7 @@ export class FactoryDecisionDispatcher {
   readonly #reconcileToolResults?: () => Promise<void>;
   readonly #prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
   readonly #primeCredentials?: (tenant: { orgId: string; userId: string }) => Promise<void>;
+  readonly #resolveIntake?: FactoryIntakeResolver;
   #timer?: ReturnType<typeof setInterval>;
   #activeRun?: Promise<void>;
 
@@ -141,6 +185,7 @@ export class FactoryDecisionDispatcher {
     this.#reconcileToolResults = options.reconcileToolResults;
     this.#prepareBinding = options.prepareBinding;
     this.#primeCredentials = options.primeCredentials;
+    this.#resolveIntake = options.intake;
   }
 
   start(): void {
@@ -203,7 +248,9 @@ export class FactoryDecisionDispatcher {
       const completed = await this.#storage.completeDeferredDecision(leaseIdentity(record, this.#ownerId), new Date());
       if (!completed) throw new Error('Factory decision lease was lost before completion.');
     } catch (error) {
-      const terminal = record.attempts >= MAX_ATTEMPTS;
+      const flaggedTerminal =
+        typeof error === 'object' && error !== null && (error as { terminal?: boolean }).terminal === true;
+      const terminal = flaggedTerminal || record.attempts >= MAX_ATTEMPTS;
       await this.#storage.failDeferredDecision({
         ...leaseIdentity(record, this.#ownerId),
         now: new Date(),
@@ -337,8 +384,79 @@ export class FactoryDecisionDispatcher {
             dedupeKey: record.idempotencyKey,
           }),
         );
+        return;
+      }
+      case 'updateExternalSource': {
+        await this.#executeUpdateExternalSource(record, decision);
+        return;
+      }
+      case 'commentExternalSource': {
+        await this.#executeCommentExternalSource(record, decision);
+        return;
       }
     }
+  }
+
+  async #resolveExternalIntake(record: FactoryDeferredDecisionRecord): Promise<FactoryIntakeResolution | null> {
+    if (!this.#resolveIntake) {
+      const err = new Error('Factory external-source dispatch is not configured.');
+      (err as Error & { terminal?: boolean }).terminal = true;
+      throw err;
+    }
+    const workItem = await this.#requireItem(record);
+    const resolution = await this.#resolveIntake({
+      orgId: record.orgId,
+      factoryProjectId: record.factoryProjectId,
+      workItem,
+    });
+    if (!resolution || resolution.actingUserId) return resolution;
+    const actor = record.actor;
+    return actor?.type === 'human' && typeof actor.id === 'string'
+      ? { ...resolution, actingUserId: actor.id }
+      : resolution;
+  }
+
+  async #executeUpdateExternalSource(
+    record: FactoryDeferredDecisionRecord,
+    decision: Extract<FactoryCommitDecision, { type: 'updateExternalSource' }>,
+  ): Promise<void> {
+    const resolution = await this.#resolveExternalIntake(record);
+    if (!resolution) return;
+    const { intake, connection, sourceId, issueId, actingUserId } = resolution;
+    const current = await intake.getIssue({ connection, ...(sourceId ? { sourceId } : {}), issueId });
+    if (current) {
+      if (decision.state.kind === 'byType' && current.stateType === decision.state.stateType) return;
+      if (
+        decision.state.kind === 'byName' &&
+        current.state !== null &&
+        current.state.toLowerCase() === decision.state.name.toLowerCase()
+      ) {
+        return;
+      }
+    }
+    await intake.updateIssue({
+      connection,
+      ...(sourceId ? { sourceId } : {}),
+      issueId,
+      state: decision.state,
+      ...(actingUserId ? { actingUserId } : {}),
+    });
+  }
+
+  async #executeCommentExternalSource(
+    record: FactoryDeferredDecisionRecord,
+    decision: Extract<FactoryCommitDecision, { type: 'commentExternalSource' }>,
+  ): Promise<void> {
+    const resolution = await this.#resolveExternalIntake(record);
+    if (!resolution) return;
+    const { intake, connection, sourceId, issueId, actingUserId } = resolution;
+    await intake.createComment({
+      connection,
+      ...(sourceId ? { sourceId } : {}),
+      issueId,
+      body: decision.body,
+      ...(actingUserId ? { actingUserId } : {}),
+    });
   }
 
   async #upsertLinkedItem(

--- a/mastracode/factory/src/rules/github-service.test.ts
+++ b/mastracode/factory/src/rules/github-service.test.ts
@@ -239,7 +239,7 @@ describe('FactoryGithubEventService', () => {
 
     const [item] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
     expect(item).toMatchObject({
-      externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:42' },
+      externalSource: { integrationId: 'github', type: 'issue', externalId: '10:42' },
       stages: ['triage'],
       sessions: {
         triage: {
@@ -274,7 +274,7 @@ describe('FactoryGithubEventService', () => {
 
     const [rematerialized] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
     expect(rematerialized).toMatchObject({
-      externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:42' },
+      externalSource: { integrationId: 'github', type: 'issue', externalId: '10:42' },
       stages: ['triage'],
     });
     expect(rematerialized?.id).not.toBe(item?.id);

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -125,9 +125,11 @@ export interface FactoryLinearRuleContext extends FactoryRuleContextBase {
   };
 }
 
+export type FactoryRuleHandlerResult = FactoryRuleDecision | readonly FactoryRuleDecision[] | void;
+
 export type FactoryRuleHandler<TContext> = (
   context: Readonly<TContext>,
-) => FactoryRuleDecision | void | Promise<FactoryRuleDecision | void>;
+) => FactoryRuleHandlerResult | Promise<FactoryRuleHandlerResult>;
 
 export interface FactoryBoardRuleLeaf {
   onEnter?: FactoryRuleHandler<FactoryStageRuleContext>;
@@ -228,12 +230,27 @@ export interface FactoryNotifyDecision extends FactoryCommitDecisionBase {
   level?: 'info' | 'warning' | 'error';
 }
 
+export type FactoryExternalSourceTargetState =
+  { kind: 'byType'; stateType: 'unstarted' | 'started' | 'completed' | 'canceled' } | { kind: 'byName'; name: string };
+
+export interface FactoryUpdateExternalSourceDecision extends FactoryCommitDecisionBase {
+  type: 'updateExternalSource';
+  state: FactoryExternalSourceTargetState;
+}
+
+export interface FactoryCommentExternalSourceDecision extends FactoryCommitDecisionBase {
+  type: 'commentExternalSource';
+  body: string;
+}
+
 export type FactoryCommitDecision =
   | FactoryTransitionDecision
   | FactoryUpsertLinkedWorkItemDecision
   | FactoryInvokeSkillDecision
   | FactorySendMessageDecision
-  | FactoryNotifyDecision;
+  | FactoryNotifyDecision
+  | FactoryUpdateExternalSourceDecision
+  | FactoryCommentExternalSourceDecision;
 
 export type FactoryRuleDecision = FactoryRuleRejectDecision | FactoryCommitDecision;
 

--- a/mastracode/factory/src/rules/validation.test.ts
+++ b/mastracode/factory/src/rules/validation.test.ts
@@ -26,11 +26,69 @@ describe('Factory rule validation', () => {
       { type: 'invokeSkill', idempotencyKey: 'skill-1', role: 'review', skillName: 'understand-pr' },
       { type: 'sendMessage', idempotencyKey: 'message-1', role: 'work', message: 'Assess completion.' },
       { type: 'notify', idempotencyKey: 'notify-1', title: 'Factory update', level: 'info' },
+      {
+        type: 'updateExternalSource',
+        idempotencyKey: 'ext-state-1',
+        state: { kind: 'byType', stateType: 'started' },
+      },
+      {
+        type: 'updateExternalSource',
+        idempotencyKey: 'ext-state-2',
+        state: { kind: 'byName', name: 'In Review' },
+      },
+      {
+        type: 'commentExternalSource',
+        idempotencyKey: 'ext-comment-1',
+        body: 'Factory picked this up.',
+      },
     ];
 
     const validated = validateFactoryRuleDecisions(decisions);
-    expect(validated).toHaveLength(5);
+    expect(validated).toHaveLength(8);
     expect(JSON.parse(JSON.stringify(validated))).toEqual(validated);
+  });
+
+  it('rejects invalid updateExternalSource + commentExternalSource shapes', () => {
+    expect(() =>
+      validateFactoryRuleDecision({
+        type: 'updateExternalSource',
+        idempotencyKey: 'ext-state-bad',
+        state: { kind: 'byType', stateType: 'in-review' },
+      }),
+    ).toThrow(/stateType is invalid/i);
+
+    expect(() =>
+      validateFactoryRuleDecision({
+        type: 'updateExternalSource',
+        idempotencyKey: 'ext-state-bad',
+        state: { kind: 'byOther' },
+      }),
+    ).toThrow(/state kind is invalid/i);
+
+    expect(() =>
+      validateFactoryRuleDecision({
+        type: 'updateExternalSource',
+        idempotencyKey: 'ext-state-bad',
+        state: { kind: 'byName', name: 'x'.repeat(129) },
+      }),
+    ).toThrow(/state name is invalid/i);
+
+    expect(() =>
+      validateFactoryRuleDecision({
+        type: 'commentExternalSource',
+        idempotencyKey: 'ext-comment-bad',
+        body: '',
+      }),
+    ).toThrow(/body is invalid/i);
+
+    expect(() =>
+      validateFactoryRuleDecision({
+        type: 'commentExternalSource',
+        idempotencyKey: 'ext-comment-bad',
+        body: 'ok',
+        extra: true,
+      }),
+    ).toThrow(/unsupported field/i);
   });
 
   it('keeps rejection exclusive from commit-only fields and decisions', () => {

--- a/mastracode/factory/src/rules/validation.ts
+++ b/mastracode/factory/src/rules/validation.ts
@@ -23,6 +23,8 @@ const MAX_REASON_LENGTH = 512;
 const MAX_TITLE_LENGTH = 512;
 const MAX_MESSAGE_LENGTH = 8_192;
 const MAX_ARGUMENTS_LENGTH = 4_096;
+const MAX_EXTERNAL_STATE_NAME_LENGTH = 128;
+const EXTERNAL_STATE_TYPES = ['unstarted', 'started', 'completed', 'canceled'] as const;
 const MAX_ROLE_LENGTH = 32;
 const MAX_SKILL_NAME_LENGTH = 128;
 const MAX_SOURCE_KEY_LENGTH = 256;
@@ -297,6 +299,47 @@ export function validateFactoryRuleDecision(value: unknown, causalDepth = 0): Fa
         ...(priority ? { priority } : {}),
         ...(idleBehavior ? { idleBehavior } : {}),
         ...(value.prepareBinding === true ? { prepareBinding: true } : {}),
+      };
+    }
+    case 'updateExternalSource': {
+      assertExactKeys(value, ['type', 'idempotencyKey', 'state'], 'Factory update external source decision');
+      if (!isPlainObject(value.state)) {
+        throw new FactoryRuleValidationError('Factory update external source state must be an object.');
+      }
+      const kind = value.state.kind;
+      let state:
+        { kind: 'byType'; stateType: (typeof EXTERNAL_STATE_TYPES)[number] } | { kind: 'byName'; name: string };
+      if (kind === 'byType') {
+        assertExactKeys(value.state, ['kind', 'stateType'], 'Factory update external source state');
+        state = {
+          kind: 'byType',
+          stateType: enumValue(value.state.stateType, EXTERNAL_STATE_TYPES, 'Factory update external source stateType'),
+        };
+      } else if (kind === 'byName') {
+        assertExactKeys(value.state, ['kind', 'name'], 'Factory update external source state');
+        state = {
+          kind: 'byName',
+          name: boundedString(
+            value.state.name,
+            'Factory update external source state name',
+            MAX_EXTERNAL_STATE_NAME_LENGTH,
+          ),
+        };
+      } else {
+        throw new FactoryRuleValidationError('Factory update external source state kind is invalid.');
+      }
+      return {
+        type,
+        ...commonCommitFields(value),
+        state,
+      };
+    }
+    case 'commentExternalSource': {
+      assertExactKeys(value, ['type', 'idempotencyKey', 'body'], 'Factory comment external source decision');
+      return {
+        type,
+        ...commonCommitFields(value),
+        body: boundedString(value.body, 'Factory comment external source body', MAX_MESSAGE_LENGTH),
       };
     }
     case 'notify': {

--- a/mastracode/factory/src/storage/domains/source-control/base.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.ts
@@ -327,11 +327,7 @@ export interface SourceControlStorageHandle {
   readonly repositories: {
     list(args: { orgId: string; installationId: string }): Promise<SourceControlRepository[]>;
     get(args: { orgId: string; id: string }): Promise<SourceControlRepository | null>;
-    findByExternalId(args: {
-      orgId: string;
-      installationId: string;
-      externalId: string;
-    }): Promise<SourceControlRepository | null>;
+    findByExternalId(args: { orgId: string; externalId: string }): Promise<SourceControlRepository | null>;
     findBySlug(args: { orgId: string; installationId: string; slug: string }): Promise<SourceControlRepository | null>;
     upsert(args: { orgId: string; input: UpsertSourceControlRepositoryInput }): Promise<SourceControlRepository>;
   };
@@ -716,13 +712,12 @@ export class SourceControlStorage extends FactoryStorageDomain {
           );
         },
         get: getRepository,
-        findByExternalId: async ({ orgId, installationId, externalId }) => {
-          await requireInstallation({ orgId, id: installationId });
-          const row = await db().findOne<RepositoryDbRow>(REPOSITORIES, {
-            installation_id: installationId,
-            external_id: externalId,
-          });
-          return row ? toRepository(row) : null;
+        findByExternalId: async ({ orgId, externalId }) => {
+          const rows = await db().findMany<RepositoryDbRow>(REPOSITORIES, { external_id: externalId });
+          for (const row of rows) {
+            if (await getInstallation({ orgId, id: row.installation_id })) return toRepository(row);
+          }
+          return null;
         },
         findBySlug: async ({ orgId, installationId, slug }) => {
           await requireInstallation({ orgId, id: installationId });


### PR DESCRIPTION
Adds validated updateExternalSource and commentExternalSource decisions to Factory’s deferred dispatcher. Integrations own connection and external-ID resolution, state writes are idempotency-guarded, and infrastructure failures use the existing retry path.

Stacked on #20111.

Verification:
- dispatcher and validation tests pass
- Factory lint clean
- no new typecheck errors