### PR TITLE
Route @mastra/platform-workspace to regional workspace proxies

### DIFF
--- a/.changeset/chatty-teeth-attend.md
+++ b/.changeset/chatty-teeth-attend.md
@@ -3,3 +3,13 @@
 ---
 
 Added automatic regional workspace proxy routing for EU and US Platform deployments while preserving explicit proxy overrides and the legacy fallback.
+
+```bash
+# Injected by Platform on managed deployments; EU deployments route to the EU proxy.
+MASTRA_PLATFORM_REGION=EU npm start
+
+# An explicit proxy URL still takes precedence over the region.
+MASTRA_WORKSPACE_PROXY_URL=https://workspaces.example.com npm start
+```
+
+Runtimes without a region variable continue to use `https://workspaces.mastra.ai`.

--- a/.changeset/chatty-teeth-attend.md
+++ b/.changeset/chatty-teeth-attend.md
@@ -1,0 +1,5 @@
+---
+'@mastra/platform-workspace': patch
+---
+
+Added automatic regional workspace proxy routing for EU and US Platform deployments while preserving explicit proxy overrides and the legacy fallback.

--- a/.changeset/fuzzy-ducks-route.md
+++ b/.changeset/fuzzy-ducks-route.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Route Platform GitHub and Linear integration calls through the regional integrations service selected by `MASTRA_PLATFORM_REGION`, with constructor `region` options taking precedence.

--- a/mastracode/factory/src/integrations/platform/api-client.test.ts
+++ b/mastracode/factory/src/integrations/platform/api-client.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { PlatformApiClient, PlatformApiError, platformApiClientConfigFromEnv } from './api-client.js';
+import {
+  PlatformApiClient,
+  PlatformApiError,
+  platformApiClientConfigFromEnv,
+  platformIntegrationsClientConfigFromEnv,
+} from './api-client.js';
 
 const accessToken = 'platform-secret-token';
 
