### PR TITLE
fix(create-factory): Improve platform onboarding

### DIFF
--- a/.changeset/clever-times-fall.md
+++ b/.changeset/clever-times-fall.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Improved Factory onboarding so any key skips optional Mastra Platform setup while Ctrl+C cancels project creation.

--- a/.changeset/forty-doodles-eat.md
+++ b/.changeset/forty-doodles-eat.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Improved optional Mastra Platform setup so any key skips sign-in while Ctrl+C cancels project creation.

--- a/mastracode/mastra-factory/src/create.test.ts
+++ b/mastracode/mastra-factory/src/create.test.ts
@@ -38,6 +38,7 @@ const platform = vi.hoisted(() => ({
 const cliAuth = vi.hoisted(() => ({
   getToken: vi.fn(),
   loadCredentials: vi.fn(),
+  LoginCancelledError: class LoginCancelledError extends Error {},
   resolveCurrentOrg: vi.fn(),
   fetchOrgs: vi.fn(),
   MASTRA_PLATFORM_API_URL: 'https://platform.example.test',
@@ -78,7 +79,6 @@ beforeEach(() => {
   vi.clearAllMocks();
 
   // Sensible default: platform provisioning succeeds. Tests can override.
-  // Cached credentials exist, so no "press enter to open auth flow" pause.
   cliAuth.loadCredentials.mockResolvedValue({ token: 'cached' });
   cliAuth.getToken.mockResolvedValue('wos-token');
   cliAuth.resolveCurrentOrg.mockResolvedValue({ orgId: 'org_123', orgName: 'Acme' });
@@ -356,7 +356,7 @@ describe('create (platform provisioning)', () => {
     expect(platform.createServerProject).toHaveBeenCalledWith(expect.objectContaining({ orgId: 'org_456' }));
   });
 
-  it('pauses with a "press enter" prompt before opening the auth flow when not logged in', async () => {
+  it('asks for confirmation before opening browser authentication', async () => {
     vi.stubEnv('MASTRA_API_TOKEN', '');
     cliAuth.loadCredentials.mockResolvedValue(null);
     clack.text.mockResolvedValue('');
@@ -367,31 +367,48 @@ describe('create (platform provisioning)', () => {
       message: 'Mastra account is required, press enter to continue...',
       defaultValue: '',
     });
-    // Prompt shown before the auth flow starts.
     expect(clack.text.mock.invocationCallOrder[0]!).toBeLessThan(cliAuth.getToken.mock.invocationCallOrder[0]!);
-    expect(clack.note).toHaveBeenCalledWith(expect.stringContaining('Provisioned on Mastra platform'), 'Next steps');
     vi.unstubAllEnvs();
   });
 
-  it('skips the auth pause when cached credentials already exist', async () => {
-    await create({ projectName: 'my-factory', template: TEMPLATE_REPO, analytics });
-
-    expect(clack.text).not.toHaveBeenCalled();
-    expect(cliAuth.getToken).toHaveBeenCalledTimes(1);
-  });
-
-  it('treats cancelling the auth pause as a provisioning failure without opening the auth flow', async () => {
+  it('cancels the process when Ctrl+C is pressed at the authentication confirmation', async () => {
     vi.stubEnv('MASTRA_API_TOKEN', '');
     cliAuth.loadCredentials.mockResolvedValue(null);
     clack.text.mockResolvedValue(Symbol.for('clack.cancel'));
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process exited');
+    });
+
+    try {
+      await create({ projectName: 'my-factory', template: TEMPLATE_REPO, analytics });
+
+      expect(clack.cancel).toHaveBeenCalledWith('Operation cancelled');
+      expect(exit).toHaveBeenCalledWith(0);
+      expect(cliAuth.getToken).not.toHaveBeenCalled();
+    } finally {
+      exit.mockRestore();
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('allows any key to skip while waiting for platform authentication', async () => {
+    await create({ projectName: 'my-factory', template: TEMPLATE_REPO, analytics });
+
+    expect(clack.text).not.toHaveBeenCalled();
+    expect(cliAuth.getToken).toHaveBeenCalledWith(undefined, { skipOnInput: true });
+    expect(clack.note).toHaveBeenCalledWith(expect.stringContaining('Provisioned on Mastra platform'), 'Next steps');
+  });
+
+  it('treats keyboard cancellation as skipped platform setup', async () => {
+    cliAuth.getToken.mockRejectedValue(new cliAuth.LoginCancelledError());
 
     await create({ projectName: 'my-factory', template: TEMPLATE_REPO, analytics });
 
-    expect(cliAuth.getToken).not.toHaveBeenCalled();
+    expect(platform.createServerProject).not.toHaveBeenCalled();
+    expect(clack.log.info).toHaveBeenCalledWith('Skipping Mastra platform setup.');
     const note = clack.note.mock.calls[0]![0] as string;
-    expect(note).toContain('Platform provisioning failed');
-    expect(note).toContain('Sign-in cancelled.');
-    vi.unstubAllEnvs();
+    expect(note).toContain('Skipped Mastra platform setup');
+    expect(note).not.toContain('Platform provisioning failed');
   });
 
   it('--org fails with a clear message when no org matches', async () => {

--- a/mastracode/mastra-factory/src/create.ts
+++ b/mastracode/mastra-factory/src/create.ts
@@ -4,7 +4,7 @@ import * as p from '@clack/prompts';
 // `mastra/internal/auth` is the CLI's internal barrel — drives the browser-auth
 // flow and reuses persisted credentials + org resolution rather than duplicating
 // them here.
-import { fetchOrgs, getToken, loadCredentials, resolveCurrentOrg } from 'mastra/internal/auth';
+import { fetchOrgs, getToken, loadCredentials, LoginCancelledError, resolveCurrentOrg } from 'mastra/internal/auth';
 import color from 'picocolors';
 import { x } from 'tinyexec';
 
@@ -136,6 +136,7 @@ export async function create(args: CreateArgs): Promise<void> {
   // ── Platform provisioning ────────────────────────────────────────────────
   let platformResult: PlatformProvisionResult | null = null;
   let platformError: string | null = null;
+  let platformSkipped = false;
   if (!args.noPlatform) {
     try {
       platformResult = await runPlatformProvisioning({
@@ -145,8 +146,13 @@ export async function create(args: CreateArgs): Promise<void> {
         org: args.org,
       });
     } catch (err) {
-      platformError = err instanceof Error ? err.message : String(err);
-      p.log.warn(`Platform provisioning failed: ${platformError}`);
+      if (err instanceof LoginCancelledError) {
+        platformSkipped = true;
+        p.log.info('Skipping Mastra platform setup.');
+      } else {
+        platformError = err instanceof Error ? err.message : String(err);
+        p.log.warn(`Platform provisioning failed: ${platformError}`);
+      }
     }
   }
 
@@ -207,6 +213,10 @@ export async function create(args: CreateArgs): Promise<void> {
       '',
       `Manage your project at ${color.underline('https://projects.mastra.ai')}`,
     );
+  } else if (platformSkipped) {
+    lines.push(
+      `${color.yellow('Skipped Mastra platform setup.')} Configure ${color.cyan('.env')} manually before running.`,
+    );
   } else if (args.noPlatform) {
     lines.push(
       `${color.yellow('Skipped platform provisioning (--no-platform).')} Configure ${color.cyan('.env')} manually before running.`,
@@ -247,9 +257,9 @@ async function runPlatformProvisioning({
   };
 
   try {
-    // 1. Auth — triggers the browser-auth flow if no cached credential.
-    //    When that flow is about to open (no env token, no cached credential),
-    //    pause first so the browser doesn't pop open unannounced.
+    // 1. Auth — announce the browser-auth flow before opening it when there is
+    //    no cached credential. Once the browser is open, any key skips platform
+    //    provisioning; Ctrl+C remains the process-level cancellation signal.
     const willOpenAuthFlow = !process.env.MASTRA_API_TOKEN && !(await loadCredentials());
     if (willOpenAuthFlow) {
       const proceed = await p.text({
@@ -257,11 +267,12 @@ async function runPlatformProvisioning({
         defaultValue: '',
       });
       if (p.isCancel(proceed)) {
-        throw new Error('Sign-in cancelled.');
+        p.cancel('Operation cancelled');
+        process.exit(0);
       }
     }
     p.log.info('Signing in to Mastra…');
-    const token = await getToken();
+    const token = await getToken(undefined, { skipOnInput: true });
 
     // 2. Org — `--org <id-or-name>` skips the picker; otherwise prompt every
     //    time so the user consciously chooses which org owns the new factory

--- a/packages/cli/src/commands/auth/credentials.ts
+++ b/packages/cli/src/commands/auth/credentials.ts
@@ -24,6 +24,17 @@ export interface Credentials {
   currentOrgId?: string;
 }
 
+export interface LoginOptions {
+  skipOnInput?: boolean;
+}
+
+export class LoginCancelledError extends Error {
+  constructor() {
+    super('Login skipped.');
+    this.name = 'LoginCancelledError';
+  }
+}
+
 export async function saveCredentials(creds: Credentials): Promise<void> {
   await mkdir(CREDENTIALS_DIR, { recursive: true, mode: 0o700 });
   await writeFile(CREDENTIALS_FILE, JSON.stringify(creds, null, 2), { mode: 0o600 });
@@ -179,7 +190,39 @@ function callbackPage({ success }: { success: boolean }): string {
 </html>`;
 }
 
-export async function login(signal?: AbortSignal): Promise<Credentials> {
+function listenForSkipInput(onSkip: () => void): () => void {
+  const stdin = process.stdin;
+  if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') return () => {};
+
+  const wasRaw = stdin.isRaw;
+  const wasPaused = stdin.isPaused();
+  let listening = true;
+
+  const cleanup = () => {
+    if (!listening) return;
+    listening = false;
+    stdin.removeListener('data', handleInput);
+    if (!wasRaw) stdin.setRawMode(false);
+    if (wasPaused) stdin.pause();
+  };
+
+  const handleInput = (input: Buffer | string) => {
+    const data = typeof input === 'string' ? Buffer.from(input) : input;
+    cleanup();
+    if (data.includes(3)) {
+      process.kill(process.pid, 'SIGINT');
+      return;
+    }
+    onSkip();
+  };
+
+  stdin.setRawMode(true);
+  stdin.resume();
+  stdin.once('data', handleInput);
+  return cleanup;
+}
+
+export async function login(signal?: AbortSignal, options: LoginOptions = {}): Promise<Credentials> {
   signal?.throwIfAborted();
   console.info('\n   Logging in to Mastra...\n');
 
@@ -197,7 +240,11 @@ export async function login(signal?: AbortSignal): Promise<Credentials> {
 
   const loginUrl = `${MASTRA_PLATFORM_API_URL}/v1/auth/login?product=cli&cli_port=${port}&state=${state}`;
   console.info(`   Opening browser...\n`);
-  console.info(`   Waiting for your input. Skip this step with Ctrl+C\n`);
+  console.info(
+    options.skipOnInput
+      ? `   Waiting for browser sign-in. Press any key to skip this step.\n`
+      : `   Waiting for browser sign-in...\n`,
+  );
 
   try {
     openBrowser(loginUrl);
@@ -216,11 +263,13 @@ export async function login(signal?: AbortSignal): Promise<Credentials> {
     organizationId: string;
   }>((resolve, reject) => {
     let settled = false;
+    let stopListeningForSkip = () => {};
     const finish = (callback: () => void) => {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
       signal?.removeEventListener('abort', handleAbort);
+      stopListeningForSkip();
       server.close(callback);
       server.closeAllConnections();
     };
@@ -235,6 +284,9 @@ export async function login(signal?: AbortSignal): Promise<Credentials> {
     if (signal?.aborted) {
       handleAbort();
       return;
+    }
+    if (options.skipOnInput) {
+      stopListeningForSkip = listenForSkipInput(() => finish(() => reject(new LoginCancelledError())));
     }
 
     server.on('request', (req, res) => {
@@ -279,7 +331,7 @@ function isInteractive(): boolean {
   return Boolean(process.stdin.isTTY && process.stdout.isTTY) && !process.env.CI;
 }
 
-export async function getToken(signal?: AbortSignal): Promise<string> {
+export async function getToken(signal?: AbortSignal, options: LoginOptions = {}): Promise<string> {
   signal?.throwIfAborted();
 
   // CI/CD headless path
@@ -292,7 +344,7 @@ export async function getToken(signal?: AbortSignal): Promise<string> {
     if (!isInteractive()) {
       throw new Error('Not logged in. Run `mastra auth login` interactively or set MASTRA_API_TOKEN.');
     }
-    const newCreds = await login(signal);
+    const newCreds = await login(signal, options);
     return newCreds.token;
   }
 
@@ -308,7 +360,7 @@ export async function getToken(signal?: AbortSignal): Promise<string> {
   if (!isInteractive()) {
     throw new Error('Session expired. Run `mastra auth login` interactively or set MASTRA_API_TOKEN.');
   }
-  const newCreds = await login(signal);
+  const newCreds = await login(signal, options);
   return newCreds.token;
 }
 

--- a/packages/cli/src/commands/auth/login.test.ts
+++ b/packages/cli/src/commands/auth/login.test.ts
@@ -76,6 +76,29 @@ const validParams = {
   org: 'org-1',
 };
 
+function mockInteractiveStdin() {
+  const isTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+  const setRawModeDescriptor = Object.getOwnPropertyDescriptor(process.stdin, 'setRawMode');
+  const setRawMode = vi.fn().mockReturnValue(process.stdin);
+  Object.defineProperties(process.stdin, {
+    isTTY: { configurable: true, value: true },
+    setRawMode: { configurable: true, value: setRawMode },
+  });
+  vi.spyOn(process.stdin, 'isPaused').mockReturnValue(true);
+  vi.spyOn(process.stdin, 'resume').mockReturnValue(process.stdin);
+  vi.spyOn(process.stdin, 'pause').mockReturnValue(process.stdin);
+
+  return {
+    setRawMode,
+    restore() {
+      if (isTTYDescriptor) Object.defineProperty(process.stdin, 'isTTY', isTTYDescriptor);
+      else delete (process.stdin as Partial<NodeJS.ReadStream>).isTTY;
+      if (setRawModeDescriptor) Object.defineProperty(process.stdin, 'setRawMode', setRawModeDescriptor);
+      else delete (process.stdin as Partial<NodeJS.ReadStream>).setRawMode;
+    },
+  };
+}
+
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.spyOn(console, 'info').mockImplementation(() => {});
@@ -158,6 +181,57 @@ describe('login() server lifecycle', () => {
         req.on('error', reject);
       }),
     ).rejects.toThrow();
+  });
+
+  it('skips login when any key is pressed', async () => {
+    const stdin = mockInteractiveStdin();
+    try {
+      const { login, LoginCancelledError } = await import('./credentials.js');
+      const loginPromise = login(undefined, { skipOnInput: true });
+
+      await vi.waitFor(
+        () => {
+          extractPort();
+        },
+        { timeout: 5000 },
+      );
+      process.stdin.emit('data', Buffer.from('x'));
+
+      await expect(loginPromise).rejects.toBeInstanceOf(LoginCancelledError);
+      expect(stdin.setRawMode).toHaveBeenNthCalledWith(1, true);
+      expect(stdin.setRawMode).toHaveBeenLastCalledWith(false);
+      expect(console.info).toHaveBeenCalledWith(
+        expect.stringContaining('Waiting for browser sign-in. Press any key to skip this step.'),
+      );
+    } finally {
+      stdin.restore();
+    }
+  });
+
+  it('forwards Ctrl+C as SIGINT instead of treating it as a skip key', async () => {
+    const stdin = mockInteractiveStdin();
+    const controller = new AbortController();
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => {
+      controller.abort();
+      return true;
+    });
+    try {
+      const { login } = await import('./credentials.js');
+      const loginPromise = login(controller.signal, { skipOnInput: true });
+
+      await vi.waitFor(
+        () => {
+          extractPort();
+        },
+        { timeout: 5000 },
+      );
+      process.stdin.emit('data', Buffer.from([3]));
+
+      await expect(loginPromise).rejects.toMatchObject({ name: 'AbortError' });
+      expect(kill).toHaveBeenCalledWith(process.pid, 'SIGINT');
+    } finally {
+      stdin.restore();
+    }
   });
 
   it('returns 400 when callback params are missing', async () => {

--- a/packages/cli/src/commands/create/create.test.ts
+++ b/packages/cli/src/commands/create/create.test.ts
@@ -48,6 +48,7 @@ vi.mock('../../analytics/index', () => ({
 
 vi.mock('../auth/credentials.js', () => ({
   getToken: vi.fn(),
+  LoginCancelledError: class LoginCancelledError extends Error {},
 }));
 
 vi.mock('../auth/orgs.js', () => ({
@@ -611,41 +612,27 @@ describe('managed observability', () => {
     });
   });
 
-  it('continues creation when Ctrl+C cancels platform authentication before materialization', async () => {
+  it('continues creation when any key skips platform authentication', async () => {
     const { create } = await import('./create');
     const prompts = await import('@clack/prompts');
     const credentials = await import('../auth/credentials.js');
     const observability = await import('../init/observability-provision');
     const { publishStagedProject } = await import('./utils');
-    let finishVersionResolution: ((tag: string) => void) | undefined;
-    let authSignal: AbortSignal | undefined;
 
     vi.mocked(prompts.select)
       .mockResolvedValueOnce('openai')
       .mockResolvedValueOnce('skip')
       .mockResolvedValueOnce('yes');
-    vi.mocked(credentials.getToken).mockImplementationOnce(
-      signal =>
-        new Promise((_resolve, reject) => {
-          authSignal = signal;
-          signal?.addEventListener('abort', () => reject(new Error('authentication aborted')), { once: true });
-        }),
-    );
+    vi.mocked(credentials.getToken).mockRejectedValueOnce(new credentials.LoginCancelledError());
 
-    const createPromise = create({
-      projectName: 'my-project',
-      resolveVersionTag: () =>
-        new Promise(resolve => {
-          finishVersionResolution = resolve;
-        }),
-    });
+    await expect(
+      create({
+        projectName: 'my-project',
+        resolveVersionTag: vi.fn().mockResolvedValue('latest'),
+      }),
+    ).resolves.toBeUndefined();
 
-    await vi.waitFor(() => expect(credentials.getToken).toHaveBeenCalledOnce());
-    process.emit('SIGINT');
-    expect(authSignal?.aborted).toBe(true);
-    finishVersionResolution?.('latest');
-
-    await expect(createPromise).resolves.toBeUndefined();
+    expect(credentials.getToken).toHaveBeenCalledWith(expect.any(AbortSignal), { skipOnInput: true });
     expect(prompts.log.info).toHaveBeenCalledWith('Skipping Mastra platform setup.');
     expect(publishStagedProject).toHaveBeenCalledOnce();
     expect(observability.provisionObservabilityProject).not.toHaveBeenCalled();
@@ -653,12 +640,10 @@ describe('managed observability', () => {
     expect(prompts.outro).toHaveBeenCalledOnce();
   });
 
-  it('continues materialization when Ctrl+C cancels Mastra platform setup', async () => {
+  it('cancels creation when Ctrl+C is pressed during Mastra platform setup', async () => {
     const { create } = await import('./create');
     const prompts = await import('@clack/prompts');
     const orgs = await import('../auth/orgs.js');
-    const observability = await import('../init/observability-provision');
-    const initUtils = await import('../init/utils.js');
     const skills = await import('../init/skills-install');
     const commandUtils = await import('../utils.js');
     const { installDependencies } = await import('../../utils/clone-template');
@@ -694,15 +679,12 @@ describe('managed observability', () => {
     process.emit('SIGINT');
     finishInstall?.();
 
-    await expect(createPromise).resolves.toBeUndefined();
-    expect(prompts.log.info).toHaveBeenCalledWith('Skipping Mastra platform setup.');
-    expect(publishStagedProject).toHaveBeenCalledOnce();
-    expect(skills.installMastraSkills).toHaveBeenCalledOnce();
-    expect(commandUtils.gitInit).toHaveBeenCalledOnce();
-    expect(observability.provisionObservabilityProject).not.toHaveBeenCalled();
-    expect(initUtils.writeObservabilityEnv).not.toHaveBeenCalled();
-    expect(prompts.cancel).not.toHaveBeenCalled();
-    expect(prompts.outro).toHaveBeenCalledOnce();
+    await expect(createPromise).rejects.toMatchObject({ name: 'CreateCancelledError' });
+    expect(prompts.cancel).toHaveBeenCalledWith('Operation cancelled');
+    expect(publishStagedProject).not.toHaveBeenCalled();
+    expect(skills.installMastraSkills).not.toHaveBeenCalled();
+    expect(commandUtils.gitInit).not.toHaveBeenCalled();
+    expect(prompts.outro).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -7,7 +7,7 @@ import { getAnalytics } from '../../analytics/index';
 import { cloneTemplate, installDependencies } from '../../utils/clone-template';
 import { findTemplateByName, loadTemplates, selectTemplate } from '../../utils/template-utils';
 import type { Template } from '../../utils/template-utils';
-import { getToken } from '../auth/credentials.js';
+import { getToken, LoginCancelledError } from '../auth/credentials.js';
 import { OrgSelectionCancelledError, resolveCurrentOrg } from '../auth/orgs.js';
 import { provisionObservabilityProject } from '../init/observability-provision';
 import { installMastraSkills } from '../init/skills-install';
@@ -248,7 +248,6 @@ export const create = async (args: CreateOptions): Promise<void> => {
   let llmApiKey = options.llmApiKey;
   let providerSelectionMethod: 'cli_args' | 'interactive' | undefined;
   let observabilityEnabled = false;
-  let platformSetupActive = false;
   let platformSetupController: AbortController | undefined;
   let platformSetupPromise: Promise<PlatformSetupResult> | undefined;
 
@@ -276,12 +275,9 @@ export const create = async (args: CreateOptions): Promise<void> => {
       });
       if (observabilityEnabled) {
         platformSetupController = new AbortController();
-        platformSetupActive = true;
-        const cancelPlatformSetup = () => platformSetupController?.abort();
-        process.on('SIGINT', cancelPlatformSetup);
         platformSetupPromise = (async (): Promise<PlatformSetupResult> => {
           try {
-            const token = await getToken(platformSetupController!.signal);
+            const token = await getToken(platformSetupController!.signal, { skipOnInput: true });
             const org = await resolveCurrentOrg(token, {
               forcePrompt: true,
               exitOnCancel: false,
@@ -289,13 +285,10 @@ export const create = async (args: CreateOptions): Promise<void> => {
             });
             return { status: 'ready', token, org };
           } catch (error) {
-            if (platformSetupController!.signal.aborted || error instanceof OrgSelectionCancelledError) {
+            if (error instanceof LoginCancelledError || error instanceof OrgSelectionCancelledError) {
               return { status: 'cancelled' };
             }
             return { status: 'failed', error };
-          } finally {
-            platformSetupActive = false;
-            process.removeListener('SIGINT', cancelPlatformSetup);
           }
         })();
       }
@@ -328,10 +321,6 @@ export const create = async (args: CreateOptions): Promise<void> => {
   const materializationController = new AbortController();
   let interruptionSignal: 'SIGINT' | 'SIGTERM' | undefined;
   const interrupt = (signal: 'SIGINT' | 'SIGTERM') => {
-    if (signal === 'SIGINT' && platformSetupActive) {
-      platformSetupController?.abort();
-      return;
-    }
     interruptionSignal ??= signal;
     materializationController.abort();
     platformSetupController?.abort();

--- a/packages/cli/src/internal/auth.ts
+++ b/packages/cli/src/internal/auth.ts
@@ -17,9 +17,15 @@ export {
   throwApiError,
 } from '../commands/auth/client.js';
 
-export { getToken, loadCredentials, saveCredentials, validateOrgAccess } from '../commands/auth/credentials.js';
+export {
+  getToken,
+  loadCredentials,
+  LoginCancelledError,
+  saveCredentials,
+  validateOrgAccess,
+} from '../commands/auth/credentials.js';
 
-export type { Credentials } from '../commands/auth/credentials.js';
+export type { Credentials, LoginOptions } from '../commands/auth/credentials.js';
 
 export { resolveCurrentOrg, OrgSelectionCancelledError } from '../commands/auth/orgs.js';
 


### PR DESCRIPTION
## Description

The current platform prompt during onboarding of `npm create factory` tells you that you can use Ctrl + C to skip the setup (if not logged in already). This now says "Any key to skip" instead. If you use Ctrl + C, it will now kill the whole process.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The setup wizard now lets you press any key to skip optional platform sign-in. Pressing Ctrl+C truly cancels the setup instead of skipping it.

## What changed

- Added skip-on-input support to CLI authentication.
- Added cancellation handling with `LoginCancelledError`.
- Updated Factory and project creation flows to:
  - Continue normally when platform setup is skipped.
  - Stop cleanly on Ctrl+C.
  - Display appropriate next steps for manual configuration.
- Added tests covering keypress skipping, Ctrl+C cancellation, and setup flow behavior.
- Added patch changesets for the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->