### PR TITLE
fix(channels): tool-approval clicks bypass resolveResourceId/resolveThreadId when creating threads

### DIFF
--- a/.changeset/hip-lions-start.md
+++ b/.changeset/hip-lions-start.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': patch
+---
+
+Fixed channel threads created from a tool-approval click bypassing the `resolveResourceId` and `resolveThreadId` hooks. The approval-button handler hardcoded the new thread's owner to `${platform}:${userId}` of whoever clicked, so a thread minted by a click (for example after a storage miss, or a click racing thread creation) was permanently scoped to the wrong owner and per-resource memory silently attached to the wrong user. Both hooks now run on every path that can create a channel thread. Fixes [#20076](https://github.com/mastra-ai/mastra/issues/20076).
+
+**Hook context change**: a button click carries no incoming message, so `ResolveResourceIdContext` and `ResolveThreadIdContext` now expose the triggering user as `actor` (the message author, or the button clicker), and `message` is optional — absent when the thread is created from a click. Hooks that read `message.author` should switch to `actor`:
+
+```ts
+// Before
+resolveResourceId: async ({ message, defaultResourceId }) =>
+  (await lookupSso(message.author.userId)) ?? defaultResourceId,
+
+// After
+resolveResourceId: async ({ actor, defaultResourceId }) =>
+  (await lookupSso(actor.userId)) ?? defaultResourceId,
+```

--- a/docs/src/content/en/reference/agents/channels.mdx
+++ b/docs/src/content/en/reference/agents/channels.mdx
@@ -110,7 +110,7 @@ The `channels` property accepts a `ChannelConfig` object with the following fiel
     type: '(ctx: ResolveResourceIdContext) => string | Promise<string>',
     isOptional: true,
     description:
