### PR TITLE
Fix Factory session boot, kickoff delivery, and board/settings UX

### DIFF
--- a/.changeset/every-hotels-fix.md
+++ b/.changeset/every-hotels-fix.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+'@mastra/core': patch
+'@mastra/pg': patch
+---
+
+Observational-memory settings no longer fail with "No session for resourceId" on the settings page: OM config routes now treat the live session as best-effort sync and fall back to the durably stored per-user settings when no agent-controller session exists for the resource (e.g. after a server restart), so settings load and save instead of 404ing

--- a/.changeset/four-words-serve.md
+++ b/.changeset/four-words-serve.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+'@mastra/core': patch
+'@mastra/pg': patch
+---
+
+Fixed session creation ignoring an exact thread id when the session was already live. Requesting a session with a threadId now resumes or creates that exact thread even when another request (like an event subscription or message listing) created the session first, preventing 'Thread not found' errors for workspace threads.

--- a/.changeset/full-worlds-think.md
+++ b/.changeset/full-worlds-think.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed a crash where the server process exited when an idle Postgres connection in the PgFactoryStorage pool dropped (for example after a network change or database restart). The pool now discards the broken connection, logs a warning, and reconnects on the next query.

--- a/.changeset/giant-breads-strive.md
+++ b/.changeset/giant-breads-strive.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+'@mastra/core': patch
+'@mastra/pg': patch
+---
+
+Fixed Factory sessions failing to start their kickoff run. Workspaces now recover automatically when the sandbox provider changes or a sandbox is wiped (the repository is re-cloned instead of failing), thread pages surface workspace preparation errors with a Retry button instead of hanging, and kickoff messages are now delivered to the session thread instead of silently failing with a permissions error.

--- a/.changeset/hip-wasps-repair.md
+++ b/.changeset/hip-wasps-repair.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+'@mastra/core': patch
+'@mastra/pg': patch
+---
+
+The factory-review skill now publishes its verdict on the pull request itself (gh pr review --approve / --request-changes with the full handoff body, falling back to a PR comment when GitHub rejects the review) instead of only posting the verdict in the Factory thread

--- a/mastracode/factory/factory-skills/factory-review/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-review/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: factory-review
-description: Review a pull request for a Factory work item — history and context first, then verdict — and mark the review complete
+description: Review a pull request for a Factory work item — history and context first, then a verdict published on the PR — and mark the review complete
 ---
 
 # Factory Review
 
-Review the pull request behind this Factory work item — build its history and context first, then judge correctness, tests, scope, and pattern-consistency — and finish by posting a verdict handoff and requesting the stage transition.
+Review the pull request behind this Factory work item — build its history and context first, then judge correctness, tests, scope, and pattern-consistency — and finish by publishing the verdict on the PR, posting a verdict handoff, and requesting the stage transition.
 
 You are working in a bound Factory session. Complete the full review in one pass, then make `factory_transition_work_item` your terminal step — one transition request, repeated only if the governed transition rejects it and only with the rejection reason addressed. Never wait for or solicit human input mid-run; every judgment call is yours to resolve.
 
@@ -57,6 +57,13 @@ First, post the **review handoff** as your final message in the conversation. It
 - **Requested changes** — one entry per change, concrete enough to act on (for a request-changes verdict).
 - **Assumptions** — every recorded judgment call from the run.
 - **Open questions** — any decision that genuinely needs a human.
+
+Next, publish the review on the PR itself — this is part of every pass, not something to wait to be asked for. Write the handoff body to a temp file (avoids shell-quoting breakage) and submit a PR review matching the verdict:
+
+- approve → `gh pr review <number> --approve --body-file <file>`
+- request changes → `gh pr review <number> --request-changes --body-file <file>`
+
+If GitHub rejects the review submission (e.g. the token authored the PR and cannot approve or request changes on it), fall back to `gh pr comment <number> --body-file <file>` so the verdict still lands on the PR, and record the fallback as an assumption.
 
 Then make your terminal `factory_transition_work_item` call. Take the current stage and `expectedRevision` from the `factory-phase` signal. Request `stage: "done"` (review board) **for both verdicts** — the transition marks the review pass complete; what to do about requested changes is the human's call from the handoff.
 

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -1286,6 +1286,48 @@ describe('ensure (materialize)', () => {
     expect(res.status).toBe(404);
   });
 
