### PR TITLE
fix(pg): avoid transactions for distributed locks

### DIFF
--- a/.changeset/chubby-ducks-stop.md
+++ b/.changeset/chubby-ducks-stop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed GitHub project locking so sandbox and network operations remain serialized without holding database transactions open.

--- a/.changeset/clear-hornets-roll.md
+++ b/.changeset/clear-hornets-roll.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed distributed locks so long-running critical sections no longer keep PostgreSQL transactions open.

--- a/mastracode/factory/src/integrations/github/project-lock-scenario.test.ts
+++ b/mastracode/factory/src/integrations/github/project-lock-scenario.test.ts
@@ -4,17 +4,16 @@ import { __resetProjectLocksForTests, hashKey, withDbAdvisoryLock, withProjectLo
 
 // ── Phase 5 distributed project-lock scenario tests ──────────────────────
 // These prove cross-replica serialization on the same key using a fake pg
-// client that faithfully models transaction-scoped advisory-lock semantics:
-//   - pg_advisory_xact_lock(k1, k2) blocks while another transaction holds the
-//     same key,
-//   - the lock auto-releases when the holding transaction COMMITs or ROLLBACKs.
+// client that faithfully models session-scoped advisory-lock semantics:
+//   - pg_advisory_lock(k1, k2) blocks while another session holds the same key,
+//   - pg_advisory_unlock(k1, k2) releases the key after the critical section.
 // Two `withProjectLock` callers sharing one fake pool model two replicas
 // pointed at one Postgres.
 
 /**
  * A fake Postgres modeling per-key advisory-lock queues. A key is "held" by at
- * most one transaction at a time; `pg_advisory_xact_lock` waits for the holder
- * to COMMIT/ROLLBACK before resolving.
+ * most one session at a time; `pg_advisory_lock` waits for the holder to call
+ * `pg_advisory_unlock` before resolving.
  */
 class FakePg implements LockPool {
   /** key -> currently-holding client (or undefined when free). */
@@ -59,15 +58,14 @@ class FakeClient implements LockClient {
   constructor(private readonly pg: FakePg) {}
 
   async query(sql: string, params?: unknown[]): Promise<unknown> {
-    if (sql === 'BEGIN') return undefined;
-    if (sql === 'COMMIT' || sql === 'ROLLBACK') {
+    const [k1, k2] = params as [number, number];
+    const key = `${k1}:${k2}`;
+    if (sql.includes('pg_advisory_unlock')) {
       this.pg.releaseAll(this);
       this.heldKeys = [];
       return undefined;
     }
-    if (sql.includes('pg_advisory_xact_lock')) {
-      const [k1, k2] = params as [number, number];
-      const key = `${k1}:${k2}`;
+    if (sql.includes('pg_advisory_lock')) {
       this.heldKeys.push(key);
       await this.pg.acquire(key, this);
       return undefined;
@@ -76,8 +74,7 @@ class FakeClient implements LockClient {
   }
 
   release(): void {
-    // Connection back to the pool; any held advisory locks would have been
-    // released by COMMIT/ROLLBACK already. Defensive cleanup mirrors pg.
+    // Destroyed or closed sessions release any advisory locks defensively.
     this.pg.releaseAll(this);
   }
 }
@@ -120,7 +117,7 @@ describe('cross-replica serialization via advisory locks', () => {
       },
       pool: pg,
     });
-    // Let A's BEGIN + advisory-lock acquisition settle.
+    // Let A's advisory-lock acquisition settle.
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
@@ -191,7 +188,7 @@ describe('cross-replica serialization via advisory locks', () => {
 });
 
 describe('lock released on failure', () => {
-  it('rolls back and frees the key so the next caller acquires (no deadlock)', async () => {
+  it('unlocks and frees the key so the next caller acquires (no deadlock)', async () => {
     const pg = new FakePg();
     __resetProjectLocksForTests();
     const [k1, k2] = hashKey('proj1:user1');
@@ -207,7 +204,7 @@ describe('lock released on failure', () => {
       }),
     ).rejects.toThrow('boom');
 
-    // Lock must be free after the failed (rolled-back) transaction.
+    // Lock must be free after the failed critical section.
     expect(pg.isHeld(key)).toBe(false);
 
     let ran = false;

--- a/mastracode/factory/src/integrations/github/project-lock.ts
+++ b/mastracode/factory/src/integrations/github/project-lock.ts
@@ -10,7 +10,7 @@
  *  1. An **in-process** promise-chain mutex keyed by the lock key, so repeated
  *     same-replica callers stay cheap and never touch the database for ordering.
  *  2. The factory storage backend's **`withDistributedLock` capability** (pg:
- *     transaction-scoped advisory locks) so that *different replicas*
+ *     session-scoped advisory locks) so that *different replicas*
  *     operating on the same key also serialize. Backends without the
  *     capability (libsql: local single-writer) fall back to the in-process
  *     mutex alone — correct for single-replica deployments.
@@ -29,7 +29,7 @@ export interface LockPool {
 }
 export interface LockClient {
   query(sql: string, params?: unknown[]): Promise<unknown>;
-  release(): void;
+  release(error?: Error): void;
 }
 
 const inProcessLocks = new Map<string, Promise<unknown>>();
@@ -46,7 +46,7 @@ export function isDistributedLockEnabled(storage: FactoryStorage | undefined): b
 
 /**
  * Hash a lock key into the two signed 32-bit integers that the two-arg form of
- * `pg_advisory_xact_lock(int4, int4)` expects. Using two int4 args (rather than
+ * `pg_advisory_lock(int4, int4)` expects. Using two int4 args (rather than
  * one int8) keeps the key inside the GitHub-feature advisory-lock namespace and
  * avoids collisions with other single-int8 advisory locks.
  */
@@ -61,7 +61,7 @@ export function hashKey(key: string): [number, number] {
 /**
  * Run `fn` while holding the lock for `key`. Same-replica callers serialize via
  * the in-process mutex; cross-replica callers additionally serialize via a
- * Postgres transaction-scoped advisory lock (unless disabled).
+ * Postgres session-scoped advisory lock (unless disabled).
  *
  * The in-process chain swallows rejections so one failed operation does not
  * poison the lock for subsequent callers.
@@ -128,20 +128,20 @@ export async function withDbAdvisoryLock<T>(options: {
 async function advisoryLockOver<T>(pool: LockPool, key: string, fn: () => Promise<T>): Promise<T> {
   const [k1, k2] = hashKey(key);
   const client = await pool.connect();
+  let locked = false;
   try {
-    await client.query('BEGIN');
-    // Blocks until no other transaction holds this advisory key. Auto-released
-    // when the transaction ends below.
-    await client.query('SELECT pg_advisory_xact_lock($1, $2)', [k1, k2]);
-    try {
-      const result = await fn();
-      await client.query('COMMIT');
-      return result;
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    }
+    await client.query('SELECT pg_advisory_lock($1, $2)', [k1, k2]);
+    locked = true;
+    return await fn();
   } finally {
+    if (locked) {
+      try {
+        await client.query('SELECT pg_advisory_unlock($1, $2)', [k1, k2]);
+      } catch (error) {
+        client.release(error instanceof Error ? error : new Error(String(error)));
+        throw error;
+      }
+    }
     client.release();
   }
 }

--- a/stores/pg/src/storage/factory-storage.test.ts
+++ b/stores/pg/src/storage/factory-storage.test.ts
@@ -1,8 +1,16 @@
 import { describeFactoryStorageContract } from '@internal/storage-test-utils';
 import { describe, expect, it } from 'vitest';
 
-import { PgFactoryStorage } from './factory-storage';
+import { hashAdvisoryLockKey, PgFactoryStorage } from './factory-storage';
 import { connectionString } from './test-utils';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 describeFactoryStorageContract('pg', async () => {
   const storage = new PgFactoryStorage({ connectionString });
@@ -27,6 +35,41 @@ describe('PgFactoryStorage capabilities', () => {
       );
       expect(maxActive).toBe(1);
     } finally {
+      await storage.close();
+    }
+  });
+
+  it('does not hold an open transaction while the critical section runs', async () => {
+    const storage = new PgFactoryStorage({ connectionString });
+    const enteredCriticalSection = deferred();
+    const releaseCriticalSection = deferred();
+    const key = 'non-transactional-lock-key';
+    const [classId, objectId] = hashAdvisoryLockKey(key);
+
+    try {
+      const lockPromise = storage.withDistributedLock(key, async () => {
+        enteredCriticalSection.resolve();
+        await releaseCriticalSection.promise;
+      });
+      await enteredCriticalSection.promise;
+      const pool = storage.authDatabase().pool;
+      const result = await pool.query<{ state: string }>(
+        `SELECT activity.state
+         FROM pg_locks locks
+         JOIN pg_stat_activity activity ON activity.pid = locks.pid
+         WHERE locks.locktype = 'advisory'
+           AND locks.classid = $1
+           AND locks.objid = $2
+           AND locks.objsubid = 2
+           AND locks.granted`,
+        [classId >>> 0, objectId >>> 0],
+      );
+
+      expect(result.rows).toEqual([{ state: 'idle' }]);
+      releaseCriticalSection.resolve();
+      await lockPromise;
+    } finally {
+      releaseCriticalSection.resolve();
       await storage.close();
     }
   });

--- a/stores/pg/src/storage/factory-storage.ts
+++ b/stores/pg/src/storage/factory-storage.ts
@@ -437,7 +437,7 @@ class PgFactoryStorageOps implements FactoryStorageOps {
  * (via a wrapped {@link PostgresStore}) and app-owned collections (via
  * {@link FactoryStorageOps}), sharing a single pool.
  *
- * Provides `withDistributedLock` (transaction-scoped advisory locks) for
+ * Provides `withDistributedLock` (session-scoped advisory locks) for
  * cross-replica serialization and `authDatabase()` exposing the shared pool.
  */
 export class PgFactoryStorage extends FactoryStorage {
@@ -516,27 +516,35 @@ export class PgFactoryStorage extends FactoryStorage {
   }
 
   /**
-   * Run `fn` while holding a Postgres transaction-scoped advisory lock for
-   * `key`, serializing callers across replicas. The lock releases when the
-   * transaction ends (commit, rollback, or connection loss), so a crashed
-   * replica can never hold it forever.
+   * Run `fn` while holding a Postgres session-scoped advisory lock for `key`,
+   * serializing callers across replicas without keeping a database transaction
+   * open while the critical section performs external I/O. The dedicated pool
+   * client keeps the lock bound to one session and releases it on completion or
+   * connection loss.
    */
   async withDistributedLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
     const [k1, k2] = hashAdvisoryLockKey(key);
     const client = await this.#pool.connect();
+    let locked = false;
     try {
-      await client.query('BEGIN');
-      // Blocks until no other transaction holds this advisory key.
-      await client.query('SELECT pg_advisory_xact_lock($1, $2)', [k1, k2]);
-      try {
-        const result = await fn();
-        await client.query('COMMIT');
-        return result;
-      } catch (error) {
-        await client.query('ROLLBACK');
-        throw error;
-      }
+      await client.query('SELECT pg_advisory_lock($1, $2)', [k1, k2]);
+      locked = true;
+      return await fn();
     } finally {
+      if (locked) {
+        try {
+          const result = await client.query<{ unlocked: boolean }>('SELECT pg_advisory_unlock($1, $2) AS unlocked', [
+            k1,
+            k2,
+          ]);
+          if (!result.rows[0]?.unlocked) {
+            throw new Error(`PgFactoryStorage: failed to release distributed lock '${key}'`);
+          }
+        } catch (error) {
+          client.release(error instanceof Error ? error : new Error(String(error)));
+          throw error;
+        }
+      }
       client.release();
     }
   }


### PR DESCRIPTION
## Summary

Replace PostgreSQL transaction-scoped advisory locks with session-scoped advisory locks for Factory distributed locking.

GitHub project operations still need serialization because ensure, commit, push, and PR flows can mutate shared checkout state. Dropping the lock would allow concurrent replicas to interleave those operations. Adding Redis would introduce a new dependency without addressing the existing PostgreSQL implementation directly.

The previous implementation held an open transaction for the entire critical section. When sandbox or GitHub I/O stalled, PostgreSQL showed an idle transaction waiting in ClientRead while the advisory lock remained held. The new implementation checks out a dedicated pool connection, acquires pg_advisory_lock, runs the critical section without BEGIN, and explicitly unlocks before returning the connection. PostgreSQL still releases the session lock automatically if the connection is lost.

This keeps cross-replica serialization while removing the long-lived transaction. It does still reserve one pool connection per active distributed lock, which is required for a session-scoped PostgreSQL lock, but the connection remains idle rather than idle-in-transaction.

## Test plan

- Factory GitHub project-lock scenario tests: 4 passed
- ESLint on all changed TypeScript files: passed
- git diff --check: passed
- Added a PostgreSQL regression test that inspects pg_locks and pg_stat_activity during the critical section and verifies the lock-holding session is idle, not idle in transaction
- The focused PostgreSQL test/build is currently blocked before reaching these tests by unresolved @mastra/core workspace dist imports; the focused Factory scenario test passes