### PR TITLE
fix(factory): bound project-lock critical section with an AbortSignal timeout

### DIFF
--- a/.changeset/factory-lock-timeout.md
+++ b/.changeset/factory-lock-timeout.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Bound the `withProjectLock` / `withDbAdvisoryLock` critical section with an `AbortSignal` timeout (default 60s, configurable via `timeoutMs`). Previously, an unbounded outbound call inside the lock could keep the transaction open for up to Neon's `idle_in_transaction_session_timeout` (5 minutes), pinning the pool connection and the advisory lock the entire time. On timeout the wrapper aborts the `fn`'s signal, rolls the transaction back, releases the connection, and throws `ProjectLockTimeoutError`.

--- a/.changeset/sdk-anthropic-oauth-timeout.md
+++ b/.changeset/sdk-anthropic-oauth-timeout.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Added a 15s `AbortSignal` timeout to the Anthropic OAuth token-exchange and refresh fetches so an unresponsive upstream cannot pin the caller indefinitely.

--- a/mastracode/factory/src/integrations/github/project-lock-scenario.test.ts
+++ b/mastracode/factory/src/integrations/github/project-lock-scenario.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { LockClient, LockPool } from './project-lock.js';
-import { __resetProjectLocksForTests, hashKey, withDbAdvisoryLock, withProjectLock } from './project-lock.js';
+import {
+  __resetProjectLocksForTests,
+  hashKey,
+  ProjectLockTimeoutError,
+  withDbAdvisoryLock,
+  withProjectLock,
+} from './project-lock.js';
 
 // ── Phase 5 distributed project-lock scenario tests ──────────────────────
 // These prove cross-replica serialization on the same key using a fake pg
@@ -243,5 +249,106 @@ describe('disabled distributed lock falls back to in-process only', () => {
     });
     expect(ran).toBe(true);
     expect(connects).toBe(0);
+  });
+});
+
+// The 2025-07-23 shipyard incident: an untimed outbound call inside `fn` left
+// the advisory-lock transaction open in `idle in transaction` for up to
+// 5 minutes (Neon's IIT killer), pinning the pool connection and the lock. The
+// timeout is the belt-and-suspenders fix: even if `fn` hangs forever, the
+// wrapper aborts, rolls back, releases the connection, and surfaces
+// `ProjectLockTimeoutError` to the caller.
+describe('critical section timeout', () => {
+  it('aborts the fn signal and rolls back when fn exceeds timeoutMs', async () => {
+    const pg = new FakePg();
+    const [k1, k2] = hashKey('proj1:user1');
+    const key = `${k1}:${k2}`;
+
+    let sawAbort = false;
+    const rejected = withProjectLock({
+      key: 'proj1:user1',
+      timeoutMs: 20,
+      fn: signal =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              sawAbort = true;
+              // Model an outbound call that eventually reports the abort
+              // back to the caller. The wrapper does not wait for us.
+              reject(new Error('aborted'));
+            },
+            { once: true },
+          );
+          // Never resolves on its own.
+        }),
+      pool: pg,
+    });
+
+    await expect(rejected).rejects.toBeInstanceOf(ProjectLockTimeoutError);
+    expect(sawAbort).toBe(true);
+    // ROLLBACK ran and released the advisory lock.
+    expect(pg.isHeld(key)).toBe(false);
+
+    // A follow-up caller acquires the same key without waiting.
+    let ran = false;
+    await withProjectLock({
+      key: 'proj1:user1',
+      fn: async () => {
+        ran = true;
+      },
+      pool: pg,
+    });
+    expect(ran).toBe(true);
+    expect(pg.isHeld(key)).toBe(false);
+  });
+
+  it('leaves a well-behaved fast fn completely alone', async () => {
+    const pg = new FakePg();
+    const [k1, k2] = hashKey('proj1:user1');
+    const key = `${k1}:${k2}`;
+
+    const result = await withProjectLock({
+      key: 'proj1:user1',
+      timeoutMs: 1_000,
+      fn: async () => 'ok',
+      pool: pg,
+    });
+    expect(result).toBe('ok');
+    expect(pg.isHeld(key)).toBe(false);
+  });
+
+  it('does not fire when fn ignores the signal but completes in time', async () => {
+    const pg = new FakePg();
+    const value = await withProjectLock({
+      key: 'proj1:user1',
+      timeoutMs: 200,
+      fn: async () => {
+        await new Promise(r => setTimeout(r, 20));
+        return 42;
+      },
+      pool: pg,
+    });
+    expect(value).toBe(42);
+  });
+
+  it('also applies to withDbAdvisoryLock invoked directly', async () => {
+    const pg = new FakePg();
+    const [k1, k2] = hashKey('proj1:user1');
+    const key = `${k1}:${k2}`;
+
+    await expect(
+      withDbAdvisoryLock({
+        key: 'proj1:user1',
+        timeoutMs: 20,
+        // Callback ignores the signal — the timeout still fires and the
+        // wrapper resolves before `fn` ever settles.
+        fn: () => new Promise<never>(() => {}),
+        pool: pg,
+      }),
+    ).rejects.toBeInstanceOf(ProjectLockTimeoutError);
+
+    // Lock released even though fn never returned.
+    expect(pg.isHeld(key)).toBe(false);
   });
 });

