### PR TITLE
fix(factory-ui): invalidate sidebar session list when a Factory run starts

### DIFF
--- a/mastracode/factory-ui/src/hooks/__tests__/useStartFactoryRun.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useStartFactoryRun.msw.test.tsx
@@ -3,6 +3,7 @@
  * multiple seconds; cards narrate it via `pendingRuns[].phase`. These tests gate
  * each endpoint to pin the phase the hook reports at every step.
  */
+import { QueryClient } from '@tanstack/react-query';
 import { act, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
@@ -10,6 +11,7 @@ import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../e2e/ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import { useWorkspacesQuery } from '../useWorkspaces';
 import { useStartFactoryRun } from '../useStartFactoryRun';
 
 const FACTORY_ID = 'fp-1';
@@ -26,8 +28,12 @@ function deferred() {
 function stubKickoffEndpoints() {
   const sessionGate = deferred();
   const runGate = deferred();
+  // The workspace list the sidebar renders from. The kickoff POST appends to it,
+  // so a re-read only sees the new row if the hook invalidated the sessions key.
+  const sessions: Array<{ sessionId: string; branch: string; updatedAt: string }> = [];
 
   server.use(
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () => HttpResponse.json({ sessions })),
     http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
       HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
     ),
@@ -51,7 +57,9 @@ function stubKickoffEndpoints() {
     ),
     http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, async () => {
       await sessionGate.promise;
-      return HttpResponse.json({ session: { sessionId: 'session-1', branch: 'feat/investigate-1' } });
+      const session = { sessionId: 'session-1', branch: 'feat/investigate-1', updatedAt: '2026-01-01T00:00:00.000Z' };
+      sessions.push(session);
+      return HttpResponse.json({ session });
     }),
     http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/runs/start`, async () => {
       await runGate.promise;
@@ -75,16 +83,18 @@ function stubKickoffEndpoints() {
 }
 
 /** The hook reads `:factoryId` and navigates, so it renders inside a real router. */
-function renderStartFactoryRun() {
-  let latest!: ReturnType<typeof useStartFactoryRun>;
+function renderStartFactoryRun(client?: QueryClient) {
+  // The sidebar's workspace list is mounted alongside the hook, so the test sees
+  // exactly what a user staring at the sidebar during kickoff would see.
+  let latest!: ReturnType<typeof useStartFactoryRun> & { workspaces: ReturnType<typeof useWorkspacesQuery> };
   function Probe() {
-    latest = useStartFactoryRun();
+    latest = { ...useStartFactoryRun(), workspaces: useWorkspacesQuery(REPO_ID) };
     return null;
   }
   const router = createMemoryRouter([{ path: '/factories/:factoryId/*', element: <Probe /> }], {
     initialEntries: [`/factories/${FACTORY_ID}/work`],
   });
-  const rendered = renderWithProviders(<RouterProvider router={router} />);
+  const rendered = renderWithProviders(<RouterProvider router={router} />, client);
   return { ...rendered, router, current: () => latest };
 }
 
@@ -128,6 +138,44 @@ describe('useStartFactoryRun', () => {
     await waitFor(() => expect(current().pendingRuns).toHaveLength(0));
     await waitFor(() =>
       expect(router.state.location.pathname).toBe(`/factories/${FACTORY_ID}/workspaces/session-1/threads/thread-1`),
+    );
+  });
+
+  it('refreshes the sidebar workspace list as soon as the kickoff creates its session', async () => {
+    const { sessionGate, runGate } = stubKickoffEndpoints();
+    // Mirror the app's staleTime: without an explicit invalidation the sidebar
+    // would serve the pre-kickoff list from cache instead of refetching.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, staleTime: 30_000 } },
+    });
+    const { current } = renderStartFactoryRun(client);
+
+    await waitFor(() => expect(current().enabled).toBe(true));
+    // Prime the cache the way the mounted sidebar does, before any session exists.
+    await waitFor(() => expect(current().workspaces.data?.workspaces).toEqual([]));
+
+    act(() => {
+      current().start.mutate({
+        branch: 'feat/investigate-1',
+        threadTitle: 'Investigate #1',
+        workItem: {
+          id: 'item-1',
+          role: 'investigator',
+          stages: ['triage'],
+          source: 'github-issue',
+          sourceKey: 'github-issue:1',
+          title: 'Investigate #1',
+        },
+      });
+    });
+
+    sessionGate.resolve();
+    runGate.resolve();
+
+    await waitFor(() =>
+      expect(current().workspaces.data?.workspaces).toEqual([
+        expect.objectContaining({ sessionId: 'session-1', branch: 'feat/investigate-1' }),
+      ]),
     );
   });
 });

--- a/mastracode/factory-ui/src/hooks/useStartFactoryRun.ts
+++ b/mastracode/factory-ui/src/hooks/useStartFactoryRun.ts
@@ -131,6 +131,7 @@ export function useStartFactoryRun() {
           queryKey: queryKeys.agentControllerThreads(AGENT_CONTROLLER_ID, sessionId, undefined),
         }),
         queryClient.invalidateQueries({ queryKey: queryKeys.workItems(factoryId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.sessions(repository.projectRepositoryId) }),
       ]);
       void navigate(`/factories/${factoryId}/workspaces/${sessionId}/threads/${prepared.threadId}`);
     },


### PR DESCRIPTION
Starting a Factory run from intake creates a workspace, but the sidebar's Work/Review session row for it didn't show up for up to 30 seconds. The work item appeared almost immediately, which made the sidebar look selectively stale.

The kickoff mutation invalidated `agentControllerThreads` and `workItems` but not the `sessions` query the sidebar rows actually render from. That query has no polling and no `refetchOnWindowFocus`, so nothing rescued it until the 30s `staleTime` lapsed — whereas `workItems` polls every 5s and self-healed. `useCreateWorkspaceMutation` already invalidates this key via `invalidateSessionQueries`; the kickoff path just never did the same.

Before:

```ts
await Promise.all([
  queryClient.invalidateQueries({ queryKey: queryKeys.agentControllerThreads(...) }),
  queryClient.invalidateQueries({ queryKey: queryKeys.workItems(factoryId) }),
]);
```

After:

```ts
await Promise.all([
  queryClient.invalidateQueries({ queryKey: queryKeys.agentControllerThreads(...) }),
  queryClient.invalidateQueries({ queryKey: queryKeys.workItems(factoryId) }),
  queryClient.invalidateQueries({ queryKey: queryKeys.sessions(repository.projectRepositoryId) }),
]);
```

Added an MSW regression test that mounts `useWorkspacesQuery` alongside the hook with the app's real 30s `staleTime`, primes an empty list, then runs kickoff. It fails without the fix and passes with it. Typecheck is clean and the full `test:msw` suite passes (59 files, 294 tests). No changeset since `@internal/factory-ui` is covered by the `@internal/*` ignore rule.

One thing I noticed but left alone: review sessions are classified by `item?.source === 'github-pr'`, so a review started from an intake issue (`github-issue`) groups under Work Sessions instead of Review Sessions. Separate classification bug, not caching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a Factory run starts, the sidebar now immediately shows the new session instead of making you wait up to 30 seconds. A regression test verifies this behavior.

## Changes

- Invalidate the `sessions` query when kickoff creates a new session.
- Added an MSW regression test covering sidebar refresh with React Query stale time.
- Typecheck and the full `test:msw` suite pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->