### PR TITLE
fix(web): quiet success state and uniform row spacing in chat transcript

### DIFF
--- a/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/TranscriptPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/TranscriptPanel.tsx
@@ -9,7 +9,7 @@ import { EmptyThreadState } from './EmptyThreadState';
 import { WorkingIndicator } from './WorkingIndicator';
 
 const transcriptScrollClass =
-  'flex min-h-0 min-w-0 flex-1 flex-col gap-4 overflow-y-auto px-3 pb-2 pt-6 md:px-5 [&>*]:mx-auto [&>*]:w-full [&>*]:min-w-0 [&>*]:max-w-[80ch]';
+  'flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-3 pb-2 pt-6 md:px-5 [&>*]:mx-auto [&>*]:w-full [&>*]:min-w-0 [&>*]:max-w-[80ch]';
 
 export function TranscriptPanel() {
   const { transcript, showWorkingIndicator, loadMore } = useChatTranscript();

--- a/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
@@ -14,7 +14,6 @@ import type { FilePart, MessageRoleRenderers, ReasoningPart, TextPart, ToolInvoc
 import {
   Bell,
   BookOpen,
-  Check,
   ChevronDown,
   CircleDot,
   CircleX,
@@ -61,7 +60,7 @@ const resultBlock =
   'm-0 mt-1 max-h-72 max-w-full overflow-auto whitespace-pre rounded-sm bg-surface1 p-2 font-mono text-xs leading-normal text-icon5';
 
 // Prompt cards (approval / suspension) — an elevated card with a colored left rail.
-const promptCardBase = 'rounded-lg border border-border1 bg-surface3 px-4 py-3 shadow-md';
+const promptCardBase = 'my-2 rounded-lg border border-border1 bg-surface3 px-4 py-3 shadow-md';
 const promptCardApproval = `${promptCardBase} border-l-4 border-l-warning1`;
 const promptCardSuspension = `${promptCardBase} border-l-4 border-l-accent2`;
 const promptTitle = 'mb-1.5 text-sm font-semibold text-icon6';
@@ -149,11 +148,11 @@ function SkillActivationCard({ activation }: { activation: SkillActivation }) {
 // Tool card (collapsible)
 // ---------------------------------------------------------------------------
 
-/** Quiet status indicator: muted spinner while running, colored check/cross when settled. */
+/** Quiet status indicator: muted spinner while running, red cross on failure, nothing on success. */
 function ToolStatusIcon({ status }: { status: ToolCall['status'] }) {
   if (status === 'running') return <Spinner size="sm" aria-label="Running" className="size-3.5 text-icon3" />;
   if (status === 'error') return <X size={14} role="img" aria-label="Failed" className="text-error" />;
-  return <Check size={14} role="img" aria-label="Done" className="text-accent1" />;
+  return null;
 }
 
 /** Label + copy header for a section inside a tool card body. */
@@ -544,7 +543,7 @@ function AskUserCard({
 
 function SubagentCard({ entry }: { entry: SubagentEntry }) {
   return (
-    <div className="rounded-lg border border-l-4 border-border1 border-l-accent5 bg-surface2 px-3 py-2 shadow-sm">
+    <div className="my-2 rounded-lg border border-l-4 border-border1 border-l-accent5 bg-surface2 px-3 py-2 shadow-sm">
       <div className="flex items-center gap-2">
         <Badge variant={entry.done ? 'success' : 'info'}>subagent: {entry.agentType}</Badge>
         <Txt variant="ui-xs" className="text-icon3">
@@ -761,24 +760,6 @@ export function Transcript() {
   );
 }
 
-function followsToolEntry(entries: TimelineEntry[], index: number): boolean {
-  const current = entries[index];
-  if (current?.kind !== 'message' || current.message.role !== 'assistant') return false;
-
-  for (let previousIndex = index - 1; previousIndex >= 0; previousIndex--) {
-    const previous = entries[previousIndex];
-    if (previous.kind !== 'message') return false;
-    if (previous.message.role === 'user') return false;
-    if (previous.message.role === 'signal') continue;
-
-    const parts = previous.message.content.parts;
-    if (parts.some(part => part.type === 'text' && part.text.trim().length > 0)) return false;
-    if (parts.some(part => part.type === 'tool-invocation')) return true;
-  }
-
-  return false;
-}
-
 export function TranscriptEntries({
   entries,
   isSubmitting = false,
@@ -805,14 +786,13 @@ export function TranscriptEntries({
 
   return (
     <>
-      {entries.map((entry, index) => {
+      {entries.map(entry => {
         switch (entry.kind) {
           case 'message':
             return (
               <MessageBubble
                 key={entry.id}
                 entry={entry}
-                followsToolEntry={followsToolEntry(entries, index)}
                 suspensions={suspensions}
                 isSubmitting={isSubmitting}
                 onRespond={onRespond}
@@ -842,13 +822,11 @@ export function TranscriptEntries({
 
 function MessageBubble({
   entry,
-  followsToolEntry,
   suspensions,
   isSubmitting,
   onRespond,
 }: {
   entry: MessageEntry;
-  followsToolEntry: boolean;
   suspensions: ReadonlyMap<string, SuspensionPrompt>;
   isSubmitting: boolean;
   onRespond: (toolCallId: string, resumeData: string | string[] | PlanResume, promptId: string) => void;
@@ -878,7 +856,7 @@ function MessageBubble({
 
   const roles: MessageRoleRenderers = {
     User: ({ children }) => (
-      <div className="flex w-full flex-col items-end">
+      <div className="my-3 flex w-full flex-col items-end">
         <div
           className={`max-w-[70%] break-words rounded-xl px-4 py-2 text-text1 ${
             entry.steer ? 'bg-warning1/10' : 'bg-surface3'
@@ -895,10 +873,6 @@ function MessageBubble({
 
   const renderers = {
     Text: (part: TextPart) => {
-      const renderedPart: unknown = part;
-      const partIndex = parts.findIndex(candidate => candidate === renderedPart);
-      const followsTool = partIndex > 0 && parts[partIndex - 1]?.type === 'tool-invocation';
-
       if (entry.message.role === 'user') {
         const activation = parseSkillActivation(part.text);
         return activation ? (
@@ -911,7 +885,7 @@ function MessageBubble({
       }
 
       return (
-        <div className={cn('prose', followsToolEntry ? 'mt-4' : followsTool ? 'mt-3' : undefined)}>
+        <div className="prose my-3">
           <Markdown>{part.text}</Markdown>
           {entry.streaming && part === lastTextPart && (
             <span className="ml-0.5 inline-block h-[1em] w-0.5 animate-pulse bg-accent1 align-text-bottom" />
@@ -948,7 +922,7 @@ function MessageBubble({
   const notifications = notificationMetadata(entry);
   if (notifications.length > 0) {
     return (
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col">
         {notifications.map(notification =>
           notification.kind === 'notification' ? (
             <NotificationCard key={notification.id} entry={notification} />
@@ -1201,12 +1175,16 @@ function statusMetadata(entry: MessageEntry): StatusMetadata | undefined {
 }
 
 function StatusMetadataCard({ status }: { status: StatusMetadata }) {
-  return <Notice variant={status.level === 'error' ? 'destructive' : 'info'}>{status.text}</Notice>;
+  return (
+    <Notice className="my-2" variant={status.level === 'error' ? 'destructive' : 'info'}>
+      {status.text}
+    </Notice>
+  );
 }
 
 function NoticeCard({ entry }: { entry: NoticeEntry }) {
   return (
-    <Notice variant={entry.level === 'error' ? 'destructive' : 'info'}>
+    <Notice className="my-2" variant={entry.level === 'error' ? 'destructive' : 'info'}>
       <div className="prose">
         <Markdown>{entry.text}</Markdown>
       </div>

--- a/mastracode/web/src/web/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
@@ -1,0 +1,89 @@
+import type { MastraDBMessage } from '@mastra/core/agent-controller';
+import { screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithProviders } from '../../../../../../../e2e/web-ui/render';
+import type { TimelineEntry } from '../../services/transcript';
+import { TranscriptEntries } from '../Transcript';
+
+const CREATED_AT = new Date('2026-07-15T10:00:00.000Z');
+
+function assistantMessage(id: string, parts: MastraDBMessage['content']['parts']): TimelineEntry {
+  return {
+    kind: 'message',
+    id,
+    message: { id, role: 'assistant', createdAt: CREATED_AT, content: { format: 2, parts } },
+  };
+}
+
+function userMessage(id: string, text: string): TimelineEntry {
+  return {
+    kind: 'message',
+    id,
+    message: { id, role: 'user', createdAt: CREATED_AT, content: { format: 2, parts: [{ type: 'text', text }] } },
+  };
+}
+
+function doneTool(toolCallId: string, toolName: string): MastraDBMessage['content']['parts'][number] {
+  return {
+    type: 'tool-invocation',
+    toolInvocation: { state: 'result', toolCallId, toolName, args: { path: 'src/index.ts' }, result: 'ok' },
+  };
+}
+
+function renderEntries(entries: TimelineEntry[]) {
+  return renderWithProviders(<TranscriptEntries entries={entries} onApprove={() => {}} onRespond={() => {}} />);
+}
+
+describe('TranscriptEntries tool rows', () => {
+  it('shows no status icon on success — only running and failed carry indicators', () => {
+    renderEntries([
+      assistantMessage('msg-1', [
+        doneTool('call-1', 'view'),
+        {
+          type: 'tool-invocation',
+          toolInvocation: { state: 'call', toolCallId: 'call-2', toolName: 'execute_command', args: {} },
+        },
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'output-error',
+            toolCallId: 'call-3',
+            toolName: 'write_file',
+            args: {},
+            errorText: 'boom',
+          },
+        },
+      ]),
+    ]);
+
+    // Success is the quiet default: no check mark / "Done" indicator anywhere.
+    expect(screen.queryByLabelText('Done')).not.toBeInTheDocument();
+    const doneRow = screen.getByRole('group', { name: 'Tool: view' });
+    expect(within(doneRow).queryByRole('img')).not.toBeInTheDocument();
+
+    // Running keeps its spinner.
+    const runningRow = screen.getByRole('group', { name: 'Tool: execute_command' });
+    expect(within(runningRow).getByLabelText('Running')).toBeInTheDocument();
+
+    // Failure keeps its red cross.
+    const failedRow = screen.getByRole('group', { name: 'Tool: write_file' });
+    expect(within(failedRow).getByRole('img', { name: 'Failed' })).toBeInTheDocument();
+  });
+
+  it('gives prose entries their own vertical margins so rows stay on a uniform rhythm', () => {
+    renderEntries([
+      userMessage('msg-user', 'Please run the tests'),
+      assistantMessage('msg-tools', [doneTool('call-1', 'execute_command')]),
+      assistantMessage('msg-text', [{ type: 'text', text: 'All 36 tests passed.' }]),
+    ]);
+
+    // The transcript container no longer adds gaps between entries, so prose
+    // content must own its breathing room via explicit margins.
+    const userBubbleWrapper = screen.getByText('Please run the tests').closest('.items-end');
+    expect(userBubbleWrapper).toHaveClass('my-3');
+
+    const assistantProse = screen.getByText('All 36 tests passed.').closest('.prose');
+    expect(assistantProse).toHaveClass('my-3');
+  });
+});


### PR DESCRIPTION
Two small transcript polish changes in mastracode/web.

Successful tool rows no longer show a green check — success is the quiet default now, so only running (spinner) and failed (red cross) tools carry a status indicator.

Row spacing is now uniform: previously tool rows within one assistant message sat ~12px apart while rows in adjacent entries got an extra 16px from the container gap, producing tight clusters with random big gaps between them. The container gap is gone and each entry owns its spacing — collapsible rows (tools, signals, notifications) all sit on the same 12px rhythm regardless of message boundaries, while user bubbles, assistant prose, prompt cards, and notices keep breathing room via explicit margins.

Test plan: added TranscriptToolRows.msw.test.tsx asserting the status-icon behavior (no icon on success, spinner on running, red cross on failure) and the prose margin invariants. Full web-ui MSW suite (54 files / 281 tests) and tsc checks pass. Worth a quick visual pass on a real thread with mixed tool/signal/prose content to catch any rarely-rendered card now sitting flush against a neighbor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The chat transcript now has cleaner spacing and clearer tool statuses. Finished tools stay quiet, while running and failed tools still show indicators.

## Changes

- Removed transcript container gaps and standardized row spacing.
- Added consistent margins for user messages, assistant prose, prompt cards, subagent cards, and notices.
- Simplified transcript spacing logic.
- Added MSW coverage for tool status icons and prose margins.
- Full web UI MSW suite and TypeScript checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->