### PR TITLE
fix(core): serialize plain stream() runs across instances (acquire lease in registerRun)

### DIFF
--- a/.changeset/lemon-icons-eat.md
+++ b/.changeset/lemon-icons-eat.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed multi-instance thread subscriptions to replay completed streams consistently, reject stale active runs using lease ownership, and route remote abort requests to the owning process.
+Fixed multi-instance thread subscriptions to replay completed streams consistently, reject stale active runs using lease ownership, and route remote abort requests to the owning process. Plain `stream()`/`generate()` runs now acquire and renew the thread lease too, so a contending run on another instance serializes behind a live run instead of interleaving with it.

--- a/packages/core/src/agent/__tests__/agent-thread-lease.test.ts
+++ b/packages/core/src/agent/__tests__/agent-thread-lease.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Every thread-bound run registered through `registerRun` must hold the
+ * cross-process thread lease while it is live. PR #19806 made lease ownership
+ * authoritative for run liveness (markActiveIfLive / #waitForRemoteRunToFinish
+ * treat a lease-less run as a ghost), so a plain `agent.stream()` run that
+ * never acquires the lease is invisible to contending instances — they start
+ * competing runs instead of serializing behind it.
+ *
+ * Kept in its own file (rather than agent-signals.test.ts) so the suite Tyler's
+ * PR shipped stays untouched.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { PubSub } from '../../events/pubsub';
+import type { LeaseProvider } from '../../events/pubsub';
+import type { EventCallback } from '../../events/types';
+import type { Agent } from '../agent';
+import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+
+const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
+
+function nextTick() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function waitForCondition(predicate: () => boolean, timeoutMs = 2_000) {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error('Timed out waiting for condition');
+    }
+    await nextTick();
+  }
+}
+
+/**
+ * Minimal in-memory pubsub that also implements LeaseProvider, mirroring
+ * ControlledLeasePubSub in agent-signals.test.ts (copied, not imported, to
+ * keep that file untouched).
+ */
+class ControlledLeasePubSub extends PubSub implements LeaseProvider {
+  owners = new Map<string, string>();
+  #subscribers = new Map<string, Set<EventCallback>>();
+  #pending = new Set<Promise<void>>();
+  #index = 0;
+
+  async publish(topic: string, event: any): Promise<void> {
+    const envelope = { ...event, id: `event-${this.#index}`, createdAt: new Date(), index: this.#index++ };
+    const subscribers = [...(this.#subscribers.get(topic) ?? [])];
+    const pending = new Promise<void>(resolve => {
+      setTimeout(() => {
+        for (const subscriber of subscribers) subscriber(envelope);
+        resolve();
+      }, 0);
+    });
+    this.#pending.add(pending);
+    void pending.finally(() => this.#pending.delete(pending));
+  }
+
+  async subscribe(topic: string, cb: EventCallback): Promise<void> {
+    const subscribers = this.#subscribers.get(topic) ?? new Set<EventCallback>();
+    subscribers.add(cb);
+    this.#subscribers.set(topic, subscribers);
+  }
+
+  async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
+    this.#subscribers.get(topic)?.delete(cb);
+  }
+
+  async flush(): Promise<void> {
+    await Promise.all([...this.#pending]);
+  }
+
+  async acquireLease(key: string, owner: string): Promise<{ acquired: boolean; owner?: string }> {
+    const current = this.owners.get(key);
+    if (current && current !== owner) return { acquired: false, owner: current };
+    this.owners.set(key, owner);
+    return { acquired: true, owner };
+  }
+
+  async getLeaseOwner(key: string): Promise<string | undefined> {
+    return this.owners.get(key);
+  }
+
+  async releaseLease(key: string, owner: string): Promise<void> {
+    if (this.owners.get(key) === owner) this.owners.delete(key);
+  }
+
+  async renewLease(key: string, owner: string): Promise<boolean> {
+    return this.owners.get(key) === owner;
+  }
+
+  async transferLease(key: string, fromOwner: string, toOwner: string): Promise<boolean> {
+    if (this.owners.get(key) !== fromOwner) return false;
+    this.owners.set(key, toOwner);
+    return true;
+  }
+}
+
+describe('registerRun thread lease', () => {
+  it('acquires the thread lease for a plain thread-bound run and releases it on completion', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new ControlledLeasePubSub();
+    const agent = { id: 'plain-lease-agent' } as Agent<any, any, any, any>;
+    const threadId = 'plain-lease-thread';
+    const resourceId = 'plain-lease-user';
+    const key = [resourceId, threadId].join(AGENT_THREAD_KEY_SEPARATOR);
+    const runId = 'plain-lease-run-1';
+
+    let finish!: () => void;
+    const finished = new Promise<void>(resolve => {
+      finish = resolve;
+    });
+    const fullStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: 'start', runId });
+        controller.enqueue({
+          type: 'finish',
+          runId,
+          payload: { usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 }, finishReason: 'stop' },
+        });
+        controller.close();
+      },
+    });
+
+    const registered = runtime.registerRun(
+      agent,
+      {
+        runId,
+        status: 'running',
+        fullStream,
+        _waitUntilFinished: () => finished,
+      } as any,
+      { memory: { thread: threadId, resource: resourceId } } as any,
+      pubsub,
+    );
+    expect(registered).toBeDefined();
+    await registered;
+
+    // A plain (non-signal) run must own the cross-process thread lease once
+    // registration settles — otherwise remote liveness checks treat it as a
+    // ghost and contending instances start competing runs.
+    expect(pubsub.owners.get(key)).toBe(runId);
+
+    finish();
+    // Release is fire-and-forget inside the completion watcher's finally —
+    // poll rather than asserting immediately.
+    await waitForCondition(() => pubsub.owners.get(key) === undefined);
+  });
+});

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -887,12 +887,34 @@ export class AgentThreadStreamRuntime {
     state.threadKeysByRunId.set(output.runId, key);
     state.activeThreadRunIds.set(key, output.runId);
     state.activeThreadStreamIds.set(key, streamId);
-    const registered = this.#publishAndWait(pubsub, key, {
-      type: 'run-registered',
-      runId: output.runId,
-      streamId,
-      streamSeq,
-    });
+    const resolvedPubSub = this.#getPubSub(pubsub);
+    const registered = (async () => {
+      // Every thread-bound run must hold the cross-process lease while it is
+      // live: the liveness checks (markActiveIfLive / #waitForRemoteRunToFinish)
+      // treat a lease-less run as a ghost, so a plain `agent.stream()` run that
+      // never acquired would let contending instances start competing runs
+      // instead of serializing behind it. Acquire BEFORE publishing
+      // `run-registered` so an observer that checks liveness on receipt finds
+      // the lease held. Same-owner acquire is an idempotent TTL refresh, so
+      // signal-woken runs that already hold the lease under this runId just
+      // renew. Fail-open on loss or error (simultaneous-start race): proceed
+      // and never roll back the local registration — matches pre-lease
+      // semantics and sendSignal's documented fail-open rationale. A thrown
+      // acquire (transient provider error) is treated as acquired so renewal
+      // starts: if the acquire landed server-side but the response failed,
+      // skipping renewal would let the lease expire mid-run; renewal
+      // self-stops when we don't own the key.
+      const lease = await this.#getLeaseProvider(resolvedPubSub)
+        .acquireLease(key, output.runId, AGENT_THREAD_LEASE_TTL_MS)
+        .catch(() => ({ acquired: true as boolean }));
+      if (lease.acquired) this.#startLeaseRenewal(resolvedPubSub, key, output.runId);
+      await this.#publishAndWait(pubsub, key, {
+        type: 'run-registered',
+        runId: output.runId,
+        streamId,
+        streamSeq,
+      });
+    })();
     // Always drive the run's stream to completion, even when no caller consumes
     // the returned output (e.g. a fire-and-forget schedule wake). The broadcast
     // tee buffers every part, so a later/external subscriber still replays the
