### PR TITLE
feat(core): preserve completed scorer results on failure

### DIFF
--- a/.changeset/mighty-parks-pay.md
+++ b/.changeset/mighty-parks-pay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added scorer failure results so callers can inspect completed stages and `status: 'failed'` judge executions in `error.result.judge` after `scorer.run()` rejects.

--- a/.changeset/mighty-parks-pay.md
+++ b/.changeset/mighty-parks-pay.md
@@ -3,3 +3,17 @@
 ---
 
 Added scorer failure results so callers can inspect completed stages and `status: 'failed'` judge executions in `error.result.judge` after `scorer.run()` rejects.
+
+```typescript
+import { ScorerRunError } from '@mastra/core/evals';
+
+try {
+  await scorer.run(input);
+} catch (error) {
+  if (error instanceof ScorerRunError) {
+    console.log(error.failedStep);
+    console.log(error.completedSteps);
+    console.log(error.result);
+  }
+}
+```

--- a/docs/src/content/en/reference/evals/mastra-scorer.mdx
+++ b/docs/src/content/en/reference/evals/mastra-scorer.mdx
@@ -142,16 +142,19 @@ const result = await scorer.run({
 The optional `judge` record contains details about the judge model calls made by prompt-based scorer steps. Its known keys are `preprocess`, `analyze`, `generateScore`, and `generateReason`. Each key contains an ordered `executions` array.
 
 ```typescript
-interface ScorerJudgeExecutionSuccess {
-  status: 'success'
+interface ScorerJudgeExecutionBase {
   prompt: string
-  output: JSONValue
   judgeModelId: string
   judgeProvider?: string
-  usage: ScorerJudgeUsage
   attemptCount: number
   modelCallCount: number
   durationMs: number
+}
+
+interface ScorerJudgeExecutionSuccess extends ScorerJudgeExecutionBase {
+  status: 'success'
+  output: JSONValue
+  usage: ScorerJudgeUsage
   cost?: {
     amount: number
     unit: string
@@ -159,7 +162,20 @@ interface ScorerJudgeExecutionSuccess {
   }
 }
 
-type ScorerJudgeExecution = ScorerJudgeExecutionSuccess
+interface ScorerJudgeExecutionFailure extends ScorerJudgeExecutionBase {
+  status: 'failed'
+  output?: JSONValue
+  rawOutput?: string
+  usage?: ScorerJudgeUsage
+  finishReason?: string
+  error: {
+    name: string
+    message: string
+    code?: string
+  }
+}
+
+type ScorerJudgeExecution = ScorerJudgeExecutionSuccess | ScorerJudgeExecutionFailure
 
 interface ScorerJudgeUsage {
   inputTokens?: number
@@ -185,17 +201,76 @@ const execution = result.judge?.generateScore?.executions[0]
 
 console.log(execution?.status)
 console.log(execution?.judgeModelId)
-console.log(execution?.usage.totalTokens)
+console.log(execution?.usage?.totalTokens)
 console.log(execution?.durationMs)
 ```
 
-The `status` value describes the outcome of the logical prompt-step execution, not the quality of the evaluated response. A structured-output fallback that eventually succeeds creates one `success` execution with an `attemptCount` greater than one.
+The `status` value describes the outcome of the logical prompt-step execution, not the quality of the evaluated response. A structured-output fallback that eventually succeeds creates one `success` execution with an `attemptCount` greater than one. Exhausted attempts create one `failed` execution.
+
+Successful executions require validated `output` and normalized `usage`. Failed executions require an `error` summary and include only the evidence the runtime received. A failed execution includes `output` only when the output was validated before a later callback or orchestration failure. Mastra doesn't parse `rawOutput` to create `output`.
 
 `attemptCount` counts judge invocations, including a structured-output fallback. `modelCallCount` counts the completed model steps across those attempts. `durationMs` covers the full prompt-step execution.
 
-Function steps don't create `judge` entries. Usage in this record belongs to the scorer's judge model, not the agent or workflow being evaluated. The optional `cost` field is present only when the execution directly reports an authoritative cost, source, and unit.
+Function steps don't create `judge` entries. Usage in this record belongs to the scorer's judge model, not the agent or workflow being evaluated. Filter by `status` when aggregating successful executions. Include both statuses when aggregating all completed provider usage. The optional `cost` field is present only on successful executions that directly report an authoritative cost, source, and unit.
 
 Use Mastra metrics to query aggregate usage, latency, and estimated cost across scorer runs. The `judge` record describes one scorer run and doesn't query metrics or traces.
+
+### Failed runs
+
+A failed scorer stage still rejects the `.run()` promise. Catch `ScorerRunError` to inspect completed stages and any results they produced:
+
+```typescript
+import { ScorerRunError } from '@mastra/core/evals'
+
+try {
+  const result = await scorer.run({ input, output })
+  console.log(result.score)
+} catch (error) {
+  if (error instanceof ScorerRunError) {
+    console.log(error.failedStep)
+    console.log(error.completedSteps)
+    console.log(error.result?.score)
+
+    const failedExecution = error.result?.judge?.[error.failedStep]?.executions.find(
+      execution => execution.status === 'failed',
+    )
+    console.log(failedExecution?.error)
+  }
+
+  throw error
+}
+```
+
+`ScorerRunError` exposes these properties:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'failedStep',
+    type: 'ScorerStepName',
+    description: 'The scorer stage that failed.',
+  },
+  {
+    name: 'completedSteps',
+    type: 'ScorerStepName[]',
+    description: 'The scorer stages that completed before the failure, in execution order.',
+  },
+  {
+    name: 'result',
+    type: 'ScorerRunResultSnapshot | undefined',
+    description:
+      'Outputs from completed scorer stages and judge execution evidence from attempted prompt stages. This property is omitted when neither is available.',
+  },
+]}
+/>
+
+The `result` snapshot contains completed stage outputs and judge execution evidence. For example, if `generateReason` fails after `generateScore` returns `0`, `error.result.score` is `0`, the `generateScore` execution has `status: 'success'`, and the `generateReason` execution has `status: 'failed'`. The run remains failed.
+
+A prompt failure can create `error.result` with only run identity, input, and a failed `judge` entry. A function stage that fails before producing a scorer field doesn't create a result.
+
+`JSON.stringify(error)` uses the standard `MastraError` serialization and omits `result`, including successful and failed judge evidence. Read `result` explicitly when you need scorer artifacts or raw failed output.
+
+An in-memory experiment result can keep a completed score or reason from a failed scorer along with `error`, `failedStep`, and `completedSteps`. The scorer is still treated as failed, and a recovered score isn't written to legacy successful-score storage.
 
 ## Step execution flow
 

