### PR TITLE
feat(metrics): redesign Factory metrics page

### DIFF
--- a/.changeset/forty-tables-doubt.md
+++ b/.changeset/forty-tables-doubt.md
@@ -1,0 +1,13 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added a reusable `MetricsBarChart` for responsive metric dashboards with themed bars, axes, formatted tooltips, and accessible descriptions.
+
+```tsx
+<MetricsBarChart
+  data={points}
+  series={[{ dataKey: 'done', label: 'Completed work', color: 'var(--chart-2)' }]}
+  description="Daily completed work."
+/>
+```

--- a/.changeset/nice-hornets-punch.md
+++ b/.changeset/nice-hornets-punch.md
@@ -3,3 +3,12 @@
 ---
 
 Added the items behind each stage's automation rate to the Factory metrics endpoint (`stageAutomation[].automatedItems`), so the Metrics page can now drill into a stage's automated passes: selecting a stage bar in Automation coverage lists the concrete items with their outcome (reworked first), each linking to its source issue or PR.
+
+```ts
+const response = await fetch(`/web/factory/projects/${projectId}/metrics?from=${from}&to=${to}`);
+const { metrics } = await response.json();
+
+for (const item of metrics.stageAutomation[0]?.automatedItems ?? []) {
+  console.log(item.title, item.outcome);
+}
+```

--- a/.changeset/nice-hornets-punch.md
+++ b/.changeset/nice-hornets-punch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Added the items behind each stage's automation rate to the Factory metrics endpoint (`stageAutomation[].automatedItems`), so the Metrics page can now drill into a stage's automated passes: selecting a stage bar in Automation coverage lists the concrete items with their outcome (reworked first), each linking to its source issue or PR.

--- a/mastracode/factory/src/routes/work-items.test.ts
+++ b/mastracode/factory/src/routes/work-items.test.ts
@@ -715,11 +715,36 @@ describe('GET /web/factory/projects/:id/metrics', () => {
 
     expect(metrics.stageAutomation).toEqual([
       // Human-entered (creation), automation-exited → not automated.
-      { stage: 'intake', exits: 1, automated: 0, outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 } },
+      {
+        stage: 'intake',
+        exits: 1,
+        automated: 0,
+        outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 },
+        automatedItems: [],
+      },
       // Automation-entered and -exited, first visit → clean automated pass, item is done.
-      { stage: 'triage', exits: 1, automated: 1, outcomes: { done: 1, canceled: 0, reworked: 0, inFlight: 0 } },
+      {
+        stage: 'triage',
+        exits: 1,
+        automated: 1,
+        outcomes: { done: 1, canceled: 0, reworked: 0, inFlight: 0 },
+        automatedItems: [
+          {
+            id: workItem.id,
+            title: 'Fix the login flow',
+            url: 'https://github.com/acme/app/issues/42',
+            outcome: 'done',
+          },
+        ],
+      },
       // Automation-entered, human-exited → not automated.
-      { stage: 'planning', exits: 1, automated: 0, outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 } },
+      {
+        stage: 'planning',
+        exits: 1,
+        automated: 0,
+        outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 },
+        automatedItems: [],
+      },
     ]);
     // Global split matches: 4 entered stages, 2 by automation.
     expect(metrics.transitions).toEqual({ human: 2, total: 4 });

--- a/mastracode/factory/src/storage/domains/work-items/metrics.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/metrics.test.ts
@@ -397,8 +397,20 @@ describe('computeFactoryMetrics', () => {
 
     expect(metrics.transitions).toEqual({ human: 1, total: 3 });
     expect(metrics.stageAutomation).toEqual([
-      { stage: 'intake', exits: 1, automated: 0, outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 } },
-      { stage: 'triage', exits: 1, automated: 1, outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 1 } },
+      {
+        stage: 'intake',
+        exits: 1,
+        automated: 0,
+        outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 },
+        automatedItems: [],
+      },
+      {
+        stage: 'triage',
+        exits: 1,
+        automated: 1,
+        outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 1 },
+        automatedItems: [{ id: '00000000-0000-4000-8000-000000000001', title: 'Item', url: null, outcome: 'inFlight' }],
+      },
     ]);
   });
 
@@ -418,8 +430,22 @@ describe('computeFactoryMetrics', () => {
       const metrics = computeFactoryMetrics([item], lastDays(7));
 
       expect(metrics.stageAutomation).toEqual([
-        { stage: 'triage', exits: 1, automated: 1, outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 1 } },
-        { stage: 'planning', exits: 1, automated: 0, outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 } },
+        {
+          stage: 'triage',
+          exits: 1,
+          automated: 1,
+          outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 1 },
+          automatedItems: [
+            { id: '00000000-0000-4000-8000-000000000001', title: 'Item', url: null, outcome: 'inFlight' },
+          ],
+        },
+        {
+          stage: 'planning',
+          exits: 1,
+          automated: 0,
+          outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 },
+          automatedItems: [],
+        },
       ]);
     });
 
@@ -439,7 +465,15 @@ describe('computeFactoryMetrics', () => {
 
       // Second visit is never automated even with automation actors on both ends.
       expect(metrics.stageAutomation).toEqual([
-        { stage: 'triage', exits: 2, automated: 1, outcomes: { done: 0, canceled: 0, reworked: 1, inFlight: 0 } },
+        {
+          stage: 'triage',
+          exits: 2,
+          automated: 1,
+          outcomes: { done: 0, canceled: 0, reworked: 1, inFlight: 0 },
+          automatedItems: [
+            { id: '00000000-0000-4000-8000-000000000001', title: 'Item', url: null, outcome: 'reworked' },
+          ],
+        },
       ]);
     });
 
@@ -468,7 +502,13 @@ describe('computeFactoryMetrics', () => {
       const metrics = computeFactoryMetrics(items, lastDays(7));
 
       expect(metrics.stageAutomation).toEqual([
-        { stage: 'triage', exits: 2, automated: 0, outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 } },
+        {
+          stage: 'triage',
+          exits: 2,
+          automated: 0,
+          outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 },
+          automatedItems: [],
+        },
       ]);
     });
 
@@ -503,7 +543,17 @@ describe('computeFactoryMetrics', () => {
       const metrics = computeFactoryMetrics(items, lastDays(7));
 
       expect(metrics.stageAutomation).toEqual([
-        { stage: 'triage', exits: 3, automated: 3, outcomes: { done: 1, canceled: 1, reworked: 0, inFlight: 1 } },
+        {
+          stage: 'triage',
+          exits: 3,
+          automated: 3,
+          outcomes: { done: 1, canceled: 1, reworked: 0, inFlight: 1 },
+          automatedItems: [
+            { id: '00000000-0000-4000-8000-000000000001', title: 'Item', url: null, outcome: 'done' },
+            { id: '00000000-0000-4000-8000-000000000002', title: 'Item', url: null, outcome: 'canceled' },
+            { id: '00000000-0000-4000-8000-000000000003', title: 'Item', url: null, outcome: 'inFlight' },
+          ],
+        },
       ]);
     });
 

--- a/mastracode/factory/src/storage/domains/work-items/metrics.ts
+++ b/mastracode/factory/src/storage/domains/work-items/metrics.ts
@@ -72,8 +72,17 @@ export interface FactoryMetrics {
      * `canceled`, then `inFlight`.
      */
     outcomes: { done: number; canceled: number; reworked: number; inFlight: number };
+    /**
+     * The automated passes' items (one per automated pass, in pass order),
+     * each tagged with its `outcomes` bucket — feeds the UI drill-down so a
+     * stage's automation rate can be traced to the concrete items behind it.
+     */
+    automatedItems: { id: string; title: string; url: string | null; outcome: AutomationOutcome }[];
   }[];
 }
+
+/** One automated pass's `outcomes` bucket (see `stageAutomation.outcomes`). */
+export type AutomationOutcome = 'done' | 'canceled' | 'reworked' | 'inFlight';
 
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
 /** Datetime carrying an explicit `Z` or `±HH:MM` offset. */
@@ -265,6 +274,7 @@ export function computeFactoryMetrics(
           exits: 0,
           automated: 0,
           outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 },
+          automatedItems: [],
         };
         automationByStage.set(entry.stage, row);
       }
@@ -276,10 +286,20 @@ export function computeFactoryMetrics(
       if (firstVisitIndex !== i || !isAutomationActor(entry.by) || !isAutomationActor(entry.exitedBy)) continue;
       row.automated += 1;
       const reworked = item.stageHistory.some((e, j) => j > i && e.stage === entry.stage);
-      if (reworked) row.outcomes.reworked += 1;
-      else if (itemDone) row.outcomes.done += 1;
-      else if (itemCanceled) row.outcomes.canceled += 1;
-      else row.outcomes.inFlight += 1;
+      const outcome: AutomationOutcome = reworked
+        ? 'reworked'
+        : itemDone
+          ? 'done'
+          : itemCanceled
+            ? 'canceled'
+            : 'inFlight';
+      row.outcomes[outcome] += 1;
+      row.automatedItems.push({
+        id: item.id,
+        title: item.title,
+        url: item.externalSource?.url ?? null,
+        outcome,
+      });
     }
   }
 

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/QueueHealthChart.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/QueueHealthChart.msw.test.tsx
@@ -3,17 +3,16 @@
  *
  * Drives the real component through the shared provider stack; no network is
  * involved (the chart is fed a `QueueHealth` aggregate directly), so these
- * specs focus on proportional rendering, empty/active states, selection, and
- * reduced-motion. The `.msw` suffix routes this file into the component-test
- * harness (the default vitest config only collects `.test.ts`).
+ * specs focus on proportional rendering, progressive hover/focus details,
+ * empty and active states, stage summaries, and cohort selection.
  */
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { renderWithProviders } from '../../../../../../e2e/web-ui/render';
-import type { QueueHealth, QueueHealthStage } from '../queue-health';
+import type { QueueHealth, QueueHealthEntry, QueueHealthStage } from '../queue-health';
 import type { QueueHealthSelection } from '../components/QueueHealthChart';
 import { QueueHealthChart } from '../components/QueueHealthChart';
 
@@ -28,8 +27,21 @@ function stageAgg(overrides: Partial<QueueHealthStage> & { stage: string }): Que
   };
 }
 