@@ -39,6 +44,26 @@ describe('PlatformApiClient', () => {
     vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
     vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'legacy-token');
     expect(() => platformApiClientConfigFromEnv()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
+  });
+
+  it('routes integration clients from MASTRA_PLATFORM_REGION with constructor override precedence', () => {
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', accessToken);
+    vi.stubEnv('MASTRA_PLATFORM_REGION', 'EU');
+
+    expect(platformIntegrationsClientConfigFromEnv()).toEqual({
+      baseUrl: 'https://integrations.eu.mastra.ai',
+      accessToken,
+    });
+    expect(platformIntegrationsClientConfigFromEnv({ region: 'US' })).toEqual({
+      baseUrl: 'https://integrations.mastra.ai',
+      accessToken,
+    });
+
+    vi.stubEnv('MASTRA_PLATFORM_REGION', 'unknown');
+    expect(platformIntegrationsClientConfigFromEnv()).toEqual({
+      baseUrl: 'https://integrations.mastra.ai',
+      accessToken,
+    });
   });
 
   it('uses bearer authentication without ambient cookie credentials', async () => {

--- a/mastracode/factory/src/integrations/platform/api-client.ts
+++ b/mastracode/factory/src/integrations/platform/api-client.ts
@@ -4,17 +4,44 @@ export interface PlatformApiClientConfig {
   fetchImpl?: typeof fetch;
 }
 
+export interface PlatformIntegrationsClientOptions {
+  region?: string;
+}
+
+const DEFAULT_PLATFORM_API_URL = 'https://platform.mastra.ai/v1';
+const DEFAULT_INTEGRATIONS_URL = 'https://integrations.mastra.ai';
+const REGIONAL_INTEGRATIONS_URLS: Record<string, string> = {
+  EU: 'https://integrations.eu.mastra.ai',
+  US: DEFAULT_INTEGRATIONS_URL,
+};
+
 export function platformApiClientConfigFromEnv(): PlatformApiClientConfig {
-  const sharedApiUrl = process.env.MASTRA_SHARED_API_URL?.trim() || 'https://platform.mastra.ai/v1';
+  return {
+    baseUrl: normalizeBaseUrl(process.env.MASTRA_SHARED_API_URL?.trim() || DEFAULT_PLATFORM_API_URL),
+    accessToken: requirePlatformSecretKey(),
+  };
+}
+
+export function platformIntegrationsClientConfigFromEnv(
+  options: PlatformIntegrationsClientOptions = {},
+): PlatformApiClientConfig {
+  const region = (options.region ?? process.env.MASTRA_PLATFORM_REGION)?.trim().toUpperCase();
+  return {
+    baseUrl: normalizeBaseUrl((region ? REGIONAL_INTEGRATIONS_URLS[region] : undefined) ?? DEFAULT_INTEGRATIONS_URL),
+    accessToken: requirePlatformSecretKey(),
+  };
+}
+
+function requirePlatformSecretKey(): string {
   const accessToken = process.env.MASTRA_PLATFORM_SECRET_KEY?.trim();
   if (!accessToken) {
     throw new Error('Platform integration: missing required environment variable MASTRA_PLATFORM_SECRET_KEY.');
   }
-  return { baseUrl: normalizeSharedApiUrl(sharedApiUrl), accessToken };
+  return accessToken;
 }
 
-function normalizeSharedApiUrl(sharedApiUrl: string): string {
-  return sharedApiUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
 }
 
 export class PlatformApiError extends Error {

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -129,12 +129,12 @@ describe('PlatformGithubIntegration', () => {
     ]);
     expect(fetchImpl).toHaveBeenNthCalledWith(
       1,
-      'https://platform.example.com/v1/server/github-app/installations',
+      'https://integrations.mastra.ai/v1/server/github-app/installations',
       expect.objectContaining({ headers: expect.objectContaining({ authorization: 'Bearer platform-token' }) }),
     );
     expect(fetchImpl).toHaveBeenNthCalledWith(
       2,
-      'https://platform.example.com/v1/server/github-app/installations/7/repositories',
+      'https://integrations.mastra.ai/v1/server/github-app/installations/7/repositories',
       expect.anything(),
     );
     const [storedInstallation] = await storage.installations.list({ orgId: 'org-1' });
@@ -354,10 +354,10 @@ describe('PlatformGithubIntegration', () => {
     });
 
     expect(fetchImpl.mock.calls.map(call => [String(call[0]), (call[1] as RequestInit).method])).toEqual([
-      ['https://platform.example.com/v1/server/github/repos/acme/app/pulls', 'POST'],
-      ['https://platform.example.com/v1/server/github/repos/acme/app/pulls/34/reviews', 'POST'],
-      ['https://platform.example.com/v1/server/github/repos/acme/app/pulls/34/comments', 'POST'],
-      ['https://platform.example.com/v1/server/github/repos/acme/app/pulls/34/requested-reviewers', 'POST'],
+      ['https://integrations.mastra.ai/v1/server/github/repos/acme/app/pulls', 'POST'],
+      ['https://integrations.mastra.ai/v1/server/github/repos/acme/app/pulls/34/reviews', 'POST'],
+      ['https://integrations.mastra.ai/v1/server/github/repos/acme/app/pulls/34/comments', 'POST'],
+      ['https://integrations.mastra.ai/v1/server/github/repos/acme/app/pulls/34/requested-reviewers', 'POST'],
     ]);
     expect(JSON.parse(String((fetchImpl.mock.calls[1]?.[1] as RequestInit).body))).toMatchObject({ event: 'APPROVE' });
     expect(JSON.parse(String((fetchImpl.mock.calls[2]?.[1] as RequestInit).body))).toMatchObject({ side: 'RIGHT' });
@@ -724,7 +724,7 @@ describe('PlatformGithubIntegration', () => {
     expect(integration.workers(context).map(worker => worker.name)).toEqual(['platform-github-events']);
     expect(integration.diagnostics()).toEqual({
       mode: 'platform',
-      endpointHost: 'platform.example.com',
+      endpointHost: 'integrations.mastra.ai',
       polling: { enabled: true },
     });
     expect(JSON.stringify(integration.diagnostics())).not.toContain(config.accessToken);
@@ -870,7 +870,7 @@ describe('PlatformGithubIntegration', () => {
       reason: 'ready',
     });
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://platform.example.com/v1/server/github-app/user-connection?userId=user-1',
+      'https://integrations.mastra.ai/v1/server/github-app/user-connection?userId=user-1',
       expect.anything(),
     );
     await expect(context.storage.sourceControl.installations.list({ orgId: 'org-1' })).resolves.toEqual([
@@ -883,7 +883,7 @@ describe('PlatformGithubIntegration', () => {
       'https://github.com/apps/mastra/installations/new?state=platform-state',
     );
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://platform.example.com/v1/server/github-app/install-url?action=install&redirectTo=%2F&originator=https%3A%2F%2Ffactory.example',
+      'https://integrations.mastra.ai/v1/server/github-app/install-url?action=install&redirectTo=%2F&originator=https%3A%2F%2Ffactory.example',
       expect.anything(),
     );
 
@@ -893,7 +893,7 @@ describe('PlatformGithubIntegration', () => {
       'https://github.com/login/oauth/authorize?client_id=abc&state=platform-state',
     );
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://platform.example.com/v1/server/github-app/authenticate?userId=user-1&redirectTo=%2F&originator=https%3A%2F%2Ffactory.example',
+      'https://integrations.mastra.ai/v1/server/github-app/authenticate?userId=user-1&redirectTo=%2F&originator=https%3A%2F%2Ffactory.example',
       expect.anything(),
     );
   });
@@ -996,9 +996,17 @@ describe('PlatformGithubIntegration', () => {
     });
   });
 
-  it('defaults the Platform base URL and requires MASTRA_PLATFORM_SECRET_KEY', () => {
+  it('defaults the Platform integrations URL, honors regional overrides, and requires MASTRA_PLATFORM_SECRET_KEY', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', '');
-    expect(new PlatformGithubIntegration().diagnostics()).toMatchObject({ endpointHost: 'platform.mastra.ai' });
+    expect(new PlatformGithubIntegration().diagnostics()).toMatchObject({ endpointHost: 'integrations.mastra.ai' });
+
+    vi.stubEnv('MASTRA_PLATFORM_REGION', 'EU');
+    expect(new PlatformGithubIntegration().diagnostics()).toMatchObject({
+      endpointHost: 'integrations.eu.mastra.ai',
+    });
+    expect(new PlatformGithubIntegration({ region: 'US' }).diagnostics()).toMatchObject({
+      endpointHost: 'integrations.mastra.ai',
+    });
 
     vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
     vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'legacy-token');
@@ -1019,12 +1027,12 @@ describe('PlatformGithubIntegration', () => {
 
     await expect(integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace')).resolves.toBe('maintain');
     expect(String(fetchImpl.mock.calls[0]?.[0])).toBe(
-      'https://platform.example.com/v1/server/github/repos/acme/app/collaborators/grace/permission',
+      'https://integrations.mastra.ai/v1/server/github/repos/acme/app/collaborators/grace/permission',
     );
     expect(integration.workers({} as IntegrationContext)).toEqual([]);
     expect(integration.diagnostics()).toEqual({
       mode: 'platform',
-      endpointHost: 'platform.example.com',
+      endpointHost: 'integrations.mastra.ai',
       polling: { enabled: false, intervalMs: 9_000 },
     });
   });

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -57,10 +57,13 @@ import {
   logPlatformWarn,
   PlatformApiClient,
   PlatformApiError,
-  platformApiClientConfigFromEnv,
+  platformIntegrationsClientConfigFromEnv,
+  type PlatformIntegrationsClientOptions,
 } from '../api-client.js';
 import { PlatformGithubEventWorker } from './event-worker.js';
 import type { PlatformGithubEventStorage } from './event-worker.js';
+
+export interface PlatformGithubIntegrationOptions extends PlatformIntegrationsClientOptions {}
 
 type GithubActor = { login: string; avatarUrl: string | null; htmlUrl: string | null } | null;
 
@@ -399,8 +402,8 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     removeRequestedReviewers: input => this.#requestedReviewers('DELETE', input),
   };
 
-  constructor() {
-    const config = platformApiClientConfigFromEnv();
+  constructor(options: PlatformGithubIntegrationOptions = {}) {
+    const config = platformIntegrationsClientConfigFromEnv(options);
     this.#client = new PlatformApiClient(config);
     this.#endpointHost = new URL(config.baseUrl).host;
     this.#pollingEnabled = process.env.MASTRA_PLATFORM_GITHUB_POLLING_ENABLED?.trim().toLowerCase() !== 'false';

--- a/mastracode/factory/src/integrations/platform/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.test.ts
@@ -146,7 +146,7 @@ describe('PlatformLinearIntegration', () => {
     ]);
     expect(fetchImpl).toHaveBeenNthCalledWith(
       1,
-      'https://platform.example.com/v1/server/linear/workspaces',
+      'https://integrations.mastra.ai/v1/server/linear/workspaces',
       expect.objectContaining({ headers: expect.objectContaining({ authorization: 'Bearer platform-token' }) }),
     );
   });
@@ -480,7 +480,7 @@ describe('PlatformLinearIntegration', () => {
     await expect(integration.agentTools({ requestContext })).resolves.toEqual(
       expect.objectContaining({ linear_get_issue: expect.anything(), linear_create_comment: expect.anything() }),
     );
-    expect(integration.diagnostics()).toEqual({ mode: 'platform', endpointHost: 'platform.example.com' });
+    expect(integration.diagnostics()).toEqual({ mode: 'platform', endpointHost: 'integrations.mastra.ai' });
     expect(JSON.stringify(integration.diagnostics())).not.toContain(config.accessToken);
   });
 
@@ -549,11 +549,21 @@ describe('PlatformLinearIntegration', () => {
     );
   });
 
-  it('defaults the Platform base URL and requires MASTRA_PLATFORM_SECRET_KEY', () => {
+  it('defaults the Platform integrations URL, honors regional overrides, and requires MASTRA_PLATFORM_SECRET_KEY', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', '');
     expect(new PlatformLinearIntegration().diagnostics()).toEqual({
       mode: 'platform',
-      endpointHost: 'platform.mastra.ai',
+      endpointHost: 'integrations.mastra.ai',
+    });
+
+    vi.stubEnv('MASTRA_PLATFORM_REGION', 'EU');
+    expect(new PlatformLinearIntegration().diagnostics()).toEqual({
+      mode: 'platform',
+      endpointHost: 'integrations.eu.mastra.ai',
+    });
+    expect(new PlatformLinearIntegration({ region: 'US' }).diagnostics()).toEqual({
+      mode: 'platform',
+      endpointHost: 'integrations.mastra.ai',
     });
 
     vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');

--- a/mastracode/factory/src/integrations/platform/linear/integration.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.ts
@@ -19,7 +19,11 @@ import {
   PlatformApiClient,
   PlatformApiError,
   platformApiClientConfigFromEnv,
+  platformIntegrationsClientConfigFromEnv,
+  type PlatformIntegrationsClientOptions,
 } from '../api-client.js';
+
+export interface PlatformLinearIntegrationOptions extends PlatformIntegrationsClientOptions {}
 
 type PageInfo = { hasNextPage: boolean; endCursor: string | null };
 type LinearUser = {
@@ -95,6 +99,7 @@ function routeBaseUrl(ctx: IntegrationContext, requestUrl: string): string {
 export class PlatformLinearIntegration implements FactoryIntegration {
   readonly id = 'linear';
   readonly #client: PlatformApiClient;
+  readonly #platformClient: PlatformApiClient;
   readonly #endpointHost: string;
   #projects: FactoryProjectsStorage | undefined;
   #auth: RouteAuth | undefined;
@@ -243,9 +248,10 @@ export class PlatformLinearIntegration implements FactoryIntegration {
     },
   };
 
-  constructor() {
-    const config = platformApiClientConfigFromEnv();
+  constructor(options: PlatformLinearIntegrationOptions = {}) {
+    const config = platformIntegrationsClientConfigFromEnv(options);
     this.#client = new PlatformApiClient(config);
+    this.#platformClient = new PlatformApiClient(platformApiClientConfigFromEnv());
     this.#endpointHost = new URL(config.baseUrl).host;
   }
 
@@ -387,7 +393,7 @@ export class PlatformLinearIntegration implements FactoryIntegration {
           originator,
         });
         const query = new URLSearchParams({ return_to: returnTo, originator });
-        const location = await this.#client.requestRedirect('GET', `${API_PREFIX}/authorize?${query}`);
+        const location = await this.#platformClient.requestRedirect('GET', `${API_PREFIX}/authorize?${query}`);
         return c.redirect(location);
       },
     });

--- a/workspaces/platform-workspace/README.md
+++ b/workspaces/platform-workspace/README.md
@@ -21,7 +21,7 @@ All options can be passed to the constructor or read from environment variables:
 
 `MASTRA_PLATFORM_ACCESS_TOKEN` is still read as a deprecated fallback for `accessToken`.
 
-The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` env var (useful for staging).
+The proxy URL is selected from the Platform-managed `MASTRA_PLATFORM_REGION`: `EU` uses `https://workspaces.eu.mastra.ai` and `US` uses `https://workspaces.us.mastra.ai`. Missing or unknown regions continue to use the backward-compatible `https://workspaces.mastra.ai` endpoint. `MASTRA_WORKSPACE_PROXY_URL` remains the highest-priority override for staging and local development.
 
 Requests to the proxy are authenticated with `Authorization: Bearer <accessToken>`.
 

--- a/workspaces/platform-workspace/src/client.test.ts
+++ b/workspaces/platform-workspace/src/client.test.ts
@@ -29,6 +29,41 @@ describe('PlatformClient', () => {
     expect(init.method).toBe('POST');
   });
 
+  it.each([
+    ['EU', 'https://workspaces.eu.mastra.ai'],
+    ['eu', 'https://workspaces.eu.mastra.ai'],
+    ['US', 'https://workspaces.us.mastra.ai'],
+    ['us', 'https://workspaces.us.mastra.ai'],
+  ])('selects the %s regional workspace proxy', (region, expectedProxyUrl) => {
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'sk_secret');
+    vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');
+    vi.stubEnv('MASTRA_PLATFORM_REGION', region);
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', undefined);
+
+    expect(resolvePlatformOptions({}).proxyUrl).toBe(expectedProxyUrl);
+  });
+
+  it.each([undefined, '', 'APAC', 'unknown'])(
+    'falls back to the legacy workspace proxy for missing or unknown region %s',
+    region => {
+      vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'sk_secret');
+      vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');
+      vi.stubEnv('MASTRA_PLATFORM_REGION', region);
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', undefined);
+
+      expect(resolvePlatformOptions({}).proxyUrl).toBe('https://workspaces.mastra.ai');
+    },
+  );
+
+  it('prefers MASTRA_WORKSPACE_PROXY_URL over regional routing', () => {
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'sk_secret');
+    vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');
+    vi.stubEnv('MASTRA_PLATFORM_REGION', 'EU');
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test/');
+
+    expect(resolvePlatformOptions({}).proxyUrl).toBe('https://proxy.test');
+  });
+
   it('reads the access token from MASTRA_PLATFORM_SECRET_KEY', () => {
     vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'sk_secret');
     vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');

--- a/workspaces/platform-workspace/src/client.ts
+++ b/workspaces/platform-workspace/src/client.ts
@@ -9,6 +9,18 @@ export interface PlatformRequestOptions extends RequestInit {
 }
 
 const DEFAULT_PROXY_URL = 'https://workspaces.mastra.ai';
+const REGIONAL_PROXY_URLS: Record<string, string> = {
+  EU: 'https://workspaces.eu.mastra.ai',
+  US: 'https://workspaces.us.mastra.ai',
+};
+
+function resolveProxyUrl(env: NodeJS.ProcessEnv): string {
+  const override = env.MASTRA_WORKSPACE_PROXY_URL?.trim();
+  if (override) return override.replace(/\/+$/, '');
+
+  const region = env.MASTRA_PLATFORM_REGION?.trim().toUpperCase();
+  return (region ? REGIONAL_PROXY_URLS[region] : undefined) ?? DEFAULT_PROXY_URL;
+}
 
 /**
  * Default per-request timeout for calls to the workspace proxy. Applied only
@@ -32,7 +44,7 @@ export function resolvePlatformOptions(options: PlatformClientOptions) {
       'accessToken',
     ),
     projectId: requireOption(options.projectId ?? process.env.MASTRA_PROJECT_ID, 'projectId'),
-    proxyUrl: (process.env.MASTRA_WORKSPACE_PROXY_URL ?? DEFAULT_PROXY_URL).replace(/\/$/, ''),
+    proxyUrl: resolveProxyUrl(process.env),
     fetch: options.fetch ?? fetch,
   };
 }


### PR DESCRIPTION
## Summary

Third of three PRs for regional workspace-proxy routing (after mastra-ai/infrastructure#197 and mastra-ai/platform#1772). `@mastra/platform-workspace` now selects the workspace-proxy base URL from the runtime region so EU deployments get low-latency sandbox and filesystem operations.

### Resolution order in `resolvePlatformOptions()`
1. Explicit `MASTRA_WORKSPACE_PROXY_URL` — unchanged, highest priority.
2. `MASTRA_PLATFORM_REGION` (case-insensitive, injected by Platform as a managed deployment variable):
   - `EU` → `https://workspaces.eu.mastra.ai`
   - `US` → `https://workspaces.us.mastra.ai`
3. Missing/unknown region → legacy `https://workspaces.mastra.ai` (US), fully backward compatible.

### Changes
- `workspaces/platform-workspace/src/client.ts`: region-to-endpoint mapping in `resolvePlatformOptions()`.
- `workspaces/platform-workspace/src/client.test.ts`: EU/US routing, precedence of explicit override, and unknown-region fallback regressions.
- README configuration docs + patch changeset.

No behavior change for `PlatformSandbox`/`PlatformFilesystem` beyond base-URL selection; both replicas are stateless and share persistence/auth.

## Test plan
- [x] `@mastra/platform-workspace` vitest: 3 files / 35 tests pass.
- [x] Package build, lint, and Prettier pass.
- [ ] After infra + platform merge: verify an EU deployment resolves `workspaces.eu.mastra.ai` and a runtime without the region variable still resolves `workspaces.mastra.ai`.

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When your app asks for a “workspace,” this change automatically sends that request to the right EU or US workspace service based on `MASTRA_PLATFORM_REGION`. If you explicitly set `MASTRA_WORKSPACE_PROXY_URL`, that custom URL always wins; otherwise it falls back to the old `https://workspaces.mastra.ai` for missing/unknown regions.

## Changes
- Route `@mastra/platform-workspace` requests to regional workspace proxies based on `MASTRA_PLATFORM_REGION` (EU/US), with legacy fallback for missing/unknown values.
- Keep `MASTRA_WORKSPACE_PROXY_URL` as the highest-priority override (trims trailing slashes when set).
- Add regression tests covering region selection, fallback behavior, and override precedence.
- Update `workspaces/platform-workspace/README.md` with the new environment variable behavior and URL examples.
- Add a patch changeset documenting the usage/precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->