### PR TITLE
fix(factory): recover from reinstalled GitHub App with changed installation ID

### DIFF
--- a/.changeset/ready-tires-design.md
+++ b/.changeset/ready-tires-design.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory losing repository access after a GitHub App is reinstalled with a new installation ID.

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -1129,16 +1129,10 @@ describe('PlatformGithubIntegration', () => {
         accountType: 'Organization',
       });
 
-      // Create a NEW repository for the NEW installation
-      await storage.repositories.upsert({
-        orgId: 'org-1',
-        input: {
-          installationId: newInstallation.id,
-          externalId: '101', // Same repository external ID
-          slug: 'acme/app', // Same slug
-          defaultBranch: 'main',
-        },
-      });
+      // NOTE: We don't create a new repository row here.
+      // In a real scenario, intake.listSources creates the installation row,
+      // but repositories are registered lazily. The recovery flow will
+      // migrate the old repository's installation_id to the new installation.
 
       // Mock Platform API:
       // - Returns 404 for OLD installation token request
@@ -1164,6 +1158,10 @@ describe('PlatformGithubIntegration', () => {
         cloneUrl: 'https://github.com/acme/app.git',
         authorization: { scheme: 'bearer', token: 'ghs_recovered' },
       });
+
+      // Verify the repository's installation_id was migrated to the new installation
+      const migratedRepository = await storage.repositories.get({ orgId: 'org-1', id: oldRepository.id });
+      expect(migratedRepository?.installationId).toBe(newInstallation.id);
     });
   });
 });

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -1093,4 +1093,77 @@ describe('PlatformGithubIntegration', () => {
       ).resolves.toBeNull();
     });
   });
+
+  describe('installation recovery', () => {
+    it('recovers when a GitHub App installation is reinstalled with a new installation ID', async () => {
+      const { sourceControl } = await createPlatformStorageForTests();
+      const storage = sourceControl.forIntegration('github');
+
+      // Create an OLD installation (simulating before reinstall)
+      const oldInstallation = await storage.installations.upsert({
+        orgId: 'org-1',
+        connectedByUserId: 'user-1',
+        externalId: '7', // OLD GitHub installation ID
+        accountName: 'acme',
+        accountType: 'Organization',
+      });
+
+      // Create an OLD repository for the OLD installation
+      const oldRepository = await storage.repositories.upsert({
+        orgId: 'org-1',
+        input: {
+          installationId: oldInstallation.id,
+          externalId: '101',
+          slug: 'acme/app',
+          defaultBranch: 'main',
+        },
+      });
+
+      // Create a NEW installation (simulating after reinstall)
+      // This would be created by intake.listSources after the reinstall
+      const newInstallation = await storage.installations.upsert({
+        orgId: 'org-1',
+        connectedByUserId: 'user-1',
+        externalId: '456', // NEW GitHub installation ID
+        accountName: 'acme', // Same account name
+        accountType: 'Organization',
+      });
+
+      // Create a NEW repository for the NEW installation
+      await storage.repositories.upsert({
+        orgId: 'org-1',
+        input: {
+          installationId: newInstallation.id,
+          externalId: '101', // Same repository external ID
+          slug: 'acme/app', // Same slug
+          defaultBranch: 'main',
+        },
+      });
+
+      // Mock Platform API:
+      // - Returns 404 for OLD installation token request
+      // - Returns token for NEW installation token request
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ error: 'Installation not found' }), {
+            status: 404,
+            headers: { 'content-type': 'application/json' },
+          }),
+        )
+        .mockResolvedValueOnce(json({ token: 'ghs_recovered', expiresAt: '2026-07-21T18:00:00Z' }));
+
+      const integration = createIntegration(fetchImpl);
+      integration.versionControl.initialize({ storage });
+
+      // Try to get repository access using OLD repository
+      // This should recover and succeed using the NEW installation
+      await expect(
+        integration.versionControl.getRepositoryAccess({ orgId: 'org-1', repositoryId: oldRepository.id }),
+      ).resolves.toEqual({
+        cloneUrl: 'https://github.com/acme/app.git',
+        authorization: { scheme: 'bearer', token: 'ghs_recovered' },
+      });
+    });
+  });
 });

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -389,6 +389,15 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         if (!newInstallation) throw err;
         const newInstallationId = parsePositiveInteger(newInstallation.externalId);
         if (newInstallationId === null) throw err;
