### PR TITLE
fix(factory): reduce GitHub polling log noise

### DIFF
--- a/.changeset/clever-oranges-occur.md
+++ b/.changeset/clever-oranges-occur.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Move Github log to debug instead of info in factory

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -285,7 +285,7 @@ export class PlatformGithubEventWorker extends MastraWorker {
         'GET',
         `${API_PREFIX}/repositories/${repositoryId}/events?${query}`,
       );
-      this.deps?.logger.info('Platform GitHub repository event poll completed', {
+      this.deps?.logger.debug('Platform GitHub repository event poll completed', {
         repositoryId,
         eventCount: page.events.length,
         latencyMs: Math.round(performance.now() - pollStartedAt),


### PR DESCRIPTION
The repository event poll completes on every polling cycle, so logging it at info makes normal operation noisy.

This changes `logger.info(...)` to `logger.debug(...)`, keeping the polling details available when needed without filling standard logs.