-function makeHealth(stages: QueueHealthStage[]): QueueHealth {
-  return { stages, entries: [] };
+function makeHealth(stages: QueueHealthStage[], entries: QueueHealthEntry[] = []): QueueHealth {
+  return { stages, entries };
+}
+
+function healthEntry(overrides: Partial<QueueHealthEntry> = {}): QueueHealthEntry {
+  return {
+    itemId: 'item-1',
+    title: 'Example task',
+    url: null,
+    stage: 'execute',
+    ageSeconds: 3600,
+    bucket: 'green',
+    active: false,
+    ...overrides,
+  };
 }
 
 /** The five non-done board stages, overridable per stage. */
@@ -44,137 +56,149 @@ function Harness({ health }: { health: QueueHealth }) {
   return (
     <div>
       <QueueHealthChart health={health} thresholdsSeconds={THRESHOLDS} selected={selected} onSelect={setSelected} />
-      <output data-testid="selection">{selected ? `${selected.stage}:${selected.bucket ?? 'none'}` : 'cleared'}</output>
+      <output data-testid="selection">{selected?.bucket ?? 'cleared'}</output>
     </div>
   );
 }
 
+const INTAKE_ENTRIES = [
+  healthEntry({ itemId: 'fresh-1', stage: 'intake' }),
+  healthEntry({ itemId: 'fresh-2', stage: 'intake' }),
+  healthEntry({ itemId: 'aging-1', stage: 'intake', bucket: 'amber' }),
+  healthEntry({ itemId: 'critical-1', stage: 'intake', bucket: 'red' }),
+  healthEntry({ itemId: 'critical-2', stage: 'intake', bucket: 'red' }),
+  healthEntry({ itemId: 'critical-3', stage: 'intake', bucket: 'red' }),
+];
+
 describe('QueueHealthChart', () => {
-  it('renders one bar per non-done stage with segment labels carrying bucket + count', () => {
+  it('summarizes unique tasks by age and reveals range and counts on hover', async () => {
+    const user = userEvent.setup();
     const health = makeHealth(
       defaultStages({
         intake: { buckets: { green: 2, amber: 1, orange: 0, red: 3 }, total: 6 },
       }),
+      INTAKE_ENTRIES,
     );
     renderWithProviders(<Harness health={health} />);
 
-    // One labeled segment per non-zero bucket, not color-alone.
-    expect(screen.getByRole('button', { name: 'Intake Fresh: 2' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Intake Aging: 1' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Intake Critical: 3' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Intake Stale/ })).not.toBeInTheDocument();
-    // Legend pairs every bucket label with its threshold window.
-    const legend = screen.getByTestId('queue-health-legend');
-    expect(within(legend).getByText(/Fresh/)).toBeInTheDocument();
-    expect(within(legend).getByText(/\(< 4h\)/)).toBeInTheDocument();
-    expect(within(legend).getByText(/Critical/)).toBeInTheDocument();
-    expect(within(legend).getByText(/\(≥ 3d\)/)).toBeInTheDocument();
+    const fresh = screen.getByRole('button', { name: 'Fresh: 2 tasks, under 4h, 0 active' });
+    expect(screen.getByRole('button', { name: 'Aging: 1 task, 4h–1d, 0 active' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Critical: 3 tasks, 3d or more, 0 active' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Stale/ })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('queue-health-legend')).not.toBeInTheDocument();
+
+    await user.hover(fresh);
+    const range = await screen.findByText('Under 4h');
+    const hoverCard = range.parentElement;
+    expect(hoverCard).not.toBeNull();
+    expect(within(hoverCard!).getByText('Tasks')).toBeInTheDocument();
+    expect(within(hoverCard!).getByText('2')).toBeInTheDocument();
   });
 
-  it('sizes segments proportionally to their counts via flex-grow', () => {
+  it('sizes aggregate segments proportionally to unique task counts', () => {
     const health = makeHealth(
       defaultStages({
-        execute: { buckets: { green: 1, amber: 0, orange: 0, red: 4 }, total: 5 },
+        intake: { buckets: { green: 2, amber: 0, orange: 0, red: 3 }, total: 5 },
       }),
+      INTAKE_ENTRIES.filter(entry => entry.bucket === 'green' || entry.bucket === 'red'),
     );
     renderWithProviders(<Harness health={health} />);
 
-    const green = screen.getByRole('button', { name: 'Building Fresh: 1' });
-    const red = screen.getByRole('button', { name: 'Building Critical: 4' });
-    expect(green).toHaveStyle({ flexGrow: '1' });
-    expect(red).toHaveStyle({ flexGrow: '4' });
+    expect(screen.getByRole('button', { name: 'Fresh: 2 tasks, under 4h, 0 active' })).toHaveStyle({ flexGrow: '2' });
+    expect(screen.getByRole('button', { name: 'Critical: 3 tasks, 3d or more, 0 active' })).toHaveStyle({
+      flexGrow: '3',
+    });
   });
 
-  it('renders an empty-state bar for a stage with zero items and no NaN widths', () => {
-    const health = makeHealth(defaultStages()); // all zero
-    renderWithProviders(<Harness health={health} />);
+  it('renders a clean empty distribution while retaining stage totals', () => {
+    renderWithProviders(<Harness health={makeHealth(defaultStages())} />);
 
+    expect(screen.getByText('No work in queue')).toBeInTheDocument();
     for (const label of ['Intake', 'Triage', 'Planning', 'Building', 'Review']) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
-    // Empty stages show the "0" empty-state, never a NaN-proportioned segment.
-    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(5);
+    expect(screen.getAllByText('0 tasks')).toHaveLength(5);
     expect(screen.queryByRole('button', { name: /Fresh|Aging|Stale|Critical/ })).not.toBeInTheDocument();
   });
 
-  it('shows the active-stripe overlay only when the stage has active work', () => {
+  it('reveals active work in the corresponding age segment', async () => {
+    const user = userEvent.setup();
+    const entries = [
+      healthEntry({ itemId: 'item-1', active: true }),
+      healthEntry({ itemId: 'item-2', active: true }),
+      healthEntry({ itemId: 'item-3' }),
+      healthEntry({ itemId: 'item-4' }),
+    ];
     const health = makeHealth(
       defaultStages({
-        intake: { buckets: { green: 2, amber: 0, orange: 0, red: 0 }, total: 2, activeCount: 0 },
         execute: { buckets: { green: 4, amber: 0, orange: 0, red: 0 }, total: 4, activeCount: 2 },
       }),
+      entries,
     );
     renderWithProviders(<Harness health={health} />);
 
-    expect(screen.getByRole('img', { name: 'Building: 2 active' })).toBeInTheDocument();
-    expect(screen.queryByRole('img', { name: /Intake: .* active/ })).not.toBeInTheDocument();
-    // The summary text carries the active count too (not pattern-alone).
-    expect(screen.getByText(/2 active/)).toBeInTheDocument();
+    await user.hover(screen.getByRole('button', { name: 'Fresh: 4 tasks, under 4h, 2 active' }));
+    const range = await screen.findByText('Under 4h');
+    const hoverCard = range.parentElement;
+    expect(hoverCard).not.toBeNull();
+    expect(within(hoverCard!).getByText('Active')).toBeInTheDocument();
+    expect(within(hoverCard!).getByText('2')).toBeInTheDocument();
   });
 
-  it('selects a cohort on click and clears it on clicking the selected segment again', async () => {
+  it('selects an age cohort and clears it when selected again', async () => {
     const user = userEvent.setup();
     const health = makeHealth(
       defaultStages({
         review: { buckets: { green: 0, amber: 3, orange: 0, red: 0 }, total: 3 },
       }),
+      [
+        healthEntry({ itemId: 'item-1', stage: 'review', bucket: 'amber' }),
+        healthEntry({ itemId: 'item-2', stage: 'review', bucket: 'amber' }),
+        healthEntry({ itemId: 'item-3', stage: 'review', bucket: 'amber' }),
+      ],
     );
     renderWithProviders(<Harness health={health} />);
 
-    const segment = screen.getByRole('button', { name: 'Review Aging: 3' });
+    const segment = screen.getByRole('button', { name: 'Aging: 3 tasks, 4h–1d, 0 active' });
     await user.click(segment);
-    expect(screen.getByTestId('selection')).toHaveTextContent('review:amber');
+    expect(screen.getByTestId('selection')).toHaveTextContent('amber');
     expect(segment).toHaveAttribute('aria-pressed', 'true');
 
     await user.click(segment);
     expect(screen.getByTestId('selection')).toHaveTextContent('cleared');
   });
 
-  it('clears the selection when the bar background is clicked', async () => {
+  it('reveals each stage age breakdown on hover', async () => {
     const user = userEvent.setup();
     const health = makeHealth(
       defaultStages({
-        triage: { buckets: { green: 1, amber: 0, orange: 0, red: 0 }, total: 1 },
+        execute: { buckets: { green: 2, amber: 0, orange: 0, red: 1 }, total: 3, activeCount: 1 },
       }),
     );
-    const { container } = renderWithProviders(<Harness health={health} />);
+    renderWithProviders(<Harness health={health} />);
 
-    await user.click(screen.getByRole('button', { name: 'Triage Fresh: 1' }));
-    expect(screen.getByTestId('selection')).toHaveTextContent('triage:green');
-
-    // The bar background is the segment's parent container.
-    const background = screen.getByRole('button', { name: 'Triage Fresh: 1' }).parentElement!;
-    await user.click(background);
-    expect(screen.getByTestId('selection')).toHaveTextContent('cleared');
-    expect(container.querySelectorAll('[aria-pressed="true"]')).toHaveLength(0);
+    await user.hover(
+      screen.getByRole('group', { name: 'Building: 3 tasks. Oldest work: Critical, 3d or more' }),
+    );
+    const active = await screen.findByText('Active');
+    const hoverCard = active.closest('dl');
+    expect(hoverCard).not.toBeNull();
+    expect(within(hoverCard!).getByText('Fresh')).toBeInTheDocument();
+    expect(within(hoverCard!).getByText('Critical')).toBeInTheDocument();
   });
 
-  it('omits the stripe animation class under prefers-reduced-motion', () => {
-    const matchMediaSpy = vi.spyOn(window, 'matchMedia').mockImplementation(
-      (query: string) =>
-        ({
-          matches: query.includes('prefers-reduced-motion'),
-          media: query,
-          addEventListener: () => {},
-          removeEventListener: () => {},
-          addListener: () => {},
-          removeListener: () => {},
-          onchange: null,
-          dispatchEvent: () => false,
-        }) as MediaQueryList,
+  it('opens aggregate details from keyboard focus', async () => {
+    const user = userEvent.setup();
+    const health = makeHealth(
+      defaultStages({
+        execute: { buckets: { green: 2, amber: 0, orange: 0, red: 0 }, total: 2 },
+      }),
+      [healthEntry({ itemId: 'item-1' }), healthEntry({ itemId: 'item-2' })],
     );
-    try {
-      const health = makeHealth(
-        defaultStages({
-          execute: { buckets: { green: 2, amber: 0, orange: 0, red: 0 }, total: 2, activeCount: 1 },
-        }),
-      );
-      renderWithProviders(<Harness health={health} />);
-      const overlay = screen.getByRole('img', { name: 'Building: 1 active' });
-      // With `prefers-reduced-motion` matched, the animation class is omitted.
-      expect(overlay.className).not.toContain('animate-queue-health-stripes');
-    } finally {
-      matchMediaSpy.mockRestore();
-    }
+    renderWithProviders(<Harness health={health} />);
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Fresh: 2 tasks, under 4h, 0 active' })).toHaveFocus();
+    expect(await screen.findByText('Under 4h')).toBeInTheDocument();
   });
 });

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/StageAutomation.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/StageAutomation.msw.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Component coverage for the Metrics page's automation-coverage section.
+ *
+ * Drives the real component through the shared provider stack; no network is
+ * involved (it is fed a `FactoryMetrics` aggregate directly). Specs cover the
+ * empty state, per-stage rates, hover details, and the select-a-stage
+ * drill-down into the automated passes' items.
+ */
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithProviders } from '../../../../../../e2e/web-ui/render';
+import { StageAutomation } from '../components/StageAutomation';
+import type { FactoryMetrics } from '../services/metrics';
+
+type StageAutomationRow = FactoryMetrics['stageAutomation'][number];
+
+function automationRow(overrides: Partial<StageAutomationRow> & { stage: string }): StageAutomationRow {
+  return {
+    exits: 0,
+    automated: 0,
+    outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 },
+    automatedItems: [],
+    ...overrides,
+  };
+}
+
+/** Metrics stub — only `stageAutomation` is read by the component. */
+function makeMetrics(stageAutomation: StageAutomationRow[]): FactoryMetrics {
+  return {
+    windowDays: 30,
+    earliestItemAt: null,
+    throughput: [],
+    cycleTime: { medianMs: null, p90Ms: null, samples: 0 },
+    stageDurations: [],
+    wip: [],
+    wipTotal: 0,
+    agingWip: [],
+    sourceMix: [],
+    transitions: { human: 0, total: 0 },
+    stageAutomation,
+  };
+}
+
+describe('StageAutomation', () => {
+  it('renders the empty state when no stage had a completed pass', () => {
+    renderWithProviders(<StageAutomation metrics={makeMetrics([])} />);
+
+    expect(screen.getByText('No completed stage passes in this window yet.')).toBeInTheDocument();
+  });
+
+  it('shows per-stage automation rates and reveals pass counts on hover', async () => {
+    const user = userEvent.setup();
+    const metrics = makeMetrics([
+      automationRow({
+        stage: 'triage',
+        exits: 4,
+        automated: 3,
+        outcomes: { done: 2, canceled: 0, reworked: 1, inFlight: 0 },
+        automatedItems: [
+          { id: 'item-1', title: 'Fix login', url: null, outcome: 'done' },
+          { id: 'item-2', title: 'Update docs', url: null, outcome: 'done' },
+          { id: 'item-3', title: 'Refactor auth', url: null, outcome: 'reworked' },
+        ],
+      }),
+    ]);
+    renderWithProviders(<StageAutomation metrics={metrics} />);
+
+    const bar = screen.getByRole('button', { name: 'Triage: 3 of 4 completed passes automated' });
+    expect(screen.getByText('75%')).toBeInTheDocument();
+    // Stages with no data render with an em-dash and stay unselectable.
+    expect(screen.getByRole('button', { name: 'Planning: no completed passes' })).not.toHaveAttribute('aria-pressed');
+
+    await user.hover(bar);
+    const passes = await screen.findByText('Completed passes');
+    const hoverCard = passes.closest('dl');
+    expect(hoverCard).not.toBeNull();
+    expect(within(hoverCard!).getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('2 done, 1 reworked — select to inspect')).toBeInTheDocument();
+  });
+
+  it('selects a stage to list its automated items, failures first, and clears on reselect', async () => {
+    const user = userEvent.setup();
+    const metrics = makeMetrics([
+      automationRow({
+        stage: 'triage',
+        exits: 3,
+        automated: 3,
+        outcomes: { done: 1, canceled: 0, reworked: 1, inFlight: 1 },
+        automatedItems: [
+          { id: 'item-1', title: 'Fix login', url: 'https://github.com/acme/app/issues/1', outcome: 'done' },
+          { id: 'item-2', title: 'Update docs', url: null, outcome: 'inFlight' },
+          { id: 'item-3', title: 'Refactor auth', url: null, outcome: 'reworked' },
+        ],
+      }),
+    ]);
+    renderWithProviders(<StageAutomation metrics={metrics} />);
+
+    const bar = screen.getByRole('button', { name: 'Triage: 3 of 3 completed passes automated' });
+    await user.click(bar);
+    expect(bar).toHaveAttribute('aria-pressed', 'true');
+
+    expect(screen.getByText('Automated through triage — 3 items')).toBeInTheDocument();
+    const rows = screen
+      .getAllByRole('listitem')
+      .filter(row => within(row).queryByText(/Fix login|Update docs|Refactor auth/));
+    expect(rows.map(row => within(row).getByText(/Fix login|Update docs|Refactor auth/).textContent)).toEqual([
+      'Refactor auth',
+      'Update docs',
+      'Fix login',
+    ]);
+    expect(screen.getByText('Reworked')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Fix login' })).toHaveAttribute(
+      'href',
+      'https://github.com/acme/app/issues/1',
+    );
+
+    await user.click(bar);
+    expect(bar).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.queryByText('Automated through triage — 3 items')).not.toBeInTheDocument();
+  });
+
+  it('does not toggle a drill-down for stages without automated passes', async () => {
+    const user = userEvent.setup();
+    const metrics = makeMetrics([automationRow({ stage: 'triage', exits: 2, automated: 0 })]);
+    renderWithProviders(<StageAutomation metrics={metrics} />);
+
+    const bar = screen.getByRole('button', { name: 'Triage: 0 of 2 completed passes automated' });
+    await user.click(bar);
+
+    expect(bar).not.toHaveAttribute('aria-pressed');
+    expect(screen.queryByText(/Automated through/)).not.toBeInTheDocument();
+  });
+});

--- a/mastracode/web/src/web/ui/domains/factory/components/QueueHealthChart.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/QueueHealthChart.tsx
@@ -1,21 +1,13 @@
 /**
- * The Metrics page's queue-health chart: one horizontal bar per board stage,
- * segmented left→right by age bucket (green → amber → orange → red) with width
- * proportional to how many work items sit in that cohort. A diagonal-stripe
- * overlay marks the right-anchored portion of each bar where an agent is
- * actively running. Clicking a segment (or focusing it and pressing
- * Enter/Space) selects that `(stage, bucket)` cohort so the page can list the
- * matching tasks; clicking the background or pressing Escape clears.
- *
- * Age is never signaled by color alone: each segment carries its bucket label
- * + count, the legend repeats label + threshold text, and the active overlay
- * is a stripe *pattern* (independent of the age colors) that is also labeled.
+ * Compact queue-health chart for the Metrics page. The primary bar summarizes
+ * unique work items by their oldest active stage age. Stage totals stay visible
+ * below it, while hover/focus cards progressively reveal the full breakdown.
  */
 
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@mastra/playground-ui/components/HoverCard';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { useEffect, useState } from 'react';
+import { cn } from '@mastra/playground-ui/utils/cn';
 
-import { relativeTime } from '../../../../../shared/lib/date';
 import type { AgeBucket, QueueHealth } from '../queue-health';
 import { AGE_BUCKETS } from '../queue-health';
 import { stageLabel } from '../stages';
@@ -27,7 +19,6 @@ const BUCKET_BAR: Record<AgeBucket, string> = {
   orange: 'bg-orange-500',
   red: 'bg-red-500',
 };
-const BUCKET_SWATCH: Record<AgeBucket, string> = BUCKET_BAR;
 
 const BUCKET_LABEL: Record<AgeBucket, string> = {
   green: 'Fresh',
@@ -36,196 +27,217 @@ const BUCKET_LABEL: Record<AgeBucket, string> = {
   red: 'Critical',
 };
 
+interface BucketSummary {
+  count: number;
+  activeCount: number;
+}
+
+interface ItemHealthSummary {
+  bucket: AgeBucket;
+  active: boolean;
+}
+
 export interface QueueHealthSelection {
-  stage: string;
-  bucket: AgeBucket | null;
+  bucket: AgeBucket;
 }
 
 export interface QueueHealthChartProps {
   health: QueueHealth;
-  /** Ordered age boundaries in seconds (for legend threshold text). */
+  /** Ordered age boundaries in seconds, shown in segment hover cards. */
   thresholdsSeconds: number[];
-  /** Currently selected cohort (controlled by the page). */
+  /** Currently selected age cohort (controlled by the page). */
   selected: QueueHealthSelection | null;
   onSelect: (selection: QueueHealthSelection | null) => void;
 }
 
-/** Human-readable age bound for the legend, e.g. 14400 → "4h". */
+/** Human-readable age bound, e.g. 14400 → "4h". */
 function boundLabel(seconds: number): string {
   if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
   if (seconds < 86400) return `${Math.round(seconds / 3600)}h`;
   return `${Math.round(seconds / 86400)}d`;
 }
 
-/** Legend text for each bucket's age window, derived from the config. */
+/** Age window for a bucket, derived from the project configuration. */
 function bucketRangeLabel(bucket: AgeBucket, thresholds: number[]): string {
   const index = AGE_BUCKETS.indexOf(bucket);
   const lower = index === 0 ? 0 : thresholds[index - 1]!;
   const upper = thresholds[index];
-  if (index === 0) return `< ${boundLabel(upper!)}`;
-  if (upper === undefined) return `≥ ${boundLabel(lower)}`;
+  if (index === 0) return `Under ${boundLabel(upper!)}`;
+  if (upper === undefined) return `${boundLabel(lower)} or more`;
   return `${boundLabel(lower)}–${boundLabel(upper)}`;
 }
 
 export function QueueHealthChart({ health, thresholdsSeconds, selected, onSelect }: QueueHealthChartProps) {
+  const itemHealth = new Map<string, ItemHealthSummary>();
+  for (const entry of health.entries) {
+    const current = itemHealth.get(entry.itemId);
+    const isOlder = current === undefined || AGE_BUCKETS.indexOf(entry.bucket) > AGE_BUCKETS.indexOf(current.bucket);
+    itemHealth.set(entry.itemId, {
+      bucket: isOlder ? entry.bucket : current.bucket,
+      active: entry.active || current?.active === true,
+    });
+  }
+
+  const buckets: Record<AgeBucket, BucketSummary> = {
+    green: { count: 0, activeCount: 0 },
+    amber: { count: 0, activeCount: 0 },
+    orange: { count: 0, activeCount: 0 },
+    red: { count: 0, activeCount: 0 },
+  };
+  for (const item of itemHealth.values()) {
+    buckets[item.bucket].count += 1;
+    if (item.active) buckets[item.bucket].activeCount += 1;
+  }
+
   return (
-    <div className="flex flex-col gap-3">
-      <ul className="m-0 flex list-none flex-col gap-2 p-0">
+    <div className="flex flex-col gap-5">
+      {itemHealth.size === 0 ? (
+        <div className="flex h-6 items-center justify-center rounded-md bg-surface4">
+          <Txt as="span" variant="ui-xs" className="text-icon3">
+            No work in queue
+          </Txt>
+        </div>
+      ) : (
+        <div className="flex h-6 gap-1.5" aria-label="Queue age distribution">
+          {AGE_BUCKETS.map(bucket => {
+            const summary = buckets[bucket];
+            if (summary.count === 0) return null;
+
+            const isSelected = selected?.bucket === bucket;
+            const range = bucketRangeLabel(bucket, thresholdsSeconds);
+            const taskLabel = summary.count === 1 ? 'task' : 'tasks';
+
+            return (
+              <HoverCard key={bucket}>
+                <HoverCardTrigger
+                  delay={100}
+                  closeDelay={0}
+                  render={
+                    <button
+                      type="button"
+                      aria-pressed={isSelected}
+                      aria-label={`${BUCKET_LABEL[bucket]}: ${summary.count} ${taskLabel}, ${range.toLowerCase()}, ${summary.activeCount} active`}
+                      style={{ flexGrow: summary.count }}
+                      className={cn(
+                        'h-full min-w-5 basis-0 cursor-pointer rounded-md outline-none transition-opacity duration-150 motion-reduce:transition-none focus-visible:ring-2 focus-visible:ring-border2 focus-visible:ring-offset-2 focus-visible:ring-offset-surface2',
+                        BUCKET_BAR[bucket],
+                        isSelected ? 'opacity-100 ring-2 ring-border2' : 'opacity-80 hover:opacity-100',
+                      )}
+                      onClick={() => onSelect(isSelected ? null : { bucket })}
+                      onKeyDown={event => {
+                        if (event.key === 'Escape') onSelect(null);
+                      }}
+                    />
+                  }
+                />
+                <BucketHoverCard bucket={bucket} range={range} summary={summary} />
+              </HoverCard>
+            );
+          })}
+        </div>
+      )}
+
+      <ul className="m-0 flex list-none flex-col gap-2.5 p-0">
         {health.stages.map(stage => (
-          <StageBar key={stage.stage} stage={stage} selected={selected} onSelect={onSelect} />
+          <StageSummaryRow key={stage.stage} stage={stage} thresholdsSeconds={thresholdsSeconds} />
         ))}
       </ul>
-      <Legend thresholdsSeconds={thresholdsSeconds} />
     </div>
   );
 }
 
-function StageBar({
+function BucketHoverCard({ bucket, range, summary }: { bucket: AgeBucket; range: string; summary: BucketSummary }) {
+  return (
+    <HoverCardContent side="top" align="center" className="w-48 border-border2 bg-surface3 p-3 shadow-none">
+      <Txt as="p" variant="ui-sm" className="m-0 font-medium text-icon6">
+        {BUCKET_LABEL[bucket]}
+      </Txt>
+      <Txt as="p" variant="ui-xs" className="mt-0.5 mb-0 text-icon3">
+        {range}
+      </Txt>
+      <dl className="mt-2 grid grid-cols-[1fr_auto] gap-x-4 gap-y-1 text-ui-xs">
+        <dt className="text-icon3">Tasks</dt>
+        <dd className="m-0 tabular-nums text-icon5">{summary.count}</dd>
+        <dt className="text-icon3">Active</dt>
+        <dd className="m-0 tabular-nums text-icon5">{summary.activeCount}</dd>
+      </dl>
+      <Txt as="p" variant="ui-xs" className="mt-2 mb-0 border-t border-border1 pt-2 text-icon3">
+        Select to inspect tasks
+      </Txt>
+    </HoverCardContent>
+  );
+}
+
+function StageSummaryRow({
   stage,
-  selected,
-  onSelect,
+  thresholdsSeconds,
 }: {
   stage: QueueHealth['stages'][number];
-  selected: QueueHealthSelection | null;
-  onSelect: (selection: QueueHealthSelection | null) => void;
+  thresholdsSeconds: number[];
 }) {
-  const isEmpty = stage.total === 0;
+  let oldestBucket: AgeBucket | null = null;
+  for (const bucket of AGE_BUCKETS) {
+    if (stage.buckets[bucket] > 0) oldestBucket = bucket;
+  }
+
+  const taskLabel = stage.total === 1 ? 'task' : 'tasks';
+  const oldestLabel = oldestBucket ? `${BUCKET_LABEL[oldestBucket]}, ${bucketRangeLabel(oldestBucket, thresholdsSeconds)}` : 'Empty';
+
   return (
-    <li className="grid grid-cols-[7rem_1fr_auto] items-center gap-3">
-      <Txt as="span" variant="ui-sm" className="text-icon4">
-        {stageLabel(stage.stage)}
-      </Txt>
-
-      {isEmpty ? (
-        <div className="flex h-5 items-center rounded-md border border-dashed border-border1 px-2">
-          <Txt as="span" variant="ui-xs" className="text-icon3">
-            0
-          </Txt>
-        </div>
-      ) : (
-        // Bar background: clicking it clears any selection.
-        <div
-          role="presentation"
-          className="relative flex h-5 overflow-hidden rounded-md bg-surface4"
-          onClick={() => onSelect(null)}
-        >
-          {AGE_BUCKETS.map(bucket => {
-            const count = stage.buckets[bucket];
-            if (count === 0) return null;
-            const isSelected = selected?.stage === stage.stage && selected.bucket === bucket;
-            return (
-              <button
-                key={bucket}
-                type="button"
-                aria-pressed={isSelected}
-                aria-label={`${stageLabel(stage.stage)} ${BUCKET_LABEL[bucket]}: ${count}`}
-                title={`${BUCKET_LABEL[bucket]} · ${count}`}
-                style={{ flexGrow: count }}
-                className={[
-                  'h-full min-w-0 basis-0 cursor-pointer transition-[flex-grow] duration-300',
-                  BUCKET_BAR[bucket],
-                  isSelected ? 'opacity-100 ring-2 ring-inset ring-white/70' : 'opacity-90 hover:opacity-100',
-                ].join(' ')}
-                onClick={event => {
-                  event.stopPropagation();
-                  onSelect(isSelected ? null : { stage: stage.stage, bucket });
-                }}
-                onKeyDown={event => {
-                  if (event.key === 'Escape') onSelect(null);
-                }}
-              >
-                <span className="sr-only">
-                  {count} {BUCKET_LABEL[bucket]}
-                </span>
-              </button>
-            );
-          })}
-
-          {/* Active-work overlay: right-anchored, width ∝ activeCount. */}
-          {stage.activeCount > 0 ? (
-            <ActiveStripes key="active" stage={stage.stage} activeCount={stage.activeCount} total={stage.total} />
-          ) : null}
-        </div>
-      )}
-
-      <Txt as="span" variant="ui-xs" className="text-right text-icon3">
-        {stage.total}
-        {stage.activeCount > 0 ? ` · ${stage.activeCount} active` : ''}
-      </Txt>
+    <li>
+      <HoverCard>
+        <HoverCardTrigger
+          delay={100}
+          closeDelay={0}
+          render={
+            <div
+              role="group"
+              tabIndex={0}
+              aria-label={`${stageLabel(stage.stage)}: ${stage.total} ${taskLabel}. Oldest work: ${oldestLabel}`}
+              className="flex cursor-help items-center justify-between gap-4 rounded-md px-1 py-0.5 outline-none hover:bg-surface3 focus-visible:bg-surface3 focus-visible:ring-1 focus-visible:ring-border2"
+            >
+              <span className="flex min-w-0 items-center gap-2.5">
+                <span
+                  aria-hidden="true"
+                  className={cn('size-2.5 shrink-0 rounded-full', oldestBucket ? BUCKET_BAR[oldestBucket] : 'bg-surface4')}
+                />
+                <Txt as="span" variant="ui-sm" className="truncate font-medium text-icon5">
+                  {stageLabel(stage.stage)}
+                </Txt>
+              </span>
+              <Txt as="span" variant="ui-sm" className="shrink-0 tabular-nums text-icon3">
+                {stage.total} {taskLabel}
+              </Txt>
+            </div>
+          }
+        />
+        <HoverCardContent side="right" align="center" className="w-52 border-border2 bg-surface3 p-3 shadow-none">
+          <div className="flex items-baseline justify-between gap-4">
+            <Txt as="p" variant="ui-sm" className="m-0 font-medium text-icon6">
+              {stageLabel(stage.stage)}
+            </Txt>
+            <Txt as="span" variant="ui-xs" className="tabular-nums text-icon3">
+              {stage.total} {taskLabel}
+            </Txt>
+          </div>
+          <dl className="mt-2 grid grid-cols-[1fr_auto] gap-x-4 gap-y-1 text-ui-xs">
+            {AGE_BUCKETS.map(bucket =>
+              stage.buckets[bucket] > 0 ? (
+                <div key={bucket} className="col-span-2 grid grid-cols-subgrid">
+                  <dt className="flex items-center gap-2 text-icon3">
+                    <span aria-hidden="true" className={cn('size-2 rounded-full', BUCKET_BAR[bucket])} />
+                    {BUCKET_LABEL[bucket]}
+                  </dt>
+                  <dd className="m-0 tabular-nums text-icon5">{stage.buckets[bucket]}</dd>
+                </div>
+              ) : null,
+            )}
+            <dt className="mt-1 border-t border-border1 pt-1 text-icon3">Active</dt>
+            <dd className="mt-1 border-t border-border1 pt-1 text-right tabular-nums text-icon5">{stage.activeCount}</dd>
+          </dl>
+        </HoverCardContent>
+      </HoverCard>
     </li>
   );
 }
 
-/**
- * Diagonal-stripe active-work marker. Width is proportional to the stage's
- * active share; the stripes drift left→right via the `queue-health-stripes`
- * keyframe, and the animation is disabled under `prefers-reduced-motion`.
- */
-function ActiveStripes({ stage, activeCount, total }: { stage: string; activeCount: number; total: number }) {
-  const reduceMotion = usePrefersReducedMotion();
-  const widthPct = Math.max(2, Math.round((activeCount / total) * 100));
-  return (
-    <div
-      role="img"
-      aria-label={`${stageLabel(stage)}: ${activeCount} active`}
-      title={`${activeCount} active`}
-      style={{
-        width: `${widthPct}%`,
-        backgroundImage: 'repeating-linear-gradient(45deg, rgba(255,255,255,0.55) 0 4px, transparent 4px 12px)',
-        backgroundSize: '16px 16px',
-      }}
-      className={[
-        'pointer-events-none absolute inset-y-0 right-0',
-        reduceMotion ? '' : 'animate-queue-health-stripes',
-      ].join(' ')}
-    />
-  );
-}
-
-/** True when the user asked for reduced motion; tracks the live media query. */
-function usePrefersReducedMotion(): boolean {
-  const [reduce, setReduce] = useState(
-    () => typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches,
-  );
-  useEffect(() => {
-    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const onChange = () => setReduce(query.matches);
-    query.addEventListener('change', onChange);
-    return () => query.removeEventListener('change', onChange);
-  }, []);
-  return reduce;
-}
-
-function Legend({ thresholdsSeconds }: { thresholdsSeconds: number[] }) {
-  return (
-    <div data-testid="queue-health-legend" className="flex flex-wrap items-center gap-x-4 gap-y-1">
-      {AGE_BUCKETS.map(bucket => (
-        <span key={bucket} className="inline-flex items-center gap-1.5">
-          <span className={`h-2.5 w-2.5 rounded-sm ${BUCKET_SWATCH[bucket]}`} aria-hidden="true" />
-          <Txt as="span" variant="ui-xs" className="text-icon3">
-            {BUCKET_LABEL[bucket]} ({bucketRangeLabel(bucket, thresholdsSeconds)})
-          </Txt>
-        </span>
-      ))}
-      <span className="inline-flex items-center gap-1.5">
-        <span
-          aria-hidden="true"
-          className="h-2.5 w-2.5 rounded-sm"
-          style={{
-            backgroundImage:
-              'repeating-linear-gradient(45deg, rgba(255,255,255,0.9) 0 2px, rgba(255,255,255,0.2) 2px 6px)',
-            backgroundColor: 'rgba(255,255,255,0.15)',
-          }}
-        />
-        <Txt as="span" variant="ui-xs" className="text-icon3">
-          Active work
-        </Txt>
-      </span>
-    </div>
-  );
-}
-
-/** Humanize an entry's age in seconds for the drill-down list. */
-export function formatAgeSeconds(ageSeconds: number): string {
-  return relativeTime(new Date(Date.now() - ageSeconds * 1000).toISOString()) || 'just now';
-}

--- a/mastracode/web/src/web/ui/domains/factory/components/QueueHealthSection.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/QueueHealthSection.tsx
@@ -9,6 +9,7 @@
  * (`useWorkspaceActivity`); the section merges that polled activity map with
  * the work items + age thresholds it fetches via React Query.
  */
+import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useMemo, useState } from 'react';
@@ -48,10 +49,18 @@ export function QueueHealthSection({ factoryProjectId }: { factoryProjectId: str
   }, [workItemsQuery.data, activePaths, thresholdsQuery.data]);
 
   if (workItemsQuery.isError) {
-    return <Notice variant="destructive">{(workItemsQuery.error as Error).message}</Notice>;
+    return (
+      <Notice variant="destructive">
+        {workItemsQuery.error instanceof Error ? workItemsQuery.error.message : 'Failed to load queue health'}
+      </Notice>
+    );
   }
   if (thresholdsQuery.isError) {
-    return <Notice variant="destructive">{(thresholdsQuery.error as Error).message}</Notice>;
+    return (
+      <Notice variant="destructive">
+        {thresholdsQuery.error instanceof Error ? thresholdsQuery.error.message : 'Failed to load queue thresholds'}
+      </Notice>
+    );
   }
 
   const thresholds = health ? (thresholdsQuery.data?.thresholdsSeconds ?? [14400, 86400, 259200]) : [];
@@ -60,12 +69,19 @@ export function QueueHealthSection({ factoryProjectId }: { factoryProjectId: str
     : null;
 
   return (
-    <section className="flex flex-col gap-3 rounded-lg border border-border1 bg-surface2 p-3">
-      <div className="flex items-baseline justify-between gap-2">
-        <h2 className="m-0 text-ui-md font-medium text-icon5">Queue health</h2>
-        <Txt as="span" variant="ui-xs" className="text-icon3">
-          Live — not scoped to the date range
-        </Txt>
+    <section className="flex flex-col gap-4 border-t border-border1 pt-7">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <Txt as="h2" variant="ui-md" className="m-0 font-medium text-icon6">
+            Queue health
+          </Txt>
+          <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
+            Current work by stage and age. Select a segment to inspect its tasks.
+          </Txt>
+        </div>
+        <Badge size="sm" variant="success">
+          Live
+        </Badge>
       </div>
       {!workItemsQuery.data ? (
         <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
@@ -134,31 +150,33 @@ function DrillDownList({
         {entries.map(entry => (
           <li
             key={`${entry.itemId}:${entry.stage}`}
-            className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-3 border-b border-border1 py-1.5 last:border-b-0"
+            className="flex min-w-0 flex-col gap-2 border-b border-border1 py-2.5 last:border-b-0 sm:flex-row sm:items-center"
           >
-            {entry.url ? (
-              <a
-                href={entry.url}
-                target="_blank"
-                rel="noreferrer"
-                className="truncate text-ui-sm text-icon5 no-underline hover:text-icon6 hover:underline"
-              >
-                {entry.title}
-              </a>
-            ) : (
-              <span className="truncate text-ui-sm text-icon5">{entry.title}</span>
-            )}
-            <span className="rounded-full bg-surface5 px-1.5 py-0.5 text-ui-xs text-icon4">
-              {stageLabel(entry.stage)}
-            </span>
-            <Txt as="span" variant="ui-xs" className="text-icon3">
-              in stage {formatAgeSeconds(entry.ageSeconds)}
-            </Txt>
-            {entry.active ? (
-              <span className="rounded-full bg-green-500/15 px-1.5 py-0.5 text-ui-xs text-green-500">active</span>
-            ) : (
-              <span />
-            )}
+            <div className="min-w-0 flex-1">
+              {entry.url ? (
+                <a
+                  href={entry.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="block truncate text-ui-sm font-medium text-icon5 no-underline hover:text-icon6 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent1"
+                >
+                  {entry.title}
+                </a>
+              ) : (
+                <span className="block truncate text-ui-sm font-medium text-icon5">{entry.title}</span>
+              )}
+              <Txt as="span" variant="ui-xs" className="mt-0.5 block text-icon3">
+                In this stage {formatAgeSeconds(entry.ageSeconds)}
+              </Txt>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge size="xs">{stageLabel(entry.stage)}</Badge>
+              {entry.active ? (
+                <Badge size="xs" variant="success">
+                  Active
+                </Badge>
+              ) : null}
+            </div>
           </li>
         ))}
       </ul>

--- a/mastracode/web/src/web/ui/domains/factory/components/QueueHealthSection.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/QueueHealthSection.tsx
@@ -1,7 +1,6 @@
 /**
- * The Metrics page's queue-health section: one bar per stage segmented by
- * work-item age, with a stripe overlay where agents are actively running, and
- * a click-to-filter drill-down list of the matching tasks below the chart.
+ * The Metrics page's live queue-health section: a compact age distribution,
+ * stage totals, and click-to-filter task drill-down.
  *
  * Unlike the rest of the Metrics dashboard this is a live snapshot — it is
  * not scoped by the page's date-range control. Aggregation is client-side
@@ -10,6 +9,7 @@
  * the work items + age thresholds it fetches via React Query.
  */
 import { Badge } from '@mastra/playground-ui/components/Badge';
+import { Card, CardContent } from '@mastra/playground-ui/components/Card';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useMemo, useState } from 'react';
@@ -22,9 +22,10 @@ import { useQueueHealthThresholds } from '../../../../../shared/hooks/useQueueHe
 import { useWorkItemsQuery } from '../../../../../shared/hooks/useWorkItems';
 import { useWorkspaceActivity } from '../../../../../shared/hooks/useWorkspaceActivity';
 import { useWorkspacesQuery } from '../../../../../shared/hooks/useWorkspaces';
+import { relativeTime } from '../../../../../shared/lib/date/relativeTime';
 import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 import type { QueueHealthSelection } from './QueueHealthChart';
-import { QueueHealthChart, formatAgeSeconds } from './QueueHealthChart';
+import { QueueHealthChart } from './QueueHealthChart';
 import type { AgeBucket, QueueHealthEntry } from '../queue-health';
 import { computeQueueHealth } from '../queue-health';
 import { stageLabel } from '../stages';
@@ -35,6 +36,18 @@ const BUCKET_LABEL: Record<AgeBucket, string> = {
   orange: 'Stale',
   red: 'Critical',
 };
+
+function entriesForBucket(entries: QueueHealthEntry[], bucket: AgeBucket): QueueHealthEntry[] {
+  const entriesByItem = new Map<string, QueueHealthEntry>();
+  for (const entry of entries) {
+    if (entry.bucket === bucket && !entriesByItem.has(entry.itemId)) entriesByItem.set(entry.itemId, entry);
+  }
+  return [...entriesByItem.values()];
+}
+
+function formatAgeSeconds(ageSeconds: number): string {
+  return relativeTime(new Date(Date.now() - ageSeconds * 1000).toISOString()) || 'just now';
+}
 
 export function QueueHealthSection({ factoryProjectId }: { factoryProjectId: string | undefined }) {
   const workItemsQuery = useWorkItemsQuery(factoryProjectId);
@@ -63,20 +76,25 @@ export function QueueHealthSection({ factoryProjectId }: { factoryProjectId: str
     );
   }
 
-  const thresholds = health ? (thresholdsQuery.data?.thresholdsSeconds ?? [14400, 86400, 259200]) : [];
-  const drillDown = selected
-    ? health.entries.filter(entry => entry.stage === selected.stage && entry.bucket === selected.bucket)
-    : null;
+  const thresholds = thresholdsQuery.data?.thresholdsSeconds ?? [14400, 86400, 259200];
+  const drillDown = selected ? entriesForBucket(health.entries, selected.bucket) : null;
+
+  const currentItemIds = new Set<string>();
+  const activeItemIds = new Set<string>();
+  for (const entry of health.entries) {
+    currentItemIds.add(entry.itemId);
+    if (entry.active) activeItemIds.add(entry.itemId);
+  }
 
   return (
-    <section className="flex flex-col gap-4 border-t border-border1 pt-7">
+    <section className="flex flex-col gap-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-col gap-1">
+        <div className="flex max-w-2xl flex-col gap-1">
           <Txt as="h2" variant="ui-md" className="m-0 font-medium text-icon6">
             Queue health
           </Txt>
-          <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
-            Current work by stage and age. Select a segment to inspect its tasks.
+          <Txt as="p" variant="ui-sm" className="m-0 text-pretty text-icon3">
+            Current work by age and stage. Hover for details; select an age segment to inspect its tasks.
           </Txt>
         </div>
         <Badge size="sm" variant="success">
@@ -84,12 +102,43 @@ export function QueueHealthSection({ factoryProjectId }: { factoryProjectId: str
         </Badge>
       </div>
       {!workItemsQuery.data ? (
-        <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
-          Loading queue health…
-        </Txt>
+        <Card>
+          <CardContent>
+            <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
+              Loading queue health…
+            </Txt>
+          </CardContent>
+        </Card>
       ) : (
         <>
-          <QueueHealthChart health={health} thresholdsSeconds={thresholds} selected={selected} onSelect={setSelected} />
+          <Card>
+            <CardContent className="flex flex-col gap-5">
+              <div className="flex items-end justify-between gap-4">
+                <div>
+                  <Txt as="span" variant="ui-sm" className="text-icon3">
+                    Current total
+                  </Txt>
+                  <div className="mt-0.5 flex items-baseline gap-2">
+                    <span className="text-header-lg font-medium tabular-nums text-icon6">{currentItemIds.size}</span>
+                    <Txt as="span" variant="ui-sm" className="text-icon4">
+                      {currentItemIds.size === 1 ? 'task' : 'tasks'}
+                    </Txt>
+                  </div>
+                </div>
+                {activeItemIds.size > 0 ? (
+                  <Badge size="xs" variant="success">
+                    {activeItemIds.size} active
+                  </Badge>
+                ) : null}
+              </div>
+              <QueueHealthChart
+                health={health}
+                thresholdsSeconds={thresholds}
+                selected={selected}
+                onSelect={setSelected}
+              />
+            </CardContent>
+          </Card>
           <DrillDownList selected={selected} entries={drillDown} />
         </>
       )}
@@ -125,15 +174,9 @@ function DrillDownList({
   selected: QueueHealthSelection | null;
   entries: QueueHealthEntry[] | null;
 }) {
-  if (!selected || !entries || selected.bucket === null) {
-    return (
-      <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
-        Select a segment above to see its tasks.
-      </Txt>
-    );
-  }
+  if (!selected || !entries) return null;
   const bucket = selected.bucket;
-  const heading = `${stageLabel(selected.stage)} · ${BUCKET_LABEL[bucket]}`;
+  const heading = `${BUCKET_LABEL[bucket]} work`;
   if (entries.length === 0) {
     return (
       <Txt as="p" variant="ui-sm" className="m-0 text-icon3">

--- a/mastracode/web/src/web/ui/domains/factory/components/StageAutomation.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/StageAutomation.tsx
@@ -1,0 +1,200 @@
+/**
+ * Per-stage automation coverage for the Metrics page: what share of completed
+ * passes through each stage was fully automated (entered and exited by
+ * automation, first visit), and how the automated passes' items ended up.
+ *
+ * Each stage bar doubles as a toggle: selecting a stage with automated passes
+ * reveals the concrete items behind its rate (the server ships them alongside
+ * the counts), so a poor rate can be traced to the reworked items causing it.
+ */
+
+import { Badge } from '@mastra/playground-ui/components/Badge';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@mastra/playground-ui/components/HoverCard';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import { useState } from 'react';
+
+import type { AutomationOutcome, FactoryMetrics } from '../services/metrics';
+import { BOARD_STAGES, stageLabel, stageOrder } from '../stages';
+
+/** Terminal stages have no "pass through", so they never get automation rows. */
+const TERMINAL_STAGE_IDS = new Set(['done', 'canceled']);
+
+const EM_DASH = '—';
+
+const OUTCOME_LABEL: Record<AutomationOutcome, string> = {
+  done: 'Done',
+  canceled: 'Canceled',
+  reworked: 'Reworked',
+  inFlight: 'In flight',
+};
+
+const OUTCOME_BADGE_VARIANT: Record<AutomationOutcome, 'success' | 'default' | 'warning' | 'info'> = {
+  done: 'success',
+  canceled: 'default',
+  reworked: 'warning',
+  inFlight: 'info',
+};
+
+/** Drill-down order: automation failures first, then still-open, then settled. */
+const OUTCOME_ORDER: Record<AutomationOutcome, number> = { reworked: 0, inFlight: 1, done: 2, canceled: 3 };
+
+export function StageAutomation({ metrics }: { metrics: FactoryMetrics }) {
+  const [selectedStage, setSelectedStage] = useState<string | null>(null);
+
+  // Rows only exist for stages with ≥1 exit, so an empty list means no stage
+  // had a completed pass in the window.
+  if (metrics.stageAutomation.length === 0) {
+    return (
+      <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
+        No completed stage passes in this window yet.
+      </Txt>
+    );
+  }
+
+  const rowsByStage = new Map(metrics.stageAutomation.map(row => [row.stage, row]));
+  // Non-terminal board stages in column order, plus any stages present in the
+  // data but unknown to the board (raw id, sorted last — same rule as
+  // stageLabel/stageOrder).
+  const stageIds = new Set<string>();
+  for (const stage of BOARD_STAGES) {
+    if (!TERMINAL_STAGE_IDS.has(stage.id)) stageIds.add(stage.id);
+  }
+  for (const row of metrics.stageAutomation) {
+    stageIds.add(row.stage);
+  }
+  const stages = [...stageIds].sort((a, b) => stageOrder(a) - stageOrder(b));
+
+  // A refetch can drop the selected stage's row (e.g. the range moved) —
+  // render as unselected rather than holding a stale selection.
+  const selectedRow = selectedStage ? rowsByStage.get(selectedStage) : undefined;
+
+  return (
+    <div className="flex flex-col gap-5">
+      <ul className="m-0 flex list-none flex-col gap-3 p-0">
+        {stages.map(stage => {
+          const row = rowsByStage.get(stage);
+          const exits = row?.exits ?? 0;
+          const automated = row?.automated ?? 0;
+          const pct = exits === 0 ? null : Math.round((automated / exits) * 100);
+          const selectable = automated > 0;
+          const isSelected = selectable && selectedStage === stage;
+          const accessibleSummary =
+            pct === null
+              ? `${stageLabel(stage)}: no completed passes`
+              : `${stageLabel(stage)}: ${automated} of ${exits} completed passes automated`;
+
+          return (
+            <li key={stage} className="grid gap-2">
+              <div className="flex items-baseline justify-between gap-3">
+                <Txt as="span" variant="ui-sm" className="font-medium text-icon5">
+                  {stageLabel(stage)}
+                </Txt>
+                <Txt as="span" variant="ui-xs" className="text-right tabular-nums text-icon3">
+                  {pct === null ? EM_DASH : `${pct}%`}
+                </Txt>
+              </div>
+              <HoverCard>
+                <HoverCardTrigger
+                  render={
+                    <button
+                      type="button"
+                      aria-label={accessibleSummary}
+                      aria-pressed={selectable ? isSelected : undefined}
+                      className={cn(
+                        'h-2 w-full overflow-hidden rounded-full bg-surface4 p-0 outline-none focus-visible:ring-1 focus-visible:ring-border2',
+                        selectable ? 'cursor-pointer' : 'cursor-help',
+                        isSelected && 'ring-2 ring-border2',
+                      )}
+                      onClick={() => {
+                        if (selectable) setSelectedStage(isSelected ? null : stage);
+                      }}
+                      onKeyDown={event => {
+                        if (event.key === 'Escape') setSelectedStage(null);
+                      }}
+                    >
+                      {pct !== null && automated > 0 ? (
+                        <span
+                          className="block h-full rounded-full"
+                          style={{ width: `${Math.max(2, pct)}%`, backgroundColor: 'var(--chart-4)' }}
+                        />
+                      ) : null}
+                    </button>
+                  }
+                />
+                <HoverCardContent side="top" align="start" className="w-56 border-border2 bg-surface3 p-3 shadow-none">
+                  <Txt as="p" variant="ui-sm" className="m-0 font-medium text-icon6">
+                    {stageLabel(stage)}
+                  </Txt>
+                  <dl className="mt-2 grid grid-cols-[1fr_auto] gap-x-4 gap-y-1.5 text-ui-xs">
+                    <dt className="text-icon3">Completed passes</dt>
+                    <dd className="m-0 tabular-nums text-icon5">{exits}</dd>
+                    <dt className="text-icon3">Automated</dt>
+                    <dd className="m-0 tabular-nums text-icon5">
+                      {automated}
+                      {pct === null ? '' : ` · ${pct}%`}
+                    </dd>
+                  </dl>
+                  {row && automated > 0 ? (
+                    <Txt as="p" variant="ui-xs" className="mt-2 mb-0 border-t border-border1 pt-2 text-icon3">
+                      {outcomeSummary(row.outcomes)} — select to inspect
+                    </Txt>
+                  ) : null}
+                </HoverCardContent>
+              </HoverCard>
+            </li>
+          );
+        })}
+      </ul>
+      {selectedRow ? <AutomatedItemsList row={selectedRow} /> : null}
+    </div>
+  );
+}
+
+/** Compact split of automated-pass outcomes, omitting zero buckets. */
+function outcomeSummary(outcomes: FactoryMetrics['stageAutomation'][number]['outcomes']): string {
+  const parts: string[] = [];
+  if (outcomes.done > 0) parts.push(`${outcomes.done} done`);
+  if (outcomes.canceled > 0) parts.push(`${outcomes.canceled} canceled`);
+  if (outcomes.reworked > 0) parts.push(`${outcomes.reworked} reworked`);
+  if (outcomes.inFlight > 0) parts.push(`${outcomes.inFlight} in flight`);
+  return parts.join(', ');
+}
+
+/** The selected stage's automated passes, failures (reworked) first. */
+function AutomatedItemsList({ row }: { row: FactoryMetrics['stageAutomation'][number] }) {
+  const items = [...row.automatedItems].sort((a, b) => OUTCOME_ORDER[a.outcome] - OUTCOME_ORDER[b.outcome]);
+  return (
+    <div className="flex flex-col gap-2 border-t border-border1 pt-4">
+      <Txt as="p" variant="ui-sm" className="m-0 text-icon4">
+        Automated through {stageLabel(row.stage).toLowerCase()} — {items.length} {items.length === 1 ? 'item' : 'items'}
+      </Txt>
+      <ul className="m-0 flex list-none flex-col p-0">
+        {items.map(item => (
+          <li
+            key={item.id}
+            className="flex min-w-0 flex-col gap-2 border-b border-border1 py-2.5 last:border-b-0 last:pb-0 sm:flex-row sm:items-center"
+          >
+            <div className="min-w-0 flex-1">
+              {item.url ? (
+                <a
+                  href={item.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="block truncate text-ui-sm font-medium text-icon5 no-underline hover:text-icon6 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent1"
+                >
+                  {item.title}
+                </a>
+              ) : (
+                <span className="block truncate text-ui-sm font-medium text-icon5">{item.title}</span>
+              )}
+            </div>
+            <Badge size="xs" variant={OUTCOME_BADGE_VARIANT[item.outcome]}>
+              {OUTCOME_LABEL[item.outcome]}
+            </Badge>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/mastracode/web/src/web/ui/domains/factory/services/metrics.ts
+++ b/mastracode/web/src/web/ui/domains/factory/services/metrics.ts
@@ -40,8 +40,13 @@ export interface FactoryMetrics {
      * items land (e.g. an `inFlight` pass becomes `done` on a later query).
      */
     outcomes: { done: number; canceled: number; reworked: number; inFlight: number };
+    /** The automated passes' items (one per pass), tagged with their `outcomes` bucket. */
+    automatedItems: { id: string; title: string; url: string | null; outcome: AutomationOutcome }[];
   }[];
 }
+
+/** One automated pass's `outcomes` bucket (see `stageAutomation.outcomes`). */
+export type AutomationOutcome = 'done' | 'canceled' | 'reworked' | 'inFlight';
 
 /** Inclusive UTC calendar-date bounds (`yyyy-MM-dd`) for a metrics request. */
 export interface FactoryMetricsRange {

--- a/mastracode/web/src/web/ui/pages/MetricsPage.tsx
+++ b/mastracode/web/src/web/ui/pages/MetricsPage.tsx
@@ -1,11 +1,14 @@
 import { DateRangeTimeline, getDateRangeBounds } from '@mastra/playground-ui/components/DateRangeTimeline';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import type { DateRangeValue } from '@mastra/playground-ui/components/DateRangeTimeline';
-import { MetricsLineChart } from '@mastra/playground-ui/components/MetricsLineChart';
+import {
+  MetricsBarChart,
+  type MetricsBarChartSeries,
+} from '@mastra/playground-ui/components/MetricsBarChart';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { Bot, CircleCheck, Clock3, Layers3, Workflow } from 'lucide-react';
+import { Bot, Clock3, Layers3, Workflow } from 'lucide-react';
 import { useState, type ReactNode } from 'react';
 import { useParams } from 'react-router';
 
@@ -44,7 +47,30 @@ function defaultRange(today: string): DateRangeValue {
   return { from: shiftUtcDay(today, -29), to: today };
 }
 
-const THROUGHPUT_SERIES = [{ dataKey: 'done', label: 'Completed work', color: 'var(--chart-2)' }];
+const THROUGHPUT_COLOR = 'oklch(from var(--accent1) l calc(c * 0.72) h)';
+const THROUGHPUT_LEGEND_STYLE = { backgroundColor: THROUGHPUT_COLOR };
+const THROUGHPUT_SERIES: Array<MetricsBarChartSeries> = [
+  { dataKey: 'done', label: 'Completed work', color: THROUGHPUT_COLOR, appearance: 'dotted' },
+];
+const THROUGHPUT_AXIS_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  day: 'numeric',
+  month: 'short',
+  timeZone: 'UTC',
+});
+const THROUGHPUT_TOOLTIP_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+function formatThroughputDate(value: unknown, formatter: Intl.DateTimeFormat): string {
+  if (typeof value !== 'string') return String(value ?? '');
+
+  const timestamp = Date.parse(`${value}T00:00:00.000Z`);
+  return Number.isNaN(timestamp) ? value : formatter.format(timestamp);
+}
+
 
 const SOURCE_LABELS: Record<string, string> = {
   'github:issue': 'GitHub issues',
@@ -94,15 +120,6 @@ function MetricsContent({ factoryProjectId }: { factoryProjectId: string | undef
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 pb-8">
-      <header className="flex flex-col gap-1 pt-1">
-        <Txt as="h1" variant="header-sm" className="m-0 text-icon6">
-          Metrics
-        </Txt>
-        <Txt as="p" variant="ui-sm" className="m-0 max-w-2xl text-icon3">
-          See how work moves through the Factory and where it needs attention.
-        </Txt>
-      </header>
-
       <MetricsSection
         title="Reporting period"
         description="Drag the range or use the date controls to compare a different window."
@@ -217,33 +234,6 @@ function FlowOverview({
         <Badge size="sm">{windowDays}-day view</Badge>
       </div>
 
-      <div className="min-w-0">
-        <div className="mb-3 flex flex-wrap items-end justify-between gap-x-4 gap-y-2">
-          <div>
-            <Txt as="span" variant="ui-sm" className="text-icon3">
-              Completed
-            </Txt>
-            <div className="mt-0.5 flex items-baseline gap-2">
-              <span className="text-header-xl font-medium tabular-nums text-icon6">{completed}</span>
-              <Txt as="span" variant="ui-xs" className="text-icon3">
-                {averagePerDay.toLocaleString(undefined, { maximumFractionDigits: 1 })} per day
-              </Txt>
-            </div>
-          </div>
-          <div className="flex items-center gap-1.5 text-ui-xs text-icon3">
-            <CircleCheck aria-hidden="true" className="size-3.5 text-positive1" />
-            Daily completions
-          </div>
-        </div>
-        <MetricsLineChart
-          data={metrics.throughput.map(point => ({ time: point.date, done: point.count }))}
-          series={THROUGHPUT_SERIES}
-          height={220}
-          xAxisInterval="preserveStartEnd"
-          xAxisMinTickGap={40}
-        />
-      </div>
-
       <dl className="m-0 grid grid-cols-2 gap-x-5 gap-y-4 border-t border-border1 pt-4 lg:grid-cols-4 lg:gap-0 lg:divide-x lg:divide-border1">
         <OverviewReadout
           icon={<Clock3 aria-hidden="true" />}
@@ -278,6 +268,36 @@ function FlowOverview({
           }
         />
       </dl>
+
+      <div className="min-w-0">
+        <div className="mb-3 flex flex-wrap items-end justify-between gap-x-4 gap-y-2">
+          <div>
+            <Txt as="span" variant="ui-sm" className="text-icon3">
+              Completed
+            </Txt>
+            <div className="mt-0.5 flex items-baseline gap-2">
+              <span className="text-header-xl font-medium tabular-nums text-icon6">{completed}</span>
+              <Txt as="span" variant="ui-xs" className="text-icon3">
+                {averagePerDay.toLocaleString(undefined, { maximumFractionDigits: 1 })} per day
+              </Txt>
+            </div>
+          </div>
+          <div className="flex items-center gap-1.5 text-ui-xs text-icon3">
+            <span aria-hidden="true" className="size-2 rounded-sm" style={THROUGHPUT_LEGEND_STYLE} />
+            Daily completions
+          </div>
+        </div>
+        <MetricsBarChart
+          data={metrics.throughput.map(point => ({ time: point.date, done: point.count }))}
+          series={THROUGHPUT_SERIES}
+          description="Daily completed work for the selected reporting period."
+          height={220}
+          xAxisInterval="preserveStartEnd"
+          xAxisMinTickGap={40}
+          xAxisTickFormatter={value => formatThroughputDate(value, THROUGHPUT_AXIS_DATE_FORMATTER)}
+          tooltipLabelFormatter={value => formatThroughputDate(value, THROUGHPUT_TOOLTIP_DATE_FORMATTER)}
+        />
+      </div>
     </section>
   );
 }

--- a/mastracode/web/src/web/ui/pages/MetricsPage.tsx
+++ b/mastracode/web/src/web/ui/pages/MetricsPage.tsx
@@ -1,10 +1,7 @@
 import { DateRangeTimeline, getDateRangeBounds } from '@mastra/playground-ui/components/DateRangeTimeline';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import type { DateRangeValue } from '@mastra/playground-ui/components/DateRangeTimeline';
-import {
-  MetricsBarChart,
-  type MetricsBarChartSeries,
-} from '@mastra/playground-ui/components/MetricsBarChart';
+import { MetricsBarChart, type MetricsBarChartSeries } from '@mastra/playground-ui/components/MetricsBarChart';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
@@ -22,8 +19,9 @@ import { formatDuration, relativeTime } from '../../../shared/lib/date';
 import { AGENT_CONTROLLER_ID } from '../domains/chat/services/constants';
 import { DocumentFactoryPageShell } from '../domains/factory/components/FactoryPageShell';
 import { QueueHealthSection } from '../domains/factory/components/QueueHealthSection';
+import { StageAutomation } from '../domains/factory/components/StageAutomation';
 import type { FactoryMetrics } from '../domains/factory/services/metrics';
-import { BOARD_STAGES, stageLabel, stageOrder } from '../domains/factory/stages';
+import { stageLabel } from '../domains/factory/stages';
 
 const DAY_MS = 86_400_000;
 const EMPTY_BOARD_LOOKBACK_DAYS = 90;
@@ -52,6 +50,7 @@ const THROUGHPUT_LEGEND_STYLE = { backgroundColor: THROUGHPUT_COLOR };
 const THROUGHPUT_SERIES: Array<MetricsBarChartSeries> = [
   { dataKey: 'done', label: 'Completed work', color: THROUGHPUT_COLOR, appearance: 'dotted' },
 ];
+const METRICS_PALETTE = ['var(--chart-1)', 'var(--chart-4)', 'var(--chart-3)', 'var(--chart-2)'] as const;
 const THROUGHPUT_AXIS_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
   day: 'numeric',
   month: 'short',
@@ -71,16 +70,12 @@ function formatThroughputDate(value: unknown, formatter: Intl.DateTimeFormat): s
   return Number.isNaN(timestamp) ? value : formatter.format(timestamp);
 }
 
-
 const SOURCE_LABELS: Record<string, string> = {
   'github:issue': 'GitHub issues',
   'github:pull-request': 'GitHub PRs',
   'linear:issue': 'Linear issues',
   manual: 'Manual',
 };
-
-/** Terminal stages have no "pass through", so they never get automation rows. */
-const TERMINAL_STAGE_IDS = new Set(['done', 'canceled']);
 
 const EM_DASH = '—';
 
@@ -119,7 +114,7 @@ function MetricsContent({ factoryProjectId }: { factoryProjectId: string | undef
   const bounds = getDateRangeBounds(earliestDay < range.from ? earliestDay : range.from, today);
 
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 pb-8">
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 pb-8">
       <MetricsSection
         title="Reporting period"
         description="Drag the range or use the date controls to compare a different window."
@@ -145,7 +140,7 @@ function MetricsContent({ factoryProjectId }: { factoryProjectId: string | undef
           <div className="grid items-start gap-8 xl:grid-cols-2">
             <MetricsSection
               title="Automation coverage"
-              description="Completed stage passes handled end to end by automation."
+              description="Completed stage passes handled end to end by automation. Select a stage bar to inspect its automated items."
             >
               <StageAutomation metrics={metrics} />
             </MetricsSection>
@@ -189,11 +184,7 @@ function useAgentsRunningCount(): number {
 
 function MetricsLoading() {
   return (
-    <div className="grid gap-5 border-t border-border1 pt-7" aria-label="Loading Factory metrics">
-      <div className="flex items-center justify-between gap-4">
-        <Skeleton className="h-4 w-32" />
-        <Skeleton className="h-6 w-16 rounded-full" />
-      </div>
+    <div className="grid gap-5" aria-label="Loading Factory metrics">
       <Skeleton className="h-64 w-full" />
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <Skeleton className="h-16 w-full" />
@@ -221,23 +212,12 @@ function FlowOverview({
     metrics.transitions.total === 0 ? EM_DASH : `${Math.round((automatedMoves / metrics.transitions.total) * 100)}%`;
 
   return (
-    <section className="flex flex-col gap-5 border-t border-border1 pt-7">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-col gap-1">
-          <Txt as="h2" variant="ui-md" className="m-0 font-medium text-icon6">
-            Delivery flow
-          </Txt>
-          <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
-            Completed work over time, with the Factory's current operating state.
-          </Txt>
-        </div>
-        <Badge size="sm">{windowDays}-day view</Badge>
-      </div>
-
-      <dl className="m-0 grid grid-cols-2 gap-x-5 gap-y-4 border-t border-border1 pt-4 lg:grid-cols-4 lg:gap-0 lg:divide-x lg:divide-border1">
+    <section className="flex flex-col gap-5">
+      <dl className="m-0 grid grid-cols-2 gap-x-5 gap-y-4 lg:grid-cols-4 lg:gap-0 lg:divide-x lg:divide-border1">
         <OverviewReadout
           icon={<Clock3 aria-hidden="true" />}
           label="Median cycle time"
+          tone={METRICS_PALETTE[0]}
           value={formatDuration(metrics.cycleTime.medianMs)}
           detail={
             metrics.cycleTime.p90Ms === null
@@ -248,23 +228,32 @@ function FlowOverview({
         <OverviewReadout
           icon={<Layers3 aria-hidden="true" />}
           label="In flight"
+          tone={METRICS_PALETTE[1]}
           value={String(metrics.wipTotal)}
           detail="Items in non-terminal stages"
         />
         <OverviewReadout
           icon={<Bot aria-hidden="true" />}
           label="Agents running"
+          tone={METRICS_PALETTE[2]}
           value={String(agentsRunning)}
           detail="Live across active worktrees"
         />
         <OverviewReadout
           icon={<Workflow aria-hidden="true" />}
           label="Automated moves"
+          tone={METRICS_PALETTE[3]}
           value={automationRate}
           detail={
-            metrics.transitions.total === 0
-              ? 'No stage moves in this window'
-              : `${automatedMoves} of ${metrics.transitions.total} stage moves`
+            metrics.transitions.total === 0 ? (
+              'No stage moves in this window'
+            ) : (
+              <OverviewProgressBadge
+                count={automatedMoves}
+                total={metrics.transitions.total}
+                label="stage moves automated"
+              />
+            )
           }
         />
       </dl>
@@ -307,23 +296,68 @@ function OverviewReadout({
   label,
   value,
   detail,
+  tone,
 }: {
   icon: ReactNode;
   label: string;
   value: string;
-  detail: string;
+  detail: ReactNode;
+  tone: string;
 }) {
   return (
     <div className="flex min-w-0 flex-col lg:px-4 lg:first:pl-0 lg:last:pr-0">
-      <dt className="flex items-center gap-1.5 text-ui-xs text-icon3 [&>svg]:size-3.5">
-        {icon}
+      <dt className="flex items-center gap-1.5 text-ui-xs text-icon3">
+        <span
+          className="grid size-5 shrink-0 place-items-center rounded-md bg-surface3 [&>svg]:size-3.5"
+          style={{ color: tone }}
+        >
+          {icon}
+        </span>
         {label}
       </dt>
       <dd className="m-0 mt-1 text-header-sm font-medium tabular-nums text-icon6">{value}</dd>
-      <Txt as="span" variant="ui-xs" className="mt-0.5 text-icon3">
-        {detail}
-      </Txt>
+      <div className="mt-1 flex min-h-6 items-center">
+        {typeof detail === 'string' ? (
+          <Txt as="span" variant="ui-xs" className="text-icon3">
+            {detail}
+          </Txt>
+        ) : (
+          detail
+        )}
+      </div>
     </div>
+  );
+}
+
+function OverviewProgressBadge({ count, total, label }: { count: number; total: number; label: string }) {
+  const circumference = 2 * Math.PI * 5;
+  const ratio = total === 0 ? 0 : Math.min(count / total, 1);
+  const dashOffset = circumference * (1 - ratio);
+
+  return (
+    <span
+      aria-label={`${count} of ${total} ${label}`}
+      title={`${count} of ${total} ${label}`}
+      className="flex h-6 w-fit shrink-0 items-center justify-center gap-1.5 rounded-full border border-border1 bg-surface2 px-2 text-ui-xs font-medium tabular-nums text-icon4"
+    >
+      <svg viewBox="0 0 14 14" className="size-3.5 -rotate-90" aria-hidden="true">
+        <circle cx="7" cy="7" r="5" fill="none" strokeWidth="2" className="stroke-border1" />
+        <circle
+          cx="7"
+          cy="7"
+          r="5"
+          fill="none"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          className="stroke-icon5 transition-[stroke-dashoffset] motion-reduce:transition-none"
+        />
+      </svg>
+      <span aria-hidden="true">
+        {count}/{total}
+      </span>
+    </span>
   );
 }
 
@@ -339,13 +373,13 @@ function MetricsSection({
   children: ReactNode;
 }) {
   return (
-    <section className="flex flex-col gap-4 border-t border-border1 pt-7">
+    <section className="flex flex-col gap-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-col gap-1">
+        <div className="flex max-w-2xl flex-col gap-1">
           <Txt as="h2" variant="ui-md" className="m-0 font-medium text-icon6">
             {title}
           </Txt>
-          <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
+          <Txt as="p" variant="ui-sm" className="m-0 text-pretty text-icon3">
             {description}
           </Txt>
         </div>
@@ -354,79 +388,6 @@ function MetricsSection({
       {children}
     </section>
   );
-}
-
-/**
- * Per-stage automation: what share of completed passes through each stage was
- * fully automated (entered and exited by automation, first visit), and how
- * the automated passes' items ended up.
- */
-function StageAutomation({ metrics }: { metrics: FactoryMetrics }) {
-  // Rows only exist for stages with ≥1 exit, so an empty list means no stage
-  // had a completed pass in the window.
-  if (metrics.stageAutomation.length === 0) {
-    return (
-      <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
-        No completed stage passes in this window yet.
-      </Txt>
-    );
-  }
-
-  const rowsByStage = new Map(metrics.stageAutomation.map(row => [row.stage, row]));
-  // Non-terminal board stages in column order, plus any stages present in the
-  // data but unknown to the board (raw id, sorted last — same rule as
-  // stageLabel/stageOrder).
-  const stageIds = new Set<string>();
-  for (const stage of BOARD_STAGES) {
-    if (!TERMINAL_STAGE_IDS.has(stage.id)) stageIds.add(stage.id);
-  }
-  for (const row of metrics.stageAutomation) {
-    stageIds.add(row.stage);
-  }
-  const stages = [...stageIds].sort((a, b) => stageOrder(a) - stageOrder(b));
-
-  return (
-    <ul className="m-0 flex list-none flex-col p-0">
-      {stages.map(stage => {
-        const row = rowsByStage.get(stage);
-        const exits = row?.exits ?? 0;
-        const automated = row?.automated ?? 0;
-        const pct = exits === 0 ? null : Math.round((automated / exits) * 100);
-        return (
-          <li key={stage} className="grid gap-1.5 border-b border-border1 py-3 first:pt-0 last:border-b-0 last:pb-0">
-            <div className="flex items-baseline justify-between gap-3">
-              <Txt as="span" variant="ui-sm" className="font-medium text-icon5">
-                {stageLabel(stage)}
-              </Txt>
-              <Txt as="span" variant="ui-xs" className="text-right tabular-nums text-icon3">
-                {pct === null ? 'No completed passes' : `${pct}% automated · ${automated}/${exits}`}
-              </Txt>
-            </div>
-            <div className="h-1.5 overflow-hidden rounded-full bg-surface4" aria-hidden="true">
-              {pct !== null && automated > 0 ? (
-                <div className="h-full rounded-full bg-accent1" style={{ width: `${Math.max(2, pct)}%` }} />
-              ) : null}
-            </div>
-            {row && automated > 0 ? (
-              <Txt as="span" variant="ui-xs" className="text-icon3">
-                Current outcomes: {outcomeSummary(row.outcomes)}
-              </Txt>
-            ) : null}
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
-
-/** Compact split of automated-pass outcomes, omitting zero buckets. */
-function outcomeSummary(outcomes: FactoryMetrics['stageAutomation'][number]['outcomes']): string {
-  const parts: string[] = [];
-  if (outcomes.done > 0) parts.push(`${outcomes.done} done`);
-  if (outcomes.canceled > 0) parts.push(`${outcomes.canceled} canceled`);
-  if (outcomes.reworked > 0) parts.push(`${outcomes.reworked} reworked`);
-  if (outcomes.inFlight > 0) parts.push(`${outcomes.inFlight} in flight`);
-  return parts.join(', ');
 }
 
 function AgingWipTable({ metrics }: { metrics: FactoryMetrics }) {
@@ -477,26 +438,43 @@ function SourceMix({ metrics }: { metrics: FactoryMetrics }) {
       </Txt>
     );
   }
+
+  const sources = metrics.sourceMix.map((entry, index) => ({
+    ...entry,
+    percentage: Math.round((entry.count / total) * 100),
+    color: METRICS_PALETTE[index % METRICS_PALETTE.length] ?? METRICS_PALETTE[0],
+  }));
+
   return (
-    <ul className="m-0 flex list-none flex-col gap-3 p-0">
-      {metrics.sourceMix.map(entry => {
-        const percentage = Math.round((entry.count / total) * 100);
-        return (
-          <li key={entry.source} className="grid gap-1.5">
-            <div className="flex items-baseline justify-between gap-3">
-              <Txt as="span" variant="ui-sm" className="font-medium text-icon5">
-                {SOURCE_LABELS[entry.source] ?? entry.source}
+    <div className="flex flex-col gap-4">
+      <div className="flex h-2.5 w-full gap-1" aria-hidden="true">
+        {sources.map(source => (
+          <span
+            key={source.source}
+            className="h-full min-w-1 basis-0 rounded-full"
+            style={{ flexGrow: source.count, backgroundColor: source.color }}
+          />
+        ))}
+      </div>
+      <ul className="m-0 flex list-none flex-col gap-2.5 p-0">
+        {sources.map(source => (
+          <li key={source.source} className="flex items-baseline justify-between gap-3">
+            <span className="flex min-w-0 items-center gap-2">
+              <span
+                className="size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: source.color }}
+                aria-hidden="true"
+              />
+              <Txt as="span" variant="ui-sm" className="truncate font-medium text-icon5">
+                {SOURCE_LABELS[source.source] ?? source.source}
               </Txt>
-              <Txt as="span" variant="ui-xs" className="tabular-nums text-icon3">
-                {entry.count} · {percentage}%
-              </Txt>
-            </div>
-            <div className="h-1.5 overflow-hidden rounded-full bg-surface4" aria-hidden="true">
-              <div className="h-full rounded-full bg-accent3" style={{ width: `${Math.max(2, percentage)}%` }} />
-            </div>
+            </span>
+            <Txt as="span" variant="ui-xs" className="shrink-0 tabular-nums text-icon3">
+              {source.count} · {source.percentage}%
+            </Txt>
           </li>
-        );
-      })}
-    </ul>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/packages/playground-ui/src/ds/components/MetricsBarChart/index.ts
+++ b/packages/playground-ui/src/ds/components/MetricsBarChart/index.ts
@@ -1,0 +1,6 @@
+export {
+  MetricsBarChart,
+  type MetricsBarChartProps,
+  type MetricsBarChartSeries,
+} from './metrics-bar-chart';
+export { MetricsBarChartTooltip } from './metrics-bar-chart-tooltip';

--- a/packages/playground-ui/src/ds/components/MetricsBarChart/metrics-bar-chart-tooltip.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsBarChart/metrics-bar-chart-tooltip.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react';
+
+type MetricsBarChartTooltipEntry = {
+  color?: string;
+  dataKey?: string | number;
+  fill?: string;
+  name?: string | number;
+  value?: string | number;
+};
+
+export function MetricsBarChartTooltip({
+  active,
+  payload,
+  label,
+  labelFormatter,
+}: {
+  active?: boolean;
+  payload?: Array<MetricsBarChartTooltipEntry>;
+  label?: unknown;
+  labelFormatter?: (value: unknown) => ReactNode;
+}) {
+  if (!active || !payload?.length) return null;
+
+  const formattedLabel = labelFormatter?.(label) ?? String(label ?? '');
+
+  return (
+    <div className="min-w-32 rounded-md border border-border2 bg-surface3 px-2.5 py-2 text-ui-xs">
+      <p className="mb-1 font-medium text-icon6">{formattedLabel}</p>
+      {payload.map(entry => {
+        if (entry.value === undefined) return null;
+
+        const entryKey = String(entry.dataKey ?? entry.name ?? 'value');
+        const entryName = String(entry.name ?? entry.dataKey ?? 'Value');
+        const entryValue = typeof entry.value === 'number' ? entry.value.toLocaleString() : entry.value;
+
+        return (
+          <p key={entryKey} className="flex items-center justify-between gap-3 text-icon3">
+            <span className="inline-flex items-center gap-2">
+              <span
+                aria-hidden="true"
+                className="size-2 shrink-0 rounded-sm"
+                style={{ backgroundColor: entry.color ?? entry.fill }}
+              />
+              {entryName}
+            </span>
+            <span className="font-medium tabular-nums text-icon6">{entryValue}</span>
+          </p>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/playground-ui/src/ds/components/MetricsBarChart/metrics-bar-chart.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsBarChart/metrics-bar-chart.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { MetricsBarChart, type MetricsBarChartSeries } from './metrics-bar-chart';
+
+const data = [
+  { time: '2026-07-10', done: 2 },
+  { time: '2026-07-11', done: 4 },
+  { time: '2026-07-12', done: 1 },
+  { time: '2026-07-13', done: 6 },
+  { time: '2026-07-14', done: 3 },
+  { time: '2026-07-15', done: 8 },
+  { time: '2026-07-16', done: 5 },
+  { time: '2026-07-17', done: 7 },
+  { time: '2026-07-18', done: 4 },
+  { time: '2026-07-19', done: 9 },
+  { time: '2026-07-20', done: 6 },
+  { time: '2026-07-21', done: 10 },
+  { time: '2026-07-22', done: 7 },
+  { time: '2026-07-23', done: 12 },
+];
+const series: Array<MetricsBarChartSeries> = [
+  {
+    dataKey: 'done',
+    label: 'Completed work',
+    color: 'oklch(from var(--accent1) l calc(c * 0.72) h)',
+    appearance: 'dotted',
+  },
+];
+const AXIS_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  day: 'numeric',
+  month: 'short',
+  timeZone: 'UTC',
+});
+const TOOLTIP_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+function formatDate(value: unknown, formatter: Intl.DateTimeFormat): string {
+  if (typeof value !== 'string') return String(value ?? '');
+
+  const timestamp = Date.parse(`${value}T00:00:00.000Z`);
+  return Number.isNaN(timestamp) ? value : formatter.format(timestamp);
+}
+
+const meta: Meta<typeof MetricsBarChart> = {
+  title: 'Metrics/MetricsBarChart',
+  component: MetricsBarChart,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MetricsBarChart>;
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ width: '48rem' }}>
+      <MetricsBarChart
+        data={data}
+        series={series}
+        description="Daily completed work for the selected reporting period."
+        height={240}
+        xAxisInterval="preserveStartEnd"
+        xAxisMinTickGap={40}
+        xAxisTickFormatter={value => formatDate(value, AXIS_DATE_FORMATTER)}
+        tooltipLabelFormatter={value => formatDate(value, TOOLTIP_DATE_FORMATTER)}
+      />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/MetricsBarChart/metrics-bar-chart.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsBarChart/metrics-bar-chart.tsx
@@ -1,0 +1,112 @@
+import { useId, type ReactNode } from 'react';
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+
+import { MetricsBarChartTooltip } from './metrics-bar-chart-tooltip';
+
+const AXIS_TICK_STYLE = {
+  fill: 'var(--neutral3)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+};
+const BAR_RADIUS: [number, number, number, number] = [4, 4, 4, 4];
+const ACTIVE_BAR_STYLE = { fillOpacity: 1 };
+const BAR_FILL_OPACITY = 0.78;
+const CHART_MARGIN = { left: 0, right: 8 };
+const TOOLTIP_CURSOR = { fill: 'var(--surface4)', opacity: 0.55 };
+
+export type MetricsBarChartSeries = {
+  dataKey: string;
+  label: string;
+  color: string;
+  appearance?: 'solid' | 'dotted';
+};
+
+export type MetricsBarChartProps = {
+  data: Array<Record<string, unknown>>;
+  series: Array<MetricsBarChartSeries>;
+  description?: string;
+  height?: number;
+  xAxisDataKey?: string;
+  xAxisInterval?: number | 'preserveStart' | 'preserveEnd' | 'preserveStartEnd';
+  xAxisMinTickGap?: number;
+  xAxisTickFormatter?: (value: unknown, index: number) => string;
+  tooltipLabelFormatter?: (value: unknown) => ReactNode;
+};
+
+/**
+ * Responsive metric bars with the shared Playground chart palette, axes, and tooltip.
+ * Recharts stays encapsulated so consumers do not need their own chart dependency.
+ */
+export function MetricsBarChart({
+  data,
+  series,
+  description,
+  height = 210,
+  xAxisDataKey = 'time',
+  xAxisInterval = 5,
+  xAxisMinTickGap,
+  xAxisTickFormatter,
+  tooltipLabelFormatter,
+}: MetricsBarChartProps) {
+  const patternPrefix = useId().replaceAll(':', '');
+
+  return (
+    <div className="min-w-0 [&_.recharts-surface]:outline-none" style={{ height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart accessibilityLayer data={data} desc={description} margin={CHART_MARGIN}>
+          <defs>
+            {series.map(item =>
+              item.appearance === 'dotted' ? (
+                <pattern
+                  key={item.dataKey}
+                  id={`${patternPrefix}-${item.dataKey}`}
+                  x="0"
+                  y="0"
+                  width="5"
+                  height="5"
+                  patternUnits="userSpaceOnUse"
+                >
+                  <rect width="5" height="5" fill={item.color} opacity="0.08" />
+                  <circle cx="2.5" cy="2.5" r="1" fill={item.color} opacity="0.58" />
+                </pattern>
+              ) : null,
+            )}
+          </defs>
+          <XAxis
+            dataKey={xAxisDataKey}
+            tick={AXIS_TICK_STYLE}
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            interval={xAxisInterval}
+            minTickGap={xAxisMinTickGap}
+            tickFormatter={xAxisTickFormatter}
+          />
+          <YAxis
+            tick={AXIS_TICK_STYLE}
+            tickLine={false}
+            axisLine={false}
+            allowDecimals={false}
+            width={30}
+          />
+          <Tooltip cursor={TOOLTIP_CURSOR} content={<MetricsBarChartTooltip labelFormatter={tooltipLabelFormatter} />} />
+          {series.map(item => (
+            <Bar
+              key={item.dataKey}
+              dataKey={item.dataKey}
+              name={item.label}
+              fill={item.appearance === 'dotted' ? `url(#${patternPrefix}-${item.dataKey})` : item.color}
+              fillOpacity={BAR_FILL_OPACITY}
+              activeBar={ACTIVE_BAR_STYLE}
+              stroke={item.appearance === 'dotted' ? item.color : undefined}
+              strokeWidth={item.appearance === 'dotted' ? 1 : undefined}
+              radius={BAR_RADIUS}
+              maxBarSize={24}
+              isAnimationActive={false}
+            />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
Redesigns the Factory Metrics page into a cleaner operational dashboard with progressive detail instead of persistent legends and dense explanatory rows.

**Metrics page**

- Removes duplicate framing, section dividers, and compensating padding in favor of consistent 48px section rhythm.
- Presents cycle time, in-flight work, running agents, and automated moves as compact overview readouts.
- Uses a circular ratio badge for automated stage moves.
- Adds the reusable `MetricsBarChart` for responsive, accessible daily throughput with themed dotted bars and formatted tooltips.

**Queue health**

- Replaces the dense per-stage graph and permanent age legend with a card-style current total, one aggregate age-distribution bar, and compact stage totals.
- Reveals age thresholds, counts, active work, and per-stage bucket breakdowns on hover or keyboard focus.
- Lets users select an age segment to inspect its underlying tasks.
- Classifies multi-stage work by its oldest current-stage age so aggregate segments match the unique task total.

**Automation coverage**

- Keeps the resting view to stage, percentage, and progress.
- Moves completed-pass counts and outcome summaries into hover/focus details.
- Extends the Factory metrics endpoint with `stageAutomation[].automatedItems`, allowing stage selection to list the concrete automated items, source links, and outcomes with reworked items first.

```tsx
<MetricsBarChart
  data={points}
  series={[{ dataKey: 'done', label: 'Completed work', color, appearance: 'dotted' }]}
/>
```

**Verification**

Verified from a clean detached worktree at the PR head:

- Playground UI typecheck passed.
- Factory dependency-graph build and typecheck passed.
- Factory metrics tests passed: 2 files, 80 tests.
- MastraCode UI typecheck passed.
- Queue health and automation component tests passed: 2 files, 11 tests.
- MastraCode production UI build passed.
- Browser-verified the final aggregate queue graph and its bucket, stage, and automation hover details.
- React Doctor reported no findings in the changed metrics components; its only remaining warning in that directory is pre-existing in `FactoryItemActions.tsx`.