### PR TITLE
refactor(mastracode): share the provider OM default between Factory and the SDK

### DIFF
--- a/.changeset/early-papayas-argue.md
+++ b/.changeset/early-papayas-argue.md
@@ -1,0 +1,15 @@
+---
+'@mastra/code-sdk': minor
+---
+
+Added `resolveProviderOMDefault` to `@mastra/code-sdk/onboarding/packs`, which returns the small, cheap observational memory model for a provider, or the model you pass in when that provider has none.
+
+The built-in OM packs are now a single table, so the list offered during onboarding and the per-provider default can no longer drift apart.
+
+```ts
+import { resolveProviderOMDefault } from '@mastra/code-sdk/onboarding/packs';
+
+resolveProviderOMDefault('anthropic').modelId; // 'anthropic/claude-haiku-4-5'
+resolveProviderOMDefault('openai-codex').modelId; // 'openai/gpt-5.4-mini'
+resolveProviderOMDefault('xai', 'xai/grok-4.5').modelId; // 'xai/grok-4.5'
+```

--- a/.changeset/strict-turkeys-punch.md
+++ b/.changeset/strict-turkeys-punch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Changed the observational memory defaults a factory gets when you connect a provider: Google and DeepSeek now seed OM with their small, cheap model instead of the model you selected for the factory, matching what Anthropic and OpenAI already did. Providers without a cheap OM model keep using your selected model, and OM models you already set are still left untouched.

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -631,10 +631,10 @@ describe('OM routes with a tenant', () => {
 
   function buildApp(
     session: ReturnType<typeof makeOmSession> | null,
-    opts: { withStorage?: boolean; authEnabled?: boolean } = {},
+    opts: { withStorage?: boolean; authEnabled?: boolean; provider?: string } = {},
   ) {
     const controller = {
-      ...makeAgentController([{ provider: 'anthropic', hasApiKey: true }]),
+      ...makeAgentController([{ provider: opts.provider ?? 'anthropic', hasApiKey: true }]),
       getSessionByResource: async () => session ?? undefined,
     };
     const app = new Hono();
@@ -692,6 +692,60 @@ describe('OM routes with a tenant', () => {
     await expect(seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).resolves.toMatchObject({
       observerModelId: 'anthropic/claude-haiku-4-5',
       reflectorModelId: 'anthropic/claude-haiku-4-5',
+    });
+  });
+
+  it('reads the OpenAI OM default through a Codex credential', async () => {
+    await seed.credentials.setCredential({ orgId: 'org1', userId: 'user-a' }, 'openai-codex', {
+      type: 'api_key',
+      key: 'sk-openai',
+    });
+
+    const res = await postJson(buildApp(makeOmSession(), { provider: 'openai' }), '/web/config/om/provider-defaults', {
+      providerId: 'openai',
+      factoryModelId: 'openai/gpt-5.6',
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).config).toMatchObject({
+      observerModelId: 'openai/gpt-5.4-mini',
+      reflectorModelId: 'openai/gpt-5.4-mini',
+    });
+  });
+
+  it('prefers the low-cost OM pack over the selected factory model', async () => {
+    await seed.credentials.setCredential({ orgId: 'org1', userId: 'user-a' }, 'google', {
+      type: 'api_key',
+      key: 'sk-google',
+    });
+
+    const res = await postJson(buildApp(makeOmSession(), { provider: 'google' }), '/web/config/om/provider-defaults', {
+      providerId: 'google',
+      factoryModelId: 'google/gemini-3.5-pro',
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).config).toMatchObject({
+      observerModelId: 'google/gemini-3.5-flash',
+      reflectorModelId: 'google/gemini-3.5-flash',
+    });
+  });
+
+  it('keeps the selected factory model for providers without an OM pack', async () => {
+    await seed.credentials.setCredential({ orgId: 'org1', userId: 'user-a' }, 'xai', {
+      type: 'api_key',
+      key: 'sk-xai',
+    });
+
+    const res = await postJson(buildApp(makeOmSession(), { provider: 'xai' }), '/web/config/om/provider-defaults', {
+      providerId: 'xai',
+      factoryModelId: 'xai/grok-4.5',
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).config).toMatchObject({
+      observerModelId: 'xai/grok-4.5',
+      reflectorModelId: 'xai/grok-4.5',
     });
   });
 

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -1,6 +1,6 @@
 import type { AuthStorage } from '@mastra/code-sdk/auth/storage';
 import { DEFAULT_OM_MODEL_ID } from '@mastra/code-sdk/constants';
-import { getAvailableModePacks } from '@mastra/code-sdk/onboarding/packs';
+import { getAvailableModePacks, resolveProviderOMDefault } from '@mastra/code-sdk/onboarding/packs';
 import type { ModePack, ProviderAccess, ProviderAccessLevel } from '@mastra/code-sdk/onboarding/packs';
 import { getCustomProviderId, THREAD_ACTIVE_MODEL_PACK_ID_KEY } from '@mastra/code-sdk/onboarding/settings';
 import type { CustomProviderSetting } from '@mastra/code-sdk/onboarding/settings';
@@ -488,17 +488,6 @@ export interface OMConfigInfo {
 export interface ProviderOMDefaultsResponse {
   ok: true;
   config: OMConfigInfo;
-}
-
-function providerOMModelId(providerId: string, factoryModelId: string): string {
-  switch (providerId) {
-    case 'anthropic':
-      return 'anthropic/claude-haiku-4-5';
-    case 'openai':
-      return 'openai/gpt-5.4-mini';
-    default:
-      return factoryModelId || DEFAULT_OM_MODEL_ID;
-  }
 }
 
 export function readOMConfig(session: OMSession): OMConfigInfo {
@@ -1064,7 +1053,7 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
             });
             if (!access[providerId]) return c.json({ error: `Provider "${providerId}" is not configured` }, 400);
 
-            const modelId = providerOMModelId(providerId, factoryModelId);
+            const modelId = resolveProviderOMDefault(providerId, factoryModelId).modelId;
             const record = await context.storage.patch({
               orgId: context.orgId,
               userId: context.userId,

--- a/mastracode/sdk/src/onboarding/__tests__/packs.test.ts
+++ b/mastracode/sdk/src/onboarding/__tests__/packs.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
 import { PROVIDER_DEFAULT_MODELS } from '../../auth/storage.js';
-import { getAvailableModePacks } from '../packs.js';
+import { getAvailableModePacks, getAvailableOmPacks, resolveProviderOMDefault, type ProviderAccess } from '../packs.js';
+
+function providerAccess(overrides: Partial<ProviderAccess> = {}): ProviderAccess {
+  return {
+    anthropic: false,
+    openai: false,
+    cerebras: false,
+    google: false,
+    deepseek: false,
+    'github-copilot': false,
+    ...overrides,
+  };
+}
 
 describe('getAvailableModePacks', () => {
   it('uses GPT-5.6 for OpenAI plan and build modes while keeping fast on GPT-5.4 mini', () => {
@@ -79,5 +91,45 @@ describe('getAvailableModePacks', () => {
     });
 
     expect(packs.find(p => p.id === 'github-copilot')).toBeUndefined();
+  });
+});
+
+describe('OM packs', () => {
+  it.each([
+    ['anthropic', 'anthropic', 'anthropic/claude-haiku-4-5'],
+    ['openai-codex', 'openai', 'openai/gpt-5.4-mini'],
+    ['openai', 'openai', 'openai/gpt-5.4-mini'],
+    ['google', 'gemini', 'google/gemini-3.5-flash'],
+  ])('maps %s to the %s OM pack', (providerId, packId, modelId) => {
+    expect(resolveProviderOMDefault(providerId)).toMatchObject({ id: packId, modelId });
+  });
+
+  it('uses the selected provider model for unsupported providers', () => {
+    expect(resolveProviderOMDefault('xai', 'xai/grok-4.5')).toMatchObject({
+      id: 'custom',
+      modelId: 'xai/grok-4.5',
+    });
+  });
+
+  it('lists only reachable packs, labelled by how each provider is reached', () => {
+    const packs = getAvailableOmPacks(providerAccess({ google: 'apikey', anthropic: 'oauth', deepseek: 'apikey' }));
+
+    expect(packs).toEqual([
+      { id: 'gemini', name: 'Gemini Flash', description: 'Via Google API key', modelId: 'google/gemini-3.5-flash' },
+      {
+        id: 'anthropic',
+        name: 'Claude Haiku',
+        description: 'Via Max subscription',
+        modelId: 'anthropic/claude-haiku-4-5',
+      },
+      { id: 'deepseek', name: 'DeepSeek', description: 'Via DeepSeek API key', modelId: 'deepseek/deepseek-v4-flash' },
+      { id: 'custom', name: 'Custom', description: 'Choose any available model', modelId: '' },
+    ]);
+  });
+
+  it('offers the custom pack even when no provider is reachable', () => {
+    expect(getAvailableOmPacks(providerAccess())).toEqual([
+      { id: 'custom', name: 'Custom', description: 'Choose any available model', modelId: '' },
+    ]);
   });
 });

--- a/mastracode/sdk/src/onboarding/packs.ts
+++ b/mastracode/sdk/src/onboarding/packs.ts
@@ -4,6 +4,7 @@
  * Each pack assigns a default model to the build, plan, and fast modes,
  * plus an OM (observational memory) model.
  */
+import { DEFAULT_OM_MODEL_ID } from '../constants.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,6 +26,14 @@ export interface OMPack {
   name: string;
   description: string;
   modelId: string;
+}
+
+interface BuiltinOMPack {
+  id: string;
+  providerId: string;
+  name: string;
+  modelId: string;
+  description: (access: Exclude<ProviderAccessLevel, false>) => string;
 }
 
 /** How a provider is accessed: OAuth subscription, API key, or not at all. */
@@ -133,44 +142,75 @@ export function getAvailableModePacks(
 // OM Packs
 // ---------------------------------------------------------------------------
 
+const BUILTIN_OM_PACKS: BuiltinOMPack[] = [
+  {
+    id: 'gemini',
+    providerId: 'google',
+    name: 'Gemini Flash',
+    modelId: 'google/gemini-3.5-flash',
+    description: access => (access === 'oauth' ? 'Via Google OAuth' : 'Via Google API key'),
+  },
+  {
+    id: 'anthropic',
+    providerId: 'anthropic',
+    name: 'Claude Haiku',
+    modelId: 'anthropic/claude-haiku-4-5',
+    description: access => (access === 'oauth' ? 'Via Max subscription' : 'Via Anthropic API key'),
+  },
+  {
+    id: 'openai',
+    providerId: 'openai',
+    name: 'OpenAI Mini',
+    modelId: 'openai/gpt-5.4-mini',
+    description: access => (access === 'oauth' ? 'Via Codex subscription' : 'Via OpenAI API key'),
+  },
+  {
+    id: 'deepseek',
+    providerId: 'deepseek',
+    name: 'DeepSeek',
+    modelId: 'deepseek/deepseek-v4-flash',
+    description: () => 'Via DeepSeek API key',
+  },
+];
+
+function normalizeOMProviderId(providerId: string): string {
+  return providerId === 'openai-codex' ? 'openai' : providerId;
+}
+
+/** A provider's low-cost OM pack, or a custom pack on `fallbackModelId` when it has none. */
+export function resolveProviderOMDefault(providerId: string, fallbackModelId = DEFAULT_OM_MODEL_ID): OMPack {
+  const normalizedProviderId = normalizeOMProviderId(providerId);
+  const builtin = BUILTIN_OM_PACKS.find(pack => pack.providerId === normalizedProviderId);
+  if (builtin) {
+    return {
+      id: builtin.id,
+      name: builtin.name,
+      description: builtin.description('apikey'),
+      modelId: builtin.modelId,
+    };
+  }
+
+  return {
+    id: 'custom',
+    name: 'Custom',
+    description: 'Uses the selected provider model',
+    modelId: fallbackModelId || DEFAULT_OM_MODEL_ID,
+  };
+}
+
 export function getAvailableOmPacks(access: ProviderAccess): OMPack[] {
-  const packs: OMPack[] = [];
-
-  if (access.google) {
-    packs.push({
-      id: 'gemini',
-      name: 'Gemini Flash',
-      description: access.google === 'oauth' ? 'Via Google OAuth' : 'Via Google API key',
-      modelId: 'google/gemini-3.5-flash',
-    });
-  }
-
-  if (access.anthropic) {
-    packs.push({
-      id: 'anthropic',
-      name: 'Claude Haiku',
-      description: access.anthropic === 'oauth' ? 'Via Max subscription' : 'Via Anthropic API key',
-      modelId: 'anthropic/claude-haiku-4-5',
-    });
-  }
-
-  if (access.openai) {
-    packs.push({
-      id: 'openai',
-      name: 'OpenAI Mini',
-      description: access.openai === 'oauth' ? 'Via Codex subscription' : 'Via OpenAI API key',
-      modelId: 'openai/gpt-5.4-mini',
-    });
-  }
-
-  if (access.deepseek) {
-    packs.push({
-      id: 'deepseek',
-      name: 'DeepSeek',
-      description: 'Via DeepSeek API key',
-      modelId: 'deepseek/deepseek-v4-flash',
-    });
-  }
+  const packs = BUILTIN_OM_PACKS.flatMap(pack => {
+    const providerAccess = access[pack.providerId];
+    if (!providerAccess) return [];
+    return [
+      {
+        id: pack.id,
+        name: pack.name,
+        description: pack.description(providerAccess),
+        modelId: pack.modelId,
+      },
+    ];
+  });
 
   // Custom — always available; user picks any model
   packs.push({


### PR DESCRIPTION
Factory decided which observational memory model a provider gets with its own little switch in `routes/config.ts`: Claude Haiku for Anthropic, GPT-5.4 mini for OpenAI, and the model you selected for the factory for anything else. The SDK already knew the same thing, spelled differently — four `if (access.x)` blocks in `getAvailableOmPacks` building the pack list shown during onboarding. Two copies of one table, each free to drift from the other.

I collapsed both onto a single `BUILTIN_OM_PACKS` table and exported `resolveProviderOMDefault` from the SDK, which Factory now calls. The onboarding pack list and the per-provider default are derived from the same rows, so adding a provider is one entry instead of two edits in two packages.

This is not purely mechanical, and that is worth a second look from a reviewer. Matching against the whole table means Google and DeepSeek now resolve to their own cheap OM model in Factory (`google/gemini-3.5-flash`, `deepseek/deepseek-v4-flash`) instead of falling through to the selected factory model. That is the behaviour I want — the old switch simply never covered them, and observing with a full-size coding model is expensive — but it is a real change for anyone running a Google or DeepSeek factory. Providers genuinely without a cheap pack still keep the selected model, and OM models a user already chose are untouched either way.

`getAvailableOmPacks` had no tests at all. Before landing the rewrite I checked it against the previous implementation over all 729 `ProviderAccess` combinations (six providers, three access levels) and the output was identical; that scaffolding was throwaway, so what stays is two tests covering the ordering, the OAuth-versus-API-key labels and the always-present custom pack, plus three Factory route cases for the OpenAI-via-Codex, Google and xAI paths.

Ran `tsc --noEmit` on `mastracode/sdk` and `mastracode/factory`, oxlint on the touched files, the 47 tests in `sdk/src/onboarding` and the 55 in `factory/src/routes/config.test.ts`. I did not run the TUI E2E suite here — nothing in this branch touches the TUI.

This is the first of two. The provider-aware OM seeding for Mastra Code itself (`selectPreferredOMPack`, the startup seed, `/login`) stacks on top in #20291, which I have retargeted onto this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR gives all parts of the SDK one shared list of recommended memory models, so onboarding and Factory always make the same choice. Google and DeepSeek now use their cheaper memory models automatically, while custom choices remain unchanged.

## Summary

- Centralized built-in observational memory packs in `BUILTIN_OM_PACKS`.
- Added and exported `resolveProviderOMDefault`.
- Updated Factory to use shared provider defaults, including OpenAI Codex, Google, and DeepSeek.
- Preserved user-selected OM models and fallback behavior for providers without built-in packs.
- Added SDK tests for pack ordering, access labels, custom packs, and provider resolution.
- Added Factory route tests for provider-specific defaults.
- Updated SDK changesets and verified type checking, linting, and relevant tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->