### PR TITLE
feat(channels): stop auto-injecting channel reaction tools into agents

### DIFF
--- a/.changeset/violet-camels-refuse.md
+++ b/.changeset/violet-camels-refuse.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': minor
+---
+
+Channel reaction tools (`add_reaction`, `remove_reaction`) are no longer injected into a channel-bearing agent's toolset automatically. Replies are unaffected — they stream back to the channel without a tool. If you want your agent to react to channel messages, add the tools explicitly:
+
+```ts
+const channels = new AgentChannels({
+  adapters: { slack: createSlackAdapter() },
+});
+
+const agent = new Agent({
+  name: 'assistant',
+  model: 'openai/gpt-5',
+  channels,
+  tools: { ...channels.getTools() },
+});
+```

--- a/docs/src/content/en/reference/agents/channels.mdx
+++ b/docs/src/content/en/reference/agents/channels.mdx
@@ -72,7 +72,7 @@ The `channels` property accepts a `ChannelConfig` object with the following fiel
     isOptional: true,
     defaultValue: 'true',
     description:
-      'Include channel-specific tools (`add_reaction`, `remove_reaction`). Set to `false` for models that do not support function calling.',
+      'Whether `getTools()` returns the channel-specific tools (`add_reaction`, `remove_reaction`). Set to `false` for models that do not support function calling. Channel tools are never added to the agent automatically — pass them explicitly via `tools: { ...channels.getTools() }`.',
   },
   {
     name: 'state',
@@ -231,6 +231,38 @@ const agent = new Agent({
   },
 ]}
 />
+
+## Channel tools
+
+Channels expose two tools — `add_reaction` and `remove_reaction` — via
+`getTools()`. They are not added to the agent automatically: replies already
+stream back to the channel without a tool, so most agents don't need them. To
+let the agent react to channel messages, construct the channels yourself and
+pass the tools explicitly:
+
+```typescript title="src/mastra/agents/reacting-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { AgentChannels } from '@mastra/core/channels'
+import { createSlackAdapter } from '@chat-adapter/slack'
+
+const channels = new AgentChannels({
+  adapters: {
+    slack: createSlackAdapter(),
+  },
+})
+
+const agent = new Agent({
+  id: 'reacting-agent',
+  name: 'Reacting Agent',
+  instructions: '...',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  channels,
+  tools: { ...channels.getTools() },
+})
+```
+
+Setting `tools: false` on the channel config makes `getTools()` return an
+empty object, for models that don't support function calling.
 
 ## Tool display modes
 

--- a/docs/src/content/en/reference/agents/channels.mdx
+++ b/docs/src/content/en/reference/agents/channels.mdx
@@ -232,38 +232,6 @@ const agent = new Agent({
 ]}
 />
 
-## Channel tools
-
-Channels expose two tools — `add_reaction` and `remove_reaction` — via
-`getTools()`. They are not added to the agent automatically: replies already
-stream back to the channel without a tool, so most agents don't need them. To
-let the agent react to channel messages, construct the channels yourself and
-pass the tools explicitly:
-
-```typescript title="src/mastra/agents/reacting-agent.ts"
-import { Agent } from '@mastra/core/agent'
-import { AgentChannels } from '@mastra/core/channels'
-import { createSlackAdapter } from '@chat-adapter/slack'
-
-const channels = new AgentChannels({
-  adapters: {
-    slack: createSlackAdapter(),
-  },
-})
-
-const agent = new Agent({
-  id: 'reacting-agent',
-  name: 'Reacting Agent',
-  instructions: '...',
-  model: '__GATEWAY_OPENAI_MODEL__',
-  channels,
-  tools: { ...channels.getTools() },
-})
-```
-
-Setting `tools: false` on the channel config makes `getTools()` return an
-empty object, for models that don't support function calling.
-
 ## Tool display modes
 
 `toolDisplay` controls how tool calls render in chat. The default `'cards'`

