### PR TITLE
fix(code-sdk): sandbox file tools fail on absolute paths and macOS-hosted sandboxes

### DIFF
--- a/.changeset/sandbox-fs-absolute-paths.md
+++ b/.changeset/sandbox-fs-absolute-paths.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fix sandbox file tools failing in Factory sessions. `SandboxFilesystem` now accepts absolute paths that already live under the session workdir (the agent prompt advertises the workdir, so tools are called with fully-qualified paths that previously got re-joined onto the workdir and reported "Path not found"). Also replaced GNU-only shell usage (`stat -c`, `find -printf`) with portable equivalents so view/write/list tools work on macOS-hosted local sandboxes, not just Linux VMs.

--- a/.changeset/sandbox-fs-absolute-paths.md
+++ b/.changeset/sandbox-fs-absolute-paths.md
@@ -2,4 +2,4 @@
 '@mastra/code-sdk': patch
 ---
 
-Fix sandbox file tools failing in Factory sessions. `SandboxFilesystem` now accepts absolute paths that already live under the session workdir (the agent prompt advertises the workdir, so tools are called with fully-qualified paths that previously got re-joined onto the workdir and reported "Path not found"). Also replaced GNU-only shell usage (`stat -c`, `find -printf`) with portable equivalents so view/write/list tools work on macOS-hosted local sandboxes, not just Linux VMs.
+Fixed sandbox file tools (view, write, edit, list) failing with "Path not found" in Factory sessions when called with absolute paths inside the session working directory. File tools now also work on macOS-hosted local sandboxes, not just Linux VMs.

--- a/.changeset/sandbox-fs-conformance.md
+++ b/.changeset/sandbox-fs-conformance.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Run the shared workspace filesystem conformance suite against SandboxFilesystem and fix the gaps it found: typed FileNotFoundError/FileExistsError/IsDirectoryError errors, reading a directory as a file now rejects, moveFile/copyFile create the destination parent directory, filesystem ids are unique per workdir when one sandbox backs multiple worktrees, and getInfo reports status.

--- a/.changeset/sandbox-fs-conformance.md
+++ b/.changeset/sandbox-fs-conformance.md
@@ -2,4 +2,4 @@
 '@mastra/code-sdk': patch
 ---
 
-Run the shared workspace filesystem conformance suite against SandboxFilesystem and fix the gaps it found: typed FileNotFoundError/FileExistsError/IsDirectoryError errors, reading a directory as a file now rejects, moveFile/copyFile create the destination parent directory, filesystem ids are unique per workdir when one sandbox backs multiple worktrees, and getInfo reports status.
+Sandbox filesystem operations now behave like local ones: missing files, existing destinations, and directory misuse raise typed errors instead of generic ones, reading a directory as a file fails instead of returning empty content, moving or copying a file into a new directory works, overwrite protection can no longer be raced by concurrent writers, and each filesystem reports a unique id and status.

--- a/mastracode/sdk/package.json
+++ b/mastracode/sdk/package.json
@@ -80,6 +80,7 @@
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
+    "@internal/workspace-test-utils": "workspace:*",
     "@libsql/client": "^0.17.4",
     "@types/node": "22.20.1",
     "eslint": "^10.7.0",

--- a/mastracode/sdk/src/agents/sandbox-filesystem.conformance.test.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.conformance.test.ts
@@ -1,0 +1,88 @@
+/**
+ * SandboxFilesystem conformance tests.
+ *
+ * Runs the shared `@internal/workspace-test-utils` filesystem suite against a
+ * `SandboxFilesystem` backed by a real local shell (`sh -c` on the host, the
+ * same executor a LocalSandbox uses). This exercises every shell-quoted code
+ * path — base64 reads/writes, the portable stat/readdir fallbacks — on the
+ * host OS, so running it on macOS covers the BSD variants and CI covers GNU.
+ */
+
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createFilesystemTestSuite } from '@internal/workspace-test-utils';
+import { afterAll } from 'vitest';
+
+import type { SandboxCommandResult, SandboxExec } from './sandbox-filesystem';
+import { SandboxFilesystem } from './sandbox-filesystem';
+
+/** Minimal SandboxExec that runs commands on the host, like LocalSandbox does. */
+function createLocalShellExec(): SandboxExec {
+  return {
+    id: 'local-shell-test',
+    executeCommand(command, args = [], options): Promise<SandboxCommandResult> {
+      return new Promise(resolve => {
+        execFile(
+          command,
+          args,
+          { timeout: options?.timeout, maxBuffer: 64 * 1024 * 1024, encoding: 'utf8' },
+          (error, stdout, stderr) => {
+            const exitCode =
+              error && typeof (error as NodeJS.ErrnoException & { code?: unknown }).code === 'number'
+                ? ((error as unknown as { code: number }).code ?? 1)
+                : error
+                  ? 1
+                  : 0;
+            resolve({ exitCode, stdout, stderr });
+          },
+        );
+      });
+    },
+  };
+}
+
+const tmpDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of tmpDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+});
+
+function createSandboxFilesystem(): SandboxFilesystem {
+  // realpathSync: on macOS tmpdir() is a symlink (/var -> /private/var); the
+  // filesystem's realpath containment guard needs the resolved workdir.
+  const workdir = realpathSync(mkdtempSync(join(tmpdir(), 'mastra-sandbox-fs-')));
+  tmpDirs.push(workdir);
+  return new SandboxFilesystem({ sandbox: createLocalShellExec(), workdir });
+}
+
+createFilesystemTestSuite({
+  suiteName: 'SandboxFilesystem Conformance (local shell)',
+  createFilesystem: () => createSandboxFilesystem(),
+  capabilities: {
+    supportsAppend: true,
+    supportsBinaryFiles: true,
+    supportsForceDelete: true,
+    supportsOverwrite: true,
+    supportsEmptyDirectories: true,
+    deleteThrowsOnMissing: true,
+    supportsConcurrency: true,
+    supportsPermissions: false,
+    supportsMounting: false,
+    // Write payloads travel as base64 inside a single `sh -c` argument, so
+    // they are bounded by the host's ARG_MAX (~1MB on macOS). Keep test
+    // payloads comfortably under that.
+    maxTestFileSize: 128 * 1024,
+  },
+  // Every operation shells out (often several commands), so give slow CI
+  // hosts more headroom than the 5s default.
+  testTimeout: 20000,
+});

