### PR TITLE
fix(core): acknowledge thread stream events

### DIFF
--- a/.changeset/spotty-cats-lick.md
+++ b/.changeset/spotty-cats-lick.md
@@ -3,4 +3,4 @@
 '@mastra/core': patch
 ---
 
-Thread event subscriptions now acknowledge events after processing them, so persistent PubSub backends like Redis no longer accumulate unacknowledged events over time.
+Fixed thread event subscriptions so successfully handled events are acknowledged and persistent backends do not accumulate pending deliveries.

--- a/.changeset/spotty-cats-lick.md
+++ b/.changeset/spotty-cats-lick.md
@@ -1,0 +1,6 @@
+---
+'@mastra/redis-streams': patch
+'@mastra/core': patch
+---
+
+Thread event subscriptions now acknowledge events after processing them, so persistent PubSub backends like Redis no longer accumulate unacknowledged events over time.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -139,6 +139,109 @@ class AsyncCallbackPubSub extends PubSub {
   }
 }
 
+class AckTrackingPubSub extends PubSub {
+  #subscribers = new Map<string, Set<EventCallback>>();
+  #index = 0;
+  #pendingCallbacks = new Set<Promise<void>>();
+  delivered = 0;
+  acked = 0;
+  nacked = 0;
+
+  constructor(private readonly rejectAckForEvent?: (event: any) => boolean) {
+    super();
+  }
+
+  get pending() {
+    return this.delivered - this.acked - this.nacked;
+  }
+
+  subscriberCount(topic: string) {
+    return this.#subscribers.get(topic)?.size ?? 0;
+  }
+
+  async publish(topic: string, event: any, _options?: { localOnly?: boolean }): Promise<void> {
+    const envelope = {
+      ...event,
+      id: `tracked-event-${this.#index++}`,
+      createdAt: new Date(),
+    };
+    for (const subscriber of [...(this.#subscribers.get(topic) ?? [])]) {
+      this.delivered += 1;
+      let settled = false;
+      const ack = async () => {
+        if (settled) return;
+        if (this.rejectAckForEvent?.(envelope)) {
+          throw new Error('Acknowledgement failed');
+        }
+        settled = true;
+        this.acked += 1;
+      };
+      const nack = async () => {
+        if (settled) return;
+        settled = true;
+        this.nacked += 1;
+      };
+      try {
+        const result = subscriber(envelope, ack, nack);
+        if (result) {
+          const pending = result.catch(nack);
+          this.#pendingCallbacks.add(pending);
+          void pending.finally(() => this.#pendingCallbacks.delete(pending));
+        }
+      } catch {
+        await nack();
+      }
+    }
+  }
+
+  async subscribe(topic: string, cb: EventCallback): Promise<void> {
+    const subscribers = this.#subscribers.get(topic) ?? new Set<EventCallback>();
+    subscribers.add(cb);
+    this.#subscribers.set(topic, subscribers);
+  }
+
+  async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
+    this.#subscribers.get(topic)?.delete(cb);
+  }
+
+  async flush(): Promise<void> {
+    while (this.#pendingCallbacks.size > 0) {
+      await Promise.all([...this.#pendingCallbacks]);
+    }
+  }
+}
+
+class AckTrackingLeasePubSub extends AckTrackingPubSub implements LeaseProvider {
+  owners = new Map<string, string>();
+  ownerReadWait: Promise<void> | undefined;
+
+  async acquireLease(key: string, owner: string): Promise<{ acquired: boolean; owner?: string }> {
+    const current = this.owners.get(key);
+    if (current && current !== owner) return { acquired: false, owner: current };
+    this.owners.set(key, owner);
+    return { acquired: true, owner };
+  }
+
+  async getLeaseOwner(key: string): Promise<string | undefined> {
+    await this.ownerReadWait;
+    return this.owners.get(key);
+  }
+
+  async releaseLease(key: string, owner: string): Promise<void> {
+    if (this.owners.get(key) === owner) this.owners.delete(key);
+  }
+
+  async renewLease(key: string, owner: string): Promise<boolean> {
+    return this.owners.get(key) === owner;
+  }
+
+  async transferLease(key: string, fromOwner: string, toOwner: string): Promise<boolean> {
+    if (this.owners.get(key) !== fromOwner) return false;
+    this.owners.set(key, toOwner);
+    return true;
+  }
+}
+
 class RetainedAsyncCallbackPubSub extends PubSub {
   #subscribers = new Map<string, Set<EventCallback>>();
   #history = new Map<string, any[]>();
@@ -3732,6 +3835,149 @@ describe('Agent signals', () => {
     await pubsub.releaseLease('remote-resource\u0000remote-thread', 'remote-run-1');
     ownerSubscription.unsubscribe();
     senderSubscription.unsubscribe();
+  });
+
+  it('acknowledges persistent thread events after subscription and remote-run wait handlers process them', async () => {
+    const pubsub = new AckTrackingPubSub();
+    const runtime = new AgentThreadStreamRuntime();
+    const owner = { id: 'ack-owner-agent' } as Agent<any, any, any, any>;
+    const waiter = { id: 'ack-waiter-agent' } as Agent<any, any, any, any>;
+    const resourceId = 'ack-resource';
+    const threadId = 'ack-thread';
+    const runId = 'ack-run';
+    const streamId = 'ack-stream';
+    const topic = `agent.thread-stream.${encodeURIComponent(`${resourceId}\u0000${threadId}`)}`;
+    const subscription = await runtime.subscribeToThread(owner, { resourceId, threadId }, pubsub);
+
+    try {
+      await pubsub.publish(topic, {
+        type: 'agent.thread-stream',
+        runId,
+        data: { type: 'run-registered', runId, streamId, streamSeq: 1 },
+      });
+      await pubsub.flush();
+
+      const waiting = runtime.waitForCrossAgentThreadRun(
+        waiter,
+        { memory: { resource: resourceId, thread: threadId } },
+        pubsub,
+      );
+
+      await pubsub.publish(topic, {
+        type: 'agent.thread-stream',
+        runId,
+        data: { type: 'stream-part', runId, streamId, part: { type: 'text-delta' }, sourceId: 'remote-runtime' },
+      });
+      await pubsub.publish(topic, {
+        type: 'agent.thread-stream',
+        runId,
+        data: { type: 'run-completed', runId, streamId },
+      });
+
+      await waiting;
+      await pubsub.flush();
+
+      expect(pubsub.delivered).toBe(5);
+      expect(pubsub.acked).toBe(pubsub.delivered);
+      expect(pubsub.nacked).toBe(0);
+      expect(pubsub.pending).toBe(0);
+    } finally {
+      subscription.unsubscribe();
+    }
+  });
+
+  it('waits for serialized async thread processing before acknowledging an event', async () => {
+    const pubsub = new AckTrackingLeasePubSub();
+    const runtime = new AgentThreadStreamRuntime();
+    const resourceId = 'ordered-ack-resource';
+    const threadId = 'ordered-ack-thread';
+    const runId = 'ordered-ack-run';
+    const streamId = 'ordered-ack-stream';
+    const key = `${resourceId}\u0000${threadId}`;
+    const topic = `agent.thread-stream.${encodeURIComponent(key)}`;
+    let releaseOwnerRead!: () => void;
+    pubsub.ownerReadWait = new Promise<void>(resolve => {
+      releaseOwnerRead = resolve;
+    });
+    pubsub.owners.set(key, runId);
+    const subscription = await runtime.subscribeToThread(
+      { id: 'ordered-ack-agent' } as Agent<any, any, any, any>,
+      { resourceId, threadId },
+      pubsub,
+    );
+
+    try {
+      await pubsub.publish(topic, {
+        type: 'agent.thread-stream',
+        runId,
+        data: { type: 'run-registered', runId, streamId, streamSeq: 1 },
+      });
+      await nextTick();
+
+      expect(subscription.activeRunId()).toBeNull();
+      expect(pubsub.acked).toBe(0);
+      expect(pubsub.pending).toBe(1);
+
+      releaseOwnerRead();
+      await pubsub.flush();
+
+      expect(subscription.activeRunId()).toBe(runId);
+      expect(pubsub.acked).toBe(1);
+      expect(pubsub.nacked).toBe(0);
+      expect(pubsub.pending).toBe(0);
+    } finally {
+      subscription.unsubscribe();
+    }
+  });
+
+  it('settles remote-run waiters and nacks when terminal event acknowledgement fails', async () => {
+    const pubsub = new AckTrackingPubSub(event => event.data?.type === 'run-completed');
+    const runtime = new AgentThreadStreamRuntime();
+    const owner = { id: 'ack-failure-owner-agent' } as Agent<any, any, any, any>;
+    const waiter = { id: 'ack-failure-waiter-agent' } as Agent<any, any, any, any>;
+    const resourceId = 'ack-failure-resource';
+    const threadId = 'ack-failure-thread';
+    const runId = 'ack-failure-run';
+    const streamId = 'ack-failure-stream';
+    const topic = `agent.thread-stream.${encodeURIComponent(`${resourceId}\u0000${threadId}`)}`;
+    const subscription = await runtime.subscribeToThread(owner, { resourceId, threadId }, pubsub);
+
+    try {
+      await pubsub.publish(topic, {
+        type: 'agent.thread-stream',
+        runId,
+        data: { type: 'run-registered', runId, streamId, streamSeq: 1 },
+      });
+      await pubsub.flush();
+
+      const waiting = runtime.waitForCrossAgentThreadRun(
+        waiter,
+        { memory: { resource: resourceId, thread: threadId } },
+        pubsub,
+      );
+
+      await pubsub.publish(topic, {
+        type: 'agent.thread-stream',
+        runId,
+        data: { type: 'stream-part', runId, streamId, part: { type: 'text-delta' }, sourceId: 'remote-runtime' },
+      });
+      await pubsub.publish(topic, {
+        type: 'agent.thread-stream',
+        runId,
+        data: { type: 'run-completed', runId, streamId },
+      });
+
+      await withTimeout(waiting, 'Timed out waiting after terminal acknowledgement failure');
+      await pubsub.flush();
+
+      expect(pubsub.delivered).toBe(5);
+      expect(pubsub.acked).toBe(3);
+      expect(pubsub.nacked).toBe(2);
+      expect(pubsub.pending).toBe(0);
+      expect(pubsub.subscriberCount(topic)).toBe(1);
+    } finally {
+      subscription.unsubscribe();
+    }
   });
 
   it('wakes a new run instead of delivering to a stale remote active run id', async () => {

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -1397,15 +1397,33 @@ export class AgentThreadStreamRuntime {
       }
       timer = setTimeout(() => void checkLease(), AGENT_THREAD_LEASE_TTL_MS);
     };
-    const onEvent: EventCallback = event => {
+    const inFlightSettlements = new Set<Promise<void>>();
+    const settleEvent = (ack?: () => Promise<void>, nack?: () => Promise<void>) => {
+      const settlement = (async () => {
+        try {
+          await ack?.();
+        } catch (error) {
+          await nack?.().catch(() => {});
+          throw error;
+        }
+      })();
+      inFlightSettlements.add(settlement);
+      void settlement.then(
+        () => inFlightSettlements.delete(settlement),
+        () => inFlightSettlements.delete(settlement),
+      );
+      return settlement;
+    };
+    const onEvent: EventCallback = (event, ack, nack) => {
       const data = event.data as AgentThreadStreamRuntimeEvent | undefined;
-      if (
+      const isTerminalEvent =
         (data?.type === 'run-completed' || data?.type === 'run-aborted' || data?.type === 'run-failed') &&
-        data.runId === runId
-      ) {
+        data.runId === runId;
+      if (isTerminalEvent) {
         clearRemoteActive(data.streamId);
-        finish();
       }
+      const settlement = settleEvent(ack, nack);
+      return isTerminalEvent ? settlement.finally(finish) : settlement;
     };
 
     try {
@@ -1418,6 +1436,9 @@ export class AgentThreadStreamRuntime {
       await wait;
     } finally {
       if (timer) clearTimeout(timer);
+      while (inFlightSettlements.size > 0) {
+        await Promise.allSettled([...inFlightSettlements]);
+      }
       if (subscribed) await resolvedPubSub.unsubscribe(topic, onEvent).catch(() => {});
     }
   }
@@ -1669,9 +1690,25 @@ export class AgentThreadStreamRuntime {
       }
     };
 
+    const processEvent = async (
+      event: Parameters<EventCallback>[0],
+      ack?: Parameters<EventCallback>[1],
+      nack?: Parameters<EventCallback>[2],
+    ) => {
+      try {
+        await handleEvent(event);
+        await ack?.();
+      } catch (error) {
+        await nack?.().catch(() => {});
+        throw error;
+      }
+    };
+
     let eventTail = Promise.resolve();
-    const onEvent: EventCallback = event => {
-      eventTail = eventTail.then(() => handleEvent(event)).catch(() => {});
+    const onEvent: EventCallback = (event, ack, nack) => {
+      const processing = eventTail.then(() => processEvent(event, ack, nack));
+      eventTail = processing.catch(() => {});
+      return processing;
     };
 
     await resolvedPubSub.subscribe(topic, onEvent);
@@ -1686,7 +1723,7 @@ export class AgentThreadStreamRuntime {
     const unsubscribe = () => {
       if (done) return;
       done = true;
-      void resolvedPubSub.unsubscribe(topic, onEvent).catch(() => {});
+      void eventTail.then(() => resolvedPubSub.unsubscribe(topic, onEvent)).catch(() => {});
       // Cancel current reader so the generator's inner loop breaks.
       if (currentReader) {
         try {

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -90,9 +90,14 @@ export interface SubscribeOptions {
  * Callback signature for PubSub subscribers.
  *
  * @param event - The delivered event
- * @param ack - Acknowledge successful processing. Message is removed from the queue.
+ * @param ack - Acknowledge successful processing for this subscription. Persistent backends may retain the event
+ *              for other subscribers or replay.
  * @param nack - Negative acknowledge. Message is requeued for redelivery after a delay.
- *               Not calling either ack or nack leaves the message in-flight until the
- *               backend's ack deadline expires (typically 10s for GCP).
+ *               Not calling either ack or nack leaves the message in-flight according to the backend's delivery
+ *               policy; some backends retain it indefinitely.
  */
-export type EventCallback = (event: Event, ack?: () => Promise<void>, nack?: () => Promise<void>) => void;
+export type EventCallback = (
+  event: Event,
+  ack?: () => Promise<void>,
+  nack?: () => Promise<void>,
+) => void | Promise<void>;

--- a/pubsub/redis-streams/src/agent-thread-cross-process.test.ts
+++ b/pubsub/redis-streams/src/agent-thread-cross-process.test.ts
@@ -137,6 +137,41 @@ describe.skipIf(!process.env.REDIS_URL && !process.env.CI && process.env.SKIP_RE
       await flushRedis(REDIS_URL).catch(() => {});
     });
 
+    it('acknowledges thread events so the private fanout pending list stays empty', async () => {
+      const resourceId = `ack-${Date.now()}`;
+      const threadId = `thread-${Date.now()}`;
+      const streamKey = threadStreamKeyFor(resourceId, threadId);
+      const worker = spawnWorker('ack-worker', {
+        RESOURCE_ID: resourceId,
+        THREAD_ID: threadId,
+        RUN_MS: '200',
+      });
+      workers = [worker];
+
+      await waitForLine(worker, '"type":"ready"');
+      worker.send({ cmd: 'send', sigId: 'ack-signal' });
+      await waitForLine(worker, '"type":"run-finished"');
+
+      const inspector = createClient({ url: REDIS_URL });
+      await inspector.connect();
+      try {
+        await waitFor(async () => {
+          const groups = await inspector.xInfoGroups(streamKey);
+          return (
+            (await inspector.xLen(streamKey)) >= 2 &&
+            groups.length > 0 &&
+            groups.every(group => Number(group.lag) === 0)
+          );
+        });
+
+        const groups = await inspector.xInfoGroups(streamKey);
+        expect(groups.every(group => group.name.startsWith('__fanout-'))).toBe(true);
+        expect(groups.reduce((total, group) => total + Number(group.pending), 0)).toBe(0);
+      } finally {
+        await inspector.quit();
+      }
+    }, 30_000);
+
     it('converts persisted-signal finish chunks across processes', async () => {
       const resourceId = `persisted-${Date.now()}`;
       const threadId = `thread-${Date.now()}`;

--- a/pubsub/redis-streams/src/index.ts
+++ b/pubsub/redis-streams/src/index.ts
@@ -787,10 +787,9 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     };
 
     try {
-      // EventCallback is typed `=> void` but handlers commonly return a
-      // promise (TS allows Promise<void> to satisfy void). If we get one
-      // back, attach a catch handler so async rejections route to nack
-      // instead of silently dropping the message. We do NOT await here —
+      // EventCallback may return a promise. Attach a catch handler so async
+      // rejections route to nack instead of silently dropping the message.
+      // We do NOT await here —
       // serializing messages on a subscription would deadlock orchestration
       // callbacks that await their own future events.
       const result: unknown = sub.cb(event, ack, nack);


### PR DESCRIPTION
Fixes #20154.

RedisStreamsPubSub implements fan-out subscriptions with private consumer groups, but the Core-owned thread subscription and remote-run waiter ignored the acknowledgement callback. Processed thread events therefore remained in each group's pending entries list until a clean unsubscribe destroyed the group, which could cause substantial Redis memory growth for long-lived subscriptions or leave pending state behind after an abrupt process exit.

This change acknowledges every thread event after it has been successfully inspected and applied. The terminal-event waiter waits for acknowledgement before unsubscribing, so the private group is not torn down ahead of the final XACK. It also makes the existing async EventCallback behavior explicit in the callback type and clarifies that acknowledgement is subscription-scoped rather than deleting a retained event.

The Core regression covers both the main thread subscriber and the temporary remote-run waiter. The Redis integration regression keeps a real private fan-out group open, waits until it has consumed the thread stream, and verifies that its total pending count is zero.

Validated with `pnpm build:core`, the full 85-test Agent signals suite, `pnpm --filter ./packages/core check`, targeted ESLint/Prettier checks, and the real Redis cross-process PEL regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The system now confirms each thread event after it finishes processing. This prevents Redis from retaining old events and growing its pending-event list.

## Changes

- Acknowledge processed and filtered thread events.
- Keep failed events eligible for redelivery.
- Wait for terminal-event acknowledgement before unsubscribing remote-run waiters.
- Support asynchronous `Promise<void>` event callbacks.
- Clarify acknowledgement scope and behavior in `EventCallback` documentation.
- Add Core regression tests for successful processing, delayed acknowledgement, and failed acknowledgement.
- Add a Redis integration test that verifies private fan-out groups have zero pending entries.
- Add patch changesets for `@mastra/core` and `@mastra/redis-streams`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->