### PR TITLE
fix(factory): record named steps under project lock for diagnostic breadcrumbs

### DIFF
--- a/.changeset/factory-lock-step-breadcrumbs.md
+++ b/.changeset/factory-lock-step-breadcrumbs.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Add a step recorder to `withProjectLock` so we can tell which platform call was in flight when a critical section runs long or times out. `fn` now receives a `LockStepRecorder` as its second argument; wrapping each named boundary (e.g. `fleet.resolveSandbox`, `sandbox.commitAll`, `github.getRepositoryAccess`, `sandbox.pushBranch`) captures start time, duration, and outcome. On timeout the recorded steps and the currently-running step are attached to `ProjectLockTimeoutError`. When a critical section completes but exceeds `MASTRACODE_PROJECT_LOCK_SLOW_WARN_MS` (default 5s), a structured `warn` is emitted with the same breadcrumbs so platform-call regressions are visible before they cascade into a full timeout. All four GitHub route lock sites (commit / push / pr / sandbox teardown) are wired.

--- a/.changeset/factory-lock-timeout.md
+++ b/.changeset/factory-lock-timeout.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Bound the `withProjectLock` / `withDbAdvisoryLock` critical section with an `AbortSignal` timeout (default 60s, configurable via `timeoutMs`). Previously, an unbounded outbound call inside the lock could keep the transaction open for up to Neon's `idle_in_transaction_session_timeout` (5 minutes), pinning the pool connection and the advisory lock the entire time. On timeout the wrapper aborts the `fn`'s signal, rolls the transaction back, releases the connection, and throws `ProjectLockTimeoutError`.

--- a/.changeset/sdk-anthropic-oauth-timeout.md
+++ b/.changeset/sdk-anthropic-oauth-timeout.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Added a 15s `AbortSignal` timeout to the Anthropic OAuth token-exchange and refresh fetches so an unresponsive upstream cannot pin the caller indefinitely.

--- a/mastracode/factory/src/integrations/github/project-lock-scenario.test.ts
+++ b/mastracode/factory/src/integrations/github/project-lock-scenario.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { LockClient, LockPool } from './project-lock.js';
-import { __resetProjectLocksForTests, hashKey, withDbAdvisoryLock, withProjectLock } from './project-lock.js';
+import {
+  __resetProjectLocksForTests,
+  hashKey,
+  ProjectLockTimeoutError,
+  withDbAdvisoryLock,
+  withProjectLock,
+} from './project-lock.js';
 
 // ── Phase 5 distributed project-lock scenario tests ──────────────────────
 // These prove cross-replica serialization on the same key using a fake pg
@@ -243,5 +249,106 @@ describe('disabled distributed lock falls back to in-process only', () => {
     });
     expect(ran).toBe(true);
     expect(connects).toBe(0);
+  });
+});
+
+// The 2025-07-23 shipyard incident: an untimed outbound call inside `fn` left
+// the advisory-lock transaction open in `idle in transaction` for up to
+// 5 minutes (Neon's IIT killer), pinning the pool connection and the lock. The
+// timeout is the belt-and-suspenders fix: even if `fn` hangs forever, the
+// wrapper aborts, rolls back, releases the connection, and surfaces
+// `ProjectLockTimeoutError` to the caller.
+describe('critical section timeout', () => {
+  it('aborts the fn signal and rolls back when fn exceeds timeoutMs', async () => {
+    const pg = new FakePg();
+    const [k1, k2] = hashKey('proj1:user1');
+    const key = `${k1}:${k2}`;
+
+    let sawAbort = false;
+    const rejected = withProjectLock({
+      key: 'proj1:user1',
+      timeoutMs: 20,
+      fn: signal =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              sawAbort = true;
+              // Model an outbound call that eventually reports the abort
+              // back to the caller. The wrapper does not wait for us.
+              reject(new Error('aborted'));
+            },
+            { once: true },
+          );
+          // Never resolves on its own.
+        }),
+      pool: pg,
+    });
+
+    await expect(rejected).rejects.toBeInstanceOf(ProjectLockTimeoutError);
+    expect(sawAbort).toBe(true);
+    // ROLLBACK ran and released the advisory lock.
+    expect(pg.isHeld(key)).toBe(false);
+
+    // A follow-up caller acquires the same key without waiting.
+    let ran = false;
+    await withProjectLock({
+      key: 'proj1:user1',
+      fn: async () => {
+        ran = true;
+      },
+      pool: pg,
+    });
+    expect(ran).toBe(true);
+    expect(pg.isHeld(key)).toBe(false);
+  });
+
+  it('leaves a well-behaved fast fn completely alone', async () => {
+    const pg = new FakePg();
+    const [k1, k2] = hashKey('proj1:user1');
+    const key = `${k1}:${k2}`;
+
+    const result = await withProjectLock({
+      key: 'proj1:user1',
+      timeoutMs: 1_000,
+      fn: async () => 'ok',
+      pool: pg,
+    });
+    expect(result).toBe('ok');
+    expect(pg.isHeld(key)).toBe(false);
+  });
+
+  it('does not fire when fn ignores the signal but completes in time', async () => {
+    const pg = new FakePg();
+    const value = await withProjectLock({
+      key: 'proj1:user1',
+      timeoutMs: 200,
+      fn: async () => {
+        await new Promise(r => setTimeout(r, 20));
+        return 42;
+      },
+      pool: pg,
+    });
+    expect(value).toBe(42);
+  });
+
+  it('also applies to withDbAdvisoryLock invoked directly', async () => {
+    const pg = new FakePg();
+    const [k1, k2] = hashKey('proj1:user1');
+    const key = `${k1}:${k2}`;
+
+    await expect(
+      withDbAdvisoryLock({
+        key: 'proj1:user1',
+        timeoutMs: 20,
+        // Callback ignores the signal — the timeout still fires and the
+        // wrapper resolves before `fn` ever settles.
+        fn: () => new Promise<never>(() => {}),
+        pool: pg,
+      }),
+    ).rejects.toBeInstanceOf(ProjectLockTimeoutError);
+
+    // Lock released even though fn never returned.
+    expect(pg.isHeld(key)).toBe(false);
   });
 });