+  it('self-heals a stale sandbox provider by recomputing the workdir against the current fleet', async () => {
+    // The row was linked while a different provider was active — its workdir
+    // points into that provider's filesystem and would fail to clone here.
+    tables.projectRepositories.push(
+      projectRepositoryRow({
+        id: 'p1',
+        orgId: 'org1',
+        userId: 'u1',
+        installationId: 7,
+        repoFullName: 'octo/hello',
+        defaultBranch: 'main',
+        sandboxProvider: 'platform',
+        sandboxWorkdir: '/old-provider/hello',
+      }),
+    );
+    // A per-user binding already inherited the stale workdir and thinks it is materialized.
+    tables.sandboxes.push(
+      sandboxRow({
+        id: 'sbrow-1',
+        projectRepositoryId: 'p1',
+        userId: 'u1',
+        sandboxId: 'sb-old',
+        sandboxWorkdir: '/old-provider/hello',
+        materializedAt: new Date(),
+      }),
+    );
+    const res = await buildApp({ workosId: 'u1' }).request('/web/github/projects/p1/ensure', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ projectRepositoryId: 'p1', sandboxWorkdir: '/workspace/hello' });
+    // The project row was healed to the current fleet's provider + workdir…
+    expect(tables.projectRepositories[0]).toMatchObject({
+      sandboxProvider: 'railway',
+      sandboxWorkdir: '/workspace/hello',
+    });
+    // …and the per-user binding was re-pointed and forced to re-materialize.
+    expect(tables.sandboxes[0]).toMatchObject({ sandboxWorkdir: '/workspace/hello', materializedAt: null });
+    expect(materializeRepo).toHaveBeenCalledOnce();
+    expect(materializeRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ row: expect.objectContaining({ sandboxWorkdir: '/workspace/hello' }) }),
+    );
+  });
+
   it('streams server-side progress events when the client accepts an event stream', async () => {
     tables.projectRepositories.push(
       projectRepositoryRow({

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -1116,8 +1116,33 @@ async function prepareProject(options: {
   userId: string;
   onProgress?: ProgressFn;
 }): Promise<EnsureResult> {
-  const { github, fleet, project, userId, onProgress } = options;
-  const sandboxRow = await loadOrCreateSandboxRow(github, project, userId);
+  const { github, fleet, userId, onProgress } = options;
+  // Self-heal a sandbox provider switch. The project row snapshots
+  // sandboxProvider/sandboxWorkdir at link time, so when the server's provider
+  // later changes (platform ↔ local) the stored workdir points into the old
+  // provider's filesystem (e.g. `/workspace/…` on a macOS host, where the
+  // clone dies on the read-only root volume). Recompute against the current
+  // fleet and persist so every later open uses the corrected target.
+  let project = options.project;
+  if (project.sandboxProvider !== fleet.provider) {
+    const sandboxWorkdir = fleet.computeWorkdir(project.repository.slug);
+    await github.sourceControlStorage.projectRepositories.update({
+      orgId: project.installation.orgId,
+      id: project.id,
+      input: { sandboxProvider: fleet.provider, sandboxWorkdir },
+    });
+    project = { ...project, sandboxProvider: fleet.provider, sandboxWorkdir };
+  }
+  let sandboxRow = await loadOrCreateSandboxRow(github, project, userId);
+  // The per-user binding inherits its workdir at creation time — re-point it
+  // (and force a re-clone) whenever the project's workdir has since moved.
+  if (sandboxRow.sandboxWorkdir !== project.sandboxWorkdir) {
+    await github.sourceControlStorage.sandboxes.setWorkdir({
+      id: sandboxRow.id,
+      sandboxWorkdir: project.sandboxWorkdir,
+    });
+    sandboxRow = { ...sandboxRow, sandboxWorkdir: project.sandboxWorkdir, materializedAt: null };
+  }
   const access = await github.versionControl.getRepositoryAccess({
     orgId: project.installation.orgId,
     repositoryId: project.repository.id,

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -238,7 +238,12 @@ describe('materializeRepo', () => {
   });
 
   it('pulls (not clones) on re-open', async () => {
-    const sandbox = new FakeSandbox();
+    const sandbox = new FakeSandbox(script => {
+      if (script.includes('remote get-url origin')) {
+        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
+      }
+      return OK;
+    });
     await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok-xyz');
 
     const joined = sandbox.calls.join('\n');
@@ -246,6 +251,29 @@ describe('materializeRepo', () => {
     expect(joined).toContain('pull --ff-only');
     expect(sandbox.calls.some(c => c.includes('git clone'))).toBe(false);
     expect(joined).toContain('https://x-access-token:tok-xyz@github.com/octocat/hello.git');
+  });
+
+  it('re-clones when the DB says materialized but the sandbox disk was wiped', async () => {
+    // A platform/remote sandbox can expire and come back with an empty disk
+    // while the binding row still says `materializedAt`. Trusting the row made
+    // every `git -C <workdir>` fail with "cannot change to ...: No such file
+    // or directory" and the workspace never recovered. Disk is the truth: no
+    // checkout on disk means clone, regardless of the row.
+    const sandbox = new FakeSandbox(script => {
+      if (script.includes('remote get-url origin')) {
+        return {
+          exitCode: 128,
+          stdout: '',
+          stderr: "fatal: cannot change to '/workspace/hello': No such file or directory",
+        };
+      }
+      return OK;
+    });
+    await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok-abc');
+
+    expect(sandbox.calls.some(c => c.includes('git clone'))).toBe(true);
+    expect(sandbox.calls.some(c => c.includes('pull --ff-only'))).toBe(false);
+    expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
   });
 
   it('pulls (not clones) when the DB says first open but the workdir already holds this repo', async () => {
@@ -343,6 +371,9 @@ describe('materializeRepo', () => {
   it('scrubs the tokenized remote even when the pull fails on re-open', async () => {
     const sandbox = new FakeSandbox(script => {
       if (script === 'git --version') return OK;
+      if (script.includes('remote get-url origin')) {
+        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
+      }
       if (script.includes('pull --ff-only')) {
         return { exitCode: 1, stdout: '', stderr: 'fatal: not a fast-forward' };
       }
@@ -366,6 +397,32 @@ describe('materializeRepo', () => {
     expect(scrub).not.toContain('tok-secret');
     // The repo is not marked materialized when the pull failed.
     expect(dbUpdates.some(u => 'materializedAt' in u)).toBe(false);
+  });
+
+  it('surfaces the pull failure (not the scrub failure) when both fail', async () => {
+    // Regression: the scrub in the `finally` used to throw over the in-flight
+    // clone/pull error, hiding the actionable failure (e.g. "cannot change to
+    // <workdir>") behind "Failed to scrub installation token".
+    const sandbox = new FakeSandbox(script => {
+      if (script === 'git --version') return OK;
+      if (script.includes('remote get-url origin')) {
+        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
+      }
+      if (script.includes('pull --ff-only')) {
+        return { exitCode: 1, stdout: '', stderr: 'fatal: not a fast-forward' };
+      }
+      if (script.includes('remote set-url origin') && !script.includes('x-access-token')) {
+        return { exitCode: 1, stdout: '', stderr: 'error: could not write config' };
+      }
+      return OK;
+    });
+
+    const err = await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok').catch(
+      e => e,
+    );
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(String(err.message)).toContain('not a fast-forward');
+    expect(String(err.message)).not.toContain('scrub');
   });
 
   it('surfaces a scrub failure on the success path when the remote reset fails', async () => {

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -183,12 +183,17 @@ export async function materializeRepo(options: {
 
   const authUrl = tokenUrl(repo, token);
 
-  // The DB's `materializedAt` can drift from disk — a fresh per-user binding
-  // row over an already-populated workdir (local dev DB resets, repaired
-  // rows, earlier flows) would make `git clone` fail on the non-empty
-  // directory. Re-detect an existing checkout of this repo and pull instead.
-  const alreadyMaterialized = Boolean(sandboxRow.materializedAt) || (await hasExistingCheckout(sandbox, workdir, repo));
+  // The DB's `materializedAt` can drift from disk in both directions: a fresh
+  // binding row over an already-populated workdir (local dev DB resets,
+  // repaired rows, earlier flows) must pull instead of failing `git clone` on
+  // the non-empty directory, and a stale `materializedAt` over an empty
+  // sandbox (an expired/recreated VM whose disk was wiped) must re-clone
+  // instead of running `git -C <workdir>` against a directory that no longer
+  // exists. Disk is the source of truth: detect the checkout instead of
+  // trusting the row.
+  const alreadyMaterialized = await hasExistingCheckout(sandbox, workdir, repo);
 
+  let succeeded = false;
   try {
     if (!alreadyMaterialized) {
       // 2a. First open: shallow-clone the default branch into the workdir. A
@@ -217,12 +222,14 @@ export async function materializeRepo(options: {
         throw classifyGitFailure(pull, 'pull-failed');
       }
     }
+    succeeded = true;
   } finally {
     // 3. Always scrub the token from the remote so it isn't left in the VM's
     // git config, even when the clone/pull above failed partway through. This
-    // is best-effort on the failure path (the workdir may not exist yet after a
-    // failed clone); on the success path the scrub must succeed or we surface it.
-    await scrubRemote(sandbox, workdir, repo, alreadyMaterialized);
+    // is best-effort on the failure path (the workdir may not even exist, and
+    // a scrub error must never mask the primary failure); on the success path
+    // the scrub must succeed or we surface it.
+    await scrubRemote(sandbox, workdir, repo, succeeded);
   }
 
   // 4. Mark materialized.
@@ -293,7 +300,8 @@ async function hasExistingCheckout(
  * Reset the git remote back to the tokenless URL. On a successful clone/pull the
  * workdir always has a `.git`, so a non-zero exit code here means the token may
  * still be persisted — surface it. On the failure path the workdir may not exist
- * (e.g. a failed clone), so a non-zero exit is tolerated.
+ * (e.g. a failed clone), so a non-zero exit is tolerated — and never masks the
+ * primary failure being thrown through the `finally`.
  */
 async function scrubRemote(
   sandbox: MaterializationSandbox,

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -630,12 +630,12 @@ describe('OM routes with a tenant', () => {
   }
 
   function buildApp(
-    session: ReturnType<typeof makeOmSession>,
+    session: ReturnType<typeof makeOmSession> | null,
     opts: { withStorage?: boolean; authEnabled?: boolean } = {},
   ) {
     const controller = {
       ...makeAgentController([{ provider: 'anthropic', hasApiKey: true }]),
-      getSessionByResource: async () => session,
+      getSessionByResource: async () => session ?? undefined,
     };
     const app = new Hono();
     if (opts.authEnabled !== false) {
@@ -802,6 +802,35 @@ describe('OM routes with a tenant', () => {
       observerModelId: 'anthropic/claude-fable-5',
       observationThreshold: 25000,
       reflectionThreshold: 45000,
+      observeAttachments: false,
+    });
+  });
+
+  it('falls back to the stored row when the resourceId has no live session', async () => {
+    // The settings page addresses the factory-level resource, which has no
+    // live agent-controller session after a restart or before any chat. The
+    // stored row is authoritative and new sessions hydrate from it, so reads
+    // and writes must succeed session-less instead of 404ing.
+    const app = buildApp(null);
+
+    const initial = await app.request('/web/config/om?resourceId=r1');
+    expect(initial.status).toBe(200);
+    expect((await initial.json()).config.observerModelId).toBe(DEFAULT_OM_MODEL_ID);
+
+    expect(
+      (await putJson(app, '/web/config/om/observer/model', { resourceId: 'r1', modelId: 'anthropic/claude-fable-5' }))
+        .status,
+    ).toBe(200);
+    expect(
+      (await putJson(app, '/web/config/om/thresholds', { resourceId: 'r1', observationThreshold: 25000 })).status,
+    ).toBe(200);
+    expect((await putJson(app, '/web/config/om/observe-attachments', { resourceId: 'r1', value: false })).status).toBe(
+      200,
+    );
+
+    await expect(seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).resolves.toMatchObject({
+      observerModelId: 'anthropic/claude-fable-5',
+      observationThreshold: 25000,
       observeAttachments: false,
     });
   });

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -1099,8 +1099,12 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
             const record = await context.storage.get({ orgId: context.orgId, userId: context.userId });
             if (!resourceId) return c.json({ config: readStoredOMConfig(record) });
 
+            // Session sync is best-effort: the stored row is authoritative and
+            // new sessions hydrate from it, so a resourceId without a live
+            // session (e.g. settings page after a restart) still reads the
+            // stored config instead of failing.
             const session = await controller.getSessionByResource?.(resourceId, scope);
-            if (!session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
+            if (!session) return c.json({ config: readStoredOMConfig(record) });
             await hydrateSessionMemorySettings(session, record);
             return c.json({ config: readOMConfig(session) });
           } catch (error) {
@@ -1134,8 +1138,9 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           });
           if ('response' in context) return context.response;
           try {
+            // Best-effort session sync: persist regardless, apply to the live
+            // session only when one exists for the resourceId.
             const session = resourceId ? await controller.getSessionByResource?.(resourceId, scope) : undefined;
-            if (resourceId && !session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
             const otherRole = session ? (role === 'observer' ? session.om.reflector : session.om.observer) : undefined;
             const otherRoleCurrentModelId = otherRole?.modelId() ?? null;
             await session?.om[role].switchModel({ modelId });
@@ -1195,8 +1200,9 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           });
           if ('response' in context) return context.response;
           try {
+            // Best-effort session sync: persist regardless, apply to the live
+            // session only when one exists for the resourceId.
             const session = resourceId ? await controller.getSessionByResource?.(resourceId, scope) : undefined;
-            if (resourceId && !session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
             if (observation !== undefined && session) {
               await session.state.set({ observationThreshold: observation });
               await session.thread.setSetting({ key: 'observationThreshold', value: observation });
@@ -1243,8 +1249,9 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           });
           if ('response' in context) return context.response;
           try {
+            // Best-effort session sync: persist regardless, apply to the live
+            // session only when one exists for the resourceId.
             const session = resourceId ? await controller.getSessionByResource?.(resourceId, scope) : undefined;
-            if (resourceId && !session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
             if (session) {
               await session.state.set({ observeAttachments: value });
               await session.thread.setSetting({ key: 'observeAttachments', value });

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -948,11 +948,13 @@ describe('FactoryDecisionDispatcher', () => {
         },
       },
     });
+    const primeCredentials = vi.fn(async () => {});
     const dispatcher = new FactoryDecisionDispatcher({
       controller: controller as never,
       transitionService,
       storage,
       ownerId: 'worker-1',
+      primeCredentials,
     });
 
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
@@ -966,6 +968,11 @@ describe('FactoryDecisionDispatcher', () => {
 
     expect(delivered).toEqual(['factory-kickoff:kickoff-1']);
     expect(sendNotificationSignal).toHaveBeenCalledTimes(1);
+    // Kickoff wake runs build the Factory workspace, which requires the
+    // authenticated session owner on the request context.
+    expect(primeCredentials).toHaveBeenCalledWith({ orgId: 'org-1', userId: 'user-1' });
+    const kickoffOptions = sendNotificationSignal.mock.calls[0]![1];
+    expect(kickoffOptions?.requestContext?.get('user')).toEqual({ workosId: 'user-1', organizationId: 'org-1' });
     expect((await storage.listPendingStarts('org-1', PROJECT_ID))[0]?.status).toBe('sent');
   });
 

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -500,6 +500,14 @@ export class FactoryDecisionDispatcher {
             candidate => candidate.id === record.bindingId && candidate.status === 'active',
           );
           if (!binding) throw new Error('Prepared Factory binding is unavailable or revoked.');
+          // Wake runs build the Factory workspace, which requires the
+          // authenticated session owner on the request context.
+          const item = await this.#storage.get({ orgId: record.orgId, id: binding.workItemId });
+          const startedBy = item?.sessions[binding.role]?.startedBy;
+          if (!startedBy) throw new Error(`Factory binding ${binding.id} has no authenticated session owner.`);
+          await this.#primeCredentials?.({ orgId: record.orgId, userId: startedBy });
+          const requestContext = new RequestContext();
+          requestContext.set('user', { workosId: startedBy, organizationId: record.orgId });
           const session = await this.#requireSession(binding);
           await awaitNotification(
             await session.sendNotificationSignal(
@@ -512,7 +520,7 @@ export class FactoryDecisionDispatcher {
                 sourceId: record.id,
                 dedupeKey: `factory-kickoff:${record.kickoffKey}`,
               },
-              { ifActive: { behavior: 'deliver' }, ifIdle: { behavior: 'wake' } },
+              { ifActive: { behavior: 'deliver' }, ifIdle: { behavior: 'wake' }, requestContext },
             ),
             true,
           );

--- a/mastracode/factory/src/storage/domains/source-control/base.test.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.test.ts
@@ -255,6 +255,18 @@ describe('SourceControlStorage', () => {
     ).toBeNull();
   });
 
+  it('re-points a sandbox binding workdir and clears its materialization', async () => {
+    const project = await createProject();
+    const link = await linkRepository({ factoryProjectId: project.id });
+    const binding = await github.sandboxes.getOrCreate({ projectRepository: link, userId: 'user-1' });
+    await github.sandboxes.markMaterialized({ id: binding.id });
+
+    await github.sandboxes.setWorkdir({ id: binding.id, sandboxWorkdir: '/local/mastra-ai/mastra' });
+
+    const updated = await github.sandboxes.getById({ id: binding.id });
+    expect(updated).toMatchObject({ sandboxWorkdir: '/local/mastra-ai/mastra', materializedAt: null });
+  });
+
   it('rejects cross-org, cross-provider, and cross-installation links', async () => {
     const project = await createProject();
     const otherProject = await createProject({ orgId: 'org-2', name: 'Other org' });

--- a/mastracode/factory/src/storage/domains/source-control/base.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.ts
@@ -351,6 +351,12 @@ export interface SourceControlStorageHandle {
   readonly sandboxes: {
     getOrCreate(args: { projectRepository: ProjectRepository; userId: string }): Promise<ProjectRepositorySandbox>;
     getById(args: { id: string }): Promise<ProjectRepositorySandbox | null>;
+    /**
+     * Point the binding at a new workdir and clear `materializedAt` — a moved
+     * workdir means the checkout must be re-cloned. Used to heal bindings whose
+     * inherited workdir went stale (e.g. the sandbox provider changed).
+     */
+    setWorkdir(args: { id: string; sandboxWorkdir: string }): Promise<void>;
     setSandboxId(args: { id: string; sandboxId: string }): Promise<void>;
     clearBinding(args: { id: string }): Promise<void>;
     markMaterialized(args: { id: string }): Promise<void>;
@@ -909,6 +915,10 @@ export class SourceControlStorage extends FactoryStorageDomain {
           }
         },
         getById: ({ id }) => getSandbox(id),
+        setWorkdir: async ({ id, sandboxWorkdir }) => {
+          await requireSandbox(id);
+          await db().updateMany(SANDBOXES, { id }, { sandbox_workdir: sandboxWorkdir, materialized_at: null });
+        },
         setSandboxId: async ({ id, sandboxId }) => {
           await requireSandbox(id);
           await db().updateMany(SANDBOXES, { id }, { sandbox_id: sandboxId });

--- a/mastracode/factory/src/storage/domains/source-control/inmemory.ts
+++ b/mastracode/factory/src/storage/domains/source-control/inmemory.ts
@@ -302,6 +302,10 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
     },
     getById: async ({ id }: { id: string }): Promise<ProjectRepositorySandbox | null> =>
       this.sandboxesRows.find(row => row.id === id) ?? null,
+    setWorkdir: async ({ id, sandboxWorkdir }: { id: string; sandboxWorkdir: string }): Promise<void> => {
+      const row = this.sandboxesRows.find(candidate => candidate.id === id);
+      if (row) Object.assign(row, { sandboxWorkdir, materializedAt: null });
+    },
     setSandboxId: async ({ id, sandboxId }: { id: string; sandboxId: string }): Promise<void> => {
       const row = this.sandboxesRows.find(candidate => candidate.id === id);
       if (row) row.sandboxId = sandboxId;

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -269,6 +269,10 @@ describe('getFactoryWorkspace', () => {
     const review = await read('factory-review');
     expect(review).toContain('Verdict: approve');
     expect(review).toContain('Verdict: request changes');
+    // The verdict must be published on the PR itself, unprompted.
+    expect(review).toContain('gh pr review <number> --approve --body-file');
+    expect(review).toContain('gh pr review <number> --request-changes --body-file');
+    expect(review).toContain('gh pr comment <number> --body-file');
   });
 
   it('adds read-only Web Factory skills and keeps them authoritative over project shadows', async () => {

--- a/mastracode/web/.env.schema
+++ b/mastracode/web/.env.schema
@@ -83,7 +83,9 @@ MASTRA_ENVIRONMENT_ID=
 # @public @type=url
 MASTRA_WORKSPACE_PROXY_URL=
 # GitHub event polling is enabled by default. Set false to disable it.
-# @public @type=enum("", "true", "false")
+# (Bare true/false are listed alongside the quoted forms because varlock
+# coerces unquoted booleans before enum validation.)
+# @public @type=enum("", "true", "false", true, false)
 MASTRA_PLATFORM_GITHUB_POLLING_ENABLED=
 # Optional positive polling interval in milliseconds. Defaults to 5000.
 # @public @type=string(matches="^(|[1-9][0-9]*)$")
@@ -111,7 +113,9 @@ WORKOS_COOKIE_PASSWORD=
 # hand-creating an org. Enabled by default. Set to 0 for deployments that
 # provision orgs themselves (e.g. SSO). Requires the WorkOS API key to have
 # permission to create organizations and memberships.
-# @public @type=enum("", "0", "1")
+# (Bare 0/1 are listed alongside the quoted forms because varlock coerces
+# unquoted numbers before enum validation.)
+# @public @type=enum("", "0", "1", 0, 1)
 MASTRACODE_BOOTSTRAP_PERSONAL_ORG=
 
 # ---------------------------------------------------------------------------

--- a/mastracode/web/src/shared/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
+++ b/mastracode/web/src/shared/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
@@ -137,6 +137,51 @@ describe('useAgentControllerConnection', () => {
     expect(receivedState).toEqual({ state: { projectPath: '/sandbox/repo', ...factorySessionState } });
   });
 
+  it('given a workspace session with a conventional thread id, when the connection initializes, then session creation binds that exact thread', async () => {
+    // Regression: a factory workspace's thread id is its sessionId (seeded by
+    // FactoryStartCoordinator). If init omits `threadId` and provisioning was
+    // interrupted (or storage was reset), the server binds a fresh random-id
+    // thread and the route's thread lookup 404s forever. Passing the exact id
+    // makes init a get-or-create for the conventional thread.
+    let createBody: unknown;
+    const onEvent = vi.fn();
+
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, async ({ request }) => {
+        createBody = await request.json();
+        return HttpResponse.json({ controllerId, resourceId, threadId: resourceId });
+      }),
+      http.get(sessionUrl, () =>
+        HttpResponse.json({
+          controllerId,
+          resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: resourceId,
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        }),
+      ),
+      http.get(
+        `${sessionUrl}/stream`,
+        () =>
+          new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+            headers: { 'content-type': 'text/event-stream' },
+          }),
+      ),
+    );
+
+    const { result } = renderHookWithProviders(() =>
+      useAgentControllerConnection({
+        ...hookArgs,
+        sessionThreadId: resourceId,
+        onEvent,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(createBody).toMatchObject({ resourceId, threadId: resourceId });
+  });
+
   it('given the event callback changes after connection, then the active stream is not resubscribed', async () => {
     const onStream = vi.fn();
     const onEvent = vi.fn();

--- a/mastracode/web/src/shared/hooks/useAgentControllerSessionInit.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerSessionInit.ts
@@ -16,6 +16,15 @@ interface UseAgentControllerSessionInitArgs {
    * tag so the server side can round-trip it.
    */
   scope?: string;
+  /**
+   * The session's conventional thread id (=== its sessionId for factory and
+   * user workspaces). When set, session creation is an exact-thread
+   * get-or-create: it binds the existing thread or (re)creates it with this
+   * id, healing sessions whose thread provisioning was interrupted or whose
+   * backing storage was reset. Without it, a missing thread would silently
+   * bind the session to a fresh random-id thread the route can never load.
+   */
+  sessionThreadId?: string;
   factorySessionState?: FactorySessionState;
   baseUrl?: string;
   enabled?: boolean;
@@ -25,6 +34,7 @@ export function useAgentControllerSessionInit({
   agentControllerId,
   resourceId,
   scope,
+  sessionThreadId,
   factorySessionState,
   baseUrl = '',
   enabled = true,
@@ -42,10 +52,14 @@ export function useAgentControllerSessionInit({
       ...queryKeys.agentControllerConnection(agentControllerId, resourceId, scope),
       'init',
       factorySessionState,
+      sessionThreadId ?? null,
     ],
     queryFn: async () => {
       const activeSession = requireAgentControllerSession(session);
-      const created = await activeSession.create({ tags: scope ? { projectPath: scope } : undefined });
+      const created = await activeSession.create({
+        tags: scope ? { projectPath: scope } : undefined,
+        threadId: sessionThreadId,
+      });
       // Factory sessions have no scope but still need their state seeded —
       // server-side gates (the transition tool, factory-phase processor)
       // resolve the session address from `factoryProjectId` in state.

--- a/mastracode/web/src/web/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Clicking a board card is a commitment to work, not a blank chat: the card's
+ * click target starts its default run (with an invocation) so the resulting
+ * thread gets a kickoff message instead of an empty "What can I help you
+ * build?" session. Only cards with no run spec fall back to a plain session.
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../e2e/web-ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../e2e/web-ui/render';
+import { createAppRoutes } from '../router';
+
+const FACTORY_ID = 'fp-1';
+const REPO_ID = 'repo-1';
+
+// Wire shape as served by /web/factory/*/work-items: the client derives
+// `source`/`url` from `externalSource` (see fromWireWorkItem).
+const issueWorkItem = {
+  id: 'item-1',
+  orgId: 'org-1',
+  createdBy: 'user-1',
+  factoryProjectId: FACTORY_ID,
+  externalSource: {
+    integrationId: 'github',
+    type: 'issue',
+    externalId: 'github-issue:7',
+    url: 'https://github.com/acme/app/issues/7',
+  },
+  parentWorkItemId: null,
+  title: 'Fix login bug',
+  stages: ['triage'],
+  stageHistory: [],
+  sessions: {},
+  metadata: { number: 7 },
+  revision: 1,
+  createdAt: '2026-07-18T00:00:00.000Z',
+  updatedAt: '2026-07-18T00:00:00.000Z',
+};
+
+/**
+ * Stubs the board's data endpoints and captures run-start requests. The run
+ * start never resolves, keeping the test on the board (no thread navigation).
+ */
+function stubBoardEndpoints({ issues = [] as object[] } = {}) {
+  const startRequests: Array<Record<string, unknown>> = [];
+
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'conn-1',
+            installationId: 'inst-1',
+            repositories: [
+              {
+                id: REPO_ID,
+                branch: 'main',
+                sandboxWorkdir: '/repo',
+                repository: { slug: 'acme/app', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+      HttpResponse.json({ workItems: [issueWorkItem] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions`, () =>
+      HttpResponse.json({ decisions: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/intake/config`, () =>
+      HttpResponse.json({
+        config: {
+          github: { enabled: true, sourceIds: ['acme/app'] },
+          linear: { enabled: false, sourceIds: null },
+        },
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/linear/status`, () =>
+      HttpResponse.json({ enabled: false, connected: false, workspace: null }),
+    ),
+    // The label-filtered (auto-triaged) feed stays empty; the plain feed
+    // serves the candidate under test.
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/issues`, ({ request }) =>
+      HttpResponse.json({ issues: new URL(request.url).searchParams.has('label') ? [] : issues, nextPage: null }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () => HttpResponse.json({ sessions: [] })),
+    http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () => HttpResponse.json({ ok: true })),
+    http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+      HttpResponse.json({ session: { sessionId: 'session-1', branch: 'factory/issue-7' } }),
+    ),
+    http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/runs/start`, async ({ request }) => {
+      startRequests.push((await request.json()) as Record<string, unknown>);
+      await new Promise(() => {}); // never resolves — assertions read startRequests
+      return HttpResponse.json({});
+    }),
+  );
+
+  return { startRequests };
+}
+
+function renderWorkBoard() {
+  const router = createMemoryRouter(createAppRoutes(), { initialEntries: [`/factories/${FACTORY_ID}/work`] });
+  return renderWithProviders(<RouterProvider router={router} />);
+}
+
+describe('Board card click starts the default run', () => {
+  it('starts the default run with its invocation when a sessionless work-item card is clicked', async () => {
+    const { startRequests } = stubBoardEndpoints();
+    const user = userEvent.setup();
+    renderWorkBoard();
+
+    // The click target announces the default run, not a blank thread.
+    const cardButton = await screen.findByRole('button', { name: 'Investigate Fix login bug' });
+    expect(screen.queryByRole('button', { name: 'Create thread for Fix login bug' })).not.toBeInTheDocument();
+    await user.click(cardButton);
+
+    await waitFor(() => expect(startRequests).toHaveLength(1));
+    expect(startRequests[0]).toMatchObject({
+      invocation: { type: 'skill', skillName: 'factory-triage' },
+      workItem: { id: 'item-1', role: 'plan' },
+    });
+  });
+
+  it('starts the default run with its invocation when a candidate card title is clicked', async () => {
+    const { startRequests } = stubBoardEndpoints({
+      issues: [
+        {
+          number: 9,
+          title: 'Crash on logout',
+          url: 'https://github.com/acme/app/issues/9',
+          author: 'octocat',
+          labels: [],
+          comments: 0,
+          createdAt: '2026-07-18T00:00:00.000Z',
+          updatedAt: '2026-07-18T00:00:00.000Z',
+        },
+      ],
+    });
+    const user = userEvent.setup();
+    renderWorkBoard();
+
+    await user.click(await screen.findByRole('button', { name: 'Issue: Crash on logout' }));
+
+    await waitFor(() => expect(startRequests).toHaveLength(1));
+    expect(startRequests[0]).toMatchObject({
+      invocation: { type: 'skill', skillName: 'factory-triage' },
+      workItem: { role: 'plan' },
+    });
+  });
+});

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatConnectionProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatConnectionProvider.tsx
@@ -14,11 +14,13 @@ export function ChatConnectionProvider({
   children: ReactNode;
   onEvent: (event: AgentControllerEvent) => void;
 }) {
-  const { resourceId, projectPath, factorySessionState, sessionEnabled, baseUrl } = useChatSessionContext();
+  const { resourceId, projectPath, sessionThreadId, factorySessionState, sessionEnabled, baseUrl } =
+    useChatSessionContext();
   const connection = useAgentControllerConnection({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
     scope: projectPath,
+    sessionThreadId,
     factorySessionState,
     baseUrl,
     enabled: sessionEnabled,

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionContext.ts
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionContext.ts
@@ -11,7 +11,23 @@ export interface ChatSessionContextApi {
   resourceId: string;
   sessionEnabled: boolean;
   resourceEnabled: boolean;
+  /**
+   * Failure while preparing the session's workspace (sandbox provision /
+   * repo materialization). While set, the session never becomes enabled, so
+   * surfaces must show this error instead of an eternal loading state.
+   */
+  sessionError?: Error;
+  /** Re-runs workspace preparation after a `sessionError`. */
+  retrySession?: () => void;
   projectPath?: string;
+  /**
+   * The session's conventional thread id (=== its sessionId, seeded by
+   * FactoryStartCoordinator). Passing it through session creation makes init
+   * an exact-thread get-or-create, so a session whose provisioning was
+   * interrupted (or whose backing DB was reset) recreates its thread instead
+   * of binding to a fresh random-id thread the route can never find.
+   */
+  sessionThreadId?: string;
   factorySessionState?: FactorySessionState;
   baseUrl: string;
   /**

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@mastra/playground-ui/components/Button';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import type { ReactNode } from 'react';
 import { createContext, useContext } from 'react';
@@ -62,11 +63,15 @@ export function ChatSessionConfigProvider({
   const sessionEnabled = userScoped
     ? Boolean(storedSession) && !resolvingSession
     : ensureQuery.isSuccess && Boolean(storedSession) && !resolvingSession;
+  const sessionError = userScoped ? undefined : (ensureQuery.error ?? undefined);
   const value = {
     resourceId: resourceId ?? '',
     sessionEnabled,
     resourceEnabled: userScoped ? Boolean(resourceId) : ensureQuery.isSuccess,
+    sessionError,
+    retrySession: sessionError ? () => void ensureQuery.refetch() : undefined,
     projectPath,
+    sessionThreadId: storedSession?.sessionId,
     factorySessionState:
       factory && repository
         ? {
@@ -147,6 +152,26 @@ export function ChatMessageBoundary({ children }: { children: ReactNode }) {
 }
 
 function ChatMessageFeedback({ threadId, isPending, error }: ChatThreadMessagesApi) {
+  const { sessionError, retrySession } = useChatSessionContext();
+
+  // A failed workspace preparation keeps the session disabled, which leaves
+  // the messages query pending forever — surface the real failure instead of
+  // an eternal skeleton.
+  if (sessionError) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col place-items-center gap-4 overflow-y-auto scroll-smooth px-3 pt-6 pb-2 md:px-5 [&>*]:mx-auto [&>*]:w-full [&>*]:max-w-[80ch]">
+        <Notice variant="destructive">Failed to prepare the workspace: {sessionError.message}</Notice>
+        {retrySession && (
+          <div>
+            <Button variant="default" onClick={retrySession}>
+              Retry
+            </Button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   if (threadId && isPending) {
     return (
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto scroll-smooth px-3 pt-6 pb-2 md:px-5 [&>*]:mx-auto [&>*]:w-full [&>*]:max-w-[80ch]">

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerConnection.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerConnection.ts
@@ -15,6 +15,8 @@ interface UseAgentControllerConnectionArgs {
   agentControllerId: string;
   resourceId: string;
   scope?: string;
+  /** Exact thread id to bind on session creation (see ChatSessionContextApi). */
+  sessionThreadId?: string;
   factorySessionState?: FactorySessionState;
   baseUrl?: string;
   enabled?: boolean;
@@ -25,6 +27,7 @@ export function useAgentControllerConnection({
   agentControllerId,
   resourceId,
   scope,
+  sessionThreadId,
   factorySessionState,
   baseUrl = '',
   enabled = true,
@@ -45,6 +48,7 @@ export function useAgentControllerConnection({
     agentControllerId,
     resourceId,
     scope,
+    sessionThreadId,
     factorySessionState,
     baseUrl,
     enabled,

--- a/mastracode/web/src/web/ui/pages/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/pages/BoardPage.tsx
@@ -946,25 +946,6 @@ function BoardContent({
                         },
                       })
                     }
-                    onOpenSession={() =>
-                      start.mutate({
-                        branch: candidate.branch,
-                        threadTitle: candidate.threadTitle,
-                        workItem: {
-                          role: 'chat',
-                          stages: [candidate.column],
-                          source: candidate.source,
-                          sourceKey: candidate.sourceKey,
-                          parentWorkItemId:
-                            candidate.source === 'github-pr'
-                              ? inferredParentWorkItemId(candidate.metadata, allWorkItems)
-                              : undefined,
-                          title: candidate.title,
-                          url: candidate.url,
-                          metadata: candidate.metadata,
-                        },
-                      })
-                    }
                     onFile={() => handleDrop({ kind: 'candidate', candidate }, candidate.column)}
                     onTriage={candidate.issue ? () => triage.mutate(candidate.issue!) : undefined}
                   />
@@ -1386,7 +1367,7 @@ function WorkItemCard({
   retryingDecisionId?: string;
   onRetryDecision: (decisionId: string) => void;
   pendingRunRoles: ReadonlyMap<string, FactoryRunPhase | undefined>;
-  /** Title click when the card has no live session: open an empty session (no run). */
+  /** Card click fallback when the item has no run spec: open an empty session (no run). */
   onCreateSession: (spec: { branch: string; threadTitle: string }) => void;
   onStartRun: (spec: ItemRunSpec, action: RunAction) => void;
   onMove: (toStage: string) => void;
@@ -1436,14 +1417,25 @@ function WorkItemCard({
           className="focus-visible:outline-accent1 absolute inset-0 z-10 cursor-pointer rounded-xl outline-none focus-visible:outline-2 focus-visible:outline-offset-2"
         />
       ) : (
+        // Card click starts the default run (first unused action, e.g. Review
+        // for PRs) so clicking a card kicks off its work; cards with no run
+        // spec fall back to opening a plain chat session on the item's branch.
         <button
           type="button"
           draggable={false}
           disabled={runDisabled}
           aria-busy={pendingRunRoles.size > 0 || undefined}
-          aria-label={`Create thread for ${item.title}`}
+          aria-label={
+            runSpec !== null && runActions[0] !== undefined
+              ? `${runActions[0].label} ${item.title}`
+              : `Create thread for ${item.title}`
+          }
           className="focus-visible:outline-accent1 absolute inset-0 z-10 cursor-pointer rounded-xl outline-none focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed"
-          onClick={() => onCreateSession(itemSessionSpec(item))}
+          onClick={() =>
+            runSpec !== null && runActions[0] !== undefined
+              ? onStartRun(runSpec, runActions[0])
+              : onCreateSession(itemSessionSpec(item))
+          }
         />
       )}
       <div className="absolute top-2 right-2 z-20">
@@ -1590,7 +1582,6 @@ function CandidateCard({
   triageStarting,
   disabled,
   onRun,
-  onOpenSession,
   onFile,
   onTriage,
 }: {
@@ -1600,8 +1591,6 @@ function CandidateCard({
   disabled: boolean;
   /** Start a run; `prompt` undefined = the action's default prompt. */
   onRun: (action: RunAction, prompt?: string) => void;
-  /** Title click: materialize the card + open an empty session (no run). */
-  onOpenSession: () => void;
   /** File the candidate onto the board without starting a run. */
   onFile: () => void;
   /** Run first-contact issue triage without leaving the board. */
@@ -1638,7 +1627,9 @@ function CandidateCard({
             type="button"
             disabled={disabled}
             aria-busy={pendingRunRoles.has(defaultAction.role) || undefined}
-            onClick={onOpenSession}
+            // Title click starts the default run — same as the primary action
+            // button — so clicking a candidate always kicks off its work.
+            onClick={() => onRun(defaultAction)}
             className="text-ui-smd text-icon6 min-w-0 flex-1 truncate text-left font-semibold hover:underline disabled:opacity-60"
           >
             <SourceTitle source={candidate.source} title={candidate.title} />

--- a/mastracode/web/src/web/ui/pages/__tests__/ThreadPageEnsureError.msw.test.tsx
+++ b/mastracode/web/src/web/ui/pages/__tests__/ThreadPageEnsureError.msw.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Regression coverage for workspace-preparation failures on the factory
+ * thread route: when the sandbox `/ensure` call fails (e.g. a stale workdir
+ * from a previous sandbox provider makes the clone die), the page must show
+ * the real error with a Retry action — not an eternal loading skeleton with
+ * a silently disabled composer.
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../e2e/web-ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../../e2e/web-ui/render';
+import { createAppRoutes } from '../../router';
+
+const FACTORY_ID = 'fp-1';
+const REPO_ID = 'ghp-1';
+const SESSION_ID = 'sess-1';
+const AC = `${TEST_BASE_URL}/api/agent-controller/code`;
+
+const workspaceSession = {
+  id: 'row-1',
+  sessionId: SESSION_ID,
+  projectRepositoryId: REPO_ID,
+  orgId: 'org-1',
+  userId: 'user-1',
+  branch: 'factory/issue-1',
+  baseBranch: 'main',
+  sandboxId: null,
+  sandboxWorkdir: null,
+  materializedAt: null,
+  createdAt: '2026-07-23T00:00:00.000Z',
+  updatedAt: '2026-07-23T00:00:00.000Z',
+};
+
+/** Stubs the thread route's network surface with a controllable `/ensure`. */
+function stubThreadRoute() {
+  let ensureCalls = 0;
+  let ensureFailures = 1;
+
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'conn-1',
+            installationId: 'inst-1',
+            repositories: [
+              {
+                id: REPO_ID,
+                branch: 'main',
+                sandboxWorkdir: '/repo',
+                repository: { slug: 'acme/app', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+      HttpResponse.json({ sessions: [workspaceSession] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/user-sessions/${SESSION_ID}`, () =>
+      HttpResponse.json({ session: workspaceSession }),
+    ),
+    // The materialization call under test: fails first, succeeds on retry.
+    http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () => {
+      ensureCalls += 1;
+      if (ensureCalls <= ensureFailures) {
+        return HttpResponse.json(
+          { error: 'clone-failed', message: "git clone failed: could not create '/workspace/acme/app'" },
+          { status: 502 },
+        );
+      }
+      return HttpResponse.json({
+        resourceId: SESSION_ID,
+        factoryProjectId: FACTORY_ID,
+        projectRepositoryId: REPO_ID,
+        sandboxId: 'sb-1',
+        sandboxWorkdir: '/local/acme/app',
+      });
+    }),
+    // Agent-controller surface mounted once the workspace is prepared.
+    http.post(`${AC}/sessions`, () =>
+      HttpResponse.json({ controllerId: 'code', resourceId: SESSION_ID, threadId: SESSION_ID }),
+    ),
+    http.get(`${AC}/sessions/:resourceId`, () =>
+      HttpResponse.json({
+        controllerId: 'code',
+        resourceId: SESSION_ID,
+        modeId: 'build',
+        modelId: 'openai/gpt-4o-mini',
+        threadId: SESSION_ID,
+        settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+      }),
+    ),
+    http.put(`${AC}/sessions/:resourceId/state`, () => HttpResponse.json({ ok: true })),
+    http.get(
+      `${AC}/sessions/:resourceId/stream`,
+      () =>
+        new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    ),
+    http.get(`${AC}/sessions/:resourceId/permissions`, () => HttpResponse.json({})),
+    http.get(`${AC}/sessions/:resourceId/threads`, () => HttpResponse.json({ threads: [] })),
+    http.get(`${AC}/sessions/:resourceId/threads/:threadId/messages`, () => HttpResponse.json({ messages: [] })),
+    http.get(`${AC}/modes`, () => HttpResponse.json({ modes: [] })),
+    http.get(`${TEST_BASE_URL}/web/workspace/rendered/list`, () =>
+      HttpResponse.json({ workspacePath: `/ws/${SESSION_ID}`, root: '.artifacts', rootPath: '', entries: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+      HttpResponse.json({ workItems: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/subscriptions`, () => HttpResponse.json({ subscriptions: [] })),
+  );
+}
+
+function renderThreadRoute() {
+  const router = createMemoryRouter(createAppRoutes(), {
+    initialEntries: [`/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${SESSION_ID}`],
+  });
+  return renderWithProviders(<RouterProvider router={router} />);
+}
+
+describe('ThreadPage workspace preparation failure', () => {
+  it('surfaces the ensure error with a Retry action instead of an eternal loading state', async () => {
+    stubThreadRoute();
+    renderThreadRoute();
+
+    // The materialization failure is shown to the user, verbatim.
+    expect(
+      await screen.findByText(
+        "Failed to prepare the workspace: git clone failed: could not create '/workspace/acme/app'",
+      ),
+    ).toBeInTheDocument();
+    const retry = screen.getByRole('button', { name: 'Retry' });
+
+    // Retry re-runs preparation; on success the error clears and the thread mounts.
+    await userEvent.click(retry);
+    expect(await screen.findByRole('region', { name: 'Thread composer' })).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Failed to prepare the workspace: git clone failed: could not create '/workspace/acme/app'",
+      ),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -382,7 +382,26 @@ export class AgentController<TState = {}> {
     // resource+scope resolve to one session.
     const existing = this.#sessionsByResource.get(registryKey);
     if (existing) {
-      return existing;
+      const session = await existing;
+      // An exact thread binding is part of the createSession contract
+      // ("existing threads are resumed; missing threads are created with this
+      // id"), so honor it on cached sessions too. Without this, whichever
+      // request creates the session first wins: a thread-agnostic caller (SSE
+      // subscribe, message listing) racing ahead of an exact-thread create
+      // would leave the session bound to a different thread and the requested
+      // thread never created.
+      if (threadId && session.thread.getId() !== threadId) {
+        const existingThread = await session.thread.getById({ threadId });
+        if (existingThread) {
+          if (existingThread.resourceId !== effectiveResourceId) {
+            throw new Error(`Thread not found: ${threadId}`);
+          }
+          await session.thread.switch({ threadId });
+        } else {
+          await session.thread.create({ id: threadId });
+        }
+      }
+      return session;
     }
 
     const creation = this.#createSessionForResource(effectiveOwnerId, effectiveSessionId, effectiveResourceId, tags, {

--- a/packages/core/src/agent-controller/exact-thread-id.test.ts
+++ b/packages/core/src/agent-controller/exact-thread-id.test.ts
@@ -95,6 +95,71 @@ describe('AgentController exact thread id creation', () => {
     expect(await a.thread.list()).toHaveLength(1);
   });
 
+  it('honors the exact thread id when a thread-agnostic caller created the session first', async () => {
+    const controller = await createController(new InMemoryStore());
+    // Simulates an SSE subscribe / message list racing ahead of the exact-thread create.
+    const first = await controller.createSession({ id: 'session-1', ownerId: 'owner-1', resourceId: 'session-1' });
+    const initialThreadId = first.thread.getId();
+    expect(initialThreadId).not.toBe('session-1');
+
+    const second = await controller.createSession({
+      id: 'session-1',
+      ownerId: 'owner-1',
+      resourceId: 'session-1',
+      threadId: 'session-1',
+    });
+
+    expect(second).toBe(first);
+    expect(second.thread.getId()).toBe('session-1');
+    expect((await second.thread.getById({ threadId: 'session-1' }))?.resourceId).toBe('session-1');
+  });
+
+  it('switches a cached session back to an existing exact thread', async () => {
+    const controller = await createController(new InMemoryStore());
+    const session = await controller.createSession({
+      id: 'session-1',
+      ownerId: 'owner-1',
+      resourceId: 'session-1',
+      threadId: 'session-1',
+    });
+    await session.thread.create({ title: 'detour' });
+    expect(session.thread.getId()).not.toBe('session-1');
+
+    const again = await controller.createSession({
+      id: 'session-1',
+      ownerId: 'owner-1',
+      resourceId: 'session-1',
+      threadId: 'session-1',
+    });
+
+    expect(again).toBe(session);
+    expect(again.thread.getId()).toBe('session-1');
+    expect(await again.thread.list()).toHaveLength(2);
+  });
+
+  it('rejects an exact thread owned by another resource on a cached session', async () => {
+    const storage = new InMemoryStore();
+    const controller = await createController(storage);
+    await controller.createSession({
+      id: 'session-a',
+      ownerId: 'owner-1',
+      resourceId: 'resource-a',
+      threadId: 'thread-a',
+    });
+    const cached = await controller.createSession({ id: 'session-b', ownerId: 'owner-1', resourceId: 'resource-b' });
+
+    await expect(
+      controller.createSession({
+        id: 'session-b',
+        ownerId: 'owner-1',
+        resourceId: 'resource-b',
+        threadId: 'thread-a',
+      }),
+    ).rejects.toThrow('Thread not found: thread-a');
+    // The cached session keeps its original binding.
+    expect(cached.thread.getId()).not.toBe('thread-a');
+  });
+
   it('keeps default multi-thread behavior when threadId is omitted', async () => {
     const controller = await createController(new InMemoryStore());
     const session = await controller.createSession({ id: 'session-1', ownerId: 'owner-1', resourceId: 'resource-1' });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1928,8 +1928,8 @@ importers:
   embedders/voyageai:
     dependencies:
       voyageai:
-        specifier: ^0.2.1
-        version: 0.2.1(encoding@0.1.13)(onnxruntime-node@1.26.0)
+        specifier: ^0.3.1
+        version: 0.3.1(encoding@0.1.13)(onnxruntime-node@1.26.0)
     devDependencies:
       '@internal/ai-sdk-v4':
         specifier: workspace:*
@@ -30208,8 +30208,8 @@ packages:
       jsdom:
         optional: true
 
-  voyageai@0.2.1:
-    resolution: {integrity: sha512-ym7Dk6p8Si6lR9wDh58EzxwT0ziD/pqXjzzzceOSySO3Ic3uosHZLOTAsb3Gq+1OaKdEMnni/p8TohKUNvLTkg==}
+  voyageai@0.3.1:
+    resolution: {integrity: sha512-+f6gRsnuV7gi2tFvSFWTqERkZhox1VQCT0G+ALUDAwz75OpzpqaXgy6TSRkbrf6az9WZsXoAyDtplDksHLSbag==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@huggingface/transformers': ^3.8.0
@@ -55560,7 +55560,7 @@ snapshots:
       - msw
     optional: true
 
-  voyageai@0.2.1(encoding@0.1.13)(onnxruntime-node@1.26.0):
+  voyageai@0.3.1(encoding@0.1.13)(onnxruntime-node@1.26.0):
     dependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:

--- a/stores/pg/src/storage/factory-storage.ts
+++ b/stores/pg/src/storage/factory-storage.ts
@@ -449,6 +449,16 @@ export class PgFactoryStorage extends FactoryStorage {
     } else {
       this.#pool = new pg.Pool({ connectionString: config.connectionString });
       this.#ownsPool = true;
+      // pg emits 'error' on the pool when an idle client's connection drops
+      // (backend restart, network partition, local address changes). Without a
+      // listener Node escalates the event to an uncaughtException and crashes
+      // the process. Only pools this storage creates get the listener — a
+      // wrapped store keeps its own listeners, mirroring close().
+      this.#pool.on('error', err => {
+        console.warn(
+          `PgFactoryStorage: idle pool client error (pool discards the client and reconnects on next checkout): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
     }
     this.ops = new PgFactoryStorageOps(this.#pool, this.#schemas);
   }

--- a/stores/pg/src/storage/pool-error-listener.test.ts
+++ b/stores/pg/src/storage/pool-error-listener.test.ts
@@ -1,6 +1,7 @@
 import pg from 'pg';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
+import { PgFactoryStorage } from './factory-storage';
 import { PostgresStore, PostgresStoreVNext } from '.';
 
 // Points at a dead port — these tests need no live database. The pool only
@@ -45,6 +46,34 @@ describe('PostgresStore pool error listeners', () => {
       expect(userPool.listenerCount('error')).toBe(0);
     } finally {
       await store.close();
+      await userPool.end();
+    }
+  });
+
+  it('PgFactoryStorage attaches an error listener to pools it creates', async () => {
+    const storage = new PgFactoryStorage({ connectionString: DEAD_CONNECTION_STRING });
+    const db = storage.authDatabase();
+    if (db.dialect !== 'postgres') throw new Error('expected a postgres auth database');
+    const pool = db.pool as pg.Pool;
+
+    try {
+      expect(pool.listenerCount('error')).toBe(1);
+      expect(() => pool.emit('error', new Error('idle client dropped'))).not.toThrow();
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it('PgFactoryStorage does not add a listener to a wrapped store pool', async () => {
+    const userPool = new pg.Pool({ connectionString: DEAD_CONNECTION_STRING });
+    const store = new PostgresStore({ id: 'pool-error-test', pool: userPool });
+    const storage = new PgFactoryStorage({ store });
+
+    try {
+      // The wrapped store's pool keeps the caller's listeners, mirroring close().
+      expect(userPool.listenerCount('error')).toBe(0);
+    } finally {
+      await storage.close();
       await userPool.end();
     }
   });


### PR DESCRIPTION
## Summary

Opening a Factory thread, kicking off a run from the board, and reviewing a PR were broken or confusing at several points in the chain. This PR fixes the full path — from Postgres connection resilience, through session/thread identity and sandbox materialization, to kickoff delivery and the board/settings UX.

### `@mastra/pg`
- `PgFactoryStorage` now attaches an error listener to its internal `pg.Pool` (like every other pool in the package), so a network error on an idle client logs a warning instead of crashing the host process with an unhandled `error` event.

### `@mastra/core`
- `AgentController.createSession` honors the `threadId` override on **cached** sessions. Previously the override only applied when the session was first created; re-entering a session resumed whatever thread it was already bound to, producing 500 `Thread not found` errors on thread pages. Cached sessions now switch to (or create) the requested thread.

### `@mastra/factory`
- **Sandbox self-heal**: when a project repository's stored sandbox provider no longer matches the current fleet provider, the workdir is recomputed for the current fleet and the row is updated, instead of trying to use a workdir that can't exist (e.g. `/workspace/...` on a local Mac).
- **Materialization trusts disk state**: `materializeRepo` re-clones when there is no checkout on disk even if `materializedAt` is set (sandbox wiped/recreated), and a failed remote-scrub in `finally` no longer masks the primary clone/pull error.
- **Kickoff delivery**: pending-start dispatch now resolves the starter, primes credentials, and runs with an authenticated `RequestContext` (matching the other dispatch branches), fixing kickoffs failing with "Factory session is not available to the current user".
- **OM settings routes** treat the live session as best-effort sync and fall back to the durably stored per-user settings when the resource has no live session, so the settings page loads and saves instead of 404ing after a server restart.
- **factory-review skill** publishes its verdict on the PR itself — `gh pr review --approve` / `--request-changes` with the full handoff body, falling back to `gh pr comment` when GitHub rejects the review — instead of only posting the verdict in the Factory thread.

### Web UI (`mastracode/web`)
- Workspace-preparation failures on the thread page now render an error banner with a Retry button instead of an eternally disabled composer.
- Session init passes the workspace session's exact `threadId` through to `session.create()`, so the UI and the coordinator agree on which thread a session is bound to.
- Board cards auto-start their default run action on click (Review for PRs, Investigate for issues) instead of opening a blank "What can I help you build?" session; blank sessions remain the fallback for cards without run metadata.
- `.env.schema`: enum env vars accept bare booleans/numbers alongside quoted forms, since varlock coerces unquoted values before enum validation (`MASTRA_PLATFORM_GITHUB_POLLING_ENABLED=false` no longer fails validation).

Changesets included for `@mastra/pg` (patch), `@mastra/core` (patch), and `@mastra/factory` (patch ×3). The lockfile update is a sync with `embedders/voyageai/package.json` (`voyageai ^0.3.1`), which the pre-commit frozen-lockfile check requires.

## Test plan

- `stores/pg`: `pool-error-listener.test.ts` — 2 new regression tests (5 total pass), typecheck clean
- `packages/core`: `exact-thread-id.test.ts` — 3 new tests for the cached-session override (400/400 agent-controller tests pass)
- `mastracode/factory`: new/updated coverage in `routes.test.ts` (self-heal), `base.test.ts` (`setWorkdir`), `sandbox.test.ts` (re-clone + error unmasking, 61 pass), `dispatcher.test.ts` (kickoff RequestContext, 18 pass), `config.test.ts` (session-less OM reads/writes, 52 pass), `workspace.test.ts` (review-skill publishes to the PR, 21 pass); `tsc --noEmit` clean
- `mastracode/web`: new MSW tests `ThreadPageEnsureError`, `BoardPageCardClickStartsRun`, exact-thread session init in `useAgentControllerConnection.msw.test.tsx`; full web suite passes; typecheck clean
- Verified end-to-end in the browser against a live dev server: thread pages load, a PR review kickoff was delivered (notification `delivered`), and the review agent ran in the platform sandbox

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes Factory sessions and workspace setup more reliable, especially after restarts or when repositories change. It also improves review publishing and makes the web UI clearer and easier to recover when something goes wrong.

## Summary

- Prevents PostgreSQL pool connection errors from crashing the server.
- Honors requested thread IDs for cached agent sessions.
- Recovers from stale or missing repository sandboxes by re-materializing them.
- Delivers pending kickoffs with the correct authenticated user context.
- Persists and loads settings even without an active session.
- Publishes Factory review verdicts directly to pull requests, with comment fallback.
- Adds workspace preparation errors and retry controls to the web UI.
- Starts default board actions when opening PR or issue cards.
- Accepts bare boolean and numeric values in the environment schema.
- Adds regression coverage across PostgreSQL, core, Factory, and web flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->