### PR TITLE
fix(playground-ui): size Sankey labels to the space each column has

### DIFF
--- a/.changeset/dirty-weeks-rush.md
+++ b/.changeset/dirty-weeks-rush.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed Sankey chart labels overlapping between neighbouring columns on narrow charts. Node names and column headers are now measured against the space each column actually has, and a label that no longer fits is clipped with an ellipsis. Hovering a clipped label still shows its full text.

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
@@ -6,7 +6,9 @@ import {
   getSankeyChartCurveSelection,
   getSankeyChartNodeWeights,
   getSankeyChartValue,
+  getSankeyLabelWidths,
   reorderSankeyChartColumns,
+  truncateSankeyLabel,
 } from './sankey-chart-utils';
 
 const columns = [
@@ -300,6 +302,101 @@ describe('SankeyChart utilities', () => {
 
       expect(reordered.map(column => column.id)).toEqual(['model', 'status', 'source']);
       expect(columns.map(column => column.id)).toEqual(['source', 'model', 'status']);
+    });
+  });
+
+  describe('when budgeting horizontal space for labels', () => {
+    const nodeWidth = 7;
+    const layout = { chartWidth: 800, columnCount: 4, marginLeft: 32, marginRight: 32 };
+    const columnPitch = (layout.chartWidth - layout.marginLeft - layout.marginRight - nodeWidth) / 3;
+
+    it('keeps two centered neighbours apart', () => {
+      const { centered } = getSankeyLabelWidths(layout);
+
+      expect(centered / 2 + centered / 2).toBeLessThan(columnPitch);
+    });
+
+    it('keeps an edge label clear of its centered neighbour', () => {
+      const { centered, edge } = getSankeyLabelWidths(layout);
+
+      expect(edge + centered / 2).toBeLessThan(columnPitch + nodeWidth / 2);
+    });
+
+    it('shrinks the budget as the chart narrows', () => {
+      const wide = getSankeyLabelWidths(layout);
+      const narrow = getSankeyLabelWidths({ ...layout, chartWidth: 400 });
+
+      expect(narrow.centered).toBeLessThan(wide.centered);
+      expect(narrow.edge).toBeLessThan(wide.edge);
+    });
+
+    it('never budgets negative space', () => {
+      const { centered, edge } = getSankeyLabelWidths({ ...layout, chartWidth: 40 });
+
+      expect(centered).toBe(0);
+      expect(edge).toBe(0);
+    });
+
+    it('leaves labels unbounded before the chart is measured', () => {
+      expect(getSankeyLabelWidths({ ...layout, chartWidth: 0 })).toEqual({
+        centered: Number.POSITIVE_INFINITY,
+        edge: Number.POSITIVE_INFINITY,
+      });
+    });
+
+    it('leaves labels unbounded when a single column has no neighbour', () => {
+      expect(getSankeyLabelWidths({ ...layout, columnCount: 1 })).toEqual({
+        centered: Number.POSITIVE_INFINITY,
+        edge: Number.POSITIVE_INFINITY,
+      });
+    });
+  });
+
+  describe('when a label fits its budget', () => {
+    it('leaves it untouched', () => {
+      expect(truncateSankeyLabel('Success', { fontSize: 11, maxWidth: 220 })).toBe('Success');
+    });
+
+    it('leaves it untouched when the width is unbounded', () => {
+      const label = 'Repeated command calls without confirmation';
+
+      expect(truncateSankeyLabel(label, { fontSize: 11, maxWidth: Number.POSITIVE_INFINITY })).toBe(label);
+    });
+  });
+
+  describe('when a label overflows its budget', () => {
+    it('clips it to an ellipsis that fits', () => {
+      const label = 'Repeated command calls without confirmation';
+      const truncated = truncateSankeyLabel(label, { fontSize: 11, maxWidth: 80 });
+
+      expect(truncated.endsWith('…')).toBe(true);
+      expect(truncated.length).toBeLessThan(label.length);
+    });
+
+    it('drops the trailing space before the ellipsis', () => {
+      expect(truncateSankeyLabel('Repeated command calls', { fontSize: 11, maxWidth: 70 })).toBe('Repeated…');
+    });
+
+    it('collapses to a lone ellipsis when there is no room at all', () => {
+      expect(truncateSankeyLabel('Anything', { fontSize: 11, maxWidth: 0 })).toBe('…');
+    });
+  });
+
+  describe('when a character cap is set alongside the width budget', () => {
+    it('applies the cap on an unbounded width', () => {
+      const truncated = truncateSankeyLabel('a'.repeat(40), {
+        fontSize: 11,
+        maxWidth: Number.POSITIVE_INFINITY,
+        maxCharacters: 23,
+      });
+
+      expect(truncated).toBe(`${'a'.repeat(22)}…`);
+    });
+
+    it('applies the width budget when it is tighter than the cap', () => {
+      const truncated = truncateSankeyLabel('a'.repeat(40), { fontSize: 11, maxWidth: 80, maxCharacters: 23 });
+
+      expect(truncated.length).toBeLessThan(23);
     });
   });
 });

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
@@ -203,6 +203,60 @@ export function buildSankeyChartGraph(
   return { nodes, links: [...linksById.values()] };
 }
 
