### PR TITLE
feat(voice): expose realtime session events

### DIFF
--- a/.changeset/quiet-voices-connect.md
+++ b/.changeset/quiet-voices-connect.md
@@ -1,0 +1,7 @@
+---
+'@mastra/voice-openai-realtime': minor
+---
+
+Added raw OpenAI Realtime and socket lifecycle events, plus a public `sendEvent` method for custom session control.
+
+Fixed function calls so only tools registered with `addTools` are executed and continued automatically.

--- a/voice/openai-realtime-api/src/index.test.ts
+++ b/voice/openai-realtime-api/src/index.test.ts
@@ -160,6 +160,25 @@ describe('OpenAIRealtimeVoice', () => {
       );
       expect(sent.filter((ev: any) => ev.type === 'response.create')).toHaveLength(0);
     });
+
+    it('should not execute or continue function calls that were not added', async () => {
+      (voice as any).ws = { on: vi.fn(), send: vi.fn(), close: vi.fn() };
+
+      await (voice as any).handleFunctionCalls({
+        response: {
+          output: [
+            {
+              type: 'function_call',
+              name: 'external_tool',
+              call_id: 'external-1',
+              arguments: '{}',
+            },
+          ],
+        },
+      });
+
+      expect((voice as any).ws.send).not.toHaveBeenCalled();
+    });
   });
 
   describe('event handling', () => {
@@ -182,6 +201,73 @@ describe('OpenAIRealtimeVoice', () => {
       (voice as any).emit('speak', 'test');
 
       expect(mockCallback).not.toHaveBeenCalled();
+    });
+
+    it('should expose raw events and socket lifecycle', () => {
+      const handlers = new Map<string, (...args: any[]) => void>();
+      (voice as any).ws = {
+        on: vi.fn((event, callback) => handlers.set(event, callback)),
+        send: vi.fn(),
+        close: vi.fn(),
+      };
+      const rawCallback = vi.fn();
+      const openCallback = vi.fn();
+      const closeCallback = vi.fn();
+      const errorCallback = vi.fn();
+      voice.on('openAIRealtime:input_audio_buffer.committed', rawCallback);
+      voice.on('openAIRealtime:socket.open', openCallback);
+      voice.on('openAIRealtime:socket.close', closeCallback);
+      voice.on('openAIRealtime:socket.error', errorCallback);
+      (voice as any).setupEventListeners();
+
+      handlers.get('open')?.();
+      const committed = { type: 'input_audio_buffer.committed' };
+      handlers.get('message')?.(Buffer.from(JSON.stringify(committed)));
+      const error = new Error('socket failed');
+      handlers.get('error')?.(error);
+      handlers.get('close')?.(1006, Buffer.from('remote close'));
+
+      expect(openCallback).toHaveBeenCalledTimes(1);
+      expect(rawCallback).toHaveBeenCalledWith(committed);
+      expect(errorCallback).toHaveBeenCalledWith(error);
+      expect(closeCallback).toHaveBeenCalledWith({
+        code: 1006,
+        reason: Buffer.from('remote close'),
+      });
+      expect((voice as any).state).toBe('close');
+    });
+
+    it('should flush raw events queued before the socket opens', () => {
+      const handlers = new Map<string, (...args: any[]) => void>();
+      const send = vi.fn();
+      (voice as any).ws = {
+        OPEN: 1,
+        readyState: 0,
+        on: vi.fn((event, callback) => handlers.set(event, callback)),
+        send,
+        close: vi.fn(),
+      };
+      voice.sendEvent('conversation.item.create', {
+        item: { type: 'message', role: 'user' },
+      });
+      (voice as any).setupEventListeners();
+      (voice as any).ws.readyState = 1;
+
+      handlers.get('message')?.(
+        Buffer.from(
+          JSON.stringify({
+            type: 'session.created',
+            session: { id: 'session-1' },
+          }),
+        ),
+      );
+
+      expect(send).toHaveBeenCalledWith(
+        JSON.stringify({
+          type: 'conversation.item.create',
+          item: { type: 'message', role: 'user' },
+        }),
+      );
     });
 
     it('should handle current OpenAI output audio events', async () => {

--- a/voice/openai-realtime-api/src/index.ts
+++ b/voice/openai-realtime-api/src/index.ts
@@ -567,12 +567,23 @@ export class OpenAIRealtimeVoice extends MastraVoice {
 
     this.ws.on('message', message => {
       const data = JSON.parse(message.toString());
+      this.emit(`openAIRealtime:${data.type}`, data);
       this.client.emit(data.type, data);
 
       if (this.debug) {
         const { delta, ...fields } = data;
         console.info(data.type, fields, delta?.length < 100 ? delta : '');
       }
+    });
+    this.ws.on('open', () => {
+      this.emit('openAIRealtime:socket.open');
+    });
+    this.ws.on('close', (code, reason) => {
+      this.state = 'close';
+      this.emit('openAIRealtime:socket.close', { code, reason });
+    });
+    this.ws.on('error', error => {
+      this.emit('openAIRealtime:socket.error', error);
     });
 
     this.client.on('session.created', ev => {
@@ -657,7 +668,7 @@ export class OpenAIRealtimeVoice extends MastraVoice {
   private async handleFunctionCalls(ev: any) {
     let handledFunctionCall = false;
     for (const output of ev.response?.output ?? []) {
-      if (output.type === 'function_call') {
+      if (output.type === 'function_call' && this.tools?.[output.name]) {
         handledFunctionCall = true;
         await this.handleFunctionCall(output);
       }
@@ -733,7 +744,11 @@ export class OpenAIRealtimeVoice extends MastraVoice {
     return btoa(binary);
   }
 
-  private sendEvent(type: string, data: any) {
+  /**
+   * Sends a raw event to the underlying OpenAI Realtime session.
+   * Events are queued until the WebSocket is open.
+   */
+  sendEvent(type: string, data: Record<string, unknown> = {}) {
     if (!this.ws || this.ws.readyState !== this.ws.OPEN) {
       this.queue.push({ type: type, ...data });
     } else {


### PR DESCRIPTION
Fixes #20219

This exposes the raw OpenAI Realtime event stream and WebSocket lifecycle on `OpenAIRealtimeVoice`, adds a public `sendEvent` API for custom session control, and stops the provider from auto-continuing function calls it doesn't own. It unblocks consumers who need lower-level session hooks (custom conversation items, socket state) without forking the provider, and fixes a bug where externally-triggered tool calls were being executed as if they were registered.

## Changes

- **Raw event + socket lifecycle emission.** Every inbound message is now re-emitted under an `openAIRealtime:${data.type}` namespace alongside the existing client-level emit, so consumers can subscribe to any raw Realtime event. Added dedicated `openAIRealtime:socket.open`, `socket.close`, and `socket.error` events wired to the underlying `ws` handlers, with `close` also flipping internal `state` to `'close'`.
- **Public `sendEvent` API.** Promoted `sendEvent` from private to public and gave it a documented signature (`type: string`, `data` defaulting to `{}`). It preserves the existing queue-until-open behavior, so events sent before the socket is ready are flushed once it opens.
- **Scoped function-call handling.** `handleFunctionCalls` now only executes/continues a `function_call` when the tool name exists in `this.tools` (i.e. registered via `addTools`). Previously any `function_call` in the response output was run automatically, which meant externally-owned tools were incorrectly invoked.
- **Changeset.** Minor bump for `@mastra/voice-openai-realtime` documenting the new events, `sendEvent`, and the function-call fix.

## Testing

This PR includes provider-level unit tests in `voice/openai-realtime-api/src/index.test.ts`:

- **Unregistered function calls are ignored** — asserts `handleFunctionCalls` does not send anything on the socket for a `function_call` whose tool wasn't added.
- **Raw events + socket lifecycle** — drives the `ws` handlers directly and verifies `socket.open`, a raw `input_audio_buffer.committed` event, `socket.error`, and `socket.close` (with `{ code, reason }`) all fire, and that `state` becomes `'close'`.
- **Queue flush before open** — calls `sendEvent` before the socket is open, then simulates the socket opening and confirms the queued `conversation.item.create` is serialized and sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This gives the OpenAI voice connection easier ways to send messages, listen for connection changes, and receive raw events. It also makes sure only approved tools can be run.

## Changes

- Re-emits raw OpenAI Realtime events under `openAIRealtime:${data.type}`.
- Adds socket lifecycle events for open, close, and error.
- Makes `sendEvent(type, data = {})` public while preserving pre-connection queueing.
- Restricts function calls to tools registered through `addTools`.
- Adds tests covering events, socket lifecycle, queued messages, and unregistered tools.
- Adds a minor changeset for `@mastra/voice-openai-realtime`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->