### PR TITLE
fix(server): honor non-blocking A2A message sends

### DIFF
--- a/.changeset/cold-mammals-turn.md
+++ b/.changeset/cold-mammals-turn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed A2A message/send requests with configuration.blocking set to false so they return a working task while execution continues.

--- a/packages/server/src/server/handlers/a2a.test.ts
+++ b/packages/server/src/server/handlers/a2a.test.ts
@@ -106,6 +106,17 @@ function createStreamResult({
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
 describe('A2A Handler', () => {
   describe('getAgentCardByIdHandler', () => {
     let mockMastra: Mastra;
@@ -376,7 +387,7 @@ describe('A2A Handler', () => {
     it('should return a working task before non-blocking execution completes', async () => {
       const taskId = 'non-blocking-task-id';
       const contextId = 'non-blocking-context-id';
-      const generation = Promise.withResolvers<{ text: string }>();
+      const generation = createDeferred<{ text: string }>();
       const mockAgent = {
         generate: vi.fn().mockReturnValue(generation.promise),
       } as unknown as Agent;
@@ -444,9 +455,65 @@ describe('A2A Handler', () => {
       });
     });
 
+    it('should return an existing working task without starting duplicate non-blocking execution', async () => {
+      const taskId = 'duplicate-non-blocking-task-id';
+      const generation = createDeferred<{ text: string }>();
+      const mockAgent = {
+        generate: vi.fn().mockReturnValue(generation.promise),
+      } as unknown as Agent;
+
+      const firstResponse = await handleMessageSend({
+        requestId: 'first-non-blocking-request-id',
+        params: {
+          message: {
+            messageId: 'first-non-blocking-message-id',
+            taskId,
+            kind: 'message',
+            role: 'user',
+            parts: [{ kind: 'text', text: 'Run once' }],
+          },
+          configuration: { blocking: false },
+        },
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId: 'test-agent',
+        requestContext: new RequestContext(),
+      });
+
+      const duplicateResponse = await handleMessageSend({
+        requestId: 'duplicate-non-blocking-request-id',
+        params: {
+          message: {
+            messageId: 'duplicate-non-blocking-message-id',
+            taskId,
+            kind: 'message',
+            role: 'user',
+            parts: [{ kind: 'text', text: 'Run again' }],
+          },
+          configuration: { blocking: false },
+        },
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId: 'test-agent',
+        requestContext: new RequestContext(),
+      });
+
+      expect(firstResponse.result?.status.state).toBe('working');
+      expect(duplicateResponse.result).toEqual(firstResponse.result);
+      expect(mockAgent.generate).toHaveBeenCalledTimes(1);
+      expect((await mockTaskStore.load({ agentId: 'test-agent', taskId }))?.history).toHaveLength(1);
+
+      generation.resolve({ text: 'Completed once' });
+      await vi.waitFor(async () => {
+        expect(await mockTaskStore.load({ agentId: 'test-agent', taskId })).toMatchObject({
+          status: { state: 'completed' },
+        });
+      });
+    });
+
     it('should persist non-blocking execution failures after returning', async () => {
       const taskId = 'failed-background-task-id';
-      const generation = Promise.withResolvers<{ text: string }>();
+      const generation = createDeferred<{ text: string }>();
       const mockAgent = {
         generate: vi.fn().mockReturnValue(generation.promise),
       } as unknown as Agent;
@@ -486,7 +553,7 @@ describe('A2A Handler', () => {
 
     it('should not overwrite a canceled non-blocking task when execution finishes', async () => {
       const taskId = 'canceled-background-task-id';
-      const generation = Promise.withResolvers<{ text: string }>();
+      const generation = createDeferred<{ text: string }>();
       const mockAgent = {
         generate: vi.fn().mockReturnValue(generation.promise),
       } as unknown as Agent;
@@ -521,11 +588,11 @@ describe('A2A Handler', () => {
       await vi.advanceTimersByTimeAsync(0);
 
       expect((await mockTaskStore.load({ agentId: 'test-agent', taskId }))?.status.state).toBe('canceled');
-      expect(save).toHaveBeenCalledTimes(3);
+      expect(save.mock.calls.some(([{ data }]) => data.status.state === 'completed')).toBe(false);
     });
 
     it('should wait for execution when blocking is true', async () => {
-      const generation = Promise.withResolvers<{ text: string }>();
+      const generation = createDeferred<{ text: string }>();
       const mockAgent = {
         generate: vi.fn().mockReturnValue(generation.promise),
       } as unknown as Agent;
@@ -1310,7 +1377,7 @@ describe('A2A Handler', () => {
         fetch: fetchMock,
         lookup: vi.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]),
       });
-      const generation = Promise.withResolvers<{ text: string }>();
+      const generation = createDeferred<{ text: string }>();
 
       const params: MessageSendParams = {
         message: {

--- a/packages/server/src/server/handlers/a2a.test.ts
+++ b/packages/server/src/server/handlers/a2a.test.ts
@@ -373,6 +373,195 @@ describe('A2A Handler', () => {
       });
     });
 
+    it('should return a working task before non-blocking execution completes', async () => {
+      const taskId = 'non-blocking-task-id';
+      const contextId = 'non-blocking-context-id';
+      const generation = Promise.withResolvers<{ text: string }>();
+      const mockAgent = {
+        generate: vi.fn().mockReturnValue(generation.promise),
+      } as unknown as Agent;
+      const params: MessageSendParams = {
+        message: {
+          messageId: 'non-blocking-message-id',
+          taskId,
+          contextId,
+          kind: 'message',
+          role: 'user',
+          parts: [{ kind: 'text', text: 'Run this in the background' }],
+        },
+        configuration: { blocking: false },
+      };
+      const requestContext = new RequestContext();
+
+      const responsePromise = handleMessageSend({
+        requestId: 'non-blocking-request-id',
+        params,
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId: 'test-agent',
+        requestContext,
+      });
+      let returned = false;
+      void responsePromise.then(() => {
+        returned = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(returned).toBe(true);
+      const response = await responsePromise;
+      expect(response.result).toMatchObject({
+        id: taskId,
+        contextId,
+        status: { state: 'working' },
+      });
+      expect(mockAgent.generate).toHaveBeenCalledWith(expect.any(Array), {
+        runId: taskId,
+        requestContext,
+        threadId: contextId,
+        resourceId: 'test-agent',
+      });
+      expect((await mockTaskStore.load({ agentId: 'test-agent', taskId }))?.status.state).toBe('working');
+
+      generation.resolve({ text: 'Background result' });
+
+      await vi.waitFor(async () => {
+        expect(
+          await handleTaskGet({
+            requestId: 'get-completed-task',
+            taskStore: mockTaskStore,
+            agentId: 'test-agent',
+            taskId,
+          }),
+        ).toMatchObject({
+          result: {
+            id: taskId,
+            contextId,
+            status: { state: 'completed' },
+            artifacts: [{ parts: [{ kind: 'text', text: 'Background result' }] }],
+          },
+        });
+      });
+    });
+
+    it('should persist non-blocking execution failures after returning', async () => {
+      const taskId = 'failed-background-task-id';
+      const generation = Promise.withResolvers<{ text: string }>();
+      const mockAgent = {
+        generate: vi.fn().mockReturnValue(generation.promise),
+      } as unknown as Agent;
+
+      const response = await handleMessageSend({
+        requestId: 'failed-background-request-id',
+        params: {
+          message: {
+            messageId: 'failed-background-message-id',
+            taskId,
+            kind: 'message',
+            role: 'user',
+            parts: [{ kind: 'text', text: 'Fail later' }],
+          },
+          configuration: { blocking: false },
+        },
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId: 'test-agent',
+        requestContext: new RequestContext(),
+      });
+
+      expect(response.result?.status.state).toBe('working');
+      generation.reject(new Error('Background failure'));
+
+      await vi.waitFor(async () => {
+        expect(await mockTaskStore.load({ agentId: 'test-agent', taskId })).toMatchObject({
+          status: {
+            state: 'failed',
+            message: {
+              parts: [{ kind: 'text', text: 'Handler failed: Background failure' }],
+            },
+          },
+        });
+      });
+    });
+
+    it('should not overwrite a canceled non-blocking task when execution finishes', async () => {
+      const taskId = 'canceled-background-task-id';
+      const generation = Promise.withResolvers<{ text: string }>();
+      const mockAgent = {
+        generate: vi.fn().mockReturnValue(generation.promise),
+      } as unknown as Agent;
+      const save = vi.spyOn(mockTaskStore, 'save');
+
+      await handleMessageSend({
+        requestId: 'canceled-background-request-id',
+        params: {
+          message: {
+            messageId: 'canceled-background-message-id',
+            taskId,
+            kind: 'message',
+            role: 'user',
+            parts: [{ kind: 'text', text: 'Cancel me' }],
+          },
+          configuration: { blocking: false },
+        },
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId: 'test-agent',
+        requestContext: new RequestContext(),
+      });
+
+      await handleTaskCancel({
+        requestId: 'cancel-request-id',
+        taskStore: mockTaskStore,
+        agentId: 'test-agent',
+        taskId,
+      });
+      generation.resolve({ text: 'Too late' });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect((await mockTaskStore.load({ agentId: 'test-agent', taskId }))?.status.state).toBe('canceled');
+      expect(save).toHaveBeenCalledTimes(3);
+    });
+
+    it('should wait for execution when blocking is true', async () => {
+      const generation = Promise.withResolvers<{ text: string }>();
+      const mockAgent = {
+        generate: vi.fn().mockReturnValue(generation.promise),
+      } as unknown as Agent;
+      const responsePromise = handleMessageSend({
+        requestId: 'blocking-request-id',
+        params: {
+          message: {
+            messageId: 'blocking-message-id',
+            kind: 'message',
+            role: 'user',
+            parts: [{ kind: 'text', text: 'Wait for me' }],
+          },
+          configuration: { blocking: true },
+        },
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId: 'test-agent',
+        requestContext: new RequestContext(),
+      });
+      let returned = false;
+      void responsePromise.then(() => {
+        returned = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(returned).toBe(false);
+
+      generation.resolve({ text: 'Blocking result' });
+      await expect(responsePromise).resolves.toMatchObject({
+        result: {
+          status: { state: 'completed' },
+          artifacts: [{ parts: [{ kind: 'text', text: 'Blocking result' }] }],
+        },
+      });
+    });
+
     it('should accept file parts (FileWithUri + FileWithBytes) and pass them through to the converter', async () => {
       // Regression test for the handler-level schema rejecting non-text parts.
       // Pre-fix, params.message.parts was validated as `kind: z.enum(['text'])`
@@ -1121,6 +1310,7 @@ describe('A2A Handler', () => {
         fetch: fetchMock,
         lookup: vi.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]),
       });
+      const generation = Promise.withResolvers<{ text: string }>();
 
       const params: MessageSendParams = {
         message: {
@@ -1131,6 +1321,7 @@ describe('A2A Handler', () => {
           parts: [{ kind: 'text', text: 'Notify me when done' }],
         },
         configuration: {
+          blocking: false,
           pushNotificationConfig: {
             url: 'https://example.com/webhook',
             token: 'notification-token',
@@ -1139,8 +1330,8 @@ describe('A2A Handler', () => {
       };
 
       const mockAgent = mockMastra.getAgentById(agentId);
-      // @ts-expect-error - mockResolvedValue is not available on the Agent class
-      mockAgent.generate.mockResolvedValue({ text: 'Done.' });
+      // @ts-expect-error - mockReturnValue is not available on the Agent class
+      mockAgent.generate.mockReturnValue(generation.promise);
 
       const result = await handleMessageSend({
         requestId,
@@ -1153,7 +1344,8 @@ describe('A2A Handler', () => {
         requestContext: new RequestContext(),
       });
 
-      expect(result.result?.status.state).toBe('completed');
+      expect(result.result?.status.state).toBe('working');
+      expect(fetchMock).not.toHaveBeenCalled();
 
       const storedConfig = pushNotificationStore.get({
         agentId,
@@ -1168,7 +1360,14 @@ describe('A2A Handler', () => {
         },
       });
 
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      generation.resolve({ text: 'Done.' });
+
+      await vi.waitFor(async () => {
+        expect(await mockTaskStore.load({ agentId, taskId })).toMatchObject({
+          status: { state: 'completed' },
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
       expect(fetchMock).toHaveBeenCalledWith(
         'https://93.184.216.34/webhook',
         expect.objectContaining({

--- a/packages/server/src/server/handlers/a2a.ts
+++ b/packages/server/src/server/handlers/a2a.ts
@@ -707,6 +707,10 @@ export async function handleMessageSend({
   const { message, metadata } = params;
   const { contextId } = message;
   const taskId = message.taskId || crypto.randomUUID();
+  const existingTask = await taskStore.load({ agentId, taskId });
+  if (params.configuration?.blocking === false && existingTask?.status.state === 'working') {
+    return createSuccessResponse(requestId, existingTask);
+  }
   const {
     pushNotificationStore: resolvedPushNotificationStore,
     pushNotificationSender: resolvedPushNotificationSender,

--- a/packages/server/src/server/handlers/a2a.ts
+++ b/packages/server/src/server/handlers/a2a.ts
@@ -23,7 +23,7 @@ import { convertToCoreMessage, normalizeError, createSuccessResponse } from '../
 import { DefaultPushNotificationSender } from '../a2a/push-notification-sender';
 import { InMemoryPushNotificationStore } from '../a2a/push-notification-store';
 import type { InMemoryTaskStore } from '../a2a/store';
-import { applyUpdateToTask, createTaskContext, loadOrCreateTask } from '../a2a/tasks';
+import { applyUpdateToTask, loadOrCreateTask } from '../a2a/tasks';
 import {
   a2aAgentIdPathParams,
   agentExecutionBodySchema,
@@ -558,6 +558,129 @@ function getTaskArtifactUpdates({ previous, next }: { previous: Task; next: Task
   }));
 }
 
+async function executeMessageSend({
+  requestId,
+  message,
+  metadata,
+  currentData,
+  taskStore,
+  pushNotificationSender,
+  agent,
+  agentId,
+  logger,
+  requestContext,
+}: {
+  requestId: number | string;
+  message: MessageSendParams['message'];
+  metadata: MessageSendParams['metadata'];
+  currentData: Task;
+  taskStore: InMemoryTaskStore;
+  pushNotificationSender: DefaultPushNotificationSender;
+  agent: Agent;
+  agentId: string;
+  logger?: IMastraLogger;
+  requestContext: RequestContext;
+}) {
+  const { contextId } = message;
+
+  try {
+    // Pass contextId as threadId for memory persistence across A2A conversations
+    // Allow user to pass resourceId via metadata, fall back to agentId
+    const resourceId = (metadata?.resourceId as string) ?? (message.metadata?.resourceId as string) ?? agentId;
+    const result = await agent.generate([convertToCoreMessage(message)], {
+      runId: currentData.id,
+      requestContext,
+      ...(contextId ? { threadId: contextId, resourceId } : {}),
+    });
+
+    const latestTask = await taskStore.load({ agentId, taskId: currentData.id });
+    if (latestTask?.status.state === 'canceled') {
+      return createSuccessResponse(requestId, latestTask);
+    }
+    currentData = latestTask ?? currentData;
+
+    const artifactUpdate = createArtifactUpdate({
+      taskId: currentData.id,
+      contextId: currentData.contextId,
+      text: result.text,
+      data: result.object as Record<string, unknown> | undefined,
+    });
+
+    if (artifactUpdate) {
+      currentData = applyUpdateToTask(currentData, artifactUpdate);
+    }
+
+    const previousTask = currentData;
+    currentData = applyUpdateToTask(currentData, {
+      state: 'completed',
+      message: undefined,
+    });
+
+    // Store execution details in task metadata
+    currentData.metadata = {
+      ...currentData.metadata,
+      execution: {
+        toolCalls: result.toolCalls,
+        toolResults: result.toolResults,
+        usage: result.usage,
+        finishReason: result.finishReason,
+      },
+    };
+
+    await saveTaskAndMaybeSendPushNotification({
+      taskStore,
+      pushNotificationSender,
+      previousTask,
+      nextTask: currentData,
+      agentId,
+      logger,
+    });
+  } catch (handlerError) {
+    const latestTask = await taskStore.load({ agentId, taskId: currentData.id });
+    if (latestTask?.status.state === 'canceled') {
+      return createSuccessResponse(requestId, latestTask);
+    }
+    currentData = latestTask ?? currentData;
+
+    // If handler throws, apply 'failed' status, save, and rethrow
+    const failureStatusUpdate: Omit<TaskStatus, 'timestamp'> = {
+      state: 'failed',
+      message: {
+        messageId: crypto.randomUUID(),
+        role: 'agent',
+        parts: [
+          {
+            kind: 'text',
+            text: `Handler failed: ${handlerError instanceof Error ? handlerError.message : String(handlerError)}`,
+          },
+        ],
+        kind: 'message',
+      },
+    };
+    const previousTask = currentData;
+    currentData = applyUpdateToTask(currentData, failureStatusUpdate);
+
+    try {
+      await saveTaskAndMaybeSendPushNotification({
+        taskStore,
+        pushNotificationSender,
+        previousTask,
+        nextTask: currentData,
+        agentId,
+        logger,
+      });
+    } catch (saveError) {
+      // @ts-expect-error saveError is an unknown error
+      logger?.error(`Failed to save task ${currentData.id} after handler error:`, saveError?.message);
+    }
+
+    return normalizeError(handlerError, requestId, currentData.id, logger); // Rethrow original error
+  }
+
+  // The loop finished, send the final task state
+  return createSuccessResponse(requestId, currentData);
+}
+
 export async function handleMessageSend({
   requestId,
   params,
@@ -592,7 +715,6 @@ export async function handleMessageSend({
     pushNotificationSender,
   });
 
-  // Load or create task
   let currentData = await loadOrCreateTask({
     taskId,
     taskStore,
@@ -609,97 +731,44 @@ export async function handleMessageSend({
     });
   }
 
-  // Use the new TaskContext definition, passing history
-  const context = createTaskContext({
-    task: currentData,
-    userMessage: message,
-    history: currentData.history || [],
-    activeCancellations: taskStore.activeCancellations,
+  currentData = applyUpdateToTask(currentData, {
+    state: 'working',
+    message: {
+      messageId: crypto.randomUUID(),
+      kind: 'message',
+      role: 'agent',
+      parts: [{ kind: 'text', text: 'Generating response...' }],
+    },
+  });
+  await saveTaskAndMaybeSendPushNotification({
+    taskStore,
+    pushNotificationSender: resolvedPushNotificationSender,
+    nextTask: currentData,
+    agentId,
+    logger,
   });
 
-  try {
-    // Pass contextId as threadId for memory persistence across A2A conversations
-    // Allow user to pass resourceId via metadata, fall back to agentId
-    const resourceId = (metadata?.resourceId as string) ?? (message.metadata?.resourceId as string) ?? agentId;
-    const result = await agent.generate([convertToCoreMessage(message)], {
-      runId: taskId,
-      requestContext,
-      ...(contextId ? { threadId: contextId, resourceId } : {}),
+  const execution = executeMessageSend({
+    requestId,
+    message,
+    metadata,
+    currentData,
+    taskStore,
+    pushNotificationSender: resolvedPushNotificationSender,
+    agent,
+    agentId,
+    logger,
+    requestContext,
+  });
+
+  if (params.configuration?.blocking === false) {
+    void execution.catch(error => {
+      logger?.error(`Unexpected background failure for A2A task ${currentData.id}`, error);
     });
-
-    const artifactUpdate = createArtifactUpdate({
-      taskId: currentData.id,
-      contextId: currentData.contextId,
-      text: result.text,
-      data: result.object as Record<string, unknown> | undefined,
-    });
-
-    if (artifactUpdate) {
-      currentData = applyUpdateToTask(currentData, artifactUpdate);
-    }
-
-    currentData = applyUpdateToTask(currentData, {
-      state: 'completed',
-      message: undefined,
-    });
-
-    // Store execution details in task metadata
-    currentData.metadata = {
-      ...currentData.metadata,
-      execution: {
-        toolCalls: result.toolCalls,
-        toolResults: result.toolResults,
-        usage: result.usage,
-        finishReason: result.finishReason,
-      },
-    };
-
-    await saveTaskAndMaybeSendPushNotification({
-      taskStore,
-      pushNotificationSender: resolvedPushNotificationSender,
-      previousTask: context.task,
-      nextTask: currentData,
-      agentId,
-      logger,
-    });
-    context.task = currentData;
-  } catch (handlerError) {
-    // If handler throws, apply 'failed' status, save, and rethrow
-    const failureStatusUpdate: Omit<TaskStatus, 'timestamp'> = {
-      state: 'failed',
-      message: {
-        messageId: crypto.randomUUID(),
-        role: 'agent',
-        parts: [
-          {
-            kind: 'text',
-            text: `Handler failed: ${handlerError instanceof Error ? handlerError.message : String(handlerError)}`,
-          },
-        ],
-        kind: 'message',
-      },
-    };
-    currentData = applyUpdateToTask(currentData, failureStatusUpdate);
-
-    try {
-      await saveTaskAndMaybeSendPushNotification({
-        taskStore,
-        pushNotificationSender: resolvedPushNotificationSender,
-        previousTask: context.task,
-        nextTask: currentData,
-        agentId,
-        logger,
-      });
-    } catch (saveError) {
-      // @ts-expect-error saveError is an unknown error
-      logger?.error(`Failed to save task ${currentData.id} after handler error:`, saveError?.message);
-    }
-
-    return normalizeError(handlerError, requestId, currentData.id, logger); // Rethrow original error
+    return createSuccessResponse(requestId, currentData);
   }
 
-  // The loop finished, send the final task state
-  return createSuccessResponse(requestId, currentData);
+  return execution;
 }
 
 export async function handleTaskGet({


### PR DESCRIPTION
## Description

Fixes #20090.

The A2A `message/send` handler parsed `configuration.blocking`, but always
awaited `agent.generate()` before returning. A request with `blocking: false`
therefore remained open until the task was already completed.

This change persists the task as `working`, returns that task immediately when
`blocking` is explicitly `false`, and continues execution through the same
completion, failure, and push-notification path used by blocking requests. The
background path reloads the latest task before a terminal write so it does not
overwrite a concurrent `tasks/cancel` result. Default and explicit blocking
requests continue to wait for the terminal response.

The change is process-local, matching the existing in-memory A2A task store; it
does not add a queue or change the public request schema.

## Related issue(s)

Fixes #20090

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Verification

- `pnpm build:server`
- `pnpm exec vitest run packages/server/src/server/handlers/a2a.test.ts`
- `pnpm --filter ./packages/server lint`
- `pnpm exec oxfmt --check packages/server/src/server/handlers/a2a.ts packages/server/src/server/handlers/a2a.test.ts .changeset/cold-mammals-turn.md`

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you tell the server to send a message but **not block** (`configuration.blocking: false`), it now replies right away with “I’m working on it” instead of waiting. The server continues the work in the background and later records the final result (success/failure/cancel) and sends notifications—without messing up cancellation.

## What changed

- Fixed default A2A `message/send` handling for `configuration.blocking: false`.
- When non-blocking and the request targets an existing task already in `working`, the handler returns that same task immediately (avoids duplicate runs).
- Persists a `working` task and returns it right away, while agent execution continues asynchronously.
- Added an internal `executeMessageSend` helper to run `agent.generate`, then **reload the latest task state** before applying terminal updates (prevents overwriting cancellation results from races).
- Continues the existing flow for artifacts, failures, cancellation, and push notifications during background execution.
- Preserves stable `taskId` / `contextId` plus authentication and request context across async execution.
- Kept blocking behavior unchanged for default and `configuration.blocking: true`.
- Expanded integration tests covering:
  - non-blocking working return + eventual completion
  - re-sending non-blocking requests for an existing working task (no duplicate execution)
  - persisting background failures after the initial response
  - cancellation race safety (no completed-overwrite)
  - push-notification timing for non-blocking vs blocking
- Added a patch changeset for `@mastra/server` documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->