### PR TITLE
Unify sidebar session rows, keep the shell mounted while loading, and add per-row open feedback

### DIFF
--- a/mastracode/web/src/web/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -1,0 +1,91 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
+import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
+import { GitBranch, MoreHorizontal, Trash2 } from 'lucide-react';
+
+/**
+ * Shared sidebar row for workspace/user sessions. Built on `MainSidebar.NavLink`
+ * so every session list (work, review, user) renders with identical density,
+ * hover, and active states. The optional status dot (agent running/finished)
+ * hides on hover so the actions menu can take its place.
+ */
+export function SessionNavRow({
+  name,
+  title,
+  url,
+  active,
+  disabled,
+  status,
+  onSelect,
+  onDelete,
+}: {
+  name: string;
+  /** Hover tooltip, typically the branch name. */
+  title: string;
+  url: string;
+  active: boolean;
+  disabled: boolean;
+  status?: 'running' | 'attention';
+  onSelect: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <MainSidebar.NavLink
+      link={{ name, url }}
+      isActive={active}
+      className="group/session"
+      render={
+        <button
+          type="button"
+          aria-current={active ? 'page' : undefined}
+          aria-label={name}
+          disabled={disabled}
+          onClick={onSelect}
+          title={title}
+        >
+          <GitBranch />
+          <MainSidebar.NavLabel>{name}</MainSidebar.NavLabel>
+          {status === 'running' ? (
+            <span
+              role="status"
+              aria-label={`Agent working in ${name}`}
+              title="Agent working"
+              className="ml-auto size-2 shrink-0 animate-pulse rounded-full bg-accent1 group-hover/session:opacity-0"
+            />
+          ) : status === 'attention' ? (
+            <span
+              role="status"
+              aria-label={`Agent finished in ${name}`}
+              title="Agent finished — open to dismiss"
+              className="ml-auto size-2 shrink-0 rounded-full bg-accent1 group-hover/session:opacity-0"
+            />
+          ) : null}
+        </button>
+      }
+      action={
+        <DropdownMenu>
+          <DropdownMenu.Trigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`Session actions for ${name}`}
+                disabled={disabled}
+                className="opacity-0 group-hover/session:opacity-100 group-focus-within/session:opacity-100 data-[popup-open]:opacity-100"
+              >
+                <MoreHorizontal />
+              </Button>
+            }
+          />
+          <DropdownMenu.Content align="end" className="min-w-28">
+            <DropdownMenu.Item variant="destructive" onClick={onDelete}>
+              <Trash2 />
+              Delete
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      }
+    />
+  );
+}

--- a/mastracode/web/src/web/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
+import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { GitBranch, MoreHorizontal, Trash2 } from 'lucide-react';
 
 /**
@@ -15,6 +16,7 @@ export function SessionNavRow({
   url,
   active,
   disabled,
+  loading,
   status,
   onSelect,
   onDelete,
@@ -25,6 +27,8 @@ export function SessionNavRow({
   url: string;
   active: boolean;
   disabled: boolean;
+  /** True while this row's async open is in flight — shows a spinner and blocks clicks. */
+  loading?: boolean;
   status?: 'running' | 'attention';
   onSelect: () => void;
   onDelete: () => void;
