### PR TITLE
fix(factory): remove work-item coordination locks

### DIFF
--- a/.changeset/large-experts-itch.md
+++ b/.changeset/large-experts-itch.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Improved Factory work-item concurrency by relying on atomic database claims and idempotent replay instead of holding distributed locks.
+Improved Factory work-item concurrency by relying on atomic claims, idempotent replay, and serializable relationship transactions instead of distributed advisory locks.

--- a/.changeset/large-experts-itch.md
+++ b/.changeset/large-experts-itch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved Factory work-item concurrency by relying on atomic database claims and idempotent replay instead of holding distributed locks.

--- a/.changeset/large-experts-itch.md
+++ b/.changeset/large-experts-itch.md
@@ -1,5 +1,7 @@
 ---
+'@mastra/core': patch
 '@mastra/factory': patch
+'@mastra/pg': patch
 ---
 
-Improved Factory work-item concurrency by relying on atomic claims, idempotent replay, and serializable relationship transactions instead of distributed advisory locks.
+Improved Factory work-item concurrency by replacing distributed advisory locks with atomic claims, idempotent replay, and serializable relationship transactions.

--- a/.changeset/tiny-ravens-trade.md
+++ b/.changeset/tiny-ravens-trade.md
@@ -1,6 +1,0 @@
----
-'@mastra/core': patch
-'@mastra/pg': patch
----
-
-Replaced the generic Factory distributed-lock capability with optional serializable transactions for database-enforced relationship coordination.

--- a/.changeset/tiny-ravens-trade.md
+++ b/.changeset/tiny-ravens-trade.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/pg': patch
+---
+
+Replaced the generic Factory distributed-lock capability with optional serializable transactions for database-enforced relationship coordination.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -385,16 +385,6 @@ export class MastraFactory {
       },
     });
 
-    // Parent/child work-item mutations still require cross-replica
-    // serialization until their relationship invariants move into the database.
-    if (pubsub && typeof storage.withDistributedLock !== 'function') {
-      process.stderr.write(
-        'MastraCode Web: pubsub is configured (multi-replica?) but the storage backend has no ' +
-          'withDistributedLock capability — parent/child work-item mutations serialize per replica only. ' +
-          'Use PgFactoryStorage for multi-replica deployments.\n',
-      );
-    }
-
     // Repository execution needs one sandbox per project-repository link,
     // cloned from the configured machine. A machine without `clone()` would
     // only fail on first use, so fail fast at boot instead.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -385,13 +385,12 @@ export class MastraFactory {
       },
     });
 
-    // Multi-replica deployments (distributed pubsub configured) need
-    // cross-replica serialization; warn loud when the storage backend can't
-    // provide it so the operator knows locks are per-replica only.
+    // Parent/child work-item mutations still require cross-replica
+    // serialization until their relationship invariants move into the database.
     if (pubsub && typeof storage.withDistributedLock !== 'function') {
       process.stderr.write(
         'MastraCode Web: pubsub is configured (multi-replica?) but the storage backend has no ' +
-          'withDistributedLock capability — project locks serialize per replica only. ' +
+          'withDistributedLock capability — parent/child work-item mutations serialize per replica only. ' +
           'Use PgFactoryStorage for multi-replica deployments.\n',
       );
     }

