### PR TITLE
Collapse empty Factory board columns

### DIFF
--- a/mastracode/web/src/web/ui/__tests__/BoardPageLoading.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/BoardPageLoading.msw.test.tsx
@@ -116,13 +116,13 @@ describe('Board loading states', () => {
     expect(screen.queryByLabelText(/visible board tasks in Planning/)).not.toBeInTheDocument();
 
     // Phase 2: work items resolved, intake/triage feeds still resolving —
-    // non-intake columns settle into their content while intake keeps its
-    // column skeleton.
+    // settled empty workflow columns collapse while intake keeps its column
+    // skeleton.
     workItemsGate.resolve();
     const planning = screen.getByTestId('board-column-planning');
-    await waitFor(() => expect(within(planning).getByText('Nothing in planning')).toBeInTheDocument());
+    await waitFor(() => expect(planning).toHaveAccessibleName('Planning, empty'));
     expect(within(planning).queryByRole('status')).not.toBeInTheDocument();
-    expect(screen.getByLabelText('0 of 0 visible board tasks in Planning')).toBeInTheDocument();
+    expect(within(planning).queryByText('Nothing in planning')).not.toBeInTheDocument();
     const intake = screen.getByTestId('board-column-intake');
     within(intake).getByRole('status', { name: 'Loading Intake column' });
     const triage = screen.getByTestId('board-column-triage');

--- a/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -3,7 +3,7 @@
  * card must announce where it is going ("Moving to Planning…") instead of
  * silently waiting, and drop the status once the server answers.
  */
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { delay, http, HttpResponse } from 'msw';
 import { createMemoryRouter, matchRoutes, RouterProvider } from 'react-router';
@@ -218,5 +218,26 @@ describe('Board card pending states', () => {
 
     expect(transitionRequests).toEqual([]);
     expect(currentColumn).toContainElement(card);
+  });
+
+  it('moves a card when it is dropped into a collapsed empty column', async () => {
+    const { transitionGate, transitionRequests } = stubBoardEndpoints();
+    renderWorkBoard();
+
+    const card = await screen.findByTestId('work-item-card');
+    const planningColumn = screen.getByTestId('board-column-planning');
+    expect(planningColumn).toHaveAccessibleName('Planning, empty');
+    const dataTransfer = createDataTransfer();
+
+    fireEvent.dragStart(card, { dataTransfer });
+    fireEvent.dragOver(planningColumn, { dataTransfer });
+    expect(dataTransfer.dropEffect).toBe('move');
+    fireEvent.drop(planningColumn, { dataTransfer });
+
+    await waitFor(() => expect(transitionRequests).toEqual([ITEM_ID]));
+    expect(within(planningColumn).getByTestId('work-item-card')).toHaveTextContent('Fix login bug');
+
+    transitionGate.resolve();
+    await waitFor(() => expect(screen.queryByText('Moving to Planning…')).not.toBeInTheDocument());
   });
 });