+
+        // Persist the migration so we don't hit the 404 path on every call.
+        // This updates the repository's installation_id to the new installation.
+        await this.storage.repositories.migrateInstallation({
+          orgId,
+          id: repositoryId,
+          newInstallationId: newInstallation.id,
+        });
+
         const token = await this.#client.request<{ token: string }>(
           'POST',
           `${API_PREFIX}/github-app/installations/${newInstallationId}/token`,

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -381,7 +381,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         // GitHub assigns a new installation ID. Platform creates a new installation row,
         // and Factory's intake.listSources creates a new local installation row with the
         // new externalId. Try to find the new installation by accountName.
-        if (!(err instanceof PlatformApiError) || err.status !== 404 || !installation.accountName) throw err;
+        if (!isNotFound(err) || !installation.accountName) throw err;
         const installations = await this.storage.installations.list({ orgId });
         const newInstallation = installations.find(
           inst => inst.accountName === installation.accountName && inst.id !== installation.id,

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -360,20 +360,50 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       const installationId = parsePositiveInteger(installation.externalId);
       if (installationId === null) throw new Error('GitHub installation id is invalid.');
       const repositoryName = splitRepository(repository.slug).repo;
-      const token = await this.#client.request<{ token: string }>(
-        'POST',
-        `${API_PREFIX}/github-app/installations/${installationId}/token`,
-        { repositories: [repositoryName], permissions: REPOSITORY_TOKEN_PERMISSIONS },
-      );
-      const access: RepositoryAccess = {
-        cloneUrl,
-        authorization: { scheme: 'bearer', token: token.token },
-      };
-      setBounded(this.#repositoryAccessCache, cacheKey, {
-        access,
-        expiresAt: Date.now() + REPOSITORY_ACCESS_CACHE_TTL_MS,
-      });
-      return access;
+
+      try {
+        const token = await this.#client.request<{ token: string }>(
+          'POST',
+          `${API_PREFIX}/github-app/installations/${installationId}/token`,
+          { repositories: [repositoryName], permissions: REPOSITORY_TOKEN_PERMISSIONS },
+        );
+        const access: RepositoryAccess = {
+          cloneUrl,
+          authorization: { scheme: 'bearer', token: token.token },
+        };
+        setBounded(this.#repositoryAccessCache, cacheKey, {
+          access,
+          expiresAt: Date.now() + REPOSITORY_ACCESS_CACHE_TTL_MS,
+        });
+        return access;
+      } catch (err) {
+        // Recover from stale installation: when a GitHub App is uninstalled and reinstalled,
+        // GitHub assigns a new installation ID. Platform creates a new installation row,
+        // and Factory's intake.listSources creates a new local installation row with the
+        // new externalId. Try to find the new installation by accountName.
+        if (!(err instanceof PlatformApiError) || err.status !== 404 || !installation.accountName) throw err;
+        const installations = await this.storage.installations.list({ orgId });
+        const newInstallation = installations.find(
+          inst => inst.accountName === installation.accountName && inst.id !== installation.id,
+        );
+        if (!newInstallation) throw err;
+        const newInstallationId = parsePositiveInteger(newInstallation.externalId);
+        if (newInstallationId === null) throw err;
+        const token = await this.#client.request<{ token: string }>(
+          'POST',
+          `${API_PREFIX}/github-app/installations/${newInstallationId}/token`,
+          { repositories: [repositoryName], permissions: REPOSITORY_TOKEN_PERMISSIONS },
+        );
+        const access: RepositoryAccess = {
+          cloneUrl,
+          authorization: { scheme: 'bearer', token: token.token },
+        };
+        setBounded(this.#repositoryAccessCache, cacheKey, {
+          access,
+          expiresAt: Date.now() + REPOSITORY_ACCESS_CACHE_TTL_MS,
+        });
+        return access;
+      }
     },
     listPullRequests: input => this.#listPullRequests(input),
     getPullRequest: input => this.#getPullRequest(input),

