### PR TITLE
feat(core): add PIIRedactor deterministic PII processor

### DIFF
--- a/.changeset/nine-files-prove.md
+++ b/.changeset/nine-files-prove.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': minor
+---
+
+Added PIIRedactor, a deterministic processor that detects and redacts pattern-shaped PII (emails, phone numbers, credit cards, SSNs, API keys, and more) using regex only. It never calls an LLM, so message content never leaves the process through this processor. Use it when compliance rules forbid sending content to a model provider, or when you need deterministic, auditable redaction.
+
+```ts
+import { PIIRedactor } from '@mastra/core/processors';
+
+const redactor = new PIIRedactor({
+  detectionTypes: ['email', 'phone', 'credit-card'],
+  strategy: 'redact',
+  redactionMethod: 'mask',
+});
+```
+
+For context-dependent PII (names, addresses, dates of birth), keep using the LLM-based PIIDetector.

--- a/docs/src/content/en/docs/agents/guardrails.mdx
+++ b/docs/src/content/en/docs/agents/guardrails.mdx
@@ -193,6 +193,28 @@ export const privateAgent = new Agent({
 
 Visit [`PIIDetector()`](/reference/processors/pii-detector) reference for a full list of configuration options.
 
+### Redact PII without an LLM
+
+The `PIIRedactor()` detects and redacts pattern-shaped PII using regex only. It never calls an LLM, so message content can't leave the process through this processor. Use it when compliance rules forbid sending content to a model provider, or when you need deterministic redaction. For context-dependent types such as names and addresses, use `PIIDetector()` instead.
+
+```typescript {7-12} title="src/mastra/agents/regulated-agent.ts"
+import { PIIRedactor } from '@mastra/core/processors'
+
+export const regulatedAgent = new Agent({
+  id: 'regulated-agent',
+  name: 'Regulated Agent',
+  inputProcessors: [
+    new PIIRedactor({
+      detectionTypes: ['email', 'phone', 'credit-card'],
+      strategy: 'redact',
+      redactionMethod: 'mask',
+    }),
+  ],
+})
+```
+
+Visit [`PIIRedactor()`](/reference/processors/pii-redactor) reference for a full list of configuration options.
+
 ### Enforce cost limits
 
 The `CostGuardProcessor()` monitors cumulative estimated cost across the agentic loop, blocking or warning when a monetary limit is exceeded. It queries cost data from observability storage before each LLM call. Cost checks are approximate — metrics are persisted asynchronously, so fast-running agents may briefly exceed the configured limit before the guard triggers.

--- a/docs/src/content/en/reference/processors/pii-redactor.mdx
+++ b/docs/src/content/en/reference/processors/pii-redactor.mdx
@@ -46,14 +46,12 @@ const agent = new Agent({
   id: 'my-agent',
   name: 'my-agent',
   model: '__GATEWAY_OPENAI_MODEL_NANO__',
-  processors: {
-    input: [
-      new PIIRedactor({
-        detectionTypes: ['email', 'phone'],
-        strategy: 'redact',
-      }),
-    ],
-  },
+  inputProcessors: [
+    new PIIRedactor({
+      detectionTypes: ['email', 'phone'],
+      strategy: 'redact',
+    }),
+  ],
 })
 ```
 

--- a/docs/src/content/en/reference/processors/pii-redactor.mdx
+++ b/docs/src/content/en/reference/processors/pii-redactor.mdx
@@ -1,0 +1,166 @@
+---
+title: "Reference: PIIRedactor | Processors"
+description: "API reference for PIIRedactor, a deterministic regex-based processor that detects and redacts pattern-shaped PII without any LLM calls."
+packages:
+  - "@mastra/core"
+---
+
+# PIIRedactor
+
+The `PIIRedactor` detects and redacts pattern-shaped personally identifiable information (PII) using regex only. It never calls an LLM, so message content can't leave the process through this processor. Detection is deterministic: the same input always produces the same redaction.
+
+For context-dependent PII such as names, addresses, and dates of birth, use the LLM-based [`PIIDetector()`](/reference/processors/pii-detector). For generic pattern filtering with custom rules, use [`RegexFilterProcessor`](/reference/processors/regex-filter-processor).
+
+## Usage example
+
+Redact emails and phone numbers in input messages:
+
+```typescript
+import { PIIRedactor } from '@mastra/core/processors'
+
+const redactor = new PIIRedactor({
+  detectionTypes: ['email', 'phone', 'credit-card'],
+  strategy: 'redact',
+  redactionMethod: 'mask',
+})
+```
+
+Block content containing PII instead of redacting it:
+
+```typescript
+import { PIIRedactor } from '@mastra/core/processors'
+
+const redactor = new PIIRedactor({
+  detectionTypes: ['ssn', 'credit-card', 'api-key'],
+  strategy: 'block',
+})
+```
+
+Attach to an agent:
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { PIIRedactor } from '@mastra/core/processors'
+
+const agent = new Agent({
+  id: 'my-agent',
+  name: 'my-agent',
+  model: '__GATEWAY_OPENAI_MODEL_NANO__',
+  processors: {
+    input: [
+      new PIIRedactor({
+        detectionTypes: ['email', 'phone'],
+        strategy: 'redact',
+      }),
+    ],
+  },
+})
+```
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'detectionTypes',
+    type: 'RegexDetectablePIIType[]',
+    description:
+      "PII types to detect. Only regex-detectable types are accepted: 'email', 'phone', 'credit-card', 'ssn', 'api-key', 'ip-address', 'url', 'uuid', 'crypto-wallet', 'iban'. The constructor throws for context-dependent types such as 'name', 'address', and 'date-of-birth', which require PIIDetector.",
+    isOptional: false,
+  },
+  {
+    name: 'strategy',
+    type: "'block' | 'warn' | 'filter' | 'redact'",
+    description:
+      "Strategy when PII is detected. 'block' aborts with a TripWire error. 'warn' logs a warning but passes content through unchanged. 'filter' removes flagged messages. 'redact' replaces detected PII with redacted versions.",
+    isOptional: true,
+    defaultValue: "'redact'",
+  },
+  {
+    name: 'redactionMethod',
+    type: "'mask' | 'hash' | 'remove' | 'placeholder'",
+    description:
+      "How detected values are rewritten. 'mask' replaces characters with asterisks. 'hash' replaces the value with a truncated SHA-256 hash. 'remove' deletes the value. 'placeholder' replaces the value with a type tag such as [EMAIL].",
+    isOptional: true,
+    defaultValue: "'mask'",
+  },
+  {
+    name: 'preserveFormat',
+    type: 'boolean',
+    description:
+      "Whether masking preserves the value's structure, for example ***-**-1234 for SSNs and X-masked digits for phone numbers.",
+    isOptional: true,
+    defaultValue: 'true',
+  },
+  {
+    name: 'lastMessageOnly',
+    type: 'boolean',
+    description: 'When true, only the last message is checked instead of all messages.',
+    isOptional: true,
+    defaultValue: 'false',
+  },
+]}
+/>
+
+## Returns
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: "'pii-redactor'",
+    description: 'Processor identifier.',
+    isOptional: false,
+  },
+  {
+    name: 'name',
+    type: "'PII Redactor'",
+    description: 'Processor display name.',
+    isOptional: false,
+  },
+  {
+    name: 'processInput',
+    type: '(args: ProcessInputArgs) => ProcessInputResult',
+    description:
+      'Checks input messages for the configured PII types. Blocks, warns, filters, or redacts depending on strategy. Non-text message parts are preserved.',
+    isOptional: false,
+  },
+  {
+    name: 'processOutputStream',
+    type: '(args: ProcessOutputStreamArgs) => Promise<ChunkType | null | undefined>',
+    description:
+      'Checks streaming text chunks. A tail of recent characters is carried between chunks so PII split across chunk boundaries is still detected.',
+    isOptional: false,
+  },
+  {
+    name: 'processOutputResult',
+    type: '(args: ProcessOutputResultArgs) => ProcessorMessageResult',
+    description:
+      'Checks final output messages for the configured PII types. Blocks, warns, filters, or redacts depending on strategy.',
+    isOptional: false,
+  },
+]}
+/>
+
+## Error behavior
+
+When the `block` strategy is active, `PIIRedactor` throws a `TripWire` error with `retry: false` when PII is detected. The TripWire metadata includes:
+
+- `processorId`: `'pii-redactor'`
+- `detectedTypes`: Array of detected PII type names
+- `detectionCount`: Number of detections
+- `strategy`: `'block'`
+
+The metadata never contains the matched values themselves, so logging the error can't leak the PII it caught.
+
+## Streaming behavior
+
+`PIIRedactor` carries a tail of recent characters between streaming chunks. This catches PII that's split across chunk boundaries, for example `test@` in one chunk and `example.com` in the next. Only the portion of a detection inside the current chunk can be rewritten; characters that streamed out in an earlier chunk are already delivered. When this partial redaction isn't acceptable, apply the processor to `processOutputResult` (final output messages), or buffer chunks first with [`BatchPartsProcessor`](/reference/processors/batch-parts-processor).
+
+## Comparison with other processors
+
+| Processor | Detection | LLM calls | Best for |
+| - | - | - | - |
+| `PIIRedactor` | Regex, deterministic | Never | Compliance setups where content must not leave the process |
+| [`PIIDetector()`](/reference/processors/pii-detector) | LLM-based | Yes | Context-dependent PII such as names and addresses |
+| [`RegexFilterProcessor`](/reference/processors/regex-filter-processor) | Regex, custom rules | Never | Generic pattern filtering with your own rules |

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -532,6 +532,7 @@ const sidebars = {
         { type: 'doc', id: 'processors/message-history-processor', label: 'MessageHistory' },
         { type: 'doc', id: 'processors/moderation-processor', label: 'ModerationProcessor' },
         { type: 'doc', id: 'processors/pii-detector', label: 'PIIDetector' },
+        { type: 'doc', id: 'processors/pii-redactor', label: 'PIIRedactor' },
         { type: 'doc', id: 'processors/prefill-error-handler', label: 'PrefillErrorHandler' },
         { type: 'doc', id: 'processors/processor-interface', label: 'Processor Interface' },
         {

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -205,6 +205,7 @@ export const piiRedactorProvider: ProcessorProvider = {
     lastMessageOnly: z.boolean().optional(),
   }),
   availablePhases: ['processInput', 'processOutputStream', 'processOutputResult'] as ProcessorPhase[],
+  /** Build a PIIRedactor from a config already validated by `configSchema`. */
   createProcessor(config) {
     return new PIIRedactor(config as unknown as PIIRedactorOptions);
   },

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -202,8 +202,9 @@ export const piiRedactorProvider: ProcessorProvider = {
     strategy: z.enum(['block', 'warn', 'filter', 'redact']).optional(),
     redactionMethod: z.enum(['mask', 'hash', 'remove', 'placeholder']).optional(),
     preserveFormat: z.boolean().optional(),
+    lastMessageOnly: z.boolean().optional(),
   }),
