### PR TITLE
fix: stop per-delta message deep clones (OOM) and prune stale TUI references

### DIFF
--- a/.changeset/mighty-cameras-leave.md
+++ b/.changeset/mighty-cameras-leave.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed runaway terminal rendering allocations in long Mastra Code sessions by bounding retained chat history and releasing stale component references.

--- a/.changeset/mighty-cameras-leave.md
+++ b/.changeset/mighty-cameras-leave.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Fixed runaway terminal rendering allocations in long Mastra Code sessions by bounding retained chat history and releasing stale component references.
+Fixed oversized chat trees continuing to grow during streaming renders and released stale references when old components are pruned.

--- a/.changeset/violet-eyes-argue.md
+++ b/.changeset/violet-eyes-argue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed out-of-memory crashes during long streamed responses by replacing the per-delta deep clone of the accumulated message in the agent-controller run engine with a shallow snapshot that shares immutable payloads. Previously every text/reasoning/tool delta cloned the entire message content — including embedded tool results — making allocation quadratic in message size and exhausting the V8 heap when subscribers retained snapshots (e.g. plugin tools such as adversarial review).

--- a/mastracode/tui/package.json
+++ b/mastracode/tui/package.json
@@ -82,6 +82,7 @@
     "render-smoke:install": "node scripts/install-render-smoke-settings.mjs",
     "render-smoke:server": "node scripts/render-smoke-server.mjs",
     "render-smoke:uninstall": "node scripts/uninstall-render-smoke-settings.mjs",
+    "repro:render-churn": "node --expose-gc scripts/repro-render-churn.mjs",
     "test": "vitest",
     "lint": "oxlint . && eslint .",
     "lint:fix": "oxlint --fix . && eslint --fix .",

--- a/mastracode/tui/scripts/README.md
+++ b/mastracode/tui/scripts/README.md
@@ -1,5 +1,30 @@
 # Mastra Code scripts
 
+## Render churn reproduction
+
+This deterministic benchmark measures the cumulative output allocated when `pi-tui` repeatedly renders a retained chat tree. It does not call a model or read user settings.
+
+Reproduce the former 5,000-child chat buffer under 30,000 renders (40 minutes at the TUI's 80 ms render interval):
+
+```sh
+pnpm --filter ./mastracode/tui repro:render-churn -- 5000 30000 2000 120
+```
+
+Compare it with the restored 200-child limit:
+
+```sh
+pnpm --filter ./mastracode/tui repro:render-churn -- 200 30000 2000 120
+```
+
+Arguments are `childCount`, `renders`, `payloadBytes`, and terminal `width`. The JSON result reports cumulative rendered GiB, elapsed time, RSS, V8 heap, and peak RSS. `renderedGiB` represents allocation/output churn, not simultaneously resident memory.
+
+Reference results on an Apple Silicon Mac with Node 24.11.1:
+
+| Children | Renders |   Rendered |  Elapsed |  Peak RSS |
+| -------: | ------: | ---------: | -------: | --------: |
+|    5,000 |  30,000 | 301.75 GiB | 120.30 s | 340.9 MiB |
+|      200 |  30,000 |  12.07 GiB |   4.31 s |  96.4 MiB |
+
 ## Render Smoke
 
 Render Smoke is a local OpenAI-compatible streaming mock used to stress-test Mastra Code TUI rendering with large streamed tool arguments.

--- a/mastracode/tui/scripts/README.md
+++ b/mastracode/tui/scripts/README.md
@@ -4,13 +4,13 @@
 
 This deterministic benchmark measures the cumulative output allocated when `pi-tui` repeatedly renders a retained chat tree. It does not call a model or read user settings.
 
-Reproduce the former 5,000-child chat buffer under 30,000 renders (40 minutes at the TUI's 80 ms render interval):
+Measure the current 5,000-child chat buffer under 30,000 renders (40 minutes at the TUI's 80 ms render interval):
 
 ```sh
 pnpm --filter ./mastracode/tui repro:render-churn -- 5000 30000 2000 120
 ```
 
-Compare it with the restored 200-child limit:
+Compare the render amplification against a 200-child tree:
 
 ```sh
 pnpm --filter ./mastracode/tui repro:render-churn -- 200 30000 2000 120

--- a/mastracode/tui/scripts/repro-render-churn.mjs
+++ b/mastracode/tui/scripts/repro-render-churn.mjs
@@ -1,0 +1,65 @@
+import { Container, Text } from '@earendil-works/pi-tui';
+
+const args = process.argv.slice(2).filter(argument => argument !== '--');
+const childCount = parsePositiveInteger(args[0] ?? '5000', 'childCount');
+const renders = parsePositiveInteger(args[1] ?? '30000', 'renders');
+const payloadBytes = parsePositiveInteger(args[2] ?? '2000', 'payloadBytes');
+const width = parsePositiveInteger(args[3] ?? '120', 'width');
+
+const container = new Container();
+const payload = 'x'.repeat(payloadBytes);
+for (let index = 0; index < childCount; index++) {
+  container.addChild(new Text(`${index}: ${payload}`, 0, 0));
+}
+
+globalThis.gc?.();
+const before = process.memoryUsage();
+const startedAt = performance.now();
+let renderedBytes = 0;
+
+for (let index = 0; index < renders; index++) {
+  const lines = container.render(width);
+  for (const line of lines) {
+    renderedBytes += Buffer.byteLength(line);
+  }
+}
+
+globalThis.gc?.();
+const elapsedMs = performance.now() - startedAt;
+const after = process.memoryUsage();
+const usage = process.resourceUsage();
+
+console.log(
+  JSON.stringify(
+    {
+      childCount,
+      renders,
+      payloadBytes,
+      width,
+      elapsedMs: Math.round(elapsedMs),
+      renderedGiB: toGiB(renderedBytes),
+      beforeRssMiB: toMiB(before.rss),
+      afterRssMiB: toMiB(after.rss),
+      afterHeapUsedMiB: toMiB(after.heapUsed),
+      maxRssMiB: Number((usage.maxRSS / 1024).toFixed(1)),
+    },
+    null,
+    2,
+  ),
+);
+
+function parsePositiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer, received: ${value}`);
+  }
+  return parsed;
+}
+
+function toMiB(bytes) {
+  return Number((bytes / 1024 ** 2).toFixed(1));
+}
+
+function toGiB(bytes) {
+  return Number((bytes / 1024 ** 3).toFixed(2));
+}

