### PR TITLE
fix(server): return 501 when observability storage domain is disabled

### DIFF
--- a/.changeset/nice-ants-love.md
+++ b/.changeset/nice-ants-love.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'@internal/playground': patch
+---
+
+Fixed Studio repeatedly polling observability endpoints when the observability storage domain is disabled. Studio now treats the disabled domain as an unavailable capability: score and log views stop polling, failed requests are not retried, and the Logs page shows a clear unavailable state instead of a generic error. Related to [#20157](https://github.com/mastra-ai/mastra/issues/20157).

--- a/.changeset/vast-hotels-kiss.md
+++ b/.changeset/vast-hotels-kiss.md
@@ -2,4 +2,4 @@
 '@mastra/server': patch
 ---
 
-Fixed observability endpoints returning HTTP 500 when the observability storage domain is disabled (e.g. `domains: { observability: false }` on a composite store). The server now responds with HTTP 501 Not Implemented and a clear message — consistent with how other capability gaps (delta polling, workspace v1) are reported — so an intentionally disabled capability is no longer reported as an internal server failure, and Studio stops polling and retrying instead of producing a continuous stream of errors. Fixes [#20157](https://github.com/mastra-ai/mastra/issues/20157).
+Fixed observability endpoints returning HTTP 500 when the observability storage domain is disabled (e.g. `domains: { observability: false }` on a composite store). The server now responds with HTTP 501 Not Implemented and a clear message — consistent with how other capability gaps (delta polling, workspace v1) are reported — so an intentionally disabled capability is no longer reported as an internal server failure. Fixes [#20157](https://github.com/mastra-ai/mastra/issues/20157).

--- a/.changeset/vast-hotels-kiss.md
+++ b/.changeset/vast-hotels-kiss.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed observability endpoints returning HTTP 500 when the observability storage domain is disabled (e.g. `domains: { observability: false }` on a composite store). The server now responds with HTTP 501 Not Implemented and a clear message — consistent with how other capability gaps (delta polling, workspace v1) are reported — so an intentionally disabled capability is no longer reported as an internal server failure, and Studio stops polling and retrying instead of producing a continuous stream of errors. Fixes [#20157](https://github.com/mastra-ai/mastra/issues/20157).

--- a/packages/playground-ui/src/domains/logs/components/logs-error-content.test.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-error-content.test.tsx
@@ -17,4 +17,17 @@ describe('LogsErrorContent', () => {
     expect(screen.getByText('Logs are not available with your current storage')).toBeTruthy();
     expect(screen.queryByText('Failed to load logs')).toBeNull();
   });
+
+  it('renders an unavailable state when the observability storage domain is disabled', () => {
+    render(
+      <LogsErrorContent
+        error={new Error('HTTP error! status: 501 - {"error":"Observability storage domain is not available"}')}
+        resource="logs"
+        errorTitle="Failed to load logs"
+      />,
+    );
+
+    expect(screen.getByText('Observability storage is not available')).toBeTruthy();
+    expect(screen.queryByText('Failed to load logs')).toBeNull();
+  });
 });

--- a/packages/playground-ui/src/domains/logs/components/logs-error-content.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-error-content.tsx
@@ -6,6 +6,7 @@ import { SessionExpired } from '@/ds/components/SessionExpired';
 import {
   is401UnauthorizedError,
   is403ForbiddenError,
+  isObservabilityUnavailableError,
   isUnsupportedObservabilityOperationError,
 } from '@/lib/query-utils';
 
@@ -26,6 +27,15 @@ export interface LogsErrorContentProps {
 export function LogsErrorContent({ error, resource, errorTitle }: LogsErrorContentProps) {
   if (is401UnauthorizedError(error)) return <SessionExpired />;
   if (is403ForbiddenError(error)) return <PermissionDenied resource={resource} />;
+  if (isObservabilityUnavailableError(error)) {
+    return (
+      <EmptyState
+        iconSlot={<CircleSlashIcon />}
+        titleSlot="Observability storage is not available"
+        descriptionSlot="The observability storage domain is disabled or not configured. Enable it in your storage configuration to view logs in Studio."
+      />
+    );
+  }
   if (isUnsupportedObservabilityOperationError(error, 'logs')) {
     return (
       <EmptyState

--- a/packages/playground-ui/src/domains/logs/hooks/use-logs.test.ts
+++ b/packages/playground-ui/src/domains/logs/hooks/use-logs.test.ts
@@ -14,6 +14,16 @@ describe('getLogsRefetchInterval', () => {
     expect(getLogsRefetchInterval(query)).toBe(false);
   });
 
+  it('disables polling when the observability storage domain is unavailable', () => {
+    const query = {
+      state: {
+        error: new Error('HTTP error! status: 501 - {"error":"Observability storage domain is not available"}'),
+      },
+    } as Query;
+
+    expect(getLogsRefetchInterval(query)).toBe(false);
+  });
+
   it('keeps polling for supported logs queries', () => {
     const query = { state: { error: null } } as Query;
 

--- a/packages/playground-ui/src/domains/logs/hooks/use-logs.ts
+++ b/packages/playground-ui/src/domains/logs/hooks/use-logs.ts
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 
 import type { LogRecord } from '../types';
 import { useInView } from '@/hooks/use-in-view';
-import { isUnsupportedObservabilityOperationError } from '@/lib/query-utils';
+import { isObservabilityUnavailableError, isUnsupportedObservabilityOperationError } from '@/lib/query-utils';
 
 interface UseLogsReturn {
   data: LogRecord[] | undefined;
@@ -52,7 +52,10 @@ function selectLogs(data: { pages: ListLogsResponse[] }) {
 }
 
 export function getLogsRefetchInterval(query: { state: { error: unknown } }) {
-  if (isUnsupportedObservabilityOperationError(query.state.error, 'logs')) {
+  if (
+    isUnsupportedObservabilityOperationError(query.state.error, 'logs') ||
+    isObservabilityUnavailableError(query.state.error)
+  ) {
     return false;
   }
   return LOGS_REFETCH_INTERVAL_MS;

--- a/packages/playground-ui/src/lib/query-utils.test.ts
+++ b/packages/playground-ui/src/lib/query-utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { isUnsupportedObservabilityOperationError } from './query-utils';
+import {
+  isObservabilityUnavailableError,
+  isUnsupportedObservabilityOperationError,
+  shouldRetryQuery,
+} from './query-utils';
 
 describe('isUnsupportedObservabilityOperationError', () => {
   it('matches the requested unsupported observability operation', () => {
@@ -8,5 +12,33 @@ describe('isUnsupportedObservabilityOperationError', () => {
 
     expect(isUnsupportedObservabilityOperationError(error, 'logs')).toBe(true);
     expect(isUnsupportedObservabilityOperationError(error, 'metrics')).toBe(false);
+  });
+});
+
+describe('isObservabilityUnavailableError', () => {
+  it('matches the disabled observability domain error from the server', () => {
+    const error = new Error('HTTP error! status: 501 - {"error":"Observability storage domain is not available"}');
+
+    expect(isObservabilityUnavailableError(error)).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isObservabilityUnavailableError(new Error('Network request failed'))).toBe(false);
+    expect(isObservabilityUnavailableError(null)).toBe(false);
+  });
+});
+
+describe('shouldRetryQuery', () => {
+  it('does not retry 501 capability gaps', () => {
+    const error = new Error('HTTP error! status: 501 - {"error":"Observability storage domain is not available"}');
+
+    expect(shouldRetryQuery(0, error)).toBe(false);
+  });
+
+  it('retries transient server errors up to 3 times', () => {
+    const error = new Error('HTTP error! status: 503');
+
+    expect(shouldRetryQuery(0, error)).toBe(true);
+    expect(shouldRetryQuery(3, error)).toBe(false);
   });
 });

--- a/packages/playground-ui/src/lib/query-utils.ts
+++ b/packages/playground-ui/src/lib/query-utils.ts
@@ -126,11 +126,9 @@ export function isUnsupportedObservabilityOperationError(
 
 /**
  * Check if an error came from a server whose observability storage domain is
- * unavailable — e.g. explicitly disabled with `domains: { observability: false }`
- * on a composite store. This affects every observability endpoint (traces, logs,
- * metrics, scores, feedback), so unlike the per-operation check above it takes
- * no operation argument. Matches the stable message thrown by the server's
- * `getObservabilityStore()`.
+ * unavailable — e.g. disabled with `domains: { observability: false }` on a
+ * composite store. Affects every observability endpoint, so no operation
+ * argument. Matches the stable message from the server's `getObservabilityStore()`.
  */
 export function isObservabilityUnavailableError(error: unknown): boolean {
   if (!error || typeof error !== 'object' || !('message' in error)) return false;

--- a/packages/playground-ui/src/lib/query-utils.ts
+++ b/packages/playground-ui/src/lib/query-utils.ts
@@ -4,8 +4,9 @@
  * - 401: Unauthorized (needs re-auth, not retry)
  * - 403: Forbidden (RBAC permission denied)
  * - 404: Not Found (resource doesn't exist)
+ * - 501: Not Implemented (capability gap, e.g. disabled storage domain, won't change)
  */
-const HTTP_NO_RETRY_STATUSES = [400, 401, 403, 404];
+const HTTP_NO_RETRY_STATUSES = [400, 401, 403, 404, 501];
 
 /**
  * Check if error is a 401 Unauthorized response.
@@ -124,6 +125,21 @@ export function isUnsupportedObservabilityOperationError(
 }
 
 /**
+ * Check if an error came from a server whose observability storage domain is
+ * unavailable — e.g. explicitly disabled with `domains: { observability: false }`
+ * on a composite store. This affects every observability endpoint (traces, logs,
+ * metrics, scores, feedback), so unlike the per-operation check above it takes
+ * no operation argument. Matches the stable message thrown by the server's
+ * `getObservabilityStore()`.
+ */
+export function isObservabilityUnavailableError(error: unknown): boolean {
+  if (!error || typeof error !== 'object' || !('message' in error)) return false;
+  const message = (error as { message: unknown }).message;
+  if (typeof message !== 'string') return false;
+  return message.includes('Observability storage domain is not available');
+}
+
+/**
  * Check if error has a status code that shouldn't be retried.
  * Used to prevent retrying client errors that won't resolve.
  */
@@ -155,7 +171,7 @@ export function isNonRetryableError(error: unknown): boolean {
 
 /**
  * Default retry function for TanStack Query.
- * Does not retry 4xx client errors (400, 401, 403, 404).
+ * Does not retry 4xx client errors (400, 401, 403, 404) or 501 capability gaps.
  * Retries other errors up to 3 times.
  */
 export function shouldRetryQuery(failureCount: number, error: unknown): boolean {

--- a/packages/playground/src/domains/scores/hooks/__tests__/scores-refetch-interval.test.ts
+++ b/packages/playground/src/domains/scores/hooks/__tests__/scores-refetch-interval.test.ts
@@ -1,0 +1,44 @@
+import type { Query } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+
+import { getScoresRefetchInterval } from '../use-scorers';
+import { getTraceSpanScoresRefetchInterval } from '../use-trace-span-scores';
+
+const unavailableError = new Error(
+  'HTTP error! status: 501 - {"error":"Observability storage domain is not available"}',
+);
+const unsupportedError = new Error('This storage provider does not support listing scores');
+
+describe('getScoresRefetchInterval', () => {
+  it('disables polling when the observability storage domain is unavailable', () => {
+    const query = { state: { error: unavailableError } } as Query;
+
+    expect(getScoresRefetchInterval(query)).toBe(false);
+  });
+
+  it('disables polling when the storage provider cannot list scores', () => {
+    const query = { state: { error: unsupportedError } } as Query;
+
+    expect(getScoresRefetchInterval(query)).toBe(false);
+  });
+
+  it('keeps polling for supported scores queries', () => {
+    const query = { state: { error: null } } as Query;
+
+    expect(getScoresRefetchInterval(query)).toBe(5000);
+  });
+});
+
+describe('getTraceSpanScoresRefetchInterval', () => {
+  it('disables polling when the observability storage domain is unavailable', () => {
+    const query = { state: { error: unavailableError } } as Query;
+
+    expect(getTraceSpanScoresRefetchInterval(query)).toBe(false);
+  });
+
+  it('keeps polling for supported queries', () => {
+    const query = { state: { error: null } } as Query;
+
+    expect(getTraceSpanScoresRefetchInterval(query)).toBe(3000);
+  });
+});

--- a/packages/playground/src/domains/scores/hooks/use-scorers.tsx
+++ b/packages/playground/src/domains/scores/hooks/use-scorers.tsx
@@ -1,5 +1,9 @@
 import type { GetScorerResponse, ListScoresResponse } from '@mastra/client-js';
 import { useInView } from '@mastra/playground-ui/hooks/use-in-view';
+import {
+  isObservabilityUnavailableError,
+  isUnsupportedObservabilityOperationError,
+} from '@mastra/playground-ui/utils/query-utils';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useMastraClient } from '@mastra/react';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
@@ -7,6 +11,17 @@ import { useEffect, useState } from 'react';
 import { useMergedRequestContext } from '@/domains/request-context';
 
 const SCORES_PER_PAGE = 25;
+const SCORES_REFETCH_INTERVAL_MS = 5000;
+
+export function getScoresRefetchInterval(query: { state: { error: unknown } }) {
+  if (
+    isUnsupportedObservabilityOperationError(query.state.error, 'scores') ||
+    isObservabilityUnavailableError(query.state.error)
+  ) {
+    return false;
+  }
+  return SCORES_REFETCH_INTERVAL_MS;
+}
 
 type UseScoresByScorerIdProps = {
   scorerId: string;
@@ -37,14 +52,20 @@ export const useScoresByScorerId = ({ scorerId, entityId, entityType }: UseScore
   const client = useMastraClient();
   const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
 
-  const query = useInfiniteQuery({
+  const query = useInfiniteQuery<
+    ListScoresResponse,
+    Error,
+    ReturnType<typeof selectFlatScores>,
+    readonly unknown[],
+    number
+  >({
     queryKey: ['scores', scorerId, entityId, entityType],
     queryFn: ({ pageParam }) =>
       client.listScoresByScorerId({ scorerId, page: pageParam, perPage: SCORES_PER_PAGE, entityId, entityType }),
     initialPageParam: 0,
     getNextPageParam: getScoresNextPageParam,
     select: selectFlatScores,
-    refetchInterval: 5000,
+    refetchInterval: getScoresRefetchInterval,
   });
 
   const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;

--- a/packages/playground/src/domains/scores/hooks/use-trace-span-scores.tsx
+++ b/packages/playground/src/domains/scores/hooks/use-trace-span-scores.tsx
@@ -1,5 +1,21 @@
+import {
+  isObservabilityUnavailableError,
+  isUnsupportedObservabilityOperationError,
+} from '@mastra/playground-ui/utils/query-utils';
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
+
+const TRACE_SPAN_SCORES_REFETCH_INTERVAL_MS = 3000;
+
+export function getTraceSpanScoresRefetchInterval(query: { state: { error: unknown } }) {
+  if (
+    isUnsupportedObservabilityOperationError(query.state.error, 'scores') ||
+    isObservabilityUnavailableError(query.state.error)
+  ) {
+    return false;
+  }
+  return TRACE_SPAN_SCORES_REFETCH_INTERVAL_MS;
+}
 
 type useTraceSpanScoresProps = {
   traceId?: string;
@@ -13,7 +29,7 @@ export const useTraceSpanScores = ({ traceId = '', spanId = '', page }: useTrace
     queryKey: ['trace-span-scores', traceId, spanId, page],
     queryFn: () => client.listScoresBySpan({ traceId, spanId, page: page || 0, perPage: 10 }),
     enabled: !!traceId && !!spanId,
-    refetchInterval: 3000,
+    refetchInterval: getTraceSpanScoresRefetchInterval,
     gcTime: 0,
     staleTime: 0,
   });

--- a/packages/server/src/server/handlers/observability-shared.test.ts
+++ b/packages/server/src/server/handlers/observability-shared.test.ts
@@ -1,0 +1,40 @@
+import type { Mastra } from '@mastra/core/mastra';
+import type { MastraCompositeStore } from '@mastra/core/storage';
+import { describe, it, expect, vi } from 'vitest';
+import { HTTPException } from '../http-exception';
+import { getObservabilityStore } from './observability-shared';
+
+const createMockMastra = (storage?: Partial<MastraCompositeStore>): Mastra =>
+  ({
+    getStorage: vi.fn(() => storage as MastraCompositeStore),
+  }) as unknown as Mastra;
+
+describe('getObservabilityStore', () => {
+  it('returns the observability store when the domain is available', async () => {
+    const observabilityStore = { listScores: vi.fn() };
+    const mastra = createMockMastra({
+      getStore: vi.fn(() => Promise.resolve(observabilityStore)) as unknown as MastraCompositeStore['getStore'],
+    });
+
+    await expect(getObservabilityStore(mastra)).resolves.toBe(observabilityStore);
+  });
+
+  it('throws 501 when the observability domain is disabled or missing', async () => {
+    const mastra = createMockMastra({
+      getStore: vi.fn(() => Promise.resolve(undefined)) as unknown as MastraCompositeStore['getStore'],
+    });
+
+    const error = await getObservabilityStore(mastra).catch(e => e);
+    expect(error).toBeInstanceOf(HTTPException);
+    expect(error.status).toBe(501);
+    expect(error.message).toBe('Observability storage domain is not available');
+  });
+
+  it('throws 500 when no storage is configured at all', async () => {
+    const mastra = createMockMastra(undefined);
+
+    const error = await getObservabilityStore(mastra).catch(e => e);
+    expect(error).toBeInstanceOf(HTTPException);
+    expect(error.status).toBe(500);
+  });
+});

--- a/packages/server/src/server/handlers/observability-shared.ts
+++ b/packages/server/src/server/handlers/observability-shared.ts
@@ -45,12 +45,17 @@ export function getStorage(mastra: Mastra): MastraCompositeStore {
   return storage;
 }
 
-/** Retrieves the observability storage domain or throws 500 if unavailable. */
+/** Retrieves the observability storage domain or throws 501 if unavailable. */
 export async function getObservabilityStore(mastra: Mastra): Promise<ObservabilityStorage> {
   const storage = getStorage(mastra);
   const observability = await storage.getStore('observability');
   if (!observability) {
-    throw new HTTPException(500, { message: 'Observability storage domain is not available' });
+    // 501, not 500: a missing or explicitly disabled observability domain
+    // (e.g. `domains: { observability: false }`) is a capability gap, not a
+    // server failure. Matches the 501s used for other capability gaps (see
+    // assertObservabilityDeltaSupported below); Studio treats 501 as
+    // non-retryable and stops polling.
+    throw new HTTPException(501, { message: 'Observability storage domain is not available' });
   }
   return observability;
 }

--- a/packages/server/src/server/handlers/observability-shared.ts
+++ b/packages/server/src/server/handlers/observability-shared.ts
@@ -52,9 +52,7 @@ export async function getObservabilityStore(mastra: Mastra): Promise<Observabili
   if (!observability) {
     // 501, not 500: a missing or explicitly disabled observability domain
     // (e.g. `domains: { observability: false }`) is a capability gap, not a
-    // server failure. Matches the 501s used for other capability gaps (see
-    // assertObservabilityDeltaSupported below); Studio treats 501 as
-    // non-retryable and stops polling.
+    // server failure — matching the other 501s in this file.
     throw new HTTPException(501, { message: 'Observability storage domain is not available' });
   }
   return observability;


### PR DESCRIPTION
## Description

Disabling the observability storage domain (e.g. `domains: { observability: false }` on a `MastraCompositeStore`) made every `/api/observability/*` endpoint return HTTP 500, and Studio kept polling and retrying those endpoints — producing a continuous stream of error responses (scores every 5s, span scores every 3s, logs every 10s, plus one request per scorer on the scorers list page, each retried up to 3 times).

The 500 came from `getObservabilityStore()` in `@mastra/server`, written (#14270) before per-domain disabling existed (#19059) — the two features were never integrated, so an intentionally disabled capability was reported as an internal server failure.

## Before
<img width="1410" height="646" alt="image" src="https://github.com/user-attachments/assets/480abee4-c9b8-419a-bc76-3aeb45f88cc7" />

## After
<img width="1436" height="756" alt="image" src="https://github.com/user-attachments/assets/793bbaa9-2846-4c8d-82d4-c58f32779c2f" />

## Related Issue(s)

Fixes #20157

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If observability storage is turned off, Studio now treats logs and scores as “not supported” instead of “the backend is broken.” That means it shows a clear “not available” message and stops repeatedly asking for data that can’t be produced.

## What changed

- **Server:** Observability requests fail with **HTTP 501 Not Implemented** (with a stable “Observability storage domain is not available” message) when the observability domain is disabled, instead of **HTTP 500**.
- **Studio logs UI:** The logs error component now detects this “observability unavailable” condition and renders an **unavailable empty state** (rather than the generic error).
- **Studio polling/retries:** Logs and scores hooks disable polling and ensure queries **do not retry** for this capability gap (including adding **501** to the “no retry” logic).
- **Scores polling helpers:** Added `getScoresRefetchInterval` / `getTraceSpanScoresRefetchInterval` to return `false` (no refetch) when scores/observability are unavailable.
- **Shared error detection:** Added `isObservabilityUnavailableError` to consistently detect the disabled-domain condition by message content.
- **Tests + changesets:** Added/extended unit tests for server 501 behavior, UI unavailable state rendering, and polling/retry interval logic; included changesets for the affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->