### PR TITLE
feat(stores): persist experiment execution outcomes

### DIFF
--- a/.changeset/chubby-llamas-search.md
+++ b/.changeset/chubby-llamas-search.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mysql': patch
+---
+
+Added durable storage for explicit experiment execution and scorer counts, per-item execution status, and experiment threshold snapshots in the MySQL provider. Existing experiment tables are upgraded in place, and historical rows derive target execution counts from the legacy counters.

--- a/.changeset/curly-friends-heal.md
+++ b/.changeset/curly-friends-heal.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Added durable storage for explicit experiment execution and scorer counts, per-item execution status, and experiment threshold snapshots in the LibSQL provider. Existing experiment tables are upgraded in place, and historical rows derive target execution counts from the legacy counters.

--- a/.changeset/pink-owls-remain.md
+++ b/.changeset/pink-owls-remain.md
@@ -1,0 +1,5 @@
+---
+'@mastra/spanner': patch
+---
+
+Added durable storage for explicit experiment execution and scorer counts, per-item execution status, and experiment threshold snapshots in the Spanner provider. Existing experiment tables are upgraded in place, and historical rows derive target execution counts from the legacy counters.

--- a/.changeset/plain-breads-accept.md
+++ b/.changeset/plain-breads-accept.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Added durable storage for explicit experiment execution and scorer counts, per-item execution status, and experiment threshold snapshots in the PostgreSQL provider. Existing experiment tables are upgraded in place, and historical rows derive target execution counts from the legacy counters.

--- a/.changeset/salty-coats-eat.md
+++ b/.changeset/salty-coats-eat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mongodb': patch
+---
+
+Added durable storage for explicit experiment execution and scorer counts, per-item execution status, and experiment threshold snapshots in the MongoDB provider. Historical documents derive target execution counts from the legacy counters without inventing scorer counts or thresholds.

--- a/stores/_test-utils/src/domains/experiments/index.ts
+++ b/stores/_test-utils/src/domains/experiments/index.ts
@@ -46,14 +46,29 @@ export function createExperimentsTests({
           targetType: 'agent',
           targetId: 'agent-1',
           totalItems: 5,
+          thresholds: [
+            { scorerId: 'quality', threshold: { min: 0.7, max: 0.9 }, targetScope: 'span' },
+            { scorerId: 'style', threshold: 0.6, targetScope: 'span', stepId: 'draft' },
+          ],
         });
 
         expect(exp.id).toBeDefined();
         expect(exp.name).toBe('test-exp');
         expect(exp.status).toBe('pending');
+        expect(exp.executionStatusCounts).toEqual({ completed: 0, skipped: 0, error: 0, cancelled: 0 });
+        expect(exp.scorerStatusCounts).toEqual({ completed: 0, error: 0 });
+        expect(exp.thresholds).toEqual([
+          { scorerId: 'quality', threshold: { min: 0.7, max: 0.9 }, targetScope: 'span' },
+          { scorerId: 'style', threshold: 0.6, targetScope: 'span', stepId: 'draft' },
+        ]);
         expect(exp.succeededCount).toBe(0);
         expect(exp.failedCount).toBe(0);
         expect(exp.skippedCount).toBe(0);
