### PR TITLE
feat(factory): open intake issues externally

### DIFF
--- a/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -201,6 +201,59 @@ describe('Board card pending states', () => {
     expect(matches?.at(-1)?.route.path).toBe('threads/:threadId');
   });
 
+  it('opens GitHub and Linear intake issues in their external provider', async () => {
+    stubBoardEndpoints();
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+        HttpResponse.json({
+          workItems: [
+            {
+              ...workItem,
+              id: 'github-item',
+              factoryProjectId: FACTORY_ID,
+              title: 'GitHub intake issue',
+              stages: ['intake'],
+              sessions: {},
+              externalSource: {
+                integrationId: 'github',
+                type: 'issue',
+                externalId: '42',
+                url: 'https://github.com/acme/app/issues/42',
+              },
+            },
+            {
+              ...workItem,
+              id: 'linear-item',
+              factoryProjectId: FACTORY_ID,
+              title: 'Linear intake issue',
+              stages: ['intake'],
+              sessions: {},
+              externalSource: {
+                integrationId: 'linear',
+                type: 'issue',
+                externalId: 'ENG-42',
+                url: 'https://linear.app/acme/issue/ENG-42/linear-intake-issue',
+              },
+            },
+          ],
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWorkBoard();
+
+    await user.click(await screen.findByRole('button', { name: 'Actions for GitHub intake issue' }));
+    const githubLink = await screen.findByRole('menuitem', { name: 'Open in GitHub' });
+    expect(githubLink).toHaveAttribute('href', 'https://github.com/acme/app/issues/42');
+    expect(githubLink).toHaveAttribute('target', '_blank');
+    await user.keyboard('{Escape}');
+
+    await user.click(screen.getByRole('button', { name: 'Actions for Linear intake issue' }));
+    const linearLink = await screen.findByRole('menuitem', { name: 'Open in Linear' });
+    expect(linearLink).toHaveAttribute('href', 'https://linear.app/acme/issue/ENG-42/linear-intake-issue');
+    expect(linearLink).toHaveAttribute('target', '_blank');
+  });
+
   it('ignores a card dropped back into its current column', async () => {
     const { transitionRequests } = stubBoardEndpoints();
     renderWorkBoard();

--- a/mastracode/web/src/web/ui/pages/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/pages/BoardPage.tsx
@@ -1468,6 +1468,14 @@ function WorkItemCard({
                   </DropdownMenu.Item>
                 );
               })}
+            {columnStage === 'intake' &&
+              item.url !== null &&
+              (item.source === 'github-issue' || item.source === 'linear-issue') && (
+                <DropdownMenu.Item render={<a href={item.url} target="_blank" rel="noreferrer" />}>
+                  <ArrowUpRight aria-hidden />
+                  <span>{externalLinkLabel(item.source)}</span>
+                </DropdownMenu.Item>
+              )}
             {itemStageOptions(item)
               .filter(stage => stage.id !== columnStage)
               .map(stage => (


### PR DESCRIPTION
## Summary

Add an external-link action to intake work-item menus. GitHub issues open in GitHub and Linear issues open in Linear, both in a new tab.

## Test plan

- `pnpm exec vitest run --config e2e/web-ui/vitest.config.ts src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx --reporter=dot --bail 1`
- `pnpm check:ui`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Intake items from GitHub and Linear now have a menu option to open the original issue. These links open in a new browser tab, and tests verify the behavior.

## Changes

- Added provider-specific external links to intake work-item menus:
  - **Open in GitHub**
  - **Open in Linear**
- Added MSW coverage verifying link URLs and new-tab behavior.
- Test plan: `pnpm check:ui`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->