### PR TITLE
fix(libsql): prevent local database corruption

### DIFF
--- a/.changeset/sixty-seas-follow.md
+++ b/.changeset/sixty-seas-follow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed database corruption in concurrent Mastra Code sessions by using safer journaling for the shared local database.

--- a/.changeset/vast-eyes-feel.md
+++ b/.changeset/vast-eyes-feel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Fixed local LibSQL stores so concurrent writes are serialized and applications can select safer DELETE journaling for multi-process databases.

--- a/mastracode/sdk/src/utils/__tests__/storage-config.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/storage-config.test.ts
@@ -1,3 +1,8 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { Client } from '@libsql/client';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 describe('getStorageConfig', () => {
@@ -144,6 +149,27 @@ describe('createStorage', () => {
     expect(result.storage.constructor.name).toBe('LibSQLStore');
     expect(result.backend).toBe('libsql');
     expect(result.warning).toBeUndefined();
+  });
+
+  it('uses DELETE journaling for the shared local Mastra Code database', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mastracode-storage-mode-'));
+    const dbPath = path.join(tmpDir, 'mastra.db');
+    const { createStorage } = await import('../storage-factory.js');
+    const result = await createStorage({
+      backend: 'libsql',
+      url: `file:${dbPath}`,
+      isRemote: false,
+    });
+
+    try {
+      await result.storage.init();
+      const client = (result.storage as unknown as { client: Client }).client;
+      const mode = await client.execute('PRAGMA journal_mode;');
+      expect(Object.values(mode.rows[0] ?? {})[0]).toBe('delete');
+    } finally {
+      await result.storage.close?.();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it('falls back to LibSQL with warning when pg has no connection info', async () => {

--- a/mastracode/sdk/src/utils/storage-factory.ts
+++ b/mastracode/sdk/src/utils/storage-factory.ts
@@ -34,6 +34,7 @@ export function buildLibSQLStore(opts: {
     url: opts.url,
     ...(opts.authToken ? { authToken: opts.authToken } : {}),
     ...(opts.retention ? { retention: opts.retention } : {}),
+    ...(opts.url.startsWith('file:') && !opts.url.includes(':memory:') ? { journalMode: 'delete' as const } : {}),
     localPragmas: MASTRA_CODE_LOCAL_PRAGMAS,
   });
 }

--- a/stores/libsql/src/storage/__fixtures__/delete-mode-worker.mjs
+++ b/stores/libsql/src/storage/__fixtures__/delete-mode-worker.mjs
@@ -1,0 +1,39 @@
+import { createClient } from '@libsql/client';
+
+const [dbPath, workerId, writeCountArg] = process.argv.slice(2);
+const writeCount = Number(writeCountArg);
+if (!dbPath || !workerId || !Number.isSafeInteger(writeCount) || writeCount < 1) {
+  throw new Error('Expected a database path, worker ID, and positive integer write count');
+}
+
+const client = createClient({ url: `file:${dbPath}`, timeout: 5000 });
+
+async function executeWithRetry(statement) {
+  let delay = 20;
+  for (let attempt = 1; attempt <= 10; attempt++) {
+    try {
+      return await client.execute(statement);
+    } catch (error) {
+      const isBusy = error?.code === 'SQLITE_BUSY' || error?.code === 'SQLITE_LOCKED';
+      if (!isBusy || attempt === 10) throw error;
+      await new Promise(resolve => setTimeout(resolve, delay));
+      delay *= 2;
+    }
+  }
+}
+
+try {
+  const mode = await executeWithRetry('PRAGMA journal_mode=DELETE;');
+  if (Object.values(mode.rows[0] ?? {})[0] !== 'delete') {
+    throw new Error(`SQLite did not enter DELETE mode: ${JSON.stringify(mode.rows)}`);
+  }
+
+  for (let index = 0; index < writeCount; index++) {
+    await executeWithRetry({
+      sql: 'INSERT INTO stress_writes (id, worker_id, write_index) VALUES (?, ?, ?)',
+      args: [`${workerId}-${index}`, workerId, index],
+    });
+  }
+} finally {
+  client.close();
+}

--- a/stores/libsql/src/storage/close.test.ts
+++ b/stores/libsql/src/storage/close.test.ts
@@ -45,6 +45,38 @@ describe('LibSQLStore.close()', () => {
     expect(client.closed).toBe(true);
   });
 
+  it('keeps DELETE-mode databases out of the WAL cleanup path', async () => {
+    const dbPath = path.join(tmpDir, 'delete-mode.db');
+    const store = new LibSQLStore({ id: 'close-delete', url: `file:${dbPath}`, journalMode: 'delete' });
+    await store.init();
+
+    const client = getClient(store);
+    const mode = await client.execute('PRAGMA journal_mode;');
+    expect(Object.values(mode.rows[0] ?? {})[0]).toBe('delete');
+
+    const executeSpy = vi.spyOn(client, 'execute');
+    await store.close();
+
+    const executedSql = executedSqlFrom(executeSpy);
+    expect(executedSql).not.toContain('PRAGMA wal_checkpoint(TRUNCATE);');
+    expect(executedSql).not.toContain('PRAGMA journal_mode=DELETE;');
+    expect(client.closed).toBe(true);
+  });
+
+  it('fails initialization rather than silently keeping WAL when DELETE mode cannot be applied', async () => {
+    const dbPath = path.join(tmpDir, 'locked-wal.db');
+    const walStore = new LibSQLStore({ id: 'wal-owner', url: `file:${dbPath}` });
+    await walStore.init();
+    const deleteStore = new LibSQLStore({ id: 'delete-owner', url: `file:${dbPath}`, journalMode: 'delete' });
+
+    try {
+      await expect(deleteStore.init()).rejects.toThrow();
+    } finally {
+      await deleteStore.close().catch(() => undefined);
+      await walStore.close();
+    }
+  });
+
   it('is idempotent — a second close() is a no-op', async () => {
     const dbPath = path.join(tmpDir, 'mastra.db');
     const store = new LibSQLStore({ id: 'close-idempotent', url: `file:${dbPath}` });

--- a/stores/libsql/src/storage/db/write-lock.test.ts
+++ b/stores/libsql/src/storage/db/write-lock.test.ts
@@ -2,7 +2,8 @@ import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { Client } from '@libsql/client';
+import { createClient } from '@libsql/client';
+import type { Client, Transaction } from '@libsql/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { LibSQLStore } from '..';
@@ -236,6 +237,114 @@ describe('LibSQL observational-memory write-lock regression', () => {
     // The workflow snapshot must also survive the contention.
     const snapshot = await workflows.loadWorkflowSnapshot({ workflowName, runId });
     expect(snapshot).toBeDefined();
+  });
+
+  it('does not roll back a message save that races a failing OM buffer transaction', async () => {
+    const rawClient = createClient({ url: `file:${path.join(tmpDir, 'om-message-race.db')}` });
+    let pauseNextTransaction = false;
+    let transactionStarted!: () => void;
+    let resumeTransaction!: () => void;
+    const transactionStartedPromise = new Promise<void>(resolve => {
+      transactionStarted = resolve;
+    });
+    const resumeTransactionPromise = new Promise<void>(resolve => {
+      resumeTransaction = resolve;
+    });
+
+    const client = new Proxy(rawClient, {
+      get(target, property) {
+        if (property === 'transaction') {
+          return async (...args: Parameters<Client['transaction']>) => {
+            const transaction = await target.transaction(...args);
+            if (!pauseNextTransaction) return transaction;
+            pauseNextTransaction = false;
+
+            let paused = false;
+            return new Proxy(transaction, {
+              get(transactionTarget, transactionProperty) {
+                const value = Reflect.get(transactionTarget, transactionProperty, transactionTarget);
+                if (transactionProperty === 'execute' && typeof value === 'function') {
+                  return async (...executeArgs: Parameters<Transaction['execute']>) => {
+                    if (!paused) {
+                      paused = true;
+                      transactionStarted();
+                      await resumeTransactionPromise;
+                    }
+                    return value.apply(transactionTarget, executeArgs);
+                  };
+                }
+                return typeof value === 'function' ? value.bind(transactionTarget) : value;
+              },
+            });
+          };
+        }
+
+        const value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+    store = new LibSQLStore({ id: 'om-message-race', client });
+    const memory = store.stores.memory!;
+    await memory.init();
+
+    const threadId = `thread-${randomUUID()}`;
+    const resourceId = `resource-${randomUUID()}`;
+    await memory.saveThread({
+      thread: {
+        id: threadId,
+        resourceId,
+        title: 'OM race',
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    pauseNextTransaction = true;
+    const failingBuffer = memory
+      .updateBufferedObservations({
+        id: 'missing-om-record',
+        chunk: {
+          cycleId: `cycle-${randomUUID()}`,
+          observations: 'will roll back',
+          tokenCount: 50,
+          messageIds: ['buffer-message'],
+          messageTokens: 100,
+          lastObservedAt: new Date(),
+        },
+      })
+      .catch(error => error);
+
+    await transactionStartedPromise;
+
+    const messageId = `message-${randomUUID()}`;
+    const savedMessage = memory.saveMessages({
+      messages: [
+        {
+          id: messageId,
+          threadId,
+          resourceId,
+          role: 'user',
+          type: 'v2',
+          content: { format: 2, parts: [{ type: 'text', text: 'survive OM rollback' }] },
+          createdAt: new Date(),
+        },
+      ],
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 25));
+    resumeTransaction();
+
+    await expect(failingBuffer).resolves.toBeInstanceOf(Error);
+    await expect(savedMessage).resolves.toBeDefined();
+
+    const persisted = await memory.listMessagesById({ messageIds: [messageId] });
+    expect(persisted.messages).toHaveLength(1);
+    expect(persisted.messages[0]?.id).toBe(messageId);
+
+    const integrity = await rawClient.execute('PRAGMA quick_check');
+    expect(integrity.rows[0]?.quick_check).toBe('ok');
   });
 
   // Verifies that a failed OM operation does not contaminate or roll back

--- a/stores/libsql/src/storage/delete-mode-concurrency.test.ts
+++ b/stores/libsql/src/storage/delete-mode-concurrency.test.ts
@@ -1,0 +1,69 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createClient } from '@libsql/client';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const workerPath = fileURLToPath(new URL('./__fixtures__/delete-mode-worker.mjs', import.meta.url));
+
+function runWorker(dbPath: string, workerId: number, writeCount: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [workerPath, dbPath, String(workerId), String(writeCount)], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('exit', code => {
+      if (code === 0) resolve();
+      else reject(new Error(`DELETE-mode worker ${workerId} exited with ${code}: ${stderr}`));
+    });
+  });
+}
+
+describe('local DELETE journal concurrency', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves all writes across processes without WAL sidecars', async () => {
+    const workerCount = 6;
+    const writesPerWorker = 30;
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'libsql-delete-concurrency-'));
+    tempDirs.push(tempDir);
+    const dbPath = path.join(tempDir, 'stress.db');
+
+    const setupClient = createClient({ url: `file:${dbPath}`, timeout: 5000 });
+    await setupClient.execute('PRAGMA journal_mode=DELETE;');
+    await setupClient.execute(
+      'CREATE TABLE stress_writes (id TEXT PRIMARY KEY, worker_id INTEGER NOT NULL, write_index INTEGER NOT NULL);',
+    );
+    setupClient.close();
+
+    await Promise.all(
+      Array.from({ length: workerCount }, (_, workerId) => runWorker(dbPath, workerId, writesPerWorker)),
+    );
+
+    const verifyClient = createClient({ url: `file:${dbPath}` });
+    const count = await verifyClient.execute('SELECT COUNT(*) AS count FROM stress_writes;');
+    const integrity = await verifyClient.execute('PRAGMA quick_check;');
+    const mode = await verifyClient.execute('PRAGMA journal_mode;');
+    verifyClient.close();
+
+    expect(count.rows[0]?.count).toBe(workerCount * writesPerWorker);
+    expect(Object.values(integrity.rows[0] ?? {})[0]).toBe('ok');
+    expect(Object.values(mode.rows[0] ?? {})[0]).toBe('delete');
+    expect(fs.existsSync(`${dbPath}-wal`)).toBe(false);
+    expect(fs.existsSync(`${dbPath}-shm`)).toBe(false);
+  });
+});

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -718,18 +718,20 @@ export class MemoryLibSQL extends MemoryStorage {
       const messageStatements = batchStatements.slice(0, -1);
       const threadUpdateStatement = batchStatements[batchStatements.length - 1];
 
-      // Process message statements in batches
-      for (let i = 0; i < messageStatements.length; i += BATCH_SIZE) {
-        const batch = messageStatements.slice(i, i + BATCH_SIZE);
-        if (batch.length > 0) {
-          await this.#client.batch(batch, 'write');
+      await withClientWriteLock(this.#client, async () => {
+        // Process message statements in batches
+        for (let i = 0; i < messageStatements.length; i += BATCH_SIZE) {
+          const batch = messageStatements.slice(i, i + BATCH_SIZE);
+          if (batch.length > 0) {
+            await this.#client.batch(batch, 'write');
+          }
         }
-      }
 
-      // Execute thread update separately
-      if (threadUpdateStatement) {
-        await this.#client.execute(threadUpdateStatement);
-      }
+        // Execute thread update separately
+        if (threadUpdateStatement) {
+          await this.#client.execute(threadUpdateStatement);
+        }
+      });
 
       const list = new MessageList().add(messages as any, 'memory');
       return { messages: list.get.all.db() };
@@ -768,7 +770,7 @@ export class MemoryLibSQL extends MemoryStorage {
       return [];
     }
 
-    const batchStatements = [];
+    const batchStatements: Parameters<Client['batch']>[0] = [];
     const threadIdsToUpdate = new Set<string>();
     const columnMapping: Record<string, string> = {
       threadId: 'thread_id',
@@ -845,7 +847,7 @@ export class MemoryLibSQL extends MemoryStorage {
       }
     }
 
-    await this.#client.batch(batchStatements, 'write');
+    await withClientWriteLock(this.#client, () => this.#client.batch(batchStatements, 'write'));
 
     const updatedResult = await this.#client.execute({ sql: selectSql, args: messageIds });
     return updatedResult.rows.map(row => this.parseRow(row));
@@ -861,49 +863,51 @@ export class MemoryLibSQL extends MemoryStorage {
       const BATCH_SIZE = 100;
       const threadIds = new Set<string>();
 
-      // Use a transaction to ensure consistency
-      const tx = await this.#client.transaction('write');
+      await withClientWriteLock(this.#client, async () => {
+        // Use a transaction to ensure consistency
+        const tx = await this.#client.transaction('write');
 
-      try {
-        for (let i = 0; i < messageIds.length; i += BATCH_SIZE) {
-          const batch = messageIds.slice(i, i + BATCH_SIZE);
-          const placeholders = batch.map(() => '?').join(',');
+        try {
+          for (let i = 0; i < messageIds.length; i += BATCH_SIZE) {
+            const batch = messageIds.slice(i, i + BATCH_SIZE);
+            const placeholders = batch.map(() => '?').join(',');
 
-          // Get thread IDs for this batch
-          const result = await tx.execute({
-            sql: `SELECT DISTINCT thread_id FROM "${TABLE_MESSAGES}" WHERE id IN (${placeholders})`,
-            args: batch,
-          });
+            // Get thread IDs for this batch
+            const result = await tx.execute({
+              sql: `SELECT DISTINCT thread_id FROM "${TABLE_MESSAGES}" WHERE id IN (${placeholders})`,
+              args: batch,
+            });
 
-          result.rows?.forEach(row => {
-            if (row.thread_id) threadIds.add(row.thread_id as string);
-          });
+            result.rows?.forEach(row => {
+              if (row.thread_id) threadIds.add(row.thread_id as string);
+            });
 
-          // Delete messages in this batch
-          await tx.execute({
-            sql: `DELETE FROM "${TABLE_MESSAGES}" WHERE id IN (${placeholders})`,
-            args: batch,
-          });
-        }
-
-        // Update thread timestamps within the transaction
-        if (threadIds.size > 0) {
-          const now = new Date().toISOString();
-          for (const threadId of threadIds) {
+            // Delete messages in this batch
             await tx.execute({
-              sql: `UPDATE "${TABLE_THREADS}" SET "updatedAt" = ? WHERE id = ?`,
-              args: [now, threadId],
+              sql: `DELETE FROM "${TABLE_MESSAGES}" WHERE id IN (${placeholders})`,
+              args: batch,
             });
           }
-        }
 
-        // Commit the transaction
-        await tx.commit();
-      } catch (error) {
-        // Rollback on error
-        await tx.rollback();
-        throw error;
-      }
+          // Update thread timestamps within the transaction
+          if (threadIds.size > 0) {
+            const now = new Date().toISOString();
+            for (const threadId of threadIds) {
+              await tx.execute({
+                sql: `UPDATE "${TABLE_THREADS}" SET "updatedAt" = ? WHERE id = ?`,
+                args: [now, threadId],
+              });
+            }
+          }
+
+          // Commit the transaction
+          await tx.commit();
+        } catch (error) {
+          // Rollback on error
+          if (!tx.closed) await tx.rollback();
+          throw error;
+        }
+      });
 
       // TODO: Delete from vector store if semantic recall is enabled
     } catch (error) {
@@ -1005,10 +1009,12 @@ export class MemoryLibSQL extends MemoryStorage {
 
     values.push(resourceId);
 
-    await this.#client.execute({
-      sql: `UPDATE ${TABLE_RESOURCES} SET ${updates.join(', ')} WHERE id = ?`,
-      args: values,
-    });
+    await withClientWriteLock(this.#client, () =>
+      this.#client.execute({
+        sql: `UPDATE ${TABLE_RESOURCES} SET ${updates.join(', ')} WHERE id = ?`,
+        args: values,
+      }),
+    );
 
     return updatedResource;
   }
@@ -1272,10 +1278,12 @@ export class MemoryLibSQL extends MemoryStorage {
     };
 
     try {
-      await this.#client.execute({
-        sql: `UPDATE ${TABLE_THREADS} SET title = ?, metadata = jsonb(?), updatedAt = ? WHERE id = ?`,
-        args: [title, JSON.stringify(updatedThread.metadata), now.toISOString(), id],
-      });
+      await withClientWriteLock(this.#client, () =>
+        this.#client.execute({
+          sql: `UPDATE ${TABLE_THREADS} SET title = ?, metadata = jsonb(?), updatedAt = ? WHERE id = ?`,
+          args: [title, JSON.stringify(updatedThread.metadata), now.toISOString(), id],
+        }),
+      );
 
       return updatedThread;
     } catch (error) {
@@ -1294,17 +1302,17 @@ export class MemoryLibSQL extends MemoryStorage {
 
   async deleteThread({ threadId }: { threadId: string }): Promise<void> {
     try {
-      // Delete messages first (child records), then thread
-      // Note: Not using a transaction to avoid SQLITE_BUSY errors when multiple
-      // deleteThread calls run concurrently. The two deletes are independent and
-      // orphaned messages (if thread delete fails) would be cleaned up on next delete attempt.
-      await this.#client.execute({
-        sql: `DELETE FROM ${TABLE_MESSAGES} WHERE thread_id = ?`,
-        args: [threadId],
-      });
-      await this.#client.execute({
-        sql: `DELETE FROM ${TABLE_THREADS} WHERE id = ?`,
-        args: [threadId],
+      await withClientWriteLock(this.#client, async () => {
+        // Delete messages first (child records), then thread. Keep both writes in
+        // the same critical section so neither can enter another open transaction.
+        await this.#client.execute({
+          sql: `DELETE FROM ${TABLE_MESSAGES} WHERE thread_id = ?`,
+          args: [threadId],
+        });
+        await this.#client.execute({
+          sql: `DELETE FROM ${TABLE_THREADS} WHERE id = ?`,
+          args: [threadId],
+        });
       });
     } catch (error) {
       throw new MastraError(
@@ -1418,77 +1426,79 @@ export class MemoryLibSQL extends MemoryStorage {
         updatedAt: now,
       };
 
-      // Use transaction for consistency
-      const tx = await this.#client.transaction('write');
+      return await withClientWriteLock(this.#client, async () => {
+        // Use transaction for consistency
+        const tx = await this.#client.transaction('write');
 
-      try {
-        // Insert the new thread
-        await tx.execute({
-          sql: `INSERT INTO "${TABLE_THREADS}" (id, "resourceId", title, metadata, "createdAt", "updatedAt")
-                VALUES (?, ?, ?, jsonb(?), ?, ?)`,
-          args: [
-            newThread.id,
-            newThread.resourceId,
-            newThread.title ?? '',
-            JSON.stringify(newThread.metadata),
-            nowStr,
-            nowStr,
-          ],
-        });
-
-        // Clone messages with new IDs
-        const clonedMessages: MastraDBMessage[] = [];
-        const messageIdMap: Record<string, string> = {};
-        const targetResourceId = resourceId || sourceThread.resourceId;
-
-        for (const sourceMsg of sourceMessages) {
-          const newMessageId = crypto.randomUUID();
-          messageIdMap[sourceMsg.id as string] = newMessageId;
-          const contentStr = sourceMsg.content as string;
-          let parsedContent: MastraDBMessage['content'];
-          try {
-            parsedContent = JSON.parse(contentStr);
-          } catch {
-            // use content as is - wrap in format 2 structure if needed
-            parsedContent = { format: 2, parts: [{ type: 'text', text: contentStr }] };
-          }
-
+        try {
+          // Insert the new thread
           await tx.execute({
-            sql: `INSERT INTO "${TABLE_MESSAGES}" (id, thread_id, content, role, type, "createdAt", "resourceId")
-                  VALUES (?, ?, ?, ?, ?, ?, ?)`,
+            sql: `INSERT INTO "${TABLE_THREADS}" (id, "resourceId", title, metadata, "createdAt", "updatedAt")
+                  VALUES (?, ?, ?, jsonb(?), ?, ?)`,
             args: [
-              newMessageId,
-              newThreadId,
-              contentStr,
-              sourceMsg.role as string,
-              (sourceMsg.type as string) || 'v2',
-              sourceMsg.createdAt as string,
-              targetResourceId,
+              newThread.id,
+              newThread.resourceId,
+              newThread.title ?? '',
+              JSON.stringify(newThread.metadata),
+              nowStr,
+              nowStr,
             ],
           });
 
-          clonedMessages.push({
-            id: newMessageId,
-            threadId: newThreadId,
-            content: parsedContent,
-            role: sourceMsg.role as MastraDBMessage['role'],
-            type: (sourceMsg.type as string) || undefined,
-            createdAt: new Date(sourceMsg.createdAt as string),
-            resourceId: targetResourceId,
-          });
+          // Clone messages with new IDs
+          const clonedMessages: MastraDBMessage[] = [];
+          const messageIdMap: Record<string, string> = {};
+          const targetResourceId = resourceId || sourceThread.resourceId;
+
+          for (const sourceMsg of sourceMessages) {
+            const newMessageId = crypto.randomUUID();
+            messageIdMap[sourceMsg.id as string] = newMessageId;
+            const contentStr = sourceMsg.content as string;
+            let parsedContent: MastraDBMessage['content'];
+            try {
+              parsedContent = JSON.parse(contentStr);
+            } catch {
+              // use content as is - wrap in format 2 structure if needed
+              parsedContent = { format: 2, parts: [{ type: 'text', text: contentStr }] };
+            }
+
+            await tx.execute({
+              sql: `INSERT INTO "${TABLE_MESSAGES}" (id, thread_id, content, role, type, "createdAt", "resourceId")
+                    VALUES (?, ?, ?, ?, ?, ?, ?)`,
+              args: [
+                newMessageId,
+                newThreadId,
+                contentStr,
+                sourceMsg.role as string,
+                (sourceMsg.type as string) || 'v2',
+                sourceMsg.createdAt as string,
+                targetResourceId,
+              ],
+            });
+
+            clonedMessages.push({
+              id: newMessageId,
+              threadId: newThreadId,
+              content: parsedContent,
+              role: sourceMsg.role as MastraDBMessage['role'],
+              type: (sourceMsg.type as string) || undefined,
+              createdAt: new Date(sourceMsg.createdAt as string),
+              resourceId: targetResourceId,
+            });
+          }
+
+          await tx.commit();
+
+          return {
+            thread: newThread,
+            clonedMessages,
+            messageIdMap,
+          };
+        } catch (error) {
+          if (!tx.closed) await tx.rollback();
+          throw error;
         }
-
-        await tx.commit();
-
-        return {
-          thread: newThread,
-          clonedMessages,
-          messageIdMap,
-        };
-      } catch (error) {
-        await tx.rollback();
-        throw error;
-      }
+      });
     } catch (error) {
       if (error instanceof MastraError) {
         throw error;

--- a/stores/libsql/src/storage/domains/workflows/index.ts
+++ b/stores/libsql/src/storage/domains/workflows/index.ts
@@ -51,12 +51,6 @@ export class WorkflowsLibSQL extends WorkflowsStorage {
       maxRetries,
       initialBackoffMs,
     });
-
-    // Set PRAGMA settings to help with database locks
-    // Note: This is async but we can't await in constructor, so we'll handle it as a fire-and-forget
-    this.setupPragmaSettings().catch(err =>
-      this.logger.warn('LibSQL Workflows: Failed to setup PRAGMA settings.', err),
-    );
   }
 
   supportsConcurrentUpdates(): boolean {
@@ -105,32 +99,6 @@ export class WorkflowsLibSQL extends WorkflowsStorage {
       order: ['workflowSnapshot'],
     });
     return runPrune({ db: this.#db, domain: 'workflows', targets, options, logger: this.logger });
-  }
-
-  private async setupPragmaSettings() {
-    try {
-      // Set busy timeout to wait longer before returning busy errors
-      await this.#client.execute('PRAGMA busy_timeout = 10000;');
-      this.logger.debug('LibSQL Workflows: PRAGMA busy_timeout=10000 set.');
-
-      // Enable WAL mode for better concurrency (if supported)
-      try {
-        await this.#client.execute('PRAGMA journal_mode = WAL;');
-        this.logger.debug('LibSQL Workflows: PRAGMA journal_mode=WAL set.');
-      } catch {
-        this.logger.debug('LibSQL Workflows: WAL mode not supported, using default journal mode.');
-      }
-
-      // Set synchronous mode for better durability vs performance trade-off
-      try {
-        await this.#client.execute('PRAGMA synchronous = NORMAL;');
-        this.logger.debug('LibSQL Workflows: PRAGMA synchronous=NORMAL set.');
-      } catch {
-        this.logger.debug('LibSQL Workflows: Failed to set synchronous mode.');
-      }
-    } catch (err) {
-      this.logger.warn('LibSQL Workflows: Failed to set PRAGMA settings.', err);
-    }
   }
 
   async updateWorkflowResults({

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -56,6 +56,7 @@ export type { LibSQLDomainConfig } from './db';
 export { LibSQLFactoryStorage, type LibSQLFactoryStorageConfig } from './factory-storage';
 
 export type LibSQLStorageDomain = keyof StorageDomains;
+export type LibSQLLocalJournalMode = 'wal' | 'delete';
 
 const DEFAULT_LOCAL_CACHE_SIZE = -16000;
 const DEFAULT_LOCAL_MMAP_SIZE = 134217728;
@@ -103,6 +104,12 @@ export type LibSQLBaseConfig = {
    * @default 5000
    */
   connectionTimeoutMs?: number;
+  /**
+   * SQLite journal mode for owned local file databases. Remote, in-memory, and
+   * injected clients keep their existing behavior.
+   * @default 'wal'
+   */
+  journalMode?: LibSQLLocalJournalMode;
   /**
    * Overrides local SQLite PRAGMA values used for startup/read performance.
    * Only applies to local file and in-memory databases.
@@ -171,7 +178,10 @@ export class LibSQLStore extends MastraCompositeStore {
   private readonly connectionTimeoutMs: number;
   private readonly pragmasReady: Promise<void>;
   private readonly isLocalDb: boolean;
+  private readonly isLocalFileDb: boolean;
+  private readonly journalMode: LibSQLLocalJournalMode;
   private readonly localPragmas: Required<LibSQLLocalPragmaOptions>;
+  private closePromise?: Promise<void>;
 
   stores: StorageDomains;
 
@@ -179,11 +189,15 @@ export class LibSQLStore extends MastraCompositeStore {
     if (!config.id || typeof config.id !== 'string' || config.id.trim() === '') {
       throw new Error('LibSQLStore: id must be provided and cannot be empty.');
     }
+    if (config.journalMode !== undefined && config.journalMode !== 'wal' && config.journalMode !== 'delete') {
+      throw new Error("LibSQLStore: journalMode must be either 'wal' or 'delete'.");
+    }
     super({ id: config.id, name: `LibSQLStore`, disableInit: config.disableInit, retention: config.retention });
 
     this.maxRetries = config.maxRetries ?? 5;
     this.initialBackoffMs = config.initialBackoffMs ?? 100;
     this.connectionTimeoutMs = config.connectionTimeoutMs ?? DEFAULT_CONNECTION_TIMEOUT_MS;
+    this.journalMode = config.journalMode ?? 'wal';
     this.localPragmas = {
       cacheSize: config.localPragmas?.cacheSize ?? DEFAULT_LOCAL_CACHE_SIZE,
       mmapSize: config.localPragmas?.mmapSize ?? DEFAULT_LOCAL_MMAP_SIZE,
@@ -196,6 +210,7 @@ export class LibSQLStore extends MastraCompositeStore {
       }
 
       this.isLocalDb = config.url.startsWith('file:') || config.url.includes(':memory:');
+      this.isLocalFileDb = config.url.startsWith('file:') && !config.url.includes(':memory:');
 
       this.client = createClient({
         url: config.url,
@@ -205,9 +220,11 @@ export class LibSQLStore extends MastraCompositeStore {
         ...(this.isLocalDb ? { timeout: this.connectionTimeoutMs } : {}),
       });
       this.pragmasReady = this.isLocalDb ? this.applyLocalPragmas() : Promise.resolve();
+      void this.pragmasReady.catch(() => undefined);
     } else {
       this.client = config.client;
       this.isLocalDb = false;
+      this.isLocalFileDb = false;
       this.pragmasReady = Promise.resolve();
     }
 
@@ -267,8 +284,27 @@ export class LibSQLStore extends MastraCompositeStore {
   }
 
   private async applyLocalPragmas(): Promise<void> {
+    const journalMode = (this.isLocalFileDb ? this.journalMode : 'wal').toUpperCase();
+    try {
+      const result = await this.client.execute(`PRAGMA journal_mode=${journalMode};`);
+
+      if (this.isLocalFileDb && this.journalMode === 'delete') {
+        const appliedMode = Object.values(result.rows[0] ?? {})[0];
+        if (typeof appliedMode !== 'string' || appliedMode.toLowerCase() !== 'delete') {
+          throw new Error(
+            `LibSQLStore: Failed to set PRAGMA journal_mode=DELETE; SQLite reported ${String(appliedMode)}.`,
+          );
+        }
+      }
+      this.logger.debug(`LibSQLStore: PRAGMA journal_mode=${journalMode} set.`);
+    } catch (err) {
+      if (this.isLocalFileDb && this.journalMode === 'delete') {
+        throw err;
+      }
+      this.logger.warn(`LibSQLStore: Failed to set PRAGMA journal_mode=${journalMode}.`, err);
+    }
+
     const pragmas = [
-      ['journal_mode=WAL', 'PRAGMA journal_mode=WAL;'],
       // Keep in sync with the connection-level `timeout` passed to createClient
       // so a custom connectionTimeoutMs isn't clobbered back to a hardcoded value.
       [`busy_timeout=${this.connectionTimeoutMs}`, `PRAGMA busy_timeout=${this.connectionTimeoutMs};`],
@@ -341,27 +377,39 @@ export class LibSQLStore extends MastraCompositeStore {
   /**
    * Closes the underlying libsql client, releasing all OS file handles.
    *
-   * For local file databases, first runs PRAGMA wal_checkpoint(TRUNCATE) and
-   * switches back to journal_mode=DELETE so that Windows releases the -wal
-   * and -shm sidecar files promptly. Without this, the handles stay open
-   * until process exit, causing EBUSY errors when callers try to fs.rm the
-   * storage directory after Mastra.shutdown().
+   * Local file databases configured for WAL are checkpointed and switched to
+   * journal_mode=DELETE so that Windows releases the -wal and -shm sidecar
+   * files promptly. Databases already configured for DELETE skip that work.
    *
    * Remote (Turso) databases skip the WAL pragmas and just close the client.
    *
-   * Safe to call more than once; subsequent calls are no-ops.
+   * Safe to call more than once; concurrent calls share the same close operation.
    */
-  async close(): Promise<void> {
+  close(): Promise<void> {
+    if (!this.closePromise) {
+      this.closePromise = this.closeClient();
+    }
+    return this.closePromise;
+  }
+
+  private async closeClient(): Promise<void> {
     if (this.client.closed) {
       return;
     }
 
-    // A store built from an injected client may still point at a local file even
-    // though `isLocalDb` (derived from the url config) is false, so also trust the
-    // client's own protocol to decide whether WAL cleanup is needed.
-    const isLocalFileDb = this.isLocalDb || this.client.protocol === 'file';
+    let readinessError: unknown;
+    try {
+      await this.pragmasReady;
+    } catch (err) {
+      readinessError = err;
+    }
 
-    if (isLocalFileDb) {
+    // Injected local clients have unknown journal policy, so preserve the
+    // existing WAL cleanup behavior for them.
+    const needsWalCleanup =
+      (this.isLocalFileDb && this.journalMode === 'wal') || (!this.isLocalDb && this.client.protocol === 'file');
+
+    if (!readinessError && needsWalCleanup) {
       try {
         await this.client.execute('PRAGMA wal_checkpoint(TRUNCATE);');
         await this.client.execute('PRAGMA journal_mode=DELETE;');
@@ -371,6 +419,10 @@ export class LibSQLStore extends MastraCompositeStore {
     }
 
     this.client.close();
+
+    if (readinessError) {
+      throw readinessError;
+    }
   }
 }
 


### PR DESCRIPTION
Mastra Code can have several processes writing to the same local database. Keeping that database in WAL mode leaves those processes coordinating through shared WAL state, which can corrupt the database during concurrent observational-memory and message writes.

Before:
```ts
new LibSQLStore({ id, url }) // WAL
```

After:
```ts
new LibSQLStore({ id, url, journalMode: 'delete' })
```

LibSQL stores still default to WAL, while Mastra Code now selects DELETE journaling for its shared local database. This also serializes memory-domain writes on each shared client, removes the workflow domain's independent WAL override, and makes storage shutdown initialization-aware and idempotent.

Verified with the full @mastra/libsql suite (899 passed, 19 skipped), focused multi-process and write-lock tests, the Mastra Code storage tests, package builds, type checks, lint, and formatting.