@@ -1577,7 +1599,7 @@ export class AgentThreadStreamRuntime {
           seenStreamIds.delete(eventStreamId);
         }
         if (errorRun) enqueueRun(errorRun);
-        await this.#drainPendingIdleSignals(state, resolvedPubSub, key);
+        await this.#drainPendingIdleSignals(state, resolvedPubSub, key, data.runId);
         wake();
         return;
       }
@@ -1610,7 +1632,7 @@ export class AgentThreadStreamRuntime {
           } catch {}
         }
         if (data.type !== 'run-suspended') {
-          await this.#drainPendingIdleSignals(state, resolvedPubSub, key);
+          await this.#drainPendingIdleSignals(state, resolvedPubSub, key, data.runId);
         }
         wake();
       }

--- a/pubsub/redis-streams/src/agent-thread-cross-process.test.ts
+++ b/pubsub/redis-streams/src/agent-thread-cross-process.test.ts
@@ -491,5 +491,93 @@ describe.skipIf(!process.env.REDIS_URL && !process.env.CI && process.env.SKIP_RE
       }
       expect(maxFreeRunMs).toBeLessThan(300);
     }, 60_000);
+
+    it('serializes a contending plain stream() behind a live plain run on another instance', async () => {
+      const resourceId = `plain-serial-${Date.now()}`;
+      const threadId = `thread-${Date.now()}`;
+      const env = { RESOURCE_ID: resourceId, THREAD_ID: threadId };
+      const leaseKey = leaseKeyFor(resourceId, threadId);
+
+      // A runs long (6s) so B's contention window is unambiguous even when the
+      // pre-B lease poll below burns its full 2s timeout (the red case); B
+      // runs short.
+      const a = spawnWorker('plain-a', { ...env, RUN_MS: '6000' });
+      const b = spawnWorker('plain-b', { ...env, RUN_MS: '200' });
+      workers = [a, b];
+      await Promise.all([waitForLine(a, '"type":"ready"'), waitForLine(b, '"type":"ready"')]);
+      await new Promise(r => setTimeout(r, 300)); // let subscriptions settle
+
+      a.send({ cmd: 'stream-plain', sigId: 'plain-a' });
+      await waitFor(async () => eventsByType(a, 'run-started').length > 0, 5_000);
+
+      // Before sending B, wait until A's lease acquire has landed in Redis —
+      // the run-registered publish follows it in the same promise chain, so a
+      // held lease means B's subscription can observe A's run. On unfixed code
+      // plain runs never acquire, so this poll times out; keep it non-fatal so
+      // the test fails at the interleave assertion below, not at this probe.
+      const probe = createClient({ url: REDIS_URL });
+      await probe.connect();
+      try {
+        await waitFor(async () => (await probe.get(leaseKey)) !== null, 2_000).catch(() => {});
+        // Give B's subscription a beat to process A's run-registered event.
+        await new Promise(r => setTimeout(r, 300));
+
+        b.send({ cmd: 'stream-plain', sigId: 'plain-b' });
+        await new Promise(r => setTimeout(r, 1_000));
+
+        // A (6s run) must still be in flight, and B must not have started —
+        // this is the serialization guarantee that regressed: without a lease,
+        // B refuses to treat A's run as live and starts immediately. Assert
+        // the interleave (B started) before the liveness guard so the red
+        // failure signature names the actual regression.
+        expect(eventsByType(b, 'run-started')).toHaveLength(0);
+        expect(eventsByType(a, 'run-finished')).toHaveLength(0);
+
+        // Once A finishes, B's wait resolves and its run goes through.
+        await waitFor(async () => eventsByType(a, 'run-finished').length > 0, 15_000);
+        await waitFor(async () => eventsByType(b, 'plain-wait-resolved').length > 0, 20_000);
+        await waitFor(async () => eventsByType(b, 'run-started').length > 0, 10_000);
+        await waitFor(async () => eventsByType(b, 'run-finished').length > 0, 10_000);
+      } finally {
+        await probe.quit();
+      }
+    }, 60_000);
+
+    it('a plain stream() run holds the thread lease while live', async () => {
+      const resourceId = `plain-lease-${Date.now()}`;
+      const threadId = `thread-${Date.now()}`;
+      const env = { RESOURCE_ID: resourceId, THREAD_ID: threadId, RUN_MS: '3000' };
+      const leaseKey = leaseKeyFor(resourceId, threadId);
+
+      const a = spawnWorker('plain-holder', env);
+      workers = [a];
+      await waitForLine(a, '"type":"ready"');
+      await new Promise(r => setTimeout(r, 300)); // let subscription settle
+
+      a.send({ cmd: 'stream-plain', sigId: 'plain-hold' });
+      await waitFor(async () => eventsByType(a, 'run-started').length > 0, 5_000);
+      const runId = eventsByType(a, 'run-started')[0]?.runId as string;
+
+      const probe = createClient({ url: REDIS_URL });
+      await probe.connect();
+      try {
+        // Poll, not one-shot: the stub emits run-started before registerRun and
+        // the acquire lands inside the unawaited registered promise, so even on
+        // fixed code an immediate GET races the acquire.
+        let owner: string | null = null;
+        await waitFor(async () => {
+          owner = await probe.get(leaseKey);
+          return owner === runId;
+        }, 2_000).catch(() => {});
+        expect(owner).toBe(runId);
+
+        // After the run finishes the lease is released — release is
+        // fire-and-forget, so poll rather than asserting immediately.
+        await waitFor(async () => eventsByType(a, 'run-finished').length > 0, 10_000);
+        await waitFor(async () => (await probe.get(leaseKey)) === null, 5_000);
+      } finally {
+        await probe.quit();
+      }
+    }, 30_000);
   },
 );

