### PR TITLE
fix(server-adapters): enforce body size limits and parse body on DELETE requests (#20013)

### DIFF
--- a/.changeset/server-adapters-delete-body-limit.md
+++ b/.changeset/server-adapters-delete-body-limit.md
@@ -1,0 +1,8 @@
+---
+"@mastra/express": patch
+"@mastra/fastify": patch
+"@mastra/hono": patch
+"@mastra/nestjs": patch
+---
+
+fix(server-adapters): enforce body size limits and parse body on DELETE requests (#20013)

--- a/.changeset/server-adapters-delete-body-limit.md
+++ b/.changeset/server-adapters-delete-body-limit.md
@@ -5,4 +5,4 @@
 "@mastra/nestjs": patch
 ---
 
-DELETE requests now honor configured body size limits and parse request bodies consistently across the Express, Fastify, Hono, and NestJS adapters.
+DELETE requests, including those handled by ALL routes, now honor configured body size limits and parse request bodies consistently across the Express, Fastify, Hono, and NestJS adapters.

--- a/.changeset/server-adapters-delete-body-limit.md
+++ b/.changeset/server-adapters-delete-body-limit.md
@@ -5,4 +5,4 @@
 "@mastra/nestjs": patch
 ---
 
-fix(server-adapters): enforce body size limits and parse body on DELETE requests (#20013)
+DELETE requests now honor configured body size limits and parse request bodies consistently across the Express, Fastify, Hono, and NestJS adapters.

--- a/server-adapters/express/src/__tests__/express-adapter.test.ts
+++ b/server-adapters/express/src/__tests__/express-adapter.test.ts
@@ -1230,5 +1230,53 @@ describe('Express Server Adapter', () => {
       const data = await response.json();
       expect(data).toEqual({ message: 'Hello from custom route!' });
     });
+
+    it('enforces body size limits on DELETE requests with a body', async () => {
+      const customRoutes = [
+        registerApiRoute('/test-delete-body', {
+          method: 'DELETE',
+          handler: async c => {
+            const body = await c.req.json();
+            return c.json({ received: body });
+          },
+        }),
+      ];
+
+      const app = express();
+      app.use(express.json());
+      const mastra = new Mastra({});
+
+      const adapter = new MastraServer({
+        app,
+        mastra,
+        customApiRoutes: customRoutes,
+        bodyLimitOptions: {
+          maxSize: 50,
+          onError: () => ({ error: 'Body limit exceeded' }),
+        },
+      });
+
+      await adapter.init();
+
+      server = await new Promise(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      const largeBody = JSON.stringify({ data: 'a'.repeat(100) });
+      const response = await fetch(`http://localhost:${port}/test-delete-body`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': String(Buffer.byteLength(largeBody)),
+        },
+        body: largeBody,
+      });
+
+      expect(response.status).toBe(413);
+      const data = await response.json();
+      expect(data).toEqual({ error: 'Body limit exceeded' });
+    });
   });
 });

--- a/server-adapters/express/src/__tests__/express-adapter.test.ts
+++ b/server-adapters/express/src/__tests__/express-adapter.test.ts
@@ -1231,10 +1231,10 @@ describe('Express Server Adapter', () => {
       expect(data).toEqual({ message: 'Hello from custom route!' });
     });
 
