### PR TITLE
Render submitted plan markdown in the chat transcript

### DIFF
--- a/.changeset/chubby-chairs-judge.md
+++ b/.changeset/chubby-chairs-judge.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Added a plans endpoint (POST /web/plans/file) so the web UI can display the markdown content of a plan submitted with submit_plan. The live approval card now fetches and renders the plan while it awaits review, and resolved plan entries render the persisted plan markdown without any extra request. The endpoint only serves relative .md files under .mastracode/plans/.

--- a/mastracode/factory/src/routes/fs.ts
+++ b/mastracode/factory/src/routes/fs.ts
@@ -279,6 +279,20 @@ export async function readWorkspaceFile(root: string, workspacePath: string, pat
   const safePath = assertRelativePath(path, 'path');
   const relativeRoot = safePath.split('/')[0] ?? '';
   assertApprovedRenderedRoot(relativeRoot);
+  return readConfinedWorkspaceFile(root, workspacePath, path);
+}
+
+/**
+ * Read a workspace-relative file, confined to the workspace (and browsable
+ * root) but WITHOUT the rendered-root allowlist check. Callers must enforce
+ * their own path allowlist before calling (see `readWorkspaceFile` and the
+ * plans routes).
+ */
+export async function readConfinedWorkspaceFile(
+  root: string,
+  workspacePath: string,
+  path: string,
+): Promise<WorkspaceFile> {
   const {
     workspace,
     path: confinedPath,
@@ -351,7 +365,7 @@ export interface SessionFsDeps {
  * matches (the caller should fall back to local-path handling), and throws
  * when a session exists but belongs to another tenant.
  */
-async function resolveAuthorizedSession(
+export async function resolveAuthorizedSession(
   c: Context,
   deps: SessionFsDeps | undefined,
   workspacePath: string,
@@ -458,6 +472,20 @@ export async function readSessionWorkspaceFile(
 ): Promise<WorkspaceFile> {
   const safePath = assertRelativePath(path, 'path');
   assertApprovedRenderedRoot(safePath.split('/')[0] ?? '');
+  return readConfinedSessionWorkspaceFile(fleet, session, path);
+}
+
+/**
+ * Read a file inside a session's sandbox workdir WITHOUT the rendered-root
+ * allowlist check. Callers must enforce their own path allowlist before
+ * calling (see `readSessionWorkspaceFile` and the plans routes).
+ */
+export async function readConfinedSessionWorkspaceFile(
+  fleet: SandboxFleet,
+  session: SourceControlSession,
+  path: string,
+): Promise<WorkspaceFile> {
+  const safePath = assertRelativePath(path, 'path');
 
   const handle = await sessionSandbox(fleet, session);
   if (!handle) throw new Error('Session workspace is not available');

--- a/mastracode/factory/src/routes/plans.test.ts
+++ b/mastracode/factory/src/routes/plans.test.ts
@@ -1,0 +1,132 @@
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { assertPlanPath, buildPlanRoutes } from './plans.js';
+import { mountApiRoutes } from './test-utils.js';
+
+async function makeWorkspace(): Promise<{ root: string; workspace: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'mc-plans-root-'));
+  const workspace = join(root, 'workspace');
+  await mkdir(workspace);
+  return { root, workspace };
+}
+
+function makeApp(root: string): Hono {
+  const app = new Hono();
+  mountApiRoutes(app as never, buildPlanRoutes({ root }));
+  return app;
+}
+
+async function requestPlan(app: Hono, body: unknown): Promise<Response> {
+  return app.request('/web/plans/file', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('assertPlanPath', () => {
+  it('normalizes valid plan paths', () => {
+    expect(assertPlanPath('.mastracode/plans/add-dark-mode.md')).toBe('.mastracode/plans/add-dark-mode.md');
+    expect(assertPlanPath('.mastracode/plans/nested/plan.md')).toBe('.mastracode/plans/nested/plan.md');
+  });
+
+  it('rejects paths outside the plans directory', () => {
+    expect(() => assertPlanPath('src/index.md')).toThrow('outside the plans directory');
+    expect(() => assertPlanPath('.mastracode/plansX/evil.md')).toThrow('outside the plans directory');
+    expect(() => assertPlanPath('.mastracode/plans.md')).toThrow('outside the plans directory');
+  });
+
+  it('rejects traversal, absolute paths, and non-markdown files', () => {
+    expect(() => assertPlanPath('.mastracode/plans/../../secret.md')).toThrow();
+    expect(() => assertPlanPath('/etc/passwd')).toThrow('must be relative');
+    expect(() => assertPlanPath('.mastracode/plans/script.sh')).toThrow('markdown');
+  });
+});
+
+describe('POST /web/plans/file', () => {
+  it('returns raw markdown for a valid plan path', async () => {
+    const { root, workspace } = await makeWorkspace();
+    const plansDir = join(workspace, '.mastracode', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'feature.md'), '# My Plan\n\nDetails.');
+
+    const res = await requestPlan(makeApp(root), { workspacePath: workspace, path: '.mastracode/plans/feature.md' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      path: '.mastracode/plans/feature.md',
+      content: '# My Plan\n\nDetails.',
+      truncated: false,
+    });
+  });
+
+  it('rejects missing body fields with 400', async () => {
+    const { root, workspace } = await makeWorkspace();
+    const app = makeApp(root);
+
+    expect((await requestPlan(app, { path: '.mastracode/plans/x.md' })).status).toBe(400);
+    expect((await requestPlan(app, { workspacePath: workspace })).status).toBe(400);
+  });
+
+  it('rejects absolute paths with 403', async () => {
+    const { root, workspace } = await makeWorkspace();
+
+    const res = await requestPlan(makeApp(root), { workspacePath: workspace, path: '/etc/passwd' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects traversal out of the plans directory with 403', async () => {
+    const { root, workspace } = await makeWorkspace();
+    await writeFile(join(workspace, 'secret.md'), 'secret');
+
+    const res = await requestPlan(makeApp(root), {
+      workspacePath: workspace,
+      path: '.mastracode/plans/../../secret.md',
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects workspace paths outside the plans directory with 403', async () => {
+    const { root, workspace } = await makeWorkspace();
+    await writeFile(join(workspace, 'README.md'), 'readme');
+
+    const res = await requestPlan(makeApp(root), { workspacePath: workspace, path: 'README.md' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects non-markdown files with 403', async () => {
+    const { root, workspace } = await makeWorkspace();
+    const plansDir = join(workspace, '.mastracode', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'script.sh'), 'echo hi');
+
+    const res = await requestPlan(makeApp(root), { workspacePath: workspace, path: '.mastracode/plans/script.sh' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for a missing plan file', async () => {
+    const { root, workspace } = await makeWorkspace();
+
+    const res = await requestPlan(makeApp(root), { workspacePath: workspace, path: '.mastracode/plans/missing.md' });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects workspaces outside the browsable root with 403', async () => {
+    const { root } = await makeWorkspace();
+    const outside = await mkdtemp(join(tmpdir(), 'mc-plans-outside-'));
+
+    const res = await requestPlan(makeApp(root), { workspacePath: outside, path: '.mastracode/plans/x.md' });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/mastracode/factory/src/routes/plans.ts
+++ b/mastracode/factory/src/routes/plans.ts
@@ -1,0 +1,131 @@
+import { isAbsolute, posix as posixPath } from 'node:path';
+
+import { registerApiRoute } from '@mastra/core/server';
+import type { ApiRoute } from '@mastra/core/server';
+import type { Context } from 'hono';
+
+import type { SessionFsDeps } from './fs.js';
+import {
+  readConfinedSessionWorkspaceFile,
+  readConfinedWorkspaceFile,
+  resolveAuthorizedSession,
+  resolveFsRoot,
+} from './fs.js';
+
+/**
+ * Plan-file read endpoint for the web UI.
+ *
+ * Core's `submit_plan` tool suspends with only a workspace-relative `path`
+ * pointing at a markdown plan file (by convention under `.mastracode/plans/`).
+ * The web transcript fetches that file here to render the plan during the
+ * approval window. Access is strictly confined: only relative paths under
+ * `.mastracode/plans/`, only `.md` files. Workspace/root confinement and
+ * symlink clamping from the fs helpers apply as a second layer.
+ */
+
+const PLANS_ROOT = '.mastracode/plans';
+
+/** Response shape for `POST /web/plans/file`. */
+export interface PlanFile {
+  /** Normalized workspace-relative plan path. */
+  path: string;
+  /** Raw plan markdown. */
+  content: string;
+  truncated: boolean;
+  updatedAt: string;
+}
+
+/** Erase a route handler's path-parameterized context to a plain `Context`. */
+function loose(c: unknown): Context {
+  return c as Context;
+}
+
+/**
+ * Validate that `path` is a relative markdown path confined to
+ * `.mastracode/plans/`. Returns the normalized POSIX path, or throws.
+ */
+export function assertPlanPath(path: string): string {
+  const trimmed = path.trim();
+  if (!trimmed) throw new Error('Missing required field: path');
+  const posixLike = trimmed.replace(/\\/g, '/');
+  if (isAbsolute(trimmed) || posixLike.startsWith('/')) throw new Error('path must be relative');
+  const normalized = posixPath.normalize(posixLike);
+  if (normalized.split('/').includes('..')) throw new Error('path escapes workspace');
+  if (normalized !== PLANS_ROOT && !normalized.startsWith(`${PLANS_ROOT}/`))
+    throw new Error('path is outside the plans directory');
+  if (!normalized.endsWith('.md')) throw new Error('path must be a markdown (.md) file');
+  return normalized;
+}
+
+/**
+ * Build the plan-file routes as Mastra `apiRoutes`:
+ *   - `POST /web/plans/file` with body `{ workspacePath, path }` — read raw
+ *     plan markdown, confined to `.mastracode/plans/*.md`.
+ */
+export function buildPlanRoutes(options: { root?: string; sessionFs?: SessionFsDeps } = {}): ApiRoute[] {
+  const root = resolveFsRoot(options.root);
+  const sessionFs = options.sessionFs;
+
+  return [
+    registerApiRoute('/web/plans/file', {
+      method: 'POST',
+      requiresAuth: false,
+      handler: async c => {
+        let body: { workspacePath?: unknown; path?: unknown };
+        try {
+          body = await c.req.json();
+        } catch {
+          return c.json({ error: 'Invalid JSON body' }, 400);
+        }
+        const workspacePath = typeof body.workspacePath === 'string' ? body.workspacePath : '';
+        const path = typeof body.path === 'string' ? body.path : '';
+        if (!workspacePath) return c.json({ error: 'Missing required field: workspacePath' }, 400);
+        if (!path) return c.json({ error: 'Missing required field: path' }, 400);
+
+        let safePath: string;
+        try {
+          safePath = assertPlanPath(path);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return c.json({ error: message }, 403);
+        }
+
+        try {
+          const session = await resolveAuthorizedSession(loose(c), sessionFs, workspacePath);
+          const file =
+            session && sessionFs
+              ? await readConfinedSessionWorkspaceFile(sessionFs.fleet, session, safePath)
+              : await readConfinedWorkspaceFile(root, workspacePath, safePath);
+          if (file.contentType !== 'text') return c.json({ error: 'Plan file is not readable text' }, 400);
+          const planFile: PlanFile = {
+            path: file.path,
+            content: file.content ?? '',
+            truncated: file.truncated ?? false,
+            updatedAt: file.updatedAt,
+          };
+          return c.json(planFile);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          // A nonexistent plan file surfaces from the confined resolver as
+          // 'Path is outside the workspace' (it conflates non-existence with
+          // symlink escape). The path shape is already validated above, so
+          // treat it as not-found rather than forbidden.
+          const status =
+            message === 'Path is outside the workspace'
+              ? 404
+              : message.includes('outside') ||
+                  message.includes('relative') ||
+                  message.includes('escapes') ||
+                  message.includes('not available')
+                ? 403
+                : message === 'Path is a directory'
+                  ? 400
+                  : message.includes('not found') || message.includes('ENOENT') || message.includes('no such file')
+                    ? 404
+                    : 500;
+          return c.json({ error: message }, status);
+        }
+      },
+    }),
+  ];
+}

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -33,6 +33,7 @@ import { invalidateCustomProvidersSnapshots } from './custom-provider-source.js'
 import { buildFsRoutes } from './fs.js';
 import { IntakeRoutes } from './intake.js';
 import { OAuthRoutes } from './oauth.js';
+import { buildPlanRoutes } from './plans.js';
 import type { RouteAuth } from './route.js';
 import { SkillRoutes } from './skills.js';
 import { invalidateTenantCredentialSnapshots } from './tenant-credentials.js';
@@ -360,6 +361,14 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
 
   return [
     ...buildFsRoutes({
+      root: deps.fsRoot,
+      sessionFs: {
+        auth: deps.auth,
+        fleet: deps.fleet,
+        sessions: deps.sourceControlStorage.forIntegration('github').sessions,
+      },
+    }),
+    ...buildPlanRoutes({
       root: deps.fsRoot,
       sessionFs: {
         auth: deps.auth,

--- a/mastracode/web/src/shared/api/keys.ts
+++ b/mastracode/web/src/shared/api/keys.ts
@@ -64,6 +64,8 @@ export const queryKeys = {
     ['workspace-rendered-list', workspacePath ?? null, renderedRoot ?? null] as const,
   workspaceFile: (workspacePath: string | undefined, filePath: string | undefined) =>
     ['workspace-file', workspacePath ?? null, filePath ?? null] as const,
+  planFile: (workspacePath: string | undefined, filePath: string | undefined) =>
+    ['plan-file', workspacePath ?? null, filePath ?? null] as const,
   agentControllerModes: (agentControllerId: string | undefined) =>
     ['agent-controller', agentControllerId ?? null, 'modes'] as const,
   // Sessions are scoped per worktree (projectPath), so every session-derived key

--- a/mastracode/web/src/shared/api/types.ts
+++ b/mastracode/web/src/shared/api/types.ts
@@ -25,6 +25,7 @@ import type {
   WorkspaceRenderedEntry,
   WorkspaceRenderedListing,
 } from '@mastra/factory/routes/fs';
+import type { PlanFile } from '@mastra/factory/routes/plans';
 
 export type { ProviderInfo, CustomProviderInfo, ModelPackInfo, OMConfigInfo, ProviderOMDefaultsResponse };
 export type {
@@ -32,6 +33,7 @@ export type {
   ArtifactListing,
   DirectoryEntry,
   DirectoryListing,
+  PlanFile,
   WorkspaceFile,
   WorkspaceRenderedEntry,
   WorkspaceRenderedListing,

--- a/mastracode/web/src/shared/hooks/__tests__/use-fs.msw.test.tsx
+++ b/mastracode/web/src/shared/hooks/__tests__/use-fs.msw.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../../e2e/web-ui/msw-server';
 import { TEST_BASE_URL, renderHookWithProviders } from '../../../../e2e/web-ui/render';
-import { useArtifactListing, useDirectoryListing, useWorkspaceFile, useWorkspaceRenderedListing } from '../use-fs';
+import { useArtifactListing, useDirectoryListing, usePlanFile, useWorkspaceFile, useWorkspaceRenderedListing } from '../use-fs';
 import { listing } from './fixtures/fs';
 
 const URL = `${TEST_BASE_URL}/web/fs/list`;
@@ -219,5 +219,56 @@ describe('useWorkspaceFile', () => {
     expect(seenWorkspacePath).toBe('/home/user/project');
     expect(seenPath).toBe('.artifacts/understand-pr/HISTORY.md');
     expect(result.current.data?.content).toBe('notes');
+  });
+});
+
+const PLAN_FILE_URL = `${TEST_BASE_URL}/web/plans/file`;
+
+describe('usePlanFile', () => {
+  it('does not fetch when disabled', () => {
+    let called = false;
+    server.use(
+      http.post(PLAN_FILE_URL, () => {
+        called = true;
+        return HttpResponse.json({ path: '', content: '', truncated: false, updatedAt: '' });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() =>
+      usePlanFile('/home/user/project', '.mastracode/plans/plan.md', { enabled: false }),
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(called).toBe(false);
+  });
+
+  it('posts the workspace path and plan path in the request body', async () => {
+    let seenBody: unknown;
+    server.use(
+      http.post(PLAN_FILE_URL, async ({ request }) => {
+        seenBody = await request.json();
+        return HttpResponse.json({
+          path: '.mastracode/plans/plan.md',
+          content: '# My plan\n\nDetails.',
+          truncated: false,
+          updatedAt: '2026-07-23T00:00:00.000Z',
+        });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => usePlanFile('/home/user/project', '.mastracode/plans/plan.md'));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(seenBody).toEqual({ workspacePath: '/home/user/project', path: '.mastracode/plans/plan.md' });
+    expect(result.current.data?.content).toBe('# My plan\n\nDetails.');
+  });
+
+  it('surfaces read failures as errors', async () => {
+    server.use(http.post(PLAN_FILE_URL, () => HttpResponse.json({ error: 'not found' }, { status: 404 })));
+
+    const { result } = renderHookWithProviders(() => usePlanFile('/home/user/project', '.mastracode/plans/plan.md'));
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
   });
 });

--- a/mastracode/web/src/shared/hooks/use-fs.ts
+++ b/mastracode/web/src/shared/hooks/use-fs.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
-import type { ArtifactListing, DirectoryListing, WorkspaceFile, WorkspaceRenderedListing } from '../api/types';
+import type { ArtifactListing, DirectoryListing, PlanFile, WorkspaceFile, WorkspaceRenderedListing } from '../api/types';
 
 /**
  * Server-driven directory listing for the project picker (mirrors
@@ -57,5 +57,24 @@ export function useWorkspaceFile(
       client.get<WorkspaceFile>(
         `/web/workspace/file?workspacePath=${encodeURIComponent(workspacePath ?? '')}&path=${encodeURIComponent(filePath ?? '')}`,
       ),
+  });
+}
+
+/**
+ * Read a `submit_plan` markdown file (mirrors `POST /web/plans/file`). The
+ * server only serves relative `.md` paths under `.mastracode/plans/`, so this
+ * is used exclusively by the live plan-approval card to render the plan the
+ * agent just submitted. POST keeps workspace paths out of URL logs.
+ */
+export function usePlanFile(
+  workspacePath: string | undefined,
+  filePath: string | undefined,
+  options: { enabled?: boolean } = {},
+) {
+  const { client } = useApiConfig();
+  return useQuery<PlanFile>({
+    queryKey: queryKeys.planFile(workspacePath, filePath),
+    enabled: Boolean(workspacePath && filePath && (options.enabled ?? true)),
+    queryFn: () => client.post<PlanFile>('/web/plans/file', { workspacePath, path: filePath }),
   });
 }

--- a/mastracode/web/src/web/ui/domains/chat/components/ToolFactory.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ToolFactory.tsx
@@ -90,14 +90,17 @@ interface PlanData {
   content: string;
 }
 
-function planData(input: unknown): PlanData {
+function planData(input: unknown, output: unknown): PlanData {
+  // Resolved entries persist the full plan in the tool result (`submittedPlan`);
+  // prefer it so historical transcripts render offline without any fetch.
+  const submitted = record(record(output)?.submittedPlan);
   const payload = record(input);
   const plan = record(payload?.plan) ?? payload;
-  const path = stringValue(plan?.path) ?? stringValue(payload?.path);
+  const path = stringValue(submitted?.path) ?? stringValue(plan?.path) ?? stringValue(payload?.path);
   return {
-    title: stringValue(plan?.title) ?? 'Plan',
+    title: stringValue(submitted?.title) ?? stringValue(plan?.title) ?? 'Plan',
     ...(path ? { path } : {}),
-    content: stringValue(plan?.content) ?? stringValue(plan?.summary) ?? '',
+    content: stringValue(submitted?.plan) ?? stringValue(plan?.content) ?? stringValue(plan?.summary) ?? '',
   };
 }
 
@@ -132,7 +135,7 @@ function ToolFactoryComponent({
   if (!isTranscriptToolVisible(toolName)) return null;
 
   if (toolName === 'submit_plan') {
-    const plan = planData(input);
+    const plan = planData(input, output);
     return (
       <Plan role="group" aria-label="Plan approval">
         <PlanHeader>

--- a/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
@@ -6,6 +6,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/pla
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Notice } from '@mastra/playground-ui/components/Notice';
+import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
@@ -28,6 +29,7 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import { highlightCode, languageForPath } from '../../../ui/highlight';
+import { usePlanFile } from '../../../../../shared/hooks/use-fs';
 import { useChatSessionContext } from '../context/useChatSessionContext';
 import { useChatTranscript } from '../context/useChatTranscript';
 import {
@@ -414,36 +416,7 @@ function SuspensionCard({
   const payload = suspensionPayloadShape(prompt.suspendPayload);
 
   if (prompt.toolName === 'submit_plan') {
-    return (
-      <div className={promptCardSuspension} role="group" aria-label="Plan approval">
-        <div className={promptTitle}>Plan: {payload.plan?.title ?? payload.title ?? 'Proposed plan'}</div>
-        {payload.plan?.summary && (
-          <div className="whitespace-pre-wrap break-words font-mono text-ui-smd leading-relaxed text-icon5">
-            {payload.plan.summary}
-          </div>
-        )}
-        <div className={promptActions}>
-          <Button
-            variant="primary"
-            size="sm"
-            aria-label="Approve the plan and switch to build"
-            autoFocus
-            disabled={isSubmitting}
-            onClick={() => onRespond(prompt.toolCallId, { action: 'approved' }, prompt.id)}
-          >
-            Approve &amp; build
-          </Button>
-          <Button
-            size="sm"
-            aria-label="Reject the plan"
-            disabled={isSubmitting}
-            onClick={() => onRespond(prompt.toolCallId, { action: 'rejected' }, prompt.id)}
-          >
-            Reject
-          </Button>
-        </div>
-      </div>
-    );
+    return <SubmitPlanCard prompt={prompt} payload={payload} isSubmitting={isSubmitting} onRespond={onRespond} />;
   }
 
   if (prompt.toolName === 'request_access') {
@@ -476,6 +449,83 @@ function SuspensionCard({
   }
 
   return <AskUserCard prompt={prompt} payload={payload} isSubmitting={isSubmitting} onRespond={onRespond} />;
+}
+
+/** First `# heading` of a markdown document, used as the plan title. */
+function firstMarkdownHeading(markdown: string): string | undefined {
+  const match = markdown.match(/^#\s+(.+)$/m);
+  return match?.[1]?.trim() || undefined;
+}
+
+function SubmitPlanCard({
+  prompt,
+  payload,
+  isSubmitting,
+  onRespond,
+}: {
+  prompt: SuspensionPrompt;
+  payload: SuspendPayloadShape;
+  isSubmitting: boolean;
+  onRespond: (toolCallId: string, resumeData: PlanResume, promptId: string) => void;
+}) {
+  // The suspend payload only carries the plan file's workspace-relative path;
+  // fetch the markdown while the approval window is open. `resourceId` is the
+  // session id, which the plans endpoint resolves as the workspace.
+  const { resourceId } = useChatSessionContext();
+  const planQuery = usePlanFile(resourceId || undefined, payload.requestedPath);
+  const content = planQuery.data?.content;
+  const title =
+    (content ? firstMarkdownHeading(content) : undefined) ?? payload.plan?.title ?? payload.title ?? 'Proposed plan';
+
+  return (
+    <div className={promptCardSuspension} role="group" aria-label="Plan approval">
+      <div className={promptTitle}>Plan: {title}</div>
+      {payload.requestedPath && <div className="mb-1 font-mono text-xs text-icon3">{payload.requestedPath}</div>}
+      {payload.plan?.summary && (
+        <div className="whitespace-pre-wrap break-words font-mono text-ui-smd leading-relaxed text-icon5">
+          {payload.plan.summary}
+        </div>
+      )}
+      {planQuery.isLoading && (
+        <div className="mt-1 flex flex-col gap-1.5" aria-label="Loading plan content">
+          <Skeleton className="h-3.5 w-3/4" />
+          <Skeleton className="h-3.5 w-full" />
+          <Skeleton className="h-3.5 w-5/6" />
+        </div>
+      )}
+      {planQuery.isError && (
+        <div className="mt-1 text-xs text-error" role="alert">
+          Couldn&apos;t load plan content: {planQuery.error instanceof Error ? planQuery.error.message : 'unknown error'}
+        </div>
+      )}
+      {content !== undefined && (
+        <div className="mt-1 max-h-96 overflow-y-auto text-ui-smd leading-relaxed text-icon5">
+          <Markdown>{content}</Markdown>
+          {planQuery.data?.truncated && <div className="mt-1 text-xs text-icon3">Plan content truncated.</div>}
+        </div>
+      )}
+      <div className={promptActions}>
+        <Button
+          variant="primary"
+          size="sm"
+          aria-label="Approve the plan and switch to build"
+          autoFocus
+          disabled={isSubmitting}
+          onClick={() => onRespond(prompt.toolCallId, { action: 'approved' }, prompt.id)}
+        >
+          Approve &amp; build
+        </Button>
+        <Button
+          size="sm"
+          aria-label="Reject the plan"
+          disabled={isSubmitting}
+          onClick={() => onRespond(prompt.toolCallId, { action: 'rejected' }, prompt.id)}
+        >
+          Reject
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 function AskUserCard({
@@ -903,6 +953,11 @@ function MessageBubble({
       const tool = toolFromInvocationPart(part, runtime);
       const suspension = suspensions.get(tool.toolCallId);
       if (tool.toolName === 'ask_user' && tool.status === 'running' && !suspension) return null;
+      // While a submit_plan is awaiting approval, render the live card (which
+      // fetches the plan markdown) instead of the generic tool entry.
+      if (tool.toolName === 'submit_plan' && suspension) {
+        return <SuspensionCard prompt={suspension} isSubmitting={isSubmitting} onRespond={onRespond} />;
+      }
       return (
         <ToolFactory
           toolName={tool.toolName}

--- a/mastracode/web/src/web/ui/domains/chat/components/__tests__/TranscriptSubmitPlan.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/__tests__/TranscriptSubmitPlan.msw.test.tsx
@@ -1,0 +1,164 @@
+import type { MastraDBMessage } from '@mastra/core/agent-controller';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../../../../../e2e/web-ui/msw-server';
+import { TEST_BASE_URL, renderWithProviders } from '../../../../../../../e2e/web-ui/render';
+import { ChatSessionContext } from '../../context/ChatSessionContext';
+import type { TimelineEntry } from '../../services/transcript';
+import { TranscriptEntries } from '../Transcript';
+
+const PLAN_FILE_URL = `${TEST_BASE_URL}/web/plans/file`;
+const PLAN_PATH = '.mastracode/plans/render-markdown.md';
+const SESSION_ID = 'session-1';
+
+function withSession(children: ReactNode) {
+  return (
+    <ChatSessionContext.Provider
+      value={{
+        resourceId: SESSION_ID,
+        sessionEnabled: true,
+        resourceEnabled: true,
+        baseUrl: TEST_BASE_URL,
+        kind: 'user',
+      }}
+    >
+      {children}
+    </ChatSessionContext.Provider>
+  );
+}
+
+function suspension(): TimelineEntry {
+  return {
+    kind: 'suspension',
+    id: 'suspension-call-1',
+    toolCallId: 'call-1',
+    toolName: 'submit_plan',
+    args: { path: PLAN_PATH },
+    suspendPayload: { path: PLAN_PATH },
+  };
+}
+
+function assistantMessage(parts: MastraDBMessage['content']['parts']): TimelineEntry {
+  return {
+    kind: 'message',
+    id: 'msg-1',
+    message: {
+      id: 'msg-1',
+      role: 'assistant',
+      createdAt: new Date('2026-07-23T10:00:00.000Z'),
+      content: { format: 2, parts },
+    },
+  };
+}
+
+function renderEntries(entries: TimelineEntry[], onRespond: (...args: unknown[]) => void = () => {}) {
+  return renderWithProviders(withSession(<TranscriptEntries entries={entries} onApprove={() => {}} onRespond={onRespond} />));
+}
+
+describe('submit_plan live suspension card', () => {
+  it('shows a loading skeleton, then renders the plan markdown fetched from the plans endpoint', async () => {
+    let seenBody: unknown;
+    server.use(
+      http.post(PLAN_FILE_URL, async ({ request }) => {
+        seenBody = await request.json();
+        return HttpResponse.json({
+          path: PLAN_PATH,
+          content: '# Render markdown\n\nAdd a plans endpoint.',
+          truncated: false,
+          updatedAt: '2026-07-23T00:00:00.000Z',
+        });
+      }),
+    );
+
+    renderEntries([suspension()]);
+
+    expect(screen.getByLabelText('Loading plan content')).toBeInTheDocument();
+
+    await waitFor(() => expect(screen.getByText('Plan: Render markdown')).toBeInTheDocument());
+    expect(screen.getByText('Add a plans endpoint.')).toBeInTheDocument();
+    expect(seenBody).toEqual({ workspacePath: SESSION_ID, path: PLAN_PATH });
+  });
+
+  it('keeps Approve & build clickable when the plan content cannot be read', async () => {
+    server.use(http.post(PLAN_FILE_URL, () => HttpResponse.json({ error: 'plan not found' }, { status: 404 })));
+
+    const onRespond = vi.fn();
+    renderEntries([suspension()], onRespond);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByRole('alert')).toHaveTextContent(/Couldn't load plan content/);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Approve the plan and switch to build' }));
+    expect(onRespond).toHaveBeenCalledWith('call-1', { action: 'approved' }, 'suspension-call-1');
+  });
+
+  it('renders the live fetching card instead of the generic tool entry when the canonical tool part exists', async () => {
+    server.use(
+      http.post(PLAN_FILE_URL, () =>
+        HttpResponse.json({
+          path: PLAN_PATH,
+          content: '# Canonical plan\n\nBody.',
+          truncated: false,
+          updatedAt: '2026-07-23T00:00:00.000Z',
+        }),
+      ),
+    );
+
+    renderEntries([
+      assistantMessage([
+        {
+          type: 'tool-invocation',
+          toolInvocation: { state: 'call', toolCallId: 'call-1', toolName: 'submit_plan', args: { path: PLAN_PATH } },
+        },
+      ]),
+      suspension(),
+    ]);
+
+    await waitFor(() => expect(screen.getByText('Plan: Canonical plan')).toBeInTheDocument());
+    // Only one card renders for the suspended tool call.
+    expect(screen.getAllByRole('group', { name: 'Plan approval' })).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Approve the plan and switch to build' })).toBeEnabled();
+  });
+});
+
+describe('submit_plan resolved entry', () => {
+  it('renders the persisted submittedPlan markdown without fetching', async () => {
+    let fetched = false;
+    server.use(
+      http.post(PLAN_FILE_URL, () => {
+        fetched = true;
+        return HttpResponse.json({ path: PLAN_PATH, content: '', truncated: false, updatedAt: '' });
+      }),
+    );
+
+    renderEntries([
+      assistantMessage([
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'result',
+            toolCallId: 'call-1',
+            toolName: 'submit_plan',
+            args: { path: PLAN_PATH },
+            result: {
+              submittedPlan: {
+                title: 'Render markdown',
+                path: PLAN_PATH,
+                plan: '# Render markdown\n\nPersisted plan body.',
+              },
+            },
+          },
+        },
+      ]),
+    ]);
+
+    await waitFor(() => expect(screen.getByText('Persisted plan body.')).toBeInTheDocument());
+    // PlanPath renders the filename with the full path as the tooltip.
+    expect(screen.getByTitle(PLAN_PATH)).toHaveTextContent('render-markdown.md');
+    expect(fetched).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

When an agent submits a plan with `submit_plan`, the web chat transcript previously only showed the plan file path. This PR makes the plan content itself visible in the transcript:

- Adds a `POST /web/plans/file` endpoint to `@mastra/factory` that reads plan markdown files, strictly confined to relative `.md` files under `.mastracode/plans/` (works for both local workspaces and sandboxed sessions).
- The live approval card now fetches and renders the plan markdown while it awaits review.
- Resolved plan entries render the persisted plan markdown directly, without any extra request.

## Test plan

- `mastracode/factory/src/routes/plans.test.ts` — endpoint behavior including path allowlist enforcement (rejects non-`.md` files, absolute paths, and paths outside `.mastracode/plans/`).
- `mastracode/web/src/web/ui/domains/chat/components/__tests__/TranscriptSubmitPlan.msw.test.tsx` — MSW tests covering the approval card fetching/rendering plan markdown and resolved entries rendering persisted markdown.
- Extended `use-fs.msw.test.tsx` for the new plan-file hook.