### PR TITLE
fix(mastracode): use default workspace menu width

### DIFF
--- a/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -314,7 +314,7 @@ export function WorkspaceRow({
               </Button>
             }
           />
-          <DropdownMenu.Content align="end" className="min-w-28">
+          <DropdownMenu.Content align="end">
             <DropdownMenu.Item variant="destructive" onClick={onDelete}>
               <Trash2 />
               Delete


### PR DESCRIPTION
Removes the local minimum-width override from the workspace actions dropdown so it uses the shared DropdownMenu sizing consistently.

Validated with React Doctor on the changed scope (100/100) and `git diff --check`. The full UI typecheck could not run in this fresh worktree because linked workspace package declarations are not built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The workspace actions menu no longer forces its own width. It now uses the same sizing rules as other dropdown menus for a more consistent look.

## Changes

- Removed the local `min-w-28` override from the workspace actions dropdown.

## Validation

- React Doctor: 100/100
- `git diff --check`
- Full UI typechecking was not run because linked workspace declarations were not built.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->