+
+        const fetched = await experimentsStorage.getExperimentById({ id: exp.id });
+        expect(fetched?.executionStatusCounts).toEqual(exp.executionStatusCounts);
+        expect(fetched?.scorerStatusCounts).toEqual(exp.scorerStatusCounts);
+        expect(fetched?.thresholds).toEqual(exp.thresholds);
       });
 
       it('createExperiment accepts custom id', async () => {
@@ -133,11 +148,17 @@ export function createExperimentsTests({
         const updated = await experimentsStorage.updateExperiment({
           id: exp.id,
           status: 'running',
+          executionStatusCounts: { completed: 1, skipped: 0, error: 1, cancelled: 1 },
+          scorerStatusCounts: { completed: 4, error: 2 },
           succeededCount: 1,
+          failedCount: 2,
         });
 
         expect(updated.status).toBe('running');
+        expect(updated.executionStatusCounts).toEqual({ completed: 1, skipped: 0, error: 1, cancelled: 1 });
+        expect(updated.scorerStatusCounts).toEqual({ completed: 4, error: 2 });
         expect(updated.succeededCount).toBe(1);
+        expect(updated.failedCount).toBe(2);
         expect(updated.id).toBe(exp.id);
       });
 
@@ -163,6 +184,7 @@ export function createExperimentsTests({
         expect(updated.description).toBe('A test');
         expect(updated.metadata).toEqual({ key: 'value' });
         expect(updated.skippedCount).toBe(1);
+        expect(updated.executionStatusCounts).toEqual({ completed: 0, skipped: 1, error: 0, cancelled: 0 });
       });
 
       it('createExperiment sets initial totalItems and updateExperiment persists change', async () => {
@@ -296,6 +318,7 @@ export function createExperimentsTests({
           output: { a: 'world' },
           groundTruth: null,
           error: null,
+          executionStatus: 'completed',
           startedAt: new Date(),
           completedAt: new Date(),
           retryCount: 0,
@@ -304,6 +327,10 @@ export function createExperimentsTests({
         expect(result.id).toBeDefined();
         expect(result.experimentId).toBe(exp.id);
         expect(result.input).toEqual({ q: 'hello' });
+        expect(result.executionStatus).toBe('completed');
+
+        const fetched = await experimentsStorage.getExperimentResultById({ id: result.id });
+        expect(fetched?.executionStatus).toBe('completed');
       });
 
       it('addExperimentResult with integer itemDatasetVersion', async () => {

--- a/stores/libsql/src/storage/domains/experiments/index.ts
+++ b/stores/libsql/src/storage/domains/experiments/index.ts
@@ -70,12 +70,19 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
     await this.#db.alterTable({
       tableName: TABLE_EXPERIMENTS,
       schema: EXPERIMENTS_SCHEMA,
-      ifNotExists: ['agentVersion', 'organizationId', 'projectId'],
+      ifNotExists: [
+        'agentVersion',
+        'organizationId',
+        'projectId',
+        'executionStatusCounts',
+        'scorerStatusCounts',
+        'thresholds',
+      ],
     });
     await this.#db.alterTable({
       tableName: TABLE_EXPERIMENT_RESULTS,
       schema: EXPERIMENT_RESULTS_SCHEMA,
-      ifNotExists: ['status', 'tags', 'toolMockReport', 'organizationId', 'projectId'],
+      ifNotExists: ['status', 'tags', 'toolMockReport', 'organizationId', 'projectId', 'executionStatus'],
     });
 
     // Indexes — idempotent, safe to run on every init
@@ -189,6 +196,17 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       metadata: row.metadata ? safelyParseJSON(row.metadata as string) : undefined,
       status: row.status as Experiment['status'],
       totalItems: row.totalItems as number,
+      executionStatusCounts:
+        row.executionStatusCounts != null
+          ? safelyParseJSON(row.executionStatusCounts as string)
+          : {
+              completed: row.succeededCount as number,
+              skipped: (row.skippedCount as number) ?? 0,
+              error: row.failedCount as number,
+              cancelled: 0,
+            },
+      scorerStatusCounts: row.scorerStatusCounts != null ? safelyParseJSON(row.scorerStatusCounts as string) : null,
+      thresholds: row.thresholds != null ? safelyParseJSON(row.thresholds as string) : null,
       succeededCount: row.succeededCount as number,
       failedCount: row.failedCount as number,
       skippedCount: (row.skippedCount as number) ?? 0,
@@ -212,6 +230,7 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       output: row.output ? safelyParseJSON(row.output as string) : null,
       groundTruth: row.groundTruth ? safelyParseJSON(row.groundTruth as string) : null,
       error: row.error ? safelyParseJSON(row.error as string) : null,
+      executionStatus: (row.executionStatus as ExperimentResult['executionStatus']) ?? null,
       startedAt: ensureDate(row.startedAt as string | Date)!,
       completedAt: ensureDate(row.completedAt as string | Date)!,
       retryCount: row.retryCount as number,
@@ -229,6 +248,12 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       const id = input.id ?? crypto.randomUUID();
       const now = new Date();
       const nowIso = now.toISOString();
+      const thresholds = (input.thresholds ?? []).map(binding => ({
+        ...binding,
+        threshold: typeof binding.threshold === 'number' ? binding.threshold : { ...binding.threshold },
+      }));
+      const executionStatusCounts = { completed: 0, skipped: 0, error: 0, cancelled: 0 };
+      const scorerStatusCounts = { completed: 0, error: 0 };
 
       await this.#db.insert({
         tableName: TABLE_EXPERIMENTS,
@@ -246,6 +271,9 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
           metadata: input.metadata ?? null,
           status: 'pending',
           totalItems: input.totalItems,
+          executionStatusCounts,
+          scorerStatusCounts,
+          thresholds,
           succeededCount: 0,
           failedCount: 0,
           skippedCount: 0,
@@ -270,6 +298,9 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
         metadata: input.metadata,
         status: 'pending',
         totalItems: input.totalItems,
+        executionStatusCounts,
+        scorerStatusCounts,
+        thresholds,
         succeededCount: 0,
         failedCount: 0,
         skippedCount: 0,
@@ -302,6 +333,20 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
         });
       }
 
+      const hasLegacyCountUpdate =
+        input.succeededCount !== undefined || input.failedCount !== undefined || input.skippedCount !== undefined;
+      const executionStatusCounts =
+        input.executionStatusCounts !== undefined
+          ? input.executionStatusCounts
+          : hasLegacyCountUpdate
+            ? {
+                completed: input.succeededCount ?? existing.succeededCount,
+                skipped: input.skippedCount ?? existing.skippedCount,
+                error: input.failedCount ?? existing.failedCount,
+                cancelled: 0,
+              }
+            : undefined;
+
       const now = new Date().toISOString();
       const updates: string[] = ['updatedAt = ?'];
       const values: InValue[] = [now];
@@ -333,6 +378,14 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       if (input.skippedCount !== undefined) {
         updates.push('skippedCount = ?');
         values.push(input.skippedCount);
+      }
+      if (executionStatusCounts !== undefined) {
+        updates.push('executionStatusCounts = ?');
+        values.push(executionStatusCounts === null ? null : JSON.stringify(executionStatusCounts));
+      }
+      if (input.scorerStatusCounts !== undefined) {
+        updates.push('scorerStatusCounts = ?');
+        values.push(input.scorerStatusCounts === null ? null : JSON.stringify(input.scorerStatusCounts));
       }
       if (input.name !== undefined) {
         updates.push('name = ?');
@@ -527,6 +580,7 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
           output: input.output,
           groundTruth: input.groundTruth,
           error: input.error ?? null,
+          executionStatus: input.executionStatus ?? null,
           startedAt: input.startedAt.toISOString(),
           completedAt: input.completedAt.toISOString(),
           retryCount: input.retryCount,
@@ -549,6 +603,7 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
         output: input.output,
         groundTruth: input.groundTruth,
         error: input.error,
+        executionStatus: input.executionStatus ?? null,
         startedAt: input.startedAt,
         completedAt: input.completedAt,
         retryCount: input.retryCount,

--- a/stores/libsql/src/storage/migration.test.ts
+++ b/stores/libsql/src/storage/migration.test.ts
@@ -5,11 +5,14 @@ import {
   OLD_SPAN_SCHEMA,
   TABLE_SPANS,
   TABLE_SCHEMAS,
+  TABLE_EXPERIMENTS,
+  TABLE_EXPERIMENT_RESULTS,
   TABLE_THREADS,
   TABLE_WORKFLOW_SNAPSHOT,
 } from '@mastra/core/storage';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { LibSQLDB } from './db';
+import { ExperimentsLibSQL } from './domains/experiments';
 import { LibSQLStore } from './index';
 
 /**
@@ -984,6 +987,63 @@ describe('LibSQL Migration Required Error', () => {
         (row: any) => row.name === 'mastra_ai_spans_spanid_traceid_idx' && row.unique === 1,
       );
       expect(uniqueIndex).toBeDefined();
+    } finally {
+      testClient.close();
+    }
+  });
+});
+
+describe('LibSQL experiment status migration', () => {
+  it('adds nullable status columns idempotently and derives historical execution counts', async () => {
+    const testClient = createClient({ url: ':memory:' });
+    const db = new LibSQLDB({ client: testClient, maxRetries: 5, initialBackoffMs: 100 });
+    const omittedExperimentColumns = new Set(['executionStatusCounts', 'scorerStatusCounts', 'thresholds']);
+    const omittedResultColumns = new Set(['executionStatus']);
+    const oldExperimentSchema = Object.fromEntries(
+      Object.entries(TABLE_SCHEMAS[TABLE_EXPERIMENTS]).filter(([name]) => !omittedExperimentColumns.has(name)),
+    );
+    const oldResultSchema = Object.fromEntries(
+      Object.entries(TABLE_SCHEMAS[TABLE_EXPERIMENT_RESULTS]).filter(([name]) => !omittedResultColumns.has(name)),
+    );
+
+    try {
+      await db.createTable({ tableName: TABLE_EXPERIMENTS, schema: oldExperimentSchema });
+      await db.createTable({ tableName: TABLE_EXPERIMENT_RESULTS, schema: oldResultSchema });
+      await testClient.execute({
+        sql: `INSERT INTO "${TABLE_EXPERIMENTS}"
+          ("id", "datasetId", "datasetVersion", "targetType", "targetId", "status", "totalItems", "succeededCount", "failedCount", "skippedCount", "createdAt", "updatedAt")
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        args: [
+          'legacy-experiment',
+          null,
+          null,
+          'agent',
+          'agent-1',
+          'completed',
+          4,
+          1,
+          2,
+          1,
+          '2024-01-01T00:00:00.000Z',
+          '2024-01-01T00:00:01.000Z',
+        ],
+      });
+
+      const storage = new ExperimentsLibSQL({ client: testClient });
+      await storage.init();
+      await storage.init();
+
+      const experimentColumns = await testClient.execute(`PRAGMA table_info("${TABLE_EXPERIMENTS}")`);
+      const resultColumns = await testClient.execute(`PRAGMA table_info("${TABLE_EXPERIMENT_RESULTS}")`);
+      expect(experimentColumns.rows.map(row => row.name)).toEqual(
+        expect.arrayContaining(['executionStatusCounts', 'scorerStatusCounts', 'thresholds']),
+      );
+      expect(resultColumns.rows.map(row => row.name)).toContain('executionStatus');
+
+      const legacy = await storage.getExperimentById({ id: 'legacy-experiment' });
+      expect(legacy?.executionStatusCounts).toEqual({ completed: 1, skipped: 1, error: 2, cancelled: 0 });
+      expect(legacy?.scorerStatusCounts).toBeNull();
+      expect(legacy?.thresholds).toBeNull();
     } finally {
       testClient.close();
     }

--- a/stores/mongodb/src/storage/domains/experiments/index.ts
+++ b/stores/mongodb/src/storage/domains/experiments/index.ts
@@ -70,6 +70,20 @@ function transformExperimentRow(row: Record<string, unknown>): Experiment {
     targetId: row.targetId as string,
     status: row.status as Experiment['status'],
     totalItems: Number(row.totalItems ?? 0),
+    executionStatusCounts:
+      row.executionStatusCounts != null
+        ? (parseJsonField(row.executionStatusCounts) as Experiment['executionStatusCounts'])
+        : {
+            completed: Number(row.succeededCount ?? 0),
+            skipped: Number(row.skippedCount ?? 0),
+            error: Number(row.failedCount ?? 0),
+            cancelled: 0,
+          },
+    scorerStatusCounts:
+      row.scorerStatusCounts != null
+        ? (parseJsonField(row.scorerStatusCounts) as Experiment['scorerStatusCounts'])
+        : null,
+    thresholds: row.thresholds != null ? (parseJsonField(row.thresholds) as Experiment['thresholds']) : null,
     succeededCount: Number(row.succeededCount ?? 0),
     failedCount: Number(row.failedCount ?? 0),
     skippedCount: Number(row.skippedCount ?? 0),
@@ -93,6 +107,7 @@ function transformExperimentResultRow(row: Record<string, unknown>): ExperimentR
     output: parseJsonField(row.output) ?? null,
     groundTruth: parseJsonField(row.groundTruth) ?? null,
     error: parseJsonField(row.error) ?? null,
+    executionStatus: (row.executionStatus as ExperimentResult['executionStatus']) ?? null,
     startedAt: toDate(row.startedAt),
     completedAt: toDate(row.completedAt),
     retryCount: Number(row.retryCount ?? 0),
@@ -257,6 +272,12 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
   async createExperiment(input: CreateExperimentInput): Promise<Experiment> {
     const id = input.id ?? randomUUID();
     const now = new Date();
+    const thresholds = (input.thresholds ?? []).map(binding => ({
+      ...binding,
+      threshold: typeof binding.threshold === 'number' ? binding.threshold : { ...binding.threshold },
+    }));
+    const executionStatusCounts = { completed: 0, skipped: 0, error: 0, cancelled: 0 };
+    const scorerStatusCounts = { completed: 0, error: 0 };
 
     const doc = {
       id,
@@ -271,6 +292,9 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
       targetId: input.targetId,
       status: 'pending' as const,
       totalItems: input.totalItems,
+      executionStatusCounts,
+      scorerStatusCounts,
+      thresholds,
       succeededCount: 0,
       failedCount: 0,
       skippedCount: 0,
@@ -298,6 +322,9 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
         targetId: input.targetId,
         status: 'pending',
         totalItems: input.totalItems,
+        executionStatusCounts,
+        scorerStatusCounts,
+        thresholds,
         succeededCount: 0,
         failedCount: 0,
         skippedCount: 0,
@@ -321,6 +348,28 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
   }
 
   async updateExperiment(input: UpdateExperimentInput): Promise<Experiment> {
+    const existing = await this.getExperimentById({ id: input.id });
+    if (!existing) {
+      throw new MastraError({
+        id: createStorageErrorId('MONGODB', 'UPDATE_EXPERIMENT', 'NOT_FOUND'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { experimentId: input.id },
+      });
+    }
+    const hasLegacyCountUpdate =
+      input.succeededCount !== undefined || input.failedCount !== undefined || input.skippedCount !== undefined;
+    const executionStatusCounts =
+      input.executionStatusCounts !== undefined
+        ? input.executionStatusCounts
+        : hasLegacyCountUpdate
+          ? {
+              completed: input.succeededCount ?? existing.succeededCount,
+              skipped: input.skippedCount ?? existing.skippedCount,
+              error: input.failedCount ?? existing.failedCount,
+              cancelled: 0,
+            }
+          : undefined;
     const updateFields: Record<string, unknown> = { updatedAt: new Date() };
 
     if (input.name !== undefined) updateFields.name = input.name;
@@ -331,6 +380,8 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
     if (input.succeededCount !== undefined) updateFields.succeededCount = input.succeededCount;
     if (input.failedCount !== undefined) updateFields.failedCount = input.failedCount;
     if (input.skippedCount !== undefined) updateFields.skippedCount = input.skippedCount;
+    if (executionStatusCounts !== undefined) updateFields.executionStatusCounts = executionStatusCounts;
+    if (input.scorerStatusCounts !== undefined) updateFields.scorerStatusCounts = input.scorerStatusCounts;
     if (input.startedAt !== undefined) updateFields.startedAt = input.startedAt;
     if (input.completedAt !== undefined) updateFields.completedAt = input.completedAt;
 
@@ -517,6 +568,7 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
       output: input.output ?? null,
       groundTruth: input.groundTruth ?? null,
       error: input.error ?? null,
+      executionStatus: input.executionStatus ?? null,
       startedAt: input.startedAt,
       completedAt: input.completedAt,
       retryCount: input.retryCount,
@@ -542,6 +594,7 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
         output: input.output ?? null,
         groundTruth: input.groundTruth ?? null,
         error: input.error ?? null,
+        executionStatus: input.executionStatus ?? null,
         startedAt: input.startedAt,
         completedAt: input.completedAt,
         retryCount: input.retryCount,

--- a/stores/mongodb/src/storage/migration.test.ts
+++ b/stores/mongodb/src/storage/migration.test.ts
@@ -1,5 +1,6 @@
 import { MastraError } from '@mastra/core/error';
 import { SpanType, EntityType } from '@mastra/core/observability';
+import { TABLE_EXPERIMENTS, TABLE_EXPERIMENT_RESULTS } from '@mastra/core/storage';
 import { MongoClient } from 'mongodb';
 import { describe, expect, it, beforeAll, afterAll } from 'vitest';
 import { MongoDBStore } from './index';
@@ -886,6 +887,71 @@ describe('MongoDB Migration Required Error', () => {
       await store.close();
     } finally {
       await cleanupDatabase(testDbName);
+    }
+  });
+});
+
+describe('MongoDB experiment status compatibility', () => {
+  it('derives target counts and leaves unavailable historical fields null', async () => {
+    const dbName = `experiment_status_migration_${Date.now().toString(36)}`;
+    const client = new MongoClient(TEST_CONFIG.url);
+    const now = new Date('2024-01-01T00:00:00.000Z');
+    const store = new MongoDBStore({ id: `experiment-migration-${Date.now()}`, url: TEST_CONFIG.url, dbName });
+
+    try {
+      await client.connect();
+      const db = client.db(dbName);
+      await db.collection(TABLE_EXPERIMENTS).insertOne({
+        id: 'legacy-experiment',
+        datasetId: null,
+        datasetVersion: null,
+        agentVersion: null,
+        targetType: 'agent',
+        targetId: 'agent-1',
+        status: 'completed',
+        totalItems: 4,
+        succeededCount: 1,
+        failedCount: 2,
+        skippedCount: 1,
+        startedAt: now,
+        completedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await db.collection(TABLE_EXPERIMENT_RESULTS).insertOne({
+        id: 'legacy-result',
+        experimentId: 'legacy-experiment',
+        itemId: 'item-1',
+        itemDatasetVersion: null,
+        input: { prompt: 'hello' },
+        output: null,
+        groundTruth: null,
+        error: { message: 'failed' },
+        startedAt: now,
+        completedAt: now,
+        retryCount: 0,
+        traceId: null,
+        status: null,
+        tags: null,
+        createdAt: now,
+      });
+
+      await store.init();
+      const experiments = await store.getStore('experiments');
+      const experiment = await experiments?.getExperimentById({ id: 'legacy-experiment' });
+      const result = await experiments?.getExperimentResultById({ id: 'legacy-result' });
+
+      expect(experiment?.executionStatusCounts).toEqual({ completed: 1, skipped: 1, error: 2, cancelled: 0 });
+      expect(experiment?.scorerStatusCounts).toBeNull();
+      expect(experiment?.thresholds).toBeNull();
+      expect(result?.executionStatus).toBeNull();
+    } finally {
+      await store.close();
+      await client
+        .db(dbName)
+        .dropDatabase()
+        .catch(() => {});
+      await client.close();
     }
   });
 });

--- a/stores/mysql/src/storage/domains/experiments/index.ts
+++ b/stores/mysql/src/storage/domains/experiments/index.ts
@@ -59,6 +59,9 @@ interface ExperimentRow {
   metadata: string | null;
   status: string;
   totalItems: number;
+  executionStatusCounts: string | null;
+  scorerStatusCounts: string | null;
+  thresholds: string | null;
   succeededCount: number;
   failedCount: number;
   skippedCount: number;
@@ -79,6 +82,7 @@ interface ExperimentResultRow {
   output: string | null;
   groundTruth: string | null;
   error: string | null;
+  executionStatus: string | null;
   startedAt: Date | string;
   completedAt: Date | string;
   retryCount: number;
@@ -180,12 +184,19 @@ export class ExperimentsMySQL extends ExperimentsStorage {
     await this.operations.alterTable({
       tableName: TABLE_EXPERIMENTS,
       schema: EXPERIMENTS_SCHEMA,
-      ifNotExists: ['agentVersion', 'organizationId', 'projectId'],
+      ifNotExists: [
+        'agentVersion',
+        'organizationId',
+        'projectId',
+        'executionStatusCounts',
+        'scorerStatusCounts',
+        'thresholds',
+      ],
     });
     await this.operations.alterTable({
       tableName: TABLE_EXPERIMENT_RESULTS,
       schema: EXPERIMENT_RESULTS_SCHEMA,
-      ifNotExists: ['organizationId', 'projectId'],
+      ifNotExists: ['organizationId', 'projectId', 'executionStatus'],
     });
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
@@ -211,6 +222,14 @@ export class ExperimentsMySQL extends ExperimentsStorage {
       metadata: parseJSON<Record<string, unknown>>(row.metadata),
       status: row.status as Experiment['status'],
       totalItems: row.totalItems,
+      executionStatusCounts: parseJSON<Experiment['executionStatusCounts']>(row.executionStatusCounts) ?? {
+        completed: row.succeededCount,
+        skipped: row.skippedCount ?? 0,
+        error: row.failedCount,
+        cancelled: 0,
+      },
+      scorerStatusCounts: parseJSON<Experiment['scorerStatusCounts']>(row.scorerStatusCounts) ?? null,
+      thresholds: parseJSON<Experiment['thresholds']>(row.thresholds) ?? null,
       succeededCount: row.succeededCount,
       failedCount: row.failedCount,
       skippedCount: row.skippedCount ?? 0,
@@ -233,6 +252,7 @@ export class ExperimentsMySQL extends ExperimentsStorage {
       output: row.output ? parseJSON<Record<string, unknown>>(row.output) : null,
       groundTruth: row.groundTruth ? parseJSON<Record<string, unknown>>(row.groundTruth) : null,
       error: row.error ? (parseJSON<{ message: string; stack?: string; code?: string }>(row.error) ?? null) : null,
+      executionStatus: (row.executionStatus as ExperimentResult['executionStatus']) ?? null,
       startedAt: parseDateTime(row.startedAt) ?? new Date(),
       completedAt: parseDateTime(row.completedAt) ?? new Date(),
       retryCount: row.retryCount,
@@ -247,6 +267,12 @@ export class ExperimentsMySQL extends ExperimentsStorage {
     try {
       const id = input.id ?? randomUUID();
       const now = new Date();
+      const thresholds = (input.thresholds ?? []).map(binding => ({
+        ...binding,
+        threshold: typeof binding.threshold === 'number' ? binding.threshold : { ...binding.threshold },
+      }));
+      const executionStatusCounts = { completed: 0, skipped: 0, error: 0, cancelled: 0 };
+      const scorerStatusCounts = { completed: 0, error: 0 };
 
       await this.operations.insert({
         tableName: TABLE_EXPERIMENTS,
@@ -264,6 +290,9 @@ export class ExperimentsMySQL extends ExperimentsStorage {
           metadata: input.metadata ? JSON.stringify(input.metadata) : null,
           status: 'pending',
           totalItems: input.totalItems,
+          executionStatusCounts: JSON.stringify(executionStatusCounts),
+          scorerStatusCounts: JSON.stringify(scorerStatusCounts),
+          thresholds: JSON.stringify(thresholds),
           succeededCount: 0,
           failedCount: 0,
           skippedCount: 0,
@@ -288,6 +317,9 @@ export class ExperimentsMySQL extends ExperimentsStorage {
         metadata: input.metadata,
         status: 'pending',
         totalItems: input.totalItems,
+        executionStatusCounts,
+        scorerStatusCounts,
+        thresholds,
         succeededCount: 0,
         failedCount: 0,
         skippedCount: 0,
@@ -320,12 +352,31 @@ export class ExperimentsMySQL extends ExperimentsStorage {
         });
       }
 
+      const hasLegacyCountUpdate =
+        input.succeededCount !== undefined || input.failedCount !== undefined || input.skippedCount !== undefined;
+      const executionStatusCounts =
+        input.executionStatusCounts !== undefined
+          ? input.executionStatusCounts
+          : hasLegacyCountUpdate
+            ? {
+                completed: input.succeededCount ?? existing.succeededCount,
+                skipped: input.skippedCount ?? existing.skippedCount,
+                error: input.failedCount ?? existing.failedCount,
+                cancelled: 0,
+              }
+            : undefined;
       const data: Record<string, any> = { updatedAt: new Date() };
 
       if (input.status !== undefined) data.status = input.status;
       if (input.succeededCount !== undefined) data.succeededCount = input.succeededCount;
       if (input.failedCount !== undefined) data.failedCount = input.failedCount;
       if (input.skippedCount !== undefined) data.skippedCount = input.skippedCount;
+      if (executionStatusCounts !== undefined) {
+        data.executionStatusCounts = executionStatusCounts === null ? null : JSON.stringify(executionStatusCounts);
+      }
+      if (input.scorerStatusCounts !== undefined) {
+        data.scorerStatusCounts = input.scorerStatusCounts === null ? null : JSON.stringify(input.scorerStatusCounts);
+      }
       if (input.totalItems !== undefined) data.totalItems = input.totalItems;
       if (input.startedAt !== undefined) data.startedAt = input.startedAt ?? null;
       if (input.completedAt !== undefined) data.completedAt = input.completedAt ?? null;
@@ -559,6 +610,7 @@ export class ExperimentsMySQL extends ExperimentsStorage {
           output: input.output ? JSON.stringify(input.output) : null,
           groundTruth: input.groundTruth ? JSON.stringify(input.groundTruth) : null,
           error: input.error ? JSON.stringify(input.error) : null,
+          executionStatus: input.executionStatus ?? null,
           startedAt: input.startedAt,
           completedAt: input.completedAt,
           retryCount: input.retryCount,
@@ -580,6 +632,7 @@ export class ExperimentsMySQL extends ExperimentsStorage {
         output: input.output,
         groundTruth: input.groundTruth,
         error: input.error,
+        executionStatus: input.executionStatus ?? null,
         startedAt: input.startedAt,
         completedAt: input.completedAt,
         retryCount: input.retryCount,

--- a/stores/pg/src/storage/domains/experiments/index.ts
+++ b/stores/pg/src/storage/domains/experiments/index.ts
@@ -90,12 +90,19 @@ export class ExperimentsPG extends ExperimentsStorage {
     await this.#db.alterTable({
       tableName: TABLE_EXPERIMENTS,
       schema: EXPERIMENTS_SCHEMA,
-      ifNotExists: ['agentVersion', 'organizationId', 'projectId'],
+      ifNotExists: [
+        'agentVersion',
+        'organizationId',
+        'projectId',
+        'executionStatusCounts',
+        'scorerStatusCounts',
+        'thresholds',
+      ],
     });
     await this.#db.alterTable({
       tableName: TABLE_EXPERIMENT_RESULTS,
       schema: EXPERIMENT_RESULTS_SCHEMA,
-      ifNotExists: ['status', 'tags', 'toolMockReport', 'organizationId', 'projectId'],
+      ifNotExists: ['status', 'tags', 'toolMockReport', 'organizationId', 'projectId', 'executionStatus'],
     });
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
@@ -244,6 +251,17 @@ export class ExperimentsPG extends ExperimentsStorage {
       targetId: row.targetId as string,
       status: row.status as Experiment['status'],
       totalItems: row.totalItems as number,
+      executionStatusCounts:
+        row.executionStatusCounts != null
+          ? safelyParseJSON(row.executionStatusCounts)
+          : {
+              completed: row.succeededCount as number,
+              skipped: (row.skippedCount as number) ?? 0,
+              error: row.failedCount as number,
+              cancelled: 0,
+            },
+      scorerStatusCounts: row.scorerStatusCounts != null ? safelyParseJSON(row.scorerStatusCounts) : null,
+      thresholds: row.thresholds != null ? safelyParseJSON(row.thresholds) : null,
       succeededCount: row.succeededCount as number,
       failedCount: row.failedCount as number,
       skippedCount: (row.skippedCount as number) ?? 0,
@@ -266,6 +284,7 @@ export class ExperimentsPG extends ExperimentsStorage {
       output: row.output ? safelyParseJSON(row.output) : null,
       groundTruth: row.groundTruth ? safelyParseJSON(row.groundTruth) : null,
       error: row.error ? safelyParseJSON(row.error) : null,
+      executionStatus: (row.executionStatus as ExperimentResult['executionStatus']) ?? null,
       startedAt: ensureDate(row.startedAtZ || row.startedAt)!,
       completedAt: ensureDate(row.completedAtZ || row.completedAt)!,
       retryCount: row.retryCount as number,
@@ -284,6 +303,12 @@ export class ExperimentsPG extends ExperimentsStorage {
       const id = input.id ?? crypto.randomUUID();
       const now = new Date();
       const nowIso = now.toISOString();
+      const thresholds = (input.thresholds ?? []).map(binding => ({
+        ...binding,
+        threshold: typeof binding.threshold === 'number' ? binding.threshold : { ...binding.threshold },
+      }));
+      const executionStatusCounts = { completed: 0, skipped: 0, error: 0, cancelled: 0 };
+      const scorerStatusCounts = { completed: 0, error: 0 };
 
       await this.#db.insert({
         tableName: TABLE_EXPERIMENTS,
@@ -301,6 +326,9 @@ export class ExperimentsPG extends ExperimentsStorage {
           targetId: input.targetId,
           status: 'pending',
           totalItems: input.totalItems,
+          executionStatusCounts,
+          scorerStatusCounts,
+          thresholds,
           succeededCount: 0,
           failedCount: 0,
           skippedCount: 0,
@@ -325,6 +353,9 @@ export class ExperimentsPG extends ExperimentsStorage {
         targetId: input.targetId,
         status: 'pending',
         totalItems: input.totalItems,
+        executionStatusCounts,
+        scorerStatusCounts,
+        thresholds,
         succeededCount: 0,
         failedCount: 0,
         skippedCount: 0,
@@ -356,6 +387,20 @@ export class ExperimentsPG extends ExperimentsStorage {
           details: { experimentId: input.id },
         });
       }
+
+      const hasLegacyCountUpdate =
+        input.succeededCount !== undefined || input.failedCount !== undefined || input.skippedCount !== undefined;
+      const executionStatusCounts =
+        input.executionStatusCounts !== undefined
+          ? input.executionStatusCounts
+          : hasLegacyCountUpdate
+            ? {
+                completed: input.succeededCount ?? existing.succeededCount,
+                skipped: input.skippedCount ?? existing.skippedCount,
+                error: input.failedCount ?? existing.failedCount,
+                cancelled: 0,
+              }
+            : undefined;
 
       const tableName = getTableName({ indexName: TABLE_EXPERIMENTS, schemaName: getSchemaName(this.#schema) });
       const now = new Date().toISOString();
@@ -394,6 +439,14 @@ export class ExperimentsPG extends ExperimentsStorage {
       if (input.skippedCount !== undefined) {
         setClauses.push(`"skippedCount" = $${paramIndex++}`);
         values.push(input.skippedCount);
+      }
+      if (executionStatusCounts !== undefined) {
+        setClauses.push(`"executionStatusCounts" = $${paramIndex++}`);
+        values.push(executionStatusCounts === null ? null : JSON.stringify(executionStatusCounts));
+      }
+      if (input.scorerStatusCounts !== undefined) {
+        setClauses.push(`"scorerStatusCounts" = $${paramIndex++}`);
+        values.push(input.scorerStatusCounts === null ? null : JSON.stringify(input.scorerStatusCounts));
       }
       if (input.startedAt !== undefined) {
         setClauses.push(`"startedAt" = $${paramIndex++}`);
@@ -589,6 +642,7 @@ export class ExperimentsPG extends ExperimentsStorage {
           output: input.output ?? null,
           groundTruth: input.groundTruth ?? null,
           error: input.error ?? null,
+          executionStatus: input.executionStatus ?? null,
           startedAt: input.startedAt.toISOString(),
           completedAt: input.completedAt.toISOString(),
           retryCount: input.retryCount,
@@ -611,6 +665,7 @@ export class ExperimentsPG extends ExperimentsStorage {
         output: input.output ?? null,
         groundTruth: input.groundTruth ?? null,
         error: input.error ?? null,
+        executionStatus: input.executionStatus ?? null,
         startedAt: input.startedAt,
         completedAt: input.completedAt,
         retryCount: input.retryCount,

--- a/stores/pg/src/storage/migration.test.ts
+++ b/stores/pg/src/storage/migration.test.ts
@@ -4,12 +4,15 @@ import {
   OLD_SPAN_SCHEMA,
   TABLE_SPANS,
   TABLE_SCHEMAS,
+  TABLE_EXPERIMENTS,
+  TABLE_EXPERIMENT_RESULTS,
   TABLE_THREADS,
   TABLE_WORKFLOW_SNAPSHOT,
 } from '@mastra/core/storage';
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { PgDB } from './db';
+import { ExperimentsPG } from './domains/experiments';
 import type { ObservabilityPG } from './domains/observability';
 import { TEST_CONFIG, connectionString } from './test-utils';
 import { PostgresStore } from '.';
@@ -1609,5 +1612,91 @@ describe('PostgreSQL Workflow Snapshot Migration', () => {
       ['new-workflow', 'run-1'],
     );
     expect(newSnapshot?.snapshot).toEqual({ status: 'new', data: [1, 2, 3] });
+  }, 30000);
+});
+
+describe('PostgreSQL experiment status migration', () => {
+  it('adds nullable status columns idempotently and derives historical execution counts', async () => {
+    const schemaName = `experiment_status_migration_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+    const pool = new Pool({ connectionString });
+    const omittedExperimentColumns = new Set(['executionStatusCounts', 'scorerStatusCounts', 'thresholds']);
+    const omittedResultColumns = new Set(['executionStatus']);
+    const toColumns = (schema: Record<string, (typeof TABLE_SCHEMAS)[typeof TABLE_EXPERIMENTS][string]>) =>
+      Object.entries(schema)
+        .map(([name, column]) => {
+          const type =
+            column.type === 'jsonb'
+              ? 'JSONB'
+              : column.type === 'timestamp'
+                ? 'TIMESTAMP'
+                : column.type === 'integer'
+                  ? 'INTEGER'
+                  : column.type === 'bigint'
+                    ? 'BIGINT'
+                    : column.type === 'boolean'
+                      ? 'BOOLEAN'
+                      : column.type === 'float'
+                        ? 'DOUBLE PRECISION'
+                        : 'TEXT';
+          return `"${name}" ${type}${column.primaryKey ? ' PRIMARY KEY' : ''}${column.nullable === false ? ' NOT NULL' : ''}`;
+        })
+        .join(', ');
+    const oldExperimentSchema = Object.fromEntries(
+      Object.entries(TABLE_SCHEMAS[TABLE_EXPERIMENTS]).filter(([name]) => !omittedExperimentColumns.has(name)),
+    );
+    const oldResultSchema = Object.fromEntries(
+      Object.entries(TABLE_SCHEMAS[TABLE_EXPERIMENT_RESULTS]).filter(([name]) => !omittedResultColumns.has(name)),
+    );
+
+    try {
+      await pool.query(`CREATE SCHEMA "${schemaName}"`);
+      await pool.query(`CREATE TABLE "${schemaName}"."${TABLE_EXPERIMENTS}" (${toColumns(oldExperimentSchema)})`);
+      await pool.query(`CREATE TABLE "${schemaName}"."${TABLE_EXPERIMENT_RESULTS}" (${toColumns(oldResultSchema)})`);
+      await pool.query(
+        `INSERT INTO "${schemaName}"."${TABLE_EXPERIMENTS}"
+          ("id", "datasetId", "datasetVersion", "targetType", "targetId", "status", "totalItems", "succeededCount", "failedCount", "skippedCount", "createdAt", "updatedAt")
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+        [
+          'legacy-experiment',
+          null,
+          null,
+          'agent',
+          'agent-1',
+          'completed',
+          4,
+          1,
+          2,
+          1,
+          new Date('2024-01-01T00:00:00.000Z'),
+          new Date('2024-01-01T00:00:01.000Z'),
+        ],
+      );
+
+      const storage = new ExperimentsPG({ pool, schemaName });
+      await storage.init();
+      await storage.init();
+
+      const { rows: columns } = await pool.query<{ table_name: string; column_name: string }>(
+        `SELECT table_name, column_name FROM information_schema.columns
+         WHERE table_schema = $1 AND table_name IN ($2, $3)`,
+        [schemaName, TABLE_EXPERIMENTS, TABLE_EXPERIMENT_RESULTS],
+      );
+      const experimentColumns = columns.filter(row => row.table_name === TABLE_EXPERIMENTS).map(row => row.column_name);
+      const resultColumns = columns
+        .filter(row => row.table_name === TABLE_EXPERIMENT_RESULTS)
+        .map(row => row.column_name);
+      expect(experimentColumns).toEqual(
+        expect.arrayContaining(['executionStatusCounts', 'scorerStatusCounts', 'thresholds']),
+      );
+      expect(resultColumns).toContain('executionStatus');
+
+      const legacy = await storage.getExperimentById({ id: 'legacy-experiment' });
+      expect(legacy?.executionStatusCounts).toEqual({ completed: 1, skipped: 1, error: 2, cancelled: 0 });
+      expect(legacy?.scorerStatusCounts).toBeNull();
+      expect(legacy?.thresholds).toBeNull();
+    } finally {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch(() => {});
+      await pool.end();
+    }
   }, 30000);
 });

--- a/stores/spanner/src/storage/domains/experiments/index.ts
+++ b/stores/spanner/src/storage/domains/experiments/index.ts
@@ -49,6 +49,17 @@ function rowToExperiment(row: Record<string, any>): Experiment {
     targetId: String(t.targetId),
     status: t.status,
     totalItems: Number(t.totalItems ?? 0),
+    executionStatusCounts:
+      t.executionStatusCounts != null
+        ? t.executionStatusCounts
+        : {
+            completed: Number(t.succeededCount ?? 0),
+            skipped: Number(t.skippedCount ?? 0),
+            error: Number(t.failedCount ?? 0),
+            cancelled: 0,
+          },
+    scorerStatusCounts: t.scorerStatusCounts ?? null,
+    thresholds: t.thresholds ?? null,
     succeededCount: Number(t.succeededCount ?? 0),
     failedCount: Number(t.failedCount ?? 0),
     skippedCount: Number(t.skippedCount ?? 0),
@@ -73,6 +84,7 @@ function rowToExperimentResult(row: Record<string, any>): ExperimentResult {
     output: t.output ?? null,
     groundTruth: t.groundTruth ?? null,
     error: (t.error ?? null) as ExperimentResult['error'],
+    executionStatus: (t.executionStatus ?? null) as ExperimentResult['executionStatus'],
     startedAt: toDate(t.startedAt),
     completedAt: toDate(t.completedAt),
     retryCount: Number(t.retryCount ?? 0),
@@ -114,12 +126,12 @@ export class ExperimentsSpanner extends ExperimentsStorage {
     await this.db.alterTable({
       tableName: TABLE_EXPERIMENTS,
       schema: TABLE_SCHEMAS[TABLE_EXPERIMENTS],
-      ifNotExists: ['organizationId', 'projectId'],
+      ifNotExists: ['organizationId', 'projectId', 'executionStatusCounts', 'scorerStatusCounts', 'thresholds'],
     });
     await this.db.alterTable({
       tableName: TABLE_EXPERIMENT_RESULTS,
       schema: TABLE_SCHEMAS[TABLE_EXPERIMENT_RESULTS],
-      ifNotExists: ['organizationId', 'projectId'],
+      ifNotExists: ['organizationId', 'projectId', 'executionStatus'],
     });
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
@@ -177,6 +189,12 @@ export class ExperimentsSpanner extends ExperimentsStorage {
     try {
       const now = new Date();
       const id = input.id ?? randomUUID();
+      const thresholds = (input.thresholds ?? []).map(binding => ({
+        ...binding,
+        threshold: typeof binding.threshold === 'number' ? binding.threshold : { ...binding.threshold },
+      }));
+      const executionStatusCounts = { completed: 0, skipped: 0, error: 0, cancelled: 0 };
+      const scorerStatusCounts = { completed: 0, error: 0 };
       const experiment: Experiment = {
         id,
         name: input.name ?? undefined,
@@ -190,6 +208,9 @@ export class ExperimentsSpanner extends ExperimentsStorage {
         targetId: input.targetId,
         status: 'pending',
         totalItems: input.totalItems,
+        executionStatusCounts,
+        scorerStatusCounts,
+        thresholds,
         succeededCount: 0,
         failedCount: 0,
         skippedCount: 0,
@@ -214,6 +235,9 @@ export class ExperimentsSpanner extends ExperimentsStorage {
           targetId: experiment.targetId,
           status: experiment.status,
           totalItems: experiment.totalItems,
+          executionStatusCounts: experiment.executionStatusCounts,
+          scorerStatusCounts: experiment.scorerStatusCounts,
+          thresholds: experiment.thresholds,
           succeededCount: 0,
           failedCount: 0,
           skippedCount: 0,
@@ -250,6 +274,19 @@ export class ExperimentsSpanner extends ExperimentsStorage {
         });
       }
 
+      const hasLegacyCountUpdate =
+        input.succeededCount !== undefined || input.failedCount !== undefined || input.skippedCount !== undefined;
+      const executionStatusCounts =
+        input.executionStatusCounts !== undefined
+          ? input.executionStatusCounts
+          : hasLegacyCountUpdate
+            ? {
+                completed: input.succeededCount ?? existing.succeededCount,
+                skipped: input.skippedCount ?? existing.skippedCount,
+                error: input.failedCount ?? existing.failedCount,
+                cancelled: 0,
+              }
+            : undefined;
       const data: Record<string, any> = {};
       if (input.name !== undefined) data.name = input.name;
       if (input.description !== undefined) data.description = input.description;
@@ -259,6 +296,8 @@ export class ExperimentsSpanner extends ExperimentsStorage {
       if (input.succeededCount !== undefined) data.succeededCount = input.succeededCount;
       if (input.failedCount !== undefined) data.failedCount = input.failedCount;
       if (input.skippedCount !== undefined) data.skippedCount = input.skippedCount;
+      if (executionStatusCounts !== undefined) data.executionStatusCounts = executionStatusCounts;
+      if (input.scorerStatusCounts !== undefined) data.scorerStatusCounts = input.scorerStatusCounts;
       if (input.startedAt !== undefined) data.startedAt = input.startedAt;
       if (input.completedAt !== undefined) data.completedAt = input.completedAt;
       data.updatedAt = new Date();
@@ -488,6 +527,7 @@ export class ExperimentsSpanner extends ExperimentsStorage {
         output: input.output ?? null,
         groundTruth: input.groundTruth ?? null,
         error: input.error ?? null,
+        executionStatus: input.executionStatus ?? null,
         startedAt: input.startedAt,
         completedAt: input.completedAt,
         retryCount: input.retryCount,
@@ -510,6 +550,7 @@ export class ExperimentsSpanner extends ExperimentsStorage {
           output: result.output,
           groundTruth: result.groundTruth,
           error: result.error,
+          executionStatus: result.executionStatus,
           startedAt: result.startedAt,
           completedAt: result.completedAt,
           retryCount: result.retryCount,


### PR DESCRIPTION
## PR 3 of 5

Parent: #20146 (`yujohn/mastra-4460-core-statuses`)

## Summary

- migrates LibSQL, PostgreSQL, MySQL, and Spanner experiment tables with nullable execution-count, scorer-count, threshold-snapshot, and per-item execution-status fields
- persists and hydrates the same fields in MongoDB documents
- derives historical target execution counts from the deprecated success/failure/skipped counters while leaving unavailable historical scorer counts and thresholds as `null`
- verifies round trips through the shared experiment storage contract and validates in-place upgrade behavior for LibSQL, PostgreSQL, and MongoDB

## Intentionally deferred

- threshold-derived analytics belongs to PR 4
- server/client contracts and documentation belong to PR 5
- canonical structured scorer-result persistence and per-scorer `scorerStatus` remain dependent on MASTRA-4513 through MASTRA-4516; this PR does not add a competing scorer-result shape

## Test plan

- [x] shared experiment storage suite through LibSQL, PostgreSQL, MySQL, MongoDB, and Spanner
- [x] LibSQL, PostgreSQL, and MongoDB historical-row migration tests
- [x] package lint for all five providers
- [x] package builds for all five providers