### PR TITLE
fix(playground): allow JWT auth setup in Studio settings

### DIFF
--- a/packages/playground/src/domains/auth/components/__tests__/auth-required.msw.test.tsx
+++ b/packages/playground/src/domains/auth/components/__tests__/auth-required.msw.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import type { RouteResponse } from '@mastra/client-js';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthRequired } from '../auth-required';
+import { credentialsAuthCapabilities, jwtAuthCapabilities } from './fixtures/auth-capabilities';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+function renderAuthRequired(pathname: string, capabilities: RouteResponse<'GET /auth/capabilities'>) {
+  const onCapabilitiesRequest = vi.fn();
+  server.use(
+    http.get(`${BASE_URL}/api/auth/capabilities`, () => {
+      onCapabilitiesRequest();
+      return HttpResponse.json(capabilities);
+    }),
+  );
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[pathname]}>
+          <AuthRequired>
+            <div>Studio content</div>
+          </AuthRequired>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+
+  return onCapabilitiesRequest;
+}
+
+afterEach(() => cleanup());
+
+describe('AuthRequired', () => {
+  describe('when authentication is enabled without a login method', () => {
+    it('renders Studio content on the Settings bootstrap route', async () => {
+      const onCapabilitiesRequest = renderAuthRequired('/settings', jwtAuthCapabilities);
+
+      await waitFor(() => expect(onCapabilitiesRequest).toHaveBeenCalledOnce());
+
+      expect(screen.getByText('Studio content')).not.toBeNull();
+      expect(screen.queryByText('Authentication Required')).toBeNull();
+    });
+
+    it('keeps protected Studio routes gated', async () => {
+      renderAuthRequired('/agents', jwtAuthCapabilities);
+
+      expect(await screen.findByText('Authentication Required')).not.toBeNull();
+      expect(screen.queryByText('Studio content')).toBeNull();
+    });
+  });
+
+  describe('when authentication provides a credentials login method', () => {
+    it('keeps the Settings route gated behind sign-in', async () => {
+      renderAuthRequired('/settings', credentialsAuthCapabilities);
+
+      expect(await screen.findByText('Sign in to continue')).not.toBeNull();
+      expect(screen.queryByText('Studio content')).toBeNull();
+    });
+  });
+});

--- a/packages/playground/src/domains/auth/components/__tests__/auth-required.msw.test.tsx
+++ b/packages/playground/src/domains/auth/components/__tests__/auth-required.msw.test.tsx
@@ -35,7 +35,7 @@ function renderAuthRequired(pathname: string, capabilities: RouteResponse<'GET /
     </MastraReactProvider>,
   );
 
-  return onCapabilitiesRequest;
+  return { onCapabilitiesRequest, queryClient };
 }
 
 afterEach(() => cleanup());
@@ -43,8 +43,9 @@ afterEach(() => cleanup());
 describe('AuthRequired', () => {
   describe('when authentication is enabled without a login method', () => {
     it('renders Studio content on the Settings bootstrap route', async () => {
-      const onCapabilitiesRequest = renderAuthRequired('/settings', jwtAuthCapabilities);
+      const { onCapabilitiesRequest, queryClient } = renderAuthRequired('/settings', jwtAuthCapabilities);
 
+      await waitFor(() => expect(queryClient.getQueryState(['auth', 'capabilities'])?.status).toBe('success'));
       await waitFor(() => expect(onCapabilitiesRequest).toHaveBeenCalledOnce());
 
       expect(screen.getByText('Studio content')).not.toBeNull();

--- a/packages/playground/src/domains/auth/components/__tests__/fixtures/auth-capabilities.ts
+++ b/packages/playground/src/domains/auth/components/__tests__/fixtures/auth-capabilities.ts
@@ -1,0 +1,13 @@
+import type { RouteResponse } from '@mastra/client-js';
+
+type AuthCapabilitiesResponse = RouteResponse<'GET /auth/capabilities'>;
+
+export const jwtAuthCapabilities = {
+  enabled: true,
+  login: null,
+} satisfies AuthCapabilitiesResponse;
+
+export const credentialsAuthCapabilities = {
+  enabled: true,
+  login: { type: 'credentials' as const },
+} satisfies AuthCapabilitiesResponse;

--- a/packages/playground/src/domains/auth/components/auth-required.tsx
+++ b/packages/playground/src/domains/auth/components/auth-required.tsx
@@ -1,5 +1,6 @@
 import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import { Lock } from 'lucide-react';
+import { useLocation } from 'react-router';
 import { useAuthCapabilities } from '../hooks/use-auth-capabilities';
 import { isAuthenticated } from '../types';
 import { LoginButton } from './login-button';
@@ -33,6 +34,7 @@ export type AuthRequiredProps = {
  */
 export function AuthRequired({ children, loginUrl = '/login', signupUrl = '/signup' }: AuthRequiredProps) {
   const { data: capabilities, isLoading } = useAuthCapabilities();
+  const { pathname } = useLocation();
 
   // While loading, show nothing (or could show a skeleton)
   if (isLoading) {
@@ -46,6 +48,11 @@ export function AuthRequired({ children, loginUrl = '/login', signupUrl = '/sign
 
   // If user is authenticated, render children
   if (isAuthenticated(capabilities)) {
+    return <>{children}</>;
+  }
+
+  // Header-based auth has no login flow, so Settings must remain available for configuring its request header.
+  if (!capabilities.login && pathname === '/settings') {
     return <>{children}</>;
   }
 


### PR DESCRIPTION
## Summary

- keep Studio Settings reachable when authentication is enabled but the provider exposes no login method, as with `MastraJwtAuth`
- preserve the authentication gate for all protected routes and for providers with a credentials or SSO login flow
- add MSW-backed regression coverage for the Settings bootstrap route and both guard-preservation cases

Without this exception, header-based auth creates a bootstrap deadlock: Studio requires an authenticated request before users can reach the page where the required `Authorization` header is configured.

## Test plan

- `pnpm --filter @internal/playground exec vitest run src/domains/auth/components/__tests__/auth-required.msw.test.tsx src/domains/auth/components/__tests__/route-permission-guard.test.tsx`
- `pnpm --filter @internal/playground typecheck`
- `pnpm --filter @internal/playground lint`
- `pnpm exec oxfmt --check packages/playground/src/domains/auth/components/auth-required.tsx packages/playground/src/domains/auth/components/__tests__/auth-required.msw.test.tsx packages/playground/src/domains/auth/components/__tests__/fixtures/auth-capabilities.ts`

Fixes #20223


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
If your Studio auth provider is configured but doesn’t offer any way to “sign in,” Studio can still open **Settings** so you can paste the required **JWT token**. Other pages that require an authenticated user stay locked, and providers that do have a login flow still show the usual sign-in prompt.

## What changed
- Updated `AuthRequired` to allow the `/settings` route to render when auth is enabled but the provider exposes no `login` method (e.g., JWT-only capability), while preserving the auth gate for other protected routes.
- Added MSW-backed regression coverage for both cases:
  - No login method: `/settings` renders “Studio content,” while protected routes (e.g. `/agents`) remain gated.
  - Credentials login present: `/settings` remains gated behind a “Sign in to continue” prompt.
- Introduced auth-capabilities test fixtures for:
  - JWT-enabled with `login: null`
  - Credentials-enabled with `login.type: 'credentials'`
- Test synchronization improvement: the tests wait for the authentication capabilities query before asserting behavior.
- Validation: targeted Vitest tests, typechecking, linting, and formatting checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->