### PR TITLE
fix: format ThreadPageEnsureError test to unblock Lint CI

### DIFF
--- a/mastracode/web/src/web/ui/pages/__tests__/ThreadPageEnsureError.msw.test.tsx
+++ b/mastracode/web/src/web/ui/pages/__tests__/ThreadPageEnsureError.msw.test.tsx
@@ -148,9 +148,7 @@ describe('ThreadPage workspace preparation failure', () => {
     await userEvent.click(retry);
     expect(await screen.findByRole('region', { name: 'Thread composer' })).toBeInTheDocument();
     expect(
-      screen.queryByText(
-        "Failed to prepare the workspace: git clone failed: could not create '/workspace/acme/app'",
-      ),
+      screen.queryByText("Failed to prepare the workspace: git clone failed: could not create '/workspace/acme/app'"),
     ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
The root `lint:format` check (`oxfmt --check`) is failing on `main` because `mastracode/web/src/web/ui/pages/__tests__/ThreadPageEnsureError.msw.test.tsx` was committed with line wrapping that oxfmt normalizes. Since the changesets release branch is generated from `main`, this is also what's failing the Lint job on #20247.

This PR runs `oxfmt` on the file (whitespace-only change) so the Lint workflow passes again on `main` and on the release PR after the changesets action rebases.

## Test plan
- `pnpm exec oxfmt --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*' '!observability/_examples/**/*'` passes locally (10374 files, 0 issues)
- Formatting-only change, no behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes the formatting of one test file so automated checks pass. It only changes whitespace and does not affect behavior.

## Changes

- Reformatted the `ThreadPageEnsureError` test with `oxfmt`.
- Confirmed formatting checks pass for 10,374 files with zero issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->