### PR TITLE
fix(core): stream JSON fallback treats valid falsy structured output as undefined

### DIFF
--- a/.changeset/fix-stream-json-fallback-falsy-object.md
+++ b/.changeset/fix-stream-json-fallback-falsy-object.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `tryStreamWithJsonFallback` treating a valid falsy structured-output value as undefined. The first-attempt check used `!object`, so a schema resolving to a falsy-but-defined value (e.g. `z.boolean()` -> `false`, `z.number()` -> `0`) was wrongly rejected and triggered an unnecessary JSON-prompt fallback stream. It now checks `object === undefined`, matching the generate path and the stream fallback path.

--- a/packages/core/src/agent/utils.test.ts
+++ b/packages/core/src/agent/utils.test.ts
@@ -164,6 +164,18 @@ describe('agent/utils', () => {
       expect(stream.mock.calls[1][1].structuredOutput.jsonPromptInjection).toBe(true);
     });
 
+    it('returns the first result without a fallback for a valid falsy object', async () => {
+      // A structuredOutput schema can legitimately resolve to a falsy-but-defined
+      // value (e.g. z.boolean() -> false, z.number() -> 0). That is a successful
+      // first attempt and must not trigger the JSON-prompt fallback.
+      const firstResult = { object: Promise.resolve(false) };
+      const stream = vi.fn().mockResolvedValueOnce(firstResult);
+      const options = { structuredOutput: { schema: z.boolean() } } as any;
+
+      await expect(tryStreamWithJsonFallback(makeStreamAgent(stream), 'prompt', options)).resolves.toBe(firstResult);
+      expect(stream).toHaveBeenCalledTimes(1);
+    });
+
     it.each([
       ['retryable provider error', makeAPICallError(true)],
       ['non-retryable provider error', makeAPICallError(false)],

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -118,7 +118,7 @@ export async function tryStreamWithJsonFallback<OUTPUT extends {}>(
     void onStream?.(result as unknown as Awaited<ReturnType<Agent['stream']>>);
     try {
       const object = await result.object;
-      if (!object) {
+      if (object === undefined) {
         throw new MastraError({
           id: 'STRUCTURED_OUTPUT_OBJECT_UNDEFINED',
           domain: ErrorDomain.AGENT,


### PR DESCRIPTION
Fixes #20627

## Description

`tryStreamWithJsonFallback` in `packages/core/src/agent/utils.ts` checked the first-attempt structured output with `if (!object)`. A `structuredOutput` schema can legitimately resolve to a falsy-but-defined value (`z.boolean()` -> `false`, `z.number()` -> `0`, `z.string()` -> `""`). Those valid results were wrongly rejected as `STRUCTURED_OUTPUT_OBJECT_UNDEFINED`, which triggered an unnecessary `jsonPromptInjection` fallback stream (a wasted second model call).

The three sibling checks all use `object === undefined`:
- generate first-attempt (`utils.ts:59`)
- generate fallback (`utils.ts:83`)
- stream fallback (`utils.ts:151`)

Only the stream first-attempt used `!object`. The `generate()` path already handles a valid falsy object correctly on the first try, confirming this is a bug rather than intended behavior.

## Fix

Change the stream first-attempt check to `object === undefined`, unifying all four call sites on one predicate.

## Tests

Adds a regression test to `utils.test.ts`: a stream whose first attempt resolves to `false` (valid `z.boolean()` output) must return the first result and call `stream()` exactly once. Verified failing before the fix (the buggy path fired a second stream call) and passing after. The full `agent/utils.test.ts` suite (27 tests) passes with no type errors.