### PR TITLE
fix(cli): declare the Factory UI build dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -78,6 +78,7 @@
   },
   "devDependencies": {
     "@commander-js/extra-typings": "^14.0.0",
+    "@internal/factory-ui": "workspace:*",
     "@internal/lint": "workspace:*",
     "@internal/playground": "workspace:*",
     "@internal/types-builder": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4179,6 +4179,9 @@ importers:
       '@commander-js/extra-typings':
         specifier: ^14.0.0
         version: 14.0.0(commander@14.0.3)
+      '@internal/factory-ui':
+        specifier: workspace:*
+        version: link:../../mastracode/factory-ui
       '@internal/lint':
         specifier: workspace:*
         version: link:../_config


### PR DESCRIPTION
The studio preview Vercel build broke on main right after #20237 landed: `mastra#build:lib` dies with `Cannot find package '@tailwindcss/vite'` while building Factory UI, right after vite warns "Local package.json exists, but node_modules missing".

The cause is #20246: the CLI's tsup `onSuccess` now shells into `mastracode/factory-ui` to build the Factory SPA, but `packages/cli` never declares that package as a dependency. Any filtered install of the CLI's graph (`pnpm install --filter mastra...`) therefore skips factory-ui entirely, and the vite build there cannot resolve its own dependencies. The preview's root install is filtered, so it hit this first, but any filtered-install consumer of the CLI would break the same way.

I added `@internal/factory-ui` as a devDependency of the CLI, mirroring the `@internal/playground` line that exists for exactly the same reason. No changeset: the published package content is unchanged, this only fixes dependency-graph completeness for installs.

Verified by reproducing the Vercel flow locally on this branch: app install with `--ignore-workspace`, the filtered root install (factory-ui now gets its node_modules, `@tailwindcss/vite` resolves), a real turbo build, and `mastra build` producing `.vercel/output`. Not verified on Vercel itself; the next preview build after this merges should confirm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The CLI now knows to install the Factory UI tools it needs to build successfully. This prevents filtered installs from failing while leaving the published package unchanged.

## Changes

- Added `@internal/factory-ui` as a CLI `devDependency` using `workspace:*`.
- No changeset or published package contents were added.
- Verified filtered installation, dependency resolution, Turbo build, and `mastra build`; Vercel verification is pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->