-  availablePhases: ['processInput'] as ProcessorPhase[],
+  availablePhases: ['processInput', 'processOutputStream', 'processOutputResult'] as ProcessorPhase[],
   createProcessor(config) {
     return new PIIRedactor(config as unknown as PIIRedactorOptions);
   },

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -7,6 +7,9 @@ import { ModerationProcessor } from '../../processors/processors/moderation';
 import type { ModerationOptions } from '../../processors/processors/moderation';
 import type { PIIDetectorOptions } from '../../processors/processors/pii-detector';
 import { PIIDetector } from '../../processors/processors/pii-detector';
+import type { PIIRedactorOptions } from '../../processors/processors/pii-redactor';
+import { PIIRedactor } from '../../processors/processors/pii-redactor';
+import { REGEX_DETECTABLE_PII_TYPES } from '../../processors/processors/pii-shared';
 import { PromptInjectionDetector } from '../../processors/processors/prompt-injection-detector';
 import type { PromptInjectionOptions } from '../../processors/processors/prompt-injection-detector';
 import { SystemPromptScrubber } from '../../processors/processors/system-prompt-scrubber';
@@ -185,6 +188,28 @@ export const piiDetectorProvider: ProcessorProvider = {
 };
 
 // ---------------------------------------------------------------------------
