### PR TITLE
feat(platform-workspace): direct exec data plane via exec-lease

### DIFF
--- a/.changeset/dry-cities-drum.md
+++ b/.changeset/dry-cities-drum.md
@@ -1,0 +1,9 @@
+---
+'@mastra/platform-workspace': patch
+---
+
+**Added:** Direct exec data plane for `PlatformSandbox`.
+
+Commands now execute against Railway's WebSocket endpoint directly using a short-lived JWT lease minted by the workspace proxy, instead of proxying every exec through the HTTP proxy. This removes the workspace proxy from the exec hot path — cutting latency for large-payload commands (e.g. `pnpm install`) and eliminating duplicated observability spans.
+
+The change is transparent: `executeCommand` still returns the same `CommandResult` shape. If the proxy's `/exec-lease` endpoint is unavailable (older deployments), the client automatically falls back to the legacy `POST /sandbox/:id/exec` route for the lifetime of the sandbox.

--- a/workspaces/platform-workspace/src/direct-exec.test.ts
+++ b/workspaces/platform-workspace/src/direct-exec.test.ts
@@ -222,6 +222,60 @@ describe('execViaLease', () => {
     });
   });
 
+  it('enforces a handshake deadline when no caller timeout is set, so a stalled connect cannot hang the promise', async () => {
+    vi.useFakeTimers();
+    try {
+      // Factory returns a socket that NEVER fires onopen/onmessage/onclose —
+      // the caller has no timeoutMs, so only the internal handshake deadline
+      // can unblock the promise. If it's missing, the promise hangs forever.
+      const { factory } = scriptedFactory(() => {
+        /* deliberately do nothing */
+      });
+
+      const promise = execViaLease(LEASE, { command: 'never', webSocketFactory: factory });
+      // Advance past the 30s handshake deadline defined in direct-exec.ts.
+      await vi.advanceTimersByTimeAsync(30_000);
+      const result = await promise;
+
+      // Handshake deadline is transport failure, NOT timeout — timedOut stays
+      // false so the caller can distinguish "stalled connect" from "ran too long".
+      expect(result).toEqual({
+        exitCode: null,
+        stdout: '',
+        stderr: '',
+        truncated: false,
+        timedOut: false,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears the handshake deadline once the socket opens (no false transport failure on long-running exec without timeout)', async () => {
+    vi.useFakeTimers();
+    try {
+      const { factory, sockets } = scriptedFactory(socket => {
+        socket.fireOpen();
+        // Never send an exit frame — a real long-running exec might legitimately
+        // take longer than the handshake deadline. If we forgot to clear the
+        // deadline in onopen, this would resolve with exitCode=null after 30s.
+      });
+
+      const promise = execViaLease(LEASE, { command: 'sleep 3600', webSocketFactory: factory });
+      // Push well past the handshake deadline; the promise must NOT settle.
+      await vi.advanceTimersByTimeAsync(60_000);
+      // Race with a microtask sentinel so we can assert `promise` is still pending.
+      const sentinel = Symbol('pending');
+      const winner = await Promise.race([promise, Promise.resolve(sentinel)]);
+      expect(winner).toBe(sentinel);
+      // Clean up: fire exit so the promise resolves before the test tears down fake timers.
+      sockets[0]!.fireText(JSON.stringify({ type: 'exit', data: { exit_code: 0 } }));
+      await promise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('enforces timeoutMs by closing the socket and returning timedOut=true, exit=124', async () => {
     vi.useFakeTimers();
     try {

--- a/workspaces/platform-workspace/src/direct-exec.test.ts
+++ b/workspaces/platform-workspace/src/direct-exec.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DirectExecWebSocket, DirectExecWebSocketFactory, ExecLease } from './direct-exec.js';
+import { execViaLease } from './direct-exec.js';
+
+const LEASE: ExecLease = {
+  jwt: 'jwt.value.here',
+  wsEndpoint: 'wss://ssh.railway.com:2226/ws/exec',
+  subprotocol: 'railway-shell',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+};
+
+/**
+ * In-memory fake WebSocket that lets tests drive the connect → frame → exit
+ * state machine deterministically. The direct-exec client only touches the
+ * subset of the WebSocket API declared on {@link DirectExecWebSocket}, so
+ * this is a full implementation of what the module uses.
+ */
+class FakeSocket implements DirectExecWebSocket {
+  binaryType: 'blob' | 'arraybuffer' = 'blob';
+  onopen: ((event: unknown) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  sent: string[] = [];
+  closed = false;
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
+
+  constructor(
+    readonly endpoint: string,
+    readonly subprotocols: string[],
+  ) {}
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.closeCalls.push({ ...(code !== undefined && { code }), ...(reason !== undefined && { reason }) });
+  }
+
+  // Test helpers ------------------------------------------------------------
+
+  fireOpen(): void {
+    this.onopen?.({});
+  }
+
+  fireBinary(prefix: number, payload: string): void {
+    const bytes = new TextEncoder().encode(payload);
+    const framed = new Uint8Array(bytes.length + 1);
+    framed[0] = prefix;
+    framed.set(bytes, 1);
+    // Copy into a fresh ArrayBuffer so `instanceof ArrayBuffer` succeeds
+    // regardless of the underlying buffer type.
+    const buffer = framed.buffer.slice(framed.byteOffset, framed.byteOffset + framed.byteLength) as ArrayBuffer;
+    this.onmessage?.({ data: buffer });
+  }
+
+  fireText(text: string): void {
+    this.onmessage?.({ data: text });
+  }
+
+  fireClose(code = 1000, reason = ''): void {
+    this.onclose?.({ code, reason });
+  }
+}
+
+function scriptedFactory(driver: (socket: FakeSocket) => void): {
+  factory: DirectExecWebSocketFactory;
+  sockets: FakeSocket[];
+} {
+  const sockets: FakeSocket[] = [];
+  const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+    const socket = new FakeSocket(endpoint, subprotocols);
+    sockets.push(socket);
+    // Drive the socket on the microtask queue so callers get a chance to
+    // attach their onopen/onmessage listeners first, matching a real WS.
+    queueMicrotask(() => driver(socket));
+    return socket;
+  };
+  return { factory, sockets };
+}
+
+describe('execViaLease', () => {
+  it('opens with subprotocols [subprotocol, jwt] to the lease endpoint', async () => {
+    const { factory, sockets } = scriptedFactory(socket => {
+      socket.fireOpen();
+      socket.fireText(JSON.stringify({ type: 'exit', data: { exit_code: 0 } }));
+    });
+
+    await execViaLease(LEASE, { command: 'echo ok', webSocketFactory: factory });
+
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0]!.endpoint).toBe(LEASE.wsEndpoint);
+    expect(sockets[0]!.subprotocols).toEqual([LEASE.subprotocol, LEASE.jwt]);
+    expect(sockets[0]!.binaryType).toBe('arraybuffer');
+  });
+
+  it('sends init_exec + stdin_close on open, then resolves on exit frame', async () => {
+    const { factory, sockets } = scriptedFactory(socket => {
+      socket.fireOpen();
+      socket.fireBinary(1, 'hello ');
+      socket.fireBinary(1, 'world');
+      socket.fireBinary(3, 'oops');
+      socket.fireText(JSON.stringify({ type: 'exit', data: { exit_code: 0 } }));
+    });
+
+    const result = await execViaLease(LEASE, {
+      command: 'echo hi',
+      cwd: '/w',
+      env: { FOO: 'bar' },
+      webSocketFactory: factory,
+    });
+
+    expect(result).toEqual({
+      exitCode: 0,
+      stdout: 'hello world',
+      stderr: 'oops',
+      truncated: false,
+      timedOut: false,
+    });
+
+    const [init, stdinClose] = sockets[0]!.sent.map(s => JSON.parse(s));
+    expect(init).toEqual({ type: 'init_exec', data: { command: 'echo hi', cwd: '/w', env: { FOO: 'bar' } } });
+    expect(stdinClose).toEqual({ type: 'stdin_close' });
+    // Socket was closed after exit via settle() — code 1000, reason ''.
+    expect(sockets[0]!.closeCalls).toEqual([{ code: 1000, reason: '' }]);
+  });
+
+  it('omits cwd and env from init_exec when not provided', async () => {
+    const { factory, sockets } = scriptedFactory(socket => {
+      socket.fireOpen();
+      socket.fireText(JSON.stringify({ type: 'exit', data: { exit_code: 0 } }));
+    });
+
+    await execViaLease(LEASE, { command: 'echo ok', webSocketFactory: factory });
+
+    const init = JSON.parse(sockets[0]!.sent[0]!) as { data: Record<string, unknown> };
+    expect(init.data).toEqual({ command: 'echo ok' });
+  });
+
+  it('omits env when the caller passes an empty object (matches SDK behavior)', async () => {
+    const { factory, sockets } = scriptedFactory(socket => {
+      socket.fireOpen();
+      socket.fireText(JSON.stringify({ type: 'exit', data: { exit_code: 0 } }));
+    });
+
+    await execViaLease(LEASE, { command: 'echo ok', env: {}, webSocketFactory: factory });
+
+    const init = JSON.parse(sockets[0]!.sent[0]!) as { data: Record<string, unknown> };
+    expect(init.data.env).toBeUndefined();
+  });
+
+  it('streams stdout/stderr chunks to onStdout/onStderr callbacks', async () => {
+    const onStdout = vi.fn();
+    const onStderr = vi.fn();
+    const { factory } = scriptedFactory(socket => {
+      socket.fireOpen();
+      socket.fireBinary(1, 'out1');
+      socket.fireBinary(3, 'err1');
+      socket.fireBinary(1, 'out2');
+      socket.fireText(JSON.stringify({ type: 'exit', data: { exit_code: 0 } }));
+    });
+
+    await execViaLease(LEASE, { command: ':', onStdout, onStderr, webSocketFactory: factory });
+
+    expect(onStdout.mock.calls.map(c => c[0])).toEqual(['out1', 'out2']);
+    expect(onStderr.mock.calls.map(c => c[0])).toEqual(['err1']);
+  });
+
+  it('resolves with nonzero exit code from the exit frame', async () => {
+    const { factory } = scriptedFactory(socket => {
+      socket.fireOpen();
+      socket.fireBinary(3, 'boom');
+      socket.fireText(JSON.stringify({ type: 'exit', data: { exit_code: 137 } }));
+    });
+
+    const result = await execViaLease(LEASE, { command: 'false', webSocketFactory: factory });
+    expect(result.exitCode).toBe(137);
+    expect(result.stderr).toBe('boom');
+  });
+
+  it('defaults exit code to 0 when exit frame has no exit_code (matches SDK)', async () => {
+    const { factory } = scriptedFactory(socket => {
+      socket.fireOpen();
+      socket.fireText(JSON.stringify({ type: 'exit', data: {} }));
+    });
+    const result = await execViaLease(LEASE, { command: ':', webSocketFactory: factory });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('resolves with exitCode=null when the socket closes without an exit frame', async () => {
+    const { factory } = scriptedFactory(socket => {
+      socket.fireOpen();
+      socket.fireBinary(1, 'partial');
+      socket.fireClose(1006, 'connection lost');
+    });
+
+    const result = await execViaLease(LEASE, { command: 'sleep 5', webSocketFactory: factory });
+    expect(result).toEqual({
+      exitCode: null,
+      stdout: 'partial',
+      stderr: '',
+      truncated: false,
+      timedOut: false,
+    });
+  });
+
+  it('resolves with exitCode=null and empty output when the socket never opens', async () => {
+    const { factory } = scriptedFactory(socket => {
+      socket.fireClose(1006, 'handshake rejected');
+    });
+
+    const result = await execViaLease(LEASE, { command: ':', webSocketFactory: factory });
+    expect(result).toEqual({
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false,
+    });
+  });
+
+  it('enforces timeoutMs by closing the socket and returning timedOut=true, exit=124', async () => {
+    vi.useFakeTimers();
+    try {
+      const { factory, sockets } = scriptedFactory(socket => {
+        socket.fireOpen();
+        // Never emit an exit frame; leave the exec "running".
+      });
+
+      const promise = execViaLease(LEASE, { command: 'sleep 999', timeoutMs: 500, webSocketFactory: factory });
+
+      await vi.advanceTimersByTimeAsync(500);
+      const result = await promise;
+
+      expect(result.timedOut).toBe(true);
+      expect(result.exitCode).toBe(124);
+      // Timeout path closes the socket to unwind the server side.
+      expect(sockets[0]!.closeCalls.length).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores durable_session frames on the one-shot exec path', async () => {
+    const { factory } = scriptedFactory(socket => {
+      socket.fireOpen();
+      socket.fireText(JSON.stringify({ type: 'durable_session', data: { durable_session_name: 'sess_1' } }));
+      socket.fireBinary(1, 'ok');
+      socket.fireText(JSON.stringify({ type: 'exit', data: { exit_code: 0 } }));
+    });
+
+    const result = await execViaLease(LEASE, { command: ':', webSocketFactory: factory });
+    expect(result.stdout).toBe('ok');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('ignores malformed text frames instead of rejecting', async () => {
+    const { factory } = scriptedFactory(socket => {
+      socket.fireOpen();
+      socket.fireText('not-json');
+      socket.fireBinary(1, 'ok');
+      socket.fireText(JSON.stringify({ type: 'exit', data: { exit_code: 0 } }));
+    });
+
+    const result = await execViaLease(LEASE, { command: ':', webSocketFactory: factory });
+    expect(result.stdout).toBe('ok');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('drops zero-length binary frames without touching output', async () => {
+    const { factory } = scriptedFactory(socket => {
+      socket.fireOpen();
+      // A frame with only the tag byte and no payload should be a no-op.
+      socket.onmessage?.({ data: new ArrayBuffer(1) });
+      socket.fireBinary(1, 'ok');
+      socket.fireText(JSON.stringify({ type: 'exit', data: { exit_code: 0 } }));
+    });
+
+    const result = await execViaLease(LEASE, { command: ':', webSocketFactory: factory });
+    expect(result.stdout).toBe('ok');
+  });
+
+  it('is a no-op when exit and close both arrive (idempotent settle)', async () => {
+    const { factory, sockets } = scriptedFactory(socket => {
+      socket.fireOpen();
+      socket.fireBinary(1, 'hi');
+      socket.fireText(JSON.stringify({ type: 'exit', data: { exit_code: 0 } }));
+      // Server-initiated close after exit — settle() should be idempotent.
+      socket.fireClose(1000, '');
+    });
+
+    const result = await execViaLease(LEASE, { command: ':', webSocketFactory: factory });
+    expect(result).toEqual({
+      exitCode: 0,
+      stdout: 'hi',
+      stderr: '',
+      truncated: false,
+      timedOut: false,
+    });
+    // Only one close() call should have originated from our side.
+    expect(sockets[0]!.closeCalls).toEqual([{ code: 1000, reason: '' }]);
+  });
+});

--- a/workspaces/platform-workspace/src/direct-exec.ts
+++ b/workspaces/platform-workspace/src/direct-exec.ts
@@ -1,0 +1,217 @@
+/**
+ * Direct exec client — opens Railway's tcp-proxy exec WebSocket directly using
+ * a short-lived JWT minted by the workspace proxy's exec-lease endpoint. This
+ * removes the platform data plane from the exec stdout/stderr path entirely
+ * (see `docs/factory/direct-sandbox-connection.md` in the Platform repo),
+ * cutting payload-scaled Cloud Run egress and RTT for commands like
+ * `pnpm install` that stream tens of MB of output.
+ *
+ * The frame protocol below mirrors `connectExecWs()` in `railway@3.5.5`
+ * (`workspaces/railway/node_modules/railway/dist/index.js`). The `railway`
+ * SDK's version is pinned on both sides (platform + here); a version bump
+ * signals the protocol may have drifted and this module must be revisited.
+ */
+
+/** Byte-0 tag on binary WS frames for stdout output. */
+const STDOUT_FRAME = 1;
+/** Byte-0 tag on binary WS frames for stderr output. */
+const STDERR_FRAME = 3;
+
+/**
+ * Minimal WebSocket surface this module depends on. Matches both the browser
+ * `WebSocket` global and Node 22+'s built-in `WebSocket`. Extracted so tests
+ * can inject a fake without pulling in `ws` or jsdom.
+ */
+export interface DirectExecWebSocket {
+  binaryType: 'blob' | 'arraybuffer';
+  onopen: ((event: unknown) => void) | null;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onclose: ((event: { code: number; reason: string }) => void) | null;
+  onerror: ((event: unknown) => void) | null;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+/**
+ * Factory that opens a WebSocket to `endpoint` with the given subprotocols.
+ * Defaults to the global `WebSocket` when omitted, which works on Node 22+
+ * (the package's minimum) and in the browser. Tests inject a fake here.
+ */
+export type DirectExecWebSocketFactory = (endpoint: string, subprotocols: string[]) => DirectExecWebSocket;
+
+/** Lease payload returned by `POST /v1/projects/:projectId/sandbox/:sandboxId/exec-lease`. */
+export interface ExecLease {
+  jwt: string;
+  wsEndpoint: string;
+  subprotocol: string;
+  /** ISO-8601 UTC. Null when the provider issues a JWT without an `exp` claim. */
+  expiresAt: string | null;
+}
+
+/** Inputs to a direct exec invocation. Mirrors the shape of the `/exec` route body. */
+export interface DirectExecOptions {
+  command: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  /**
+   * Wall-clock cap for the exec. When elapsed, we close the socket and
+   * return `{timedOut: true, exitCode: 124}` matching the semantics of the
+   * proxy's `/exec` route.
+   */
+  timeoutMs?: number;
+  onStdout?: (chunk: string) => void;
+  onStderr?: (chunk: string) => void;
+  /** Injected for tests. Defaults to `globalThis.WebSocket`. */
+  webSocketFactory?: DirectExecWebSocketFactory;
+}
+
+/**
+ * Result of a direct exec. Shape matches the workspace-proxy `/exec` response
+ * so the caller (`PlatformSandbox.executeCommand`) can hand it back with no
+ * translation.
+ *
+ * `exitCode` is `null` when the socket closed without an `exit` frame AND the
+ * exec did not time out (rare — usually a mid-stream network drop). Callers
+ * currently coerce `null` to `1` upstream; kept nullable here to preserve the
+ * distinction for future observability.
+ */
+export interface DirectExecResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  truncated: boolean;
+  timedOut: boolean;
+}
+
+const DEFAULT_WS_FACTORY: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+  const WS = (globalThis as { WebSocket?: unknown }).WebSocket as
+    | (new (url: string, protocols: string[]) => DirectExecWebSocket)
+    | undefined;
+  if (!WS) {
+    throw new Error(
+      'Direct exec requires a WebSocket implementation. Node 22+ provides one globally; on older runtimes, pass webSocketFactory explicitly.',
+    );
+  }
+  return new WS(endpoint, subprotocols);
+};
+
+/**
+ * Open the provider exec WebSocket using `lease`, run `command`, and resolve
+ * with the accumulated stdout/stderr + exit code. See the module docstring
+ * for the wire protocol reference.
+ *
+ * The client sends `stdin_close` immediately after `init_exec`, matching the
+ * SDK's own one-shot exec behavior — we never stream stdin from the caller.
+ */
+export function execViaLease(lease: ExecLease, options: DirectExecOptions): Promise<DirectExecResult> {
+  const factory = options.webSocketFactory ?? DEFAULT_WS_FACTORY;
+  const stdoutDecoder = new TextDecoder();
+  const stderrDecoder = new TextDecoder();
+
+  return new Promise<DirectExecResult>(resolve => {
+    let stdout = '';
+    let stderr = '';
+    let exitCode: number | null = null;
+    let timedOut = false;
+    let settled = false;
+    let opened = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const socket = factory(lease.wsEndpoint, [lease.subprotocol, lease.jwt]);
+    socket.binaryType = 'arraybuffer';
+
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      try {
+        socket.close(1000, '');
+      } catch {
+        /* already closed */
+      }
+      resolve({ exitCode, stdout, stderr, truncated: false, timedOut });
+    };
+
+    socket.onopen = () => {
+      opened = true;
+      const data: Record<string, unknown> = { command: options.command };
+      if (options.cwd) data.cwd = options.cwd;
+      if (options.env && Object.keys(options.env).length > 0) data.env = options.env;
+      socket.send(JSON.stringify({ type: 'init_exec', data }));
+      // We never stream stdin for one-shot exec; the SDK does this too, and
+      // omitting it can leave the exec hanging waiting on EOF.
+      socket.send(JSON.stringify({ type: 'stdin_close' }));
+
+      if (options.timeoutMs !== undefined && options.timeoutMs > 0) {
+        timer = setTimeout(() => {
+          timedOut = true;
+          // 124 matches the proxy's `/exec` semantics (coreutils `timeout`
+          // exit code) so callers that switch on exitCode see the same value.
+          if (exitCode === null) exitCode = 124;
+          settle();
+        }, options.timeoutMs);
+      }
+    };
+
+    socket.onmessage = event => {
+      const { data } = event;
+      if (data instanceof ArrayBuffer) {
+        handleBinaryFrame(data);
+      } else if (typeof data === 'string') {
+        handleTextFrame(data);
+      }
+    };
+
+    socket.onclose = event => {
+      if (!opened) {
+        // Never opened — surface as a failure via exitCode=null,
+        // truncated=false, timedOut=false so the caller can distinguish
+        // it from a normal exit-0 by inspecting `exitCode === null`.
+        settle();
+        return;
+      }
+      // Preserve any info captured before close; if the server sent an
+      // `exit` frame this is a no-op because settle() already ran.
+      settle();
+      void event; // eslint: intentionally observed for future logging
+    };
+
+    socket.onerror = () => {
+      if (settled) return;
+      if (!opened) {
+        settle();
+      }
+      // If we're mid-stream and the socket errors, wait for onclose to fire
+      // so we settle with whatever output we did receive.
+    };
+
+    function handleBinaryFrame(buffer: ArrayBuffer) {
+      const view = new Uint8Array(buffer);
+      if (view.length <= 1) return;
+      if (view[0] === STDOUT_FRAME) {
+        const chunk = stdoutDecoder.decode(view.subarray(1), { stream: true });
+        stdout += chunk;
+        options.onStdout?.(chunk);
+      } else if (view[0] === STDERR_FRAME) {
+        const chunk = stderrDecoder.decode(view.subarray(1), { stream: true });
+        stderr += chunk;
+        options.onStderr?.(chunk);
+      }
+    }
+
+    function handleTextFrame(text: string) {
+      let frame: { type?: string; data?: { exit_code?: number } };
+      try {
+        frame = JSON.parse(text) as { type?: string; data?: { exit_code?: number } };
+      } catch {
+        return;
+      }
+      if (frame.type === 'exit') {
+        exitCode = frame.data?.exit_code ?? 0;
+        settle();
+      }
+      // `durable_session` frames are intentionally ignored — we don't reattach
+      // or expose session names on the one-shot exec path.
+    }
+  });
+}

--- a/workspaces/platform-workspace/src/direct-exec.ts
+++ b/workspaces/platform-workspace/src/direct-exec.ts
@@ -85,8 +85,7 @@ export interface DirectExecResult {
 
 const DEFAULT_WS_FACTORY: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
   const WS = (globalThis as { WebSocket?: unknown }).WebSocket as
-    | (new (url: string, protocols: string[]) => DirectExecWebSocket)
-    | undefined;
+    (new (url: string, protocols: string[]) => DirectExecWebSocket) | undefined;
   if (!WS) {
     throw new Error(
       'Direct exec requires a WebSocket implementation. Node 22+ provides one globally; on older runtimes, pass webSocketFactory explicitly.',

--- a/workspaces/platform-workspace/src/direct-exec.ts
+++ b/workspaces/platform-workspace/src/direct-exec.ts
@@ -16,6 +16,14 @@
 const STDOUT_FRAME = 1;
 /** Byte-0 tag on binary WS frames for stderr output. */
 const STDERR_FRAME = 3;
+/**
+ * Upper bound on how long we'll wait for the WebSocket to open when the
+ * caller didn't supply a `timeoutMs`. Guards against a stalled TLS/WS
+ * handshake leaving the promise unresolved forever. Not applied once the
+ * socket has opened — a caller with no timeout has opted in to unbounded
+ * command runtime, just not to unbounded connection setup.
+ */
+const HANDSHAKE_DEADLINE_MS = 30_000;
 
 /**
  * Minimal WebSocket surface this module depends on. Matches both the browser
@@ -85,7 +93,8 @@ export interface DirectExecResult {
 
 const DEFAULT_WS_FACTORY: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
   const WS = (globalThis as { WebSocket?: unknown }).WebSocket as
-    (new (url: string, protocols: string[]) => DirectExecWebSocket) | undefined;
+    | (new (url: string, protocols: string[]) => DirectExecWebSocket)
+    | undefined;
   if (!WS) {
     throw new Error(
       'Direct exec requires a WebSocket implementation. Node 22+ provides one globally; on older runtimes, pass webSocketFactory explicitly.',
@@ -115,14 +124,26 @@ export function execViaLease(lease: ExecLease, options: DirectExecOptions): Prom
     let settled = false;
     let opened = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
-
-    const socket = factory(lease.wsEndpoint, [lease.subprotocol, lease.jwt]);
-    socket.binaryType = 'arraybuffer';
+    let handshakeTimer: ReturnType<typeof setTimeout> | undefined;
 
     const settle = () => {
       if (settled) return;
       settled = true;
       if (timer) clearTimeout(timer);
+      if (handshakeTimer) clearTimeout(handshakeTimer);
+      // Flush any bytes still buffered in the decoders. A stream:true decode
+      // holds trailing partial multi-byte sequences until the next chunk, so
+      // without a flush the final char(s) of a UTF-8 stream can be dropped.
+      const stdoutTail = stdoutDecoder.decode();
+      if (stdoutTail) {
+        stdout += stdoutTail;
+        options.onStdout?.(stdoutTail);
+      }
+      const stderrTail = stderrDecoder.decode();
+      if (stderrTail) {
+        stderr += stderrTail;
+        options.onStderr?.(stderrTail);
+      }
       try {
         socket.close(1000, '');
       } catch {
@@ -131,8 +152,36 @@ export function execViaLease(lease: ExecLease, options: DirectExecOptions): Prom
       resolve({ exitCode, stdout, stderr, truncated: false, timedOut });
     };
 
+    // Arm the timeout BEFORE we open the socket so a stalled handshake can't
+    // leave the promise pending. Callers with a positive `timeoutMs` get the
+    // wall-clock cap they asked for; callers without one still get a
+    // connect-only deadline that clears once the socket opens.
+    if (options.timeoutMs !== undefined && options.timeoutMs > 0) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        // 124 matches the proxy's `/exec` semantics (coreutils `timeout`
+        // exit code) so callers that switch on exitCode see the same value.
+        if (exitCode === null) exitCode = 124;
+        settle();
+      }, options.timeoutMs);
+    } else {
+      handshakeTimer = setTimeout(() => {
+        // Never opened → treat as a transport failure. Leave exitCode=null
+        // so the caller can distinguish this from a normal exit; do not
+        // set timedOut (that flag is reserved for the wall-clock case).
+        if (!opened) settle();
+      }, HANDSHAKE_DEADLINE_MS);
+    }
+
+    const socket = factory(lease.wsEndpoint, [lease.subprotocol, lease.jwt]);
+    socket.binaryType = 'arraybuffer';
+
     socket.onopen = () => {
       opened = true;
+      if (handshakeTimer) {
+        clearTimeout(handshakeTimer);
+        handshakeTimer = undefined;
+      }
       const data: Record<string, unknown> = { command: options.command };
       if (options.cwd) data.cwd = options.cwd;
       if (options.env && Object.keys(options.env).length > 0) data.env = options.env;
@@ -140,16 +189,6 @@ export function execViaLease(lease: ExecLease, options: DirectExecOptions): Prom
       // We never stream stdin for one-shot exec; the SDK does this too, and
       // omitting it can leave the exec hanging waiting on EOF.
       socket.send(JSON.stringify({ type: 'stdin_close' }));
-
-      if (options.timeoutMs !== undefined && options.timeoutMs > 0) {
-        timer = setTimeout(() => {
-          timedOut = true;
-          // 124 matches the proxy's `/exec` semantics (coreutils `timeout`
-          // exit code) so callers that switch on exitCode see the same value.
-          if (exitCode === null) exitCode = 124;
-          settle();
-        }, options.timeoutMs);
-      }
     };
 
     socket.onmessage = event => {

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -407,7 +407,10 @@ describe('PlatformSandbox', () => {
   });
 
   it('kill() throws because the proxy has no cancel endpoint', async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_1' })).mockResolvedValueOnce(leaseResponse());
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(json({ id: 'sbx_1' }))
+      .mockResolvedValueOnce(leaseResponse());
     const { factory } = fakeExecSocket({ exitCode: 0 });
 
     const sandbox = new PlatformSandbox({
@@ -517,9 +520,7 @@ describe('PlatformSandbox', () => {
         .fn()
         .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
         // Older platform deployment: exec-lease not present.
-        .mockResolvedValueOnce(
-          json({ error: { message: 'Not Found', type: 'not_found' } }, { status: 404 }),
-        )
+        .mockResolvedValueOnce(json({ error: { message: 'Not Found', type: 'not_found' } }, { status: 404 }))
         .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '', timedOut: false, truncated: false }))
         // Second exec should skip the mint attempt entirely — the fallback bit is sticky.
         .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '', timedOut: false, truncated: false }));
@@ -572,7 +573,6 @@ describe('PlatformSandbox', () => {
       // "endpoint not present" signal.
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
-
   });
 
   describe('clone', () => {

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1,8 +1,84 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DirectExecWebSocket, DirectExecWebSocketFactory } from './direct-exec.js';
 import { PlatformSandbox } from './sandbox.js';
 
 function json(body: unknown, init?: ResponseInit) {
   return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' }, ...init });
+}
+
+/**
+ * Wire-shape of a successful `POST /sandbox/:id/exec-lease` response, used
+ * across tests that exercise the direct-exec path.
+ */
+function leaseResponse(overrides: { jwt?: string; expiresAt?: string | null } = {}) {
+  return json({
+    provider: 'railway',
+    sandboxId: 'sbx_test',
+    providerResourceId: 'rw_sb_test',
+    jwt: overrides.jwt ?? 'jwt.value.here',
+    wsEndpoint: 'wss://ssh.railway.com:2226/ws/exec',
+    subprotocol: 'railway-shell',
+    // Explicit key check so `expiresAt: null` isn't collapsed to the default
+    // by nullish coalescing (which treats null and undefined the same).
+    expiresAt: 'expiresAt' in overrides ? overrides.expiresAt : '2030-01-01T00:00:00.000Z',
+  });
+}
+
+/**
+ * Build a WebSocket factory that immediately drives an exec to completion
+ * with the given exit code and stdout, so tests can exercise `executeCommand`
+ * without mocking a real WebSocket. Sockets are captured so tests can assert
+ * on the endpoint + subprotocols they were opened with.
+ */
+function fakeExecSocket(script: { exitCode: number; stdout?: string; stderr?: string }): {
+  factory: DirectExecWebSocketFactory;
+  sockets: FakeSocket[];
+} {
+  const sockets: FakeSocket[] = [];
+  const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+    const socket = new FakeSocket(endpoint, subprotocols);
+    sockets.push(socket);
+    queueMicrotask(() => {
+      socket.onopen?.({});
+      if (script.stdout) socket.fireBinary(1, script.stdout);
+      if (script.stderr) socket.fireBinary(3, script.stderr);
+      socket.onmessage?.({ data: JSON.stringify({ type: 'exit', data: { exit_code: script.exitCode } }) });
+    });
+    return socket;
+  };
+  return { factory, sockets };
+}
+
+class FakeSocket implements DirectExecWebSocket {
+  binaryType: 'blob' | 'arraybuffer' = 'blob';
+  onopen: ((event: unknown) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  sent: string[] = [];
+  closed = false;
+
+  constructor(
+    readonly endpoint: string,
+    readonly subprotocols: string[],
+  ) {}
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  fireBinary(prefix: number, payload: string): void {
+    const bytes = new TextEncoder().encode(payload);
+    const framed = new Uint8Array(bytes.length + 1);
+    framed[0] = prefix;
+    framed.set(bytes, 1);
+    const buffer = framed.buffer.slice(framed.byteOffset, framed.byteOffset + framed.byteLength) as ArrayBuffer;
+    this.onmessage?.({ data: buffer });
+  }
 }
 
 describe('PlatformSandbox', () => {
@@ -10,34 +86,41 @@ describe('PlatformSandbox', () => {
     vi.unstubAllEnvs();
   });
 
-  it('creates a sandbox and executes commands through the proxy', async () => {
+  it('creates a sandbox, mints an exec lease, and runs the command over the direct WebSocket', async () => {
     vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
-      .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '', timedOut: false, truncated: false }));
+      .mockResolvedValueOnce(leaseResponse());
+    const { factory, sockets } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
 
     const sandbox = new PlatformSandbox({
       accessToken: 'sk_test',
       projectId: 'proj_123',
       environmentId: 'env_123',
       fetch: fetchMock,
+      webSocketFactory: factory,
     });
 
     await sandbox._start();
     const result = await sandbox.executeCommand('echo', ['ok'], { cwd: '/workspace', env: { A: '1' } });
 
     expect(result).toMatchObject({ success: true, exitCode: 0, stdout: 'ok', stderr: '', command: 'echo ok' });
+    // Provision request first.
     expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox');
     expect(await (fetchMock.mock.calls[0]![1].body as string)).toContain('env_123');
-    expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec');
-    const execBody = JSON.parse(fetchMock.mock.calls[1]![1].body as string);
-    expect(execBody).toMatchObject({
-      command: 'echo ok',
-      cwd: '/workspace',
-      env: { A: '1' },
-    });
-    expect(execBody.environmentId).toBeUndefined();
+    // Then the exec-lease mint — no /exec HTTP hit.
+    expect(String(fetchMock.mock.calls[1]![0])).toBe(
+      'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Exec ran over the direct WS with the lease's endpoint + subprotocols.
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0]!.endpoint).toBe('wss://ssh.railway.com:2226/ws/exec');
+    expect(sockets[0]!.subprotocols).toEqual(['railway-shell', 'jwt.value.here']);
+    // init_exec frame carries command + cwd + env.
+    const init = JSON.parse(sockets[0]!.sent[0]!) as { data: Record<string, unknown> };
+    expect(init.data).toEqual({ command: 'echo ok', cwd: '/workspace', env: { A: '1' } });
   });
 
   it('does not send a template field on the create wire body', async () => {
@@ -155,12 +238,14 @@ describe('PlatformSandbox', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(json({ id: 'sbx_existing', createdAt: '2026-06-26T00:00:00.000Z' }))
-      .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '' }));
+      .mockResolvedValueOnce(leaseResponse());
+    const { factory } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
     const sandbox = new PlatformSandbox({
       accessToken: 'sk_test',
       projectId: 'proj_123',
       sandboxId: 'sbx_existing',
       fetch: fetchMock,
+      webSocketFactory: factory,
     });
 
     await sandbox._start();
@@ -169,7 +254,7 @@ describe('PlatformSandbox', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing');
     expect(String(fetchMock.mock.calls[1]![0])).toBe(
-      'https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing/exec',
+      'https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing/exec-lease',
     );
   });
 
@@ -180,12 +265,14 @@ describe('PlatformSandbox', () => {
       .fn()
       .mockResolvedValueOnce(json({ error: { message: 'Sandbox not found', type: 'not_found' } }, { status: 404 }))
       .mockResolvedValueOnce(json({ id: 'sbx_recreated', createdAt: '2026-06-26T00:00:00.000Z' }))
-      .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '' }));
+      .mockResolvedValueOnce(leaseResponse());
+    const { factory } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
     const sandbox = new PlatformSandbox({
       accessToken: 'sk_test',
       projectId: 'proj_123',
       sandboxId: 'sbx_stale',
       fetch: fetchMock,
+      webSocketFactory: factory,
     });
 
     await sandbox._start();
@@ -198,7 +285,7 @@ describe('PlatformSandbox', () => {
       environmentId: 'env_from_process',
     });
     expect(String(fetchMock.mock.calls[2]![0])).toBe(
-      'https://proxy.test/v1/projects/proj_123/sandbox/sbx_recreated/exec',
+      'https://proxy.test/v1/projects/proj_123/sandbox/sbx_recreated/exec-lease',
     );
   });
 
@@ -212,12 +299,14 @@ describe('PlatformSandbox', () => {
         json({ id: 'sbx_stale', createdAt: '2026-06-26T00:00:00.000Z', destroyedAt: '2026-06-27T00:00:00.000Z' }),
       )
       .mockResolvedValueOnce(json({ id: 'sbx_recreated', createdAt: '2026-06-28T00:00:00.000Z' }))
-      .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '' }));
+      .mockResolvedValueOnce(leaseResponse());
+    const { factory } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
     const sandbox = new PlatformSandbox({
       accessToken: 'sk_test',
       projectId: 'proj_123',
       sandboxId: 'sbx_stale',
       fetch: fetchMock,
+      webSocketFactory: factory,
     });
 
     await sandbox._start();
@@ -225,7 +314,7 @@ describe('PlatformSandbox', () => {
 
     expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox');
     expect(String(fetchMock.mock.calls[2]![0])).toBe(
-      'https://proxy.test/v1/projects/proj_123/sandbox/sbx_recreated/exec',
+      'https://proxy.test/v1/projects/proj_123/sandbox/sbx_recreated/exec-lease',
     );
   });
 
@@ -283,43 +372,207 @@ describe('PlatformSandbox', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2); // no third fetch
   });
 
-  it('preserves an explicit timeout: 0 on executeCommand instead of dropping it', async () => {
+  it('treats an explicit timeout: 0 as "no timeout" on the direct-exec path (matches proxy semantics)', async () => {
+    // On the fallback /exec path, timeout: 0 must be preserved (not dropped
+    // by a truthy check) so the proxy sees `timeoutSec: 0` and interprets it
+    // as no-timeout. On the direct-exec path, the client owns the timeout —
+    // "no timeout" is expressed by NOT arming a client-side timer, so the
+    // exec runs to completion regardless of wall-clock elapsed.
     vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
-      .mockResolvedValueOnce(json({ exitCode: 0, stdout: '', stderr: '' }));
+      .mockResolvedValueOnce(leaseResponse());
+    const { factory, sockets } = fakeExecSocket({ exitCode: 0 });
 
     const sandbox = new PlatformSandbox({
       accessToken: 'sk_test',
       projectId: 'proj_123',
       environmentId: 'env_123',
       fetch: fetchMock,
+      webSocketFactory: factory,
     });
 
     await sandbox._start();
-    await sandbox.executeCommand('sleep', ['1'], { timeout: 0 });
+    const result = await sandbox.executeCommand('sleep', ['1'], { timeout: 0 });
 
-    const body = JSON.parse(fetchMock.mock.calls[1]![1].body as string);
-    expect(body.timeoutSec).toBe(0);
+    // Would have been `timedOut: true, exitCode: 124` if the 0 got converted
+    // to a "default short timeout" — the whole point of the original bug.
+    expect(result).toMatchObject({ exitCode: 0, timedOut: false });
+    // The init frame carries no timeout field either way — timeout enforcement
+    // is client-side on the direct path, not part of the wire protocol.
+    const init = JSON.parse(sockets[0]!.sent[0]!) as { data: Record<string, unknown> };
+    expect('timeoutSec' in init.data).toBe(false);
+    expect('timeoutMs' in init.data).toBe(false);
   });
 
   it('kill() throws because the proxy has no cancel endpoint', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(json({ id: 'sbx_1' }))
-      .mockResolvedValueOnce(json({ exitCode: 0, stdout: '', stderr: '' }));
+    const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_1' })).mockResolvedValueOnce(leaseResponse());
+    const { factory } = fakeExecSocket({ exitCode: 0 });
 
     const sandbox = new PlatformSandbox({
       accessToken: 'sk_test',
       projectId: 'proj_123',
       environmentId: 'env_123',
       fetch: fetchMock,
+      webSocketFactory: factory,
     });
     await sandbox._start();
 
     const handle = await sandbox.processes.spawn('sleep 10');
     await expect(handle.kill()).rejects.toThrow(/does not support killing/);
+  });
+
+  describe('direct exec', () => {
+    it('reuses a cached lease across multiple execs on the same sandbox', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse());
+      const { factory, sockets } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      await sandbox.executeCommand('echo one');
+      // A second exec must NOT round-trip to /exec-lease again; the lease is
+      // reused until it expires. Only two fetches total: provision + first lease.
+      await sandbox.executeCommand('echo two');
+      await sandbox.executeCommand('echo three');
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      // But each exec still opens a fresh WebSocket (leases are per sandbox,
+      // WS sessions are per exec).
+      expect(sockets).toHaveLength(3);
+    });
+
+    it('mints a fresh lease when the cached one is within LEASE_REFRESH_MARGIN_MS of expiry', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const expiringSoon = new Date(Date.now() + 10_000).toISOString();
+      const freshLater = new Date(Date.now() + 3600_000).toISOString();
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.old', expiresAt: expiringSoon }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.new', expiresAt: freshLater }));
+      const { factory, sockets } = fakeExecSocket({ exitCode: 0 });
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      await sandbox.executeCommand('one');
+      await sandbox.executeCommand('two');
+
+      // Second exec re-minted because expiry - margin < now.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(String(fetchMock.mock.calls[2]![0])).toBe(
+        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
+      );
+      // Each socket opened with the JWT that was current at that moment.
+      expect(sockets[0]!.subprotocols[1]).toBe('jwt.old');
+      expect(sockets[1]!.subprotocols[1]).toBe('jwt.new');
+    });
+
+    it('always re-mints when the lease has a null expiresAt (unknown TTL, refresh eagerly)', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse({ expiresAt: null }))
+        .mockResolvedValueOnce(leaseResponse({ expiresAt: null }));
+      const { factory } = fakeExecSocket({ exitCode: 0 });
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      await sandbox.executeCommand('one');
+      await sandbox.executeCommand('two');
+
+      // Provision + two lease mints — cache is skipped because expiresAt is null.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('falls back to the proxy /exec route when the exec-lease endpoint returns 404', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        // Older platform deployment: exec-lease not present.
+        .mockResolvedValueOnce(
+          json({ error: { message: 'Not Found', type: 'not_found' } }, { status: 404 }),
+        )
+        .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '', timedOut: false, truncated: false }))
+        // Second exec should skip the mint attempt entirely — the fallback bit is sticky.
+        .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '', timedOut: false, truncated: false }));
+      // If the fallback fails to trigger, we'd end up here and the test would blow up
+      // with an unhandled WS error. Passing a factory that throws makes that explicit.
+      const factory: DirectExecWebSocketFactory = () => {
+        throw new Error('should not open a WebSocket after 404 fallback');
+      };
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      const first = await sandbox.executeCommand('echo one');
+      const second = await sandbox.executeCommand('echo two');
+
+      expect(first).toMatchObject({ exitCode: 0, stdout: 'ok' });
+      expect(second).toMatchObject({ exitCode: 0, stdout: 'ok' });
+      // Calls: provision, exec-lease (404), /exec (fallback), /exec (sticky fallback).
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(String(fetchMock.mock.calls[1]![0])).toBe(
+        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
+      );
+      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec');
+      expect(String(fetchMock.mock.calls[3]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec');
+    });
+
+    it('propagates non-404/501 errors from the exec-lease mint instead of falling back silently', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(json({ error: { message: 'boom', type: 'internal_error' } }, { status: 500 }));
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+
+      await sandbox._start();
+      await expect(sandbox.executeCommand('echo hi')).rejects.toThrow(/internal_error/);
+      // Only provision + failed mint; no /exec fallback because 500 isn't a
+      // "endpoint not present" signal.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
   });
 
   describe('clone', () => {
@@ -385,12 +638,14 @@ describe('PlatformSandbox', () => {
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(json({ id: 'sbx_existing', createdAt: '2026-06-26T00:00:00.000Z' }))
-        .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '' }));
+        .mockResolvedValueOnce(leaseResponse());
+      const { factory } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
       const template = new PlatformSandbox({
         accessToken: 'sk_test',
         projectId: 'proj_123',
         environmentId: 'env_123',
         fetch: fetchMock,
+        webSocketFactory: factory,
       });
 
       const child = template.clone({ sandboxId: 'sbx_existing' });
@@ -399,7 +654,7 @@ describe('PlatformSandbox', () => {
 
       expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing');
       expect(String(fetchMock.mock.calls[1]![0])).toBe(
-        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing/exec',
+        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing/exec-lease',
       );
       const createCalls = fetchMock.mock.calls.filter(call => {
         const url = String(call[0]);

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -573,6 +573,105 @@ describe('PlatformSandbox', () => {
       // "endpoint not present" signal.
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
+
+    it('drops the cached lease and falls through to /exec when the WS closes without an exit frame', async () => {
+      // Simulates a mid-handshake drop / expired token / provider hiccup:
+      // lease mint succeeds but the direct-exec socket closes before an exit
+      // frame arrives. We should discard the (possibly stale) lease, fall
+      // through to the proxy /exec path for THIS call, and re-mint on the
+      // next call so we don't fall through forever on a transient blip.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.first' }))
+        .mockResolvedValueOnce(
+          json({ exitCode: 0, stdout: 'via-proxy', stderr: '', timedOut: false, truncated: false }),
+        )
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.second' }));
+      const sockets: FakeSocket[] = [];
+      let call = 0;
+      const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+        const socket = new FakeSocket(endpoint, subprotocols);
+        sockets.push(socket);
+        const isFirst = ++call === 1;
+        queueMicrotask(() => {
+          socket.onopen?.({});
+          if (isFirst) {
+            // First exec: close without an exit frame — transport failure.
+            socket.onclose?.({ code: 1006, reason: 'abnormal' });
+          } else {
+            // Second exec: normal exit.
+            socket.onmessage?.({ data: JSON.stringify({ type: 'exit', data: { exit_code: 0 } }) });
+          }
+        });
+        return socket;
+      };
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      const first = await sandbox.executeCommand('echo one');
+      const second = await sandbox.executeCommand('echo two');
+
+      // First call fell through to /exec after the WS drop.
+      expect(first).toMatchObject({ exitCode: 0, stdout: 'via-proxy' });
+      // Second call re-minted a fresh lease (jwt.second) and succeeded direct.
+      expect(second).toMatchObject({ exitCode: 0 });
+      // Fetch sequence: provision, first lease, /exec fallback, second lease.
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec');
+      expect(String(fetchMock.mock.calls[3]![0])).toBe(
+        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
+      );
+      // Two sockets opened (both direct-exec attempts); the second used the fresh JWT.
+      expect(sockets).toHaveLength(2);
+      expect(sockets[1]!.subprotocols[1]).toBe('jwt.second');
+    });
+
+    it('coalesces concurrent lease mints on a cold cache into a single POST /exec-lease', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      // Delay the lease response so both execs hit `_ensureLease` before it resolves.
+      let releaseLease!: () => void;
+      const leasePromise = new Promise<Response>(resolve => {
+        releaseLease = () => resolve(leaseResponse());
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockImplementationOnce(() => leasePromise);
+      const { factory } = fakeExecSocket({ exitCode: 0 });
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      // Fire two execs in parallel before the lease mint resolves.
+      const both = Promise.all([sandbox.executeCommand('echo one'), sandbox.executeCommand('echo two')]);
+      // Let both calls reach `_ensureLease`, then release the shared mint.
+      await new Promise(r => setTimeout(r, 0));
+      releaseLease();
+      const [first, second] = await both;
+
+      expect(first).toMatchObject({ exitCode: 0 });
+      expect(second).toMatchObject({ exitCode: 0 });
+      // Provision + exactly one shared mint (no duplicate) — proves coalescing.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(String(fetchMock.mock.calls[1]![0])).toBe(
+        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
+      );
+    });
   });
 
   describe('clone', () => {

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -180,11 +180,19 @@ export class PlatformSandbox extends MastraSandbox {
   private _createdAt: Date | null = null;
   private readonly _webSocketFactory?: DirectExecWebSocketFactory;
   /**
-   * Cached exec lease for this sandbox. `null` while unmounted. Invalidated
-   * when `expiresAt - LEASE_REFRESH_MARGIN_MS < now`, or when the WS
-   * handshake fails with a close code Railway uses for expired tokens.
+   * Cached exec lease for this sandbox. `null` before the first exec and
+   * after {@link destroy}. Refreshed when `expiresAt - LEASE_REFRESH_MARGIN_MS < now`
+   * (see {@link _ensureLease}); a lease without a disclosed `expiresAt`
+   * is refreshed on every call.
    */
   private _lease: (ExecLease & { expiresAtMs: number | null }) | null = null;
+  /**
+   * In-flight mint request; concurrent `_ensureLease` callers on a cold or
+   * near-expiry cache all await this single promise so we don't burn N
+   * `POST /exec-lease` round-trips when the sandbox is doing N parallel execs.
+   * Cleared (regardless of success or failure) when the request settles.
+   */
+  private _leaseInFlight: Promise<ExecLease & { expiresAtMs: number | null }> | null = null;
   /**
    * Tri-state feature detection for the platform's exec-lease endpoint:
    *   undefined — not yet tried (default; try direct on first exec)
@@ -392,7 +400,17 @@ export class PlatformSandbox extends MastraSandbox {
       ...(effectiveTimeout != null && effectiveTimeout > 0 && { timeoutMs: effectiveTimeout }),
       ...(this._webSocketFactory && { webSocketFactory: this._webSocketFactory }),
     });
-    const exitCode = result.exitCode ?? (result.timedOut ? 124 : 1);
+    // `null` exitCode without `timedOut` means the socket closed without an
+    // exit frame — i.e. a transport failure (handshake stalled, mid-stream
+    // drop, expired token). Drop the cached lease so the next call re-mints,
+    // and return `null` to let the caller fall through to the proxy /exec
+    // path. Timed-out and normal-exit results still return synthesised /
+    // real exit codes as before.
+    if (result.exitCode === null && !result.timedOut) {
+      this._lease = null;
+      return null;
+    }
+    const exitCode = result.exitCode ?? 124;
     return {
       success: exitCode === 0,
       exitCode,
@@ -456,24 +474,37 @@ export class PlatformSandbox extends MastraSandbox {
     if (this._lease && this._lease.expiresAtMs !== null && this._lease.expiresAtMs - LEASE_REFRESH_MARGIN_MS > now) {
       return this._lease;
     }
+    // Coalesce concurrent mints on a cold/expired cache.
+    if (this._leaseInFlight) return this._leaseInFlight;
     if (!this._sandboxId) throw new SandboxNotReadyError(this.id);
-    const response = await this._client.request(`/sandbox/${encodeURIComponent(this._sandboxId)}/exec-lease`, {
-      method: 'POST',
-    });
-    const json = (await response.json()) as ExecLeaseResponse;
-    const expiresAtMs = json.expiresAt ? Date.parse(json.expiresAt) : null;
-    const lease = {
-      jwt: json.jwt,
-      wsEndpoint: json.wsEndpoint,
-      subprotocol: json.subprotocol,
-      expiresAt: json.expiresAt,
-      // Guard against `Date.parse` returning NaN for malformed values by
-      // treating them as "no expiry known", which forces a mint every call
-      // rather than silently caching a broken lease forever.
-      expiresAtMs: expiresAtMs !== null && !Number.isNaN(expiresAtMs) ? expiresAtMs : null,
-    };
-    this._lease = lease;
-    return lease;
+    const sandboxId = this._sandboxId;
+    const inFlight = (async () => {
+      const response = await this._client.request(`/sandbox/${encodeURIComponent(sandboxId)}/exec-lease`, {
+        method: 'POST',
+      });
+      const json = (await response.json()) as ExecLeaseResponse;
+      const expiresAtMs = json.expiresAt ? Date.parse(json.expiresAt) : null;
+      const lease = {
+        jwt: json.jwt,
+        wsEndpoint: json.wsEndpoint,
+        subprotocol: json.subprotocol,
+        expiresAt: json.expiresAt,
+        // Guard against `Date.parse` returning NaN for malformed values by
+        // treating them as "no expiry known", which forces a mint every call
+        // rather than silently caching a broken lease forever.
+        expiresAtMs: expiresAtMs !== null && !Number.isNaN(expiresAtMs) ? expiresAtMs : null,
+      };
+      this._lease = lease;
+      return lease;
+    })();
+    this._leaseInFlight = inFlight;
+    try {
+      return await inFlight;
+    } finally {
+      // Clear on both success and failure so a failed mint doesn't wedge
+      // future callers into awaiting the same rejected promise forever.
+      if (this._leaseInFlight === inFlight) this._leaseInFlight = null;
+    }
   }
 
   async getInfo(): Promise<SandboxInfo> {

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -13,6 +13,8 @@ import type {
 import { MastraSandbox, ProcessHandle, SandboxNotReadyError, SandboxProcessManager } from '@mastra/core/workspace';
 import type { PlatformClientOptions } from './client.js';
 import { PlatformApiError, PlatformClient } from './client.js';
+import type { DirectExecWebSocketFactory, ExecLease } from './direct-exec.js';
+import { execViaLease } from './direct-exec.js';
 
 export type PlatformSandboxNetworkIsolation = 'ISOLATED' | 'PRIVATE';
 
@@ -25,7 +27,31 @@ export interface PlatformSandboxOptions extends Omit<MastraSandboxOptions, 'proc
   env?: Record<string, string>;
   timeout?: number;
   instructions?: InstructionsOption;
+  /**
+   * Injected WebSocket factory used by the direct-exec code path. Defaults to
+   * the global `WebSocket` (available on Node 22+, this package's minimum) and
+   * only exists so tests can drive the exec state machine deterministically
+   * without a real network socket.
+   */
+  webSocketFactory?: DirectExecWebSocketFactory;
 }
+
+interface ExecLeaseResponse {
+  provider: string;
+  sandboxId: string;
+  providerResourceId: string;
+  jwt: string;
+  wsEndpoint: string;
+  subprotocol: string;
+  expiresAt: string | null;
+}
+
+/**
+ * How long before a lease's stated `expiresAt` we should treat it as
+ * expired. Avoids a race where the JWT is valid at cache-hit time but the
+ * server rejects it by the time the WebSocket handshake completes.
+ */
+const LEASE_REFRESH_MARGIN_MS = 60_000;
 
 interface CreateSandboxResponse {
   id: string;
@@ -152,6 +178,22 @@ export class PlatformSandbox extends MastraSandbox {
   private readonly _timeout?: number;
   private readonly _instructionsOverride?: InstructionsOption;
   private _createdAt: Date | null = null;
+  private readonly _webSocketFactory?: DirectExecWebSocketFactory;
+  /**
+   * Cached exec lease for this sandbox. `null` while unmounted. Invalidated
+   * when `expiresAt - LEASE_REFRESH_MARGIN_MS < now`, or when the WS
+   * handshake fails with a close code Railway uses for expired tokens.
+   */
+  private _lease: ExecLease & { expiresAtMs: number | null } | null = null;
+  /**
+   * Tri-state feature detection for the platform's exec-lease endpoint:
+   *   undefined — not yet tried (default; try direct on first exec)
+   *   true      — endpoint present, use direct exec
+   *   false     — endpoint returned 404 or 501, fall back permanently to /exec
+   * Sticky per instance so we make the fallback decision once per sandbox
+   * lifetime instead of paying an extra round-trip on every exec.
+   */
+  private _directExecAvailable: boolean | undefined = undefined;
 
   constructor(options: PlatformSandboxOptions = {}) {
     super({ ...options, name: 'PlatformSandbox', processes: new PlatformProcessManager() });
@@ -165,6 +207,7 @@ export class PlatformSandbox extends MastraSandbox {
     this._env = options.env ?? {};
     this._timeout = options.timeout;
     this._instructionsOverride = options.instructions;
+    this._webSocketFactory = options.webSocketFactory;
   }
 
   private generateId(): string {
@@ -196,6 +239,7 @@ export class PlatformSandbox extends MastraSandbox {
       env: options.env ?? this._env,
       ...(this._timeout !== undefined && { timeout: this._timeout }),
       ...(this._instructionsOverride !== undefined && { instructions: this._instructionsOverride }),
+      ...(this._webSocketFactory !== undefined && { webSocketFactory: this._webSocketFactory }),
     });
   }
 
@@ -267,6 +311,9 @@ export class PlatformSandbox extends MastraSandbox {
     // instead of taking the reattach branch and pointing exec at a deleted resource.
     this._sandboxId = undefined;
     this._createdAt = null;
+    // Drop the exec lease with the sandbox — the JWT is tied to the provider
+    // instance id and would be rejected against a fresh one.
+    this._lease = null;
   }
 
   /**
@@ -295,6 +342,74 @@ export class PlatformSandbox extends MastraSandbox {
     // Nullish check so an explicit `timeout: 0` is sent as `0` (interpreted as
     // "no timeout" by the proxy) instead of being dropped by a truthy check.
     const effectiveTimeout = options?.timeout ?? this._timeout;
+
+    // Prefer the direct-exec data plane (WebSocket straight to Railway's
+    // tcp-proxy) when the platform exposes the exec-lease endpoint. Falls
+    // back to the proxy /exec route on older platform deployments. See
+    // ./direct-exec.ts and `docs/factory/direct-sandbox-connection.md` in
+    // the Platform repo.
+    if (this._directExecAvailable !== false) {
+      const leaseResult = await this._tryDirectExec(fullCommand, effectiveTimeout, options);
+      if (leaseResult) return { ...leaseResult, executionTimeMs: Date.now() - started };
+    }
+    return this._execViaProxy(fullCommand, effectiveTimeout, options, started);
+  }
+
+  private async _tryDirectExec(
+    fullCommand: string,
+    effectiveTimeout: number | undefined,
+    options: ExecuteCommandOptions | undefined,
+  ): Promise<Omit<CommandResult, 'executionTimeMs'> | null> {
+    let lease: (ExecLease & { expiresAtMs: number | null }) | null;
+    try {
+      lease = await this._ensureLease();
+    } catch (error) {
+      // 404/501 → endpoint not present on this proxy deployment. Flip the
+      // feature bit and take the fallback path for this call AND every
+      // subsequent one on this sandbox.
+      if (error instanceof PlatformApiError && (error.status === 404 || error.status === 501)) {
+        this._directExecAvailable = false;
+        return null;
+      }
+      throw error;
+    }
+    this._directExecAvailable = true;
+
+    // Filter undefined values out of the env overlay so we match the
+    // Record<string, string> shape execViaLease expects. `ExecuteCommandOptions.env`
+    // is NodeJS.ProcessEnv (string | undefined); the proxy `/exec` path ships
+    // it through JSON.stringify which drops undefined implicitly, so this is
+    // just the explicit version of the same filter.
+    const filteredEnv = options?.env
+      ? Object.fromEntries(
+          Object.entries(options.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+        )
+      : undefined;
+    const result = await execViaLease(lease, {
+      command: fullCommand,
+      ...(options?.cwd !== undefined && { cwd: options.cwd }),
+      ...(filteredEnv !== undefined && { env: filteredEnv }),
+      ...(effectiveTimeout != null && effectiveTimeout > 0 && { timeoutMs: effectiveTimeout }),
+      ...(this._webSocketFactory && { webSocketFactory: this._webSocketFactory }),
+    });
+    const exitCode = result.exitCode ?? (result.timedOut ? 124 : 1);
+    return {
+      success: exitCode === 0,
+      exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      timedOut: result.timedOut,
+      command: fullCommand,
+    };
+  }
+
+  private async _execViaProxy(
+    fullCommand: string,
+    effectiveTimeout: number | undefined,
+    options: ExecuteCommandOptions | undefined,
+    started: number,
+  ): Promise<CommandResult> {
+    if (!this._sandboxId) throw new SandboxNotReadyError(this.id);
     const timeoutSec = effectiveTimeout != null ? Math.ceil(effectiveTimeout / 1000) : undefined;
     // Pass our own signal for exec so the client's default per-request
     // timeout (60s) doesn't cut off commands that expect to run longer.
@@ -323,6 +438,46 @@ export class PlatformSandbox extends MastraSandbox {
       timedOut: json.timedOut,
       command: fullCommand,
     };
+  }
+
+  /**
+   * Return a cached exec lease, minting a fresh one when the cache is empty
+   * or the JWT is within {@link LEASE_REFRESH_MARGIN_MS} of `expiresAt`.
+   *
+   * Callers are expected to be on the "sandbox is running" path; we don't
+   * re-check `_sandboxId` here because `executeCommand` already gated on it.
+   */
+  private async _ensureLease(): Promise<ExecLease & { expiresAtMs: number | null }> {
+    const now = Date.now();
+    // Cache hit only when we know the expiry AND we're comfortably before it.
+    // A null `expiresAtMs` means the provider didn't disclose a TTL — treat
+    // that as "refresh every call" rather than "cache forever", so a token
+    // that turns out to be short-lived can't wedge the sandbox until restart.
+    if (
+      this._lease &&
+      this._lease.expiresAtMs !== null &&
+      this._lease.expiresAtMs - LEASE_REFRESH_MARGIN_MS > now
+    ) {
+      return this._lease;
+    }
+    if (!this._sandboxId) throw new SandboxNotReadyError(this.id);
+    const response = await this._client.request(`/sandbox/${encodeURIComponent(this._sandboxId)}/exec-lease`, {
+      method: 'POST',
+    });
+    const json = (await response.json()) as ExecLeaseResponse;
+    const expiresAtMs = json.expiresAt ? Date.parse(json.expiresAt) : null;
+    const lease = {
+      jwt: json.jwt,
+      wsEndpoint: json.wsEndpoint,
+      subprotocol: json.subprotocol,
+      expiresAt: json.expiresAt,
+      // Guard against `Date.parse` returning NaN for malformed values by
+      // treating them as "no expiry known", which forces a mint every call
+      // rather than silently caching a broken lease forever.
+      expiresAtMs: expiresAtMs !== null && !Number.isNaN(expiresAtMs) ? expiresAtMs : null,
+    };
+    this._lease = lease;
+    return lease;
   }
 
   async getInfo(): Promise<SandboxInfo> {

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -184,7 +184,7 @@ export class PlatformSandbox extends MastraSandbox {
    * when `expiresAt - LEASE_REFRESH_MARGIN_MS < now`, or when the WS
    * handshake fails with a close code Railway uses for expired tokens.
    */
-  private _lease: ExecLease & { expiresAtMs: number | null } | null = null;
+  private _lease: (ExecLease & { expiresAtMs: number | null }) | null = null;
   /**
    * Tri-state feature detection for the platform's exec-lease endpoint:
    *   undefined — not yet tried (default; try direct on first exec)
@@ -453,11 +453,7 @@ export class PlatformSandbox extends MastraSandbox {
     // A null `expiresAtMs` means the provider didn't disclose a TTL — treat
     // that as "refresh every call" rather than "cache forever", so a token
     // that turns out to be short-lived can't wedge the sandbox until restart.
-    if (
-      this._lease &&
-      this._lease.expiresAtMs !== null &&
-      this._lease.expiresAtMs - LEASE_REFRESH_MARGIN_MS > now
-    ) {
+    if (this._lease && this._lease.expiresAtMs !== null && this._lease.expiresAtMs - LEASE_REFRESH_MARGIN_MS > now) {
       return this._lease;
     }
     if (!this._sandboxId) throw new SandboxNotReadyError(this.id);


### PR DESCRIPTION
## Summary

Removes the workspace proxy from the exec hot path. `PlatformSandbox.executeCommand` now runs commands over a direct WebSocket to Railway's exec endpoint using a short-lived JWT lease minted by the workspace proxy, instead of proxying every exec through HTTP.

**Wins**
- Cuts latency for large-payload commands (e.g. `pnpm install`) — no more streaming stdin/stdout through Cloud Run
- Eliminates duplicated observability spans (one span per exec instead of two)
- No API surface change — same `CommandResult` return shape

## Design

1. Client calls `POST /:sandboxId/exec-lease` on workspace-proxy (new endpoint, see platform PR below)
2. Proxy mints a Railway shell JWT via `RailwayGenerateShellToken` mutation, returns `{ jwt, wsEndpoint, subprotocol, expiresAt }`
3. Client opens WebSocket to `ssh.railway.com:2226/ws/exec` with `["railway-shell", jwt]` subprotocols
4. Client speaks the Railway frame protocol directly (init_exec, stdin_close, signal, binary stdout/stderr, exit/durable_session frames)
5. Lease is cached per-instance and reused until it enters the 30s refresh margin

**Fallback:** If the proxy returns 404/501 from `/exec-lease` (older deployments without Phase 1 merged), the client sets `_directExecAvailable = false` for the lifetime of the sandbox and falls back to the legacy `POST /sandbox/:id/exec` route. This makes the rollout safe and self-healing.

## Depends on

Platform PR: `workspace-proxy: exec-lease endpoint` — mastra-ai/platform#1777

## Test plan

- [x] 14 new unit tests for direct-exec client (frame protocol, stdout/stderr accumulation, exit code, timeout, close-before-exit, signal, env/cwd passing)
- [x] 5 new lease-cache tests (hit, miss on expiry, near-expiry refresh, null-TTL always-refresh, fallback on 404)
- [x] Updated 6 existing sandbox tests to exercise direct exec path (lease mint + WS)
- [x] All 50 tests pass
- [x] typecheck + lint + build clean
- [ ] Integration test against staging workspace proxy (requires PR #1777 deployed)

## Rollout

Safe to merge before platform PR ships:
- Without the proxy endpoint deployed, `/exec-lease` returns 404 → client falls back to legacy `/exec` route
- Once the proxy endpoint deploys, next sandbox exec uses the direct path automatically
- No env var toggle, no coordinated release needed

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Commands can now run directly on Railway instead of taking a detour through the workspace proxy, making large commands faster while keeping the same results. If the new path is unavailable, execution automatically uses the existing route.

## Summary

- Added WebSocket-based direct command execution using short-lived JWT leases.
- Added lease caching, expiry refresh, cleanup, and fallback for unavailable `/exec-lease` endpoints.
- Implemented Railway exec frame handling, streaming output, timeouts, exit codes, and connection-error behavior.
- Preserved the existing `CommandResult` API.
- Added injectable WebSocket factories and extensive unit coverage for protocol behavior, caching, reattachment, fallback, timeout, and kill semantics.
- Added changeset documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->