### PR TITLE
feat(core): opt-in 'called' tool-call concurrency strategy

### DIFF
--- a/.changeset/batch-aware-tool-concurrency.md
+++ b/.changeset/batch-aware-tool-concurrency.md
@@ -1,0 +1,20 @@
+---
+'@mastra/core': minor
+---
+
+Add an opt-in `'called'` tool-call concurrency strategy so batches of purely safe tool calls run in parallel even when an approval/suspending tool stays registered on the agent.
+
+`toolCallConcurrency` now accepts an object form in addition to a number:
+
+```ts
+// number (unchanged): concurrency limit, 'available' strategy
+toolCallConcurrency: 8
+
+// object form: pick the limit and/or strategy
+toolCallConcurrency: { limit: 8, strategy: 'called' }
+```
+
+- `strategy: 'available'` (default, unchanged): any approval/suspending tool *available* in the step forces the whole batch sequential, even if the model did not call it. Conservative — a suspend can never race a sibling.
+- `strategy: 'called'`: only the tools the model *actually called* this step are checked. An available-but-uncalled approval/suspend tool no longer serializes a batch of safe calls; a batch that *does* call one still runs sequentially (concurrency 1), and a run-wide `requireToolApproval` policy still forces sequential. Useful for agents (e.g. multi-step generation pipelines) that keep an approval tool registered across a run but never mix it into the same batch as parallelizable calls.
+
+Applies to both the standard loop and the durable (`@mastra/inngest` / `@mastra/temporal`) engine.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -7,22 +7,22 @@
 
 export type Simplify<T> = { [K in keyof T]: T[K] } & {};
 
-type Shared_Auxiliary_290 =
+type Shared_Auxiliary_294 =
   | string
   | number
   | boolean
   | null
-  | Shared_Auxiliary_290[]
+  | Shared_Auxiliary_294[]
   | {
-      [key: string]: Shared_Auxiliary_290;
+      [key: string]: Shared_Auxiliary_294;
     };
 