+// 7b. pii-redactor
+// ---------------------------------------------------------------------------
+export const piiRedactorProvider: ProcessorProvider = {
+  info: {
+    id: 'pii-redactor',
+    name: 'PII Redactor',
+    description:
+      'Deterministically redacts pattern-shaped personally identifiable information using regex, without any LLM calls.',
+  },
+  configSchema: z.object({
+    detectionTypes: z.array(z.enum(REGEX_DETECTABLE_PII_TYPES)).min(1),
+    strategy: z.enum(['block', 'warn', 'filter', 'redact']).optional(),
+    redactionMethod: z.enum(['mask', 'hash', 'remove', 'placeholder']).optional(),
+    preserveFormat: z.boolean().optional(),
+  }),
+  availablePhases: ['processInput'] as ProcessorPhase[],
+  createProcessor(config) {
+    return new PIIRedactor(config as unknown as PIIRedactorOptions);
+  },
+};
+
+// ---------------------------------------------------------------------------
 // 8. language-detector
 // ---------------------------------------------------------------------------
 export const languageDetectorProvider: ProcessorProvider = {
@@ -247,6 +272,7 @@ export const BUILT_IN_PROCESSOR_PROVIDERS: Record<string, ProcessorProvider> = {
   moderation: moderationProvider,
   'prompt-injection-detector': promptInjectionDetectorProvider,
   'pii-detector': piiDetectorProvider,
+  'pii-redactor': piiRedactorProvider,
   'language-detector': languageDetectorProvider,
   'system-prompt-scrubber': systemPromptScrubberProvider,
 };

--- a/packages/core/src/processors/processors/index.ts
+++ b/packages/core/src/processors/processors/index.ts
@@ -19,6 +19,8 @@ export {
   type PIICategoryScores,
   type PIIDetection,
 } from './pii-detector';
+export { PIIRedactor, type PIIRedactorOptions, type PIIRedactorTripwireMetadata } from './pii-redactor';
+export { REGEX_DETECTABLE_PII_TYPES, type PIIRedactionMethod, type RegexDetectablePIIType } from './pii-shared';
 export {
   LanguageDetector,
   type LanguageDetectorOptions,

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -1,4 +1,3 @@
-import * as crypto from 'node:crypto';
 import type { SharedV2ProviderOptions } from '@ai-sdk/provider-v5';
 import { z } from 'zod/v4';
 import { Agent, isSupportedLanguageModel } from '../../agent';
@@ -16,57 +15,22 @@ import type { Processor } from '../index';
 import { REPROCESS_PART_KEY } from '../stream-reprocess';
 import { selectMessagesToCheck } from './message-selection';
 import type { LastMessageOnlyOption } from './message-selection';
+import {
+  applyPIIRedaction,
+  detectPIIWithPatterns,
+  LLM_ONLY_PII_TYPES,
+  PII_REGEX_CARRYOVER_SIZE,
+  redactPIIValue,
+} from './pii-shared';
+import type { PIIDetection, PIIDetectionResult } from './pii-shared';
 
-/**
- * PII categories for detection and redaction
- */
-export interface PIICategories {
-  email?: boolean;
-  phone?: boolean;
-  'credit-card'?: boolean;
-  ssn?: boolean;
-  'api-key'?: boolean;
-  'ip-address'?: boolean;
-  name?: boolean;
-  address?: boolean;
-  'date-of-birth'?: boolean;
-  url?: boolean;
-  uuid?: boolean;
-  'crypto-wallet'?: boolean;
-  iban?: boolean;
-  [customType: string]: boolean | undefined;
-}
-
-/**
- * Individual PII category score
- */
-export interface PIICategoryScore {
-  type: string;
-  score: number;
-}
-
-export type PIICategoryScores = PIICategoryScore[];
-
-/**
- * Individual PII detection with location and redaction info
- */
-export interface PIIDetection {
-  type: string;
-  value: string;
-  confidence: number;
-  start: number;
-  end: number;
-  redacted_value?: string | null; // Only present when strategy is 'redact'
-}
-
-/**
- * Result structure for PII detection (simplified for minimal tokens)
- */
-export interface PIIDetectionResult {
-  categories: PIICategoryScores | null;
-  detections: PIIDetection[] | null;
-  redacted_content?: string | null; // Only present when strategy is 'redact'
-}
+export type {
+  PIICategories,
+  PIICategoryScore,
+  PIICategoryScores,
+  PIIDetection,
+  PIIDetectionResult,
+} from './pii-shared';
 
 /**
  * Configuration options for PIIDetector
@@ -198,36 +162,8 @@ export class PIIDetector implements Processor<'pii-detector'> {
     'iban', // International Bank Account Numbers
   ];
 
-  /**
-   * Regex patterns for local (zero-cost) PII detection during streaming.
-   * These run instead of LLM calls in processOutputStream to eliminate
-   * per-chunk API costs and latency.
-   */
-  private static readonly PII_PATTERNS: Record<string, RegExp> = {
-    email: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
-    phone: /(?:\+?\d{1,3}[-.\ ]?)?\(?\d{3}\)?[-.\ ]?\d{3}[-.\ ]?\d{4}/g,
-    'credit-card': /\b(?:\d{4}[-\s]?){3}\d{4}\b/g,
-    ssn: /\b\d{3}-\d{2}-\d{4}\b/g,
-    'api-key':
-      /(?:(?:sk|pk)[-_](?:live|test|proj)[-_][A-Za-z0-9]{16,}|(?:api[_-]?key|apikey|api[_-]?secret)\s*[:=]\s*["']?[a-zA-Z0-9_\-]{20,}["']?)/gi,
-    'ip-address': /\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b/g,
-    url: /https?:\/\/[^\s<>"']+/gi,
-    uuid: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
-    'crypto-wallet': /\b(?:0x[a-fA-F0-9]{40}|[13][a-km-zA-HJ-NP-Z1-9]{25,34}|bc1[a-zA-HJ-NP-Z0-9]{39,59})\b/g,
-    iban: /\b[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}(?:[A-Z0-9]?){0,16}\b/g,
-  };
-
-  /** PII types that require LLM context and cannot be detected by regex */
-  private static readonly LLM_ONLY_TYPES = new Set(['name', 'address', 'date-of-birth']);
-
   /** Default character threshold for flushing the LLM buffer during streaming. */
   private static readonly DEFAULT_BUFFER_SIZE = 200;
-
-  /**
-   * Number of characters to carry over between chunks for regex detection.
-   * Ensures PII split across chunk boundaries (e.g. "test@" + "example.com") is caught.
-   */
-  private static readonly REGEX_CARRYOVER_SIZE = 128;
 
   constructor(options: PIIDetectorOptions) {
     this.detectionTypes = options.detectionTypes || PIIDetector.DEFAULT_DETECTION_TYPES;
@@ -497,114 +433,17 @@ export class PIIDetector implements Processor<'pii-detector'> {
    * Apply redaction method to content
    */
   private applyRedactionMethod(content: string, detections: PIIDetection[]): string {
-    let redacted = content;
-
-    // Sort detections by start position in reverse order to maintain indices
-    const sortedDetections = [...detections].sort((a, b) => b.start - a.start);
-
-    for (const detection of sortedDetections) {
-      const redactedValue = this.redactValue(detection.value, detection.type);
-      redacted = redacted.slice(0, detection.start) + redactedValue + redacted.slice(detection.end);
-    }
-
-    return redacted;
+    return applyPIIRedaction(content, detections, {
+      method: this.redactionMethod,
+      preserveFormat: this.preserveFormat,
+    });
   }
 
   /**
    * Redact individual PII value based on method and type
    */
   private redactValue(value: string, type: string): string {
-    switch (this.redactionMethod) {
-      case 'mask':
-        return this.maskValue(value, type);
-      case 'hash':
-        return this.hashValue(value);
-      case 'remove':
-        return '';
-      case 'placeholder':
-        return `[${type.toUpperCase()}]`;
-      default:
-        return this.maskValue(value, type);
-    }
-  }
-
-  /**
-   * Mask PII value while optionally preserving format
-   */
-  private maskValue(value: string, type: string): string {
-    if (!this.preserveFormat) {
-      return '*'.repeat(Math.min(value.length, 8));
-    }
-
-    switch (type) {
-      case 'email':
-        const emailParts = value.split('@');
-        if (emailParts.length === 2) {
-          const [local, domain] = emailParts;
-          const maskedLocal =
-            local && local.length > 2 ? local[0] + '*'.repeat(local.length - 2) + local[local.length - 1] : '***';
-          const domainParts = domain?.split('.');
-          const maskedDomain =
-            domainParts && domainParts.length > 1
-              ? '*'.repeat(domainParts[0]?.length ?? 0) + '.' + domainParts.slice(1).join('.')
-              : '***';
-          return `${maskedLocal}@${maskedDomain}`;
-        }
-        break;
-
-      case 'phone':
-        // Preserve format like XXX-XXX-1234 or (XXX) XXX-1234
-        return value.replace(/\d/g, (match, index) => {
-          // Keep last 4 digits
-          return index >= value.length - 4 ? match : 'X';
-        });
-
-      case 'credit-card':
-        // Show last 4 digits: ****-****-****-1234
-        return value.replace(/\d/g, (match, index) => {
-          return index >= value.length - 4 ? match : '*';
-        });
-
-      case 'ssn':
-        // Show last 4 digits: ***-**-1234
-        return value.replace(/\d/g, (match, index) => {
-          return index >= value.length - 4 ? match : '*';
-        });
-
-      case 'uuid':
-        // Mask UUID: ********-****-****-****-************
-        return value.replace(/[a-f0-9]/gi, '*');
-
-      case 'crypto-wallet':
-        // Show first 4 and last 4 characters: 1Lbc...X71
-        if (value.length > 8) {
-          return value.slice(0, 4) + '*'.repeat(value.length - 8) + value.slice(-4);
-        }
-        return '*'.repeat(value.length);
-
-      case 'iban':
-        // Show country code and last 4 digits: DE**************3000
-        if (value.length > 6) {
-          return value.slice(0, 2) + '*'.repeat(value.length - 6) + value.slice(-4);
-        }
-        return '*'.repeat(value.length);
-
-      default:
-        // Generic masking - show first and last character if long enough
-        if (value.length <= 3) {
-          return '*'.repeat(value.length);
-        }
-        return value[0] + '*'.repeat(value.length - 2) + value[value.length - 1];
-    }
-
-    return '*'.repeat(Math.min(value.length, 8));
-  }
-
-  /**
-   * Hash PII value using SHA256
-   */
-  private hashValue(value: string): string {
-    return `[HASH:${crypto.createHash('sha256').update(value).digest('hex').slice(0, 8)}]`;
+    return redactPIIValue(value, type, { method: this.redactionMethod, preserveFormat: this.preserveFormat });
   }
 
   /**
@@ -647,52 +486,16 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
    * here and handled by the LLM-based detectPII in processOutputResult.
    */
   private detectPIILocal(content: string): PIIDetectionResult {
-    const categories: PIICategoryScores = [];
-    const detections: PIIDetection[] = [];
-
-    for (const type of this.detectionTypes) {
-      if (PIIDetector.LLM_ONLY_TYPES.has(type)) continue;
-
-      const pattern = PIIDetector.PII_PATTERNS[type];
-      if (!pattern) continue;
-
-      // Reset lastIndex for /g patterns
-      pattern.lastIndex = 0;
-      let match;
-      while ((match = pattern.exec(content)) !== null) {
-        detections.push({
-          type,
-          value: match[0],
-          confidence: 1.0,
-          start: match.index,
-          end: match.index + match[0].length,
-          ...(this.strategy === 'redact' ? { redacted_value: this.redactValue(match[0], type) } : {}),
-        });
-      }
-    }
-
-    const detectedTypes = new Set(detections.map(d => d.type));
-    for (const type of detectedTypes) {
-      categories.push({ type, score: 1.0 });
-    }
-
-    let redacted_content: string | null | undefined;
-    if (this.strategy === 'redact' && detections.length > 0) {
-      redacted_content = this.applyRedactionMethod(content, detections);
-    } else if (this.strategy === 'redact') {
-      redacted_content = null;
-    }
-
-    return {
-      categories: categories.length > 0 ? categories : null,
-      detections: detections.length > 0 ? detections : null,
-      ...(this.strategy === 'redact' ? { redacted_content } : {}),
-    };
+    return detectPIIWithPatterns(
+      content,
+      this.detectionTypes,
+      this.strategy === 'redact' ? { method: this.redactionMethod, preserveFormat: this.preserveFormat } : undefined,
+    );
   }
 
   /** Whether any of the configured detection types require LLM-based analysis */
   private get hasLLMOnlyTypes(): boolean {
-    return this.detectionTypes.some(t => PIIDetector.LLM_ONLY_TYPES.has(t));
+    return this.detectionTypes.some(t => LLM_ONLY_PII_TYPES.has(t));
   }
 
   /**
@@ -855,7 +658,7 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
       const combined = tail + textContent;
       const regexResult = this.detectPIILocal(combined);
       // Update tail for next chunk
-      state._piiRegexTail = combined.slice(-PIIDetector.REGEX_CARRYOVER_SIZE);
+      state._piiRegexTail = combined.slice(-PII_REGEX_CARRYOVER_SIZE);
 
       // Only flag if PII overlaps with the new chunk (not just the carryover tail)
       const hasNewPII =

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -165,6 +165,9 @@ export class PIIDetector implements Processor<'pii-detector'> {
   /** Default character threshold for flushing the LLM buffer during streaming. */
   private static readonly DEFAULT_BUFFER_SIZE = 200;
 
+  /**
+   * Create a PIIDetector and its internal detection agent.
+   */
   constructor(options: PIIDetectorOptions) {
     this.detectionTypes = options.detectionTypes || PIIDetector.DEFAULT_DETECTION_TYPES;
     this.threshold = options.threshold ?? 0.6;
@@ -189,6 +192,9 @@ export class PIIDetector implements Processor<'pii-detector'> {
     });
   }
 
+  /**
+   * Scan incoming messages with the detection agent and apply the configured strategy.
+   */
   async processInput(
     args: {
       messages: MastraDBMessage[];

--- a/packages/core/src/processors/processors/pii-redactor.test.ts
+++ b/packages/core/src/processors/processors/pii-redactor.test.ts
@@ -154,6 +154,45 @@ describe('PIIRedactor', () => {
       expect(textPart && 'text' in textPart ? textPart.text : '').toBe('reach me at [EMAIL]');
     });
 
+    it('redacts PII that only the flattened content carries', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], redactionMethod: 'placeholder' });
+      const message: MastraDBMessage = {
+        id: 'msg-1',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [{ type: 'text' as const, text: 'nothing sensitive here' }],
+          content: 'nothing sensitive here, but also test@example.com',
+        },
+        createdAt: new Date(),
+      };
+
+      const result = (await redactor.processInput(createInputArgs([message]))) as MastraDBMessage[];
+
+      expect(result[0]!.content.content).toBe('nothing sensitive here, but also [EMAIL]');
+    });
+
+    it('reports one detection when a part and the flattened content hold the same text', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], strategy: 'block' });
+      const message: MastraDBMessage = {
+        id: 'msg-1',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [{ type: 'text' as const, text: 'leak test@example.com' }],
+          content: 'leak test@example.com',
+        },
+        createdAt: new Date(),
+      };
+
+      try {
+        await redactor.processInput(createInputArgs([message]));
+        expect.fail('Expected TripWire');
+      } catch (error) {
+        expect((error as TripWire<any>).options.metadata).toMatchObject({ detectionCount: 1 });
+      }
+    });
+
     it('returns messages unchanged when no PII is found', async () => {
       const redactor = new PIIRedactor({ detectionTypes: ['email', 'phone'] });
       const messages = [createMessage('nothing sensitive here')];
@@ -218,6 +257,28 @@ describe('PIIRedactor', () => {
 
       expect(result).toBe(messages);
       expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('email'));
+    });
+
+    it('block catches PII that only the flattened content carries', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], strategy: 'block' });
+      const message: MastraDBMessage = {
+        id: 'msg-1',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [{ type: 'text' as const, text: 'all clear' }],
+          content: 'all clear, and test@example.com',
+        },
+        createdAt: new Date(),
+      };
+
+      try {
+        await redactor.processInput(createInputArgs([message]));
+        expect.fail('Expected TripWire');
+      } catch (error) {
+        expect(error).toBeInstanceOf(TripWire);
+        expect((error as TripWire<any>).options.metadata).toMatchObject({ detectedTypes: ['email'] });
+      }
     });
 
     it('filter drops flagged messages and keeps clean ones', async () => {

--- a/packages/core/src/processors/processors/pii-redactor.test.ts
+++ b/packages/core/src/processors/processors/pii-redactor.test.ts
@@ -161,6 +161,22 @@ describe('PIIRedactor', () => {
       expect(result).toBe(messages);
     });
 
+    it('keeps the earlier, longer match when detection spans overlap', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email', 'url'], redactionMethod: 'placeholder' });
+      const result = await redactor.processInput(
+        createInputArgs([createMessage('see https://example.com/u/a@b.io done')]),
+      );
+
+      expect(getText((result as MastraDBMessage[])[0]!)).toBe('see [URL] done');
+    });
+
+    it('does not garble text when two types match the same digits', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['phone', 'credit-card'], redactionMethod: 'placeholder' });
+      const result = await redactor.processInput(createInputArgs([createMessage('card 4111-1111-1111-1111 end')]));
+
+      expect(getText((result as MastraDBMessage[])[0]!)).toBe('card [CREDIT-CARD] end');
+    });
+
     it('only checks the last message when lastMessageOnly is set', async () => {
       const redactor = new PIIRedactor({
         detectionTypes: ['email'],

--- a/packages/core/src/processors/processors/pii-redactor.test.ts
+++ b/packages/core/src/processors/processors/pii-redactor.test.ts
@@ -6,6 +6,7 @@ import { ChunkFrom } from '../../stream/types';
 import type { ProcessInputArgs, ProcessOutputResultArgs, ProcessOutputStreamArgs } from '../index';
 import { PIIRedactor } from './pii-redactor';
 
+/** Build a V2 user or assistant message whose single text part holds `text`. */
 function createMessage(text: string, role: 'user' | 'assistant' = 'user'): MastraDBMessage {
   return {
     id: `msg-${Math.random()}`,
@@ -15,6 +16,7 @@ function createMessage(text: string, role: 'user' | 'assistant' = 'user'): Mastr
   };
 }
 
+/** Wrap messages in the argument shape `processInput` expects. */
 function createInputArgs(messages: MastraDBMessage[]): ProcessInputArgs {
   return {
     messages,
@@ -29,6 +31,7 @@ function createInputArgs(messages: MastraDBMessage[]): ProcessInputArgs {
   };
 }
 
+/** Wrap messages in the argument shape `processOutputResult` expects. */
 function createOutputResultArgs(messages: MastraDBMessage[]): ProcessOutputResultArgs {
   return {
     messages,
@@ -42,6 +45,7 @@ function createOutputResultArgs(messages: MastraDBMessage[]): ProcessOutputResul
   };
 }
 
+/** Build a text-delta stream chunk carrying `text`. */
 function createTextChunk(text: string): ChunkType {
   return {
     type: 'text-delta',
@@ -51,6 +55,7 @@ function createTextChunk(text: string): ChunkType {
   };
 }
 
+/** Wrap a chunk in the argument shape `processOutputStream` expects, with carry-over state. */
 function createStreamArgs(part: ChunkType, state: Record<string, any> = {}): ProcessOutputStreamArgs {
   return {
     part,
@@ -64,6 +69,7 @@ function createStreamArgs(part: ChunkType, state: Record<string, any> = {}): Pro
   };
 }
 
+/** Read the text of a message's first text part. */
 function getText(message: MastraDBMessage): string {
   const part = message.content.parts?.[0];
   return part && part.type === 'text' && 'text' in part ? (part.text as string) : '';

--- a/packages/core/src/processors/processors/pii-redactor.test.ts
+++ b/packages/core/src/processors/processors/pii-redactor.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MastraDBMessage, MessageList } from '../../agent/message-list';
+import { TripWire } from '../../agent/trip-wire';
+import type { ChunkType } from '../../stream';
+import { ChunkFrom } from '../../stream/types';
+import type { ProcessInputArgs, ProcessOutputResultArgs, ProcessOutputStreamArgs } from '../index';
+import { PIIRedactor } from './pii-redactor';
+
+function createMessage(text: string, role: 'user' | 'assistant' = 'user'): MastraDBMessage {
+  return {
+    id: `msg-${Math.random()}`,
+    role,
+    content: { format: 2, parts: [{ type: 'text' as const, text }] },
+    createdAt: new Date(),
+  };
+}
+
+function createInputArgs(messages: MastraDBMessage[]): ProcessInputArgs {
+  return {
+    messages,
+    messageList: {} as MessageList,
+    abort: ((reason?: string) => {
+      throw new TripWire(reason ?? 'aborted', { retry: false });
+    }) as any,
+    retryCount: 0,
+    model: { modelId: 'test', provider: 'test', specificationVersion: 'v2' } as any,
+    systemMessages: [],
+    state: {},
+  };
+}
+
+function createOutputResultArgs(messages: MastraDBMessage[]): ProcessOutputResultArgs {
+  return {
+    messages,
+    messageList: {} as MessageList,
+    abort: ((reason?: string) => {
+      throw new TripWire(reason ?? 'aborted', { retry: false });
+    }) as any,
+    retryCount: 0,
+    model: { modelId: 'test', provider: 'test', specificationVersion: 'v2' } as any,
+    state: {},
+  };
+}
+
+function createTextChunk(text: string): ChunkType {
+  return {
+    type: 'text-delta',
+    payload: { text, id: 'text-1' },
+    runId: 'run-1',
+    from: ChunkFrom.AGENT,
+  };
+}
+
+function createStreamArgs(part: ChunkType, state: Record<string, any> = {}): ProcessOutputStreamArgs {
+  return {
+    part,
+    streamParts: [],
+    abort: ((reason?: string) => {
+      throw new TripWire(reason ?? 'aborted', { retry: false });
+    }) as any,
+    retryCount: 0,
+    model: { modelId: 'test', provider: 'test', specificationVersion: 'v2' } as any,
+    state,
+  };
+}
+
+function getText(message: MastraDBMessage): string {
+  const part = message.content.parts?.[0];
+  return part && part.type === 'text' && 'text' in part ? (part.text as string) : '';
+}
+
+describe('PIIRedactor', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  describe('constructor', () => {
+    it('throws if no detection types are provided', () => {
+      expect(() => new PIIRedactor({ detectionTypes: [] })).toThrow('PIIRedactor requires at least one detection type');
+    });
+
+    it('throws for LLM-only types with a pointer to PIIDetector', () => {
+      expect(() => new PIIRedactor({ detectionTypes: ['name' as any] })).toThrow(/use PIIDetector with a model/);
+    });
+
+    it('throws for unknown types', () => {
+      expect(() => new PIIRedactor({ detectionTypes: ['passport' as any] })).toThrow(/not a regex-detectable PII type/);
+    });
+
+    it('accepts regex-detectable types', () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email', 'phone'] });
+      expect(redactor.id).toBe('pii-redactor');
+      expect(redactor.name).toBe('PII Redactor');
+    });
+  });
+
+  describe('processInput - redact strategy (default)', () => {
+    it('masks email addresses while preserving format', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'] });
+      const result = await redactor.processInput(createInputArgs([createMessage('Contact me at test@example.com')]));
+
+      const messages = result as MastraDBMessage[];
+      const text = getText(messages[0]!);
+      expect(text).not.toContain('test@example.com');
+      expect(text).toContain('@');
+      expect(text).toContain('Contact me at');
+    });
+
+    it('replaces values with placeholders when redactionMethod is placeholder', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email', 'ssn'], redactionMethod: 'placeholder' });
+      const result = await redactor.processInput(
+        createInputArgs([createMessage('Email test@example.com and SSN 123-45-6789')]),
+      );
+
+      const text = getText((result as MastraDBMessage[])[0]!);
+      expect(text).toBe('Email [EMAIL] and SSN [SSN]');
+    });
+
+    it('hashes values when redactionMethod is hash', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], redactionMethod: 'hash' });
+      const result = await redactor.processInput(createInputArgs([createMessage('test@example.com')]));
+
+      const text = getText((result as MastraDBMessage[])[0]!);
+      expect(text).toMatch(/^\[HASH:[0-9a-f]{8}\]$/);
+    });
+
+    it('removes values when redactionMethod is remove', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], redactionMethod: 'remove' });
+      const result = await redactor.processInput(createInputArgs([createMessage('before test@example.com after')]));
+
+      const text = getText((result as MastraDBMessage[])[0]!);
+      expect(text).toBe('before  after');
+    });
+
+    it('preserves non-text parts and message fields', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], redactionMethod: 'placeholder' });
+      const message: MastraDBMessage = {
+        id: 'msg-1',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'step-start' } as any, { type: 'text' as const, text: 'reach me at test@example.com' }],
+        },
+        createdAt: new Date(),
+      };
+
+      const result = (await redactor.processInput(createInputArgs([message]))) as MastraDBMessage[];
+      expect(result[0]!.id).toBe('msg-1');
+      expect(result[0]!.content.parts?.[0]).toEqual({ type: 'step-start' });
+      const textPart = result[0]!.content.parts?.[1];
+      expect(textPart && 'text' in textPart ? textPart.text : '').toBe('reach me at [EMAIL]');
+    });
+
+    it('returns messages unchanged when no PII is found', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email', 'phone'] });
+      const messages = [createMessage('nothing sensitive here')];
+      const result = await redactor.processInput(createInputArgs(messages));
+      expect(result).toBe(messages);
+    });
+
+    it('only checks the last message when lastMessageOnly is set', async () => {
+      const redactor = new PIIRedactor({
+        detectionTypes: ['email'],
+        redactionMethod: 'placeholder',
+        lastMessageOnly: true,
+      });
+      const first = createMessage('old email test@example.com');
+      const last = createMessage('new email new@example.com');
+      const result = (await redactor.processInput(createInputArgs([first, last]))) as MastraDBMessage[];
+
+      expect(getText(result[0]!)).toBe('old email test@example.com');
+      expect(getText(result[1]!)).toBe('new email [EMAIL]');
+    });
+  });
+
+  describe('processInput - other strategies', () => {
+    it('block throws a TripWire with type metadata and no raw values', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], strategy: 'block' });
+      try {
+        await redactor.processInput(createInputArgs([createMessage('leak test@example.com')]));
+        expect.fail('Expected TripWire');
+      } catch (error) {
+        expect(error).toBeInstanceOf(TripWire);
+        const tripwire = error as TripWire<any>;
+        expect(tripwire.options.metadata).toMatchObject({
+          processorId: 'pii-redactor',
+          strategy: 'block',
+          detectedTypes: ['email'],
+          detectionCount: 1,
+        });
+        expect(JSON.stringify(tripwire.options.metadata)).not.toContain('test@example.com');
+      }
+    });
+
+    it('warn logs and passes messages through unchanged', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], strategy: 'warn' });
+      const messages = [createMessage('email test@example.com')];
+      const result = await redactor.processInput(createInputArgs(messages));
+
+      expect(result).toBe(messages);
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('email'));
+    });
+
+    it('filter drops flagged messages and keeps clean ones', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], strategy: 'filter' });
+      const clean = createMessage('all clear');
+      const flagged = createMessage('email test@example.com');
+      const result = (await redactor.processInput(createInputArgs([clean, flagged]))) as MastraDBMessage[];
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(clean.id);
+    });
+  });
+
+  describe('processOutputResult', () => {
+    it('redacts assistant output', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['phone'], redactionMethod: 'placeholder' });
+      const result = await redactor.processOutputResult(
+        createOutputResultArgs([createMessage('call 555-123-4567 today', 'assistant')]),
+      );
+
+      expect(getText((result as MastraDBMessage[])[0]!)).toBe('call [PHONE] today');
+    });
+  });
+
+  describe('processOutputStream', () => {
+    it('passes clean chunks through unchanged', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'] });
+      const part = createTextChunk('hello world');
+      const result = await redactor.processOutputStream(createStreamArgs(part));
+      expect(result).toBe(part);
+    });
+
+    it('passes non-text chunks through unchanged', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'] });
+      const part = { type: 'tool-call', payload: {}, runId: 'run-1', from: ChunkFrom.AGENT } as unknown as ChunkType;
+      const result = await redactor.processOutputStream(createStreamArgs(part));
+      expect(result).toBe(part);
+    });
+
+    it('redacts PII inside a single chunk', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], redactionMethod: 'placeholder' });
+      const result = await redactor.processOutputStream(createStreamArgs(createTextChunk('mail test@example.com ok')));
+
+      expect(result && result.type === 'text-delta' ? result.payload.text : '').toBe('mail [EMAIL] ok');
+    });
+
+    it('detects PII split across chunk boundaries via carryover', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], redactionMethod: 'placeholder' });
+      const state: Record<string, any> = {};
+
+      const first = await redactor.processOutputStream(createStreamArgs(createTextChunk('contact test@'), state));
+      expect(first && first.type === 'text-delta' ? first.payload.text : '').toBe('contact test@');
+
+      const second = await redactor.processOutputStream(createStreamArgs(createTextChunk('example.com now'), state));
+      expect(second && second.type === 'text-delta' ? second.payload.text : '').toBe('[EMAIL] now');
+    });
+
+    it('does not re-flag PII that was fully contained in the carryover tail', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], redactionMethod: 'placeholder' });
+      const state: Record<string, any> = {};
+
+      await redactor.processOutputStream(createStreamArgs(createTextChunk('mail test@example.com done'), state));
+      const next = await redactor.processOutputStream(createStreamArgs(createTextChunk(' more text'), state));
+      expect(next && next.type === 'text-delta' ? next.payload.text : '').toBe(' more text');
+    });
+
+    it('block strategy throws a TripWire on streaming PII', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], strategy: 'block' });
+      await expect(
+        redactor.processOutputStream(createStreamArgs(createTextChunk('leak test@example.com'))),
+      ).rejects.toBeInstanceOf(TripWire);
+    });
+
+    it('filter strategy drops the chunk', async () => {
+      const redactor = new PIIRedactor({ detectionTypes: ['email'], strategy: 'filter' });
+      const result = await redactor.processOutputStream(createStreamArgs(createTextChunk('leak test@example.com')));
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/processors/processors/pii-redactor.ts
+++ b/packages/core/src/processors/processors/pii-redactor.ts
@@ -12,6 +12,7 @@ import type {
 import { selectMessagesToCheck } from './message-selection';
 import type { LastMessageOnlyOption } from './message-selection';
 import {
+  deoverlapPIIDetections,
   detectPIIWithPatterns,
   LLM_ONLY_PII_TYPES,
   PII_PATTERNS,
@@ -283,7 +284,7 @@ export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwir
    * that was already emitted, which would shift slice offsets.
    */
   private redactNewRegion(combined: string, tailLength: number, detections: PIIDetection[]): string {
-    const sorted = [...detections].sort((a, b) => a.start - b.start);
+    const sorted = deoverlapPIIDetections(detections);
     let cursor = tailLength;
     let out = '';
     for (const detection of sorted) {

--- a/packages/core/src/processors/processors/pii-redactor.ts
+++ b/packages/core/src/processors/processors/pii-redactor.ts
@@ -1,0 +1,321 @@
+import type { MastraDBMessage } from '../../agent/message-list';
+import { TripWire } from '../../agent/trip-wire';
+import type { ChunkType } from '../../stream';
+import type {
+  ProcessInputArgs,
+  ProcessInputResult,
+  ProcessOutputResultArgs,
+  ProcessOutputStreamArgs,
+  ProcessorMessageResult,
+  Processor,
+} from '../index';
+import { selectMessagesToCheck } from './message-selection';
+import type { LastMessageOnlyOption } from './message-selection';
+import {
+  detectPIIWithPatterns,
+  LLM_ONLY_PII_TYPES,
+  PII_PATTERNS,
+  PII_REGEX_CARRYOVER_SIZE,
+  redactPIIValue,
+  REGEX_DETECTABLE_PII_TYPES,
+} from './pii-shared';
+import type { PIIDetection, PIIRedactionMethod, PIIRedactionOptions, RegexDetectablePIIType } from './pii-shared';
+
+/**
+ * Metadata attached to the TripWire when PIIRedactor blocks.
+ * Never includes the matched values.
+ */
+export interface PIIRedactorTripwireMetadata {
+  processorId: 'pii-redactor';
+  detectedTypes: string[];
+  detectionCount: number;
+  strategy: 'block';
+}
+
+/**
+ * Configuration options for PIIRedactor
+ */
+export interface PIIRedactorOptions extends LastMessageOnlyOption {
+  /**
+   * PII types to detect. Only regex-detectable types are accepted.
+   * Context-dependent types (name, address, date-of-birth) require the
+   * LLM-based PIIDetector instead.
+   */
+  detectionTypes: RegexDetectablePIIType[];
+
+  /**
+   * Strategy when PII is detected:
+   * - 'block': Reject the content with a TripWire error
+   * - 'warn': Log a warning but allow content through
+   * - 'filter': Remove flagged messages but continue with remaining
+   * - 'redact': Replace detected PII with redacted versions (default)
+   */
+  strategy?: 'block' | 'warn' | 'filter' | 'redact';
+
+  /**
+   * Redaction method for PII (default: 'mask'):
+   * - 'mask': Replace with asterisks (***@***.com)
+   * - 'hash': Replace with SHA256 hash
+   * - 'remove': Remove entirely
+   * - 'placeholder': Replace with type placeholder ([EMAIL], [PHONE], etc.)
+   */
+  redactionMethod?: PIIRedactionMethod;
+
+  /**
+   * Whether to preserve PII format during redaction (default: true)
+   * When true, maintains structure like ***-**-1234 for phone numbers
+   */
+  preserveFormat?: boolean;
+}
+
+/**
+ * PIIRedactor detects and redacts pattern-shaped PII using regex only.
+ * No LLM calls are made and no agent is constructed, so message content
+ * never leaves the process through this processor.
+ *
+ * For context-dependent PII (names, addresses, dates of birth), use the
+ * LLM-based PIIDetector instead.
+ *
+ * @example Redact emails and phone numbers:
+ * ```typescript
+ * new PIIRedactor({
+ *   detectionTypes: ['email', 'phone', 'credit-card'],
+ *   strategy: 'redact',
+ *   redactionMethod: 'mask',
+ * })
+ * ```
+ */
+export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwireMetadata> {
+  public readonly id = 'pii-redactor' as const;
+  public readonly name = 'PII Redactor';
+
+  private detectionTypes: RegexDetectablePIIType[];
+  private strategy: 'block' | 'warn' | 'filter' | 'redact';
+  private redactionOptions: PIIRedactionOptions;
+  private lastMessageOnly: boolean;
+
+  constructor(options: PIIRedactorOptions) {
+    if (!options.detectionTypes || options.detectionTypes.length === 0) {
+      throw new Error('PIIRedactor requires at least one detection type');
+    }
+
+    for (const type of options.detectionTypes) {
+      if (!PII_PATTERNS[type]) {
+        const reason = LLM_ONLY_PII_TYPES.has(type)
+          ? `"${type}" requires LLM-based detection; use PIIDetector with a model instead`
+          : `"${type}" is not a regex-detectable PII type`;
+        throw new Error(`PIIRedactor: ${reason}. Supported types: ${REGEX_DETECTABLE_PII_TYPES.join(', ')}`);
+      }
+    }
+
+    this.detectionTypes = options.detectionTypes;
+    this.strategy = options.strategy ?? 'redact';
+    this.redactionOptions = {
+      method: options.redactionMethod ?? 'mask',
+      preserveFormat: options.preserveFormat ?? true,
+    };
+    this.lastMessageOnly = options.lastMessageOnly ?? false;
+  }
+
+  processInput(args: ProcessInputArgs<PIIRedactorTripwireMetadata>): ProcessInputResult | Promise<ProcessInputResult> {
+    return this.processMessages(args.messages, 'input');
+  }
+
+  processOutputResult(args: ProcessOutputResultArgs<PIIRedactorTripwireMetadata>): ProcessorMessageResult {
+    return this.processMessages(args.messages, 'output');
+  }
+
+  /**
+   * Process streaming text chunks. A tail of recent characters is carried
+   * over between chunks so PII split across chunk boundaries is still
+   * detected; only the portion inside the current chunk can be rewritten.
+   */
+  async processOutputStream(
+    args: ProcessOutputStreamArgs<PIIRedactorTripwireMetadata>,
+  ): Promise<ChunkType | null | undefined> {
+    const { part, state } = args;
+
+    if (part.type !== 'text-delta' || !part.payload?.text) {
+      return part;
+    }
+
+    const tail = (state._piiRedactorTail as string | undefined) ?? '';
+    const combined = tail + part.payload.text;
+    const result = detectPIIWithPatterns(combined, this.detectionTypes);
+    state._piiRedactorTail = combined.slice(-PII_REGEX_CARRYOVER_SIZE);
+
+    // Only act on detections that overlap the new chunk; tail-only
+    // detections were already handled when their chunk was processed.
+    const newDetections = (result.detections ?? []).filter(d => d.end > tail.length);
+    if (newDetections.length === 0) {
+      return part;
+    }
+
+    switch (this.strategy) {
+      case 'block':
+        this.blockWithTripWire(newDetections, 'streaming content');
+        return null;
+
+      case 'warn':
+        console.warn(`[PIIRedactor] PII detected in streaming content: ${this.uniqueTypes(newDetections).join(', ')}`);
+        return part;
+
+      case 'filter':
+        console.info(`[PIIRedactor] Filtered streaming part with PII: ${this.uniqueTypes(newDetections).join(', ')}`);
+        return null;
+
+      case 'redact':
+        return {
+          ...part,
+          payload: { ...part.payload, text: this.redactNewRegion(combined, tail.length, newDetections) },
+        };
+
+      default:
+        return part;
+    }
+  }
+
+  private processMessages(messages: MastraDBMessage[], context: string): MastraDBMessage[] {
+    if (messages.length === 0) {
+      return messages;
+    }
+
+    const messagesToCheck = selectMessagesToCheck(messages, this.lastMessageOnly);
+    const checkedMessageIds = new Set(messagesToCheck.map(message => message.id));
+
+    const flaggedMessageIds = new Set<string>();
+    const allDetections: PIIDetection[] = [];
+    for (const message of messages) {
+      if (!checkedMessageIds.has(message.id)) continue;
+      const detections = this.detectInMessage(message);
+      if (detections.length > 0) {
+        flaggedMessageIds.add(message.id);
+        allDetections.push(...detections);
+      }
+    }
+
+    if (allDetections.length === 0) {
+      return messages;
+    }
+
+    switch (this.strategy) {
+      case 'block':
+        this.blockWithTripWire(allDetections, context);
+        return messages;
+
+      case 'warn':
+        console.warn(`[PIIRedactor] PII detected: ${this.uniqueTypes(allDetections).join(', ')}`);
+        return messages;
+
+      case 'filter':
+        console.info(`[PIIRedactor] Filtered ${flaggedMessageIds.size} message(s) with PII`);
+        return messages.filter(message => !flaggedMessageIds.has(message.id));
+
+      case 'redact':
+        return messages.map(message => (flaggedMessageIds.has(message.id) ? this.redactMessage(message) : message));
+
+      default:
+        return messages;
+    }
+  }
+
+  private detectInMessage(message: MastraDBMessage): PIIDetection[] {
+    const detections: PIIDetection[] = [];
+    for (const segment of this.extractSegments(message)) {
+      detections.push(...(detectPIIWithPatterns(segment, this.detectionTypes).detections ?? []));
+    }
+    return detections;
+  }
+
+  private extractSegments(message: MastraDBMessage): string[] {
+    // At runtime, content may be a plain string even though MastraDBMessage types it as MastraMessageContentV2
+    if (typeof message.content === 'string') {
+      return [message.content];
+    }
+    const segments: string[] = [];
+    if (message.content?.parts) {
+      for (const part of message.content.parts) {
+        if (part.type === 'text' && 'text' in part && typeof part.text === 'string') {
+          segments.push(part.text);
+        }
+      }
+    }
+    if (segments.length === 0 && typeof message.content?.content === 'string') {
+      segments.push(message.content.content);
+    }
+    return segments;
+  }
+
+  private redactMessage(message: MastraDBMessage): MastraDBMessage {
+    if (typeof message.content === 'string') {
+      return { ...message, content: this.redactText(message.content) } as unknown as MastraDBMessage;
+    }
+    if (!message.content?.parts) {
+      if (typeof message.content?.content === 'string') {
+        return { ...message, content: { ...message.content, content: this.redactText(message.content.content) } };
+      }
+      return message;
+    }
+
+    const newParts = message.content.parts.map(part => {
+      if (part.type === 'text' && 'text' in part && typeof part.text === 'string') {
+        return { ...part, text: this.redactText(part.text) };
+      }
+      return part;
+    });
+
+    const newContent: MastraDBMessage['content'] = { ...message.content, parts: newParts };
+    if (typeof message.content.content === 'string') {
+      newContent.content = this.redactText(message.content.content);
+    }
+
+    return { ...message, content: newContent };
+  }
+
+  private redactText(text: string): string {
+    const result = detectPIIWithPatterns(text, this.detectionTypes, this.redactionOptions);
+    return result.redacted_content ?? text;
+  }
+
+  /**
+   * Rewrite only the region of `combined` past `tailLength`, replacing the
+   * in-chunk portion of each detection. Avoids re-redacting tail content
+   * that was already emitted, which would shift slice offsets.
+   */
+  private redactNewRegion(combined: string, tailLength: number, detections: PIIDetection[]): string {
+    const sorted = [...detections].sort((a, b) => a.start - b.start);
+    let cursor = tailLength;
+    let out = '';
+    for (const detection of sorted) {
+      const start = Math.max(detection.start, tailLength);
+      if (start > cursor) {
+        out += combined.slice(cursor, start);
+      }
+      if (detection.end > cursor) {
+        out += redactPIIValue(detection.value, detection.type, this.redactionOptions);
+        cursor = detection.end;
+      }
+    }
+    if (cursor < combined.length) {
+      out += combined.slice(cursor);
+    }
+    return out;
+  }
+
+  private uniqueTypes(detections: PIIDetection[]): string[] {
+    return [...new Set(detections.map(d => d.type))];
+  }
+
+  private blockWithTripWire(detections: PIIDetection[], context: string): never {
+    const detectedTypes = this.uniqueTypes(detections);
+    throw new TripWire<PIIRedactorTripwireMetadata>(`PII detected in ${context}. Types: ${detectedTypes.join(', ')}`, {
+      retry: false,
+      metadata: {
+        processorId: this.id,
+        detectedTypes,
+        detectionCount: detections.length,
+        strategy: 'block',
+      },
+    });
+  }
+}

--- a/packages/core/src/processors/processors/pii-redactor.ts
+++ b/packages/core/src/processors/processors/pii-redactor.ts
@@ -250,8 +250,14 @@ export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwir
 
   /**
    * Pull the scannable text out of a message: a plain string content, each
-   * text part, or the flattened `content.content` fallback when no text part
-   * exists. Non-text parts are ignored.
+   * text part, and the flattened `content.content`. Non-text parts are ignored.
+   *
+   * `content.content` is scanned even when text parts exist, because
+   * `redactMessage` rewrites it in that case too. Skipping it here would let a
+   * flattened string that carries PII the parts don't go undetected, which
+   * leaves the message unflagged and untouched under every strategy. It is
+   * skipped only when a part already covers the exact same text, so the normal
+   * case does not report the same detection twice.
    */
   private extractSegments(message: MastraDBMessage): string[] {
     // At runtime, content may be a plain string even though MastraDBMessage types it as MastraMessageContentV2
@@ -266,8 +272,9 @@ export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwir
         }
       }
     }
-    if (segments.length === 0 && typeof message.content?.content === 'string') {
-      segments.push(message.content.content);
+    const flattened = message.content?.content;
+    if (typeof flattened === 'string' && !segments.includes(flattened)) {
+      segments.push(flattened);
     }
     return segments;
   }

--- a/packages/core/src/processors/processors/pii-redactor.ts
+++ b/packages/core/src/processors/processors/pii-redactor.ts
@@ -95,6 +95,12 @@ export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwir
   private redactionOptions: PIIRedactionOptions;
   private lastMessageOnly: boolean;
 
+  /**
+   * Create a PIIRedactor.
+   *
+   * @throws If `detectionTypes` is empty, or contains a type that regex cannot
+   * detect (context-dependent types such as name, address, and date-of-birth).
+   */
   constructor(options: PIIRedactorOptions) {
     if (!options.detectionTypes || options.detectionTypes.length === 0) {
       throw new Error('PIIRedactor requires at least one detection type');
@@ -118,10 +124,16 @@ export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwir
     this.lastMessageOnly = options.lastMessageOnly ?? false;
   }
 
+  /**
+   * Scan incoming user messages and apply the configured strategy.
+   */
   processInput(args: ProcessInputArgs<PIIRedactorTripwireMetadata>): ProcessInputResult | Promise<ProcessInputResult> {
     return this.processMessages(args.messages, 'input');
   }
 
+  /**
+   * Scan the completed agent response and apply the configured strategy.
+   */
   processOutputResult(args: ProcessOutputResultArgs<PIIRedactorTripwireMetadata>): ProcessorMessageResult {
     return this.processMessages(args.messages, 'output');
   }
@@ -176,6 +188,11 @@ export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwir
     }
   }
 
+  /**
+   * Detect PII across the selected messages and apply the configured strategy.
+   * `context` only labels the location ('input' or 'output') in warnings and
+   * TripWire messages. Returns the original array when nothing is detected.
+   */
   private processMessages(messages: MastraDBMessage[], context: string): MastraDBMessage[] {
     if (messages.length === 0) {
       return messages;
@@ -220,6 +237,9 @@ export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwir
     }
   }
 
+  /**
+   * Collect PII detections from every text segment of a single message.
+   */
   private detectInMessage(message: MastraDBMessage): PIIDetection[] {
     const detections: PIIDetection[] = [];
     for (const segment of this.extractSegments(message)) {
@@ -228,6 +248,11 @@ export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwir
     return detections;
   }
 
+  /**
+   * Pull the scannable text out of a message: a plain string content, each
+   * text part, or the flattened `content.content` fallback when no text part
+   * exists. Non-text parts are ignored.
+   */
   private extractSegments(message: MastraDBMessage): string[] {
     // At runtime, content may be a plain string even though MastraDBMessage types it as MastraMessageContentV2
     if (typeof message.content === 'string') {
@@ -247,6 +272,10 @@ export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwir
     return segments;
   }
 
+  /**
+   * Return a copy of the message with PII redacted in every text location,
+   * keeping non-text parts and all other message fields untouched.
+   */
   private redactMessage(message: MastraDBMessage): MastraDBMessage {
     if (typeof message.content === 'string') {
       return { ...message, content: this.redactText(message.content) } as unknown as MastraDBMessage;
@@ -273,6 +302,10 @@ export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwir
     return { ...message, content: newContent };
   }
 
+  /**
+   * Apply the configured redaction method to one string, returning it
+   * unchanged when no PII is found.
+   */
   private redactText(text: string): string {
     const result = detectPIIWithPatterns(text, this.detectionTypes, this.redactionOptions);
     return result.redacted_content ?? text;
@@ -303,10 +336,20 @@ export class PIIRedactor implements Processor<'pii-redactor', PIIRedactorTripwir
     return out;
   }
 
+  /**
+   * List the distinct PII types present in a detection set. Used for logs and
+   * TripWire metadata, which never carry the matched values.
+   */
   private uniqueTypes(detections: PIIDetection[]): string[] {
     return [...new Set(detections.map(d => d.type))];
   }
 
+  /**
+   * Abort processing for the 'block' strategy.
+   *
+   * @throws A non-retryable {@link TripWire} carrying the detected types and
+   * count, but never the matched values.
+   */
   private blockWithTripWire(detections: PIIDetection[], context: string): never {
     const detectedTypes = this.uniqueTypes(detections);
     throw new TripWire<PIIRedactorTripwireMetadata>(`PII detected in ${context}. Types: ${detectedTypes.join(', ')}`, {

--- a/packages/core/src/processors/processors/pii-shared.ts
+++ b/packages/core/src/processors/processors/pii-shared.ts
@@ -56,11 +56,24 @@ export interface PIIDetectionResult {
  */
 export type PIIRedactionMethod = 'mask' | 'hash' | 'remove' | 'placeholder';
 
+/** All regex-detectable PII types */
+export const REGEX_DETECTABLE_PII_TYPES = [
+  'email',
+  'phone',
+  'credit-card',
+  'ssn',
+  'api-key',
+  'ip-address',
+  'url',
+  'uuid',
+  'crypto-wallet',
+  'iban',
+] as const;
+
 /**
  * PII types detectable with regex patterns alone (no LLM required)
  */
-export type RegexDetectablePIIType =
-  'email' | 'phone' | 'credit-card' | 'ssn' | 'api-key' | 'ip-address' | 'url' | 'uuid' | 'crypto-wallet' | 'iban';
+export type RegexDetectablePIIType = (typeof REGEX_DETECTABLE_PII_TYPES)[number];
 
 /**
  * Regex patterns for local (zero-cost) PII detection
@@ -78,9 +91,6 @@ export const PII_PATTERNS: Record<RegexDetectablePIIType, RegExp> = {
   'crypto-wallet': /\b(?:0x[a-fA-F0-9]{40}|[13][a-km-zA-HJ-NP-Z1-9]{25,34}|bc1[a-zA-HJ-NP-Z0-9]{39,59})\b/g,
   iban: /\b[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}(?:[A-Z0-9]?){0,16}\b/g,
 };
-
-/** All regex-detectable PII types */
-export const REGEX_DETECTABLE_PII_TYPES = Object.keys(PII_PATTERNS) as RegexDetectablePIIType[];
 
 /** PII types that require LLM context and cannot be detected by regex */
 export const LLM_ONLY_PII_TYPES = new Set(['name', 'address', 'date-of-birth']);
@@ -126,7 +136,7 @@ export function maskPIIValue(value: string, type: string, preserveFormat: boolea
   }
 
   switch (type) {
-    case 'email':
+    case 'email': {
       const emailParts = value.split('@');
       if (emailParts.length === 2) {
         const [local, domain] = emailParts;
@@ -140,6 +150,7 @@ export function maskPIIValue(value: string, type: string, preserveFormat: boolea
         return `${maskedLocal}@${maskedDomain}`;
       }
       break;
+    }
 
     case 'phone':
       // Preserve format like XXX-XXX-1234 or (XXX) XXX-1234
@@ -197,13 +208,31 @@ export function hashPIIValue(value: string): string {
 }
 
 /**
+ * Drop detections that overlap an earlier-starting (or same-start, longer) one
+ * so span replacement always operates on disjoint ranges. Patterns run
+ * independently, so e.g. an email inside a matched URL produces overlapping
+ * spans that would garble spliced output.
+ */
+export function deoverlapPIIDetections(detections: PIIDetection[]): PIIDetection[] {
+  const sorted = [...detections].sort((a, b) => a.start - b.start || b.end - a.end);
+  const disjoint: PIIDetection[] = [];
+  let lastEnd = -1;
+  for (const detection of sorted) {
+    if (detection.start < lastEnd) continue;
+    disjoint.push(detection);
+    lastEnd = detection.end;
+  }
+  return disjoint;
+}
+
+/**
  * Apply redaction to content given a set of detections
  */
 export function applyPIIRedaction(content: string, detections: PIIDetection[], options: PIIRedactionOptions): string {
   let redacted = content;
 
   // Sort detections by start position in reverse order to maintain indices
-  const sortedDetections = [...detections].sort((a, b) => b.start - a.start);
+  const sortedDetections = deoverlapPIIDetections(detections).sort((a, b) => b.start - a.start);
 
   for (const detection of sortedDetections) {
     const redactedValue = redactPIIValue(detection.value, detection.type, options);
@@ -249,21 +278,23 @@ export function detectPIIWithPatterns(
     }
   }
 
-  const detectedTypes = new Set(detections.map(d => d.type));
+  const disjointDetections = deoverlapPIIDetections(detections);
+
+  const detectedTypes = new Set(disjointDetections.map(d => d.type));
   for (const type of detectedTypes) {
     categories.push({ type, score: 1.0 });
   }
 
   let redacted_content: string | null | undefined;
-  if (redact && detections.length > 0) {
-    redacted_content = applyPIIRedaction(content, detections, redact);
+  if (redact && disjointDetections.length > 0) {
+    redacted_content = applyPIIRedaction(content, disjointDetections, redact);
   } else if (redact) {
     redacted_content = null;
   }
 
   return {
     categories: categories.length > 0 ? categories : null,
-    detections: detections.length > 0 ? detections : null,
+    detections: disjointDetections.length > 0 ? disjointDetections : null,
     ...(redact ? { redacted_content } : {}),
   };
 }

--- a/packages/core/src/processors/processors/pii-shared.ts
+++ b/packages/core/src/processors/processors/pii-shared.ts
@@ -28,6 +28,7 @@ export interface PIICategoryScore {
   score: number;
 }
 
+/** Confidence scores for every PII category considered during detection */
 export type PIICategoryScores = PIICategoryScore[];
 
 /**

--- a/packages/core/src/processors/processors/pii-shared.ts
+++ b/packages/core/src/processors/processors/pii-shared.ts
@@ -1,0 +1,269 @@
+import * as crypto from 'node:crypto';
+
+/**
+ * PII categories for detection and redaction
+ */
+export interface PIICategories {
+  email?: boolean;
+  phone?: boolean;
+  'credit-card'?: boolean;
+  ssn?: boolean;
+  'api-key'?: boolean;
+  'ip-address'?: boolean;
+  name?: boolean;
+  address?: boolean;
+  'date-of-birth'?: boolean;
+  url?: boolean;
+  uuid?: boolean;
+  'crypto-wallet'?: boolean;
+  iban?: boolean;
+  [customType: string]: boolean | undefined;
+}
+
+/**
+ * Individual PII category score
+ */
+export interface PIICategoryScore {
+  type: string;
+  score: number;
+}
+
+export type PIICategoryScores = PIICategoryScore[];
+
+/**
+ * Individual PII detection with location and redaction info
+ */
+export interface PIIDetection {
+  type: string;
+  value: string;
+  confidence: number;
+  start: number;
+  end: number;
+  redacted_value?: string | null; // Only present when strategy is 'redact'
+}
+
+/**
+ * Result structure for PII detection (simplified for minimal tokens)
+ */
+export interface PIIDetectionResult {
+  categories: PIICategoryScores | null;
+  detections: PIIDetection[] | null;
+  redacted_content?: string | null; // Only present when strategy is 'redact'
+}
+
+/**
+ * Redaction method applied to detected PII values
+ */
+export type PIIRedactionMethod = 'mask' | 'hash' | 'remove' | 'placeholder';
+
+/**
+ * PII types detectable with regex patterns alone (no LLM required)
+ */
+export type RegexDetectablePIIType =
+  'email' | 'phone' | 'credit-card' | 'ssn' | 'api-key' | 'ip-address' | 'url' | 'uuid' | 'crypto-wallet' | 'iban';
+
+/**
+ * Regex patterns for local (zero-cost) PII detection
+ */
+export const PII_PATTERNS: Record<RegexDetectablePIIType, RegExp> = {
+  email: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+  phone: /(?:\+?\d{1,3}[-.\ ]?)?\(?\d{3}\)?[-.\ ]?\d{3}[-.\ ]?\d{4}/g,
+  'credit-card': /\b(?:\d{4}[-\s]?){3}\d{4}\b/g,
+  ssn: /\b\d{3}-\d{2}-\d{4}\b/g,
+  'api-key':
+    /(?:(?:sk|pk)[-_](?:live|test|proj)[-_][A-Za-z0-9]{16,}|(?:api[_-]?key|apikey|api[_-]?secret)\s*[:=]\s*["']?[a-zA-Z0-9_\-]{20,}["']?)/gi,
+  'ip-address': /\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b/g,
+  url: /https?:\/\/[^\s<>"']+/gi,
+  uuid: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+  'crypto-wallet': /\b(?:0x[a-fA-F0-9]{40}|[13][a-km-zA-HJ-NP-Z1-9]{25,34}|bc1[a-zA-HJ-NP-Z0-9]{39,59})\b/g,
+  iban: /\b[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}(?:[A-Z0-9]?){0,16}\b/g,
+};
+
+/** All regex-detectable PII types */
+export const REGEX_DETECTABLE_PII_TYPES = Object.keys(PII_PATTERNS) as RegexDetectablePIIType[];
+
+/** PII types that require LLM context and cannot be detected by regex */
+export const LLM_ONLY_PII_TYPES = new Set(['name', 'address', 'date-of-birth']);
+
+/**
+ * Number of characters to carry over between chunks for regex detection.
+ * Ensures PII split across chunk boundaries (e.g. "test@" + "example.com") is caught.
+ */
+export const PII_REGEX_CARRYOVER_SIZE = 128;
+
+/**
+ * Options controlling how detected PII values are rewritten
+ */
+export interface PIIRedactionOptions {
+  method: PIIRedactionMethod;
+  preserveFormat: boolean;
+}
+
+/**
+ * Redact an individual PII value based on method and type
+ */
+export function redactPIIValue(value: string, type: string, options: PIIRedactionOptions): string {
+  switch (options.method) {
+    case 'mask':
+      return maskPIIValue(value, type, options.preserveFormat);
+    case 'hash':
+      return hashPIIValue(value);
+    case 'remove':
+      return '';
+    case 'placeholder':
+      return `[${type.toUpperCase()}]`;
+    default:
+      return maskPIIValue(value, type, options.preserveFormat);
+  }
+}
+
+/**
+ * Mask a PII value while optionally preserving format
+ */
+export function maskPIIValue(value: string, type: string, preserveFormat: boolean): string {
+  if (!preserveFormat) {
+    return '*'.repeat(Math.min(value.length, 8));
+  }
+
+  switch (type) {
+    case 'email':
+      const emailParts = value.split('@');
+      if (emailParts.length === 2) {
+        const [local, domain] = emailParts;
+        const maskedLocal =
+          local && local.length > 2 ? local[0] + '*'.repeat(local.length - 2) + local[local.length - 1] : '***';
+        const domainParts = domain?.split('.');
+        const maskedDomain =
+          domainParts && domainParts.length > 1
+            ? '*'.repeat(domainParts[0]?.length ?? 0) + '.' + domainParts.slice(1).join('.')
+            : '***';
+        return `${maskedLocal}@${maskedDomain}`;
+      }
+      break;
+
+    case 'phone':
+      // Preserve format like XXX-XXX-1234 or (XXX) XXX-1234
+      return value.replace(/\d/g, (match, index) => {
+        // Keep last 4 digits
+        return index >= value.length - 4 ? match : 'X';
+      });
+
+    case 'credit-card':
+      // Show last 4 digits: ****-****-****-1234
+      return value.replace(/\d/g, (match, index) => {
+        return index >= value.length - 4 ? match : '*';
+      });
+
+    case 'ssn':
+      // Show last 4 digits: ***-**-1234
+      return value.replace(/\d/g, (match, index) => {
+        return index >= value.length - 4 ? match : '*';
+      });
+
+    case 'uuid':
+      // Mask UUID: ********-****-****-****-************
+      return value.replace(/[a-f0-9]/gi, '*');
+
+    case 'crypto-wallet':
+      // Show first 4 and last 4 characters: 1Lbc...X71
+      if (value.length > 8) {
+        return value.slice(0, 4) + '*'.repeat(value.length - 8) + value.slice(-4);
+      }
+      return '*'.repeat(value.length);
+
+    case 'iban':
+      // Show country code and last 4 digits: DE**************3000
+      if (value.length > 6) {
+        return value.slice(0, 2) + '*'.repeat(value.length - 6) + value.slice(-4);
+      }
+      return '*'.repeat(value.length);
+
+    default:
+      // Generic masking - show first and last character if long enough
+      if (value.length <= 3) {
+        return '*'.repeat(value.length);
+      }
+      return value[0] + '*'.repeat(value.length - 2) + value[value.length - 1];
+  }
+
+  return '*'.repeat(Math.min(value.length, 8));
+}
+
+/**
+ * Hash a PII value using SHA256
+ */
+export function hashPIIValue(value: string): string {
+  return `[HASH:${crypto.createHash('sha256').update(value).digest('hex').slice(0, 8)}]`;
+}
+
+/**
+ * Apply redaction to content given a set of detections
+ */
+export function applyPIIRedaction(content: string, detections: PIIDetection[], options: PIIRedactionOptions): string {
+  let redacted = content;
+
+  // Sort detections by start position in reverse order to maintain indices
+  const sortedDetections = [...detections].sort((a, b) => b.start - a.start);
+
+  for (const detection of sortedDetections) {
+    const redactedValue = redactPIIValue(detection.value, detection.type, options);
+    redacted = redacted.slice(0, detection.start) + redactedValue + redacted.slice(detection.end);
+  }
+
+  return redacted;
+}
+
+/**
+ * Detect PII using regex patterns (zero-cost, no LLM calls).
+ * Types without a regex pattern (LLM-only or unknown custom types) are skipped.
+ * When `redact` options are provided, detections carry a `redacted_value` and
+ * the result includes `redacted_content`.
+ */
+export function detectPIIWithPatterns(
+  content: string,
+  detectionTypes: string[],
+  redact?: PIIRedactionOptions,
+): PIIDetectionResult {
+  const categories: PIICategoryScores = [];
+  const detections: PIIDetection[] = [];
+
+  for (const type of detectionTypes) {
+    const pattern = PII_PATTERNS[type as RegexDetectablePIIType];
+    if (!pattern) continue;
+
+    // Fresh regex per call so shared /g patterns keep no lastIndex state across runs
+    const regex = new RegExp(pattern.source, pattern.flags);
+    let match;
+    while ((match = regex.exec(content)) !== null) {
+      detections.push({
+        type,
+        value: match[0],
+        confidence: 1.0,
+        start: match.index,
+        end: match.index + match[0].length,
+        ...(redact ? { redacted_value: redactPIIValue(match[0], type, redact) } : {}),
+      });
+      if (match[0].length === 0) {
+        regex.lastIndex++;
+      }
+    }
+  }
+
+  const detectedTypes = new Set(detections.map(d => d.type));
+  for (const type of detectedTypes) {
+    categories.push({ type, score: 1.0 });
+  }
+
+  let redacted_content: string | null | undefined;
+  if (redact && detections.length > 0) {
+    redacted_content = applyPIIRedaction(content, detections, redact);
+  } else if (redact) {
+    redacted_content = null;
+  }
+
+  return {
+    categories: categories.length > 0 ? categories : null,
+    detections: detections.length > 0 ? detections : null,
+    ...(redact ? { redacted_content } : {}),
+  };
+}

--- a/packages/editor/src/editor-processors.test.ts
+++ b/packages/editor/src/editor-processors.test.ts
@@ -841,6 +841,7 @@ describe('Stored Agents with Processor Providers', () => {
       expect(providers['moderation']).toBeDefined();
       expect(providers['prompt-injection-detector']).toBeDefined();
       expect(providers['pii-detector']).toBeDefined();
+      expect(providers['pii-redactor']).toBeDefined();
       expect(providers['language-detector']).toBeDefined();
       expect(providers['system-prompt-scrubber']).toBeDefined();
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1928,8 +1928,8 @@ importers:
   embedders/voyageai:
     dependencies:
       voyageai:
-        specifier: ^0.2.1
-        version: 0.2.1(encoding@0.1.13)(onnxruntime-node@1.26.0)
+        specifier: ^0.3.1
+        version: 0.3.1(encoding@0.1.13)(onnxruntime-node@1.26.0)
     devDependencies:
       '@internal/ai-sdk-v4':
         specifier: workspace:*
@@ -30208,8 +30208,8 @@ packages:
       jsdom:
         optional: true
 
-  voyageai@0.2.1:
-    resolution: {integrity: sha512-ym7Dk6p8Si6lR9wDh58EzxwT0ziD/pqXjzzzceOSySO3Ic3uosHZLOTAsb3Gq+1OaKdEMnni/p8TohKUNvLTkg==}
+  voyageai@0.3.1:
+    resolution: {integrity: sha512-+f6gRsnuV7gi2tFvSFWTqERkZhox1VQCT0G+ALUDAwz75OpzpqaXgy6TSRkbrf6az9WZsXoAyDtplDksHLSbag==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@huggingface/transformers': ^3.8.0
@@ -55560,7 +55560,7 @@ snapshots:
       - msw
     optional: true
 
-  voyageai@0.2.1(encoding@0.1.13)(onnxruntime-node@1.26.0):
+  voyageai@0.3.1(encoding@0.1.13)(onnxruntime-node@1.26.0):
     dependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:


### PR DESCRIPTION
## Description

Adds `PIIRedactor`, a PII processor that only uses regex. It never constructs an agent, so message content can't leave the process through it, and the same input always produces the same redaction.

- Extracts PIIDetector's regex engine (patterns and redaction methods) into a shared `pii-shared` module. PIIDetector delegates to it with no behavior change, its existing tests pass unchanged.
- `PIIRedactor` covers `processInput`, `processOutputStream` (with cross-chunk carryover), and `processOutputResult`, with block/warn/filter/redact strategies and mask/hash/remove/placeholder redaction methods.
- LLM-only types (`name`, `address`, `date-of-birth`) are rejected at the type level with an error pointing to PIIDetector.
- Registers a `pii-redactor` processor provider so file-based agents can use it.
- Includes a reference docs page and a guardrails section.

```ts
import { PIIRedactor } from '@mastra/core/processors';

const redactor = new PIIRedactor({
  detectionTypes: ['email', 'phone', 'credit-card'],
  strategy: 'redact',
  redactionMethod: 'mask',
});
```

## Related issue(s)

Closes #20234

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a “privacy scrubber” that looks for sensitive patterns (like emails or card-like numbers) in your text and replaces them using only built-in regex rules. It never uses an LLM, so it can’t send your message content out—yet it still works even when outputs arrive in streaming chunks.

## What changed
- Added a deterministic, regex-only `PIIRedactor` processor (`pii-redactor`) that never calls an LLM or sends message content to external providers.
- Refactored the existing regex PII detection/redaction contracts into a shared `pii-shared` module (without changing `PIIDetector`’s behavior), and re-used it for redaction.
- Implemented `PIIRedactor` across processing phases:
  - `processInput` (batch redaction)
  - `processOutputStream` (streaming redaction with cross-chunk carryover)
  - `processOutputResult` (final output redaction)
- Streaming carryover support: detects PII split across chunk boundaries and avoids re-flagging/redacting already-handled carryover regions.
- Added overlap-safe redaction so multiple detected spans don’t corrupt each other.
- Supported strategies: `block`, `warn`, `filter`, `redact`
  - `block` throws `TripWire` with metadata (and does not expose matched raw detected values)
  - `warn` logs and passes through
  - `filter` removes only flagged messages/chunks
  - `redact` rewrites detected text (including relevant `parts` text)
- Supported redaction methods: `mask`, `hash`, `remove`, `placeholder` (with `preserveFormat` where applicable).
- Enforced “regex-detectable only” constraints:
  - rejects LLM-only detection types at the type level
  - requires context-dependent types (like names/addresses/DOB) to be handled by `PIIDetector`
- Registered a built-in processor provider under the `'pii-redactor'` key for file-based agents, including validated options and supported phases.
- Added documentation/guardrails guidance and an API reference page for `PIIRedactor`.
- Added comprehensive tests for option validation, batch + streaming behavior (including carryover), strategy-specific behavior (including `TripWire` metadata), and output handling (including assistant outputs and flattened content + `parts` cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->