--- a/mastracode/factory/src/integrations/github/project-lock-scenario.test.ts
+++ b/mastracode/factory/src/integrations/github/project-lock-scenario.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { LockClient, LockPool } from './project-lock.js';
+import type { LockClient, LockLogger, LockPool } from './project-lock.js';
 import {
   __resetProjectLocksForTests,
+  DEFAULT_PROJECT_LOCK_SLOW_WARN_MS,
   hashKey,
   ProjectLockTimeoutError,
   withDbAdvisoryLock,
@@ -350,5 +351,138 @@ describe('critical section timeout', () => {
 
     // Lock released even though fn never returned.
     expect(pg.isHeld(key)).toBe(false);
+  });
+});
+
+// When a critical section runs long or times out, we need to know which
+// named platform-call boundary was in flight — otherwise the timeout error
+// only tells us "60s elapsed" and we have to guess. The step recorder
+// records those boundaries; on timeout they're attached to
+// `ProjectLockTimeoutError.steps` / `.currentStep`; on non-timeout slow
+// completions they're emitted as a `warn`.
+describe('lock step recorder', () => {
+  function collectingLogger(): LockLogger & { warnings: Array<{ message: string; meta?: Record<string, unknown> }> } {
+    const warnings: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+    return {
+      warnings,
+      warn(message, meta) {
+        warnings.push({ message, meta });
+      },
+    };
+  }
+
+  it('records completed steps in order with durations and ok outcomes', async () => {
+    const pg = new FakePg();
+    const captured: { steps: readonly unknown[] } = { steps: [] };
+    await withProjectLock({
+      key: 'proj1:user1',
+      fn: async (_signal, recorder) => {
+        await recorder.step('fleet.resolveSandbox', () => new Promise(r => setTimeout(r, 5)));
+        await recorder.step('sandbox.commitAll', () => Promise.resolve('ok'));
+        captured.steps = recorder.entries;
+      },
+      pool: pg,
+    });
+    expect(captured.steps).toHaveLength(2);
+    expect(captured.steps[0]).toMatchObject({ name: 'fleet.resolveSandbox', outcome: 'ok' });
+    expect(captured.steps[1]).toMatchObject({ name: 'sandbox.commitAll', outcome: 'ok' });
+  });
+
+  it('records an error outcome for a failing step and rethrows', async () => {
+    const pg = new FakePg();
+    let capturedEntries: readonly { name: string; outcome: string }[] = [];
+    await expect(
+      withProjectLock({
+        key: 'proj1:user1',
+        fn: async (_signal, recorder) => {
+          await recorder.step('ok.step', () => Promise.resolve());
+          try {
+            await recorder.step('bad.step', () => Promise.reject(new Error('boom')));
+          } finally {
+            capturedEntries = recorder.entries.map(e => ({ name: e.name, outcome: e.outcome }));
+          }
+        },
+        pool: pg,
+      }),
+    ).rejects.toThrow('boom');
+    expect(capturedEntries).toEqual([
+      { name: 'ok.step', outcome: 'ok' },
+      { name: 'bad.step', outcome: 'error' },
+    ]);
+  });
+
+  it('attaches step history and currentStep to ProjectLockTimeoutError', async () => {
+    const pg = new FakePg();
+    let caught: ProjectLockTimeoutError | undefined;
+    try {
+      await withProjectLock({
+        key: 'proj1:user1',
+        timeoutMs: 30,
+        fn: async (_signal, recorder) => {
+          await recorder.step('step.fast', () => Promise.resolve());
+          await recorder.step('step.hanging', () => new Promise<void>(() => {}));
+        },
+        pool: pg,
+      });
+    } catch (err) {
+      caught = err as ProjectLockTimeoutError;
+    }
+    expect(caught).toBeInstanceOf(ProjectLockTimeoutError);
+    expect(caught?.currentStep).toBe('step.hanging');
+    expect(caught?.steps.map(s => s.name)).toEqual(['step.fast', 'step.hanging']);
+    const hanging = caught?.steps.find(s => s.name === 'step.hanging');
+    expect(hanging?.outcome).toBe('running');
+    expect(hanging?.durationMs).toBeGreaterThan(0);
+    // Error message surfaces the currentStep for quick log-scanning.
+    expect(caught?.message).toContain('step.hanging');
+  });
+
+  it('emits a slow-lock warn when total exceeds the threshold', async () => {
+    const pg = new FakePg();
+    process.env.MASTRACODE_PROJECT_LOCK_SLOW_WARN_MS = '10';
+    const logger = collectingLogger();
+    try {
+      await withProjectLock({
+        key: 'proj1:user1',
+        logger,
+        fn: async (_signal, recorder) => {
+          await recorder.step('slow.thing', () => new Promise(r => setTimeout(r, 25)));
+        },
+        pool: pg,
+      });
+    } finally {
+      delete process.env.MASTRACODE_PROJECT_LOCK_SLOW_WARN_MS;
+    }
+    expect(logger.warnings).toHaveLength(1);
+    const warning = logger.warnings[0]!;
+    expect(warning.message).toContain('slow critical section');
+    expect(warning.meta).toMatchObject({
+      key: 'proj1:user1',
+      thresholdMs: 10,
+    });
+    const steps = warning.meta?.steps as Array<{ name: string; outcome: string }>;
+    expect(steps.map(s => s.name)).toEqual(['slow.thing']);
+    expect(steps[0]?.outcome).toBe('ok');
+  });
+
+  it('does not warn when the critical section stays under the threshold', async () => {
+    const pg = new FakePg();
+    // Explicitly raise the threshold so the test is deterministic
+    // regardless of the default.
+    process.env.MASTRACODE_PROJECT_LOCK_SLOW_WARN_MS = String(DEFAULT_PROJECT_LOCK_SLOW_WARN_MS);
+    const logger = collectingLogger();
+    try {
+      await withProjectLock({
+        key: 'proj1:user1',
+        logger,
+        fn: async (_signal, recorder) => {
+          await recorder.step('quick.thing', () => Promise.resolve());
+        },
+        pool: pg,
+      });
+    } finally {
+      delete process.env.MASTRACODE_PROJECT_LOCK_SLOW_WARN_MS;
+    }
+    expect(logger.warnings).toHaveLength(0);
   });
 });

