### PR TITLE
Speed up Factory hot paths: auth caching, parallel repo sync, workspace dedup, bounded lease scans

### DIFF
--- a/.changeset/tough-hands-race.md
+++ b/.changeset/tough-hands-race.md
@@ -3,4 +3,9 @@
 '@mastra/auth-studio': patch
 ---
 
-Speed up Factory hot paths: cache verified Studio auth credentials (30s TTL) with bounded verify fetches, parallelize GitHub repository sync with Platform response caching, deduplicate concurrent session workspace materialization with sandbox command timeouts, and bound dispatcher lease scans with queue-table indexes. Adds boot/auth timing instrumentation.
+Speed up Factory hot paths:
+
+- Much lower latency on authenticated requests — successful auth verifications are cached briefly instead of hitting the platform on every request, and auth calls can no longer hang indefinitely
+- Faster GitHub repository listing and connecting
+- Opening the same session concurrently no longer provisions duplicate sandboxes, and stuck sandbox commands now fail with a clear error instead of hanging
+- Factory run dispatching stays fast as work-item history grows

--- a/.changeset/tough-hands-race.md
+++ b/.changeset/tough-hands-race.md
@@ -5,7 +5,7 @@
 
 Speed up Factory hot paths:
 
-- Much lower latency on authenticated requests — successful auth verifications are cached briefly instead of hitting the platform on every request, and auth calls can no longer hang indefinitely
+- Much lower latency on authenticated requests — successful auth verifications are cached briefly instead of hitting the platform on every request, and credential verification requests time out after 15 seconds instead of hanging
 - Faster GitHub repository listing and connecting
 - Opening the same session concurrently no longer provisions duplicate sandboxes, and stuck sandbox commands now fail with a clear error instead of hanging
 - Factory run dispatching stays fast as work-item history grows

--- a/.changeset/tough-hands-race.md
+++ b/.changeset/tough-hands-race.md
@@ -1,0 +1,6 @@
+---
+'@mastra/factory': patch
+'@mastra/auth-studio': patch
+---
+
+Speed up Factory hot paths: cache verified Studio auth credentials (30s TTL) with bounded verify fetches, parallelize GitHub repository sync with Platform response caching, deduplicate concurrent session workspace materialization with sandbox command timeouts, and bound dispatcher lease scans with queue-table indexes. Adds boot/auth timing instrumentation.

--- a/auth/studio/src/index.test.ts
+++ b/auth/studio/src/index.test.ts
@@ -247,6 +247,89 @@ describe('MastraAuthStudio', () => {
   });
 
   // -------------------------------------------------------------------------
