### PR TITLE
fix(core): compact repeated request bodies in suspended snapshots

### DIFF
--- a/.changeset/calm-dodos-rest.md
+++ b/.changeset/calm-dodos-rest.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Reduce suspended agent snapshot size by deduplicating repeated provider request bodies across buffered model steps.

--- a/packages/core/src/loop/workflows/prune-snapshot.test.ts
+++ b/packages/core/src/loop/workflows/prune-snapshot.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { expandStreamStateRequestBodies } from '../../stream/base/serialized-state';
+import type { WorkflowRunState } from '../../workflows/types';
+import { pruneAgentLoopSnapshot } from './prune-snapshot';
+
+function countOccurrences(value: unknown, marker: string) {
+  return JSON.stringify(value).split(marker).length - 1;
+}
+
+describe('pruneAgentLoopSnapshot request bodies', () => {
+  it('compacts repeated step request bodies in live and foreach suspension state', () => {
+    const requestMarker = 'request-body-marker';
+    const requestBody = {
+      system: requestMarker.repeat(50_000),
+      tools: [{ name: 'approvalTool', schema: { type: 'object' } }],
+    };
+    const streamState = {
+      status: 'suspended',
+      bufferedSteps: Array.from({ length: 13 }, (_, index) => ({
+        text: `step-${index}`,
+        request: { body: requestBody, headers: { 'x-step': String(index) } },
+      })),
+      messageList: { messages: [] },
+    };
+    const suspendedEntry = {
+      status: 'suspended',
+      suspendPayload: { __streamState: streamState },
+    };
+    const snapshot = {
+      status: 'suspended',
+      context: {
+        input: {},
+        loop: {
+          status: 'suspended',
+          suspendPayload: {
+            __streamState: streamState,
+            __workflow_meta: { foreachOutput: { 0: suspendedEntry } },
+          },
+        },
+      },
+      result: undefined,
+    } as unknown as WorkflowRunState;
+    const unprunedSize = JSON.stringify(snapshot).length;
+
+    const pruned = pruneAgentLoopSnapshot({ snapshot });
+    const prunedSize = JSON.stringify(pruned).length;
+    const suspendPayload = (pruned.context as any).loop.suspendPayload;
+    const liveState = suspendPayload.__streamState;
+    const foreachState = suspendPayload.__workflow_meta.foreachOutput[0].suspendPayload.__streamState;
+
+    expect(unprunedSize).toBeGreaterThan(16 * 1024 * 1024);
+    expect(prunedSize).toBeLessThan(16 * 1024 * 1024);
+    expect(countOccurrences(pruned, requestBody.system)).toBe(2);
+    expect(prunedSize).toBeLessThan(unprunedSize * 0.15);
+    expect(expandStreamStateRequestBodies(liveState)).toEqual(streamState);
+    expect(expandStreamStateRequestBodies(foreachState)).toEqual(streamState);
+
+    // Snapshot pruning remains copy-on-write.
+    expect((snapshot.context as any).loop.suspendPayload.__streamState.bufferedSteps[12].request.body).toBe(
+      requestBody,
+    );
+  });
+});