-    it('enforces body size limits on DELETE requests with a body', async () => {
+    it('enforces body size limits on DELETE requests to ALL routes', async () => {
       const customRoutes = [
         registerApiRoute('/test-delete-body', {
-          method: 'DELETE',
+          method: 'ALL',
           handler: async c => {
             const body = await c.req.json();
             return c.json({ received: body });

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -419,7 +419,7 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
     const prefix = prefixParam ?? this.prefix ?? '';
 
     // Determine if body limits should be applied
-    const shouldApplyBodyLimit = this.bodyLimitOptions && ['POST', 'PUT', 'PATCH'].includes(route.method.toUpperCase());
+    const shouldApplyBodyLimit = this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
 
     // Get the body size limit for this route (route-specific or default)
     const maxSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -420,7 +420,7 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
 
     // Determine if body limits should be applied
     const shouldApplyBodyLimit =
-      this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
+      this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE', 'ALL'].includes(route.method.toUpperCase());
 
     // Get the body size limit for this route (route-specific or default)
     const maxSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -419,7 +419,8 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
     const prefix = prefixParam ?? this.prefix ?? '';
 
     // Determine if body limits should be applied
-    const shouldApplyBodyLimit = this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
+    const shouldApplyBodyLimit =
+      this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
 
     // Get the body size limit for this route (route-specific or default)
     const maxSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;
@@ -632,6 +633,20 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
       );
       const shouldRunCustomRouteAuth = isProtectedCustomRoute(path, method, this.customRouteAuthConfig);
       const shouldRunCustomRouteFGA = !!matchedRoute?.route.fga;
+      const maxSize = this.bodyLimitOptions?.maxSize;
+
+      if (
+        matchedRoute &&
+        maxSize &&
+        ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method.toUpperCase()) &&
+        parseInt(req.headers['content-length'] ?? '0', 10) > maxSize
+      ) {
+        try {
+          return res.status(413).json(this.bodyLimitOptions!.onError({ error: 'Request body too large' }));
+        } catch {
+          return res.status(413).json({ error: 'Request body too large' });
+        }
+      }
 
       if (shouldRunCustomRouteAuth || shouldRunCustomRouteFGA) {
         const serverRoute: ServerRoute = {

--- a/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
+++ b/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
@@ -935,14 +935,14 @@ describe('Fastify Server Adapter', () => {
       await app.close();
     });
 
-    it('enforces body size limits on custom DELETE routes', async () => {
+    it('enforces body size limits on DELETE requests to custom ALL routes', async () => {
       const app = Fastify();
       const adapter = new MastraServer({
         app,
         mastra: new Mastra({}),
         customApiRoutes: [
           registerApiRoute('/custom/delete-body', {
-            method: 'DELETE',
+            method: 'ALL',
             handler: async c => c.json(await c.req.json()),
           }),
         ],

--- a/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
+++ b/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
@@ -934,6 +934,35 @@ describe('Fastify Server Adapter', () => {
       expect(data).toEqual({ message: 'Hello from custom route!' });
       await app.close();
     });
+
+    it('enforces body size limits on custom DELETE routes', async () => {
+      const app = Fastify();
+      const adapter = new MastraServer({
+        app,
+        mastra: new Mastra({}),
+        customApiRoutes: [
+          registerApiRoute('/custom/delete-body', {
+            method: 'DELETE',
+            handler: async c => c.json(await c.req.json()),
+          }),
+        ],
+        bodyLimitOptions: {
+          maxSize: 50,
+          onError: () => ({ error: 'Body limit exceeded' }),
+        },
+      });
+
+      await adapter.init();
+      const address = await app.listen({ port: 0 });
+      const response = await fetch(`${address}/custom/delete-body`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: 'a'.repeat(100) }),
+      });
+
+      expect(response.status).toBe(413);
+      await app.close();
+    });
   });
 
   describe('Custom route stream disconnect handling', () => {

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -708,7 +708,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
     };
 
     // Add body limit if configured
-    const shouldApplyBodyLimit = this.bodyLimitOptions && ['POST', 'PUT', 'PATCH'].includes(route.method.toUpperCase());
+    const shouldApplyBodyLimit = this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
     const maxSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;
 
     const config = shouldApplyBodyLimit && maxSize ? { bodyLimit: maxSize } : undefined;

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -709,7 +709,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
 
     // Add body limit if configured
     const shouldApplyBodyLimit =
-      this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
+      this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE', 'ALL'].includes(route.method.toUpperCase());
     const maxSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;
 
     const bodyLimit = shouldApplyBodyLimit && maxSize ? maxSize : undefined;
@@ -869,7 +869,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
       };
 
       const shouldApplyBodyLimit =
-        this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
+        this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE', 'ALL'].includes(route.method.toUpperCase());
       const maxSize = this.bodyLimitOptions?.maxSize;
       const bodyLimit = shouldApplyBodyLimit && maxSize ? maxSize : undefined;
 

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -708,10 +708,11 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
     };
 
     // Add body limit if configured
-    const shouldApplyBodyLimit = this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
+    const shouldApplyBodyLimit =
+      this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
     const maxSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;
 
-    const config = shouldApplyBodyLimit && maxSize ? { bodyLimit: maxSize } : undefined;
+    const bodyLimit = shouldApplyBodyLimit && maxSize ? maxSize : undefined;
 
     // Handle ALL method by registering for each HTTP method
     // Fastify doesn't support 'ALL' method natively like Express
@@ -725,7 +726,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
             method,
             url: fastifyPath,
             handler,
-            config,
+            bodyLimit,
           });
         } catch (err) {
           // Skip duplicate route errors - can happen if route is registered multiple times
@@ -740,7 +741,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         method: route.method as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
         url: fastifyPath,
         handler,
-        config,
+        bodyLimit,
       });
     }
   }
@@ -867,16 +868,22 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         await this.writeCustomRouteResponse(response, reply.raw, request.abortSignal);
       };
 
+      const shouldApplyBodyLimit =
+        this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
+      const maxSize = this.bodyLimitOptions?.maxSize;
+      const bodyLimit = shouldApplyBodyLimit && maxSize ? maxSize : undefined;
+
       if (route.method === 'ALL') {
         const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const;
         for (const method of methods) {
-          this.app.route({ method, url: route.path, handler: fastifyHandler });
+          this.app.route({ method, url: route.path, handler: fastifyHandler, bodyLimit });
         }
       } else {
         this.app.route({
           method: route.method as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
           url: route.path,
           handler: fastifyHandler,
+          bodyLimit,
         });
       }
     }

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -922,6 +922,37 @@ describe('Hono Server Adapter', () => {
       expect(data).toEqual({ echo: { test: 'data' } });
     });
 
