### PR TITLE
fix(libsql): preserve shared WAL state on close

### DIFF
--- a/.changeset/swift-flies-mate.md
+++ b/.changeset/swift-flies-mate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Fixed local LibSQL stores changing shared database journal state when they close.

--- a/stores/libsql/src/storage/close.test.ts
+++ b/stores/libsql/src/storage/close.test.ts
@@ -27,7 +27,7 @@ describe('LibSQLStore.close()', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('checkpoints/truncates the WAL and closes the client for local file DBs', async () => {
+  it('closes the client without changing local database state', async () => {
     const dbPath = path.join(tmpDir, 'mastra.db');
     const store = new LibSQLStore({ id: 'close-local', url: `file:${dbPath}` });
     await store.init();
@@ -39,8 +39,8 @@ describe('LibSQLStore.close()', () => {
     await store.close();
 
     const executedSql = executedSqlFrom(executeSpy);
-    expect(executedSql).toContain('PRAGMA wal_checkpoint(TRUNCATE);');
-    expect(executedSql).toContain('PRAGMA journal_mode=DELETE;');
+    expect(executedSql).not.toContain('PRAGMA wal_checkpoint(TRUNCATE);');
+    expect(executedSql).not.toContain('PRAGMA journal_mode=DELETE;');
     expect(closeSpy).toHaveBeenCalledTimes(1);
     expect(client.closed).toBe(true);
   });
@@ -63,29 +63,37 @@ describe('LibSQLStore.close()', () => {
     expect(closeSpy).not.toHaveBeenCalled();
   });
 
-  it('runs WAL cleanup for an injected client that points at a local file', async () => {
+  it('does not change WAL mode or interrupt another store sharing the database', async () => {
+    const dbPath = path.join(tmpDir, 'shared.db');
+    const storeA = new LibSQLStore({ id: 'close-shared-a', url: `file:${dbPath}` });
+    const storeB = new LibSQLStore({ id: 'close-shared-b', url: `file:${dbPath}` });
+    await storeA.init();
+    await storeB.init();
+
+    const clientB = getClient(storeB);
+
+    try {
+      await clientB.execute('CREATE TABLE close_regression (id INTEGER PRIMARY KEY, value TEXT NOT NULL);');
+      await clientB.execute("INSERT INTO close_regression (id, value) VALUES (1, 'before-close');");
+
+      await storeA.close();
+
+      const journalMode = await clientB.execute('PRAGMA journal_mode;');
+      expect(journalMode.rows[0]?.journal_mode).toBe('wal');
+
+      await clientB.execute("INSERT INTO close_regression (id, value) VALUES (2, 'after-close');");
+      const rows = await clientB.execute('SELECT value FROM close_regression ORDER BY id;');
+      expect(rows.rows.map(row => row.value)).toEqual(['before-close', 'after-close']);
+    } finally {
+      await storeA.close();
+      await storeB.close();
+    }
+  });
+
+  it('closes injected local clients without WAL cleanup', async () => {
     const dbPath = path.join(tmpDir, 'injected.db');
     const client = createClient({ url: `file:${dbPath}` });
     const store = new LibSQLStore({ id: 'close-injected-local', client });
-    await store.init();
-
-    expect(client.protocol).toBe('file');
-
-    const executeSpy = vi.spyOn(client, 'execute');
-    const closeSpy = vi.spyOn(client, 'close');
-
-    await store.close();
-
-    expect(executedSqlFrom(executeSpy)).toContain('PRAGMA wal_checkpoint(TRUNCATE);');
-    expect(closeSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('skips WAL pragmas for non-file (remote) clients', async () => {
-    const client = createClient({ url: `file:${path.join(tmpDir, 'remote.db')}` });
-    // Pretend this is a remote connection without touching the underlying file logic.
-    Object.defineProperty(client, 'protocol', { value: 'https', configurable: true });
-
-    const store = new LibSQLStore({ id: 'close-remote', client });
     await store.init();
 
     const executeSpy = vi.spyOn(client, 'execute');
@@ -97,37 +105,5 @@ describe('LibSQLStore.close()', () => {
     expect(executedSql).not.toContain('PRAGMA wal_checkpoint(TRUNCATE);');
     expect(executedSql).not.toContain('PRAGMA journal_mode=DELETE;');
     expect(closeSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('still closes the client and warns when WAL checkpoint fails', async () => {
-    const dbPath = path.join(tmpDir, 'wal-fail.db');
-    const store = new LibSQLStore({ id: 'close-wal-fail', url: `file:${dbPath}` });
-    await store.init();
-
-    const client = getClient(store);
-    vi.spyOn(client, 'execute').mockRejectedValue(new Error('boom'));
-    const closeSpy = vi.spyOn(client, 'close');
-    const warnSpy = vi.spyOn((store as unknown as { logger: { warn: (...args: unknown[]) => void } }).logger, 'warn');
-
-    await expect(store.close()).resolves.toBeUndefined();
-
-    expect(warnSpy).toHaveBeenCalled();
-    expect(closeSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('removes WAL sidecar files so the storage dir can be deleted', async () => {
-    const dbPath = path.join(tmpDir, 'sidecars.db');
-    const store = new LibSQLStore({ id: 'close-sidecars', url: `file:${dbPath}` });
-    await store.init();
-
-    // Force some writes so the WAL sidecar files exist.
-    const client = getClient(store);
-    await client.execute('CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY);');
-    await client.execute('INSERT INTO t (id) VALUES (1);');
-
-    await store.close();
-
-    expect(fs.existsSync(`${dbPath}-wal`)).toBe(false);
-    expect(fs.existsSync(`${dbPath}-shm`)).toBe(false);
   });
 });

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -339,38 +339,14 @@ export class LibSQLStore extends MastraCompositeStore {
   }
 
   /**
-   * Closes the underlying libsql client, releasing all OS file handles.
-   *
-   * For local file databases, first runs PRAGMA wal_checkpoint(TRUNCATE) and
-   * switches back to journal_mode=DELETE so that Windows releases the -wal
-   * and -shm sidecar files promptly. Without this, the handles stay open
-   * until process exit, causing EBUSY errors when callers try to fs.rm the
-   * storage directory after Mastra.shutdown().
-   *
-   * Remote (Turso) databases skip the WAL pragmas and just close the client.
+   * Closes the underlying libsql client, releasing this store's OS file handles.
    *
    * Safe to call more than once; subsequent calls are no-ops.
    */
   async close(): Promise<void> {
-    if (this.client.closed) {
-      return;
+    if (!this.client.closed) {
+      this.client.close();
     }
-
-    // A store built from an injected client may still point at a local file even
-    // though `isLocalDb` (derived from the url config) is false, so also trust the
-    // client's own protocol to decide whether WAL cleanup is needed.
-    const isLocalFileDb = this.isLocalDb || this.client.protocol === 'file';
-
-    if (isLocalFileDb) {
-      try {
-        await this.client.execute('PRAGMA wal_checkpoint(TRUNCATE);');
-        await this.client.execute('PRAGMA journal_mode=DELETE;');
-      } catch (err) {
-        this.logger.warn('LibSQLStore: Failed to checkpoint WAL before close.', err);
-      }
-    }
-
-    this.client.close();
   }
 }
 

--- a/stores/libsql/src/vector/close.test.ts
+++ b/stores/libsql/src/vector/close.test.ts
@@ -27,7 +27,7 @@ describe('LibSQLVector.close()', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('checkpoints/truncates the WAL and closes the client for local file DBs', async () => {
+  it('closes the client without changing local database state', async () => {
     const dbPath = path.join(tmpDir, 'vectors.db');
     const vector = new LibSQLVector({ id: 'close-local', url: `file:${dbPath}` });
     await vector.createIndex({ indexName: 'close_test', dimension: 4 });
@@ -39,8 +39,8 @@ describe('LibSQLVector.close()', () => {
     await vector.close();
 
     const executedSql = executedSqlFrom(executeSpy);
-    expect(executedSql).toContain('PRAGMA wal_checkpoint(TRUNCATE);');
-    expect(executedSql).toContain('PRAGMA journal_mode=DELETE;');
+    expect(executedSql).not.toContain('PRAGMA wal_checkpoint(TRUNCATE);');
+    expect(executedSql).not.toContain('PRAGMA journal_mode=DELETE;');
     expect(closeSpy).toHaveBeenCalledTimes(1);
     expect(client.closed).toBe(true);
   });

--- a/stores/libsql/src/vector/index.ts
+++ b/stores/libsql/src/vector/index.ts
@@ -103,31 +103,14 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   }
 
   /**
-   * Closes the underlying libsql client, releasing all OS file handles.
-   *
-   * For local file databases, first runs PRAGMA wal_checkpoint(TRUNCATE) and
-   * switches back to journal_mode=DELETE so the -wal and -shm sidecar files
-   * are released promptly (mirrors LibSQLStore.close()).
-   *
-   * Remote (Turso) databases skip the WAL pragmas and just close the client.
+   * Closes the underlying libsql client, releasing this vector store's OS file handles.
    *
    * Safe to call more than once; subsequent calls are no-ops.
    */
   async close(): Promise<void> {
-    if (this.turso.closed) {
-      return;
+    if (!this.turso.closed) {
+      this.turso.close();
     }
-
-    if (this.turso.protocol === 'file' && !this.isMemoryDb) {
-      try {
-        await this.turso.execute('PRAGMA wal_checkpoint(TRUNCATE);');
-        await this.turso.execute('PRAGMA journal_mode=DELETE;');
-      } catch (err) {
-        this.logger.warn('LibSQLVector: Failed to checkpoint WAL before close.', err);
-      }
-    }
-
-    this.turso.close();
   }
 
   private async discoverVectorIndexes(): Promise<Set<string>> {


### PR DESCRIPTION
Closing a local LibSQL store previously ran global SQLite cleanup during `close()`, which could change the journal mode or truncate WAL state while another process still used the database.

Before, closing one store could run `PRAGMA journal_mode=DELETE`. Now `close()` only releases its own client, so concurrent stores keep using WAL normally. Added a regression test that closes one shared store while the other continues to read and write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Closing one local database connection no longer changes settings that other connections rely on. This keeps shared databases working normally while still closing the connection safely.

## Summary

- Simplified `LibSQLStore.close()` and `LibSQLVector.close()` to only close their own client.
- Removed WAL checkpointing and journal-mode changes during shutdown.
- Added regression coverage for shared local databases and updated close behavior tests.
- Added a patch changeset for `@mastra/libsql`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->