@@ -39,13 +43,15 @@ export function SessionNavRow({
           type="button"
           aria-current={active ? 'page' : undefined}
           aria-label={name}
-          disabled={disabled}
+          disabled={disabled || loading}
           onClick={onSelect}
           title={title}
         >
           <GitBranch />
           <MainSidebar.NavLabel>{name}</MainSidebar.NavLabel>
-          {status === 'running' ? (
+          {loading ? (
+            <Spinner size="sm" aria-label={`Opening ${name}`} className="ml-auto shrink-0 text-icon3" />
+          ) : status === 'running' ? (
             <span
               role="status"
               aria-label={`Agent working in ${name}`}
@@ -63,28 +69,30 @@ export function SessionNavRow({
         </button>
       }
       action={
-        <DropdownMenu>
-          <DropdownMenu.Trigger
-            render={
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                aria-label={`Session actions for ${name}`}
-                disabled={disabled}
-                className="opacity-0 group-hover/session:opacity-100 group-focus-within/session:opacity-100 data-[popup-open]:opacity-100"
-              >
-                <MoreHorizontal />
-              </Button>
-            }
-          />
-          <DropdownMenu.Content align="end" className="min-w-28">
-            <DropdownMenu.Item variant="destructive" onClick={onDelete}>
-              <Trash2 />
-              Delete
-            </DropdownMenu.Item>
-          </DropdownMenu.Content>
-        </DropdownMenu>
+        loading ? undefined : (
+          <DropdownMenu>
+            <DropdownMenu.Trigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={`Session actions for ${name}`}
+                  disabled={disabled}
+                  className="opacity-0 group-hover/session:opacity-100 group-focus-within/session:opacity-100 data-[popup-open]:opacity-100"
+                >
+                  <MoreHorizontal />
+                </Button>
+              }
+            />
+            <DropdownMenu.Content align="end" className="min-w-28">
+              <DropdownMenu.Item variant="destructive" onClick={onDelete}>
+                <Trash2 />
+                Delete
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu>
+        )
       }
     />
   );

--- a/mastracode/web/src/web/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -1,14 +1,13 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@mastra/playground-ui/components/Dialog';
-import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { toast } from '@mastra/playground-ui/components/Toaster';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { GitBranch, MoreHorizontal, Plus, Trash2 } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { useState } from 'react';
-import type { FormEvent, KeyboardEvent } from 'react';
+import type { FormEvent } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 
 import { useApiConfig } from '../../../../../shared/api/config';
@@ -20,6 +19,7 @@ import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 import { USER_SESSION_BRANCH_PREFIX } from '../services/github';
 import type { FactoryUserSession } from '../services/github';
 import { createUserSession, deleteUserSession } from '../services/github';
+import { SessionNavRow } from './SessionNavRow';
 
 function sessionLabel(session: FactoryUserSession): string {
   return session.branch.startsWith(USER_SESSION_BRANCH_PREFIX)
@@ -125,20 +125,14 @@ export function UserSessionsSection() {
     }
   };
 
-  const resetCreate = () => {
+  const closeCreateDialog = () => {
     setCreating(false);
     setName('');
+    createSession.reset();
   };
   const submitCreate = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (name.trim()) createSession.mutate(name);
-  };
-  const onCreateKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Escape') resetCreate();
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      if (name.trim()) createSession.mutate(name);
-    }
   };
 
   return (
@@ -147,13 +141,7 @@ export function UserSessionsSection() {
         <Txt as="span" variant="ui-xs" className="text-icon3 uppercase tracking-wide">
           User Sessions
         </Txt>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          aria-label="New user session"
-          onClick={() => setCreating(true)}
-          disabled={creating || pending}
-        >
+        <Button variant="ghost" size="icon-sm" aria-label="New user session" onClick={() => setCreating(true)} disabled={pending}>
           <Plus size={15} />
         </Button>
       </div>
@@ -166,78 +154,58 @@ export function UserSessionsSection() {
             const active = location.pathname === url;
 
             return (
-              <MainSidebar.NavLink
+              <SessionNavRow
                 key={session.sessionId}
-                link={{ name, url }}
-                isActive={active}
-                className="group/session"
-                render={
-                  <button
-                    type="button"
-                    aria-current={active ? 'page' : undefined}
-                    aria-label={name}
-                    disabled={pending}
-                    onClick={() => void openSession(session)}
-                    title={session.branch}
-                  >
-                    <GitBranch />
-                    <MainSidebar.NavLabel>{name}</MainSidebar.NavLabel>
-                  </button>
-                }
-                action={
-                  <DropdownMenu>
-                    <DropdownMenu.Trigger
-                      render={
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-sm"
-                          aria-label={`Session actions for ${name}`}
-                          disabled={pending}
-                          className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover/session:opacity-100 group-focus-within/session:opacity-100 data-[popup-open]:opacity-100"
-                        >
-                          <MoreHorizontal />
-                        </Button>
-                      }
-                    />
-                    <DropdownMenu.Content align="end" className="min-w-28">
-                      <DropdownMenu.Item variant="destructive" onClick={() => setConfirmDelete(session)}>
-                        <Trash2 />
-                        Delete
-                      </DropdownMenu.Item>
-                    </DropdownMenu.Content>
-                  </DropdownMenu>
-                }
+                name={name}
+                title={session.branch}
+                url={url}
+                active={active}
+                disabled={pending}
+                onSelect={() => void openSession(session)}
+                onDelete={() => setConfirmDelete(session)}
               />
             );
           })}
         </MainSidebar.NavList>
-        {sessions.length === 0 && !creating && (
+        {sessions.length === 0 && (
           <Txt as="p" variant="ui-xs" className="m-0 px-2 py-1 text-icon3">
             No sessions yet
           </Txt>
         )}
-
-        {creating && (
-          <form aria-label="Create user session" className="flex flex-col gap-1" onSubmit={submitCreate}>
-            <Input
-              aria-label="Session name"
-              autoFocus
-              value={name}
-              onChange={event => setName(event.target.value)}
-              onKeyDown={onCreateKeyDown}
-              placeholder="session-name"
-              disabled={createSession.isPending}
-              className="h-8 text-xs"
-            />
-            {createSession.error && (
-              <Txt as="p" variant="ui-xs" className="m-0 text-red-400">
-                {createSession.error instanceof Error ? createSession.error.message : 'Failed to create session'}
-              </Txt>
-            )}
-          </form>
-        )}
       </div>
+
+      {creating && (
+        <Dialog open onOpenChange={open => !open && closeCreateDialog()}>
+          <DialogContent className="w-full max-w-sm" aria-label="New user session">
+            <DialogHeader className="px-5 pt-4 pb-2">
+              <DialogTitle>New user session</DialogTitle>
+            </DialogHeader>
+            <form aria-label="Create user session" className="flex flex-col gap-4 px-5 pb-4" onSubmit={submitCreate}>
+              <Input
+                aria-label="Session name"
+                autoFocus
+                value={name}
+                onChange={event => setName(event.target.value)}
+                placeholder="session-name"
+                disabled={createSession.isPending}
+              />
+              {createSession.error && (
+                <Txt as="p" variant="ui-xs" className="m-0 text-red-400">
+                  {createSession.error instanceof Error ? createSession.error.message : 'Failed to create session'}
+                </Txt>
+              )}
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="ghost" onClick={closeCreateDialog} disabled={createSession.isPending}>
+                  Cancel
+                </Button>
+                <Button type="submit" variant="primary" disabled={createSession.isPending || !name.trim()}>
+                  {createSession.isPending ? 'Creating…' : 'Create'}
+                </Button>
+              </div>
+            </form>
+          </DialogContent>
+        </Dialog>
+      )}
 
       {confirmDelete && (
         <Dialog open onOpenChange={open => !open && setConfirmDelete(null)}>

--- a/mastracode/web/src/web/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -146,7 +146,13 @@ export function UserSessionsSection() {
         <Txt as="span" variant="ui-xs" className="text-icon3 uppercase tracking-wide">
           User Sessions
         </Txt>
-        <Button variant="ghost" size="icon-sm" aria-label="New user session" onClick={() => setCreating(true)} disabled={pending}>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="New user session"
+          onClick={() => setCreating(true)}
+          disabled={pending}
+        >
           <Plus size={15} />
         </Button>
       </div>

--- a/mastracode/web/src/web/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -38,6 +38,7 @@ export function UserSessionsSection() {
   const [creating, setCreating] = useState(false);
   const [name, setName] = useState('');
   const [confirmDelete, setConfirmDelete] = useState<FactoryUserSession | null>(null);
+  const [openingId, setOpeningId] = useState<string | null>(null);
 
   const repository = factoryQuery.data?.repositories[0];
   const sessionsEnabled = Boolean(repository);
@@ -117,11 +118,15 @@ export function UserSessionsSection() {
   const pending = createSession.isPending || deleteSession.isPending;
 
   const openSession = async (session: FactoryUserSession) => {
+    if (openingId) return;
+    setOpeningId(session.sessionId);
     try {
       await controllerSession(session.sessionId).create({ threadId: session.sessionId });
       void navigate(`/factories/${factoryId}/user/threads/${session.sessionId}`);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to open session');
+    } finally {
+      setOpeningId(null);
     }
   };
 
@@ -161,6 +166,7 @@ export function UserSessionsSection() {
                 url={url}
                 active={active}
                 disabled={pending}
+                loading={openingId === session.sessionId}
                 onSelect={() => void openSession(session)}
                 onDelete={() => setConfirmDelete(session)}
               />

--- a/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -40,6 +40,7 @@ export function WorkspacesSection() {
   });
   const deleteWorkspace = useDeleteWorkspaceMutation(factoryId, projectRepositoryId, session, scope);
   const [confirmDelete, setConfirmDelete] = useState<FactoryUserSession | null>(null);
+  const [openingId, setOpeningId] = useState<string | null>(null);
   const workItems = useWorkItemsQuery(factoryId);
   const workspaceRows = workspaces.data?.workspaces ?? [];
   const activityOptions = {
@@ -101,6 +102,8 @@ export function WorkspacesSection() {
   const pending = deleteWorkspace.isPending;
 
   const openWorkspaceThread = async (workspace: FactoryUserSession) => {
+    if (openingId) return;
+    setOpeningId(workspace.sessionId);
     clearAttention(workspace.sessionId);
     try {
       // Workspace sessions (and their threads) live under the session's own id
@@ -138,6 +141,8 @@ export function WorkspacesSection() {
       }
     } catch {
       void navigate(`/factories/${factoryId}/workspaces/${workspace.sessionId}`, { state: { from: location } });
+    } finally {
+      setOpeningId(null);
     }
   };
 
@@ -155,6 +160,7 @@ export function WorkspacesSection() {
           title="Work Sessions"
           rows={workRows}
           pending={pending}
+          openingId={openingId}
           onSelect={openWorkspaceThread}
           onDelete={setConfirmDelete}
         />
@@ -164,6 +170,7 @@ export function WorkspacesSection() {
           title="Review Sessions"
           rows={reviewRows}
           pending={pending}
+          openingId={openingId}
           onSelect={openWorkspaceThread}
           onDelete={setConfirmDelete}
         />
@@ -216,12 +223,14 @@ function WorkspaceGroup({
   title,
   rows,
   pending,
+  openingId,
   onSelect,
   onDelete,
 }: {
   title: 'Work Sessions' | 'Review Sessions';
   rows: FactoryWorkspaceRow[];
   pending: boolean;
+  openingId: string | null;
   onSelect: (workspace: FactoryUserSession) => void;
   onDelete: (workspace: FactoryUserSession) => void;
 }) {
@@ -241,6 +250,7 @@ function WorkspaceGroup({
             url={row.url}
             active={row.active}
             disabled={pending}
+            loading={openingId === row.workspace.sessionId}
             status={row.running ? 'running' : row.attention ? 'attention' : undefined}
             onSelect={() => onSelect(row.workspace)}
             onDelete={() => onDelete(row.workspace)}

--- a/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -1,9 +1,8 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@mastra/playground-ui/components/Dialog';
-import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
+import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useQueryClient } from '@tanstack/react-query';
-import { GitBranch, MoreHorizontal, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 
@@ -21,6 +20,7 @@ import { useChatSessionContext } from '../../chat/context/useChatSessionContext'
 import { createAgentControllerClient, requireAgentControllerSession } from '../../chat/services/agentControllerClient';
 import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 import type { FactoryUserSession } from '../services/github';
+import { SessionNavRow } from './SessionNavRow';
 
 export function WorkspacesSection() {
   const { factoryId, sessionId } = useParams<{ factoryId: string; sessionId: string }>();
@@ -69,6 +69,7 @@ export function WorkspacesSection() {
     return [
       {
         workspace,
+        url: `/factories/${factoryId}/workspaces/${workspace.sessionId}`,
         label: titleByPath[workspace.sessionId],
         active,
         running,
@@ -202,6 +203,7 @@ export function WorkspacesSection() {
 
 interface FactoryWorkspaceRow {
   workspace: FactoryUserSession;
+  url: string;
   label?: string;
   active: boolean;
   running: boolean;
@@ -230,98 +232,21 @@ function WorkspaceGroup({
           {title}
         </Txt>
       </div>
-      <div className="flex flex-col gap-1">
+      <MainSidebar.NavList>
         {rows.map(row => (
-          <WorkspaceRow
+          <SessionNavRow
             key={row.workspace.sessionId}
-            workspace={row.workspace}
-            label={row.label}
+            name={row.label ?? row.workspace.branch}
+            title={row.workspace.branch}
+            url={row.url}
             active={row.active}
-            running={row.running}
-            attention={row.attention}
             disabled={pending}
+            status={row.running ? 'running' : row.attention ? 'attention' : undefined}
             onSelect={() => onSelect(row.workspace)}
             onDelete={() => onDelete(row.workspace)}
           />
         ))}
-      </div>
+      </MainSidebar.NavList>
     </section>
-  );
-}
-
-export function WorkspaceRow({
-  workspace,
-  label,
-  active,
-  running,
-  attention,
-  disabled,
-  onSelect,
-  onDelete,
-}: {
-  workspace: FactoryUserSession;
-  label?: string;
-  active: boolean;
-  running: boolean;
-  attention: boolean;
-  disabled: boolean;
-  onSelect: () => void;
-  onDelete?: () => void;
-}) {
-  const name = label ?? workspace.branch;
-  return (
-    <div className={`group relative rounded-md ${active ? 'bg-sidebar-nav-active' : 'hover:bg-sidebar-nav-hover'}`}>
-      <button
-        type="button"
-        aria-current={active ? 'true' : undefined}
-        aria-label={name}
-        disabled={disabled}
-        onClick={onSelect}
-        title={workspace.branch}
-        className={`flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition ${active ? 'text-icon6' : 'text-icon3 hover:text-icon5'} disabled:cursor-default disabled:opacity-70`}
-      >
-        <GitBranch size={13} />
-        <span className="min-w-0 flex-1 truncate">{name}</span>
-        {running ? (
-          <span
-            role="status"
-            aria-label={`Agent working in ${name}`}
-            title="Agent working"
-            className="ml-auto size-2 shrink-0 animate-pulse rounded-full bg-accent1 group-hover:opacity-0"
-          />
-        ) : attention ? (
-          <span
-            role="status"
-            aria-label={`Agent finished in ${name}`}
-            title="Agent finished — open to dismiss"
-            className="ml-auto size-2 shrink-0 rounded-full bg-accent1 group-hover:opacity-0"
-          />
-        ) : null}
-      </button>
-      {onDelete && (
-        <DropdownMenu>
-          <DropdownMenu.Trigger
-            render={
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Workspace actions"
-                disabled={disabled}
-                className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 data-[popup-open]:opacity-100"
-              >
-                <MoreHorizontal size={15} />
-              </Button>
-            }
-          />
-          <DropdownMenu.Content align="end" className="min-w-28">
-            <DropdownMenu.Item variant="destructive" onClick={onDelete}>
-              <Trash2 />
-              Delete
-            </DropdownMenu.Item>
-          </DropdownMenu.Content>
-        </DropdownMenu>
-      )}
-    </div>
   );
 }

--- a/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/SessionRowOpenPending.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/SessionRowOpenPending.msw.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * BDD coverage for the sidebar session-row pending state: clicking a row kicks
+ * off an async open (agent-controller session create + navigation), so while
+ * that is in flight the row shows an "Opening <name>" spinner, is disabled,
+ * and further clicks do not fire duplicate session-create requests.
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../../e2e/web-ui/msw-server';
+import { TEST_BASE_URL, renderWithProviders } from '../../../../../../../e2e/web-ui/render';
+import type { FactoryUserSession } from '../../services/github';
+import { UserSessionsSection } from '../UserSessionsSection';
+
+const projectRepositoryId = 'ghp-1';
+
+const existingSession: FactoryUserSession = {
+  id: 'row-1',
+  sessionId: 'sess-1',
+  projectRepositoryId,
+  orgId: 'org-1',
+  userId: 'user-1',
+  branch: 'user/my-feature',
+  baseBranch: 'main',
+  sandboxId: null,
+  sandboxWorkdir: null,
+  materializedAt: null,
+  createdAt: '2026-07-23T00:00:00.000Z',
+  updatedAt: '2026-07-23T00:00:00.000Z',
+};
+
+/** Stub the factory (with one linked repository) + the session list. */
+function stubFactoryWithRepository(sessions: FactoryUserSession[]) {
+  server.use(
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: 'fp-1', name: 'Mastra' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'conn-1',
+            installationId: 'inst-7',
+            repositories: [
+              {
+                id: projectRepositoryId,
+                branch: 'main',
+                sandboxWorkdir: '/workspace/hello',
+                repository: { slug: 'octo/hello', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${projectRepositoryId}/sessions`, () =>
+      HttpResponse.json({ sessions }),
+    ),
+  );
+}
+
+function LocationProbe() {
+  return <output data-testid="pathname">{useLocation().pathname}</output>;
+}
+
+function renderSection() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/factories/fp-1']}>
+      <Routes>
+        <Route path="/factories/:factoryId" element={<UserSessionsSection />} />
+        <Route path="*" element={<UserSessionsSection />} />
+      </Routes>
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+}
+
+describe('Session row open pending state', () => {
+  it('shows a spinner on the clicked row, blocks duplicate opens, then navigates once resolved', async () => {
+    stubFactoryWithRepository([existingSession]);
+
+    let createCalls = 0;
+    let releaseCreate!: () => void;
+    const createGate = new Promise<void>(resolve => {
+      releaseCreate = resolve;
+    });
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/code/sessions`, async () => {
+        createCalls += 1;
+        await createGate;
+        return HttpResponse.json({ controllerId: 'code', resourceId: 'sess-1', threadId: 'sess-1' });
+      }),
+    );
+    const user = userEvent.setup();
+
+    renderSection();
+
+    const row = await screen.findByRole('button', { name: 'my-feature' });
+    await user.click(row);
+
+    // The clicked row shows a spinner and is disabled while the open is in flight.
+    const spinner = await screen.findByRole('status', { name: 'Opening my-feature' });
+    expect(spinner).toBeInTheDocument();
+    expect(row).toBeDisabled();
+
+    // A second click while pending does not fire another session create.
+    await user.click(row);
+    expect(createCalls).toBe(1);
+
+    releaseCreate();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pathname')).toHaveTextContent('/factories/fp-1/user/threads/sess-1'),
+    );
+    expect(screen.queryByRole('status', { name: 'Opening my-feature' })).not.toBeInTheDocument();
+    expect(row).toBeEnabled();
+    expect(createCalls).toBe(1);
+  });
+});

--- a/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/UserSessionsCreateDialog.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/UserSessionsCreateDialog.msw.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * BDD coverage for the sidebar "New user session" flow: the Plus button opens
+ * a naming dialog (no inline sidebar input), creating slugs the name into a
+ * `user/<slug>` branch, binds an agent-controller chat session/thread, and
+ * navigates to the new session thread.
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../../e2e/web-ui/msw-server';
+import { TEST_BASE_URL, renderWithProviders } from '../../../../../../../e2e/web-ui/render';
+import type { FactoryUserSession } from '../../services/github';
+import { UserSessionsSection } from '../UserSessionsSection';
+
+const projectRepositoryId = 'ghp-1';
+
+const createdSession: FactoryUserSession = {
+  id: 'row-1',
+  sessionId: 'sess-1',
+  projectRepositoryId,
+  orgId: 'org-1',
+  userId: 'user-1',
+  branch: 'user/my-feature',
+  baseBranch: 'main',
+  sandboxId: null,
+  sandboxWorkdir: null,
+  materializedAt: null,
+  createdAt: '2026-07-23T00:00:00.000Z',
+  updatedAt: '2026-07-23T00:00:00.000Z',
+};
+
+/** Stub the factory (with one linked repository) + an empty session list. */
+function stubFactoryWithRepository(sessions: FactoryUserSession[] = []) {
+  server.use(
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: 'fp-1', name: 'Mastra' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'conn-1',
+            installationId: 'inst-7',
+            repositories: [
+              {
+                id: projectRepositoryId,
+                branch: 'main',
+                sandboxWorkdir: '/workspace/hello',
+                repository: { slug: 'octo/hello', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${projectRepositoryId}/sessions`, () =>
+      HttpResponse.json({ sessions }),
+    ),
+  );
+}
+
+function LocationProbe() {
+  return <output data-testid="pathname">{useLocation().pathname}</output>;
+}
+
+function renderSection() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/factories/fp-1']}>
+      <Routes>
+        <Route path="/factories/:factoryId" element={<UserSessionsSection />} />
+        <Route path="*" element={<UserSessionsSection />} />
+      </Routes>
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+}
+
+describe('User sessions create dialog', () => {
+  it('opens a naming dialog from the Plus button instead of an inline sidebar input', async () => {
+    stubFactoryWithRepository();
+    const user = userEvent.setup();
+
+    renderSection();
+
+    // Before opening: no input anywhere in the sidebar.
+    expect(await screen.findByText('No sessions yet')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'New user session' }));
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'New user session' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Session name')).toHaveFocus();
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
+
+  it('creates the session with a user/<slug> branch, then navigates to its thread', async () => {
+    stubFactoryWithRepository();
+    let createBody: unknown;
+    let controllerCreateBody: unknown;
+    let renamedTitle: unknown;
+    server.use(
+      http.post(`${TEST_BASE_URL}/web/github/projects/${projectRepositoryId}/sessions`, async ({ request }) => {
+        createBody = await request.json();
+        return HttpResponse.json({ session: createdSession });
+      }),
+      http.post(`${TEST_BASE_URL}/api/agent-controller/code/sessions`, async ({ request }) => {
+        controllerCreateBody = await request.json();
+        return HttpResponse.json({ controllerId: 'code', resourceId: 'sess-1', threadId: 'sess-1' });
+      }),
+      http.put(
+        `${TEST_BASE_URL}/api/agent-controller/code/sessions/sess-1/threads/sess-1`,
+        async ({ request }) => {
+          renamedTitle = ((await request.json()) as { title: string }).title;
+          return HttpResponse.json({});
+        },
+      ),
+    );
+    const user = userEvent.setup();
+
+    renderSection();
+
+    await user.click(await screen.findByRole('button', { name: 'New user session' }));
+    await user.type(screen.getByLabelText('Session name'), 'My Feature');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pathname')).toHaveTextContent('/factories/fp-1/user/threads/sess-1'),
+    );
+    expect(createBody).toMatchObject({ branch: 'user/my-feature' });
+    expect(controllerCreateBody).toMatchObject({ threadId: 'sess-1' });
+    expect(renamedTitle).toBe('My Feature');
+    // The dialog closes once the session exists.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows the create error inside the dialog and keeps the entered name', async () => {
+    stubFactoryWithRepository();
+    server.use(
+      http.post(`${TEST_BASE_URL}/web/github/projects/${projectRepositoryId}/sessions`, () =>
+        HttpResponse.json({ message: 'Branch already exists' }, { status: 400 }),
+      ),
+    );
+    const user = userEvent.setup();
+
+    renderSection();
+
+    await user.click(await screen.findByRole('button', { name: 'New user session' }));
+    await user.type(screen.getByLabelText('Session name'), 'My Feature');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(await screen.findByText('Branch already exists')).toBeInTheDocument();
+    expect(screen.getByLabelText('Session name')).toHaveValue('My Feature');
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('closing the dialog via Cancel leaves no input behind in the sidebar', async () => {
+    stubFactoryWithRepository();
+    const user = userEvent.setup();
+
+    renderSection();
+
+    await user.click(await screen.findByRole('button', { name: 'New user session' }));
+    await user.type(screen.getByLabelText('Session name'), 'scratch');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+
+    // Reopening starts fresh.
+    await user.click(screen.getByRole('button', { name: 'New user session' }));
+    expect(await screen.findByLabelText('Session name')).toHaveValue('');
+  });
+});

--- a/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/UserSessionsCreateDialog.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/UserSessionsCreateDialog.msw.test.tsx
@@ -111,13 +111,10 @@ describe('User sessions create dialog', () => {
         controllerCreateBody = await request.json();
         return HttpResponse.json({ controllerId: 'code', resourceId: 'sess-1', threadId: 'sess-1' });
       }),
-      http.put(
-        `${TEST_BASE_URL}/api/agent-controller/code/sessions/sess-1/threads/sess-1`,
-        async ({ request }) => {
-          renamedTitle = ((await request.json()) as { title: string }).title;
-          return HttpResponse.json({});
-        },
-      ),
+      http.put(`${TEST_BASE_URL}/api/agent-controller/code/sessions/sess-1/threads/sess-1`, async ({ request }) => {
+        renamedTitle = ((await request.json()) as { title: string }).title;
+        return HttpResponse.json({});
+      }),
     );
     const user = userEvent.setup();
 

--- a/mastracode/web/src/web/ui/pages/ThreadPage.tsx
+++ b/mastracode/web/src/web/ui/pages/ThreadPage.tsx
@@ -34,13 +34,8 @@ export function ThreadPage() {
   const workspaceFactory = factoryQuery.data;
   const workspacePath = isUserThreadRoute ? userSessionQuery.data?.sessionId : sessionId;
 
-  if (factoryQuery.isPending || (isUserThreadRoute && userSessionQuery.isPending)) {
-    return (
-      <div className="flex h-full w-full items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
+  const resolvingSession = factoryQuery.isPending || (isUserThreadRoute && userSessionQuery.isPending);
+
   return (
     <ChatLayout
       sidebar={<Sidebar />}
@@ -61,9 +56,15 @@ export function ThreadPage() {
         ) : undefined
       }
       main={
-        <ChatSessionBoundary threadId={threadId}>
-          <ThreadPageMain />
-        </ChatSessionBoundary>
+        resolvingSession ? (
+          <div className="grid h-full min-h-0 place-items-center">
+            <Spinner aria-label="Loading session" className="text-icon3" />
+          </div>
+        ) : (
+          <ChatSessionBoundary threadId={threadId}>
+            <ThreadPageMain />
+          </ChatSessionBoundary>
+        )
       }
     />
   );

--- a/mastracode/web/src/web/ui/pages/__tests__/ThreadPageLoading.msw.test.tsx
+++ b/mastracode/web/src/web/ui/pages/__tests__/ThreadPageLoading.msw.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Regression coverage for the ThreadPage loading shell: while an uncached
+ * user-session thread resolves, the app frame (sidebar + header) must stay
+ * mounted with a centered spinner in the main slot only — clicking around the
+ * sidebar must never blank the whole shell (the old early-return behavior).
+ */
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../e2e/web-ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../../e2e/web-ui/render';
+import { createAppRoutes } from '../../router';
+
+const FACTORY_ID = 'fp-1';
+const REPO_ID = 'ghp-1';
+const SESSION_ID = 'sess-1';
+const AC = `${TEST_BASE_URL}/api/agent-controller/code`;
+
+const userSession = {
+  id: 'row-1',
+  sessionId: SESSION_ID,
+  projectRepositoryId: REPO_ID,
+  orgId: 'org-1',
+  userId: 'user-1',
+  branch: 'user/my-feature',
+  baseBranch: 'main',
+  sandboxId: null,
+  sandboxWorkdir: null,
+  materializedAt: null,
+  createdAt: '2026-07-23T00:00:00.000Z',
+  updatedAt: '2026-07-23T00:00:00.000Z',
+};
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(r => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * Stubs the whole network surface of the user-session thread route, gating
+ * only `/web/user-sessions/:sessionId` (the fetch that used to unmount the
+ * shell while pending).
+ */
+function stubThreadRoute() {
+  const sessionGate = deferred();
+
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'conn-1',
+            installationId: 'inst-1',
+            repositories: [
+              {
+                id: REPO_ID,
+                branch: 'main',
+                sandboxWorkdir: '/repo',
+                repository: { slug: 'acme/app', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+      HttpResponse.json({ sessions: [userSession] }),
+    ),
+    http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () => HttpResponse.json({ ok: true })),
+    // The gated fetch: the user-session lookup that resolves the workspace.
+    http.get(`${TEST_BASE_URL}/web/user-sessions/${SESSION_ID}`, async () => {
+      await sessionGate.promise;
+      return HttpResponse.json({ session: userSession });
+    }),
+    // Agent-controller session surface mounted once the session resolves.
+    http.post(`${AC}/sessions`, () =>
+      HttpResponse.json({ controllerId: 'code', resourceId: SESSION_ID, threadId: SESSION_ID }),
+    ),
+    http.get(`${AC}/sessions/:resourceId`, () =>
+      HttpResponse.json({
+        controllerId: 'code',
+        resourceId: SESSION_ID,
+        modeId: 'build',
+        modelId: 'openai/gpt-4o-mini',
+        threadId: SESSION_ID,
+        settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+      }),
+    ),
+    http.put(`${AC}/sessions/:resourceId/state`, () => HttpResponse.json({ ok: true })),
+    http.get(
+      `${AC}/sessions/:resourceId/stream`,
+      () =>
+        new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    ),
+    http.get(`${AC}/sessions/:resourceId/permissions`, () => HttpResponse.json({})),
+    http.get(`${AC}/sessions/:resourceId/threads`, () => HttpResponse.json({ threads: [] })),
+    http.get(`${AC}/sessions/:resourceId/threads/:threadId/messages`, () => HttpResponse.json({ messages: [] })),
+    http.get(`${AC}/modes`, () => HttpResponse.json({ modes: [] })),
+    // Right workspace-files panel, which appears once workspacePath resolves.
+    http.get(`${TEST_BASE_URL}/web/workspace/rendered/list`, () =>
+      HttpResponse.json({ workspacePath: `/ws/${SESSION_ID}`, root: '.artifacts', rootPath: '', entries: [] }),
+    ),
+  );
+
+  return { sessionGate };
+}
+
+function renderThreadRoute() {
+  const router = createMemoryRouter(createAppRoutes(), {
+    initialEntries: [`/factories/${FACTORY_ID}/user/threads/${SESSION_ID}`],
+  });
+  return renderWithProviders(<RouterProvider router={router} />);
+}
+
+describe('ThreadPage loading shell', () => {
+  it('keeps the sidebar mounted with a main-slot spinner while the session resolves, then shows the thread', async () => {
+    const { sessionGate } = stubThreadRoute();
+    renderThreadRoute();
+
+    // Pending phase: the shell is up — sidebar navigation renders alongside
+    // the loading spinner instead of a bare full-page placeholder.
+    expect(await screen.findByLabelText('Loading session')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'User sessions' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'New user session' })).toBeInTheDocument();
+    // The thread chrome itself is not mounted yet.
+    expect(screen.queryByRole('region', { name: 'Thread composer' })).not.toBeInTheDocument();
+
+    // Resolved phase: spinner swaps for the thread main content; the sidebar
+    // never unmounted.
+    sessionGate.resolve();
+    expect(await screen.findByRole('region', { name: 'Thread composer' })).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByLabelText('Loading session')).not.toBeInTheDocument());
+    expect(screen.getByRole('region', { name: 'User sessions' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Improves the left-sidebar session UX in the MastraCode web UI:

- **Unified session rows.** Workspace (work/review) and user-session rows previously used two different custom components with diverging styles and interactions. They now share a single `SessionNavRow` built on the design-system `MainSidebar.NavLink`, so all session lists render with identical density, hover, active states, status dots, and a delete-actions menu.
- **Create-session dialog.** The user-session "+" button now opens a proper naming dialog (focused input, disabled submit until non-empty, inline errors, pending state) instead of an inline editable row in the sidebar.
- **Sidebar stays mounted while a thread loads.** `ThreadPage` used to early-return a full-page centered spinner while factory/user-session data was pending, which unmounted the whole shell (sidebar included) and made navigation feel like a full refresh. The pending spinner now renders inside the `ChatLayout` main slot so the sidebar and header remain in place.
- **Per-row open feedback.** Clicking a workspace or user-session row runs an async open (agent-controller session create + thread resolution) before navigating. The clicked row now shows a spinner on its right side, is disabled, and duplicate clicks are ignored until the open settles.

## Test plan

- New MSW regression tests:
  - `UserSessionsCreateDialog.msw.test.tsx` — dialog flow, `user/<slug>` branch creation, session/thread binding, navigation, error + cancel behavior
  - `ThreadPageLoading.msw.test.tsx` — sidebar stays mounted while session data is pending
  - `SessionRowOpenPending.msw.test.tsx` — row spinner + disabled state, double-click guard, navigation after resolve
- `check:ui` typecheck clean
- Full web-ui MSW suite green: 56 files, 285 tests
- Manual: clicked uncached workspace/user-session rows — spinner shows on the row, shell stays mounted, navigation lands in chat; delete dropdown still works when idle

cc @damien-schneider — this replaces the old `WorkspaceRow` that #20103/#20116 touched; the same styling now comes from the shared `SessionNavRow` on the design-system nav link.

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes workspace and user-session items look and behave consistently in the sidebar. It also adds a clearer session-creation dialog and keeps the sidebar visible while sessions load, with feedback that prevents duplicate clicks.

## What changed

- Added a shared `SessionNavRow` for workspace and user-session sidebar entries.
- Standardized loading states, status indicators, navigation, and delete actions.
- Replaced inline user-session creation with a validated naming dialog supporting:
  - Pending and error states
  - Cancellation and reset behavior
  - Navigation after successful creation
- Prevented duplicate session or workspace opens by disabling the selected row and showing a spinner.
- Kept the sidebar and header mounted while `ThreadPage` resolves session data.
- Added MSW coverage for session creation, loading behavior, error handling, cancellation, and pending row interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->