### PR TITLE
docs(voice): rename LiveKit page to Realtime Voice

### DIFF
--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -504,8 +504,8 @@ const sidebars = {
             },
             {
               type: 'doc',
-              id: 'voice/livekit',
-              label: 'LiveKit',
+              id: 'voice/realtime-voice',
+              label: 'Realtime Voice',
             },
           ],
         },

--- a/docs/src/content/en/docs/voice/overview.mdx
+++ b/docs/src/content/en/docs/voice/overview.mdx
@@ -19,6 +19,7 @@ packages:
   - "@mastra/voice-speechify"
   - "@mastra/voice-inworld"
   - "@mastra/voice-xai-realtime"
+  - "@mastra/livekit"
 ---
 
 import { AudioPlayback } from "@site/src/components/AudioPlayback";
@@ -808,6 +809,10 @@ For detailed configuration options and advanced features, check out [Speech to S
   </TabItem>
 </Tabs>
 
+### Realtime voice
+
+Run live calls a user can talk over, in the browser or over the phone. Mastra hands the audio loop to LiveKit, which covers voice activity detection, semantic turn detection, and barge-in, while your agent generates each reply with its own model, tools, and memory. For setup and configuration options, check out [Realtime voice](./realtime-voice).
+
 ## Voice configuration
 
 Each voice provider can be configured with different models and options. Below are the detailed configuration options for all supported providers:
@@ -1285,5 +1290,6 @@ For more information on the CompositeVoice, refer to the [CompositeVoice Referen
 - [AWS Nova Sonic Voice](/reference/voice/aws-nova-sonic)
 - [Deepgram Voice](/reference/voice/deepgram)
 - [Inworld Voice](/reference/voice/inworld)
+- [LiveKit](/reference/voice/livekit)
 - [PlayAI Voice](/reference/voice/playai)
 - [Voice Examples](https://github.com/mastra-ai/voice-examples)

--- a/docs/src/content/en/docs/voice/realtime-voice.mdx
+++ b/docs/src/content/en/docs/voice/realtime-voice.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Using LiveKit with Mastra | Voice'
+title: 'Realtime voice | Voice'
 description: 'Learn how to turn Mastra agents into realtime voice agents with LiveKit, including semantic turn detection and barge-in.'
 packages:
   - '@mastra/livekit'
@@ -8,11 +8,13 @@ packages:
 import Steps from "@site/src/components/Steps";
 import StepItem from "@site/src/components/StepItem";
 
-# Using LiveKit with Mastra
+# Realtime voice
 
-[LiveKit](https://livekit.io) is an open source WebRTC platform for realtime audio and video. The [`@mastra/livekit`](/reference/voice/livekit) package connects Mastra agents to the [LiveKit Agents framework](https://docs.livekit.io/agents/): LiveKit owns the audio loop like voice activity detection, streaming speech-to-text, semantic turn detection, barge-in, and text-to-speech. Your Mastra agent generates every reply with its own model, tools, and memory.
+Realtime voice turns a Mastra agent into a live call a user can talk over, in the browser or over the phone. Mastra builds it on [LiveKit](https://livekit.io), an open source WebRTC platform for realtime audio and video.
 
-Use this integration when you need low-latency, interruptible voice conversations. For provider-based speech-to-speech without LiveKit, see [Speech to Speech](/docs/voice/speech-to-speech).
+The [`@mastra/livekit`](/reference/voice/livekit) package connects Mastra agents to the [LiveKit Agents framework](https://docs.livekit.io/agents/): LiveKit owns the audio loop like voice activity detection, streaming speech-to-text, semantic turn detection, barge-in, and text-to-speech. Your Mastra agent generates every reply with its own model, tools, and memory.
+
+Use realtime voice when you need low-latency, interruptible voice conversations. For provider-based speech-to-speech without LiveKit, see [Speech to Speech](/docs/voice/speech-to-speech).
 
 ## Quickstart
 

--- a/docs/src/content/en/reference/voice/livekit.mdx
+++ b/docs/src/content/en/reference/voice/livekit.mdx
@@ -9,7 +9,7 @@ packages:
 
 The `@mastra/livekit` package connects Mastra agents to the LiveKit Agents framework. LiveKit runs the audio pipeline (voice activity detection, speech-to-text, turn detection, text-to-speech, barge-in) and the package bridges reply generation to a Mastra agent's `stream()` call.
 
-See [Using LiveKit with Mastra](/docs/voice/livekit) for setup and concepts.
+See [Realtime voice](/docs/voice/realtime-voice) for setup and concepts.
 
 The package has three entry points:
 
@@ -328,7 +328,7 @@ Returns: `VoiceTurnMessage[]`, where each entry is `{ role: 'system' | 'user' | 
 
 ## `MastraLLM`
 
-A standard LiveKit LLM plugin (`llm.LLM`) backed by a Mastra agent. Use it when you build the `voice.AgentSession` yourself and want Mastra in the `llm` slot; [`createLiveKitWorker()`](#createlivekitworker) is the managed alternative. See [Use Mastra as the LLM component](/docs/voice/livekit#use-mastra-as-the-llm-component) for how to choose.
+A standard LiveKit LLM plugin (`llm.LLM`) backed by a Mastra agent. Use it when you build the `voice.AgentSession` yourself and want Mastra in the `llm` slot; [`createLiveKitWorker()`](#createlivekitworker) is the managed alternative. See [Use Mastra as the LLM component](/docs/voice/realtime-voice#use-mastra-as-the-llm-component) for how to choose.
 
 With `remote`, the plugin streams each turn from your Mastra server over HTTP using Server-Sent Events (SSE). The agent loop, tools, and memory run server-side, and interrupting the agent aborts the server-side generation.
 
@@ -912,5 +912,5 @@ The metadata travels as a JSON string. `liveKitConnectionRoute()` and `dispatchV
 
 ## Related
 
-- [Using LiveKit with Mastra](/docs/voice/livekit)
+- [Realtime voice](/docs/voice/realtime-voice)
 - [LiveKit Agents docs](https://docs.livekit.io/agents/)

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -21,6 +21,11 @@
       "permanent": true
     },
     {
+      "source": "/docs/voice/livekit",
+      "destination": "/docs/voice/realtime-voice",
+      "permanent": true
+    },
+    {
       "source": "/docs/observability/tracing/exporters/cloud",
       "destination": "/docs/observability/integrations/exporters/mastra-platform",
       "permanent": true
@@ -1028,6 +1033,11 @@
     {
       "source": "/docs/agents/channels/llms.txt",
       "destination": "/docs/capabilities/channels/overview/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/voice/livekit/llms.txt",
+      "destination": "/docs/voice/realtime-voice/llms.txt",
       "permanent": true
     },
     {

--- a/docs/vercel.redirects.json
+++ b/docs/vercel.redirects.json
@@ -6,6 +6,11 @@
       "permanent": true
     },
     {
+      "source": "/docs/voice/livekit",
+      "destination": "/docs/voice/realtime-voice",
+      "permanent": true
+    },
+    {
       "source": "/docs/observability/tracing/exporters/cloud",
       "destination": "/docs/observability/integrations/exporters/mastra-platform",
       "permanent": true

--- a/integrations/livekit/README.md
+++ b/integrations/livekit/README.md
@@ -443,6 +443,6 @@ See the example's own [`README.md`](https://github.com/mastra-ai/mastra/tree/mai
 
 ## Documentation
 
-- [Using LiveKit with Mastra](https://mastra.ai/docs/voice/livekit)
+- [Realtime voice](https://mastra.ai/docs/voice/realtime-voice)
 - [`@mastra/livekit` reference](https://mastra.ai/reference/voice/livekit)
 - [LiveKit Agents docs](https://docs.livekit.io/agents/)

--- a/integrations/livekit/docs/workflow-entrypoint-design.md
+++ b/integrations/livekit/docs/workflow-entrypoint-design.md
@@ -362,7 +362,7 @@ Phase 1 — **Workflow entrypoint (this doc's core):**
      filtering; `resultText` fallback; cancel → `run.cancel()`; error propagation vs. silent
      barge-in.
    - `bridge.test.ts`: agent path unchanged; generator seam delegates correctly.
-6. Docs: `README.md` workflow section + `docs/voice/livekit.mdx` / `reference/voice/livekit.mdx`;
+6. Docs: `README.md` workflow section + `docs/voice/realtime-voice.mdx` / `reference/voice/livekit.mdx`;
    add a changeset (minor — additive).
 
 Phase 2 — **Transcript-fidelity memory (follow-up):** subscribe to LiveKit transcript events in


### PR DESCRIPTION
Renames `/docs/voice/livekit` to `/docs/voice/realtime-voice` so the Voice sidebar lists a capability rather than a vendor, sitting alongside Text to Speech, Speech to Text, and Speech to Speech. The page content still uses LiveKit throughout, only the title, H1, and URL changed.

Sidebar goes from `{ id: 'voice/livekit', label: 'LiveKit' }` to `{ id: 'voice/realtime-voice', label: 'Realtime Voice' }`, with a permanent redirect added to `vercel.redirects.json` (regenerated `vercel.json` via `pnpm run generate-vercel-redirects`, which also picked up the `/llms.txt` companion). Inbound links updated in the `@mastra/livekit` reference page and the package README.

While in there I noticed `voice/overview.mdx` never linked to this page at all, so it now gets a short Realtime voice subsection like the other capabilities have. The reference page stays at `/reference/voice/livekit` labeled "LiveKit", matching the other vendor-named package references.

`pnpm run build` passes with `onBrokenLinks: 'throw'`, so no broken links anywhere. Worth a look: "Realtime Voice" now sits right under "Speech to Speech", and that page is itself all realtime providers (OpenAI Realtime, Gemini Live, xAI Realtime, Nova Sonic, Inworld Realtime) — the two names may read as overlapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The voice documentation got a clearer name: “Realtime Voice” instead of “LiveKit.” Old links still work, and related pages now point to the renamed guide.

## Changes

- Renamed the voice guide and updated its title, heading, and sidebar label.
- Added permanent redirects from the old LiveKit documentation URL, including its `llms.txt` path.
- Updated links in the LiveKit README, reference documentation, workflow design notes, and voice overview.
- Kept the LiveKit reference page at `/reference/voice/livekit`, labeled “LiveKit.”
- Verified with `pnpm run build`, treating broken links as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->