### PR TITLE
fix(mastracode-web): show subscribed PRs in the Factory session status line

### DIFF
--- a/.changeset/factory-pr-chip-resource-id.md
+++ b/.changeset/factory-pr-chip-resource-id.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Show subscribed pull requests in the Factory session status line. Subscriptions are stored keyed on the factory project id, but the chat UI queried them with the session resourceId, so the PR chip never rendered for factory-bound sessions.

--- a/mastracode/web/src/web/ui/domains/chat/components/StatusLine/PullRequestLinks.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/StatusLine/PullRequestLinks.tsx
@@ -95,11 +95,15 @@ export function PullRequestLinks({
     .filter(id => typeof id === 'string')
     .join(':');
   const enabled = typeof projectRepositoryId === 'string' && Boolean(threadId);
+  // Subscriptions are stored keyed on the factory project id (see the server's
+  // subscriptionInput: resourceId = connection.factoryProjectId), so factory
+  // sessions must query with it — the chat resourceId only matches legacy rows.
+  const subscriptionResourceId = factoryProjectKey ?? resourceId;
   const query = useQuery({
-    queryKey: ['github', 'subscriptions', resourceId, threadId, projectPath],
+    queryKey: ['github', 'subscriptions', subscriptionResourceId, threadId, projectPath],
     queryFn: async () => {
       if (!threadId) return { subscriptions: [] };
-      const params = new URLSearchParams({ resourceId, threadId });
+      const params = new URLSearchParams({ resourceId: subscriptionResourceId, threadId });
       if (projectPath) params.set('scope', projectPath);
       const response = await fetch(`${baseUrl}/web/github/subscriptions?${params}`, { credentials: 'include' });
       if (!response.ok) throw new Error(`Failed to load pull request subscriptions (${response.status}).`);

--- a/mastracode/web/src/web/ui/domains/chat/components/__tests__/PullRequestLinks.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/__tests__/PullRequestLinks.msw.test.tsx
@@ -1,0 +1,74 @@
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../../e2e/web-ui/msw-server';
+import { renderWithProviders } from '../../../../../../../e2e/web-ui/render';
+import { PullRequestLinks } from '../StatusLine/PullRequestLinks';
+
+const FACTORY_PROJECT_ID = 'factory-project-1';
+const SESSION_RESOURCE_ID = 'thread-1';
+const THREAD_ID = 'thread-1';
+
+function renderLinks({ factoryProjectId }: { factoryProjectId?: string } = {}) {
+  return renderWithProviders(
+    <PullRequestLinks
+      baseUrl="http://localhost:4111"
+      resourceId={SESSION_RESOURCE_ID}
+      projectPath={undefined}
+      projectRepositoryId="project-repo-1"
+      factoryProjectId={factoryProjectId}
+      repositorySlug="acme/widgets"
+      threadId={THREAD_ID}
+      transcriptEntries={[]}
+      busy={false}
+    />,
+  );
+}
+
+describe('PullRequestLinks subscription lookup', () => {
+  it('queries subscriptions with the factory project id when the session is factory-bound', async () => {
+    const seenResourceIds: (string | null)[] = [];
+    server.use(
+      http.get('*/web/factory/projects/:id/work-items', () => HttpResponse.json({ workItems: [] })),
+      http.get('*/web/github/subscriptions', ({ request }) => {
+        const url = new URL(request.url);
+        seenResourceIds.push(url.searchParams.get('resourceId'));
+        return HttpResponse.json({
+          subscriptions: [
+            {
+              id: 'sub-1',
+              repoFullName: 'acme/widgets',
+              pullRequestNumber: 65,
+              status: 'open',
+              url: 'https://github.com/acme/widgets/pull/65',
+            },
+          ],
+        });
+      }),
+    );
+
+    renderLinks({ factoryProjectId: FACTORY_PROJECT_ID });
+
+    // Subscriptions are stored keyed on the factory project id, so the chip
+    // only renders when the query carries it instead of the chat resourceId.
+    expect(await screen.findByText('PR #65')).toBeInTheDocument();
+    await waitFor(() => expect(seenResourceIds).toContain(FACTORY_PROJECT_ID));
+    expect(seenResourceIds).not.toContain(SESSION_RESOURCE_ID);
+  });
+
+  it('falls back to the chat resourceId outside factory sessions', async () => {
+    const seenResourceIds: (string | null)[] = [];
+    server.use(
+      http.get('*/web/github/subscriptions', ({ request }) => {
+        const url = new URL(request.url);
+        seenResourceIds.push(url.searchParams.get('resourceId'));
+        return HttpResponse.json({ subscriptions: [] });
+      }),
+    );
+
+    renderLinks();
+
+    await waitFor(() => expect(seenResourceIds).toContain(SESSION_RESOURCE_ID));
+  });
+});


### PR DESCRIPTION
## Summary

PR subscriptions created from factory sessions (via `github_subscribe_pr` or the automatic `gh pr create` subscription) never showed up as the PR chip in the session status line.

The server stores subscriptions with `resourceId = connection.factoryProjectId` (`session-subscriptions.ts`, since #19849) and webhook delivery resolves sessions the same way — but the `PullRequestLinks` component still queried `/web/github/subscriptions` with the chat session's `resourceId`. For factory-bound sessions those ids never match, so the endpoint always returned an empty list.

The fix queries with the factory project id when the session is factory-bound, falling back to the chat `resourceId` otherwise.

## Test plan

- New MSW test `PullRequestLinks.msw.test.tsx`: factory-bound session queries with the factory project id and renders the chip (red before the fix); non-factory session falls back to the chat resourceId.
- `vitest run src/web/ui/domains/chat` — 32 passed.
- `pnpm run check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory sessions now look up subscribed pull requests using the correct project ID, so PR links appear in the session status line. Older non-factory sessions keep using their existing resource ID.

## Changes

- Updated `PullRequestLinks` to prefer `factoryProjectId` and fall back to `resourceId`.
- Added MSW tests covering factory-bound and non-factory sessions.
- Added a patch changeset for `mastra`.
- Chat-domain tests pass (32 tests), and `pnpm run check` succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->