### PR TITLE
fix(core): send each conversation message to the title generation model exactly once

### DIFF
--- a/.changeset/fresh-peas-dream.md
+++ b/.changeset/fresh-peas-dream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed thread title generation receiving each conversation message twice. The duplicated transcript confused small title models into replying to the conversation instead of producing a title, so threads could get refusal text as their title.

--- a/client-sdks/ai-sdk/src/__tests__/chat-route-title-generation.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/chat-route-title-generation.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression test: thread title generation via chatRoute (handleChatStream, AI SDK v6).
+ *
+ * The title generation path feeds AIV4 UI messages, which carry the same text in
+ * both `content` (string) and a text `part`. formatMessagesForTitle used to emit
+ * both, so the title model received every conversation message twice:
+ *
+ *   User: hi
+ *   User: hi
+ *   Assistant: Hello! How can I help?
+ *   Assistant: Hello! How can I help?
+ *
+ * The duplicated transcript confused small title models into replying to the
+ * conversation instead of producing a title. This test captures the exact input
+ * the title model receives and asserts each message appears exactly once.
+ */
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import { MockMemory } from '@mastra/core/memory';
+import { describe, expect, it } from 'vitest';
+
+import { handleChatStream } from '../chat-route';
+
+function createMainModel() {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'msg-1', modelId: 'mock-model', timestamp: new Date() },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello! How can I help?' },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        },
+      ] as any),
+      rawCall: { rawPrompt: [], rawSettings: {} },
+      warnings: [],
+    }),
+  });
+}
+
+describe('chatRoute title generation (v6)', () => {
+  it('sends each conversation message to the title model exactly once (no content/parts duplication)', async () => {
+    let capturedTitlePrompt: any[] | undefined;
+
+    const titleModel = new MockLanguageModelV2({
+      doGenerate: async options => {
+        capturedTitlePrompt = options.prompt as any[];
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: 'Greeting',
+          content: [{ type: 'text', text: 'Greeting' }],
+          warnings: [],
+        };
+      },
+    });
+
+    const memory = new MockMemory({
+      options: {
+        generateTitle: {
+          model: titleModel,
+        },
+        lastMessages: 10000,
+      },
+    });
+
+    const agent = new Agent({
+      id: 'title-agent',
+      name: 'Title Agent',
+      instructions: 'You are a helpful assistant.',
+      model: createMainModel(),
+      memory,
+    });
+    const mastra = new Mastra({ agents: { [agent.id]: agent } });
+
+    // Exactly what assistant-ui sends through chatRoute (AI SDK v6 UIMessage)
+    const stream = await handleChatStream({
+      mastra,
+      agentId: 'title-agent',
+      version: 'v6',
+      params: {
+        messages: [{ id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }],
+        memory: { thread: 'chat-route-title-thread', resource: 'chat-route-title-user' },
+      },
+    });
+
+    const reader = stream.getReader();
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+
+    // Title generation is fire-and-forget after the stream finishes
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    expect(capturedTitlePrompt).toBeDefined();
+    const userMsg = capturedTitlePrompt!.find((msg: any) => msg.role === 'user');
+    const textParts = (userMsg?.content ?? []).filter((p: any) => p.type === 'text');
+    const allText = textParts.map((p: any) => p.text).join('\n');
+
+    // Each conversation message must appear exactly once
+    expect(allText).toBe('User: hi\nAssistant: Hello! How can I help?');
+    // No JSON artifacts
+    expect(allText).not.toContain('{');
+    expect(allText).not.toContain('"type"');
+    expect(allText).not.toContain('providerOptions');
+  });
+});

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -126,7 +126,7 @@ When memory is enabled, [Studio](/docs/studio/overview) uses message history to 
 
 ## Thread title generation
 