--- a/mastracode/factory/src/storage/domains/source-control/base.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.ts
@@ -337,12 +337,15 @@ export interface SourceControlStorageHandle {
     findBySlug(args: { orgId: string; installationId: string; slug: string }): Promise<SourceControlRepository | null>;
     upsert(args: { orgId: string; input: UpsertSourceControlRepositoryInput }): Promise<SourceControlRepository>;
     /**
-     * Update the installation_id of a repository row. Used to migrate repositories
-     * when a GitHub App is reinstalled with a new installation ID on the same account.
-     * Returns true if the update succeeded, false if a unique constraint violation
-     * occurred (repository already exists under the new installation).
+     * Migrate a repository and its dependent connections to a new installation.
+     * Used when a GitHub App is reinstalled with a new installation ID on the same account.
+     * Returns the repository under the new installation (either migrated or existing).
      */
-    migrateInstallation(args: { orgId: string; id: string; newInstallationId: string }): Promise<boolean>;
+    migrateInstallation(args: {
+      orgId: string;
+      id: string;
+      newInstallationId: string;
+    }): Promise<SourceControlRepository>;
   };
   readonly connections: {
     list(args: { orgId: string; factoryProjectId: string }): Promise<ProjectSourceControlConnection[]>;
@@ -765,15 +768,32 @@ export class SourceControlStorage extends FactoryStorageDomain {
         },
         migrateInstallation: async ({ orgId, id, newInstallationId }) => {
           const existing = await getRepository({ orgId, id });
-          if (!existing) return false;
+          if (!existing) {
+            throw new Error(`Repository ${id} not found in organization ${orgId}`);
+          }
           await requireInstallation({ orgId, id: newInstallationId });
           try {
             await db().updateMany(REPOSITORIES, { id }, { installation_id: newInstallationId, updated_at: new Date() });
-            return true;
+            // Migrate dependent connections to the new installation
+            await db().updateMany(
+              CONNECTIONS,
+              { installation_id: existing.installationId },
+              { installation_id: newInstallationId },
+            );
+            // Return the updated repository
+            const updated = await getRepository({ orgId, id });
+            if (!updated) throw new Error('Repository disappeared after update');
+            return updated;
           } catch (error) {
             // Unique constraint violation: repository already exists under the new installation
             if (!(error instanceof UniqueViolationError)) throw error;
-            return false;
+            // Find and return the existing repository under the new installation
+            const conflictRow = await db().findOne<RepositoryDbRow>(REPOSITORIES, {
+              installation_id: newInstallationId,
+              external_id: existing.externalId,
+            });
+            if (!conflictRow) throw error; // Should never happen if we got a unique violation
+            return toRepository(conflictRow);
           }
         },
       },

--- a/mastracode/factory/src/storage/domains/source-control/base.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.ts
@@ -336,6 +336,13 @@ export interface SourceControlStorageHandle {
     findByExternalId(args: { orgId: string; externalId: string }): Promise<SourceControlRepository | null>;
     findBySlug(args: { orgId: string; installationId: string; slug: string }): Promise<SourceControlRepository | null>;
     upsert(args: { orgId: string; input: UpsertSourceControlRepositoryInput }): Promise<SourceControlRepository>;
+    /**
+     * Update the installation_id of a repository row. Used to migrate repositories
+     * when a GitHub App is reinstalled with a new installation ID on the same account.
+     * Returns true if the update succeeded, false if a unique constraint violation
+     * occurred (repository already exists under the new installation).
+     */
+    migrateInstallation(args: { orgId: string; id: string; newInstallationId: string }): Promise<boolean>;
   };
   readonly connections: {
     list(args: { orgId: string; factoryProjectId: string }): Promise<ProjectSourceControlConnection[]>;
@@ -755,6 +762,19 @@ export class SourceControlStorage extends FactoryStorageDomain {
             updated_at: now,
           });
           return toRepository(row);
+        },
+        migrateInstallation: async ({ orgId, id, newInstallationId }) => {
+          const existing = await getRepository({ orgId, id });
+          if (!existing) return false;
+          await requireInstallation({ orgId, id: newInstallationId });
+          try {
+            await db().updateMany(REPOSITORIES, { id }, { installation_id: newInstallationId, updated_at: new Date() });
+            return true;
+          } catch (error) {
+            // Unique constraint violation: repository already exists under the new installation
+            if (!(error instanceof UniqueViolationError)) throw error;
+            return false;
+          }
         },
       },
       connections: {

--- a/mastracode/factory/src/storage/domains/source-control/inmemory.ts
+++ b/mastracode/factory/src/storage/domains/source-control/inmemory.ts
@@ -145,6 +145,29 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
       this.repositoriesRows.push(created);
       return created;
     },
