### PR TITLE
docs: explain Trace Intelligence private beta

### DIFF
--- a/docs/src/content/en/docs/mastra-platform/overview.mdx
+++ b/docs/src/content/en/docs/mastra-platform/overview.mdx
@@ -8,12 +8,14 @@ description: The Mastra platform, with Observability, Studio, and Server, is the
 The [Mastra platform](https://projects.mastra.ai) provides three products for deploying, monitoring, and managing AI applications built with the Mastra framework:
 
 - [**Observability**](/docs/mastra-platform/observability): The baseline product for every platform project, with searchable traces, logs, and metrics across Mastra projects and deploys
-- [**Studio**](/docs/mastra-platform/studio): A hosted visual environment for testing agents, running workflows, and inspecting traces. Starting with Studio also gives you Observability.
+- [**Studio**](/docs/mastra-platform/studio): A hosted visual environment for testing agents and running workflows, with tools for inspecting traces. Starting with Studio also gives you Observability.
 - [**Server**](/docs/mastra-platform/server): A production deployment target that runs your Mastra application as an API server. Starting with Server also gives you Observability.
 
 Deploy with a single command, [`mastra deploy`](/docs/mastra-platform/deploy), or connect a GitHub repository for push-to-deploy. See the [GitHub integration](/docs/mastra-platform/github) for the repository-linked flow.
 
 Each project can run multiple [**Environments**](/docs/mastra-platform/environments) (for example `production` and `staging`), provision [**Hosted databases**](/docs/mastra-platform/database) from the CLI or project settings to persist application data, and get a managed [**Workspace**](/docs/mastra-platform/workspace) per environment that gives agents a filesystem and a sandbox with no manual configuration.
+
+[**Trace Intelligence**](/docs/mastra-platform/trace-intelligence) finds recurring goals, outcomes, behaviors, and sentiment across your agent traces. Trace Intelligence is available in private beta for selected projects.
 
 ## Get started
 
@@ -28,7 +30,7 @@ Choose the path that matches what you want to do:
 
 ## Key concepts
 
-**Projects** are the shared parent entity across all products. A single project can have Observability, a Studio deployment, and a Server deployment. Projects belong to an **Organization**, which is the multi-tenant container for your team.
+**Projects** are the shared parent entity across all products. A single project can include every product: Observability, Studio, and Server. Projects belong to an **Organization**, which is the multi-tenant container for your team.
 
 Your Mastra application is built from three building blocks:
 

--- a/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
+++ b/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
@@ -22,7 +22,7 @@ Trace Intelligence is available by invitation for selected Mastra platform proje
 
 1. Submit the [Trace Intelligence private beta form](https://mastra.ai/trace-intelligence) to request access.
 1. Confirm that [Mastra platform Observability](/docs/mastra-platform/observability) is enabled and that completed agent traces appear under **Traces**.
-1. Install `@mastra/core@1.53.0` and `mastra@1.20.2`, then deploy or redeploy Studio for the enrolled project. Local Studio and server-only deployments aren't supported during the private beta.
+1. Requires at least `@mastra/core@1.53.0` and `mastra@1.20.2`. Upgrade your project then deploy or redeploy Studio for the enrolled project. Local Studio and server-only deployments aren't supported during the private beta.
 1. Open the deployed Studio and select **Trace Intelligence** in the sidebar.
 1. Send representative traffic to your agent and allow time for analysis.
 
@@ -99,7 +99,7 @@ Filtering the flow by a theme is unavailable for snapshots with more than 2,000 
 
 ### Trace Intelligence isn't in the sidebar
 
-Confirm that Mastra enrolled the correct project, that you use the beta-compatible Mastra version, and that you redeployed Studio. The private beta doesn't support local Studio or server-only deployments.
+Confirm that Mastra enrolled the correct project, that you use the beta-compatible Mastra version, and that you redeployed Studio. The private beta doesn't support local Studio.
 
 ### An agent is missing
 

--- a/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
+++ b/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
@@ -40,7 +40,7 @@ Use representative traffic. A small set of repeated test prompts can produce unr
 
 ## Understand the analysis
 
-Each completed trace produces four trace signals:
+Each analyzable completed trace produces four trace signals:
 
 | Trace signal | Meaning |
 | - | - |

--- a/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
+++ b/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
@@ -15,7 +15,7 @@ Use Trace Intelligence to investigate questions such as:
 - How does user sentiment relate to goals and outcomes?
 
 :::warning Private beta
-Trace Intelligence is available by invitation for selected Mastra platform projects. Its summaries and theme labels are AI-generated. Validate them against the examples and relevant traces before acting on them.
+Trace Intelligence is available by invitation for selected Mastra platform projects.
 :::
 
 ## Get access
@@ -116,7 +116,6 @@ Collect more representative traffic and compare a later snapshot. Varied or rare
 ## Private-beta limitations
 
 - Trace Intelligence is available only for enrolled projects in deployed Studio.
-- Analysis is asynchronous and doesn't update immediately after each trace.
 - Initial analysis requires at least 100 processed traces per agent. Some agents may require more.
 - Results depend on the diversity and quality of captured traces.
 - Trace signal summaries, theme labels, clustering, thresholds, and UI behavior can change during the beta.

--- a/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
+++ b/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
@@ -20,7 +20,7 @@ Trace Intelligence is available by invitation for selected Mastra platform proje
 
 ## Get access
 
-1. Ask your Mastra contact to enroll your project. Include your organization and project IDs.
+1. Submit the [Trace Intelligence private beta form](https://mastra.ai/trace-intelligence) to request access.
 1. Confirm that [Mastra platform Observability](/docs/mastra-platform/observability) is enabled and that completed agent traces appear under **Traces**.
 1. Use the beta-compatible Mastra version provided by your contact, then deploy or redeploy Studio for the enrolled project. Local Studio and server-only deployments aren't supported during the private beta.
 1. Open the deployed Studio and select **Trace Intelligence** in the sidebar.

--- a/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
+++ b/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
@@ -22,7 +22,7 @@ Trace Intelligence is available by invitation for selected Mastra platform proje
 
 1. Submit the [Trace Intelligence private beta form](https://mastra.ai/trace-intelligence) to request access.
 1. Confirm that [Mastra platform Observability](/docs/mastra-platform/observability) is enabled and that completed agent traces appear under **Traces**.
-1. Use the beta-compatible Mastra version provided by your contact, then deploy or redeploy Studio for the enrolled project. Local Studio and server-only deployments aren't supported during the private beta.
+1. Install `@mastra/core@1.53.0` and `mastra@1.20.2`, then deploy or redeploy Studio for the enrolled project. Local Studio and server-only deployments aren't supported during the private beta.
 1. Open the deployed Studio and select **Trace Intelligence** in the sidebar.
 1. Send representative traffic to your agent and allow time for analysis.
 

--- a/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
+++ b/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
@@ -23,7 +23,7 @@ Trace Intelligence is available by invitation for selected Mastra platform proje
 1. Submit the [Trace Intelligence private beta form](https://mastra.ai/trace-intelligence) to request access.
 1. Confirm that [Mastra platform Observability](/docs/mastra-platform/observability) is enabled and that completed agent traces appear under **Traces**.
 1. Requires at least `@mastra/core@1.53.0` and `mastra@1.20.2`. Upgrade your project then deploy or redeploy Studio for the enrolled project. Local Studio and server-only deployments aren't supported during the private beta.
-1. Open the deployed Studio and select **Trace Intelligence** in the sidebar.
+1. Open the deployed Studio and select **Intelligence** in the sidebar.
 1. Send representative traffic to your agent and allow time for analysis.
 
 Once Mastra enrolls the project, you don't need to change your agent definition or calls.
@@ -97,7 +97,7 @@ Filtering the flow by a theme is unavailable for snapshots with more than 2,000 
 
 ## Troubleshooting
 
-### Trace Intelligence isn't in the sidebar
+### Intelligence isn't in the sidebar
 
 Confirm that Mastra enrolled the correct project, that you use the beta-compatible Mastra version, and that you redeployed Studio. The private beta doesn't support local Studio.
 

--- a/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
+++ b/docs/src/content/en/docs/mastra-platform/trace-intelligence.mdx
@@ -1,0 +1,129 @@
+---
+title: "Trace Intelligence | Mastra platform"
+description: Find recurring goals, outcomes, behaviors, and sentiment across your agent traces with Trace Intelligence on Mastra platform.
+---
+
+# Trace Intelligence on Mastra platform
+
+Trace Intelligence finds recurring patterns across your agent's interactions. It analyzes traces captured by Mastra Observability, produces trace signals for four dimensions, and clusters similar trace signals into themes.
+
+Use Trace Intelligence to investigate questions such as:
+
+- What are users trying to accomplish?
+- Which goals tend to succeed, remain unresolved, or become blocked?
+- Which agent behaviors appear in successful and unsuccessful interactions?
+- How does user sentiment relate to goals and outcomes?
+
+:::warning Private beta
+Trace Intelligence is available by invitation for selected Mastra platform projects. Its summaries and theme labels are AI-generated. Validate them against the examples and relevant traces before acting on them.
+:::
+
+## Get access
+
+1. Ask your Mastra contact to enroll your project. Include your organization and project IDs.
+1. Confirm that [Mastra platform Observability](/docs/mastra-platform/observability) is enabled and that completed agent traces appear under **Traces**.
+1. Use the beta-compatible Mastra version provided by your contact, then deploy or redeploy Studio for the enrolled project. Local Studio and server-only deployments aren't supported during the private beta.
+1. Open the deployed Studio and select **Trace Intelligence** in the sidebar.
+1. Send representative traffic to your agent and allow time for analysis.
+
+Once Mastra enrolls the project, you don't need to change your agent definition or calls.
+
+### When data is available
+
+Trace Intelligence needs enough processed traces from one agent to identify recurring patterns. Initial themes are usually available after at least **100 completed traces** from that agent have been processed.
+
+The trace count under **Traces** can reach 100 before Trace Intelligence is ready because the analysis pipeline runs asynchronously. Processing can take several minutes after the threshold is reached. Traces that can't be analyzed don't contribute, so 100 is a minimum, not an exact UI trigger.
+
+Trace Intelligence updates automatically as more traces arrive. Studio needs themes for at least two trace signal types before it can display the relationship flow.
+
+Use representative traffic. A small set of repeated test prompts can produce unrepresentative results, such as one broad theme or mostly Noise.
+
+## Understand the analysis
+
+Each completed trace produces four trace signals:
+
+| Trace signal | Meaning |
+| - | - |
+| **Goal** | What the user is trying to achieve or have completed. |
+| **Outcome** | The final completed, partial, blocked, failed, unresolved, or unclear state. |
+| **Behavior** | Observable agent actions and patterns, including tool use, omissions, retries, failures, and recovery. |
+| **Sentiment** | The user's emotional state or attitude. |
+
+Themes are clusters generated from similar trace signals. Clustering happens independently for each trace signal type. One trace can belong to a separate theme in every dimension: Goal, Outcome, Behavior, and Sentiment.
+
+### Themes and relationships
+
+The flow chart connects themes in adjacent trace signal columns:
+
+- A **node** represents a theme. Its count is the number of distinct traces assigned to that theme in the selected snapshot.
+- A **ribbon** connects traces assigned to themes in both adjacent columns. Its width represents the shared trace count.
+- Hover over or focus a node or ribbon to isolate its relationships.
+
+The flow shows association, not causation or execution order. For example, a ribbon between a Goal and an Outcome means that both themes occurred in the same traces. It doesn't show that the goal caused the outcome.
+
+### Distributions, Other, and Noise
+
+The cards below the flow show each trace signal's theme distribution:
+
+- **Trace count**: The number of distinct traces assigned to a theme in the selected snapshot.
+- **Stage share**: The percentage of analyzed traces for that trace signal assigned to the theme.
+
+Studio shows the most common themes for each trace signal type. It may combine smaller themes into **Other** to preserve totals without overcrowding the chart.
+
+**Noise** contains summaries that didn't consistently match a recurring theme in the selected snapshot. It doesn't necessarily indicate an error or a low-quality interaction. Noise can include rare requests and emerging patterns. It can also contain ambiguous interactions or unrelated cases. A large Noise share can indicate highly varied traffic or insufficient data for stable themes.
+
+### Snapshots
+
+A snapshot is a moving analysis window over a set of traces. Snapshots can overlap, so don't add their trace counts together. Compare trace count and stage share together because traffic volume can change between windows.
+
+A theme can persist, disappear, split, merge, or return across snapshots. Treat theme names and descriptions as generated summaries, not fixed taxonomies.
+
+## Use the Trace Intelligence page
+
+1. Use the **Agent** selector to switch between agents with available analysis. An agent doesn't appear until its first themes are ready.
+1. Select a theme in the flow to filter every column to traces containing that theme.
+1. Select **View theme details** to inspect its description, trace count, stage share, generated examples, and history.
+1. Select **Clear filter** to restore the complete flow.
+
+You can also:
+
+- Select a theme in a distribution card to open its details and generated example summaries.
+- Select **Noise** in a distribution card to inspect its distribution and generated example summaries.
+- Drag the distribution cards to reorder the trace signal columns and see a different relationship perspective.
+- Use the timeline to select a snapshot, or select **Play** to watch themes change over time.
+- Open a theme's history to see whether it persisted and how its coverage changed.
+
+Filtering the flow by a theme is unavailable for snapshots with more than 2,000 traces. Choose another snapshot or clear the active filter to return to the full flow. Theme and Noise details remain available from the distribution cards.
+
+## Troubleshooting
+
+### Trace Intelligence isn't in the sidebar
+
+Confirm that Mastra enrolled the correct project, that you use the beta-compatible Mastra version, and that you redeployed Studio. The private beta doesn't support local Studio or server-only deployments.
+
+### An agent is missing
+
+Confirm that its completed traces are listed under **Traces**. The agent is listed only after its first themes are ready. If it recently reached 100 traces, allow time for asynchronous processing.
+
+### The relationship flow is unavailable
+
+The flow requires themes for at least two trace signal types. Continue sending representative traffic and allow processing to finish.
+
+### Most summaries are Noise
+
+Collect more representative traffic and compare a later snapshot. Varied or rare interactions are harder to group, while repeated test prompts can produce an unrepresentative distribution.
+
+## Private-beta limitations
+
+- Trace Intelligence is available only for enrolled projects in deployed Studio.
+- Analysis is asynchronous and doesn't update immediately after each trace.
+- Initial analysis requires at least 100 processed traces per agent. Some agents may require more.
+- Results depend on the diversity and quality of captured traces.
+- Trace signal summaries, theme labels, clustering, thresholds, and UI behavior can change during the beta.
+
+When reporting feedback, include the organization ID, project ID, agent ID, selected snapshot, and the theme or Noise examples that illustrate the issue.
+
+## Related
+
+- [Observability on Mastra platform](/docs/mastra-platform/observability)
+- [Studio on Mastra platform](/docs/mastra-platform/studio)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -1048,6 +1048,14 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'mastra-platform/trace-intelligence',
+          label: 'Trace Intelligence',
+          customProps: {
+            tags: ['beta'],
+          },
+        },
+        {
+          type: 'doc',
           id: 'mastra-platform/studio',
           label: 'Studio',
         },


### PR DESCRIPTION
Adds a Mastra platform guide for the Trace Intelligence private beta. The guide explains access requirements, the four trace signals, how themes are clustered from trace signals, flow and snapshot interpretation, common workflows, limitations, and troubleshooting. It also adds the page to the platform sidebar and overview.

Validated with the documentation frontmatter and sidebar checks, Prettier, Oxfmt, Remark, Vale, and a production Docusaurus build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This adds a simple guide explaining Mastra’s Trace Intelligence private beta, which helps users find patterns in agent activity. It also makes the guide easier to find in the platform navigation and clarifies product availability.

## What changed

- Added a Trace Intelligence guide covering:
  - Access requirements and private beta limitations
  - Trace signals and theme clustering
  - Flows, distributions, noise, and snapshots
  - Common workflows and UI usage
  - Troubleshooting and related documentation
- Added Trace Intelligence to the Mastra platform sidebar with a beta label.
- Updated the platform overview with clearer descriptions of Studio, Server, Projects, and Trace Intelligence availability.
- Linked private beta users to the public access request form.
- Verified documentation checks, formatting, linting, and the production Docusaurus build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->