### PR TITLE
fix(core): route concurrent workflow approvals

### DIFF
--- a/.changeset/fresh-pugs-mate.md
+++ b/.changeset/fresh-pugs-mate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed concurrent workflow tool approvals so each suspended call resumes the correct workflow run.

--- a/packages/core/src/agent/__tests__/concurrent-workflow-tool-approval.test.ts
+++ b/packages/core/src/agent/__tests__/concurrent-workflow-tool-approval.test.ts
@@ -172,6 +172,15 @@ describe('concurrent workflow tool approvals', () => {
             );
             expect(successfulToolCallIds).toEqual(new Set(['call-workflow-a', 'call-workflow-b']));
             expect(chunks.filter(chunk => chunk.type === 'tool-error' || chunk.type === 'error')).toEqual([]);
+            expect(
+              chunks
+                .filter(chunk => chunk.type === 'text-delta')
+                .map(chunk => chunk.payload.text)
+                .join(''),
+            ).toContain('Both workflows completed.');
+            expect(chunks.some(chunk => chunk.type === 'finish' && chunk.payload.stepResult?.reason === 'stop')).toBe(
+              true,
+            );
           },
           { timeout: 10_000 },
         );

--- a/packages/core/src/agent/__tests__/concurrent-workflow-tool-approval.test.ts
+++ b/packages/core/src/agent/__tests__/concurrent-workflow-tool-approval.test.ts
@@ -1,0 +1,185 @@
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Mastra } from '../../mastra';
+import { MockMemory } from '../../memory/mock';
+import { InMemoryStore } from '../../storage';
+import { createStep, createWorkflow } from '../../workflows';
+import { Agent } from '../agent';
+import { agentThreadStreamRuntime } from '../thread-stream-runtime';
+
+const usage = { inputTokens: 1, outputTokens: 1, totalTokens: 2 };
+
+function createConcurrentWorkflowModel() {
+  return new MockLanguageModelV2({
+    doStream: async options => {
+      const hasToolResult = JSON.stringify(options.prompt).includes('"type":"tool-result"');
+      const parts = hasToolResult
+        ? [
+            { type: 'stream-start' as const, warnings: [] },
+            {
+              type: 'response-metadata' as const,
+              id: 'final-response',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            { type: 'text-start' as const, id: 'final-text' },
+            { type: 'text-delta' as const, id: 'final-text', delta: 'Both workflows completed.' },
+            { type: 'text-end' as const, id: 'final-text' },
+            { type: 'finish' as const, finishReason: 'stop' as const, usage },
+          ]
+        : [
+            { type: 'stream-start' as const, warnings: [] },
+            {
+              type: 'response-metadata' as const,
+              id: 'tool-call-response',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'call-workflow-a',
+              toolName: 'workflow-workflowA',
+              input: JSON.stringify({
+                inputData: { ticket: 'A' },
+                suspendedToolRunId: null,
+                resumeData: null,
+              }),
+            },
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'call-workflow-b',
+              toolName: 'workflow-workflowB',
+              input: JSON.stringify({
+                inputData: { ticket: 'B' },
+                suspendedToolRunId: null,
+                resumeData: null,
+              }),
+            },
+            { type: 'finish' as const, finishReason: 'tool-calls' as const, usage },
+          ];
+
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream(parts),
+      };
+    },
+  });
+}
+
+function createSuspendingWorkflow(id: string) {
+  const schema = z.object({ ticket: z.string() });
+  const step = createStep({
+    id: `${id}-step`,
+    inputSchema: schema,
+    outputSchema: z.object({ ticket: z.string(), completed: z.boolean() }),
+    suspendSchema: z.object({ ticket: z.string() }),
+    resumeSchema: z.object({ approved: z.boolean() }),
+    execute: async ({ inputData, resumeData, suspend }) => {
+      if (!resumeData) {
+        return suspend({ ticket: inputData.ticket });
+      }
+
+      return { ticket: inputData.ticket, completed: resumeData.approved };
+    },
+  });
+
+  return createWorkflow({
+    id,
+    inputSchema: schema,
+    outputSchema: z.object({ ticket: z.string(), completed: z.boolean() }),
+  })
+    .then(step)
+    .commit();
+}
+
+afterEach(() => {
+  agentThreadStreamRuntime.resetForTests();
+});
+
+describe('concurrent workflow tool approvals', () => {
+  it.each(['forward', 'reverse', 'concurrent'] as const)(
+    'resumes every suspended workflow in %s order',
+    async order => {
+      const workflowA = createSuspendingWorkflow('workflow-a');
+      const workflowB = createSuspendingWorkflow('workflow-b');
+      const agent = new Agent({
+        id: 'concurrent-workflow-agent',
+        name: 'Concurrent Workflow Agent',
+        instructions: 'Run both workflows.',
+        model: createConcurrentWorkflowModel(),
+        memory: new MockMemory(),
+        workflows: { workflowA, workflowB },
+      });
+      const mastra = new Mastra({
+        agents: { agent },
+        workflows: { workflowA, workflowB },
+        storage: new InMemoryStore(),
+        logger: false,
+      });
+      const registeredAgent = mastra.getAgent('agent');
+      const threadId = `concurrent-workflow-${order}`;
+      const resourceId = 'concurrent-workflow-user';
+      const chunks: any[] = [];
+      const subscription = await registeredAgent.subscribeToThread({ threadId, resourceId });
+      const consumeSubscription = (async () => {
+        for await (const chunk of subscription.stream) {
+          chunks.push(chunk);
+        }
+      })();
+
+      try {
+        await registeredAgent.stream('Run workflow A and workflow B together.', {
+          maxSteps: 6,
+          memory: { thread: threadId, resource: resourceId },
+        });
+
+        await vi.waitFor(
+          () => {
+            expect(chunks.filter(chunk => chunk.type === 'tool-call-suspended')).toHaveLength(2);
+          },
+          { timeout: 10_000 },
+        );
+
+        const suspendedIds = chunks
+          .filter(chunk => chunk.type === 'tool-call-suspended')
+          .map(chunk => chunk.payload.toolCallId as string);
+
+        const orderedIds = order === 'reverse' ? [...suspendedIds].reverse() : suspendedIds;
+        const approve = (toolCallId: string) =>
+          registeredAgent.sendToolApproval({
+            threadId,
+            resourceId,
+            toolCallId,
+            approved: true,
+            resumeData: { approved: true },
+          });
+
+        if (order === 'concurrent') {
+          await Promise.all(orderedIds.map(approve));
+        } else {
+          for (const toolCallId of orderedIds) {
+            await approve(toolCallId);
+          }
+        }
+
+        await vi.waitFor(
+          () => {
+            const successfulToolCallIds = new Set(
+              chunks.filter(chunk => chunk.type === 'tool-result').map(chunk => chunk.payload.toolCallId as string),
+            );
+            expect(successfulToolCallIds).toEqual(new Set(['call-workflow-a', 'call-workflow-b']));
+            expect(chunks.filter(chunk => chunk.type === 'tool-error' || chunk.type === 'error')).toEqual([]);
+          },
+          { timeout: 10_000 },
+        );
+      } finally {
+        subscription.unsubscribe();
+        await consumeSubscription;
+      }
+    },
+    30_000,
+  );
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -8894,16 +8894,41 @@ export class Agent<
 
     const resumeOptions = (streamOptions ?? {}) as AgentExecutionOptionsBase<unknown> & { toolCallId?: string };
 
-    await this.resumeStream(resumeData, {
-      ...resumeOptions,
+    await agentThreadStreamRuntime.queueStreamResume(
       runId,
-      ...(resumableRun.toolCallId ? { toolCallId: resumableRun.toolCallId } : {}),
-      memory: {
-        ...(resumeOptions.memory ?? {}),
-        thread: threadId,
-        resource: resourceId,
+      async () => {
+        const queuedResumableRun = agentThreadStreamRuntime.getResumableThreadRun(
+          { threadId, resourceId, runId, toolCallId: resumableRun.toolCallId },
+          this.getPubSub(),
+        );
+        if (!queuedResumableRun) {
+          throw new MastraError({
+            id: 'AGENT_SEND_STREAM_RESUME_NO_SUSPENDED_THREAD_RUN',
+            domain: ErrorDomain.AGENT,
+            category: ErrorCategory.USER,
+            text: `Agent "${this.name}" sendStreamResume() could not find a suspended run "${runId}" for thread "${threadId}".`,
+            details: {
+              threadId,
+              resourceId,
+              runId,
+              agentName: this.name,
+            },
+          });
+        }
+
+        return this.resumeStream(resumeData, {
+          ...resumeOptions,
+          runId,
+          ...(queuedResumableRun.toolCallId ? { toolCallId: queuedResumableRun.toolCallId } : {}),
+          memory: {
+            ...(resumeOptions.memory ?? {}),
+            thread: threadId,
+            resource: resourceId,
+          },
+        });
       },
-    });
+      this.getPubSub(),
+    );
 
     return { accepted: true, runId, toolCallId: resumableRun.toolCallId };
   }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -8897,10 +8897,12 @@ export class Agent<
     await agentThreadStreamRuntime.queueStreamResume(
       runId,
       async () => {
-        const queuedResumableRun = agentThreadStreamRuntime.getResumableThreadRun(
-          { threadId, resourceId, runId, toolCallId: resumableRun.toolCallId },
-          this.getPubSub(),
-        );
+        const queuedResumableRun = hasLocalRun
+          ? agentThreadStreamRuntime.getResumableThreadRun(
+              { threadId, resourceId, runId, toolCallId: resumableRun.toolCallId },
+              this.getPubSub(),
+            )
+          : resumableRun;
         if (!queuedResumableRun) {
           throw new MastraError({
             id: 'AGENT_SEND_STREAM_RESUME_NO_SUSPENDED_THREAD_RUN',

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -85,7 +85,7 @@ type AgentThreadRunRecord<OUTPUT = unknown> = {
   streamId: string;
   streamSeq: number;
   lifecycle: AgentThreadRunLifecycle;
-  suspension?: AgentThreadRunSuspension;
+  suspensions?: Map<string | undefined, AgentThreadRunSuspension>;
   /** When the record was parked as suspended (ms epoch); drives the TTL sweep. */
   suspendedAt?: number;
   threadId: string;
@@ -127,7 +127,7 @@ type AgentThreadRuntimeState = {
   streamSeqByRunId: Map<string, number>;
   approvalSuspendedRunIds: Set<string>;
   suspendedRunIds: Set<string>;
-  suspensionMetadataByRunId: Map<string, AgentThreadRunSuspension>;
+  suspensionMetadataByRunId: Map<string, Map<string | undefined, AgentThreadRunSuspension>>;
   pendingSignalsByThread: Map<string, CreatedAgentSignal[]>;
   // Signals queued for a run that is starting but has not made its first model
   // request yet. The first LLM step drains these and folds them into that
@@ -137,6 +137,7 @@ type AgentThreadRuntimeState = {
   pendingContinuationsByThread: Map<string, PendingContinuation<any>[]>;
   watchedThreadStreamIds: Set<string>;
   preparedRunsById: Map<string, PreparedThreadRun>;
+  resumeTailsByRunId: Map<string, Promise<void>>;
   abortedRunIds: Set<string>;
   /**
    * Active lease-renewal timers keyed by runId. Set when the owner
@@ -179,6 +180,7 @@ function createRuntimeState(): AgentThreadRuntimeState {
     pendingContinuationsByThread: new Map(),
     watchedThreadStreamIds: new Set(),
     preparedRunsById: new Map(),
+    resumeTailsByRunId: new Map(),
     abortedRunIds: new Set(),
     leaseRenewalTimers: new Map(),
   };
@@ -408,7 +410,7 @@ export class AgentThreadStreamRuntime {
       record.output.status === 'suspended' ||
       record.lifecycle === 'suspending' ||
       record.lifecycle === 'suspended' ||
-      !!record.suspension ||
+      !!record.suspensions?.size ||
       this.#isSuspendedRun(state, record.runId)
     );
   }
@@ -430,11 +432,13 @@ export class AgentThreadStreamRuntime {
     suspension: AgentThreadRunSuspension,
   ) {
     state.suspendedRunIds.add(runId);
-    state.suspensionMetadataByRunId.set(runId, suspension);
+    const suspensions = state.suspensionMetadataByRunId.get(runId) ?? new Map();
+    suspensions.set(suspension.toolCallId, suspension);
+    state.suspensionMetadataByRunId.set(runId, suspensions);
     const record = state.threadRunsByStreamId.get(streamId) ?? state.threadRunsById.get(runId);
     if (record) {
       record.lifecycle = 'suspending';
-      record.suspension = suspension;
+      record.suspensions = suspensions;
     }
     if (suspension.kind === 'approval') {
       state.approvalSuspendedRunIds.add(runId);
@@ -445,6 +449,24 @@ export class AgentThreadStreamRuntime {
     state.suspendedRunIds.delete(runId);
     state.suspensionMetadataByRunId.delete(runId);
     state.approvalSuspendedRunIds.delete(runId);
+    const record = state.threadRunsById.get(runId);
+    if (record) {
+      record.suspensions = undefined;
+    }
+  }
+
+  #clearSuspendedToolCall(state: AgentThreadRuntimeState, runId: string, toolCallId: string) {
+    const suspensions = state.suspensionMetadataByRunId.get(runId);
+    suspensions?.delete(toolCallId);
+
+    if (suspensions?.size) {
+      if (![...suspensions.values()].some(suspension => suspension.kind === 'approval')) {
+        state.approvalSuspendedRunIds.delete(runId);
+      }
+      return;
+    }
+
+    this.#clearSuspendedRun(state, runId);
   }
 
   #generateSignalMessageId(
@@ -706,12 +728,58 @@ export class AgentThreadStreamRuntime {
       return undefined;
     }
 
-    const suspension = record.suspension ?? state.suspensionMetadataByRunId.get(options.runId);
-    if (options.toolCallId && suspension?.toolCallId && suspension.toolCallId !== options.toolCallId) {
+    const suspensions = state.suspensionMetadataByRunId.get(options.runId);
+    const suspension = options.toolCallId ? suspensions?.get(options.toolCallId) : suspensions?.values().next().value;
+    if (options.toolCallId && !suspension) {
       return undefined;
     }
 
     return { runId: options.runId, toolCallId: options.toolCallId ?? suspension?.toolCallId };
+  }
+
+  /**
+   * Starts resumes for the same parent run one at a time. A resume mutates the
+   * parent's persisted workflow snapshot, so overlapping resumes can each load
+   * the same stale snapshot and lose a sibling tool result. Callers still
+   * resolve as soon as their resumed stream starts; only the next queued resume
+   * waits for the current stream to suspend or finish.
+   */
+  async queueStreamResume<OUTPUT>(
+    runId: string,
+    resume: () => Promise<MastraModelOutput<OUTPUT>>,
+    pubsub?: PubSub,
+  ): Promise<MastraModelOutput<OUTPUT>> {
+    const state = this.#getState(pubsub);
+    const previousTail = state.resumeTailsByRunId.get(runId) ?? Promise.resolve();
+    let resolveStarted!: (output: MastraModelOutput<OUTPUT>) => void;
+    let rejectStarted!: (error: unknown) => void;
+    const started = new Promise<MastraModelOutput<OUTPUT>>((resolve, reject) => {
+      resolveStarted = resolve;
+      rejectStarted = reject;
+    });
+
+    const resumeTail = previousTail
+      .catch(() => {})
+      .then(async () => {
+        try {
+          const output = await resume();
+          resolveStarted(output);
+          await output._waitUntilFinished();
+        } catch (error) {
+          rejectStarted(error);
+          throw error;
+        }
+      });
+    const settledTail = resumeTail
+      .catch(() => {})
+      .finally(() => {
+        if (state.resumeTailsByRunId.get(runId) === settledTail) {
+          state.resumeTailsByRunId.delete(runId);
+        }
+      });
+    state.resumeTailsByRunId.set(runId, settledTail);
+
+    return started;
   }
 
   abortThread(options: AgentSubscribeToThreadOptions, pubsub?: PubSub): boolean {
@@ -770,6 +838,7 @@ export class AgentThreadStreamRuntime {
     state.streamSeqByRunId.clear();
     state.watchedThreadStreamIds.clear();
     state.preparedRunsById.clear();
+    state.resumeTailsByRunId.clear();
     state.abortedRunIds.clear();
   }
 
@@ -958,6 +1027,13 @@ export class AgentThreadStreamRuntime {
       createSubscriberStream,
       startBroadcast,
     } = this.#withBroadcastStream(output, pubsub, key, streamId);
+    const resumedToolCallId = (streamOptions as AgentExecutionOptions<OUTPUT> & { toolCallId?: string }).toolCallId;
+    if (resumedToolCallId) {
+      this.#clearSuspendedToolCall(state, output.runId, resumedToolCallId);
+    } else {
+      this.#clearSuspendedRun(state, output.runId);
+    }
+
     const record: AgentThreadRunRecord<OUTPUT> = {
       agent,
       output: outputForSubscribers,
@@ -969,9 +1045,9 @@ export class AgentThreadStreamRuntime {
       resourceId,
       streamOptions: streamOptions as AgentThreadRunRecord<OUTPUT>['streamOptions'],
       createSubscriberStream,
+      suspensions: state.suspensionMetadataByRunId.get(output.runId),
     };
 
-    this.#clearSuspendedRun(state, output.runId);
     state.threadRunsById.set(output.runId, record);
     state.threadRunsByStreamId.set(streamId, record);
     state.threadKeysByRunId.set(output.runId, key);

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -829,6 +829,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                   toolCallId: inputData.toolCallId,
                   toolName: inputData.toolName,
                   resumeLabel: options?.resumeLabel,
+                  suspendedToolRunId: options?.runId,
                 },
                 {
                   resumeLabel: inputData.toolCallId,


### PR DESCRIPTION
Fixes #20322

Concurrent workflow-as-tool suspensions were stored as one entry per parent run, so sibling tool calls overwrote each other. Fast approvals could also resume the same persisted parent snapshot at the same time, and the generic suspension snapshot did not retain the inner workflow run id.

This tracks suspension metadata per tool call, persists each suspended workflow run id, and queues resumes for the same parent run until the previous stream suspends or finishes. sendToolApproval still returns when its resumed stream starts.

The regression test covers forward, reverse, and concurrent approval order and verifies that both workflow tool calls produce successful results without stream errors.

Validated with 127 focused tests (3 skipped), Oxlint, ESLint, Oxfmt, diff-check, and the @mastra/core library build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When two workflow tools pause at the same time, each approval now resumes the correct workflow. The system queues resumes safely so both results complete without errors.

## Changes

- Track suspended workflow tool calls by `toolCallId`.
- Preserve each suspended workflow run ID, including IDs recovered from storage.
- Queue resumes for the same parent run until the active stream suspends or finishes.
- Keep `sendToolApproval` responsive when the resumed stream starts.
- Add coverage for forward, reverse, and concurrent approval orders.
- Add a patch changeset for `@mastra/core`.

## Validation

- 127 focused tests passed.
- Oxlint, ESLint, Oxfmt, and diff-check passed.
- `@mastra/core` built successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->