--- a/packages/core/src/agent/utils.test.ts
+++ b/packages/core/src/agent/utils.test.ts
@@ -136,6 +136,57 @@ describe('agent/utils', () => {
   });
 
   describe('tryStreamWithJsonFallback', () => {
+    it('records one stream attempt for a successful invocation', async () => {
+      const result = { object: Promise.resolve({ decision: 'done' }) };
+      const stream = vi.fn().mockResolvedValue(result);
+      const onStreamAttempt = vi.fn();
+
+      await expect(
+        tryStreamWithJsonFallback(makeStreamAgent(stream), 'prompt', {
+          ...baseOptions,
+          onStreamAttempt,
+        } as any),
+      ).resolves.toBe(result);
+
+      expect(onStreamAttempt).toHaveBeenCalledTimes(1);
+      expect(stream).toHaveBeenCalledTimes(1);
+    });
+
+    it('records both stream attempts for a structured-output fallback', async () => {
+      const fallbackResult = { object: Promise.resolve({ decision: 'continue' }) };
+      const stream = vi
+        .fn()
+        .mockRejectedValueOnce(new JSONParseError({ text: 'not json', cause: new SyntaxError('Unexpected token') }))
+        .mockResolvedValueOnce(fallbackResult);
+      const onStreamAttempt = vi.fn();
+
+      await expect(
+        tryStreamWithJsonFallback(makeStreamAgent(stream), 'prompt', {
+          ...baseOptions,
+          onStreamAttempt,
+        } as any),
+      ).resolves.toBe(fallbackResult);
+
+      expect(onStreamAttempt).toHaveBeenCalledTimes(2);
+      expect(stream).toHaveBeenCalledTimes(2);
+    });
+
+    it('records a stream attempt before the provider rejects', async () => {
+      const error = new Error('provider failed');
+      const stream = vi.fn().mockRejectedValue(error);
+      const onStreamAttempt = vi.fn();
+
+      await expect(
+        tryStreamWithJsonFallback(makeStreamAgent(stream), 'prompt', {
+          ...baseOptions,
+          onStreamAttempt,
+        } as any),
+      ).rejects.toBe(error);
+
+      expect(onStreamAttempt).toHaveBeenCalledTimes(1);
+      expect(stream).toHaveBeenCalledTimes(1);
+    });
+
     it('retries with jsonPromptInjection for a structured-output parse error', async () => {
       const fallbackResult = { object: Promise.resolve({ decision: 'continue' }) };
       const stream = vi

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -98,6 +98,8 @@ export async function tryStreamWithJsonFallback<OUTPUT extends {}>(
   options: AgentExecutionOptionsBase<OUTPUT> & {
     structuredOutput: StructuredOutputOptions<OUTPUT>;
     onStream?: (stream: Awaited<ReturnType<Agent['stream']>>) => void | Promise<void>;
+    /** Called immediately before each primary or fallback stream invocation. */
+    onStreamAttempt?: () => void | Promise<void>;
     /** Called after each stream invocation is consumed, including a failed structured-output attempt. */
     onStreamFinish?: (stream: Awaited<ReturnType<Agent['stream']>>) => void | Promise<void>;
   },
@@ -111,9 +113,10 @@ export async function tryStreamWithJsonFallback<OUTPUT extends {}>(
     });
   }
 
-  const { onStream, onStreamFinish, ...streamOptions } = options;
+  const { onStream, onStreamAttempt, onStreamFinish, ...streamOptions } = options;
 
   try {
+    await onStreamAttempt?.();
     const result = await agent.stream(prompt, streamOptions);
     void onStream?.(result as unknown as Awaited<ReturnType<Agent['stream']>>);
     try {
@@ -134,6 +137,7 @@ export async function tryStreamWithJsonFallback<OUTPUT extends {}>(
     if (!isStructuredOutputFormatError(error)) throw error;
 
     console.warn('Error in tryStreamWithJsonFallback. Attempting fallback.', error);
+    await onStreamAttempt?.();
     const result = await agent.stream(prompt, {
       ...streamOptions,
       structuredOutput: {

--- a/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { z } from 'zod';
+import { ScorerRunError } from '../../../evals/base';
 import type { MastraScorer } from '../../../evals/base';
 import type { Mastra } from '../../../mastra';
 import { RequestContext } from '../../../request-context';
@@ -311,6 +312,8 @@ describe('runExperiment', () => {
       // Scorer error should be captured in score result
       expect(result.results[0].scores[0].error).toBe('Scorer crashed');
       expect(result.results[0].scores[0].score).toBeNull();
+      expect(result.results[0].scores[0].failedStep).toBeUndefined();
+      expect(result.results[0].scores[0].completedSteps).toBeUndefined();
     });
 
     it('failing scorer does not affect other scorers', async () => {
@@ -344,6 +347,77 @@ describe('runExperiment', () => {
       const workingScore = result.results[0].scores.find(s => s.scorerId === 'working');
       expect(workingScore?.score).toBe(1.0);
       expect(workingScore?.error).toBeNull();
+    });
+
+    it('retains completed scorer output and stage context without persisting a failed score', async () => {
+      const recoveredFailure = new ScorerRunError({
+        scorerId: 'partial-scorer',
+        steps: ['analyze', 'generateScore', 'generateReason'],
+        failedStep: 'generateReason',
+        completedSteps: ['analyze', 'generateScore'],
+        result: {
+          output: 'Response',
+          runId: 'partial-run',
+          score: 0,
+          analyzeStepResult: { relevant: true },
+          analyzePrompt: 'analyze the response',
+          generateScorePrompt: 'score the response',
+        },
+        cause: new Error('reason failed'),
+      });
+      const partialScorer = {
+        id: 'partial-scorer',
+        name: 'Partial Scorer',
+        description: 'Fails after computing a score',
+        run: vi.fn().mockRejectedValue(recoveredFailure),
+      } as unknown as MastraScorer<any, any, any, any>;
+      const emptyFailureScorer = {
+        id: 'empty-failure-scorer',
+        name: 'Empty Failure Scorer',
+        description: 'Fails before computing a score',
+        run: vi.fn().mockRejectedValue(
+          new ScorerRunError({
+            scorerId: 'empty-failure-scorer',
+            steps: ['generateScore'],
+            failedStep: 'generateScore',
+            completedSteps: [],
+            cause: new Error('score failed'),
+          }),
+        ),
+      } as unknown as MastraScorer<any, any, any, any>;
+      const workingScorer = createMockScorer('working', 'Working Scorer');
+
+      const result = await runExperiment(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        scorers: [partialScorer, emptyFailureScorer, workingScorer],
+      });
+
+      const partialResult = result.results[0].scores.find(score => score.scorerId === 'partial-scorer');
+      expect(partialResult).toMatchObject({
+        score: 0,
+        reason: null,
+        error: 'Scorer Run Failed: reason failed',
+        failedStep: 'generateReason',
+        completedSteps: ['analyze', 'generateScore'],
+        targetScope: 'span',
+      });
+      expect(result.results[0].scores.find(score => score.scorerId === 'empty-failure-scorer')).toMatchObject({
+        score: null,
+        reason: null,
+        error: 'Scorer Run Failed: score failed',
+        failedStep: 'generateScore',
+        completedSteps: [],
+      });
+      expect(result.results[0].scores.find(score => score.scorerId === 'working')).toMatchObject({
+        score: 1,
+        error: null,
+      });
+      const scoreStoreLookups = (mockStorage.getStore as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([domain]) => domain === 'scores',
+      );
+      expect(scoreStoreLookups).toHaveLength(2);
     });
   });
 

--- a/packages/core/src/datasets/experiment/__tests__/scorer-trajectory.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/scorer-trajectory.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { z } from 'zod';
+import { ScorerRunError } from '../../../evals/base';
 import type { MastraScorer } from '../../../evals/base';
 import type { Trajectory } from '../../../evals/types';
 import type { Mastra } from '../../../mastra';
@@ -263,6 +264,61 @@ describe('steps scorer config — per-step dispatch', () => {
     expect(echoResult?.score).toBe(0.5);
     expect(echoResult?.targetScope).toBe('span');
     expect(echoResult?.stepId).toBe('echo');
+  });
+
+  it('retains completed output from a failed step scorer without persisting its recovered score', async () => {
+    const workflow = buildTwoStepWorkflow();
+    (mastra.getWorkflowById as ReturnType<typeof vi.fn>).mockReturnValue(workflow);
+    (mastra.getWorkflow as ReturnType<typeof vi.fn>).mockReturnValue(workflow);
+
+    const recoveredFailure = new ScorerRunError({
+      scorerId: 'partial-step-scorer',
+      steps: ['generateScore', 'generateReason'],
+      failedStep: 'generateReason',
+      completedSteps: ['generateScore'],
+      result: {
+        output: { upper: 'HELLO' },
+        runId: 'partial-step-run',
+        score: 0,
+        generateScorePrompt: 'score the upper-case output',
+      },
+      cause: new Error('step reason failed'),
+    });
+    const partialScorer = {
+      id: 'partial-step-scorer',
+      name: 'partial-step-scorer',
+      description: '',
+      type: 'agent' as const,
+      run: vi.fn().mockRejectedValue(recoveredFailure),
+    } as unknown as MastraScorer<any, any, any, any>;
+    const workingScorer = createAgentScorer('working-step-scorer');
+
+    const result = await runExperiment(mastra, {
+      datasetId,
+      targetType: 'workflow',
+      targetId: 'two-step-wf',
+      scorers: { steps: { upper: [partialScorer, workingScorer] } } as any,
+    });
+
+    const scores = result.results[0]?.scores ?? [];
+    expect(scores.find(score => score.scorerId === 'partial-step-scorer')).toMatchObject({
+      score: 0,
+      reason: null,
+      error: 'Scorer Run Failed: step reason failed',
+      failedStep: 'generateReason',
+      completedSteps: ['generateScore'],
+      targetScope: 'span',
+      stepId: 'upper',
+    });
+    expect(scores.find(score => score.scorerId === 'working-step-scorer')).toMatchObject({
+      score: 1,
+      error: null,
+      stepId: 'upper',
+    });
+    const scoreStoreLookups = (storage.getStore as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([domain]) => domain === 'scores',
+    );
+    expect(scoreStoreLookups).toHaveLength(1);
   });
 
   it('skips step scorers for steps that did not run successfully', async () => {

--- a/packages/core/src/datasets/experiment/scorer.ts
+++ b/packages/core/src/datasets/experiment/scorer.ts
@@ -1,3 +1,4 @@
+import { ScorerRunError } from '../../evals/base';
 import type { MastraScorer } from '../../evals/base';
 import { extractTrajectory, extractTrajectoryFromTrace } from '../../evals/types';
 import type { ScorerRunInputForAgent, ScorerRunOutputForAgent, Trajectory } from '../../evals/types';
@@ -135,8 +136,8 @@ export async function runScorersForItem(
         workflowData,
       );
 
-      // Persist score if storage available and score was computed
-      if (storage && result.score !== null) {
+      // Persist only scores from successful scorer runs.
+      if (storage && result.error === null && result.score !== null) {
         try {
           // Legacy score-store emission. This path is being deprecated.
           await validateAndSaveScore(storage, {
@@ -196,6 +197,37 @@ interface ScorerPromptMetadata {
   preprocessPrompt?: string;
   analyzeStepResult?: Record<string, unknown>;
   analyzePrompt?: string;
+}
+
+function extractScorerRunFields(scoreResult: unknown): {
+  score: number | null;
+  reason: string | null;
+  promptMetadata: ScorerPromptMetadata;
+} {
+  if (typeof scoreResult !== 'object' || scoreResult === null) {
+    return { score: null, reason: null, promptMetadata: {} };
+  }
+
+  const fields = scoreResult as Record<string, unknown>;
+  const str = (key: string): string | undefined =>
+    typeof fields[key] === 'string' ? (fields[key] as string) : undefined;
+  const obj = (key: string): Record<string, unknown> | undefined => {
+    const value = fields[key];
+    return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined;
+  };
+
+  return {
+    score: typeof fields.score === 'number' ? fields.score : null,
+    reason: typeof fields.reason === 'string' ? fields.reason : null,
+    promptMetadata: {
+      generateScorePrompt: str('generateScorePrompt'),
+      generateReasonPrompt: str('generateReasonPrompt'),
+      preprocessStepResult: obj('preprocessStepResult'),
+      preprocessPrompt: str('preprocessPrompt'),
+      analyzeStepResult: obj('analyzeStepResult'),
+      analyzePrompt: str('analyzePrompt'),
+    },
+  };
 }
 
 /**
@@ -260,16 +292,7 @@ async function runScorerSafe(
       };
     }
 
-    const fields = scoreResult as Record<string, unknown>;
-    const score = typeof fields.score === 'number' ? fields.score : null;
-    const reason = typeof fields.reason === 'string' ? fields.reason : null;
-
-    const str = (key: string): string | undefined =>
-      typeof fields[key] === 'string' ? (fields[key] as string) : undefined;
-    const obj = (key: string): Record<string, unknown> | undefined => {
-      const val = fields[key];
-      return typeof val === 'object' && val !== null ? (val as Record<string, unknown>) : undefined;
-    };
+    const { score, reason, promptMetadata } = extractScorerRunFields(scoreResult);
 
     return {
       result: {
@@ -280,16 +303,26 @@ async function runScorerSafe(
         error: null,
         targetScope: effectiveScope,
       },
-      promptMetadata: {
-        generateScorePrompt: str('generateScorePrompt'),
-        generateReasonPrompt: str('generateReasonPrompt'),
-        preprocessStepResult: obj('preprocessStepResult'),
-        preprocessPrompt: str('preprocessPrompt'),
-        analyzeStepResult: obj('analyzeStepResult'),
-        analyzePrompt: str('analyzePrompt'),
-      },
+      promptMetadata,
     };
   } catch (error) {
+    if (error instanceof ScorerRunError) {
+      const { score, reason, promptMetadata } = extractScorerRunFields(error.result);
+      return {
+        result: {
+          scorerId: scorer.id,
+          scorerName: scorer.name,
+          score,
+          reason,
+          error: error.message,
+          failedStep: error.failedStep,
+          completedSteps: error.completedSteps,
+          targetScope: trajectoryOutput ? 'trajectory' : 'span',
+        },
+        promptMetadata,
+      };
+    }
+
     return {
       result: {
         scorerId: scorer.id,
@@ -454,6 +487,21 @@ export async function runStepScorersForItem(
             stepId,
           };
         } catch (error) {
+          if (error instanceof ScorerRunError) {
+            const { score, reason } = extractScorerRunFields(error.result);
+            return {
+              scorerId: scorer.id,
+              scorerName: scorer.name,
+              score,
+              reason,
+              error: error.message,
+              failedStep: error.failedStep,
+              completedSteps: error.completedSteps,
+              targetScope: 'span' as const,
+              stepId,
+            };
+          }
+
           return {
             scorerId: scorer.id,
             scorerName: scorer.name,

--- a/packages/core/src/datasets/experiment/types.ts
+++ b/packages/core/src/datasets/experiment/types.ts
@@ -1,5 +1,5 @@
 import type { AgentScorerConfig, WorkflowScorerConfig } from '../../evals';
-import type { MastraScorer } from '../../evals/base';
+import type { MastraScorer, ScorerStepName } from '../../evals/base';
 import type { Mastra } from '../../mastra';
 import type { VersionOverrides } from '../../mastra/types';
 import type { DatasetTenancyFilters, TargetType, ExperimentStatus } from '../../storage/types';
@@ -176,12 +176,16 @@ export interface ScorerResult {
   scorerId: string;
   /** Display name of the scorer */
   scorerName: string;
-  /** Computed score (null if scorer failed) */
+  /** Computed score, or null when no score was produced */
   score: number | null;
-  /** Reason/explanation for the score */
+  /** Reason/explanation for the score, or null when no reason was produced */
   reason: string | null;
   /** Error message if scorer failed */
   error: string | null;
+  /** Scorer stage that failed, when the scorer exposes stage context */
+  failedStep?: ScorerStepName;
+  /** Scorer stages that completed before the failure */
+  completedSteps?: ScorerStepName[];
   /**
    * Scope this score targets. Mirrors the canonical `ScorerTargetScope`
    * taxonomy from observability so consumers can differentiate span-level

--- a/packages/core/src/evals/base.test.ts
+++ b/packages/core/src/evals/base.test.ts
@@ -6,8 +6,8 @@ import { Agent } from '../agent';
 import { SpanType } from '../observability';
 import { StreamErrorRetryProcessor } from '../processors';
 import { createMockModel } from '../test-utils/llm-mock';
-import { createScorer } from './base';
-import type { ScorerJudgeExecutionSuccess } from './base';
+import { createScorer, ScorerRunError } from './base';
+import type { ScorerJudgeExecutionFailure, ScorerJudgeExecutionSuccess } from './base';
 import {
   AsyncFunctionBasedScorerBuilders,
   FunctionBasedScorerBuilders,
@@ -137,7 +137,9 @@ function createMockSpan(traceId: string, type: SpanType) {
 function createMockMastra(options?: { addScoreImpl?: ReturnType<typeof vi.fn>; startSpan?: () => unknown }) {
   const logger = {
     debug: vi.fn(),
+    error: vi.fn(),
     warn: vi.fn(),
+    trackException: vi.fn(),
   };
 
   return {
@@ -272,7 +274,12 @@ describe('createScorer', () => {
       expect(Object.keys(result.judge ?? {})).toEqual(['preprocess', 'analyze', 'generateReason']);
 
       const preprocessExecution = result.judge?.preprocess?.executions[0];
-      expectTypeOf(preprocessExecution).toEqualTypeOf<ScorerJudgeExecutionSuccess | undefined>();
+      expect(preprocessExecution?.status).toBe('success');
+      if (preprocessExecution?.status === 'success') {
+        expectTypeOf(preprocessExecution).toEqualTypeOf<ScorerJudgeExecutionSuccess>();
+        expectTypeOf(preprocessExecution.output).not.toBeUndefined();
+        expectTypeOf(preprocessExecution.usage).not.toBeUndefined();
+      }
       expect(preprocessExecution).toMatchObject({
         status: 'success',
         prompt: 'Test Preprocess prompt',
@@ -981,7 +988,7 @@ describe('createScorer', () => {
       }
     });
 
-    it('propagates caller onFinish callback errors from the judge invocation', async () => {
+    it('propagates caller onFinish callback errors while retaining completed judge telemetry', async () => {
       const model = createJudgeModel([JSON.stringify({ score: 1 })]).model;
       const callbackError = new Error('judge finish callback failed');
       const onFinish = vi.fn(async () => {
@@ -989,10 +996,28 @@ describe('createScorer', () => {
       });
       const streamSpy = vi.spyOn(Agent.prototype, 'stream').mockImplementation((async (...args: any[]) => {
         const options = args[1];
-        await options.onFinish({
+        const completedStep = {
           model: { modelId: 'mock-model-id', provider: 'mock-provider' },
-        });
-        throw new Error('unreachable');
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          finishReason: 'stop',
+          text: JSON.stringify({ score: 1 }),
+        };
+
+        return {
+          object: Promise.resolve({ score: 1 }),
+          text: Promise.resolve(completedStep.text),
+          totalUsage: Promise.resolve(completedStep.usage),
+          steps: Promise.resolve([completedStep]),
+          finishReason: Promise.resolve(completedStep.finishReason),
+          consumeStream: async () => {
+            await options.onStepFinish(completedStep);
+            await options.onFinish({
+              ...completedStep,
+              steps: [completedStep],
+              totalUsage: completedStep.usage,
+            });
+          },
+        };
       }) as any);
 
       try {
@@ -1002,7 +1027,23 @@ describe('createScorer', () => {
           judge: { model, instructions: 'Return a score.', onFinish },
         }).generateScore({ description: 'score', createPrompt: () => 'score this output' });
 
-        await expect(scorer.run(testData.scoringInput)).rejects.toThrow('judge finish callback failed');
+        const error = await scorer.run(testData.scoringInput).catch(error => error);
+
+        expect(error).toBeInstanceOf(ScorerRunError);
+        expect(error).toMatchObject({ failedStep: 'generateScore', completedSteps: [] });
+        expect(error.result).not.toHaveProperty('score');
+        expect(error.result?.judge?.generateScore?.executions).toHaveLength(1);
+        expect(error.result?.judge?.generateScore?.executions[0]).toMatchObject({
+          status: 'failed',
+          prompt: 'score this output',
+          output: 1,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          attemptCount: 1,
+          modelCallCount: 1,
+          finishReason: 'stop',
+          rawOutput: JSON.stringify({ score: 1 }),
+          error: { message: 'judge finish callback failed' },
+        });
         expect(onFinish).toHaveBeenCalledTimes(1);
       } finally {
         streamSpy.mockRestore();
@@ -1035,6 +1076,201 @@ describe('createScorer', () => {
         });
       } finally {
         streamSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('Scorer run failures', () => {
+    it('retains analyze output when score generation fails', async () => {
+      const scoreError = new Error('score generation failed');
+      const scorer = createScorer({
+        id: 'analyze-result-failure-scorer',
+        description: 'Retains analyze output on score failure',
+      })
+        .analyze(() => ({ status: false, note: '' }))
+        .generateScore(() => {
+          throw scoreError;
+        });
+
+      const error = await scorer.run({ ...testData.scoringInput, runId: 'failure-run-id' }).catch(error => error);
+
+      expect(error).toBeInstanceOf(ScorerRunError);
+      const scorerError = error as ScorerRunError<any>;
+      expect(scorerError).toMatchObject({
+        id: 'MASTR_SCORER_FAILED_TO_RUN_WORKFLOW_FAILED',
+        domain: 'SCORER',
+        category: 'USER',
+        details: {
+          failedStep: 'generateScore',
+          completedSteps: 'analyze',
+        },
+        failedStep: 'generateScore',
+        completedSteps: ['analyze'],
+      });
+      expect(scorerError.message).toBe('Scorer Run Failed: score generation failed');
+      expect(scorerError.cause).toBeDefined();
+      expect(scorerError.result).toMatchObject({
+        input: testData.scoringInput.input,
+        output: testData.scoringInput.output,
+        analyzeStepResult: { status: false, note: '' },
+        runId: 'failure-run-id',
+      });
+      expect(scorerError.result).not.toHaveProperty('score');
+      expect(scorerError.result).not.toHaveProperty('judge');
+      expect(scorerError).not.toHaveProperty('failedJudgeExecution');
+
+      const serialized = JSON.stringify(scorerError);
+      expect(serialized).not.toContain('analyzeStepResult');
+      expect(JSON.parse(serialized)).not.toHaveProperty('result');
+    });
+
+    it('retains score zero and successful judge entries when reason generation fails', async () => {
+      const { model } = createJudgeModel([
+        JSON.stringify({ score: 0 }),
+        createProviderError(400, false, 'reason provider failed'),
+      ]);
+      const scorer = createScorer({
+        id: 'reason-failure-scorer',
+        description: 'Retains a completed score on reason failure',
+        judge: { model, instructions: 'Evaluate the output.' },
+      })
+        .generateScore({ description: 'score', createPrompt: () => 'score this output' })
+        .generateReason({ description: 'reason', createPrompt: () => 'explain this score' });
+
+      const error = await scorer.run(testData.scoringInput).catch(error => error);
+
+      expect(error).toBeInstanceOf(ScorerRunError);
+      const scorerError = error as ScorerRunError;
+      expect(scorerError.failedStep).toBe('generateReason');
+      expect(scorerError.completedSteps).toEqual(['generateScore']);
+      expect(scorerError.result?.score).toBe(0);
+      expect(scorerError.result?.judge?.generateScore?.executions).toHaveLength(1);
+      expect(scorerError.result?.judge?.generateScore?.executions[0]?.status).toBe('success');
+      expect(scorerError.result?.judge?.generateReason?.executions).toHaveLength(1);
+      const failedExecution = scorerError.result?.judge?.generateReason?.executions[0];
+      expect(failedExecution).toMatchObject({
+        status: 'failed',
+        prompt: 'explain this score',
+        judgeModelId: 'mock-model-id',
+        judgeProvider: 'mock-provider',
+        attemptCount: 1,
+        modelCallCount: 0,
+        error: { message: 'reason provider failed' },
+      });
+      expect(failedExecution).not.toHaveProperty('usage');
+      expect(failedExecution).not.toHaveProperty('output');
+      if (failedExecution?.status === 'failed') {
+        expectTypeOf(failedExecution).toEqualTypeOf<ScorerJudgeExecutionFailure>();
+        expectTypeOf(failedExecution.error).not.toBeUndefined();
+      }
+      const allExecutions = Object.values(scorerError.result?.judge ?? {}).flatMap(step => step.executions);
+      expect(allExecutions.reduce((total, execution) => total + (execution.usage?.inputTokens ?? 0), 0)).toBe(10);
+      expect(scorerError).not.toHaveProperty('failedJudgeExecution');
+    });
+
+    it('does not emit a recovered score to observability', async () => {
+      const mockMastra = createMockMastra();
+      const scorer = createScorer({
+        id: 'recovered-score-observability-scorer',
+        description: 'Does not emit a score from a failed run',
+      })
+        .generateScore(() => 0)
+        .generateReason(() => {
+          throw new Error('reason failed');
+        });
+      scorer.__registerMastra(mockMastra as any);
+
+      const error = await scorer.run(testData.scoringInput).catch(error => error);
+
+      expect(error).toBeInstanceOf(ScorerRunError);
+      expect(error.result?.score).toBe(0);
+      expect(mockMastra.observability.addScore).not.toHaveBeenCalled();
+    });
+
+    it('does not create a result when the first scorer step fails without output', async () => {
+      const scorer = createScorer({
+        id: 'first-step-failure-scorer',
+        description: 'Fails before producing a scorer result',
+      }).generateScore(() => {
+        throw new Error('no score available');
+      });
+
+      const error = await scorer.run(testData.scoringInput).catch(error => error);
+
+      expect(error).toBeInstanceOf(ScorerRunError);
+      expect(error).toMatchObject({
+        failedStep: 'generateScore',
+        completedSteps: [],
+        result: undefined,
+      });
+      expect(error).not.toHaveProperty('failedJudgeExecution');
+    });
+
+    it('records a provider attempt without fabricating completed judge telemetry', async () => {
+      const { model, getCallCount } = createJudgeModel([createProviderError(503, false)]);
+      const scorer = createScorer({
+        id: 'provider-attempt-failure-scorer',
+        description: 'Records an attempted judge invocation',
+        judge: { model, instructions: 'Return a score.' },
+      }).generateScore({ description: 'score', createPrompt: () => 'score this output' });
+
+      const error = await scorer.run(testData.scoringInput).catch(error => error);
+
+      expect(getCallCount()).toBe(1);
+      expect(error).toBeInstanceOf(ScorerRunError);
+      expect(error.result).not.toHaveProperty('score');
+      expect(error.result?.judge?.generateScore?.executions).toHaveLength(1);
+      const failedExecution = error.result?.judge?.generateScore?.executions[0];
+      expect(failedExecution).toMatchObject({
+        status: 'failed',
+        prompt: 'score this output',
+        attemptCount: 1,
+        modelCallCount: 0,
+      });
+      expect(failedExecution).not.toHaveProperty('usage');
+      expect(failedExecution).not.toHaveProperty('output');
+      expect(failedExecution).not.toHaveProperty('rawOutput');
+      expect(failedExecution?.finishReason).toBe('error');
+      expect(failedExecution?.status === 'failed' ? failedExecution.error : undefined).not.toHaveProperty(
+        'responseHeaders',
+      );
+    });
+
+    it('records exhausted fallback attempts as one failed logical judge execution', async () => {
+      const { model, getCallCount } = createJudgeModel(['not valid JSON', 'still not valid JSON']);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        const scorer = createScorer({
+          id: 'fallback-failure-scorer',
+          description: 'Retains completed fallback telemetry on failure',
+          judge: { model, instructions: 'Return a score.' },
+        }).generateScore({ description: 'score', createPrompt: () => 'score this output' });
+
+        const error = await scorer.run(testData.scoringInput).catch(error => error);
+
+        expect(getCallCount()).toBe(2);
+        expect(error).toBeInstanceOf(ScorerRunError);
+        expect(error.result).not.toHaveProperty('score');
+        expect(error.result?.judge?.generateScore?.executions).toHaveLength(1);
+        const failedExecution = error.result?.judge?.generateScore?.executions[0];
+        expect(failedExecution).toMatchObject({
+          status: 'failed',
+          prompt: 'score this output',
+          usage: { inputTokens: 20, outputTokens: 40, totalTokens: 60 },
+          attemptCount: 2,
+          modelCallCount: 2,
+          durationMs: expect.any(Number),
+          finishReason: 'error',
+          rawOutput: 'still not valid JSON',
+        });
+        expect(Number.isInteger(failedExecution?.durationMs)).toBe(true);
+        const serialized = JSON.stringify(error);
+        expect(JSON.parse(serialized)).not.toHaveProperty('result');
+        expect(serialized).not.toContain('score this output');
+        expect(serialized).not.toContain('still not valid JSON');
+      } finally {
+        warnSpy.mockRestore();
       }
     });
   });

--- a/packages/core/src/evals/base.test.ts
+++ b/packages/core/src/evals/base.test.ts
@@ -1236,6 +1236,41 @@ describe('createScorer', () => {
       );
     });
 
+    it('records a rejected fallback attempt without fabricating another model call', async () => {
+      const { model, getCallCount } = createJudgeModel([
+        'not valid JSON',
+        createProviderError(503, false, 'fallback provider failed'),
+      ]);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        const scorer = createScorer({
+          id: 'fallback-provider-failure-scorer',
+          description: 'Separates attempted fallback invocations from completed model calls',
+          judge: { model, instructions: 'Return a score.' },
+        }).generateScore({ description: 'score', createPrompt: () => 'score this output' });
+
+        const error = await scorer.run(testData.scoringInput).catch(error => error);
+
+        expect(getCallCount()).toBe(2);
+        expect(error).toBeInstanceOf(ScorerRunError);
+        expect(error.result).not.toHaveProperty('score');
+        expect(error.result?.judge?.generateScore?.executions).toHaveLength(1);
+        const failedExecution = error.result?.judge?.generateScore?.executions[0];
+        expect(failedExecution).toMatchObject({
+          status: 'failed',
+          prompt: 'score this output',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          attemptCount: 2,
+          modelCallCount: 1,
+          rawOutput: 'not valid JSON',
+        });
+        expect(failedExecution).not.toHaveProperty('output');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it('records exhausted fallback attempts as one failed logical judge execution', async () => {
       const { model, getCallCount } = createJudgeModel(['not valid JSON', 'still not valid JSON']);
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -261,7 +261,8 @@ type GenerateReasonContext<TAccumulated extends Record<string, any>, TInput, TRu
   score: TAccumulated extends Record<'generateScoreStepResult', infer TScore> ? TScore : never;
 };
 
-export type ScorerJudgeStepName = 'preprocess' | 'analyze' | 'generateScore' | 'generateReason';
+export type ScorerStepName = 'preprocess' | 'analyze' | 'generateScore' | 'generateReason';
+export type ScorerJudgeStepName = ScorerStepName;
 
 export interface ScorerJudgeUsage {
   inputTokens?: number;
@@ -294,7 +295,22 @@ export interface ScorerJudgeExecutionSuccess extends ScorerJudgeExecutionBase {
   cost?: ScorerJudgeCost;
 }
 
-export type ScorerJudgeExecution = ScorerJudgeExecutionSuccess;
+export interface ScorerJudgeErrorSummary {
+  name: string;
+  message: string;
+  code?: string;
+}
+
+export interface ScorerJudgeExecutionFailure extends ScorerJudgeExecutionBase {
+  status: 'failed';
+  output?: JSONValue;
+  rawOutput?: string;
+  usage?: ScorerJudgeUsage;
+  finishReason?: string;
+  error: ScorerJudgeErrorSummary;
+}
+
+export type ScorerJudgeExecution = ScorerJudgeExecutionSuccess | ScorerJudgeExecutionFailure;
 
 export interface ScorerJudgeStepResult {
   executions: ScorerJudgeExecution[];
@@ -325,6 +341,50 @@ export type ScorerRunResult<
 
   judge?: ScorerJudgeResults;
 } & { runId: string };
+
+export type ScorerRunResultSnapshot<TResult extends ScorerRunResult = ScorerRunResult> = Omit<TResult, 'score'> &
+  Partial<Pick<TResult, 'score'>>;
+
+export interface ScorerRunErrorOptions<TResult extends ScorerRunResult = ScorerRunResult> {
+  scorerId: string;
+  steps: ScorerStepName[];
+  failedStep: ScorerStepName;
+  completedSteps: ScorerStepName[];
+  result?: ScorerRunResultSnapshot<TResult>;
+  cause: unknown;
+}
+
+export class ScorerRunError<TResult extends ScorerRunResult = ScorerRunResult> extends MastraError {
+  public readonly failedStep: ScorerStepName;
+  public readonly completedSteps: ScorerStepName[];
+  public readonly result?: ScorerRunResultSnapshot<TResult>;
+
+  constructor(options: ScorerRunErrorOptions<TResult>) {
+    const cause = getErrorFromUnknown(options.cause, {
+      fallbackMessage: 'Scorer workflow failed',
+    });
+
+    super(
+      {
+        id: 'MASTR_SCORER_FAILED_TO_RUN_WORKFLOW_FAILED',
+        domain: ErrorDomain.SCORER,
+        category: ErrorCategory.USER,
+        text: `Scorer Run Failed: ${cause.message}`,
+        details: {
+          scorerId: options.scorerId,
+          steps: options.steps.join(', '),
+          failedStep: options.failedStep,
+          completedSteps: options.completedSteps.join(', '),
+        },
+      },
+      cause,
+    );
+
+    this.failedStep = options.failedStep;
+    this.completedSteps = options.completedSteps;
+    this.result = options.result;
+  }
+}
 
 const jsonValueSchema: z.ZodType<JSONValue> = z.lazy(() =>
   z.union([
@@ -365,8 +425,32 @@ const scorerJudgeExecutionSuccessSchema = z.object({
     .optional(),
 });
 
+const scorerJudgeExecutionFailureSchema = z.object({
+  status: z.literal('failed'),
+  prompt: z.string(),
+  output: jsonValueSchema.optional(),
+  rawOutput: z.string().optional(),
+  judgeModelId: z.string(),
+  judgeProvider: z.string().optional(),
+  usage: scorerJudgeUsageSchema.optional(),
+  attemptCount: z.number().int().positive(),
+  modelCallCount: z.number().int().nonnegative(),
+  durationMs: z.number().int().nonnegative(),
+  finishReason: z.string().optional(),
+  error: z.object({
+    name: z.string(),
+    message: z.string(),
+    code: z.string().optional(),
+  }),
+});
+
+const scorerJudgeExecutionSchema = z.discriminatedUnion('status', [
+  scorerJudgeExecutionSuccessSchema,
+  scorerJudgeExecutionFailureSchema,
+]);
+
 const scorerJudgeStepResultSchema = z.object({
-  executions: z.array(scorerJudgeExecutionSuccessSchema),
+  executions: z.array(scorerJudgeExecutionSchema),
 });
 
 const scorerJudgeResultsSchema = z.object({

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -36,7 +36,7 @@ import type {
 import { RequestContext } from '../request-context';
 import type { PublicSchema } from '../schema';
 import { toStandardSchema, standardSchemaToJSONSchema } from '../schema';
-import type { JSONValue, LanguageModelUsage, MastraOnFinishCallback } from '../stream';
+import type { JSONValue, MastraOnFinishCallback } from '../stream';
 import type { MastraOnStepFinishCallback } from '../stream/types';
 import { createWorkflow } from '../workflows/create';
 import { createStep } from '../workflows/workflow';
@@ -263,6 +263,17 @@ type GenerateReasonContext<TAccumulated extends Record<string, any>, TInput, TRu
 
 export type ScorerStepName = 'preprocess' | 'analyze' | 'generateScore' | 'generateReason';
 export type ScorerJudgeStepName = ScorerStepName;
+
+const scorerStepNames = [
+  'preprocess',
+  'analyze',
+  'generateScore',
+  'generateReason',
+] as const satisfies readonly ScorerStepName[];
+
+function isScorerStepName(stepName: unknown): stepName is ScorerStepName {
+  return typeof stepName === 'string' && (scorerStepNames as readonly string[]).includes(stepName);
+}
 
 export interface ScorerJudgeUsage {
   inputTokens?: number;
@@ -507,9 +518,99 @@ function addScorerJudgeUsage(accumulated: ScorerJudgeUsage, usage: ScorerJudgeUs
 interface ScorerJudgeTelemetryAccumulator {
   usage: ScorerJudgeUsage;
   attemptCount: number;
+  completedAttemptCount: number;
   modelCallCount: number;
   judgeModelId?: string;
   judgeProvider?: string;
+  rawOutput?: string;
+  finishReason?: string;
+}
+
+const failedJudgeExecutionKey = '__mastraScorerFailedJudgeExecution';
+const failedScorerStepKey = '__mastraScorerFailedStep';
+
+function toScorerJudgeErrorSummary(error: unknown): ScorerJudgeErrorSummary {
+  const normalizedError = getErrorFromUnknown(error, {
+    fallbackMessage: 'Judge execution failed',
+    supportSerialization: false,
+  });
+  const errorRecord = error && typeof error === 'object' ? (error as Record<string, unknown>) : undefined;
+  const code =
+    typeof errorRecord?.id === 'string'
+      ? errorRecord.id
+      : typeof errorRecord?.code === 'string'
+        ? errorRecord.code
+        : undefined;
+
+  return {
+    name: normalizedError.name,
+    message: normalizedError.message,
+    ...(code ? { code } : {}),
+  };
+}
+
+function attachFailedJudgeExecution(error: unknown, execution: ScorerJudgeExecutionFailure): Error {
+  const normalizedError = getErrorFromUnknown(error, {
+    fallbackMessage: 'Judge execution failed',
+  });
+  const transportError = new Error(normalizedError.message, { cause: normalizedError });
+  transportError.name = normalizedError.name;
+  Object.defineProperty(transportError, failedJudgeExecutionKey, {
+    value: execution,
+    enumerable: true,
+    configurable: true,
+  });
+  return transportError;
+}
+
+function takeFailedJudgeExecution(error: unknown): ScorerJudgeExecutionFailure | undefined {
+  const visited = new Set<object>();
+  let current = error;
+
+  while (current && typeof current === 'object' && !visited.has(current)) {
+    visited.add(current);
+    const errorRecord = current as Record<string, unknown>;
+    if (failedJudgeExecutionKey in errorRecord) {
+      const execution = errorRecord[failedJudgeExecutionKey] as ScorerJudgeExecutionFailure | undefined;
+      delete errorRecord[failedJudgeExecutionKey];
+      return execution;
+    }
+    current = errorRecord.cause;
+  }
+
+  return undefined;
+}
+
+function attachFailedScorerStep(error: unknown, failedStep: ScorerStepName): Error {
+  const normalizedError = getErrorFromUnknown(error, {
+    fallbackMessage: 'Scorer step failed',
+  });
+  const transportError = new Error(normalizedError.message, { cause: normalizedError });
+  transportError.name = normalizedError.name;
+  Object.defineProperty(transportError, failedScorerStepKey, {
+    value: failedStep,
+    enumerable: true,
+    configurable: true,
+  });
+  return transportError;
+}
+
+function takeFailedScorerStep(error: unknown): ScorerStepName | undefined {
+  const visited = new Set<object>();
+  let current = error;
+
+  while (current && typeof current === 'object' && !visited.has(current)) {
+    visited.add(current);
+    const errorRecord = current as Record<string, unknown>;
+    if (failedScorerStepKey in errorRecord) {
+      const failedStep = errorRecord[failedScorerStepKey];
+      delete errorRecord[failedScorerStepKey];
+      return isScorerStepName(failedStep) ? failedStep : undefined;
+    }
+    current = errorRecord.cause;
+  }
+
+  return undefined;
 }
 
 // Conditional type for PromptObject context
@@ -880,7 +981,28 @@ class MastraScorer<
           }),
       });
     } catch (error) {
-      evalSpan?.error({ error: error as Error, endSpan: true });
+      const workflowFailure = getErrorFromUnknown(error, {
+        fallbackMessage: 'Scorer workflow failed',
+      });
+      const failedJudgeExecution = takeFailedJudgeExecution(workflowFailure);
+      const failedStep = takeFailedScorerStep(workflowFailure);
+      evalSpan?.error({ error: workflowFailure, endSpan: true });
+      if (failedStep) {
+        const finalStepResult = failedJudgeExecution
+          ? this.appendFailedJudgeExecution(undefined, failedStep, failedJudgeExecution)
+          : undefined;
+        const result = this.hasScorerResultFields(finalStepResult)
+          ? this.transformToScorerResult({ finalStepResult, originalInput: run })
+          : undefined;
+        throw new ScorerRunError<ScorerRunResult<TAccumulatedResults, TInput, TRunOutput>>({
+          scorerId: this.config.id ?? this.config.name,
+          steps: this.steps.map(step => step.name).filter(isScorerStepName),
+          failedStep,
+          completedSteps: [],
+          ...(result ? { result } : {}),
+          cause: workflowFailure,
+        });
+      }
       throw error;
     }
 
@@ -888,23 +1010,50 @@ class MastraScorer<
       const workflowFailure = getErrorFromUnknown(workflowResult.error, {
         fallbackMessage: 'Scorer workflow failed',
       });
+      const failedJudgeExecution = takeFailedJudgeExecution(workflowFailure);
+      const failedStepFromError = takeFailedScorerStep(workflowFailure);
+      const failureState = this.getWorkflowFailureState(workflowResult);
+      const failedStep = failedStepFromError ?? failureState.failedStep;
+      const { completedSteps, latestSuccessfulOutput } = failureState;
       evalSpan?.error({ error: workflowFailure, endSpan: true });
-      throw new MastraError(
-        {
-          id: 'MASTR_SCORER_FAILED_TO_RUN_WORKFLOW_FAILED',
-          domain: ErrorDomain.SCORER,
-          category: ErrorCategory.USER,
-          text: `Scorer Run Failed: ${workflowFailure.message}`,
-          details: {
-            scorerId: this.config.id ?? this.config.name,
-            steps: this.steps.map(s => s.name).join(', '),
+
+      if (!failedStep) {
+        throw new MastraError(
+          {
+            id: 'MASTR_SCORER_FAILED_TO_RUN_WORKFLOW_FAILED',
+            domain: ErrorDomain.SCORER,
+            category: ErrorCategory.USER,
+            text: `Scorer Run Failed: ${workflowFailure.message}`,
+            details: {
+              scorerId: this.config.id ?? this.config.name,
+              steps: this.steps.map(s => s.name).join(', '),
+            },
           },
-        },
-        workflowFailure,
-      );
+          workflowFailure,
+        );
+      }
+
+      const finalStepResult = failedJudgeExecution
+        ? this.appendFailedJudgeExecution(latestSuccessfulOutput, failedStep, failedJudgeExecution)
+        : latestSuccessfulOutput;
+      const result = this.hasScorerResultFields(finalStepResult)
+        ? this.transformToScorerResult({ finalStepResult, originalInput: run })
+        : undefined;
+      throw new ScorerRunError<ScorerRunResult<TAccumulatedResults, TInput, TRunOutput>>({
+        scorerId: this.config.id ?? this.config.name,
+        steps: this.steps.map(step => step.name).filter(isScorerStepName),
+        failedStep,
+        completedSteps,
+        ...(result ? { result } : {}),
+        cause: workflowFailure,
+      });
     }
 
-    const scorerResult = this.transformToScorerResult({ workflowResult, originalInput: run });
+    const scorerResult = this.transformToScorerResult({
+      finalStepResult: 'result' in workflowResult ? workflowResult.result : undefined,
+      originalInput: run,
+      includeUndefinedFields: true,
+    });
     evalSpan?.end({
       output: {
         success: true,
@@ -1044,7 +1193,7 @@ class MastraScorer<
             });
           } catch (error) {
             stepSpan?.error({ error: error as Error, endSpan: true });
-            throw error;
+            throw attachFailedScorerStep(error, scorerStep.name as ScorerStepName);
           }
 
           if (prompt !== undefined || judgeModel !== undefined) {
@@ -1214,6 +1363,7 @@ class MastraScorer<
     const telemetry: ScorerJudgeTelemetryAccumulator = {
       usage: {},
       attemptCount: 0,
+      completedAttemptCount: 0,
       modelCallCount: 0,
       judgeModelId: judgeModel,
       judgeProvider: resolvedModel.provider,
@@ -1221,31 +1371,82 @@ class MastraScorer<
     let pendingStepUsage: ScorerJudgeUsage = {};
     let pendingStepCount = 0;
     let completedOnFinishCount = 0;
-    const recordCurrentUsage = (usage: LanguageModelUsage) => {
-      addScorerJudgeUsage(telemetry.usage, normalizeScorerJudgeUsage(usage));
+    let validatedOutput: JSONValue | undefined;
+    const recordAttempt = () => {
+      telemetry.attemptCount += 1;
     };
     const recordStreamResult = async (result: Awaited<ReturnType<Agent['stream']>>) => {
+      let consumeError: unknown;
       if (typeof result.consumeStream === 'function') {
-        await result.consumeStream();
+        try {
+          await result.consumeStream();
+        } catch (error) {
+          consumeError = error;
+        }
       }
-      const [totalUsageResult, stepsResult] = await Promise.allSettled([result.totalUsage, result.steps]);
+      const [totalUsageResult, stepsResult, textResult, finishReasonResult, objectResult] = await Promise.allSettled([
+        result.totalUsage,
+        result.steps,
+        result.text,
+        result.finishReason,
+        result.object,
+      ]);
       const totalUsage = totalUsageResult.status === 'fulfilled' ? totalUsageResult.value : undefined;
       const steps = stepsResult.status === 'fulfilled' && Array.isArray(stepsResult.value) ? stepsResult.value : [];
+      const rawOutput = textResult.status === 'fulfilled' ? textResult.value : undefined;
+      const finishReason = finishReasonResult.status === 'fulfilled' ? finishReasonResult.value : undefined;
+      const object = objectResult.status === 'fulfilled' ? objectResult.value : undefined;
+      if (scorerStep.name === 'generateReason' && typeof rawOutput === 'string') {
+        validatedOutput = rawOutput;
+      } else if (scorerStep.name === 'generateScore' && object && typeof object === 'object' && 'score' in object) {
+        const score = (object as { score?: unknown }).score;
+        if (typeof score === 'number') {
+          validatedOutput = score;
+        }
+      } else if (object !== undefined) {
+        validatedOutput = object as JSONValue;
+      }
+      const lastStep = steps.at(-1) as Record<string, unknown> | undefined;
+      const modelFinishReason = typeof lastStep?.finishReason === 'string' ? lastStep.finishReason : finishReason;
+      const completedUsage = totalUsage ?? pendingStepUsage;
+      const normalizedCompletedUsage = normalizeScorerJudgeUsage(completedUsage);
+      const hasReportedUsage = Object.values(normalizedCompletedUsage).some(value => value !== undefined && value > 0);
+      const hasRawOutput = typeof rawOutput === 'string' && rawOutput.length > 0;
+      const hasCompletedModelEvidence =
+        (consumeError === undefined || pendingStepCount > 0) &&
+        (pendingStepCount > 0 ||
+          hasReportedUsage ||
+          hasRawOutput ||
+          Boolean(modelFinishReason && modelFinishReason !== 'error'));
 
-      telemetry.attemptCount += 1;
-      telemetry.modelCallCount += Math.max(steps.length, pendingStepCount, 1);
-      if (totalUsage) {
-        recordCurrentUsage(totalUsage);
-      } else {
-        addScorerJudgeUsage(telemetry.usage, pendingStepUsage);
+      if (hasCompletedModelEvidence) {
+        telemetry.completedAttemptCount += 1;
+        telemetry.modelCallCount += Math.max(steps.length, pendingStepCount, 1);
+        addScorerJudgeUsage(telemetry.usage, normalizedCompletedUsage);
+        if (typeof rawOutput === 'string') {
+          telemetry.rawOutput = rawOutput;
+        }
+      }
+      if (
+        typeof modelFinishReason === 'string' &&
+        (modelFinishReason !== 'error' || telemetry.finishReason === undefined)
+      ) {
+        telemetry.finishReason = modelFinishReason;
       }
 
-      if (completedOnFinishCount < telemetry.attemptCount) {
+      pendingStepUsage = {};
+      pendingStepCount = 0;
+
+      if (consumeError) {
+        throw consumeError;
+      }
+
+      if (completedOnFinishCount < telemetry.completedAttemptCount) {
         const lastStep = steps.at(-1);
         const finishEvent = {
           ...(lastStep ?? {}),
           steps,
-          totalUsage: totalUsage ?? pendingStepUsage,
+          totalUsage: completedUsage,
           model: {
             modelId: telemetry.judgeModelId ?? judgeModel,
             provider: telemetry.judgeProvider,
@@ -1254,12 +1455,9 @@ class MastraScorer<
         completedOnFinishCount += 1;
         await onFinish?.(finishEvent);
       }
-
-      pendingStepUsage = {};
-      pendingStepCount = 0;
     };
     const recordLegacyUsage = (usage: unknown, steps: unknown) => {
-      telemetry.attemptCount += 1;
+      telemetry.completedAttemptCount += 1;
       telemetry.modelCallCount += Array.isArray(steps) ? Math.max(steps.length, 1) : 1;
       addScorerJudgeUsage(telemetry.usage, normalizeScorerJudgeUsage(usage));
     };
@@ -1274,6 +1472,51 @@ class MastraScorer<
       modelCallCount: Math.max(telemetry.modelCallCount, 1),
       durationMs: Math.round(performance.now() - startedAt),
     });
+    const createFailedExecution = (error: unknown): ScorerJudgeExecutionFailure | undefined => {
+      if (telemetry.attemptCount === 0) {
+        return undefined;
+      }
+
+      const usage = { ...telemetry.usage };
+      let modelCallCount = telemetry.modelCallCount;
+      let rawOutput = telemetry.rawOutput;
+      let finishReason = telemetry.finishReason;
+      const hasUnrecordedAttempt = telemetry.completedAttemptCount < telemetry.attemptCount;
+
+      if (hasUnrecordedAttempt) {
+        const errorRecord = error && typeof error === 'object' ? (error as Record<string, unknown>) : undefined;
+        const errorUsage = normalizeScorerJudgeUsage(errorRecord?.usage);
+        const unrecordedUsage = Object.keys(errorUsage).length > 0 ? errorUsage : pendingStepUsage;
+        addScorerJudgeUsage(usage, unrecordedUsage);
+        if (typeof errorRecord?.text === 'string') {
+          rawOutput = errorRecord.text;
+        }
+        if (typeof errorRecord?.finishReason === 'string') {
+          finishReason = errorRecord.finishReason;
+        }
+        const hasCompletedModelEvidence =
+          pendingStepCount > 0 ||
+          Object.keys(unrecordedUsage).length > 0 ||
+          rawOutput !== telemetry.rawOutput ||
+          finishReason !== telemetry.finishReason;
+        modelCallCount += Math.max(pendingStepCount, hasCompletedModelEvidence ? 1 : 0);
+      }
+
+      return {
+        status: 'failed',
+        prompt,
+        judgeModelId: telemetry.judgeModelId ?? judgeModel,
+        ...(telemetry.judgeProvider ? { judgeProvider: telemetry.judgeProvider } : {}),
+        ...(validatedOutput !== undefined ? { output: validatedOutput } : {}),
+        ...(Object.keys(usage).length > 0 ? { usage } : {}),
+        attemptCount: telemetry.attemptCount,
+        modelCallCount,
+        durationMs: Math.round(performance.now() - startedAt),
+        ...(finishReason ? { finishReason } : {}),
+        ...(rawOutput !== undefined ? { rawOutput } : {}),
+        error: toScorerJudgeErrorSummary(error),
+      };
+    };
 
     const judge = new Agent({
       id: 'judge',
@@ -1299,13 +1542,22 @@ class MastraScorer<
     const createJudgeStreamRunOptions = () => ({
       ...judgeRunOptions,
       onStepFinish: async (event: Parameters<MastraOnStepFinishCallback<unknown>>[0]) => {
-        pendingStepCount += 1;
-        addScorerJudgeUsage(pendingStepUsage, normalizeScorerJudgeUsage(event.usage));
+        const eventRecord = event as unknown as Record<string, unknown>;
+        if (eventRecord.finishReason !== 'error') {
+          pendingStepCount += 1;
+          addScorerJudgeUsage(pendingStepUsage, normalizeScorerJudgeUsage(event.usage));
+          if (typeof eventRecord.text === 'string') {
+            telemetry.rawOutput = eventRecord.text;
+          }
+        }
         if (event.model?.modelId) {
           telemetry.judgeModelId = event.model.modelId;
         }
         if (event.model?.provider) {
           telemetry.judgeProvider = event.model.provider;
+        }
+        if (typeof eventRecord.finishReason === 'string') {
+          telemetry.finishReason = eventRecord.finishReason;
         }
         await onStepFinish?.(event);
       },
@@ -1317,109 +1569,241 @@ class MastraScorer<
         if (event.model?.provider) {
           telemetry.judgeProvider = event.model.provider;
         }
+        const eventRecord = event as unknown as Record<string, unknown>;
+        if (eventRecord.finishReason !== 'error') {
+          if (Object.keys(pendingStepUsage).length === 0) {
+            addScorerJudgeUsage(pendingStepUsage, normalizeScorerJudgeUsage(eventRecord.totalUsage));
+          }
+          if (Array.isArray(eventRecord.steps)) {
+            pendingStepCount = Math.max(pendingStepCount, eventRecord.steps.length);
+          }
+          if (typeof eventRecord.text === 'string') {
+            telemetry.rawOutput = eventRecord.text;
+          }
+        }
+        if (
+          typeof eventRecord.finishReason === 'string' &&
+          (eventRecord.finishReason !== 'error' || telemetry.finishReason === undefined)
+        ) {
+          telemetry.finishReason = eventRecord.finishReason;
+        }
         await onFinish?.(event);
       },
     });
 
-    // GenerateScore output must be a number
-    if (scorerStep.name === 'generateScore') {
-      let result;
-      if (isSupportedLanguageModel(resolvedModel)) {
-        result = await tryStreamWithJsonFallback(judge, prompt, {
-          structuredOutput: {
-            schema: z.object({ score: z.number() }),
-            jsonPromptInjection,
-          },
-          ...createJudgeStreamRunOptions(),
-          ...(onStream ? { onStream } : {}),
-          onStreamFinish: recordStreamResult,
-        });
-        const object = await result.object;
-        const score = (object as { score: number }).score;
-        return { result: score, prompt, judgeModel, execution: createExecution(score) };
-      } else {
-        const schema = z.object({
-          score: z.number(),
-        });
-        const standardSchema = toStandardSchema(schema as PublicSchema);
-        result = await judge.generateLegacy(prompt, {
-          output: standardSchemaToJSONSchema(standardSchema),
-          ...judgeRunOptions,
-        });
-        recordLegacyUsage(result.usage, (result as { steps?: unknown }).steps);
-        const score = (result.object as { score: number }).score;
-        return { result: score, prompt, judgeModel, execution: createExecution(score) };
-      }
+    try {
+      // GenerateScore output must be a number
+      if (scorerStep.name === 'generateScore') {
+        let result;
+        if (isSupportedLanguageModel(resolvedModel)) {
+          result = await tryStreamWithJsonFallback(judge, prompt, {
+            structuredOutput: {
+              schema: z.object({ score: z.number() }),
+              jsonPromptInjection,
+            },
+            ...createJudgeStreamRunOptions(),
+            ...(onStream ? { onStream } : {}),
+            onStreamAttempt: recordAttempt,
+            onStreamFinish: recordStreamResult,
+          });
+          const object = await result.object;
+          const score = (object as { score: number }).score;
+          return { result: score, prompt, judgeModel, execution: createExecution(score) };
+        } else {
+          const schema = z.object({
+            score: z.number(),
+          });
+          const standardSchema = toStandardSchema(schema as PublicSchema);
+          recordAttempt();
+          result = await judge.generateLegacy(prompt, {
+            output: standardSchemaToJSONSchema(standardSchema),
+            ...judgeRunOptions,
+          });
+          recordLegacyUsage(result.usage, (result as { steps?: unknown }).steps);
+          const score = (result.object as { score: number }).score;
+          return { result: score, prompt, judgeModel, execution: createExecution(score) };
+        }
 
-      // GenerateReason output must be a string
-    } else if (scorerStep.name === 'generateReason') {
-      if (isSupportedLanguageModel(resolvedModel)) {
-        const result = await judge.stream(prompt, createJudgeStreamRunOptions());
-        void onStream?.(result as unknown as Awaited<ReturnType<Agent['stream']>>);
-        const reason = await result.text;
-        await recordStreamResult(result);
+        // GenerateReason output must be a string
+      } else if (scorerStep.name === 'generateReason') {
+        if (isSupportedLanguageModel(resolvedModel)) {
+          recordAttempt();
+          const result = await judge.stream(prompt, createJudgeStreamRunOptions());
+          void onStream?.(result as unknown as Awaited<ReturnType<Agent['stream']>>);
+          const reason = await (async () => {
+            try {
+              return await result.text;
+            } finally {
+              await recordStreamResult(result);
+            }
+          })();
+          return { result: reason, prompt, judgeModel, execution: createExecution(reason) };
+        }
+
+        recordAttempt();
+        const result = await judge.generateLegacy(prompt, judgeRunOptions);
+        recordLegacyUsage(result.usage, (result as { steps?: unknown }).steps);
+        const reason = result.text;
         return { result: reason, prompt, judgeModel, execution: createExecution(reason) };
-      }
-
-      const result = await judge.generateLegacy(prompt, judgeRunOptions);
-      recordLegacyUsage(result.usage, (result as { steps?: unknown }).steps);
-      const reason = await result.text;
-      return { result: reason, prompt, judgeModel, execution: createExecution(reason) };
-    } else {
-      const promptStep = originalStep as PromptObject<any, any, any, TInput, TRunOutput>;
-      // Convert to StandardSchemaWithJSON at runtime to ensure ~standard.jsonSchema is available
-      // Cast to PublicSchema since outputSchema can be any schema type
-      const standardSchema = toStandardSchema(promptStep.outputSchema as PublicSchema);
-      let result;
-      if (isSupportedLanguageModel(resolvedModel)) {
-        // Use type assertion to any to bypass complex type checking - runtime schema is validated by toStandardSchema
-        result = await tryStreamWithJsonFallback(judge, prompt, {
-          structuredOutput: {
-            schema: standardSchema as any,
-            jsonPromptInjection,
-          },
-          ...createJudgeStreamRunOptions(),
-          ...(onStream ? { onStream } : {}),
-          onStreamFinish: recordStreamResult,
-        });
-        const object = (await result.object) as JSONValue;
-        return { result: object, prompt, judgeModel, execution: createExecution(object) };
       } else {
-        result = await judge.generateLegacy(prompt, {
-          output: standardSchemaToJSONSchema(standardSchema),
-          ...judgeRunOptions,
-        });
-        recordLegacyUsage(result.usage, (result as { steps?: unknown }).steps);
-        const object = result.object as JSONValue;
-        return { result: object, prompt, judgeModel, execution: createExecution(object) };
+        const promptStep = originalStep as PromptObject<any, any, any, TInput, TRunOutput>;
+        // Convert to StandardSchemaWithJSON at runtime to ensure ~standard.jsonSchema is available
+        // Cast to PublicSchema since outputSchema can be any schema type
+        const standardSchema = toStandardSchema(promptStep.outputSchema as PublicSchema);
+        let result;
+        if (isSupportedLanguageModel(resolvedModel)) {
+          // Use type assertion to any to bypass complex type checking - runtime schema is validated by toStandardSchema
+          result = await tryStreamWithJsonFallback(judge, prompt, {
+            structuredOutput: {
+              schema: standardSchema as any,
+              jsonPromptInjection,
+            },
+            ...createJudgeStreamRunOptions(),
+            ...(onStream ? { onStream } : {}),
+            onStreamAttempt: recordAttempt,
+            onStreamFinish: recordStreamResult,
+          });
+          const object = (await result.object) as JSONValue;
+          return { result: object, prompt, judgeModel, execution: createExecution(object) };
+        } else {
+          recordAttempt();
+          result = await judge.generateLegacy(prompt, {
+            output: standardSchemaToJSONSchema(standardSchema),
+            ...judgeRunOptions,
+          });
+          recordLegacyUsage(result.usage, (result as { steps?: unknown }).steps);
+          const object = result.object as JSONValue;
+          return { result: object, prompt, judgeModel, execution: createExecution(object) };
+        }
       }
+    } catch (error) {
+      const failedExecution = createFailedExecution(error);
+      if (failedExecution) {
+        throw attachFailedJudgeExecution(error, failedExecution);
+      }
+      throw error;
     }
   }
 
-  private transformToScorerResult({
-    workflowResult,
-    originalInput,
-  }: {
-    workflowResult: any;
-    originalInput: ScorerRun<TInput, TRunOutput> & { runId: string; scoreTraceId?: string };
-  }) {
-    const finalStepResult = workflowResult.result;
-    const accumulatedResults = finalStepResult?.accumulatedResults || {};
-    const generatedPrompts = finalStepResult?.generatedPrompts || {};
+  private appendFailedJudgeExecution(
+    finalStepResult: any,
+    failedStep: ScorerJudgeStepName,
+    failedExecution: ScorerJudgeExecutionFailure,
+  ): any {
     const judge = finalStepResult?.judge as ScorerJudgeResults | undefined;
 
     return {
-      ...originalInput,
-      score: accumulatedResults.generateScoreStepResult,
-      generateScorePrompt: generatedPrompts.generateScorePrompt,
-      reason: accumulatedResults.generateReasonStepResult,
-      generateReasonPrompt: generatedPrompts.generateReasonPrompt,
-      preprocessStepResult: accumulatedResults.preprocessStepResult,
-      preprocessPrompt: generatedPrompts.preprocessPrompt,
-      analyzeStepResult: accumulatedResults.analyzeStepResult,
-      analyzePrompt: generatedPrompts.analyzePrompt,
-      ...(judge && Object.keys(judge).length > 0 ? { judge } : {}),
+      ...(finalStepResult ?? {}),
+      judge: {
+        ...(judge ?? {}),
+        [failedStep]: {
+          executions: [...(judge?.[failedStep]?.executions ?? []), failedExecution],
+        },
+      },
     };
+  }
+
+  private getWorkflowFailureState(workflowResult: any): {
+    failedStep?: ScorerStepName;
+    completedSteps: ScorerStepName[];
+    latestSuccessfulOutput?: unknown;
+  } {
+    const configuredSteps = this.steps.map(step => step.name).filter(isScorerStepName);
+    const executionPath: ScorerStepName[] = Array.isArray(workflowResult.stepExecutionPath)
+      ? [...new Set(workflowResult.stepExecutionPath.filter(isScorerStepName) as ScorerStepName[])]
+      : [];
+    const orderedSteps = executionPath.length > 0 ? executionPath : configuredSteps;
+    const completedSteps: ScorerStepName[] = [];
+    let failedStep: ScorerStepName | undefined;
+    let latestSuccessfulOutput: unknown;
+
+    for (const stepName of orderedSteps) {
+      const stepResult = workflowResult.steps?.[stepName];
+      if (stepResult?.status === 'success') {
+        completedSteps.push(stepName);
+        latestSuccessfulOutput = stepResult.output;
+      } else if (stepResult?.status === 'failed') {
+        failedStep = stepName;
+        break;
+      }
+    }
+
+    failedStep ??= configuredSteps.find(stepName => workflowResult.steps?.[stepName]?.status === 'failed');
+
+    return { failedStep, completedSteps, latestSuccessfulOutput };
+  }
+
+  private hasScorerResultFields(finalStepResult: any): boolean {
+    if (!finalStepResult || typeof finalStepResult !== 'object') {
+      return false;
+    }
+
+    const accumulatedResults = finalStepResult.accumulatedResults ?? {};
+    const generatedPrompts = finalStepResult.generatedPrompts ?? {};
+    const judge = finalStepResult.judge as ScorerJudgeResults | undefined;
+
+    return (
+      [
+        accumulatedResults.generateScoreStepResult,
+        accumulatedResults.generateReasonStepResult,
+        accumulatedResults.preprocessStepResult,
+        accumulatedResults.analyzeStepResult,
+        generatedPrompts.generateScorePrompt,
+        generatedPrompts.generateReasonPrompt,
+        generatedPrompts.preprocessPrompt,
+        generatedPrompts.analyzePrompt,
+      ].some(value => value !== undefined) || Boolean(judge && Object.keys(judge).length > 0)
+    );
+  }
+
+  private transformToScorerResult({
+    finalStepResult,
+    originalInput,
+    includeUndefinedFields = false,
+  }: {
+    finalStepResult: any;
+    originalInput: ScorerRun<TInput, TRunOutput> & { runId: string; scoreTraceId?: string };
+    includeUndefinedFields?: boolean;
+  }): ScorerRunResult<TAccumulatedResults, TInput, TRunOutput> {
+    const accumulatedResults = finalStepResult?.accumulatedResults ?? {};
+    const generatedPrompts = finalStepResult?.generatedPrompts ?? {};
+    const judge = finalStepResult?.judge as ScorerJudgeResults | undefined;
+    const score = accumulatedResults.generateScoreStepResult;
+    const reason = accumulatedResults.generateReasonStepResult;
+    const preprocessStepResult = accumulatedResults.preprocessStepResult;
+    const analyzeStepResult = accumulatedResults.analyzeStepResult;
+    const generateScorePrompt = generatedPrompts.generateScorePrompt;
+    const generateReasonPrompt = generatedPrompts.generateReasonPrompt;
+    const preprocessPrompt = generatedPrompts.preprocessPrompt;
+    const analyzePrompt = generatedPrompts.analyzePrompt;
+
+    if (includeUndefinedFields) {
+      return {
+        ...originalInput,
+        score,
+        generateScorePrompt,
+        reason,
+        generateReasonPrompt,
+        preprocessStepResult,
+        preprocessPrompt,
+        analyzeStepResult,
+        analyzePrompt,
+        ...(judge && Object.keys(judge).length > 0 ? { judge } : {}),
+      } as ScorerRunResult<TAccumulatedResults, TInput, TRunOutput>;
+    }
+
+    return {
+      ...originalInput,
+      ...(score !== undefined ? { score } : {}),
+      ...(generateScorePrompt !== undefined ? { generateScorePrompt } : {}),
+      ...(reason !== undefined ? { reason } : {}),
+      ...(generateReasonPrompt !== undefined ? { generateReasonPrompt } : {}),
+      ...(preprocessStepResult !== undefined ? { preprocessStepResult } : {}),
+      ...(preprocessPrompt !== undefined ? { preprocessPrompt } : {}),
+      ...(analyzeStepResult !== undefined ? { analyzeStepResult } : {}),
+      ...(analyzePrompt !== undefined ? { analyzePrompt } : {}),
+      ...(judge && Object.keys(judge).length > 0 ? { judge } : {}),
+    } as ScorerRunResult<TAccumulatedResults, TInput, TRunOutput>;
   }
 }
 

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -518,7 +518,7 @@ function addScorerJudgeUsage(accumulated: ScorerJudgeUsage, usage: ScorerJudgeUs
 interface ScorerJudgeTelemetryAccumulator {
   usage: ScorerJudgeUsage;
   attemptCount: number;
-  completedAttemptCount: number;
+  recordedAttemptCount: number;
   modelCallCount: number;
   judgeModelId?: string;
   judgeProvider?: string;
@@ -1363,7 +1363,7 @@ class MastraScorer<
     const telemetry: ScorerJudgeTelemetryAccumulator = {
       usage: {},
       attemptCount: 0,
-      completedAttemptCount: 0,
+      recordedAttemptCount: 0,
       modelCallCount: 0,
       judgeModelId: judgeModel,
       judgeProvider: resolvedModel.provider,
@@ -1420,7 +1420,7 @@ class MastraScorer<
           Boolean(modelFinishReason && modelFinishReason !== 'error'));
 
       if (hasCompletedModelEvidence) {
-        telemetry.completedAttemptCount += 1;
+        telemetry.recordedAttemptCount += 1;
         telemetry.modelCallCount += Math.max(steps.length, pendingStepCount, 1);
         addScorerJudgeUsage(telemetry.usage, normalizedCompletedUsage);
         if (typeof rawOutput === 'string') {
@@ -1441,7 +1441,7 @@ class MastraScorer<
         throw consumeError;
       }
 
-      if (completedOnFinishCount < telemetry.completedAttemptCount) {
+      if (completedOnFinishCount < telemetry.recordedAttemptCount) {
         const lastStep = steps.at(-1);
         const finishEvent = {
           ...(lastStep ?? {}),
@@ -1457,7 +1457,7 @@ class MastraScorer<
       }
     };
     const recordLegacyUsage = (usage: unknown, steps: unknown) => {
-      telemetry.completedAttemptCount += 1;
+      telemetry.recordedAttemptCount += 1;
       telemetry.modelCallCount += Array.isArray(steps) ? Math.max(steps.length, 1) : 1;
       addScorerJudgeUsage(telemetry.usage, normalizeScorerJudgeUsage(usage));
     };
@@ -1481,7 +1481,7 @@ class MastraScorer<
       let modelCallCount = telemetry.modelCallCount;
       let rawOutput = telemetry.rawOutput;
       let finishReason = telemetry.finishReason;
-      const hasUnrecordedAttempt = telemetry.completedAttemptCount < telemetry.attemptCount;
+      const hasUnrecordedAttempt = telemetry.recordedAttemptCount < telemetry.attemptCount;
 
       if (hasUnrecordedAttempt) {
         const errorRecord = error && typeof error === 'object' ? (error as Record<string, unknown>) : undefined;


### PR DESCRIPTION
This implements MASTRA-4514. A scorer run still rejects when any stage fails, but the resulting `ScorerRunError` now preserves completed scorer output and identifies the failed and completed stages. Prompt-stage failures are recorded alongside successful judge executions in the same discriminated `ScorerJudgeExecution` history under `result.judge[step].executions`.

```ts
try {
  await scorer.run(input)
} catch (error) {
  if (error instanceof ScorerRunError) {
    const failedExecution = error.result?.judge?.[error.failedStep]?.executions.find(
      execution => execution.status === 'failed',
    )

    console.log(error.result?.score)
    console.log(failedExecution?.error)
    console.log(failedExecution?.usage)
  }
}
```

A successful structured-output fallback remains one `status: 'success'` execution with multiple attempts. Exhausted attempts produce one `status: 'failed'` execution containing only the validated output, raw output, usage, finish reason, attempts, model calls, and normalized error actually observed. Function-stage failures do not fabricate judge evidence, and safe `MastraError` serialization continues to omit the recovered result and judge history.

Completed score and reason values also survive the top-level and workflow-step experiment paths while the scorer result remains errored. Recovered scores are not written to the legacy successful-score store.

This PR is temporarily stacked on the MASTRA-4513 follow-up in #20263, which adds the successful execution discriminant. After #20263 merges, this branch will be rebased onto `main`.

Verified with the focused scorer, utility, and experiment tests; the core typecheck; targeted ESLint; the core build; documentation Remark validation; declaration inspection; and `git diff --check`. Repository-wide docs validation reaches the existing stale sidebar `new` tags for Agent Builder and GitHub integration; those failures are unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a scorer starts working and then crashes halfway, this PR makes sure we keep the parts that already finished (like partial scores and judge attempts) instead of throwing everything away. It also tells you exactly which step failed and includes detailed “what the judge tried” info in the error.

## Summary

- Added `ScorerRunError` that preserves completed scorer progress when `scorer.run()` fails, including `failedStep`, `completedSteps`, and a structured `result` snapshot.
- Extended judge execution modeling to a discriminated union (`success`/`failed`) and documented/validated richer `error.result.judge[...]` evidence, including failed judge attempts and normalized failure details.
- Updated structured-output streaming retries to track attempts via `onStreamAttempt`, ensuring fallback and failure scenarios are represented with the right execution evidence.
- Ensured function-stage scorer failures don’t fabricate judge evidence; only the configured prompt/judge step wrappers contribute judge execution entries.
- Preserved completed score/reason context in top-level and workflow-step experiment results while avoiding persistence of recovered failed-score data to the legacy successful-score store.
- Continued safe error serialization so recovered results and judge history are omitted from standard `MastraError` serialization.
- Updated documentation, types, and tests (core scorer/experiment utilities, streaming fallback behavior, and experiment recovery scenarios) and added a minor `@mastra/core` changeset describing the new failure-result surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->