### PR TITLE
fix(duckdb): stop trace list queries from scanning the whole database

### DIFF
--- a/.changeset/fruity-mice-flow.md
+++ b/.changeset/fruity-mice-flow.md
@@ -1,0 +1,21 @@
+---
+'@mastra/duckdb': patch
+---
+
+Fixed severe CPU and memory spikes when listing traces from large DuckDB databases.
+
+Opening the traces page in Studio (or calling the list traces / list branches APIs) against a multi-GB trace database previously decompressed the entire span_events table for every page load, poll, and scroll — pinning all CPU cores and ballooning memory by several GB per query. On multi-GB databases, trace list queries now use roughly 5x less CPU and stay within a bounded memory budget:
+
+- Page queries now scan only the time range containing the requested spans instead of the whole table
+- Filtered and custom-ordered queries (status, hasChildError, order by endedAt) now paginate on a narrow column set before reconstructing full span payloads
+- Delta polls now short-circuit when there is no new data
+
+Also added `memoryLimit` and `threads` options to `DuckDBStore`. DuckDB previously used its default memory budget of 80% of system RAM, which could push application servers into swap; it now defaults to 2GB. File-backed databases spill larger-than-memory operations to disk. Note that `:memory:` databases cannot spill, so if you run very large queries against an in-memory database, raise `memoryLimit`.
+
+```typescript
+const store = new DuckDBStore({
+  path: 'mastra.duckdb',
+  memoryLimit: '4GB', // default '2GB'
+  threads: 2, // default: one per CPU core
+});
+```

--- a/docs/src/content/en/reference/storage/duckdb.mdx
+++ b/docs/src/content/en/reference/storage/duckdb.mdx
@@ -110,6 +110,22 @@ const duckdb = new DuckDBStore({ path: ':memory:' })
     isOptional: true,
     defaultValue: "'mastra.duckdb'",
   },
+  {
+    name: 'memoryLimit',
+    type: 'string',
+    description:
+      "Maximum memory DuckDB may use, such as '2GB' or '512MB'. Larger-than-memory operations spill to disk for file-backed databases. Raise this for dedicated analytical workloads.",
+    isOptional: true,
+    defaultValue: "'2GB'",
+  },
+  {
+    name: 'threads',
+    type: 'number',
+    description:
+      'Number of threads DuckDB may use. Lower this to keep queries from monopolizing all cores of a shared application server.',
+    isOptional: true,
+    defaultValue: 'one per CPU core',
+  },
 ]}
 />
 

--- a/stores/duckdb/src/storage/db/index.test.ts
+++ b/stores/duckdb/src/storage/db/index.test.ts
@@ -108,4 +108,33 @@ describe('DuckDBConnection', () => {
       }
     });
   });
+
+  describe('resource limits', () => {
+    it('applies the 2GB default memory limit', async () => {
+      const db = new DuckDBConnection({ path: ':memory:' });
+
+      try {
+        const rows = await db.query<{ value: string }>(`SELECT current_setting('memory_limit') AS value`);
+        expect(rows[0]?.value).toMatch(/^(1\.8|1\.9|2\.0) GiB$/);
+      } finally {
+        await db.close();
+      }
+    });
+
+    it('applies configured memoryLimit and threads', async () => {
+      const db = new DuckDBConnection({ path: ':memory:', memoryLimit: '512MB', threads: 2 });
+
+      try {
+        const rows = await db.query<{ memoryLimit: string; threads: number }>(`
+          SELECT
+            current_setting('memory_limit') AS memoryLimit,
+            current_setting('threads') AS threads
+        `);
+        expect(rows[0]?.memoryLimit).toMatch(/^(476\.\d+|488\.\d+|512\.0) MiB$/);
+        expect(Number(rows[0]?.threads)).toBe(2);
+      } finally {
+        await db.close();
+      }
+    });
+  });
 });