--- a/docs/src/content/en/reference/channels/slack-provider.mdx
+++ b/docs/src/content/en/reference/channels/slack-provider.mdx
@@ -159,7 +159,8 @@ await slack.configure({
     name: 'tools',
     type: "ChannelConfig['tools']",
     isOptional: true,
-    description: 'Whether to include channel tools (`add_reaction`, `remove_reaction`).',
+    description:
+      'Whether the channel exposes channel tools (`add_reaction`, `remove_reaction`) via `AgentChannels.getTools()`. These tools are never added to the agent automatically — pass them explicitly via `tools: { ...channels.getTools() }` to use them.',
   },
   {
     name: 'state',

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3716,67 +3716,6 @@ export class Agent<
   }
 
   /**
-   * Returns tools provided by the agent's channels (e.g. discord_send_message).
-   * @internal
-   */
-  private async listChannelTools({
-    runId,
-    resourceId,
-    threadId,
-    requestContext,
-    mastraProxy,
-    autoResumeSuspendedTools,
-    backgroundTaskEnabled,
-    ...rest
-  }: {
-    runId?: string;
-    resourceId?: string;
-    threadId?: string;
-    requestContext: RequestContext;
-    mastraProxy?: MastraUnion;
-    autoResumeSuspendedTools?: boolean;
-    backgroundTaskEnabled?: boolean;
-  } & Partial<ObservabilityContext>) {
-    const observabilityContext = resolveObservabilityContext(rest);
-    const convertedChannelTools: Record<string, CoreTool> = {};
-
-    if (!this.#agentChannels) {
-      return convertedChannelTools;
-    }
-
-    const channelTools = this.#agentChannels.getTools();
-
-    if (Object.keys(channelTools).length > 0) {
-      const memory = await this.getMemory({ requestContext });
-
-      for (const [toolName, tool] of Object.entries(channelTools)) {
-        const options: ToolOptions = {
-          name: toolName,
-          runId,
-          threadId,
-          resourceId,
-          logger: this.logger,
-          mastra: mastraProxy as MastraUnion | undefined,
-          memory,
-          agentName: this.name,
-          requestContext,
-          ...observabilityContext,
-          tracingPolicy: this.#options?.tracingPolicy,
-        };
-        convertedChannelTools[toolName] = makeCoreTool(
-          tool as ToolToConvert,
-          options,
-          undefined,
-          autoResumeSuspendedTools,
-          backgroundTaskEnabled,
-        );
-      }
-    }
-
-    return convertedChannelTools;
-  }
-
-  /**
    * Returns skill tools (skill, skill_search, skill_read) when the workspace
    * has skills configured. These are added at the Agent level (like workspace
    * tools) rather than inside a processor, so they persist across turns and
@@ -6042,17 +5981,6 @@ export class Agent<
       suppressEagerSkillTools: hasOnDemandProcessor && !hasSkillsProcessor,
     });
 
-    const channelTools = await this.listChannelTools({
-      runId,
-      resourceId,
-      threadId,
-      requestContext,
-      ...observabilityContext,
-      mastraProxy,
-      autoResumeSuspendedTools,
-      backgroundTaskEnabled,
-    });
-
     const browserTools = await this.listBrowserTools({
       runId,
       resourceId,
@@ -6085,7 +6013,6 @@ export class Agent<
       ...workflowTools,
       ...workspaceTools,
       ...skillTools,
-      ...channelTools,
       ...browserTools,
       ...inputProcessorLoadedTools,
     };

--- a/packages/core/src/channels/__tests__/agent-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-channels.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { Agent } from '../../agent';
 import { InMemoryDB } from '../../storage/domains/inmemory-db';
 import { InMemoryMemory } from '../../storage/domains/memory/inmemory';
 import { AgentChannels } from '../agent-channels';
@@ -101,6 +102,46 @@ describe('AgentChannels', () => {
         tools: false,
       });
       expect(Object.keys(disabled.getTools())).toHaveLength(0);
+    });
+  });
+
+  describe('channel tools are not auto-injected into an agent toolset', () => {
+    it('resolves a channel-bearing agent toolset without the channel tools', async () => {
+      // getTools() still returns the channel tools (the explicit opt-in)...
+      const channels = new AgentChannels({ adapters: { discord: createMockAdapter('discord') } });
+      expect(Object.keys(channels.getTools())).toContain('add_reaction');
+
+      // ...but attaching channels to an agent does not inject them into the
+      // agent's resolved toolset.
+      const agent = new Agent({
+        id: 'no-auto-tools',
+        name: 'no-auto-tools',
+        instructions: 'test',
+        model: 'openai/gpt-4o',
+      });
+      agent.setChannels(channels);
+
+      const resolved = await agent.getToolsForExecution({});
+      const toolNames = Object.keys(resolved);
+      expect(toolNames).not.toContain('add_reaction');
+      expect(toolNames).not.toContain('remove_reaction');
+    });
+
+    it('resolves the channel tools when passed explicitly via tools: { ...channels.getTools() }', async () => {
+      const channels = new AgentChannels({ adapters: { discord: createMockAdapter('discord') } });
+      const agent = new Agent({
+        id: 'explicit-tools',
+        name: 'explicit-tools',
+        instructions: 'test',
+        model: 'openai/gpt-4o',
+        tools: { ...(channels.getTools() as Record<string, any>) },
+      });
+      agent.setChannels(channels);
+
+      const resolved = await agent.getToolsForExecution({});
+      const toolNames = Object.keys(resolved);
+      expect(toolNames).toContain('add_reaction');
+      expect(toolNames).toContain('remove_reaction');
     });
   });
 

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -688,8 +688,21 @@ export class AgentChannels {
   }
 
   /**
-   * Returns generic channel tools (send_message, add_reaction, etc.)
-   * that resolve the target adapter from the current request context.
+   * Returns generic channel tools (add_reaction, remove_reaction) that resolve
+   * the target adapter from the current request context.
+   *
+   * These are not injected into the agent automatically — pass them explicitly
+   * if the agent should react to channel messages:
+   *
+   * ```ts
+   * const agent = new Agent({
+   *   channels,
+   *   tools: { ...channels.getTools() },
+   * });
+   * ```
+   *
+   * Replies don't need a tool: the agent's response streams back to the
+   * channel through the output processor.
    */
   getTools(): Record<string, unknown> {
     if (!this.toolsEnabled) return {};
@@ -1365,7 +1378,7 @@ export class AgentChannels {
 
   /**
    * Generate generic channel tools that resolve the adapter from request context.
-   * Tool names are platform-agnostic (e.g. `send_message`, not `discord_send_message`).
+   * Tool names are platform-agnostic (e.g. `add_reaction`, not `discord_add_reaction`).
    */
   private makeChannelTools() {
     return {

--- a/packages/core/src/channels/types.ts
+++ b/packages/core/src/channels/types.ts
@@ -464,8 +464,10 @@ export interface ChannelConfig {
   };
 
   /**
-   * Whether to include channel tools (add_reaction, remove_reaction).
-   * Set to `false` for models that don't support function calling.
+   * Whether `getTools()` returns the channel tools (add_reaction,
+   * remove_reaction). Set to `false` for models that don't support function
+   * calling. Channel tools are never injected into the agent automatically —
+   * pass them explicitly via `tools: { ...channels.getTools() }`.
    *
    * @default true
    */


### PR DESCRIPTION
## What

Channel tools (`add_reaction` and `remove_reaction` — the only two) are no longer automatically injected into a channel-bearing agent's resolved toolset. They are now explicit opt-in:

```ts
const channels = new AgentChannels({
  adapters: { slack: createSlackAdapter() },
});

const agent = new Agent({
  name: 'assistant',
  model: 'openai/gpt-5',
  channels,
  tools: { ...channels.getTools() },
});
```

## Why

Attaching channels to an agent silently mutated its toolset. The implicit injection bought very little:

- **Replies never needed a tool.** The agent's response streams back to the channel through the channels output processor — there is no `send_message` tool (some doc comments claimed otherwise; fixed here).
- The only injected capabilities were emoji reactions, which most agents never use.
- An agent's toolset should be what the author declared, not declared-plus-surprise-extras.

`AgentChannels.getTools()` is unchanged and remains the supported way to get the tools. A Chat-SDK-native tools path (e.g. `createChatTools(chat)`) may replace it later; nothing is deprecated in this PR.

## Changes

- `Agent.convertTools`: removed the channel-tool injection site and deleted the now-orphaned private `listChannelTools` helper.
- Doc comments: `getTools()` and the `tools` config flag now document the explicit opt-in; removed references to a nonexistent `send_message` tool.
- Tests: a channel-bearing agent's resolved toolset omits the channel tools; passing `tools: { ...channels.getTools() }` still resolves them.
- Changeset: `@mastra/core` minor with the migration example.
- Docs: the `tools` parameter description in `reference/agents/channels.mdx` documents the explicit opt-in.

## Test plan

- `packages/core` channels suite: 9 files, 241 tests pass (includes 2 new tests).
- `packages/core` agent suites: 88 files, 1049 tests pass.
- `pnpm --filter ./packages/core check` clean; prettier (root + docs configs) and remark clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Your agent will no longer automatically learn how to react to channel messages. If you want it to react (e.g. with `add_reaction` / `remove_reaction`), you must explicitly opt in by adding `tools: { ...channels.getTools() }`.

## Changes
- Stopped automatic channel-tool injection in `Agent.convertTools`, removing the unused `listChannelTools` helper.
- Updated `@mastra/core` JSDoc and docs to clarify that channel reaction tools are only available via `channels.getTools()` and are never added unless explicitly passed in `tools`.
- Removed stale documentation references to a nonexistent `send_message` tool and tightened channel-tool guidance in the agent channels docs.
- Added/updated tests to verify channel tools are omitted by default and included only when explicitly provided.
- Added a minor `@mastra/core` changeset with migration guidance for the new opt-in behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->