### PR TITLE
fix(factory): reduce GitHub event polling frequency

### DIFF
--- a/.changeset/cyan-aliens-care.md
+++ b/.changeset/cyan-aliens-care.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Improved Platform GitHub event polling efficiency and added event-count logging for each poll.
+Improved Platform GitHub event polling efficiency and added event-count and latency logging for each poll.

--- a/.changeset/cyan-aliens-care.md
+++ b/.changeset/cyan-aliens-care.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved Platform GitHub event polling efficiency and added event-count logging for each poll.

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -280,6 +280,7 @@ export class PlatformGithubEventWorker extends MastraWorker {
       if ('afterEventId' in cursor) query.set('afterEventId', cursor.afterEventId);
       else query.set('afterTimestamp', String(cursor.afterTimestamp));
 
+      const pollStartedAt = performance.now();
       const page = await this.#client.request<{ events: EventLogEntry[]; nextCursor: string | null }>(
         'GET',
         `${API_PREFIX}/repositories/${repositoryId}/events?${query}`,
@@ -287,6 +288,7 @@ export class PlatformGithubEventWorker extends MastraWorker {
       this.deps?.logger.info('Platform GitHub repository event poll completed', {
         repositoryId,
         eventCount: page.events.length,
+        latencyMs: Math.round(performance.now() - pollStartedAt),
       });
       if (page.events.length === 0 || !page.nextCursor) return;
 

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -16,7 +16,7 @@ import type { PlatformApiClient } from '../api-client.js';
 import { PlatformApiError } from '../api-client.js';
 
 const API_PREFIX = '/v1/server/github-app';
-const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_POLL_INTERVAL_MS = 20_000;
 const EVENT_PAGE_SIZE = 500;
 const MIN_LEASE_TTL_MS = 30_000;
 const CURSOR_ORG_ID = '__platform_github_event_worker__';
@@ -284,6 +284,10 @@ export class PlatformGithubEventWorker extends MastraWorker {
         'GET',
         `${API_PREFIX}/repositories/${repositoryId}/events?${query}`,
       );
+      this.deps?.logger.info('Platform GitHub repository event poll completed', {
+        repositoryId,
+        eventCount: page.events.length,
+      });
       if (page.events.length === 0 || !page.nextCursor) return;
 
       for (const event of page.events) {


### PR DESCRIPTION
Platform GitHub event workers now poll every 20 seconds by default instead of every 5 seconds. Each repository poll also logs the repository ID and number of events returned, including zero-event polls.

Validated with ESLint on the changed worker and `git diff --check`. Focused tests and package typechecking are currently blocked in this fresh worktree by unresolved workspace build artifacts and an existing TypeScript 6 deprecation failure in `@internal/llm-recorder`.