--- a/pubsub/redis-streams/src/agent-thread-cross-process.test.ts
+++ b/pubsub/redis-streams/src/agent-thread-cross-process.test.ts
@@ -543,10 +543,17 @@ describe.skipIf(!process.env.REDIS_URL && !process.env.CI && process.env.SKIP_RE
       }
     }, 60_000);
 
-    it('a plain stream() run holds the thread lease while live', async () => {
+    it('a plain stream() run holds and renews the thread lease while live', async () => {
       const resourceId = `plain-lease-${Date.now()}`;
       const threadId = `thread-${Date.now()}`;
-      const env = { RESOURCE_ID: resourceId, THREAD_ID: threadId, RUN_MS: '3000' };
+      // TTL shorter than the run: the lease only survives to the end of the
+      // run if renewal is running, so this also proves #startLeaseRenewal.
+      const env = {
+        RESOURCE_ID: resourceId,
+        THREAD_ID: threadId,
+        RUN_MS: '6000',
+        MASTRA_AGENT_THREAD_LEASE_TTL_MS: '1000',
+      };
       const leaseKey = leaseKeyFor(resourceId, threadId);
 
       const a = spawnWorker('plain-holder', env);
@@ -570,6 +577,13 @@ describe.skipIf(!process.env.REDIS_URL && !process.env.CI && process.env.SKIP_RE
           return owner === runId;
         }, 2_000).catch(() => {});
         expect(owner).toBe(runId);
+
+        // Renewal proof: wait two full TTLs past the acquire while the run is
+        // still live. Without renewal the 1000ms lease would have expired and
+        // the key would be nil; with renewal the owner is unchanged.
+        await new Promise(r => setTimeout(r, 2_000));
+        expect(eventsByType(a, 'run-finished')).toHaveLength(0); // run must still be live for this to prove anything
+        expect(await probe.get(leaseKey)).toBe(runId);
 
         // After the run finishes the lease is released — release is
         // fire-and-forget, so poll rather than asserting immediately.

--- a/pubsub/redis-streams/test-fixtures/agent-thread-worker.entry.ts
+++ b/pubsub/redis-streams/test-fixtures/agent-thread-worker.entry.ts
@@ -276,6 +276,26 @@ async function main() {
       return;
     }
 
+    if (cmd.cmd === 'stream-plain') {
+      // Mirrors a plain (non-signal) `agent.stream()` call: the same pre-run
+      // cross-instance wait Agent.stream performs, then the stub stream (which
+      // itself mirrors the prepareRunOptions -> registerRun boundary). No
+      // sendSignal involved — this is the path an ordinary HTTP request takes.
+      const sigId: string = cmd.sigId;
+      try {
+        await runtime.waitForCrossAgentThreadRun(
+          agent as any,
+          { memory: { resource: RESOURCE_ID, thread: THREAD_ID } } as any,
+          pubsub,
+        );
+        emit({ type: 'plain-wait-resolved', sigId });
+        await agent.stream(sigId, { memory: { resource: RESOURCE_ID, thread: THREAD_ID } } as any);
+      } catch (err) {
+        emit({ type: 'command-error', cmd: cmd.cmd, error: String(err) });
+      }
+      return;
+    }
+
     if (cmd.cmd === 'abort-active') {
       const runId = defaultSubscription.activeRunId();
       emit({ type: 'abort-result', runId, aborted: defaultSubscription.abort() });


### PR DESCRIPTION
## What

Fixes the regression [Bickio reported on #19806](https://github.com/mastra-ai/mastra/pull/19806): after this PR made cross-process thread-lease ownership authoritative for run liveness, a plain `agent.stream()` run on one instance stopped serializing contending runs on other instances.

Stacked on top of #19806 (base = `fix/thread-subscription-multi-instance-redis-streams`), so the diff here is only the 4 commits that address the regression.

## Root cause

#19806 made the lease authoritative for "is this remote run alive": `markActiveIfLive` refuses to mark a remote run active unless the thread lease is held, and `#waitForRemoteRunToFinish` declares a lease-less run dead after one TTL. But lease acquisition only ever happened on the `sendSignal` wake path and drained follow-ups. `registerRun` — the path every plain `agent.stream()`/`generate()` takes — never acquired.

Result: instance B sees A's plain run but refuses to treat it as active, so `waitForCrossAgentThreadRun` has nothing to wait on and B starts immediately, interleaving with A's live run.

## Fix

`registerRun` now acquires the thread lease for every thread-bound run, **before** publishing `run-registered` (so an observer that checks liveness on receipt finds the lease held), and starts the existing renewal timer on success. Fail-open on acquire loss (a true simultaneous-start race) — the run proceeds without the lease, matching pre-lease semantics and `sendSignal`'s documented fail-open rationale. No signature changes, no changes to the lease release/transfer paths.

Same-owner acquire is an idempotent TTL refresh, so signal-woken runs that already hold the lease under their reserved runId just renew — no double-acquire.

One knock-on this surfaced: the thread-subscription handler's `run-completed`/`run-failed` drains did a bare acquire for queued idle signals (no `fromRunId`). That only worked because plain runs held no lease — now they do, so those two drain sites transfer the finishing run's lease instead, mirroring the completion-watcher and continuation paths.

## Behavioral note

A suspended run (e.g. awaiting tool approval) keeps holding the thread lease — renewal keeps ticking and `#watchThreadRunCompletion` returns early on suspend without releasing. That was already the semantics for signal-woken runs; plain runs now share it. Intentional (a suspended thread awaiting resume shouldn't be stealable; process death frees it via TTL), but plain HITL flows are a bigger population, so calling it out.

## Test plan

New cross-process coverage (real Redis, separate OS processes — the ECS multi-instance topology):

- `serializes a contending plain stream() behind a live plain run on another instance` — red on #19806's head (B emits `run-started` while A is live), green with the fix.
- `a plain stream() run holds and renews the thread lease while live` — mechanism test; lease key equals the runId while live, TTL set shorter than the run so renewal is proven too, released after.
- A focused core test asserting `registerRun` acquires/releases via an in-memory `LeaseProvider`.

All of #19806's existing lease-scenario tests plus the ghost-run rejection test stay green unmodified, as does the 92-test agent-signals suite. Full `pnpm test:core` is green (0 failures).

Out of scope: the unpersisted-run replay behavior also flagged on #19806 — orthogonal to the serialization regression; worth its own discussion.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-8) <noreply@mastra.ai>