+  // verification caching + fetch timeout
+  // -------------------------------------------------------------------------
+
+  describe('verification caching', () => {
+    it('should reuse a successful cookie verification without refetching', async () => {
+      fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockMeResponse), { status: 200 }));
+
+      const req = mockRequest({ cookie: 'wos-session=sealed-token-abc' });
+      const first = await auth.authenticateToken('', req);
+      const second = await auth.authenticateToken('', mockRequest({ cookie: 'wos-session=sealed-token-abc' }));
+
+      expect(first?.id).toBe('user-1');
+      expect(second).toEqual(first);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reuse a successful bearer verification without refetching', async () => {
+      fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockVerifyResponse), { status: 200 }));
+
+      const first = await auth.authenticateToken('cli-token-xyz', mockRequest());
+      const second = await auth.authenticateToken('cli-token-xyz', mockRequest());
+
+      expect(first?.id).toBe('user-2');
+      expect(second).toEqual(first);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not share cache entries between different credentials', async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify(mockVerifyResponse), { status: 200 }));
+
+      await auth.authenticateToken('token-a', mockRequest());
+      await auth.authenticateToken('token-b', mockRequest());
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should refetch after the cache TTL expires', async () => {
+      vi.useFakeTimers();
+      try {
+        fetchSpy.mockResolvedValue(new Response(JSON.stringify(mockMeResponse), { status: 200 }));
+
+        await auth.authenticateToken('', mockRequest({ cookie: 'wos-session=sealed' }));
+        vi.advanceTimersByTime(31_000);
+        await auth.authenticateToken('', mockRequest({ cookie: 'wos-session=sealed' }));
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should not cache failed verifications', async () => {
+      fetchSpy.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+      fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockMeResponse), { status: 200 }));
+
+      const first = await auth.authenticateToken('', mockRequest({ cookie: 'wos-session=flaky' }));
+      const second = await auth.authenticateToken('', mockRequest({ cookie: 'wos-session=flaky' }));
+
+      expect(first).toBeNull();
+      expect(second?.id).toBe('user-1');
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should pass an abort signal so verification fetches are time-bounded', async () => {
+      fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockMeResponse), { status: 200 }));
+      await auth.authenticateToken('', mockRequest({ cookie: 'wos-session=abc' }));
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${SHARED_API}/auth/me`,
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it('should return null when the verification fetch times out', async () => {
+      fetchSpy.mockRejectedValueOnce(new DOMException('The operation timed out.', 'TimeoutError'));
+
+      const user = await auth.authenticateToken('', mockRequest({ cookie: 'wos-session=slow' }));
+
+      expect(user).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // authorizeUser
   // -------------------------------------------------------------------------
 

--- a/auth/studio/src/index.test.ts
+++ b/auth/studio/src/index.test.ts
@@ -298,6 +298,34 @@ describe('MastraAuthStudio', () => {
       }
     });
 
+    it('should not cache users whose org bootstrap has not completed', async () => {
+      // First response: brand-new user, no organization yet. Caching it would
+      // pin the no-org state for the TTL and delay org bootstrap pickup.
+      const noOrgMe = { ...mockMeResponse, organizationId: undefined };
+      fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(noOrgMe), { status: 200 }));
+      fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockMeResponse), { status: 200 }));
+
+      const first = await auth.authenticateToken('', mockRequest({ cookie: 'wos-session=new-user' }));
+      const second = await auth.authenticateToken('', mockRequest({ cookie: 'wos-session=new-user' }));
+
+      expect(first?.organizationId).toBeUndefined();
+      expect(second?.organizationId).toBe(mockMeResponse.organizationId);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not cache bearer users whose org bootstrap has not completed', async () => {
+      const noOrgVerify = { ...mockVerifyResponse, organizationId: undefined };
+      fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(noOrgVerify), { status: 200 }));
+      fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockVerifyResponse), { status: 200 }));
+
+      const first = await auth.authenticateToken('new-user-token', mockRequest());
+      const second = await auth.authenticateToken('new-user-token', mockRequest());
+
+      expect(first?.organizationId).toBeUndefined();
+      expect(second?.organizationId).toBe(mockVerifyResponse.organizationId);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
     it('should not cache failed verifications', async () => {
       fetchSpy.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
       fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockMeResponse), { status: 200 }));

--- a/auth/studio/src/index.ts
+++ b/auth/studio/src/index.ts
@@ -689,7 +689,9 @@ export class MastraAuthStudio
         permissions: data.permissions,
         memberOrgIds: data.memberOrgIds,
       };
-      this.cacheVerification(cacheKey, user);
+      // Don't pin brand-new users in the no-org state: org bootstrap runs on
+      // the next request, which must re-read /auth/me to see the new org.
+      if (user.organizationId) this.cacheVerification(cacheKey, user);
       return user;
     } catch (error) {
       this.logger.error('verifySessionCookie: fetch to shared API failed', {
@@ -745,7 +747,9 @@ export class MastraAuthStudio
         role: data.role,
         memberOrgIds: data.memberOrgIds,
       };
-      this.cacheVerification(cacheKey, user);
+      // Same no-org guard as verifySessionCookie: cache only after the user's
+      // organization bootstrap has completed.
+      if (user.organizationId) this.cacheVerification(cacheKey, user);
       return user;
     } catch (error) {
       this.logger.error('verifyBearerToken: fetch to shared API failed', {

--- a/auth/studio/src/index.ts
+++ b/auth/studio/src/index.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type {
   IOrganizationsProvider,
   ISSOProvider,
@@ -57,6 +59,20 @@ export interface MastraAuthStudioOptions extends MastraAuthProviderOptions<Studi
 const COOKIE_NAME = 'wos-session';
 
 /**
+ * Upper bound for shared-API verification fetches. Matches the platform API
+ * client's request budget: a slow shared API must fail a single request in
+ * bounded time instead of hanging every authenticated endpoint behind it.
+ */
+const VERIFY_FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * How long a successful credential verification may be reused without
+ * re-contacting the shared API. Bounds revocation lag: a signed-out or
+ * revoked session can be honored for at most this long.
+ */
+const VERIFY_CACHE_TTL_MS = 30_000;
+
+/**
  * Auth provider for Mastra Studio deployed instances.
  *
  * Proxies all authentication through the shared API, keeping the
@@ -86,6 +102,16 @@ export class MastraAuthStudio
    */
   private userSessionCookies = new Map<string, string>();
   private readonly maxCachedSessions = 1000;
+
+  /**
+   * Short-TTL cache of SUCCESSFUL credential verifications, keyed by a
+   * sha256 of the credential (never the raw cookie/token). Every protected
+   * request re-verifies against the shared API otherwise — one network
+   * round trip per request. Failures are never cached, so a rejected
+   * credential is always re-checked. Bounded + insert-order evicted.
+   */
+  private verifiedCredentials = new Map<string, { user: StudioUser; expiresAt: number }>();
+  private readonly maxCachedVerifications = 1000;
 
   /**
    * In-flight `ensureOrganization` promises keyed by userId. Concurrent calls
@@ -553,6 +579,30 @@ export class MastraAuthStudio
     }
   }
 
+  /** Cache key for a verified credential — hash, never the raw secret. */
+  private verificationKey(kind: 'cookie' | 'bearer', credential: string): string {
+    return createHash('sha256').update(`${kind}:${credential}`).digest('hex');
+  }
+
+  private getCachedVerification(key: string): StudioUser | null {
+    const entry = this.verifiedCredentials.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= Date.now()) {
+      this.verifiedCredentials.delete(key);
+      return null;
+    }
+    return entry.user;
+  }
+
+  private cacheVerification(key: string, user: StudioUser): void {
+    this.verifiedCredentials.delete(key);
+    this.verifiedCredentials.set(key, { user, expiresAt: Date.now() + VERIFY_CACHE_TTL_MS });
+    if (this.verifiedCredentials.size > this.maxCachedVerifications) {
+      const oldest = this.verifiedCredentials.keys().next().value;
+      if (oldest !== undefined) this.verifiedCredentials.delete(oldest);
+    }
+  }
+
   /**
    * Fetch the shared API's `/auth/me` and return the raw response body, or
    * `null` on any non-OK / network error. Split out so `ensureOrganization`
@@ -567,6 +617,7 @@ export class MastraAuthStudio
     try {
       const res = await fetch(`${this.sharedApiUrl}/auth/me`, {
         headers: { Cookie: `${COOKIE_NAME}=${sessionCookie}` },
+        signal: AbortSignal.timeout(VERIFY_FETCH_TIMEOUT_MS),
       });
       if (!res.ok) return null;
       return (await res.json()) as {
@@ -585,11 +636,20 @@ export class MastraAuthStudio
    * to validate it and get user info.
    */
   private async verifySessionCookie(sessionCookie: string): Promise<StudioUser | null> {
+    const cacheKey = this.verificationKey('cookie', sessionCookie);
+    const cached = this.getCachedVerification(cacheKey);
+    if (cached) {
+      // Keep the userId → cookie mapping warm for IOrganizationsProvider.
+      this.rememberUserSession(cached.id, sessionCookie);
+      return cached;
+    }
+
     try {
       const res = await fetch(`${this.sharedApiUrl}/auth/me`, {
         headers: {
           Cookie: `${COOKIE_NAME}=${sessionCookie}`,
         },
+        signal: AbortSignal.timeout(VERIFY_FETCH_TIMEOUT_MS),
       });
 
       if (!res.ok) {
@@ -619,7 +679,7 @@ export class MastraAuthStudio
       // methods (invoked with only a userId) can act on the user's behalf.
       this.rememberUserSession(data.user.id, sessionCookie);
 
-      return {
+      const user: StudioUser = {
         id: data.user.id,
         email: data.user.email,
         name: [data.user.firstName, data.user.lastName].filter(Boolean).join(' ') || undefined,
@@ -629,6 +689,8 @@ export class MastraAuthStudio
         permissions: data.permissions,
         memberOrgIds: data.memberOrgIds,
       };
+      this.cacheVerification(cacheKey, user);
+      return user;
     } catch (error) {
       this.logger.error('verifySessionCookie: fetch to shared API failed', {
         url: `${this.sharedApiUrl}/auth/me`,
@@ -643,11 +705,16 @@ export class MastraAuthStudio
    * to validate it and get user info (used for CLI tokens).
    */
   private async verifyBearerToken(token: string): Promise<StudioUser | null> {
+    const cacheKey = this.verificationKey('bearer', token);
+    const cached = this.getCachedVerification(cacheKey);
+    if (cached) return cached;
+
     try {
       const res = await fetch(`${this.sharedApiUrl}/auth/verify`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
+        signal: AbortSignal.timeout(VERIFY_FETCH_TIMEOUT_MS),
       });
 
       if (!res.ok) {
@@ -670,7 +737,7 @@ export class MastraAuthStudio
         memberOrgIds?: string[];
       };
 
-      return {
+      const user: StudioUser = {
         id: data.user.id,
         email: data.user.email,
         name: [data.user.firstName, data.user.lastName].filter(Boolean).join(' ') || undefined,
@@ -678,6 +745,8 @@ export class MastraAuthStudio
         role: data.role,
         memberOrgIds: data.memberOrgIds,
       };
+      this.cacheVerification(cacheKey, user);
+      return user;
     } catch (error) {
       this.logger.error('verifyBearerToken: fetch to shared API failed', {
         url: `${this.sharedApiUrl}/auth/verify`,

--- a/mastracode/factory/src/auth.ts
+++ b/mastracode/factory/src/auth.ts
@@ -11,6 +11,7 @@ import type { ApiRoute, IMastraAuthProvider, ISessionProvider } from '@mastra/co
 import type { Context, Hono } from 'hono';
 
 import type { RouteAuth } from './routes/route.js';
+import { timedAboveThreshold } from './timing.js';
 
 /**
  * Provider-neutral factory auth gating for the MastraCode web server.
@@ -644,7 +645,11 @@ export function createFactoryAuthGate(provider: IMastraAuthProvider) {
     }
 
     const token = getBearerToken(c.req.header('Authorization'));
-    const user = await authenticateRequest(provider, token, c.req.raw);
+    // A slow verification here delays EVERY protected request — surface
+    // outliers so auth-backend latency is attributable from server logs.
+    const user = await timedAboveThreshold('auth.gate.authenticate', 1_000, () =>
+      authenticateRequest(provider, token, c.req.raw),
+    );
 
     if (user) {
       // Bootstrap a personal org for no-org accounts so the org id resolves on

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -485,8 +485,7 @@ export class MastraFactory {
       integrations.some(integration => integration.intake !== undefined) && storage.isDomainReady('intake');
     const factoryReady = storage.isDomainReady('projects') && storage.isDomainReady('work-items');
     const githubIntegration = integrations.find(integration => integration.id === 'github') as
-      | GithubIntegration
-      | undefined;
+      GithubIntegration | undefined;
     const workItemsReady = storage.isDomainReady('work-items');
     const transitionService = workItemsReady
       ? new FactoryTransitionService({ rules, storage: workItemsStorage })

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -485,7 +485,8 @@ export class MastraFactory {
       integrations.some(integration => integration.intake !== undefined) && storage.isDomainReady('intake');
     const factoryReady = storage.isDomainReady('projects') && storage.isDomainReady('work-items');
     const githubIntegration = integrations.find(integration => integration.id === 'github') as
-      GithubIntegration | undefined;
+      | GithubIntegration
+      | undefined;
     const workItemsReady = storage.isDomainReady('work-items');
     const transitionService = workItemsReady
       ? new FactoryTransitionService({ rules, storage: workItemsStorage })
@@ -551,178 +552,181 @@ export class MastraFactory {
     // MCP, providers) — identical to the terminal app. Agent state lives in
     // the storage backend's Mastra store alongside the Factory app tables —
     // one shared database for all users, separated by `resourceId` scoping.
-    const controllerMountStart = performance.now();
-    const prepared = await prepareAgentControllerMount({
-      controllerId: CONTROLLER_ID,
-      workspace: createWorkspaceFactory({
-        ...(this.#config.sandbox ? { sandbox: this.#config.sandbox } : {}),
-        ...(githubIntegration ? { github: githubIntegration } : {}),
-        ...(workItemsStorage ? { workItems: workItemsStorage } : {}),
-        fleet,
-      }),
-      disableGithubSignals: true,
-      // Memory settings live in the factory's `memory-settings` app table (per
-      // org/user), so the host machine's TUI settings.json must not seed them.
-      disableSettingsOmSeed: true,
-      storage: storage.getMastraStorage(),
-      ...(mastraStorageBackend ? { storageBackend: mastraStorageBackend } : {}),
-      ...(factoryProcessor ? { inputProcessors: [factoryProcessor] } : {}),
-      ...(vector ? { vector } : {}),
-      ...(toolIntegrations.length > 0 || (workItemsStorage && transitionService)
-        ? {
-            extraTools: async ({ requestContext }: { requestContext: RequestContext }) => {
-              const tools: IntegrationTools = {};
-              const toolOwners = new Map<string, string>();
-              const mergeTools = (ownerId: string, contributed: IntegrationTools) => {
-                for (const [name, tool] of Object.entries(contributed)) {
-                  const owner = toolOwners.get(name);
-                  if (owner) {
-                    throw new Error(
-                      `MastraFactory: integration tool '${name}' from '${ownerId}' conflicts with '${owner}'.`,
-                    );
-                  }
-                  toolOwners.set(name, ownerId);
-                  tools[name] = tool;
-                }
-              };
-              if (workItemsStorage && transitionService) {
-                mergeTools(
-                  'factory',
-                  await createFactoryTransitionTools({ requestContext, storage: workItemsStorage, transitionService }),
-                );
-              }
-              for (const { integration, ready, ensureReady } of toolIntegrations) {
-                if (!ready && ensureReady) {
-                  try {
-                    await ensureReady();
-                  } catch {
-                    continue;
-                  }
-                }
-                if (integration.agentTools) {
-                  mergeTools(integration.id, await integration.agentTools({ requestContext }));
-                }
-                if (integration.sessionTools) {
-                  mergeTools(integration.id, integration.sessionTools({ requestContext }));
-                }
-              }
-              return tools;
-            },
-          }
-        : {}),
-      postToolObserver: async (toolContext: IntegrationPostToolContext) => {
-        const requestContext = (toolContext.context as { requestContext?: RequestContext } | undefined)?.requestContext;
-        if (requestContext) {
-          await observeAgentGitAction({
-            audit: auditDomain,
-            toolContext: { ...toolContext, context: requestContext },
-          });
-        }
-        await Promise.all(
-          integrations.map(async integration => {
-            if (!integration.postToolObserver) return;
-            try {
-              await integration.postToolObserver({ toolContext, requestContext });
-            } catch (error) {
-              console.warn(`[factory] Integration '${integration.id}' post-tool observer failed:`, error);
-            }
-          }),
-        );
-      },
-      ...(pubsub ? { pubsub, crossProcessPubSub: true } : {}),
-      buildApiRoutes: ({ controller, authStorage }: BuildApiRoutesDeps) => [
-        // Public `/auth/*` routes (login/callback/logout/me). Folded in as
-        // `apiRoutes` (not plain Hono routes) because the entry can't touch the
-        // Hono app the deployer generates. `requiresAuth: false`; the gate
-        // skips `/auth/*`.
-        ...(auth ? buildAuthRoutes(auth, { publicUrl: publicOrigin }) : []),
-        // Custom `/web/*` routes (fs / config / integrations / factory / audit).
-        ...assembleFactoryApiRoutes({
-          controllerId: CONTROLLER_ID,
-          controller,
-          auth: routeAuth,
-          authStorage,
-          audit: auditDomain,
-          publicOrigin,
-          stateSigner,
+    const prepared = await timedPhase('prepare.controllerMount', () =>
+      prepareAgentControllerMount({
+        controllerId: CONTROLLER_ID,
+        workspace: createWorkspaceFactory({
+          ...(this.#config.sandbox ? { sandbox: this.#config.sandbox } : {}),
+          ...(githubIntegration ? { github: githubIntegration } : {}),
+          ...(workItemsStorage ? { workItems: workItemsStorage } : {}),
           fleet,
-          factoryStorage: storage,
-          integrationStorage,
-          sourceControlStorage,
-          domains,
-          integrations: integrationRegistrations,
-          intakeReady,
-          factoryReady,
-          rules,
-          factoryTransitionService: transitionService,
-          onFactoryRuntime: ({ transitionService: runtimeTransitionService, prepareBinding }) => {
-            this.#dispatcher ??= new FactoryDecisionDispatcher({
-              controller,
-              transitionService: runtimeTransitionService,
-              storage: storage.getDomain<WorkItemsStorage>('work-items'),
-              reconcileToolResults: () => factoryProcessor?.reconcileAllBoundThreads() ?? Promise.resolve(),
-              prepareBinding,
-              primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
-            });
-          },
         }),
-        ...projectRoutes.routes(),
-        ...auditDomain.routes(),
-      ],
-      buildServerConfig: () => {
-        const cors = allowedOrigins.length ? { cors: { origin: allowedOrigins, credentials: true } } : {};
-        // Log route errors with method/path/stack and answer with structured
-        // JSON instead of an opaque `Internal Server Error`. Applied by the
-        // deployer to both the top-level app and the custom-route sub-app.
-        const onError = { onError: handleServerError };
-        // Same-origin SPA: when a vite build is present (see resolveUiDistDir),
-        // serve it at `/` from this server. Mounted last so the auth gate (when
-        // enabled) covers it; it always passes `/api`, `/web`, `/auth` through.
-        const uiDist = resolveUiDistDir();
-        const spa = uiDist ? [createSpaStaticMiddleware(uiDist)] : [];
-        if (!auth) {
-          // Auth disabled: no gate. Still prime the sentinel-local custom
-          // provider snapshot so model calls see DB rows, then SPA + CORS.
+        disableGithubSignals: true,
+        // Memory settings live in the factory's `memory-settings` app table (per
+        // org/user), so the host machine's TUI settings.json must not seed them.
+        disableSettingsOmSeed: true,
+        storage: storage.getMastraStorage(),
+        ...(mastraStorageBackend ? { storageBackend: mastraStorageBackend } : {}),
+        ...(factoryProcessor ? { inputProcessors: [factoryProcessor] } : {}),
+        ...(vector ? { vector } : {}),
+        ...(toolIntegrations.length > 0 || (workItemsStorage && transitionService)
+          ? {
+              extraTools: async ({ requestContext }: { requestContext: RequestContext }) => {
+                const tools: IntegrationTools = {};
+                const toolOwners = new Map<string, string>();
+                const mergeTools = (ownerId: string, contributed: IntegrationTools) => {
+                  for (const [name, tool] of Object.entries(contributed)) {
+                    const owner = toolOwners.get(name);
+                    if (owner) {
+                      throw new Error(
+                        `MastraFactory: integration tool '${name}' from '${ownerId}' conflicts with '${owner}'.`,
+                      );
+                    }
+                    toolOwners.set(name, ownerId);
+                    tools[name] = tool;
+                  }
+                };
+                if (workItemsStorage && transitionService) {
+                  mergeTools(
+                    'factory',
+                    await createFactoryTransitionTools({
+                      requestContext,
+                      storage: workItemsStorage,
+                      transitionService,
+                    }),
+                  );
+                }
+                for (const { integration, ready, ensureReady } of toolIntegrations) {
+                  if (!ready && ensureReady) {
+                    try {
+                      await ensureReady();
+                    } catch {
+                      continue;
+                    }
+                  }
+                  if (integration.agentTools) {
+                    mergeTools(integration.id, await integration.agentTools({ requestContext }));
+                  }
+                  if (integration.sessionTools) {
+                    mergeTools(integration.id, integration.sessionTools({ requestContext }));
+                  }
+                }
+                return tools;
+              },
+            }
+          : {}),
+        postToolObserver: async (toolContext: IntegrationPostToolContext) => {
+          const requestContext = (toolContext.context as { requestContext?: RequestContext } | undefined)
+            ?.requestContext;
+          if (requestContext) {
+            await observeAgentGitAction({
+              audit: auditDomain,
+              toolContext: { ...toolContext, context: requestContext },
+            });
+          }
+          await Promise.all(
+            integrations.map(async integration => {
+              if (!integration.postToolObserver) return;
+              try {
+                await integration.postToolObserver({ toolContext, requestContext });
+              } catch (error) {
+                console.warn(`[factory] Integration '${integration.id}' post-tool observer failed:`, error);
+              }
+            }),
+          );
+        },
+        ...(pubsub ? { pubsub, crossProcessPubSub: true } : {}),
+        buildApiRoutes: ({ controller, authStorage }: BuildApiRoutesDeps) => [
+          // Public `/auth/*` routes (login/callback/logout/me). Folded in as
+          // `apiRoutes` (not plain Hono routes) because the entry can't touch the
+          // Hono app the deployer generates. `requiresAuth: false`; the gate
+          // skips `/auth/*`.
+          ...(auth ? buildAuthRoutes(auth, { publicUrl: publicOrigin }) : []),
+          // Custom `/web/*` routes (fs / config / integrations / factory / audit).
+          ...assembleFactoryApiRoutes({
+            controllerId: CONTROLLER_ID,
+            controller,
+            auth: routeAuth,
+            authStorage,
+            audit: auditDomain,
+            publicOrigin,
+            stateSigner,
+            fleet,
+            factoryStorage: storage,
+            integrationStorage,
+            sourceControlStorage,
+            domains,
+            integrations: integrationRegistrations,
+            intakeReady,
+            factoryReady,
+            rules,
+            factoryTransitionService: transitionService,
+            onFactoryRuntime: ({ transitionService: runtimeTransitionService, prepareBinding }) => {
+              this.#dispatcher ??= new FactoryDecisionDispatcher({
+                controller,
+                transitionService: runtimeTransitionService,
+                storage: storage.getDomain<WorkItemsStorage>('work-items'),
+                reconcileToolResults: () => factoryProcessor?.reconcileAllBoundThreads() ?? Promise.resolve(),
+                prepareBinding,
+                primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
+              });
+            },
+          }),
+          ...projectRoutes.routes(),
+          ...auditDomain.routes(),
+        ],
+        buildServerConfig: () => {
+          const cors = allowedOrigins.length ? { cors: { origin: allowedOrigins, credentials: true } } : {};
+          // Log route errors with method/path/stack and answer with structured
+          // JSON instead of an opaque `Internal Server Error`. Applied by the
+          // deployer to both the top-level app and the custom-route sub-app.
+          const onError = { onError: handleServerError };
+          // Same-origin SPA: when a vite build is present (see resolveUiDistDir),
+          // serve it at `/` from this server. Mounted last so the auth gate (when
+          // enabled) covers it; it always passes `/api`, `/web`, `/auth` through.
+          const uiDist = resolveUiDistDir();
+          const spa = uiDist ? [createSpaStaticMiddleware(uiDist)] : [];
+          if (!auth) {
+            // Auth disabled: no gate. Still prime the sentinel-local custom
+            // provider snapshot so model calls see DB rows, then SPA + CORS.
+            return {
+              middleware: [
+                createCustomProvidersPrimer({ auth: routeAuth, storage: customProvidersStorage, authEnabled: false }),
+                ...spa,
+              ],
+              ...cors,
+              ...onError,
+            };
+          }
+
+          // Ordered middleware. The deployer applies these AFTER its context
+          // middleware sets `c.set('mastra', mastra)` and BEFORE routes, so:
+          //   1. gate   — validates the auth session, stashes the user, and 401s /
+          //               redirects unauthenticated requests. Skips public `/auth/*`.
+          //   2. primers — hydrate the caller's model-credential and custom
+          //               provider snapshots so the request's first model call
+          //               resolves tenant credentials and custom providers.
+          //   3. spa    — serves the built UI for everything the server doesn't own.
+          // `auth` also lands on `server.auth` so the core auth middleware (and
+          // Studio's dual-auth routing — see `studio.auth` on the returned args)
+          // authenticates core `/api/*` routes with the same provider.
           return {
+            auth,
             middleware: [
-              createCustomProvidersPrimer({ auth: routeAuth, storage: customProvidersStorage, authEnabled: false }),
+              createFactoryAuthGate(auth),
+              createTenantCredentialPrimer({ auth: routeAuth, credentials: modelCredentialsStorage }),
+              createCustomProvidersPrimer({
+                auth: routeAuth,
+                storage: customProvidersStorage,
+                authEnabled: Boolean(auth),
+              }),
               ...spa,
             ],
             ...cors,
             ...onError,
           };
-        }
-
-        // Ordered middleware. The deployer applies these AFTER its context
-        // middleware sets `c.set('mastra', mastra)` and BEFORE routes, so:
-        //   1. gate   — validates the auth session, stashes the user, and 401s /
-        //               redirects unauthenticated requests. Skips public `/auth/*`.
-        //   2. primers — hydrate the caller's model-credential and custom
-        //               provider snapshots so the request's first model call
-        //               resolves tenant credentials and custom providers.
-        //   3. spa    — serves the built UI for everything the server doesn't own.
-        // `auth` also lands on `server.auth` so the core auth middleware (and
-        // Studio's dual-auth routing — see `studio.auth` on the returned args)
-        // authenticates core `/api/*` routes with the same provider.
-        return {
-          auth,
-          middleware: [
-            createFactoryAuthGate(auth),
-            createTenantCredentialPrimer({ auth: routeAuth, credentials: modelCredentialsStorage }),
-            createCustomProvidersPrimer({
-              auth: routeAuth,
-              storage: customProvidersStorage,
-              authEnabled: Boolean(auth),
-            }),
-            ...spa,
-          ],
-          ...cors,
-          ...onError,
-        };
-      },
-    });
-    process.stderr.write(
-      `[factory:timing] prepare.controllerMount ${Math.round(performance.now() - controllerMountStart)}ms\n`,
+        },
+      }),
     );
 
     this.#prepared = prepared;

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -75,6 +75,7 @@ import { FactoryProjectsStorage } from './storage/domains/projects/base.js';
 import { QueueHealthStorage } from './storage/domains/queue-health/base.js';
 import { SourceControlStorage } from './storage/domains/source-control/base.js';
 import { WorkItemsStorage } from './storage/domains/work-items/base.js';
+import { timedPhase } from './timing.js';
 import { createWorkspaceFactory } from './workspace.js';
 
 type BuildApiRoutesDeps = Pick<FactoryApiRoutesDeps, 'controller' | 'authStorage'>;
@@ -426,12 +427,14 @@ export class MastraFactory {
     // Failures surface here, at prepare() — a misconfigured provider must
     // not boot.
     if (auth && hasAuthInit(auth)) {
-      await auth.init({ database: storage.authDatabase?.(), publicUrl: publicOrigin, allowedOrigins });
+      await timedPhase('prepare.auth.init', () =>
+        auth.init({ database: storage.authDatabase?.(), publicUrl: publicOrigin, allowedOrigins }),
+      );
     }
 
     // Single init path: backend connection failure is a hard boot error;
     // registered app domains initialize fail-soft inside FactoryStorage.
-    await storage.init();
+    await timedPhase('prepare.storage.init', () => storage.init());
 
     // Per-tenant model credentials: once the credentials domain is up, model
     // resolution goes through the caller's own store and the SDK stops
@@ -549,6 +552,7 @@ export class MastraFactory {
     // MCP, providers) — identical to the terminal app. Agent state lives in
     // the storage backend's Mastra store alongside the Factory app tables —
     // one shared database for all users, separated by `resourceId` scoping.
+    const controllerMountStart = performance.now();
     const prepared = await prepareAgentControllerMount({
       controllerId: CONTROLLER_ID,
       workspace: createWorkspaceFactory({
@@ -718,6 +722,9 @@ export class MastraFactory {
         };
       },
     });
+    process.stderr.write(
+      `[factory:timing] prepare.controllerMount ${Math.round(performance.now() - controllerMountStart)}ms\n`,
+    );
 
     this.#prepared = prepared;
     this.#factoryProcessor = factoryProcessor;
@@ -770,8 +777,11 @@ export class MastraFactory {
     if (!this.#prepared) {
       throw new Error('MastraFactory.finalize() called before prepare()');
     }
-    await this.#prepared.finalize();
-    await this.#factoryProcessor?.reconcileAllBoundThreads();
+    await timedPhase('finalize.controller', () => this.#prepared!.finalize());
+    await timedPhase(
+      'finalize.reconcileBoundThreads',
+      () => this.#factoryProcessor?.reconcileAllBoundThreads() ?? Promise.resolve(),
+    );
     this.#dispatcher?.start();
   }
 

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -1072,6 +1072,26 @@ describe('repos route', () => {
     expect(res.status).toBe(500);
     expect(tables.installations).toHaveLength(1);
   });
+
+  it('lists multiple installations concurrently', async () => {
+    install(7, 'octo');
+    install(8, 'other');
+    let inFlight = 0;
+    let maxInFlight = 0;
+    vi.mocked(listInstallationRepos).mockImplementation(async (installationId: number) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      inFlight -= 1;
+      return defaultImpl(installationId);
+    });
+
+    const res = await buildApp({ workosId: 'u1' }).request('/web/github/repos');
+
+    expect(res.status).toBe(200);
+    // Serial listing would never overlap; the route must fan out.
+    expect(maxInFlight).toBe(2);
+  });
 });
 
 describe('auth scoping', () => {

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -641,48 +641,70 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
         const resolved = await resolveOrgTenant(loose(c), auth);
         if ('response' in resolved) return resolved.response;
 
-        const installs = await github.sourceControlStorage.installations.list({ orgId: resolved.tenant.orgId });
+        const orgId = resolved.tenant.orgId;
+        const installs = await github.sourceControlStorage.installations.list({ orgId });
 
         const query = (c.req.query('q') ?? '').toLowerCase();
-        const repos = [];
+        // List every installation's repositories in parallel — installations
+        // are independent upstream calls, and serial listing multiplied
+        // worst-case latency by installation count.
+        const listed = await Promise.all(
+          installs.map(async inst => {
+            try {
+              return { inst, list: await github.listInstallationRepos(Number(inst.externalId)) };
+            } catch (err) {
+              // GitHub 404s when the installation no longer exists for this app
+              // (app uninstalled/reinstalled, or the row was recorded under
+              // different app credentials). Prune the stale row so `/status`
+              // reflects reality and the UI prompts a reconnect, then keep
+              // listing the remaining installations.
+              if ((err as { status?: number }).status !== 404) throw err;
+              console.error(`[Mastra Factory] pruning stale GitHub installation ${inst.externalId} (404 from GitHub)`);
+              await github.sourceControlStorage.installations.delete({ orgId, id: inst.id });
+              return { inst, list: [] };
+            }
+          }),
+        );
+
+        // Filter + dedupe by repo id in installation order — same result
+        // ordering as the previous serial loop.
+        const matches = [];
         const seenRepositoryIds = new Set<number>();
-        for (const inst of installs) {
-          let list;
-          try {
-            list = await github.listInstallationRepos(Number(inst.externalId));
-          } catch (err) {
-            // GitHub 404s when the installation no longer exists for this app
-            // (app uninstalled/reinstalled, or the row was recorded under
-            // different app credentials). Prune the stale row so `/status`
-            // reflects reality and the UI prompts a reconnect, then keep
-            // listing the remaining installations.
-            if ((err as { status?: number }).status !== 404) throw err;
-            console.error(`[Mastra Factory] pruning stale GitHub installation ${inst.externalId} (404 from GitHub)`);
-            await github.sourceControlStorage.installations.delete({ orgId: resolved.tenant.orgId, id: inst.id });
-            continue;
-          }
+        for (const { inst, list } of listed) {
           for (const repo of list) {
             if (query && !repo.fullName.toLowerCase().includes(query)) continue;
             if (seenRepositoryIds.has(repo.id)) continue;
             seenRepositoryIds.add(repo.id);
-            const repository = await github.sourceControlStorage.repositories.upsert({
-              orgId: resolved.tenant.orgId,
-              input: {
-                installationId: inst.id,
-                externalId: repo.id.toString(),
-                slug: repo.fullName,
-                defaultBranch: isValidGitRef(repo.defaultBranch) ? repo.defaultBranch : 'main',
-                providerMetadata: { private: repo.private, owner: repo.owner },
-              },
-            });
-            repos.push({
-              ...repo,
-              installationStorageId: inst.id,
-              repositoryStorageId: repository.id,
-              sandboxProvider: fleet.provider,
-              sandboxWorkdir: fleet.computeWorkdir(repo.fullName),
-            });
+            matches.push({ inst, repo });
           }
+        }
+
+        // Mirror matches into storage with bounded concurrency instead of one
+        // awaited upsert per repository.
+        const repos = new Array(matches.length);
+        const upsertConcurrency = 10;
+        for (let start = 0; start < matches.length; start += upsertConcurrency) {
+          await Promise.all(
+            matches.slice(start, start + upsertConcurrency).map(async ({ inst, repo }, offset) => {
+              const repository = await github.sourceControlStorage.repositories.upsert({
+                orgId,
+                input: {
+                  installationId: inst.id,
+                  externalId: repo.id.toString(),
+                  slug: repo.fullName,
+                  defaultBranch: isValidGitRef(repo.defaultBranch) ? repo.defaultBranch : 'main',
+                  providerMetadata: { private: repo.private, owner: repo.owner },
+                },
+              });
+              repos[start + offset] = {
+                ...repo,
+                installationStorageId: inst.id,
+                repositoryStorageId: repository.id,
+                sandboxProvider: fleet.provider,
+                sandboxWorkdir: fleet.computeWorkdir(repo.fullName),
+              };
+            }),
+          );
         }
         return c.json({ repos });
       },

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -742,6 +742,15 @@ describe('runWorktreeSetup', () => {
       vi.useRealTimers();
     }
   });
+
+  it('forwards the hang-guard budget to the provider so it can kill the process', async () => {
+    const sandbox = new FakeSandbox();
+    const spy = vi.spyOn(sandbox, 'executeCommand');
+
+    await runWorktreeSetup(sandbox, '/workspace/worktrees/feat-x', 'pnpm i');
+
+    expect(spy).toHaveBeenCalledWith('sh', ['-c', expect.any(String)], { timeout: 15 * 60_000 });
+  });
 });
 
 describe('createPullRequest', () => {

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -724,6 +724,24 @@ describe('runWorktreeSetup', () => {
     expect(err.message).toContain('exit 1');
     expect(err.message).toContain('ERR_PNPM_NO_LOCKFILE');
   });
+
+  it('fails with a phase-tagged timeout instead of hanging on a wedged sandbox', async () => {
+    vi.useFakeTimers();
+    try {
+      const sandbox = new FakeSandbox();
+      // A sandbox whose shell never returns must not hang the request forever.
+      sandbox.executeCommand = () => new Promise<never>(() => {});
+      const pending = runWorktreeSetup(sandbox, '/workspace/worktrees/feat-x', 'pnpm i');
+      const outcome = pending.catch(e => e);
+      await vi.advanceTimersByTimeAsync(15 * 60_000 + 1_000);
+      const err = await outcome;
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toContain('timed out');
+      expect(err.message).toContain('worktree setup');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('createPullRequest', () => {

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -128,7 +128,9 @@ async function sh(
     timer.unref?.();
   });
   try {
-    return await Promise.race([sandbox.executeCommand('sh', ['-c', script]), hangGuard]);
+    // Forward the budget to the provider too so it can terminate the wedged
+    // process; the race stays as the outer guard for providers that ignore it.
+    return await Promise.race([sandbox.executeCommand('sh', ['-c', script], { timeout: timeoutMs }), hangGuard]);
   } finally {
     clearTimeout(timer);
   }

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -95,9 +95,43 @@ export function shellQuote(value: string): string {
   return `'` + value.split(`'`).join(`'\\''`) + `'`;
 }
 
-/** Run a shell script in the sandbox via `sh -c`. */
-async function sh(sandbox: MaterializationSandbox, script: string): Promise<SandboxCommandResult> {
-  return sandbox.executeCommand('sh', ['-c', script]);
+/**
+ * Default hang guard for sandbox shell commands. Generous by design — large
+ * clones and dependency installs legitimately take minutes; the guard exists
+ * so a wedged sandbox surfaces a failure instead of hanging the request that
+ * triggered materialization forever.
+ */
+const DEFAULT_COMMAND_TIMEOUT_MS = 15 * 60_000;
+/** Branch checkout only fetches one ref — a much tighter budget applies. */
+export const CHECKOUT_COMMAND_TIMEOUT_MS = 5 * 60_000;
+
+interface ShOptions {
+  /** Override the hang-guard budget for this command. */
+  timeoutMs?: number;
+  /** Human-readable phase name included in the timeout error. */
+  phase?: string;
+}
+
+/** Run a shell script in the sandbox via `sh -c`, bounded by a hang guard. */
+async function sh(
+  sandbox: MaterializationSandbox,
+  script: string,
+  options: ShOptions = {},
+): Promise<SandboxCommandResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const hangGuard = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const phase = options.phase ? ` during ${options.phase}` : '';
+      reject(new Error(`Sandbox command timed out after ${Math.round(timeoutMs / 1000)}s${phase}.`));
+    }, timeoutMs);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([sandbox.executeCommand('sh', ['-c', script]), hangGuard]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /** Error raised when the sandbox cannot materialize the repo (actionable). */
@@ -201,6 +235,7 @@ export async function materializeRepo(options: {
       const clone = await sh(
         sandbox,
         `git clone --depth=1 --single-branch --branch ${shellQuote(repoInfo.defaultBranch)} ${shellQuote(authUrl)} ${shellQuote(workdir)}`,
+        { phase: 'repository clone' },
       );
       if (clone.exitCode !== 0) {
         throw classifyGitFailure(clone, 'clone-failed');
@@ -212,7 +247,7 @@ export async function materializeRepo(options: {
       if (setUrl.exitCode !== 0) {
         throw new MaterializeError(`Failed to set git remote: ${setUrl.stderr}`, 'pull-failed');
       }
-      const pull = await sh(sandbox, `git -C ${shellQuote(workdir)} pull --ff-only`);
+      const pull = await sh(sandbox, `git -C ${shellQuote(workdir)} pull --ff-only`, { phase: 'repository pull' });
       if (pull.exitCode !== 0) {
         throw classifyGitFailure(pull, 'pull-failed');
       }
@@ -265,6 +300,7 @@ export async function checkoutSessionBranch(
     const fetch = await sh(
       sandbox,
       `git -C ${shellQuote(workdir)} fetch origin ${shellQuote(baseBranch)} && git -C ${shellQuote(workdir)} checkout -b ${shellQuote(branch)} FETCH_HEAD`,
+      { timeoutMs: CHECKOUT_COMMAND_TIMEOUT_MS, phase: 'branch checkout' },
     );
     if (fetch.exitCode !== 0) throw classifyGitFailure(fetch, 'clone-failed');
   } finally {
@@ -667,7 +703,7 @@ export async function runWorktreeSetup(
   worktreePath: string,
   command: string,
 ): Promise<void> {
-  const result = await sh(sandbox, `cd ${shellQuote(worktreePath)} && { ${command}\n}`);
+  const result = await sh(sandbox, `cd ${shellQuote(worktreePath)} && { ${command}\n}`, { phase: 'worktree setup' });
   if (result.exitCode !== 0) {
     const detail = (result.stderr.trim() || result.stdout.trim()).slice(-2000);
     throw new WorktreeError(`Setup command failed (exit ${result.exitCode}): ${detail}`, 'setup-failed');

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -617,6 +617,28 @@ describe('PlatformGithubIntegration', () => {
     }
   });
 
+  it('evicts the oldest installation listing once the cache bound is reached', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => json({ repositories: [] }));
+      const integration = createIntegration(fetchImpl);
+
+      // Fill the cache past its 1000-entry bound; installation 1 is oldest.
+      for (let installationId = 1; installationId <= 1001; installationId++) {
+        await integration.listInstallationRepos(installationId);
+      }
+      expect(fetchImpl).toHaveBeenCalledTimes(1001);
+
+      // Installation 1 was evicted (refetches); a recent entry is still cached.
+      await integration.listInstallationRepos(1);
+      expect(fetchImpl).toHaveBeenCalledTimes(1002);
+      await integration.listInstallationRepos(1001);
+      expect(fetchImpl).toHaveBeenCalledTimes(1002);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('reuses repository access grants within the cache TTL', async () => {
     vi.useFakeTimers();
     try {

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -587,6 +587,71 @@ describe('PlatformGithubIntegration', () => {
     });
   });
 
+  it('reuses installation repository listings within the cache TTL', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () =>
+        json({
+          repositories: [
+            { id: 101, owner: 'acme', name: 'app', fullName: 'acme/app', private: true, defaultBranch: 'main' },
+          ],
+        }),
+      );
+      const integration = createIntegration(fetchImpl);
+
+      const first = await integration.listInstallationRepos(7);
+      const second = await integration.listInstallationRepos(7);
+      expect(second).toBe(first);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+      // A different installation is a different cache entry.
+      await integration.listInstallationRepos(8);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+      // Expired entries are refetched.
+      vi.advanceTimersByTime(31_000);
+      await integration.listInstallationRepos(7);
+      expect(fetchImpl).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reuses repository access grants within the cache TTL', async () => {
+    vi.useFakeTimers();
+    try {
+      const { sourceControl } = await createPlatformStorageForTests();
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockImplementation(async () => json({ token: 'ghs_scoped', expiresAt: '2026-07-21T18:00:00Z' }));
+      const integration = createIntegration(fetchImpl);
+      integration.versionControl.initialize({ storage: sourceControl.forIntegration('github') });
+      const installation = await integration.versionControl.registerInstallation({
+        orgId: 'org-1',
+        userId: 'user-1',
+        installation: { externalId: '7', accountName: 'acme', accountType: 'Organization' },
+      });
+      const [repository] = await integration.versionControl.registerRepositories({
+        orgId: 'org-1',
+        installationId: installation.id,
+        repositories: [{ externalId: '101', slug: 'acme/app', defaultBranch: 'main' }],
+      });
+
+      const input = { orgId: 'org-1', repositoryId: repository!.id };
+      const first = await integration.versionControl.getRepositoryAccess(input);
+      const second = await integration.versionControl.getRepositoryAccess(input);
+      expect(second).toBe(first);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+      // Expired grants re-mint through the platform.
+      vi.advanceTimersByTime(5 * 60_000 + 1_000);
+      await integration.versionControl.getRepositoryAccess(input);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('exposes platform-backed routes and session tools without local callback or webhook routes', async () => {
     const seed = await createPlatformStorageForTests();
     const integration = createIntegration();

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -149,6 +149,23 @@ const INSTALLATION_REPOS_CACHE_TTL_MS = 30_000;
  * margin while collapsing the per-session-materialization mint round trip.
  */
 const REPOSITORY_ACCESS_CACHE_TTL_MS = 5 * 60_000;
+/**
+ * Upper bound for both TTL caches. Entries expire lazily on re-access, so
+ * without a hard cap keys that stop being queried would accumulate for the
+ * integration's (long) lifetime. Insertion-order eviction — matches the
+ * bounded verification cache in `@mastra/auth-studio`.
+ */
+const MAX_CACHE_ENTRIES = 1000;
+
+function setBounded<K, V>(cache: Map<K, V>, key: K, value: V): void {
+  cache.delete(key);
+  cache.set(key, value);
+  if (cache.size > MAX_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+}
+
 const REPOSITORY_TOKEN_PERMISSIONS = {
   contents: 'write',
   issues: 'write',
@@ -350,7 +367,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         cloneUrl,
         authorization: { scheme: 'bearer', token: token.token },
       };
-      this.#repositoryAccessCache.set(cacheKey, {
+      setBounded(this.#repositoryAccessCache, cacheKey, {
         access,
         expiresAt: Date.now() + REPOSITORY_ACCESS_CACHE_TTL_MS,
       });
@@ -701,7 +718,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       }>;
     }>('GET', `${API_PREFIX}/github-app/installations/${installationId}/repositories`);
     const repos = result.repositories.map(repository => ({ ...repository, installationId }));
-    this.#installationReposCache.set(installationId, {
+    setBounded(this.#installationReposCache, installationId, {
       repos,
       expiresAt: Date.now() + INSTALLATION_REPOS_CACHE_TTL_MS,
     });

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -26,6 +26,7 @@ import type {
   PullRequest,
   PullRequestComment,
   PullRequestRef,
+  RepositoryAccess,
   Review,
   ReviewComment,
   ReviewRef,
@@ -136,6 +137,18 @@ type GithubReviewComment = GithubComment & {
 
 const PAGE_SIZE = 30;
 const API_PREFIX = '/v1/server';
+/**
+ * How long an installation's repository listing may be reused. The repos
+ * route and token minting both call it — often several times within one UI
+ * interaction — and each call is a full Platform round trip.
+ */
+const INSTALLATION_REPOS_CACHE_TTL_MS = 30_000;
+/**
+ * How long a minted repository-scoped token may be reused. GitHub
+ * installation tokens live ~60 minutes; 5 minutes keeps a wide validity
+ * margin while collapsing the per-session-materialization mint round trip.
+ */
+const REPOSITORY_ACCESS_CACHE_TTL_MS = 5 * 60_000;
 const REPOSITORY_TOKEN_PERMISSIONS = {
   contents: 'write',
   issues: 'write',
@@ -158,6 +171,10 @@ export class PlatformGithubIntegration implements FactoryIntegration {
   readonly #pollingIntervalMs: number | undefined;
   #storage: SourceControlStorageHandle | undefined;
   #integrationStorage: GithubSubscriptionStorage | undefined;
+  /** installationId → cached repository listing (TTL-bounded). */
+  readonly #installationReposCache = new Map<number, { repos: RepoSummary[]; expiresAt: number }>();
+  /** `orgId:repositoryId` → cached repository access (TTL-bounded). */
+  readonly #repositoryAccessCache = new Map<string, { access: RepositoryAccess; expiresAt: number }>();
 
   readonly intake: Intake = {
     resolveIntakeDispatch: input => this.#resolveIntakeDispatch(input),
@@ -308,6 +325,14 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         ),
       ),
     getRepositoryAccess: async ({ orgId, repositoryId }) => {
+      // Every session materialization requests access; reuse a recent grant
+      // instead of re-minting through the Platform each time. The TTL keeps
+      // a wide margin under GitHub's ~60min installation-token lifetime.
+      const cacheKey = `${orgId}:${repositoryId}`;
+      const cached = this.#repositoryAccessCache.get(cacheKey);
+      if (cached && cached.expiresAt > Date.now()) return cached.access;
+      this.#repositoryAccessCache.delete(cacheKey);
+
       const repository = await this.storage.repositories.get({ orgId, id: repositoryId });
       if (!repository) throw new Error('Version-control repository not found.');
       const cloneUrl = `https://github.com/${repository.slug}.git`;
@@ -321,10 +346,15 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         `${API_PREFIX}/github-app/installations/${installationId}/token`,
         { repositories: [repositoryName], permissions: REPOSITORY_TOKEN_PERMISSIONS },
       );
-      return {
+      const access: RepositoryAccess = {
         cloneUrl,
         authorization: { scheme: 'bearer', token: token.token },
       };
+      this.#repositoryAccessCache.set(cacheKey, {
+        access,
+        expiresAt: Date.now() + REPOSITORY_ACCESS_CACHE_TTL_MS,
+      });
+      return access;
     },
     listPullRequests: input => this.#listPullRequests(input),
     getPullRequest: input => this.#getPullRequest(input),
@@ -653,6 +683,13 @@ export class PlatformGithubIntegration implements FactoryIntegration {
   }
 
   async listInstallationRepos(installationId: number): Promise<RepoSummary[]> {
+    // Hot in two places — the repos route and token minting (which re-lists
+    // only to validate the 1–10 repo rule). A short TTL collapses repeat
+    // Platform round trips within one UI interaction.
+    const cached = this.#installationReposCache.get(installationId);
+    if (cached && cached.expiresAt > Date.now()) return cached.repos;
+    this.#installationReposCache.delete(installationId);
+
     const result = await this.#client.request<{
       repositories: Array<{
         id: number;
@@ -663,7 +700,12 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         defaultBranch: string;
       }>;
     }>('GET', `${API_PREFIX}/github-app/installations/${installationId}/repositories`);
-    return result.repositories.map(repository => ({ ...repository, installationId }));
+    const repos = result.repositories.map(repository => ({ ...repository, installationId }));
+    this.#installationReposCache.set(installationId, {
+      repos,
+      expiresAt: Date.now() + INSTALLATION_REPOS_CACHE_TTL_MS,
+    });
+    return repos;
   }
 
   async mintInstallationToken(installationId: number): Promise<string> {

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -147,6 +147,49 @@ describe('FactoryDecisionDispatcher', () => {
     expect(left.length + right.length).toBe(1);
   });
 
+  it('claims a pending decision even when many older terminal rows exist', async () => {
+    const seed = await createFactoryStorageForTests();
+    const storage = seed.workItems;
+    // Terminal rows accumulate forever; they must be excluded from the bounded
+    // candidate window instead of crowding out the claimable row.
+    const base = new Date('2029-01-01T00:00:00Z');
+    for (let i = 0; i < 60; i++) {
+      await seed.storage.ops.insertOne('factory_deferred_decisions', {
+        org_id: 'org-1',
+        factory_project_id: PROJECT_ID,
+        evaluation_id: `eval-${i}`,
+        idempotency_key: `done-${i}`,
+        effect_ordinal: 0,
+        effect_hash: `hash-${i}`,
+        causal_chain: [],
+        decision: { type: 'sendMessage', role: 'work', message: 'done', idempotencyKey: `done-${i}` },
+        status: 'succeeded',
+        attempts: 1,
+        available_at: base,
+        completed_at: base,
+        created_at: new Date(base.getTime() + i),
+        updated_at: base,
+      });
+    }
+    await queueDecision(storage, {
+      type: 'sendMessage',
+      role: 'work',
+      message: 'Review completion.',
+      idempotencyKey: 'message-1',
+    });
+    const now = new Date('2030-01-01T00:00:00Z');
+
+    const claimed = await storage.claimDeferredDecisions({
+      ownerId: 'owner',
+      now,
+      leaseExpiresAt: new Date(now.getTime() + 30_000),
+      limit: 1,
+    });
+
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0]!.idempotencyKey).toBe('message-1');
+  });
+
   it('recovers an expired lease and fences the stale owner', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     await queueDecision(storage, {

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -608,6 +608,7 @@ const FACTORY_GOVERNANCE_SCHEMAS: CollectionSchema[] = [
         columns: ['org_id', 'factory_project_id', 'idempotency_key'],
       },
     ],
+    indexes: [{ name: 'factory_deferred_decisions_claim_idx', columns: ['status', 'created_at'] }],
   },
   {
     name: 'factory_run_bindings',
@@ -625,6 +626,16 @@ const FACTORY_GOVERNANCE_SCHEMAS: CollectionSchema[] = [
       created_at: { type: 'timestamp' },
       revoked_at: { type: 'timestamp', nullable: true },
     },
+    indexes: [
+      // Exact-address lookups run on every processor message; status filter is
+      // applied on top of the address columns.
+      {
+        name: 'factory_run_bindings_session_idx',
+        columns: ['factory_project_id', 'thread_id', 'resource_id', 'session_id'],
+      },
+      // Restart reconciler enumerates active bindings across all tenants.
+      { name: 'factory_run_bindings_status_idx', columns: ['status'] },
+    ],
   },
   {
     name: 'factory_tool_result_cursors',
@@ -662,6 +673,7 @@ const FACTORY_GOVERNANCE_SCHEMAS: CollectionSchema[] = [
         columns: ['org_id', 'factory_project_id', 'kickoff_key'],
       },
     ],
+    indexes: [{ name: 'factory_pending_starts_claim_idx', columns: ['status', 'created_at'] }],
   },
 ];
 
@@ -766,7 +778,14 @@ export class WorkItemsStorage extends FactoryStorageDomain {
   ): Promise<T[]> {
     const claim = () =>
       this.storage.withTransaction(async ops => {
-        const candidates = await ops.findMany<GovernanceDbRow>(table, {}, { orderBy: [['created_at', 'asc']] });
+        // Bounded candidate window: only rows in claimable/expirable statuses,
+        // oldest first. Terminal rows (sent/succeeded/failed) accumulate over a
+        // deployment's lifetime and must never be scanned per dispatch tick.
+        const candidates = await ops.findMany<GovernanceDbRow>(
+          table,
+          { status: { in: ['pending', 'retry', 'leased'] } },
+          { orderBy: [['created_at', 'asc']], limit: Math.max(input.limit * 5, 50) },
+        );
         const claimed: T[] = [];
         for (const candidate of candidates) {
           if (claimed.length >= input.limit) break;

--- a/mastracode/factory/src/timing.ts
+++ b/mastracode/factory/src/timing.ts
@@ -1,0 +1,33 @@
+/**
+ * Lightweight phase timing for factory boot and hot request paths.
+ *
+ * Deliberately not a metrics framework: structured stderr lines that can be
+ * grepped (`[factory:timing]`) and diffed across runs to localize slow boot
+ * phases and slow per-request dependencies.
+ */
+
+/** Run `fn`, always logging its duration under `phase`. Boot-phase use. */
+export async function timedPhase<T>(phase: string, fn: () => Promise<T>): Promise<T> {
+  const start = performance.now();
+  try {
+    return await fn();
+  } finally {
+    process.stderr.write(`[factory:timing] ${phase} ${Math.round(performance.now() - start)}ms\n`);
+  }
+}
+
+/**
+ * Run `fn`, logging only when it exceeds `thresholdMs`. Request-path use,
+ * where per-request logging would be noise but slow outliers must surface.
+ */
+export async function timedAboveThreshold<T>(phase: string, thresholdMs: number, fn: () => Promise<T>): Promise<T> {
+  const start = performance.now();
+  try {
+    return await fn();
+  } finally {
+    const elapsed = performance.now() - start;
+    if (elapsed > thresholdMs) {
+      process.stderr.write(`[factory:timing] slow ${phase} ${Math.round(elapsed)}ms\n`);
+    }
+  }
+}

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -368,6 +368,25 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.sessions.find(session => session.id === 'session-b')?.sandboxWorkdir).toBe(workdirB);
   });
 
+  it('deduplicates concurrent materializations of the same session workspace', async () => {
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    // Hold materialization open long enough for the follower to arrive while
+    // the leader is still in flight.
+    mocks.materializeRepo.mockImplementationOnce(() => new Promise(resolve => setTimeout(resolve, 20)));
+
+    const [first, second] = await Promise.all([
+      workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') }),
+      workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') }),
+    ]);
+
+    expect(second).toBe(first);
+    expect(mocks.ensureSandbox).toHaveBeenCalledTimes(1);
+    expect(mocks.materializeRepo).toHaveBeenCalledTimes(1);
+    expect(mocks.checkoutSessionBranch).toHaveBeenCalledTimes(1);
+  });
+
   it('uses repository-scoped access when materializing a Factory session', async () => {
     const { workspace } = await createLocalFactory();
     addProject();

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -128,6 +128,10 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     string,
     { inject: (token: string) => void; patKind: GithubPatKind; ghToken: string }
   >();
+  // Concurrent requests for the same session (thread list + activity polling +
+  // chat) must not each provision a sandbox and clone the repository. The
+  // first caller materializes; followers await the same promise.
+  const inflightMaterializations = new Map<string, Promise<Workspace>>();
 
   return async ({ requestContext, mastra, skillExtension }: DynamicWorkspaceContext) => {
     const effectiveSkillExtension = skillExtension ?? factorySkillExtension;
@@ -211,76 +215,99 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       // Not registered yet.
     }
 
-    const access = await github.versionControl.getRepositoryAccess({
-      orgId: session.orgId,
-      repositoryId: repository.id,
-    });
-    const token = access.authorization?.token;
-    if (!token) throw new Error('Repository access did not include a bearer token for the Factory session');
+    const materialize = async (): Promise<Workspace> => {
+      const access = await github.versionControl.getRepositoryAccess({
+        orgId: session.orgId,
+        repositoryId: repository.id,
+      });
+      const token = access.authorization?.token;
+      if (!token) throw new Error('Repository access did not include a bearer token for the Factory session');
 
-    // The `gh` CLI needs a PAT when the org configured one (installation
-    // tokens 403 on integration-restricted endpoints); git clone/checkout
-    // below keep using the minted installation token. Review-board sessions
-    // (run-binding role `review`) authenticate `gh` as the reviewer account
-    // when a reviewer token is configured; everything else — including
-    // sessions with no resolvable run binding — uses the worker token.
-    let patKind: GithubPatKind = 'default';
-    if (workItems) {
-      try {
-        const address = getFactorySessionAddress(requestContext);
-        const runBinding = address ? await workItems.findRunBindingBySession(address) : null;
-        if (runBinding?.role === 'review' && runBinding.orgId === session.orgId) patKind = 'reviewer';
-      } catch {
-        // No resolvable binding — worker token.
+      // The `gh` CLI needs a PAT when the org configured one (installation
+      // tokens 403 on integration-restricted endpoints); git clone/checkout
+      // below keep using the minted installation token. Review-board sessions
+      // (run-binding role `review`) authenticate `gh` as the reviewer account
+      // when a reviewer token is configured; everything else — including
+      // sessions with no resolvable run binding — uses the worker token.
+      let patKind: GithubPatKind = 'default';
+      if (workItems) {
+        try {
+          const address = getFactorySessionAddress(requestContext);
+          const runBinding = address ? await workItems.findRunBindingBySession(address) : null;
+          if (runBinding?.role === 'review' && runBinding.orgId === session.orgId) patKind = 'reviewer';
+        } catch {
+          // No resolvable binding — worker token.
+        }
       }
-    }
-    const ghCliToken = (await getGithubPat(() => github.integrationStorage, session.orgId, patKind)) ?? token;
+      const ghCliToken = (await getGithubPat(() => github.integrationStorage, session.orgId, patKind)) ?? token;
 
-    const sandbox = await fleet.ensureSandbox(
-      binding,
-      { GH_TOKEN: ghCliToken },
-      undefined,
-      isLocalSandbox ? { workingDirectory: workdir } : {},
-    );
-    await materializeRepo({
-      row: { id: session.id, sandboxWorkdir: workdir, materializedAt: session.materializedAt },
-      repoInfo: { repoFullName: repoFullName, defaultBranch: repository.defaultBranch },
-      sandbox,
-      token,
-      storage: storage.sessions,
-    });
-    await checkoutSessionBranch(sandbox, workdir, {
-      branch: session.branch,
-      baseBranch: session.baseBranch || projectRepository.branch || repository.defaultBranch,
-      token,
-      repoFullName: repoFullName,
-    });
-    if (projectRepository.setupCommand) await runWorktreeSetup(sandbox, workdir, projectRepository.setupCommand);
+      const sandbox = await fleet.ensureSandbox(
+        binding,
+        { GH_TOKEN: ghCliToken },
+        undefined,
+        isLocalSandbox ? { workingDirectory: workdir } : {},
+      );
+      await materializeRepo({
+        row: { id: session.id, sandboxWorkdir: workdir, materializedAt: session.materializedAt },
+        repoInfo: { repoFullName: repoFullName, defaultBranch: repository.defaultBranch },
+        sandbox,
+        token,
+        storage: storage.sessions,
+      });
+      await checkoutSessionBranch(sandbox, workdir, {
+        branch: session.branch,
+        baseBranch: session.baseBranch || projectRepository.branch || repository.defaultBranch,
+        token,
+        repoFullName: repoFullName,
+      });
+      if (projectRepository.setupCommand) await runWorktreeSetup(sandbox, workdir, projectRepository.setupCommand);
 
-    const injectGithubToken = (freshToken: string) => {
-      if (!sandbox.setEnvironmentVariable) {
-        throw new Error('The active sandbox provider does not support runtime GitHub token refresh.');
-      }
-      sandbox.setEnvironmentVariable('GH_TOKEN', freshToken);
-      const registered = githubTokenInjectors.get(workspaceId);
-      if (registered) registered.ghToken = freshToken;
+      const injectGithubToken = (freshToken: string) => {
+        if (!sandbox.setEnvironmentVariable) {
+          throw new Error('The active sandbox provider does not support runtime GitHub token refresh.');
+        }
+        sandbox.setEnvironmentVariable('GH_TOKEN', freshToken);
+        const registered = githubTokenInjectors.get(workspaceId);
+        if (registered) registered.ghToken = freshToken;
+      };
+      githubTokenInjectors.set(workspaceId, { inject: injectGithubToken, patKind, ghToken: ghCliToken });
+      registerGithubTokenInjector(requestContext, injectGithubToken);
+      registerGithubPatKind(requestContext, patKind);
+
+      const filesystem = new SandboxFilesystem({ sandbox, workdir });
+      const projectSkillPaths = [path.join(configDir, 'skills'), '.claude/skills', '.agents/skills'];
+      const skillPaths = [...(effectiveSkillExtension?.paths ?? []), ...projectSkillPaths];
+      return new Workspace({
+        id: workspaceId,
+        name: 'Mastra Code Factory Session Workspace',
+        filesystem,
+        sandbox: sandbox as unknown as ConstructorParameters<typeof Workspace>[0]['sandbox'],
+        tools: MASTRACODE_WORKSPACE_TOOLS,
+        skills: skillPaths,
+        skillSource: effectiveSkillExtension?.createSource(filesystem, projectSkillPaths) ?? filesystem,
+      });
     };
-    githubTokenInjectors.set(workspaceId, { inject: injectGithubToken, patKind, ghToken: ghCliToken });
-    registerGithubTokenInjector(requestContext, injectGithubToken);
-    registerGithubPatKind(requestContext, patKind);
 
-    const filesystem = new SandboxFilesystem({ sandbox, workdir });
-    const projectSkillPaths = [path.join(configDir, 'skills'), '.claude/skills', '.agents/skills'];
-    const skillPaths = [...(effectiveSkillExtension?.paths ?? []), ...projectSkillPaths];
-    return new Workspace({
-      id: workspaceId,
-      name: 'Mastra Code Factory Session Workspace',
-      filesystem,
-      sandbox: sandbox as unknown as ConstructorParameters<typeof Workspace>[0]['sandbox'],
-      tools: MASTRACODE_WORKSPACE_TOOLS,
-      skills: skillPaths,
-      skillSource: effectiveSkillExtension?.createSource(filesystem, projectSkillPaths) ?? filesystem,
-    });
+    // Dedupe concurrent materializations of the same workspace: followers
+    // await the leader's promise instead of provisioning a second sandbox,
+    // then bind the shared token injector into their own request context.
+    const inflight = inflightMaterializations.get(workspaceId);
+    if (inflight) {
+      const workspace = await inflight;
+      const registered = githubTokenInjectors.get(workspaceId);
+      if (registered) {
+        registerGithubTokenInjector(requestContext, registered.inject);
+        registerGithubPatKind(requestContext, registered.patKind);
+      }
+      return workspace;
+    }
+    const materialization = materialize();
+    inflightMaterializations.set(workspaceId, materialization);
+    try {
+      return await materialization;
+    } finally {
+      inflightMaterializations.delete(workspaceId);
+    }
   };
 }
 


### PR DESCRIPTION
## Summary

Factory instances were slow to boot and frequently timed out on endpoint requests. This PR optimizes the four hottest paths, plus instrumentation to measure them, in five reviewable commits:

1. **Timing instrumentation** — debug timings around `MastraFactory.prepare()`/`finalize()` phases and a warning when an auth-gate request exceeds 1s, so regressions are visible in logs (`[factory:timing] …`).
2. **Studio auth caching** (`@mastra/auth-studio`) — every authenticated request previously made an uncached, untimed network call to `/auth/me` or `/auth/verify`. Successful verifications are now cached by credential hash for 30s (~1000 entries, failures never cached), and all verify fetches abort after 15s instead of hanging.
3. **GitHub repo sync** — `GET /web/github/repos` listed installations and upserted repositories serially. Installations are now listed in parallel, repo upserts run at bounded concurrency, Platform repository listings are cached for 30s, and repository-scoped access tokens for 5 minutes.
4. **Session workspace materialization** — first use of a Factory session provisions a sandbox, clones, checks out, and runs setup synchronously. Concurrent requests for the same session each raced that pipeline; they now share one in-flight materialization per workspace ID. Sandbox shell commands get hang timeouts (15min clone/fetch/setup, 5min checkout) that fail with a phase-tagged error instead of wedging the request.
5. **Dispatcher lease claims** — lease claiming scanned entire queue tables each tick and filtered in memory, so terminal rows made every tick slower forever. Claims now scan only active-status rows, oldest first, capped at `max(limit * 5, 50)`, backed by new `(status, created_at)` indexes on both queue tables and run-binding lookup indexes.

## Measured before/after (booted web server)

Built `mastracode/web` (`pnpm web:build`), booted `node .mastra/output/index.mjs` against local Postgres + Redis with `MASTRA_SHARED_API_URL=https://platform.mastra.ai/v1` (real WAN auth round trips) and a valid Platform org API key. "Before" = step-0 instrumentation commit only (auth path identical to published `@mastra/auth-studio@1.3.2`); "after" = full branch.

**Authenticated endpoint latency — `GET /web/factory/projects`, 12 sequential requests:**

| | before | after |
|---|---|---|
| request 1 (cold) | 3.34s | 0.37s |
| requests 2–12 | 0.58–1.86s each | **1.7–2.7ms each** |
| auth-gate time | 233–2582ms *every* request | 357ms once, then **0ms** |

Baseline logged `[factory:timing] slow auth.gate.authenticate 2582ms / 1516ms / 1065ms` warnings under light sequential load; after, only the first verify per credential pays the round trip. After the 30s TTL expires, exactly one request re-verifies (~0.7s observed) and the path returns to ~2ms — the deliberate ≤30s revocation-lag bound.

**Boot phases** (`[factory:timing]`, local pg): unchanged within noise — before: storage.init 102ms cold / 61ms warm, controllerMount 75–78ms, finalize.controller 150–207ms; after: storage.init 77ms cold / 105ms warm, controllerMount 76–97ms, finalize.controller 148–231ms. The new queue-table indexes add no measurable DDL cost.

**Not measurable end-to-end here:** the test org has no GitHub App installations on Platform, so the `/web/github/repos` installation fan-out and workspace materialization paths couldn't be exercised live; both are covered by the new unit regressions (parallel listing, cache TTLs, materialization dedup, command timeouts).

Note for deployment: the built web server resolves `@mastra/auth-studio` from the published registry inside its deploy bundle, so the auth-cache win lands once the patch release from this PR's changeset is published.

## Test plan

- New regressions per step: auth cache TTL/eviction/timeout behavior (105 auth-studio tests), Platform GitHub cache reuse + parallel listing, workspace materialization dedup, sandbox command timeout, and a lease-claim crowding test (pending row still claimed with 60 older terminal rows).
- Full `@mastra/factory` suite: 1025/1026 passing — the single failure (`bindings.test.ts` kickoff replay) reproduces identically on the merge-base without these changes.
- `@mastra/auth-studio` tests 105/105, lint, typecheck, and `pnpm turbo build` for both packages pass.
- Live boot comparison above performed with the Platform-configured server on branch vs. step-0 baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes the “Factory” system start and respond faster by stopping it from repeating the same slow work (like auth checks and GitHub setup) and by running independent steps at the same time. It also adds timing logs and test coverage so slow/hanging parts are easier to spot and regressions are harder to introduce.

## What changed
- **Added timing instrumentation**
  - New async timing helpers in `mastracode/factory/src/timing.ts`: `timedPhase` (always logs duration) and `timedAboveThreshold` (logs only when slow).
  - Factories now time key boot and lifecycle phases (auth init, storage init, controller mount, controller finalize, bound-thread reconciliation).
  - Auth-gate now times per-request credential verification and emits a “slow” log when it exceeds **1,000ms**.

- **Hardened + sped up Studio auth verification**
  - `MastraAuthStudio` caches **successful** credential verifications in-memory for **30s**, using **SHA-256** cache keys and **bounded insert-order eviction (max 1000)**.
  - Cache is **isolated by credential type** (cookie vs bearer) and credential value; **failed verifications are not cached**.
  - Cached only when the verified user includes an `organizationId`; users without org bootstrap are not cached.
  - Shared-API verification calls now use `AbortSignal.timeout(VERIFY_FETCH_TIMEOUT_MS)` with a **15s** limit (covers `/auth/me` and `/auth/verify`).

- **Improved GitHub repo sync performance + safety**
  - `GET /web/github/repos` now fetches installation repos **in parallel**, filters by `q` (case-insensitive substring), **deduplicates by GitHub repo id**, and mirrors matches to storage using **bounded concurrency (chunk size 10)**.
  - When a specific installation’s repo listing returns **404**, stale installation rows are pruned while other installations continue.
  - `PlatformGithubIntegration` adds TTL-bounded in-memory memoization for:
    - `listInstallationRepos(installationId)`
    - `getRepositoryAccess(orgId, repositoryId)` (minted clone URL + bearer access)
  - Regression tests verify cache reuse/eviction and parallel overlap.

- **Deduplicated concurrent workspace materialization**
  - `createWorkspaceFactory` now deduplicates **in-flight** workspace materializations per `workspaceId` so concurrent callers share the same `Promise<Workspace>`.
  - Ensures the follower path re-binds the already-created token injector context after awaiting the shared materialization.
  - Adds a regression test asserting only one sandbox/setup/materialization occurs.

- **Bounded sandbox command timeouts (phase-specific)**
  - Upgraded the sandbox `sh(...)` wrapper to enforce a default **15-minute** hang guard with proper timer cleanup.
  - Adds/uses phase-specific timeout budgets (including `CHECKOUT_COMMAND_TIMEOUT_MS = 5 * 60_000`) so hung commands fail with clearer, phase-specific timeout errors.
  - Adds tests covering hang behavior and timeout forwarding.

- **Reduced dispatcher/lease scanning work**
  - Lease-claim candidate selection now uses **status-filtered, bounded queries** (pending/retry/leased) ordered oldest-first, before per-row atomic claim/expire checks.
  - Adds supporting database indexes for deferred decisions, active bindings enumeration, and pending starts claim patterns.
  - Regression test verifies claiming the newest pending decision works even with many older succeeded rows.

- **Tests + release metadata**
  - Adds regression tests for auth verification caching + abort/timeout behavior, GitHub concurrency + caching/eviction, workspace materialization dedupe, sandbox command hang/timeout forwarding, and dispatcher deferred-decision claiming.
  - Updates changesets to publish `@mastra/factory` and `@mastra/auth-studio` as **patch** releases.

## Performance
Repeated authenticated endpoint requests improved from approximately **0.58–1.86 seconds** down to **1.7–2.7 milliseconds**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->