--- a/mastracode/tui/src/tui/__tests__/prune-chat.test.ts
+++ b/mastracode/tui/src/tui/__tests__/prune-chat.test.ts
@@ -28,8 +28,8 @@ function createState(childrenCount: number): TUIState {
 }
 
 describe('pruneChatContainer', () => {
-  it('keeps the last 100 children and removes every reference to pruned components', () => {
-    const state = createState(201);
+  it('keeps the last 3000 children and removes every reference to pruned components', () => {
+    const state = createState(5001);
 
     const removedTool = { toolName: 'removed-tool' };
     const keptTool = { toolName: 'kept-tool' };
@@ -53,11 +53,11 @@ describe('pruneChatContainer', () => {
     state.chatContainer.children[60] = removedSubagent;
     state.chatContainer.children[70] = removedAskUser;
     state.chatContainer.children[80] = removedSubmitPlan;
-    state.chatContainer.children[150] = keptTool as any;
-    state.chatContainer.children[170] = keptSlash as any;
-    state.chatContainer.children[180] = keptReminder as any;
-    state.chatContainer.children[190] = keptShell as any;
-    state.chatContainer.children[200] = keptMessage;
+    state.chatContainer.children[3500] = keptTool as any;
+    state.chatContainer.children[3700] = keptSlash as any;
+    state.chatContainer.children[3800] = keptReminder as any;
+    state.chatContainer.children[3900] = keptShell as any;
+    state.chatContainer.children[5000] = keptMessage;
 
     state.allToolComponents = [removedTool as any, keptTool as any];
     state.allSlashCommandComponents = [removedSlash, keptSlash];
@@ -71,12 +71,12 @@ describe('pruneChatContainer', () => {
 
     pruneChatContainer(state);
 
-    expect(state.chatContainer.children).toHaveLength(100);
-    expect(state.chatContainer.children[49]).toBe(keptTool);
-    expect(state.chatContainer.children[69]).toBe(keptSlash);
-    expect(state.chatContainer.children[79]).toBe(keptReminder);
-    expect(state.chatContainer.children[89]).toBe(keptShell);
-    expect(state.chatContainer.children[99]).toBe(keptMessage);
+    expect(state.chatContainer.children).toHaveLength(3000);
+    expect(state.chatContainer.children[1499]).toBe(keptTool);
+    expect(state.chatContainer.children[1699]).toBe(keptSlash);
+    expect(state.chatContainer.children[1799]).toBe(keptReminder);
+    expect(state.chatContainer.children[1899]).toBe(keptShell);
+    expect(state.chatContainer.children[2999]).toBe(keptMessage);
     expect(state.allToolComponents).toEqual([keptTool]);
     expect(state.allSlashCommandComponents).toEqual([keptSlash]);
     expect(state.allSystemReminderComponents).toEqual([keptReminder]);
@@ -88,12 +88,12 @@ describe('pruneChatContainer', () => {
   });
 
   it('does nothing when the container is already within the limit', () => {
-    const state = createState(200);
+    const state = createState(5000);
     const originalChildren = [...state.chatContainer.children];
 
     pruneChatContainer(state);
 
-    expect(state.chatContainer.children).toHaveLength(200);
+    expect(state.chatContainer.children).toHaveLength(5000);
     expect(state.chatContainer.children).toEqual(originalChildren);
   });
 });

--- a/mastracode/tui/src/tui/__tests__/prune-chat.test.ts
+++ b/mastracode/tui/src/tui/__tests__/prune-chat.test.ts
@@ -18,14 +18,18 @@ function createState(childrenCount: number): TUIState {
     allToolComponents: [],
     allSlashCommandComponents: [],
     allSystemReminderComponents: [],
+    messageComponentsById: new Map(),
     allShellComponents: [],
+    pendingSubagents: new Map(),
+    pendingAskUserComponents: new Map(),
+    pendingSubmitPlanComponents: new Map(),
     pendingSignalMessageComponentsById: new Map(),
   } as unknown as TUIState;
 }
 
 describe('pruneChatContainer', () => {
-  it('keeps the last 3000 children and removes tracked components that were pruned', () => {
-    const state = createState(6000);
+  it('keeps the last 100 children and removes every reference to pruned components', () => {
+    const state = createState(201);
 
     const removedTool = { toolName: 'removed-tool' };
     const keptTool = { toolName: 'kept-tool' };
@@ -35,41 +39,61 @@ describe('pruneChatContainer', () => {
     const keptReminder = new SystemReminderComponent({ message: 'Kept body' });
     const removedShell = { id: 'removed-shell' };
     const keptShell = { id: 'kept-shell' };
+    const removedMessage = new Text('removed-message', 0, 0);
+    const keptMessage = new Text('kept-message', 0, 0);
+    const removedSubagent = new Text('removed-subagent', 0, 0);
+    const removedAskUser = new Text('removed-ask-user', 0, 0);
+    const removedSubmitPlan = new Text('removed-submit-plan', 0, 0);
 
     state.chatContainer.children[10] = removedTool as any;
     state.chatContainer.children[20] = removedSlash as any;
     state.chatContainer.children[30] = removedReminder as any;
     state.chatContainer.children[40] = removedShell as any;
-    state.chatContainer.children[5500] = keptTool as any;
-    state.chatContainer.children[5700] = keptSlash as any;
-    state.chatContainer.children[5800] = keptReminder as any;
-    state.chatContainer.children[5900] = keptShell as any;
+    state.chatContainer.children[50] = removedMessage;
+    state.chatContainer.children[60] = removedSubagent;
+    state.chatContainer.children[70] = removedAskUser;
+    state.chatContainer.children[80] = removedSubmitPlan;
+    state.chatContainer.children[150] = keptTool as any;
+    state.chatContainer.children[170] = keptSlash as any;
+    state.chatContainer.children[180] = keptReminder as any;
+    state.chatContainer.children[190] = keptShell as any;
+    state.chatContainer.children[200] = keptMessage;
 
     state.allToolComponents = [removedTool as any, keptTool as any];
     state.allSlashCommandComponents = [removedSlash, keptSlash];
     state.allSystemReminderComponents = [removedReminder, keptReminder];
     state.allShellComponents = [removedShell as any, keptShell as any];
+    state.messageComponentsById.set('removed', removedMessage);
+    state.messageComponentsById.set('kept', keptMessage);
+    state.pendingSubagents.set('removed', removedSubagent as any);
+    state.pendingAskUserComponents.set('removed', removedAskUser as any);
+    state.pendingSubmitPlanComponents.set('removed', removedSubmitPlan as any);
 
     pruneChatContainer(state);
 
-    expect(state.chatContainer.children).toHaveLength(3000);
-    expect(state.chatContainer.children[2500]).toBe(keptTool);
-    expect(state.chatContainer.children[2700]).toBe(keptSlash);
-    expect(state.chatContainer.children[2800]).toBe(keptReminder);
-    expect(state.chatContainer.children[2900]).toBe(keptShell);
+    expect(state.chatContainer.children).toHaveLength(100);
+    expect(state.chatContainer.children[49]).toBe(keptTool);
+    expect(state.chatContainer.children[69]).toBe(keptSlash);
+    expect(state.chatContainer.children[79]).toBe(keptReminder);
+    expect(state.chatContainer.children[89]).toBe(keptShell);
+    expect(state.chatContainer.children[99]).toBe(keptMessage);
     expect(state.allToolComponents).toEqual([keptTool]);
     expect(state.allSlashCommandComponents).toEqual([keptSlash]);
     expect(state.allSystemReminderComponents).toEqual([keptReminder]);
     expect(state.allShellComponents).toEqual([keptShell]);
+    expect(state.messageComponentsById).toEqual(new Map([['kept', keptMessage]]));
+    expect(state.pendingSubagents).toEqual(new Map());
+    expect(state.pendingAskUserComponents).toEqual(new Map());
+    expect(state.pendingSubmitPlanComponents).toEqual(new Map());
   });
 
   it('does nothing when the container is already within the limit', () => {
-    const state = createState(5000);
+    const state = createState(200);
     const originalChildren = [...state.chatContainer.children];
 
     pruneChatContainer(state);
 
-    expect(state.chatContainer.children).toHaveLength(5000);
+    expect(state.chatContainer.children).toHaveLength(200);
     expect(state.chatContainer.children).toEqual(originalChildren);
   });
 });

--- a/mastracode/tui/src/tui/__tests__/state.test.ts
+++ b/mastracode/tui/src/tui/__tests__/state.test.ts
@@ -160,12 +160,12 @@ describe('createTUIState', () => {
       session: session as never,
     });
 
-    state.chatContainer.children.push(...(Array.from({ length: 201 }, (_, index) => ({ index })) as never[]));
+    state.chatContainer.children.push(...(Array.from({ length: 5001 }, (_, index) => ({ index })) as never[]));
 
     state.renderScheduler!.flush();
 
-    expect(state.chatContainer.children).toHaveLength(100);
-    expect(state.chatContainer.children[0]).toEqual({ index: 101 });
+    expect(state.chatContainer.children).toHaveLength(3000);
+    expect(state.chatContainer.children[0]).toEqual({ index: 2001 });
     expect(state.ui.requestRender).toHaveBeenCalledOnce();
   });
 });

--- a/mastracode/tui/src/tui/__tests__/state.test.ts
+++ b/mastracode/tui/src/tui/__tests__/state.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('@earendil-works/pi-tui', () => {
   class MockContainer {
     children: unknown[] = [];
+    invalidate = vi.fn();
   }
 
   class MockProcessTerminal {
@@ -10,6 +11,8 @@ vi.mock('@earendil-works/pi-tui', () => {
   }
 
   class MockTUI {
+    requestRender = vi.fn();
+
     constructor(public terminal: MockProcessTerminal) {}
   }
 
@@ -148,5 +151,21 @@ describe('createTUIState', () => {
 
     expect(state.editor.getModeColor?.()).toBe('#7c3aed');
     expect(controller.session.mode.resolve).toHaveBeenCalled();
+  });
+
+  it('prunes retained chat history before rendering', () => {
+    const session = createSession();
+    const state = createTUIState({
+      controller: createAgentController(session) as never,
+      session: session as never,
+    });
+
+    state.chatContainer.children.push(...(Array.from({ length: 201 }, (_, index) => ({ index })) as never[]));
+
+    state.renderScheduler!.flush();
+
+    expect(state.chatContainer.children).toHaveLength(100);
+    expect(state.chatContainer.children[0]).toEqual({ index: 101 });
+    expect(state.ui.requestRender).toHaveBeenCalledOnce();
   });
 });

--- a/mastracode/tui/src/tui/prune-chat.ts
+++ b/mastracode/tui/src/tui/prune-chat.ts
@@ -2,8 +2,8 @@ import type { Component } from '@earendil-works/pi-tui';
 
 import type { TUIState } from './state.js';
 
-const MAX_CHILDREN = 200;
-const KEEP_CHILDREN = 100;
+const MAX_CHILDREN = 5000;
+const KEEP_CHILDREN = 3000;
 
 export function pruneChatContainer(state: TUIState): void {
   const children = state.chatContainer.children as Component[];

--- a/mastracode/tui/src/tui/prune-chat.ts
+++ b/mastracode/tui/src/tui/prune-chat.ts
@@ -2,8 +2,8 @@ import type { Component } from '@earendil-works/pi-tui';
 
 import type { TUIState } from './state.js';
 
-const MAX_CHILDREN = 5000;
-const KEEP_CHILDREN = 3000;
+const MAX_CHILDREN = 200;
+const KEEP_CHILDREN = 100;
 
 export function pruneChatContainer(state: TUIState): void {
   const children = state.chatContainer.children as Component[];
@@ -25,6 +25,26 @@ export function pruneChatContainer(state: TUIState): void {
   state.allShellComponents = state.allShellComponents.filter(
     component => !removed.has(component as unknown as Component),
   );
+  for (const [id, component] of state.messageComponentsById) {
+    if (removed.has(component)) {
+      state.messageComponentsById.delete(id);
+    }
+  }
+  for (const [id, component] of state.pendingSubagents) {
+    if (removed.has(component as unknown as Component)) {
+      state.pendingSubagents.delete(id);
+    }
+  }
+  for (const [id, component] of state.pendingAskUserComponents) {
+    if (removed.has(component as unknown as Component)) {
+      state.pendingAskUserComponents.delete(id);
+    }
+  }
+  for (const [id, component] of state.pendingSubmitPlanComponents) {
+    if (removed.has(component as unknown as Component)) {
+      state.pendingSubmitPlanComponents.delete(id);
+    }
+  }
   for (const [id, pending] of state.pendingSignalMessageComponentsById) {
     if (removed.has(pending.component as unknown as Component)) {
       state.pendingSignalMessageComponentsById.delete(id);

--- a/mastracode/tui/src/tui/state.ts
+++ b/mastracode/tui/src/tui/state.ts
@@ -40,6 +40,7 @@ import { showError, showInfo } from './display.js';
 
 import { GoalManager } from './goal-manager.js';
 import type { OnboardingInlineComponent } from './onboarding-inline.js';
+import { pruneChatContainer } from './prune-chat.js';
 import { RenderScheduler } from './render-scheduler.js';
 import { getEditorTheme, mastra, TERM_WIDTH_BUFFER } from './theme.js';
 import { VoiceController } from './voice/voice-controller.js';
@@ -344,7 +345,11 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
     });
   }
   const ui = new TUI(terminal);
-  const renderScheduler = new RenderScheduler(() => ui.requestRender());
+  let result: TUIState;
+  const renderScheduler = new RenderScheduler(() => {
+    pruneChatContainer(result);
+    ui.requestRender();
+  });
 
   // Perf profiling removed
 
@@ -353,7 +358,7 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
   const footer = new Container();
   const editor = new CustomEditor(ui, getEditorTheme());
   editor.requestRender = () => renderScheduler.request();
-  const result: TUIState = {
+  result = {
     // Core dependencies
     controller: options.controller,
     session: options.session,

--- a/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
@@ -222,6 +222,65 @@ describe('SessionRunEngine — MastraDBMessage contract', () => {
     expect(callPart.toolInvocation).not.toHaveProperty('result');
   });
 
+  it('Given an emitted snapshot, When later chunks mutate reasoning and metadata in place, Then the snapshot is unchanged', async () => {
+    const { engine, events } = createHarness();
+    const state = engine.createStreamState();
+    const ctx = requestContext();
+
+    await engine.processStreamChunk(state, chunk({ type: 'reasoning-start', payload: { id: 'r1' } }), ctx);
+    await engine.processStreamChunk(
+      state,
+      chunk({ type: 'reasoning-delta', payload: { id: 'r1', text: 'first' } }),
+      ctx,
+    );
+    const snapshot = lastMessageEvent(events);
+
+    await engine.processStreamChunk(
+      state,
+      chunk({ type: 'reasoning-delta', payload: { id: 'r1', text: ' second' } }),
+      ctx,
+    );
+    // Rotating the message calls setStopReason(), which mutates content.metadata in place.
+    await engine.processStreamChunk(state, chunk({ type: 'data-user-message', data: { id: 'sig-1' } }), ctx);
+
+    expect(snapshot.content.parts).toEqual([
+      { type: 'reasoning', reasoning: 'first', details: [{ type: 'text', text: 'first' }] },
+    ]);
+    expect(snapshot.content.metadata?.stopReason).toBeUndefined();
+  });
+
+  it('Given consecutive snapshots, When emitted, Then they share unmutated payloads instead of deep-cloning them', async () => {
+    // cloneMessage() runs on EVERY stream delta. It must copy only the levels
+    // the engine mutates in place, sharing everything deeper (tool args/results,
+    // strings) by reference — a deep clone here makes per-delta allocation
+    // proportional to the full accumulated message (including embedded tool
+    // results) and exhausts the heap when subscribers retain snapshots.
+    const { engine, events } = createHarness();
+    const state = engine.createStreamState();
+    const ctx = requestContext();
+    const args = { path: 'a.ts' };
+
+    await engine.processStreamChunk(
+      state,
+      chunk({ type: 'tool-call', payload: { toolCallId: 'tc1', toolName: 'read', args } }),
+      ctx,
+    );
+    const first = lastMessageEvent(events);
+    await engine.processStreamChunk(state, chunk({ type: 'text-start', payload: { id: 't1' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-delta', payload: { id: 't1', text: 'hi' } }), ctx);
+    const second = lastMessageEvent(events);
+
+    const firstTool = first.content.parts.find(part => part.type === 'tool-invocation');
+    const secondTool = second.content.parts.find(part => part.type === 'tool-invocation');
+    if (firstTool?.type !== 'tool-invocation' || secondTool?.type !== 'tool-invocation') {
+      throw new Error('missing tool invocation parts');
+    }
+    expect(secondTool).not.toBe(firstTool);
+    expect(secondTool.toolInvocation).not.toBe(firstTool.toolInvocation);
+    expect(secondTool.toolInvocation.args).toBe(firstTool.toolInvocation.args);
+    expect(secondTool.toolInvocation.args).toBe(args);
+  });
+
   it('Given a non-success finish reason, When the stream finishes, Then terminal state lives on message metadata', async () => {
     const { engine, events } = createHarness();
 

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -257,13 +257,32 @@ export class SessionRunEngine {
   }
 
   /**
-   * Snapshot a message for emission. The engine mutates parts in place
-   * (text/reasoning deltas, tool-invocation upgrades) and `setStopReason` /
-   * `setErrorMessage` mutate `content.metadata`, so emitted snapshots must
-   * deep-clone the content or later mutations rewrite earlier snapshots.
+   * Snapshot a message for emission. The engine mutates the current message in
+   * place, but only at three depths: `content.parts` (push), part properties
+   * (text/reasoning deltas, `providerMetadata`, `Object.assign` on
+   * `toolInvocation`), and `content.metadata` keys (`setStopReason` /
+   * `setErrorMessage`). Everything deeper — part text, tool args/results,
+   * provider metadata values — is only ever *replaced* by reference, never
+   * mutated, so copying those three levels isolates earlier snapshots from
+   * later mutations while sharing the underlying (immutable) strings.
+   *
+   * Do NOT deep-clone here (e.g. `structuredClone`): this runs on every stream
+   * delta, so cloning the full accumulated content — including embedded tool
+   * results — makes allocation quadratic in message size. With megabyte tool
+   * results that exhausts the V8 heap when subscribers retain snapshots.
    */
   private cloneMessage(message: MastraDBMessage): MastraDBMessage {
-    return { ...message, content: structuredClone(message.content) };
+    const content = message.content;
+    return {
+      ...message,
+      content: {
+        ...content,
+        ...(content.metadata ? { metadata: { ...content.metadata } } : {}),
+        parts: content.parts.map(part =>
+          part.type === 'tool-invocation' ? { ...part, toolInvocation: { ...part.toolInvocation } } : { ...part },
+        ),
+      },
+    };
   }
 
   private setStopReason(message: MastraDBMessage, stopReason: string, force = false): void {


### PR DESCRIPTION
This PR fixes two independent memory defects in long Mastra Code sessions: an out-of-memory crash caused by per-delta deep cloning in the core streaming engine, and unbounded/stale component retention in the TUI.

## Part 1 — `@mastra/core`: OOM from deep-cloning the full message on every stream delta

### Problem

`SessionRunEngine.cloneMessage()` ran `structuredClone` over the **entire accumulated message content** for every emitted `message_update` — i.e. on every text delta, reasoning delta, tool call, and tool result. Once a large tool result (e.g. a multi-megabyte `git diff`) is embedded in the message, every subsequent few-character delta allocates another full copy of it. Allocation is quadratic in message size.

Any subscriber that retains snapshots then holds N full copies. The `adversarial_review` plugin tool retains every event for the duration of a review, so the reported `/goal/plan` loop crash (`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`, stack dominated by `node::worker::(anonymous namespace)::StructuredClone` → `ValueDeserializer::ReadTwoByteString`) is exactly this path — Node implements `structuredClone` via the worker serializer, which is why the stack mentions workers with no worker thread involved.

### Reproduction

A message containing one 2 MB tool result plus 15-character text deltas, snapshots retained by a subscriber:

| variant | result |
|---|---|
| `structuredClone` per delta (before) | **OOM at ~2,000 deltas** (4 GB heap limit), identical fatal stack to the production crash |
| shallow snapshot (after) | **~5 MiB heap growth for 2,000 deltas** through the real `SessionRunEngine.processStreamChunk` path with all 4,010 events retained |

### Fix

The engine only mutates the current message in place at three depths: the `content.parts` array (push), part properties (delta text, `providerMetadata`, `Object.assign` on `toolInvocation`), and `content.metadata` keys. Everything deeper — part text, tool args/results, provider metadata values — is only ever replaced by reference. The snapshot now copies exactly those three levels and shares the underlying immutable strings/objects, preserving snapshot isolation (covered by new regression tests, including reference-sharing assertions so a deep clone can't silently come back).

## Part 2 — `mastracode`: TUI pruning gaps

### Problem

MastraCode retains up to 5,000 TUI chat components so users can scroll through long sessions. The pruning logic had two gaps:

1. It ran only when an agent completed, aborted, or errored. A long-running stream could therefore continue adding components past the configured limit until the lifecycle event occurred.
2. Removing components from the visible chat container did not remove every reference to them. Entries in `messageComponentsById`, `pendingSubagents`, `pendingAskUserComponents`, and `pendingSubmitPlanComponents` could keep pruned component graphs and their message/tool payloads reachable.

### Fix

- Prune the chat container before scheduled streaming renders once it exceeds the existing limit.
- Remove pruned components from every identity-based side index.
- Preserve the existing **5,000 retained / 3,000 after pruning** scrollback behavior.

### Render-churn evidence

A standalone benchmark repeatedly renders the same `pi-tui` `Container`/`Text` tree used by MastraCode:

```bash
pnpm --filter ./mastracode/tui repro:render-churn -- 200 30000 2000
pnpm --filter ./mastracode/tui repro:render-churn -- 5000 30000 2000
```

The two runs rendered approximately **12.07 GiB** and **301.75 GiB** respectively, demonstrating how retained-tree size amplifies cumulative full-tree rendering work. This PR keeps the scrollback setting unchanged and fixes the unbounded streaming and stale-reference defects around it. Note that with Part 1, per-delta event payload cloning — previously a comparable churn source feeding these renders — is also eliminated.

## Test plan

- [x] `pnpm --filter ./packages/core exec vitest run src/agent-controller` (43 files, 406 tests, type errors: none)
- [x] Real-path A/B memory measurement through `SessionRunEngine.processStreamChunk` (OOM before / ~5 MiB after, see Part 1)
- [x] `pnpm --filter ./packages/core check`
- [x] `pnpm --filter ./packages/core lint`
- [x] `pnpm --filter ./mastracode/tui exec vitest run src/tui/__tests__/prune-chat.test.ts src/tui/__tests__/state.test.ts --reporter=dot --bail 1`
- [x] `pnpm --filter ./mastracode/tui check`
- [x] `pnpm --filter ./mastracode/tui lint`
- [x] `pnpm build:mastracode`
- [x] `git diff --check`

## Follow-up (separate repo)

The `adversarial_review` tool in `mastra-ai-plan` retains every session event in an array; it only needs `message_end` assistant events. With this core fix its retention is bounded by final message size instead of N snapshots, but the plugin should still filter what it retains.