--- a/packages/core/src/loop/workflows/prune-snapshot.ts
+++ b/packages/core/src/loop/workflows/prune-snapshot.ts
@@ -1,3 +1,4 @@
+import { compactStreamStateRequestBodies } from '../../stream/base/serialized-state';
 import type { WorkflowRunState } from '../../workflows/types';
 
 /**
@@ -145,17 +146,19 @@ function pruneStepResult(result: Record<string, any>): Record<string, any> {
   // aggregation entries which get the same per-entry rules (completed
   // iterations stripped, still-suspended ones preserved).
   if (isPlainObject(pruned.suspendPayload)) {
-    const meta = pruned.suspendPayload.__workflow_meta;
+    let suspendPayload = { ...pruned.suspendPayload };
+    const meta = suspendPayload.__workflow_meta;
     if (isPlainObject(meta) && isPlainObject(meta.foreachOutput)) {
       const foreachOutput: Record<string, any> = {};
       for (const [index, entry] of Object.entries(meta.foreachOutput)) {
         foreachOutput[index] = pruneStepResult(entry as Record<string, any>);
       }
-      pruned.suspendPayload = {
-        ...pruned.suspendPayload,
-        __workflow_meta: { ...meta, foreachOutput },
-      };
+      suspendPayload = { ...suspendPayload, __workflow_meta: { ...meta, foreachOutput } };
     }
+    if (isPlainObject(suspendPayload.__streamState)) {
+      suspendPayload.__streamState = compactStreamStateRequestBodies(suspendPayload.__streamState);
+    }
+    pruned.suspendPayload = suspendPayload;
   }
 
   return pruned;

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -30,6 +30,7 @@ import type {
 import { safeClose, safeEnqueue } from './input';
 import { createJsonTextStreamTransformer, createObjectStreamTransformer } from './output-format-handlers';
 import { getTransformedSchema } from './schema';
+import { expandStreamStateRequestBodies } from './serialized-state';
 
 /**
  * Helper function to create a destructurable version of MastraModelOutput.
@@ -1933,6 +1934,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
   }
 
   deserializeState(state: any) {
+    state = expandStreamStateRequestBodies(state);
     this.#status = state.status;
     this.#bufferedSteps = state.bufferedSteps;
     this.#bufferedReasoningDetails = state.bufferedReasoningDetails;

--- a/packages/core/src/stream/base/serialized-state.test.ts
+++ b/packages/core/src/stream/base/serialized-state.test.ts
@@ -1,0 +1,80 @@
+import { ReadableStream } from 'node:stream/web';
+import { describe, expect, it } from 'vitest';
+import { MessageList } from '../../agent/message-list';
+import type { ChunkType } from '../types';
+import { MastraModelOutput } from './output';
+import { compactStreamStateRequestBodies, expandStreamStateRequestBodies } from './serialized-state';
+
+function makeSteps(bodies: unknown[]) {
+  return bodies.map((body, index) => ({
+    text: `step-${index}`,
+    request: { body, headers: { 'x-step': String(index) } },
+  }));
+}
+
+describe('serialized model-output state', () => {
+  it('deduplicates only repeated request bodies and round-trips without mutation', () => {
+    const repeatedBody = { tools: [{ description: 'x'.repeat(100_000) }], system: 'instructions' };
+    const uniqueBody = { messages: ['unique'] };
+    const state = {
+      status: 'suspended',
+      bufferedSteps: makeSteps([repeatedBody, repeatedBody, uniqueBody, repeatedBody]),
+    };
+    const before = structuredClone(state);
+
+    const compacted = compactStreamStateRequestBodies(state);
+
+    expect(state).toEqual(before);
+    expect(JSON.stringify(compacted).length).toBeLessThan(JSON.stringify(state).length * 0.4);
+    expect((compacted as any).bufferedSteps[2].request.body).toEqual(uniqueBody);
+    expect(expandStreamStateRequestBodies(compacted)).toEqual(state);
+  });
+
+  it('leaves states without duplicate JSON request bodies unchanged', () => {
+    const state = {
+      status: 'suspended',
+      bufferedSteps: makeSteps([{ value: 1 }, { value: 2 }]),
+    };
+
+    expect(compactStreamStateRequestBodies(state)).toBe(state);
+    expect(expandStreamStateRequestBodies(state)).toBe(state);
+  });
+
+  it('expands compacted request bodies before MastraModelOutput resumes', () => {
+    const messageList = new MessageList({ threadId: 'request-body-resume' });
+    const stream = new ReadableStream<ChunkType>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const baseOutput = new MastraModelOutput({
+      model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+      stream,
+      messageList,
+      messageId: 'message-id',
+      options: { runId: 'request-body-resume' },
+    });
+    const repeatedBody = { tools: [{ description: 'large schema' }], system: 'instructions' };
+    const initialState = {
+      ...baseOutput.serializeState(),
+      status: 'suspended',
+      bufferedSteps: makeSteps([repeatedBody, repeatedBody]),
+    };
+    const compacted = compactStreamStateRequestBodies(initialState);
+
+    const resumedOutput = new MastraModelOutput({
+      model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+      stream: new ReadableStream<ChunkType>({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      messageList: new MessageList({ threadId: 'request-body-resume' }),
+      messageId: 'message-id',
+      options: { runId: 'request-body-resume' },
+      initialState: compacted,
+    });
+
+    expect(resumedOutput.serializeState().bufferedSteps).toEqual(initialState.bufferedSteps);
+  });
+});

--- a/packages/core/src/stream/base/serialized-state.ts
+++ b/packages/core/src/stream/base/serialized-state.ts
@@ -1,0 +1,103 @@
+const SHARED_REQUEST_BODIES_KEY = '__mastraSharedRequestBodies';
+const REQUEST_BODY_REF_KEY = '__mastraRequestBodyRef';
+
+type SerializableRecord = Record<string, any>;
+
+function isPlainObject(value: unknown): value is SerializableRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function serializeBody(body: unknown): string | undefined {
+  try {
+    const serialized = JSON.stringify(body);
+    return serialized === undefined ? undefined : `${typeof body}:${serialized}`;
+  } catch {
+    // A workflow snapshot must ultimately be JSON serializable, but keep the
+    // pruning hook fail-open if a custom provider puts an unsupported value
+    // in request metadata.
+    return undefined;
+  }
+}
+
+/**
+ * Deduplicates byte-identical request bodies in a serialized model-output
+ * state. Provider request bodies often repeat large, invariant tool schemas
+ * and system instructions for every step in an agent loop.
+ *
+ * Only bodies that occur more than once are moved into the shared table.
+ * Copy-on-write; the live model output and the snapshot passed to the pruning
+ * hook are never mutated.
+ */
+export function compactStreamStateRequestBodies<T>(state: T): T {
+  if (!isPlainObject(state) || !Array.isArray(state.bufferedSteps)) return state;
+  if (SHARED_REQUEST_BODIES_KEY in state) return state;
+
+  const occurrences = new Map<string, { body: unknown; count: number; ref?: number }>();
+  const serializedByStep = new Map<number, string>();
+
+  for (const [index, step] of state.bufferedSteps.entries()) {
+    if (!isPlainObject(step) || !isPlainObject(step.request)) continue;
+    if (REQUEST_BODY_REF_KEY in step.request || !Object.prototype.hasOwnProperty.call(step.request, 'body')) continue;
+
+    const serialized = serializeBody(step.request.body);
+    if (serialized === undefined) continue;
+
+    serializedByStep.set(index, serialized);
+    const occurrence = occurrences.get(serialized);
+    if (occurrence) {
+      occurrence.count++;
+    } else {
+      occurrences.set(serialized, { body: step.request.body, count: 1 });
+    }
+  }
+
+  const sharedRequestBodies: unknown[] = [];
+  for (const occurrence of occurrences.values()) {
+    if (occurrence.count > 1) {
+      occurrence.ref = sharedRequestBodies.length;
+      sharedRequestBodies.push(occurrence.body);
+    }
+  }
+  if (sharedRequestBodies.length === 0) return state;
+
+  const bufferedSteps = state.bufferedSteps.map((step: unknown, index: number) => {
+    if (!isPlainObject(step) || !isPlainObject(step.request)) return step;
+    const serialized = serializedByStep.get(index);
+    const ref = serialized === undefined ? undefined : occurrences.get(serialized)?.ref;
+    if (ref === undefined) return step;
+
+    const request: SerializableRecord = { ...step.request, [REQUEST_BODY_REF_KEY]: ref };
+    delete request.body;
+    return { ...step, request };
+  });
+
+  return {
+    ...state,
+    bufferedSteps,
+    [SHARED_REQUEST_BODIES_KEY]: sharedRequestBodies,
+  } as T;
+}
+
+/**
+ * Restores request bodies compacted by `compactStreamStateRequestBodies`.
+ * Older snapshots without the marker pass through unchanged.
+ */
+export function expandStreamStateRequestBodies<T>(state: T): T {
+  if (!isPlainObject(state) || !Array.isArray(state.bufferedSteps)) return state;
+  const sharedRequestBodies = state[SHARED_REQUEST_BODIES_KEY];
+  if (!Array.isArray(sharedRequestBodies)) return state;
+
+  const bufferedSteps = state.bufferedSteps.map((step: unknown) => {
+    if (!isPlainObject(step) || !isPlainObject(step.request)) return step;
+    const ref = step.request[REQUEST_BODY_REF_KEY];
+    if (!Number.isInteger(ref) || ref < 0 || ref >= sharedRequestBodies.length) return step;
+
+    const request: SerializableRecord = { ...step.request, body: sharedRequestBodies[ref] };
+    delete request[REQUEST_BODY_REF_KEY];
+    return { ...step, request };
+  });
+
+  const expanded: SerializableRecord = { ...state, bufferedSteps };
+  delete expanded[SHARED_REQUEST_BODIES_KEY];
+  return expanded as T;
+}


