### PR TITLE
fix(mastracode): use ghost button for PR links

### DIFF
--- a/mastracode/web/src/web/ui/domains/chat/components/StatusLine/PullRequestLinks.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/StatusLine/PullRequestLinks.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@mastra/playground-ui/components/Button';
 import { useQuery } from '@tanstack/react-query';
 import { CircleDot, CircleX, GitMerge } from 'lucide-react';
 import { useEffect, useRef } from 'react';
@@ -23,10 +24,10 @@ function PullRequestIcon({ status }: { status: PullRequestSubscription['status']
   return <CircleDot size={13} aria-hidden />;
 }
 
-function statusColor(status: PullRequestSubscription['status']): string {
-  if (status === 'merged') return 'text-accent3 hover:text-accent3';
-  if (status === 'closed') return 'text-error hover:text-error';
-  return 'text-accent1 hover:text-accent1';
+function statusHoverColor(status: PullRequestSubscription['status']): string {
+  if (status === 'merged') return 'group-hover:text-accent3';
+  if (status === 'closed') return 'group-hover:text-error';
+  return 'group-hover:text-accent1';
 }
 
 interface PullRequestLinksProps {
@@ -131,16 +132,20 @@ export function PullRequestLinks({
   return (
     <div className="ml-auto flex items-center gap-2">
       {links.map(subscription => (
-        <a
+        <Button
           key={subscription.id}
+          as="a"
+          variant="ghost"
+          size="xs"
           href={subscription.url}
           target="_blank"
           rel="noreferrer"
-          className={`inline-flex items-center gap-1 ${statusColor(subscription.status)}`}
+          className="group"
           aria-label={`Open ${subscription.status} ${subscription.repoFullName} pull request ${subscription.pullRequestNumber}`}
         >
-          <PullRequestIcon status={subscription.status} /> PR #{subscription.pullRequestNumber}
-        </a>
+          <PullRequestIcon status={subscription.status} />
+          <span className={statusHoverColor(subscription.status)}>PR #{subscription.pullRequestNumber}</span>
+        </Button>
       ))}
     </div>
   );

--- a/mastracode/web/src/web/ui/domains/chat/components/StatusLine/PullRequestLinks.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/StatusLine/PullRequestLinks.tsx
@@ -24,10 +24,10 @@ function PullRequestIcon({ status }: { status: PullRequestSubscription['status']
   return <CircleDot size={13} aria-hidden />;
 }
 
-function statusHoverColor(status: PullRequestSubscription['status']): string {
-  if (status === 'merged') return 'group-hover:text-accent3';
-  if (status === 'closed') return 'group-hover:text-error';
-  return 'group-hover:text-accent1';
+function statusColor(status: PullRequestSubscription['status']): string {
+  if (status === 'merged') return 'text-accent3';
+  if (status === 'closed') return 'text-error';
+  return 'text-accent1';
 }
 
 interface PullRequestLinksProps {
@@ -140,11 +140,10 @@ export function PullRequestLinks({
           href={subscription.url}
           target="_blank"
           rel="noreferrer"
-          className="group"
           aria-label={`Open ${subscription.status} ${subscription.repoFullName} pull request ${subscription.pullRequestNumber}`}
         >
           <PullRequestIcon status={subscription.status} />
-          <span className={statusHoverColor(subscription.status)}>PR #{subscription.pullRequestNumber}</span>
+          <span className={statusColor(subscription.status)}>PR #{subscription.pullRequestNumber}</span>
         </Button>
       ))}
     </div>


### PR DESCRIPTION
Uses the shared ghost Button for pull request links in the chat status line. The PR label keeps its open, closed, or merged color by default while the control retains the standard ghost behavior.

Verified with `pnpm check:ui`, Prettier, `git diff --check`, and changed-scope React Doctor (92/100, no changed-scope issues).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Pull request links in the chat now use the app’s standard button style, while still showing whether each pull request is open, closed, or merged.

## Changes

- Replaced raw pull request links with the shared ghost `Button` component.
- Preserved status colors in all states, not just on hover.
- Kept extra-small sizing and anchor behavior.

## Verification

- `pnpm check:ui`
- Prettier
- `git diff --check`
- Changed-scope React Doctor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->