+export const SANKEY_NODE_WIDTH = 7;
+
+// mono faces we ship advance at ~0.6em — 0.62 biases toward truncating early
+const LABEL_CHARACTER_WIDTH_RATIO = 0.62;
+const LABEL_GUTTER = 16;
+const LABEL_ELLIPSIS = '…';
+
+export type SankeyLabelWidths = {
+  centered: number;
+  edge: number;
+};
+
+export function getSankeyLabelWidths({
+  chartWidth,
+  columnCount,
+  marginLeft,
+  marginRight,
+}: {
+  chartWidth: number;
+  columnCount: number;
+  marginLeft: number;
+  marginRight: number;
+}): SankeyLabelWidths {
+  if (chartWidth <= 0 || columnCount < 2) {
+    return { centered: Number.POSITIVE_INFINITY, edge: Number.POSITIVE_INFINITY };
+  }
+
+  const columnPitch = (chartWidth - marginLeft - marginRight - SANKEY_NODE_WIDTH) / (columnCount - 1);
+  const centered = Math.max(0, columnPitch - LABEL_GUTTER);
+  // edge columns anchor at start/end, so their label spreads toward one neighbour instead of two
+  const edge = Math.max(0, columnPitch + SANKEY_NODE_WIDTH / 2 - LABEL_GUTTER - centered / 2);
+
+  return { centered, edge };
+}
+
+export function truncateSankeyLabel(
+  label: string,
+  {
+    fontSize,
+    maxWidth,
+    maxCharacters = Number.POSITIVE_INFINITY,
+  }: { fontSize: number; maxWidth: number; maxCharacters?: number },
+): string {
+  const widthLimit = Number.isFinite(maxWidth)
+    ? Math.floor(maxWidth / (fontSize * LABEL_CHARACTER_WIDTH_RATIO))
+    : Number.POSITIVE_INFINITY;
+  const limit = Math.min(widthLimit, maxCharacters);
+
+  if (label.length <= limit) return label;
+  if (limit <= 1) return LABEL_ELLIPSIS;
+
+  return `${label.slice(0, limit - 1).trimEnd()}${LABEL_ELLIPSIS}`;
+}
+
 export function buildFixedSankeyGeometry(
   graph: SankeyChartGraph,
   {

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -156,6 +156,63 @@ describe('SankeyChart', () => {
     });
   });
 
