### PR TITLE
fix(factory-ui): render live signal contents

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -1,4 +1,5 @@
 import type { PlanResume } from '@mastra/client-js';
+import { mastraDBMessageToSignal } from '@mastra/core/signals';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeBlock as DsCodeBlock } from '@mastra/playground-ui/components/CodeBlock';
@@ -675,9 +676,31 @@ function NotificationSummaryCard({ entry }: { entry: NotificationSummaryEntry })
   );
 }
 
-/** Collapsible row for state/reminder/reactive signals, mirroring NotificationRow. */
+/** Compact row for state/reminder/reactive signals, collapsible when it has details. */
 function SignalRow({ kind, label, message }: { kind: string; label: string; message: string }) {
   const [expanded, setExpanded] = useState(false);
+  const icon =
+    kind === 'state' ? (
+      <Layers size={13} className="text-purple-400" />
+    ) : kind === 'reminder' ? (
+      <Info size={13} className="text-accent3" />
+    ) : (
+      <Info size={13} className="text-icon3" />
+    );
+
+  if (!message) {
+    return (
+      <div className="max-w-full min-w-0" data-signal-kind={kind} role="group" aria-label={`Signal: ${label}`}>
+        <span className="flex w-full items-center gap-2 px-2 py-1.5">
+          <span className="flex shrink-0 items-center">{icon}</span>
+          <Txt as="span" variant="ui-smd" className="text-icon5 shrink-0">
+            {label}
+          </Txt>
+        </span>
+      </div>
+    );
+  }
+
   return (
     <Collapsible
       open={expanded}
@@ -696,15 +719,7 @@ function SignalRow({ kind, label, message }: { kind: string; label: string; mess
               expanded ? 'rotate-0' : '-rotate-90',
             )}
           />
-          <span className="flex shrink-0 items-center">
-            {kind === 'state' ? (
-              <Layers size={13} className="text-purple-400" />
-            ) : kind === 'reminder' ? (
-              <Info size={13} className="text-accent3" />
-            ) : (
-              <Info size={13} className="text-icon3" />
-            )}
-          </span>
+          <span className="flex shrink-0 items-center">{icon}</span>
           <Txt as="span" variant="ui-smd" className="text-icon5 shrink-0">
             {label}
           </Txt>
@@ -1079,9 +1094,11 @@ function signalNotifications(entry: MessageEntry): Array<NotificationEntry | Not
 }
 
 function signalPartsText(entry: MessageEntry): string {
-  return (entry.message.content.parts ?? [])
-    .map(part => (part.type === 'text' ? part.text : ''))
-    .filter(Boolean)
+  const { contents } = mastraDBMessageToSignal(entry.message);
+  if (typeof contents === 'string') return contents.trim();
+
+  return contents
+    .flatMap(part => (part.type === 'text' && part.text ? [part.text] : []))
     .join('\n')
     .trim();
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptSignalRows.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptSignalRows.msw.test.tsx
@@ -1,5 +1,5 @@
 import type { MastraDBMessage } from '@mastra/core/agent-controller';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 
@@ -63,6 +63,30 @@ function reactiveSignalEntry(id: string, tagName: string, text: string): Timelin
   return { kind: 'message', id, message: signalDBMessage({ id, type: 'reactive', tagName, text }) };
 }
 
+function streamedReactiveSignalEntry(id: string, tagName: string, text: string): TimelineEntry {
+  const signal = {
+    id,
+    type: 'reactive',
+    tagName,
+    contents: text,
+    createdAt: CREATED_AT.toISOString(),
+  };
+  return {
+    kind: 'message',
+    id,
+    message: {
+      id,
+      role: 'signal',
+      createdAt: CREATED_AT,
+      content: {
+        format: 2,
+        parts: [{ type: 'data-signal', data: signal }],
+        metadata: { signal },
+      },
+    },
+  };
+}
+
 function renderEntries(entries: TimelineEntry[]) {
   return renderWithProviders(<TranscriptEntries entries={entries} onApprove={() => {}} onRespond={() => {}} />);
 }
@@ -119,6 +143,24 @@ describe('TranscriptEntries signal rows', () => {
 
     const row = screen.getByRole('group', { name: 'Signal: System reminder' });
     expect(row).toHaveAttribute('data-signal-kind', 'reminder');
+  });
+
+  it('renders the contents of a live system reminder data part', async () => {
+    renderEntries([
+      streamedReactiveSignalEntry('sig-reminder', 'system-reminder', 'Remember to run the focused tests.'),
+    ]);
+
+    await userEvent.click(screen.getByRole('button', { name: /System reminder/ }));
+
+    expect(screen.getAllByText('Remember to run the focused tests.')).toHaveLength(2);
+  });
+
+  it('renders a content-less system reminder without an empty disclosure', () => {
+    renderEntries([reactiveSignalEntry('sig-reminder', 'system-reminder', '')]);
+
+    const row = screen.getByRole('group', { name: 'Signal: System reminder' });
+    expect(row).toHaveTextContent('System reminder');
+    expect(within(row).queryByRole('button')).not.toBeInTheDocument();
   });
 
   it('keeps rendering persisted notification signals as notification rows', () => {


### PR DESCRIPTION
Factory chat now renders live signal contents instead of showing empty expandable blocks. Live AgentController signals store their text in the data-signal payload, but the transcript only read persisted text parts.

Signals with content remain collapsible. Signals without content render as a compact row without an empty disclosure.

Checks:
- focused TranscriptSignalRows suite: 8 passing
- Factory UI typecheck
- Prettier
- React Doctor: no changed-scope issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory chat reminders now show their actual message instead of an empty expandable box. Reminders with text can still be expanded, while empty reminders stay compact.

## Changes

- Render signal text from normalized `data-signal` payloads, supporting both strings and content parts.
- Keep populated signal rows collapsible.
- Render empty signal rows without disclosure controls.
- Added tests for live signal content and content-less reminders.

## Validation

- TranscriptSignalRows suite
- Factory UI typecheck
- Prettier
- React Doctor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->