### PR TITLE
fix(factory): drop unregistered harmless intake entries instead of rejecting save

### DIFF
--- a/mastracode/factory/src/routes/intake.test.ts
+++ b/mastracode/factory/src/routes/intake.test.ts
@@ -148,6 +148,14 @@ describe('intake configuration', () => {
     expect(await seed.intake.getConfig({ orgId: 'org1', userId: 'u1' })).toEqual({
       github: { enabled: true, sourceIds: ['repo-1'] },
     });
+    expect(auditEvents).toEqual([
+      {
+        action: 'factory.intake.config_updated',
+        metadata: {
+          github: { enabled: true, sources: 1 },
+        },
+      },
+    ]);
   });
 
   it('still rejects an unregistered integration the client actually tried to use', async () => {

--- a/mastracode/factory/src/routes/intake.test.ts
+++ b/mastracode/factory/src/routes/intake.test.ts
@@ -126,6 +126,54 @@ describe('intake configuration', () => {
     });
     expect(invalid.status).toBe(400);
   });
+
+  it('silently drops a harmless default entry for an unregistered integration', async () => {
+    // Regression test for #20277: a generated client (create-factory) may
+    // submit a disabled placeholder for an integration that isn't
+    // registered in this deployment. That should save successfully, with
+    // the unregistered key dropped rather than rejected.
+    const config = {
+      github: { enabled: true, sourceIds: ['repo-1'] },
+      linear: { enabled: false, sourceIds: null },
+    };
+    const response = await buildApp(orgUser, [{ id: 'github', intake: github }]).request('/web/intake/config', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(config),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      config: { github: { enabled: true, sourceIds: ['repo-1'] } },
+    });
+    expect(await seed.intake.getConfig({ orgId: 'org1', userId: 'u1' })).toEqual({
+      github: { enabled: true, sourceIds: ['repo-1'] },
+    });
+  });
+
+  it('still rejects an unregistered integration the client actually tried to use', async () => {
+    const enabledUnknown = await buildApp(orgUser, [{ id: 'github', intake: github }]).request('/web/intake/config', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        github: { enabled: true, sourceIds: null },
+        linear: { enabled: true, sourceIds: null },
+      }),
+    });
+    expect(enabledUnknown.status).toBe(400);
+
+    const unknownWithSources = await buildApp(orgUser, [{ id: 'github', intake: github }]).request(
+      '/web/intake/config',
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          github: { enabled: true, sourceIds: null },
+          linear: { enabled: false, sourceIds: ['team-1'] },
+        }),
+      },
+    );
+    expect(unknownWithSources.status).toBe(400);
+  });
 });
 
 describe('aggregated intake', () => {

--- a/mastracode/factory/src/routes/intake.ts
+++ b/mastracode/factory/src/routes/intake.ts
@@ -130,26 +130,44 @@ export class IntakeRoutes extends Route<IntakeRoutesDeps> {
             return c.json({ error: 'Invalid JSON body' }, 400);
           }
           const config = parseIntakeConfig(body);
-          if (!config || Object.keys(config).some(integrationId => !integrationIds.includes(integrationId))) {
+          if (!config) {
             return c.json({ error: 'invalid_config' }, 400);
           }
 
+          // Keep only integrations registered in this deployment. Generated
+          // clients (e.g. create-factory) may submit a harmless default entry
+          // for an integration that isn't configured here (disabled, no
+          // sources selected) purely to keep their local state shape
+          // consistent -- drop those silently instead of failing the save.
+          // An unregistered integration that the client actually tried to
+          // use (enabled, or with sources picked) is still rejected.
+          const registeredConfig: IntakeConfig = {};
+          for (const [integrationId, selection] of Object.entries(config)) {
+            if (integrationIds.includes(integrationId)) {
+              registeredConfig[integrationId] = selection;
+              continue;
+            }
+            if (selection.enabled || (selection.sourceIds?.length ?? 0) > 0) {
+              return c.json({ error: 'invalid_config' }, 400);
+            }
+          }
+
           await intake.ensureReady();
-          await intake.saveConfig({ ...tenant, config });
+          await intake.saveConfig({ ...tenant, config: registeredConfig });
           await audit.emit({
             context: loose(c),
             input: {
               action: 'factory.intake.config_updated',
               targets: [{ type: 'intake_config', id: tenant.orgId }],
               metadata: Object.fromEntries(
-                Object.entries(config).map(([integrationId, selection]) => [
+                Object.entries(registeredConfig).map(([integrationId, selection]) => [
                   integrationId,
                   { enabled: selection.enabled, sources: selection.sourceIds?.length ?? null },
                 ]),
               ),
             },
           });
-          return c.json({ config });
+          return c.json({ config: registeredConfig });
         },
       }),
       registerApiRoute('/web/intake/sources', {


### PR DESCRIPTION
## Description

In a clean `create-factory` scaffold, saving an intake source selection (e.g. enabling a connected GitHub repo) fails with `invalid_config` whenever an integration is not registered in the deployment (e.g. Linear, when `LINEAR_CLIENT_ID`/`LINEAR_CLIENT_SECRET` are unset).

**Root cause:** the generated Factory UI always normalizes the `GET /web/intake/config` response into a fixed `{ github, linear }` shape client-side (`normalizeIntakeConfig`), filling in a disabled default for any integration the deployment didn't return. When the user saves, that full object — including the synthetic disabled `linear` entry — is serialized back in `PUT /web/intake/config`. The server rejected the *entire* request if it contained any key outside its registered integration list, so the harmless synthetic entry alone was enough to block saving even a valid GitHub-only configuration.

**Fix:** the `PUT /web/intake/config` handler now only rejects an integration key that isn't registered if the client actually tried to *use* it (`enabled: true`, or a non-empty `sourceIds`). A harmless default/disabled entry for an unregistered integration is silently dropped before persisting and before the response is built, so generated clients can send a superset of keys without needing to know exactly which integrations are registered server-side.

This matches the "Expected Behavior" the issue proposed: *"The client should submit only integration keys returned by the server, or the server should safely ignore disabled entries for integrations that are not registered."*

### Verification
- Added two regression tests in `intake.test.ts`: one reproducing the exact bug scenario (GitHub registered, disabled default Linear entry submitted → now saves successfully), and one confirming an unregistered integration that's actually enabled or has sources selected is still rejected with `400`.
- All existing `intake.test.ts` tests pass unchanged, including the pre-existing strict-rejection test for a genuinely unknown/misused integration.
- Ran the full `mastracode/factory` test suite; confirmed (via `git stash`/pop comparison) that the only failures present are pre-existing and unrelated to this change (a few tests requiring packages not built in this environment, and one known-flaky concurrency test in `bindings.test.ts`).
- `oxlint` clean on both changed files.

## Related issue(s)

Fixes #20277

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Sometimes clients send “off” integration entries that the current deployment doesn’t even have installed. This change makes the server ignore those harmless entries, while still blocking any attempt to actually enable or use an integration that isn’t registered.

## Changes

- Updated `PUT /web/intake/config` to:
  - Drop unregistered integrations when they are **disabled** and have **no selected `sourceIds`**.
  - Reject unregistered integrations when they are **enabled** or when they include any **selected `sourceIds`**.
- Ensured the **filtered** integration list is used for:
  - Saved configuration
  - Audit metadata (so filtered-out entries don’t appear)
  - Response construction
- Added regression tests covering both the “drop disabled unregistered” and “reject enabled/selected unregistered” scenarios, including audit-metadata assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->