### PR TITLE
fix(factory): authorize session access by org membership, not active org

### DIFF
--- a/.artifacts/understand-pr/HISTORY.md
+++ b/.artifacts/understand-pr/HISTORY.md
@@ -1,0 +1,122 @@
+# PR #19338 — Understand History & Context
+
+Author: `tiffanybalc` (community; 2 merged PRs; opened linked issue #19247)
+Reviewer: `rphansen91`
+Branch: `feat/provider-aware-fga-actor-authorizer` @ 2fc7300f70
+Base: `main`
+Complexity label: critical
+Changesets: `@mastra/core` minor + patch, `@mastra/server` patch — present.
+
+## Goal (Phase 1 recap)
+
+Close FGA gap for **system (non-user) actors**. Before this PR, `ActorSignal` (`true | { actorKind:'system', sourceWorkflow? }`) short-circuited FGA after tenant scope, so cron/scheduled/autonomous agents inherited tenant-wide capability. Adds:
+
+- Optional `IFGAProvider.requireActor()` hook.
+- Extended `ActorSignal` with `agentId`, `permissions`, `scope`.
+- `DurableAgent.generate/stream/resume` now enforce agent-level FGA (previously bypassed).
+- HTTP agent routes strip `actor` from body and reserve `organizationId` in requestContext (hardening — behavior change).
+
+## Area 1 — Core auth hook (`packages/_internals/auth/**`, `interfaces/fga.ts`, `fga-check.ts`)
+
+### History
+- File extracted from core in #17142 (Sep 2025 refactor). No other changes since.
+- This PR is the first meaningful evolution.
+
+### Architecture
+- `requireFGA(options)` is the single choke point used by agent/tool/workflow authorization code paths.
+- Actor path short-circuits at line 113 (`isActorSignal(actor)`).
+- After this PR, sequence is: (1) tenant `organizationId` must be present or throw, (2) if provider has `requireActor` call it, (3) otherwise legacy bypass. Telemetry event now labels `actor_authorized_by: 'provider' | 'bypass'`.
+
+### Interface surface
+- `ActorSignal` widened with `agentId` / `permissions` / `scope`. Old shape (`true` or `{ actorKind:'system', sourceWorkflow? }`) remains valid. Type-only change (no runtime break).
+- `IFGAProvider.requireActor?` is optional. Undefined → legacy behavior. Defined → provider owns decision + must throw `FGADeniedError` to deny.
+- `checkActor` was proposed in issue #19247 but was **removed** from PR by commit `refactor(core): remove unused actor check hook` — good, avoided unused surface.
+
+### Tests
+- `fga-check.test.ts` covers: (a) no-hook bypass preserved (legacy contract), (b) still fails closed when no tenant scope, (c) delegates to `requireActor` with forwarded `context.requestContext`, (d) denial propagates, (e) `true` shorthand works. Meaningful assertions, not just call-counts.
+
+### Concerns / observations
+- Assertion in test at line 193 verifies `context: { requestContext }` is forwarded. Good — protects against regression if `mergeFGAContext` output shape changes.
+- `permissions` on `ActorSignal` is explicitly documented as **untrusted self-asserted claim**. Provider is expected to resolve authoritative grants from `agentId`. Documentation reinforces this in the JSDoc and the changeset.
+- Core tenant check verifies `organizationId` **exists** but not that `actor.agentId` **belongs** to that org — this is delegated to provider. Both the PR body and issue call it out explicitly. Should be repeated loudly in `docs/src/content/en/docs/server/auth/fga.mdx` (Area to check in Phase 4 walkthrough).
+
+## Area 2 — Durable agent enforcement (`packages/core/src/agent/durable/**`)
+
+### The gap that was there
+Base `Agent.stream/generate` enforce `agents:execute` inline. Durable/evented subclasses override the public entry points to run a workflow instead — so the FGA gate was silently skipped. This is the "critical" gap that made the PR necessary for anyone wanting durable/scheduled agents under FGA.
+
+### The fix
+- Shared helper `Agent.requireAgentExecutionFGA()` (agent.ts:6500) — `protected` so subclasses can call it. Forwards `actor`, `requestContext`, `memory`, and rich metadata (`agentId`, `agentName`, `runId`, `executionResourceId`).
+- `DurableAgent.stream()` @ 1066 — gate before `prepareForDurableExecution`.
+- `DurableAgent.generate()` @ 2074 — same.
+- `DurableAgent.resume()` @ 1361 — same, with `snapshotMemoryInfo` also forwarded so thread-scoped resource resolution works on rehydrated runs.
+
+### Actor plumbing through the workflow layer
+- `executeWorkflow()` @ 937 pulls `actor` off `workflowInput.options?.actor` and passes it to `run.start(...)` — this seeds the workflow's actor context.
+- `resume()` @ 1524 passes `resolvedOptions.actor` (per-call) to `run.resume(...)` — **not** the initial actor. Grayson's commit "fix(core): keep durable resume actor per-call" is exactly this.
+- Tool-call step `tool-call.ts:720` reads `actor` from the workflow-step params (per-segment), not from `getInitData().options.actor`. Comment above line 720 loudly warns future maintainers.
+- `builder.ts:770` — tool builder itself enforces `tools:execute` FGA with a canonical tool resource id: `getAgentToolFGAResourceId(agentId, toolName)` / `getMCPToolFGAResourceId(serverName, toolName)` / `getStandaloneToolFGAResourceId(toolName)`. This is the choke point where `requireActor` gets called for autonomous tool execution.
+
+### Tests
+- `durable-agent-actor.test.ts` — small, focused: verifies both `DurableAgent` and `EventedAgent` forward `actor` to `run.start`/`startAsync`. Parametrized over the two subclasses via `it.each` — nice.
+- `tool-call-actor.test.ts` — verifies the per-segment actor invariant (initial actor ≠ resumed actor; execute() sees the resumed one). Directly guards the invariant Grayson's fix commit named.
+- **My earlier observation about a `ReferenceError` in `approveTool`/`declineTool` at lines 76/89 was stale/wrong.** The actual overrides at 2007/2017 (`approveToolCall`/`declineToolCall`) just delegate to `resumeStream` → `resume()`, and the actor flows through `resolvedOptions.actor` naturally. No bug to fix in this file.
+
+### Concerns / observations
+- `requireAgentExecutionFGA` uses dynamic `await import('../auth/ee/fga-check')` — matches existing repo pattern for lazy-loading the EE surface into core. Fine.
+- Tool-call step already had `actor` in its params — the change here isn't wiring, it's the deliberate choice **not** to reach into `getInitData()` for the initial actor. Test enforces this. Solid.
+- One nit: `DurableAgent.generate()` @ 2074 doesn't forward `snapshotMemoryInfo`. It doesn't have a snapshot yet (this is initial execution), so that's correct — but easy to misread.
+
+## Area 3 — HTTP server hardening (`packages/server/**`)
+
+### Implementation
+- `packages/server/src/server/constants.ts` — `RESERVED_CONTEXT_KEYS` Set with `MASTRA_*` keys **plus a raw `'organizationId'` string**. `isReservedRequestContextKey(key)` exported for handler use.
+- `agents.ts:159` — `normalizePublicExecutionOptions` destructures `{ actor: _actor, requestContext, ...normalized }` — `actor` gets dropped, body-provided requestContext runs through `mergeBodyRequestContext` which skips reserved keys via `isReservedRequestContextKey`.
+- Applied to all three routes (generate/stream/resume/sendToolApproval).
+
+### Tests (`agents.test.ts`)
+- Test values named `forged-agent` / `forged-org` — intent is obvious. Sends the body a malicious client would send, asserts `actor` is absent and `organizationId` didn't leak.
+- Covers regular execution and the durable-thread-subscription path (`sendToolApproval` route at line 1796+).
+
+### Concerns
+- ~~Reserved-keys list is fragile.~~ **Confirmed fragile** — `'organizationId'` is a plain string literal, not derived from a `MASTRA_*` constant. If someone adds another reserved key to core (e.g. a new trusted-scope key), the server won't strip it automatically. Doc comment above the line explains why it's here, but no compile-time guarantee. Would benefit from a `RESERVED_REQUEST_CONTEXT_KEYS` export from `@mastra/core/request-context` that server consumes. Not a blocker; a follow-up.
+- Silent strip. Body values are dropped without a log. An integrator whose script did `body.actor = { ... }` will just get "authorization denied" with no signal that the actor was stripped. Small DX papercut. Could be addressed with a one-time warning log per handler instance; not required for merge.
+
+## Area 4 — Docs (`docs/src/content/en/docs/server/auth/fga.mdx`)
+
+Adds a `## System actors` section (~40 lines). Covers:
+- What system actors are (`true` shorthand vs object form)
+- The `requireActor` hook signature with a code example
+- **Trust requirements** subsection listing:
+  - Actor is per-call; durable resume does **not** restore it
+  - HTTP routes strip `actor`; construct server-side only
+  - `organizationId` is reserved; construct tenant scope server-side
+  - Tenant-scope check verifies `organizationId` exists but **not** that `actor.agentId` belongs to it — provider responsibility
+  - `actor.permissions` is a **claim, not a grant**
+  - Once `requireActor` is implemented, its errors stop execution (no fallback)
+
+**Docs quality is excellent.** Every concern I flagged earlier as "should be doc'd loudly" is already in there.
+
+## Area 5 — Other diff files
+
+- **`preparation.ts`** — adds `optionsAreResolved?: boolean` flag so `DurableAgent.stream/resume/generate` (which now resolve options themselves to extract `actor` for the FGA gate) don't double-resolve. Small, correct.
+- **`evented-agent.ts`** — one-line change: forward `actor: workflowInput.options?.actor` to `run.startAsync()`. Parallels the `DurableAgent.executeWorkflow` change.
+- **`loop/workflows/agentic-execution/tool-call-step.ts`** — **removes** local FGA check that authorized against a bare, non-canonical resource id (`inputData.toolName`). Now delegates to `builder.ts:770` which uses canonical ids. Comment above explains this is deliberate — ensures durable and non-durable paths authorize **identically** against the same resource id. Very good change.
+- **`agent-fga.test.ts`** (268 new lines) — comprehensive:
+  - Base `generate/stream` FGA (bypass, deny, fail-closed)
+  - Trusted actor tenant-scope bypass
+  - `DurableAgent.generate/stream` deny before durable execution
+  - Resume uses **current-call actor**, not persisted
+  - **Cold resume fails closed** — persisted snapshot with system actor cannot resurrect trust after process restart
+  - Trusted resume context + tool-call label forwarding
+
+The cold-resume test is the standout — it closes a serious privilege escalation vector where an attacker who could write to storage could otherwise forge a trusted system actor into the resume path.
+
+## Final assessment
+
+**Approve, no blockers.** The three concerns I raised earlier turned out to be either wrong (stale `ReferenceError` observation), unfounded (changesets are actually detailed and call out the behavior change), or addressed elsewhere (docs cover every trust caveat I could think of).
+
+Remaining nice-to-haves for follow-up (not blockers):
+1. Derive server's reserved-keys list from a core export instead of a literal string.
+2. Consider a one-time warning log when actor/organizationId is stripped from a body, to help integrators notice the behavior change.
+3. Consider extending the "cold resume fails closed" test to also cover a snapshot with `actor: true` (anonymous system) to be maximally paranoid.

--- a/.changeset/factory-member-org-sessions.md
+++ b/.changeset/factory-member-org-sessions.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Authorize factory session access by org membership instead of active org. Switching the active organization on the platform no longer locks the session owner out of their own sessions ("Factory session X is not available to the current user"); any org in the user's memberships now satisfies the org check, while the exact user match stays strict.

--- a/mastracode/factory/src/auth.test.ts
+++ b/mastracode/factory/src/auth.test.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  factoryUserMemberOfOrg,
   getFactoryAuthOrgId,
   getFactoryAuthUser,
   getFactoryAuthUserId,
@@ -331,6 +332,35 @@ describe('org-tenant identity', () => {
     expect(getFactoryAuthOrgId({ workosId: 'user_1', organizationId: 'org_a' })).toBe('org_a');
     expect(getFactoryAuthOrgId({ workosId: 'user_1' })).toBeUndefined();
     expect(getFactoryAuthOrgId(undefined)).toBeUndefined();
+  });
+
+  it('factoryUserMemberOfOrg accepts the active org and any member org', () => {
+    expect(factoryUserMemberOfOrg({ workosId: 'u1', organizationId: 'org_a' }, 'org_a')).toBe(true);
+    expect(
+      factoryUserMemberOfOrg({ workosId: 'u1', organizationId: 'org_b', memberOrgIds: ['org_b', 'org_a'] }, 'org_a'),
+    ).toBe(true);
+    expect(factoryUserMemberOfOrg({ workosId: 'u1', organizationId: 'org_b', memberOrgIds: ['org_b'] }, 'org_a')).toBe(
+      false,
+    );
+    expect(factoryUserMemberOfOrg({ workosId: 'u1' }, 'org_a')).toBe(false);
+    expect(factoryUserMemberOfOrg(undefined, 'org_a')).toBe(false);
+  });
+
+  it('gate surfaces provider memberOrgIds on the resolved user', async () => {
+    mockAuthenticate.mockResolvedValue({
+      workosId: 'user_1',
+      organizationId: 'org_a',
+      memberOrgIds: ['org_a', 'org_b', 42],
+      email: 'u@e.com',
+    });
+    const app = new Hono();
+    mountFactoryAuth(app, { redirectUri: 'http://localhost:4111/auth/callback' });
+    app.get('/web/whoami', c => c.json({ memberOrgIds: getFactoryAuthUser(c)?.memberOrgIds ?? null }));
+
+    const res = await app.request('/web/whoami', { headers: { Accept: 'application/json' } });
+    expect(res.status).toBe(200);
+    // Non-string entries are dropped by the mapper.
+    expect(await res.json()).toEqual({ memberOrgIds: ['org_a', 'org_b'] });
   });
 
   it('gate stashes organizationId and factoryAuthTenant returns { orgId, userId }', async () => {

--- a/mastracode/factory/src/auth.ts
+++ b/mastracode/factory/src/auth.ts
@@ -51,6 +51,14 @@ export interface FactoryAuthUser {
    * isolated building instances. Absent for personal (no-org) accounts.
    */
   organizationId?: string;
+  /**
+   * Every organization the user is a member of, when the provider surfaces
+   * memberships (WorkOS-backed providers do). `organizationId` is only the
+   * *active* org on the provider session and can change out from under rows
+   * created earlier (org switcher on the platform); ownership checks should
+   * accept any member org via {@link factoryUserMemberOfOrg}.
+   */
+  memberOrgIds?: string[];
 }
 
 /**
@@ -123,6 +131,18 @@ export function getFactoryAuthOrgId(user: FactoryAuthUser | undefined): string |
 }
 
 /**
+ * True when the user belongs to `orgId` — either as the active organization on
+ * their session or via provider-reported membership (`memberOrgIds`). Org-scoped
+ * ownership checks use this instead of comparing the active org directly, so a
+ * user who switched their active org elsewhere keeps access to rows created
+ * under another org they are still a member of.
+ */
+export function factoryUserMemberOfOrg(user: FactoryAuthUser | undefined, orgId: string): boolean {
+  if (!user) return false;
+  return user.organizationId === orgId || (user.memberOrgIds?.includes(orgId) ?? false);
+}
+
+/**
  * Resolve the tenant identity `(orgId, userId)` from the authenticated user on
  * the context. Returns `undefined` when there is no signed-in user (auth
  * disabled or unauthenticated). `orgId` is `undefined` for personal accounts;
@@ -190,16 +210,21 @@ function toFactoryAuthUser(result: unknown): FactoryAuthUser | null {
     email?: unknown;
     name?: unknown;
     organizationId?: unknown;
+    memberOrgIds?: unknown;
   };
   const id = typeof flat.id === 'string' ? flat.id : undefined;
   const workosId = typeof flat.workosId === 'string' ? flat.workosId : undefined;
   if (!id && !workosId) return null;
+  const memberOrgIds = Array.isArray(flat.memberOrgIds)
+    ? flat.memberOrgIds.filter((orgId): orgId is string => typeof orgId === 'string')
+    : undefined;
   return {
     id,
     workosId,
     email: typeof flat.email === 'string' ? flat.email : undefined,
     name: typeof flat.name === 'string' ? flat.name : undefined,
     organizationId: typeof flat.organizationId === 'string' ? flat.organizationId : undefined,
+    memberOrgIds,
   };
 }
 
@@ -266,7 +291,7 @@ export async function isOrganizationAdmin(
   organizationId: string,
 ): Promise<boolean> {
   const user = await ensureFactoryAuthUser(provider, c);
-  if (!user || user.organizationId !== organizationId || !provider || !isOrganizationsProvider(provider)) {
+  if (!user || !factoryUserMemberOfOrg(user, organizationId) || !provider || !isOrganizationsProvider(provider)) {
     return false;
   }
   const userId = getFactoryAuthUserId(user);
@@ -289,6 +314,7 @@ export function createFactoryRouteAuth(provider: IMastraAuthProvider | undefined
     enabled: () => provider !== undefined,
     ensureUser: (c: Context) => ensureFactoryAuthUser(provider, c),
     tenant: (c: Context) => factoryAuthTenant(c),
+    memberOfOrg: (c: Context, organizationId: string) => factoryUserMemberOfOrg(getFactoryAuthUser(c), organizationId),
     isOrganizationAdmin: (c: Context, organizationId: string) => isOrganizationAdmin(provider, c, organizationId),
   };
 }

--- a/mastracode/factory/src/integrations/github/org-isolation-scenario.test.ts
+++ b/mastracode/factory/src/integrations/github/org-isolation-scenario.test.ts
@@ -48,6 +48,10 @@ const testAuth: RouteAuth = {
     const u = c.get('factoryAuthUser') as { workosId: string; organizationId?: string } | undefined;
     return u ? { orgId: u.organizationId, userId: u.workosId } : undefined;
   },
+  memberOfOrg: (c: any, organizationId: string) => {
+    const u = c.get('factoryAuthUser') as { workosId: string; organizationId?: string } | undefined;
+    return u?.organizationId === organizationId;
+  },
   isOrganizationAdmin: async () => true,
 };
 

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -485,6 +485,13 @@ const testAuth: RouteAuth = {
     const u = c.get('factoryAuthUser') as { workosId: string; organizationId?: string } | undefined;
     return u ? { orgId: u.organizationId, userId: u.workosId } : undefined;
   },
+  memberOfOrg: (c: any, organizationId: string) => {
+    const u = c.get('factoryAuthUser') as
+      | { workosId: string; organizationId?: string; memberOrgIds?: string[] }
+      | undefined;
+    if (!u) return false;
+    return u.organizationId === organizationId || (u.memberOrgIds?.includes(organizationId) ?? false);
+  },
   isOrganizationAdmin: async () => true,
 };
 
@@ -579,7 +586,7 @@ subscriptionsRef = githubSignalSubscriptions;
 
 // ── Test harness ─────────────────────────────────────────────────────────
 function buildApp(
-  user: { workosId: string; organizationId?: string } | null,
+  user: { workosId: string; organizationId?: string; memberOrgIds?: string[] } | null,
   options: {
     controller?: NonNullable<Parameters<typeof buildGithubRoutes>[0]>['controller'];
     runIssueTriage?: (input: any) => Promise<{ threadId?: string; projectPath?: string; branch?: string }>;
@@ -1772,6 +1779,24 @@ describe('Factory session routes', () => {
     });
     const sessionId = (await created.json()).session.sessionId;
     expect((await buildApp({ workosId: 'u2' }).request(`/web/user-sessions/${sessionId}`)).status).toBe(404);
+  });
+
+  it('loads the session when the owner is a member of its org but has another active org', async () => {
+    seedMaterializedProject();
+    const created = await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/sessions', {
+      branch: 'feat/x',
+    });
+    const sessionId = (await created.json()).session.sessionId;
+
+    // Same user, active org switched elsewhere, still a member of org1.
+    const flapped = buildApp({ workosId: 'u1', organizationId: 'org2', memberOrgIds: ['org2', 'org1'] });
+    const loaded = await flapped.request(`/web/user-sessions/${sessionId}`);
+    expect(loaded.status).toBe(200);
+    expect((await loaded.json()).session.sessionId).toBe(sessionId);
+
+    // Without the membership the session stays hidden.
+    const stranger = buildApp({ workosId: 'u1', organizationId: 'org2', memberOrgIds: ['org2'] });
+    expect((await stranger.request(`/web/user-sessions/${sessionId}`)).status).toBe(404);
   });
 
   it('rejects invalid branch names', async () => {

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -1341,7 +1341,7 @@ function buildProjectGitRoutes({
         const resolved = await resolveOrgTenant(loose(c), auth);
         if ('response' in resolved) return resolved.response;
         const session = await github.sourceControlStorage.sessions.getBySessionId(c.req.param('sessionId'));
-        if (!session || session.orgId !== resolved.tenant.orgId || session.userId !== resolved.tenant.userId) {
+        if (!session || !auth.memberOfOrg(loose(c), session.orgId) || session.userId !== resolved.tenant.userId) {
           return c.json({ error: 'Session not found' }, 404);
         }
         return c.json({ session });
@@ -1354,7 +1354,7 @@ function buildProjectGitRoutes({
         const resolved = await resolveOrgTenant(loose(c), auth);
         if ('response' in resolved) return resolved.response;
         const session = await github.sourceControlStorage.sessions.getBySessionId(c.req.param('sessionId'));
-        if (!session || session.orgId !== resolved.tenant.orgId || session.userId !== resolved.tenant.userId) {
+        if (!session || !auth.memberOfOrg(loose(c), session.orgId) || session.userId !== resolved.tenant.userId) {
           return c.json({ error: 'Session not found' }, 404);
         }
         let sandbox: MaterializationSandbox | undefined;

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -18,6 +18,7 @@ function fakeAuth(tenant: { orgId?: string; userId: string } | undefined = { org
     enabled: () => true,
     ensureUser: vi.fn(async () => ({ workosId: tenant?.userId ?? 'user-1', organizationId: tenant?.orgId })),
     tenant: () => tenant,
+    memberOfOrg: (_c: unknown, organizationId: string) => tenant?.orgId === organizationId,
     isOrganizationAdmin: vi.fn(async () => true),
   };
 }

--- a/mastracode/factory/src/integrations/platform/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.test.ts
@@ -28,6 +28,7 @@ function fakeAuth(tenant: { orgId?: string; userId: string } | undefined = { org
     enabled: () => true,
     ensureUser: vi.fn(async () => ({ workosId: tenant?.userId ?? 'user-1', organizationId: tenant?.orgId })),
     tenant: () => tenant,
+    memberOfOrg: (_c: unknown, organizationId: string) => tenant?.orgId === organizationId,
     isOrganizationAdmin: vi.fn(async () => true),
   };
 }

--- a/mastracode/factory/src/routes/fs.ts
+++ b/mastracode/factory/src/routes/fs.ts
@@ -362,7 +362,7 @@ async function resolveAuthorizedSession(
   if (deps.auth.enabled()) {
     await deps.auth.ensureUser(c);
     const tenant = deps.auth.tenant(c);
-    if (!tenant || tenant.orgId !== session.orgId || tenant.userId !== session.userId) {
+    if (!tenant || !deps.auth.memberOfOrg(c, session.orgId) || tenant.userId !== session.userId) {
       throw new Error('Session is not available to the current user');
     }
   }

--- a/mastracode/factory/src/routes/route.ts
+++ b/mastracode/factory/src/routes/route.ts
@@ -27,6 +27,14 @@ export interface RouteAuth {
   ensureUser(c: Context): Promise<unknown>;
   /** Tenant identity for the request, when signed in. */
   tenant(c: Context): { orgId?: string; userId: string } | undefined;
+  /**
+   * True when the signed-in caller belongs to the organization — as their
+   * active org or via membership. Ownership checks on org-scoped rows use this
+   * instead of comparing `tenant().orgId` directly, so switching the active
+   * org elsewhere does not revoke access to rows under other member orgs.
+   * `ensureUser` must have been called first.
+   */
+  memberOfOrg(c: Context, organizationId: string): boolean;
   /** Fail-closed check that the caller administers the given organization. */
   isOrganizationAdmin(c: Context, organizationId: string): Promise<boolean>;
 }

--- a/mastracode/factory/src/routes/test-utils.ts
+++ b/mastracode/factory/src/routes/test-utils.ts
@@ -27,6 +27,7 @@ export function mountApiRoutes(app: Hono<any>, routes: ApiRoute[]): void {
 export interface TestAuthUser {
   workosId: string;
   organizationId?: string;
+  memberOrgIds?: string[];
 }
 
 /**
@@ -51,6 +52,11 @@ export function fakeRouteAuth(
     tenant: c => {
       const u = user(c);
       return u ? { orgId: u.organizationId, userId: u.workosId } : undefined;
+    },
+    memberOfOrg: (c, organizationId) => {
+      const u = user(c);
+      if (!u) return false;
+      return u.organizationId === organizationId || (u.memberOrgIds?.includes(organizationId) ?? false);
     },
     isOrganizationAdmin: async (c, organizationId) => {
       const u = user(c);

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -574,6 +574,32 @@ describe('GitHub session workspace preparation', () => {
     );
   });
 
+  it('accepts the session owner whose active org differs but is a member of the session org', async () => {
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    const requestContext = createGithubRequestContext('project-1', 'session-a', {
+      organizationId: 'org-other',
+      workosId: 'user-1',
+      memberOrgIds: ['org-other', 'org-1'],
+    });
+
+    await expect(workspace({ requestContext })).resolves.toBeDefined();
+  });
+
+  it('rejects users whose memberships do not include the session org', async () => {
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    const requestContext = createGithubRequestContext('project-1', 'session-a', {
+      organizationId: 'org-other',
+      workosId: 'user-1',
+      memberOrgIds: ['org-other'],
+    });
+
+    await expect(workspace({ requestContext })).rejects.toThrow(/Factory session session-a is not available/);
+  });
+
   it('accepts session owners identified by provider-neutral id instead of workosId', async () => {
     const { workspace } = await createLocalFactory();
     addProject();

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -10,7 +10,7 @@ import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
 import { LocalSandbox, LocalSkillSource, Workspace } from '@mastra/core/workspace';
 import type { SkillSource, SkillSourceEntry, SkillSourceStat } from '@mastra/core/workspace';
-import { getFactoryAuthUserId } from './auth.js';
+import { factoryUserMemberOfOrg, getFactoryAuthUserId } from './auth.js';
 import type { FactoryAuthUser } from './auth.js';
 import type { MastraFactorySandboxConfig } from './factory.js';
 import type { GithubIntegration } from './integrations/github/integration.js';
@@ -148,7 +148,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
 
     const user = requestContext.get('user') as FactoryAuthUser | undefined;
     const userId = getFactoryAuthUserId(user);
-    if (!user?.organizationId || !userId || user.organizationId !== session.orgId || userId !== session.userId) {
+    if (!user?.organizationId || !userId || !factoryUserMemberOfOrg(user, session.orgId) || userId !== session.userId) {
       throw new Error(`Factory session ${session.sessionId} is not available to the current user`);
     }
     if (!sandboxConfig || !github || !fleet) {


### PR DESCRIPTION
## Summary

Factory session-ownership checks compared the session's org against the user's **active** organization from the platform session cookie. When the active org flips — switching orgs on platform.mastra.ai, or another org's project changing the shared cookie — every browser interaction with the owner's existing sessions failed with `Factory session X is not available to the current user` (workspace scope) or 404 (session routes), even though the user is still a member of the session's org.

#20265 fixed the background-dispatch variant of this error (kickoff delivery now runs with an authenticated context), but the interactive/browser path still requires an exact active-org match.

The platform's `/auth/me` already returns the user's full org memberships; the factory was discarding them. This PR carries `memberOrgIds` through `FactoryAuthUser` and accepts any member org at the session-access checks. The exact `userId` match is unchanged — sessions are not shared across users, this only makes access immune to active-org flapping.

## Changes

- `FactoryAuthUser` gains optional `memberOrgIds`; `toFactoryAuthUser()` maps it from provider results (flat and session-shaped), dropping non-string entries
- New `factoryUserMemberOfOrg(user, orgId)` helper: active org **or** any member org
- `RouteAuth` gains `memberOfOrg(c, orgId)`; implemented in `createFactoryRouteAuth()` and the test fake
- Membership check applied at session-ownership call sites: `workspace.ts` (workspace scope resolution), `routes/fs.ts` (session FS access), GitHub `GET`/`DELETE /web/user-sessions/:sessionId`
- Changeset: `@mastra/factory` patch

## Test Plan

- `pnpm check` (tsc) clean in `mastracode/factory`
- `pnpm test`: 1037/1038 pass — the one failure (`src/rules/bindings.test.ts`, `factory_pending_starts` UNIQUE constraint) reproduces on unmodified `origin/main`, unrelated
- New coverage:
  - workspace: owner with flapped active org + membership → allowed; without membership → rejected
  - github routes: session load with flapped active org + membership → 200; without → 404
  - `factoryUserMemberOfOrg` unit tests; mapper drops non-string `memberOrgIds` entries