### PR DESCRIPTION
## Summary

- deduplicate byte-identical provider request bodies across buffered model steps when pruning suspended agent snapshots
- preserve distinct per-step bodies and all surrounding request metadata
- expand compacted bodies before `MastraModelOutput` resumes, while keeping older snapshots compatible

Fixes #20288.

## Why

A single HITL suspension can persist the same large tool schema/system prompt in every `bufferedSteps[*].request.body`. The live stream state is also retained in the parent suspension and foreach aggregation, so a 13-step run can exceed MongoDB's 16 MB document limit before it can be resumed.

The pruning hook now moves only JSON-identical bodies that occur more than once into a shared table. Bodies that differ, cannot be serialized, or occur once are left unchanged. Deserialization restores the original step shape before any runtime consumer sees it.

## Validation

- regression fixture: unpruned snapshot >16 MB; compacted snapshot <16 MB and <15% of the original size
- compact/expand round-trip, copy-on-write, distinct-body, legacy-state, and `MastraModelOutput` resume coverage
- 54 related output, foreach suspension, approval, snapshot-size, and resume tests passed
- focused post-rebase suite: 6 tests passed with 0 type errors
- Oxfmt, Oxlint, ESLint, and `git diff --check` passed
- `@mastra/core` ESM/CJS/type build passed

## AI assistance

Implemented with Codex assistance. I reviewed the issue, current pruning/resume paths, generated diff, and test results; the PR remains draft pending final human review.