### PR TITLE
fix(playground): limit Studio preview build concurrency

### DIFF
--- a/packages/playground/vercel-preview/scripts/build-linked-workspace-deps.mjs
+++ b/packages/playground/vercel-preview/scripts/build-linked-workspace-deps.mjs
@@ -18,7 +18,12 @@ execFileSync(
 );
 
 // app's own pinned turbo — script must also work outside pnpm run, where .bin is not on PATH
+// keep peak memory within Vercel's preview builder limit when the full dependency graph misses cache
 const turboBin = path.join(appDir, 'node_modules', '.bin', 'turbo');
-execFileSync(turboBin, ['--cwd', repoRoot, 'build', ...linkedPackages.flatMap(name => ['--filter', name])], {
-  stdio: 'inherit',
-});
+execFileSync(
+  turboBin,
+  ['--cwd', repoRoot, 'build', '--concurrency=2', ...linkedPackages.flatMap(name => ['--filter', name])],
+  {
+    stdio: 'inherit',
+  },
+);


### PR DESCRIPTION
Studio preview builds can be killed with exit 137 when Turbo expands the linked workspace build to 52 tasks and runs too many bundlers at once.

This caps that preview-only Turbo invocation at two concurrent tasks. The dependency graph and cache behavior stay unchanged.

Verified with the complete preview build on Node 24.18.0: all 52 Turbo tasks passed and `mastra build` generated `.vercel/output`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The preview build now does only two jobs at a time instead of many at once. This reduces memory usage and prevents Vercel preview builds from crashing while keeping the same build results and caching.

## Changes

- Added `--concurrency=2` to the linked workspace Turbo build.
- Updated comments to document the Vercel memory-limit rationale.
- Preserved the existing dependency graph, filters, working directory, and cache behavior.
- Verified the complete preview build on Node 24.18.0, including `.vercel/output` generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->