### PR TITLE
fix(mongodb): pin bson to 7.2.0 to avoid circular-reference hang

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ catalogs:
       version: 4.4.3
 
 overrides:
+  bson: 7.2.0
   typescript: ^6.0.3
   '@types/node': 22.19.15
   cookie: '>=1.1.1 <2'
@@ -21002,8 +21003,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  bson@7.3.1:
-    resolution: {integrity: sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==}
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
     engines: {node: '>=20.19.0'}
 
   buffer-crc32@0.2.13:
@@ -44285,7 +44286,7 @@ snapshots:
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.5)
 
-  bson@7.3.1: {}
+  bson@7.2.0: {}
 
   buffer-crc32@0.2.13: {}
 
@@ -49990,7 +49991,7 @@ snapshots:
   mongodb@7.2.0(@aws-sdk/credential-providers@3.1006.0)(@mongodb-js/zstd@7.0.0)(socks@2.8.9):
     dependencies:
       '@mongodb-js/saslprep': 1.4.12
-      bson: 7.3.1
+      bson: 7.2.0
       mongodb-connection-string-url: 7.0.1
     optionalDependencies:
       '@aws-sdk/credential-providers': 3.1006.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -144,6 +144,14 @@ trustPolicyExclude:
   # without the trusted-publisher evidence that older @mesadev/sdk versions had.
   - '@mesadev/sdk@0.38.0'
 overrides:
+  # bson 7.3.0+ introduced a regression where BSON.calculateObjectSize hangs
+  # indefinitely (blocks the event loop, no error, no timeout) on a document
+  # containing a circular JS object reference, instead of throwing like
+  # bson@7.2.0 (and JSON.stringify) do. This is what the mongodb store's
+  # shared "should handle metadata with circular references" vector test
+  # exercises. Pin to 7.2.0 until the regression is fixed upstream; see
+  # https://github.com/mongodb/js-bson (issue TBD).
+  bson: 7.2.0
   typescript: ^6.0.3
   '@types/node': 22.19.15
   # Capped below 2: cookie@2 renamed parse/serialize to parseCookie/stringifyCookie,


### PR DESCRIPTION
## Summary

Fixes #20177

Temporarily pin `bson` to `7.2.0` to avoid a hang in `@internal/storage-test-utils`'s shared vector test suite (`'should handle metadata with circular references'`) caused by a regression in `bson` 7.3.0+. See #20177 for the full root-cause investigation and a minimal reproduction.

## Changes

- Add a `pnpm-workspace.yaml` override pinning `bson` to `7.2.0`.
- Add a changeset for `@mastra/mongodb`.

## Test plan

- [x] Full `stores/mongodb` suite (870 tests) passes locally with the pin in place — previously hung indefinitely without it.
- [ ] Will unpin once the regression is fixed upstream in `bson` (tracked in #20177).
