### PR TITLE
fix(ci): avoid stable publish push races

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -189,6 +189,9 @@ jobs:
         id: check_files
         shell: bash
         run: |
+          git fetch origin main
+          git merge --ff-only origin/main
+
           if [[ -f .changeset/pre.json ]]; then
             echo "files_exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -220,8 +223,6 @@ jobs:
       - name: Exit prerelease mode
         if: steps.check_files.outputs.files_exists == 'true'
         run: |
-          git fetch origin main
-          git merge --ff-only origin/main
           pnpm changeset-cli pre exit
           pnpm changeset-cli version
           git add -A

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -220,22 +220,20 @@ jobs:
       - name: Exit prerelease mode
         if: steps.check_files.outputs.files_exists == 'true'
         run: |
+          git fetch origin main
+          git merge --ff-only origin/main
           pnpm changeset-cli pre exit
           pnpm changeset-cli version
-          git pull
           git add -A
           git commit -m 'chore: version - exit prerelease mode' --no-verify
-          git push
           pnpm install
           pnpm build
         env:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
 
       - name: Push version changes
-        if: ${{ !inputs.dry_run }}
-        run: |
-          git push
-          pnpm install
+        if: steps.check_files.outputs.files_exists == 'true' && !inputs.dry_run
+        run: git push origin HEAD:main
         env:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
 
@@ -288,6 +286,7 @@ jobs:
         run: pnpm publish -r --dry-run --access public --no-git-checks
 
       - name: Add tags
+        if: ${{ !inputs.dry_run }}
         run: |
           pnpm changeset-cli tag
           git push origin --tags


### PR DESCRIPTION
The stable publish job currently pushes its version commit before the post-version build, then attempts a second push after the build. If main advances in between, the redundant push fails after the release commit has already landed.

Before:

```sh
git commit ...
git push
pnpm build
git push
```

After:

```sh
git fetch origin main
git merge --ff-only origin/main
git commit ...
pnpm build
git push origin HEAD:main
```

This validates the generated release commit before pushing it, pushes only when prerelease mode was exited, and prevents dry runs from pushing commits or tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This updates the “stable publish” workflow so it double-checks it’s working with the very latest `main`, then builds/tests the release commit before sending anything upstream. It also avoids pushing commits or creating/publishing tags when you’re doing a dry run.

## Changes

- In the stable job’s “exit prerelease mode / versioning” flow, it now syncs with `origin/main` first by doing `git fetch origin main` and `git merge --ff-only origin/main` before running `pnpm changeset-cli pre exit` and `pnpm changeset-cli version`.
- It builds and validates the release commit before performing any push.
- It performs the push to `main` only when prerelease mode is exited (i.e., only when `.changeset/pre.json` exists) and only when `dry_run` is false, using `git push origin HEAD:main`.
- It prevents any tag creation/pushing during dry runs by adding an explicit `if: ${{ !inputs.dry_run }}` guard for the “Add tags” step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->