### PR TITLE
feat(mastracode): float workspace files

### DIFF
--- a/mastracode/web/src/shared/api/keys.ts
+++ b/mastracode/web/src/shared/api/keys.ts
@@ -60,8 +60,9 @@ export const queryKeys = {
   om: (resourceId: string | undefined) => ['om', resourceId ?? null] as const,
   fsList: (path: string | undefined) => ['fs-list', path ?? null] as const,
   artifactsList: (path: string | undefined) => ['artifacts-list', path ?? null] as const,
+  workspaceRenderedListAll: () => ['workspace-rendered-list'] as const,
   workspaceRenderedList: (workspacePath: string | undefined, renderedRoot: string | undefined) =>
-    ['workspace-rendered-list', workspacePath ?? null, renderedRoot ?? null] as const,
+    [...queryKeys.workspaceRenderedListAll(), workspacePath ?? null, renderedRoot ?? null] as const,
   workspaceFile: (workspacePath: string | undefined, filePath: string | undefined) =>
     ['workspace-file', workspacePath ?? null, filePath ?? null] as const,
   agentControllerModes: (agentControllerId: string | undefined) =>

--- a/mastracode/web/src/shared/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
+++ b/mastracode/web/src/shared/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
@@ -13,10 +13,12 @@ import {
   useAgentControllerConnection,
 } from '../../../web/ui/domains/chat/hooks/useAgentControllerConnection';
 import { reconnectRefetchInterval } from '../useAgentControllerSessionSync';
+import { useWorkspaceRenderedListing } from '../use-fs';
 
 const controllerId = 'code';
 const resourceId = 'resource-test';
 const sessionUrl = `${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions/${resourceId}`;
+const workspaceRenderedUrl = `${TEST_BASE_URL}/web/workspace/rendered/list`;
 const hookArgs = { agentControllerId: controllerId, resourceId, baseUrl: TEST_BASE_URL, enabled: true };
 
 describe('useAgentControllerConnection', () => {
@@ -223,6 +225,68 @@ describe('useAgentControllerConnection', () => {
     await waitFor(() => expect(result.current.state?.running).toBe(true));
     expect(result.current.status).toBe('ready');
     expect(onStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('given an active workspace listing, when a file mutation ends, then the listing refreshes', async () => {
+    const encoder = new TextEncoder();
+    const onListing = vi.fn();
+    let emit: (event: AgentControllerEvent) => void = () => {};
+
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, () =>
+        HttpResponse.json({ controllerId, resourceId, threadId: 'created-thread' }),
+      ),
+      http.get(sessionUrl, () =>
+        HttpResponse.json({
+          controllerId,
+          resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: 'state-thread',
+          running: true,
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        }),
+      ),
+      http.get(
+        `${sessionUrl}/stream`,
+        () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                emit = event => controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+              },
+              cancel() {},
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          ),
+      ),
+      http.get(workspaceRenderedUrl, () => {
+        onListing();
+        return HttpResponse.json({
+          workspacePath: '/workspace',
+          root: '.artifacts',
+          rootPath: '/workspace/.artifacts',
+          entries: [],
+        });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => {
+      const connection = useAgentControllerConnection({ ...hookArgs, onEvent: vi.fn() });
+      const workspaceListing = useWorkspaceRenderedListing('/workspace', '.artifacts');
+      return { connection, workspaceListing };
+    });
+
+    await waitFor(() => {
+      expect(result.current.connection.status).toBe('ready');
+      expect(result.current.workspaceListing.isSuccess).toBe(true);
+    });
+    expect(onListing).toHaveBeenCalledOnce();
+
+    emit({ type: 'tool_start', toolCallId: 'write-1', toolName: 'write_file', args: { path: '.artifacts/a.md' } });
+    emit({ type: 'tool_end', toolCallId: 'write-1', result: { ok: true } });
+
+    await waitFor(() => expect(onListing).toHaveBeenCalledTimes(2));
   });
 
   it('given reconnect polling is disconnected, then it backs off and stops at the retry cap', () => {

--- a/mastracode/web/src/shared/hooks/use-fs.ts
+++ b/mastracode/web/src/shared/hooks/use-fs.ts
@@ -32,11 +32,15 @@ export function useArtifactListing(path: string | undefined) {
   });
 }
 
+const WORKSPACE_RENDERED_POLL_MS = 5_000;
+
 export function useWorkspaceRenderedListing(workspacePath: string | undefined, renderedRoot: string | undefined) {
   const { client } = useApiConfig();
   return useQuery<WorkspaceRenderedListing>({
     queryKey: queryKeys.workspaceRenderedList(workspacePath, renderedRoot),
     enabled: Boolean(workspacePath && renderedRoot),
+    refetchInterval: WORKSPACE_RENDERED_POLL_MS,
+    refetchOnWindowFocus: true,
     queryFn: () =>
       client.get<WorkspaceRenderedListing>(
         `/web/workspace/rendered/list?workspacePath=${encodeURIComponent(workspacePath ?? '')}&root=${encodeURIComponent(renderedRoot ?? '')}`,

--- a/mastracode/web/src/shared/hooks/use-fs.ts
+++ b/mastracode/web/src/shared/hooks/use-fs.ts
@@ -32,15 +32,15 @@ export function useArtifactListing(path: string | undefined) {
   });
 }
 
-const WORKSPACE_RENDERED_POLL_MS = 5_000;
-
 export function useWorkspaceRenderedListing(workspacePath: string | undefined, renderedRoot: string | undefined) {
   const { client } = useApiConfig();
   return useQuery<WorkspaceRenderedListing>({
     queryKey: queryKeys.workspaceRenderedList(workspacePath, renderedRoot),
     enabled: Boolean(workspacePath && renderedRoot),
-    refetchInterval: WORKSPACE_RENDERED_POLL_MS,
-    refetchOnWindowFocus: true,
+    // Controller mutation and run-completion events invalidate this query.
+    // Reuse that fresh result across observers and refresh when the tab returns.
+    staleTime: Infinity,
+    refetchOnWindowFocus: 'always',
     queryFn: () =>
       client.get<WorkspaceRenderedListing>(
         `/web/workspace/rendered/list?workspacePath=${encodeURIComponent(workspacePath ?? '')}&root=${encodeURIComponent(renderedRoot ?? '')}`,

--- a/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/TranscriptPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/TranscriptPanel.tsx
@@ -9,7 +9,7 @@ import { EmptyThreadState } from './EmptyThreadState';
 import { WorkingIndicator } from './WorkingIndicator';
 
 const transcriptScrollClass =
-  'flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-3 pb-2 pt-6 md:px-5 [&>*]:mx-auto [&>*]:w-full [&>*]:min-w-0 [&>*]:max-w-[80ch]';
+  'flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-3 pb-2 pt-6 transition-[padding-right] duration-220 ease-[cubic-bezier(0.32,0.72,0,1)] md:px-5 lg:in-data-[panel-open=true]:pr-[calc(var(--chat-right-panel-width)+0.5rem)] motion-reduce:transition-none in-data-[panel-gesture=active]:transition-none [&>*]:mx-auto [&>*]:w-full [&>*]:min-w-0 [&>*]:max-w-[80ch]';
 
 export function TranscriptPanel() {
   const { transcript, showWorkingIndicator, loadMore } = useChatTranscript();

--- a/mastracode/web/src/web/ui/domains/chat/components/TaskPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/TaskPanel.tsx
@@ -9,7 +9,12 @@ export function TaskPanel() {
   if (!hasVisibleTasks) return null;
 
   return (
-    <div className="w-full px-3 md:px-5" role="region" aria-label="Current tasks" data-testid="task-panel">
+    <div
+      className="w-full px-3 transition-[padding-right] duration-220 ease-[cubic-bezier(0.32,0.72,0,1)] md:px-5 lg:in-data-[panel-open=true]:pr-[calc(var(--chat-right-panel-width)+0.5rem)] motion-reduce:transition-none in-data-[panel-gesture=active]:transition-none"
+      role="region"
+      aria-label="Current tasks"
+      data-testid="task-panel"
+    >
       <div className="mx-auto w-full max-w-[80ch]">
         <TaskList tasks={transcript.tasks} />
       </div>

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerConnection.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerConnection.ts
@@ -1,6 +1,6 @@
 import type { AgentControllerEvent, AgentControllerSessionState } from '@mastra/client-js';
 import { useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { queryKeys } from '../../../../../shared/api/keys';
 import type { FactorySessionState } from '../context/ChatSessionContext';
 import { createAgentControllerClient } from '../services/agentControllerClient';
@@ -10,6 +10,16 @@ import { useAgentControllerSessionSync } from '../../../../../shared/hooks/useAg
 
 export type ConnectionStatus = 'connecting' | 'ready' | 'reconnecting' | 'error';
 type SseConnectionState = 'never' | 'connected' | 'dropped';
+
+// Browser-side subset of the canonical MC_TOOLS names in @mastra/code-sdk/tool-names.
+const WORKSPACE_MUTATION_TOOLS: Record<string, true> = {
+  write_file: true,
+  string_replace_lsp: true,
+  delete_file: true,
+  mkdir: true,
+  ast_smart_edit: true,
+  execute_command: true,
+};
 
 interface UseAgentControllerConnectionArgs {
   agentControllerId: string;
@@ -31,6 +41,7 @@ export function useAgentControllerConnection({
   onEvent,
 }: UseAgentControllerConnectionArgs) {
   const queryClient = useQueryClient();
+  const workspaceMutationCallsRef = useRef(new Set<string>());
   const [sseConnectionState, setSseConnectionState] = useState<SseConnectionState>('never');
   const sseConnected = sseConnectionState === 'connected';
   const hasEverConnected = sseConnectionState !== 'never';
@@ -82,6 +93,21 @@ export function useAgentControllerConnection({
         current => (current ? { ...current, running } : current),
         { updatedAt },
       );
+    }
+    if (
+      event.type === 'tool_start' &&
+      typeof event.toolCallId === 'string' &&
+      typeof event.toolName === 'string' &&
+      WORKSPACE_MUTATION_TOOLS[event.toolName] === true
+    ) {
+      workspaceMutationCallsRef.current.add(event.toolCallId);
+    }
+    const mutatingToolEnded =
+      event.type === 'tool_end' &&
+      typeof event.toolCallId === 'string' &&
+      workspaceMutationCallsRef.current.delete(event.toolCallId);
+    if (mutatingToolEnded || event.type === 'subagent_end' || event.type === 'agent_end') {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.workspaceRenderedListAll() });
     }
     onEvent(event);
   };

--- a/mastracode/web/src/web/ui/domains/factory/components/RelatedFactorySessions.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/RelatedFactorySessions.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Link2 } from 'lucide-react';
 import { Link, useNavigate, useParams } from 'react-router';
+import type { ReactNode } from 'react';
 
 import { useUserSessionQuery, useWorkspacesQuery } from '../../../../../shared/hooks/useWorkspaces';
 import { useWorkItemsQuery } from '../../../../../shared/hooks/useWorkItems';
@@ -26,24 +27,55 @@ function sessionTitle(item: WorkItem): string {
   return item.title;
 }
 
-export function FactorySessionHeader() {
+function FactorySessionHeaderFrame({ children }: { children: ReactNode }) {
+  return (
+    <header role="region" className="border-b border-border1 px-3 py-2.5 md:px-5" aria-label="Factory session">
+      {children}
+    </header>
+  );
+}
+
+function FactorySessionHeaderActions({ actions }: { actions?: ReactNode }) {
+  if (!actions) return null;
+  return (
+    <FactorySessionHeaderFrame>
+      <div className="flex min-h-8 items-center justify-end">{actions}</div>
+    </FactorySessionHeaderFrame>
+  );
+}
+
+export function FactorySessionHeader({ actions }: { actions?: ReactNode }) {
   const { factoryId, sessionId, threadId } = useParams<{ factoryId: string; sessionId: string; threadId: string }>();
+
+  if (!threadId || !factoryId || !sessionId) return <FactorySessionHeaderActions actions={actions} />;
+
+  return (
+    <ResolvedFactorySessionHeader actions={actions} factoryId={factoryId} sessionId={sessionId} threadId={threadId} />
+  );
+}
+
+function ResolvedFactorySessionHeader({
+  actions,
+  factoryId,
+  sessionId,
+  threadId,
+}: {
+  actions?: ReactNode;
+  factoryId: string;
+  sessionId: string;
+  threadId: string;
+}) {
   const navigate = useNavigate();
   const sessionQuery = useUserSessionQuery(sessionId);
   const projectRepositoryId = sessionQuery.data?.projectRepositoryId;
   const items = useWorkItemsQuery(factoryId);
   const workspaces = useWorkspacesQuery(projectRepositoryId);
 
-  if (!threadId || !factoryId || !sessionId) return null;
-
   const allItems = items.data ?? [];
-  const activeProjectPath = sessionId;
   const currentItem = allItems.find(item =>
-    Object.values(item.sessions).some(
-      session => session.threadId === threadId && (!activeProjectPath || session.sessionId === activeProjectPath),
-    ),
+    Object.values(item.sessions).some(session => session.threadId === threadId && session.sessionId === sessionId),
   );
-  if (!currentItem) return null;
+  if (!currentItem) return <FactorySessionHeaderActions actions={actions} />;
 
   const relatedItems = relatedWorkItems(currentItem, allItems);
   const livePaths = new Set((workspaces.data?.workspaces ?? []).map(workspace => workspace.sessionId));
@@ -57,7 +89,7 @@ export function FactorySessionHeader() {
   };
 
   return (
-    <header role="region" className="border-b border-border1 px-3 py-2.5 md:px-5" aria-label="Factory session">
+    <FactorySessionHeaderFrame>
       <div className="flex w-full min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <nav className="flex min-w-0 items-center gap-2 text-ui-sm" aria-label="Factory session breadcrumb">
           <Link to={sectionPath} className="shrink-0 font-medium text-icon4 hover:text-icon6 hover:underline">
@@ -68,7 +100,7 @@ export function FactorySessionHeader() {
           </span>
           <span className="truncate text-icon6">{sessionTitle(currentItem)}</span>
         </nav>
-        {destinations.length > 0 ? (
+        {destinations.length > 0 || actions ? (
           <div className="flex shrink-0 flex-wrap items-center gap-1">
             {destinations.map(({ item, session }) => {
               const label = relationshipLabel(item);
@@ -99,9 +131,10 @@ export function FactorySessionHeader() {
                 </Button>
               );
             })}
+            {actions}
           </div>
         ) : null}
       </div>
-    </header>
+    </FactorySessionHeaderFrame>
   );
 }

--- a/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
+++ b/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
@@ -183,7 +183,10 @@ export function WorkspaceFileBrowser({
   };
 
   return (
-    <aside className="flex h-full w-full min-w-0 flex-col rounded-xl bg-surface3" aria-label="Workspace files">
+    <aside
+      className="flex max-h-full min-h-0 w-full min-w-0 flex-col overflow-hidden rounded-xl bg-surface3"
+      aria-label="Workspace files"
+    >
       <div className="flex items-center justify-end gap-2 px-3 py-2 lg:pr-12">
         <Button size="sm" variant="ghost" onClick={onRefresh} aria-label="Refresh workspace files">
           <RefreshCw size={14} />

--- a/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
+++ b/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
@@ -154,6 +154,7 @@ function WorkspaceTreeItem({
 
 interface WorkspaceFileBrowserProps {
   renderedPaths: RenderedWorkspacePath[];
+  title?: string;
   selectedPath: RenderedWorkspacePath;
   selectedFilePath?: string;
   listing?: WorkspaceRenderedListing;
@@ -166,6 +167,7 @@ interface WorkspaceFileBrowserProps {
 
 export function WorkspaceFileBrowser({
   renderedPaths,
+  title,
   selectedPath,
   selectedFilePath,
   listing,
@@ -177,6 +179,7 @@ export function WorkspaceFileBrowser({
 }: WorkspaceFileBrowserProps) {
   const [openFolders, setOpenFolders] = useState<Record<string, boolean>>({});
   const nodes = buildTree(listing?.entries ?? []);
+  const heading = title ?? 'Workspace files';
 
   const setFolderOpen = (path: string, open: boolean) => {
     setOpenFolders(previous => ({ ...previous, [path]: open }));
@@ -185,7 +188,7 @@ export function WorkspaceFileBrowser({
   return (
     <aside
       className="relative flex max-h-full min-h-0 w-full min-w-0 flex-col overflow-hidden rounded-xl bg-surface3"
-      aria-label="Workspace files"
+      aria-label={heading}
     >
       <Button
         size="icon-md"
@@ -196,8 +199,13 @@ export function WorkspaceFileBrowser({
       >
         <RefreshCw size={14} />
       </Button>
+      <div className="flex min-h-12 items-center px-3 pr-12">
+        <Txt as="h2" variant="ui-sm" className="m-0 truncate font-medium text-icon5">
+          {heading}
+        </Txt>
+      </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-2 pt-12">
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
         <Tree
           selectedId={selectedFilePath ? `${selectedPath.root}/${selectedFilePath}` : undefined}
           onSelect={id => {

--- a/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
+++ b/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Tree } from '@mastra/playground-ui/components/Tree';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { File, FileCode, FileJson, FileText, Folder, FolderOpen, Image, NotepadText, RefreshCw } from 'lucide-react';
+import { File, FileCode, FileJson, FileText, Folder, FolderOpen, Image, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 import type { ReactNode } from 'react';
 
@@ -183,14 +183,8 @@ export function WorkspaceFileBrowser({
   };
 
   return (
-    <aside className="flex h-full w-full min-w-0 flex-col bg-surface1" aria-label="Workspace files">
-      <div className="flex items-center justify-between gap-2 px-3 py-2 pl-4 lg:pr-12">
-        <div className="flex min-w-0 items-center gap-2">
-          <NotepadText size={15} className="shrink-0 text-icon4" />
-          <Txt variant="ui-sm" className="truncate font-medium text-icon6">
-            Files
-          </Txt>
-        </div>
+    <aside className="flex h-full w-full min-w-0 flex-col rounded-xl bg-surface3" aria-label="Workspace files">
+      <div className="flex items-center justify-end gap-2 px-3 py-2 lg:pr-12">
         <Button size="sm" variant="ghost" onClick={onRefresh} aria-label="Refresh workspace files">
           <RefreshCw size={14} />
         </Button>

--- a/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
+++ b/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
@@ -184,16 +184,20 @@ export function WorkspaceFileBrowser({
 
   return (
     <aside
-      className="flex max-h-full min-h-0 w-full min-w-0 flex-col overflow-hidden rounded-xl bg-surface3"
+      className="relative flex max-h-full min-h-0 w-full min-w-0 flex-col overflow-hidden rounded-xl bg-surface3"
       aria-label="Workspace files"
     >
-      <div className="flex items-center justify-end gap-2 px-3 py-2 lg:pr-12">
-        <Button size="sm" variant="ghost" onClick={onRefresh} aria-label="Refresh workspace files">
-          <RefreshCw size={14} />
-        </Button>
-      </div>
+      <Button
+        size="icon-md"
+        variant="ghost"
+        onClick={onRefresh}
+        aria-label="Refresh workspace files"
+        className="absolute right-2 top-2 z-10 rounded-md"
+      >
+        <RefreshCw size={14} />
+      </Button>
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+      <div className="min-h-0 flex-1 overflow-y-auto p-2 pt-12">
         <Tree
           selectedId={selectedFilePath ? `${selectedPath.root}/${selectedFilePath}` : undefined}
           onSelect={id => {

--- a/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileViewer.tsx
+++ b/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileViewer.tsx
@@ -31,7 +31,7 @@ export function WorkspaceFileViewer({ filePath, file, isLoading, error }: Worksp
 
   return (
     <section
-      className="flex h-full min-w-0 flex-col border-l border-border1 bg-surface1"
+      className="flex h-full min-w-0 flex-col rounded-xl border-l border-border1 bg-surface3"
       aria-label="Workspace file viewer"
     >
       <div className="flex items-center justify-between gap-2 border-b border-border1 px-3 py-2 pl-10 lg:pl-3">

--- a/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileViewer.tsx
+++ b/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceFileViewer.tsx
@@ -31,7 +31,7 @@ export function WorkspaceFileViewer({ filePath, file, isLoading, error }: Worksp
 
   return (
     <section
-      className="flex h-full min-w-0 flex-col rounded-xl border-l border-border1 bg-surface3"
+      className="flex max-h-full min-h-0 min-w-0 flex-col rounded-xl border-l border-border1 bg-surface3"
       aria-label="Workspace file viewer"
     >
       <div className="flex items-center justify-between gap-2 border-b border-border1 px-3 py-2 pl-10 lg:pl-3">

--- a/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
@@ -71,9 +71,12 @@ function WorkspaceViewerPanelInner({
   };
 
   return (
-    <div className="relative flex h-full w-full min-w-0 rounded-xl bg-surface3" data-testid="workspace-viewer-panel">
+    <div
+      className="relative flex max-h-[calc(70dvh-1rem)] w-full min-w-0 overflow-hidden rounded-xl bg-surface3"
+      data-testid="workspace-viewer-panel"
+    >
       {viewerOpen ? (
-        <div className="relative h-full min-w-0 flex-1 overflow-hidden">
+        <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
           <Button
             size="icon-sm"
             variant="ghost"
@@ -103,8 +106,8 @@ function WorkspaceViewerPanelInner({
       <div
         className={
           viewerOpen
-            ? 'hidden h-full min-w-0 shrink-0 overflow-hidden lg:block'
-            : 'h-full min-w-0 flex-1 overflow-hidden'
+            ? 'hidden max-h-full min-h-0 min-w-0 shrink-0 overflow-hidden lg:block'
+            : 'max-h-full min-h-0 min-w-0 flex-1 overflow-hidden'
         }
         style={viewerOpen ? { width: browserWidth } : undefined}
       >

--- a/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
@@ -71,7 +71,7 @@ function WorkspaceViewerPanelInner({
   };
 
   return (
-    <div className="relative flex h-full w-full min-w-0 bg-surface1" data-testid="workspace-viewer-panel">
+    <div className="relative flex h-full w-full min-w-0 rounded-xl bg-surface3" data-testid="workspace-viewer-panel">
       {viewerOpen ? (
         <div className="relative h-full min-w-0 flex-1 overflow-hidden">
           <Button

--- a/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
@@ -111,11 +111,10 @@ function WorkspaceViewerPanelInner({
         }
         style={viewerOpen ? { width: browserWidth } : undefined}
       >
-        <div className="sr-only">
-          {title ?? 'Workspace viewer'} {context ?? ''}
-        </div>
+        {context ? <div className="sr-only">{context}</div> : null}
         <WorkspaceFileBrowser
           renderedPaths={renderedPaths}
+          title={title}
           selectedPath={selectedRenderedPath}
           selectedFilePath={selectedFilePath}
           listing={listing.data}

--- a/mastracode/web/src/web/ui/domains/workspace-viewer/components/__tests__/WorkspaceViewerPanel.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspace-viewer/components/__tests__/WorkspaceViewerPanel.msw.test.tsx
@@ -82,7 +82,7 @@ describe('WorkspaceViewerPanel', () => {
 
     renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />);
 
-    expect(await screen.findByText('Files')).toBeInTheDocument();
+    expect(await screen.findByLabelText('Workspace files')).toBeInTheDocument();
     await userEvent.click(await screen.findByRole('button', { name: 'Artifacts' }));
     expect(await screen.findByText('No artifacts yet. Session files created will appear here.')).toBeInTheDocument();
   });

--- a/mastracode/web/src/web/ui/domains/workspace-viewer/components/__tests__/WorkspaceViewerPanel.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspace-viewer/components/__tests__/WorkspaceViewerPanel.msw.test.tsx
@@ -83,6 +83,7 @@ describe('WorkspaceViewerPanel', () => {
     renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />);
 
     expect(await screen.findByLabelText('Workspace files')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Workspace files' })).toBeInTheDocument();
     await userEvent.click(await screen.findByRole('button', { name: 'Artifacts' }));
     expect(await screen.findByText('No artifacts yet. Session files created will appear here.')).toBeInTheDocument();
   });

--- a/mastracode/web/src/web/ui/layouts/ChatLayout.tsx
+++ b/mastracode/web/src/web/ui/layouts/ChatLayout.tsx
@@ -1,11 +1,9 @@
 import { Button } from '@mastra/playground-ui/components/Button';
+import { ResizeHandleIndicator } from '@mastra/playground-ui/primitives/resize-handle-indicator';
 import { useIsMobile } from '@mastra/playground-ui/hooks/use-is-mobile';
 import { PanelDrawer } from '@mastra/playground-ui/resize/panel-drawer';
-import { PanelGroup } from '@mastra/playground-ui/resize/panel-group';
-import { PanelSeparator } from '@mastra/playground-ui/resize/separator';
 import { useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
-import { Panel, usePanelRef } from 'react-resizable-panels';
 import { PanelRightIcon } from 'lucide-react';
 
 import { ViewportLayout } from './PageLayout';
@@ -98,56 +96,106 @@ function DesktopRightPanelFrame({
   children: ReactNode;
   onRightPanelClose?: () => void;
 }) {
-  const rightPanelRef = usePanelRef();
+  const frameRef = useRef<HTMLDivElement>(null);
+  const rightPanelSlotRef = useRef<HTMLDivElement>(null);
+  const resizeCleanupRef = useRef<(() => void) | undefined>(undefined);
   const hasRightPanel = rightPanel !== undefined;
-  const previousInitialWidthRef = useRef(initialWidth);
-  const previousHasRightPanelRef = useRef(hasRightPanel);
 
   useEffect(() => {
-    const previousInitialWidth = previousInitialWidthRef.current;
-    const previouslyHadRightPanel = previousHasRightPanelRef.current;
-    previousInitialWidthRef.current = initialWidth;
-    previousHasRightPanelRef.current = hasRightPanel;
-    if (hasRightPanel && previouslyHadRightPanel && previousInitialWidth !== initialWidth) {
-      rightPanelRef.current?.resize(initialWidth);
+    frameRef.current?.style.setProperty('--chat-right-panel-width', `${initialWidth}px`);
+    return () => resizeCleanupRef.current?.();
+  }, [initialWidth]);
+
+  const setPanelWidth = (requestedWidth: number) => {
+    const frame = frameRef.current;
+    if (!frame) return;
+
+    const maximumWidth = Math.max(MIN_RIGHT_PANEL_WIDTH, frame.getBoundingClientRect().width - MIN_CHAT_WIDTH);
+    const nextWidth = Math.min(maximumWidth, Math.max(MIN_RIGHT_PANEL_WIDTH, requestedWidth));
+    frame.style.setProperty('--chat-right-panel-width', `${nextWidth}px`);
+  };
+
+  const startResize = (event: React.PointerEvent<HTMLButtonElement>) => {
+    const panelSlot = rightPanelSlotRef.current;
+    if (!panelSlot) return;
+
+    event.preventDefault();
+    resizeCleanupRef.current?.();
+    frameRef.current?.setAttribute('data-panel-gesture', 'active');
+    const startX = event.clientX;
+    const startWidth = panelSlot.getBoundingClientRect().width || initialWidth;
+    const onPointerMove = (moveEvent: PointerEvent) => {
+      setPanelWidth(startWidth - (moveEvent.clientX - startX));
+    };
+    const cleanup = () => {
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', cleanup);
+      window.removeEventListener('pointercancel', cleanup);
+      frameRef.current?.removeAttribute('data-panel-gesture');
+      resizeCleanupRef.current = undefined;
+    };
+
+    resizeCleanupRef.current = cleanup;
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', cleanup);
+    window.addEventListener('pointercancel', cleanup);
+  };
+
+  const resizeWithKeyboard = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    const currentWidth = rightPanelSlotRef.current?.getBoundingClientRect().width || initialWidth;
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      setPanelWidth(currentWidth + 24);
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      setPanelWidth(currentWidth - 24);
     }
-  }, [hasRightPanel, initialWidth, rightPanelRef]);
+  };
 
   return (
-    <PanelGroup className="h-full min-h-0 w-full min-w-0">
-      <Panel id="chat-main-slot" minSize={MIN_CHAT_WIDTH} className="min-w-0">
+    <div
+      ref={frameRef}
+      data-expanded={initialWidth === EXPANDED_RIGHT_PANEL_WIDTH}
+      className={
+        hasRightPanel
+          ? 'relative grid h-full min-h-0 w-full min-w-0 flex-1 grid-cols-[minmax(var(--chat-main-min-width),1fr)_var(--chat-right-panel-width)] [--chat-main-min-width:420px] [--chat-right-panel-width:320px] data-[expanded=true]:[--chat-right-panel-width:720px]'
+          : 'relative grid h-full min-h-0 w-full min-w-0 flex-1 grid-cols-1 [--chat-main-min-width:420px] [--chat-right-panel-width:320px]'
+      }
+    >
+      <div id="chat-main-slot" className="h-full min-h-0 min-w-0">
         {children}
-      </Panel>
+      </div>
       {hasRightPanel ? (
-        <>
-          <PanelSeparator />
-          <Panel
-            id="chat-right-slot"
-            panelRef={rightPanelRef}
-            minSize={MIN_RIGHT_PANEL_WIDTH}
-            defaultSize={initialWidth}
-            groupResizeBehavior="preserve-pixel-size"
-            className="min-w-0"
+        <div ref={rightPanelSlotRef} id="chat-right-slot" className="relative h-full min-h-0 min-w-0 p-2">
+          <button
+            type="button"
+            className="group absolute top-0 left-1 z-20 flex h-full w-2 -translate-x-1/2 cursor-col-resize touch-none items-center justify-center focus-visible:outline-hidden"
+            onPointerDown={startResize}
+            onKeyDown={resizeWithKeyboard}
+            aria-label="Resize workspace files"
           >
-            <div className="relative h-full min-w-0">
-              {rightPanel}
-              {onRightPanelClose ? (
-                <Button
-                  size="icon-md"
-                  variant="ghost"
-                  tooltip="Close workspace files"
-                  className="absolute right-2 top-2 z-10 rounded-md"
-                  onClick={onRightPanelClose}
-                  aria-label="Close workspace files"
-                  aria-expanded="true"
-                >
-                  <PanelRightIcon />
-                </Button>
-              ) : null}
-            </div>
-          </Panel>
-        </>
+            <ResizeHandleIndicator
+              className="group-hover:opacity-100 group-focus-visible:via-accent1 group-focus-visible:opacity-100 in-data-[panel-gesture=active]:via-neutral6/45 in-data-[panel-gesture=active]:opacity-100"
+            />
+          </button>
+          <div className="relative h-full min-w-0 rounded-xl border border-border1/40 bg-surface3 shadow-main-frame">
+            {rightPanel}
+            {onRightPanelClose ? (
+              <Button
+                size="icon-md"
+                variant="ghost"
+                tooltip="Close workspace files"
+                className="absolute right-2 top-2 z-10 rounded-md"
+                onClick={onRightPanelClose}
+                aria-label="Close workspace files"
+                aria-expanded="true"
+              >
+                <PanelRightIcon />
+              </Button>
+            ) : null}
+          </div>
+        </div>
       ) : null}
-    </PanelGroup>
+    </div>
   );
 }

--- a/mastracode/web/src/web/ui/layouts/ChatLayout.tsx
+++ b/mastracode/web/src/web/ui/layouts/ChatLayout.tsx
@@ -28,7 +28,6 @@ type ChatLayoutProps = {
 const COMPACT_RIGHT_PANEL_WIDTH = 320;
 const EXPANDED_RIGHT_PANEL_WIDTH = 720;
 const MIN_RIGHT_PANEL_WIDTH = 260;
-const MIN_CHAT_WIDTH = 420;
 
 /** Slot-based chat content arrangement inside the shared application page frame. */
 export function ChatLayout({
@@ -110,8 +109,9 @@ function DesktopRightPanelFrame({
     const frame = frameRef.current;
     if (!frame) return;
 
-    const maximumWidth = Math.max(MIN_RIGHT_PANEL_WIDTH, frame.getBoundingClientRect().width - MIN_CHAT_WIDTH);
-    const nextWidth = Math.min(maximumWidth, Math.max(MIN_RIGHT_PANEL_WIDTH, requestedWidth));
+    const maximumWidth = frame.getBoundingClientRect().width / 2;
+    const minimumWidth = Math.min(MIN_RIGHT_PANEL_WIDTH, maximumWidth);
+    const nextWidth = Math.min(maximumWidth, Math.max(minimumWidth, requestedWidth));
     frame.style.setProperty('--chat-right-panel-width', `${nextWidth}px`);
   };
 
@@ -158,8 +158,8 @@ function DesktopRightPanelFrame({
       data-expanded={initialWidth === EXPANDED_RIGHT_PANEL_WIDTH}
       className={
         hasRightPanel
-          ? 'relative grid h-full min-h-0 w-full min-w-0 flex-1 grid-cols-[minmax(var(--chat-main-min-width),1fr)_var(--chat-right-panel-width)] [--chat-main-min-width:420px] [--chat-right-panel-width:320px] data-[expanded=true]:[--chat-right-panel-width:720px]'
-          : 'relative grid h-full min-h-0 w-full min-w-0 flex-1 grid-cols-1 [--chat-main-min-width:420px] [--chat-right-panel-width:320px]'
+          ? 'relative grid h-full min-h-0 w-full min-w-0 flex-1 grid-cols-[minmax(0,1fr)_min(var(--chat-right-panel-width),50%)] [--chat-right-panel-width:320px] data-[expanded=true]:[--chat-right-panel-width:720px]'
+          : 'relative grid h-full min-h-0 w-full min-w-0 flex-1 grid-cols-1 [--chat-right-panel-width:320px]'
       }
     >
       <div id="chat-main-slot" className="h-full min-h-0 min-w-0">
@@ -174,9 +174,7 @@ function DesktopRightPanelFrame({
             onKeyDown={resizeWithKeyboard}
             aria-label="Resize workspace files"
           >
-            <ResizeHandleIndicator
-              className="group-hover:opacity-100 group-focus-visible:via-accent1 group-focus-visible:opacity-100 in-data-[panel-gesture=active]:via-neutral6/45 in-data-[panel-gesture=active]:opacity-100"
-            />
+            <ResizeHandleIndicator className="group-hover:opacity-100 group-focus-visible:via-accent1 group-focus-visible:opacity-100 in-data-[panel-gesture=active]:via-neutral6/45 in-data-[panel-gesture=active]:opacity-100" />
           </button>
           <div className="relative h-full min-w-0 rounded-xl border border-border1/40 bg-surface3 shadow-main-frame">
             {rightPanel}

--- a/mastracode/web/src/web/ui/layouts/ChatLayout.tsx
+++ b/mastracode/web/src/web/ui/layouts/ChatLayout.tsx
@@ -109,7 +109,7 @@ function DesktopRightPanelFrame({
     const frame = frameRef.current;
     if (!frame) return;
 
-    const maximumWidth = frame.getBoundingClientRect().width / 2;
+    const maximumWidth = Math.min(EXPANDED_RIGHT_PANEL_WIDTH, Math.max(0, frame.getBoundingClientRect().width - 16));
     const minimumWidth = Math.min(MIN_RIGHT_PANEL_WIDTH, maximumWidth);
     const nextWidth = Math.min(maximumWidth, Math.max(minimumWidth, requestedWidth));
     frame.style.setProperty('--chat-right-panel-width', `${nextWidth}px`);
@@ -156,27 +156,27 @@ function DesktopRightPanelFrame({
     <div
       ref={frameRef}
       data-expanded={initialWidth === EXPANDED_RIGHT_PANEL_WIDTH}
-      className={
-        hasRightPanel
-          ? 'relative grid h-full min-h-0 w-full min-w-0 flex-1 grid-cols-[minmax(0,1fr)_min(var(--chat-right-panel-width),50%)] [--chat-right-panel-width:320px] data-[expanded=true]:[--chat-right-panel-width:720px]'
-          : 'relative grid h-full min-h-0 w-full min-w-0 flex-1 grid-cols-1 [--chat-right-panel-width:320px]'
-      }
+      className="relative h-full min-h-0 w-full min-w-0 flex-1 [--chat-right-panel-width:320px] data-[expanded=true]:[--chat-right-panel-width:720px]"
     >
       <div id="chat-main-slot" className="h-full min-h-0 min-w-0">
         {children}
       </div>
       {hasRightPanel ? (
-        <div ref={rightPanelSlotRef} id="chat-right-slot" className="relative h-full min-h-0 min-w-0 p-2">
+        <div
+          ref={rightPanelSlotRef}
+          id="chat-right-slot"
+          className="absolute right-0 top-0 z-20 flex max-h-[70dvh] w-(--chat-right-panel-width) max-w-[calc(100%-1rem)] min-w-0 p-2"
+        >
           <button
             type="button"
-            className="group absolute top-0 left-1 z-20 flex h-full w-2 -translate-x-1/2 cursor-col-resize touch-none items-center justify-center focus-visible:outline-hidden"
+            className="group absolute inset-y-2 left-2 z-20 flex w-2 -translate-x-1/2 cursor-col-resize touch-none items-center justify-center focus-visible:outline-hidden"
             onPointerDown={startResize}
             onKeyDown={resizeWithKeyboard}
             aria-label="Resize workspace files"
           >
             <ResizeHandleIndicator className="group-hover:opacity-100 group-focus-visible:via-accent1 group-focus-visible:opacity-100 in-data-[panel-gesture=active]:via-neutral6/45 in-data-[panel-gesture=active]:opacity-100" />
           </button>
-          <div className="relative h-full min-w-0 rounded-xl border border-border1/40 bg-surface3 shadow-main-frame">
+          <div className="relative flex max-h-[calc(70dvh-1rem)] min-h-0 w-full overflow-hidden rounded-xl border border-border1/40 bg-surface3 shadow-main-frame">
             {rightPanel}
             {onRightPanelClose ? (
               <Button

--- a/mastracode/web/src/web/ui/layouts/ChatLayout.tsx
+++ b/mastracode/web/src/web/ui/layouts/ChatLayout.tsx
@@ -105,11 +105,12 @@ function DesktopRightPanelFrame({
     return () => resizeCleanupRef.current?.();
   }, [initialWidth]);
 
-  const setPanelWidth = (requestedWidth: number) => {
+  const setPanelWidth = (requestedWidth: number, frameWidth?: number) => {
     const frame = frameRef.current;
     if (!frame) return;
 
-    const maximumWidth = Math.min(EXPANDED_RIGHT_PANEL_WIDTH, Math.max(0, frame.getBoundingClientRect().width - 16));
+    const availableWidth = frameWidth ?? frame.getBoundingClientRect().width;
+    const maximumWidth = Math.min(EXPANDED_RIGHT_PANEL_WIDTH, Math.max(0, availableWidth - 16));
     const minimumWidth = Math.min(MIN_RIGHT_PANEL_WIDTH, maximumWidth);
     const nextWidth = Math.min(maximumWidth, Math.max(minimumWidth, requestedWidth));
     frame.style.setProperty('--chat-right-panel-width', `${nextWidth}px`);
@@ -124,8 +125,9 @@ function DesktopRightPanelFrame({
     frameRef.current?.setAttribute('data-panel-gesture', 'active');
     const startX = event.clientX;
     const startWidth = panelSlot.getBoundingClientRect().width || initialWidth;
+    const frameWidth = frameRef.current?.getBoundingClientRect().width;
     const onPointerMove = (moveEvent: PointerEvent) => {
-      setPanelWidth(startWidth - (moveEvent.clientX - startX));
+      setPanelWidth(startWidth - (moveEvent.clientX - startX), frameWidth);
     };
     const cleanup = () => {
       window.removeEventListener('pointermove', onPointerMove);

--- a/mastracode/web/src/web/ui/layouts/ChatLayout.tsx
+++ b/mastracode/web/src/web/ui/layouts/ChatLayout.tsx
@@ -1,10 +1,8 @@
-import { Button } from '@mastra/playground-ui/components/Button';
 import { ResizeHandleIndicator } from '@mastra/playground-ui/primitives/resize-handle-indicator';
 import { useIsMobile } from '@mastra/playground-ui/hooks/use-is-mobile';
 import { PanelDrawer } from '@mastra/playground-ui/resize/panel-drawer';
 import { useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
-import { PanelRightIcon } from 'lucide-react';
 
 import { ViewportLayout } from './PageLayout';
 
@@ -20,9 +18,7 @@ type ChatLayoutProps = {
   /** Optional workspace panel rendered inline on desktop and in a drawer on mobile. */
   rightPanel?: ReactNode;
   rightPanelExpanded?: boolean;
-  rightPanelAvailable?: boolean;
-  onRightPanelOpen?: () => void;
-  onRightPanelClose?: () => void;
+  rightPanelOpen?: boolean;
 };
 
 const COMPACT_RIGHT_PANEL_WIDTH = 320;
@@ -38,9 +34,7 @@ export function ChatLayout({
   footer,
   rightPanel,
   rightPanelExpanded = false,
-  rightPanelAvailable = false,
-  onRightPanelOpen,
-  onRightPanelClose,
+  rightPanelOpen = false,
 }: ChatLayoutProps) {
   const isMobile = useIsMobile();
 
@@ -49,8 +43,8 @@ export function ChatLayout({
       <div className="relative flex h-full min-w-0 flex-1 overflow-visible">
         <DesktopRightPanelFrame
           initialWidth={rightPanelExpanded ? EXPANDED_RIGHT_PANEL_WIDTH : COMPACT_RIGHT_PANEL_WIDTH}
+          open={rightPanelOpen}
           rightPanel={isMobile ? undefined : rightPanel}
-          onRightPanelClose={onRightPanelClose}
         >
           <div className="flex h-full min-w-0 flex-1 flex-col overflow-hidden">
             {main ?? (
@@ -66,19 +60,6 @@ export function ChatLayout({
             {rightPanel}
           </PanelDrawer>
         ) : null}
-        {!rightPanel && rightPanelAvailable ? (
-          <Button
-            size="icon-md"
-            variant="ghost"
-            tooltip="Open workspace files"
-            className="absolute right-2 top-2 z-10 hidden rounded-md lg:inline-flex"
-            onClick={onRightPanelOpen}
-            aria-label="Open workspace files"
-            aria-expanded="false"
-          >
-            <PanelRightIcon className="rotate-180" />
-          </Button>
-        ) : null}
       </div>
     </ViewportLayout>
   );
@@ -86,14 +67,14 @@ export function ChatLayout({
 
 function DesktopRightPanelFrame({
   initialWidth,
+  open,
   rightPanel,
   children,
-  onRightPanelClose,
 }: {
   initialWidth: number;
+  open: boolean;
   rightPanel?: ReactNode;
   children: ReactNode;
-  onRightPanelClose?: () => void;
 }) {
   const frameRef = useRef<HTMLDivElement>(null);
   const rightPanelSlotRef = useRef<HTMLDivElement>(null);
@@ -158,7 +139,7 @@ function DesktopRightPanelFrame({
     <div
       ref={frameRef}
       data-expanded={initialWidth === EXPANDED_RIGHT_PANEL_WIDTH}
-      className="relative h-full min-h-0 w-full min-w-0 flex-1 [--chat-right-panel-width:320px] data-[expanded=true]:[--chat-right-panel-width:720px]"
+      className="relative h-full min-h-0 w-full min-w-0 flex-1 [--chat-right-panel-width:320px] [--chat-session-header-height:3.25rem] data-[expanded=true]:[--chat-right-panel-width:720px]"
     >
       <div id="chat-main-slot" className="h-full min-h-0 min-w-0">
         {children}
@@ -167,7 +148,10 @@ function DesktopRightPanelFrame({
         <div
           ref={rightPanelSlotRef}
           id="chat-right-slot"
-          className="absolute right-0 top-0 z-20 flex max-h-[70dvh] w-(--chat-right-panel-width) max-w-[calc(100%-1rem)] min-w-0 p-2"
+          data-open={open}
+          aria-hidden={!open}
+          inert={!open}
+          className="absolute right-0 top-[calc(var(--chat-session-header-height)+0.5rem)] z-20 flex max-h-[70dvh] w-(--chat-right-panel-width) max-w-[calc(100%-1rem)] min-w-0 p-2 opacity-100 transition-[width,opacity,translate] duration-220 ease-[cubic-bezier(0.32,0.72,0,1)] data-[open=false]:pointer-events-none data-[open=false]:translate-x-2 data-[open=false]:opacity-0 motion-reduce:transition-none in-data-[panel-gesture=active]:transition-none"
         >
           <button
             type="button"
@@ -180,19 +164,6 @@ function DesktopRightPanelFrame({
           </button>
           <div className="relative flex max-h-[calc(70dvh-1rem)] min-h-0 w-full overflow-hidden rounded-xl border border-border1/40 bg-surface3 shadow-main-frame">
             {rightPanel}
-            {onRightPanelClose ? (
-              <Button
-                size="icon-md"
-                variant="ghost"
-                tooltip="Close workspace files"
-                className="absolute right-2 top-2 z-10 rounded-md"
-                onClick={onRightPanelClose}
-                aria-label="Close workspace files"
-                aria-expanded="true"
-              >
-                <PanelRightIcon />
-              </Button>
-            ) : null}
           </div>
         </div>
       ) : null}

--- a/mastracode/web/src/web/ui/layouts/PageLayout.tsx
+++ b/mastracode/web/src/web/ui/layouts/PageLayout.tsx
@@ -26,7 +26,7 @@ export function ViewportLayout({ sidebar, header, children }: PageLayoutProps) {
       <aside className="h-full min-h-0 shrink-0 overflow-hidden py-2">{sidebar}</aside>
       <div className="relative z-1 flex min-w-0 flex-1 flex-col overflow-hidden border-l border-border1 bg-surface2">
         {header}
-        <main className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</main>
+        <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">{children}</main>
       </div>
     </div>
   );

--- a/mastracode/web/src/web/ui/layouts/__tests__/ChatLayout.msw.test.tsx
+++ b/mastracode/web/src/web/ui/layouts/__tests__/ChatLayout.msw.test.tsx
@@ -76,6 +76,7 @@ describe('ChatLayout', () => {
           content={<div />}
           rightPanel={<StatefulRightPanel />}
           rightPanelExpanded={false}
+          rightPanelOpen
         />,
       );
 
@@ -83,27 +84,31 @@ describe('ChatLayout', () => {
       expect(screen.getByRole('button', { name: 'right-panel-opened' })).toBeInTheDocument();
 
       rerender(
-        <ChatLayout sidebar={<div />} content={<div />} rightPanel={<StatefulRightPanel />} rightPanelExpanded />,
+        <ChatLayout
+          sidebar={<div />}
+          content={<div />}
+          rightPanel={<StatefulRightPanel />}
+          rightPanelExpanded
+          rightPanelOpen
+        />,
       );
 
       expect(screen.getByRole('button', { name: 'right-panel-opened' })).toBeInTheDocument();
     });
 
-    it('closes the panel from its top-right toggle', async () => {
-      const onRightPanelClose = vi.fn();
-      const user = userEvent.setup();
-      render(
-        <ChatLayout
-          sidebar={<div />}
-          content={<div />}
-          rightPanel={<div>workspace-panel</div>}
-          onRightPanelClose={onRightPanelClose}
-        />,
+    it('keeps a closed panel mounted but outside the accessibility tree', () => {
+      const { rerender } = render(
+        <ChatLayout sidebar={<div />} content={<div />} rightPanel={<div>workspace-panel</div>} />,
       );
 
-      await user.click(screen.getByRole('button', { name: 'Close workspace files' }));
+      expect(screen.getByText('workspace-panel')).toBeInTheDocument();
+      expect(screen.queryByText('workspace-panel', { selector: '[aria-hidden="false"] *' })).not.toBeInTheDocument();
 
-      expect(onRightPanelClose).toHaveBeenCalledOnce();
+      rerender(
+        <ChatLayout sidebar={<div />} content={<div />} rightPanel={<div>workspace-panel</div>} rightPanelOpen />,
+      );
+
+      expect(screen.getByText('workspace-panel')).toBeVisible();
     });
 
     it('can remove and restore the right panel repeatedly', () => {

--- a/mastracode/web/src/web/ui/pages/MetricsPage.tsx
+++ b/mastracode/web/src/web/ui/pages/MetricsPage.tsx
@@ -172,11 +172,7 @@ function useAgentsRunningCount(): number {
 
 function MetricsLoading() {
   return (
-    <div className="grid gap-5 border-t border-border1 pt-7" aria-label="Loading Factory metrics">
-      <div className="flex items-center justify-between gap-4">
-        <Skeleton className="h-4 w-32" />
-        <Skeleton className="h-6 w-16 rounded-full" />
-      </div>
+    <div className="grid gap-5" aria-label="Loading Factory metrics">
       <Skeleton className="h-64 w-full" />
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <Skeleton className="h-16 w-full" />
@@ -204,19 +200,7 @@ function FlowOverview({
     metrics.transitions.total === 0 ? EM_DASH : `${Math.round((automatedMoves / metrics.transitions.total) * 100)}%`;
 
   return (
-    <section className="flex flex-col gap-5 border-t border-border1 pt-7">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-col gap-1">
-          <Txt as="h2" variant="ui-md" className="m-0 font-medium text-icon6">
-            Delivery flow
-          </Txt>
-          <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
-            Completed work over time, with the Factory's current operating state.
-          </Txt>
-        </div>
-        <Badge size="sm">{windowDays}-day view</Badge>
-      </div>
-
+    <section className="flex flex-col gap-5">
       <div className="min-w-0">
         <div className="mb-3 flex flex-wrap items-end justify-between gap-x-4 gap-y-2">
           <div>

--- a/mastracode/web/src/web/ui/pages/MetricsPage.tsx
+++ b/mastracode/web/src/web/ui/pages/MetricsPage.tsx
@@ -45,6 +45,7 @@ function defaultRange(today: string): DateRangeValue {
 }
 
 const THROUGHPUT_SERIES = [{ dataKey: 'done', label: 'Completed work', color: 'var(--chart-2)' }];
+const METRICS_PALETTE = ['var(--chart-1)', 'var(--chart-4)', 'var(--chart-3)', 'var(--chart-2)'] as const;
 
 const SOURCE_LABELS: Record<string, string> = {
   'github:issue': 'GitHub issues',
@@ -232,6 +233,7 @@ function FlowOverview({
         <OverviewReadout
           icon={<Clock3 aria-hidden="true" />}
           label="Median cycle time"
+          tone={METRICS_PALETTE[0]}
           value={formatDuration(metrics.cycleTime.medianMs)}
           detail={
             metrics.cycleTime.p90Ms === null
@@ -242,18 +244,21 @@ function FlowOverview({
         <OverviewReadout
           icon={<Layers3 aria-hidden="true" />}
           label="In flight"
+          tone={METRICS_PALETTE[1]}
           value={String(metrics.wipTotal)}
           detail="Items in non-terminal stages"
         />
         <OverviewReadout
           icon={<Bot aria-hidden="true" />}
           label="Agents running"
+          tone={METRICS_PALETTE[2]}
           value={String(agentsRunning)}
           detail="Live across active worktrees"
         />
         <OverviewReadout
           icon={<Workflow aria-hidden="true" />}
           label="Automated moves"
+          tone={METRICS_PALETTE[3]}
           value={automationRate}
           detail={
             metrics.transitions.total === 0
@@ -271,16 +276,23 @@ function OverviewReadout({
   label,
   value,
   detail,
+  tone,
 }: {
   icon: ReactNode;
   label: string;
   value: string;
   detail: string;
+  tone: string;
 }) {
   return (
     <div className="flex min-w-0 flex-col lg:px-4 lg:first:pl-0 lg:last:pr-0">
-      <dt className="flex items-center gap-1.5 text-ui-xs text-icon3 [&>svg]:size-3.5">
-        {icon}
+      <dt className="flex items-center gap-1.5 text-ui-xs text-icon3">
+        <span
+          className="grid size-5 shrink-0 place-items-center rounded-md bg-surface3 [&>svg]:size-3.5"
+          style={{ color: tone }}
+        >
+          {icon}
+        </span>
         {label}
       </dt>
       <dd className="m-0 mt-1 text-header-sm font-medium tabular-nums text-icon6">{value}</dd>
@@ -368,7 +380,10 @@ function StageAutomation({ metrics }: { metrics: FactoryMetrics }) {
             </div>
             <div className="h-1.5 overflow-hidden rounded-full bg-surface4" aria-hidden="true">
               {pct !== null && automated > 0 ? (
-                <div className="h-full rounded-full bg-accent1" style={{ width: `${Math.max(2, pct)}%` }} />
+                <div
+                  className="h-full rounded-full"
+                  style={{ width: `${Math.max(2, pct)}%`, backgroundColor: 'var(--chart-4)' }}
+                />
               ) : null}
             </div>
             {row && automated > 0 ? (
@@ -441,26 +456,43 @@ function SourceMix({ metrics }: { metrics: FactoryMetrics }) {
       </Txt>
     );
   }
+
+  const sources = metrics.sourceMix.map((entry, index) => ({
+    ...entry,
+    percentage: Math.round((entry.count / total) * 100),
+    color: METRICS_PALETTE[index % METRICS_PALETTE.length] ?? METRICS_PALETTE[0],
+  }));
+
   return (
-    <ul className="m-0 flex list-none flex-col gap-3 p-0">
-      {metrics.sourceMix.map(entry => {
-        const percentage = Math.round((entry.count / total) * 100);
-        return (
-          <li key={entry.source} className="grid gap-1.5">
-            <div className="flex items-baseline justify-between gap-3">
-              <Txt as="span" variant="ui-sm" className="font-medium text-icon5">
-                {SOURCE_LABELS[entry.source] ?? entry.source}
+    <div className="flex flex-col gap-4">
+      <div className="flex h-2.5 w-full gap-1" aria-hidden="true">
+        {sources.map(source => (
+          <span
+            key={source.source}
+            className="h-full min-w-1 basis-0 rounded-full"
+            style={{ flexGrow: source.count, backgroundColor: source.color }}
+          />
+        ))}
+      </div>
+      <ul className="m-0 flex list-none flex-col gap-2.5 p-0">
+        {sources.map(source => (
+          <li key={source.source} className="flex items-baseline justify-between gap-3">
+            <span className="flex min-w-0 items-center gap-2">
+              <span
+                className="size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: source.color }}
+                aria-hidden="true"
+              />
+              <Txt as="span" variant="ui-sm" className="truncate font-medium text-icon5">
+                {SOURCE_LABELS[source.source] ?? source.source}
               </Txt>
-              <Txt as="span" variant="ui-xs" className="tabular-nums text-icon3">
-                {entry.count} · {percentage}%
-              </Txt>
-            </div>
-            <div className="h-1.5 overflow-hidden rounded-full bg-surface4" aria-hidden="true">
-              <div className="h-full rounded-full bg-accent3" style={{ width: `${Math.max(2, percentage)}%` }} />
-            </div>
+            </span>
+            <Txt as="span" variant="ui-xs" className="shrink-0 tabular-nums text-icon3">
+              {source.count} · {source.percentage}%
+            </Txt>
           </li>
-        );
-      })}
-    </ul>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/mastracode/web/src/web/ui/pages/MetricsPage.tsx
+++ b/mastracode/web/src/web/ui/pages/MetricsPage.tsx
@@ -228,7 +228,7 @@ function FlowOverview({
         />
       </div>
 
-      <dl className="m-0 grid grid-cols-2 gap-x-5 gap-y-4 border-t border-border1 pt-4 lg:grid-cols-4 lg:gap-0 lg:divide-x lg:divide-border1">
+      <dl className="m-0 grid grid-cols-2 gap-x-5 gap-y-4 lg:grid-cols-4 lg:gap-0 lg:divide-x lg:divide-border1">
         <OverviewReadout
           icon={<Clock3 aria-hidden="true" />}
           label="Median cycle time"

--- a/mastracode/web/src/web/ui/pages/ThreadPage.tsx
+++ b/mastracode/web/src/web/ui/pages/ThreadPage.tsx
@@ -23,7 +23,8 @@ import { useFactoryQuery } from '../../../shared/hooks/useFactories';
 import { useUserSessionQuery } from '../../../shared/hooks/useWorkspaces';
 import { useWorkspaceRenderedListing } from '../../../shared/hooks/use-fs';
 
-const threadComposerContainerClass = 'w-full p-3 md:p-5';
+const threadComposerContainerClass =
+  'w-full p-3 transition-[padding-right] duration-220 ease-[cubic-bezier(0.32,0.72,0,1)] lg:in-data-[panel-open=true]:pr-[calc(var(--chat-right-panel-width)+0.5rem)] md:p-5 motion-reduce:transition-none in-data-[panel-gesture=active]:transition-none';
 const threadComposerInnerClass = 'mx-auto w-full max-w-[80ch]';
 
 export function ThreadPage() {
@@ -122,7 +123,7 @@ function ThreadPageMain({
       <FactorySessionHeader actions={workspacePanelAction} />
       <div
         data-panel-open={workspacePanelOpen}
-        className="grid min-h-0 min-w-0 flex-1 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden transition-[padding-right] duration-220 ease-[cubic-bezier(0.32,0.72,0,1)] lg:data-[panel-open=true]:pr-[calc(var(--chat-right-panel-width)+0.5rem)] motion-reduce:transition-none in-data-[panel-gesture=active]:transition-none"
+        className="grid min-h-0 min-w-0 flex-1 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden"
       >
         <ChatMessageBoundary>
           <ThreadPageContent />

--- a/mastracode/web/src/web/ui/pages/ThreadPage.tsx
+++ b/mastracode/web/src/web/ui/pages/ThreadPage.tsx
@@ -1,5 +1,9 @@
 import { useIsMobile } from '@mastra/playground-ui/hooks/use-is-mobile';
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
+import { PanelRightIcon } from 'lucide-react';
 import { useMatch, useParams } from 'react-router';
 
 import { Sidebar } from '../Sidebar';
@@ -18,15 +22,14 @@ import { useThreadPageKickoffs } from '../domains/chat/hooks/useThreadPageKickof
 import { useFactoryQuery } from '../../../shared/hooks/useFactories';
 import { useUserSessionQuery } from '../../../shared/hooks/useWorkspaces';
 import { useWorkspaceRenderedListing } from '../../../shared/hooks/use-fs';
-import { Spinner } from '@mastra/playground-ui/components/Spinner';
 
 const threadComposerContainerClass = 'w-full p-3 md:p-5';
 const threadComposerInnerClass = 'mx-auto w-full max-w-[80ch]';
 
 export function ThreadPage() {
   const { factoryId, sessionId, threadId } = useParams<{ factoryId: string; sessionId?: string; threadId?: string }>();
-  const userThreadMatch = useMatch('/factories/:factoryId/user/threads/:threadId');
   const isMobile = useIsMobile();
+  const userThreadMatch = useMatch('/factories/:factoryId/user/threads/:threadId');
   const [workspaceViewerExpanded, setWorkspaceViewerExpanded] = useState(false);
   const [workspaceViewerOverride, setWorkspaceViewerOverride] = useState<{
     workspacePath: string;
@@ -48,6 +51,7 @@ export function ThreadPage() {
     if (!workspacePath) return;
     setWorkspaceViewerOverride({ workspacePath, visible });
   };
+  const workspacePanelToggleLabel = workspaceViewerVisible ? 'Close workspace files' : 'Open workspace files';
 
   const resolvingSession = factoryQuery.isPending || (isUserThreadRoute && userSessionQuery.isPending);
   return (
@@ -55,11 +59,9 @@ export function ThreadPage() {
       sidebar={<Sidebar />}
       header={<ChatHeader />}
       rightPanelExpanded={workspaceViewerExpanded}
-      rightPanelAvailable={Boolean(workspacePath)}
-      onRightPanelOpen={() => setWorkspaceViewerVisible(true)}
-      onRightPanelClose={() => setWorkspaceViewerVisible(false)}
+      rightPanelOpen={workspaceViewerVisible}
       rightPanel={
-        workspacePath && (workspaceViewerVisible || isMobile) ? (
+        workspacePath ? (
           <WorkspaceViewerPanel
             workspacePath={workspacePath}
             renderedPaths={renderedPaths}
@@ -76,7 +78,29 @@ export function ThreadPage() {
           </div>
         ) : (
           <ChatSessionBoundary threadId={threadId}>
-            <ThreadPageMain />
+            <ThreadPageMain
+              workspacePanelOpen={workspaceViewerVisible}
+              workspacePanelAction={
+                workspacePath && !isMobile ? (
+                  <Button
+                    type="button"
+                    size="icon-md"
+                    variant="ghost"
+                    tooltip={workspacePanelToggleLabel}
+                    className="hidden rounded-md lg:inline-flex"
+                    onClick={() => setWorkspaceViewerVisible(!workspaceViewerVisible)}
+                    aria-label={workspacePanelToggleLabel}
+                    aria-controls="chat-right-slot"
+                    aria-expanded={workspaceViewerVisible}
+                  >
+                    <PanelRightIcon
+                      data-open={workspaceViewerVisible}
+                      className="transition-transform duration-220 data-[open=false]:rotate-180 motion-reduce:transition-none"
+                    />
+                  </Button>
+                ) : undefined
+              }
+            />
           </ChatSessionBoundary>
         )
       }
@@ -84,16 +108,28 @@ export function ThreadPage() {
   );
 }
 
-function ThreadPageMain() {
+function ThreadPageMain({
+  workspacePanelOpen,
+  workspacePanelAction,
+}: {
+  workspacePanelOpen: boolean;
+  workspacePanelAction?: ReactNode;
+}) {
   useGlobalShortcuts();
 
   return (
-    <div className="grid h-full min-h-0 min-w-0 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden">
-      <ChatMessageBoundary>
-        <ThreadPageContent />
-      </ChatMessageBoundary>
-      <TaskPanel />
-      <ThreadComposer />
+    <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+      <FactorySessionHeader actions={workspacePanelAction} />
+      <div
+        data-panel-open={workspacePanelOpen}
+        className="grid min-h-0 min-w-0 flex-1 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden transition-[padding-right] duration-220 ease-[cubic-bezier(0.32,0.72,0,1)] lg:data-[panel-open=true]:pr-[calc(var(--chat-right-panel-width)+0.5rem)] motion-reduce:transition-none in-data-[panel-gesture=active]:transition-none"
+      >
+        <ChatMessageBoundary>
+          <ThreadPageContent />
+        </ChatMessageBoundary>
+        <TaskPanel />
+        <ThreadComposer />
+      </div>
     </div>
   );
 }
@@ -114,7 +150,6 @@ function ThreadPageContent() {
 
   return (
     <div className="flex min-h-0 min-w-0 flex-col">
-      <FactorySessionHeader />
       <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
         <ChatMessageList />
       </div>

--- a/mastracode/web/src/web/ui/pages/ThreadPage.tsx
+++ b/mastracode/web/src/web/ui/pages/ThreadPage.tsx
@@ -28,7 +28,10 @@ export function ThreadPage() {
   const userThreadMatch = useMatch('/factories/:factoryId/user/threads/:threadId');
   const isMobile = useIsMobile();
   const [workspaceViewerExpanded, setWorkspaceViewerExpanded] = useState(false);
-  const [workspaceViewerVisible, setWorkspaceViewerVisible] = useState(true);
+  const [workspaceViewerOverride, setWorkspaceViewerOverride] = useState<{
+    workspacePath: string;
+    visible: boolean;
+  }>();
   const isUserThreadRoute = Boolean(userThreadMatch);
   const routeSessionId = isUserThreadRoute ? threadId : sessionId;
   const factoryQuery = useFactoryQuery(factoryId);
@@ -37,6 +40,14 @@ export function ThreadPage() {
   const workspacePath = userSessionQuery.data?.sandboxWorkdir ?? undefined;
   const artifactsListing = useWorkspaceRenderedListing(workspacePath, renderedPaths[0]?.root);
   const hasWorkspaceFiles = (artifactsListing.data?.entries.length ?? 0) > 0;
+  const workspaceViewerVisible =
+    workspaceViewerOverride && workspaceViewerOverride.workspacePath === workspacePath
+      ? workspaceViewerOverride.visible
+      : hasWorkspaceFiles;
+  const setWorkspaceViewerVisible = (visible: boolean) => {
+    if (!workspacePath) return;
+    setWorkspaceViewerOverride({ workspacePath, visible });
+  };
 
   if (factoryQuery.isPending || (Boolean(routeSessionId) && userSessionQuery.isPending)) {
     return (
@@ -50,11 +61,11 @@ export function ThreadPage() {
       sidebar={<Sidebar />}
       header={<ChatHeader />}
       rightPanelExpanded={workspaceViewerExpanded}
-      rightPanelAvailable={Boolean(workspacePath && hasWorkspaceFiles)}
+      rightPanelAvailable={Boolean(workspacePath)}
       onRightPanelOpen={() => setWorkspaceViewerVisible(true)}
       onRightPanelClose={() => setWorkspaceViewerVisible(false)}
       rightPanel={
-        workspacePath && hasWorkspaceFiles && (workspaceViewerVisible || isMobile) ? (
+        workspacePath && (workspaceViewerVisible || isMobile) ? (
           <WorkspaceViewerPanel
             workspacePath={workspacePath}
             renderedPaths={renderedPaths}

--- a/mastracode/web/src/web/ui/pages/ThreadPage.tsx
+++ b/mastracode/web/src/web/ui/pages/ThreadPage.tsx
@@ -17,6 +17,7 @@ import { useRouteThreadSync } from '../../../shared/hooks/useRouteThreadSync';
 import { useThreadPageKickoffs } from '../domains/chat/hooks/useThreadPageKickoffs';
 import { useFactoryQuery } from '../../../shared/hooks/useFactories';
 import { useUserSessionQuery } from '../../../shared/hooks/useWorkspaces';
+import { useWorkspaceRenderedListing } from '../../../shared/hooks/use-fs';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 
 const threadComposerContainerClass = 'w-full p-3 md:p-5';
@@ -28,13 +29,16 @@ export function ThreadPage() {
   const isMobile = useIsMobile();
   const [workspaceViewerExpanded, setWorkspaceViewerExpanded] = useState(false);
   const [workspaceViewerVisible, setWorkspaceViewerVisible] = useState(true);
-  const factoryQuery = useFactoryQuery(factoryId);
-  const userSessionQuery = useUserSessionQuery(userThreadMatch ? threadId : undefined);
   const isUserThreadRoute = Boolean(userThreadMatch);
+  const routeSessionId = isUserThreadRoute ? threadId : sessionId;
+  const factoryQuery = useFactoryQuery(factoryId);
+  const userSessionQuery = useUserSessionQuery(routeSessionId);
   const workspaceFactory = factoryQuery.data;
-  const workspacePath = isUserThreadRoute ? userSessionQuery.data?.sessionId : sessionId;
+  const workspacePath = userSessionQuery.data?.sandboxWorkdir ?? undefined;
+  const artifactsListing = useWorkspaceRenderedListing(workspacePath, renderedPaths[0]?.root);
+  const hasWorkspaceFiles = (artifactsListing.data?.entries.length ?? 0) > 0;
 
-  if (factoryQuery.isPending || (isUserThreadRoute && userSessionQuery.isPending)) {
+  if (factoryQuery.isPending || (Boolean(routeSessionId) && userSessionQuery.isPending)) {
     return (
       <div className="flex h-full w-full items-center justify-center">
         <Spinner />
@@ -46,11 +50,11 @@ export function ThreadPage() {
       sidebar={<Sidebar />}
       header={<ChatHeader />}
       rightPanelExpanded={workspaceViewerExpanded}
-      rightPanelAvailable={Boolean(workspacePath)}
+      rightPanelAvailable={Boolean(workspacePath && hasWorkspaceFiles)}
       onRightPanelOpen={() => setWorkspaceViewerVisible(true)}
       onRightPanelClose={() => setWorkspaceViewerVisible(false)}
       rightPanel={
-        workspacePath && (workspaceViewerVisible || isMobile) ? (
+        workspacePath && hasWorkspaceFiles && (workspaceViewerVisible || isMobile) ? (
           <WorkspaceViewerPanel
             workspacePath={workspacePath}
             renderedPaths={renderedPaths}

--- a/mastracode/web/src/web/ui/pages/ThreadPage.tsx
+++ b/mastracode/web/src/web/ui/pages/ThreadPage.tsx
@@ -77,7 +77,7 @@ function ThreadPageMain() {
   useGlobalShortcuts();
 
   return (
-    <div className="grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden">
+    <div className="grid h-full min-h-0 min-w-0 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden">
       <ChatMessageBoundary>
         <ThreadPageContent />
       </ChatMessageBoundary>
@@ -102,9 +102,9 @@ function ThreadPageContent() {
   useThreadPageKickoffs();
 
   return (
-    <div className="flex min-h-0 flex-col">
+    <div className="flex min-h-0 min-w-0 flex-col">
       <FactorySessionHeader />
-      <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
         <ChatMessageList />
       </div>
     </div>

--- a/mastracode/web/src/web/ui/pages/__tests__/ThreadPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/pages/__tests__/ThreadPage.msw.test.tsx
@@ -1,5 +1,6 @@
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -10,10 +11,19 @@ import type { WorkspaceRenderedEntry } from '../../../../shared/api/types';
 import { ThreadPage } from '../ThreadPage';
 
 vi.mock('../../layouts/ChatLayout', () => ({
-  ChatLayout: ({ rightPanel, rightPanelAvailable }: { rightPanel?: ReactNode; rightPanelAvailable?: boolean }) => (
+  ChatLayout: ({
+    rightPanel,
+    rightPanelAvailable,
+    onRightPanelOpen,
+  }: {
+    rightPanel?: ReactNode;
+    rightPanelAvailable?: boolean;
+    onRightPanelOpen?: () => void;
+  }) => (
     <div>
       <span>{rightPanel ? 'workspace-panel-visible' : 'workspace-panel-hidden'}</span>
       <span>{rightPanelAvailable ? 'workspace-panel-available' : 'workspace-panel-unavailable'}</span>
+      {rightPanelAvailable && !rightPanel ? <button onClick={onRightPanelOpen}>Open workspace files</button> : null}
     </div>
   ),
 }));
@@ -30,9 +40,7 @@ function installHandlers(entries: WorkspaceRenderedEntry[]) {
   const onListing = vi.fn();
   const listingWorkspacePaths: Array<string | null> = [];
   server.use(
-    http.get(FACTORIES_URL, () =>
-      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Factory' }] }),
-    ),
+    http.get(FACTORIES_URL, () => HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Factory' }] })),
     http.get(CONNECTIONS_URL, () => HttpResponse.json({ connections: [] })),
     http.get(USER_SESSION_URL, () =>
       HttpResponse.json({
@@ -81,14 +89,19 @@ function renderThreadPage() {
 
 describe('ThreadPage workspace panel', () => {
   describe('when the workspace has no rendered artifacts', () => {
-    it('keeps the workspace panel hidden', async () => {
+    it('keeps the workspace panel available behind its open button', async () => {
+      const user = userEvent.setup();
       const { onListing } = installHandlers([]);
 
       renderThreadPage();
 
       await waitFor(() => expect(onListing).toHaveBeenCalledOnce());
       expect(screen.getByText('workspace-panel-hidden')).toBeInTheDocument();
-      expect(screen.getByText('workspace-panel-unavailable')).toBeInTheDocument();
+      expect(screen.getByText('workspace-panel-available')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Open workspace files' }));
+
+      expect(screen.getByText('workspace-panel-visible')).toBeInTheDocument();
     });
   });
 

--- a/mastracode/web/src/web/ui/pages/__tests__/ThreadPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/pages/__tests__/ThreadPage.msw.test.tsx
@@ -1,0 +1,114 @@
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../../../e2e/web-ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../../e2e/web-ui/render';
+import type { WorkspaceRenderedEntry } from '../../../../shared/api/types';
+import { ThreadPage } from '../ThreadPage';
+
+vi.mock('../../layouts/ChatLayout', () => ({
+  ChatLayout: ({ rightPanel, rightPanelAvailable }: { rightPanel?: ReactNode; rightPanelAvailable?: boolean }) => (
+    <div>
+      <span>{rightPanel ? 'workspace-panel-visible' : 'workspace-panel-hidden'}</span>
+      <span>{rightPanelAvailable ? 'workspace-panel-available' : 'workspace-panel-unavailable'}</span>
+    </div>
+  ),
+}));
+
+const FACTORY_ID = 'factory-1';
+const SESSION_ID = 'session-1';
+const SANDBOX_WORKDIR = '/sandbox/repo';
+const FACTORIES_URL = `${TEST_BASE_URL}/web/factory/projects`;
+const CONNECTIONS_URL = `${FACTORIES_URL}/${FACTORY_ID}/source-control-connections`;
+const USER_SESSION_URL = `${TEST_BASE_URL}/web/user-sessions/${SESSION_ID}`;
+const LIST_URL = `${TEST_BASE_URL}/web/workspace/rendered/list`;
+
+function installHandlers(entries: WorkspaceRenderedEntry[]) {
+  const onListing = vi.fn();
+  const listingWorkspacePaths: Array<string | null> = [];
+  server.use(
+    http.get(FACTORIES_URL, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Factory' }] }),
+    ),
+    http.get(CONNECTIONS_URL, () => HttpResponse.json({ connections: [] })),
+    http.get(USER_SESSION_URL, () =>
+      HttpResponse.json({
+        session: {
+          id: 'stored-session-1',
+          sessionId: SESSION_ID,
+          projectRepositoryId: 'repository-1',
+          orgId: 'org-1',
+          userId: 'user-1',
+          branch: 'factory/demo',
+          baseBranch: 'main',
+          sandboxId: 'sandbox-1',
+          sandboxWorkdir: SANDBOX_WORKDIR,
+          materializedAt: '2026-07-23T00:00:00.000Z',
+          createdAt: '2026-07-23T00:00:00.000Z',
+          updatedAt: '2026-07-23T00:00:00.000Z',
+        },
+      }),
+    ),
+    http.get(LIST_URL, ({ request }) => {
+      onListing();
+      listingWorkspacePaths.push(new URL(request.url).searchParams.get('workspacePath'));
+      return HttpResponse.json({
+        workspacePath: SANDBOX_WORKDIR,
+        root: '.artifacts',
+        rootPath: `${SANDBOX_WORKDIR}/.artifacts`,
+        entries,
+      });
+    }),
+  );
+  return { onListing, listingWorkspacePaths };
+}
+
+function renderThreadPage() {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/factories/:factoryId/workspaces/:sessionId/threads/:threadId',
+        element: <ThreadPage />,
+      },
+    ],
+    { initialEntries: [`/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/thread-1`] },
+  );
+  return renderWithProviders(<RouterProvider router={router} />);
+}
+
+describe('ThreadPage workspace panel', () => {
+  describe('when the workspace has no rendered artifacts', () => {
+    it('keeps the workspace panel hidden', async () => {
+      const { onListing } = installHandlers([]);
+
+      renderThreadPage();
+
+      await waitFor(() => expect(onListing).toHaveBeenCalledOnce());
+      expect(screen.getByText('workspace-panel-hidden')).toBeInTheDocument();
+      expect(screen.getByText('workspace-panel-unavailable')).toBeInTheDocument();
+    });
+  });
+
+  describe('when the workspace has a rendered artifact', () => {
+    it('shows the workspace panel', async () => {
+      const { listingWorkspacePaths } = installHandlers([
+        {
+          name: 'report.md',
+          path: 'report.md',
+          type: 'file',
+          size: 12,
+          updatedAt: '2026-07-23T00:00:00.000Z',
+        },
+      ]);
+
+      renderThreadPage();
+
+      expect(await screen.findByText('workspace-panel-visible')).toBeInTheDocument();
+      expect(screen.getByText('workspace-panel-available')).toBeInTheDocument();
+      expect(listingWorkspacePaths).toEqual([SANDBOX_WORKDIR]);
+    });
+  });
+});

--- a/mastracode/web/src/web/ui/pages/__tests__/ThreadPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/pages/__tests__/ThreadPage.msw.test.tsx
@@ -12,21 +12,33 @@ import { ThreadPage } from '../ThreadPage';
 
 vi.mock('../../layouts/ChatLayout', () => ({
   ChatLayout: ({
+    main,
     rightPanel,
-    rightPanelAvailable,
-    onRightPanelOpen,
+    rightPanelOpen,
   }: {
+    main?: ReactNode;
     rightPanel?: ReactNode;
-    rightPanelAvailable?: boolean;
-    onRightPanelOpen?: () => void;
+    rightPanelOpen?: boolean;
   }) => (
     <div>
-      <span>{rightPanel ? 'workspace-panel-visible' : 'workspace-panel-hidden'}</span>
-      <span>{rightPanelAvailable ? 'workspace-panel-available' : 'workspace-panel-unavailable'}</span>
-      {rightPanelAvailable && !rightPanel ? <button onClick={onRightPanelOpen}>Open workspace files</button> : null}
+      <span>{rightPanel ? 'workspace-panel-mounted' : 'workspace-panel-missing'}</span>
+      <span>{rightPanelOpen ? 'workspace-panel-open' : 'workspace-panel-closed'}</span>
+      {main}
     </div>
   ),
 }));
+
+vi.mock('../../domains/chat/context/ChatSessionProvider', () => ({
+  ChatSessionBoundary: ({ children }: { children: ReactNode }) => children,
+  ChatMessageBoundary: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('../../domains/chat/components/ChatMessageList', () => ({ ChatMessageList: () => null }));
+vi.mock('../../domains/chat/components/ComposerPanel', () => ({ ComposerPanel: () => null }));
+vi.mock('../../domains/chat/components/TaskPanel', () => ({ TaskPanel: () => null }));
+vi.mock('../../domains/chat/hooks/useGlobalShortcuts', () => ({ useGlobalShortcuts: vi.fn() }));
+vi.mock('../../domains/chat/hooks/useThreadPageKickoffs', () => ({ useThreadPageKickoffs: vi.fn() }));
+vi.mock('../../../../shared/hooks/useRouteThreadSync', () => ({ useRouteThreadSync: vi.fn() }));
 
 const FACTORY_ID = 'factory-1';
 const SESSION_ID = 'session-1';
@@ -78,30 +90,31 @@ function renderThreadPage() {
   const router = createMemoryRouter(
     [
       {
-        path: '/factories/:factoryId/workspaces/:sessionId/threads/:threadId',
+        path: '/factories/:factoryId/user/threads/:threadId',
         element: <ThreadPage />,
       },
     ],
-    { initialEntries: [`/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/thread-1`] },
+    { initialEntries: [`/factories/${FACTORY_ID}/user/threads/${SESSION_ID}`] },
   );
   return renderWithProviders(<RouterProvider router={router} />);
 }
 
 describe('ThreadPage workspace panel', () => {
   describe('when the workspace has no rendered artifacts', () => {
-    it('keeps the workspace panel available behind its open button', async () => {
+    it('opens the mounted workspace panel from the session header', async () => {
       const user = userEvent.setup();
       const { onListing } = installHandlers([]);
 
       renderThreadPage();
 
       await waitFor(() => expect(onListing).toHaveBeenCalledOnce());
-      expect(screen.getByText('workspace-panel-hidden')).toBeInTheDocument();
-      expect(screen.getByText('workspace-panel-available')).toBeInTheDocument();
+      expect(screen.getByText('workspace-panel-mounted')).toBeInTheDocument();
+      expect(screen.getByText('workspace-panel-closed')).toBeInTheDocument();
 
       await user.click(screen.getByRole('button', { name: 'Open workspace files' }));
 
-      expect(screen.getByText('workspace-panel-visible')).toBeInTheDocument();
+      expect(screen.getByText('workspace-panel-open')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Close workspace files' })).toBeInTheDocument();
     });
   });
 
@@ -119,8 +132,9 @@ describe('ThreadPage workspace panel', () => {
 
       renderThreadPage();
 
-      expect(await screen.findByText('workspace-panel-visible')).toBeInTheDocument();
-      expect(screen.getByText('workspace-panel-available')).toBeInTheDocument();
+      expect(await screen.findByText('workspace-panel-open')).toBeInTheDocument();
+      expect(screen.getByText('workspace-panel-mounted')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Close workspace files' })).toBeInTheDocument();
       expect(listingWorkspacePaths).toEqual([SANDBOX_WORKDIR]);
     });
   });


### PR DESCRIPTION
Turns workspace files into a content-sized floating panel beside the chat. The files toggle now lives in the session header; opening and closing the panel smoothly animates the panel and the chat content's right-side inset while the transcript scroll container remains full-width, so its scrollbar stays fixed at the viewport edge. The card begins just below the session header, keeps pointer and keyboard resizing, and shows a visible Workspace files title with refresh at the top-right corner.

Rendered workspace listings no longer poll every five seconds. They load once, refresh after filesystem-mutating tools, subagents, and controller runs complete, and refresh when the browser returns to the tab. The toggle remains available for every materialized workspace even when the listing is empty, so users can open the panel and refresh manually.

Artifact lookup resolves the session's materialized `sandboxWorkdir` instead of treating the session ID as a filesystem path.

Factory metrics remove the redundant Delivery flow summary and use the chart palette for overview accents, automation progress, and a stacked source-mix distribution.

Verified with `pnpm check:ui`, focused web UI tests, React Doctor, and browser checks for the stationary transcript scrollbar, animated content inset, panel title, open/close motion, compact geometry, refresh placement, and metrics colors.