### PR TITLE
docs(auth): add IFGAProvider reference page for the FGA actor authorizer

### DIFF
--- a/docs/src/content/en/docs/server/auth/fga.mdx
+++ b/docs/src/content/en/docs/server/auth/fga.mdx
@@ -263,6 +263,10 @@ class MyFGAProvider implements IFGAProvider {
 }
 ```
 
+:::note
+See the [`IFGAProvider` reference](/reference/auth/fga) for every method, parameter, and the `ActorSignal` type.
+:::
+
 ## System actors
 
 Autonomous and scheduled agents run without an end user. Mark these calls with an actor signal so FGA can tell them apart from user requests:
@@ -305,5 +309,6 @@ The actor signal is trusted input, so construct it server-side:
 
 ## Related
 
+- [`IFGAProvider` reference](/reference/auth/fga)
 - [Authentication overview](/docs/server/auth)
 - [WorkOS authentication](/docs/server/auth/workos)

--- a/docs/src/content/en/reference/auth/fga.mdx
+++ b/docs/src/content/en/reference/auth/fga.mdx
@@ -1,0 +1,215 @@
+---
+title: "Reference: IFGAProvider | Auth"
+description: "API reference for the IFGAProvider interface, which authorizes users and system actors against resources for Mastra fine-grained authorization (FGA)."
+packages:
+  - "@mastra/core"
+---
+
+# IFGAProvider
+
+The `IFGAProvider` interface defines a fine-grained authorization (FGA) provider. Mastra calls it to decide whether a user or a system actor may perform a permission on a specific resource. Implement it to connect Mastra to an FGA backend, such as WorkOS Authorization.
+
+For concepts, configuration, and the lifecycle points where Mastra enforces FGA, see [Fine-grained authorization](/docs/server/auth/fga).
+
+## Usage example
+
+The following example implements a minimal provider. `require` throws to deny, and `check` returns a boolean.
+
+```typescript title="src/mastra/fga.ts"
+import { FGADeniedError } from '@mastra/core/auth/ee'
+import type { FGACheckParams, IFGAProvider, MastraFGAPermissionInput } from '@mastra/core/auth/ee'
+
+class MyFGAProvider implements IFGAProvider {
+  async check(user: any, params: FGACheckParams): Promise<boolean> {
+    // Your authorization logic.
+    return true
+  }
+
+  async require(user: any, params: FGACheckParams): Promise<void> {
+    if (!(await this.check(user, params))) {
+      throw new FGADeniedError(user, params.resource, params.permission)
+    }
+  }
+
+  async filterAccessible<T extends { id: string }>(
+    user: any,
+    resources: T[],
+    resourceType: string,
+    permission: MastraFGAPermissionInput,
+  ): Promise<T[]> {
+    return resources
+  }
+}
+```
+
+## Methods
+
+### `check(user, params)`
+
+Returns whether `user` has the permission on the resource. Use it for non-throwing checks, such as filtering or conditional UI.
+
+Returns: `Promise<boolean>`
+
+### `require(user, params)`
+
+Throws `FGADeniedError` when `user` lacks the permission. Mastra calls this at its [enforcement points](/docs/server/auth/fga#enforcement-points).
+
+Returns: `Promise<void>`
+
+### `filterAccessible(user, resources, resourceType, permission)`
+
+Returns the subset of `resources` that `user` can access with `permission`.
+
+Returns: `Promise<T[]>`
+
+### `requireActor(actor, params)`
+
+Authorizes a non-user system actor, such as an autonomous or scheduled agent. Optional.
+
+System actors skip the user-centric `require()` path, so implement `requireActor` to enforce per-agent least privilege for them. Throw `FGADeniedError` to deny. When a provider doesn't implement `requireActor`, Mastra preserves the trusted-actor bypass (allow after the tenant-scope check), so adding it is backward compatible.
+
+Treat `actor.permissions` as an untrusted claim. Resolve the agent's authoritative grants from a trusted source keyed by `actor.agentId`, rather than trusting the inline values. See [System actors](/docs/server/auth/fga#system-actors).
+
+```typescript
+import { FGADeniedError } from '@mastra/core/auth/ee'
+import type { ActorSignal, FGACheckParams, IFGAProvider } from '@mastra/core/auth/ee'
+
+class MyFGAProvider implements IFGAProvider {
+  // ...check, require, filterAccessible...
+
+  async requireActor(actor: ActorSignal, params: FGACheckParams): Promise<void> {
+    const agentId = actor === true ? undefined : actor.agentId
+    // Resolve the agent's authoritative grants from a trusted source keyed by agentId.
+    const granted = await this.grantsForAgent(agentId)
+    const required = Array.isArray(params.permission) ? params.permission : [params.permission]
+    if (!required.some(permission => granted.includes(permission))) {
+      throw new FGADeniedError(null, params.resource, params.permission)
+    }
+  }
+}
+```
+
+Returns: `Promise<void>`
+
+## Configuration properties
+
+Optional properties control route coverage and startup validation.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'requireForProtectedRoutes',
+    type: 'boolean',
+    isOptional: true,
+    defaultValue: 'false',
+    description:
+      'When true, protected routes without route-level FGA metadata or resolver output are denied instead of allowed through.',
+  },
+  {
+    name: 'auditProtectedRoutes',
+    type: "boolean | 'warn' | 'error'",
+    isOptional: true,
+    defaultValue: 'false',
+    description:
+      "Audits protected routes that lack built-in FGA metadata. Use true or 'warn' to log a startup warning, 'error' to fail startup, or false to disable.",
+  },
+  {
+    name: 'resolveRouteFGA',
+    type: 'FGARouteResolver',
+    isOptional: true,
+    description:
+      'Derives resource type, resource ID, and permission from the route, parsed params, and request context.',
+  },
+  {
+    name: 'validatePermissions',
+    type: '(permissions: MastraFGAPermissionInput[]) => void | Promise<void>',
+    isOptional: true,
+    description:
+      'Startup validation for provider-specific permission mappings. Throw when a permission Mastra may emit is not mapped.',
+  },
+]}
+/>
+
+## Parameters
+
+The `params` argument passed to `check`, `require`, and `requireActor`.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'resource',
+    type: '{ type: string; id: string }',
+    description: 'The resource being accessed.',
+  },
+  {
+    name: 'permission',
+    type: 'MastraFGAPermissionInput | MastraFGAPermissionInput[]',
+    description:
+      'The permission(s) being checked. When an array is provided, the actor needs any one of the listed permissions.',
+  },
+  {
+    name: 'context',
+    type: 'FGACheckContext',
+    isOptional: true,
+    description:
+      'Provider-specific context for resource resolution, including the owning resourceId, the request context, and action metadata.',
+  },
+]}
+/>
+
+## `ActorSignal`
+
+Identifies a call made by a trusted non-user actor rather than an authenticated end user. It is either `true` (the anonymous system shorthand) or an object that names the acting agent and carries the grants a provider can enforce.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'actorKind',
+    type: "'system'",
+    description: 'Marks the object form of the signal.',
+  },
+  {
+    name: 'agentId',
+    type: 'string',
+    isOptional: true,
+    description:
+      'Identity of the acting system agent. Unlike the check resource (the target), this names the actor itself, so a provider can enforce per-agent least privilege.',
+  },
+  {
+    name: 'permissions',
+    type: 'MastraFGAPermissionInput[]',
+    isOptional: true,
+    description:
+      "Permission grants claimed for this actor. This is an untrusted, self-asserted hint; a provider enforcing real least privilege resolves the agent's authoritative grants from a trusted source keyed by agentId rather than trusting these values.",
+  },
+  {
+    name: 'scope',
+    type: 'Record<string, string>',
+    isOptional: true,
+    description: 'Additional provider-specific scope for the actor, for example tenant or environment.',
+  },
+  {
+    name: 'sourceWorkflow',
+    type: 'string',
+    isOptional: true,
+    description: 'Name of the workflow that started the actor run, when applicable.',
+  },
+]}
+/>
+
+## `FGADeniedError`
+
+Thrown when an authorization check is denied. `require` and `requireActor` throw it to deny, and Mastra surfaces it as an HTTP `403`.
+
+```typescript
+import { FGADeniedError } from '@mastra/core/auth/ee'
+
+throw new FGADeniedError(user, { type: 'agent', id: 'reporter' }, 'agents:execute')
+// Optional fourth argument: a reason string included in the error message.
+```
+
+## Related
+
+- [Fine-grained authorization](/docs/server/auth/fga)
+- [System actors](/docs/server/auth/fga#system-actors)
+- [WorkOS authentication](/reference/auth/workos)

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -110,6 +110,7 @@ const sidebars = {
         { type: 'doc', id: 'auth/auth0', label: 'Auth0' },
         { type: 'doc', id: 'auth/better-auth', label: 'Better Auth' },
         { type: 'doc', id: 'auth/clerk', label: 'Clerk' },
+        { type: 'doc', id: 'auth/fga', label: 'Fine-Grained Authorization' },
         { type: 'doc', id: 'auth/firebase', label: 'Firebase' },
         { type: 'doc', id: 'auth/google', label: 'Google' },
         { type: 'doc', id: 'auth/jwt', label: 'JSON Web Token' },


### PR DESCRIPTION
## Description

Adds a reference page for the fine-grained authorization (FGA) provider interface, `IFGAProvider`. The `requireActor` method and the `ActorSignal` fields (`agentId`, `permissions`, `scope`) added in #19338 only had conceptual coverage in the FGA guide — this documents them (and the rest of the interface) in the reference section.

The new page (`reference/auth/fga.mdx`) covers:

- Methods: `check`, `require`, `filterAccessible`, and `requireActor` (with the resolve-by-`agentId` trust guidance).
- Configuration properties (`requireForProtectedRoutes`, `auditProtectedRoutes`, `resolveRouteFGA`, `validatePermissions`).
- The `FGACheckParams` shape, the `ActorSignal` type, and `FGADeniedError`.

It's registered in the reference sidebar and cross-linked from the Fine-Grained Authorization guide.

## Related issue(s)

Documents the API delivered by #19338 (feature request #19247, closed). No new open issue — this is a docs follow-up to that merged change.

## Type of change

- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] `pnpm validate` passes (frontmatter, sidebar links, and reference sidebar sort order)
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a — docs only)
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a guide explaining how fine-grained authorization works and how to use its provider interface. It also links the guide from the documentation sidebar and existing authorization content.

## Changes

- Added the `IFGAProvider` reference page, covering:
  - Provider methods and configuration
  - `FGACheckParams`
  - `ActorSignal`
  - `FGADeniedError`
  - `requireActor` and `agentId` actor resolution
- Registered the page in the Auth reference sidebar.
- Added links to the reference from the Fine-Grained Authorization guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->