--- a/mastracode/factory/src/integrations/base.ts
+++ b/mastracode/factory/src/integrations/base.ts
@@ -92,9 +92,8 @@ export interface IntegrationContext {
    */
   fleet: SandboxFleet;
   /**
-   * Root factory storage backend. Supplies the cross-replica
-   * `withDistributedLock` capability and the `appDbConfigured` diagnostic.
-   * Absent when the host runs without an application database.
+   * Root factory storage backend and source of the `appDbConfigured`
+   * diagnostic. Absent when the host runs without an application database.
    */
   factoryStorage?: FactoryStorage;
   /** Browser-facing origin (OAuth redirect base), no trailing slash. */

--- a/mastracode/factory/src/rules/bindings.test.ts
+++ b/mastracode/factory/src/rules/bindings.test.ts
@@ -32,6 +32,16 @@ async function prepareBinding(storage: WorkItemsStorage) {
 }
 
 describe('Factory run binding authority', () => {
+  it('replays concurrent preparation for the same kickoff', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+
+    const [first, second] = await Promise.all([prepareBinding(storage), prepareBinding(storage)]);
+
+    expect([first.replayed, second.replayed].sort()).toEqual([false, true]);
+    expect(second.binding.id).toBe(first.binding.id);
+    expect(second.pendingStart.id).toBe(first.pendingStart.id);
+  });
+
   it('requires the complete tenant, project, thread, resource, and session tuple', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const prepared = await prepareBinding(storage);

--- a/mastracode/factory/src/rules/transition-service.test.ts
+++ b/mastracode/factory/src/rules/transition-service.test.ts
@@ -60,6 +60,20 @@ function request(
 }
 
 describe('FactoryTransitionService', () => {
+  it('replays concurrent transitions with the same ingress identity', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const service = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+
+    const [first, second] = await Promise.all([service.transition(request(item)), service.transition(request(item))]);
+
+    expect(second).toEqual(first);
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.revision).toBe(item.revision + 1);
+  });
+
   it('queues an urgent wake-up when a board drag has no skill follow-up', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const item = await createItem(storage, { stages: ['triage'] });

--- a/mastracode/factory/src/storage/domains/work-items/base.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.test.ts
@@ -235,13 +235,9 @@ describe('WorkItemsStorage', () => {
     expect((await storage.get({ orgId: 'org1', id: child.item.id }))?.parentWorkItemId).toBeNull();
   });
 
-  it('serializes relationship writes and deletion on the project lock', async () => {
-    const backend = new LibSQLFactoryStorage({ id: 'work-items-lock-test', url: ':memory:' });
-    const locks: string[] = [];
-    backend.withDistributedLock = vi.fn(async (key, fn) => {
-      locks.push(key);
-      return fn();
-    });
+  it('uses serializable transactions for relationship writes and deletion', async () => {
+    const backend = new LibSQLFactoryStorage({ id: 'work-items-relation-test', url: ':memory:' });
+    const withTransaction = vi.spyOn(backend, 'withTransaction');
     const storage = backend.registerDomain(new WorkItemsStorage());
     await backend.init();
 
@@ -259,7 +255,11 @@ describe('WorkItemsStorage', () => {
     await storage.update({ orgId: 'org1', id: child.item.id, userId: 'u', patch: { parentWorkItemId: null } });
     await storage.delete({ orgId: 'org1', id: parent.item.id });
 
-    expect(locks).toEqual(['work-items:org1:p1', 'work-items:org1:p1', 'work-items:org1:p1']);
+    expect(withTransaction.mock.calls.map(([, options]) => options)).toEqual([
+      { isolationLevel: 'serializable' },
+      { isolationLevel: 'serializable' },
+      { isolationLevel: 'serializable' },
+    ]);
   });
 
   it('stamps the actor in both `by` and `exitedBy` when a stage move closes an entry', async () => {

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -750,11 +750,13 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     return this.ops;
   }
 
-  async #withProjectRelationLock<T>(orgId: string, factoryProjectId: string, fn: () => Promise<T>): Promise<T> {
+  async #withProjectRelationTransaction<T>(
+    orgId: string,
+    factoryProjectId: string,
+    fn: (ops: FactoryStorageOps) => Promise<T>,
+  ): Promise<T> {
     const key = `work-items:${orgId}:${factoryProjectId}`;
-    return withInProcessProjectLock(key, () =>
-      this.storage.withDistributedLock ? this.storage.withDistributedLock(key, fn) : fn(),
-    );
+    return withInProcessProjectLock(key, () => this.storage.withTransaction(fn, { isolationLevel: 'serializable' }));
   }
 
   async #claimLeases<T>(
@@ -869,14 +871,18 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     return failed ? row : null;
   }
 
-  /** List the org's work items for a project, newest first. */
-  async list({ orgId, factoryProjectId }: { orgId: string; factoryProjectId: string }): Promise<WorkItemRow[]> {
-    const rows = await this.#db.findMany<WorkItemDbRow>(
+  async #listWithOps(ops: FactoryStorageOps, orgId: string, factoryProjectId: string): Promise<WorkItemRow[]> {
+    const rows = await ops.findMany<WorkItemDbRow>(
       'work_items',
       { org_id: orgId, factory_project_id: factoryProjectId },
       { orderBy: [['updated_at', 'desc']] },
     );
     return rows.map(toWorkItem);
+  }
+
+  /** List the org's work items for a project, newest first. */
+  async list({ orgId, factoryProjectId }: { orgId: string; factoryProjectId: string }): Promise<WorkItemRow[]> {
+    return this.#listWithOps(this.#db, orgId, factoryProjectId);
   }
 
   async get({ orgId, id }: { orgId: string; id: string }): Promise<WorkItemRow | null> {
@@ -1541,29 +1547,39 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     input: CreateWorkItemInput;
     reuseMode?: 'update' | 'preserve' | 'non-stage';
   }): Promise<UpsertWorkItemResult> {
-    const run = () => this.#upsert(params);
-    return params.input.parentWorkItemId
-      ? this.#withProjectRelationLock(params.orgId, params.factoryProjectId, run)
-      : run();
+    const run = (ops: FactoryStorageOps) => this.#upsert(params, ops);
+    const execute = () =>
+      params.input.parentWorkItemId
+        ? this.#withProjectRelationTransaction(params.orgId, params.factoryProjectId, run)
+        : run(this.#db);
+    try {
+      return await execute();
+    } catch (error) {
+      if (!(error instanceof UniqueViolationError)) throw error;
+      return execute();
+    }
   }
 
-  async #upsert({
-    orgId,
-    userId,
-    factoryProjectId,
-    input,
-    reuseMode = 'update',
-  }: {
-    orgId: string;
-    userId: string;
-    factoryProjectId: string;
-    input: CreateWorkItemInput;
-    reuseMode?: 'update' | 'preserve' | 'non-stage';
-  }): Promise<UpsertWorkItemResult> {
+  async #upsert(
+    {
+      orgId,
+      userId,
+      factoryProjectId,
+      input,
+      reuseMode = 'update',
+    }: {
+      orgId: string;
+      userId: string;
+      factoryProjectId: string;
+      input: CreateWorkItemInput;
+      reuseMode?: 'update' | 'preserve' | 'non-stage';
+    },
+    ops: FactoryStorageOps,
+  ): Promise<UpsertWorkItemResult> {
     const key = sourceKey(input.externalSource);
     const reuse = async (): Promise<UpsertWorkItemResult | null> => {
       if (!key) return null;
-      const existing = await this.#db.findOne<WorkItemDbRow>('work_items', {
+      const existing = await ops.findOne<WorkItemDbRow>('work_items', {
         org_id: orgId,
         factory_project_id: factoryProjectId,
         source_key: key,
@@ -1575,7 +1591,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
       }
 
       let previous = emptyPrior();
-      const updated = await this.#db.updateAtomic<WorkItemDbRow>(
+      const updated = await ops.updateAtomic<WorkItemDbRow>(
         'work_items',
         { org_id: orgId, factory_project_id: factoryProjectId, source_key: key },
         async current => {
@@ -1590,7 +1606,11 @@ export class WorkItemsStorage extends FactoryStorageDomain {
                 }
               : fullPatch;
           if (patch.parentWorkItemId !== undefined) {
-            validateParentRelation(await this.list({ orgId, factoryProjectId }), current.id, patch.parentWorkItemId);
+            validateParentRelation(
+              await this.#listWithOps(ops, orgId, factoryProjectId),
+              current.id,
+              patch.parentWorkItemId,
+            );
           }
           return {
             external_source: input.externalSource ?? null,
@@ -1606,31 +1626,28 @@ export class WorkItemsStorage extends FactoryStorageDomain {
 
     const now = new Date();
     const stages = input.stages ?? ['intake'];
-    try {
-      validateParentRelation(await this.list({ orgId, factoryProjectId }), undefined, input.parentWorkItemId ?? null);
-      const row = await this.#db.insertOne<WorkItemDbRow>('work_items', {
-        org_id: orgId,
-        factory_project_id: factoryProjectId,
-        external_source: input.externalSource ?? null,
-        source_key: key,
-        parent_work_item_id: input.parentWorkItemId ?? null,
-        title: input.title,
-        stages,
-        stage_history: stages.map(stage => ({ stage, enteredAt: now.toISOString(), by: userId })),
-        sessions: stampSessions(input.sessions ?? {}, userId),
-        metadata: input.metadata ?? null,
-        revision: 1,
-        created_by: userId,
-        created_at: now,
-        updated_at: now,
-      });
-      return { item: toWorkItem(row), created: true, previous: emptyPrior() };
-    } catch (error) {
-      if (!(error instanceof UniqueViolationError)) throw error;
-      const winner = await reuse();
-      if (winner) return winner;
-      throw error;
-    }
+    validateParentRelation(
+      await this.#listWithOps(ops, orgId, factoryProjectId),
+      undefined,
+      input.parentWorkItemId ?? null,
+    );
+    const row = await ops.insertOne<WorkItemDbRow>('work_items', {
+      org_id: orgId,
+      factory_project_id: factoryProjectId,
+      external_source: input.externalSource ?? null,
+      source_key: key,
+      parent_work_item_id: input.parentWorkItemId ?? null,
+      title: input.title,
+      stages,
+      stage_history: stages.map(stage => ({ stage, enteredAt: now.toISOString(), by: userId })),
+      sessions: stampSessions(input.sessions ?? {}, userId),
+      metadata: input.metadata ?? null,
+      revision: 1,
+      created_by: userId,
+      created_at: now,
+      updated_at: now,
+    });
+    return { item: toWorkItem(row), created: true, previous: emptyPrior() };
   }
 
   async update({
@@ -1644,13 +1661,13 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     userId: string;
     patch: UpdateWorkItemInput;
   }): Promise<{ item: WorkItemRow; previous: WorkItemPriorState } | null> {
-    const run = async () => {
+    const run = async (ops: FactoryStorageOps) => {
       let previous = emptyPrior();
-      const row = await this.#db.updateAtomic<WorkItemDbRow>('work_items', { org_id: orgId, id }, async current => {
+      const row = await ops.updateAtomic<WorkItemDbRow>('work_items', { org_id: orgId, id }, async current => {
         previous = priorState(current);
         if (patch.parentWorkItemId !== undefined) {
           validateParentRelation(
-            await this.list({ orgId, factoryProjectId: current.factory_project_id }),
+            await this.#listWithOps(ops, orgId, current.factory_project_id),
             current.id,
             patch.parentWorkItemId,
           );
@@ -1660,22 +1677,22 @@ export class WorkItemsStorage extends FactoryStorageDomain {
       return row ? { item: toWorkItem(row), previous } : null;
     };
 
-    if (patch.parentWorkItemId === undefined) return run();
+    if (patch.parentWorkItemId === undefined) return run(this.#db);
     const candidate = await this.#db.findOne<WorkItemDbRow>('work_items', { org_id: orgId, id });
     if (!candidate) return null;
-    return this.#withProjectRelationLock(orgId, candidate.factory_project_id, run);
+    return this.#withProjectRelationTransaction(orgId, candidate.factory_project_id, run);
   }
 
   async delete({ orgId, id }: { orgId: string; id: string }): Promise<WorkItemRow | null> {
     const candidate = await this.#db.findOne<WorkItemDbRow>('work_items', { org_id: orgId, id });
     if (!candidate) return null;
 
-    return this.#withProjectRelationLock(orgId, candidate.factory_project_id, async () => {
-      const existing = await this.#db.findOne<WorkItemDbRow>('work_items', { org_id: orgId, id });
+    return this.#withProjectRelationTransaction(orgId, candidate.factory_project_id, async ops => {
+      const existing = await ops.findOne<WorkItemDbRow>('work_items', { org_id: orgId, id });
       if (!existing) return null;
-      const deleted = await this.#db.deleteMany('work_items', { org_id: orgId, id });
+      const deleted = await ops.deleteMany('work_items', { org_id: orgId, id });
       if (deleted === 0) return null;
-      await this.#db.updateMany(
+      await ops.updateMany(
         'work_items',
         { org_id: orgId, parent_work_item_id: id },
         { parent_work_item_id: null, updated_at: new Date() },

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -746,24 +746,8 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     await this.ops.deleteMany('work_items', {});
   }
 
-  #leaseQueue: Promise<void> = Promise.resolve();
-
   get #db(): FactoryStorageOps {
     return this.ops;
-  }
-
-  async #withLocalLeaseLock<T>(fn: () => Promise<T>): Promise<T> {
-    const prior = this.#leaseQueue;
-    let release!: () => void;
-    this.#leaseQueue = new Promise<void>(resolve => {
-      release = resolve;
-    });
-    await prior;
-    try {
-      return await fn();
-    } finally {
-      release();
-    }
   }
 
   async #withProjectRelationLock<T>(orgId: string, factoryProjectId: string, fn: () => Promise<T>): Promise<T> {
@@ -815,9 +799,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
         }
         return claimed;
       });
-    return this.storage.withDistributedLock
-      ? this.storage.withDistributedLock(`factory-lease:${table}`, claim)
-      : this.#withLocalLeaseLock(claim);
+    return claim();
   }
 
   async #renewLease(
@@ -1046,12 +1028,12 @@ export class WorkItemsStorage extends FactoryStorageDomain {
         }
         return { status: 'committed', item, result };
       });
-    return this.storage.withDistributedLock
-      ? this.storage.withDistributedLock(
-          `factory-ingress:${input.orgId}:${input.factoryProjectId}:${input.ingress.identity}`,
-          commit,
-        )
-      : commit();
+    try {
+      return await commit();
+    } catch (error) {
+      if (!(error instanceof UniqueViolationError)) throw error;
+      return commit();
+    }
   }
 
   async commitRuleEvaluation(input: CommitFactoryRuleEvaluationInput): Promise<CommitFactoryRuleEvaluationResult> {
@@ -1178,12 +1160,12 @@ export class WorkItemsStorage extends FactoryStorageDomain {
         }
         return { status: 'committed' as const, result };
       });
-    return this.storage.withDistributedLock
-      ? this.storage.withDistributedLock(
-          `factory-ingress:${input.orgId}:${input.factoryProjectId}:${input.ingress.identity}`,
-          commit,
-        )
-      : commit();
+    try {
+      return await commit();
+    } catch (error) {
+      if (!(error instanceof UniqueViolationError)) throw error;
+      return commit();
+    }
   }
 
   async getToolResultCursor(
@@ -1523,12 +1505,12 @@ export class WorkItemsStorage extends FactoryStorageDomain {
         });
         return { item, binding: toBinding(bindingRow), pendingStart: toPendingStart(pendingRow), replayed: false };
       });
-    return this.storage.withDistributedLock
-      ? this.storage.withDistributedLock(
-          `factory-start:${input.orgId}:${input.factoryProjectId}:${input.kickoffKey}`,
-          prepare,
-        )
-      : prepare();
+    try {
+      return await prepare();
+    } catch (error) {
+      if (!(error instanceof UniqueViolationError)) throw error;
+      return prepare();
+    }
   }
 
   async markPendingStart(

--- a/packages/core/src/storage/factory-storage.ts
+++ b/packages/core/src/storage/factory-storage.ts
@@ -15,8 +15,7 @@
  * App-table domains are written once against `ops`; backends implement the
  * small query surface once (M + N, not M × N). Nothing outside a backend
  * implementation may branch on the database dialect — optional capabilities
- * ({@link FactoryStorage.withDistributedLock},
- * {@link FactoryStorage.authDatabase}) are feature-gated on presence.
+ * such as {@link FactoryStorage.authDatabase} are feature-gated on presence.
  *
  * Contract discipline: the ops surface is deliberately small — equality-filter
  * CRUD, conflict-key upsert, ordered/limit/keyset-cursor lists, and atomic
@@ -338,20 +337,18 @@ export abstract class FactoryStorage {
   /**
    * Run a group of app-table operations atomically. The callback receives an
    * ops instance bound to the transaction; callers must not use `this.ops`
-   * inside it.
+   * inside it. Serializable callbacks may be retried after a serialization
+   * failure and therefore must contain database operations only.
    */
-  abstract withTransaction<T>(fn: (ops: FactoryStorageOps) => Promise<T>): Promise<T>;
+  abstract withTransaction<T>(
+    fn: (ops: FactoryStorageOps) => Promise<T>,
+    options?: { isolationLevel?: 'serializable' },
+  ): Promise<T>;
 
   /** Release the backend's connections (tests, shutdown). */
   abstract close(): Promise<void>;
 
   // ---- optional capabilities (feature-gate on presence, never on dialect) ----
-
-  /**
-   * Cross-replica serialization (pg: advisory locks). Absent → the backend
-   * has no multi-replica story and in-process locking is sufficient.
-   */
-  withDistributedLock?<T>(key: string, fn: () => Promise<T>): Promise<T>;
 
   /**
    * A tagged database handle auth libraries can consume (see

--- a/stores/libsql/src/storage/factory-storage.ts
+++ b/stores/libsql/src/storage/factory-storage.ts
@@ -402,9 +402,6 @@ class LibSQLFactoryStorageOps implements FactoryStorageOps {
  * LibSQL/Turso {@link FactoryStorage} backend: one libsql database powering
  * agent state (via a wrapped {@link LibSQLStore}) and app-owned collections
  * (via {@link FactoryStorageOps}), sharing a single client.
- *
- * No `withDistributedLock`: local libsql is single-writer and single-replica,
- * so in-process serialization is the correct locking story.
  */
 export class LibSQLFactoryStorage extends FactoryStorage {
   readonly ops: FactoryStorageOps;

--- a/stores/pg/src/storage/factory-storage.test.ts
+++ b/stores/pg/src/storage/factory-storage.test.ts
@@ -10,23 +10,50 @@ describeFactoryStorageContract('pg', async () => {
 });
 
 describe('PgFactoryStorage capabilities', () => {
-  it('withDistributedLock serializes concurrent critical sections', async () => {
+  it('starts serializable transactions without advisory locks', async () => {
     const storage = new PgFactoryStorage({ connectionString });
+    const release = vi.fn();
+    const query = vi.fn().mockResolvedValue(undefined);
+    const pool = storage.authDatabase().pool;
+    const connect = vi.spyOn(pool, 'connect').mockResolvedValue({ query, release } as never);
+
     try {
-      let active = 0;
-      let maxActive = 0;
-      await Promise.all(
-        Array.from({ length: 5 }, () =>
-          storage.withDistributedLock('contract-lock-key', async () => {
-            active++;
-            maxActive = Math.max(maxActive, active);
-            await new Promise(resolve => setTimeout(resolve, 5));
-            active--;
-          }),
-        ),
-      );
-      expect(maxActive).toBe(1);
+      await storage.withTransaction(async () => 'result', { isolationLevel: 'serializable' });
+      expect(query).toHaveBeenNthCalledWith(1, 'BEGIN ISOLATION LEVEL SERIALIZABLE');
+      expect(query).toHaveBeenNthCalledWith(2, 'COMMIT');
+      expect(query.mock.calls.flat().join(' ')).not.toContain('pg_advisory');
     } finally {
+      connect.mockRestore();
+      await storage.close();
+    }
+  });
+
+  it('retries serializable transactions after serialization failures', async () => {
+    const storage = new PgFactoryStorage({ connectionString });
+    const serializationFailure = Object.assign(new Error('serialization failure'), { code: '40001' });
+    const firstRelease = vi.fn();
+    const secondRelease = vi.fn();
+    const firstQuery = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(serializationFailure)
+      .mockResolvedValueOnce(undefined);
+    const secondQuery = vi.fn().mockResolvedValue(undefined);
+    const pool = storage.authDatabase().pool;
+    const connect = vi
+      .spyOn(pool, 'connect')
+      .mockResolvedValueOnce({ query: firstQuery, release: firstRelease } as never)
+      .mockResolvedValueOnce({ query: secondQuery, release: secondRelease } as never);
+    const fn = vi.fn().mockResolvedValue('result');
+
+    try {
+      await expect(storage.withTransaction(fn, { isolationLevel: 'serializable' })).resolves.toBe('result');
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(firstQuery).toHaveBeenNthCalledWith(3, 'ROLLBACK');
+      expect(secondQuery).toHaveBeenNthCalledWith(1, 'BEGIN ISOLATION LEVEL SERIALIZABLE');
+      expect(secondQuery).toHaveBeenNthCalledWith(2, 'COMMIT');
+    } finally {
+      connect.mockRestore();
       await storage.close();
     }
   });
@@ -38,15 +65,14 @@ describe('PgFactoryStorage capabilities', () => {
     const query = vi
       .fn()
       .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error('commit failed'))
       .mockRejectedValueOnce(rollbackError);
     const pool = storage.authDatabase().pool;
     const connect = vi.spyOn(pool, 'connect').mockResolvedValue({ query, release } as never);
 
     try {
-      await expect(storage.withDistributedLock('rollback-failure', async () => 'result')).rejects.toThrow(
-        'Distributed lock operation and rollback both failed',
+      await expect(storage.withTransaction(async () => 'result')).rejects.toThrow(
+        'Factory transaction and rollback both failed',
       );
       expect(release).toHaveBeenCalledWith(rollbackError);
     } finally {

--- a/stores/pg/src/storage/factory-storage.ts
+++ b/stores/pg/src/storage/factory-storage.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 
 import { FactoryStorage, UniqueViolationError } from '@mastra/core/storage';
 import type {
@@ -89,16 +89,6 @@ function assertUpsertConflict(schema: CollectionSchema, conflictKeys: string[], 
 function serializeDefault(value: string | number | boolean): string {
   if (typeof value === 'string') return `'${value.replace(/'/g, "''")}'`;
   return String(value);
-}
-
-/**
- * Hash a lock key into the two signed int4 values `pg_advisory_xact_lock(int4, int4)`
- * expects. Two int4 args keep factory locks in their own namespace, away from
- * single-int8 advisory locks other tooling might take.
- */
-export function hashAdvisoryLockKey(key: string): [number, number] {
-  const digest = createHash('sha256').update(key).digest();
-  return [digest.readInt32BE(0), digest.readInt32BE(4)];
 }
 
 type Queryable = Pick<Pool, 'query'> | Pick<PoolClient, 'query'>;
@@ -437,8 +427,8 @@ class PgFactoryStorageOps implements FactoryStorageOps {
  * (via a wrapped {@link PostgresStore}) and app-owned collections (via
  * {@link FactoryStorageOps}), sharing a single pool.
  *
- * Provides `withDistributedLock` (transaction-scoped advisory locks) for
- * cross-replica serialization and `authDatabase()` exposing the shared pool.
+ * Supports serializable app-table transactions for cross-replica invariant
+ * enforcement and `authDatabase()` exposing the shared pool.
  */
 export class PgFactoryStorage extends FactoryStorage {
   readonly ops: FactoryStorageOps;
@@ -479,21 +469,40 @@ export class PgFactoryStorage extends FactoryStorage {
     await this.#pool.query('SELECT 1');
   }
 
-  async withTransaction<T>(fn: (ops: FactoryStorageOps) => Promise<T>): Promise<T> {
-    const client = await this.#pool.connect();
-    try {
-      await client.query('BEGIN');
+  async withTransaction<T>(
+    fn: (ops: FactoryStorageOps) => Promise<T>,
+    options?: { isolationLevel?: 'serializable' },
+  ): Promise<T> {
+    const maxAttempts = options?.isolationLevel === 'serializable' ? 3 : 1;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const client = await this.#pool.connect();
+      let transactionOpen = false;
+      let releaseError: Error | undefined;
       try {
+        await client.query(options?.isolationLevel === 'serializable' ? 'BEGIN ISOLATION LEVEL SERIALIZABLE' : 'BEGIN');
+        transactionOpen = true;
         const result = await fn(new PgFactoryStorageOps(client, this.#schemas, client));
         await client.query('COMMIT');
+        transactionOpen = false;
         return result;
       } catch (error) {
-        await client.query('ROLLBACK');
-        throw error;
+        if (transactionOpen) {
+          try {
+            await client.query('ROLLBACK');
+            transactionOpen = false;
+          } catch (rollbackError) {
+            releaseError = rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError));
+            throw new AggregateError([error, rollbackError], 'Factory transaction and rollback both failed');
+          }
+        }
+        const serializationFailure =
+          typeof error === 'object' && error !== null && (error as { code?: string }).code === '40001';
+        if (!serializationFailure || attempt === maxAttempts) throw error;
+      } finally {
+        client.release(releaseError);
       }
-    } finally {
-      client.release();
     }
+    throw new Error('PgFactoryStorage: serializable transaction retry limit exceeded');
   }
 
   async ensureCollections(schemas: CollectionSchema[]): Promise<void> {
@@ -513,42 +522,6 @@ export class PgFactoryStorage extends FactoryStorage {
 
   authDatabase(): FactoryAuthDatabase {
     return { dialect: 'postgres', pool: this.#pool };
-  }
-
-  /**
-   * Run `fn` while holding a Postgres transaction-scoped advisory lock for
-   * `key`, serializing callers across replicas. The lock releases when the
-   * transaction ends (commit, rollback, or connection loss), so a crashed
-   * replica can never hold it forever.
-   */
-  async withDistributedLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-    const [k1, k2] = hashAdvisoryLockKey(key);
-    const client = await this.#pool.connect();
-    let transactionOpen = false;
-    let releaseError: Error | undefined;
-    try {
-      await client.query('BEGIN');
-      transactionOpen = true;
-      // Blocks until no other transaction holds this advisory key.
-      await client.query('SELECT pg_advisory_xact_lock($1, $2)', [k1, k2]);
-      const result = await fn();
-      await client.query('COMMIT');
-      transactionOpen = false;
-      return result;
-    } catch (error) {
-      if (transactionOpen) {
-        try {
-          await client.query('ROLLBACK');
-          transactionOpen = false;
-        } catch (rollbackError) {
-          releaseError = rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError));
-          throw new AggregateError([error, rollbackError], 'Distributed lock operation and rollback both failed');
-        }
-      }
-      throw error;
-    } finally {
-      client.release(releaseError);
-    }
   }
 
   #columnDdl(name: string, spec: CollectionColumnSpec): string {

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -160,7 +160,7 @@ export type { VNextPostgresObservabilityConfig };
 export { PoolAdapter } from './client';
 export type { DbClient, TxClient, QueryValues, Pool, PoolClient, QueryResult } from './client';
 export type { PgDomainConfig, PgDomainClientConfig, PgDomainPoolConfig, PgDomainRestConfig } from './db';
-export { PgFactoryStorage, hashAdvisoryLockKey, type PgFactoryStorageConfig } from './factory-storage';
+export { PgFactoryStorage, type PgFactoryStorageConfig } from './factory-storage';
 
 /**
  * PostgreSQL storage adapter for Mastra.


### PR DESCRIPTION
This follow-up removes Factory's distributed advisory-lock dependency.

Lease claims now rely on atomic compare-and-set updates. Rule ingress commits and pending-start preparation use their existing unique keys with conflict replay. Parent/child work-item mutations use short serializable database transactions, retried on PostgreSQL serialization failures, so those relationship invariants remain coordinated across replicas without a separate advisory lock.

The generic `FactoryStorage.withDistributedLock` capability and PostgreSQL advisory-lock implementation are removed. The PR adds coverage for concurrent replay, serializable transaction setup and retries, and relationship mutations using serializable transactions.

ESLint, Prettier, and `git diff --check` pass. Focused tests remain blocked before execution because stale workspace artifacts resolve `FactoryStorageDomain` as undefined. The Mastra Code dependency build is independently blocked by the existing `@internal/llm-recorder` TypeScript `baseUrl` deprecation error.
