### PR TITLE
fix(core): remove stale ui-utils dependency

### DIFF
--- a/.changeset/gentle-insects-read.md
+++ b/.changeset/gentle-insects-read.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Zod 4 installations reporting peer dependency warnings.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -856,7 +856,6 @@
     "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.3",
     "@ai-sdk/provider-v6": "npm:@ai-sdk/provider@3.0.14",
     "@ai-sdk/provider-v7": "npm:@ai-sdk/provider@4.0.3",
-    "@ai-sdk/ui-utils-v5": "npm:@ai-sdk/ui-utils@1.2.11",
     "@isaacs/ttlcache": "^2.1.4",
     "@lukeed/uuid": "^2.0.1",
     "@mastra/schema-compat": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4318,9 +4318,6 @@ importers:
       '@ai-sdk/provider-v7':
         specifier: npm:@ai-sdk/provider@4.0.3
         version: '@ai-sdk/provider@4.0.3'
-      '@ai-sdk/ui-utils-v5':
-        specifier: npm:@ai-sdk/ui-utils@1.2.11
-        version: '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)'
       '@isaacs/ttlcache':
         specifier: ^2.1.4
         version: 2.1.4


### PR DESCRIPTION
Removes the stale `@ai-sdk/ui-utils-v5` dependency from `@mastra/core`. Its type-only usages were replaced in #16994, but the dependency was later reintroduced by an unrelated auth refactor. Keeping it in Core's published graph makes clean Zod 4 installs report two incorrect peer dependency warnings.

Validated with `pnpm build:core`, `pnpm --filter ./packages/core check`, a frozen lockfile check, and a Bun install/import smoke using the packed tarball with `zod@4.4.3`. The clean Bun install no longer reports the warning.

Fixes #16993

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

`@mastra/core` was carrying an unused package that expected an older version of Zod. This removes it so Zod 4 users can install Core without misleading dependency warnings.

## Changes

- Removed `@ai-sdk/ui-utils-v5` from `@mastra/core` dependencies.
- Added a patch changeset documenting the Zod 4 installation fix.
- Validated with core builds/checks, frozen lockfile checks, and a Zod 4.4.3 tarball install/import smoke test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->