### PR TITLE
fix(factory): register direct Linear integration

### DIFF
--- a/mastracode/web/src/mastra/index.test.ts
+++ b/mastracode/web/src/mastra/index.test.ts
@@ -106,5 +106,16 @@ describe('platform entry (src/mastra/index.ts)', () => {
         expect(mod.mastra).toBeDefined();
       },
     );
+
+    it('registers the direct Linear integration when the full group is configured', { timeout: 60_000 }, async () => {
+      vi.resetModules();
+      vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
+      vi.stubEnv('WORKOS_COOKIE_PASSWORD', 'stable-state-secret');
+      vi.stubEnv('LINEAR_CLIENT_ID', 'lin_client');
+      vi.stubEnv('LINEAR_CLIENT_SECRET', 'linear-secret');
+      const mod = await import('./index.js');
+      const paths = mod.mastra.getServer()?.apiRoutes?.map(route => route.path) ?? [];
+      expect(paths).toContain('/auth/linear/connect');
+    });
   });
 });

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -29,6 +29,7 @@ import { getDatabasePath } from '@mastra/code-sdk/utils/project';
 import { DEFAULT_RETENTION } from '@mastra/code-sdk/utils/storage-maintenance';
 import { MastraFactory } from '@mastra/factory';
 import { GithubIntegration } from '@mastra/factory/integrations/github/integration';
+import { LinearIntegration } from '@mastra/factory/integrations/linear/integration';
 import type { IMastraAuthProvider } from '@mastra/core/server';
 
 /**
@@ -92,6 +93,19 @@ const github =
         clientSecret: githubClientSecret,
         slug: githubAppSlug,
         webhookSecret: process.env.GITHUB_APP_WEBHOOK_SECRET?.trim() || undefined,
+      })
+    : undefined;
+
+// Direct Linear OAuth fallback for self-hosted / local deploys. As with the
+// GitHub fallback, only a complete credential group enables the integration;
+// partial configuration remains available to the diagnostics routes.
+const linearClientId = process.env.LINEAR_CLIENT_ID?.trim();
+const linearClientSecret = process.env.LINEAR_CLIENT_SECRET?.trim();
+const linear =
+  linearClientId && linearClientSecret
+    ? new LinearIntegration({
+        clientId: linearClientId,
+        clientSecret: linearClientSecret,
       })
     : undefined;
 
@@ -173,9 +187,11 @@ const storage = databaseUrl
     });
 const vector = databaseUrl ? new PgVector({ id: 'mastra-code-vectors', connectionString: databaseUrl }) : undefined;
 
+const integrations = [...(github ? [github] : []), ...(linear ? [linear] : [])];
+
 export const factory = new MastraFactory({
   auth,
-  integrations: github ? [github] : undefined,
+  integrations,
   sandbox: {
     machine: sandbox,
     // Remote checkout base (nested `owner/name` per repo). LocalSandbox ignores


### PR DESCRIPTION
## Summary

Register the direct Linear integration in the deployable Factory entry when both Linear OAuth credentials are configured. This exposes the Linear connect and intake routes for self-hosted deployments while leaving partial configurations disabled for diagnostics.

## Test plan

- `pnpm exec vitest run src/mastra/index.test.ts --reporter=dot --bail 1`
- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Self-hosted Mastra deployments can now connect to Linear when both required OAuth settings are provided. If either setting is missing, Linear remains disabled.

## Changes

- Registers the direct Linear integration in the Factory configuration.
- Adds conditional support for Linear connect and intake routes.
- Adds test coverage for complete Linear credential configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->