### PR TITLE
feat(core): mark successful scorer judge executions

### DIFF
--- a/.changeset/eighty-masks-ask.md
+++ b/.changeset/eighty-masks-ask.md
@@ -2,11 +2,15 @@
 '@mastra/core': minor
 ---
 
-Added structured judge execution details to scorer results.
+Added status-bearing judge execution details to scorer results.
 
 ```typescript
 const result = await scorer.run(input);
-const usage = result.judge?.generateScore?.executions[0]?.usage;
+const execution = result.judge?.generateScore?.executions[0];
+
+if (execution?.status === 'success') {
+  console.log(execution.output, execution.usage);
+}
 ```
 
-Prompt-based scorer steps now expose their prompt, structured output, judge model identity, normalized token usage, attempt and model-call counts, and duration. Use this data to interpret one scorer run without reconstructing it from traces.
+Prompt-based scorer steps now expose successful logical executions with `status: 'success'`, their prompt, structured output, judge model identity, normalized token usage, attempt and model-call counts, and duration. A structured-output fallback that eventually succeeds remains one execution with its attempts aggregated. Use this data to interpret one scorer run without reconstructing it from traces.

--- a/docs/src/content/en/reference/evals/mastra-scorer.mdx
+++ b/docs/src/content/en/reference/evals/mastra-scorer.mdx
@@ -142,7 +142,8 @@ const result = await scorer.run({
 The optional `judge` record contains details about the judge model calls made by prompt-based scorer steps. Its known keys are `preprocess`, `analyze`, `generateScore`, and `generateReason`. Each key contains an ordered `executions` array.
 
 ```typescript
-interface ScorerJudgeExecution {
+interface ScorerJudgeExecutionSuccess {
+  status: 'success'
   prompt: string
   output: JSONValue
   judgeModelId: string
@@ -157,6 +158,8 @@ interface ScorerJudgeExecution {
     source: string
   }
 }
+
+type ScorerJudgeExecution = ScorerJudgeExecutionSuccess
 
 interface ScorerJudgeUsage {
   inputTokens?: number
@@ -180,10 +183,13 @@ Use the step key to access its judge execution details:
 ```typescript
 const execution = result.judge?.generateScore?.executions[0]
 
+console.log(execution?.status)
 console.log(execution?.judgeModelId)
 console.log(execution?.usage.totalTokens)
 console.log(execution?.durationMs)
 ```
+
+The `status` value describes the outcome of the logical prompt-step execution, not the quality of the evaluated response. A structured-output fallback that eventually succeeds creates one `success` execution with an `attemptCount` greater than one.
 
 `attemptCount` counts judge invocations, including a structured-output fallback. `modelCallCount` counts the completed model steps across those attempts. `durationMs` covers the full prompt-step execution.
 

--- a/packages/core/src/evals/base.test.ts
+++ b/packages/core/src/evals/base.test.ts
@@ -1,12 +1,13 @@
 import { APICallError } from '@internal/ai-sdk-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, expectTypeOf, beforeEach, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { Agent } from '../agent';
 import { SpanType } from '../observability';
 import { StreamErrorRetryProcessor } from '../processors';
 import { createMockModel } from '../test-utils/llm-mock';
 import { createScorer } from './base';
+import type { ScorerJudgeExecutionSuccess } from './base';
 import {
   AsyncFunctionBasedScorerBuilders,
   FunctionBasedScorerBuilders,
@@ -271,7 +272,9 @@ describe('createScorer', () => {
       expect(Object.keys(result.judge ?? {})).toEqual(['preprocess', 'analyze', 'generateReason']);
 
       const preprocessExecution = result.judge?.preprocess?.executions[0];
+      expectTypeOf(preprocessExecution).toEqualTypeOf<ScorerJudgeExecutionSuccess | undefined>();
       expect(preprocessExecution).toMatchObject({
+        status: 'success',
         prompt: 'Test Preprocess prompt',
         output: {
           reformattedInput: 'TEST INPUT',
@@ -765,6 +768,7 @@ describe('createScorer', () => {
 
         expect(generateLegacySpy).toHaveBeenCalledTimes(1);
         expect(result.judge?.generateScore?.executions[0]).toMatchObject({
+          status: 'success',
           prompt: 'score this output',
           output: 0.75,
           judgeModelId: 'mock-model-id',
@@ -909,6 +913,7 @@ describe('createScorer', () => {
         expect(onStepFinish).toHaveBeenCalledTimes(2);
         expect(onFinish).toHaveBeenCalledTimes(2);
         expect(execution).toMatchObject({
+          status: 'success',
           prompt: 'score this output',
           output: 1,
           judgeModelId: 'mock-model-id',
@@ -1023,6 +1028,7 @@ describe('createScorer', () => {
         const result = await scorer.run(testData.scoringInput);
 
         expect(result.judge?.generateScore?.executions[0]).toMatchObject({
+          status: 'success',
           attemptCount: 1,
           modelCallCount: 2,
           usage: { inputTokens: 15, outputTokens: 25, totalTokens: 40 },
@@ -1041,6 +1047,7 @@ describe('createScorer', () => {
       expect(runId).toBeDefined();
       expect(Object.keys(result.judge ?? {})).toEqual(['analyze']);
       expect(result.judge?.analyze?.executions).toHaveLength(1);
+      expect(result.judge?.analyze?.executions[0]?.status).toBe('success');
       expect(withoutJudge(result)).toMatchSnapshot();
     });
 

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -278,17 +278,23 @@ export interface ScorerJudgeCost {
   source: string;
 }
 
-export interface ScorerJudgeExecution {
+interface ScorerJudgeExecutionBase {
   prompt: string;
-  output: JSONValue;
   judgeModelId: string;
   judgeProvider?: string;
-  usage: ScorerJudgeUsage;
   attemptCount: number;
   modelCallCount: number;
   durationMs: number;
+}
+
+export interface ScorerJudgeExecutionSuccess extends ScorerJudgeExecutionBase {
+  status: 'success';
+  output: JSONValue;
+  usage: ScorerJudgeUsage;
   cost?: ScorerJudgeCost;
 }
+
+export type ScorerJudgeExecution = ScorerJudgeExecutionSuccess;
 
 export interface ScorerJudgeStepResult {
   executions: ScorerJudgeExecution[];
@@ -340,7 +346,8 @@ const scorerJudgeUsageSchema = z.object({
   cacheCreationInputTokens: z.number().optional(),
 });
 
-const scorerJudgeExecutionSchema = z.object({
+const scorerJudgeExecutionSuccessSchema = z.object({
+  status: z.literal('success'),
   prompt: z.string(),
   output: jsonValueSchema,
   judgeModelId: z.string(),
@@ -359,7 +366,7 @@ const scorerJudgeExecutionSchema = z.object({
 });
 
 const scorerJudgeStepResultSchema = z.object({
-  executions: z.array(scorerJudgeExecutionSchema),
+  executions: z.array(scorerJudgeExecutionSuccessSchema),
 });
 
 const scorerJudgeResultsSchema = z.object({
@@ -1173,6 +1180,7 @@ class MastraScorer<
       addScorerJudgeUsage(telemetry.usage, normalizeScorerJudgeUsage(usage));
     };
     const createExecution = (output: JSONValue): ScorerJudgeExecution => ({
+      status: 'success',
       prompt,
       output,
       judgeModelId: telemetry.judgeModelId ?? judgeModel,


### PR DESCRIPTION
Follow-up to #20022 for MASTRA-4513. Successful scorer judge executions now include an explicit `status: 'success'` discriminant and export `ScorerJudgeExecutionSuccess`. The status describes one logical prompt-step execution rather than the quality of the evaluated answer or each internal fallback attempt, so a structured-output fallback that eventually succeeds remains one execution with `attemptCount > 1`.

```ts
const execution = result.judge?.generateScore?.executions[0]

if (execution?.status === 'success') {
  console.log(execution.output)
  console.log(execution.usage)
}
```

This keeps the documentation and still-unreleased MASTRA-4513 changeset aligned with the runtime contract. It also prepares the successful execution shape for the discriminated success/failure union in #20195 without adding failure behavior here.

Verified with the focused scorer and utility tests, the core typecheck, targeted ESLint, the core build, documentation Remark validation, and declaration inspection. Repository-wide docs validation reaches the existing stale sidebar `new` tags for Agent Builder and GitHub integration; those failures are unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a scorer judge finishes successfully, its result now clearly says so. This makes it easier to safely read judge details, while keeping retries from looking like separate executions.

## Summary

- Added `status: 'success'` to scorer judge executions.
- Exported `ScorerJudgeExecutionSuccess` and refactored the execution types around it.
- Preserved structured-output fallback behavior as one logical execution with aggregated attempts.
- Updated runtime validation and execution creation to use the success schema.
- Expanded tests to verify success statuses and fallback attempt counts.
- Updated scorer documentation and the unreleased MASTRA-4513 changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->