--- a/mastracode/factory/src/integrations/github/project-lock.ts
+++ b/mastracode/factory/src/integrations/github/project-lock.ts
@@ -35,6 +35,56 @@ export interface LockClient {
 const inProcessLocks = new Map<string, Promise<unknown>>();
 
 /**
+ * Default hard cap on how long a critical section may run inside the project
+ * lock. Prevents an untimed outbound call (sandbox HTTP, GitHub App API, git
+ * push, etc.) from pinning both the advisory lock and the pg pool connection
+ * indefinitely — the failure mode behind the 2025-07-23 shipyard 30s plateau
+ * incident. Callers can override per call via `timeoutMs`.
+ */
+export const DEFAULT_PROJECT_LOCK_TIMEOUT_MS = 60_000;
+
+/** Thrown when the critical section under `withProjectLock` exceeds the timeout. */
+export class ProjectLockTimeoutError extends Error {
+  readonly key: string;
+  readonly timeoutMs: number;
+  constructor(key: string, timeoutMs: number) {
+    super(`Project lock critical section for "${key}" exceeded ${timeoutMs}ms`);
+    this.name = 'ProjectLockTimeoutError';
+    this.key = key;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
+ * Race `fn()` against a timeout, throwing `ProjectLockTimeoutError` if the
+ * timeout fires first. `fn()` receives an `AbortSignal` so it can (optionally)
+ * abort in-flight outbound I/O when the timeout trips. If `fn()` ignores the
+ * signal it will still resolve/reject eventually — but the caller sees the
+ * timeout error immediately, which is what lets the outer lock wrapper roll
+ * back and release the connection.
+ */
+async function runWithTimeout<T>(key: string, timeoutMs: number, fn: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const abortError = new Promise<never>((_, reject) => {
+    controller.signal.addEventListener('abort', () => reject(new ProjectLockTimeoutError(key, timeoutMs)), {
+      once: true,
+    });
+  });
+  const work = fn(controller.signal);
+  // If `fn` eventually rejects (e.g. its own fetch observes the abort signal
+  // after we already rejected via timeout), swallow it — the outer caller
+  // has already been rejected with our timeout error and we don't want an
+  // unhandled rejection.
+  work.catch(() => {});
+  try {
+    return await Promise.race([work, abortError]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * True when the cross-replica lock layer should be used: not force-disabled
  * via env, and the factory storage backend exposes the
  * `withDistributedLock` capability.
@@ -70,13 +120,20 @@ export function withProjectLock<T>(options: {
   key: string;
   /** Factory storage backend supplying the `withDistributedLock` capability, when available. */
   storage?: FactoryStorage;
-  fn: () => Promise<T>;
+  fn: (signal: AbortSignal) => Promise<T>;
   /** Test seam: fake pg pool standing in for the distributed layer. */
   pool?: LockPool;
+  /**
+   * Hard cap on the critical section. Defaults to
+   * {@link DEFAULT_PROJECT_LOCK_TIMEOUT_MS}. On timeout `fn`'s abort signal
+   * fires and the outer lock throws `ProjectLockTimeoutError`, releasing the
+   * advisory lock + pool connection.
+   */
+  timeoutMs?: number;
 }): Promise<T> {
-  const { key, storage, fn, pool } = options;
+  const { key, storage, fn, pool, timeoutMs = DEFAULT_PROJECT_LOCK_TIMEOUT_MS } = options;
   const prev = inProcessLocks.get(key) ?? Promise.resolve();
-  const run = () => withDbAdvisoryLock({ key, storage, fn, pool });
+  const run = () => withDbAdvisoryLock({ key, storage, fn, pool, timeoutMs });
   const next = prev.then(run, run);
   const tail = next.then(
     () => undefined,
@@ -108,24 +165,34 @@ export function withProjectLock<T>(options: {
 export async function withDbAdvisoryLock<T>(options: {
   key: string;
   storage?: FactoryStorage;
-  fn: () => Promise<T>;
+  fn: (signal: AbortSignal) => Promise<T>;
   pool?: LockPool;
+  timeoutMs?: number;
 }): Promise<T> {
-  const { key, storage, fn, pool } = options;
+  const { key, storage, fn, pool, timeoutMs = DEFAULT_PROJECT_LOCK_TIMEOUT_MS } = options;
   if (process.env.MASTRACODE_DISTRIBUTED_LOCK === '0') {
-    return fn();
+    return runWithTimeout(key, timeoutMs, fn);
   }
 
-  if (pool) return advisoryLockOver(pool, key, fn);
+  if (pool) return advisoryLockOver(pool, key, timeoutMs, fn);
 
   if (typeof storage?.withDistributedLock !== 'function') {
-    return fn();
+    return runWithTimeout(key, timeoutMs, fn);
   }
-  return storage.withDistributedLock(key, fn);
+  // Wrap the backend-provided lock so the critical section is bounded
+  // regardless of whether the backend implements its own timeout. The
+  // backend still owns lock acquisition/release; we own the timeout on
+  // `fn`.
+  return storage.withDistributedLock(key, () => runWithTimeout(key, timeoutMs, fn));
 }
 
 /** The pg advisory-lock body, kept for the `poolOverride` test seam. */
-async function advisoryLockOver<T>(pool: LockPool, key: string, fn: () => Promise<T>): Promise<T> {
+async function advisoryLockOver<T>(
+  pool: LockPool,
+  key: string,
+  timeoutMs: number,
+  fn: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
   const [k1, k2] = hashKey(key);
   const client = await pool.connect();
   try {
@@ -134,11 +201,19 @@ async function advisoryLockOver<T>(pool: LockPool, key: string, fn: () => Promis
     // when the transaction ends below.
     await client.query('SELECT pg_advisory_xact_lock($1, $2)', [k1, k2]);
     try {
-      const result = await fn();
+      const result = await runWithTimeout(key, timeoutMs, fn);
       await client.query('COMMIT');
       return result;
     } catch (err) {
-      await client.query('ROLLBACK');
+      // COMMIT/ROLLBACK below releases the advisory lock. If the underlying
+      // connection is already dead (e.g. Neon killed it after IIT), the
+      // rollback throws — we swallow that specifically so the original error
+      // reaches the caller.
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        /* connection already gone; nothing to roll back */
+      }
       throw err;
     }
   } finally {

--- a/mastracode/sdk/src/auth/providers/anthropic.ts
+++ b/mastracode/sdk/src/auth/providers/anthropic.ts
@@ -69,6 +69,10 @@ export async function completeAnthropicLogin(input: string, verifier: string): P
 
   const tokenResponse = await fetch(TOKEN_URL, {
     method: 'POST',
+    // Bound the OAuth exchange so an unresponsive upstream cannot pin the
+    // caller (and, in the shipyard server, the containing project lock)
+    // indefinitely. See 2025-07-23 shipyard latency incident.
+    signal: AbortSignal.timeout(15_000),
     headers: {
       'Content-Type': 'application/json',
     },
@@ -127,6 +131,7 @@ export async function loginAnthropic(
 export async function refreshAnthropicToken(refreshToken: string): Promise<OAuthCredentials> {
   const response = await fetch(TOKEN_URL, {
     method: 'POST',
+    signal: AbortSignal.timeout(15_000),
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       grant_type: 'refresh_token',


### PR DESCRIPTION
## Summary

Add a hard timeout around the `withProjectLock` / `withDbAdvisoryLock` critical section so an unbounded outbound call inside `fn()` can no longer pin the Postgres advisory lock and pool connection until Neon's `idle_in_transaction_session_timeout` (5 minutes) kills the session.

On 2025-07-23, shipyard requests plateaued at ~30s and the client-facing edge started returning `499`s. Investigation showed 10 concurrent sessions in `idle in transaction` inside `pg_stat_activity`, all executing `pg_advisory_xact_lock(...)` with `wait_event = ClientRead`, held for 3+ minutes and growing until Neon terminated them at the 5-minute mark. Every one was a distinct `(project, user)` lock key — meaning 10 independent handlers had entered `withProjectLock`, called into `commitAll` / `pushBranch` / `resolveProjectSandbox` / `getRepositoryAccess`, and hung on network I/O that had no timeout. The transaction stayed open the whole time, holding the advisory lock and the pool connection, and every subsequent request on the same key stalled behind it.

The root cause is that `fn()` inside the lock does external I/O (sandbox HTTP, GitHub App, git push) and none of those calls had a hard cap. This PR adds one at the wrapper layer: `fn()` is raced against `AbortSignal.timeout(timeoutMs)`; on timeout the wrapper aborts, rolls back, releases the pool connection, and throws `ProjectLockTimeoutError`. Callers that want to propagate the abort to their own I/O can accept the signal; existing callers that ignore it are still bounded.

Also adds a 15s `AbortSignal.timeout` on the two Anthropic OAuth token-exchange fetches — the specific untimed `fetch` that first surfaced this pathology on `POST /web/config/providers/anthropic/oauth/complete`.

## What changed

- `mastracode/factory/src/integrations/github/project-lock.ts`
  - New `runWithTimeout(key, timeoutMs, fn)` helper that races `fn(signal)` against an abort-triggered rejection.
  - `withProjectLock` and `withDbAdvisoryLock` accept an optional `timeoutMs` (default `DEFAULT_PROJECT_LOCK_TIMEOUT_MS = 60_000`) and pass an `AbortSignal` to `fn`.
  - New `ProjectLockTimeoutError` for callers that want to distinguish the timeout from other failures.
  - `advisoryLockOver`'s catch swallows a subsequent `ROLLBACK` failure so a dead connection cannot mask the original error.
- `mastracode/sdk/src/auth/providers/anthropic.ts`
  - `AbortSignal.timeout(15_000)` added to both OAuth token-exchange fetches (`completeAnthropicLogin`, `refreshAnthropicToken`).

## Test plan

- Added 4 tests to `mastracode/factory/src/integrations/github/project-lock-scenario.test.ts`:
  - Aborts `fn`'s signal, rolls back the transaction, and releases the advisory lock so the next caller acquires without delay.
  - Well-behaved fast `fn` runs untouched.
  - `fn` that ignores the signal is still bounded (wrapper resolves before `fn` settles).
  - `withDbAdvisoryLock` invoked directly also honours the timeout.
- `pnpm --filter ./mastracode/factory exec vitest run src/integrations/github` — 15 files, 266 tests passed.
- `pnpm --filter ./mastracode/sdk exec vitest run src/auth/providers/anthropic.test.ts` — 10 tests passed.
- Typecheck on `mastracode/factory` and `mastracode/sdk` — clean.
- Lint on both packages — clean.

## Notes for reviewers

- Independent of #20128 (Charlie's session-scoped-lock PR. Both fixes stack: with just this PR, a hung  releases in 60s instead of ~5min. With just Charlie's, the session is no longer  but a hung  still holds the lock indefinitely because Neon's session-idle timer is disabled. Together: no , 60s hard cap.
- The  signature widens from  to . Existing zero-arg callers in  remain valid — TypeScript allows omitting trailing parameters.
- Default of 60s is intentionally generous; large git pushes on cold sandboxes can legitimately take 20–30s. Individual routes can pass a shorter  if they know their operation should be fast (e.g. PR create).
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR stops project locks and Anthropic login requests from waiting forever. If they take too long, they are safely cancelled so connections and locks are released.

## Summary

- Added 60-second default timeouts to `withProjectLock` and `withDbAdvisoryLock`, with configurable per-call limits.
- Passed `AbortSignal` to lock callbacks and introduced `ProjectLockTimeoutError`.
- Ensured timed-out locks roll back transactions, release connections, and remain reusable.
- Prevented rollback failures from hiding the original advisory-lock error.
- Added a 15-second timeout to Anthropic OAuth token exchange and refresh requests.
- Added project-lock timeout coverage and reported passing tests, typechecks, and lint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->