### PR TITLE
fix(core): cap notification delivery attempts

### DIFF
--- a/.changeset/tricky-parrots-yell.md
+++ b/.changeset/tricky-parrots-yell.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': patch
+---
+
+Notifications now stop retrying after a delivery failure that will never succeed.
+
+A notification whose delivery deterministically fails — a missing model, a rejected request context — used to be retried on every dispatch tick forever, because a failed delivery only incremented a counter and left the record `pending`. One production notification reached 288 delivery attempts against the same error.
+
+Delivery attempts are now capped. After 5 failures the notification is marked `failed` and is no longer picked up by the dispatcher:
+
+```ts
+const [notification] = await storage.listNotifications({ threadId, status: 'failed' });
+
+notification.deliveryAttempts; // 5
+notification.lastDeliveryError; // 'No model selected. Use /models to select a model first.'
+```
+
+`failed` is a new `NotificationStatus`, so notification inbox queries can filter for delivery failures that need attention. Transient failures are unaffected — they still retry, just no longer without bound.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -1450,6 +1450,49 @@ describe('Agent signals', () => {
     }
   });
 
+  it('keeps a rejected notification summary due for retry', async () => {
+    const notifications = new InMemoryNotificationsStorage();
+    const storage = new MastraCompositeStore({ id: 'rejected-summary-storage', domains: { notifications } });
+    const agent = new Agent({
+      id: 'rejected-summary-agent',
+      name: 'Rejected Summary Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('unused'),
+      notifications: {
+        deliveryPolicy: {
+          decide: ({ now }) => ({ action: 'summarize', summaryAt: now, reason: 'test-summary-now' }),
+        },
+      },
+    });
+    new Mastra({ agents: { rejectedSummaryAgent: agent }, storage, logger: false });
+    const rejectedAccepted = Promise.reject(new Error('summary rejected'));
+    rejectedAccepted.catch(() => {});
+    const sendSignal = vi.spyOn(agentThreadStreamRuntime, 'sendSignal').mockReturnValue({
+      accepted: rejectedAccepted,
+      signal: createSignal({ type: 'notification', tagName: 'notification-summary', contents: 'Rejected' }),
+    } as any);
+
+    try {
+      const result = await agent.sendNotificationSignal(
+        { source: 'github', kind: 'ci-status', priority: 'medium', summary: 'Rejected summary' },
+        { resourceId: 'summary-user', threadId: 'summary-thread' },
+      );
+
+      expect(result.record).toMatchObject({
+        status: 'pending',
+        deliveryAttempts: 1,
+        lastDeliveryError: 'summary rejected',
+      });
+      const stored = await notifications.getNotification({ threadId: 'summary-thread', id: result.record.id });
+      expect(stored?.summaryAt).toBeInstanceOf(Date);
+      await expect(notifications.listDueNotifications({ now: new Date() })).resolves.toMatchObject([
+        { id: result.record.id },
+      ]);
+    } finally {
+      sendSignal.mockRestore();
+    }
+  });
+
   it('batches active high notifications for full delivery and active medium or low notifications for summaries', async () => {
     let releaseFirst!: () => void;
     const firstFinished = new Promise<void>(resolve => {

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -11,6 +11,7 @@ import type { EventCallback } from '../../events/types';
 import { UnixSocketPubSub } from '../../events/unix-socket-pubsub';
 import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
+import { MAX_NOTIFICATION_DELIVERY_ATTEMPTS } from '../../notifications/delivery-policy';
 import { dispatchDueNotifications } from '../../notifications/dispatcher';
 import { InMemoryNotificationsStorage } from '../../notifications/storage';
 import { createNotificationInboxTool } from '../../notifications/tool';
@@ -1464,7 +1465,7 @@ describe('Agent signals', () => {
         },
       },
     });
-    new Mastra({ agents: { rejectedSummaryAgent: agent }, storage, logger: false });
+    const mastra = new Mastra({ agents: { rejectedSummaryAgent: agent }, storage, logger: false });
     const rejectedAccepted = Promise.reject(new Error('summary rejected'));
     rejectedAccepted.catch(() => {});
     const sendSignal = vi.spyOn(agentThreadStreamRuntime, 'sendSignal').mockReturnValue({
@@ -1488,6 +1489,21 @@ describe('Agent signals', () => {
       await expect(notifications.listDueNotifications({ now: new Date() })).resolves.toMatchObject([
         { id: result.record.id },
       ]);
+
+      for (let attempt = 2; attempt <= MAX_NOTIFICATION_DELIVERY_ATTEMPTS; attempt++) {
+        await dispatchDueNotifications({ mastra, storage: notifications, now: new Date() });
+        await expect(
+          notifications.getNotification({ threadId: 'summary-thread', id: result.record.id }),
+        ).resolves.toMatchObject({ deliveryAttempts: attempt });
+      }
+
+      await expect(
+        notifications.getNotification({ threadId: 'summary-thread', id: result.record.id }),
+      ).resolves.toMatchObject({ status: 'failed', deliveryAttempts: MAX_NOTIFICATION_DELIVERY_ATTEMPTS });
+      await expect(notifications.listDueNotifications({ now: new Date() })).resolves.toEqual([]);
+
+      await dispatchDueNotifications({ mastra, storage: notifications, now: new Date() });
+      expect(sendSignal).toHaveBeenCalledTimes(MAX_NOTIFICATION_DELIVERY_ATTEMPTS);
     } finally {
       sendSignal.mockRestore();
     }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -54,7 +54,7 @@ import type { VersionOverrides } from '../mastra/types';
 import { mergeVersionOverrides } from '../mastra/types';
 import type { MastraMemory } from '../memory/memory';
 import type { MemoryConfig, MemoryConfigInternal } from '../memory/types';
-import { resolveNotificationDeliveryDecision } from '../notifications/delivery-policy';
+import { resolveDeliveryFailureUpdate, resolveNotificationDeliveryDecision } from '../notifications/delivery-policy';
 import {
   createNotificationSignal,
   createNotificationSummarySignal,
@@ -7877,7 +7877,7 @@ export class Agent<
             const failed = await notifications.updateNotification({
               id: updated.id,
               threadId: updated.threadId,
-              deliveryAttempts: (updated.deliveryAttempts ?? 0) + 1,
+              ...resolveDeliveryFailureUpdate(updated),
               lastDeliveryAttemptAt: new Date(),
               lastDeliveryError: error instanceof Error ? error.message : 'Notification summary signal was rejected',
             });
@@ -7931,7 +7931,7 @@ export class Agent<
         const failed = await notifications.updateNotification({
           id: record.id,
           threadId: record.threadId,
-          deliveryAttempts: (record.deliveryAttempts ?? 0) + 1,
+          ...resolveDeliveryFailureUpdate(record),
           lastDeliveryAttemptAt: new Date(),
           lastDeliveryError: error instanceof Error ? error.message : 'Notification signal was rejected',
           deliveryReason: decision.reason,

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -7877,6 +7877,9 @@ export class Agent<
             const failed = await notifications.updateNotification({
               id: updated.id,
               threadId: updated.threadId,
+              // `summaryAt` was cleared to emit this summary. Restore it so the
+              // record stays due and the dispatcher can retry it.
+              summaryAt: now,
               ...resolveDeliveryFailureUpdate(updated),
               lastDeliveryAttemptAt: new Date(),
               lastDeliveryError: error instanceof Error ? error.message : 'Notification summary signal was rejected',

--- a/packages/core/src/notifications/delivery-policy.ts
+++ b/packages/core/src/notifications/delivery-policy.ts
@@ -4,7 +4,28 @@ import type {
   NotificationDeliveryThreadState,
   NotificationPriority,
   NotificationRecord,
+  NotificationStatus,
 } from './types';
+
+/**
+ * Delivery attempts allowed before a notification is marked `failed`. A failed
+ * record is no longer due, so a deterministic delivery error (a missing model,
+ * a rejected request context) stops being retried on every dispatch tick.
+ */
+export const MAX_NOTIFICATION_DELIVERY_ATTEMPTS = 5;
+
+/**
+ * Attempt bookkeeping applied when a delivery attempt throws, spread into the
+ * `updateNotification` call at each failure site.
+ */
+export function resolveDeliveryFailureUpdate(record: NotificationRecord): {
+  deliveryAttempts: number;
+  status?: NotificationStatus;
+} {
+  const deliveryAttempts = (record.deliveryAttempts ?? 0) + 1;
+  if (deliveryAttempts < MAX_NOTIFICATION_DELIVERY_ATTEMPTS) return { deliveryAttempts };
+  return { deliveryAttempts, status: 'failed' };
+}
 
 export type NotificationDeliveryPolicyDecision = NotificationDeliveryAction | NotificationDeliveryDecision;
 

--- a/packages/core/src/notifications/delivery-policy.ts
+++ b/packages/core/src/notifications/delivery-policy.ts
@@ -22,7 +22,11 @@ export function resolveDeliveryFailureUpdate(record: NotificationRecord): {
   deliveryAttempts: number;
   status?: NotificationStatus;
 } {
-  const deliveryAttempts = (record.deliveryAttempts ?? 0) + 1;
+  const attempts = record.deliveryAttempts ?? 0;
+  // Records written before the cap existed can already be past it. Terminalize
+  // them at their recorded count instead of inflating it further.
+  if (attempts >= MAX_NOTIFICATION_DELIVERY_ATTEMPTS) return { deliveryAttempts: attempts, status: 'failed' };
+  const deliveryAttempts = attempts + 1;
   if (deliveryAttempts < MAX_NOTIFICATION_DELIVERY_ATTEMPTS) return { deliveryAttempts };
   return { deliveryAttempts, status: 'failed' };
 }

--- a/packages/core/src/notifications/dispatcher.ts
+++ b/packages/core/src/notifications/dispatcher.ts
@@ -3,6 +3,7 @@ import { agentThreadStreamRuntime } from '../agent/thread-stream-runtime';
 import type { SendAgentSignalOptions, SendAgentSignalResult } from '../agent/types';
 import type { PubSub } from '../events';
 import type { Mastra } from '../mastra';
+import { resolveDeliveryFailureUpdate } from './delivery-policy';
 import { createNotificationSignal, createNotificationSummarySignal, summarizeNotifications } from './signals';
 import type { NotificationsStorage } from './storage';
 import type { NotificationDeliveryThreadState, NotificationRecord } from './types';
@@ -85,7 +86,7 @@ async function recordDeliveryFailure({
   await storage.updateNotification({
     id: record.id,
     threadId: record.threadId,
-    deliveryAttempts: (record.deliveryAttempts ?? 0) + 1,
+    ...resolveDeliveryFailureUpdate(record),
     lastDeliveryAttemptAt: now,
     lastDeliveryError: errorMessage(error),
   });

--- a/packages/core/src/notifications/notifications.test.ts
+++ b/packages/core/src/notifications/notifications.test.ts
@@ -505,7 +505,10 @@ describe('notification inbox', () => {
     expect(sendSignal).toHaveBeenCalledTimes(MAX_NOTIFICATION_DELIVERY_ATTEMPTS);
   });
 
-  it('terminalizes a record already past the cap without inflating its attempt count', async () => {
+  it.each([
+    { label: 'at the cap', attempts: MAX_NOTIFICATION_DELIVERY_ATTEMPTS },
+    { label: 'far past the cap', attempts: 288 },
+  ])('terminalizes a record $label without inflating its attempt count', async ({ attempts }) => {
     const storage = new InMemoryNotificationsStorage();
     const now = new Date('2026-05-30T12:00:00Z');
     const sendSignal = vi.fn((signal, _target) => ({
@@ -524,15 +527,21 @@ describe('notification inbox', () => {
       summary: 'CI failed',
       deliverAt: now,
     });
-    await storage.updateNotification({ id: 'n1', threadId: 'thread-1', deliveryAttempts: 288 });
+    await storage.updateNotification({ id: 'n1', threadId: 'thread-1', deliveryAttempts: attempts });
 
     await dispatchDueNotifications({ mastra, storage, now });
 
     await expect(storage.getNotification({ threadId: 'thread-1', id: 'n1' })).resolves.toMatchObject({
       status: 'failed',
-      deliveryAttempts: 288,
+      deliveryAttempts: attempts,
     });
     await expect(storage.listDueNotifications({ now })).resolves.toEqual([]);
+    // A record carried over from before the cap existed gets one final
+    // attempt, in case the failure it accumulated has since been resolved.
+    expect(sendSignal).toHaveBeenCalledTimes(1);
+
+    await dispatchDueNotifications({ mastra, storage, now });
+    expect(sendSignal).toHaveBeenCalledTimes(1);
   });
 
   it('groups due summary notifications by agent, resource, and thread', async () => {

--- a/packages/core/src/notifications/notifications.test.ts
+++ b/packages/core/src/notifications/notifications.test.ts
@@ -13,6 +13,7 @@ import {
   createNotificationSignal,
   createNotificationSummarySignal,
   dispatchDueNotifications,
+  MAX_NOTIFICATION_DELIVERY_ATTEMPTS,
   resolveNotificationDeliveryDecision,
   summarizeNotifications,
 } from '.';
@@ -461,6 +462,47 @@ describe('notification inbox', () => {
       lastDeliveryError: 'signal routing failed: no model configured',
     });
     expect(stored?.deliveredSignalId).toBeUndefined();
+  });
+
+  it('marks a notification failed once delivery attempts are exhausted', async () => {
+    const storage = new InMemoryNotificationsStorage();
+    const now = new Date('2026-05-30T12:00:00Z');
+    const sendSignal = vi.fn((signal, _target) => ({
+      accepted: Promise.reject(new Error('No model selected. Use /models to select a model first.')),
+      signal,
+    }));
+    const mastra = { getAgentById: vi.fn(async () => ({ sendSignal })) } as any;
+    await storage.createNotification({
+      id: 'n1',
+      agentId: 'agent-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      source: 'github',
+      kind: 'ci-status',
+      priority: 'high',
+      summary: 'CI failed',
+      deliverAt: now,
+    });
+
+    for (let attempt = 1; attempt < MAX_NOTIFICATION_DELIVERY_ATTEMPTS; attempt++) {
+      await dispatchDueNotifications({ mastra, storage, now });
+      await expect(storage.getNotification({ threadId: 'thread-1', id: 'n1' })).resolves.toMatchObject({
+        status: 'pending',
+        deliveryAttempts: attempt,
+      });
+    }
+
+    await dispatchDueNotifications({ mastra, storage, now });
+
+    await expect(storage.getNotification({ threadId: 'thread-1', id: 'n1' })).resolves.toMatchObject({
+      status: 'failed',
+      deliveryAttempts: MAX_NOTIFICATION_DELIVERY_ATTEMPTS,
+      lastDeliveryError: 'No model selected. Use /models to select a model first.',
+    });
+    await expect(storage.listDueNotifications({ now })).resolves.toEqual([]);
+
+    await dispatchDueNotifications({ mastra, storage, now });
+    expect(sendSignal).toHaveBeenCalledTimes(MAX_NOTIFICATION_DELIVERY_ATTEMPTS);
   });
 
   it('groups due summary notifications by agent, resource, and thread', async () => {

--- a/packages/core/src/notifications/notifications.test.ts
+++ b/packages/core/src/notifications/notifications.test.ts
@@ -505,6 +505,36 @@ describe('notification inbox', () => {
     expect(sendSignal).toHaveBeenCalledTimes(MAX_NOTIFICATION_DELIVERY_ATTEMPTS);
   });
 
+  it('terminalizes a record already past the cap without inflating its attempt count', async () => {
+    const storage = new InMemoryNotificationsStorage();
+    const now = new Date('2026-05-30T12:00:00Z');
+    const sendSignal = vi.fn((signal, _target) => ({
+      accepted: Promise.reject(new Error('No model selected. Use /models to select a model first.')),
+      signal,
+    }));
+    const mastra = { getAgentById: vi.fn(async () => ({ sendSignal })) } as any;
+    await storage.createNotification({
+      id: 'n1',
+      agentId: 'agent-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      source: 'github',
+      kind: 'ci-status',
+      priority: 'high',
+      summary: 'CI failed',
+      deliverAt: now,
+    });
+    await storage.updateNotification({ id: 'n1', threadId: 'thread-1', deliveryAttempts: 288 });
+
+    await dispatchDueNotifications({ mastra, storage, now });
+
+    await expect(storage.getNotification({ threadId: 'thread-1', id: 'n1' })).resolves.toMatchObject({
+      status: 'failed',
+      deliveryAttempts: 288,
+    });
+    await expect(storage.listDueNotifications({ now })).resolves.toEqual([]);
+  });
+
   it('groups due summary notifications by agent, resource, and thread', async () => {
     const storage = new InMemoryNotificationsStorage();
     const now = new Date('2026-05-30T12:00:00Z');

--- a/packages/core/src/notifications/tool.ts
+++ b/packages/core/src/notifications/tool.ts
@@ -9,7 +9,7 @@ const notificationActionSchema = z.object({
   action: z.enum(['list', 'read', 'markSeen', 'dismiss', 'archive', 'search']),
   threadId: z.string().optional(),
   id: z.string().optional(),
-  status: z.enum(['pending', 'delivered', 'seen', 'dismissed', 'archived', 'discarded']).optional(),
+  status: z.enum(['pending', 'delivered', 'seen', 'dismissed', 'archived', 'discarded', 'failed']).optional(),
   priority: z.enum(['low', 'medium', 'high', 'urgent']).optional(),
   source: z.string().optional(),
   query: z.string().optional(),

--- a/packages/core/src/notifications/types.ts
+++ b/packages/core/src/notifications/types.ts
@@ -1,6 +1,6 @@
 export type NotificationPriority = 'low' | 'medium' | 'high' | 'urgent';
 
-export type NotificationStatus = 'pending' | 'delivered' | 'seen' | 'dismissed' | 'archived' | 'discarded';
+export type NotificationStatus = 'pending' | 'delivered' | 'seen' | 'dismissed' | 'archived' | 'discarded' | 'failed';
 
 export type NotificationSignalAttributes = Record<string, string | number | boolean | null | undefined>;
 


### PR DESCRIPTION
## Description

A notification whose delivery deterministically fails was retried on every dispatch tick forever. A failed delivery only incremented `deliveryAttempts` and left the record `pending`, and the dispatcher's due query selects on `status = 'pending'`, so the same doomed record was picked up every minute indefinitely. One production notification reached 288 delivery attempts against the same error.

- Added `MAX_NOTIFICATION_DELIVERY_ATTEMPTS` (5) and `resolveDeliveryFailureUpdate` to `notifications/delivery-policy.ts`, returning the incremented attempt count plus a terminal `failed` status once the cap is reached
- Applied the helper at all three failure sites: `notifications/dispatcher.ts` (serving its five `recordDeliveryFailure` call sites) and the two inline branches in `agent/agent.ts`
- Added `failed` to `NotificationStatus` and to the notification inbox tool's status filter, so delivery failures can be queried directly instead of inferred from a climbing counter
- Placed the helper in `delivery-policy.ts` because it imports only `./types`, avoiding an import cycle (`dispatcher.ts` already depends on `agent/`)
- No schema migration required: `status` is an unconstrained `text` column with no `CHECK`, Postgres `ENUM`, or MongoDB validator, and no new timestamp column was added since `lastDeliveryAttemptAt` already records when the final attempt happened
- Routing decisions are unaffected — `persist`, `discard`, `defer` and `summarize` return before any send, so a busy agent never burns an attempt; only a rejected `accepted` promise counts

## Related Issue(s)

Fixes #20280

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If sending a notification keeps failing, the system used to keep trying forever. Now, after 5 failed attempts, it marks the notification as `failed` so it stops getting retried.

## Summary

- Added `MAX_NOTIFICATION_DELIVERY_ATTEMPTS = 5` and centralized terminal failure handling via `resolveDeliveryFailureUpdate`.
- On delivery failure, notifications now increment `deliveryAttempts` until the cap is reached, then transition to terminal `failed` status (including notifications already at/over the cap).
- Updated dispatcher and agent delivery logic to use `resolveDeliveryFailureUpdate` for consistent attempt counting and failure-state fields.
- For rejected `notification-summary` signals, the code restores `summaryAt` so the notification remains retry-eligible until the attempt cap applies.
- Added `failed` to `NotificationStatus` and extended the notification inbox tool’s status filtering to accept `failed`.
- Expanded tests to verify retry exhaustion behavior (attempt counting, terminal `failed` transition, error/attempt fields, and that `listDueNotifications` stops returning terminally failed notifications).
- No schema migration is required; the status column is unconstrained and `lastDeliveryAttemptAt` records the final attempt time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->