### PR TITLE
fix(web): make work item cards clickable

### DIFF
--- a/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -3,7 +3,7 @@
  * card must announce where it is going ("Moving to Planning…") instead of
  * silently waiting, and drop the status once the server answers.
  */
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { delay, http, HttpResponse } from 'msw';
 import { createMemoryRouter, matchRoutes, RouterProvider } from 'react-router';
@@ -186,13 +186,17 @@ describe('Board card pending states', () => {
     await waitFor(() => expect(screen.queryByText('Moving to Planning…')).not.toBeInTheDocument());
   });
 
-  it('shows a dedicated thread link while keeping the work item title static', async () => {
+  it('uses the whole card as the thread link without rendering a separate thread action', async () => {
     stubBoardEndpoints();
     renderWorkBoard();
 
     const titleText = await screen.findByText('Fix login bug');
+    const card = titleText.closest<HTMLElement>('[data-testid="work-item-card"]');
+    if (!card) throw new Error('Expected the title inside its work item card');
     expect(titleText.closest('a, button')).toBeNull();
-    const threadLink = screen.getByRole('link', { name: 'Open thread for Fix login bug' });
+
+    const threadLink = within(card).getByRole('link', { name: 'Open thread for Fix login bug' });
+    expect(within(card).queryByText('Open thread')).not.toBeInTheDocument();
     expect(threadLink).toHaveAttribute(
       'href',
       `/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${THREAD_ID}`,

--- a/mastracode/web/src/web/ui/pages/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/pages/BoardPage.tsx
@@ -15,7 +15,6 @@ import {
   GitCompareArrows,
   GitPullRequest,
   Link2,
-  MessageSquareText,
   Plus,
   Stethoscope,
   Trash2,
@@ -1411,34 +1410,25 @@ function WorkItemCard({
         runPending && 'opacity-70',
       )}
     >
-      <div className="absolute top-2 right-2 flex items-center gap-0.5">
-        {threadSession !== null ? (
-          <Button
-            as={Link}
-            to={`/factories/${factoryId}/workspaces/${threadSession.sessionId}/threads/${threadSession.threadId}`}
-            variant="ghost"
-            size="xs"
-            aria-label={`Open thread for ${item.title}`}
-            className="transition-opacity pointer-fine:pointer-events-none pointer-fine:opacity-0 pointer-fine:group-hover:pointer-events-auto pointer-fine:group-hover:opacity-100 pointer-fine:focus-visible:pointer-events-auto pointer-fine:focus-visible:opacity-100 motion-reduce:transition-none"
-          >
-            <MessageSquareText aria-hidden />
-            Open thread
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            disabled={runDisabled}
-            aria-busy={pendingRunRoles.size > 0 || undefined}
-            aria-label={`Create thread for ${item.title}`}
-            className="transition-opacity pointer-fine:pointer-events-none pointer-fine:opacity-0 pointer-fine:group-hover:pointer-events-auto pointer-fine:group-hover:opacity-100 pointer-fine:focus-visible:pointer-events-auto pointer-fine:focus-visible:opacity-100 motion-reduce:transition-none"
-            onClick={() => onCreateSession(itemSessionSpec(item))}
-          >
-            <MessageSquareText aria-hidden />
-            New thread
-          </Button>
-        )}
+      {threadSession !== null ? (
+        <Link
+          to={`/factories/${factoryId}/workspaces/${threadSession.sessionId}/threads/${threadSession.threadId}`}
+          draggable={false}
+          aria-label={`Open thread for ${item.title}`}
+          className="absolute inset-0 z-10 cursor-pointer rounded-xl outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent1"
+        />
+      ) : (
+        <button
+          type="button"
+          draggable={false}
+          disabled={runDisabled}
+          aria-busy={pendingRunRoles.size > 0 || undefined}
+          aria-label={`Create thread for ${item.title}`}
+          className="absolute inset-0 z-10 cursor-pointer rounded-xl outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent1 disabled:cursor-not-allowed"
+          onClick={() => onCreateSession(itemSessionSpec(item))}
+        />
+      )}
+      <div className="absolute top-2 right-2 z-20">
         <DropdownMenu>
           <DropdownMenu.Trigger
             render={
@@ -1484,7 +1474,7 @@ function WorkItemCard({
         </DropdownMenu>
       </div>
       <div className="flex min-w-0 flex-col gap-1.5">
-        <span className="truncate pr-30 text-ui-xs text-icon2">{workItemMeta(item)}</span>
+        <span className="truncate pr-8 text-ui-xs text-icon2">{workItemMeta(item)}</span>
         <div className="flex min-w-0 items-center gap-1.5">
           <Icon size={16} className={cn('shrink-0', iconClassName)} aria-hidden />
           <span className="min-w-0 flex-1 truncate text-ui-smd font-semibold text-icon6">
@@ -1507,7 +1497,7 @@ function WorkItemCard({
                 ? `/factories/${factoryId}/workspaces/${relatedSession.sessionId}/threads/${relatedSession.threadId}`
                 : relationshipPath(related, factoryId)
             }
-            className="flex items-center gap-1 text-ui-xs text-icon4 hover:text-icon6 hover:underline"
+            className="relative z-20 flex items-center gap-1 text-ui-xs text-icon4 hover:text-icon6 hover:underline"
             aria-label={`Open ${relationText}`}
           >
             <Link2 size={11} aria-hidden />
@@ -1550,6 +1540,7 @@ function WorkItemCard({
               type="button"
               variant="outline"
               size="sm"
+              className="relative z-20"
               disabled={retryingDecisionId === decision.id}
               onClick={() => onRetryDecision(decision.id)}
             >


### PR DESCRIPTION
Work item cards previously showed a separate Open thread or New thread button on hover.

The card surface now opens the existing thread or creates one when needed. The actions menu, related-item links, retry controls, drag behavior, and keyboard focus remain independent.

Before, users had to reveal and click the thread button. Now, they can click anywhere on the card.

Verified with the focused BoardPage test, UI typecheck, React Doctor, and browser smoke tests for both existing and new threads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Each work-item card now behaves like a “conversation button”: click anywhere on the card to open the existing thread, or start a new one if there isn’t one yet. Other controls on the card (like the menu, related links, retry buttons, and dragging) still work normally without stealing that click.

## What changed

- Updated **WorkItemCard** in `BoardPage.tsx` to replace the old top-right “Open thread / New thread” icon/button with a **full-card clickable overlay**:
  - If a live `threadSession` exists, the overlay is a `Link` to the thread.
  - If not, the overlay is a `button` that starts the thread (using the existing `runDisabled` state).
- Kept other interactions independently interactive: the actions menu, related-item links, retry controls, drag behavior, and keyboard focus were not bundled into the new card overlay behavior.
- Adjusted card styling details (e.g., reduced meta right padding; updated stacking/z-index for related links and retry button container).
- Updated `BoardPagePendingStates.msw.test.tsx` to verify the **thread link behavior within the work-item card** (scoping to `within(card)` and ensuring standalone “Open thread” text isn’t rendered within the card).

## Verification

Confirmed via BoardPage tests, UI typecheck, React Doctor, and browser smoke tests for both existing and newly created threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->