+    migrateInstallation: async ({
+      orgId,
+      id,
+      newInstallationId,
+    }: {
+      orgId: string;
+      id: string;
+      newInstallationId: string;
+    }) => {
+      const existing = await this.repositories.get({ orgId, id });
+      if (!existing) return false;
+      if (!(await this.installations.get({ orgId, id: newInstallationId }))) {
+        throw new Error('Source-control installation not found');
+      }
+      // Check if a repository with the same external_id exists under the new installation
+      const conflict = this.repositoriesRows.find(
+        row => row.installationId === newInstallationId && row.externalId === existing.externalId,
+      );
+      if (conflict) return false; // Unique constraint violation
+      existing.installationId = newInstallationId;
+      existing.updatedAt = new Date();
+      return true;
+    },
   };
 
   readonly connections = {

--- a/mastracode/factory/src/storage/domains/source-control/inmemory.ts
+++ b/mastracode/factory/src/storage/domains/source-control/inmemory.ts
@@ -155,7 +155,9 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
       newInstallationId: string;
     }) => {
       const existing = await this.repositories.get({ orgId, id });
-      if (!existing) return false;
+      if (!existing) {
+        throw new Error(`Repository ${id} not found in organization ${orgId}`);
+      }
       if (!(await this.installations.get({ orgId, id: newInstallationId }))) {
         throw new Error('Source-control installation not found');
       }
@@ -163,10 +165,20 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
       const conflict = this.repositoriesRows.find(
         row => row.installationId === newInstallationId && row.externalId === existing.externalId,
       );
-      if (conflict) return false; // Unique constraint violation
+      if (conflict) {
+        // Return the existing repository under the new installation
+        return conflict;
+      }
+      // Update the repository's installation
       existing.installationId = newInstallationId;
       existing.updatedAt = new Date();
-      return true;
+      // Migrate dependent connections to the new installation
+      for (const conn of this.connectionsRows) {
+        if (conn.installationId === existing.installationId) {
+          conn.installationId = newInstallationId;
+        }
+      }
+      return existing;
     },
   };
 


### PR DESCRIPTION
## Summary

When a GitHub App is uninstalled and reinstalled on the same account/org, GitHub assigns a new installation ID. This causes Factory to fail when trying to access repositories because project connections still reference the old installation ID.

This fix adds automatic recovery in `getRepositoryAccess` that:
1. Catches 404 errors from Platform when the old installation ID is no longer valid
2. Finds the new installation by matching the account name (which stays the same across reinstalls)
3. Retries token minting with the new installation ID
4. Persists the migration by updating the repository's `installation_id` to the new installation

## Changes

- `src/integrations/platform/github/integration.ts`: Added recovery logic in `getRepositoryAccess` to catch 404 errors, find replacement installation by account name, and persist the migration
- `src/integrations/platform/github/integration.test.ts`: Added regression test for the recovery scenario with persistence verification
- `src/storage/domains/source-control/base.ts`: Added `migrateInstallation` method to storage interface for updating repository installation references
- `src/storage/domains/source-control/inmemory.ts`: Implemented `migrateInstallation` for in-memory storage
- `.changeset/ready-tires-design.md`: Added changeset for patch release

## Test Plan

- Added new test "recovers when a GitHub App installation is reinstalled with a new installation ID" that:
  - Creates old installation with ID 7
  - Creates new installation with ID 456 (same account name)
  - Verifies `getRepositoryAccess` recovers when Platform returns 404 for old installation
  - Verifies the repository's `installationId` is migrated to the new installation after recovery
- All 27 Platform GitHub integration tests pass
- Type check passes (`pnpm check` - only pre-existing unrelated error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When a GitHub App is removed and added again, GitHub can give it a new installation ID. This PR helps Factory notice the old ID is now invalid, find the new one for the same account, migrate the stored ID, and keep GitHub repo access working instead of failing.

## Changes
- **GitHub reinstall recovery:** `getRepositoryAccess` now catches **Platform 404** errors during repository token minting, finds the replacement GitHub App installation by matching the **unchanged account name**, retries token minting with the **new installation ID**, and caches the recovered `RepositoryAccess`.
- **Persist migration:** Added repository installation-ID migration logic so future calls don’t keep hitting the recovery path.
- **Duplicate-safe migration:** When a migrated repo conflicts with an existing repo under the new installation (unique constraint), Factory returns the already-existing repository.
- **Dependent connections migration:** Migrates dependent `connections` from the old installation ID to the new one to keep lookups consistent.
- **Test coverage:** Added a regression test (`installation recovery`) that simulates reinstall-with-new-installation-ID (old token request 404, new token request succeeds) and asserts both recovered access and migrated `installationId`.
- **Storage updates:** Extended source-control storage interfaces and implemented `migrateInstallation` for both the persistent storage contract and the in-memory storage.
- **Release note:** Added a changeset for `@mastra/factory` describing the fix.

## Verification
- Platform GitHub integration tests: **all 27 passing**
- Type checking: **fails only due to a pre-existing unrelated error**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->