-type Shared_Auxiliary_1159 = {
+type Shared_Auxiliary_1163 = {
   id?: string | undefined;
   name: string;
   type: 'file' | 'folder';
   content?: string | undefined;
-  children?: Shared_Auxiliary_1159[] | undefined;
+  children?: Shared_Auxiliary_1163[] | undefined;
 };
 
 type Shared_Type_0 = {
@@ -90,7 +90,15 @@ type Shared_Type_4 = {
   tracingOptions?: Shared_Type_3 | undefined;
   requireToolApproval?: boolean | undefined;
   autoResumeSuspendedTools?: boolean | undefined;
-  toolCallConcurrency?: number | undefined;
+  toolCallConcurrency?:
+    | (
+        | number
+        | {
+            limit?: number | undefined;
+            strategy?: ('available' | 'called') | undefined;
+          }
+      )
+    | undefined;
   includeRawChunks?: boolean | undefined;
   [x: string]: unknown;
 };
@@ -976,7 +984,7 @@ type Shared_Type_49 = {
   providerOptions?:
     | {
         [key: string]: {
-          [key: string]: Shared_Auxiliary_290;
+          [key: string]: Shared_Auxiliary_294;
         };
       }
     | undefined;
@@ -990,7 +998,7 @@ type Shared_Type_50 = {
   providerOptions?:
     | {
         [key: string]: {
-          [key: string]: Shared_Auxiliary_290;
+          [key: string]: Shared_Auxiliary_294;
         };
       }
     | undefined;
@@ -1005,13 +1013,13 @@ type Shared_Type_51 = {
     | undefined;
   metadata?:
     | {
-        [key: string]: Shared_Auxiliary_290;
+        [key: string]: Shared_Auxiliary_294;
       }
     | undefined;
   providerOptions?:
     | {
         [key: string]: {
-          [key: string]: Shared_Auxiliary_290;
+          [key: string]: Shared_Auxiliary_294;
         };
       }
     | undefined;
@@ -1099,7 +1107,7 @@ type Shared_Type_54 = {
   createdAt?: (string | Date) | undefined;
   metadata?:
     | {
-        [key: string]: Shared_Auxiliary_290;
+        [key: string]: Shared_Auxiliary_294;
       }
     | undefined;
   attributes?:
@@ -1113,7 +1121,7 @@ type Shared_Type_54 = {
   providerOptions?:
     | {
         [key: string]: {
-          [key: string]: Shared_Auxiliary_290;
+          [key: string]: Shared_Auxiliary_294;
         };
       }
     | undefined;
@@ -2538,7 +2546,7 @@ type Shared_Type_112 = {
   /** List of asset file paths */
   assets?: string[] | undefined;
   /** Full file tree structure for the skill */
-  files?: Shared_Auxiliary_1159[] | undefined;
+  files?: Shared_Auxiliary_1163[] | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | {
@@ -15800,7 +15808,7 @@ export type PostStoredSkills_Body = {
   /** List of asset file paths */
   assets?: string[] | undefined;
   /** Full file tree structure for the skill */
-  files?: Shared_Auxiliary_1159[] | undefined;
+  files?: Shared_Auxiliary_1163[] | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | {
@@ -15858,7 +15866,7 @@ export type PatchStoredSkillsStoredSkillId_Body = {
   /** List of asset file paths */
   assets?: (string[] | undefined) | undefined;
   /** Full file tree structure for the skill */
-  files?: (Shared_Auxiliary_1159[] | undefined) | undefined;
+  files?: (Shared_Auxiliary_1163[] | undefined) | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | (

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -1137,7 +1137,7 @@ export interface DefaultOptions {
   };
   requireToolApproval?: boolean;
   autoResumeSuspendedTools?: boolean;
-  toolCallConcurrency?: number;
+  toolCallConcurrency?: number | { limit?: number; strategy?: 'available' | 'called' };
   includeRawChunks?: boolean;
   [key: string]: unknown; // Allow additional provider-specific options
 }

--- a/packages/core/src/agent/__tests__/tool-concurrency-active-tools.test.ts
+++ b/packages/core/src/agent/__tests__/tool-concurrency-active-tools.test.ts
@@ -90,7 +90,7 @@ async function runAgent({
   tools: Record<string, unknown>;
   activeTools?: string[];
   prepareStep?: (args: { tools?: Record<string, unknown> }) => unknown;
-  toolCallConcurrency?: number;
+  toolCallConcurrency?: number | { limit?: number; strategy?: 'available' | 'called' };
   requireToolApproval?: boolean;
   toolNames?: string[];
 }) {
@@ -194,5 +194,41 @@ describe('active tool concurrency', () => {
 
     expect(safeTracker.peak).toBe(2);
     expect(sequentialTracker.peak).toBe(1);
+  });
+
+  describe("'called' strategy", () => {
+    it('runs safe calls concurrently when an approval tool is available but not called this step', async () => {
+      const tracker: ConcurrencyTracker = { running: 0, peak: 0, completed: [] };
+
+      await runAgent({
+        tools: {
+          'tool-1': createTrackedTool('tool-1', tracker),
+          'tool-2': createTrackedTool('tool-2', tracker),
+          'approval-tool': createApprovalTool(),
+        },
+        // No activeTools: approval-tool is available (would force sequential under the
+        // default 'available' strategy), but the batch only calls the safe tools.
+        toolCallConcurrency: { strategy: 'called', limit: 8 },
+        toolNames: ['tool-1', 'tool-2'],
+      });
+
+      expect(tracker.peak).toBe(2);
+      expect(tracker.completed).toEqual(expect.arrayContaining(['tool-1', 'tool-2']));
+    });
+
+    it('serializes when the batch actually calls a suspending tool', async () => {
+      const tracker: ConcurrencyTracker = { running: 0, peak: 0, completed: [] };
+
+      await runAgent({
+        tools: {
+          'tool-1': createTrackedTool('tool-1', tracker),
+          'suspending-tool': createTrackedTool('suspending-tool', tracker, { suspendable: true }),
+        },
+        toolCallConcurrency: { strategy: 'called', limit: 8 },
+        toolNames: ['tool-1', 'suspending-tool'],
+      });
+
+      expect(tracker.peak).toBe(1);
+    });
   });
 });

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -6,6 +6,7 @@ import type { ProviderOptions } from '../llm/model/provider-options';
 import type { MastraLanguageModel, MastraModelConfig } from '../llm/model/shared.types';
 import type { CompletionConfig, CompletionRunResult } from '../loop/network/validation';
 import type { LoopConfig, LoopOptions, PrepareStepFunction } from '../loop/types';
+import type { ToolCallConcurrency } from '../loop/workflows/agentic-execution/tool-call-concurrency';
 import type { VersionOverrides } from '../mastra/types';
 import type { ObservabilityContext, TracingOptions } from '../observability';
 import type { ErrorProcessorOrWorkflow, InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors';
@@ -588,8 +589,15 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
   /** Automatically resume suspended tools */
   autoResumeSuspendedTools?: boolean;
 
-  /** Maximum number of tool calls to execute concurrently (default: 1 when approval may be required, otherwise 10) */
-  toolCallConcurrency?: number;
+  /**
+   * Controls parallel tool-call execution. A number sets the concurrency limit
+   * (default 10, but forced to 1 whenever an approval/suspending tool is available).
+   * Pass an object to also select the strategy: `{ limit?, strategy?: 'available' | 'called' }`.
+   * `'available'` (default) forces sequential whenever such a tool is available in the
+   * step; `'called'` only forces sequential when the model actually calls one this step,
+   * so batches of purely safe calls run concurrently even with an approval tool registered.
+   */
+  toolCallConcurrency?: ToolCallConcurrency;
 
   /** Whether to include raw chunks in the stream output (not available on all model providers) */
   includeRawChunks?: boolean;

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -77,8 +77,8 @@ export interface DurableAgentStreamOptions<OUTPUT = undefined> {
   requireToolApproval?: AgentExecutionOptions<OUTPUT>['requireToolApproval'];
   /** Automatically resume suspended tools */
   autoResumeSuspendedTools?: boolean;
-  /** Maximum number of tool calls to execute concurrently */
-  toolCallConcurrency?: number;
+  /** Maximum number of tool calls to execute concurrently. See {@link AgentExecutionOptions.toolCallConcurrency}. */
+  toolCallConcurrency?: AgentExecutionOptions<OUTPUT>['toolCallConcurrency'];
   /** Whether to include raw chunks in the stream output */
   includeRawChunks?: boolean;
   /** Maximum processor retries */

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -14,6 +14,7 @@ import type { AgentBackgroundConfig } from '../../background-tasks/types';
 import type { SystemMessage } from '../../llm';
 import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
+import type { ToolCallConcurrency } from '../../loop/workflows/agentic-execution/tool-call-concurrency';
 import type { MastraMemory } from '../../memory/memory';
 import type { MemoryConfig } from '../../memory/types';
 import type { AIModelGenerationSpan, Span, SpanType, TracingContext, TracingOptions } from '../../observability';
@@ -179,8 +180,8 @@ export interface SerializableDurableOptions {
   modelSettings?: SerializableModelSettings;
   /** Whether to require tool approval globally */
   requireToolApproval?: boolean;
-  /** Concurrency limit for parallel tool calls */
-  toolCallConcurrency?: number;
+  /** Concurrency config for parallel tool calls (limit + strategy). */
+  toolCallConcurrency?: ToolCallConcurrency;
   /** Whether to auto-resume suspended tools */
   autoResumeSuspendedTools?: boolean;
   /** Maximum processor retries per generation */

--- a/packages/core/src/agent/durable/utils/serialize-state.ts
+++ b/packages/core/src/agent/durable/utils/serialize-state.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema7 } from 'json-schema';
 import type { MastraLanguageModel } from '../../../llm/model/shared.types';
+import type { ToolCallConcurrency } from '../../../loop/workflows/agentic-execution/tool-call-concurrency';
 import type { MemoryConfig } from '../../../memory/types';
 import type { CoreTool } from '../../../tools/types';
 import type { MessageList } from '../../message-list';
@@ -209,7 +210,7 @@ export function serializeDurableOptions(options: {
   activeTools?: string[];
   modelSettings?: SerializableModelSettings | Record<string, unknown>;
   requireToolApproval?: boolean;
-  toolCallConcurrency?: number;
+  toolCallConcurrency?: ToolCallConcurrency;
   autoResumeSuspendedTools?: boolean;
   maxProcessorRetries?: number;
   includeRawChunks?: boolean;

--- a/packages/core/src/agent/durable/workflows/shared/tool-call-concurrency.test.ts
+++ b/packages/core/src/agent/durable/workflows/shared/tool-call-concurrency.test.ts
@@ -11,8 +11,8 @@ function tool(overrides: Partial<SerializableToolMetadata> & { name: string }): 
   };
 }
 
-function call(_toolName: string, activeTools?: string[] | null): Pick<DurableToolCallInput, 'activeTools'> {
-  return activeTools !== undefined ? { activeTools } : {};
+function call(toolName: string, activeTools?: string[] | null): Pick<DurableToolCallInput, 'activeTools' | 'toolName'> {
+  return { toolName, ...(activeTools !== undefined ? { activeTools } : {}) };
 }
 
 describe('resolveDurableToolCallConcurrency', () => {
@@ -146,5 +146,64 @@ describe('resolveDurableToolCallConcurrency', () => {
         toolCalls: [call('a')],
       }),
     ).toBe(4);
+  });
+
+  it('extracts the limit from the object config form', () => {
+    expect(
+      resolveDurableToolCallConcurrency({
+        options: { toolCallConcurrency: { limit: 6 } },
+        toolsMetadata: [tool({ name: 'plain' })],
+      }),
+    ).toBe(6);
+  });
+
+  describe("'called' strategy", () => {
+    const meta = [
+      tool({ name: 'generate_video' }),
+      tool({ name: 'request_approval', hasSuspendSchema: true }),
+      tool({ name: 'delete_record', requireApproval: true }),
+    ];
+
+    it('stays concurrent when the batch calls only safe tools, even with an approval tool available', () => {
+      // activeTools undefined ⇒ whole set available; request_approval/delete_record
+      // are available but uncalled ⇒ cannot suspend this step.
+      expect(
+        resolveDurableToolCallConcurrency({
+          options: { toolCallConcurrency: { limit: 8, strategy: 'called' } },
+          toolsMetadata: meta,
+          toolCalls: [call('generate_video'), call('generate_video')],
+        }),
+      ).toBe(8);
+    });
+
+    it('forces sequential when the batch actually calls a suspending tool', () => {
+      expect(
+        resolveDurableToolCallConcurrency({
+          options: { toolCallConcurrency: { limit: 8, strategy: 'called' } },
+          toolsMetadata: meta,
+          toolCalls: [call('generate_video'), call('request_approval')],
+        }),
+      ).toBe(1);
+    });
+
+    it('forces sequential when the batch actually calls an approval tool', () => {
+      expect(
+        resolveDurableToolCallConcurrency({
+          options: { toolCallConcurrency: { limit: 8, strategy: 'called' } },
+          toolsMetadata: meta,
+          toolCalls: [call('delete_record')],
+        }),
+      ).toBe(1);
+    });
+
+    it('still forces sequential under a global approval policy', () => {
+      expect(
+        resolveDurableToolCallConcurrency({
+          options: { requireToolApproval: true, toolCallConcurrency: { limit: 8, strategy: 'called' } },
+          toolsMetadata: meta,
+          toolCalls: [call('generate_video')],
+        }),
+      ).toBe(1);
+    });
   });
 });

--- a/packages/core/src/agent/durable/workflows/shared/tool-call-concurrency.ts
+++ b/packages/core/src/agent/durable/workflows/shared/tool-call-concurrency.ts
@@ -1,3 +1,4 @@
+import { resolveToolCallConcurrencyStrategy } from '../../../../loop/workflows/agentic-execution/tool-call-concurrency';
 import { DurableAgentDefaults } from '../../constants';
 import type { DurableToolCallInput, SerializableDurableOptions, SerializableToolMetadata } from '../../types';
 
@@ -13,12 +14,16 @@ import type { DurableToolCallInput, SerializableDurableOptions, SerializableTool
  *   safely to sequential as well.
  * - Any tool in the step's *effective active tool set* with `requireApproval`
  *   or `hasSuspendSchema` forces sequential execution so approval/suspension
- *   flows never race with concurrent tool calls. The check is against the
- *   active tool set, NOT the tools the model actually called: a registered
- *   suspending/approval tool the model skipped this step must still force
- *   sequential execution, since a concurrently-running sibling tool would
- *   race the suspension.
- * - Otherwise the configured `toolCallConcurrency` applies
+ *   flows never race with concurrent tool calls. By default (`'available'`
+ *   strategy) the check is against the active tool set, NOT the tools the model
+ *   actually called: a registered suspending/approval tool the model skipped
+ *   this step still forces sequential execution, since a concurrently-running
+ *   sibling tool would race the suspension. The opt-in `'called'` strategy
+ *   (via `toolCallConcurrency: { strategy: 'called' }`) narrows the check to the
+ *   tools actually called this step — an uncalled tool cannot suspend, so a
+ *   batch of purely safe calls runs concurrently even while an approval/suspend
+ *   tool stays registered. A batch that *does* call one still runs sequentially.
+ * - Otherwise the configured `toolCallConcurrency` limit applies
  *   (default {@link DurableAgentDefaults.TOOL_CALL_CONCURRENCY}).
  *
  * The active tool set is the `activeTools` allowlist the LLM step stamps on
@@ -37,23 +42,36 @@ export function resolveDurableToolCallConcurrency({
 }: {
   options?: Pick<SerializableDurableOptions, 'requireToolApproval' | 'toolCallConcurrency' | 'activeTools'>;
   toolsMetadata?: SerializableToolMetadata[];
-  toolCalls?: Pick<DurableToolCallInput, 'activeTools'>[];
+  toolCalls?: Pick<DurableToolCallInput, 'activeTools' | 'toolName'>[];
 }): number {
   if (options?.requireToolApproval) {
     return 1;
   }
 
-  const stamped = toolCalls?.find(tc => tc.activeTools !== undefined);
-  const activeTools = stamped ? stamped.activeTools : options?.activeTools;
-  const consideredTools =
-    activeTools === undefined || activeTools === null
-      ? (toolsMetadata ?? [])
-      : (toolsMetadata ?? []).filter(tool => activeTools.includes(tool.name));
+  let requiresSequential: boolean;
+  if (resolveToolCallConcurrencyStrategy(options?.toolCallConcurrency) === 'called') {
+    // `'called'` strategy: only tools actually invoked this step can suspend it.
+    const called = new Set((toolCalls ?? []).map(tc => tc.toolName).filter(Boolean));
+    requiresSequential = (toolsMetadata ?? []).some(
+      tool => called.has(tool.name) && Boolean(tool.hasSuspendSchema || tool.requireApproval),
+    );
+  } else {
+    // Default `'available'` strategy: any approval/suspend tool in the step's
+    // effective active tool set forces sequential execution.
+    const stamped = toolCalls?.find(tc => tc.activeTools !== undefined);
+    const activeTools = stamped ? stamped.activeTools : options?.activeTools;
+    const consideredTools =
+      activeTools === undefined || activeTools === null
+        ? (toolsMetadata ?? [])
+        : (toolsMetadata ?? []).filter(tool => activeTools.includes(tool.name));
+    requiresSequential = consideredTools.some(tool => Boolean(tool.hasSuspendSchema || tool.requireApproval));
+  }
 
-  if (consideredTools.some(tool => tool.hasSuspendSchema || tool.requireApproval)) {
+  if (requiresSequential) {
     return 1;
   }
 
-  const configured = options?.toolCallConcurrency;
+  const configuredValue = options?.toolCallConcurrency;
+  const configured = typeof configuredValue === 'object' ? configuredValue.limit : configuredValue;
   return typeof configured === 'number' && configured > 0 ? configured : DurableAgentDefaults.TOOL_CALL_CONCURRENCY;
 }

--- a/packages/core/src/agent/workflows/prepare-stream/index.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod/v4';
 import type { BackgroundTaskManager } from '../../../background-tasks';
 import type { AgentBackgroundConfig } from '../../../background-tasks/types';
 import type { SystemMessage } from '../../../llm';
+import type { ToolCallConcurrency } from '../../../loop/workflows/agentic-execution/tool-call-concurrency';
 import { createRunScope } from '../../../mastra/run-scope';
 import type { MastraMemory } from '../../../memory/memory';
 import type { MemoryConfigInternal, StorageThreadType } from '../../../memory/types';
@@ -39,7 +40,7 @@ interface CreatePrepareStreamWorkflowOptions<OUTPUT = undefined> {
   returnScorerData?: boolean;
   saveQueueManager?: SaveQueueManager;
   requireToolApproval?: RequireToolApproval;
-  toolCallConcurrency?: number;
+  toolCallConcurrency?: ToolCallConcurrency;
   resumeContext?: {
     resumeData: any;
     snapshot: any;

--- a/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
@@ -3,6 +3,7 @@ import type { BackgroundTaskManager } from '../../../background-tasks';
 import type { AgentBackgroundConfig } from '../../../background-tasks/types';
 import { getModelMethodFromAgentMethod } from '../../../llm/model/model-method-from-agent';
 import type { ModelLoopStreamArgs, ModelMethodType } from '../../../llm/model/model.loop.types';
+import type { ToolCallConcurrency } from '../../../loop/workflows/agentic-execution/tool-call-concurrency';
 import type { MastraMemory } from '../../../memory/memory';
 import type { MemoryConfigInternal } from '../../../memory/types';
 import { resolveObservabilityContext } from '../../../observability';
@@ -23,7 +24,7 @@ interface StreamStepOptions<OUTPUT = undefined> {
   runId: string;
   returnScorerData?: boolean;
   requireToolApproval?: RequireToolApproval;
-  toolCallConcurrency?: number;
+  toolCallConcurrency?: ToolCallConcurrency;
   resumeContext?: {
     resumeData: any;
     snapshot: any;

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -44,6 +44,7 @@ import type { RequireToolApproval, ToolPayloadTransformPolicy } from '../tools';
 import type { MastraIdGenerator } from '../types';
 import type { OutputWriter } from '../workflows/types';
 import type { Workspace } from '../workspace/workspace';
+import type { ToolCallConcurrency } from './workflows/agentic-execution/tool-call-concurrency';
 
 type StopCondition = StopConditionV5<any> | StopConditionV6<any>;
 
@@ -214,7 +215,7 @@ export type LoopOptions<TOOLS extends ToolSet = ToolSet, OUTPUT = undefined> = {
   requireToolApproval?: RequireToolApproval;
   autoResumeSuspendedTools?: boolean;
   agentId: string;
-  toolCallConcurrency?: number;
+  toolCallConcurrency?: ToolCallConcurrency;
   agentName?: string;
   requestContext?: RequestContext;
   /** Trusted server-side signal for this loop's FGA checks. */

--- a/packages/core/src/loop/workflows/agentic-execution/index.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/index.ts
@@ -11,7 +11,11 @@ import { createIsTaskCompleteStep } from './is-task-complete-step';
 import { createLLMExecutionStep } from './llm-execution-step';
 import { createLLMMappingStep } from './llm-mapping-step';
 import { createSignalDrainStep } from './signal-drain-step';
-import { resolveConfiguredToolCallConcurrency, resolveToolCallConcurrency } from './tool-call-concurrency';
+import {
+  resolveConfiguredToolCallConcurrency,
+  resolveToolCallConcurrency,
+  resolveToolCallConcurrencyStrategy,
+} from './tool-call-concurrency';
 import type { ToolCallForeachOptions } from './tool-call-concurrency';
 import { createToolCallStep } from './tool-call-step';
 
@@ -23,6 +27,7 @@ export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, 
   ...rest
 }: OuterLLMRun<Tools, OUTPUT>) {
   const configuredToolCallConcurrency = resolveConfiguredToolCallConcurrency(rest.toolCallConcurrency);
+  const toolCallConcurrencyStrategy = resolveToolCallConcurrencyStrategy(rest.toolCallConcurrency);
   const toolCallForeachOptions: ToolCallForeachOptions = {
     // This initial value is a conservative fallback for resume paths that can enter
     // a suspended foreach before llm-execution recomputes the effective step tools.
@@ -113,16 +118,23 @@ export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, 
       async ({ inputData }) => {
         const typedInputData = inputData as LLMIterationData<Tools, OUTPUT>;
         const toolCalls = typedInputData.output.toolCalls || [];
-        // Recompute concurrency from the step's effective active tool set (set by
-        // llm-execution-step), NOT from the tools the model actually called. A
-        // registered approval/suspending tool that the model did not call this
-        // step must still force sequential execution, so narrowing to called
-        // tool names here would incorrectly allow concurrent execution.
+        // Recompute concurrency now that the step's effective active tool set
+        // (set by llm-execution-step) and the model's actual tool calls are known.
+        //
+        // Default (`'available'` strategy): a registered approval/suspending tool
+        // that the model did not call this step still forces sequential execution
+        // — narrowing to called tool names would incorrectly allow concurrent
+        // execution. The `'called'` strategy opts into that narrowing: only tools
+        // actually called this step are checked, so a batch of purely safe calls
+        // runs concurrently even while an approval/suspend tool stays registered.
         const stepActiveTools = _internal?.stepActiveTools as string[] | undefined;
+        const calledToolNames =
+          toolCallConcurrencyStrategy === 'called' ? toolCalls.map(toolCall => toolCall.toolName) : undefined;
         toolCallForeachOptions.concurrency = resolveToolCallConcurrency({
           requireToolApproval: rest.requireToolApproval,
           tools: ((_internal?.stepTools as Tools | undefined) ?? rest.tools) as Tools | undefined,
           activeTools: stepActiveTools,
+          calledToolNames,
           configuredConcurrency: configuredToolCallConcurrency,
         });
         return toolCalls;

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-concurrency.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-concurrency.test.ts
@@ -3,6 +3,7 @@ import {
   effectiveToolSetRequiresSequentialExecution,
   resolveConfiguredToolCallConcurrency,
   resolveToolCallConcurrency,
+  resolveToolCallConcurrencyStrategy,
 } from './tool-call-concurrency';
 
 describe('tool call concurrency resolution', () => {
@@ -127,5 +128,84 @@ describe('tool call concurrency resolution', () => {
     expect(resolveConfiguredToolCallConcurrency(0)).toBe(10);
     expect(resolveConfiguredToolCallConcurrency(-1)).toBe(10);
     expect(resolveConfiguredToolCallConcurrency(3)).toBe(3);
+  });
+
+  it('extracts the limit from the object config form', () => {
+    expect(resolveConfiguredToolCallConcurrency({ limit: 4 })).toBe(4);
+    expect(resolveConfiguredToolCallConcurrency({ limit: 4, strategy: 'called' })).toBe(4);
+    expect(resolveConfiguredToolCallConcurrency({})).toBe(10);
+    expect(resolveConfiguredToolCallConcurrency({ limit: 0 })).toBe(10);
+    expect(resolveConfiguredToolCallConcurrency({ strategy: 'called' })).toBe(10);
+  });
+
+  it('resolves the concurrency strategy (default available)', () => {
+    expect(resolveToolCallConcurrencyStrategy(undefined)).toBe('available');
+    expect(resolveToolCallConcurrencyStrategy(4)).toBe('available');
+    expect(resolveToolCallConcurrencyStrategy({ limit: 4 })).toBe('available');
+    expect(resolveToolCallConcurrencyStrategy({ strategy: 'available' })).toBe('available');
+    expect(resolveToolCallConcurrencyStrategy({ strategy: 'called' })).toBe('called');
+  });
+
+  describe("'called' strategy", () => {
+    const tools = { generate_video: safeTool, request_approval: suspendTool, delete_record: approvalTool };
+
+    it('stays parallel when the batch calls only safe tools, even with an approval tool available', () => {
+      // The batch called only generate_video; request_approval/delete_record are
+      // available (activeTools undefined ⇒ whole set) but uncalled ⇒ cannot suspend.
+      expect(
+        effectiveToolSetRequiresSequentialExecution({
+          tools,
+          activeTools: undefined,
+          calledToolNames: ['generate_video', 'generate_video'],
+        }),
+      ).toBe(false);
+      expect(
+        resolveToolCallConcurrency({
+          tools,
+          activeTools: undefined,
+          calledToolNames: ['generate_video', 'generate_video'],
+          configuredConcurrency: 8,
+        }),
+      ).toBe(8);
+    });
+
+    it('serializes when the batch actually calls a suspending tool', () => {
+      expect(
+        effectiveToolSetRequiresSequentialExecution({
+          tools,
+          calledToolNames: ['generate_video', 'request_approval'],
+        }),
+      ).toBe(true);
+      expect(
+        resolveToolCallConcurrency({
+          tools,
+          calledToolNames: ['generate_video', 'request_approval'],
+          configuredConcurrency: 8,
+        }),
+      ).toBe(1);
+    });
+
+    it('serializes when the batch actually calls an approval tool', () => {
+      expect(
+        effectiveToolSetRequiresSequentialExecution({
+          tools,
+          calledToolNames: ['delete_record'],
+        }),
+      ).toBe(true);
+    });
+
+    it('still forces sequential under a global approval policy regardless of called tools', () => {
+      expect(
+        effectiveToolSetRequiresSequentialExecution({
+          requireToolApproval: true,
+          tools,
+          calledToolNames: ['generate_video'],
+        }),
+      ).toBe(true);
+    });
+
+    it('treats an empty batch as safe', () => {
+      expect(effectiveToolSetRequiresSequentialExecution({ tools, calledToolNames: [] })).toBe(false);
+    });
   });
 });

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-concurrency.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-concurrency.ts
@@ -5,14 +5,43 @@ export type ToolCallForeachOptions = {
   concurrency: number;
 };
 
-export function resolveConfiguredToolCallConcurrency(toolCallConcurrency: number | undefined): number {
-  return toolCallConcurrency && toolCallConcurrency > 0 ? toolCallConcurrency : 10;
+/**
+ * How the sequential-vs-parallel decision is made when the agent has an
+ * approval/suspending tool available:
+ * - `'available'` (default): any such tool *available* in the step forces the
+ *   whole batch sequential, even if the model did not call it this step. This
+ *   is the conservative behavior — a suspend can never race a sibling.
+ * - `'called'`: only tools the model *actually called* this step are checked.
+ *   An available-but-uncalled approval/suspend tool no longer serializes a
+ *   batch of purely safe calls. Safe because a tool that was not called cannot
+ *   suspend this step; a batch that *does* call an approval/suspend tool still
+ *   runs sequentially. Opt-in for agents that keep an approval tool registered
+ *   across a run but never mix it into the same batch as parallelizable calls.
+ */
+export type ToolCallConcurrencyStrategy = 'available' | 'called';
+
+/**
+ * Tool-call concurrency configuration. Either a plain number (the concurrency
+ * limit, `'available'` strategy) or an object selecting the limit and strategy.
+ */
+export type ToolCallConcurrency = number | { limit?: number; strategy?: ToolCallConcurrencyStrategy };
+
+export function resolveConfiguredToolCallConcurrency(toolCallConcurrency: ToolCallConcurrency | undefined): number {
+  const limit = typeof toolCallConcurrency === 'object' ? toolCallConcurrency.limit : toolCallConcurrency;
+  return limit && limit > 0 ? limit : 10;
+}
+
+export function resolveToolCallConcurrencyStrategy(
+  toolCallConcurrency: ToolCallConcurrency | undefined,
+): ToolCallConcurrencyStrategy {
+  return (typeof toolCallConcurrency === 'object' && toolCallConcurrency.strategy) || 'available';
 }
 
 export function effectiveToolSetRequiresSequentialExecution({
   requireToolApproval,
   tools,
   activeTools,
+  calledToolNames,
 }: {
   // A function-valued global approval policy is evaluated per call at execution time;
   // before args are known we conservatively treat it like `true` and force sequential
@@ -20,6 +49,12 @@ export function effectiveToolSetRequiresSequentialExecution({
   requireToolApproval?: RequireToolApproval;
   tools?: ToolSet;
   activeTools?: readonly string[];
+  // Tool names actually called this step. When provided (the `'called'`
+  // strategy), only these tools are checked for suspend/approval — an
+  // available-but-uncalled tool cannot suspend this step, so it must not force
+  // the batch sequential. When undefined (default `'available'` strategy) the
+  // whole effective active tool set is checked.
+  calledToolNames?: readonly string[];
 }): boolean {
   if (requireToolApproval) {
     return true;
@@ -29,6 +64,18 @@ export function effectiveToolSetRequiresSequentialExecution({
     return false;
   }
 
+  const suspendsOrRequiresApproval = (tool: unknown): boolean => {
+    const maybeTool = tool as { hasSuspendSchema?: unknown; requireApproval?: unknown };
+    return Boolean(maybeTool?.hasSuspendSchema || maybeTool?.requireApproval);
+  };
+
+  // `'called'` strategy: only tools invoked this step can suspend this step.
+  if (calledToolNames !== undefined) {
+    return calledToolNames.some(toolName => suspendsOrRequiresApproval(tools[toolName]));
+  }
+
+  // Default `'available'` strategy: any approval/suspend tool available in the
+  // step's effective active tool set forces sequential execution.
   const activeToolEntries =
     activeTools === undefined
       ? Object.entries(tools)
@@ -37,27 +84,27 @@ export function effectiveToolSetRequiresSequentialExecution({
           return tool ? ([[toolName, tool]] as const) : [];
         });
 
-  return activeToolEntries.some(([, tool]) => {
-    const maybeTool = tool as { hasSuspendSchema?: unknown; requireApproval?: unknown };
-    return Boolean(maybeTool.hasSuspendSchema || maybeTool.requireApproval);
-  });
+  return activeToolEntries.some(([, tool]) => suspendsOrRequiresApproval(tool));
 }
 
 export function resolveToolCallConcurrency({
   requireToolApproval,
   tools,
   activeTools,
+  calledToolNames,
   configuredConcurrency,
 }: {
   requireToolApproval?: RequireToolApproval;
   tools?: ToolSet;
   activeTools?: readonly string[];
+  calledToolNames?: readonly string[];
   configuredConcurrency: number;
 }): number {
   return effectiveToolSetRequiresSequentialExecution({
     requireToolApproval,
     tools,
     activeTools,
+    calledToolNames,
   })
     ? 1
     : configuredConcurrency;

--- a/packages/server/src/server/schemas/default-options.ts
+++ b/packages/server/src/server/schemas/default-options.ts
@@ -70,8 +70,20 @@ export const defaultOptionsSchema = z
     /** Automatically resume suspended tools */
     autoResumeSuspendedTools: z.boolean().optional(),
 
-    /** Maximum number of tool calls to execute concurrently */
-    toolCallConcurrency: z.number().optional(),
+    /**
+     * Concurrency for parallel tool calls. A number sets the limit; an object
+     * `{ limit?, strategy? }` also selects the strategy ('available' default,
+     * or 'called' to only serialize when the batch actually calls a suspend/approval tool).
+     */
+    toolCallConcurrency: z
+      .union([
+        z.number(),
+        z.object({
+          limit: z.number().optional(),
+          strategy: z.enum(['available', 'called']).optional(),
+        }),
+      ])
+      .optional(),
 
     /** Whether to include raw chunks in the stream output */
     includeRawChunks: z.boolean().optional(),

--- a/workflows/inngest/src/durable-agent/create-inngest-agent.ts
+++ b/workflows/inngest/src/durable-agent/create-inngest-agent.ts
@@ -154,8 +154,8 @@ export interface InngestAgentStreamOptions<OUTPUT = undefined> {
   requireToolApproval?: AgentExecutionOptions<OUTPUT>['requireToolApproval'];
   /** Automatically resume suspended tools */
   autoResumeSuspendedTools?: boolean;
-  /** Maximum concurrent tool calls */
-  toolCallConcurrency?: number;
+  /** Maximum concurrent tool calls (number) or `{ limit?, strategy? }`. See {@link AgentExecutionOptions.toolCallConcurrency}. */
+  toolCallConcurrency?: AgentExecutionOptions<OUTPUT>['toolCallConcurrency'];
   /** Include raw chunks in output */
   includeRawChunks?: boolean;
   /** Maximum processor retries */


### PR DESCRIPTION
## Description

Adds an opt-in `'called'` tool-call concurrency strategy so batches of purely safe tool calls run in parallel even when an approval/suspending tool stays registered on the agent.

Today the loop decides sequential-vs-parallel from the step's *effective active tool set*: any registered-and-active tool with `requireApproval` or a `suspendSchema` forces the whole batch to `concurrency: 1`, even when the model's actual tool calls are all safe and never touch it. A long-lived agent that keeps a single approval tool registered across a run therefore can never parallelize any tool calls. A tool the model did not call this step cannot suspend this step, so serializing that batch buys no safety.

`toolCallConcurrency` now accepts an object form in addition to a number:

```ts
toolCallConcurrency: 8                                // unchanged: limit, 'available' strategy (default)
toolCallConcurrency: { limit: 8, strategy: 'called' } // NEW: decide from the tools actually called this step
```

- `strategy: 'available'` (default, unchanged): any approval/suspend tool available in the step forces sequential.
- `strategy: 'called'`: only the tools the model actually called this step are checked. A pure-safe batch parallelizes; a batch that calls an approval/suspend tool still returns `1`; a run-wide `requireToolApproval` policy still returns `1`.

This is the explicit, opt-in version of #18243 — the conservative `'available'` default that #18275 restored is preserved byte-for-byte, so it doesn't reopen that decision.

Implementation notes:
- Standard loop: `resolveToolCallConcurrency` gains an optional `calledToolNames`; the `map-tool-calls` step passes the called tool names when the strategy is `'called'` (the recompute already runs after the LLM output, where `toolCalls` are known).
- Durable engine (`@mastra/inngest` / `@mastra/temporal`): `resolveDurableToolCallConcurrency` narrows to the called tools via `inputData[].toolName` in the per-run foreach resolver added in #19329 (leak-safe, no shared mutable state).
- `toolCallConcurrency` widened to `number | { limit?: number; strategy?: 'available' | 'called' }` and threaded through the existing option types (union flows through the existing pass-throughs unchanged).

**Safety re: multi-suspend:** this does not increase concurrent suspensions. The only way multiple suspends run in parallel today is via tools that aren't statically suspendable (e.g. subagent delegations), which is unchanged. Any batch that calls a statically-suspendable tool still serializes, so it stays within the existing envelope of #16468 / #15481.

## Related issue(s)

Fixes #20100

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

Tests added:
- `loop/workflows/agentic-execution/tool-call-concurrency.test.ts` — `'called'` strategy unit cases + object-config parsing.
- `agent/durable/workflows/shared/tool-call-concurrency.test.ts` — durable `'called'` strategy unit cases.
- `agent/__tests__/tool-concurrency-active-tools.test.ts` — agent-level integration: safe batch with an approval tool registered → peak concurrency 2; a batch that calls a suspending tool → peak 1.
