### PR TITLE
fix(mastracode): make local Factory onboarding reliable

### DIFF
--- a/.changeset/nine-feet-smoke.md
+++ b/.changeset/nine-feet-smoke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved contributor guidance for Factory backend development.

--- a/.changeset/solid-suits-smoke.md
+++ b/.changeset/solid-suits-smoke.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Improved contributor guidance for the Factory scaffolder.

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -1,0 +1,50 @@
+# MastraCode contributor guide
+
+Use this guide to find the right package and run Factory locally.
+
+## Packages
+
+| Package                                        | Responsibility                                            |
+| ---------------------------------------------- | --------------------------------------------------------- |
+| [`factory`](./factory/README.md)               | Factory backend: storage, routes, rules, and integrations |
+| [`factory-ui`](./factory-ui/README.md)         | Factory React application and browser tests               |
+| [`web`](./web/README.md)                       | Local and deployable Factory host                         |
+| [`sdk`](./sdk/README.md)                       | Shared coding-agent runtime                               |
+| [`tui`](./tui/README.md)                       | Terminal interface                                        |
+| [`mastra-factory`](./mastra-factory/README.md) | `create-factory` scaffolder                               |
+
+## Setup
+
+From the repository root:
+
+```shell
+pnpm install
+pnpm --dir mastracode/web install
+pnpm --dir mastracode/web run prebuild
+```
+
+The web host is a separate pnpm project. `prebuild` builds the local packages it links to.
+
+## Run Factory
+
+First complete the [local GitHub App setup](./web/README.md#configure-local-onboarding).
+
+For backend work, run the API and bundled UI together:
+
+```shell
+pnpm --dir mastracode/web dev
+```
+
+Open `http://localhost:5873`.
+
+For UI work with hot module replacement, run these in separate terminals:
+
+```shell
+pnpm --dir mastracode/web api
+```
+
+```shell
+pnpm --filter ./mastracode/factory-ui web
+```
+
+Open `http://localhost:5173`.

--- a/mastracode/factory-ui/README.md
+++ b/mastracode/factory-ui/README.md
@@ -1,0 +1,32 @@
+# Factory UI
+
+`@internal/factory-ui` is the Factory React application. It owns pages, client state, API access, and browser tests.
+
+## Development
+
+Complete the [repository setup](../README.md#setup) and [GitHub App setup](../web/README.md#configure-local-onboarding). Then run these in separate terminals:
+
+```shell
+pnpm --dir mastracode/web api
+```
+
+```shell
+pnpm --filter ./mastracode/factory-ui web
+```
+
+Open `http://localhost:5173`.
+
+Keep policy, validation, and persistence in [`@mastra/factory`](../factory/README.md), not in React.
+
+## Tests
+
+Use unit tests for isolated code and MSW tests for pages, routes, hooks, mutations, and React Query behavior.
+
+```shell
+pnpm --filter ./mastracode/factory-ui test:unit
+pnpm --filter ./mastracode/factory-ui test:msw
+pnpm --filter ./mastracode/factory-ui typecheck
+pnpm --filter ./mastracode/factory-ui build
+```
+
+See [`AGENTS.md`](./AGENTS.md) for testing conventions.

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -1,18 +1,26 @@
-# @mastra/factory
+# `@mastra/factory`
 
-The Mastra Software Factory module: the server core behind the Mastra Software Factory — an agent-powered software delivery environment built on [Mastra](https://mastra.ai).
+`@mastra/factory` is the reusable Factory backend. It owns storage, routes, rules, integrations, sandboxes, and Factory-specific agent behavior.
 
-Like `@mastra/code-sdk`, this package ships an unbundled ESM build that preserves the `src/` module structure, so every module is importable via the `@mastra/factory/*` wildcard export.
+Put React code in [`factory-ui`](../factory-ui/README.md), host wiring in [`web`](../web/README.md), and shared agent-controller behavior in [`sdk`](../sdk/README.md).
 
-## Development (monorepo)
+## Runtime lifecycle
 
-This package lives in the `mastra-ai/mastra` monorepo at `mastracode/factory`.
+A host calls `MastraFactory.prepare()`, constructs `new Mastra(...)`, then calls `MastraFactory.finalize()`. The `new Mastra(...)` expression remains in the host entry file so the deployer can detect it.
 
-```bash
-pnpm --filter ./mastracode/factory build   # transpile src -> dist + types
-pnpm --filter ./mastracode/factory test    # vitest
-pnpm --filter ./mastracode/factory check   # tsc --noEmit
+See `mastracode/web/src/mastra/index.ts` for the host implementation.
+
+## Development
+
+```shell
+pnpm --filter ./mastracode/factory test
+pnpm --filter ./mastracode/factory check
+pnpm --filter ./mastracode/factory lint
+pnpm --filter ./mastracode/factory build:lib
+pnpm --filter ./mastracode/factory smoke:dist
 ```
+
+Tests are colocated with source as `*.test.ts`.
 
 ## License
 

--- a/mastracode/mastra-factory/README.md
+++ b/mastracode/mastra-factory/README.md
@@ -1,31 +1,25 @@
-# create-factory
+# `create-factory`
 
-Scaffolding CLI for the **Mastra Factory** — an open-source, agent-powered software delivery environment built on [Mastra](https://mastra.ai).
+`create-factory` scaffolds a Mastra Factory project.
 
-```bash
+```shell
 npm create factory
 ```
 
-The CLI is intentionally minimal: it asks for a project name, clones the [softwarefactory-template](https://github.com/mastra-ai/softwarefactory-template), installs dependencies, and initializes git. That's it — run `npm run dev` and finish setup (model providers, integrations, database) from the web UI on first load.
+It clones the public [`softwarefactory-template`](https://github.com/mastra-ai/softwarefactory-template), installs dependencies, and initializes Git. Run `create-factory --help` for options.
 
-## Flags
+## Development
 
-```text
-Usage: create-factory [options] [project-name]
+This package owns prompts, template cloning, package-manager detection, optional Mastra platform setup, dependency installation, and Git initialization.
 
-Create a new Mastra Factory project
-
-Arguments:
-  project-name                Directory name of the project
-
-Options:
-  --template <template-name>  Create a project from a template (public GitHub URL) (default: "https://github.com/mastra-ai/softwarefactory-template")
-  --no-platform               Skip Mastra platform sign-in, project, and Neon provisioning
-  --org <org>                 Mastra organization id or name — skips the interactive org picker
-  --region <region>           Platform project region (eu or us); prompts when omitted
-  -v, --version               output the version number
-  -h, --help                  display help for command
+```shell
+pnpm --filter create-factory test
+pnpm --filter create-factory check
+pnpm --filter create-factory lint
+pnpm --filter create-factory build
 ```
+
+Generated project behavior belongs to the separate template repository.
 
 ## License
 

--- a/mastracode/mastra-factory/README.md
+++ b/mastracode/mastra-factory/README.md
@@ -6,7 +6,7 @@
 npm create factory
 ```
 
-It clones the public [`softwarefactory-template`](https://github.com/mastra-ai/softwarefactory-template), installs dependencies, and initializes Git. Run `create-factory --help` for options.
+It clones the public [`softwarefactory-template`](https://github.com/mastra-ai/softwarefactory-template), installs dependencies, and initializes Git. Run `npm create factory -- --help` for options.
 
 ## Development
 

--- a/mastracode/web/.env.schema
+++ b/mastracode/web/.env.schema
@@ -120,12 +120,12 @@ MASTRACODE_BOOTSTRAP_PERSONAL_ORG=
 
 # ---------------------------------------------------------------------------
 # Application database
-# Single Postgres for the app: holds Mastra agent state (threads, messages,
-# memory, recall vectors) AND — when the GitHub App block below is configured
-# — GitHub project/installation metadata. When unset, agent state falls back
-# to a local libSQL file (bare local dev only). For local dev, run
-# `docker compose up -d` from the package root (see docker-compose.yml); the
-# container matches postgres://user:pass@localhost:54329/mastracode_web.
+# Optional Postgres database for Mastra agent state (threads, messages,
+# memory, recall vectors) and Factory application data. When unset in local
+# development, all Factory data uses a local libSQL file instead. To test with
+# Postgres locally, run `pnpm db:up` from this package (`pnpm --dir
+# mastracode/web db:up` from the monorepo root). The service uses
+# postgres://user:pass@localhost:54329/mastracode_web.
 # On the Mastra platform this is populated automatically by the managed
 # env-var sync when a Neon (or other) database is attached to the project.
 # ---------------------------------------------------------------------------
@@ -137,15 +137,15 @@ APP_DATABASE_URL=
 
 # ---------------------------------------------------------------------------
 # GitHub projects
-# When the GitHub App variables are set AND WorkOS auth is enabled, signed-in
-# users can install the GitHub App, pick repositories, and turn each repo into
-# a project. Repo and project metadata persist in the application Postgres
-# above (DATABASE_URL).
+# When all required GitHub App variables are set, signed-in users can install
+# the GitHub App, pick repositories, and turn each repository into a project.
+# Data uses local libSQL during local development or Postgres when DATABASE_URL
+# is set.
 #
-# The GitHub OAuth callback URL is always derived from MASTRACODE_PUBLIC_URL
+# The GitHub callback URL is always derived from MASTRACODE_PUBLIC_URL
 # (/auth/github/callback) — there is no separate redirect env var. Register
-# this exact URL in the GitHub App's "Callback URL" field (Settings → GitHub
-# Apps → your app → General → Callback URL).
+# this exact URL in both the GitHub App's "Callback URL" and "Setup URL"
+# fields (Settings → GitHub Apps → your app → General).
 # ---------------------------------------------------------------------------
 
 # @public
@@ -159,10 +159,9 @@ GITHUB_APP_CLIENT_ID=
 GITHUB_APP_CLIENT_SECRET=
 # @public @required=not(isEmpty($GITHUB_APP_CLIENT_SECRET))
 GITHUB_APP_SLUG=
-# Secret for install/uninstall webhooks. Also used to sign GitHub OAuth/install
-# state. REQUIRED for multi-replica deployments: without an explicit secret
-# (this or WORKOS_COOKIE_PASSWORD), state is signed with a per-process random
-# key and callbacks fail on a replica that did not sign the state.
+# Stable secret for signing GitHub OAuth/install state and verifying webhooks.
+# A configured GitHub integration requires either this value or
+# WORKOS_COOKIE_PASSWORD, even when webhooks are disabled.
 GITHUB_APP_WEBHOOK_SECRET=
 
 # ---------------------------------------------------------------------------

--- a/mastracode/web/README.md
+++ b/mastracode/web/README.md
@@ -100,12 +100,16 @@ pnpm --dir mastracode/web check
 
 UI tests live in `factory-ui`; backend tests live in `factory`.
 
-## Build and deploy
+## Build and run
 
 ```shell
 pnpm --dir mastracode/web build
 pnpm --dir mastracode/web start
-pnpm --dir mastracode/web deploy
 ```
 
-Authenticate with `mastra auth login` before deploying.
+## Deploy
+
+```shell
+mastra auth login
+pnpm --dir mastracode/web deploy
+```

--- a/mastracode/web/README.md
+++ b/mastracode/web/README.md
@@ -1,150 +1,111 @@
-# mastracode-web
+# MastraCode web host
 
-The Mastra Code web host: API routes (config/fs/GitHub/Linear), a deployable Mastra entry (`src/mastra/index.ts`), and server/controller scenario tests. Production builds and generated Factory projects use the versioned SPA bundled with the Mastra CLI. [`mastracode/factory-ui`](../factory-ui) remains the independent internal browser application for Vite-based UI development. Built on [`@mastra/code-sdk`](../sdk). One factory storage backend persists agent state (threads, messages, and memory) and web app data. When `DATABASE_URL` is set, a separate `PgVector` uses the same PostgreSQL database for recall search; explicit local development and test runs use the SDK's local LibSQL database without vector storage. (`APP_DATABASE_URL` is honored as a deprecated fallback.)
+`mastracode/web` wires environment-specific storage, authentication, integrations, event bus, and sandboxes into [`@mastra/factory`](../factory/README.md). React code belongs in [`factory-ui`](../factory-ui/README.md).
 
-This is a **standalone pnpm project** (own lockfile, not a monorepo workspace member). For development, the monorepo-provided packages (`@mastra/*`, `mastra`) are consumed via `link:` specs pointing at the monorepo directories, so you always develop against local source. For builds, `scripts/monorepo-deps.mjs` temporarily pins every declared `link:` dependency to the exact version found in the monorepo (see below).
+This is a separate pnpm project with its own lockfile and `link:` dependencies to monorepo packages.
 
 ## Setup
 
-```bash
-# from the monorepo root
-pnpm install
+From the repository root:
 
-# in mastracode/web
+```shell
 pnpm install
+pnpm --dir mastracode/web install
+pnpm --dir mastracode/web run prebuild
 ```
+
+`prebuild` builds the linked packages required by the host.
 
 ## Development
 
-For the integrated Factory server and its bundled UI:
+Local development uses LibSQL and local sandboxes. Onboarding requires sign-in and a GitHub App.
 
-```bash
-pnpm dev
+### Configure local onboarding
+
+Create a [GitHub App](https://github.com/settings/apps/new) with URLs matching the mode you will run:
+
+| Setting      | Integrated mode                              | Split UI mode                                |
+| ------------ | -------------------------------------------- | -------------------------------------------- |
+| Homepage URL | `http://localhost:5873`                      | `http://localhost:5173`                      |
+| Callback URL | `http://localhost:5873/auth/github/callback` | `http://localhost:5173/auth/github/callback` |
+| Setup URL    | `http://localhost:5873/auth/github/callback` | `http://localhost:5173/auth/github/callback` |
+
+Do not mix modes. Nothing runs on port `5173` in integrated mode.
+
+Configure the app:
+
+1. Grant **Contents**, **Issues**, and **Pull requests** read/write access and **Metadata** read-only access.
+2. Clear **Webhook → Active** for local development.
+3. Generate a client secret and private key.
+4. Add these values to `mastracode/web/.env`:
+
+```dotenv
+GITHUB_APP_ID=
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+GITHUB_APP_CLIENT_ID=
+GITHUB_APP_CLIENT_SECRET=
+GITHUB_APP_SLUG=
+GITHUB_APP_WEBHOOK_SECRET=
 ```
 
-For UI design work with Vite HMR, run the API and SPA separately:
+Generate the state-signing secret with `openssl rand -hex 32` and use it for `GITHUB_APP_WEBHOOK_SECRET`. Use escaped `\n` characters in the private key. Restart the server after changing `.env`.
 
-```bash
-# terminal 1 — in mastracode/web
-pnpm api
+See [`.env.schema`](./.env.schema) for other environment variables.
 
-# terminal 2 — in mastracode/factory-ui
-pnpm web
+### Integrated mode
+
+Use this for backend work and production-like checks:
+
+```shell
+pnpm --dir mastracode/web dev
 ```
 
-Open **http://localhost:5173**. The Factory API runs on **:4111**; the Vite SPA
-proxies `/api`, `/web`, and `/auth/` to it. The `api` script sets
-`MASTRACODE_PUBLIC_URL` to the Vite origin so local OAuth callbacks return to
-the browser UI. The UI script reads the host `.env` through `MASTRACODE_ENV_DIR`.
+Open `http://localhost:5873`.
 
-Local development works without PostgreSQL: the full web surface uses the SDK's local LibSQL database. To exercise the PostgreSQL backend and distributed-lock path, run `pnpm db:up` before `pnpm api`.
+### Split UI mode
 
-## Build & deploy
+Use this for UI work. Run these in separate terminals:
 
-```bash
-pnpm build
+```shell
+pnpm --dir mastracode/web api
 ```
 
-1. `prebuild` builds linked monorepo packages with Turbo.
-2. `scripts/monorepo-deps.mjs run -- mastra build --dir src/mastra` pins `link:` dependencies to the exact monorepo versions, bundles the API server into `.mastra/output/`, copies the Factory SPA bundled with the CLI, and restores the `link:` specs afterward, including on failure or interruption.
-3. The Factory server serves the CLI-bundled SPA artifact same-origin at `/`.
-
-Run the output with `pnpm start` (or `node .mastra/output/index.mjs` after installing output dependencies).
-
-To deploy to Mastra Cloud:
-
-```bash
-pnpm deploy
+```shell
+pnpm --filter ./mastracode/factory-ui web
 ```
 
-This builds and validates the output, then runs `mastra deploy --skip-build` to upload the existing `.mastra/output`. Deploy targets `--env production` by default and auto-selects `.env.production` if present; otherwise it offers to upload variables from the local `.env`. Requires `mastra auth login` first; pass extra flags with `pnpm deploy -- --env staging`.
+Open `http://localhost:5173`.
+
+### Optional local services
+
+To test PostgreSQL and Redis:
+
+```shell
+pnpm --dir mastracode/web db:up
+```
+
+Add these values to `mastracode/web/.env` and restart the server:
+
+```dotenv
+DATABASE_URL=postgres://user:pass@localhost:54329/mastracode_web
+REDIS_URL=redis://localhost:63799
+```
 
 ## Tests
 
-```bash
-pnpm test     # host unit and server/controller scenario tests
+```shell
+pnpm --dir mastracode/web test
+pnpm --dir mastracode/web check
 ```
 
-UI MSW tests (`*.msw.test.tsx`) and unit tests live in [`mastracode/factory-ui`](../factory-ui). Run them with `pnpm --filter ./mastracode/factory-ui test` (or `test:unit` / `test:msw` for focused suites).
+UI tests live in `factory-ui`; backend tests live in `factory`.
 
-## Factories, bindings, and repositories
+## Build and deploy
 
-In the Web UI, a **Factory** is the top-level product entity that a user creates and selects. Each Factory has one binding:
-
-- **Local folder**: A path on the host machine. Sessions use the `resourceId` resolved by `GET /web/codebase/resolve`.
-- **Server Factory**: A persisted Factory project identified by `factoryProjectId`. It can contain one or more connected repositories. Repository-specific operations use each repository's `projectRepositoryId`.
-
-Factory work items belong to the Factory project. Sandboxes, worktrees, GitHub issue and pull request feeds, and pull request subscriptions belong to a connected repository. Private HTTP routes reflect that split. Work items use `/web/factory/projects/:factoryProjectId/*`, while GitHub provider operations use `/web/github/projects/:projectRepositoryId/*`.
-
-Session continuity with the terminal user interface (TUI) keeps the Software Development Kit (SDK) names `projectPath` and `detectProject`. These names refer to the execution workspace path and codebase detection protocol, not the Factory product entity.
-
-Intake source config is asymmetric by provider. GitHub selections use `repositoryIds`, which contain connected repository UUIDs. Linear selections use `projectIds` because a Linear Project is an external provider concept.
-
-Browser state uses `mastracode-factories`. The active Factory comes from the `/factories/:factoryId/**` URL, and prerelease `mastracode-projects` keys aren't read.
-
-## Work and Review workflows
-
-Server-backed Factories split repository work across two boards:
-
-- **Work** (`/factories/:factoryId/work`): Shows manual work items, GitHub issues, and Linear issues. Its stages are **Intake**, **Triage**, **Planning**, **Building**, **Review**, and **Done**.
-- **Review** (`/factories/:factoryId/review`): Shows GitHub pull requests only. Its stages are **Intake**, **Reviewing**, and **Done**.
-
-Open GitHub issues appear as **Work** intake candidates. Open pull requests appear as **Review** intake candidates. Adding a candidate to a board creates or updates its persisted Factory work item. The source type determines which board owns that item, so a GitHub issue can't appear on **Review** and a pull request can't appear on **Work**.
-
-When a Factory pull request branch matches a related work session branch, the Review item stores the Work item as its parent. The Work card links to the Review session, and the Review card links back to the Work session. The same reciprocal links appear in the session header. Links to a thread are shown only while its referenced worktree still exists; the related board item remains available after worktree deletion.
-
-## Workspace skill invocation
-
-The private Web API can activate a user-invocable skill on an existing scoped AgentController session with `POST /web/agent-controller/:controllerId/skills/invoke`. The Web Factory packages workflow skills such as `understand-issue` and `understand-pr` as ordinary, read-only `SKILL.md` files and adds them only to workspaces created by `MastraFactory`; the shared SDK and TUI workspace resolver do not load them. The route resolves every ID through the session workspace, uses the same `<skill name="…">` activation envelope as `/skill/<name>` in the TUI, and returns an error without dispatching when the skill is missing. Authenticated requests may target only the caller's personal session or a Factory worktree owned by that organization user.
-
-## Factory metrics
-
-The **Metrics** page at `/factories/:factoryId/metrics` shows queue health for the active Factory. The Queue Health Chart contains one horizontal bar per Work stage. Each bar is segmented by item age and overlays diagonal stripes where agent work is active. Selecting a segment filters the item list below the chart. Age comes from the open `stageHistory` entry and falls back to `createdAt`. The pure `computeQueueHealth()` function in `mastracode/factory-ui/src/ui/domains/factory/queue-health.ts` performs the client-side aggregation.
-
-Queue age thresholds are server-side Factory project config in seconds. `GET /web/factory/projects/:factoryProjectId/health/thresholds` reads them from the `queue-health` storage domain. The `queue_health_settings` table keys records by `(org_id, factory_project_id)`. Defaults are `[14400, 86400, 259200]` (4h, 24h, and 72h). `saveConfig` rejects empty or non-ascending `thresholdsSeconds` values.
-
-## Factory rules
-
-`MastraFactory` accepts one authoritative `rules` tree for Work and Review stage entry and exit, completed tool results, and normalized GitHub events. Construct it with `defaultFactoryRules()` so every deployment policy has an explicit version:
-
-```ts
-import { MastraFactory } from '@mastra/factory';
-import { defaultFactoryRules } from '@mastra/factory/rules';
-
-const rules = defaultFactoryRules({
-  version: '2026-07-18.1',
-  overrides: {
-    review: {
-      intake: {
-        pullRequest: {
-          onEnter: context =>
-            context.actor.type === 'github' && !context.actor.trusted
-              ? { type: 'reject', code: 'forbidden', reason: 'A trusted author is required.' }
-              : undefined,
-        },
-      },
-    },
-    tools: {
-      submit_plan: {
-        onResult: () => undefined,
-      },
-    },
-  },
-});
-
-const factory = new MastraFactory({ rules });
+```shell
+pnpm --dir mastracode/web build
+pnpm --dir mastracode/web start
+pnpm --dir mastracode/web deploy
 ```
 
-Overrides replace the exact `onEnter`, `onExit`, `onResult`, or `onEvent` leaf; they never compose implicitly with another handler. The version is configuration identity for persisted evaluations and audits, not an event-deduplication key, and Mastra never hashes function source.
-
-Rules are trusted deployment code. They receive normalized, bounded context rather than storage handles, credentials, worktree paths, or raw webhook payloads. Each handler returns one bounded `FactoryRuleDecision` or `void`: a typed rejection, transition, linked-item upsert, skill invocation, bound-session message, or notification. Every returned decision is validated and redacted before persistence; external effects are deferred rather than executed inside rule evaluation.
-
-## GitHub pull request notifications
-
-GitHub-backed Factory sessions automatically subscribe the current thread after a successful `gh pr create`. The `github_subscribe_pr` tool is primarily for existing pull requests or recovery when automatic subscription did not occur. Use `github_unsubscribe_pr` only to stop notifications early; closing or merging the pull request retires its subscription automatically.
-
-Configure the GitHub App webhook URL as `https://your-host/web/github/webhook`, set `GITHUB_APP_WEBHOOK_SECRET` to the same secret configured in GitHub, and subscribe the App to pull request, pull request review, pull request review comment, and issue comment events. Comments and reviews are delivered only when their author has write access or is an explicitly authorized bot.
-
-## Environment
-
-See `.env.schema` (package root; varlock validates `.env` against it). Local development needs no variables and runs auth-less with local LibSQL storage; non-local deployments require `DATABASE_URL` (or the deprecated `APP_DATABASE_URL`). WorkOS auth requires both `WORKOS_API_KEY` and `WORKOS_CLIENT_ID`; alternatively set `BETTER_AUTH_SECRET`. GitHub needs the complete `GITHUB_APP_*` group plus auth; Linear needs `LINEAR_CLIENT_ID` and `LINEAR_CLIENT_SECRET`; Railway sandboxes need `RAILWAY_API_TOKEN`. `MASTRACODE_PUBLIC_URL` controls the WorkOS (`/auth/callback`), GitHub App (`/auth/github/callback`), and Linear callback URLs.
+Authenticate with `mastra auth login` before deploying.

--- a/mastracode/web/package.json
+++ b/mastracode/web/package.json
@@ -10,7 +10,7 @@
     "db:down": "docker compose down",
     "prebuild": "cd ../.. && pnpm turbo build --filter ./mastracode/sdk --filter ./mastracode/factory --filter ./client-sdks/client-js --filter ./stores/libsql --filter ./stores/pg --filter ./server-adapters/hono --filter ./workspaces/platform-workspace --filter ./pubsub/redis-streams --filter ./packages/cli",
     "api": "PORT=${PORT:-4111} MASTRACODE_PUBLIC_URL=${MASTRACODE_PUBLIC_URL:-http://localhost:5173} MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra factory dev --dir src/mastra",
-    "dev": "PORT=5873 MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra factory dev --dir src/mastra",
+    "dev": "PORT=5873 MASTRACODE_PUBLIC_URL=${MASTRACODE_PUBLIC_URL:-http://localhost:5873} MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra factory dev --dir src/mastra",
     "dev:github": "pnpm db:up && pnpm dev",
     "build": "node scripts/monorepo-deps.mjs run -- mastra build --dir src/mastra",
     "deploy": "pnpm run build && node scripts/validate-output.mjs && mastra deploy --skip-build",


### PR DESCRIPTION
Factory contributor setup was difficult to discover, and integrated authentication callbacks could return to the wrong port.

This adds concise package guides, documents the required GitHub App setup for integrated and split development, and sets the integrated host public URL to `http://localhost:5873`.

Verified with `pnpm --dir mastracode/web test`, `pnpm --dir mastracode/web check`, Prettier, and link and command validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds clearer “how to run and develop” instructions for the Factory parts of the repo, so new contributors can get started faster. It also explains how to set up the GitHub App correctly and fixes local callback/auth to use the right URL/port.

## Summary

- Added/updated contributor guides for Factory backend, Factory UI, MastraCode, and the `create-factory` CLI.
- Documented integrated vs split local development workflows (including ports, setup steps, and recommended test/build commands).
- Clarified required GitHub App onboarding/configuration, including how callback/setup URLs are derived from `MASTRACODE_PUBLIC_URL`.
- Set the integrated host public URL to `http://localhost:5873` so local authentication and GitHub callbacks return to the correct server.
- Improved `create-factory` docs/commands by separating run vs deployment instructions and fixing the scaffold help forwarding behavior (help flag through `npm create`).
- Added patch-level changesets for `@mastra/factory` and `create-factory`.
- Validated with web tests, checks, Prettier, link validation, and command validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->