### PR TITLE
fix(playground): limit signals to a selected date range

### DIFF
--- a/.changeset/sixty-lands-sip.md
+++ b/.changeset/sixty-lands-sip.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Improved Signals loading by limiting snapshots and themes to the selected date range.

--- a/packages/playground/src/ee/signals/__tests__/index.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/index.test.tsx
@@ -1,16 +1,23 @@
 // @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import SignalsOverviewPage from '..';
 import { navHandle } from '../../../lib/nav';
 import { RouteHeader } from '../../../lib/route-header/route-header';
 import {
+  drilldownThemeFlowResponse,
+  firstThemeExamplesResponse,
+  themeDetailResponse,
+  themeHistoryResponse,
+} from './fixtures/theme-drilldown';
+import {
   billingThemeSnapshotsResponse,
   emptyThemeEntitiesResponse,
+  emptyThemeSnapshotsResponse,
   lowSignalFirstThemeEntitiesResponse,
   multiAgentThemeEntitiesResponse,
   multiEligibleThemeEntitiesResponse,
@@ -55,6 +62,7 @@ function renderSignalsPageWithShell() {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe('Signals page', () => {
@@ -163,6 +171,175 @@ describe('Signals page', () => {
       renderSignalsPage();
 
       expect((await screen.findByRole('combobox', { name: 'Agent' })).textContent).toContain('support-agent');
+    });
+  });
+
+  describe('when the selected range is loading snapshots', () => {
+    it('keeps the snapshot date control available', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(populatedThemeEntitiesResponse)),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, async () => {
+          await new Promise(() => {});
+          return HttpResponse.json(themeSnapshotsResponse);
+        }),
+      );
+      renderSignalsPage();
+
+      expect(await screen.findByRole('button', { name: 'Last 7 days' })).not.toBeNull();
+      expect(screen.getByRole('status', { name: 'Loading signal analysis' })).not.toBeNull();
+    });
+  });
+
+  describe('when the selected range fails to load snapshots', () => {
+    it('keeps the snapshot date control available', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(populatedThemeEntitiesResponse)),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json({ error: 'Unable to load snapshots' }, { status: 500 }),
+        ),
+      );
+      renderSignalsPage();
+
+      expect(await screen.findByText('Unable to load signal flow.')).not.toBeNull();
+      expect(screen.getByRole('button', { name: 'Last 7 days' })).not.toBeNull();
+    });
+  });
+
+  describe('when the selected range has no snapshots', () => {
+    it('keeps the snapshot date control available', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(populatedThemeEntitiesResponse)),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json(emptyThemeSnapshotsResponse),
+        ),
+      );
+      renderSignalsPage();
+
+      expect(await screen.findByText('Waiting for traces.')).not.toBeNull();
+      expect(screen.getByRole('button', { name: 'Last 7 days' })).not.toBeNull();
+    });
+  });
+
+  describe('when an eligible agent is loaded with the default snapshot range', () => {
+    it('requests snapshots from the last seven days and labels the cutoff control', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-07-27T12:00:00.000Z').getTime());
+      const snapshotRequests: URL[] = [];
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(populatedThemeEntitiesResponse)),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, ({ request }) => {
+          snapshotRequests.push(new URL(request.url));
+          return HttpResponse.json(themeSnapshotsResponse);
+        }),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () =>
+          HttpResponse.json(themeFlowResponse),
+        ),
+      );
+
+      renderSignalsPage();
+
+      expect(await screen.findByRole('region', { name: 'Signal theme flow' })).not.toBeNull();
+      expect(screen.getByText('Snapshot date')).not.toBeNull();
+      expect(screen.getByRole('button', { name: 'Last 7 days' })).not.toBeNull();
+      expect(snapshotRequests).toHaveLength(1);
+      expect(snapshotRequests[0]?.searchParams.get('from')).toBe('2026-07-20T12:00:00.000Z');
+      expect(snapshotRequests[0]?.searchParams.has('to')).toBe(false);
+    });
+  });
+
+  describe('when the snapshot date preset changes', () => {
+    it('requests and renders flows only for snapshots returned in the new range', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-07-27T12:00:00.000Z').getTime());
+      const flowSnapshotIds: string[] = [];
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(populatedThemeEntitiesResponse)),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, ({ request }) => {
+          const from = new URL(request.url).searchParams.get('from');
+          return HttpResponse.json(
+            from === '2026-07-13T12:00:00.000Z' ? billingThemeSnapshotsResponse : themeSnapshotsResponse,
+          );
+        }),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, ({ request }) => {
+          const snapshotId = new URL(request.url).searchParams.get('snapshotId');
+          if (!snapshotId) return HttpResponse.json({ error: 'Missing snapshot' }, { status: 400 });
+          flowSnapshotIds.push(snapshotId);
+          const snapshot = billingThemeSnapshotsResponse.snapshots.find(
+            candidate => candidate.snapshotId === snapshotId,
+          );
+          return HttpResponse.json(snapshot ? { ...themeFlowResponse, snapshot } : themeFlowResponse);
+        }),
+      );
+      renderSignalsPage();
+      await screen.findByRole('region', { name: 'Signal theme flow' });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+      fireEvent.click(await screen.findByText('Last 14 days'));
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Last 14 days' })).not.toBeNull());
+      await waitFor(() => expect(flowSnapshotIds).toEqual(['snapshot-1', 'billing-snapshot-1', 'billing-snapshot-2']));
+      expect(await screen.findByText(/Snapshot 2 of 2/)).not.toBeNull();
+    });
+  });
+
+  describe('when a snapshot range changes with theme details open', () => {
+    it('clears the range-local theme selection', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(populatedThemeEntitiesResponse)),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json(themeSnapshotsResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () =>
+          HttpResponse.json(drilldownThemeFlowResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/themes/:themeId`, () =>
+          HttpResponse.json(themeDetailResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/themes/:themeId/examples`, () =>
+          HttpResponse.json(firstThemeExamplesResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/themes/:themeId/history`, () =>
+          HttpResponse.json(themeHistoryResponse),
+        ),
+      );
+      renderSignalsPage();
+      fireEvent.click(await screen.findByRole('button', { name: 'View theme details for Add transcript' }));
+      await screen.findByRole('dialog', { name: 'Add transcript' });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+      fireEvent.click(await screen.findByText('Last 24 hours'));
+
+      await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Add transcript' })).toBeNull());
+    });
+  });
+
+  describe('when a custom snapshot date range is applied', () => {
+    it('requests snapshots with inclusive start and end timestamps', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-07-27T12:00:00.000Z').getTime());
+      const snapshotRequests: URL[] = [];
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(populatedThemeEntitiesResponse)),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, ({ request }) => {
+          snapshotRequests.push(new URL(request.url));
+          return HttpResponse.json(themeSnapshotsResponse);
+        }),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () =>
+          HttpResponse.json(themeFlowResponse),
+        ),
+      );
+      renderSignalsPage();
+      await screen.findByRole('region', { name: 'Signal theme flow' });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+      fireEvent.click(await screen.findByText('Custom range...'));
+      const endPanel = (await screen.findByText('End')).parentElement;
+      if (!endPanel) throw new Error('Custom range end panel was not rendered');
+      fireEvent.click(within(endPanel).getByRole('gridcell', { name: '25' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      const expectedFrom = new Date(2026, 6, 20, 0, 0).toISOString();
+      const expectedTo = new Date(2026, 6, 25, 23, 59).toISOString();
+      await waitFor(() => expect(snapshotRequests).toHaveLength(2));
+      expect(snapshotRequests[1]?.searchParams.get('from')).toBe(expectedFrom);
+      expect(snapshotRequests[1]?.searchParams.get('to')).toBe(expectedTo);
     });
   });
 

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -52,12 +52,17 @@ class ChartResizeObserver implements ResizeObserver {
   disconnect() {}
 }
 
-function renderSankeySignals() {
+function renderSankeySignals({ dateFrom, dateTo }: { dateFrom?: Date; dateTo?: Date } = {}) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <MemoryRouter>
       <QueryClientProvider client={queryClient}>
-        <SankeySignals entityId="support-agent" signalNames={['goal', 'outcome', 'behavior', 'sentiment']} />
+        <SankeySignals
+          entityId="support-agent"
+          signalNames={['goal', 'outcome', 'behavior', 'sentiment']}
+          dateFrom={dateFrom}
+          dateTo={dateTo}
+        />
       </QueryClientProvider>
     </MemoryRouter>,
   );
@@ -409,6 +414,48 @@ describe('SankeySignals', () => {
   });
 
   describe('when a signal distribution is reordered', () => {
+    it('keeps the selected snapshot range on the perspective request', async () => {
+      const snapshotRanges: Array<[string | null, string | null]> = [];
+      const reorderedSnapshot = {
+        ...themeSnapshotsResponse.snapshots[0],
+        snapshotId: 'reordered-snapshot',
+        availableSignals: ['goal', 'behavior', 'outcome', 'sentiment'],
+      };
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, ({ request }) => {
+          const url = new URL(request.url);
+          const signalNames = url.searchParams.get('signalNames');
+          snapshotRanges.push([url.searchParams.get('from'), url.searchParams.get('to')]);
+          return HttpResponse.json(
+            signalNames === 'goal,behavior,outcome,sentiment'
+              ? { snapshots: [reorderedSnapshot] }
+              : themeSnapshotsResponse,
+          );
+        }),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, ({ request }) => {
+          const signalNames = new URL(request.url).searchParams.get('signalNames');
+          return HttpResponse.json(
+            signalNames === 'goal,behavior,outcome,sentiment'
+              ? { ...reorderedFourStageThemeFlowResponse, snapshot: reorderedSnapshot }
+              : fourStageThemeFlowResponse,
+          );
+        }),
+      );
+      renderSankeySignals({
+        dateFrom: new Date('2026-07-01T00:00:00.000Z'),
+        dateTo: new Date('2026-07-08T12:30:00.000Z'),
+      });
+      await screen.findByLabelText('Reorder Outcome');
+
+      await reorderOutcomeAfterBehavior();
+
+      await waitFor(() => expect(snapshotRanges).toHaveLength(2));
+      expect(snapshotRanges).toEqual([
+        ['2026-07-01T00:00:00.000Z', '2026-07-08T12:30:00.000Z'],
+        ['2026-07-01T00:00:00.000Z', '2026-07-08T12:30:00.000Z'],
+      ]);
+    });
+
     it('requests the new perspective only after the column is dropped', async () => {
       const snapshotOrders: string[] = [];
       const flowOrders: string[] = [];

--- a/packages/playground/src/ee/signals/__tests__/theme-flow-hooks.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/theme-flow-hooks.test.tsx
@@ -11,9 +11,9 @@ import { server } from '@/test/msw-server';
 
 const BASE_URL = window.location.origin;
 
-function TestQueryProvider({ children }: { children: ReactNode }) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+function TestQueryProvider({ children, queryClient }: { children: ReactNode; queryClient?: QueryClient }) {
+  const client = queryClient ?? new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
 describe('Agent Learning theme flow hooks', () => {
@@ -36,6 +36,43 @@ describe('Agent Learning theme flow hooks', () => {
       });
 
       await waitFor(() => expect(result.current.data).toEqual(themeSnapshotsResponse));
+    });
+
+    it('normalizes snapshot range dates into the request and query key', async () => {
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const dateFrom = new Date('2026-07-01T00:00:00.000Z');
+      const dateTo = new Date('2026-07-08T12:30:00.000Z');
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('from')).toBe('2026-07-01T00:00:00.000Z');
+          expect(url.searchParams.get('to')).toBe('2026-07-08T12:30:00.000Z');
+          return HttpResponse.json(themeSnapshotsResponse);
+        }),
+      );
+
+      const { result } = renderHook(
+        () => useThemeSnapshots('support-agent', 'agent', ['goal', 'outcome'], dateFrom, dateTo),
+        {
+          wrapper: ({ children }) => <TestQueryProvider queryClient={queryClient}>{children}</TestQueryProvider>,
+        },
+      );
+
+      await waitFor(() => expect(result.current.data).toEqual(themeSnapshotsResponse));
+      expect(
+        queryClient
+          .getQueryCache()
+          .getAll()
+          .map(query => query.queryKey),
+      ).toContainEqual([
+        'entity-learning',
+        'agent',
+        'support-agent',
+        'theme-snapshots',
+        ['goal', 'outcome'],
+        '2026-07-01T00:00:00.000Z',
+        '2026-07-08T12:30:00.000Z',
+      ]);
     });
 
     it('loads the weighted flow for a snapshot', async () => {

--- a/packages/playground/src/ee/signals/entity-learning-api.ts
+++ b/packages/playground/src/ee/signals/entity-learning-api.ts
@@ -16,12 +16,21 @@ export function fetchThemeEntities(entityType: string) {
   return learningJson<ThemeEntitiesResponse>(`/api/learning/entities?${query}`);
 }
 
-export function fetchThemeSnapshots(entityId: string, entityType: string, signalNames: string[], limit = 50) {
+export function fetchThemeSnapshots(
+  entityId: string,
+  entityType: string,
+  signalNames: string[],
+  dateFrom?: Date,
+  dateTo?: Date,
+  limit = 50,
+) {
   const query = new URLSearchParams({
     entityType,
     signalNames: signalNames.join(','),
     limit: String(limit),
   });
+  if (dateFrom) query.set('from', dateFrom.toISOString());
+  if (dateTo) query.set('to', dateTo.toISOString());
   return learningJson<ThemeSnapshotsResponse>(
     `/api/learning/entities/${encodeURIComponent(entityId)}/theme-snapshots?${query}`,
   );

--- a/packages/playground/src/ee/signals/hooks/use-theme-snapshots.ts
+++ b/packages/playground/src/ee/signals/hooks/use-theme-snapshots.ts
@@ -3,10 +3,18 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchThemeSnapshots } from '../entity-learning-api';
 import type { TraceSignalName } from '../types';
 
-export function useThemeSnapshots(entityId: string, entityType: string, signalNames: TraceSignalName[]) {
+export function useThemeSnapshots(
+  entityId: string,
+  entityType: string,
+  signalNames: TraceSignalName[],
+  dateFrom?: Date,
+  dateTo?: Date,
+) {
+  const from = dateFrom?.toISOString();
+  const to = dateTo?.toISOString();
   return useQuery({
-    queryKey: ['entity-learning', entityType, entityId, 'theme-snapshots', signalNames],
-    queryFn: () => fetchThemeSnapshots(entityId, entityType, signalNames),
+    queryKey: ['entity-learning', entityType, entityId, 'theme-snapshots', signalNames, from, to],
+    queryFn: () => fetchThemeSnapshots(entityId, entityType, signalNames, dateFrom, dateTo),
     enabled: signalNames.length >= 2,
     staleTime: 30_000,
   });

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -38,6 +38,8 @@ export interface SankeySignalsProps {
   entityId: string;
   entityType?: string;
   signalNames: TraceSignalName[];
+  dateFrom?: Date;
+  dateTo?: Date;
   height?: number;
 }
 
@@ -121,11 +123,13 @@ export function SankeySignals({
   entityId,
   entityType = 'agent',
   signalNames: initialSignalNames,
+  dateFrom,
+  dateTo,
   height,
 }: SankeySignalsProps) {
   const queryClient = useQueryClient();
   const [signalNames, setSignalNames] = useState(() => initialSignalNames);
-  const snapshotsQuery = useThemeSnapshots(entityId, entityType, signalNames);
+  const snapshotsQuery = useThemeSnapshots(entityId, entityType, signalNames, dateFrom, dateTo);
   const snapshots = [...(snapshotsQuery.data?.snapshots ?? [])].sort((left, right) => left.ordinal - right.ordinal);
   const [selectedSnapshotOrdinal, setSelectedSnapshotOrdinal] = useState<number>();
   const [isPlaying, setIsPlaying] = useState(false);
@@ -182,8 +186,16 @@ export function SankeySignals({
   const perspectiveMutation = useMutation({
     mutationFn: async (nextSignalNames: TraceSignalName[]) => {
       const nextSnapshots = await queryClient.fetchQuery({
-        queryKey: ['entity-learning', entityType, entityId, 'theme-snapshots', nextSignalNames],
-        queryFn: () => fetchThemeSnapshots(entityId, entityType, nextSignalNames),
+        queryKey: [
+          'entity-learning',
+          entityType,
+          entityId,
+          'theme-snapshots',
+          nextSignalNames,
+          dateFrom?.toISOString(),
+          dateTo?.toISOString(),
+        ],
+        queryFn: () => fetchThemeSnapshots(entityId, entityType, nextSignalNames, dateFrom, dateTo),
       });
       await Promise.all(
         nextSnapshots.snapshots.map(nextSnapshot =>

--- a/packages/playground/src/ee/signals/signals-overview-page.tsx
+++ b/packages/playground/src/ee/signals/signals-overview-page.tsx
@@ -1,3 +1,5 @@
+import { DateTimeRangePicker } from '@mastra/playground-ui/components/DateTimeRangePicker';
+import type { DateRangePreset } from '@mastra/playground-ui/components/DateTimeRangePicker';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';
 import { SignalsOverviewPage as SignalsEmptyState } from '@mastra/playground-ui/ee/signals';
 import { useState } from 'react';
@@ -15,14 +17,24 @@ function formatSignalName(signalName: TraceSignalName) {
   return signalName.charAt(0).toUpperCase() + signalName.slice(1);
 }
 
-function AgentSelector({
+function SignalsControls({
   entities,
   selectedEntityId,
   onEntityChange,
+  datePreset,
+  dateFrom,
+  dateTo,
+  onDatePresetChange,
+  onDateChange,
 }: {
   entities: ThemeLearningEntity[];
   selectedEntityId: string;
   onEntityChange: (entityId: string) => void;
+  datePreset: DateRangePreset;
+  dateFrom?: Date;
+  dateTo?: Date;
+  onDatePresetChange: (preset: DateRangePreset) => void;
+  onDateChange: (value: Date | undefined, type: 'from' | 'to') => void;
 }) {
   return (
     <div className="flex min-w-0 flex-wrap items-center gap-3 px-4 pt-4 lg:px-6 lg:pt-6">
@@ -41,6 +53,16 @@ function AgentSelector({
           ))}
         </SelectContent>
       </Select>
+      <span className="text-neutral4 text-xs font-medium">Snapshot date</span>
+      <DateTimeRangePicker
+        preset={datePreset}
+        onPresetChange={onDatePresetChange}
+        dateFrom={dateFrom}
+        dateTo={dateTo}
+        onDateChange={onDateChange}
+        presets={['last-24h', 'last-3d', 'last-7d', 'last-14d', 'last-30d', 'custom']}
+        size="sm"
+      />
     </div>
   );
 }
@@ -48,6 +70,13 @@ function AgentSelector({
 export function SignalsOverviewPage() {
   const entitiesQuery = useThemeEntities('agent');
   const [selectedEntityId, setSelectedEntityId] = useState<string>();
+  const [datePreset, setDatePreset] = useState<DateRangePreset>('last-7d');
+  const [dateFrom, setDateFrom] = useState<Date | undefined>(() => new Date(Date.now() - 7 * 24 * 60 * 60 * 1000));
+  const [dateTo, setDateTo] = useState<Date>();
+  const handleDateChange = (value: Date | undefined, type: 'from' | 'to') => {
+    if (type === 'from') setDateFrom(value);
+    else setDateTo(value);
+  };
 
   if (entitiesQuery.isPending) {
     return <SignalsLoadingSkeleton />;
@@ -71,13 +100,24 @@ export function SignalsOverviewPage() {
 
   return (
     <>
-      <AgentSelector entities={entities} selectedEntityId={entity.entityId} onEntityChange={setSelectedEntityId} />
+      <SignalsControls
+        entities={entities}
+        selectedEntityId={entity.entityId}
+        onEntityChange={setSelectedEntityId}
+        datePreset={datePreset}
+        dateFrom={dateFrom}
+        dateTo={dateTo}
+        onDatePresetChange={setDatePreset}
+        onDateChange={handleDateChange}
+      />
       {signalNames.length >= 2 ? (
         <SankeySignals
-          key={`${entity.entityId}:${signalNames.join(',')}`}
+          key={`${entity.entityId}:${signalNames.join(',')}:${dateFrom?.toISOString() ?? 'open'}:${dateTo?.toISOString() ?? 'open'}`}
           entityId={entity.entityId}
           entityType="agent"
           signalNames={signalNames}
+          dateFrom={dateFrom}
+          dateTo={dateTo}
         />
       ) : (
         <section


### PR DESCRIPTION
Adds a Snapshot date control to Studio Signals and defaults it to the last seven days. Preset and custom ranges are included in snapshot requests, React Query keys, and perspective prefetches, so flow loading and zero-count-theme stabilization only use snapshots returned for the selected range while playback stays visually stable.

The control remains available while chart content is loading, empty, or errored, and changing the range clears range-local playback and drill-in state. This depends on the Platform contract in https://github.com/mastra-ai/platform/pull/1758, which should deploy first.

Verified with the full Playground unit project (1,622 passing, 2 skipped), typecheck, lint, production build, and an interactive built-Studio browser proof covering the seven-day default, a 24-hour preset, reduced flow requests, and range-scoped themes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Signals now lets users choose which dates to view, starting with the last seven days. The selected dates are used consistently so charts, themes, and playback show the same time period.

## Summary

- Added preset and custom Snapshot date controls, available during loading, empty, and error states.
- Included selected date ranges in snapshot requests, React Query cache keys, and perspective prefetches.
- Scoped flow loading and zero-count theme stabilization to the active date range.
- Cleared range-specific playback and drill-in state when the date range changes.
- Added comprehensive tests for default, preset, custom, loading, error, empty, theme, and perspective behaviors.
- Added a patch changeset for `@internal/playground`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->