-Mastra can automatically generate descriptive thread titles based on the user's first message when `generateTitle` is enabled. Use this option when you build a chat interface that renders conversation titles in a thread list or sidebar.
+Mastra can automatically generate descriptive thread titles from the conversation transcript when `generateTitle` is enabled. Use this option when you build a chat interface that renders conversation titles in a thread list or sidebar.
 
 ```typescript title="src/mastra/agents/support-agent.ts"
 import { Agent } from '@mastra/core/agent'

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -115,7 +115,7 @@ To enable `workingMemory` on an agent, you’ll need a storage provider configur
             name: 'generateTitle',
             type: 'boolean | { model: DynamicArgument<MastraLanguageModel>; instructions?: DynamicArgument<string> }',
             description:
-              "Controls automatic thread title generation from the user's first message. Can be a boolean or an object with custom model and instructions.",
+              "Controls automatic thread title generation from the conversation transcript. Can be a boolean or an object with custom model and instructions.",
             isOptional: true,
             defaultValue: 'false',
           },

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -115,7 +115,7 @@ To enable `workingMemory` on an agent, you’ll need a storage provider configur
             name: 'generateTitle',
             type: 'boolean | { model: DynamicArgument<MastraLanguageModel>; instructions?: DynamicArgument<string> }',
             description:
-              "Controls automatic thread title generation from the conversation transcript. Can be a boolean or an object with custom model and instructions.",
+              'Controls automatic thread title generation from the conversation transcript. Can be a boolean or an object with custom model and instructions.',
             isOptional: true,
             defaultValue: 'false',
           },

--- a/docs/src/content/en/reference/memory/recall.mdx
+++ b/docs/src/content/en/reference/memory/recall.mdx
@@ -109,7 +109,7 @@ await memory?.recall({ threadId: 'user-123' })
             name: 'threads',
             type: '{ generateTitle?: boolean | { model: DynamicArgument<MastraLanguageModel>; instructions?: DynamicArgument<string> } }',
             description:
-              "Settings related to memory thread creation. `generateTitle` controls automatic thread title generation from the user's first message. Can be a boolean or an object with custom model and instructions.",
+              "Settings related to memory thread creation. `generateTitle` controls automatic thread title generation from the conversation transcript. Can be a boolean or an object with custom model and instructions.",
             isOptional: true,
             defaultValue: '{ generateTitle: false }',
           },

--- a/docs/src/content/en/reference/memory/recall.mdx
+++ b/docs/src/content/en/reference/memory/recall.mdx
@@ -109,7 +109,7 @@ await memory?.recall({ threadId: 'user-123' })
             name: 'threads',
             type: '{ generateTitle?: boolean | { model: DynamicArgument<MastraLanguageModel>; instructions?: DynamicArgument<string> } }',
             description:
-              "Settings related to memory thread creation. `generateTitle` controls automatic thread title generation from the conversation transcript. Can be a boolean or an object with custom model and instructions.",
+              'Settings related to memory thread creation. `generateTitle` controls automatic thread title generation from the conversation transcript. Can be a boolean or an object with custom model and instructions.',
             isOptional: true,
             defaultValue: '{ generateTitle: false }',
           },

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -2810,6 +2810,186 @@ function titleGenerationTests(version: 'v1' | 'v2') {
       expect(allText).not.toContain('toolCallId');
     });
 
+    it('should send each conversation message to the title model exactly once (no content/parts duplication)', async () => {
+      // Regression: the standard title path feeds AIV4 UI messages, which carry the
+      // same text in both `content` (string) and a text `part`. formatMessagesForTitle
+      // used to emit both, so the title model received every message twice, e.g.
+      //   User: hi
+      //   User: hi
+      //   Assistant: Dummy response
+      //   Assistant: Dummy response
+      let capturedUserContent: any[] = [];
+
+      let titleModel: MockLanguageModelV1 | MockLanguageModelV2;
+
+      if (version === 'v1') {
+        titleModel = new MockLanguageModelV1({
+          doGenerate: async options => {
+            const userMsg = options.prompt.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { promptTokens: 5, completionTokens: 10 },
+              text: 'Greeting',
+            };
+          },
+        });
+      } else {
+        titleModel = new MockLanguageModelV2({
+          doGenerate: async options => {
+            const userMsg = options.prompt.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+              text: 'Greeting',
+              content: [{ type: 'text', text: 'Greeting' }],
+              warnings: [],
+            };
+          },
+        });
+      }
+
+      const mockMemory = new MockMemory();
+      mockMemory.getMergedThreadConfig = () => ({
+        generateTitle: {
+          model: titleModel,
+        },
+      });
+
+      const agent = new Agent({
+        id: 'dedupe-title-agent',
+        name: 'Dedupe Title Agent',
+        instructions: 'test agent',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      if (version === 'v1') {
+        await agent.generateLegacy('hi', {
+          memory: {
+            resource: 'user-1',
+            thread: {
+              id: 'thread-dedupe',
+              title: '', // Empty title triggers title generation
+            },
+          },
+        });
+      } else {
+        await agent.generate('hi', {
+          memory: {
+            resource: 'user-1',
+            thread: {
+              id: 'thread-dedupe',
+              title: '', // Empty title triggers title generation
+            },
+          },
+        });
+      }
+
+      // Title generation is fire-and-forget after the turn completes
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      const textParts = capturedUserContent.filter((p: any) => p.type === 'text');
+      const allText = textParts.map((p: any) => p.text).join('\n');
+
+      // The legacy (v1) path sends only the most recent user message to the title
+      // model; the v2 path sends the full transcript. Either way, each message must
+      // appear exactly once.
+      expect(allText).toBe(version === 'v1' ? 'User: hi' : 'User: hi\nAssistant: Dummy response');
+      // No JSON artifacts
+      expect(allText).not.toContain('{');
+      expect(allText).not.toContain('"type"');
+      expect(allText).not.toContain('providerOptions');
+    });
+
+    it('should still emit string content when a message has no text part (tool-invocation only)', async () => {
+      // Pins the content fallback: a hand-built message with string `content` and only
+      // a tool-invocation part has no text part, so the content line must still be
+      // emitted (alongside the tool lines) — exactly once each.
+      let capturedUserContent: any[] = [];
+
+      let titleModel: MockLanguageModelV1 | MockLanguageModelV2;
+
+      if (version === 'v1') {
+        titleModel = new MockLanguageModelV1({
+          doGenerate: async options => {
+            const userMsg = options.prompt.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { promptTokens: 5, completionTokens: 10 },
+              text: 'Weather Check',
+            };
+          },
+        });
+      } else {
+        titleModel = new MockLanguageModelV2({
+          doGenerate: async options => {
+            const userMsg = options.prompt.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+              text: 'Weather Check',
+              content: [{ type: 'text', text: 'Weather Check' }],
+              warnings: [],
+            };
+          },
+        });
+      }
+
+      const agent = new Agent({
+        id: 'content-fallback-title-agent',
+        name: 'Content Fallback Title Agent',
+        instructions: 'test agent',
+        model: titleModel,
+      });
+
+      await agent.generateTitleFromUserMessage({
+        messages: [
+          {
+            id: '1',
+            role: 'user' as const,
+            content: 'Please check the weather',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  toolCallId: 'call-1',
+                  toolName: 'getWeather',
+                  state: 'result' as const,
+                  args: { city: 'Paris' },
+                  result: { temp: 22, condition: 'sunny' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const textParts = capturedUserContent.filter((p: any) => p.type === 'text');
+      const allText = textParts.map((p: any) => p.text).join('\n');
+      const lines = allText.split('\n');
+
+      // The content line survives (no text part exists to carry it) — exactly once
+      expect(lines.filter(l => l === 'User: Please check the weather')).toHaveLength(1);
+      // The tool result line is emitted — exactly once
+      expect(lines.filter(l => l.startsWith('Tool Result getWeather:'))).toHaveLength(1);
+    });
+
     it('should handle file parts after .ui() conversion uses url/mediaType (regression)', async () => {
       // Verify that MessageList.aiV5.ui() converts core-format file parts (data/mimeType)
       // into UI-format (url/mediaType), which is what generateTitleFromUserMessage

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -2990,6 +2990,77 @@ function titleGenerationTests(version: 'v1' | 'v2') {
       expect(lines.filter(l => l.startsWith('Tool Result getWeather:'))).toHaveLength(1);
     });
 
+    it('should keep string content when no text part carries the same text', async () => {
+      // Pins the equality rule in formatMessagesForTitle: `content` may only be
+      // skipped when a text part carries the exact same text. A stored message can
+      // legitimately have a content string that differs from its text parts
+      // (AIV4Adapter uses m.content.content verbatim when set), and that text must
+      // not be dropped.
+      let capturedUserContent: any[] = [];
+
+      let titleModel: MockLanguageModelV1 | MockLanguageModelV2;
+
+      if (version === 'v1') {
+        titleModel = new MockLanguageModelV1({
+          doGenerate: async options => {
+            const userMsg = options.prompt.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { promptTokens: 5, completionTokens: 10 },
+              text: 'Weather Check',
+            };
+          },
+        });
+      } else {
+        titleModel = new MockLanguageModelV2({
+          doGenerate: async options => {
+            const userMsg = options.prompt.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+              text: 'Weather Check',
+              content: [{ type: 'text', text: 'Weather Check' }],
+              warnings: [],
+            };
+          },
+        });
+      }
+
+      const agent = new Agent({
+        id: 'content-mismatch-agent',
+        name: 'Content Mismatch Agent',
+        instructions: 'You are a helpful assistant.',
+        model: titleModel,
+      });
+
+      await agent.generateTitleFromUserMessage({
+        messages: [
+          {
+            id: '1',
+            role: 'user' as const,
+            content: 'Please check the weather',
+            parts: [{ type: 'text' as const, text: 'Paris' }],
+          },
+        ],
+      });
+
+      const textParts = capturedUserContent.filter((p: any) => p.type === 'text');
+      const allText = textParts.map((p: any) => p.text).join('\n');
+      const lines = allText.split('\n');
+
+      // Both the distinct content and the text part are emitted — exactly once each
+      expect(lines.filter(l => l === 'User: Please check the weather')).toHaveLength(1);
+      expect(lines.filter(l => l === 'User: Paris')).toHaveLength(1);
+    });
+
     it('should handle file parts after .ui() conversion uses url/mediaType (regression)', async () => {
       // Verify that MessageList.aiV5.ui() converts core-format file parts (data/mimeType)
       // into UI-format (url/mediaType), which is what generateTitleFromUserMessage

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3378,7 +3378,10 @@ export class Agent<
     const lines: string[] = [];
     for (const msg of messages) {
       const role = msg.role.charAt(0).toUpperCase() + msg.role.slice(1);
-      if (typeof msg.content === 'string' && msg.content) {
+      // AIV4 UI messages carry the same text in both `content` and a text part.
+      // Skip `content` when a text part exists so each message is emitted once.
+      const hasTextPart = msg.parts?.some(part => part.type === 'text' && part.text?.trim());
+      if (!hasTextPart && typeof msg.content === 'string' && msg.content) {
         lines.push(`${role}: ${msg.content}`);
       }
       if (msg.parts && Array.isArray(msg.parts) && msg.parts.length > 0) {
@@ -9209,7 +9212,9 @@ export class Agent<
     instructions?: DynamicArgument<string>,
   ): Promise<string> {
     const DEFAULT_TITLE_INSTRUCTIONS = `