-      'Decide which `resourceId` owns resource-level memory for a channel thread, separately from who sent the message. Runs only when a new thread is created; reused threads keep their stored owner and never call the hook. Return `ctx.defaultResourceId` (`${platform}:${message.author.userId}`) to keep the built-in behavior.',
+      'Decide which `resourceId` owns resource-level memory for a channel thread, separately from who triggered it. Runs only when a new thread is created, whether from an incoming message or a tool-approval click; reused threads keep their stored owner and never call the hook. Return `ctx.defaultResourceId` (`${platform}:${actor.userId}`) to keep the built-in behavior.',
   },
   {
     name: 'resolveThreadId',
@@ -399,9 +399,9 @@ onDirectMessage: async (thread, message, defaultHandler, ctx) => {
 
 ## Resource ID resolution
 
-By default a channel thread's memory `resourceId` is `${platform}:${message.author.userId}`. The sender owns the memory, scoped per platform. For apps with a shared identity, such as single sign-on (SSO), this splits memory: the same user gets `feishu:user_123` in a Feishu DM but `user_123` on the web.
+By default a channel thread's memory `resourceId` is `${platform}:${actor.userId}`. The sender owns the memory, scoped per platform. For apps with a shared identity, such as single sign-on (SSO), this splits memory: the same user gets `feishu:user_123` in a Feishu DM but `user_123` on the web.
 
-Pass `resolveResourceId` to decide memory ownership separately from the sender. It runs only when a new thread is created. Reused threads keep their stored `resourceId` and never call the hook, so existing conversations don't depend on the resolver being available. Return `ctx.defaultResourceId` to fall back to the built-in behavior.
+Pass `resolveResourceId` to decide memory ownership separately from the sender. It runs only when a new thread is created, and covers every event that can create one: an incoming message or a tool-approval click. Reused threads keep their stored `resourceId` and never call the hook, so existing conversations don't depend on the resolver being available. Return `ctx.defaultResourceId` to fall back to the built-in behavior.
 
 ```typescript title="src/mastra/agents/sso-agent.ts"
 import { Agent } from '@mastra/core/agent'
@@ -416,10 +416,10 @@ const agent = new Agent({
     adapters: {
       slack: createSlackAdapter(),
     },
-    resolveResourceId: async ({ thread, message }) => {
+    resolveResourceId: async ({ thread, actor }) => {
       // DM: share resource-level memory with the web app by using the bare SSO id
       if (thread.isDM) {
-        return await resolveSsoUserId(message)
+        return await resolveSsoUserId(actor.userId)
       }
       // Group chat: the conversation owns the memory; the sender stays the actor
       return thread.channelId
@@ -441,18 +441,24 @@ The `ResolveResourceIdContext` passed to the function:
     name: 'thread',
     type: 'Thread',
     description:
-      'The channel thread the message arrived on. Use `thread.isDM` to tell DMs apart from group/channel threads.',
+      'The channel thread the event arrived on. Use `thread.isDM` to tell DMs apart from group/channel threads.',
+  },
+  {
+    name: 'actor',
+    type: 'Author',
+    description:
+      'The user who triggered thread creation: the message author, or the button clicker when the thread is created from a tool-approval click. Not necessarily the memory owner.',
   },
   {
     name: 'message',
     type: 'Message',
-    description: 'The incoming message. `message.author.userId` is the actor/sender, not necessarily the memory owner.',
+    isOptional: true,
+    description: 'The incoming message. Absent when the thread is created from a button click rather than a message.',
   },
   {
     name: 'defaultResourceId',
     type: 'string',
-    description:
-      'The built-in default (`${platform}:${message.author.userId}`). Return this to keep the current behavior.',
+    description: 'The built-in default (`${platform}:${actor.userId}`). Return this to keep the current behavior.',
   },
 ]}
 />
@@ -500,12 +506,19 @@ The `ResolveThreadIdContext` passed to the function:
     name: 'thread',
     type: 'Thread',
     description:
-      'The channel thread the message arrived on. Use `thread.isDM` to tell DMs apart from group/channel threads.',
+      'The channel thread the event arrived on. Use `thread.isDM` to tell DMs apart from group/channel threads.',
+  },
+  {
+    name: 'actor',
+    type: 'Author',
+    description:
+      'The user who triggered thread creation: the message author, or the button clicker when the thread is created from a tool-approval click.',
   },
   {
     name: 'message',
     type: 'Message',
-    description: 'The incoming message.',
+    isOptional: true,
+    description: 'The incoming message. Absent when the thread is created from a button click rather than a message.',
   },
   {
     name: 'resourceId',

--- a/packages/core/src/channels/__tests__/agent-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-channels.test.ts
@@ -1,3 +1,4 @@
+import { Chat } from 'chat';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { Agent } from '../../agent';
@@ -568,6 +569,7 @@ describe('AgentChannels', () => {
         expect.objectContaining({
           platform: 'discord',
           thread: chatThread,
+          actor: message.author,
           message,
           defaultResourceId: 'discord:user-1',
         }),
@@ -780,6 +782,7 @@ describe('AgentChannels', () => {
         expect.objectContaining({
           platform: 'discord',
           thread: chatThread,
+          actor: message.author,
           message,
           resourceId: 'session-abc',
           defaultThreadId: expect.any(String),
@@ -967,6 +970,172 @@ describe('AgentChannels', () => {
       expect(ctx).toEqual({ mastra: mockMastra });
 
       spy.mockRestore();
+    });
+  });
+
+  describe('tool-approval action thread creation', () => {
+    function makeMastra() {
+      const db = new InMemoryDB();
+      const memoryStore = new InMemoryMemory({ db });
+      return {
+        getStorage: () => ({ getStore: () => memoryStore }),
+        getServer: () => null,
+      } as any;
+    }
+
+    const channelMetadata = {
+      channel_platform: 'discord',
+      channel_externalThreadId: 'channel-1:thread-1',
+      channel_externalChannelId: 'channel-1',
+    };
+
+    /** Initialize channels while capturing the internally registered onAction handler. */
+    async function initWithActionHandler(channels: AgentChannels, mockMastra: any) {
+      const handlers: Array<(event: any) => Promise<void>> = [];
+      const spy = vi.spyOn(Chat.prototype, 'onAction').mockImplementation(function (this: any, handler: any) {
+        handlers.push(handler);
+        return this;
+      });
+      try {
+        await channels.initialize(mockMastra);
+      } finally {
+        spy.mockRestore();
+      }
+      return handlers[0]!;
+    }
+
+    function makeActionEvent(channels: AgentChannels, overrides: Record<string, unknown> = {}) {
+      const chatThread = {
+        id: 'channel-1:thread-1',
+        channelId: 'channel-1',
+        isDM: false,
+        adapter: channels.adapters.discord,
+        post: vi.fn().mockResolvedValue(undefined),
+      } as any;
+      return {
+        actionId: 'tool_approve:tc-1',
+        thread: chatThread,
+        messageId: 'card-msg-1',
+        user: { userId: 'clicker-1', userName: 'clicker' },
+        adapter: channels.adapters.discord,
+        ...overrides,
+      };
+    }
+
+    it('runs resolveResourceId and resolveThreadId when the click creates the thread', async () => {
+      const resolveResourceId = vi.fn(async () => 'sso-user-42');
+      const resolveThreadId = vi.fn(async ({ resourceId }: any) => `thread-for-${resourceId}`);
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord') },
+        resolveResourceId,
+        resolveThreadId,
+      });
+      channels.__setAgent(mockAgent);
+
+      const mockMastra = makeMastra();
+      const onAction = await initWithActionHandler(channels, mockMastra);
+
+      const event = makeActionEvent(channels);
+      await onAction(event);
+
+      expect(resolveResourceId).toHaveBeenCalledWith({
+        platform: 'discord',
+        thread: event.thread,
+        actor: event.user,
+        message: undefined,
+        defaultResourceId: 'discord:clicker-1',
+      });
+      expect(resolveThreadId).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platform: 'discord',
+          thread: event.thread,
+          actor: event.user,
+          message: undefined,
+          resourceId: 'sso-user-42',
+        }),
+      );
+
+      const memoryStore = await mockMastra.getStorage().getStore('memory');
+      const { threads } = await memoryStore.listThreads({ filter: { metadata: channelMetadata }, perPage: 10 });
+      expect(threads).toHaveLength(1);
+      expect(threads[0]!.resourceId).toBe('sso-user-42');
+      expect(threads[0]!.id).toBe('thread-for-sso-user-42');
+    });
+
+    it('does not run the hooks when the click reuses an existing thread (keeps stored owner)', async () => {
+      const resolveResourceId = vi.fn(async () => 'should-not-be-used');
+      const resolveThreadId = vi.fn(async () => 'should-not-be-used');
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord') },
+        resolveResourceId,
+        resolveThreadId,
+      });
+      channels.__setAgent(mockAgent);
+
+      const mockMastra = makeMastra();
+      const onAction = await initWithActionHandler(channels, mockMastra);
+
+      const memoryStore = await mockMastra.getStorage().getStore('memory');
+      await memoryStore.saveThread({
+        thread: {
+          id: 'pre-existing',
+          title: 'discord conversation',
+          resourceId: 'original-owner',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          metadata: channelMetadata,
+        },
+      });
+
+      await onAction(makeActionEvent(channels));
+
+      expect(resolveResourceId).not.toHaveBeenCalled();
+      expect(resolveThreadId).not.toHaveBeenCalled();
+      const { threads } = await memoryStore.listThreads({ filter: { metadata: channelMetadata }, perPage: 10 });
+      expect(threads).toHaveLength(1);
+      expect(threads[0]).toMatchObject({ id: 'pre-existing', resourceId: 'original-owner' });
+    });
+
+    it('defaults to `${platform}:${clicker.userId}` when no resolver is configured', async () => {
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord') },
+      });
+      channels.__setAgent(mockAgent);
+
+      const mockMastra = makeMastra();
+      const onAction = await initWithActionHandler(channels, mockMastra);
+
+      await onAction(makeActionEvent(channels));
+
+      const memoryStore = await mockMastra.getStorage().getStore('memory');
+      const { threads } = await memoryStore.listThreads({ filter: { metadata: channelMetadata }, perPage: 10 });
+      expect(threads).toHaveLength(1);
+      expect(threads[0]!.resourceId).toBe('discord:clicker-1');
+    });
+
+    it('does not save a default-owned thread when resource resolution fails', async () => {
+      const resolveResourceId = vi.fn(async () => {
+        throw new Error('SSO unavailable');
+      });
+      const resolveThreadId = vi.fn(async () => 'should-not-be-used');
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord') },
+        resolveResourceId,
+        resolveThreadId,
+      });
+      channels.__setAgent(mockAgent);
+
+      const mockMastra = makeMastra();
+      const onAction = await initWithActionHandler(channels, mockMastra);
+      const event = makeActionEvent(channels);
+
+      await onAction(event);
+
+      expect(resolveThreadId).not.toHaveBeenCalled();
+      const memoryStore = await mockMastra.getStorage().getStore('memory');
+      const { threads } = await memoryStore.listThreads({ filter: { metadata: channelMetadata }, perPage: 10 });
+      expect(threads).toHaveLength(0);
+      expect(event.thread.post).toHaveBeenCalledWith('❌ Error: SSO unavailable');
     });
   });
 });

--- a/packages/core/src/channels/__tests__/agent-controller-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-controller-channels.test.ts
@@ -384,6 +384,18 @@ describe('AgentControllerChannels', () => {
     await waitFor(() => chatThread.post.mock.calls.length >= 1, { what: 'reply on pre-existing thread' });
   }, 30_000);
 
+  it('derives the channel-thread owner when an approval click creates the mapped thread', async () => {
+    const { adapter, mastra, channels } = await createSetup();
+
+    // No message ever arrived, so the click creates the mapped thread — it must
+    // still be keyed off the channel thread, not the clicker.
+    await simulateAction(channels, adapter, 'chan-1:t-click', 'tool_approve:no-such-tool-call');
+
+    const threads = await getChannelThreads(mastra, 'chan-1:t-click');
+    expect(threads).toHaveLength(1);
+    expect(threads[0]!.resourceId).toBe('channel:chan-1:t-click');
+  }, 30_000);
+
   it('exposes webhook routes under /api/agent-controllers/{id}', async () => {
     const { channels } = await createSetup();
     const routes = channels.getWebhookRoutes();

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -1,4 +1,4 @@
-import type { Chat, Adapter, ChatConfig, Message, StateAdapter, Thread } from 'chat';
+import type { Chat, Adapter, Author, ChatConfig, Message, StateAdapter, Thread } from 'chat';
 import { z } from 'zod';
 
 import type { Agent } from '../agent/agent';
@@ -230,20 +230,23 @@ export class AgentChannels {
   }
 
   /**
-   * The memory resourceId (owner) used when `processChatMessage` creates a new
-   * channel-backed thread. Returns a thunk when a `resolveResourceId` hook is
-   * configured so the hook only runs when a new thread is actually created,
-   * never when reusing an existing one (which keeps its stored owner).
+   * The memory resourceId (owner) used when a new channel-backed thread is
+   * created, whether from an incoming message or a tool-approval click
+   * (`message` is absent on the click path). Returns a thunk when a
+   * `resolveResourceId` hook is configured so the hook only runs when a new
+   * thread is actually created, never when reusing an existing one (which
+   * keeps its stored owner).
    */
   protected resolveChannelResourceId(args: {
     platform: string;
     chatThread: Thread;
-    message: Message;
+    actor: Author;
+    message?: Message;
     defaultResourceId: string;
   }): string | (() => string | Promise<string>) {
-    const { platform, chatThread, message, defaultResourceId } = args;
+    const { platform, chatThread, actor, message, defaultResourceId } = args;
     return this.resolveResourceId
-      ? () => this.resolveResourceId!({ platform, thread: chatThread, message, defaultResourceId })
+      ? () => this.resolveResourceId!({ platform, thread: chatThread, actor, message, defaultResourceId })
       : defaultResourceId;
   }
 
@@ -474,11 +477,13 @@ export class AgentChannels {
           if (!adapter) throw new Error(`No adapter for platform "${platform}"`);
 
           const externalThreadId = this.resolveExternalThreadId({ platform, chatThread, messageId });
+          // A click can be the event that creates the thread (storage miss, or
+          // racing thread creation) — resolve identity like the message path.
           const mastraThread = await this.getOrCreateThread({
             externalThreadId,
             channelId: chatThread.channelId,
             platform,
-            resourceId: `${platform}:${event.user.userId}`,
+            ...this.threadCreationResolvers({ platform, chatThread, actor: event.user }),
             mastra,
           });
 
@@ -1011,20 +1016,11 @@ export class AgentChannels {
     // each Slack thread (including top-level DM, DM thread reply, channel mention, and
     // channel thread reply) gets its own mastra thread.
     const externalThreadId = chatThread.id;
-    const defaultResourceId = `${platform}:${message.author.userId}`;
     const mastraThread = await this.getOrCreateThread({
       externalThreadId,
       channelId: chatThread.channelId,
       platform,
-      // Lazily resolved: the hook only runs when we're actually creating a new
-      // thread, never when reusing an existing one (which keeps its stored owner).
-      resourceId: this.resolveChannelResourceId({ platform, chatThread, message, defaultResourceId }),
-      // Same laziness for the thread id hook; it runs after the resourceId
-      // resolves so hosts can align the two (e.g. thread id = session id).
-      threadId: this.resolveThreadId
-        ? (resourceId: string, defaultThreadId: string) =>
-            this.resolveThreadId!({ platform, thread: chatThread, message, resourceId, defaultThreadId })
-        : undefined,
+      ...this.threadCreationResolvers({ platform, chatThread, actor: message.author, message }),
       mastra,
     });
 
@@ -1436,6 +1432,39 @@ export class AgentChannels {
       }
       yield chunk;
     }
+  }
+
+  /**
+   * Build the lazy `resourceId`/`threadId` arguments for {@link getOrCreateThread},
+   * shared by every path that can create a channel thread (incoming messages and
+   * tool-approval clicks; `message` is absent on the click path). The owner half
+   * goes through {@link resolveChannelResourceId} so subclass overrides apply to
+   * every creation path.
+   */
+  private threadCreationResolvers({
+    platform,
+    chatThread,
+    actor,
+    message,
+  }: {
+    platform: string;
+    chatThread: Thread;
+    actor: Author;
+    message?: Message;
+  }): {
+    resourceId: string | (() => string | Promise<string>);
+    threadId?: (resolvedResourceId: string, defaultThreadId: string) => string | Promise<string>;
+  } {
+    const defaultResourceId = `${platform}:${actor.userId}`;
+    return {
+      resourceId: this.resolveChannelResourceId({ platform, chatThread, actor, message, defaultResourceId }),
+      // The thread id hook runs after the resourceId resolves so hosts can
+      // align the two (e.g. thread id = session id).
+      threadId: this.resolveThreadId
+        ? (resourceId: string, defaultThreadId: string) =>
+            this.resolveThreadId!({ platform, thread: chatThread, actor, message, resourceId, defaultThreadId })
+        : undefined,
+    };
   }
 
   /**

--- a/packages/core/src/channels/agent-controller-channels.ts
+++ b/packages/core/src/channels/agent-controller-channels.ts
@@ -1,4 +1,4 @@
-import type { Message, Thread } from 'chat';
+import type { Author, Message, Thread } from 'chat';
 
 import type { Agent } from '../agent/agent';
 import type { MastraProviderMetadata } from '../agent/message-list/state/types';
@@ -87,7 +87,8 @@ export class AgentControllerChannels extends AgentChannels {
   protected override resolveChannelResourceId(args: {
     platform: string;
     chatThread: Thread;
-    message: Message;
+    actor: Author;
+    message?: Message;
     defaultResourceId: string;
   }): string | (() => string | Promise<string>) {
     const base = super.resolveChannelResourceId(args);

--- a/packages/core/src/channels/types.ts
+++ b/packages/core/src/channels/types.ts
@@ -1,4 +1,4 @@
-import type { Adapter, CardElement, ChatConfig, Message, StateAdapter, StreamChunk, Thread } from 'chat';
+import type { Adapter, Author, CardElement, ChatConfig, Message, StateAdapter, StreamChunk, Thread } from 'chat';
 
 import type { Mastra } from '../mastra';
 import type { ApiRoute, CorsOptions } from '../server/types';
@@ -329,11 +329,13 @@ export type ChannelHandlerConfig = ChannelHandler | false | undefined;
 export interface ResolveResourceIdContext {
   /** Platform name (e.g. 'slack', 'discord'). */
   platform: string;
-  /** The channel thread the message arrived on. Use `thread.isDM` to tell DMs from group/channel threads. */
+  /** The channel thread the event arrived on. Use `thread.isDM` to tell DMs from group/channel threads. */
   thread: Thread;
-  /** The incoming message. `message.author.userId` is the actor/sender, not necessarily the memory owner. */
-  message: Message;
-  /** The built-in default: `${platform}:${message.author.userId}`. Return this to keep current behavior. */
+  /** The user who triggered thread creation: the message author, or the button clicker when the thread is created from an action (e.g. a tool-approval click). Not necessarily the memory owner. */
+  actor: Author;
+  /** The incoming message. Absent when the thread is created from a button click rather than a message. */
+  message?: Message;
+  /** The built-in default: `${platform}:${actor.userId}`. Return this to keep current behavior. */
   defaultResourceId: string;
 }
 
@@ -351,10 +353,12 @@ export type ResolveResourceId = (ctx: ResolveResourceIdContext) => string | Prom
 export interface ResolveThreadIdContext {
   /** Platform name (e.g. 'slack', 'discord'). */
   platform: string;
-  /** The channel thread the message arrived on. Use `thread.isDM` to tell DMs from group/channel threads. */
+  /** The channel thread the event arrived on. Use `thread.isDM` to tell DMs from group/channel threads. */
   thread: Thread;
-  /** The incoming message. */
-  message: Message;
+  /** The user who triggered thread creation: the message author, or the button clicker when the thread is created from an action. */
+  actor: Author;
+  /** The incoming message. Absent when the thread is created from a button click rather than a message. */
+  message?: Message;
   /** The resolved memory resourceId the new thread will belong to (after `resolveResourceId`). */
   resourceId: string;
   /** The built-in default: a random UUID. Return this to keep current behavior. */
@@ -540,16 +544,17 @@ export interface ChannelConfig {
    * from who sent the message. For example, share an SSO user's memory across Web and a
    * Feishu/Lark DM (drop the platform prefix), or scope a group chat to its `chat_id`.
    *
-   * Only affects **newly-created** threads. Once a thread exists it keeps its stored
+   * Only affects **newly-created** threads, whether creation starts from an incoming
+   * message or a tool-approval action. Once a thread exists it keeps its stored
    * `resourceId`, so this never relocates memory on an existing conversation.
    *
-   * Return `defaultResourceId` (`${platform}:${message.author.userId}`) to keep the
+   * Return `defaultResourceId` (`${platform}:${actor.userId}`) to keep the
    * built-in behavior. Not set: behavior is unchanged.
    *
    * @example
    * ```ts
-   * resolveResourceId: async ({ thread, message, defaultResourceId }) => {
-   *   if (thread.isDM) return resolveSsoUserId(message);   // shared with Web
+   * resolveResourceId: async ({ thread, actor, defaultResourceId }) => {
+   *   if (thread.isDM) return resolveSsoUserId(actor.userId); // shared with Web
    *   return thread.channelId;                             // group owns the memory
    * }
    * ```
@@ -563,7 +568,8 @@ export interface ChannelConfig {
    * thread the same id as the session it belongs to, matching how that host
    * names threads it creates itself.
    *
-   * Only affects **newly-created** threads; existing threads keep their stored id.
+   * Only affects **newly-created** threads, whether creation starts from an incoming
+   * message or a tool-approval action; existing threads keep their stored id.
    * The returned id must be unique across the memory store — on collision with an
    * existing thread, a warning is logged and a generated id is used instead.
    *


### PR DESCRIPTION
## Description

The `chat.onAction` handler (tool-approval Approve/Deny button clicks) hardcoded `resourceId: `\`${platform}:${event.user.userId}\`` when calling `getOrCreateThread`, while the message path resolves the owner through the `resolveResourceId` hook (#17471) and the thread id through `resolveThreadId` (#20147). When a button click was the event that created the thread (storage miss, or the click racing thread creation), the thread was minted with the platform-default owner instead of the host-resolved one — permanently and silently, since owners are stamped once at creation and never re-evaluated. All subsequent memory for that conversation then lived under an ID the host's identity system doesn't recognize. The hardcode dates back to the original channels implementation (#14642), before either hook existed; both hook PRs only wired the message path.

This extracts the lazy hook wiring into a single private helper (`threadCreationResolvers`) used by both `processChatMessage` and `onAction`, so every path that can create a channel thread resolves identity identically. Because action events carry no `Message`, the hook contexts gained a required `actor: Author` (message author or button clicker — always present) and `message` became optional (absent on the click path); the docs example now keys off `actor.userId`. Hooks still only run on thread creation, never on reuse, and the no-hook default is byte-identical to the previous behavior. Added tests that capture the internally registered `onAction` handler and prove: hooks run when a click creates the thread, hooks are skipped when the click reuses an existing thread, and the default `${platform}:${clicker.userId}` is preserved without resolvers (verified red without the fix).

## Related Issue(s)

Fixes #20076

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When someone clicks “approve tool,” Mastra might create a brand-new conversation thread without a chat message. This could assign the new thread to the wrong user. Now those button-created threads use the same ownership-lookup logic as normal message-created threads.

## Summary

- Introduced a shared `threadCreationResolvers` helper so both inbound message handling and `chat.onAction` (tool-approval clicks) use the same `resolveResourceId`/`resolveThreadId` logic during *thread creation*.
- Fixed the `chat.onAction` path to stop bypassing identity resolution (no longer hardcoding `${platform}:${userId}` when creating a new thread); resolvers are applied only when a new thread is minted (e.g., after storage misses/races), and are skipped when an existing matching thread is reused.
- Ensured the default resource identity remains `${platform}:${actor.userId}` when no resolvers are configured.
- Updated hook context typing/contracts: `actor` is required, and `message` is now optional (tool-approval clicks may not provide an incoming message).
- Updated channel reference docs to reflect the `actor`-based identity model and the optional `message` in resolver contexts.
- Added/updated tests for tool-approval thread creation and reuse behavior, including resolver throwing/error handling and verification of resolver call arguments.
- Included a changeset documenting the fix and the hook context contract change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->