--- a/stores/duckdb/src/storage/db/index.ts
+++ b/stores/duckdb/src/storage/db/index.ts
@@ -52,7 +52,25 @@ function toJsValue(val: unknown): unknown {
 export interface DuckDBStorageConfig {
   /** Path to the DuckDB file. Defaults to 'mastra.duckdb'. Use ':memory:' for ephemeral. */
   path?: string;
+  /**
+   * Maximum memory DuckDB may use (e.g. '2GB', '512MB').
+   * @default '2GB'
+   * DuckDB's own default is 80% of system RAM, which is far too aggressive for
+   * a store embedded in an application server — a single query against a large
+   * database can balloon the process by several GB and push the host into
+   * swap. Larger-than-memory operations spill to disk for file-backed
+   * databases. Raise this for dedicated analytical workloads.
+   */
+  memoryLimit?: string;
+  /**
+   * Number of threads DuckDB may use. Defaults to DuckDB's default (one per
+   * CPU core). Lower this to keep queries from monopolizing all cores of a
+   * shared application server.
+   */
+  threads?: number;
 }
+
+const DEFAULT_MEMORY_LIMIT = '2GB';
 
 /**
  * Shared DuckDB connection management for Mastra storage.
@@ -64,10 +82,15 @@ export class DuckDBConnection extends MastraBase {
   private initialized = false;
   private initPromise: Promise<void> | null = null;
   private path: string;
+  private instanceOptions: Record<string, string>;
 
   constructor(config: DuckDBStorageConfig = {}) {
     super({ component: 'STORAGE', name: 'DUCKDB' });
     this.path = config.path ?? 'mastra.duckdb';
+    this.instanceOptions = {
+      max_memory: config.memoryLimit ?? DEFAULT_MEMORY_LIMIT,
+      ...(config.threads !== undefined ? { threads: String(config.threads) } : {}),
+    };
   }
 
   private async initialize(): Promise<void> {
@@ -82,7 +105,7 @@ export class DuckDBConnection extends MastraBase {
 
     this.initPromise = (async () => {
       try {
-        this.instance = await DuckDBInstance.create(this.path);
+        this.instance = await DuckDBInstance.create(this.path, this.instanceOptions);
         this.initialized = true;
       } catch (error) {
         this.instance = null;

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -2299,4 +2299,123 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(result.feedback[0]!.feedbackId).toBe('feedback-retry-1');
     });
   });
+
+  // ==========================================================================
+  // Slow-path (post-aggregation) trace listing
+  //
+  // These paths paginate on a narrow reconstruction that only includes the
+  // columns the active filters/order reference, then fully reconstruct the
+  // page rows. The tests guard that every filter key which can land in the
+  // post-agg set has its columns wired up in POSTAGG_FILTER_COLUMNS and that
+  // page rows still carry full span payloads.
+  // ==========================================================================
+
+  describe('slow-path trace listing', () => {
+    const slowBase = {
+      parentSpanId: null,
+      spanType: SpanType.AGENT_RUN,
+      isEvent: false,
+      entityType: EntityType.AGENT,
+      entityId: 'agent-slow',
+      entityName: 'Slow Agent',
+      userId: null,
+      organizationId: null,
+      resourceId: null,
+      runId: null,
+      sessionId: null,
+      threadId: null,
+      requestId: null,
+      environment: null,
+      source: null,
+      serviceName: null,
+      attributes: null,
+      links: null,
+      error: null,
+    } as const;
+
+    beforeEach(async () => {
+      await storage.batchCreateSpans({
+        records: [
+          {
+            ...slowBase,
+            traceId: 'slow-a',
+            spanId: 'root-a',
+            name: 'root-a',
+            scope: { core: '1.0.0' },
+            metadata: { env: 'prod' },
+            tags: ['keep'],
+            input: { prompt: 'hello a' },
+            output: { text: 'bye a' },
+            startedAt: new Date('2026-03-01T00:00:00Z'),
+            endedAt: new Date('2026-03-01T00:00:05Z'),
+          },
+          {
+            ...slowBase,
+            traceId: 'slow-b',
+            spanId: 'root-b',
+            name: 'root-b',
+            scope: { core: '2.0.0' },
+            metadata: { env: 'dev' },
+            tags: ['drop'],
+            input: { prompt: 'hello b' },
+            output: { text: 'bye b' },
+            startedAt: new Date('2026-03-01T01:00:00Z'),
+            endedAt: new Date('2026-03-01T01:00:01Z'),
+          },
+        ],
+      });
+    });
+
+    it('filters by scope and returns full payloads on the page rows', async () => {
+      const result = await storage.listTraces({ filters: { scope: { core: '1.0.0' } } });
+
+      expect(result.pagination.total).toBe(1);
+      expect(result.spans.map(s => s.traceId)).toEqual(['slow-a']);
+      // The page row must be a full reconstruction, not the narrow filter row.
+      expect(result.spans[0]!.input).toEqual({ prompt: 'hello a' });
+      expect(result.spans[0]!.output).toEqual({ text: 'bye a' });
+      expect(result.spans[0]!.scope).toEqual({ core: '1.0.0' });
+    });
+
+    it('every post-agg filter key and order field has its reconstruct columns wired up', async () => {
+      // Each of these forces the slow path. A key missing from
+      // POSTAGG_FILTER_COLUMNS would throw a DuckDB binder error here.
+      const cases: { filters?: Record<string, unknown>; orderBy?: { field: string; direction: string } }[] = [
+        { filters: { status: 'success' } },
+        { filters: { status: 'error' } },
+        { filters: { status: 'running' } },
+        { filters: { endedAt: { start: new Date('2026-03-01T00:00:00Z') } } },
+        { filters: { tags: ['keep'] } },
+        { filters: { metadata: { env: 'prod' } } },
+        { filters: { scope: { core: '1.0.0' } } },
+        { filters: { hasChildError: false } },
+        { orderBy: { field: 'endedAt', direction: 'DESC' } },
+        // Combinations
+        { filters: { status: 'success', tags: ['keep'], metadata: { env: 'prod' }, scope: { core: '1.0.0' } } },
+      ];
+
+      for (const args of cases) {
+        await expect(storage.listTraces(args), JSON.stringify(args)).resolves.toBeTruthy();
+      }
+    });
+
+    it('orders by endedAt across the narrow pagination and full reconstruction', async () => {
+      const result = await storage.listTraces({ orderBy: { field: 'endedAt', direction: 'DESC' } });
+
+      // slow-b ended later than slow-a despite both pages being reconstructed
+      // from a time-bounded scan anchored at the earliest page row.
+      expect(result.spans.map(s => s.traceId)).toEqual(['slow-b', 'slow-a']);
+      expect(result.spans.every(s => s.input !== null && s.output !== null)).toBe(true);
+    });
+
+    it('delta poll at head short-circuits with an empty page and stable cursor', async () => {
+      const bootstrap = await storage.listTraces({ mode: 'delta' });
+      expect(bootstrap.deltaCursor).toBeTruthy();
+
+      const atHead = await storage.listTraces({ mode: 'delta', after: bootstrap.deltaCursor! });
+      expect(atHead.spans).toEqual([]);
+      expect(atHead.delta).toEqual({ limit: 10, hasMore: false });
+      expect(atHead.deltaCursor).toBe(bootstrap.deltaCursor);
+    });
+  });
 });

--- a/stores/duckdb/src/storage/domains/observability/tracing.ts
+++ b/stores/duckdb/src/storage/domains/observability/tracing.ts
@@ -130,6 +130,81 @@ const SPAN_RECONSTRUCT_SELECT_LIGHT = `
   FROM span_events
 `;
 
+/**
+ * Which reconstructed columns each post-aggregation filter key can reference.
+ * `status` is derived from endedAt + error (see buildWhereClause).
+ */
+const POSTAGG_FILTER_COLUMNS: Record<string, string[]> = {
+  status: ['endedAt', 'error'],
+  endedAt: ['endedAt'],
+  tags: ['tags'],
+  metadata: ['metadata'],
+  scope: ['scope'],
+};
+
+/**
+ * Narrow reconstruction used by the slow list paths to evaluate
+ * post-aggregation filters and ordering before pagination. Includes only the
+ * columns the active filters and order field actually reference, so the
+ * full-set aggregate never decompresses the heavy JSON payload columns
+ * (attributes, links, input, output, requestContext) and skips even the
+ * cheaper JSON columns (tags/metadata/scope) unless a filter needs them.
+ */
+function buildPostAggReconstructSelect(postAgg: Record<string, unknown>, orderByField: string): string {
+  const columns = new Set<string>();
+  if (orderByField === 'endedAt') columns.add('endedAt');
+  for (const key of Object.keys(postAgg)) {
+    for (const column of POSTAGG_FILTER_COLUMNS[key] ?? []) {
+      columns.add(column);
+    }
+  }
+  const argMaxCols = [...columns].map(col => `${argMaxNonNull(col)},`).join('\n    ');
+  return `
+  SELECT
+    traceId, spanId,
+    ${argMaxCols}
+    coalesce(min(timestamp) FILTER (WHERE eventType = 'start'), min(timestamp)) as startedAt
+  FROM span_events
+`;
+}
+
+/**
+ * Reconstruct spans for the `(traceId, spanId)` pairs selected by `anchorCte`,
+ * scanning only events at/after the CTE's earliest `anchorStartedAt`.
+ *
+ * The `(traceId, spanId) IN (subquery)` semi-join alone cannot be pushed into
+ * the table scan, so without a bound DuckDB decompresses every column of the
+ * entire table just to emit one page of spans. The time bound is a plain range
+ * predicate that zone maps can prune on (insertion order tracks event time).
+ *
+ * Correctness: span events are only 'start' (timestamp = startedAt) and 'end'
+ * (timestamp = endedAt >= startedAt), so every event of an anchored span has
+ * timestamp >= its start-row timestamp >= min(anchorStartedAt). An empty
+ * anchor set makes the bound NULL, which matches the empty IN-list result.
+ */
+function reconstructForAnchors(reconstructSelect: string, anchorCte: string): string {
+  return `
+    ${reconstructSelect}
+    WHERE timestamp >= (SELECT min(anchorStartedAt) FROM ${anchorCte})
+      AND (traceId, spanId) IN (SELECT traceId, spanId FROM ${anchorCte})
+    GROUP BY traceId, spanId`;
+}
+
+/**
+ * Same time-bound trick as {@link reconstructForAnchors}, but with the bound
+ * precomputed in JS and passed as a `?` parameter. The delta-poll query shape
+ * references its candidate CTE multiple times, which makes DuckDB materialize
+ * it and lose the dynamic-filter pushdown a scalar subquery bound relies on —
+ * a literal parameter always reaches the scan as a plain range filter.
+ */
+function reconstructForAnchorsWithBoundParam(reconstructSelect: string, anchorCte: string): string {
+  return `
+    ${reconstructSelect}
+    WHERE timestamp >= ?
+      AND (traceId, spanId) IN (SELECT traceId, spanId FROM ${anchorCte})
+    GROUP BY traceId, spanId`;
+}
+
 function rowToLightSpanRecord(row: Record<string, unknown>): LightSpanRecord {
   return {
     traceId: row.traceId as string,
@@ -663,15 +738,13 @@ async function listTraceRows<TSpan>(
 
     const pageSql = `
       WITH page_roots AS (
-        SELECT traceId, spanId
+        SELECT traceId, spanId, timestamp AS anchorStartedAt
         FROM span_events AS ${outerAlias}
         ${prefilterWhere}
         ${prefilterOrderBy}
         LIMIT ? OFFSET ?
       )
-      ${reconstructSelect}
-      WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM page_roots)
-      GROUP BY traceId, spanId
+      ${reconstructForAnchors(reconstructSelect, 'page_roots')}
       ${buildOrderByClause(orderBy)}
     `;
     const rows = await db.query(pageSql, [...prefilterParams, perPage, offset]);
@@ -683,7 +756,8 @@ async function listTraceRows<TSpan>(
     };
   }
 
-  // Slow path: reconstruct the prefilter set, then apply post-agg filters.
+  // Slow path: reconstruct only the columns post-agg filters/ordering can
+  // reference, paginate on that, then fully reconstruct just the page rows.
   const { clause: postAggClause, params: postAggParams } = buildWhereClause(postAgg);
   const postAggParts: string[] = [];
   if (postAggClause) postAggParts.push(postAggClause.replace(/^WHERE\s+/i, ''));
@@ -698,7 +772,7 @@ async function listTraceRows<TSpan>(
       ${prefilterWhere}
     ),
     root_spans AS (
-      ${reconstructSelect}
+      ${buildPostAggReconstructSelect(postAgg, orderBy.field)}
       WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM candidate_roots)
       GROUP BY traceId, spanId
     )
@@ -715,8 +789,13 @@ async function listTraceRows<TSpan>(
   const total = Number(countResult[0]?.total ?? 0);
 
   const dataSql = `
-    ${cteSql}
-    SELECT * FROM root_spans ${postAggWhere} ${orderByClause} ${paginationClause}
+    ${cteSql},
+    page_roots AS (
+      SELECT traceId, spanId, startedAt AS anchorStartedAt
+      FROM root_spans ${postAggWhere} ${orderByClause} ${paginationClause}
+    )
+    ${reconstructForAnchors(reconstructSelect, 'page_roots')}
+    ${orderByClause}
   `;
   const rows = await db.query(dataSql, [...prefilterParams, ...postAggParams, ...paginationParams]);
   const spans = rows.map(row => mapRow(row as Record<string, unknown>));
@@ -730,8 +809,6 @@ async function listTraceRows<TSpan>(
 export async function listTraces(db: DuckDBConnection, args: ListTracesArgs): Promise<ListTracesResponse> {
   const { mode, filters, pagination, orderBy, after, limit } = listTracesArgsSchema.parse(args);
   const filterRecord = (filters ?? {}) as Record<string, unknown>;
-  const page = Number(pagination.page);
-  const perPage = Number(pagination.perPage);
 
   if (mode === 'delta') {
     assertDeltaPollingEnabled();
@@ -765,6 +842,22 @@ export async function listTraces(db: DuckDBConnection, args: ListTracesArgs): Pr
     const postAggWhere = postAggParts.length > 0 ? `WHERE ${postAggParts.join(' AND ')}` : '';
 
     const outerAlias = 'outer_root';
+
+    // Precompute the reconstruct scan bound from the candidate start rows.
+    // Null bound means no new anchors since the cursor — nothing to fetch.
+    const boundResult = await db.query<{ minTs: Date | null }>(
+      `SELECT min(timestamp) as minTs FROM span_events AS ${outerAlias} ${prefilterWhere}`,
+      [afterCursorId, ...prefilterParams],
+    );
+    const minTs = boundResult[0]?.minTs ?? null;
+    if (minTs === null) {
+      return {
+        spans: [],
+        delta: { limit, hasMore: false },
+        deltaCursor: streamHeadCursor,
+      };
+    }
+
     const dataSql = `
       WITH candidate_roots AS (
         SELECT traceId, spanId, cursorId
@@ -774,9 +867,7 @@ export async function listTraces(db: DuckDBConnection, args: ListTracesArgs): Pr
       root_spans AS (
         SELECT reconstructed.*, candidate_roots.cursorId AS anchorCursorId
         FROM (
-          ${SPAN_RECONSTRUCT_SELECT}
-          WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM candidate_roots)
-          GROUP BY traceId, spanId
+          ${reconstructForAnchorsWithBoundParam(SPAN_RECONSTRUCT_SELECT, 'candidate_roots')}
         ) AS reconstructed
         INNER JOIN candidate_roots USING (traceId, spanId)
       )
@@ -785,6 +876,7 @@ export async function listTraces(db: DuckDBConnection, args: ListTracesArgs): Pr
     const rows = await db.query<Record<string, unknown>>(dataSql, [
       afterCursorId,
       ...prefilterParams,
+      minTs,
       ...postAggParams,
       limit + 1,
     ]);
@@ -801,99 +893,19 @@ export async function listTraces(db: DuckDBConnection, args: ListTracesArgs): Pr
     };
   }
 
-  const { prefilter, postAgg, hasChildError } = partitionAnchorFilters(filterRecord);
-
-  const { clause: prefilterClause, params: prefilterParams } = buildWhereClause(prefilter);
-  const prefilterParts = [`eventType = 'start'`, `parentSpanId IS NULL`];
-  if (prefilterClause) prefilterParts.push(prefilterClause.replace(/^WHERE\s+/i, ''));
-  const prefilterWhere = `WHERE ${prefilterParts.join(' AND ')}`;
-
-  const outerAlias = 'outer_root';
-
-  const orderDir = orderBy.direction.toUpperCase();
-  if (orderDir !== 'ASC' && orderDir !== 'DESC') {
-    throw new Error(`Invalid sort direction: ${orderBy.direction}`);
-  }
   const currentDeltaCursor = deltaPollingFeatureEnabled() ? await getTraceDeltaCursor(db, filters) : undefined;
 
-  const canOrderInPrefilter = SAFE_PREFILTER_ORDER_FIELDS.has(orderBy.field);
-  const hasPostAggFilters = Object.keys(postAgg).length > 0 || hasChildError !== undefined || !canOrderInPrefilter;
-
-  if (!hasPostAggFilters) {
-    const prefilterOrderBy = `ORDER BY timestamp ${orderDir}`;
-    const offset = page * perPage;
-
-    const countSql = `
-      SELECT COUNT(*) as total
-      FROM span_events AS ${outerAlias}
-      ${prefilterWhere}
-    `;
-    const countResult = await db.query<{ total: number }>(countSql, prefilterParams);
-    const total = Number(countResult[0]?.total ?? 0);
-
-    const pageSql = `
-      WITH page_roots AS (
-        SELECT traceId, spanId
-        FROM span_events AS ${outerAlias}
-        ${prefilterWhere}
-        ${prefilterOrderBy}
-        LIMIT ? OFFSET ?
-      )
-      ${SPAN_RECONSTRUCT_SELECT}
-      WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM page_roots)
-      GROUP BY traceId, spanId
-      ${buildOrderByClause(orderBy)}
-    `;
-    const rows = await db.query(pageSql, [...prefilterParams, perPage, offset]);
-    const spans = rows.map(row => rowToSpanRecord(row as Record<string, unknown>));
-
-    return {
-      pagination: { total, page, perPage, hasMore: (page + 1) * perPage < total },
-      spans: toTraceSpans(spans),
-      ...(deltaPollingFeatureEnabled() ? { deltaCursor: currentDeltaCursor } : {}),
-    };
-  }
-
-  const { clause: postAggClause, params: postAggParams } = buildWhereClause(postAgg);
-  const postAggParts: string[] = [];
-  if (postAggClause) postAggParts.push(postAggClause.replace(/^WHERE\s+/i, ''));
-  const childErrorClause = buildHasChildErrorClause(hasChildError, 'root_spans');
-  if (childErrorClause) postAggParts.push(childErrorClause);
-  const postAggWhere = postAggParts.length > 0 ? `WHERE ${postAggParts.join(' AND ')}` : '';
-
-  const cteSql = `
-    WITH candidate_roots AS (
-      SELECT traceId, spanId
-      FROM span_events AS ${outerAlias}
-      ${prefilterWhere}
-    ),
-    root_spans AS (
-      ${SPAN_RECONSTRUCT_SELECT}
-      WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM candidate_roots)
-      GROUP BY traceId, spanId
-    )
-  `;
-
-  const orderByClause = buildOrderByClause(orderBy);
-  const { clause: paginationClause, params: paginationParams } = buildPaginationClause({ page, perPage });
-
-  const countSql = `
-    ${cteSql}
-    SELECT COUNT(*) as total FROM root_spans ${postAggWhere}
-  `;
-  const countResult = await db.query<{ total: number }>(countSql, [...prefilterParams, ...postAggParams]);
-  const total = Number(countResult[0]?.total ?? 0);
-
-  const dataSql = `
-    ${cteSql}
-    SELECT * FROM root_spans ${postAggWhere} ${orderByClause} ${paginationClause}
-  `;
-  const rows = await db.query(dataSql, [...prefilterParams, ...postAggParams, ...paginationParams]);
-  const spans = rows.map(row => rowToSpanRecord(row as Record<string, unknown>));
+  const { pagination: resultPagination, spans } = await listTraceRows(
+    db,
+    { filters, pagination, orderBy },
+    SPAN_RECONSTRUCT_SELECT,
+    rowToSpanRecord,
+    toTraceSpans,
+  );
 
   return {
-    pagination: { total, page, perPage, hasMore: (page + 1) * perPage < total },
-    spans: toTraceSpans(spans),
+    pagination: resultPagination,
+    spans: spans as ListTracesResponse['spans'],
     ...(deltaPollingFeatureEnabled() ? { deltaCursor: currentDeltaCursor } : {}),
   };
 }
@@ -1021,6 +1033,22 @@ export async function listBranches(db: DuckDBConnection, args: ListBranchesArgs)
     const postAggWhere = postAggClause ? postAggClause : '';
 
     const outerAlias = 'outer_anchor';
+
+    // Precompute the reconstruct scan bound from the candidate start rows.
+    // Null bound means no new anchors since the cursor — nothing to fetch.
+    const boundResult = await db.query<{ minTs: Date | null }>(
+      `SELECT min(timestamp) as minTs FROM span_events AS ${outerAlias} ${prefilterWhere}`,
+      prefilterParams,
+    );
+    const minTs = boundResult[0]?.minTs ?? null;
+    if (minTs === null) {
+      return {
+        branches: [],
+        delta: { limit, hasMore: false },
+        deltaCursor: streamHeadCursor,
+      };
+    }
+
     const dataSql = `
       WITH candidate_anchors AS (
         SELECT traceId, spanId, cursorId
@@ -1030,15 +1058,18 @@ export async function listBranches(db: DuckDBConnection, args: ListBranchesArgs)
       branch_anchors AS (
         SELECT reconstructed.*, candidate_anchors.cursorId AS anchorCursorId
         FROM (
-          ${SPAN_RECONSTRUCT_SELECT}
-          WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM candidate_anchors)
-          GROUP BY traceId, spanId
+          ${reconstructForAnchorsWithBoundParam(SPAN_RECONSTRUCT_SELECT, 'candidate_anchors')}
         ) AS reconstructed
         INNER JOIN candidate_anchors USING (traceId, spanId)
       )
       SELECT * FROM branch_anchors ${postAggWhere} ORDER BY anchorCursorId ASC LIMIT ?
     `;
-    const rows = await db.query<Record<string, unknown>>(dataSql, [...prefilterParams, ...postAggParams, limit + 1]);
+    const rows = await db.query<Record<string, unknown>>(dataSql, [
+      ...prefilterParams,
+      minTs,
+      ...postAggParams,
+      limit + 1,
+    ]);
     const visibleRows = rows.slice(0, limit).map(row => ({
       cursorId: row.anchorCursorId,
       branch: rowToSpanRecord(row),
@@ -1113,15 +1144,13 @@ export async function listBranches(db: DuckDBConnection, args: ListBranchesArgs)
 
     const pageSql = `
       WITH page_anchors AS (
-        SELECT traceId, spanId
+        SELECT traceId, spanId, timestamp AS anchorStartedAt
         FROM span_events AS ${outerAlias}
         ${prefilterWhere}
         ${prefilterOrderBy}
         LIMIT ? OFFSET ?
       )
-      ${SPAN_RECONSTRUCT_SELECT}
-      WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM page_anchors)
-      GROUP BY traceId, spanId
+      ${reconstructForAnchors(SPAN_RECONSTRUCT_SELECT, 'page_anchors')}
       ${buildOrderByClause(orderBy)}
     `;
     const rows = await db.query(pageSql, [...prefilterParams, perPage, offset]);
@@ -1134,7 +1163,8 @@ export async function listBranches(db: DuckDBConnection, args: ListBranchesArgs)
     };
   }
 
-  // Slow path: reconstruct the prefilter set, then apply post-agg filters.
+  // Slow path: reconstruct only the columns post-agg filters/ordering can
+  // reference, paginate on that, then fully reconstruct just the page rows.
   const { clause: postAggClause, params: postAggParams } = buildWhereClause(postAgg);
   const postAggWhere = postAggClause ? postAggClause : '';
   const orderByClause = buildOrderByClause(orderBy);
@@ -1147,7 +1177,7 @@ export async function listBranches(db: DuckDBConnection, args: ListBranchesArgs)
       ${prefilterWhere}
     ),
     branch_anchors AS (
-      ${SPAN_RECONSTRUCT_SELECT}
+      ${buildPostAggReconstructSelect(postAgg, orderBy.field)}
       WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM candidate_anchors)
       GROUP BY traceId, spanId
     )
@@ -1169,8 +1199,13 @@ export async function listBranches(db: DuckDBConnection, args: ListBranchesArgs)
   }
 
   const dataSql = `
-    ${cteSql}
-    SELECT * FROM branch_anchors ${postAggWhere} ${orderByClause} ${paginationClause}
+    ${cteSql},
+    page_anchors AS (
+      SELECT traceId, spanId, startedAt AS anchorStartedAt
+      FROM branch_anchors ${postAggWhere} ${orderByClause} ${paginationClause}
+    )
+    ${reconstructForAnchors(SPAN_RECONSTRUCT_SELECT, 'page_anchors')}
+    ${orderByClause}
   `;
   const rows = await db.query(dataSql, [...prefilterParams, ...postAggParams, ...paginationParams]);
   const spans = rows.map(row => rowToSpanRecord(row as Record<string, unknown>));

--- a/stores/duckdb/src/storage/index.ts
+++ b/stores/duckdb/src/storage/index.ts
@@ -463,6 +463,19 @@ export interface DuckDBStoreConfig {
    * Use ':memory:' for an ephemeral in-memory database.
    */
   path?: string;
+  /**
+   * Maximum memory DuckDB may use (e.g. '2GB', '512MB').
+   * @default '2GB'
+   * DuckDB's own default is 80% of system RAM, which is far too aggressive
+   * for a store embedded in an application server.
+   */
+  memoryLimit?: string;
+  /**
+   * Number of threads DuckDB may use. Defaults to DuckDB's default (one per
+   * CPU core). Lower this to keep queries from monopolizing all cores of a
+   * shared application server.
+   */
+  threads?: number;
 }
 
 /**
@@ -497,7 +510,7 @@ export class DuckDBStore extends MastraCompositeStore {
     const id = config.id ?? 'duckdb';
     super({ id, name: 'DuckDBStore' });
 
-    this.db = new DuckDBConnection({ path: config.path });
+    this.db = new DuckDBConnection({ path: config.path, memoryLimit: config.memoryLimit, threads: config.threads });
     this.observabilityStore = new ObservabilityStorageDuckDB({ db: this.db });
 
     this.stores = {


### PR DESCRIPTION
Opening the Studio traces page against a large DuckDB file (2.6GB, ~2.4M span events) pinned the server at 100% CPU and pushed RSS to ~2.8GB per query. The page reconstruction query gathers spans with a `(traceId, spanId) IN (subquery)` semi-join, which DuckDB can't push into the table scan — so every page load, 5s poll, and scroll decompressed the entire `span_events` table to return 25 rows.

The fix bounds the reconstruction scan with `timestamp >= min(page root start)`, a plain range predicate that zone maps can prune (safe because every event of a span is at/after its start row). Delta polls precompute the bound as a query parameter — the scalar-subquery form loses dynamic-filter pushdown in that query shape — and short-circuit entirely when there's no new data. Filtered/custom-ordered queries (status, hasChildError, order by endedAt) now paginate on a narrow reconstruction of only the columns the active filters reference, then fully reconstruct just the page rows.

Also adds `memoryLimit` and `threads` options to `DuckDBStore`, with `memoryLimit` defaulting to 2GB instead of DuckDB's 80%-of-system-RAM:

```ts
const store = new DuckDBStore({
  path: 'mastra.duckdb',
  memoryLimit: '4GB', // default '2GB'
  threads: 2,         // default: one per core
});
```

Measured on a 2.7GB / 58k-trace repro DB: page loads ~1.2-1.3s CPU → ~0.2s, filtered queries ~2.5-2.7s → 0.4-0.6s, at-head delta polls 115ms → 27ms, RSS after a page query 2.8GB → 0.9GB. Verified row-level result equivalence against the old query shapes on the repro DB (same rows, same order, payloads and totals intact).

Test plan: 307 package tests pass including new tests for the resource-limit settings, scope filtering on the slow path, endedAt ordering across the narrow pagination, the delta short-circuit, and a guard that every post-agg filter key has its reconstruct columns wired up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Trace browsing no longer searches and unpacks the entire database every time. It only examines the relevant time range and data needed for the current page, making browsing faster and using much less memory.

## What changed

- Optimized DuckDB trace and branch listing:
  - Added timestamp-bounded reconstruction so zone maps can skip irrelevant data.
  - Paginated before fully reconstructing results where possible.
  - Reconstructs only columns needed for active filters and ordering.
  - Short-circuits delta polls when no new data exists.
- Added configurable `memoryLimit` and `threads` options to `DuckDBStore`.
  - Default memory limit is now `2GB`.
  - Documented configuration and disk-spilling behavior.
- Added tests covering:
  - Resource-limit settings.
  - Filtered and custom-ordered trace queries.
  - Full payload reconstruction.
  - Delta polling short-circuiting.
  - Reconstruction-column coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->