### PR TITLE
feat(mastracode/web): add PWA manifest so the app is installable

### DIFF
--- a/mastracode/web/src/web/ui/index.html
+++ b/mastracode/web/src/web/ui/index.html
@@ -3,7 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/mastra.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="/mastra.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0f0f0f" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <title>Mastra Factory</title>
     <script>
       // Apply the persisted/system theme class before paint to avoid a flash.

--- a/mastracode/web/src/web/ui/public/manifest.webmanifest
+++ b/mastracode/web/src/web/ui/public/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "Mastra Factory",
+  "short_name": "Factory",
+  "description": "MastraCode web UI",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#0f0f0f",
+  "theme_color": "#0f0f0f",
+  "icons": [
+    {
+      "src": "/mastra.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/mastra.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}


### PR DESCRIPTION
Makes the mastracode/web factory UI installable as a PWA on phones. Adds a `manifest.webmanifest` in the Vite public dir using the existing `mastra.svg` favicon as the app icon (`sizes: any`, `any` + `maskable` purposes), and links it from `index.html` along with `theme-color` and `apple-touch-icon`.

```html
<link rel="manifest" href="/manifest.webmanifest" />
<link rel="apple-touch-icon" href="/mastra.svg" />
<meta name="theme-color" content="#0f0f0f" />
```

Manifest-only — no service worker, so no offline support. On Android/Chrome you get the install prompt; on iOS it's Share → Add to Home Screen (iOS ignores SVG for the home-screen icon, so that one may render generic).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This makes the Mastra Factory website easier to add to a phone’s home screen. It adds the app’s name, icon, colors, and installation settings, but does not make it work offline.

## What changed

- Added a web app manifest with standalone display settings, app metadata, colors, scope, and maskable/general icons.
- Linked the manifest from `index.html`.
- Added mobile app metadata, including theme color, Apple touch icon, and mobile web app support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->