### PR TITLE
feat(core): lazy workspace resolver hook

### DIFF
--- a/.changeset/four-seals-decide.md
+++ b/.changeset/four-seals-decide.md
@@ -1,0 +1,24 @@
+---
+'@mastra/core': minor
+---
+
+Added `resolveWorkspaceById` hook for lazy workspace resolution.
+
+Dynamic workspaces (e.g. factory sessions with IDs like `mfw-<repoId>-<sessionId>-web-factory`) previously only lived in the in-memory registry that was populated as a side effect of the request that first spawned them. On container restart or a fresh replica, later lookups for the same id would 404 with `MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND` even though the underlying sandbox was still reachable.
+
+The new `Mastra` config accepts a `resolveWorkspaceById(id, { mastra })` hook. A new async `Mastra.resolveWorkspaceById(id)` method consults the in-memory registry first, and on a miss invokes the hook, registers the returned workspace (`source: 'resolver'`), and returns it. Concurrent lookups for the same id share one in-flight resolution.
+
+The sync `getWorkspaceById` is unchanged (still throws on a miss), so existing callers are not affected.
+
+```typescript
+new Mastra({
+  resolveWorkspaceById: async (id, { mastra }) => {
+    const session = await sessions.findByWorkspaceId(id);
+    if (!session) return undefined;
+    return createFactoryWorkspace(session, { mastra });
+  },
+});
+
+// Callers use the new async method to opt into lazy resolution:
+const workspace = await mastra.resolveWorkspaceById('mfw-abc-xyz-web-factory');
+```

--- a/.changeset/proud-aliens-boil.md
+++ b/.changeset/proud-aliens-boil.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Workspace HTTP handlers now use the new async `Mastra.resolveWorkspaceById` when available, so dynamic per-session workspaces can be re-materialized on demand after a container restart or on a fresh replica. Prevents spurious 404s (`MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND`) for workspaces whose durable state lives outside the process.

--- a/.changeset/proud-aliens-boil.md
+++ b/.changeset/proud-aliens-boil.md
@@ -2,4 +2,4 @@
 '@mastra/server': patch
 ---
 
-Workspace HTTP handlers now use the new async `Mastra.resolveWorkspaceById` when available, so dynamic per-session workspaces can be re-materialized on demand after a container restart or on a fresh replica. Prevents spurious 404s (`MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND`) for workspaces whose durable state lives outside the process.
+Workspace HTTP handlers now use the new async `Mastra.resolveWorkspaceById` when available, so dynamic per-session workspaces can be re-materialized on demand after a container restart or on a fresh replica. Prevents spurious 404s (`MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND`) for workspaces whose durable state lives outside the process. When the resolver is present, the legacy agent-iteration fallback is intentionally skipped — the resolver + registry are authoritative — so unresolvable ids no longer invoke every agent's function-based workspace with a default `RequestContext`. Behavior on older `@mastra/core` (no async resolver) is unchanged.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -3172,17 +3172,22 @@ export class Mastra<
     }
 
     const existing = this.#inFlightWorkspaceResolutions.get(id);
-    const pending =
-      existing ??
-      (async () => {
+    let pending = existing;
+
+    if (!pending) {
+      // Defer resolver invocation by one microtask so the in-flight promise is
+      // registered in `#inFlightWorkspaceResolutions` *before* the resolver
+      // runs. Without this deferral, a synchronously-throwing resolver would
+      // trigger `finally` (deleting a not-yet-set entry) *before* the outer
+      // `.set()` writes the rejected promise into the map — poisoning every
+      // subsequent call for the same id with a stale rejection.
+      pending = Promise.resolve().then(async () => {
         try {
           return await this.#workspaceResolver!(id, { mastra: this });
         } finally {
           this.#inFlightWorkspaceResolutions.delete(id);
         }
-      })();
-
-    if (!existing) {
+      });
       this.#inFlightWorkspaceResolutions.set(id, pending);
     }
 

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -440,6 +440,45 @@ export interface Config<
   workspace?: AnyWorkspace;
 
   /**
+   * Lazy resolver for workspaces that are not (yet) present in the in-memory
+   * registry. Invoked by {@link Mastra.resolveWorkspaceById} when a lookup misses
+   * the {@link Mastra.listWorkspaces} map.
+   *
+   * This exists so dynamic, per-session workspaces (e.g. factory sandboxes with
+   * IDs like `mfw-<repoId>-<sessionId>-web-factory`) can survive container
+   * restarts and cross-replica lookups: the durable state lives outside the
+   * process (Neon session row, Railway sandbox), and this hook rebuilds the
+   * in-memory shim on demand.
+   *
+   * Contract:
+   * - Return the workspace to materialize, or `undefined` if the id is genuinely
+   *   unknown (callers get the standard `MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND`).
+   * - Successful resolutions are cached in the registry via `addWorkspace()`
+   *   with `source: 'resolver'`; a second call for the same id is a map hit.
+   * - Concurrent calls for the same id share a single in-flight promise, so the
+   *   resolver runs at most once per outstanding lookup.
+   * - Failed resolutions (thrown or `undefined`) are **not** cached.
+   *
+   * Sync callers of `getWorkspaceById` are unaffected — they continue to throw
+   * on a registry miss. Only `resolveWorkspaceById` consults this hook.
+   *
+   * @example
+   * ```typescript
+   * new Mastra({
+   *   resolveWorkspaceById: async (id, { mastra }) => {
+   *     const session = await sessions.findByWorkspaceId(id);
+   *     if (!session) return undefined;
+   *     return createFactoryWorkspace(session, { mastra });
+   *   },
+   * });
+   * ```
+   */
+  resolveWorkspaceById?: (
+    id: string,
+    context: { mastra: Mastra },
+  ) => Promise<AnyWorkspace | undefined> | AnyWorkspace | undefined;
+
+  /**
    * Custom model router gateways for accessing LLM providers.
    * Gateways handle provider-specific authentication, URL construction, and model resolution.
    */
@@ -699,6 +738,18 @@ export class Mastra<
   #memory?: TMemory;
   #workspace?: Workspace;
   #workspaces: Record<string, RegisteredWorkspace> = {};
+  #workspaceResolver?: (
+    id: string,
+    context: { mastra: Mastra },
+  ) => Promise<AnyWorkspace | undefined> | AnyWorkspace | undefined;
+  /**
+   * In-flight lazy resolutions, keyed by workspace id. Ensures concurrent
+   * `resolveWorkspaceById` callers for the same id share one resolver
+   * invocation (avoids double-provisioning sandbox/LSP/filesystem clients).
+   * Entries are deleted as soon as the underlying promise settles, so a
+   * failed resolution does not poison future lookups.
+   */
+  #inFlightWorkspaceResolutions: Map<string, Promise<AnyWorkspace | undefined>> = new Map();
   #server?: ServerConfig;
   #serverExplicit = false;
   #studio?: StudioConfig;
