### PR TITLE
fix(mongodb): (take 2) Pin bson to 7.2.0 to avoid circular-reference hang

### DIFF
--- a/.changeset/pin-bson-version.md
+++ b/.changeset/pin-bson-version.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mongodb': patch
+---
+
+Temporarily pin bson to 7.2.0 to work around a hang in an edge case with the newer bson version. Will unpin shortly.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ catalogs:
       version: 4.4.3
 
 overrides:
+  bson: 7.2.0
   typescript: ^6.0.3
   '@types/node': 22.19.15
   cookie: '>=1.1.1 <2'
@@ -21508,8 +21509,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  bson@7.3.1:
-    resolution: {integrity: sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==}
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
     engines: {node: '>=20.19.0'}
 
   buffer-crc32@0.2.13:
@@ -45101,7 +45102,7 @@ snapshots:
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.5)
 
-  bson@7.3.1: {}
+  bson@7.2.0: {}
 
   buffer-crc32@0.2.13: {}
 
@@ -50825,7 +50826,7 @@ snapshots:
   mongodb@7.2.0(@aws-sdk/credential-providers@3.1006.0)(@mongodb-js/zstd@7.0.0)(socks@2.8.9):
     dependencies:
       '@mongodb-js/saslprep': 1.4.12
-      bson: 7.3.1
+      bson: 7.2.0
       mongodb-connection-string-url: 7.0.1
     optionalDependencies:
       '@aws-sdk/credential-providers': 3.1006.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -161,6 +161,8 @@ trustPolicyExclude:
   # without the trusted-publisher evidence that older @mesadev/sdk versions had.
   - '@mesadev/sdk@0.38.0'
 overrides:
+  # Temporarily pinning to 7.2.0; will unpin shortly.
+  bson: 7.2.0
   typescript: ^6.0.3
   '@types/node': 22.19.15
   # Capped below 2: cookie@2 renamed parse/serialize to parseCookie/stringifyCookie,


### PR DESCRIPTION
## Summary

Fixes #20177

Temporarily pin `bson` to `7.2.0` to avoid a hang in `@internal/storage-test-utils`'s shared vector test suite (`'should handle metadata with circular references'`) caused by a regression in `bson` 7.3.0+. See #20177 for the full root-cause investigation and a minimal reproduction.

## Changes

- Add a `pnpm-workspace.yaml` override pinning `bson` to `7.2.0`.
- Add a changeset for `@mastra/mongodb`.

## Test plan

- [x] Full `stores/mongodb` suite (870 tests) passes locally with the pin in place — previously hung indefinitely without it.
- [ ] Will unpin once the regression is fixed upstream in `bson` (tracked in #20177).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

MongoDB-related tests sometimes get stuck forever when they see certain circular data. This PR temporarily forces the project to use an older `bson` version (`7.2.0`) so the edge case fails safely instead of hanging, until the upstream bug is fixed.

## Summary

- Temporarily pins `bson` to `7.2.0` via `pnpm-workspace.yaml` override to avoid an infinite hang in the MongoDB vector test for circular metadata references (the `7.2.0` behavior throws a `RangeError` instead).
- Adds a changeset (`.changeset/pin-bson-version.md`) to bump `@mastra/mongodb` with a documented temporary workaround, with intent to remove the pin after the regression is resolved.
- Confirms the full MongoDB store test suite passes (870 tests) with the pin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->