### PR TITLE
fix(core): apply requestContextSchema transforms to tool execute context

### DIFF
--- a/.changeset/cute-flies-notice.md
+++ b/.changeset/cute-flies-notice.md
@@ -1,0 +1,25 @@
+---
+'@mastra/core': patch
+---
+
+Fixed request context schema transformations being discarded before tool execution. When a tool's `requestContextSchema` uses transforms (like Zod codecs or coercions), the transformed values are now passed to `execute`, matching what TypeScript infers. Previously the schema was only used for validation and `execute` received the raw untransformed values.
+
+**Before:**
+
+```typescript
+const dateCodec = z.codec(z.string(), z.date(), {
+  decode: value => new Date(value),
+  encode: value => value.toISOString(),
+});
+
+const tool = createTool({
+  id: 'example',
+  requestContextSchema: z.object({ date: dateCodec }),
+  async execute(_input, { requestContext }) {
+    const value = requestContext.get('date');
+    // TypeScript says Date, but at runtime it was still a string
+  },
+});
+```
+
+**After:** `requestContext.get('date')` returns an actual `Date` instance, consistent with how `inputSchema` and `outputSchema` already apply transformed values. Keys not covered by the schema are preserved as-is.

--- a/packages/core/src/tools/__tests__/request-context-schema.test.ts
+++ b/packages/core/src/tools/__tests__/request-context-schema.test.ts
@@ -258,6 +258,40 @@ describe('Tool requestContextSchema', () => {
       // But the transformed value does not leak back
       expect(requestContext.get('date')).toBe('2026-07-23T00:00:00.000Z');
     });
+
+    it('should apply schema defaults when execute is called without context', async () => {
+      let capturedMode: unknown;
+      const tool = createTool({
+        id: 'default-tool',
+        description: 'A test tool',
+        requestContextSchema: z.object({ mode: z.string().default('fast') }),
+        execute: async (_, context) => {
+          capturedMode = context.requestContext.get('mode');
+          return { success: true };
+        },
+      });
+
+      await tool.execute!({}, undefined as any);
+
+      expect(capturedMode).toBe('fast');
+    });
+
+    it('should apply schema defaults when context has no requestContext', async () => {
+      let capturedMode: unknown;
+      const tool = createTool({
+        id: 'default-tool',
+        description: 'A test tool',
+        requestContextSchema: z.object({ mode: z.string().default('fast') }),
+        execute: async (_, context) => {
+          capturedMode = context.requestContext.get('mode');
+          return { success: true };
+        },
+      });
+
+      await tool.execute!({}, {});
+
+      expect(capturedMode).toBe('fast');
+    });
   });
 
   describe('combined with inputSchema validation', () => {

--- a/packages/core/src/tools/__tests__/request-context-schema.test.ts
+++ b/packages/core/src/tools/__tests__/request-context-schema.test.ts
@@ -172,6 +172,94 @@ describe('Tool requestContextSchema', () => {
     });
   });
 