--- a/mastracode/sdk/src/agents/sandbox-filesystem.test.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.test.ts
@@ -25,8 +25,24 @@ class FakeSandbox implements SandboxExec {
 
 const WORKDIR = '/workspace/repo';
 
+/** The realpath containment guard script starts by assigning the target path. */
+function isContainmentCheck(script: string): boolean {
+  return script.startsWith('p=');
+}
+
+/** Containment guard output: canonicalized root on line 1, target realpath on line 2. */
+function realpathResult(real: string): SandboxCommandResult {
+  return { exitCode: 0, stdout: `${WORKDIR}\n${real}`, stderr: '' };
+}
+
 function makeFs(responder?: (script: string) => SandboxCommandResult) {
-  const sandbox = new FakeSandbox(responder);
+  const wrapped = (script: string): SandboxCommandResult => {
+    if (responder) return responder(script);
+    // Default: containment checks resolve inside the workdir, everything else succeeds.
+    if (isContainmentCheck(script)) return realpathResult(WORKDIR);
+    return { exitCode: 0, stdout: '', stderr: '' };
+  };
+  const sandbox = new FakeSandbox(wrapped);
   const fs = new SandboxFilesystem({ sandbox, workdir: WORKDIR });
   return { sandbox, fs };
 }
@@ -37,7 +53,7 @@ describe('SandboxFilesystem', () => {
     const b64 = Buffer.from(content, 'utf8').toString('base64');
     const { sandbox, fs } = makeFs(script => {
       // The realpath containment check runs first; resolve it inside the workdir.
-      if (script.startsWith('readlink')) return { exitCode: 0, stdout: `${WORKDIR}/src/index.ts`, stderr: '' };
+      if (isContainmentCheck(script)) return realpathResult(`${WORKDIR}/src/index.ts`);
       return { exitCode: 0, stdout: b64, stderr: '' };
     });
 
@@ -49,18 +65,30 @@ describe('SandboxFilesystem', () => {
 
   it('rejects a symlink whose realpath escapes the workspace root', async () => {
     const { fs } = makeFs(script => {
-      if (script.startsWith('readlink')) return { exitCode: 0, stdout: '/etc/passwd', stderr: '' };
+      if (isContainmentCheck(script)) return realpathResult('/etc/passwd');
       return { exitCode: 0, stdout: '', stderr: '' };
     });
 
     await expect(fs.readFile('/link')).rejects.toThrow(/escapes workspace root \(symlink\)/);
   });
 
+  it('fails closed when an existing path cannot be canonicalized', async () => {
+    // If no canonicalization tool works, skipping the check would let a
+    // symlink bypass containment — the operation must fail instead.
+    const { fs, sandbox } = makeFs(script => {
+      if (isContainmentCheck(script)) return { exitCode: 1, stdout: '', stderr: '' };
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    await expect(fs.readFile('/link')).rejects.toThrow(/Unable to verify path stays within workspace root/);
+    expect(sandbox.calls.some(c => c.includes('base64 <'))).toBe(false);
+  });
+
   it('rejects a write whose parent directory is a symlink escaping the workspace', async () => {
     // The leaf doesn't exist yet, but its parent `evil` resolves to /etc, so
-    // readlink -f on the parent returns an out-of-root path.
+    // the containment check on the parent returns an out-of-root realpath.
     const { fs, sandbox } = makeFs(script => {
-      if (script.startsWith('readlink')) return { exitCode: 0, stdout: '/etc', stderr: '' };
+      if (isContainmentCheck(script)) return realpathResult('/etc');
       return { exitCode: 0, stdout: '', stderr: '' };
     });
 
@@ -71,7 +99,7 @@ describe('SandboxFilesystem', () => {
 
   it('allows a write when the parent realpath stays inside the workspace', async () => {
     const { fs, sandbox } = makeFs(script => {
-      if (script.startsWith('readlink')) return { exitCode: 0, stdout: `${WORKDIR}/src`, stderr: '' };
+      if (isContainmentCheck(script)) return realpathResult(`${WORKDIR}/src`);
       return { exitCode: 0, stdout: '', stderr: '' };
     });
 
@@ -106,7 +134,7 @@ describe('SandboxFilesystem', () => {
 
   it('lists a directory and parses type/name pairs', async () => {
     const { sandbox, fs } = makeFs(script => {
-      if (script.startsWith('readlink')) return { exitCode: 0, stdout: WORKDIR, stderr: '' };
+      if (isContainmentCheck(script)) return realpathResult(WORKDIR);
       return { exitCode: 0, stdout: 'd\tsrc\nf\tREADME.md\n', stderr: '' };
     });
 
@@ -121,7 +149,7 @@ describe('SandboxFilesystem', () => {
 
   it('stats a file and returns parsed metadata', async () => {
     const { fs } = makeFs(script => {
-      if (script.startsWith('readlink')) return { exitCode: 0, stdout: `${WORKDIR}/a.txt`, stderr: '' };
+      if (isContainmentCheck(script)) return realpathResult(`${WORKDIR}/a.txt`);
       return { exitCode: 0, stdout: 'regular file|42|1700000000|-1\n', stderr: '' };
     });
 
@@ -138,7 +166,7 @@ describe('SandboxFilesystem', () => {
     // tools are called with fully-qualified paths. These must resolve in
     // place instead of being re-joined onto the workdir.
     const { sandbox, fs } = makeFs(script => {
-      if (script.startsWith('readlink')) return { exitCode: 0, stdout: `${WORKDIR}/notes/review.md`, stderr: '' };
+      if (isContainmentCheck(script)) return realpathResult(`${WORKDIR}/notes/review.md`);
       return { exitCode: 0, stdout: '', stderr: '' };
     });
 
@@ -151,7 +179,7 @@ describe('SandboxFilesystem', () => {
 
   it('normalizes .. segments inside an absolute workdir path', async () => {
     const { sandbox, fs } = makeFs(script => {
-      if (script.startsWith('readlink')) return { exitCode: 0, stdout: `${WORKDIR}/notes.txt`, stderr: '' };
+      if (isContainmentCheck(script)) return realpathResult(`${WORKDIR}/notes.txt`);
       return { exitCode: 0, stdout: '', stderr: '' };
     });
 
@@ -161,7 +189,7 @@ describe('SandboxFilesystem', () => {
 
   it('falls back to BSD stat when GNU stat is unavailable', async () => {
     const { fs } = makeFs(script => {
-      if (script.startsWith('readlink')) return { exitCode: 0, stdout: `${WORKDIR}/dir`, stderr: '' };
+      if (isContainmentCheck(script)) return realpathResult(`${WORKDIR}/dir`);
       // Simulate macOS: the `stat -c || stat -f` compound runs BSD output.
       if (script.includes('stat -c')) {
         expect(script).toContain('stat -f');
@@ -176,7 +204,7 @@ describe('SandboxFilesystem', () => {
 
   it('lists recursively without GNU find -printf', async () => {
     const { sandbox, fs } = makeFs(script => {
-      if (script.startsWith('readlink')) return { exitCode: 0, stdout: WORKDIR, stderr: '' };
+      if (isContainmentCheck(script)) return realpathResult(WORKDIR);
       return { exitCode: 0, stdout: `d\t${WORKDIR}/src\nf\t${WORKDIR}/src/index.ts\n`, stderr: '' };
     });
 

--- a/mastracode/sdk/src/agents/sandbox-filesystem.test.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.test.ts
@@ -212,7 +212,7 @@ describe('SandboxFilesystem', () => {
   it('exposes basePath and a sandbox-derived id', () => {
     const { fs } = makeFs();
     expect(fs.basePath).toBe(WORKDIR);
-    expect(fs.id).toBe('sandbox-fs:fake-sandbox');
+    expect(fs.id).toBe(`sandbox-fs:fake-sandbox:${WORKDIR}`);
     expect(fs.getInfo().metadata).toMatchObject({ basePath: WORKDIR, sandboxId: 'fake-sandbox' });
   });
 });

--- a/mastracode/sdk/src/agents/sandbox-filesystem.test.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.test.ts
@@ -122,7 +122,7 @@ describe('SandboxFilesystem', () => {
   it('stats a file and returns parsed metadata', async () => {
     const { fs } = makeFs(script => {
       if (script.startsWith('readlink')) return { exitCode: 0, stdout: `${WORKDIR}/a.txt`, stderr: '' };
-      return { exitCode: 0, stdout: 'regular file\t42\t1700000000\t-1\n', stderr: '' };
+      return { exitCode: 0, stdout: 'regular file|42|1700000000|-1\n', stderr: '' };
     });
 
     const stat = await fs.stat('/a.txt');
@@ -131,6 +131,63 @@ describe('SandboxFilesystem', () => {
     expect(stat.size).toBe(42);
     expect(stat.name).toBe('a.txt');
     expect(stat.path).toBe('/a.txt');
+  });
+
+  it('accepts absolute paths that already live under the workdir', async () => {
+    // The agent prompt advertises the workdir as the working directory, so
+    // tools are called with fully-qualified paths. These must resolve in
+    // place instead of being re-joined onto the workdir.
+    const { sandbox, fs } = makeFs(script => {
+      if (script.startsWith('readlink')) return { exitCode: 0, stdout: `${WORKDIR}/notes/review.md`, stderr: '' };
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    await fs.writeFile(`${WORKDIR}/notes/review.md`, 'verdict');
+
+    const writeCall = sandbox.calls.find(c => c.includes('base64 -d >'));
+    expect(writeCall).toContain(`base64 -d > '${WORKDIR}/notes/review.md'`);
+    expect(writeCall).not.toContain(`${WORKDIR}${WORKDIR}`);
+  });
+
+  it('normalizes .. segments inside an absolute workdir path', async () => {
+    const { sandbox, fs } = makeFs(script => {
+      if (script.startsWith('readlink')) return { exitCode: 0, stdout: `${WORKDIR}/notes.txt`, stderr: '' };
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    await fs.readFile(`${WORKDIR}/src/../notes.txt`);
+    expect(sandbox.calls.some(c => c.includes(`base64 < '${WORKDIR}/notes.txt'`))).toBe(true);
+  });
+
+  it('falls back to BSD stat when GNU stat is unavailable', async () => {
+    const { fs } = makeFs(script => {
+      if (script.startsWith('readlink')) return { exitCode: 0, stdout: `${WORKDIR}/dir`, stderr: '' };
+      // Simulate macOS: the `stat -c || stat -f` compound runs BSD output.
+      if (script.includes('stat -c')) {
+        expect(script).toContain('stat -f');
+        return { exitCode: 0, stdout: 'Directory|128|1700000000|1690000000\n', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    const stat = await fs.stat('/dir');
+    expect(stat.type).toBe('directory');
+  });
+
+  it('lists recursively without GNU find -printf', async () => {
+    const { sandbox, fs } = makeFs(script => {
+      if (script.startsWith('readlink')) return { exitCode: 0, stdout: WORKDIR, stderr: '' };
+      return { exitCode: 0, stdout: `d\t${WORKDIR}/src\nf\t${WORKDIR}/src/index.ts\n`, stderr: '' };
+    });
+
+    const entries = await fs.readdir('/', { recursive: true });
+
+    expect(entries).toEqual([
+      { name: 'src', type: 'directory' },
+      { name: 'src/index.ts', type: 'file' },
+    ]);
+    const findCall = sandbox.calls.find(c => c.includes('find '));
+    expect(findCall).not.toContain('-printf');
   });
 
   it('removes a file via rm', async () => {

--- a/mastracode/sdk/src/agents/sandbox-filesystem.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.ts
@@ -35,6 +35,7 @@ import { FileExistsError, FileNotFoundError, IsDirectoryError } from '@mastra/co
  */
 const EXIT_NOT_FOUND = 20;
 const EXIT_IS_DIRECTORY = 21;
+const EXIT_EXISTS = 22;
 
 /** Minimal command result shape we depend on. */
 export interface SandboxCommandResult {
@@ -136,13 +137,33 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
    * Lexical guard catches `..` traversal, but a symlink inside the workdir can
    * still point outside it. After resolving a path that refers to an existing
    * entry, verify its realpath is still contained in the workdir.
+   *
+   * Canonicalization tries `realpath`, then `readlink -f` (GNU/busybox), then
+   * `cd && pwd -P` for directories — covering GNU hosts, macOS/BSD, and
+   * busybox. If the path exists but cannot be canonicalized we fail CLOSED:
+   * returning without a check would let a symlink bypass containment.
    */
   private async assertContainedRealpath(abs: string, inputPath: string): Promise<void> {
-    const result = await this.exec(`readlink -f -- ${shellQuote(abs)} 2>/dev/null`);
-    const real = result.stdout.trim();
-    // If readlink couldn't resolve (path doesn't exist yet), nothing to check.
-    if (result.exitCode !== 0 || !real) return;
-    const root = posixPath.normalize(this.basePath);
+    const result = await this.exec(
+      [
+        `p=${shellQuote(abs)}`,
+        `if [ ! -e "$p" ] && [ ! -L "$p" ]; then exit ${EXIT_NOT_FOUND}; fi`,
+        // The workdir itself may contain symlinked components (/tmp on macOS),
+        // so canonicalize it as the comparison root.
+        `root=$(cd ${shellQuote(this.basePath)} 2>/dev/null && pwd -P)`,
+        `[ -n "$root" ] || exit 1`,
+        `rp=$(realpath "$p" 2>/dev/null) || rp=$(readlink -f "$p" 2>/dev/null) || { [ -d "$p" ] && rp=$(cd "$p" 2>/dev/null && pwd -P); }`,
+        `[ -n "$rp" ] || exit 1`,
+        `printf '%s\\n%s' "$root" "$rp"`,
+      ].join('\n'),
+    );
+    // Path doesn't exist yet: nothing to canonicalize (writes to a fresh leaf
+    // are covered by assertContainedDest checking the parent directory).
+    if (result.exitCode === EXIT_NOT_FOUND) return;
+    const [root, real] = result.stdout.split('\n').map(s => s.trim());
+    if (result.exitCode !== 0 || !root || !real) {
+      throw new Error(`Unable to verify path stays within workspace root: ${inputPath}`);
+    }
     if (real !== root && !real.startsWith(`${root}/`)) {
       throw new Error(`Path escapes workspace root (symlink): ${inputPath}`);
     }
@@ -185,8 +206,9 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
       `if [ -d ${shellQuote(abs)} ]; then exit ${EXIT_IS_DIRECTORY}; elif [ ! -e ${shellQuote(abs)} ]; then exit ${EXIT_NOT_FOUND}; fi; base64 < ${shellQuote(abs)}`,
     );
     if (result.exitCode === EXIT_IS_DIRECTORY) throw new IsDirectoryError(path);
+    if (result.exitCode === EXIT_NOT_FOUND) throw new FileNotFoundError(path);
     if (result.exitCode !== 0) {
-      throw new FileNotFoundError(path);
+      throw new Error(`readFile ${path} failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
     }
     const buffer = Buffer.from(result.stdout.replace(/\s/g, ''), 'base64');
     if (options?.encoding) {
@@ -202,8 +224,16 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
     const dir = posixPath.dirname(abs);
     const mkdir = options?.recursive === false ? '' : `mkdir -p ${shellQuote(dir)} && `;
     if (options?.overwrite === false) {
-      const exists = await this.exists(path);
-      if (exists) throw new FileExistsError(path);
+      // `set -C` (noclobber) makes the redirect itself the exclusivity check —
+      // no exists() pre-check that could race with a concurrent writer.
+      const result = await this.exec(
+        `${mkdir}{ (set -C; printf %s ${shellQuote(b64)} | base64 -d > ${shellQuote(abs)}) 2>/dev/null || { [ -e ${shellQuote(abs)} ] && exit ${EXIT_EXISTS} || exit 1; }; }`,
+      );
+      if (result.exitCode === EXIT_EXISTS) throw new FileExistsError(path);
+      if (result.exitCode !== 0) {
+        throw new Error(`writeFile ${path} failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+      }
+      return;
     }
     await this.execOk(`${mkdir}printf %s ${shellQuote(b64)} | base64 -d > ${shellQuote(abs)}`, `writeFile ${path}`);
   }
@@ -221,7 +251,9 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
   async deleteFile(path: string, options?: RemoveOptions): Promise<void> {
     const abs = this.resolve(path);
     if (options?.force) {
-      await this.exec(`rm -f ${shellQuote(abs)}`);
+      // `rm -f` already succeeds for a missing file, but still fails for
+      // directories and permission errors — surface those.
+      await this.execOk(`rm -f ${shellQuote(abs)}`, `deleteFile ${path}`);
       return;
     }
     const result = await this.exec(
@@ -240,8 +272,32 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
     await this.assertContainedDest(destAbs, dest);
     const recursive = options?.recursive ? '-r ' : '';
     if (options?.overwrite === false) {
-      const exists = await this.exists(dest);
-      if (exists) throw new FileExistsError(dest);
+      // Atomic no-clobber: directories claim the destination with an exclusive
+      // mkdir; files copy to a temp name then hardlink into place (link(2)
+      // fails if the destination exists). No racy exists() pre-check.
+      const result = await this.exec(
+        [
+          `src=${shellQuote(srcAbs)}`,
+          `dest=${shellQuote(destAbs)}`,
+          `if [ ! -e "$src" ] && [ ! -L "$src" ]; then exit ${EXIT_NOT_FOUND}; fi`,
+          `mkdir -p ${shellQuote(posixPath.dirname(destAbs))} || exit 1`,
+          `if [ -d "$src" ]; then`,
+          `  mkdir "$dest" 2>/dev/null || exit ${EXIT_EXISTS}`,
+          `  cp -R "$src"/. "$dest"/`,
+          `else`,
+          `  tmp="$dest.__cptmp$$"`,
+          `  cp "$src" "$tmp" || exit 1`,
+          `  ln "$tmp" "$dest" 2>/dev/null || { rm -f "$tmp"; [ -e "$dest" ] && exit ${EXIT_EXISTS} || exit 1; }`,
+          `  rm -f "$tmp"`,
+          `fi`,
+        ].join('\n'),
+      );
+      if (result.exitCode === EXIT_NOT_FOUND) throw new FileNotFoundError(src);
+      if (result.exitCode === EXIT_EXISTS) throw new FileExistsError(dest);
+      if (result.exitCode !== 0) {
+        throw new Error(`copyFile ${src} -> ${dest} failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+      }
+      return;
     }
     const result = await this.exec(
       `if [ ! -e ${shellQuote(srcAbs)} ]; then exit ${EXIT_NOT_FOUND}; fi; mkdir -p ${shellQuote(posixPath.dirname(destAbs))} && cp ${recursive}${shellQuote(srcAbs)} ${shellQuote(destAbs)}`,
@@ -258,8 +314,25 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
     await this.assertContainedRealpath(srcAbs, src);
     await this.assertContainedDest(destAbs, dest);
     if (options?.overwrite === false) {
-      const exists = await this.exists(dest);
-      if (exists) throw new FileExistsError(dest);
+      // `mv -n` exits 0 even when it skips, so detect a skipped move by the
+      // source surviving. The no-clobber rename itself is atomic; no racy
+      // exists() pre-check.
+      const result = await this.exec(
+        [
+          `src=${shellQuote(srcAbs)}`,
+          `dest=${shellQuote(destAbs)}`,
+          `if [ ! -e "$src" ] && [ ! -L "$src" ]; then exit ${EXIT_NOT_FOUND}; fi`,
+          `mkdir -p ${shellQuote(posixPath.dirname(destAbs))} || exit 1`,
+          `mv -n "$src" "$dest" 2>/dev/null || exit 1`,
+          `if [ -e "$src" ] || [ -L "$src" ]; then exit ${EXIT_EXISTS}; fi`,
+        ].join('\n'),
+      );
+      if (result.exitCode === EXIT_NOT_FOUND) throw new FileNotFoundError(src);
+      if (result.exitCode === EXIT_EXISTS) throw new FileExistsError(dest);
+      if (result.exitCode !== 0) {
+        throw new Error(`moveFile ${src} -> ${dest} failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+      }
+      return;
     }
     const result = await this.exec(
       `if [ ! -e ${shellQuote(srcAbs)} ]; then exit ${EXIT_NOT_FOUND}; fi; mkdir -p ${shellQuote(posixPath.dirname(destAbs))} && mv ${shellQuote(srcAbs)} ${shellQuote(destAbs)}`,

--- a/mastracode/sdk/src/agents/sandbox-filesystem.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.ts
@@ -27,6 +27,14 @@ import type {
   WorkspaceFilesystem,
   WriteOptions,
 } from '@mastra/core/workspace';
+import { FileExistsError, FileNotFoundError, IsDirectoryError } from '@mastra/core/workspace';
+
+/**
+ * Sentinel exit codes used by guard clauses that run before the real command,
+ * so shell failures can be mapped to typed filesystem errors.
+ */
+const EXIT_NOT_FOUND = 20;
+const EXIT_IS_DIRECTORY = 21;
 
 /** Minimal command result shape we depend on. */
 export interface SandboxCommandResult {
@@ -79,7 +87,9 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
   constructor(options: SandboxFilesystemOptions) {
     this.sandbox = options.sandbox;
     this.basePath = options.workdir;
-    this.id = options.id ?? `sandbox-fs:${options.sandbox.id}`;
+    // Include the workdir: one sandbox can back several filesystems rooted at
+    // different worktrees, and each needs a distinct id.
+    this.id = options.id ?? `sandbox-fs:${options.sandbox.id}:${options.workdir}`;
   }
 
   // ── Path handling ──────────────────────────────────────────────────────
@@ -169,9 +179,14 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
   async readFile(path: string, options?: ReadOptions): Promise<string | Buffer> {
     const abs = this.resolve(path);
     await this.assertContainedRealpath(abs, path);
-    const result = await this.exec(`base64 < ${shellQuote(abs)}`);
+    // Guard clauses first: redirecting from a directory "succeeds" with empty
+    // output on some shells, so classify before reading.
+    const result = await this.exec(
+      `if [ -d ${shellQuote(abs)} ]; then exit ${EXIT_IS_DIRECTORY}; elif [ ! -e ${shellQuote(abs)} ]; then exit ${EXIT_NOT_FOUND}; fi; base64 < ${shellQuote(abs)}`,
+    );
+    if (result.exitCode === EXIT_IS_DIRECTORY) throw new IsDirectoryError(path);
     if (result.exitCode !== 0) {
-      throw new Error(`File not found: ${path}`);
+      throw new FileNotFoundError(path);
     }
     const buffer = Buffer.from(result.stdout.replace(/\s/g, ''), 'base64');
     if (options?.encoding) {
@@ -188,7 +203,7 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
     const mkdir = options?.recursive === false ? '' : `mkdir -p ${shellQuote(dir)} && `;
     if (options?.overwrite === false) {
       const exists = await this.exists(path);
-      if (exists) throw new Error(`File already exists: ${path}`);
+      if (exists) throw new FileExistsError(path);
     }
     await this.execOk(`${mkdir}printf %s ${shellQuote(b64)} | base64 -d > ${shellQuote(abs)}`, `writeFile ${path}`);
   }
@@ -205,10 +220,16 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
 
   async deleteFile(path: string, options?: RemoveOptions): Promise<void> {
     const abs = this.resolve(path);
-    const force = options?.force ? '-f ' : '';
-    const result = await this.exec(`rm ${force}${shellQuote(abs)}`);
-    if (result.exitCode !== 0 && !options?.force) {
-      throw new Error(`File not found: ${path}`);
+    if (options?.force) {
+      await this.exec(`rm -f ${shellQuote(abs)}`);
+      return;
+    }
+    const result = await this.exec(
+      `if [ ! -e ${shellQuote(abs)} ]; then exit ${EXIT_NOT_FOUND}; fi; rm ${shellQuote(abs)}`,
+    );
+    if (result.exitCode === EXIT_NOT_FOUND) throw new FileNotFoundError(path);
+    if (result.exitCode !== 0) {
+      throw new Error(`deleteFile ${path} failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
     }
   }
 
@@ -220,9 +241,15 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
     const recursive = options?.recursive ? '-r ' : '';
     if (options?.overwrite === false) {
       const exists = await this.exists(dest);
-      if (exists) throw new Error(`Destination exists: ${dest}`);
+      if (exists) throw new FileExistsError(dest);
     }
-    await this.execOk(`cp ${recursive}${shellQuote(srcAbs)} ${shellQuote(destAbs)}`, `copyFile ${src} -> ${dest}`);
+    const result = await this.exec(
+      `if [ ! -e ${shellQuote(srcAbs)} ]; then exit ${EXIT_NOT_FOUND}; fi; mkdir -p ${shellQuote(posixPath.dirname(destAbs))} && cp ${recursive}${shellQuote(srcAbs)} ${shellQuote(destAbs)}`,
+    );
+    if (result.exitCode === EXIT_NOT_FOUND) throw new FileNotFoundError(src);
+    if (result.exitCode !== 0) {
+      throw new Error(`copyFile ${src} -> ${dest} failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+    }
   }
 
   async moveFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
@@ -232,9 +259,15 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
     await this.assertContainedDest(destAbs, dest);
     if (options?.overwrite === false) {
       const exists = await this.exists(dest);
-      if (exists) throw new Error(`Destination exists: ${dest}`);
+      if (exists) throw new FileExistsError(dest);
     }
-    await this.execOk(`mv ${shellQuote(srcAbs)} ${shellQuote(destAbs)}`, `moveFile ${src} -> ${dest}`);
+    const result = await this.exec(
+      `if [ ! -e ${shellQuote(srcAbs)} ]; then exit ${EXIT_NOT_FOUND}; fi; mkdir -p ${shellQuote(posixPath.dirname(destAbs))} && mv ${shellQuote(srcAbs)} ${shellQuote(destAbs)}`,
+    );
+    if (result.exitCode === EXIT_NOT_FOUND) throw new FileNotFoundError(src);
+    if (result.exitCode !== 0) {
+      throw new Error(`moveFile ${src} -> ${dest} failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+    }
   }
 
   // ── Directory operations ───────────────────────────────────────────────
@@ -339,7 +372,7 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
       `stat -c '%F|%s|%Y|%W' ${shellQuote(abs)} 2>/dev/null || stat -f '%HT|%z|%m|%B' ${shellQuote(abs)}`,
     );
     if (result.exitCode !== 0) {
-      throw new Error(`Path not found: ${path}`);
+      throw new FileNotFoundError(path);
     }
     const [kind, sizeStr, mtimeStr, ctimeStr] = result.stdout.trim().split('|');
     const type = kind && kind.toLowerCase().includes('directory') ? 'directory' : 'file';
@@ -376,6 +409,7 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
       id: this.id,
       name: this.name,
       provider: this.provider,
+      status: this.status,
       metadata: { basePath: this.basePath, sandboxId: this.sandbox.id },
     };
   }

--- a/mastracode/sdk/src/agents/sandbox-filesystem.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.ts
@@ -87,9 +87,23 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
   /**
    * Resolve a workspace path to an absolute path inside the sandbox, enforcing
    * that it stays within the workdir.
+   *
+   * Accepts both workspace-relative paths (`src/foo.ts`, `/src/foo.ts`) and
+   * absolute sandbox paths that already live under the workdir — the agent's
+   * prompt advertises the workdir as its working directory, so tools are
+   * routinely called with fully-qualified paths like `<workdir>/src/foo.ts`.
    */
   private resolve(inputPath: string): string {
-    const rel = inputPath.startsWith('/') ? inputPath.slice(1) : inputPath;
+    const base = posixPath.normalize(this.basePath);
+    const normalizedInput = posixPath.normalize(inputPath);
+    const rel =
+      normalizedInput === base
+        ? ''
+        : normalizedInput.startsWith(`${base}/`)
+          ? normalizedInput.slice(base.length + 1)
+          : inputPath.startsWith('/')
+            ? inputPath.slice(1)
+            : inputPath;
     const resolved = posixPath.normalize(posixPath.join(this.basePath, rel));
     const root = posixPath.normalize(this.basePath);
     if (resolved !== root && !resolved.startsWith(`${root}/`)) {
@@ -249,16 +263,20 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
     const abs = this.resolve(path);
     await this.assertContainedRealpath(abs, path);
     if (options?.recursive) {
-      // Use find for recursive listings; emit "type\tpath".
+      // Recursive listing emitting "type\tpath". `find -printf` is GNU-only
+      // (fails on macOS/BSD hosts backing a local sandbox), so classify each
+      // entry with a portable shell loop instead.
       const result = await this.exec(
-        `find ${shellQuote(abs)} -mindepth 1 ${options.maxDepth ? `-maxdepth ${Number(options.maxDepth)} ` : ''}-printf '%y\\t%p\\n' 2>/dev/null`,
+        `test -d ${shellQuote(abs)} && find ${shellQuote(abs)} -mindepth 1 ${options.maxDepth ? `-maxdepth ${Number(options.maxDepth)} ` : ''}2>/dev/null | while IFS= read -r f; do if [ -d "$f" ]; then printf 'd\\t%s\\n' "$f"; else printf 'f\\t%s\\n' "$f"; fi; done`,
       );
       if (result.exitCode !== 0) throw new Error(`Directory not found: ${path}`);
       return this.parseFindOutput(result.stdout, abs, options);
     }
-    // Non-recursive: list with name + type via a portable loop.
+    // Non-recursive: list with name + type via a portable loop. Use printf,
+    // not echo — bash-as-/bin/sh (macOS local sandboxes) does not expand \t
+    // in echo arguments.
     const result = await this.exec(
-      `cd ${shellQuote(abs)} 2>/dev/null && for f in * .[!.]*; do [ -e "$f" ] || continue; if [ -d "$f" ]; then echo "d\t$f"; else echo "f\t$f"; fi; done`,
+      `cd ${shellQuote(abs)} 2>/dev/null && for f in * .[!.]*; do [ -e "$f" ] || continue; if [ -d "$f" ]; then printf 'd\\t%s\\n' "$f"; else printf 'f\\t%s\\n' "$f"; fi; done`,
     );
     if (result.exitCode !== 0) throw new Error(`Directory not found: ${path}`);
     return this.parseListOutput(result.stdout, options);
@@ -312,13 +330,19 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
   async stat(path: string): Promise<FileStat> {
     const abs = this.resolve(path);
     await this.assertContainedRealpath(abs, path);
-    // %F=type, %s=size, %X=atime, %Y=mtime (epoch seconds), %W=birth (or -1).
-    const result = await this.exec(`stat -c '%F\\t%s\\t%Y\\t%W' ${shellQuote(abs)}`);
+    // GNU stat: %F=type, %s=size, %Y=mtime (epoch seconds), %W=birth (or -1).
+    // BSD/macOS stat (local sandbox hosts) rejects `-c`; fall back to its
+    // `-f` format with the same field order (%HT=type, %z=size, %m=mtime,
+    // %B=birth). Delimit with `|` — neither stat interprets `\t` escapes in
+    // its format string.
+    const result = await this.exec(
+      `stat -c '%F|%s|%Y|%W' ${shellQuote(abs)} 2>/dev/null || stat -f '%HT|%z|%m|%B' ${shellQuote(abs)}`,
+    );
     if (result.exitCode !== 0) {
       throw new Error(`Path not found: ${path}`);
     }
-    const [kind, sizeStr, mtimeStr, ctimeStr] = result.stdout.trim().split('\t');
-    const type = kind && kind.includes('directory') ? 'directory' : 'file';
+    const [kind, sizeStr, mtimeStr, ctimeStr] = result.stdout.trim().split('|');
+    const type = kind && kind.toLowerCase().includes('directory') ? 'directory' : 'file';
     const size = Number(sizeStr) || 0;
     const mtime = Number(mtimeStr) || 0;
     const ctime = Number(ctimeStr);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2473,6 +2473,9 @@ importers:
       '@internal/types-builder':
         specifier: workspace:*
         version: link:../../packages/_types-builder
+      '@internal/workspace-test-utils':
+        specifier: workspace:*
+        version: link:../../workspaces/_test-utils
       '@libsql/client':
         specifier: ^0.17.4
         version: 0.17.4(bufferutil@4.1.0)


### PR DESCRIPTION
## Summary

File tools (view, write_file, list, stat) in Factory session sandboxes failed with `Path not found` errors. Two independent bugs in `SandboxFilesystem`:

1. **Absolute paths were double-joined onto the workdir.** `resolve()` treated every leading-`/` path as workspace-relative: it stripped the slash and joined the rest onto the workdir, so a fully-qualified path like `<workdir>/pr-review.md` resolved to `<workdir>/Users/.../pr-review.md` — a nonexistent nested path. Since the agent's system prompt advertises the session workdir as its working directory, agents routinely call file tools with fully-qualified paths, making every such call fail.

2. **GNU-only shell commands break on BSD/macOS hosts.** The filesystem shells out through the sandbox, and was written assuming Linux VMs: `stat -c` and `find -printf` are GNU syntax that exit non-zero under macOS's BSD tools, so `stat` reported `Path not found` for every path (and recursive listings failed) when a `LocalSandbox` executes on a macOS host. `echo "\t"` also doesn't expand under macOS `/bin/sh`.

## Fix

- `resolve()` accepts absolute paths already under the workdir (normalized, containment still enforced; symlink-escape guards unchanged). Paths outside the workdir keep the legacy workspace-relative interpretation.
- `stat` runs GNU format with a BSD `-f` fallback (`stat -c ... || stat -f ...`) using a `|` delimiter, with case-insensitive type detection (`Directory` vs `directory`).
- Directory listings classify entries with portable `printf`-based loops instead of `find -printf` / `echo` escapes.

## Test plan

- 4 new regression tests: workdir-absolute path resolution, `..` normalization inside absolute paths, BSD stat fallback, recursive listing without `-printf`.
- `vitest run src/agents/sandbox-filesystem.test.ts`: 16/16 pass.
- Full agents suite: 206/206 pass. `tsc --noEmit` clean.
- Shell snippets verified live on macOS (BSD stat/find) against a real session checkout.

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Your app can run commands inside a “sandbox,” but the sandbox’s file tools were getting confused by *absolute paths* and behaved slightly differently on **Linux vs macOS**. This PR teaches the sandbox filesystem to understand paths safely (without letting them escape), and it adds more reliable, portable shell logic plus stronger error reporting and tests.

## What changed

- **Absolute path support (safe):** `SandboxFilesystem` now accepts absolute paths that are already inside the session workdir, normalizes `..` safely, and still enforces containment/symlink-escape protections.
- **Legacy behavior preserved:** Paths outside the workdir keep the older workspace-relative behavior.
- **Stronger symlink containment checks:** Canonicalization is now fail-closed using a multi-strategy approach (e.g., `realpath`, `readlink -f`, and a directory `cd && pwd -P` fallback).
- **Portable `stat`:** Tries GNU `stat -c` first, then falls back to BSD/macOS `stat -f`, with portable parsing and missing-path → `FileNotFoundError`.
- **Portable directory listing:** Replaces GNU-only `find -printf` and brittle formatting with `printf`-based listing loops that work for both recursive and non-recursive `readdir`.
- **Typed filesystem errors:** Adds/uses `FileNotFoundError`, `FileExistsError`, and `IsDirectoryError` (including rejecting directory reads as `IsDirectoryError`).
- **More correct overwrite semantics:**
  - `writeFile(..., overwrite: false)` uses atomic/exclusivity checks and throws `FileExistsError`.
  - `copyFile`/`moveFile` with `overwrite: false` detect existing destinations and throw `FileExistsError` (avoiding overwrite races).
- **Better filesystem operation correctness:**
  - `copyFile`/`moveFile` create destination parent directories when needed.
  - Missing sources are detected reliably and mapped to `FileNotFoundError`.
  - Forced deletions surface failures instead of silently succeeding.
  - `moveFile` verifies move sources remain present.
- **Filesystem identity/status:** `fs.id` now includes the workdir to avoid collisions, and `getInfo()` reports `status`.

## Tests & validation

- **Regression tests** cover absolute-path normalization, `..` handling, BSD/macOS `stat` fallback parsing, and recursive `readdir` portability (and updated payload-size assumptions for shell argument limits).
- **Conformance suite update:** Runs `SandboxFilesystem` against a real local shell executor to exercise GNU/BSD behavior, and adds filesystem conformance coverage with capability-aware expectations.
- **Reported validation:** 16/16 filesystem tests, 206/206 agents tests, and clean TypeScript compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->