### PR TITLE
fix(core): accept a typed model override on tool-approval resume methods

### DIFF
--- a/.changeset/typed-model-on-tool-approval-resume.md
+++ b/.changeset/typed-model-on-tool-approval-resume.md
@@ -1,0 +1,10 @@
+---
+'@mastra/core': patch
+---
+
+Added a typed `model` override to `approveToolCall`, `declineToolCall`, `approveToolCallGenerate`, and `declineToolCallGenerate`. The resume path already honored `model` (via `resumeStream`/`resumeGenerate`), but the public approve/decline signatures omitted it, so agents whose model is resolved per run had no typed way to pick the model for the resumed segment without casting past the signature.
+
+```ts
+// Now type-checks — previously required casting past the public type
+await agent.approveToolCall({ runId, model: myRunModel });
+```

--- a/packages/core/src/agent/agent-types.test-d.ts
+++ b/packages/core/src/agent/agent-types.test-d.ts
@@ -281,4 +281,28 @@ describe('Agent Type Tests', () => {
       });
     });
   });
+
+  describe('Issue #20201: tool-approval resume methods expose a typed `model` override', () => {
+    // `resumeStream`/`resumeGenerate` already accept and consume a per-resume `model`
+    // override, but the public approve/decline entry points previously omitted it from
+    // their option types — forcing callers to cast past the signature (the source even
+    // carried a `// @ts-expect-error - the types here are wrong`). A `model` key on the
+    // options literal must now type-check against each method's parameter type; without
+    // the fix these object literals fail excess-property checking.
+    const agent = new Agent({ id: 'a', name: 'A', model: {} as any, instructions: 'hi' });
+
+    it('accepts `model` on approveToolCall / declineToolCall (stream)', () => {
+      const approve: Parameters<typeof agent.approveToolCall>[0] = { runId: 'r', model: {} as any };
+      const decline: Parameters<typeof agent.declineToolCall>[0] = { runId: 'r', model: {} as any };
+      assertType<string>(approve.runId);
+      assertType<string>(decline.runId);
+    });
+
+    it('accepts `model` on approveToolCallGenerate / declineToolCallGenerate (generate)', () => {
+      const approve: Parameters<typeof agent.approveToolCallGenerate>[0] = { runId: 'r', model: {} as any };
+      const decline: Parameters<typeof agent.declineToolCallGenerate>[0] = { runId: 'r', model: {} as any };
+      assertType<string>(approve.runId);
+      assertType<string>(decline.runId);
+    });
+  });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -8704,7 +8704,9 @@ export class Agent<
    * ```
    */
   async approveToolCall<OUTPUT = undefined>(
-    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string },
+    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string } & {
+      model?: DynamicArgument<MastraModelConfig>;
+    },
   ): Promise<MastraModelOutput<OUTPUT>> {
     // Route standalone `new Agent({ durable: true })` calls through the
     // durable execution path.
@@ -8935,7 +8937,9 @@ export class Agent<
    * ```
    */
   async declineToolCall<OUTPUT = undefined>(
-    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string },
+    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string } & {
+      model?: DynamicArgument<MastraModelConfig>;
+    },
   ): Promise<MastraModelOutput<OUTPUT>> {
     // Route standalone `new Agent({ durable: true })` calls through the
     // durable execution path.
@@ -8965,7 +8969,9 @@ export class Agent<
    * ```
    */
   async approveToolCallGenerate<OUTPUT = undefined>(
-    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string },
+    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string } & {
+      model?: DynamicArgument<MastraModelConfig>;
+    },
   ): Promise<Awaited<ReturnType<MastraModelOutput<OUTPUT>['getFullOutput']>>> {
     // @ts-expect-error - the types here are wrong
     return this.resumeGenerate({ approved: true }, options);
@@ -8988,7 +8994,9 @@ export class Agent<
    * ```
    */
   async declineToolCallGenerate<OUTPUT = undefined>(
-    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string },
+    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string } & {
+      model?: DynamicArgument<MastraModelConfig>;
+    },
   ): Promise<Awaited<ReturnType<MastraModelOutput<OUTPUT>['getFullOutput']>>> {
     // @ts-expect-error - the types here are wrong
     return this.resumeGenerate({ approved: false }, options);


### PR DESCRIPTION
## Related issue(s)

Fixes #20201

## Description

**Problem.** `resumeStream()` / `resumeGenerate()` accept and *consume* a per-resume `model` override (their overloads all carry `& { model?: DynamicArgument<MastraModelConfig> }`, and the resume body selects the LLM via `getLLM({ model: mergedStreamOptions.model })`). But the public entry points that delegate into that path — `approveToolCall()`, `declineToolCall()`, `approveToolCallGenerate()`, `declineToolCallGenerate()` — typed their `options` as `AgentExecutionOptions<OUTPUT> & { runId; toolCallId? }`, with **no `model` field**. `model` only lived on the internal `InnerAgentExecutionOptions` (documented for a different, narrower purpose).

So for agents whose model is resolved per run (run-level override; no usable static default), there was no typed way to pick the model for the resumed segment — callers had to cast past the public signature to pass a value the implementation already forwards. The source itself flagged the mismatch with `// @ts-expect-error - the types here are wrong` at these call sites.

**Fix.** Add the same `model?: DynamicArgument<MastraModelConfig>` option to the four approve/decline entry points, so the public signature matches the behavior already honored at runtime. Purely additive and backward-compatible — no runtime change; `model` was always forwarded, it just wasn't typed. (The pre-existing `@ts-expect-error` directives are unrelated — they cover the broader `AgentExecutionOptions` vs `AgentExecutionOptionsBase` shape mismatch — and remain in place.)

## How verified

- Read `resumeStream`/`resumeGenerate` overloads (all already carry `& { model?: DynamicArgument<MastraModelConfig> }`) and confirmed `options` flows unchanged from `approveToolCall`/`declineToolCall` into both the durable path and `resumeStream`, and from the `*Generate` variants into `resumeGenerate`.
- Added type-level regression tests in `agent-types.test-d.ts` asserting `model` is an accepted key on all four methods' parameter types (object-literal excess-property checks that fail without the change; `AgentExecutionOptionsBase` has no index signature).
- Targeted `tsc --noEmit` over the change site reports no new errors and leaves the four resume-entry `@ts-expect-error` directives valid (no `TS2578`).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When approving or declining a tool request, callers can now choose which AI model continues the run. This makes the public TypeScript definitions match behavior that already worked internally.

## What changed

- Added an optional typed `model` override to:
  - `approveToolCall`
  - `declineToolCall`
  - `approveToolCallGenerate`
  - `declineToolCallGenerate`
- Added TypeScript regression tests covering all four methods.
- Added a patch changeset for `@mastra/core`.
- No runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->