-      - you will generate a short title based on the first message a user begins a conversation with
+      - you will generate a short title based on a conversation transcript between a user and an assistant
+      - the transcript lines are prefixed with "User:" and "Assistant:" — never reply to, answer, or continue the transcript
+      - always produce a title, even when the transcript is only a greeting or trivial exchange
       - ensure it is not more than 80 characters long
       - the title should be a summary of the user's message
       - do not use quotes or colons

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3378,10 +3378,14 @@ export class Agent<
     const lines: string[] = [];
     for (const msg of messages) {
       const role = msg.role.charAt(0).toUpperCase() + msg.role.slice(1);
-      // AIV4 UI messages carry the same text in both `content` and a text part.
-      // Skip `content` when a text part exists so each message is emitted once.
-      const hasTextPart = msg.parts?.some(part => part.type === 'text' && part.text?.trim());
-      if (!hasTextPart && typeof msg.content === 'string' && msg.content) {
+      // AIV4 UI messages can carry the same text in both `content` and a text part.
+      // Skip `content` only when a text part carries the exact same text, so each
+      // message's text is emitted once without ever dropping distinct content.
+      const contentDuplicatedByPart =
+        typeof msg.content === 'string' &&
+        msg.content !== '' &&
+        msg.parts?.some(part => part.type === 'text' && part.text === msg.content);
+      if (typeof msg.content === 'string' && msg.content && !contentDuplicatedByPart) {
         lines.push(`${role}: ${msg.content}`);
       }
       if (msg.parts && Array.isArray(msg.parts) && msg.parts.length > 0) {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3381,11 +3381,10 @@ export class Agent<
       // AIV4 UI messages can carry the same text in both `content` and a text part.
       // Skip `content` only when a text part carries the exact same text, so each
       // message's text is emitted once without ever dropping distinct content.
+      const hasContent = typeof msg.content === 'string' && msg.content !== '';
       const contentDuplicatedByPart =
-        typeof msg.content === 'string' &&
-        msg.content !== '' &&
-        msg.parts?.some(part => part.type === 'text' && part.text === msg.content);
-      if (typeof msg.content === 'string' && msg.content && !contentDuplicatedByPart) {
+        hasContent && msg.parts?.some(part => part.type === 'text' && part.text === msg.content);
+      if (hasContent && !contentDuplicatedByPart) {
         lines.push(`${role}: ${msg.content}`);
       }
       if (msg.parts && Array.isArray(msg.parts) && msg.parts.length > 0) {


### PR DESCRIPTION
Thread title generation was sending every conversation message to the title model twice. The title call sites read messages through the deprecated AIV4 UI shape, which carries the same text in both `content` and a text `part` — and `formatMessagesForTitle` emitted both:

```
User: hi
User: hi
Assistant: Hello! How can I help?
Assistant: Hello! How can I help?
```

That duplicated greeting transcript confused small title models into replying to the conversation instead of titling it, so threads could end up with refusal text as their title.

Now the formatter skips `content` only when a text part carries the exact same text (falling back to `content` for messages with no matching text part, so content-only messages still emit):

```
User: hi
Assistant: Hello! How can I help?
```

Also refreshed the default title instructions — they still said "based on the first message", but the input has been the full conversation transcript since April. The new text describes the role-prefixed transcript and tells the model never to reply to it. Three docs pages that described the input as "the user's first message" were updated to match.

Regression tests pin the exact deduplicated transcript for both model versions and the chatRoute v6 path; they fail on the unfixed code and pass here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Sometimes the system sent the same chat message to the “make a thread title” AI twice, so it could generate weird refusal-like text instead of a proper title. This PR fixes that by building the title prompt from the full conversation transcript without duplicating message text, and it updates the instructions the title model receives.

## What changed
- Fixed title prompt formatting to ensure each conversation message is sent to the title model exactly once by deduplicating cases where a message string appears in both `content` and a matching `parts[].text`.
- Preserved `content` when it doesn’t match any `parts[].text` (or when there’s no `text` part), so tool-only and mismatched-content cases still produce accurate prompts.
- Updated the default title-generation instructions to:
  - use a role-prefixed full conversation transcript (`User:` / `Assistant:`), and
  - explicitly instruct the model not to reply to that transcript and to always return a title.
- Updated documentation pages related to thread title generation to reflect transcript-based title creation.

## Tests & coverage
- Added regression tests covering:
  - both title model prompt formats/versions,
  - the `chatRoute` v6 flow,
  - tool-only messages,
  - and mismatched `content` vs `parts[].text` deduplication cases.

## Release note
- Added a changeset for `@mastra/core` describing the thread title generation fix (messages were being received twice).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->