### PR TITLE
fix: update Herdr manager query skill

### DIFF
--- a/.mastracode/skills/herdr-manager-query/SKILL.md
+++ b/.mastracode/skills/herdr-manager-query/SKILL.md
@@ -5,7 +5,7 @@ description: Query the authoritative global Herdr Review and Work Manager invent
 
 # Herdr Manager Query
 
-Use the enabled `herdr-mastracode` plugin as the authoritative repository-independent source for Review Manager and Work Manager data.
+Use the enabled `herdr-kit` plugin as the authoritative repository-independent source for Review Manager and Work Manager data.
 
 Activate this skill for requested reviews, authored PRs, managed checkouts, Herdr workspaces, manager review/CI/activity/freshness/cleanup state, work recommendations, or explicit Review Manager materialization.
 
@@ -24,17 +24,17 @@ Resolve the enabled plugin root through Herdr, not from the current repository:
 
 ```sh
 plugin_file=$(mktemp)
-herdr plugin list --plugin herdr-mastracode --json > "$plugin_file"
+herdr plugin list --plugin herdr-kit --json > "$plugin_file"
 plugin_root=$(python3 - "$plugin_file" <<'PY'
 import json, sys
 plugins = json.load(open(sys.argv[1]))["result"]["plugins"]
-plugin = next((p for p in plugins if p.get("plugin_id") == "herdr-mastracode"), None)
+plugin = next((p for p in plugins if p.get("plugin_id") == "herdr-kit"), None)
 if not plugin or not plugin.get("enabled") or not plugin.get("plugin_root"):
-    raise SystemExit("Enabled herdr-mastracode plugin root is unavailable")
+    raise SystemExit("Enabled herdr-kit plugin root is unavailable")
 print(plugin["plugin_root"])
 PY
 )
-manager_cli="$plugin_root/herdr-mastracode"
+manager_cli="$plugin_root/herdr-kit"
 ```
 
 Negotiate capabilities before any query or mutation:
@@ -46,9 +46,9 @@ python3 - "$capabilities_file" <<'PY'
 import json, sys
 p = json.load(open(sys.argv[1]))
 if p.get("protocol_version") != 1:
-    raise SystemExit(f"Unsupported herdr-mastracode protocol: {p.get('protocol_version')}")
+    raise SystemExit(f"Unsupported herdr-kit protocol: {p.get('protocol_version')}")
 if not p.get("operations", {}).get("manager_query", {}).get("available"):
-    raise SystemExit("herdr-mastracode manager query is unavailable")
+    raise SystemExit("herdr-kit manager query is unavailable")
 PY
 ```
 
@@ -75,6 +75,14 @@ PY
 ```
 
 Filter `inventory.items` locally. Every item identifies its source manager and includes repository/PR identity, state, checkout location, Herdr state, reviews, CI, activity, freshness, changes, and cleanup data. Review records additionally include `head_sha`, `materialization.target_path`, and PR diff statistics under `diff`.
+
+For Review Manager records, use the structured review metadata when reasoning about initial reviews and follow-up work:
+
+- `reviews.your_latest_review_at` and `reviews.your_latest_review_sha` identify the user's latest submitted review and reviewed commit.
+- `reviews.events` provides submitted review events with actors, states, timestamps, commit SHAs, and compact bodies.
+- `reviews.comments` and `reviews.unresolved_threads` provide available comment and unresolved-discussion timing.
+- `reviews.commits_since_your_review` identifies commits submitted after the user's latest review.
+- Compare event timestamps rather than assuming PR-wide `activity_at` occurred after the user's review. A missing timestamp or event remains unknown.
 
 Treat missing values as unknown, never as favorable defaults.
 

--- a/.mastracode/skills/herdr-manager-query/SKILL.md
+++ b/.mastracode/skills/herdr-manager-query/SKILL.md
@@ -24,8 +24,10 @@ Resolve the enabled plugin root through Herdr, not from the current repository:
 
 ```sh
 plugin_file=$(mktemp)
-herdr plugin list --plugin herdr-kit --json > "$plugin_file"
-plugin_root=$(python3 - "$plugin_file" <<'PY'
+if ! herdr plugin list --plugin herdr-kit --json > "$plugin_file"; then
+    exit 1
+fi
+if ! plugin_root=$(python3 - "$plugin_file" <<'PY'
 import json, sys
 plugins = json.load(open(sys.argv[1]))["result"]["plugins"]
 plugin = next((p for p in plugins if p.get("plugin_id") == "herdr-kit"), None)
@@ -33,7 +35,9 @@ if not plugin or not plugin.get("enabled") or not plugin.get("plugin_root"):
     raise SystemExit("Enabled herdr-kit plugin root is unavailable")
 print(plugin["plugin_root"])
 PY
-)
+); then
+    exit 1
+fi
 manager_cli="$plugin_root/herdr-kit"
 ```
 
@@ -80,7 +84,7 @@ For Review Manager records, use the structured review metadata when reasoning ab
 
 - `reviews.your_latest_review_at` and `reviews.your_latest_review_sha` identify the user's latest submitted review and reviewed commit.
 - `reviews.events` provides submitted review events with actors, states, timestamps, commit SHAs, and compact bodies.
-- `reviews.comments` and `reviews.unresolved_threads` provide available comment and unresolved-discussion timing.
+- `reviews.comments` and `reviews.unresolved_threads` provide available comment and unresolved-discussion timing. Compare each item's timestamp with `reviews.your_latest_review_at`: only later items are follow-up feedback, and the result remains unknown when either timestamp is unavailable.
 - `reviews.commits_since_your_review` identifies commits submitted after the user's latest review.
 - Compare event timestamps rather than assuming PR-wide `activity_at` occurred after the user's review. A missing timestamp or event remains unknown.
 


### PR DESCRIPTION
The Herdr Manager Query skill now discovers the current `herdr-kit` plugin and invokes its repository-root executable instead of the retired `herdr-mastracode` identity.

It also tells querying agents to use the authoritative review timestamp, reviewed commit, review events, comments, unresolved threads, and commits-since-review fields when deciding whether feedback needs follow-up. Missing timestamps remain unknown rather than triggering a GitHub fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This update teaches the Herdr Manager Query skill to use the currently installed `herdr-kit` tool as the “source of truth” for review/work manager data. It also tells agents how to decide whether review feedback still needs follow-up using precise review timestamps/commit info—without making up missing details.

## Changes

- Updated the Herdr Manager Query skill docs to discover the enabled `herdr-kit` plugin root via `herdr plugin list`, derive `manager_cli` from it, and invoke the plugin’s repository-root CLI.
- Added “fail closed” safety: capability negotiation is required before querying, and errors (discovery/capabilities/schema/query/validation) stop execution with no fallback.
- Documented authoritative follow-up logic using structured review metadata:
  - Latest submitted review timestamp/commit (`reviews.your_latest_review_at` / `reviews.your_latest_review_sha`)
  - Review events, comments, and unresolved threads (compare each event/comment timestamp directly vs the latest review timestamp)
  - Commits since the latest review (`reviews.commits_since_your_review`)
  - Treat missing timestamps/events as **unknown** (no GitHub fallback, and no PR-wide `activity_at` assumptions).
- Clarified explicit Review Manager materialization behavior: only materialize `manager: "review"` records with `location: "remote only"` after the authoritative query and explicit user confirmation of exact targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->