--- a/mastracode/web/src/web/ui/pages/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/pages/BoardPage.tsx
@@ -1160,13 +1160,18 @@ function BoardColumn({
   const [dragOver, setDragOver] = useState(false);
   const [dropLineTop, setDropLineTop] = useState(0);
   const cardListRef = useRef<HTMLDivElement>(null);
+  const collapsed = stage !== 'intake' && !loading && taskCount === 0;
 
   return (
     <section
       ref={laneRef}
-      aria-label={label}
+      aria-label={collapsed ? `${label}, empty` : label}
       data-testid={`board-column-${stage}`}
-      className="flex min-h-0 w-80 shrink-0 flex-col gap-4"
+      className={cn(
+        'flex min-h-0 shrink-0 flex-col transition-[width,background-color] motion-reduce:transition-none',
+        collapsed ? 'w-14 rounded-lg' : 'w-80 gap-4',
+        collapsed && dragOver && 'bg-surface2 ring-1 ring-border1',
+      )}
       onDragOver={event => {
         if (!event.dataTransfer.types.includes(CARD_MIME)) return;
         event.preventDefault();
@@ -1186,37 +1191,50 @@ function BoardColumn({
         if (payload) onDrop(payload, stage);
       }}
     >
-      <div className="flex min-h-8 items-start justify-between gap-2">
-        <div className="flex h-8 min-w-0 items-center gap-2">
-          <BoardStageIcon stage={stage} />
-          <Txt as="h2" variant="ui-smd" className="m-0 truncate font-semibold text-icon3">
+      {collapsed ? (
+        <div className="flex min-h-0 flex-1 flex-col items-center gap-3 py-1">
+          <span aria-hidden className="flex h-8 items-center text-ui-xs font-medium tabular-nums text-icon3">
+            {taskCount}
+          </span>
+          <Txt as="h2" variant="ui-smd" className="m-0 font-semibold text-icon3 [writing-mode:vertical-rl]">
             {label}
           </Txt>
-          {loading ? (
-            <Skeleton className="h-6 w-12 shrink-0 rounded-full" />
-          ) : (
-            <ColumnTaskBadge count={taskCount} total={totalTaskCount} label={label} />
-          )}
         </div>
-        {headerAction && <div className="flex h-8 shrink-0 items-center">{headerAction}</div>}
-      </div>
-      {headerExtras}
-      {/* Cards scroll inside the swimlane; the page stays fixed. */}
-      <div className="min-h-16 flex-1">
-        <ScrollArea className="h-full">
-          <div ref={cardListRef} className="relative flex flex-col gap-2.5 pb-2">
-            {children}
-            <div
-              aria-hidden
-              style={{ top: dropLineTop }}
-              className={cn(
-                'pointer-events-none absolute inset-x-0 z-10 h-0.5 rounded-full bg-neutral1 transition-opacity motion-reduce:transition-none',
-                dragOver ? 'opacity-100' : 'opacity-0',
+      ) : (
+        <>
+          <div className="flex min-h-8 items-start justify-between gap-2">
+            <div className="flex h-8 min-w-0 items-center gap-2">
+              <BoardStageIcon stage={stage} />
+              <Txt as="h2" variant="ui-smd" className="m-0 truncate font-semibold text-icon3">
+                {label}
+              </Txt>
+              {loading ? (
+                <Skeleton className="h-6 w-12 shrink-0 rounded-full" />
+              ) : (
+                <ColumnTaskBadge count={taskCount} total={totalTaskCount} label={label} />
               )}
-            />
+            </div>
+            {headerAction && <div className="flex h-8 shrink-0 items-center">{headerAction}</div>}
           </div>
-        </ScrollArea>
-      </div>
+          {headerExtras}
+          {/* Cards scroll inside the swimlane; the page stays fixed. */}
+          <div className="min-h-16 flex-1">
+            <ScrollArea className="h-full">
+              <div ref={cardListRef} className="relative flex flex-col gap-2.5 pb-2">
+                {children}
+                <div
+                  aria-hidden
+                  style={{ top: dropLineTop }}
+                  className={cn(
+                    'pointer-events-none absolute inset-x-0 z-10 h-0.5 rounded-full bg-neutral1 transition-opacity motion-reduce:transition-none',
+                    dragOver ? 'opacity-100' : 'opacity-0',
+                  )}
+                />
+              </div>
+            </ScrollArea>
+          </div>
+        </>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
Collapses settled empty workflow columns into compact vertical rails while keeping Intake expanded for source controls. The entire rail remains a drop target and gains clear drag-over feedback.

Verification:
- MastraCode web UI typecheck
- Focused board MSW tests: 5 passed
- React Doctor changed scope: no issues
- Browser drag from Triage into collapsed Planning: Planning expanded, Triage collapsed, with no console errors or horizontal overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Empty board columns now fold into slim vertical rails to save space, while still accepting dragged work items. The Intake column stays open for source controls.

## Summary

- Collapsed settled, empty non-Intake workflow columns into compact vertical rails.
- Preserved full-height drop targets, drag-over feedback, and drop-line indicators.
- Added coverage for dragging an item into collapsed Planning and completing the move.
- Updated loading-state tests to verify the collapsed empty Planning state.
- Verification passed: web UI typechecking, five focused MSW tests, React Doctor, and browser drag testing without console errors or horizontal overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->