### PR TITLE
fix(factory): stop hosted Factory agents from operating in the server's own checkout

### DIFF
--- a/.changeset/factory-session-prompt-workdir.md
+++ b/.changeset/factory-session-prompt-workdir.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Pin Factory session agents to their session workdir. The agent system prompt derives its working directory from `state.projectPath`, which for Factory sessions inherited the controller-global default — the web server's own checkout. Review agents would `cd` into the host repository and run `gh pr checkout` there, mutating the developer's working tree instead of the session sandbox. The session workspace factory now seeds `projectPath`/`projectName` with the resolved sandbox workdir when the session is created and self-heals live state on later requests.

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -95,11 +95,15 @@ function createGithubRequestContext(
   user: Record<string, unknown> = { organizationId: 'org-1', workosId: 'user-1' },
 ) {
   const requestContext = createRequestContext('/unused');
+  const state: Record<string, unknown> = { factoryProjectId: projectId };
   requestContext.set('controller', {
     modeId: 'build',
     resourceId: sessionId,
     threadId: sessionId,
-    getState: () => ({ factoryProjectId: projectId }),
+    getState: () => state,
+    setState: async (updates: Record<string, unknown>) => {
+      Object.assign(state, updates);
+    },
     session: { id: sessionId },
   });
   requestContext.set('user', user);
@@ -373,6 +377,21 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.runWorktreeSetup).toHaveBeenCalledTimes(2);
     expect(mocks.sessions.find(session => session.id === 'session-a')?.sandboxWorkdir).toBe(workdirA);
     expect(mocks.sessions.find(session => session.id === 'session-b')?.sandboxWorkdir).toBe(workdirB);
+  });
+
+  it('pins the session workdir into controller state so the agent prompt never points at the host checkout', async () => {
+    const { root, workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    const requestContext = createGithubRequestContext('project-1', 'session-a');
+
+    await workspace({ requestContext });
+
+    const ctx = requestContext.get('controller') as {
+      getState: () => { projectPath?: string; projectName?: string };
+    };
+    expect(ctx.getState().projectPath).toBe(path.join(root, 'github-sessions', 'octocat', 'hello', 'session-a'));
+    expect(ctx.getState().projectName).toBe('octocat/hello');
   });
 
   it('tears down a git-less sandbox and retries once on a fresh one', async () => {

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -176,6 +176,16 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     const workdir = isLocalSandbox
       ? fleet.computeLocalSessionWorkdir(repoFullName, session.id)
       : (session.sandboxWorkdir ?? projectRepository.sandboxWorkdir);
+    // The system prompt derives its working directory from `state.projectPath`
+    // and falls back to the server's own process.cwd() when unset — which
+    // points the agent at the host checkout (and lets it run `git checkout`
+    // there instead of in its session workdir). Pin it to the session workdir.
+    // During createSession this seeds the session's initial state (the
+    // workspace resolves before the session is built); on later requests it
+    // self-heals live state.
+    if (ctx && workdir && ctx.getState()?.projectPath !== workdir) {
+      await ctx.setState({ projectPath: workdir, projectName: repoFullName });
+    }
     const binding: SandboxBindingStore = {
       // Read through to the session row so teardown after a fresh provision
       // sees the just-persisted id instead of a stale snapshot.


### PR DESCRIPTION
## Summary

Hosted Factory session agents (review board, kickoffs) were told the **web server's own working directory** was their project path. The agent system prompt derives its working directory from `state.projectPath` and falls back to the server process's cwd when unset — and Factory sessions never set it. A review agent took the prompt at its word and ran `cd <server checkout> && gh pr checkout <n>`, checking out the PR branch in the developer's live worktree instead of its session sandbox (LocalSandbox permits absolute paths, so nothing stopped it).

## Fix

The Factory session workspace factory now pins `projectPath`/`projectName` in controller state to the resolved session sandbox workdir:

- On session creation: the workspace resolves before the `Session` is built, so the seed lands in the session's initial state and the very first generation's prompt is correct.
- On subsequent requests: live state is self-healed whenever it drifts from the resolved workdir.

This covers every entry point (dispatcher kickoffs, card-click auto-start, UI ensure flow) at a single chokepoint, since the workspace factory resolves for all Factory sessions.

## Test plan

- New regression test: `workspace.test.ts` asserts the controller state's `projectPath` is pinned to the session workdir (`github-sessions/<owner>/<repo>/<session>`) after workspace resolution.
- `vitest run src/workspace.test.ts`: 26/26 pass.
- `tsc --noEmit` clean in `mastracode/factory`.

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Each hosted session now works in its own safe workspace instead of accidentally using the developer’s checkout. This prevents review agents from changing the wrong files.

## What changed

- Pins Factory session agents to the resolved session sandbox directory.
- Stores and self-heals `projectPath` and `projectName` in controller state.
- Applies the fix across Factory session entry points.
- Adds regression coverage for per-session GitHub workspace paths.
- Adds a patch changeset for `@mastra/factory`.

Tests pass: 26/26. TypeScript compilation is clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->