### PR TITLE
fix(mastracode): use stored API keys for model router providers

### DIFF
--- a/.changeset/early-bananas-retire.md
+++ b/.changeset/early-bananas-retire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed stored provider API keys so authenticated models appear as configured and continue working during steering and follow-up messages.

--- a/mastracode/sdk/src/agents/__tests__/model.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/model.test.ts
@@ -273,6 +273,23 @@ describe('resolveModel', () => {
     expect(mockGetCopilotModelCatalog).toHaveBeenCalled();
   });
 
+  it('claims models.dev providers authenticated by the injected credential store', () => {
+    const gateway = createMastraCodeGateway({
+      mastraGatewayBaseUrl: 'https://gateway-api.mastra.ai',
+      routeThroughMastraGateway: false,
+      credentialStore: {
+        allowEnvironmentFallback: false,
+        reload() {},
+        get: provider =>
+          provider === 'alibaba-coding-plan' ? { type: 'api_key', key: 'sk-alibaba-tenant' } : undefined,
+        getStoredApiKey: () => undefined,
+        getApiKey: async () => undefined,
+      },
+    });
+
+    expect(gateway.handlesModel('alibaba-coding-plan/glm-5')).toBe(true);
+  });
+
   describe('anthropic/* models', () => {
     it('prefers Claude Max OAuth when stored OAuth credential exists', () => {
       mockAuthStorageInstance.get.mockReturnValue({
@@ -566,6 +583,17 @@ describe('resolveModel', () => {
     it('uses model router for unknown providers', () => {
       const result = resolveModel('google/gemini-2.0-flash') as Record<string, unknown>;
       expect(result.__provider).toBe('model-router');
+    });
+
+    it('passes stored API keys to model router providers', () => {
+      mockAuthStorageInstance.get.mockImplementation((provider: string) =>
+        provider === 'alibaba-coding-plan' ? { type: 'api_key', key: 'sk-alibaba-stored' } : undefined,
+      );
+
+      const result = resolveModel('alibaba-coding-plan/glm-5') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('model-router');
+      expect(result.apiKey).toBe('sk-alibaba-stored');
     });
 
     it('resolves gateway auth through the MastraCode gateway hook', () => {

--- a/mastracode/sdk/src/agents/mastracode-gateway.ts
+++ b/mastracode/sdk/src/agents/mastracode-gateway.ts
@@ -303,12 +303,16 @@ export class MastraCodeGateway extends MastraModelGateway {
     );
     if (customProvider?.apiKey) return true;
     return hasResolvedAuth(
-      MastraCodeGateway.resolveProviderAuth({
-        gatewayId: this.id,
-        providerId: parsed.providerId,
-        modelId: parsed.modelId,
-        routerId: modelId,
-      }),
+      MastraCodeGateway.resolveProviderAuth(
+        {
+          gatewayId: this.id,
+          providerId: parsed.providerId,
+          modelId: parsed.modelId,
+          routerId: modelId,
+        },
+        undefined,
+        this.#credentials,
+      ),
     );
   }
 
@@ -495,6 +499,7 @@ export class MastraCodeGateway extends MastraModelGateway {
 
     return new ModelRouterLanguageModel({
       id: `${args.providerId}/${args.modelId}` as `${string}/${string}`,
+      apiKey: args.apiKey,
       headers: args.headers,
     }) as unknown as GatewayLanguageModel;
   }


### PR DESCRIPTION
## Summary

- resolve generic model provider ownership using the injected tenant credential store
- forward resolved API keys to model router providers so steering and follow-up requests keep working
- add regression coverage for catalog authentication and model execution, plus a patch changeset for `@mastra/code-sdk`

## Test plan

- `pnpm --filter @mastra/code-sdk test`
- `pnpm --filter @mastra/code-sdk check`
- `pnpm --filter @mastra/code-sdk lint`
- `pnpm --filter @mastra/code-sdk build:lib`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes sure the gateway uses the API key saved for each tenant/provider, instead of falling back to a generic one. That way, when the system does “steering” or follow-up model calls, the right authenticated models keep working.

## Changes
- Update provider auth resolution to use the injected tenant credential store when checking/handling models.
- When routing non-provider-specific models, forward the resolved `apiKey` into `ModelRouterLanguageModel` so downstream router calls stay authenticated.
- Add regression tests that:
  - `handlesModel` returns `true` for an `alibaba-coding-plan/...` model when the credential store supplies the provider API key.
  - model router resolution includes the stored `apiKey` in the resolved result (`result.apiKey`).
- Add a `@mastra/code-sdk` patch changeset documenting the stored provider API key fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->