+  describe('schema transformations', () => {
+    const dateCodec = z.codec(z.string(), z.date(), {
+      decode: value => new Date(value),
+      encode: value => value.toISOString(),
+    });
+
+    it('should pass transformed values to execute', async () => {
+      let capturedDate: unknown;
+      const tool = createTool({
+        id: 'transform-tool',
+        description: 'A test tool',
+        requestContextSchema: z.object({ date: dateCodec }),
+        execute: async (_, context) => {
+          capturedDate = context.requestContext.get('date');
+          return { success: true };
+        },
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('date', '2026-07-23T00:00:00.000Z');
+
+      await tool.execute!({}, { requestContext });
+
+      expect(capturedDate).toBeInstanceOf(Date);
+      expect((capturedDate as Date).toISOString()).toBe('2026-07-23T00:00:00.000Z');
+    });
+
+    it('should preserve keys outside the schema', async () => {
+      let capturedContext: any;
+      const tool = createTool({
+        id: 'transform-tool',
+        description: 'A test tool',
+        requestContextSchema: z.object({ date: dateCodec }),
+        execute: async (_, context) => {
+          capturedContext = context.requestContext;
+          return { success: true };
+        },
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('date', '2026-07-23T00:00:00.000Z');
+      requestContext.set('traceId', 'trace-123');
+
+      await tool.execute!({}, { requestContext });
+
+      expect(capturedContext.get('date')).toBeInstanceOf(Date);
+      expect(capturedContext.get('traceId')).toBe('trace-123');
+    });
+
+    it('should not mutate the caller-provided requestContext', async () => {
+      const tool = createTool({
+        id: 'transform-tool',
+        description: 'A test tool',
+        requestContextSchema: z.object({ date: dateCodec }),
+        execute: async () => ({ success: true }),
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('date', '2026-07-23T00:00:00.000Z');
+
+      await tool.execute!({}, { requestContext });
+
+      expect(requestContext.get('date')).toBe('2026-07-23T00:00:00.000Z');
+    });
+
+    it('should write mutations made in execute through to the shared requestContext', async () => {
+      const tool = createTool({
+        id: 'transform-tool',
+        description: 'A test tool',
+        requestContextSchema: z.object({ date: dateCodec }),
+        execute: async (_, context) => {
+          context.requestContext.set('discoveredProvider', 'google');
+          return { success: true };
+        },
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('date', '2026-07-23T00:00:00.000Z');
+
+      await tool.execute!({}, { requestContext });
+
+      // Mutation propagates to the caller's shared context
+      expect(requestContext.get('discoveredProvider')).toBe('google');
+      // But the transformed value does not leak back
+      expect(requestContext.get('date')).toBe('2026-07-23T00:00:00.000Z');
+    });
+  });
+
   describe('combined with inputSchema validation', () => {
     it('should validate both inputSchema and requestContextSchema', async () => {
       const inputSchema = z.object({

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -25,6 +25,39 @@ import { validateToolInput, validateToolOutput, validateToolSuspendData, validat
 export const MASTRA_TOOL_MARKER = Symbol.for('mastra.core.tool.Tool');
 
 /**
+ * A per-tool view of the request context that serves values transformed by the
+ * tool's `requestContextSchema` (codecs, coercions, defaults) while writing all
+ * mutations through to the shared context. This keeps two behaviors intact:
+ * - transformed values never leak into the shared context, so other tools
+ *   re-validate against the original raw values
+ * - mutations made inside `execute` stay visible to subsequent tool calls,
+ *   which share the same underlying RequestContext reference
+ */
+class TransformedRequestContext extends RequestContext<Record<string, any>> {
+  #source: RequestContext<any>;
+
+  constructor(source: RequestContext<any>, transformedValues: Record<string, unknown>) {
+    super(Object.entries({ ...source.all, ...transformedValues }));
+    this.#source = source;
+  }
+
+  public override set(key: string, value: any): void {
+    super.set(key, value);
+    this.#source.set(key, value);
+  }
+
+  public override delete(key: string): boolean {
+    this.#source.delete(key);
+    return super.delete(key);
+  }
+
+  public override clear(): void {
+    this.#source.clear();
+    super.clear();
+  }
+}
+
+/**
  * A type-safe tool that agents and workflows can call to perform specific actions.
  *
  * @template TSchemaIn - Input schema type
@@ -328,13 +361,26 @@ export class Tool<
         }
 
         // Validate request context if schema exists
-        const { error: requestContextError } = validateRequestContext(
+        const { data: validatedRequestContext, error: requestContextError } = validateRequestContext(
           this.requestContextSchema,
           context?.requestContext,
           this.id,
         );
         if (requestContextError) {
           return requestContextError as any;
+        }
+
+        // Hand execute a view of the request context with schema transformations
+        // (codecs, coercions, defaults) applied, writing mutations through to the
+        // shared context so they remain visible to subsequent tool calls.
+        if (this.requestContextSchema && context?.requestContext) {
+          context = {
+            ...context,
+            requestContext: new TransformedRequestContext(
+              context.requestContext,
+              validatedRequestContext as Record<string, unknown>,
+            ),
+          };
         }
 
         let suspendData = null;

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -373,11 +373,11 @@ export class Tool<
         // Hand execute a view of the request context with schema transformations
         // (codecs, coercions, defaults) applied, writing mutations through to the
         // shared context so they remain visible to subsequent tool calls.
-        if (this.requestContextSchema && context?.requestContext) {
+        if (this.requestContextSchema) {
           context = {
             ...context,
             requestContext: new TransformedRequestContext(
-              context.requestContext,
+              context?.requestContext ?? new RequestContext(),
               validatedRequestContext as Record<string, unknown>,
             ),
           };

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -28,10 +28,16 @@ export const MASTRA_TOOL_MARKER = Symbol.for('mastra.core.tool.Tool');
  * A per-tool view of the request context that serves values transformed by the
  * tool's `requestContextSchema` (codecs, coercions, defaults) while writing all
  * mutations through to the shared context. This keeps two behaviors intact:
- * - transformed values never leak into the shared context, so other tools
- *   re-validate against the original raw values
+ * - automatically transformed values never leak into the shared context, so
+ *   other tools re-validate against the original raw values
  * - mutations made inside `execute` stay visible to subsequent tool calls,
  *   which share the same underlying RequestContext reference
+ *
+ * Explicit mutations are written through unmodified (matching the behavior
+ * before this view existed): setting a decoded value (e.g. a Date) into a
+ * schema key stores it as-is in the shared context, and a later validation
+ * expecting the wire format will reject it. Standard Schema has no encode
+ * direction, so values cannot be generically re-encoded on write.
  */
 class TransformedRequestContext extends RequestContext<Record<string, any>> {
   #source: RequestContext<any>;


### PR DESCRIPTION
## Description

Fixes tool `requestContextSchema` transformations (Zod codecs, coercions, defaults) being discarded before `execute` runs. The schema was validated and the transformed result computed, but only the validation error was consumed — `execute` received the raw untransformed values, while TypeScript inferred the schema's output type (e.g. `Date` in types, `string` at runtime).

- `validateRequestContext` already returned the transformed `data` (`validation.value`), but its only caller in `tool.ts` destructured `{ error }` alone — present since the feature's original commit (#12259)
- `execute` now receives a `TransformedRequestContext` view: reads serve the schema-transformed values merged over the original context (keys outside the schema are preserved), consistent with how `inputSchema`/`outputSchema` already apply parsed values
- Mutations (`set`/`delete`/`clear`) write through to the original shared context, preserving the documented behavior that tool mutations stay visible to subsequent tool calls (`request-context-mutation.scenario.test.ts`)
- Automatically transformed values never leak into the shared context, so subsequent tools re-validate against the original raw values and codecs decode correctly on every call. Explicit mutations write through unmodified — identical to the behavior before this change (verified: a tool storing a decoded value into a schema key fails the next validation the same way on pre-PR main)
- Tools without `requestContextSchema` are unaffected

## Related Issue(s)
#20109
Related to #19480 (follow-up report from the same Discord thread; the optionality part was fixed in #19680)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If a tool asks for request context data in a “cleaned up” format (for example, converting a date string into a real `Date`), Mastra now actually gives the tool that cleaned-up version when it runs. But the original shared request context stays mostly untouched, so other tools still see the original raw values—unless the tool explicitly changes something.

## What changed

- Tool execution now passes `requestContextSchema`-transformed values (codecs/coercions/defaults) into `execute` via a per-tool `TransformedRequestContext` view.
- Keys not covered by `requestContextSchema` are preserved as-is and remain available to the tool.
- Transformed values are not written back into the shared `RequestContext`, so later tools re-validate against the original raw values.
- Mutations inside `execute` (`requestContext.set`, `delete`, `clear`) are forwarded to the original shared `RequestContext`, so explicit writes still persist.
- Tools without `requestContextSchema` are unaffected.
- Added tests covering: transformation delivery to `execute`, preservation of out-of-schema keys, immutability of caller-provided transformed values, write-through mutation behavior, and applying defaults when `context` or `context.requestContext` is missing.
- Added a changeset documenting the patch to `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
