### PR TITLE
fix(factory-ui): remove duplicate metrics headings

### DIFF
--- a/mastracode/factory-ui/src/ui/pages/MetricsPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/MetricsPage.tsx
@@ -293,15 +293,7 @@ function OverviewReadout({
   );
 }
 
-function MetricsSection({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description: string;
-  children: ReactNode;
-}) {
+function MetricsSection({ title, description, children }: { title: string; description: string; children: ReactNode }) {
   return (
     <section className="border-border1 flex flex-col gap-4 border-t pt-7">
       <div className="flex flex-col gap-1">

--- a/mastracode/factory-ui/src/ui/pages/MetricsPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/MetricsPage.tsx
@@ -94,28 +94,14 @@ function MetricsContent({ factoryProjectId }: { factoryProjectId: string | undef
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 pb-8">
-      <header className="flex flex-col gap-1 pt-1">
-        <Txt as="h1" variant="header-sm" className="text-icon6 m-0">
-          Metrics
-        </Txt>
-        <Txt as="p" variant="ui-sm" className="text-icon3 m-0 max-w-2xl">
-          See how work moves through the Factory and where it needs attention.
-        </Txt>
-      </header>
-
-      <MetricsSection
-        title="Reporting period"
-        description="Drag the range or use the date controls to compare a different window."
-        action={<Badge size="sm">{windowDays} days</Badge>}
-      >
-        <DateRangeTimeline
-          key={`${bounds.min}:${bounds.max}`}
-          value={range}
-          min={bounds.min}
-          max={bounds.max}
-          onCommit={value => setRange(clampRangeSpan(value, MAX_METRICS_WINDOW_DAYS))}
-        />
-      </MetricsSection>
+      <h1 className="sr-only">Metrics</h1>
+      <DateRangeTimeline
+        key={`${bounds.min}:${bounds.max}`}
+        value={range}
+        min={bounds.min}
+        max={bounds.max}
+        onCommit={value => setRange(clampRangeSpan(value, MAX_METRICS_WINDOW_DAYS))}
+      />
 
       {!metrics ? (
         <MetricsLoading />
@@ -310,26 +296,21 @@ function OverviewReadout({
 function MetricsSection({
   title,
   description,
-  action,
   children,
 }: {
   title: string;
   description: string;
-  action?: ReactNode;
   children: ReactNode;
 }) {
   return (
     <section className="border-border1 flex flex-col gap-4 border-t pt-7">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-col gap-1">
-          <Txt as="h2" variant="ui-md" className="text-icon6 m-0 font-medium">
-            {title}
-          </Txt>
-          <Txt as="p" variant="ui-sm" className="text-icon3 m-0">
-            {description}
-          </Txt>
-        </div>
-        {action}
+      <div className="flex flex-col gap-1">
+        <Txt as="h2" variant="ui-md" className="text-icon6 m-0 font-medium">
+          {title}
+        </Txt>
+        <Txt as="p" variant="ui-sm" className="text-icon3 m-0">
+          {description}
+        </Txt>
       </div>
       {children}
     </section>


### PR DESCRIPTION
Removes the redundant Metrics page header and Reporting period copy so the date controls and delivery metrics lead the page. Keeps an accessible page heading for screen readers.

Validated with the Factory UI build, typecheck, 70 unit tests, React Doctor, and an authenticated browser check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Metrics page now gets straight to the useful date controls and delivery metrics instead of showing repeated headings. It still includes a hidden page title so screen readers can understand the page.

## Changes

- Removed the redundant “Reporting period” heading and surrounding container.
- Rendered the date-range picker directly on the Metrics page.
- Simplified `MetricsSection` by removing its optional action prop and related layout.
- Updated the section layout to a simpler vertical structure.
- Validated with the Factory UI build, typecheck, 70 unit tests, React Doctor, and an authenticated browser check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->