+  describe('when the chart is narrower than its labels need', () => {
+    const longChannel = 'A deliberately long channel label';
+    const signalsMargin = { top: 64, right: 32, bottom: 24, left: 32 };
+
+    function renderAtWidth(width: number, chartColumns = columns) {
+      vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(width);
+      return render(
+        <Sankey data={[{ channel: longChannel, region: 'EU', outcome: 'Won' }]} columns={chartColumns}>
+          <SankeyChart margin={signalsMargin} />
+        </Sankey>,
+      );
+    }
+
+    function getVisibleText(element: Element | undefined) {
+      return [...(element?.childNodes ?? [])]
+        .filter(node => node.nodeType === Node.TEXT_NODE)
+        .map(node => node.textContent)
+        .join('');
+    }
+
+    it('truncates node labels further than a wide chart does', async () => {
+      const findFirstColumnLabel = (container: HTMLElement) =>
+        [...container.querySelectorAll('svg text[font-size="11"]')].find(
+          label => label.getAttribute('text-anchor') === 'start',
+        );
+
+      const wide = renderAtWidth(800);
+      await screen.findAllByText('EU');
+      const wideLabel = getVisibleText(findFirstColumnLabel(wide.container));
+      cleanup();
+
+      const narrow = renderAtWidth(400);
+      await screen.findAllByText('EU');
+      const narrowLabel = getVisibleText(findFirstColumnLabel(narrow.container));
+
+      expect(wideLabel.endsWith('…')).toBe(true);
+      expect(narrowLabel.endsWith('…')).toBe(true);
+      expect(narrowLabel.length).toBeLessThan(wideLabel.length);
+    });
+
+    it('truncates column headers and keeps the full name in a title', async () => {
+      const { container } = renderAtWidth(400, [
+        { id: 'channel', label: 'Acquisition channel grouping' },
+        { id: 'region', label: 'Region' },
+        { id: 'outcome', label: 'Outcome' },
+      ]);
+      await screen.findAllByText('EU');
+
+      const header = [...container.querySelectorAll('svg text[font-size="12"]')].find(label =>
+        label.textContent?.includes('Acquisition'),
+      );
+
+      expect(getVisibleText(header).endsWith('…')).toBe(true);
+      expect(header?.querySelector('title')?.textContent).toBe('Acquisition channel grouping');
+    });
+  });
+
   describe('when current values change within stable layout weights', () => {
     it('changes bar height without moving its center', async () => {
       const renderFrame = (count: number) => (

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -40,7 +40,6 @@ export function SankeyChart({
 }: SankeyChartProps) {
   const { graph, enabledColumns, hueMap, usesFixedGeometry } = useSankeyRenderContext();
   const { chartContainerRef, fixedGeometry, labelWidths } = useSankeyChartMeasurements({
-    columnCount: enabledColumns.length,
     graph,
     height,
     margin,

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -6,13 +6,20 @@ import {
   getSankeyChartCurveSelection,
   getSankeyChartNodeSelection,
   getSankeyChartNodeWeights,
+  SANKEY_NODE_WIDTH,
+  truncateSankeyLabel,
 } from './sankey-chart-utils';
-import type { SankeyChartCurveSelection, SankeyChartNodeSelection } from './sankey-chart-utils';
+import type { SankeyChartCurveSelection, SankeyChartNodeSelection, SankeyLabelWidths } from './sankey-chart-utils';
 import { useSankeyRenderContext } from './sankey-context';
 import { nodeColor, nodeColorVivid } from './sankeyColor';
 import { useSankeyChartMeasurements } from './use-sankey-chart-measurements';
 import { Colors } from '@/ds/tokens';
 import { cn } from '@/lib/utils';
+
+const NODE_LABEL_FONT_SIZE = 11;
+const COLUMN_LABEL_FONT_SIZE = 12;
+// pre-measurement cap, kept so wide charts read unchanged
+const NODE_LABEL_MAX_CHARACTERS = 23;
 
 export type SankeyChartProps = {
   height?: CSSProperties['height'];
@@ -32,7 +39,8 @@ export function SankeyChart({
   isNodeClickable,
 }: SankeyChartProps) {
   const { graph, enabledColumns, hueMap, usesFixedGeometry } = useSankeyRenderContext();
-  const { chartContainerRef, fixedGeometry } = useSankeyChartMeasurements({
+  const { chartContainerRef, fixedGeometry, labelWidths } = useSankeyChartMeasurements({
+    columnCount: enabledColumns.length,
     graph,
     height,
     margin,
@@ -68,7 +76,7 @@ export function SankeyChart({
           >
             <RechartsSankey
               data={graph}
-              nodeWidth={7}
+              nodeWidth={SANKEY_NODE_WIDTH}
               nodePadding={56}
               margin={margin}
               node={(props: SankeyNodeRendererProps) => {
@@ -96,6 +104,7 @@ export function SankeyChart({
                     showColumnLabel={showColumnLabel}
                     isFirstColumn={node?.column.id === firstColumnId}
                     isLastColumn={node?.column.id === lastColumnId}
+                    labelWidths={labelWidths}
                     onFocusChange={setFocusedSourceName}
                     onHoverChange={setHoveredSourceName}
                     clickable={clickable}
@@ -166,6 +175,7 @@ type SankeyNodeProps = SankeyNodeRendererProps & {
   showColumnLabel: boolean;
   isFirstColumn: boolean;
   isLastColumn: boolean;
+  labelWidths: SankeyLabelWidths;
   clickable: boolean;
   onFocusChange: (sourceName: string | undefined) => void;
   onHoverChange: (sourceName: string | undefined) => void;
@@ -187,6 +197,7 @@ function SankeyNode({
   showColumnLabel,
   isFirstColumn,
   isLastColumn,
+  labelWidths,
   clickable,
   onFocusChange,
   onHoverChange,
@@ -198,7 +209,15 @@ function SankeyNode({
   const visibleDisplayLabel = descriptionIndex >= 0 ? displayLabel.slice(0, descriptionIndex) : displayLabel;
   const description = descriptionIndex >= 0 ? displayLabel.slice(descriptionIndex + 1) : undefined;
   const accessibleLabel = displayLabel.replaceAll('\n', '. ');
-  const visibleLabel = truncateNodeLabel(visibleDisplayLabel);
+  const nodeLabelWidth = isFirstColumn || isLastColumn ? labelWidths.edge : labelWidths.centered;
+  const visibleLabel = truncateSankeyLabel(visibleDisplayLabel, {
+    fontSize: NODE_LABEL_FONT_SIZE,
+    maxWidth: nodeLabelWidth,
+    maxCharacters: NODE_LABEL_MAX_CHARACTERS,
+  });
+  const visibleColumnLabel = columnLabel
+    ? truncateSankeyLabel(columnLabel, { fontSize: COLUMN_LABEL_FONT_SIZE, maxWidth: labelWidths.centered })
+    : undefined;
   const tooltipId = useId();
   const [isHovered, setIsHovered] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
@@ -263,9 +282,17 @@ function SankeyNode({
         tabIndex={0}
       >
         <title>{displayLabel}</title>
-        {showColumnLabel && columnLabel ? (
-          <text x={columnLabelX} y={18} textAnchor="middle" fill={nodeColor(hue)} fontSize={12} fontWeight={600}>
-            {columnLabel}
+        {showColumnLabel && visibleColumnLabel ? (
+          <text
+            x={columnLabelX}
+            y={18}
+            textAnchor="middle"
+            fill={nodeColor(hue)}
+            fontSize={COLUMN_LABEL_FONT_SIZE}
+            fontWeight={600}
+          >
+            {visibleColumnLabel === columnLabel ? null : <title>{columnLabel}</title>}
+            {visibleColumnLabel}
           </text>
         ) : null}
         <rect x={x} y={visibleY} width={width} height={visibleHeight} rx={3} fill={nodeColor(hue)} />
@@ -274,7 +301,7 @@ function SankeyNode({
           y={y - 24}
           textAnchor={textAnchor}
           fill={Colors.neutral5}
-          fontSize={11}
+          fontSize={NODE_LABEL_FONT_SIZE}
           fontFamily="var(--font-mono)"
         >
           {visibleLabel}
@@ -311,12 +338,6 @@ function SankeyNode({
 function scaleSankeyDimension(size: number, displayValue: number | undefined, layoutValue: number | undefined) {
   if (displayValue === undefined || layoutValue === undefined || layoutValue <= 0) return size;
   return size * Math.min(Math.max(displayValue / layoutValue, 0), 1);
-}
-
-function truncateNodeLabel(label: string) {
-  const maximumLength = 23;
-  if (label.length <= maximumLength) return label;
-  return `${label.slice(0, maximumLength - 1).trimEnd()}…`;
 }
 
 type SankeyLinkProps = SankeyLinkRendererProps & {

--- a/packages/playground-ui/src/ds/components/SankeyChart/use-sankey-chart-measurements.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/use-sankey-chart-measurements.ts
@@ -2,10 +2,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ComponentProps, CSSProperties } from 'react';
 import type { Sankey as RechartsSankey } from 'recharts';
 
-import { buildFixedSankeyGeometry } from './sankey-chart-utils';
+import { buildFixedSankeyGeometry, getSankeyLabelWidths, SANKEY_NODE_WIDTH } from './sankey-chart-utils';
 import type { SankeyChartGraph } from './sankey-chart-utils';
 
 type SankeyChartMeasurementsOptions = {
+  columnCount: number;
   graph: SankeyChartGraph;
   height: CSSProperties['height'];
   margin: ComponentProps<typeof RechartsSankey>['margin'];
@@ -13,6 +14,7 @@ type SankeyChartMeasurementsOptions = {
 };
 
 export function useSankeyChartMeasurements({
+  columnCount,
   graph,
   height,
   margin,
@@ -46,12 +48,23 @@ export function useSankeyChartMeasurements({
             top: Number(margin?.top ?? 64),
             bottom: measuredHeight - Number(margin?.bottom ?? 12),
             left: Number(margin?.left ?? 160),
-            right: measuredWidth - Number(margin?.right ?? 160) - 7,
+            right: measuredWidth - Number(margin?.right ?? 160) - SANKEY_NODE_WIDTH,
             nodePadding: 8,
           })
         : undefined,
     [graph, margin?.bottom, margin?.left, margin?.right, margin?.top, measuredHeight, measuredWidth, usesFixedGeometry],
   );
 
-  return { chartContainerRef, fixedGeometry };
+  const labelWidths = useMemo(
+    () =>
+      getSankeyLabelWidths({
+        chartWidth: measuredWidth,
+        columnCount,
+        marginLeft: Number(margin?.left ?? 160),
+        marginRight: Number(margin?.right ?? 160),
+      }),
+    [columnCount, margin?.left, margin?.right, measuredWidth],
+  );
+
+  return { chartContainerRef, fixedGeometry, labelWidths };
 }

--- a/packages/playground-ui/src/ds/components/SankeyChart/use-sankey-chart-measurements.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/use-sankey-chart-measurements.ts
@@ -6,7 +6,6 @@ import { buildFixedSankeyGeometry, getSankeyLabelWidths, SANKEY_NODE_WIDTH } fro
 import type { SankeyChartGraph } from './sankey-chart-utils';
 
 type SankeyChartMeasurementsOptions = {
-  columnCount: number;
   graph: SankeyChartGraph;
   height: CSSProperties['height'];
   margin: ComponentProps<typeof RechartsSankey>['margin'];
@@ -14,7 +13,6 @@ type SankeyChartMeasurementsOptions = {
 };
 
 export function useSankeyChartMeasurements({
-  columnCount,
   graph,
   height,
   margin,
@@ -55,16 +53,13 @@ export function useSankeyChartMeasurements({
     [graph, margin?.bottom, margin?.left, margin?.right, margin?.top, measuredHeight, measuredWidth, usesFixedGeometry],
   );
 
-  const labelWidths = useMemo(
-    () =>
-      getSankeyLabelWidths({
-        chartWidth: measuredWidth,
-        columnCount,
-        marginLeft: Number(margin?.left ?? 160),
-        marginRight: Number(margin?.right ?? 160),
-      }),
-    [columnCount, margin?.left, margin?.right, measuredWidth],
-  );
+  // recharts spaces columns by link depth, so the graph — not the enabled column list — sets the pitch
+  const labelWidths = getSankeyLabelWidths({
+    chartWidth: measuredWidth,
+    columnCount: new Set(graph.nodes.map(node => node.column.id)).size,
+    marginLeft: Number(margin?.left ?? 160),
+    marginRight: Number(margin?.right ?? 160),
+  });
 
   return { chartContainerRef, fixedGeometry, labelWidths };
 }


### PR DESCRIPTION
On a narrow Sankey chart the node labels of neighbouring columns run into each other. Daniel reported it on the Signals theme-flow view. The cause is that label length was never related to the space a column actually has: node names were clipped at a fixed 23 characters regardless of chart width, and column headers were not clipped at all. At a comfortable width 23 characters happen to fit; below that they don't, and since every column lays its nodes out on the same vertical slots, the labels of adjacent columns sit at the same height and collide.

The chart already measures its container — `useSankeyChartMeasurements` runs a `ResizeObserver` to feed the fixed geometry. I reused that measurement instead of adding a second observer: the hook now also derives a per-column width budget and returns it, and `SankeyNode` clips both the node name and the column header against it.

The budget has two values because the columns don't all anchor their text the same way. A middle column centers its label, so it spreads toward both neighbours and gets `columnPitch - gutter`. The first and last columns anchor at `start`/`end`, so their label spreads toward one neighbour only and has to leave room for that neighbour's half — they get roughly half as much. `getSankeyLabelWidths` returns both; the two tests in `sankey-chart-utils.test.ts` assert the separation property directly rather than pinning numbers, so the constants can move without rewriting the tests.

I kept the 23-character cap as an upper bound rather than letting the width budget alone decide. Dropping it would have made labels *longer* than today on wide charts, which is a look-and-feel change I didn't want to smuggle into a bug fix. So this is strictly conservative: identical rendering wherever things already fit, tighter only where they were overlapping. The Signals view passes `margin={{ left: 32, right: 32 }}`, and at its usual width the cap still wins, so nothing there changes until the viewport actually gets narrow.

Truncated column headers now carry their own SVG `<title>` with the full text. Node names already had one on the enclosing `<g>`, so I left that alone.

Widths are estimated from character count rather than measured with `getComputedTextLength`. Real measurement needs a two-pass render and returns 0 under jsdom, which would make this untestable. The node labels are monospace so the estimate is essentially exact there; for the sans-serif column headers it is an approximation, and the ratio is deliberately biased high (0.62 against a ~0.6 advance) so it errs toward clipping a little early rather than a little late.

This replaces #19760, which attacked the same bug but was opened before #19563, #19871, #19896 and the oxfmt migration rewrote this component. It conflicts with main and its own `ResizeObserver` would now duplicate the hook's.

Tested with `vitest run src/ds/components/SankeyChart` (60 pass), the `src/ee/signals` suites in both packages, plus typecheck and lint on `playground-ui` — lint warning count is unchanged from main at 55, all pre-existing `classnames-order`. I have not looked at the rendered chart in a browser; the component tests drive our truncation logic but recharts still lays out at its jsdom default width, so the two are not measuring the same thing.

One thing I did not fix: a column header on the first or last column is centered on its node, so at a small `margin.left`/`margin.right` it can still be clipped by the container edge. That is pre-existing, independent of the overlap, and needs a decision about whether those headers should re-anchor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When the Sankey chart gets narrow, the space available for each column label also gets smaller—so labels don’t crash into each other. The PR calculates a “width budget” per column and truncates anything that won’t fit (with an ellipsis), while still showing the full column name when you hover.

## Changes
- Added Sankey label sizing utilities (`getSankeyLabelWidths`) to compute per-column width budgets (center vs edge) from measured chart width, margins, node width, and the number of graph columns (derived from the graph).
- Added `truncateSankeyLabel` to truncate node names and column headers to fit the width budget (estimated via font size + character ratio), using an ellipsis; preserves the existing ~23-character cap so wide-chart rendering stays unchanged.
- Updated `useSankeyChartMeasurements` to return `labelWidths` alongside fixed geometry, and updated `SankeyChart` to pass `labelWidths` into `SankeyNode`.
- Updated Sankey rendering to:
  - clip node labels using the computed budgets,
  - clip column headers to the computed budgets,
  - render an SVG `<title>` tooltip with the full (untruncated) column header text when truncation occurs.
- Added unit/component tests validating label budget separation as width shrinks and truncation behavior for node labels and column headers.

## Validation
- Sankey tests
- Signals tests
- Typecheck
- Lint

## Release
- Added a patch changeset for `@mastra/playground-ui` describing the Sankey label sizing fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->