+    it('enforces body size limits on custom DELETE routes', async () => {
+      const app = new Hono();
+      const adapter = new MastraServer({
+        app,
+        mastra: new Mastra({}),
+        customApiRoutes: [
+          registerApiRoute('/delete-body', {
+            method: 'DELETE',
+            handler: async c => c.json(await c.req.json()),
+          }),
+        ],
+        bodyLimitOptions: {
+          maxSize: 50,
+          onError: () => new Response(JSON.stringify({ error: 'Body limit exceeded' }), { status: 413 }),
+        },
+      });
+
+      await adapter.init();
+
+      const response = await app.request(
+        new Request('http://localhost/delete-body', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ data: 'a'.repeat(100) }),
+        }),
+      );
+
+      expect(response.status).toBe(413);
+      await expect(response.json()).resolves.toEqual({ error: 'Body limit exceeded' });
+    });
+
     it('should propagate request abort signals to custom API route handlers', async () => {
       const signalAbort = vi.fn();
       let routeSignal: AbortSignal | undefined;

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -922,14 +922,14 @@ describe('Hono Server Adapter', () => {
       expect(data).toEqual({ echo: { test: 'data' } });
     });
 
-    it('enforces body size limits on custom DELETE routes', async () => {
+    it('enforces body size limits on DELETE requests to custom ALL routes', async () => {
       const app = new Hono();
       const adapter = new MastraServer({
         app,
         mastra: new Mastra({}),
         customApiRoutes: [
           registerApiRoute('/delete-body', {
-            method: 'DELETE',
+            method: 'ALL',
             handler: async c => c.json(await c.req.json()),
           }),
         ],

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -395,7 +395,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
     const prefix = prefixParam ?? this.prefix ?? '';
 
     // Determine if body limits should be applied
-    const shouldApplyBodyLimit = this.bodyLimitOptions && ['POST', 'PUT', 'PATCH'].includes(route.method.toUpperCase());
+    const shouldApplyBodyLimit = this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
 
     // Get the body size limit for this route (route-specific or default)
     const maxSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -396,7 +396,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
 
     // Determine if body limits should be applied
     const shouldApplyBodyLimit =
-      this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
+      this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE', 'ALL'].includes(route.method.toUpperCase());
 
     // Get the body size limit for this route (route-specific or default)
     const maxSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;
@@ -745,7 +745,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
       };
 
       const shouldApplyBodyLimit =
-        this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
+        this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE', 'ALL'].includes(route.method.toUpperCase());
       const maxSize = this.bodyLimitOptions?.maxSize;
       const middlewares =
         shouldApplyBodyLimit && maxSize

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -395,7 +395,8 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
     const prefix = prefixParam ?? this.prefix ?? '';
 
     // Determine if body limits should be applied
-    const shouldApplyBodyLimit = this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
+    const shouldApplyBodyLimit =
+      this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
 
     // Get the body size limit for this route (route-specific or default)
     const maxSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;
@@ -743,8 +744,20 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
         return response;
       };
 
+      const shouldApplyBodyLimit =
+        this.bodyLimitOptions && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(route.method.toUpperCase());
+      const maxSize = this.bodyLimitOptions?.maxSize;
+      const middlewares =
+        shouldApplyBodyLimit && maxSize
+          ? [
+              bodyLimit({
+                maxSize,
+                onError: this.bodyLimitOptions!.onError as any,
+              }),
+            ]
+          : [];
       const method = route.method.toLowerCase() as 'get' | 'post' | 'put' | 'delete' | 'patch' | 'all';
-      this.app[method](route.path, routeHandler);
+      this.app[method](route.path, ...middlewares, routeHandler);
     }
   }
 

--- a/server-adapters/nestjs/src/controllers/mastra.controller.ts
+++ b/server-adapters/nestjs/src/controllers/mastra.controller.ts
@@ -144,7 +144,7 @@ export class MastraController {
    */
   private async parseBody(req: Request, route: ServerRoute): Promise<unknown> {
     // Only parse body for methods that typically have bodies
-    if (!['POST', 'PUT', 'PATCH'].includes(req.method)) {
+    if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
       return undefined;
     }
 

--- a/server-adapters/nestjs/src/middleware/body-limit.middleware.ts
+++ b/server-adapters/nestjs/src/middleware/body-limit.middleware.ts
@@ -31,7 +31,7 @@ export class BodyLimitMiddleware implements NestMiddleware {
 
   use(req: Request, res: Response, next: NextFunction): void {
     // Only check body size for methods that typically have bodies
-    if (!['POST', 'PUT', 'PATCH'].includes(req.method)) {
+    if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
       next();
       return;
     }

--- a/server-adapters/nestjs/src/services/request-context.service.ts
+++ b/server-adapters/nestjs/src/services/request-context.service.ts
@@ -62,7 +62,7 @@ export class RequestContextService {
     const context = new RequestContext();
 
     try {
-      if (this.request.method === 'POST' || this.request.method === 'PUT' || this.request.method === 'PATCH') {
+      if (this.request.method === 'POST' || this.request.method === 'PUT' || this.request.method === 'PATCH' || this.request.method === 'DELETE') {
         if (this.request.body?.requestContext) {
           this.mergeContext(context, this.request.body.requestContext);
         }


### PR DESCRIPTION
Closes #20013

## 🐛 What was the issue?
In the Express, Fastify, Hono, and NestJS server adapters, body size limits (`bodyLimitOptions`) and request body parsing were checked against a hardcoded method array `['POST', 'PUT', 'PATCH']`.
Because `DELETE` was omitted from this list, any route with a `DELETE` method that accepted a request body (such as bulk delete endpoints) bypassed `bodySizeLimit` checks entirely, allowing unchecked payload sizes into memory.

## 🛠️ What did we fix?
- **Express Adapter** (`server-adapters/express/src/index.ts`): Included `'DELETE'` in the `shouldApplyBodyLimit` method list.
- **Fastify Adapter** (`server-adapters/fastify/src/index.ts`): Included `'DELETE'` in the `shouldApplyBodyLimit` method list.
- **Hono Adapter** (`server-adapters/hono/src/index.ts`): Included `'DELETE'` in the `shouldApplyBodyLimit` method list.
- **NestJS Adapter**:
  - `BodyLimitMiddleware` (`server-adapters/nestjs/src/middleware/body-limit.middleware.ts`): Included `'DELETE'` in early Content-Length limit checks.
  - `MastraController` (`server-adapters/nestjs/src/controllers/mastra.controller.ts`): Included `'DELETE'` in `parseBody`.
  - `RequestContextService` (`server-adapters/nestjs/src/services/request-context.service.ts`): Included `'DELETE'` in body request context parsing.

## 🧪 Testing & Verification
- Verified method array updates across Express, Fastify, Hono, and NestJS server adapters.
- Ensured `DELETE` requests with bodies properly enforce body size limits and parse request bodies consistently across all supported framework adapters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Previously, `DELETE` requests could sneak in a request body without Mastra enforcing the body-size limit you configured. Now Mastra checks `DELETE` bodies the same way it checks `POST`/`PUT`/`PATCH`, and it parses request bodies when they’re within the limit.

## Changes
- Enforced configured `bodyLimitOptions.maxSize` for `DELETE` request bodies in the Express, Fastify, and Hono server adapters (including custom route registrations), returning the configured `onError` response with `413` when exceeded.
- Updated NestJS to parse `DELETE` request bodies and to extract request-context from the request body for `DELETE`, consistent with other body-carrying methods.
- Added/expanded integration tests for Express, Fastify, and Hono custom `DELETE` routes to verify oversize payloads return `413` and the expected `{ error: 'Body limit exceeded' }`.
- Added a changeset documenting that `DELETE` now honors configured body size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->