### PR TITLE
fix(ci): update pnpm-lock.yaml for voyageai ^0.3.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1928,8 +1928,8 @@ importers:
   embedders/voyageai:
     dependencies:
       voyageai:
-        specifier: ^0.2.1
-        version: 0.2.1(encoding@0.1.13)(onnxruntime-node@1.26.0)
+        specifier: ^0.3.1
+        version: 0.3.1(encoding@0.1.13)(onnxruntime-node@1.26.0)
     devDependencies:
       '@internal/ai-sdk-v4':
         specifier: workspace:*
@@ -30208,8 +30208,8 @@ packages:
       jsdom:
         optional: true
 
-  voyageai@0.2.1:
-    resolution: {integrity: sha512-ym7Dk6p8Si6lR9wDh58EzxwT0ziD/pqXjzzzceOSySO3Ic3uosHZLOTAsb3Gq+1OaKdEMnni/p8TohKUNvLTkg==}
+  voyageai@0.3.1:
+    resolution: {integrity: sha512-+f6gRsnuV7gi2tFvSFWTqERkZhox1VQCT0G+ALUDAwz75OpzpqaXgy6TSRkbrf6az9WZsXoAyDtplDksHLSbag==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@huggingface/transformers': ^3.8.0
@@ -55560,7 +55560,7 @@ snapshots:
       - msw
     optional: true
 
-  voyageai@0.2.1(encoding@0.1.13)(onnxruntime-node@1.26.0):
+  voyageai@0.3.1(encoding@0.1.13)(onnxruntime-node@1.26.0):
     dependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:


### PR DESCRIPTION
## Description

CI is failing on every PR: all jobs die during setup with `ERR_PNPM_OUTDATED_LOCKFILE` because #19804 bumped `voyageai` to `^0.3.1` in `embedders/voyageai/package.json` without updating `pnpm-lock.yaml`.

- Regenerated the lockfile entry for `voyageai` (`0.2.1` → `0.3.1`), nothing else changed
- Verified `pnpm install --frozen-lockfile` passes and `@mastra/voyageai` builds against `voyageai@0.3.1`

## Related Issue(s)

N/A (unblocks CI broken by #19804)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