--- a/mastracode/factory/src/integrations/github/project-lock.ts
+++ b/mastracode/factory/src/integrations/github/project-lock.ts
@@ -35,6 +35,56 @@ export interface LockClient {
 const inProcessLocks = new Map<string, Promise<unknown>>();
 
 /**
+ * Default hard cap on how long a critical section may run inside the project
+ * lock. Prevents an untimed outbound call (sandbox HTTP, GitHub App API, git
+ * push, etc.) from pinning both the advisory lock and the pg pool connection
+ * indefinitely — the failure mode behind the 2025-07-23 shipyard 30s plateau
+ * incident. Callers can override per call via `timeoutMs`.
+ */
+export const DEFAULT_PROJECT_LOCK_TIMEOUT_MS = 60_000;
+
+/** Thrown when the critical section under `withProjectLock` exceeds the timeout. */
+export class ProjectLockTimeoutError extends Error {
+  readonly key: string;
+  readonly timeoutMs: number;
+  constructor(key: string, timeoutMs: number) {
+    super(`Project lock critical section for "${key}" exceeded ${timeoutMs}ms`);
+    this.name = 'ProjectLockTimeoutError';
+    this.key = key;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
+ * Race `fn()` against a timeout, throwing `ProjectLockTimeoutError` if the
+ * timeout fires first. `fn()` receives an `AbortSignal` so it can (optionally)
+ * abort in-flight outbound I/O when the timeout trips. If `fn()` ignores the
+ * signal it will still resolve/reject eventually — but the caller sees the
+ * timeout error immediately, which is what lets the outer lock wrapper roll
+ * back and release the connection.
+ */
+async function runWithTimeout<T>(key: string, timeoutMs: number, fn: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const abortError = new Promise<never>((_, reject) => {
+    controller.signal.addEventListener('abort', () => reject(new ProjectLockTimeoutError(key, timeoutMs)), {
+      once: true,
+    });
+  });
+  const work = fn(controller.signal);
+  // If `fn` eventually rejects (e.g. its own fetch observes the abort signal
+  // after we already rejected via timeout), swallow it — the outer caller
+  // has already been rejected with our timeout error and we don't want an
+  // unhandled rejection.
+  work.catch(() => {});
+  try {
+    return await Promise.race([work, abortError]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * True when the cross-replica lock layer should be used: not force-disabled
  * via env, and the factory storage backend exposes the
  * `withDistributedLock` capability.
@@ -70,13 +120,20 @@ export function withProjectLock<T>(options: {
   key: string;
   /** Factory storage backend supplying the `withDistributedLock` capability, when available. */
   storage?: FactoryStorage;
-  fn: () => Promise<T>;
+  fn: (signal: AbortSignal) => Promise<T>;
   /** Test seam: fake pg pool standing in for the distributed layer. */
   pool?: LockPool;
+  /**
+   * Hard cap on the critical section. Defaults to
+   * {@link DEFAULT_PROJECT_LOCK_TIMEOUT_MS}. On timeout `fn`'s abort signal
+   * fires and the outer lock throws `ProjectLockTimeoutError`, releasing the
+   * advisory lock + pool connection.
+   */
+  timeoutMs?: number;
 }): Promise<T> {
-  const { key, storage, fn, pool } = options;
+  const { key, storage, fn, pool, timeoutMs = DEFAULT_PROJECT_LOCK_TIMEOUT_MS } = options;
   const prev = inProcessLocks.get(key) ?? Promise.resolve();
-  const run = () => withDbAdvisoryLock({ key, storage, fn, pool });
+  const run = () => withDbAdvisoryLock({ key, storage, fn, pool, timeoutMs });
   const next = prev.then(run, run);
   const tail = next.then(
     () => undefined,
@@ -108,24 +165,34 @@ export function withProjectLock<T>(options: {
 export async function withDbAdvisoryLock<T>(options: {
   key: string;
   storage?: FactoryStorage;
-  fn: () => Promise<T>;
+  fn: (signal: AbortSignal) => Promise<T>;
   pool?: LockPool;
+  timeoutMs?: number;
 }): Promise<T> {
-  const { key, storage, fn, pool } = options;
+  const { key, storage, fn, pool, timeoutMs = DEFAULT_PROJECT_LOCK_TIMEOUT_MS } = options;
   if (process.env.MASTRACODE_DISTRIBUTED_LOCK === '0') {
-    return fn();
+    return runWithTimeout(key, timeoutMs, fn);
   }
 
-  if (pool) return advisoryLockOver(pool, key, fn);
+  if (pool) return advisoryLockOver(pool, key, timeoutMs, fn);
 
   if (typeof storage?.withDistributedLock !== 'function') {
-    return fn();
+    return runWithTimeout(key, timeoutMs, fn);
   }
-  return storage.withDistributedLock(key, fn);
+  // Wrap the backend-provided lock so the critical section is bounded
+  // regardless of whether the backend implements its own timeout. The
+  // backend still owns lock acquisition/release; we own the timeout on
+  // `fn`.
+  return storage.withDistributedLock(key, () => runWithTimeout(key, timeoutMs, fn));
 }
 
 /** The pg advisory-lock body, kept for the `poolOverride` test seam. */
-async function advisoryLockOver<T>(pool: LockPool, key: string, fn: () => Promise<T>): Promise<T> {
+async function advisoryLockOver<T>(
+  pool: LockPool,
+  key: string,
+  timeoutMs: number,
+  fn: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
   const [k1, k2] = hashKey(key);
   const client = await pool.connect();
   try {
@@ -134,11 +201,19 @@ async function advisoryLockOver<T>(pool: LockPool, key: string, fn: () => Promis
     // when the transaction ends below.
     await client.query('SELECT pg_advisory_xact_lock($1, $2)', [k1, k2]);
     try {
-      const result = await fn();
+      const result = await runWithTimeout(key, timeoutMs, fn);
       await client.query('COMMIT');
       return result;
     } catch (err) {
-      await client.query('ROLLBACK');
+      // COMMIT/ROLLBACK below releases the advisory lock. If the underlying
+      // connection is already dead (e.g. Neon killed it after IIT), the
+      // rollback throws — we swallow that specifically so the original error
+      // reaches the caller.
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        /* connection already gone; nothing to roll back */
+      }
       throw err;
     }
   } finally {

--- a/mastracode/factory/src/integrations/github/project-lock.ts
+++ b/mastracode/factory/src/integrations/github/project-lock.ts
@@ -43,42 +43,216 @@ const inProcessLocks = new Map<string, Promise<unknown>>();
  */
 export const DEFAULT_PROJECT_LOCK_TIMEOUT_MS = 60_000;
 
+/**
+ * Emit a `warn` log when a critical section completes but took longer than
+ * this many ms. Catches platform-call regressions (Fleet, sandbox HTTP,
+ * GitHub App API, our own storage) before they cascade into the timeout.
+ * Tunable via `MASTRACODE_PROJECT_LOCK_SLOW_WARN_MS`.
+ */
+export const DEFAULT_PROJECT_LOCK_SLOW_WARN_MS = 5_000;
+
+/** Cap on how many named steps we retain per invocation. Cheap ring buffer. */
+export const MAX_LOCK_STEPS = 32;
+
+function slowWarnThresholdMs(): number {
+  const raw = process.env.MASTRACODE_PROJECT_LOCK_SLOW_WARN_MS;
+  if (!raw) return DEFAULT_PROJECT_LOCK_SLOW_WARN_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_PROJECT_LOCK_SLOW_WARN_MS;
+}
+
+/** One recorded boundary from inside `fn()`. */
+export interface LockStepEntry {
+  readonly name: string;
+  /** ms since the recorder started (i.e. since `fn()` entered). */
+  readonly startedAtMs: number;
+  /** ms elapsed inside `fn`; `null` if the step never finished (still running when we captured). */
+  readonly durationMs: number | null;
+  /** `'ok'` if it resolved, `'error'` if it rejected, `'running'` if it never settled. */
+  readonly outcome: 'ok' | 'error' | 'running';
+}
+
+/**
+ * Passed to `fn()` under the lock. Wrap named boundaries with
+ * `recorder.step('sandbox.commitAll', () => commitAll(...))` so timeouts and
+ * slow-lock warnings can pinpoint which platform call was in flight when the
+ * critical section ran long. Cheap: no I/O, just Date.now() bookkeeping.
+ */
+export interface LockStepRecorder {
+  step<T>(name: string, fn: () => Promise<T>): Promise<T>;
+  /** Currently-executing step, if any. Useful in tests and diagnostics. */
+  readonly currentStep: string | null;
+  /** Immutable snapshot of the recorded step history. */
+  readonly entries: ReadonlyArray<LockStepEntry>;
+}
+
+/**
+ * The mutable recorder implementation. Not exported directly — callers only
+ * see the `LockStepRecorder` interface (via `fn(signal, recorder)`) or the
+ * frozen snapshot on `ProjectLockTimeoutError.steps`.
+ */
+class MutableLockStepRecorder implements LockStepRecorder {
+  private readonly _entries: LockStepEntry[] = [];
+  private readonly startedAt = Date.now();
+  private _currentStep: string | null = null;
+
+  get currentStep(): string | null {
+    return this._currentStep;
+  }
+
+  get entries(): ReadonlyArray<LockStepEntry> {
+    return this._entries;
+  }
+
+  totalMs(): number {
+    return Date.now() - this.startedAt;
+  }
+
+  async step<T>(name: string, fn: () => Promise<T>): Promise<T> {
+    const startedAtMs = Date.now() - this.startedAt;
+    const prevStep = this._currentStep;
+    this._currentStep = name;
+    // Reserve slot up front so a hanging step still shows up in diagnostics.
+    // We track the reserved entry by identity, not by index, so the ring
+    // buffer's `shift()` cannot silently corrupt our target slot.
+    const reserved: LockStepEntry = { name, startedAtMs, durationMs: null, outcome: 'running' };
+    this.pushEntry(reserved);
+    try {
+      const result = await fn();
+      this.replaceEntry(reserved, {
+        name,
+        startedAtMs,
+        durationMs: Date.now() - this.startedAt - startedAtMs,
+        outcome: 'ok',
+      });
+      return result;
+    } catch (err) {
+      this.replaceEntry(reserved, {
+        name,
+        startedAtMs,
+        durationMs: Date.now() - this.startedAt - startedAtMs,
+        outcome: 'error',
+      });
+      throw err;
+    } finally {
+      this._currentStep = prevStep;
+    }
+  }
+
+  private pushEntry(entry: LockStepEntry) {
+    if (this._entries.length >= MAX_LOCK_STEPS) {
+      // Drop oldest entry so the tail (which is what actually caused the
+      // slowdown or timeout) is preserved.
+      this._entries.shift();
+    }
+    this._entries.push(entry);
+  }
+
+  private replaceEntry(reserved: LockStepEntry, entry: LockStepEntry) {
+    const idx = this._entries.indexOf(reserved);
+    if (idx >= 0) {
+      this._entries[idx] = entry;
+    } else {
+      // The reserved slot was evicted by the ring buffer. Append the
+      // completed version to the tail so the outcome is not lost.
+      this.pushEntry(entry);
+    }
+  }
+
+  /**
+   * Snapshot of the current recorder state, safe to attach to an error.
+   * Any still-running step is captured as `outcome: 'running'` with a
+   * duration reflecting how long it had been running when we snapshotted.
+   */
+  snapshot(): { steps: ReadonlyArray<LockStepEntry>; currentStep: string | null; totalMs: number } {
+    const now = Date.now();
+    const steps = this._entries.map(entry =>
+      entry.outcome === 'running' ? { ...entry, durationMs: now - this.startedAt - entry.startedAtMs } : entry,
+    );
+    return { steps: Object.freeze(steps), currentStep: this._currentStep, totalMs: now - this.startedAt };
+  }
+}
+
 /** Thrown when the critical section under `withProjectLock` exceeds the timeout. */
 export class ProjectLockTimeoutError extends Error {
   readonly key: string;
   readonly timeoutMs: number;
-  constructor(key: string, timeoutMs: number) {
-    super(`Project lock critical section for "${key}" exceeded ${timeoutMs}ms`);
+  readonly steps: ReadonlyArray<LockStepEntry>;
+  readonly currentStep: string | null;
+  constructor(
+    key: string,
+    timeoutMs: number,
+    snapshot: { steps: ReadonlyArray<LockStepEntry>; currentStep: string | null } = { steps: [], currentStep: null },
+  ) {
+    const suffix = snapshot.currentStep
+      ? ` (currentStep=${snapshot.currentStep})`
+      : snapshot.steps.length > 0
+        ? ` (lastStep=${snapshot.steps[snapshot.steps.length - 1]?.name ?? 'unknown'})`
+        : '';
+    super(`Project lock critical section for "${key}" exceeded ${timeoutMs}ms${suffix}`);
     this.name = 'ProjectLockTimeoutError';
     this.key = key;
     this.timeoutMs = timeoutMs;
+    this.steps = snapshot.steps;
+    this.currentStep = snapshot.currentStep;
   }
 }
+
+/** Optional logger surface — matches the `console.warn` shape by default. */
+export interface LockLogger {
+  warn(message: string, meta?: Record<string, unknown>): void;
+}
+
+const defaultLogger: LockLogger = {
+  warn(message, meta) {
+    console.warn(message, meta ?? {});
+  },
+};
 
 /**
  * Race `fn()` against a timeout, throwing `ProjectLockTimeoutError` if the
  * timeout fires first. `fn()` receives an `AbortSignal` so it can (optionally)
- * abort in-flight outbound I/O when the timeout trips. If `fn()` ignores the
- * signal it will still resolve/reject eventually — but the caller sees the
- * timeout error immediately, which is what lets the outer lock wrapper roll
- * back and release the connection.
+ * abort in-flight outbound I/O when the timeout trips. It also receives a
+ * `LockStepRecorder` so callers can name their platform-call boundaries; on
+ * timeout the recorded steps are attached to the error and on non-timeout
+ * completion a slow-lock warn log is emitted when the total exceeds
+ * {@link DEFAULT_PROJECT_LOCK_SLOW_WARN_MS}.
  */
-async function runWithTimeout<T>(key: string, timeoutMs: number, fn: (signal: AbortSignal) => Promise<T>): Promise<T> {
+async function runWithTimeout<T>(
+  key: string,
+  timeoutMs: number,
+  fn: (signal: AbortSignal, recorder: LockStepRecorder) => Promise<T>,
+  logger: LockLogger = defaultLogger,
+): Promise<T> {
   const controller = new AbortController();
+  const recorder = new MutableLockStepRecorder();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   const abortError = new Promise<never>((_, reject) => {
-    controller.signal.addEventListener('abort', () => reject(new ProjectLockTimeoutError(key, timeoutMs)), {
-      once: true,
-    });
+    controller.signal.addEventListener(
+      'abort',
+      () => reject(new ProjectLockTimeoutError(key, timeoutMs, recorder.snapshot())),
+      { once: true },
+    );
   });
-  const work = fn(controller.signal);
+  const work = fn(controller.signal, recorder);
   // If `fn` eventually rejects (e.g. its own fetch observes the abort signal
   // after we already rejected via timeout), swallow it — the outer caller
   // has already been rejected with our timeout error and we don't want an
   // unhandled rejection.
   work.catch(() => {});
   try {
-    return await Promise.race([work, abortError]);
+    const result = await Promise.race([work, abortError]);
+    const { totalMs, steps } = recorder.snapshot();
+    const slowWarn = slowWarnThresholdMs();
+    if (slowWarn > 0 && totalMs >= slowWarn) {
+      logger.warn(`[project-lock] slow critical section for "${key}" took ${totalMs}ms`, {
+        key,
+        totalMs,
+        thresholdMs: slowWarn,
+        steps: steps.map(s => ({ name: s.name, durationMs: s.durationMs, outcome: s.outcome })),
+      });
+    }
+    return result;
   } finally {
     clearTimeout(timer);
   }
@@ -120,7 +294,7 @@ export function withProjectLock<T>(options: {
   key: string;
   /** Factory storage backend supplying the `withDistributedLock` capability, when available. */
   storage?: FactoryStorage;
-  fn: (signal: AbortSignal) => Promise<T>;
+  fn: (signal: AbortSignal, recorder: LockStepRecorder) => Promise<T>;
   /** Test seam: fake pg pool standing in for the distributed layer. */
   pool?: LockPool;
   /**
@@ -130,10 +304,12 @@ export function withProjectLock<T>(options: {
    * advisory lock + pool connection.
    */
   timeoutMs?: number;
+  /** Optional logger override; falls back to `console.warn` for slow-lock warnings. */
+  logger?: LockLogger;
 }): Promise<T> {
-  const { key, storage, fn, pool, timeoutMs = DEFAULT_PROJECT_LOCK_TIMEOUT_MS } = options;
+  const { key, storage, fn, pool, timeoutMs = DEFAULT_PROJECT_LOCK_TIMEOUT_MS, logger } = options;
   const prev = inProcessLocks.get(key) ?? Promise.resolve();
-  const run = () => withDbAdvisoryLock({ key, storage, fn, pool, timeoutMs });
+  const run = () => withDbAdvisoryLock({ key, storage, fn, pool, timeoutMs, logger });
   const next = prev.then(run, run);
   const tail = next.then(
     () => undefined,
@@ -165,25 +341,26 @@ export function withProjectLock<T>(options: {
 export async function withDbAdvisoryLock<T>(options: {
   key: string;
   storage?: FactoryStorage;
-  fn: (signal: AbortSignal) => Promise<T>;
+  fn: (signal: AbortSignal, recorder: LockStepRecorder) => Promise<T>;
   pool?: LockPool;
   timeoutMs?: number;
+  logger?: LockLogger;
 }): Promise<T> {
-  const { key, storage, fn, pool, timeoutMs = DEFAULT_PROJECT_LOCK_TIMEOUT_MS } = options;
+  const { key, storage, fn, pool, timeoutMs = DEFAULT_PROJECT_LOCK_TIMEOUT_MS, logger } = options;
   if (process.env.MASTRACODE_DISTRIBUTED_LOCK === '0') {
-    return runWithTimeout(key, timeoutMs, fn);
+    return runWithTimeout(key, timeoutMs, fn, logger);
   }
 
-  if (pool) return advisoryLockOver(pool, key, timeoutMs, fn);
+  if (pool) return advisoryLockOver(pool, key, timeoutMs, fn, logger);
 
   if (typeof storage?.withDistributedLock !== 'function') {
-    return runWithTimeout(key, timeoutMs, fn);
+    return runWithTimeout(key, timeoutMs, fn, logger);
   }
   // Wrap the backend-provided lock so the critical section is bounded
   // regardless of whether the backend implements its own timeout. The
   // backend still owns lock acquisition/release; we own the timeout on
   // `fn`.
-  return storage.withDistributedLock(key, () => runWithTimeout(key, timeoutMs, fn));
+  return storage.withDistributedLock(key, () => runWithTimeout(key, timeoutMs, fn, logger));
 }
 
 /** The pg advisory-lock body, kept for the `poolOverride` test seam. */
@@ -191,7 +368,8 @@ async function advisoryLockOver<T>(
   pool: LockPool,
   key: string,
   timeoutMs: number,
-  fn: (signal: AbortSignal) => Promise<T>,
+  fn: (signal: AbortSignal, recorder: LockStepRecorder) => Promise<T>,
+  logger?: LockLogger,
 ): Promise<T> {
   const [k1, k2] = hashKey(key);
   const client = await pool.connect();
@@ -201,7 +379,7 @@ async function advisoryLockOver<T>(
     // when the transaction ends below.
     await client.query('SELECT pg_advisory_xact_lock($1, $2)', [k1, k2]);
     try {
-      const result = await runWithTimeout(key, timeoutMs, fn);
+      const result = await runWithTimeout(key, timeoutMs, fn, logger);
       await client.query('COMMIT');
       return result;
     } catch (err) {

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -1349,25 +1349,27 @@ function buildProjectGitRoutes({
           return await withProjectLock({
             key: `${project.id}:${userId}`,
             storage,
-            fn: async () => {
-              const sandbox = await resolveProjectSandbox({ fleet, sandboxRow: sandboxBinding });
-              const result = await commitAll(
-                sandbox,
-                workdir,
-                body.message as string,
-                identityFromUser(await auth.ensureUser(loose(c))),
+            fn: async (_signal, steps) => {
+              const sandbox = await steps.step('fleet.resolveSandbox', () =>
+                resolveProjectSandbox({ fleet, sandboxRow: sandboxBinding }),
               );
-              if (result.committed) {
-                await emitAudit?.({
-                  context: loose(c),
-                  input: {
-                    action: 'factory.git.commit',
-                    factoryProjectId: project.factoryProjectId,
-                    projectRepositoryId: project.id,
-                    targets: [{ type: 'session', id: sessionWorkspace.session.sessionId }],
-                    metadata: { sessionId: sessionWorkspace.session.sessionId },
-                  },
-                });
+              const identity = identityFromUser(await steps.step('auth.ensureUser', () => auth.ensureUser(loose(c))));
+              const result = await steps.step('sandbox.commitAll', () =>
+                commitAll(sandbox, workdir, body.message as string, identity),
+              );
+              if (result.committed && emitAudit) {
+                await steps.step('audit.git.commit', () =>
+                  emitAudit({
+                    context: loose(c),
+                    input: {
+                      action: 'factory.git.commit',
+                      factoryProjectId: project.factoryProjectId,
+                      projectRepositoryId: project.id,
+                      targets: [{ type: 'session', id: sessionWorkspace.session.sessionId }],
+                      metadata: { sessionId: sessionWorkspace.session.sessionId },
+                    },
+                  }),
+                );
               }
               return c.json({ committed: result.committed });
             },
@@ -1407,24 +1409,34 @@ function buildProjectGitRoutes({
           return await withProjectLock({
             key: `${project.id}:${userId}`,
             storage,
-            fn: async () => {
-              const sandbox = await resolveProjectSandbox({ fleet, sandboxRow: sandboxBinding });
-              const access = await github.versionControl.getRepositoryAccess({
-                orgId,
-                repositoryId: project.repository.id,
-              });
+            fn: async (_signal, steps) => {
+              const sandbox = await steps.step('fleet.resolveSandbox', () =>
+                resolveProjectSandbox({ fleet, sandboxRow: sandboxBinding }),
+              );
+              const access = await steps.step('github.getRepositoryAccess', () =>
+                github.versionControl.getRepositoryAccess({
+                  orgId,
+                  repositoryId: project.repository.id,
+                }),
+              );
               if (!access.authorization) throw new Error('Repository access did not include a bearer token.');
-              await pushBranch(sandbox, workdir, branch, access.authorization.token, project.repository.slug);
-              await emitAudit?.({
-                context: loose(c),
-                input: {
-                  action: 'factory.git.push',
-                  factoryProjectId: project.factoryProjectId,
-                  projectRepositoryId: project.id,
-                  targets: [{ type: 'branch', id: branch }],
-                  metadata: { branch, sessionId: sessionWorkspace.session.sessionId },
-                },
-              });
+              await steps.step('sandbox.pushBranch', () =>
+                pushBranch(sandbox, workdir, branch, access.authorization!.token, project.repository.slug),
+              );
+              if (emitAudit) {
+                await steps.step('audit.git.push', () =>
+                  emitAudit({
+                    context: loose(c),
+                    input: {
+                      action: 'factory.git.push',
+                      factoryProjectId: project.factoryProjectId,
+                      projectRepositoryId: project.id,
+                      targets: [{ type: 'branch', id: branch }],
+                      metadata: { branch, sessionId: sessionWorkspace.session.sessionId },
+                    },
+                  }),
+                );
+              }
               return c.json({ pushed: true, branch });
             },
           });
@@ -1480,54 +1492,62 @@ function buildProjectGitRoutes({
           return await withProjectLock({
             key: `${project.id}:${userId}`,
             storage,
-            fn: async () => {
-              const result = await github.versionControl.createPullRequest({
-                connection: {
-                  type: 'app-installation',
-                  installationId: Number(project.installation.externalId),
-                },
-                sourceId: project.repository.slug,
-                baseBranch: base,
-                headBranch: head,
-                title,
-                body: prBody,
-                actingUserId: userId,
-              });
-              await emitAudit?.({
-                context: loose(c),
-                input: {
-                  action: 'factory.git.pr_opened',
-                  factoryProjectId: project.factoryProjectId,
-                  projectRepositoryId: project.id,
-                  targets: [{ type: 'pull_request', id: result.url, name: title }],
-                  metadata: { branch: head, base, url: result.url },
-                },
-              });
+            fn: async (_signal, steps) => {
+              const result = await steps.step('github.createPullRequest', () =>
+                github.versionControl.createPullRequest({
+                  connection: {
+                    type: 'app-installation',
+                    installationId: Number(project.installation.externalId),
+                  },
+                  sourceId: project.repository.slug,
+                  baseBranch: base,
+                  headBranch: head,
+                  title,
+                  body: prBody,
+                  actingUserId: userId,
+                }),
+              );
+              if (emitAudit) {
+                await steps.step('audit.git.pr_opened', () =>
+                  emitAudit({
+                    context: loose(c),
+                    input: {
+                      action: 'factory.git.pr_opened',
+                      factoryProjectId: project.factoryProjectId,
+                      projectRepositoryId: project.id,
+                      targets: [{ type: 'pull_request', id: result.url, name: title }],
+                      metadata: { branch: head, base, url: result.url },
+                    },
+                  }),
+                );
+              }
               const pullRequestNumber = pullRequestNumberFromUrl(result.url, project.repository.slug);
               if (pullRequestNumber) {
                 const sessionId = sessionWorkspace.session.sessionId;
-                await subscribeToPullRequest(
-                  {
-                    orgId,
-                    installationExternalId: project.installation.externalId,
-                    projectRepositoryId: project.id,
-                    repositoryExternalId: project.repository.externalId,
-                    repositorySlug: project.repository.slug,
-                    changeRequestId: pullRequestNumber.toString(),
-                    sessionId,
-                    ownerId: userId,
-                    resourceId: sessionId,
-                    threadId: sessionId,
-                    source: 'factory-pr-create',
-                    subscribedByUserId: userId,
-                  },
-                  github.integrationStorage,
-                ).catch((error: unknown) => {
-                  console.warn(
-                    `[GitHub] Pull request ${result.url} was created but automatic subscription failed.`,
-                    error,
-                  );
-                });
+                await steps.step('storage.subscribeToPullRequest', () =>
+                  subscribeToPullRequest(
+                    {
+                      orgId,
+                      installationExternalId: project.installation.externalId,
+                      projectRepositoryId: project.id,
+                      repositoryExternalId: project.repository.externalId,
+                      repositorySlug: project.repository.slug,
+                      changeRequestId: pullRequestNumber.toString(),
+                      sessionId,
+                      ownerId: userId,
+                      resourceId: sessionId,
+                      threadId: sessionId,
+                      source: 'factory-pr-create',
+                      subscribedByUserId: userId,
+                    },
+                    github.integrationStorage,
+                  ).catch((error: unknown) => {
+                    console.warn(
+                      `[GitHub] Pull request ${result.url} was created but automatic subscription failed.`,
+                      error,
+                    );
+                  }),
+                );
               }
               return c.json({ url: result.url });
             },
@@ -1562,14 +1582,18 @@ function buildProjectGitRoutes({
           return await withProjectLock({
             key: `${project.id}:${userId}`,
             storage,
-            fn: async () => {
-              const sandbox = await fleet.reattachSandbox(sandboxRow.sandboxId!);
-              await teardownProjectSandbox({
-                fleet,
-                row: sandboxRow,
-                storage: github.sourceControlStorage.sandboxes,
-                sandbox,
-              });
+            fn: async (_signal, steps) => {
+              const sandbox = await steps.step('fleet.reattachSandbox', () =>
+                fleet.reattachSandbox(sandboxRow.sandboxId!),
+              );
+              await steps.step('sandbox.teardown', () =>
+                teardownProjectSandbox({
+                  fleet,
+                  row: sandboxRow,
+                  storage: github.sourceControlStorage.sandboxes,
+                  sandbox,
+                }),
+              );
               return c.json({ tornDown: true });
             },
           });

--- a/mastracode/sdk/src/auth/providers/anthropic.ts
+++ b/mastracode/sdk/src/auth/providers/anthropic.ts
@@ -69,6 +69,10 @@ export async function completeAnthropicLogin(input: string, verifier: string): P
 
   const tokenResponse = await fetch(TOKEN_URL, {
     method: 'POST',
+    // Bound the OAuth exchange so an unresponsive upstream cannot pin the
+    // caller (and, in the shipyard server, the containing project lock)
+    // indefinitely. See 2025-07-23 shipyard latency incident.
+    signal: AbortSignal.timeout(15_000),
     headers: {
       'Content-Type': 'application/json',
     },
@@ -127,6 +131,7 @@ export async function loginAnthropic(
 export async function refreshAnthropicToken(refreshToken: string): Promise<OAuthCredentials> {
   const response = await fetch(TOKEN_URL, {
     method: 'POST',
+    signal: AbortSignal.timeout(15_000),
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       grant_type: 'refresh_token',


### PR DESCRIPTION
> Stacked on #20129. Review that PR first; merge base is `fix/factory-lock-and-fetch-timeouts`.

## Summary

Answer Charlie's question from #20129: *"what if the slow call is one of our own platform calls, not a third party?"* Right now `ProjectLockTimeoutError` only tells us "60s elapsed" — not whether Fleet was slow, our sandbox HTTP was slow, GitHub App API was slow, or our own storage was slow. That's not enough to diagnose the next incident.

This PR adds a `LockStepRecorder` that `fn()` receives as its second argument. Callers wrap named boundaries with `recorder.step('sandbox.commitAll', () => commitAll(...))`; the recorder captures start time, duration, and outcome for each step (cheap: no I/O, just `Date.now()` bookkeeping). Two consumers:

1. **On timeout** the recorded steps and the still-running step are attached to `ProjectLockTimeoutError.steps` and `.currentStep`, and the error message includes the current step name. So instead of `Project lock critical section for "proj123:userA" exceeded 60000ms` we get `... exceeded 60000ms (currentStep=sandbox.pushBranch)` plus the full breadcrumb array on the error.
2. **On non-timeout slow completion** — when the total exceeds `MASTRACODE_PROJECT_LOCK_SLOW_WARN_MS` (default 5s) — a structured `warn` is emitted with the same breadcrumbs. This catches platform-call regressions long before they cascade into a full timeout.

All four GitHub route lock sites are wired: commit, push, PR create, sandbox teardown. Named steps cover the platform-call surface that actually runs under the lock: `fleet.resolveSandbox`, `fleet.reattachSandbox`, `sandbox.commitAll`, `sandbox.pushBranch`, `sandbox.teardown`, `github.getRepositoryAccess`, `github.createPullRequest`, `auth.ensureUser`, `storage.subscribeToPullRequest`, and the corresponding audit emits.

## What changed

- `mastracode/factory/src/integrations/github/project-lock.ts`
  - New `LockStepRecorder` interface (and internal `MutableLockStepRecorder`) with `step(name, fn)` + `entries` + `currentStep`.
  - `ProjectLockTimeoutError` now carries `steps: ReadonlyArray<LockStepEntry>` and `currentStep: string | null`; message includes `(currentStep=…)`.
  - `runWithTimeout` builds the recorder, passes it to `fn(signal, recorder)`, snapshots on timeout, and on successful completion emits a structured `warn` when `totalMs >= slowWarnThresholdMs()`.
  - `withProjectLock` / `withDbAdvisoryLock` accept an optional `logger?: LockLogger` so callers (and tests) can capture the slow-lock warn without touching `console`.
  - Ring buffer capped at 32 entries per invocation (typical is <10). Uses object-identity to replace the reserved "running" slot on completion, so even if the ring buffer evicts an old entry the outcome is preserved as a tail append.
- `mastracode/factory/src/integrations/github/routes.ts`
  - The 4 `withProjectLock` call sites now use `fn: async (_signal, steps) => { await steps.step('…', () => …) }` for every awaited call inside the lock — including audit emits, so a slow logging backend also shows up in the breadcrumbs.

## Example output

Timeout error:
```
ProjectLockTimeoutError: Project lock critical section for "proj123:userA" exceeded 60000ms (currentStep=sandbox.pushBranch)
  steps: [
    { name: 'fleet.resolveSandbox',       startedAtMs: 0,   durationMs: 42,    outcome: 'ok'      },
    { name: 'github.getRepositoryAccess', startedAtMs: 42,  durationMs: 118,   outcome: 'ok'      },
    { name: 'sandbox.pushBranch',         startedAtMs: 160, durationMs: 59840, outcome: 'running' },
  ]
```

Slow-lock warn (total 7.2s under a 5s threshold):
```
[project-lock] slow critical section for "proj123:userA" took 7213ms
  meta: {
    key: 'proj123:userA',
    totalMs: 7213,
    thresholdMs: 5000,
    steps: [
      { name: 'fleet.resolveSandbox', durationMs: 38,   outcome: 'ok' },
      { name: 'sandbox.commitAll',    durationMs: 7160, outcome: 'ok' },
      { name: 'audit.git.commit',     durationMs: 15,   outcome: 'ok' },
    ],
  }
```

## Test plan

- 5 new tests in `project-lock-scenario.test.ts`:
  - Records completed steps in order with durations and `ok` outcomes.
  - Records `error` outcome for a failing step and rethrows.
  - Attaches step history and `currentStep` to `ProjectLockTimeoutError`, including the still-running step with a live duration.
  - Emits a slow-lock warn when total exceeds the threshold; meta payload includes key, `totalMs`, `thresholdMs`, and the step names + outcomes.
  - Does *not* warn when the critical section stays under the threshold.
- Existing 8 scenario tests still pass (cross-replica serialization, ignore-signal, `withDbAdvisoryLock` direct usage, etc.).
- `pnpm --filter ./mastracode/factory exec vitest run src/integrations/github` — 15 files, **271 tests passed**.
- Typecheck on `mastracode/factory` — clean.
- Lint on `mastracode/factory` — clean.

## Notes for reviewers

- Stacked on #20129 because the recorder extends the timeout infrastructure introduced there (`ProjectLockTimeoutError`, `runWithTimeout`, `AbortSignal` on `fn`). Merging in order: #20129 first, then this.
- The `fn(signal, recorder)` shape means the recorder is *always* live under the lock, even for callers that don't opt in — they simply produce empty `steps` arrays. There is no runtime cost when unused.
- Threshold is env-tunable (`MASTRACODE_PROJECT_LOCK_SLOW_WARN_MS`), settable to `0` to disable warns entirely for local dev.
- No production log-format lock-in: the warn goes through the existing `LockLogger` shape, so we can swap in structured logging (pino, etc.) at the caller boundary without touching `project-lock.ts`.
