### PR TITLE
chore(docs): Fix AI tells in guides

### DIFF
--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -36,7 +36,7 @@ You're now ready to follow the integration guides and recipes below!
 
 ## Integration guides
 
-Typically, you'll set up API routes that stream Mastra content in AI SDK-compatible format, and then use those routes in AI SDK UI hooks like `useChat()`. Below you'll find two main approaches to achieve this:
+Typically, you'll set up API routes that stream Mastra content in AI SDK-compatible format, and then use those routes in AI SDK UI hooks like `useChat()`. Choose one of these approaches:
 
 - [Mastra's server](#mastras-server)
 - [Framework-agnostic](#framework-agnostic)
@@ -306,7 +306,7 @@ export default function Page() {
 }
 ```
 
-Below are two approaches to implementing the backend:
+Choose a backend implementation:
 
 <Tabs>
   <TabItem value="mastra-server" label="Mastra Server">
@@ -390,7 +390,7 @@ Below are two approaches to implementing the backend:
 
 ## Custom UI
 
-Custom UI (also known as Generative UI) allows you to render custom React components based on data streamed from Mastra. Instead of displaying raw text or JSON, you can create visual components for tool outputs, workflow progress, agent network execution, and custom events.
+Custom UI (also known as Generative UI) allows you to render custom React components based on data streamed from Mastra. Instead of displaying raw text or JSON, you can create visual components for tool outputs and workflow progress, including agent network execution and custom events.
 
 Use Custom UI when you want to:
 
@@ -1016,7 +1016,7 @@ export function ChatAdditional() {
 }
 ```
 
-Two examples on how to implement the backend portion of it.
+Implement the backend with either of these examples.
 
 <Tabs>
   <TabItem value="mastra-server" label="Mastra Server">
@@ -1583,7 +1583,7 @@ For a complete implementation, see the [workflow-agent-text-stream example](http
 
 ### Multi-stage progress with branching workflows
 
-For workflows with conditional branching (e.g., express vs standard shipping), you can track progress across different branches by including a identifier in your custom events.
+For workflows with conditional branching (e.g., express vs standard delivery), you can track progress across different branches by including an identifier in your custom events.
 
 The UI Dojo example uses a `stage` field in the event data to identify which branch is executing (e.g., `"validation"`, `"standard-processing"`, `"express-processing"`). The frontend groups events by this field to show a pipeline-style progress UI.
 

--- a/docs/src/content/en/guides/build-your-ui/copilotkit/generative-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/copilotkit/generative-ui.mdx
@@ -5,27 +5,27 @@ description: "Render agent output as UI, from developer-controlled components to
 
 # CopilotKit generative UI
 
-Generative UI is the family of UI paradigms enabled by agents and useful for interacting with them. CopilotKit organizes these along a single axis, the **generative UI spectrum**, which runs from author-controlled (you decide every pixel) to agent-invented (the agent owns the rendered surface). Where you sit on the axis is a trade-off between predictability and breadth.
+Generative UI describes interfaces that agents help create and that users can interact with. CopilotKit organizes these interfaces along a single axis, the **generative UI spectrum**, which runs from author-controlled (you decide every pixel) to agent-invented (the agent owns the rendered surface). Your position on the axis is a trade-off between predictability and breadth.
 
 The spectrum has three tiers:
 
 | Tier | Who controls the surface | Primitives |
 | - | - | - |
-| **Controlled** | You wrote the component; the agent picks which one and what data to pass. | Tool call rendering, state rendering, reasoning, components as tools |
-| **Declarative** | The agent emits a structured spec; the frontend composes it from a catalog you registered. | A2UI (fixed schema and dynamic) |
+| **Controlled** | You wrote the component. The agent picks which one to use and what data to pass. | Tool call rendering, state rendering, reasoning, components as tools |
+| **Declarative** | The agent emits a structured spec. The frontend composes it from a catalog you registered. | A2UI (fixed-schema and flexible variants) |
 | **Open-ended** | The UI is invented elsewhere (an MCP server) and you sandbox it. | MCP Apps |
 
 Each tier is a Mastra agent exposed through `registerCopilotKit()` (see [CopilotKit overview](/guides/build-your-ui/copilotkit/overview)) plus the matching CopilotKit hook on the frontend. For the full concept, see CopilotKit's [generative UI spectrum](https://www.copilotkit.ai/generative-ui-spectrum) and [generative UI overview](https://docs.copilotkit.ai/concepts/generative-ui-overview).
 
 :::tip
 
-Mastra's [UI Dojo](https://ui-dojo.mastra.ai/) has working CopilotKit examples; browse the source under `src/pages/copilot-kit`.
+Mastra's [UI Dojo](https://ui-dojo.mastra.ai/) has working CopilotKit examples. Browse the source under `src/pages/copilot-kit`.
 
 :::
 
 ## Controlled
 
-You ship a fixed set of components and the agent chooses which to render, with what data. This is the workhorse of the spectrum: predictable and brand-safe, the right tool for high-traffic surfaces. The Controlled primitives use CopilotKit's v2 API, imported from `@copilotkit/react-core/v2`.
+You provide a fixed set of components. The agent chooses which component to render and supplies its data. This predictable, brand-safe approach works well for high-traffic surfaces. The Controlled primitives use CopilotKit's v2 API, imported from `@copilotkit/react-core/v2`.
 
 ### Tool call rendering
 
@@ -132,7 +132,7 @@ Reasoning is zero-config: when your Mastra agent runs a reasoning-capable model,
 
 ## Declarative
 
-Instead of a fixed component per tool, you register a catalog of typed building blocks and the agent assembles them into a UI tree per request. CopilotKit calls this **A2UI** (Agent-to-UI), available in a fixed-schema and a dynamic variant. It suits the long tail of secondary interactions where breadth matters more than pixel-perfection.
+Instead of a fixed component per tool, you register a catalog of typed building blocks and the agent assembles them into a UI tree per request. CopilotKit calls this **A2UI** (Agent-to-UI), which has fixed-schema and flexible variants. It suits the long tail of secondary interactions where breadth matters more than pixel-perfection.
 
 The path of least resistance is to pass your catalog to the `<CopilotKit>` provider. That single prop enables A2UI rendering and injects the A2UI tool into your agent, so no backend change is needed:
 
@@ -153,11 +153,11 @@ export default function Page() {
 }
 ```
 
-The catalog defines the primitives (their schemas) and the renderers (how each primitive displays). In the fixed-schema variant the components are pre-authored and the agent's tool only supplies data; the dynamic variant lets the agent compose the tree more freely. See CopilotKit's [A2UI documentation](https://docs.copilotkit.ai/a2a/generative-ui/a2ui).
+The catalog defines the primitives (their schemas) and the renderers (how each primitive displays). In the fixed-schema variant, the components are pre-authored and the agent's tool only supplies data. The flexible variant lets the agent compose the tree more freely. See CopilotKit's [A2UI documentation](https://docs.copilotkit.ai/a2a/generative-ui/a2ui).
 
 ## Open-ended
 
-At the far end of the spectrum, the agent owns the entire surface: the UI is invented elsewhere and sandboxed in your app. CopilotKit supports this through **MCP Apps**, where an MCP server ships UI that renders inside your application. This tier trades determinism for novelty and is the most experimental point on the spectrum.
+At the far end of the spectrum, the agent owns the entire surface: the UI is invented elsewhere and sandboxed in your app. CopilotKit supports this through **MCP Apps**, where an MCP server provides UI that renders inside your application. This tier trades determinism for novelty and is the most experimental point on the spectrum.
 
 The path of least resistance keeps the frontend untouched: your existing `<CopilotKit>` provider is enough. On the backend, point `registerCopilotKit()` at one or more MCP servers with the `mcpApps` option (it's forwarded to the CopilotKit runtime):
 

--- a/docs/src/content/en/guides/build-your-ui/copilotkit/overview.mdx
+++ b/docs/src/content/en/guides/build-your-ui/copilotkit/overview.mdx
@@ -8,7 +8,7 @@ import StepItem from "@site/src/components/StepItem";
 
 # Using CopilotKit
 
-[CopilotKit](https://www.copilotkit.ai/) provides React components to quickly integrate customizable AI copilots into your application. Combined with Mastra, you can build sophisticated AI apps featuring bidirectional state synchronization and interactive UIs.
+[CopilotKit](https://www.copilotkit.ai/) provides React components to quickly integrate customizable AI copilots into your application. Combined with Mastra, you can build AI apps with bidirectional state synchronization and interactive UIs.
 
 CopilotKit talks to Mastra through the [AG-UI protocol](https://docs.ag-ui.com/). The `@ag-ui/mastra` package exposes your Mastra agents as an AG-UI endpoint, and CopilotKit's React hooks and components consume it. This unlocks a spectrum of experiences on top of ordinary chat: [generative UI, human-in-the-loop, and frontend tools](/guides/build-your-ui/copilotkit/generative-ui), plus deploying the same agent to [messaging channels like Slack](/guides/build-your-ui/copilotkit/channels).
 
@@ -174,7 +174,7 @@ Your CopilotKit frontend now communicates with a standalone Mastra agent server.
 
 ## Chat UI options
 
-`CopilotChat` renders an inline, full-height chat. CopilotKit ships two other drop-in surfaces that share the same props:
+`CopilotChat` renders an inline, full-height chat. CopilotKit provides two other drop-in surfaces that share the same props:
 
 - `CopilotSidebar`: a collapsible panel docked to the side of your app.
 - `CopilotPopup`: a floating button that opens a chat window.

--- a/docs/src/content/en/guides/build-your-ui/openui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/openui.mdx
@@ -219,7 +219,7 @@ OpenUI generates UI from a component library. The library defines which componen
 
 ### Built-in libraries
 
-`@openuidev/react-ui` ships two libraries you can use as-is:
+`@openuidev/react-ui` provides two libraries you can use as-is:
 
 - `openuiChatLibrary`: components for chat interfaces (cards, forms, tables, charts).
 - `openuiDashboardLibrary`: components for dashboards and data-heavy surfaces.

--- a/docs/src/content/en/guides/concepts/multi-agent-systems.mdx
+++ b/docs/src/content/en/guides/concepts/multi-agent-systems.mdx
@@ -9,7 +9,7 @@ packages:
 
 A multi-agent system distributes a task across multiple agents instead of asking one agent to do everything. In Mastra, this usually means combining agents, workflows, or both so each part of the system has a clear role.
 
-The goal is to assign the right context, tools, and responsibilities to the right component. When that split is clear, a multi-agent system can be easier to reason about than one agent with a long prompt, many tools, and too many responsibilities.
+The goal is to assign the right context, tools, and responsibilities to the right component. When that split is clear, a multi-agent system can be easier to reason about than one agent burdened with a long prompt and too many tools or responsibilities.
 
 ## When to use multi-agent systems
 
@@ -39,9 +39,9 @@ In Mastra, implement this pattern by combining [agents](/docs/agents/overview), 
 
 A workflow pattern defines the execution path in code. Instead of asking an agent to decide what happens next, you define the sequence through steps, branches, loops, and parallel blocks.
 
-Use workflows when the task is well understood and the execution path is known in advance. The main advantage is predictability: The system is easier to debug, reason about, and audit because the structure is explicit. The tradeoff is flexibility, since workflows are less adaptive when the task changes as it unfolds.
+Use workflows when the task is well understood and the execution path is known in advance. The main advantage is predictability: The explicit structure makes the system easier to debug and audit. The tradeoff is flexibility, since workflows are less adaptive when the task changes as it unfolds.
 
-In Mastra, [workflows](/docs/workflows/overview) can implement several coordination patterns, including handoffs and councils. What makes a workflow distinct isn't which agents it calls, but that the control logic lives in the workflow itself.
+In Mastra, [workflows](/docs/workflows/overview) can implement coordination patterns such as handoffs and councils. A workflow is distinct because its control logic lives in the workflow itself, regardless of which agents it calls.
 
 ## Supervisors
 
@@ -64,7 +64,7 @@ A council pattern asks multiple agents to work on the same problem independently
 
 Use this pattern when the question is ambiguous, evaluative, or high-stakes and answer quality matters more than speed. The tradeoff is cost, since councils intentionally duplicate effort and usually take longer and use more tokens than other patterns.
 
-Mastra doesn't provide a dedicated council primitive. In Mastra, implement this pattern with [agents](/docs/agents/overview) and [workflows](/docs/workflows/overview): Run multiple agents in parallel, collect their outputs, and add a final synthesis or review step. Workflow control flow methods such as `.parallel()` provide the structure for this pattern.
+Mastra doesn't provide a dedicated council primitive. In Mastra, implement this pattern with [agents](/docs/agents/overview) and [workflows](/docs/workflows/overview): Run multiple agents in parallel and collect their outputs. Then add a final synthesis or review step. Workflow control flow methods such as `.parallel()` provide the structure for this pattern.
 
 ## Choosing a pattern
 
@@ -74,7 +74,7 @@ These patterns differ mainly in how they distribute control:
 | - | - | - | - | - |
 | Handoffs | Current specialist | Ownership should move between specialists | Context transfer becomes more important | Agents with workflows and memory |
 | Workflows | Execution graph | The path is known in advance | Less adaptive when the task changes | [Workflows](/docs/workflows/overview) |
-| Supervisor agents | One lead agent | The task needs dynamic delegation | Results depend on good coordination and clear boundaries | [Supervisor agents](/docs/agents/supervisor-agents) |
+| Supervisor agents | One lead agent | Delegation must adapt during execution | Results depend on good coordination and clear boundaries | [Supervisor agents](/docs/agents/supervisor-agents) |
 | Council | Final synthesis step | The task needs multiple independent perspectives | Higher cost and latency | Agents with workflow parallelism |
 
 In practice, these patterns are often combined:

--- a/docs/src/content/en/guides/concepts/streaming.mdx
+++ b/docs/src/content/en/guides/concepts/streaming.mdx
@@ -56,7 +56,7 @@ Here are some questions to consider:
 
 ### Agent stream properties
 
-An agent stream provides access to various response properties:
+An agent stream provides access to these response properties:
 
 - **`stream.textStream`**: A readable stream that emits text chunks.
 - **`stream.text`**: Promise that resolves to the full text response.
@@ -134,13 +134,13 @@ The event structure includes `runId` and `from` at the top level, making it easi
 
 ### Workflow stream properties
 
-A workflow stream provides access to various response properties:
+A workflow stream provides access to these response properties:
 
 - **`stream.status`**: The status of the workflow run.
 - **`stream.result`**: The result of the workflow run.
 - **`stream.usage`**: The total token usage of the workflow run.
 
-Streaming from agents or workflows provides real-time visibility into either the LLM’s output or the status of a workflow run. This feedback can be passed directly to the user, or used within applications to handle workflow status more effectively, creating a smoother and more responsive experience.
+Streaming from agents or workflows provides real-time visibility into either the LLM’s output or the status of a workflow run. Pass this feedback directly to the user, or use it in an application to display workflow status as it changes.
 
 Events emitted from agents or workflows represent different stages of generation and execution, such as when a run starts, when text is produced, or when a tool is invoked.
 
@@ -204,11 +204,11 @@ Below is an example of events that may be emitted. Each event always includes a 
 
 ## Writer API
 
-The `writer` API is shared by tools and workflow steps — see the Tools and Workflows docs for feature-specific examples.
+The `writer` API is shared by tools and workflow steps. See the Tools and Workflows docs for feature-specific examples.
 
 ## Agent using tool
 
-Agent streaming can be combined with tool calls, allowing tool outputs to be written directly into the agent’s streaming response. This makes it possible to surface tool activity as part of the overall interaction.
+Agent streaming can be combined with tool calls, allowing tool outputs to be written directly into the agent’s streaming response. This surfaces tool activity as part of the interaction.
 
 ```typescript {2,9}
 import { Agent } from '@mastra/core/agent'
@@ -225,7 +225,7 @@ export const testAgent = new Agent({
 
 ### Using `context.writer`
 
-The `context.writer` object is available in a tool's `execute()` function and can be used to emit custom events, data, or values into the active stream. This enables tools to provide intermediate results or status updates while execution is still in progress.
+The `context.writer` object is available in a tool's `execute()` function and can emit custom events, data, or values into the active stream. Tools use these events to provide intermediate results or status updates during execution.
 
 :::warning
 
@@ -289,7 +289,7 @@ export const testTool = createTool({
 
 ### Transient data chunks
 
-By default, `data-*` chunks emitted with `writer.custom()` are persisted to storage as part of the message history. For chunks that are only needed during live streaming — such as progress updates or verbose log output — set `transient: true` to skip storage persistence. Transient chunks are still streamed to the client in real time but aren't saved to the database.
+By default, `data-*` chunks emitted with `writer.custom()` are persisted to storage as part of the message history. For chunks that are only needed during live streaming, such as progress updates or verbose log output, set `transient: true` to skip storage persistence. Transient chunks are still streamed to the client in real time but aren't saved to the database.
 
 ```typescript {4}
 await context?.writer?.custom({
@@ -299,11 +299,11 @@ await context?.writer?.custom({
 })
 ```
 
-Use transient chunks when the data is large or high-frequency and only relevant during the live session. After a page refresh, transient chunks are no longer available — only the tool's return value and any non-transient chunks are loaded from storage.
+Use transient chunks when the data is large or high-frequency and only relevant during the live session. After a page refresh, transient chunks are no longer available. Only the tool's return value and any non-transient chunks are loaded from storage.
 
 ## Using the `writer` argument
 
-The `writer` argument is passed to a workflow step's `execute` function and can be used to emit custom events, data, or values into the active stream. This enables workflow steps to provide intermediate results or status updates while execution is still in progress.
+The `writer` argument is passed to a workflow step's `execute` function and can emit custom events, data, or values into the active stream. Workflow steps use these events to provide intermediate results or status updates during execution.
 
 :::warning
 

--- a/docs/src/content/en/guides/deployment/amazon-ec2.mdx
+++ b/docs/src/content/en/guides/deployment/amazon-ec2.mdx
@@ -10,7 +10,7 @@ import TabItem from "@theme/TabItem";
 
 # Deploy Mastra to Amazon EC2
 
-Deploy your Mastra server to Amazon EC2. This gives you full control over your server environment and supports long-running agents and workflows.
+Deploy your Mastra server to Amazon EC2. The server runs on infrastructure you manage and can support long-running agents and workflows.
 
 :::info
 This guide covers deploying the [Mastra server](/docs/server/mastra-server). If you're using a [server adapter](/docs/server/server-adapters) or [web framework](/docs/deployment/web-framework), deploy the way you normally would for that framework.

--- a/docs/src/content/en/guides/deployment/aws-lambda.mdx
+++ b/docs/src/content/en/guides/deployment/aws-lambda.mdx
@@ -20,7 +20,7 @@ You'll need:
 
 - A [Mastra application](/guides/getting-started/quickstart)
 - An [AWS account](https://aws.amazon.com/) with permissions for Lambda, ECR, and IAM
-- **[AWS CLI](https://aws.amazon.com/cli/)** installed — run `aws configure` to authenticate
+- **[AWS CLI](https://aws.amazon.com/cli/)** installed: Run `aws configure` to authenticate
 - **[Docker](https://www.docker.com/)** installed and running
 
 :::warning

--- a/docs/src/content/en/guides/deployment/azure-app-services.mdx
+++ b/docs/src/content/en/guides/deployment/azure-app-services.mdx
@@ -101,7 +101,7 @@ In these steps, you'll connect your Azure App Service to your GitHub repository 
     run: (cd .mastra/output && zip ../../release.zip -r .)
     ```
 
-    This ensures only the build outputs from `.mastra/output` are included in the deployment package.
+    The deployment package then contains only the build outputs from `.mastra/output`.
   </StepItem>
 
   <StepItem>

--- a/docs/src/content/en/guides/deployment/cloudflare.mdx
+++ b/docs/src/content/en/guides/deployment/cloudflare.mdx
@@ -51,7 +51,7 @@ export const mastra = new Mastra({
 })
 ```
 
-In order to test your Cloudflare Worker locally, also install the [`wrangler` CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/):
+To test your Cloudflare Worker locally, also install the [`wrangler` CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/):
 
 ```bash npm2yarn
 npm install -D wrangler

--- a/docs/src/content/en/guides/deployment/inngest.mdx
+++ b/docs/src/content/en/guides/deployment/inngest.mdx
@@ -11,11 +11,11 @@ For a complete example with advanced flow control features, see the [Inngest wor
 
 ## How Inngest works with Mastra
 
-Inngest and Mastra integrate by aligning their workflow models: Inngest organizes logic into functions composed of steps, and Mastra workflows defined using `createWorkflow()` and `createStep()` map directly onto this paradigm. Each Mastra workflow becomes an Inngest function with a unique identifier, and each step within the workflow maps to an Inngest step.
+Inngest and Mastra integrate by aligning their workflow models: Inngest organizes logic into functions composed of steps, and Mastra workflows defined using `createWorkflow()` and `createStep()` map directly onto this structure. Each Mastra workflow becomes an Inngest function with a unique identifier, and each step within the workflow maps to an Inngest step.
 
 The `serve()` function bridges the two systems by registering Mastra workflows as Inngest functions and setting up the necessary event handlers for execution and monitoring.
 
-When an event triggers a workflow, Inngest executes it step by step, memoizing each step's result. This means if a workflow is retried or resumed, completed steps are skipped, ensuring efficient and reliable execution. Control flow primitives in Mastra, such as loops, conditionals, and nested workflows are seamlessly translated into the same Inngest's function/step model, preserving advanced workflow features like composition, branching, and suspension.
+When an event triggers a workflow, Inngest executes it step by step and memoizes each result. On retry or resume, Inngest skips completed steps based on those saved results. Mastra control flow primitives, such as loops, conditionals, and nested workflows, map to the same Inngest function and step model while preserving composition, branching, and suspension.
 
 Real-time monitoring, suspend/resume, and step-level observability are enabled via Inngest's publish-subscribe system and dashboard. As each step executes, its state and output are tracked using Mastra storage and can be resumed as needed.
 
@@ -185,7 +185,7 @@ The path is `/inngest/api`, not `/api/inngest`. Mastra reserves the `/api` prefi
 
 1. Open the Inngest Dashboard at [http://localhost:8288](http://localhost:8288) and go to the **Apps** section in the sidebar to verify your Mastra workflow is registered
 
-1. Invoke the workflow by going to **Functions**, selecting your workflow, and selecting **Invoke** with the following input:
+1. In **Functions**, open your workflow. Select **Invoke** and provide the following input:
 
    ```json
    {
@@ -249,7 +249,7 @@ Before you begin, make sure you have:
    Inngest's auto-discover convention assumes `/api/inngest`. Because this guide uses `/inngest/api`, set the **URL** field on the Inngest app to your deployed origin plus `/inngest/api` (for example `https://your-app.vercel.app/inngest/api`). If you leave it on the default, the Inngest dashboard won't find your app's functions.
    :::
 
-1. Invoke the workflow by going to **Functions**, selecting `workflow.increment-workflow`, selecting **All actions** > **Invoke**, and providing the following input:
+1. In **Functions**, open `workflow.increment-workflow`. Select **All actions** > **Invoke** and provide the following input:
 
    ```json
    {
@@ -491,7 +491,7 @@ When migrating an existing production app from `serve()` to `connect()`, test th
 - `functions`: Optional array of additional Inngest functions to register alongside Mastra workflows.
 - `instanceId`: Stable identifier for the worker, shown in the Inngest dashboard. Defaults to the machine hostname.
 - `maxWorkerConcurrency`: Maximum number of steps the worker runs at a time. Defaults to unlimited.
-- `registerOptions`: Forwarded to Inngest during app registration (for example `signingKey`). When a field is set both here and at the top level, `registerOptions` wins — this matches the behavior of `serve()`.
+- `registerOptions`: Forwarded to Inngest during app registration (for example `signingKey`). When a field is set both here and at the top level, `registerOptions` wins. This matches the behavior of `serve()`.
 
 `connect()` returns Inngest's `WorkerConnection`. The Inngest SDK handles `SIGINT` and `SIGTERM` by default. Store the returned connection and call `.close()` only when your worker needs custom shutdown control.
 
@@ -660,7 +660,7 @@ All flow control options are optional. If not specified, workflows run with Inng
 
 ## Cron scheduling
 
-Inngest workflows can be automatically triggered on a schedule using cron expressions. This allows you to run workflows at regular intervals, such as daily reports, hourly data syncs, or maintenance tasks.
+Use cron expressions to trigger Inngest workflows on a schedule. Common uses include daily reports and hourly data syncs, as well as maintenance tasks.
 
 ### Basic cron scheduling
 

--- a/docs/src/content/en/guides/deployment/temporal.mdx
+++ b/docs/src/content/en/guides/deployment/temporal.mdx
@@ -156,7 +156,7 @@ await worker.run()
 
 1. Open the Temporal UI at [http://localhost:8080](http://localhost:8080) to inspect namespaces, workflows, and activities.
 
-1. Start the worker. In a new terminal, run:
+1. In a new terminal, start the worker by running:
 
    ```bash
    npx tsx src/mastra/worker.ts

--- a/docs/src/content/en/guides/deployment/vercel.mdx
+++ b/docs/src/content/en/guides/deployment/vercel.mdx
@@ -93,7 +93,7 @@ export const mastra = new Mastra({
 })
 ```
 
-After deploying, Studio is available at the root URL (`https://<your-project>.vercel.app/`) and the API remains at `/api/*`. Studio automatically connects to the API on the same origin — no additional environment variables are needed.
+After deploying, Studio is available at the root URL (`https://<your-project>.vercel.app/`) and the API remains at `/api/*`. Studio automatically connects to the API on the same origin, so you don't need additional environment variables.
 
 :::warning
 Once Studio is connected to your Mastra server, it has full access to your agents, workflows, and tools. Be sure to secure it properly in production (e.g. behind authentication, VPN, etc.) to prevent unauthorized access.

--- a/docs/src/content/en/guides/getting-started/astro.mdx
+++ b/docs/src/content/en/guides/getting-started/astro.mdx
@@ -61,7 +61,7 @@ export default defineConfig({
 })
 ```
 
-Lastly, edit the `tsconfig.json` to resolve paths:
+Edit the `tsconfig.json` to resolve paths:
 
 ```jsonc title="tsconfig.json"
 {

--- a/docs/src/content/en/guides/getting-started/electron.mdx
+++ b/docs/src/content/en/guides/getting-started/electron.mdx
@@ -383,7 +383,7 @@ This connects [`useChat()`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat
 
 ## Test your agent
 
-In order to test your agent with the chat interface, you need to run both the Mastra server and the Electron app.
+To test your agent with the chat interface, run both the Mastra server and the Electron app.
 
 1. Start the mastra development server:
 

--- a/docs/src/content/en/guides/getting-started/nestjs.mdx
+++ b/docs/src/content/en/guides/getting-started/nestjs.mdx
@@ -129,11 +129,11 @@ export class AgentService {
 
 `MastraService` exposes:
 
-- `getMastra()` — returns the underlying `Mastra` instance
-- `getAgent(id)` — shorthand for `mastra.getAgent(id)`
-- `getWorkflow(id)` — shorthand for `mastra.getWorkflow(id)`
-- `getOptions()` — returns the module configuration
-- `isShuttingDown` — `true` after graceful shutdown begins
+- `getMastra()`: Returns the underlying `Mastra` instance
+- `getAgent(id)`: Shorthand for `mastra.getAgent(id)`
+- `getWorkflow(id)`: Shorthand for `mastra.getWorkflow(id)`
+- `getOptions()`: Returns the module configuration
+- `isShuttingDown`: `true` after graceful shutdown begins
 
 ### MASTRA token
 

--- a/docs/src/content/en/guides/getting-started/vite-react.mdx
+++ b/docs/src/content/en/guides/getting-started/vite-react.mdx
@@ -259,7 +259,7 @@ It renders the response text using the [`<MessageResponse>`](https://ai-sdk.dev/
 
 ## Test your agent
 
-In order to test your agent with the chat interface, you need to run both the Mastra server and the Vite development server.
+To test your agent with the chat interface, run both the Mastra server and the Vite development server.
 
 1. Start the Mastra development server:
 

--- a/docs/src/content/en/guides/guide/chef-michel.mdx
+++ b/docs/src/content/en/guides/guide/chef-michel.mdx
@@ -10,7 +10,7 @@ import StepItem from "@site/src/components/StepItem";
 
 In this guide, you'll create a "Chef Assistant" agent that helps users cook meals with available ingredients.
 
-You'll learn how to create the agent and register it with Mastra. Next, you'll interact with the agent through your terminal and get to know different response formats. Lastly, you'll access the agent through Mastra's local API endpoints.
+You'll learn how to create the agent and register it with Mastra. Next, you'll interact with the agent through your terminal and get to know different response formats. You'll then access the agent through Mastra's local API endpoints.
 
 ## Prerequisites
 

--- a/docs/src/content/en/guides/guide/code-review-bot.mdx
+++ b/docs/src/content/en/guides/guide/code-review-bot.mdx
@@ -8,7 +8,7 @@ import StepItem from "@site/src/components/StepItem";
 
 # Building a code review bot
 
-In this guide, you'll build a code review bot that automatically reviews pull requests using workspace skills. The bot loads coding standards from skill files and provides structured feedback. You'll learn how to create a workspace with a skills directory, define an [Agent Skill](https://agentskills.io) with review instructions and reference files, and connect it to an agent that performs automated reviews.
+In this guide, you'll build a code review bot that automatically reviews pull requests using workspace skills. The bot loads coding standards from skill files and provides structured feedback. You'll create a workspace with a skills directory and define an [Agent Skill](https://agentskills.io) with review instructions and reference files. Then you'll connect the skill to an agent that performs automated reviews.
 
 ## Prerequisites
 

--- a/docs/src/content/en/guides/guide/coding-agent.mdx
+++ b/docs/src/content/en/guides/guide/coding-agent.mdx
@@ -112,7 +112,7 @@ Open [Studio](/docs/studio/overview), select **Coding Agent**, and enter:
 Inspect project-notes.md and report the project name, status, and owner. Do not modify files.
 ```
 
-The response should identify the Acme support portal, its development status, and the Platform team without changing the file. Model wording may vary.
+The response should identify the Acme support portal and describe its development status. It should report that the Platform team owns the project and leave the file unchanged. Model wording may vary.
 
 ## Create the agent controller
 
@@ -157,13 +157,13 @@ export async function createCodingAgentSession() {
 }
 ```
 
-This example uses one mode and disables the controller's additional built-in tools so the introductory UI can focus on workspace execution. This is a tutorial simplification, not a production recommendation. In a production application, enable the built-in tools your product needs and implement their UI flows: interactive tools such as `ask_user` and `submit_plan` suspend until your interface resumes them, while task and subagent tools have their own lifecycle events. See [tool approvals and suspensions](/docs/agent-controller/tool-approvals).
+This example uses one mode and disables the controller's additional built-in tools so the introductory UI can focus on workspace execution. The simplified setup is intended for this tutorial. In a production application, enable the built-in tools your product needs and implement their UI flows: interactive tools such as `ask_user` and `submit_plan` suspend until your interface resumes them, while task and subagent tools have their own lifecycle events. See [tool approvals and suspensions](/docs/agent-controller/tool-approvals).
 
 The example also omits storage, so the conversation lasts only for the current process. You can add storage later when you want to resume sessions.
 
 ## Build the terminal UI
 
-Create `src/coding-agent-tui.ts`. The UI renders assistant message updates, shows tool activity, and asks the user to approve or decline each workspace tool call.
+Create `src/coding-agent-tui.ts`. The UI renders assistant message updates and shows tool activity. It also asks the user to approve or decline each workspace tool call.
 
 ```typescript title="src/coding-agent-tui.ts"
 import { pathToFileURL } from 'node:url'
@@ -300,7 +300,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 }
 ```
 
-The optional `Terminal` parameter supports automated tests while using `ProcessTerminal` during normal execution. The UI intentionally renders only the latest response; the `Session` still maintains the conversation context for follow-up prompts.
+The optional `Terminal` parameter supports automated tests while using `ProcessTerminal` during normal execution. The UI intentionally renders only the latest response. The `Session` still maintains the conversation context for follow-up prompts.
 
 ## Run the coding agent
 

--- a/docs/src/content/en/guides/guide/dev-assistant.mdx
+++ b/docs/src/content/en/guides/guide/dev-assistant.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Guide: Building a dev assistant"
-description: Build a complete development assistant that combines filesystem, sandbox, skills, and search to write code, run tests, and maintain documentation.
+description: Build a complete development assistant that combines filesystem, sandbox, skills, and search to write code and run tests while maintaining documentation.
 ---
 
 # Building a dev assistant
@@ -12,7 +12,7 @@ In this guide, you'll build a complete development assistant that combines all w
 - [Skills](/docs/workspace/skills) for coding standards
 - [Search](/docs/workspace/search) for finding examples
 
-You'll set up a workspace with a sample project, add coding standards as a skill, and create an agent that writes code following TDD practices. By the end, you'll have an agent that can read existing code, write new implementations, run tests in a sandbox, and iterate based on results.
+You'll set up a workspace with a sample project and add coding standards as a skill. Then you'll create an agent that writes code following TDD practices. By the end, the agent can read existing code and write new implementations, then run tests in a sandbox and iterate based on the results.
 
 ## Prerequisites
 

--- a/docs/src/content/en/guides/guide/docs-manager.mdx
+++ b/docs/src/content/en/guides/guide/docs-manager.mdx
@@ -8,7 +8,7 @@ import StepItem from "@site/src/components/StepItem";
 
 # Building a docs manager
 
-In this guide, you'll build a documentation manager that maintains your project's docs. It creates well-structured markdown files, keeps documentation organized, and prevents accidental overwrites. You'll learn how to set up a workspace filesystem, create an agent with document management instructions, and use it to generate and update documentation through conversational prompts.
+In this guide, you'll build a documentation manager that maintains your project's docs. It creates well-structured markdown files and keeps documentation organized while preventing accidental overwrites. You'll set up a workspace filesystem and create an agent with document management instructions. Then you'll use conversational prompts to generate and update documentation.
 
 ## Prerequisites
 
@@ -51,7 +51,7 @@ Inside the `workspace` directory, create the following folders:
 - `docs/api/`: For API reference documentation
 - `docs/tutorials/`: For step-by-step tutorials
 
-Create a `workspace/docs/README.md` file that serves as the documentation index:
+Create `workspace/docs/README.md` as the documentation index:
 
 ```markdown title="workspace/docs/README.md"
 # Project Documentation
@@ -210,7 +210,7 @@ Try updating an existing document:
 Update the getting started guide to include a section on configuration after the Quick Example
 ```
 
-The agent should read the existing `getting-started.md` file, find the right insertion point, and add the new section without disrupting existing content.
+The agent should read the existing `getting-started.md` file and find the right insertion point. It should add the new section without disrupting existing content.
 
 ### Organize documentation
 

--- a/docs/src/content/en/guides/guide/github-actions-pr-description.mdx
+++ b/docs/src/content/en/guides/guide/github-actions-pr-description.mdx
@@ -121,11 +121,11 @@ The agent will return a formatted description with sections in English, Spanish,
 
 ## GitHub actions
 
-GitHub Actions run your workflows in short-lived environments on GitHub's infrastructure. Each run starts with a clean virtual machine, checks out your code, installs dependencies, runs your workflow steps, and then shuts down. Nothing persists between runs unless you explicitly save it as an artifact or cache.
+GitHub Actions run your workflows in short-lived environments on GitHub's infrastructure. Each run starts with a clean virtual machine and checks out your code. It installs dependencies before running your workflow steps. The environment shuts down when the run completes. Nothing persists between runs unless you explicitly save it as an artifact or cache.
 
 ### Create the workflow
 
-GitHub Actions workflows live in the `.github/workflows` directory. Create a `.github` directory at the root of your project, then create a `workflows` directory inside it. Add a file named `pr-description.yml`.
+GitHub Actions workflows live in the `.github/workflows` directory. Create a `.github` directory at the root of your project, then create a `workflows` directory inside it. Add `pr-description.yml`.
 
 This workflow runs whenever a pull request is opened or updated. It generates a diff for the PR, calls the Mastra agent to describe the changes, and writes the description directly into the PR in the GitHub UI.
 
@@ -191,7 +191,7 @@ The workflow excludes `package-lock.json` when generating the diff. Lockfiles ar
 
 ### Create the workflow script
 
-Create a `scripts` directory inside `.github` and add a file named `generate-description.ts`.
+Create a `scripts` directory inside `.github` and add `generate-description.ts`.
 
 This script reads the PR diff from `PR_DIFF_FILE`, generates a description using the Mastra agent, and writes the result to `PR_DESCRIPTION_FILE` for the workflow to publish to the pull request.
 
@@ -233,7 +233,7 @@ ${readFileSync(process.env.PR_DIFF_FILE!, 'utf-8')}
 
 You now have a GitHub Action that generates multi-language PR descriptions using a Mastra agent. Once the workflow and supporting files are merged into your main branch, the agent will run automatically the next time a pull request is created or updated. You can monitor the run in the **Actions** tab of your repository.
 
-From here, you can customize the agent instructions, change the output languages, or extend the workflow to handle other events.
+From here, customize the agent instructions or change the output languages. You can also extend the workflow to handle other events.
 
 To learn more:
 

--- a/docs/src/content/en/guides/guide/research-assistant.mdx
+++ b/docs/src/content/en/guides/guide/research-assistant.mdx
@@ -10,7 +10,7 @@ import StepItem from "@site/src/components/StepItem";
 
 In this guide, you'll create an AI research assistant that can analyze academic papers and answer specific questions about their content using Retrieval Augmented Generation (RAG).
 
-You'll use the foundational Transformer paper ["Attention Is All You Need"](https://arxiv.org/html/1706.03762) as your example. As a database you'll use a local libSQL database.
+You'll use the original Transformer paper ["Attention Is All You Need"](https://arxiv.org/html/1706.03762) as your example. As a database you'll use a local libSQL database.
 
 ## Prerequisites
 
@@ -157,7 +157,7 @@ Let's define the agent's behavior, connect it to your Mastra project, and create
 
 ## Processing documents
 
-In the following steps you'll fetch the research paper, split it into smaller chunks, generate embeddings for them, and store these chunks of information into the vector database.
+In the following steps, you'll fetch the research paper and split it into smaller chunks. You'll then generate embeddings and store the chunks in the vector database.
 
 <Steps>
   <StepItem title="Load and Process the Paper">
@@ -212,7 +212,7 @@ In the following steps you'll fetch the research paper, split it into smaller ch
 
     :::
 
-    This allows the agent to efficiently search and retrieve relevant information.
+    The agent uses the vector index to search for and retrieve relevant information.
 
     Open the `src/store.ts` file and add the following:
 

--- a/docs/src/content/en/guides/guide/research-coordinator.mdx
+++ b/docs/src/content/en/guides/guide/research-coordinator.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Guide: Build a research coordinator with supervisor agents"
-description: Build a research coordinator that orchestrates multiple specialized agents to research topics and produce comprehensive reports.
+description: Build a research coordinator that orchestrates multiple specialized agents to research topics and produce detailed reports.
 ---
 
 import Steps from "@site/src/components/Steps";
@@ -8,9 +8,9 @@ import StepItem from "@site/src/components/StepItem";
 
 # Build a research coordinator with supervisor agents
 
-In this guide, you'll build a research coordinator that orchestrates multiple specialized agents using supervisor agents. The coordinator will delegate research tasks to a research agent and writing tasks to a writing agent, then synthesize the results into a comprehensive report.
+In this guide, you'll build a research coordinator that orchestrates multiple specialized agents using supervisor agents. The coordinator will delegate research tasks to a research agent and writing tasks to a writing agent, then synthesize the results into a detailed report.
 
-You'll learn how to set up subagents with clear roles, configure a supervisor agent to coordinate them, use delegation hooks to control execution, and validate task completion with scorers.
+You'll set up subagents with clear roles and configure a supervisor agent to coordinate them. You'll also use delegation hooks to control execution and scorers to validate task completion.
 
 ## Prerequisites
 
@@ -180,7 +180,7 @@ export const mastra = new Mastra({
 The `defaultOptions` on the supervisor agent configure delegation hooks and iteration monitoring:
 
 - `onDelegationStart` modifies the research agent's prompt to request recent data
-- `onDelegationComplete` logs completion, bails on errors, and provides feedback
+- `onDelegationComplete` logs completion and stops on errors, then provides feedback
 - `messageFilter` limits context to the last 10 messages for efficiency
 - `onIterationComplete` monitors progress after each iteration
 

--- a/docs/src/content/en/guides/guide/slack-assistant.mdx
+++ b/docs/src/content/en/guides/guide/slack-assistant.mdx
@@ -129,7 +129,7 @@ The tunnel URL is for local development only. When you [deploy your application]
 
 ## Test the agent
 
-Before testing with Slack, you can refine your agent's behavior in [Studio](/docs/studio/overview). Open [http://localhost:4111/](http://localhost:4111/) to chat with your agent directly, adjust its instructions, and inspect traces to see how responses are generated.
+Before testing with Slack, you can refine your agent's behavior in [Studio](/docs/studio/overview). Open [http://localhost:4111/](http://localhost:4111/) to chat with your agent and adjust its instructions. Inspect traces to see how responses are generated.
 
 Once you're happy with the agent's responses, test the Slack integration. Invite the bot to a channel in Slack:
 

--- a/docs/src/content/en/guides/guide/stock-agent.mdx
+++ b/docs/src/content/en/guides/guide/stock-agent.mdx
@@ -8,7 +8,7 @@ import StepItem from "@site/src/components/StepItem";
 
 # Building an AI stock agent
 
-In this guide, you're going to create an agent that fetches the last day's closing stock price for a given symbol. You'll learn how to create a tool, add it to an agent, and use the agent to fetch stock prices.
+In this guide, you'll create an agent that fetches the previous day's closing stock price for a symbol. You'll create a tool and add it to an agent, then use the agent to fetch stock prices.
 
 ## Prerequisites
 

--- a/docs/src/content/en/guides/index.mdx
+++ b/docs/src/content/en/guides/index.mdx
@@ -7,6 +7,6 @@ import StartCards from "../docs/getting-started/_partial-start-cards.mdx";
 
 # Mastra Guides
 
-Mastra offers a variety of guides to help you build and work with Mastra, from building agents and workflows to using the Mastra SDK and API, and implementing different UI frameworks. Explore the guides below to find the resources you need to get started and build with Mastra.
+Mastra offers guides for building agents and workflows, using the Mastra SDK and API, and implementing different UI frameworks. Explore these guides to find the resources you need to get started and build with Mastra.
 
 <StartCards />

--- a/docs/src/content/en/guides/migrations/ai-sdk-v4-to-v5.mdx
+++ b/docs/src/content/en/guides/migrations/ai-sdk-v4-to-v5.mdx
@@ -16,7 +16,7 @@ This guide covers only the Mastra-specific aspects of the migration.
 
 ## Memory and storage
 
-Mastra automatically handles AI SDK v4 data using its internal `MessageList` class, which manages format conversion—including v4 to v5. No database migrations are required; your existing messages are translated on the fly and continue working after you upgrade.
+Mastra automatically handles AI SDK v4 data using its internal `MessageList` class, which manages format conversion, including v4 to v5. No database migrations are required. Your existing messages are translated on the fly and continue working after you upgrade.
 
 ## Message format conversion
 

--- a/docs/src/content/en/guides/migrations/mastra-cloud.mdx
+++ b/docs/src/content/en/guides/migrations/mastra-cloud.mdx
@@ -54,7 +54,7 @@ The Mastra platform replaces Mastra Cloud with separate Studio and Server produc
 
 Mastra Cloud provided a managed libSQL database, backed by [Turso](https://turso.tech). The Mastra platform doesn't host a database for you, so you need to point your storage at an externally hosted instance.
 
-If you were already using a hosted database ("bring your own"), no changes are needed. Ensure the connection string is set as an environment variable in the dashboard rather than hardcoded.
+If you were already using a hosted database ("bring your own"), keep the existing database configuration. Ensure the connection string is set as an environment variable in the dashboard rather than hardcoded.
 
 If you were using Cloud Store, follow the steps below to export your data and load it into a new libSQL database that you control.
 
@@ -62,7 +62,7 @@ If you were using Cloud Store, follow the steps below to export your data and lo
 
 You can export your Cloud Store data in two ways: download it from the dashboard, or create a manual dump with the Turso CLI.
 
-#### Option A — Export from the dashboard (recommended)
+#### Option A: Export from the dashboard (recommended)
 
 Open your project in the [Mastra dashboard](https://projects.mastra.ai) and navigate to **Runtime → Settings → Storage**. Click the **Export Database** button. The dashboard generates a full `.sql` dump of your Cloud Store and downloads it directly to your Downloads folder.
 
@@ -74,7 +74,7 @@ sqlite3 mydb.db < ~/Downloads/mastra-cloud-dump.sql
 
 You now have a portable `mydb.db` file you can inspect locally, back up, or use as the source for the new database in the steps that follow.
 
-#### Option B — Export via the Turso CLI
+#### Option B: Export via the Turso CLI
 
 If you prefer to work from the command line, or need to script the export, you can dump the database directly using the [Turso CLI](https://docs.turso.tech/cli). This approach requires the database URL and an auth token, both surfaced in the dashboard.
 
@@ -265,7 +265,7 @@ Deploy your hosted Studio instance:
 mastra studio deploy
 ```
 
-The CLI builds your project, uploads the artifact, and deploys it. On first deploy, a `.mastra-project.json` file is created to link your local project to the platform. Commit this file to your repository.
+The CLI builds your project and uploads the artifact before deploying it. On first deploy, a `.mastra-project.json` file is created to link your local project to the platform. Commit this file to your repository.
 
 A local env file is optional. When a `.env` or `.env.*` file is present in the project directory, the deploy bundles its environment variables.
 
@@ -279,14 +279,14 @@ See [Studio deployment](/docs/studio/deployment#mastra-platform) for details.
 
 ### Multiple environments
 
-A single Mastra platform project runs the same codebase across multiple named [environments](/docs/mastra-platform/environments), such as `production` and `staging`. Deploy to each with the unified [`mastra deploy`](/docs/mastra-platform/deploy) command:
+A single Mastra platform project runs the same codebase across multiple [environments](/docs/mastra-platform/environments), such as `production` and `staging`. Deploy to each with the unified [`mastra deploy`](/docs/mastra-platform/deploy) command:
 
 ```bash
 mastra deploy --env production --yes
 mastra deploy --env staging --env-file .env.staging --yes
 ```
 
-Each environment gets its own URL, its own environment variables, and its own deploy history.
+Each environment has a dedicated URL and environment variables, along with a separate deploy history.
 
 ## Deploy Server (optional)
 

--- a/docs/src/content/en/guides/migrations/network-to-supervisor.mdx
+++ b/docs/src/content/en/guides/migrations/network-to-supervisor.mdx
@@ -9,13 +9,13 @@ Supervisor agents using `Agent.stream()` and `Agent.generate()` are the recommen
 
 :::warning[.network() Deprecation]
 
-`.network()` is deprecated and will be removed in a future release. While existing code will continue to work until then, no new features will be added to it. Migrate to supervisor agents as soon as possible.
+`.network()` is deprecated and will be removed in a future release. Existing code will continue to work until then, but development now focuses on supervisor agents. Migrate to supervisor agents as soon as possible.
 
 :::
 
 ## Replace `.network()` with `.stream()` or `.generate()`
 
-The core change is replacing `.network()` calls with `.stream()` (for streaming) or `.generate()` (for non-streaming). The agent configuration stays the same -- you still define `agents`, `workflows`, `tools`, and `memory` on the agent. The difference is how you call it and how you process the results.
+The core change is replacing `.network()` calls with `.stream()` (for streaming) or `.generate()` (for non-streaming). The agent configuration stays the same. You still define `agents`, `workflows`, `tools`, and `memory` on the agent. The difference is how you call it and how you process the results.
 
 With `.network()`, you iterated over custom event types like `network-execution-event-step-finish`. With `.stream()`, you use the standard `textStream` or `fullStream` iterators.
 
@@ -57,9 +57,9 @@ console.log(result.text)
 
 ## Write clear supervisor instructions
 
-With `.network()`, the routing agent relied on generic instructions and primitive descriptions to decide what to call. Supervisor agents work the same way, but clear and specific instructions significantly improve delegation accuracy.
+With `.network()`, the routing agent relied on generic instructions and primitive descriptions to decide what to call. Supervisor agents work the same way, but clear and specific instructions improve delegation accuracy.
 
-Your supervisor's `instructions` should specify what resources are available, when to use each one, how to coordinate them, and when the task is complete.
+Your supervisor's `instructions` should identify the available resources and when to use each one. They should also explain how to coordinate those resources and recognize when the task is complete.
 
 **Before:**
 
@@ -99,7 +99,7 @@ Success criteria:
 
 ## Add descriptions to subagents
 
-Each subagent should have a `description` field that explains what it does, what format it returns, and when it should be used. The supervisor uses these descriptions to decide which agent to delegate to.
+Each subagent should have a `description` field that explains its purpose and return format. The description should also state when to use the subagent. The supervisor uses these descriptions to decide which agent to delegate to.
 
 ```typescript
 const researchAgent = new Agent({
@@ -136,7 +136,7 @@ If you were handling specific `.network()` events, update them to use the standa
 
 Supervisor agents let you hook into the delegation lifecycle to monitor, modify, or reject delegations. These hooks can be configured in the agent's `defaultOptions` or passed per-call.
 
-`onDelegationStart` is called before the supervisor delegates to a subagent. You can modify the prompt, limit the subagent's steps, or reject the delegation entirely:
+`onDelegationStart` is called before the supervisor delegates to a subagent. You can modify the prompt or limit the subagent's steps. The hook can also reject the delegation entirely:
 
 ```typescript
 const stream = await supervisorAgent.stream('Research AI in education', {
@@ -166,7 +166,7 @@ const stream = await supervisorAgent.stream('Research AI in education', {
 })
 ```
 
-`onDelegationComplete` is called after a delegation finishes. You can inspect the result, call `context.bail()` to stop the supervisor loop, and return feedback that gets saved to the supervisor's memory:
+`onDelegationComplete` is called after a delegation finishes. Inspect the result and call `context.bail()` when the supervisor loop should stop. You can also return feedback that gets saved to the supervisor's memory:
 
 ```typescript
 const stream = await supervisorAgent.stream('Research AI in education', {
@@ -186,7 +186,7 @@ const stream = await supervisorAgent.stream('Research AI in education', {
 
 ## Add message filtering
 
-By default, subagents receive the full conversation context from the supervisor. Use `messageFilter` to control what messages are shared -- for example, to remove sensitive data or limit the number of messages:
+By default, subagents receive the full conversation context from the supervisor. Use `messageFilter` to control what messages are shared. For example, remove sensitive data or limit the number of messages:
 
 ```typescript
 const stream = await supervisorAgent.stream('Research AI in education', {
@@ -207,7 +207,7 @@ const stream = await supervisorAgent.stream('Research AI in education', {
 
 ## Add iteration monitoring
 
-`onIterationComplete` is called after each iteration of the supervisor loop. You can use it to log progress, provide feedback to guide the agent, or stop execution early:
+`onIterationComplete` is called after each iteration of the supervisor loop. Use it to log progress or provide feedback that guides the agent. The hook can also stop execution early:
 
 ```typescript
 const stream = await supervisorAgent.stream('Research AI in education', {

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/agent.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/agent.mdx
@@ -32,7 +32,7 @@ npx @mastra/codemod@latest v1/mastra-plural-apis .
 
 ### `RuntimeContext` to `RequestContext`
 
-The `RuntimeContext` class has been renamed to `RequestContext` throughout the codebase. This change provides clearer naming that better describes its purpose as request-specific data and aligns with web framework conventions.
+The `RuntimeContext` class has been renamed to `RequestContext` throughout the codebase. The new name identifies the class as request-specific data and matches web framework conventions.
 
 To migrate, update all imports and parameter names from `RuntimeContext`/`runtimeContext` to `RequestContext`/`requestContext`.
 
@@ -86,7 +86,7 @@ npx @mastra/codemod@latest v1/agent-property-access .
 
 ### Voice methods moved to `agent.voice` namespace
 
-Voice-related methods have been moved from the Agent class to the `agent.voice` namespace. This change provides better organization and clearer separation of concerns.
+Voice-related methods have moved from the Agent class to the `agent.voice` namespace, which groups the voice APIs together.
 
 To migrate, update voice method calls to use the `agent.voice` namespace.
 
@@ -111,7 +111,7 @@ npx @mastra/codemod@latest v1/agent-voice .
 
 ### `agent.fetchMemory()` to `(await agent.getMemory()).recall()`
 
-The `fetchMemory()` method has been replaced with a more explicit API. This change provides better clarity about the asynchronous nature of memory access.
+The `fetchMemory()` method has been replaced with an API that makes asynchronous memory access explicit.
 
 To migrate, replace `fetchMemory()` calls with the new API.
 
@@ -170,7 +170,7 @@ Only update your imports if you want to standardize on one Zod version across yo
 
 ### Default options method renames for AI SDK versions
 
-Default options methods have been renamed to clarify legacy (AI SDK v4) vs new (AI SDK v5+) APIs. This change helps developers understand which AI SDK version they're targeting.
+Default options methods have been renamed to distinguish legacy (AI SDK v4) APIs from AI SDK v5+ APIs. The method name now indicates which AI SDK version it targets.
 
 To migrate, update method names based on which AI SDK version you're using.
 
@@ -187,7 +187,7 @@ To migrate, update method names based on which AI SDK version you're using.
 
 ### `modelSettings.abortSignal` to top-level `abortSignal`
 
-The `abortSignal` option has been moved from `modelSettings` to the top level of stream/generate options. This change provides a clearer separation between model-specific settings and execution control.
+The `abortSignal` option has moved from `modelSettings` to the top level of stream and generate options. Execution control now sits outside model-specific settings.
 
 To migrate, move `abortSignal` from `modelSettings` to the top level.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/cli.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/cli.mdx
@@ -17,7 +17,7 @@ A new `mastra migrate` command helps run database migrations when upgrading Mast
 npx mastra migrate
 ```
 
-The command bundles your project, connects to your configured storage, and runs any necessary migrations. Currently supports migrating duplicate spans entries that may prevent unique constraint creation.
+The command bundles your project and connects to your configured storage before running any necessary migrations. It currently supports migrating duplicate spans entries that may prevent unique constraint creation.
 
 See the [Storage migration guide](/guides/migrations/upgrade-to-v1/storage#duplicate-spans-migration) for details on when this migration is needed.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/cli.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/cli.mdx
@@ -17,7 +17,7 @@ A new `mastra migrate` command helps run database migrations when upgrading Mast
 npx mastra migrate
 ```
 
-The command bundles your project and connects to your configured storage before running any necessary migrations. It currently supports migrating duplicate spans entries that may prevent unique constraint creation.
+The command bundles your project and connects to your configured storage before running any necessary migrations. It currently supports migrating duplicate span entries that may prevent unique constraint creation.
 
 See the [Storage migration guide](/guides/migrations/upgrade-to-v1/storage#duplicate-spans-migration) for details on when this migration is needed.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/client.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/client.mdx
@@ -5,7 +5,7 @@ description: "Learn how to migrate client SDK changes when upgrading to v1."
 
 # Client SDK
 
-Client SDK changes align with server-side API updates including renamed utilities, updated pagination, and type naming conventions.
+Client SDK changes align with server-side API updates, including utility renames, updated pagination, and type naming conventions.
 
 ## Changed
 
@@ -137,7 +137,7 @@ npx @mastra/codemod@latest v1/client-sdk-types .
 
 ### Pagination parameters from `offset/limit` to `page/perPage`
 
-All client SDK methods that used `offset/limit` now use `page/perPage`. This change provides a more intuitive pagination model aligned with web pagination patterns.
+All client SDK methods that used `offset/limit` now use `page/perPage`, matching page-based web pagination.
 
 To migrate, update pagination parameters in all client SDK method calls. Example:
 
@@ -230,7 +230,7 @@ To migrate, use `runById()` instead, which now returns the same unified `Workflo
 
 ### `toAISdkFormat` function
 
-The `toAISdkFormat()` function has been removed from `@mastra/ai-sdk`. This change provides clearer naming for stream conversion utilities.
+The `toAISdkFormat()` function has been removed from `@mastra/ai-sdk`. Use the stream conversion utilities shown below instead.
 
 To migrate, use `toAISdkStream()` instead.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/evals.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/evals.mdx
@@ -32,7 +32,7 @@ npx @mastra/codemod@latest v1/mastra-plural-apis .
 
 ### `runExperiment` to `runEvals`
 
-The `runExperiment()` function has been renamed to `runEvals()`. This change provides clearer naming that better describes the evaluation functionality.
+The `runExperiment()` function has been renamed to `runEvals()` to identify that it runs evaluations.
 
 To migrate, update function calls from `runExperiment` to `runEvals`.
 
@@ -171,7 +171,7 @@ To migrate, update scorer implementations to use `MastraDBMessage` types and acc
 
 ### Message content structure to nested format
 
-Tool invocations and text content are now accessed through a nested `content` object structure instead of being flat properties on the message. This change provides better type safety and aligns with the database message format.
+Tool invocations and text content are now accessed through a nested `content` object instead of flat message properties. The nested structure matches the database message format and its types.
 
 To migrate, access tool invocations via `message.content.toolInvocations` and text via `message.content.content` or use the `getTextContentFromMastraDBMessage()` helper.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
@@ -279,7 +279,7 @@ To migrate, use `MastraDBMessage` for storage or AI SDK v5 message formats direc
 
 ### `processors` config from Memory constructor
 
-The `processors` config option in the Memory constructor has been deprecated and now throws an error. Configure processors at the Agent level, where processor behavior is scoped to agent execution.
+The `processors` config option in the Memory constructor is no longer supported and throws an error. Configure processors at the Agent level, where processor behavior is scoped to agent execution.
 
 To migrate, move processor configuration from Memory to Agent using `inputProcessors` and/or `outputProcessors`.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
@@ -279,7 +279,7 @@ To migrate, use `MastraDBMessage` for storage or AI SDK v5 message formats direc
 
 ### `processors` config from Memory constructor
 
-The `processors` config option in the Memory constructor has been deprecated and now throws an error. Processors should be configured at the Agent level instead. This change provides clearer configuration boundaries and better encapsulation.
+The `processors` config option in the Memory constructor has been deprecated and now throws an error. Configure processors at the Agent level, where processor behavior is scoped to agent execution.
 
 To migrate, move processor configuration from Memory to Agent using `inputProcessors` and/or `outputProcessors`.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/overview.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/overview.mdx
@@ -11,14 +11,14 @@ Before upgrading to v1, make sure you've updated to the latest 0.x version of Ma
 
 Mastra v1 was released in January 2026. We recommend starting any new projects with Mastra v1, or upgrading your existing project to continue receiving updates and support.
 
-This guide provides a comprehensive overview of breaking changes when upgrading from Mastra 0.x to v1.0. The migration is organized by package and feature area to help you systematically update your codebase.
+This guide covers the breaking changes when upgrading from Mastra 0.x to v1.0. The migration is organized by package and feature area to help you systematically update your codebase.
 
 :::tip[Need help?]
 Need help with the migration? Join our [Discord community](https://discord.gg/BTYqqHKUrf) to ask questions.
 :::
 
 :::warning[Coming from Mastra Cloud?]
-The legacy Mastra Cloud product has been replaced by the [Mastra platform](/docs/mastra-platform/overview), which splits hosting into two separate products: **Studio** (visual environment, observability) and **Server** (production API). Old Mastra Cloud access tokens don't work with Mastra platform — you must create new ones with `mastra auth tokens create`.
+The legacy Mastra Cloud product has been replaced by the [Mastra platform](/docs/mastra-platform/overview), which splits hosting into two separate products: **Studio** (visual environment, observability) and **Server** (production API). Old Mastra Cloud access tokens don't work with Mastra platform. Create new ones with `mastra auth tokens create`.
 
 If you upgrade to v1 packages without also migrating your `telemetry:` config to `observability:` and creating a Studio project, observability data will stop flowing. Follow the [Mastra Cloud migration guide](/guides/migrations/mastra-cloud) end to end.
 :::
@@ -27,7 +27,7 @@ If you upgrade to v1 packages without also migrating your `telemetry:` config to
 
 ### Update all Mastra packages to `latest` tag
 
-Use your package manager to update your project's versions. Be sure to update **all** Mastra packages at the same time to ensure compatibility (all `@mastra/*` packages and `mastra`).
+Use your package manager to update your project's versions. Update **all** Mastra packages together to ensure compatibility (all `@mastra/*` packages and `mastra`).
 
 Here's how you update the most commonly used packages:
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/processors.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/processors.mdx
@@ -30,7 +30,7 @@ To migrate, update processor definitions to use `id` as the required field.
 
 ### Processor message types from `MastraMessageV2` to `MastraDBMessage`
 
-Processor message types have changed from `MastraMessageV2` to `MastraDBMessage`. This change provides consistency with scorer configuration and better type safety by aligning with the database message format.
+Processor message types have changed from `MastraMessageV2` to `MastraDBMessage`. Processors and scorers now use the database message format and its types.
 
 To migrate, update processor message type imports and usage.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/storage.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/storage.mdx
@@ -50,7 +50,7 @@ Run the migration command which automatically deduplicates spans and adds the co
 npx mastra migrate
 ```
 
-The CLI bundles your project, connects to your configured storage, and runs the migration. It keeps the most complete record (based on `endTime` and attributes) when removing duplicates.
+The CLI bundles your project and connects to your configured storage before running the migration. It keeps the most complete record (based on `endTime` and attributes) when removing duplicates.
 
 #### Option 2: Manual SQL (PostgreSQL)
 
@@ -158,7 +158,7 @@ To migrate, update your imports and instantiation:
 ```
 
 :::note
-If you're using a single store implementation (like `PostgresStore` or `LibSQLStore`) directly, no changes are needed. This only affects code that explicitly uses `MastraStorage` for composite storage.
+If you're using a single store implementation (like `PostgresStore` or `LibSQLStore`) directly, keep the existing configuration. This only affects code that explicitly uses `MastraStorage` for composite storage.
 :::
 
 ### Required `id` property for storage instances
@@ -183,7 +183,7 @@ To migrate, add an `id` field to your storage constructor.
 
 ### Pagination from `offset/limit` to `page/perPage`
 
-All pagination APIs now use `page` and `perPage` instead of `offset` and `limit`. This change provides a more intuitive pagination model that aligns with common web pagination patterns.
+All pagination APIs now use `page` and `perPage` instead of `offset` and `limit`, matching page-based web pagination.
 
 To migrate, update all pagination parameters from `offset/limit` to `page/perPage`. Note that `page` is 0-indexed.
 
@@ -423,9 +423,9 @@ To migrate, use the memory store, remove format parameters, and update code to w
 
 ### Vector store API from positional to named arguments
 
-All vector store methods now use named arguments instead of positional arguments. This change improves code readability and makes method signatures more maintainable.
+All vector store methods now use an arguments object instead of positional arguments. This makes each value's purpose visible at the call site and lets method signatures evolve without relying on argument order.
 
-To migrate, update all vector store method calls to use named arguments.
+To migrate, update all vector store method calls to use an arguments object.
 
 ```diff
 - await vectorDB.createIndex(indexName, 3, 'cosine');
@@ -452,9 +452,9 @@ To migrate, update all vector store method calls to use named arguments.
 
 ### Vector store method renames
 
-The `updateIndexById` and `deleteIndexById` methods have been renamed to `updateVector` and `deleteVector` respectively. This change provides clearer naming that better describes the operations.
+The `updateIndexById` and `deleteIndexById` methods have been renamed to `updateVector` and `deleteVector` respectively. The new names identify that these methods operate on vectors.
 
-To migrate, rename the methods and use named arguments.
+To migrate, rename the methods and pass an arguments object.
 
 ```diff
 - await vectorDB.updateIndexById(indexName, id, update);
@@ -488,9 +488,9 @@ npx @mastra/codemod@latest v1/vector-pg-constructor .
 
 ### PGVector `defineIndex` to `buildIndex`
 
-The `defineIndex()` method has been removed in favor of `buildIndex()`. This change provides clearer naming for the index building operation.
+The `defineIndex()` method has been removed in favor of `buildIndex()`, which identifies that the method builds an index.
 
-To migrate, rename the method and use named arguments.
+To migrate, rename the method and pass an arguments object.
 
 ```diff
 - await vectorDB.defineIndex(indexName, 'cosine', { type: 'flat' });
@@ -503,7 +503,7 @@ To migrate, rename the method and use named arguments.
 
 ### `PostgresStore`: `schema` to `schemaName`
 
-The `schema` parameter has been renamed to `schemaName` in the PostgresStore constructor. This change provides clearer naming to avoid confusion with database schema concepts.
+The `schema` parameter has been renamed to `schemaName` in the PostgresStore constructor. The new name identifies the value as the database schema's name.
 
 To migrate, rename the parameter.
 
@@ -564,7 +564,7 @@ To migrate, use paginated methods via domain stores. For fetching all records, u
 
 ### `getTraces` and `getTracesPaginated`
 
-The `getTraces()` and `getTracesPaginated()` methods have been removed from storage. Traces are now handled through the observability package rather than core storage. This change provides better separation of concerns between core storage and observability features.
+The `getTraces()` and `getTracesPaginated()` methods have been removed from storage. Use the observability package to access traces instead of core storage.
 
 To migrate, use observability storage methods instead.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/tools.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/tools.mdx
@@ -11,9 +11,9 @@ Tool execution signatures have been updated to use separate input and context pa
 
 ### `createTool` execute signature to `(inputData, context)` format
 
-All `createTool` execute functions now use a new signature with separate `inputData` and `context` parameters instead of a single destructured object. This change provides clearer separation between tool inputs and execution context.
+All `createTool` execute functions now use a signature with separate `inputData` and `context` parameters instead of a single destructured object. Tool inputs and execution context are now passed independently.
 
-**Note:** This change only applies to `createTool`. If you're using `createStep` for workflows, the signature remains `async (inputData, context)` and doesn't need to be changed.
+This signature change only applies to `createTool`. For workflow `createStep` calls, keep the `async (inputData, context)` signature.
 
 To migrate, update `createTool` signatures to use `inputData` as the first parameter (typed from `inputSchema`) and `context` as the second parameter.
 
@@ -94,7 +94,7 @@ For MCP-specific tool context changes, see the [MCP migration guide](/guides/mig
 
 ### `RuntimeContext` to `RequestContext`
 
-The `RuntimeContext` class has been renamed to `RequestContext` throughout the tool execution context. This change provides clearer naming that better describes its purpose as request-specific data.
+The `RuntimeContext` class has been renamed to `RequestContext` throughout the tool execution context. The new name identifies the class as request-specific data.
 
 To migrate, update references from `runtimeContext` to `requestContext` in tool execution functions.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/tracing.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/tracing.mdx
@@ -10,12 +10,12 @@ The observability system has been restructured in v1 with a dedicated `@mastra/o
 :::warning[Observability data stops flowing on upgrade]
 If you upgrade Mastra packages to v1 without migrating your `telemetry:` config to `observability:`, the old config is ignored at runtime. Your service will start cleanly with no error, but **no traces, logs, or metrics will be sent anywhere**. If you were sending data to Mastra Cloud, the dashboard will go empty.
 
-Complete this migration in the same change that bumps your Mastra packages, and verify traces appear in [Mastra Studio](/docs/studio/observability) before considering the upgrade complete. If you previously hosted on Mastra Cloud, also follow the [Mastra Cloud migration guide](/guides/migrations/mastra-cloud) — the new platform requires a new access token and a Studio project before `MastraPlatformExporter` can route data to it.
+Complete this migration in the same change that bumps your Mastra packages, and verify traces appear in [Mastra Studio](/docs/studio/observability) before considering the upgrade complete. If you previously hosted on Mastra Cloud, also follow the [Mastra Cloud migration guide](/guides/migrations/mastra-cloud). The new platform requires a new access token and a Studio project before `MastraPlatformExporter` can route data to it.
 :::
 
 :::note[Exporter rename]
 
-`MastraPlatformExporter` (sends data to Mastra platform) replaces the previous `CloudExporter`, and `MastraStorageExporter` (persists data to Mastra Storage) replaces the previous `DefaultExporter`. The original classes still ship from `@mastra/observability` and behave identically, but they're deprecated. New code should use `MastraPlatformExporter` and `MastraStorageExporter`; existing imports of `CloudExporter`/`DefaultExporter` continue to work until they're removed in a future major version.
+`MastraPlatformExporter` (sends data to Mastra platform) replaces the previous `CloudExporter`, and `MastraStorageExporter` (persists data to Mastra Storage) replaces the previous `DefaultExporter`. The original classes remain available from `@mastra/observability` and behave identically, but they're deprecated. New code should use `MastraPlatformExporter` and `MastraStorageExporter`. Existing imports of `CloudExporter` or `DefaultExporter` continue to work until they're removed in a future major version.
 
 :::
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/voice.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/voice.mdx
@@ -11,7 +11,7 @@ Voice packages have been renamed from speech to voice with updated class names a
 
 ### Voice configuration property names
 
-Voice configuration properties have been renamed for consistency. `speakProvider` is now `output`, `listenProvider` is now `input`, and `realtimeProvider` is now `realtime`. This change provides more intuitive property names.
+Voice configuration properties have been renamed for consistency. `speakProvider` is now `output`, `listenProvider` is now `input`, and `realtimeProvider` is now `realtime`. The new names match each property's role in voice input and output.
 
 To migrate, update configuration property names when configuring agents with voice capabilities.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
@@ -80,7 +80,7 @@ npx @mastra/codemod@latest v1/workflow-create-run-async .
 
 ### `runCount` to `retryCount` (deprecated)
 
-The `runCount` parameter has been deprecated in favor of `retryCount` in workflow step execution. This change provides clearer naming that better describes retry behavior. The old `runCount` still works but shows deprecation warnings.
+The `runCount` parameter has been deprecated in favor of `retryCount` in workflow step execution. The new name identifies the value as the number of retries. The old `runCount` still works but shows deprecation warnings.
 
 To migrate, rename `runCount` to `retryCount` in step execution functions.
 


### PR DESCRIPTION
## Description

Run Vale checks and fix them on /guides section of the docs

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR just edits the documentation so the wording is clearer and more consistent. It doesn’t change how the software works—only the `/guides` text, mainly to satisfy Vale style checks.

## Summary

- Updated copy and minor formatting across many `/guides` MDX pages (UI guides, concepts, deployment, getting started, tutorials, and migrations).
- Improved clarity for integrations, streaming/event guidance, workflow/pattern descriptions, and deployment instructions.
- Refined migration documentation wording and details for v1 APIs, tools, processors, storage, memory, tracing, workflows, voice, and related upgrade paths.
- No changes to exported/public code entities; documentation-only change with low review effort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->