@@ -1549,6 +1600,10 @@ export class Mastra<
       this.#workspace = config.workspace;
       // Also register in the workspaces registry for direct lookup by ID
       this.addWorkspace(config.workspace, undefined, { source: 'mastra' });
+    }
+
+    if (config?.resolveWorkspaceById) {
+      this.#workspaceResolver = config.resolveWorkspaceById;
     }
 
     if (config?.scorers) {
@@ -3072,21 +3127,94 @@ export class Mastra<
   public getWorkspaceById(id: string): Workspace {
     const entry = this.#workspaces[id];
     if (!entry) {
-      const error = new MastraError({
-        id: 'MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND',
-        domain: ErrorDomain.MASTRA,
-        category: ErrorCategory.USER,
-        text: `Workspace with id ${id} not found`,
-        details: {
-          status: 404,
-          workspaceId: id,
-          availableIds: Object.keys(this.#workspaces).join(', '),
-        },
-      });
-      this.#logger?.trackException(error);
-      throw error;
+      throw this.#workspaceNotFoundError(id);
     }
     return entry.workspace;
+  }
+
+  /**
+   * Asynchronously retrieve a registered workspace by id, falling back to the
+   * configured {@link Config.resolveWorkspaceById} hook when the registry does
+   * not (yet) contain the id.
+   *
+   * The in-memory registry is authoritative for known workspaces; this method
+   * only diverges from {@link getWorkspaceById} when a lookup misses. On a
+   * miss:
+   *
+   * 1. If no resolver is configured, the standard 404 is thrown.
+   * 2. Otherwise the resolver is invoked (with dedup across concurrent callers).
+   * 3. A returned workspace is registered via {@link addWorkspace} with
+   *    `source: 'resolver'` and returned. Subsequent calls hit the registry.
+   * 4. If the resolver returns `undefined` (or throws), the standard 404 (or
+   *    original error) is surfaced and nothing is cached.
+   *
+   * This exists so hosts of dynamic per-session workspaces (e.g. `@mastra/factory`)
+   * can transparently re-materialize workspace shims after a container restart
+   * or on a fresh replica, without touching sync callers of `getWorkspaceById`.
+   *
+   * @throws {MastraError} `MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND` when the id
+   *   is not registered and the resolver does not produce a workspace.
+   *
+   * @example
+   * ```typescript
+   * const workspace = await mastra.resolveWorkspaceById('mfw-abc-xyz-web-factory');
+   * const files = await workspace.filesystem.readdir('/');
+   * ```
+   */
+  public async resolveWorkspaceById(id: string): Promise<Workspace> {
+    const cached = this.#workspaces[id];
+    if (cached) {
+      return cached.workspace;
+    }
+
+    if (!this.#workspaceResolver) {
+      throw this.#workspaceNotFoundError(id);
+    }
+
+    const existing = this.#inFlightWorkspaceResolutions.get(id);
+    const pending =
+      existing ??
+      (async () => {
+        try {
+          return await this.#workspaceResolver!(id, { mastra: this });
+        } finally {
+          this.#inFlightWorkspaceResolutions.delete(id);
+        }
+      })();
+
+    if (!existing) {
+      this.#inFlightWorkspaceResolutions.set(id, pending);
+    }
+
+    const resolved = await pending;
+
+    if (!resolved) {
+      throw this.#workspaceNotFoundError(id);
+    }
+
+    // Cache for subsequent lookups. `addWorkspace` is a no-op if the id was
+    // registered by a concurrent path (e.g. an agent factory) between when we
+    // started resolving and now — that's the correct behavior (first writer
+    // wins, and callers still get a consistent workspace instance).
+    this.addWorkspace(resolved, id, { source: 'resolver' });
+    const entry = this.#workspaces[id];
+    return entry ? entry.workspace : resolved;
+  }
+
+  #workspaceNotFoundError(id: string): MastraError {
+    const error = new MastraError({
+      id: 'MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND',
+      domain: ErrorDomain.MASTRA,
+      category: ErrorCategory.USER,
+      text: `Workspace with id ${id} not found`,
+      details: {
+        status: 404,
+        workspaceId: id,
+        availableIds: Object.keys(this.#workspaces).join(', '),
+      },
+    });
+    this.#logger?.trackException(error);
+    return error;
   }
 
   /**
@@ -3123,7 +3251,7 @@ export class Mastra<
   public addWorkspace(
     workspace: AnyWorkspace,
     key?: string,
-    metadata?: { source?: 'mastra' | 'agent'; agentId?: string; agentName?: string },
+    metadata?: { source?: 'mastra' | 'agent' | 'resolver'; agentId?: string; agentName?: string },
   ): void {
     if (!workspace) {
       throw createUndefinedPrimitiveError('workspace', workspace, key);

--- a/packages/core/src/mastra/workspace-lazy-resolver.test.ts
+++ b/packages/core/src/mastra/workspace-lazy-resolver.test.ts
@@ -139,6 +139,28 @@ describe('Mastra lazy workspace resolver', () => {
       expect(resolver).toHaveBeenCalledTimes(2);
     });
 
+    it('does not cache a synchronously-throwing resolver — the next call re-invokes it', async () => {
+      // Regression guard: without a microtask deferral, a sync-throwing resolver
+      // would settle its promise before it was written into the in-flight map,
+      // leaving a stale rejected promise cached and poisoning every retry.
+      const workspace = createWorkspace('sync-throw-workspace');
+      let attempt = 0;
+      const resolver = vi.fn(((_id: string) => {
+        attempt += 1;
+        if (attempt === 1) {
+          throw new Error('sync boom');
+        }
+        return workspace;
+      }) as (id: string) => Workspace);
+
+      const mastra = new Mastra({ logger: false, resolveWorkspaceById: resolver });
+
+      await expect(mastra.resolveWorkspaceById('sync-throw-workspace')).rejects.toThrow('sync boom');
+      const result = await mastra.resolveWorkspaceById('sync-throw-workspace');
+      expect(result).toBe(workspace);
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
     it('does not cache when the resolver returns undefined — the next call re-invokes it', async () => {
       const workspace = createWorkspace('appears-later');
       let attempt = 0;

--- a/packages/core/src/mastra/workspace-lazy-resolver.test.ts
+++ b/packages/core/src/mastra/workspace-lazy-resolver.test.ts
@@ -1,0 +1,182 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+import { LocalFilesystem } from '../workspace/filesystem';
+import { Workspace } from '../workspace/workspace';
+import { Mastra } from './index';
+
+/**
+ * Tests for lazy workspace resolution.
+ *
+ * Dynamic workspaces (e.g. factory sessions with IDs like
+ * `mfw-<repoId>-<sessionId>-web-factory`) are only registered as a side effect
+ * of the request context that first spawned them. On container restart or
+ * cross-replica lookup, the in-process `#workspaces` map is empty even though
+ * the underlying sandbox is still reachable. A configurable `resolveWorkspaceById`
+ * hook lets the host reconstruct the workspace shim on demand.
+ */
+describe('Mastra lazy workspace resolver', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workspace-lazy-test-'));
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  const createWorkspace = (id: string) => {
+    const filesystem = new LocalFilesystem({ basePath: tempDir });
+    return new Workspace({ id, name: `Workspace ${id}`, filesystem });
+  };
+
+  describe('resolveWorkspaceById()', () => {
+    it('returns from the in-memory registry without invoking the resolver', async () => {
+      const workspace = createWorkspace('cached-workspace');
+      const resolver = vi.fn();
+      const mastra = new Mastra({
+        logger: false,
+        workspace,
+        resolveWorkspaceById: resolver,
+      });
+
+      const result = await mastra.resolveWorkspaceById('cached-workspace');
+      expect(result).toBe(workspace);
+      expect(resolver).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the configured resolver on a registry miss and registers the result', async () => {
+      const workspace = createWorkspace('lazy-workspace');
+      const resolver = vi.fn(async (id: string) => {
+        expect(id).toBe('lazy-workspace');
+        return workspace;
+      });
+
+      const mastra = new Mastra({ logger: false, resolveWorkspaceById: resolver });
+
+      const result = await mastra.resolveWorkspaceById('lazy-workspace');
+      expect(result).toBe(workspace);
+      expect(resolver).toHaveBeenCalledTimes(1);
+
+      // Post-resolution, the workspace is cached in the registry (source: 'resolver').
+      expect(mastra.getWorkspaceById('lazy-workspace')).toBe(workspace);
+      expect(mastra.listWorkspaces()['lazy-workspace']?.source).toBe('resolver');
+
+      // Subsequent calls hit the cache, not the resolver.
+      await mastra.resolveWorkspaceById('lazy-workspace');
+      expect(resolver).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws the standard 404 error when the resolver returns undefined', async () => {
+      const resolver = vi.fn(async () => undefined);
+      const mastra = new Mastra({ logger: false, resolveWorkspaceById: resolver });
+
+      await expect(mastra.resolveWorkspaceById('missing-workspace')).rejects.toMatchObject({
+        id: 'MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND',
+      });
+      expect(resolver).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws the standard 404 error when no resolver is configured', async () => {
+      const mastra = new Mastra({ logger: false });
+
+      await expect(mastra.resolveWorkspaceById('missing-workspace')).rejects.toMatchObject({
+        id: 'MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND',
+      });
+    });
+
+    it('deduplicates concurrent lookups for the same id (single resolver invocation)', async () => {
+      const workspace = createWorkspace('concurrent-workspace');
+      let pending!: (ws: Workspace) => void;
+      const resolver = vi.fn(
+        () =>
+          new Promise<Workspace>(resolve => {
+            pending = resolve;
+          }),
+      );
+
+      const mastra = new Mastra({ logger: false, resolveWorkspaceById: resolver });
+
+      const p1 = mastra.resolveWorkspaceById('concurrent-workspace');
+      const p2 = mastra.resolveWorkspaceById('concurrent-workspace');
+      const p3 = mastra.resolveWorkspaceById('concurrent-workspace');
+
+      // Give microtasks a chance to run so all three subscribe to the same in-flight promise.
+      await Promise.resolve();
+      expect(resolver).toHaveBeenCalledTimes(1);
+
+      pending(workspace);
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+      expect(r1).toBe(workspace);
+      expect(r2).toBe(workspace);
+      expect(r3).toBe(workspace);
+      expect(resolver).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a failed resolution — the next call re-invokes the resolver', async () => {
+      const workspace = createWorkspace('retry-workspace');
+      let attempt = 0;
+      const resolver = vi.fn(async () => {
+        attempt += 1;
+        if (attempt === 1) {
+          throw new Error('transient failure');
+        }
+        return workspace;
+      });
+
+      const mastra = new Mastra({ logger: false, resolveWorkspaceById: resolver });
+
+      await expect(mastra.resolveWorkspaceById('retry-workspace')).rejects.toThrow('transient failure');
+      const result = await mastra.resolveWorkspaceById('retry-workspace');
+      expect(result).toBe(workspace);
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not cache when the resolver returns undefined — the next call re-invokes it', async () => {
+      const workspace = createWorkspace('appears-later');
+      let attempt = 0;
+      const resolver = vi.fn(async () => {
+        attempt += 1;
+        return attempt === 1 ? undefined : workspace;
+      });
+
+      const mastra = new Mastra({ logger: false, resolveWorkspaceById: resolver });
+
+      await expect(mastra.resolveWorkspaceById('appears-later')).rejects.toMatchObject({
+        id: 'MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND',
+      });
+      const result = await mastra.resolveWorkspaceById('appears-later');
+      expect(result).toBe(workspace);
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it('passes the mastra instance to the resolver context', async () => {
+      const workspace = createWorkspace('context-workspace');
+      const resolver = vi.fn(async (_id: string, ctx: { mastra: Mastra }) => {
+        expect(ctx.mastra).toBe(mastra);
+        return workspace;
+      });
+
+      const mastra = new Mastra({ logger: false, resolveWorkspaceById: resolver });
+      await mastra.resolveWorkspaceById('context-workspace');
+      expect(resolver).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sync getWorkspaceById()', () => {
+    it('remains a pure map lookup and does not invoke the resolver', () => {
+      const resolver = vi.fn();
+      const mastra = new Mastra({ logger: false, resolveWorkspaceById: resolver });
+
+      expect(() => mastra.getWorkspaceById('nope')).toThrow();
+      expect(resolver).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -461,7 +461,15 @@ export type AnyWorkspace = Workspace<WorkspaceFilesystem | undefined, WorkspaceS
 /** A workspace entry in the Mastra registry, enriched with source metadata. */
 export interface RegisteredWorkspace {
   workspace: Workspace;
-  source: 'mastra' | 'agent';
+  /**
+   * How the workspace ended up in the registry:
+   * - `'mastra'`: registered via `Mastra` config or an explicit `addWorkspace()` call
+   * - `'agent'`: auto-registered when an agent's workspace factory resolved
+   * - `'resolver'`: materialized on demand by the `resolveWorkspaceById` hook
+   *   (e.g. after container restart, on a fresh replica) — see
+   *   `Mastra#resolveWorkspaceById`.
+   */
+  source: 'mastra' | 'agent' | 'resolver';
   agentId?: string;
   agentName?: string;
 }

--- a/packages/server/src/server/handlers/workspace.test.ts
+++ b/packages/server/src/server/handlers/workspace.test.ts
@@ -500,18 +500,21 @@ describe('Workspace Handlers', () => {
       expect(resolver).toHaveBeenCalledTimes(1);
     });
 
-    it('should fall through to the agent workspace lookup when the resolver reports not-found', async () => {
-      // Agents can own a workspace that was never registered via
-      // `Mastra.addWorkspace` (e.g. the auto-registration on
-      // `agent.getWorkspace()` hasn't run yet). A configured resolver that
-      // returns `undefined` for that id must not short-circuit the agent
-      // iteration, otherwise a GET would 404 despite the agent owning it.
-      const agentWorkspace = createWorkspace('agent-owned-ws', { name: 'Agent Owned Workspace' });
+    it('should not invoke agent function-based workspaces when a resolver is configured and reports not-found', async () => {
+      // When a resolver is configured on `@mastra/core`, the resolver + registry
+      // are authoritative: a resolver miss must return a clean not-configured
+      // response without side-effect-invoking every agent's function-based
+      // workspace. Function-based agent workspaces are request-scoped; invoking
+      // them here with a default RequestContext would either register a wrong
+      // workspace under `source: 'agent'` (first-writer-wins in the registry)
+      // or throw and escape the handler as a 500. The legacy agent-iteration
+      // fallback is intentionally confined to the older-core code path.
+      const agentWorkspaceFactory = vi.fn(() => createWorkspace('agent-owned-ws', { name: 'Agent Owned' }));
       const agent = new Agent({
         name: 'lonely-agent',
         instructions: 'test',
         model: { provider: 'openai', name: 'gpt-4o' } as any,
-        workspace: agentWorkspace,
+        workspace: agentWorkspaceFactory as any,
       });
 
       const resolver = vi.fn(async () => undefined);
@@ -521,18 +524,19 @@ describe('Workspace Handlers', () => {
         agents: { lonelyAgent: agent },
       });
 
+      // Reset call count so we only measure invocations triggered by the
+      // handler itself, not any construction-time bookkeeping.
+      agentWorkspaceFactory.mockClear();
+
       const result = await GET_WORKSPACE_ROUTE.handler({
         ...createTestServerContext({ mastra }),
         workspaceId: 'agent-owned-ws',
       });
 
-      expect(result).toMatchObject({
-        isWorkspaceConfigured: true,
-        id: 'agent-owned-ws',
-        name: 'Agent Owned Workspace',
-      });
+      expect(result).toMatchObject({ isWorkspaceConfigured: false });
       expect(resolver).toHaveBeenCalledWith('agent-owned-ws', expect.objectContaining({ mastra }));
       expect(resolver).toHaveBeenCalledTimes(1);
+      expect(agentWorkspaceFactory).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/server/src/server/handlers/workspace.test.ts
+++ b/packages/server/src/server/handlers/workspace.test.ts
@@ -480,6 +480,25 @@ describe('Workspace Handlers', () => {
       expect(resolver).toHaveBeenCalledTimes(1);
       expect(mastra.listWorkspaces()['mfw-abc-xyz-web-factory']?.source).toBe('resolver');
     });
+
+    it('should propagate non-404 resolver errors (e.g. DB/network failures) instead of masking them as "not configured"', async () => {
+      // A resolver blowup is an operational problem, not a "workspace doesn't
+      // exist" signal. If we swallowed it as `undefined`, prod outages would
+      // silently surface as 404s and be near-impossible to diagnose.
+      const resolver = vi.fn(async () => {
+        throw new Error('database unreachable');
+      });
+
+      const mastra = new Mastra({ logger: false, resolveWorkspaceById: resolver });
+
+      await expect(
+        GET_WORKSPACE_ROUTE.handler({
+          ...createTestServerContext({ mastra }),
+          workspaceId: 'mfw-abc-xyz-web-factory',
+        }),
+      ).rejects.toThrow('database unreachable');
+      expect(resolver).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ===========================================================================

--- a/packages/server/src/server/handlers/workspace.test.ts
+++ b/packages/server/src/server/handlers/workspace.test.ts
@@ -531,7 +531,8 @@ describe('Workspace Handlers', () => {
         id: 'agent-owned-ws',
         name: 'Agent Owned Workspace',
       });
-      expect(resolver).toHaveBeenCalled();
+      expect(resolver).toHaveBeenCalledWith('agent-owned-ws', expect.objectContaining({ mastra }));
+      expect(resolver).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/server/src/server/handlers/workspace.test.ts
+++ b/packages/server/src/server/handlers/workspace.test.ts
@@ -457,6 +457,29 @@ describe('Workspace Handlers', () => {
         },
       });
     });
+
+    it('should materialize the workspace via resolveWorkspaceById on a registry miss', async () => {
+      // Simulates the shipyard prod scenario: the process restarted, the in-memory
+      // registry is empty, but the underlying (durable) sandbox is still reachable
+      // and the host can rebuild the workspace shim from its own state.
+      const lazyWorkspace = createWorkspace('mfw-abc-xyz-web-factory', { name: 'Lazy Factory Workspace' });
+      const resolver = vi.fn(async (id: string) => (id === 'mfw-abc-xyz-web-factory' ? lazyWorkspace : undefined));
+
+      const mastra = new Mastra({ logger: false, resolveWorkspaceById: resolver });
+
+      const result = await GET_WORKSPACE_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        workspaceId: 'mfw-abc-xyz-web-factory',
+      });
+
+      expect(result).toMatchObject({
+        isWorkspaceConfigured: true,
+        id: 'mfw-abc-xyz-web-factory',
+        name: 'Lazy Factory Workspace',
+      });
+      expect(resolver).toHaveBeenCalledTimes(1);
+      expect(mastra.listWorkspaces()['mfw-abc-xyz-web-factory']?.source).toBe('resolver');
+    });
   });
 
   // ===========================================================================

--- a/packages/server/src/server/handlers/workspace.test.ts
+++ b/packages/server/src/server/handlers/workspace.test.ts
@@ -499,6 +499,40 @@ describe('Workspace Handlers', () => {
       ).rejects.toThrow('database unreachable');
       expect(resolver).toHaveBeenCalledTimes(1);
     });
+
+    it('should fall through to the agent workspace lookup when the resolver reports not-found', async () => {
+      // Agents can own a workspace that was never registered via
+      // `Mastra.addWorkspace` (e.g. the auto-registration on
+      // `agent.getWorkspace()` hasn't run yet). A configured resolver that
+      // returns `undefined` for that id must not short-circuit the agent
+      // iteration, otherwise a GET would 404 despite the agent owning it.
+      const agentWorkspace = createWorkspace('agent-owned-ws', { name: 'Agent Owned Workspace' });
+      const agent = new Agent({
+        name: 'lonely-agent',
+        instructions: 'test',
+        model: { provider: 'openai', name: 'gpt-4o' } as any,
+        workspace: agentWorkspace,
+      });
+
+      const resolver = vi.fn(async () => undefined);
+      const mastra = new Mastra({
+        logger: false,
+        resolveWorkspaceById: resolver,
+        agents: { lonelyAgent: agent },
+      });
+
+      const result = await GET_WORKSPACE_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        workspaceId: 'agent-owned-ws',
+      });
+
+      expect(result).toMatchObject({
+        isWorkspaceConfigured: true,
+        id: 'agent-owned-ws',
+        name: 'Agent Owned Workspace',
+      });
+      expect(resolver).toHaveBeenCalled();
+    });
   });
 
   // ===========================================================================

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -163,34 +163,34 @@ async function getWorkspaceById(mastra: any, workspaceId: string): Promise<Works
   }
 
   // Prefer the async resolver — it consults the registry first and falls back
-  // to the configured `resolveWorkspaceById` hook on a miss.
+  // to the configured `resolveWorkspaceById` hook on a miss. It always throws
+  // `MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND` on a miss (rather than returning
+  // undefined), so we catch that specific error and fall through to the agent
+  // iteration below; any other error is a real operational failure and must
+  // propagate rather than be masked as a nonexistent workspace.
   if (typeof mastra.resolveWorkspaceById === 'function') {
     try {
       return await mastra.resolveWorkspaceById(workspaceId);
     } catch (err) {
-      // Only the documented "workspace not found" error should degrade to a
-      // `undefined` (which callers surface as a 404). Any other resolver
-      // failure — network/DB error, resolver bug — is an operational problem
-      // and must propagate so it's visible in logs and to the caller, rather
-      // than being masked as a nonexistent workspace.
       if ((err as { id?: string })?.id !== 'MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND') {
         throw err;
       }
-      return undefined;
+      // Fall through to the agent fallback below: an agent may own a
+      // workspace that wasn't registered via `addWorkspace` and therefore
+      // isn't visible to the sync registry / lazy resolver.
     }
-  }
-
-  // Sync registry lookup (older @mastra/core versions without the lazy resolver)
-  if (typeof mastra.getWorkspaceById === 'function') {
+  } else if (typeof mastra.getWorkspaceById === 'function') {
+    // Older @mastra/core without the lazy resolver: sync registry lookup only.
     try {
       return mastra.getWorkspaceById(workspaceId);
     } catch {
-      // Workspace not found in registry
-      return undefined;
+      // Not in the registry — fall through to the agent iteration.
     }
   }
 
-  // Fallback: Search through agents for the workspace (older @mastra/core versions)
+  // Search through agents for the workspace. This covers agents that own a
+  // workspace but never registered it via `Mastra.addWorkspace`, so neither
+  // the sync registry nor the configured resolver can find it.
   const agents = mastra.listAgents?.() ?? {};
   for (const agent of Object.values(agents)) {
     if ((agent as any).hasOwnWorkspace?.()) {

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -151,7 +151,13 @@ function requireWorkspaceV1Support(): void {
  * empty even though the underlying sandbox is still reachable.
  *
  * Backwards compatible: falls through to the sync `getWorkspaceById`, and then
- * to iterating agents, if the newer methods are not present on `@mastra/core`.
+ * to iterating agents, only when the newer async method is not present on the
+ * installed `@mastra/core`. The agent-iteration fallback is intentionally kept
+ * on the legacy path only: it invokes each agent's function-based workspace
+ * with a default `RequestContext`, which is unsafe for request-scoped factories
+ * and would side-effect-register a wrong workspace under `source: 'agent'`.
+ * Modern `@mastra/core` avoids this entirely — the resolver + registry are
+ * authoritative.
  */
 async function getWorkspaceById(mastra: any, workspaceId: string): Promise<Workspace | undefined> {
   requireWorkspaceV1Support();
@@ -165,9 +171,9 @@ async function getWorkspaceById(mastra: any, workspaceId: string): Promise<Works
   // Prefer the async resolver — it consults the registry first and falls back
   // to the configured `resolveWorkspaceById` hook on a miss. It always throws
   // `MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND` on a miss (rather than returning
-  // undefined), so we catch that specific error and fall through to the agent
-  // iteration below; any other error is a real operational failure and must
-  // propagate rather than be masked as a nonexistent workspace.
+  // undefined); we downgrade that specific error to `undefined` so callers can
+  // surface a clean 404. Any other error is a real operational failure (DB /
+  // network / resolver bug) and must propagate rather than be masked.
   if (typeof mastra.resolveWorkspaceById === 'function') {
     try {
       return await mastra.resolveWorkspaceById(workspaceId);
@@ -175,22 +181,23 @@ async function getWorkspaceById(mastra: any, workspaceId: string): Promise<Works
       if ((err as { id?: string })?.id !== 'MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND') {
         throw err;
       }
-      // Fall through to the agent fallback below: an agent may own a
-      // workspace that wasn't registered via `addWorkspace` and therefore
-      // isn't visible to the sync registry / lazy resolver.
-    }
-  } else if (typeof mastra.getWorkspaceById === 'function') {
-    // Older @mastra/core without the lazy resolver: sync registry lookup only.
-    try {
-      return mastra.getWorkspaceById(workspaceId);
-    } catch {
-      // Not in the registry — fall through to the agent iteration.
+      return undefined;
     }
   }
 
-  // Search through agents for the workspace. This covers agents that own a
-  // workspace but never registered it via `Mastra.addWorkspace`, so neither
-  // the sync registry nor the configured resolver can find it.
+  // Legacy path: older @mastra/core without the async lazy resolver. Fall back
+  // to the sync registry, and then to iterating agents. Iterating agents is
+  // deliberately confined to this branch — it invokes function-based agent
+  // workspaces with a default RequestContext, which is unsafe for request-
+  // scoped factories.
+  if (typeof mastra.getWorkspaceById === 'function') {
+    try {
+      return mastra.getWorkspaceById(workspaceId);
+    } catch {
+      // Not in the registry — fall through to the agent iteration below.
+    }
+  }
+
   const agents = mastra.listAgents?.() ?? {};
   for (const agent of Object.values(agents)) {
     if ((agent as any).hasOwnWorkspace?.()) {

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -144,8 +144,14 @@ function requireWorkspaceV1Support(): void {
 /**
  * Get a workspace by ID from Mastra's workspace registry.
  *
- * Backwards compatible: Falls back to searching through agents if
- * mastra.getWorkspaceById() is not available (older @mastra/core versions).
+ * Prefers the async `resolveWorkspaceById` when available so hosts of dynamic
+ * per-session workspaces (e.g. `@mastra/factory`) can re-materialize a
+ * workspace shim on demand — this is what keeps sessions addressable after a
+ * container restart or on a fresh replica, where the in-memory registry is
+ * empty even though the underlying sandbox is still reachable.
+ *
+ * Backwards compatible: falls through to the sync `getWorkspaceById`, and then
+ * to iterating agents, if the newer methods are not present on `@mastra/core`.
  */
 async function getWorkspaceById(mastra: any, workspaceId: string): Promise<Workspace | undefined> {
   requireWorkspaceV1Support();
@@ -156,7 +162,18 @@ async function getWorkspaceById(mastra: any, workspaceId: string): Promise<Works
     return globalWorkspace;
   }
 
-  // Try direct registry lookup if available (newer @mastra/core versions)
+  // Prefer the async resolver — it consults the registry first and falls back
+  // to the configured `resolveWorkspaceById` hook on a miss.
+  if (typeof mastra.resolveWorkspaceById === 'function') {
+    try {
+      return await mastra.resolveWorkspaceById(workspaceId);
+    } catch {
+      // Workspace not found (registry miss and either no resolver or resolver returned undefined)
+      return undefined;
+    }
+  }
+
+  // Sync registry lookup (older @mastra/core versions without the lazy resolver)
   if (typeof mastra.getWorkspaceById === 'function') {
     try {
       return mastra.getWorkspaceById(workspaceId);

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -167,8 +167,15 @@ async function getWorkspaceById(mastra: any, workspaceId: string): Promise<Works
   if (typeof mastra.resolveWorkspaceById === 'function') {
     try {
       return await mastra.resolveWorkspaceById(workspaceId);
-    } catch {
-      // Workspace not found (registry miss and either no resolver or resolver returned undefined)
+    } catch (err) {
+      // Only the documented "workspace not found" error should degrade to a
+      // `undefined` (which callers surface as a 404). Any other resolver
+      // failure — network/DB error, resolver bug — is an operational problem
+      // and must propagate so it's visible in logs and to the caller, rather
+      // than being masked as a nonexistent workspace.
+      if ((err as { id?: string })?.id !== 'MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND') {
+        throw err;
+      }
       return undefined;
     }
   }


### PR DESCRIPTION
Adds a `resolveWorkspaceById` hook to `Mastra` so dynamic per-session workspaces can be re-materialized on demand instead of 404-ing after a container restart or on a fresh replica.

Today the workspace registry (`Mastra.#workspaces`) is a plain in-process object that only gets populated as a side effect of the request that first spawned a workspace. Factory sessions with IDs like `mfw-<repoId>-<sessionId>-web-factory` therefore vanish on restart, even though the underlying Railway sandbox + checkpoint is still fully restorable. Any caller that saw the ID before (background dispatcher, notification queue, UI polling) hits `MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND`.

The hook lets the host reconstruct the shim on demand:

```typescript
new Mastra({
  resolveWorkspaceById: async (id, { mastra }) => {
    const session = await sessions.findByWorkspaceId(id);
    if (!session) return undefined;
    return createFactoryWorkspace(session, { mastra });
  },
});

// New async method opts into lazy resolution:
const workspace = await mastra.resolveWorkspaceById('mfw-abc-xyz-web-factory');
```

The sync `getWorkspaceById` is unchanged (still throws on a miss), so nothing sync-callable moves. `resolveWorkspaceById` consults the in-memory registry first, invokes the hook on a miss, registers the returned workspace with `source: 'resolver'`, and returns it. Concurrent lookups for the same id share one in-flight resolution so we don't double-provision sandbox / LSP / filesystem clients. Failed or `undefined` resolutions are not cached, so a later call can succeed.

`@mastra/server`'s workspace HTTP handlers now prefer the async resolver when it's present, which is the code path that was throwing in prod.

Test plan:
- New `packages/core/src/mastra/workspace-lazy-resolver.test.ts` covers cache hit, resolver miss, undefined-returns-404, concurrent dedup, failed-not-cached, `undefined`-not-cached, resolver context, and the sync path staying sync.
- New server-side test verifies `GET_WORKSPACE_ROUTE` materializes the workspace through `resolveWorkspaceById` on a registry miss.
- `pnpm --filter ./packages/core exec vitest run src/mastra src/agent` — 3547 passed, 1 pre-existing type-test failure in `durable-parity.test-d.ts` unrelated to this change (`experimentalTransform` key drift).
- `pnpm --filter ./packages/server exec vitest run` — 1932 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When Mastra restarts (or runs on a fresh replica), some “dynamic” workspaces might not be loaded into memory yet, so requests can incorrectly fail with “not found.” This PR teaches Mastra to rebuild missing workspaces on-demand the first time they’re requested, without doing the same work multiple times at once.

## What changed

- Added an async `Mastra.resolveWorkspaceById(id)` hook in `@mastra/core` that:
  - First checks Mastra’s in-memory workspace registry
  - Calls an optional configured resolver only on cache misses
  - Deduplicates concurrent lookups for the same `id` (only one resolver invocation runs)
  - Registers successful results into the registry with `source: 'resolver'`
  - Does **not** cache failures or `undefined` results (so later calls can retry)
  - Defers resolver invocation by one microtask so a synchronously thrown resolver error doesn’t poison the in-flight dedupe cache
- Extended types to allow `RegisteredWorkspace.source` = `'resolver'`.
- Kept `getWorkspaceById()` synchronous behavior unchanged: it still throws on missing workspaces and does **not** invoke the async resolver.
- Updated `@mastra/server` workspace HTTP handlers to use `resolveWorkspaceById` when available:
  - Only the documented “workspace not found” resolver outcome is treated as a clean not-found
  - Any other resolver error is propagated (not masked)
  - The agent-workspace “fallback” behavior is retained **only for the legacy (sync/absent async resolver) path**—when the async resolver is configured, an `undefined` result yields a clean “not configured” response without trying agent factories.

## Tests

- Added core tests for:
  - cache hits vs resolver invocation
  - resolver-backed resolution and `source: 'resolver'` tagging
  - concurrent lookup deduplication
  - non-caching of rejected/failed, `undefined`, and sync-throw resolver behavior
  - passing `{ mastra }` into the resolver context
  - ensuring `getWorkspaceById()` stays synchronous and does not call the async resolver
- Added server handler tests for correct integration, including:
  - correct responses when resolver is configured (including “not configured” when resolver returns `undefined`)
  - propagation of non-not-found resolver errors
  - agent-owned workspace fallback only on the legacy path

## Note on companion work

A follow-up change is still required in `mastracode/factory` to register the production resolver for persisted factory sessions; otherwise the hook may legitimately return `undefined` in real deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->