### PR TITLE
fix(core): forward RequestContext to durable subagent delegation

### DIFF
--- a/.changeset/durable-subagent-requestcontext.md
+++ b/.changeset/durable-subagent-requestcontext.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fix durable agents dropping `RequestContext` when delegating to a subagent on a cross-process worker (e.g. `createInngestAgent()` with a `connect()` worker).
+
+The durable LLM and tool-call steps rebuild the toolset from `input.requestContextEntries`, but that snapshot is not propagated onto the step input cross-process — only the run-level `RequestContext` (rebuilt from the run event) is available there. The rebuild therefore captured an empty context, so a delegated subagent's tools resolved with no request-scoped values (tenant/user IDs, workspace filesystem, dynamic model/memory) and silently fell back to defaults.
+
+`resolveRuntimeDependencies` and `rebuildRunToolsFromMastra` now fall back to the run-level `RequestContext` when the workflow-input snapshot is absent, so the rebuilt toolset — and any subagent delegated to inside the tool-call step — resolves with the caller's context. This extends the trigger/resume/nested-workflow guarantees from #19223 to the subagent-delegation boundary.

--- a/packages/core/src/agent/durable/utils/resolve-runtime-request-context.test.ts
+++ b/packages/core/src/agent/durable/utils/resolve-runtime-request-context.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Durable request-context fallback across the cross-process boundary (issue #20210).
+ *
+ * On a cross-process engine (e.g. the @mastra/inngest connect() worker) the
+ * durable steps run in a DIFFERENT process than the one that prepared the run.
+ * The workflow input's `requestContextEntries` snapshot is NOT propagated onto
+ * the step's input there — @mastra/inngest forwards the caller context as the
+ * run-level `event.data.requestContext`, from which the durable workflow rebuilds
+ * a populated run-level `RequestContext`.
+ *
+ * Before the fix, `resolveRuntimeDependencies` / `rebuildRunToolsFromMastra`
+ * read only `input.requestContextEntries` and, finding it absent, rebuilt the
+ * toolset with an EMPTY context — so a subagent delegated to from the tool-call
+ * step lost the caller's tenant/user/workspace values. The fix falls back to the
+ * run-level `RequestContext` (threaded from the step's params) when the snapshot
+ * is missing. These tests guard that fallback at the root-cause functions.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RequestContext } from '../../../request-context';
+import { MessageList } from '../../message-list';
+import { globalRunRegistry } from '../run-registry';
+import { rebuildRunToolsFromMastra, resolveRuntimeDependencies } from './resolve-runtime';
+
+const RUN_ID = 'run-reqctx-fallback-1';
+
+/** Build a RequestContext carrying a single tenant value. */
+function runCtx(tenant: string): RequestContext {
+  return new RequestContext([['tenant', tenant]] as Iterable<readonly [string, unknown]>);
+}
+
+/** A fake agent that records the requestContext it was resolved with. */
+function makeRecordingAgent() {
+  const seen: { tools?: RequestContext; memory?: RequestContext; workspace?: RequestContext } = {};
+  const agent = {
+    getToolsForExecution: vi.fn(async ({ requestContext }: { requestContext: RequestContext }) => {
+      seen.tools = requestContext;
+      return {};
+    }),
+    getModel: vi.fn(async () => ({
+      provider: 'test',
+      modelId: 'test',
+      specificationVersion: 'v2',
+      supportedUrls: {},
+      doGenerate: vi.fn(),
+      doStream: vi.fn(),
+    })),
+    getModelList: vi.fn(async () => null),
+    getMemory: vi.fn(async ({ requestContext }: { requestContext: RequestContext }) => {
+      seen.memory = requestContext;
+      return undefined;
+    }),
+    getWorkspace: vi.fn(async ({ requestContext }: { requestContext: RequestContext }) => {
+      seen.workspace = requestContext;
+      return undefined;
+    }),
+    listInputProcessors: vi.fn(async () => []),
+    __listLLMRequestProcessors: vi.fn(async () => []),
+    listOutputProcessors: vi.fn(async () => []),
+    listErrorProcessors: vi.fn(async () => []),
+  };
+  return { agent, seen };
+}
+
+function makeMastra(agent: unknown) {
+  return {
+    getAgentById: () => agent,
+    getLogger: () => undefined,
+  } as any;
+}
+
+function makeInput() {
+  return {
+    runId: RUN_ID,
+    agentId: 'supervisor',
+    // No requestContextEntries — simulating the cross-process worker where the
+    // workflow-input snapshot was not propagated onto the step input.
+    state: { threadId: 'thread-1', resourceId: 'user-1', memoryConfig: undefined, threadExists: false },
+    options: {},
+    modelConfig: { provider: 'test', modelId: 'test' },
+    // A real serialized empty MessageList — hand-crafting the shape omits the
+    // source-tracking fields deserialize() expects.
+    messageListState: new MessageList({ threadId: 'thread-1', resourceId: 'user-1' }).serialize(),
+  } as any;
+}
+
+afterEach(() => {
+  if (globalRunRegistry.has(RUN_ID)) globalRunRegistry.delete(RUN_ID);
+  vi.clearAllMocks();
+});
+
+describe('durable request-context cross-process fallback', () => {
+  it('resolveRuntimeDependencies falls back to the run-level RequestContext when no snapshot is present', async () => {
+    const { agent, seen } = makeRecordingAgent();
+    const runLevel = runCtx('team-42');
+
+    await resolveRuntimeDependencies({
+      mastra: makeMastra(agent),
+      runId: RUN_ID,
+      agentId: 'supervisor',
+      input: makeInput(),
+      requestContext: runLevel,
+    });
+
+    // Tools / memory / workspace all resolved with the caller's tenant, not an empty context.
+    expect(seen.tools?.get('tenant')).toBe('team-42');
+    expect(seen.memory?.get('tenant')).toBe('team-42');
+    expect(seen.workspace?.get('tenant')).toBe('team-42');
+  });
+
+  it('rebuildRunToolsFromMastra falls back to the run-level RequestContext when no snapshot is present', async () => {
+    const { agent, seen } = makeRecordingAgent();
+    const runLevel = runCtx('team-42');
+
+    await rebuildRunToolsFromMastra({
+      mastra: makeMastra(agent),
+      runId: RUN_ID,
+      agentId: 'supervisor',
+      state: { threadId: 'thread-1', resourceId: 'user-1', memoryConfig: undefined, threadExists: false } as any,
+      // requestContextEntries intentionally omitted (cross-process worker)
+      requestContext: runLevel,
+    });
+
+    expect(seen.tools?.get('tenant')).toBe('team-42');
+    expect(seen.workspace?.get('tenant')).toBe('team-42');
+  });
+
+  it('prefers the explicit snapshot over the run-level fallback when both are present', async () => {
+    const { agent, seen } = makeRecordingAgent();
+    const runLevel = runCtx('run-level');
+
+    await rebuildRunToolsFromMastra({
+      mastra: makeMastra(agent),
+      runId: RUN_ID,
+      agentId: 'supervisor',
+      state: { threadId: 'thread-1', resourceId: 'user-1', memoryConfig: undefined, threadExists: false } as any,
+      requestContextEntries: { tenant: 'snapshot' },
+      requestContext: runLevel,
+    });
+
+    // The workflow-input snapshot is authoritative; the run-level fallback only fills the gap.
+    expect(seen.tools?.get('tenant')).toBe('snapshot');
+  });
+
+  it('resolves with an empty context when neither snapshot nor run-level context is available', async () => {
+    const { agent, seen } = makeRecordingAgent();
+
+    await rebuildRunToolsFromMastra({
+      mastra: makeMastra(agent),
+      runId: RUN_ID,
+      agentId: 'supervisor',
+      state: { threadId: 'thread-1', resourceId: 'user-1', memoryConfig: undefined, threadExists: false } as any,
+    });
+
+    expect(seen.tools?.get('tenant')).toBeUndefined();
+  });
+});

--- a/packages/core/src/agent/durable/utils/resolve-runtime.ts
+++ b/packages/core/src/agent/durable/utils/resolve-runtime.ts
@@ -83,19 +83,45 @@ export interface ResolveRuntimeOptions {
   agentId: string;
   /** Workflow input containing serialized state */
   input: DurableAgenticWorkflowInput;
+  /**
+   * Run-level RequestContext for the current durable step. Used as a fallback
+   * for the caller's request context when the workflow input's
+   * `requestContextEntries` snapshot is absent (cross-process worker).
+   */
+  requestContext?: RequestContext;
   /** Logger for debugging */
   logger?: { debug?: (...args: any[]) => void; error?: (...args: any[]) => void };
 }
 
 /**
- * Restore a RequestContext from the JSON-safe `requestContextEntries`
- * snapshot serialized onto the workflow input (see preparation.ts). Returns
- * an empty context when no snapshot is present.
+ * Restore a RequestContext for a durable step.
+ *
+ * Prefers the JSON-safe `requestContextEntries` snapshot serialized onto the
+ * workflow input (see preparation.ts). When that snapshot is absent — which is
+ * the case on a cross-process engine (e.g. the @mastra/inngest connect()
+ * worker), where the workflow-input field is not propagated onto the step's
+ * `inputData` — it falls back to the run-level `RequestContext` the durable
+ * workflow already rebuilt from the run event (in @mastra/inngest, from
+ * `event.data.requestContext`). Without that fallback the rebuilt toolset —
+ * and therefore any subagent delegated to inside the tool-call step — resolves
+ * with an empty context, dropping request-scoped tenant/user/workspace values.
+ *
+ * Returns an empty context only when neither source has any entries.
  */
-function restoreRequestContext(entries?: Record<string, unknown>): RequestContext {
-  return entries
-    ? new RequestContext(Object.entries(entries) as Iterable<readonly [string, unknown]>)
-    : new RequestContext();
+function restoreRequestContext(
+  entries: Record<string, unknown> | undefined,
+  runLevel?: RequestContext,
+): RequestContext {
+  if (entries) {
+    return new RequestContext(Object.entries(entries) as Iterable<readonly [string, unknown]>);
+  }
+  if (runLevel) {
+    // Clone from the run-level context's JSON-safe entries so the rebuilt
+    // context is independent (a step must not mutate the shared run context)
+    // and carries only serializable values across the durable boundary.
+    return new RequestContext(Object.entries(runLevel.toJSON()) as Iterable<readonly [string, unknown]>);
+  }
+  return new RequestContext();
 }
 
 /**
@@ -127,7 +153,7 @@ export class DurableProcessorRebuildError extends Error {
  * process restarts.
  */
 export async function resolveRuntimeDependencies(options: ResolveRuntimeOptions): Promise<ResolvedRuntimeDependencies> {
-  const { mastra, runId, agentId, input, logger } = options;
+  const { mastra, runId, agentId, input, requestContext: runLevelRequestContext, logger } = options;
 
   // 1. Deserialize MessageList
   // Reuse the existing MessageList from the registry if available so that
@@ -187,10 +213,11 @@ export async function resolveRuntimeDependencies(options: ResolveRuntimeOptions)
       const agent = mastra.getAgentById(agentId);
 
       // Restore the caller's request context from the JSON-safe snapshot on
-      // the workflow input (mirrors durable-agent.ts resume handling), so
-      // request-scoped tools / workspace / memory / processors resolve with
-      // the same configuration as the original call site.
-      const resolveRequestContext = restoreRequestContext(input.requestContextEntries);
+      // the workflow input (mirrors durable-agent.ts resume handling), falling
+      // back to the run-level context on a cross-process worker where the
+      // snapshot field is absent, so request-scoped tools / workspace / memory /
+      // processors resolve with the same configuration as the original call site.
+      const resolveRequestContext = restoreRequestContext(input.requestContextEntries, runLevelRequestContext);
 
       tools = await agent.getToolsForExecution({
         runId,
@@ -350,16 +377,33 @@ export async function rebuildRunToolsFromMastra(options: {
   options?: SerializableDurableOptions;
   /** JSON-safe request-context snapshot from the workflow input (see preparation.ts). */
   requestContextEntries?: Record<string, unknown>;
+  /**
+   * Run-level RequestContext for the current durable step. Used as a fallback
+   * when `requestContextEntries` is absent (cross-process worker), so the
+   * rebuilt toolset — and any subagent delegated to from the tool-call step —
+   * resolves with the caller's context instead of an empty one.
+   */
+  requestContext?: RequestContext;
   logger?: { debug?: (...args: any[]) => void };
 }): Promise<RebuiltRunTools | undefined> {
-  const { mastra, runId, agentId, state, options: execOptions, requestContextEntries, logger } = options;
+  const {
+    mastra,
+    runId,
+    agentId,
+    state,
+    options: execOptions,
+    requestContextEntries,
+    requestContext: runLevelRequestContext,
+    logger,
+  } = options;
   if (!mastra) return undefined;
 
   try {
     const agent = mastra.getAgentById(agentId);
     // Restore the caller's request context so request-scoped tools, workspace
-    // and memory resolve with the same configuration as the original call.
-    const resolveRequestContext = restoreRequestContext(requestContextEntries);
+    // and memory resolve with the same configuration as the original call,
+    // falling back to the run-level context cross-process (see restoreRequestContext).
+    const resolveRequestContext = restoreRequestContext(requestContextEntries, runLevelRequestContext);
 
     const tools = await agent.getToolsForExecution({
       runId,

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -167,6 +167,9 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
         runId,
         agentId,
         input: typedInput,
+        // Fallback caller context when the workflow input carries no
+        // requestContextEntries snapshot (cross-process worker).
+        requestContext,
         logger,
       });
 

--- a/packages/core/src/agent/durable/workflows/steps/tool-call-xproc-workspace.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call-xproc-workspace.test.ts
@@ -86,6 +86,47 @@ describe('durable tool-call cross-process workspace tool resolution', () => {
     expect(result.result).toEqual({ content: 'Hello, wonderful human!' });
   });
 
+  it('forwards the run-level requestContext to the rebuild when initData carries no snapshot (issue #20210)', async () => {
+    // Cross-process worker: empty registry, and initData has NO requestContextEntries
+    // snapshot (it is not propagated onto the step input). The run-level requestContext
+    // — rebuilt by the durable workflow from the run event — is the only source of the
+    // caller's context, so the step must forward it to the rebuild. Without this, the
+    // rebuilt delegation tool captures an empty context and a delegated subagent loses
+    // the caller's tenant/user.
+    expect(globalRunRegistry.has(RUN_ID)).toBe(false);
+
+    const executeMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.mocked(resolveRuntime.rebuildRunToolsFromMastra).mockResolvedValueOnce({
+      tools: { 'agent-note_taker': { id: 'agent-note_taker', execute: executeMock } as any },
+      workspace: undefined,
+    });
+
+    // A run-level context carrying the caller's tenant (what workflow.ts rebuilds from
+    // event.data.requestContext). RequestContext is Map-like, so a Map stands in here.
+    const runLevelRequestContext = new Map([['tenant', 'team-42']]);
+
+    const step = createDurableToolCallStep();
+    await (step as any).execute({
+      inputData: { toolCallId: 'call-delegate', toolName: 'agent-note_taker', args: { prompt: 'save a note' } },
+      mastra: { getLogger: () => undefined, listTools: () => ({}) },
+      suspend: vi.fn(),
+      resumeData: undefined,
+      requestContext: runLevelRequestContext,
+      getInitData: () => makeInitData(), // no requestContextEntries
+      [PUBSUB_SYMBOL]: mockPubsub(),
+    });
+
+    // The step forwarded its run-level requestContext to the rebuild, and did NOT pass a
+    // snapshot (initData had none) — so the rebuild's own run-level fallback kicks in.
+    expect(resolveRuntime.rebuildRunToolsFromMastra).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: RUN_ID,
+        requestContext: runLevelRequestContext,
+        requestContextEntries: undefined,
+      }),
+    );
+  });
+
   it('still emits ToolNotFoundError when the Mastra rebuild also has no such tool', async () => {
     globalRunRegistry.set(RUN_ID, { isPlaceholder: true, tools: {}, model: undefined as any } as any); // placeholder (inngest resume path)
     vi.mocked(resolveRuntime.rebuildRunToolsFromMastra).mockResolvedValueOnce({

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -354,6 +354,10 @@ export function createDurableToolCallStep() {
           state: state as any,
           options: agentOptions,
           requestContextEntries: initData.requestContextEntries,
+          // Fallback caller context when the init data carries no snapshot
+          // (cross-process worker) — otherwise the rebuilt delegation tools
+          // capture an empty context and subagents lose the caller's tenant/user.
+          requestContext,
           logger,
         });
         if (rebuilt) {


### PR DESCRIPTION
## Description

A durable agent wrapped with `createInngestAgent()` loses the caller's `RequestContext` **when it delegates to a subagent**. The subagent's tools run with an empty `RequestContext`, so any request-scoped resolution (tenant/user IDs, request-scoped workspace filesystem, dynamic model/memory) silently falls back to defaults inside the subagent. Nothing errors — the delegation completes; the subagent just operates as an anonymous/default tenant.

This is the subagent-delegation sibling of #19220 (fixed by #19223, which restored `RequestContext` forwarding at the trigger, resume, and nested-workflow boundaries). A subagent delegation is none of those — it's a plain `agent.stream({ requestContext })` executed inside the durable **tool-call step**, and that path never received the caller's context on a cross-process worker.

### Root cause

`prepareForDurableExecution()` snapshots the caller's context into `workflowInput.requestContextEntries`, and `@mastra/inngest` (#19223) forwards it as the run-level `event.data.requestContext`, from which the workflow handler rebuilds a populated run-level `RequestContext`.

But the durable **steps** that rebuild the toolset on a cross-process worker read a *different* field — `input.requestContextEntries` on the step's `inputData` — which is **not** propagated from the workflow input onto the step input. So on the worker:

- `resolveRuntimeDependencies()` (LLM step) and `rebuildRunToolsFromMastra()` (tool-call step) call `restoreRequestContext(input.requestContextEntries)` with `undefined`,
- the rebuilt `listAgentTools()` delegation-tool closure captures an **empty** `RequestContext`,
- the delegated subagent's `agent.stream({ requestContext })` receives that empty context,
- the subagent's tools see no request-scoped values.

The run-level `RequestContext` in the step scope *is* correctly populated (rebuilt from `event.data.requestContext` in `workflow.ts`); it simply wasn't used as a fallback when `input.requestContextEntries` was missing.

### The fix

`restoreRequestContext()` now takes the run-level `RequestContext` as a fallback and, when the workflow-input snapshot is absent, clones from `runLevel.toJSON()` (JSON-safe, independent of the shared run context). It's threaded through both `resolveRuntimeDependencies` and `rebuildRunToolsFromMastra` from the step params (`requestContext`, already in scope). No `@mastra/inngest` change is needed — it already forwards the populated run-level context into every step; core just wasn't consuming it as a fallback.

The change is additive and gated to the cross-process rebuild path only:

- `resolveRuntimeDependencies` reaches `restoreRequestContext` only when the run registry has no hydrated entry (the cross-process branch); in-process it uses the registry wholesale.
- `rebuildRunToolsFromMastra` runs only when a tool isn't found in the in-process registry (cross-process empty registry).
- The explicit snapshot always wins when present, so same-process / resume behavior is unchanged. `runLevel.toJSON()` applies the same JSON-safe filter the snapshot uses, so the fallback carries the same entry set — no new or reserved keys cross the boundary.

### Verification

- **End-to-end**, against the minimal reproduction (real Inngest dev server + `connect()` worker in a separate process + real subagent delegation):
  - with the fix → subagent writes under `team-42/` ✅
  - same build, fix reverted → subagent writes under `anon/` ❌
- New unit regression test at the root-cause functions (fallback for both, snapshot-wins-over-fallback, empty-when-neither).
- 658 durable tests + 51 request-context tests pass; type-check, oxlint, and eslint clean.

## Related issue(s)

Fixes #20210

Minimal reproducible example: https://github.com/devangpadhiyar/mastra-inngest-subagent-requestcontext-repro

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR