### PR TITLE
fix(core): honor readOnly during tool suspension

### DIFF
--- a/.changeset/old-windows-happen.md
+++ b/.changeset/old-windows-happen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed non-durable tool-call suspensions writing messages when memory is read-only.

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -424,6 +424,31 @@ describe('createToolCallStep tool approval workflow', () => {
     await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
   });
 
+  it('should not flush messages before suspending when memory is read-only', async () => {
+    const flushMessages = vi.fn().mockResolvedValue(undefined);
+    const readOnlyStep = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      requireToolApproval: true,
+      runId: 'test-run',
+      streamState,
+      _internal: {
+        saveQueueManager: { flushMessages },
+        memoryConfig: { readOnly: true },
+        threadId: 'read-only-thread',
+        threadExists: true,
+      },
+    } as any);
+
+    const executePromise = readOnlyStep.execute(makeExecuteParams());
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(suspend).toHaveBeenCalled();
+    expect(flushMessages).not.toHaveBeenCalled();
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
   it('should handle declined tool calls without executing the tool', async () => {
     const inputData = makeInputData();
     const resumeData = { approved: false };

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -441,12 +441,13 @@ describe('createToolCallStep tool approval workflow', () => {
       },
     } as any);
 
+    suspend.mockResolvedValueOnce('completed');
     const executePromise = readOnlyStep.execute(makeExecuteParams());
     await new Promise(resolve => setImmediate(resolve));
 
     expect(suspend).toHaveBeenCalled();
     expect(flushMessages).not.toHaveBeenCalled();
-    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+    await expect(executePromise).resolves.toBe('completed');
   });
 
   it('should handle declined tool calls without executing the tool', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -353,7 +353,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         const resourceId = readScoped(scopeCtx, RESOURCE_ID_KEY, 'resourceId');
         const memory = readScoped(scopeCtx, MEMORY_KEY, 'memory');
 
-        if (!saveQueueManager || !threadId) {
+        if (!saveQueueManager || !threadId || memoryConfig?.readOnly) {
           return;
         }
 


### PR DESCRIPTION
## Description

Non-durable agent runs flush pending messages immediately before a tool-call suspension. That path did not honor `memory.options.readOnly`, so an approval or in-tool suspension could persist messages even though the run was explicitly read-only.

This change adds the same `memoryConfig.readOnly` guard used by the durable suspension path. Tool execution, suspension payloads, and resume behavior are unchanged.

A regression test drives the approval suspension path with a real save queue mock. It fails on `main` because `flushMessages` is called with `{ readOnly: true }`, and passes with this guard.

AI assistance: Codex was used to prepare the implementation and tests.

## Related issue(s)

Fixes #20341

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Validation

- Focused `tool-call-step.test.ts`: 22 passed
- `tsc --noEmit -p tsconfig.build.json`: passed
- Oxlint, ESLint, Oxfmt, and `git diff --check`: passed
- Changeset status: `@mastra/core` patch recognized

The broader `packages/core` check currently reports the existing `durable-parity.test-d.ts:140` `experimentalTransform` type assertion on unchanged `origin/main`; this branch does not modify that file.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable; no public API change)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the agent is set to “read-only” memory, it should not write/save any message history while it’s paused waiting for a tool approval. This PR adds that protection to the non-durable tool-call suspension path.

## Summary

- Updated the non-durable suspension helper (`flushMessagesBeforeSuspension`) to skip `saveQueueManager.flushMessages(...)` when `memoryConfig.readOnly` is enabled.
- Added a regression test covering the “tool approval workflow” case with `memoryConfig.readOnly: true`, asserting that `suspend` runs but `flushMessages` is not called, and the step resolves to the `suspend` mock result.
- Added a patch changeset for `@mastra/core`.
- Validation included focused tests, TypeScript compilation, linting, formatting, diff checks, and changeset recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->