### PR TITLE
fix(studio): align chat scroll button

### DIFF
--- a/.changeset/perky-steaks-look.md
+++ b/.changeset/perky-steaks-look.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed the Studio chat scroll button position so it aligns with the message column at all viewport widths.

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -197,7 +197,9 @@ export const Thread = ({
                 </div>
               )}
             </MessageScrollerViewport>
-            <MessageScrollerButton className="z-30" />
+            <div className="pointer-events-none absolute inset-x-0 bottom-4 z-30 mx-auto flex w-full max-w-3xl px-4">
+              <MessageScrollerButton className="pointer-events-auto static ms-auto translate-x-0 rtl:translate-x-0" />
+            </div>
           </MessageScroller>
 
           {showThumbnailInChat && agentId && threadId && (


### PR DESCRIPTION
The scroll-to-end control in Studio was centered against the full chat pane, so it drifted away from the constrained message column on wide layouts. I moved its consumer positioning into a pointer-transparent wrapper that uses the same `max-w-3xl px-4` geometry, while leaving the public `MessageScrollerButton` default unchanged.

Before:

```tsx
<MessageScrollerButton className="z-30" />
```

After:

```tsx
<div className="pointer-events-none absolute inset-x-0 bottom-4 z-30 mx-auto flex w-full max-w-3xl px-4">
  <MessageScrollerButton className="pointer-events-auto static ms-auto translate-x-0 rtl:translate-x-0" />
</div>
```

I verified the existing playground tests (1,642 passed, 2 skipped), playground typecheck, CLI build, and React Doctor. In Studio at 1568×1326 and 900×700, the button aligned exactly to the message column's 16px inset, stayed clickable, scrolled to the exact bottom, and hid afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The “scroll to bottom” button now stays lined up with the chat messages, even on wide screens. It remains easy to click and still scrolls exactly to the bottom.

## Changes

- Wrapped the Studio chat scroll button in a pointer-transparent, constrained container using `max-w-3xl px-4`.
- Preserved the public `MessageScrollerButton` default behavior.
- Added a changeset documenting the Studio alignment fix.

## Validation

- Playground tests: 1,642 passed, 2 skipped
- Playground typecheck, CLI build, and React Doctor checks passed
- Manual verification confirmed alignment, clickability, exact-bottom scrolling, and hiding at the bottom across two viewport sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->