### PR TITLE
fix(factory-ui): move review PR links to header

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/chat/components/PullRequestLinks.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/PullRequestLinks.tsx
@@ -3,8 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import { CircleDot, CircleX, GitMerge } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
-import { useWorkItemsQuery } from '../../../../../hooks/useWorkItems';
-import type { TranscriptState } from '../../services/transcript';
+import type { WorkItem } from '../../factory/services/workItems';
+import type { TranscriptState } from '../services/transcript';
 
 interface PullRequestSubscription {
   id: string;
@@ -35,11 +35,12 @@ interface PullRequestLinksProps {
   resourceId: string;
   projectPath: string | undefined;
   projectRepositoryId: unknown;
-  factoryProjectId: unknown;
+  reviewItem?: WorkItem;
   repositorySlug: string | undefined;
   threadId: string | undefined;
   transcriptEntries: TranscriptState['entries'];
   busy: boolean;
+  size?: 'xs' | 'sm';
 }
 
 /** Pull requests subscribed to the active GitHub-backed thread. */
@@ -48,22 +49,14 @@ export function PullRequestLinks({
   resourceId,
   projectPath,
   projectRepositoryId,
-  factoryProjectId,
+  reviewItem,
   repositorySlug,
   threadId,
   transcriptEntries,
   busy,
+  size = 'xs',
 }: PullRequestLinksProps) {
   const wasBusy = useRef(busy);
-  const factoryProjectKey = typeof factoryProjectId === 'string' ? factoryProjectId : undefined;
-  const workItems = useWorkItemsQuery(factoryProjectKey);
-  const reviewItem = workItems.data?.find(
-    item =>
-      item.source === 'github-pr' &&
-      Object.values(item.sessions).some(
-        session => session.threadId === threadId && (!projectPath || session.sessionId === projectPath),
-      ),
-  );
   const reviewNumber = reviewItem?.metadata.githubPullRequestNumber ?? reviewItem?.metadata.number;
   const normalizedReviewNumber = Number(reviewNumber);
   const factorySubscription: PullRequestSubscription | undefined =
@@ -136,7 +129,7 @@ export function PullRequestLinks({
           key={subscription.id}
           as="a"
           variant="ghost"
-          size="xs"
+          size={size}
           href={subscription.url}
           target="_blank"
           rel="noreferrer"

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/StatusLine.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/StatusLine.tsx
@@ -1,14 +1,15 @@
 import { useParams } from 'react-router';
 
 import { useFactoryQuery } from '../../../../../hooks/useFactories';
+import { useWorkItemsQuery } from '../../../../../hooks/useWorkItems';
 import { useChatSessionContext } from '../../context/useChatSessionContext';
 import { useChatTranscript } from '../../context/useChatTranscript';
+import { PullRequestLinks } from '../PullRequestLinks';
 import { ActiveModel } from './ActiveModel';
 import { ConnectionActivity } from './ConnectionActivity';
 import { GoalStatus } from './GoalStatus';
 import { ModesSelection } from './ModesSelection';
 import { OperationalMemoryStatus } from './OperationalMemoryStatus';
-import { PullRequestLinks } from './PullRequestLinks';
 import { QueuedFollowUps } from './QueuedFollowUps';
 import { RuntimeActivity } from './RuntimeActivity';
 
@@ -26,6 +27,14 @@ export function StatusLine() {
   );
   const projectRepositoryId = repository?.projectRepositoryId;
   const factoryProjectId = factorySessionState?.factoryProjectId;
+  const factoryProjectKey = typeof factoryProjectId === 'string' ? factoryProjectId : undefined;
+  const workItems = useWorkItemsQuery(factoryProjectKey);
+  const currentItem = workItems.data?.find(item =>
+    Object.values(item.sessions).some(
+      session => session.threadId === threadId && (!projectPath || session.sessionId === projectPath),
+    ),
+  );
+  const workItemsPending = Boolean(factoryProjectKey) && workItems.isPending;
 
   return (
     <div
@@ -39,17 +48,18 @@ export function StatusLine() {
       <ConnectionActivity />
       <QueuedFollowUps />
       <GoalStatus />
-      <PullRequestLinks
-        baseUrl={baseUrl}
-        resourceId={resourceId}
-        projectPath={projectPath}
-        projectRepositoryId={projectRepositoryId}
-        factoryProjectId={factoryProjectId}
-        repositorySlug={repository?.slug}
-        threadId={threadId}
-        transcriptEntries={transcript.entries}
-        busy={busy}
-      />
+      {!workItemsPending && currentItem?.source !== 'github-pr' ? (
+        <PullRequestLinks
+          baseUrl={baseUrl}
+          resourceId={resourceId}
+          projectPath={projectPath}
+          projectRepositoryId={projectRepositoryId}
+          repositorySlug={repository?.slug}
+          threadId={threadId}
+          transcriptEntries={transcript.entries}
+          busy={busy}
+        />
+      ) : null}
     </div>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
@@ -2,8 +2,12 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { Link2 } from 'lucide-react';
 import { Link, useNavigate, useParams } from 'react-router';
 
+import { useFactoryQuery } from '../../../../hooks/useFactories';
 import { useUserSessionQuery, useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
 import { useWorkItemsQuery } from '../../../../hooks/useWorkItems';
+import { PullRequestLinks } from '../../chat/components/PullRequestLinks';
+import { useChatSessionContext } from '../../chat/context/useChatSessionContext';
+import { useChatTranscript } from '../../chat/context/useChatTranscript';
 import { relatedWorkItems, relationshipLabel, relationshipPath } from '../services/relationships';
 import type { WorkItem, WorkItemSessionRef } from '../services/workItems';
 
@@ -33,6 +37,12 @@ export function FactorySessionHeader() {
   const projectRepositoryId = sessionQuery.data?.projectRepositoryId;
   const items = useWorkItemsQuery(factoryId);
   const workspaces = useWorkspacesQuery(projectRepositoryId);
+  const factoryQuery = useFactoryQuery(factoryId);
+  const { baseUrl, resourceId, projectPath } = useChatSessionContext();
+  const { transcript, busy } = useChatTranscript();
+  const repository = factoryQuery.data?.repositories.find(
+    candidate => candidate.projectRepositoryId === projectRepositoryId,
+  );
 
   if (!threadId || !factoryId || !sessionId) return null;
 
@@ -68,7 +78,7 @@ export function FactorySessionHeader() {
           </span>
           <span className="text-icon6 truncate">{sessionTitle(currentItem)}</span>
         </nav>
-        {destinations.length > 0 ? (
+        {destinations.length > 0 || isReview ? (
           <div className="flex shrink-0 flex-wrap items-center gap-1">
             {destinations.map(({ item, session }) => {
               const label = relationshipLabel(item);
@@ -99,6 +109,20 @@ export function FactorySessionHeader() {
                 </Button>
               );
             })}
+            {isReview ? (
+              <PullRequestLinks
+                baseUrl={baseUrl}
+                resourceId={resourceId}
+                projectPath={projectPath}
+                projectRepositoryId={projectRepositoryId}
+                reviewItem={currentItem}
+                repositorySlug={repository?.slug}
+                threadId={threadId}
+                transcriptEntries={transcript.entries}
+                busy={busy}
+                size="sm"
+              />
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageReviewPullRequestLink.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageReviewPullRequestLink.msw.test.tsx
@@ -1,0 +1,197 @@
+import { screen, within } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../e2e/ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../e2e/ui/render';
+import { createAppRoutes } from '../../router';
+
+const FACTORY_ID = 'fp-1';
+const REPO_ID = 'ghp-1';
+const SESSION_ID = 'sess-1';
+const THREAD_ID = 'thread-1';
+const PULL_REQUEST_NUMBER = 20338;
+const PULL_REQUEST_URL = `https://github.com/mastra-ai/mastra/pull/${PULL_REQUEST_NUMBER}`;
+const PULL_REQUEST_ACCESSIBLE_NAME = `Open open mastra-ai/mastra pull request ${PULL_REQUEST_NUMBER}`;
+const AC = `${TEST_BASE_URL}/api/agent-controller/code`;
+
+const workspaceSession = {
+  id: 'row-1',
+  sessionId: SESSION_ID,
+  projectRepositoryId: REPO_ID,
+  orgId: 'org-1',
+  userId: 'user-1',
+  branch: 'factory/item-1',
+  baseBranch: 'main',
+  sandboxId: 'sb-1',
+  sandboxWorkdir: '/local/mastra',
+  materializedAt: '2026-07-29T00:00:00.000Z',
+  createdAt: '2026-07-29T00:00:00.000Z',
+  updatedAt: '2026-07-29T00:00:00.000Z',
+};
+
+const pullRequestSubscriptions = {
+  subscriptions: [
+    {
+      id: 'subscription-1',
+      repoFullName: 'mastra-ai/mastra',
+      pullRequestNumber: PULL_REQUEST_NUMBER,
+      status: 'open',
+      url: PULL_REQUEST_URL,
+    },
+  ],
+};
+
+function createWireWorkItem(type: 'pull-request' | 'issue') {
+  return {
+    id: `work-item-${type}`,
+    orgId: 'org-1',
+    createdBy: 'user-1',
+    factoryProjectId: FACTORY_ID,
+    externalSource: {
+      integrationId: 'github',
+      type,
+      externalId: String(PULL_REQUEST_NUMBER),
+      url: PULL_REQUEST_URL,
+    },
+    parentWorkItemId: null,
+    title: type === 'pull-request' ? 'Move the pull request link' : 'Track the pull request link',
+    stages: ['review'],
+    stageHistory: [],
+    sessions: {
+      [SESSION_ID]: {
+        sessionId: SESSION_ID,
+        branch: 'factory/item-1',
+        threadId: THREAD_ID,
+        startedBy: 'user-1',
+      },
+    },
+    metadata: {
+      githubPullRequestNumber: PULL_REQUEST_NUMBER,
+      number: PULL_REQUEST_NUMBER,
+      state: 'open',
+    },
+    revision: 1,
+    createdAt: '2026-07-29T00:00:00.000Z',
+    updatedAt: '2026-07-29T00:00:00.000Z',
+  };
+}
+
+function stubThreadRoute(
+  workItem: ReturnType<typeof createWireWorkItem>,
+  subscriptions: typeof pullRequestSubscriptions,
+) {
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Mastra Factory' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'connection-1',
+            installationId: 'installation-1',
+            repositories: [
+              {
+                id: REPO_ID,
+                branch: 'main',
+                sandboxWorkdir: '/local/mastra',
+                repository: { slug: 'mastra-ai/mastra', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+      HttpResponse.json({ sessions: [workspaceSession] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/user-sessions/${SESSION_ID}`, () =>
+      HttpResponse.json({ session: workspaceSession }),
+    ),
+    http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () =>
+      HttpResponse.json({
+        resourceId: SESSION_ID,
+        factoryProjectId: FACTORY_ID,
+        projectRepositoryId: REPO_ID,
+        sandboxId: 'sb-1',
+        sandboxWorkdir: '/local/mastra',
+      }),
+    ),
+    http.post(`${AC}/sessions`, () =>
+      HttpResponse.json({ controllerId: 'code', resourceId: SESSION_ID, threadId: THREAD_ID }),
+    ),
+    http.get(`${AC}/sessions/:resourceId`, () =>
+      HttpResponse.json({
+        controllerId: 'code',
+        resourceId: SESSION_ID,
+        modeId: 'build',
+        modelId: 'openai/gpt-4o-mini',
+        threadId: THREAD_ID,
+        settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+      }),
+    ),
+    http.put(`${AC}/sessions/:resourceId/state`, () => HttpResponse.json({ ok: true })),
+    http.get(
+      `${AC}/sessions/:resourceId/stream`,
+      () =>
+        new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    ),
+    http.get(`${AC}/sessions/:resourceId/permissions`, () => HttpResponse.json({})),
+    http.get(`${AC}/sessions/:resourceId/threads`, () => HttpResponse.json({ threads: [] })),
+    http.get(`${AC}/sessions/:resourceId/threads/:threadId/messages`, () => HttpResponse.json({ messages: [] })),
+    http.get(`${AC}/modes`, () => HttpResponse.json({ modes: [] })),
+    http.get(`${TEST_BASE_URL}/web/workspace/rendered/list`, () =>
+      HttpResponse.json({ workspacePath: `/ws/${SESSION_ID}`, root: '.artifacts', rootPath: '', entries: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+      HttpResponse.json({ workItems: [workItem] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/subscriptions`, () => HttpResponse.json(subscriptions)),
+  );
+}
+
+function renderThreadRoute() {
+  const router = createMemoryRouter(createAppRoutes(), {
+    initialEntries: [`/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${THREAD_ID}`],
+  });
+  return renderWithProviders(<RouterProvider router={router} />);
+}
+
+describe('ThreadPage pull request link placement', () => {
+  describe('when the current Factory session reviews a pull request', () => {
+    it('shows the pull request in the Factory session header and not in the composer', async () => {
+      stubThreadRoute(createWireWorkItem('pull-request'), pullRequestSubscriptions);
+      renderThreadRoute();
+
+      const factorySession = await screen.findByRole('region', { name: 'Factory session' });
+      const composer = await screen.findByRole('region', { name: 'Thread composer' });
+      const link = await within(factorySession).findByRole('link', { name: PULL_REQUEST_ACCESSIBLE_NAME });
+
+      expect(link).toHaveAttribute('href', PULL_REQUEST_URL);
+      expect(within(composer).queryByRole('link', { name: PULL_REQUEST_ACCESSIBLE_NAME })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when the current Factory session is ordinary work', () => {
+    it('keeps the pull request in the composer and out of the Factory session header', async () => {
+      stubThreadRoute(createWireWorkItem('issue'), pullRequestSubscriptions);
+      renderThreadRoute();
+
+      const factorySession = await screen.findByRole('region', { name: 'Factory session' });
+      const composer = await screen.findByRole('region', { name: 'Thread composer' });
+      const link = await within(composer).findByRole('link', { name: PULL_REQUEST_ACCESSIBLE_NAME });
+
+      expect(link).toHaveAttribute('href', PULL_REQUEST_URL);
+      expect(
+        within(factorySession).queryByRole('link', { name: PULL_REQUEST_ACCESSIBLE_NAME }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Factory review sessions now show the active review PR and any other subscribed PRs at the end of the session header. Ordinary work sessions keep their PR links in the composer status line, without duplicating review links below.

Added route-level MSW coverage for both placements. Verified with Factory UI typecheck, the focused regression test, the full 309-test MSW suite, formatting, and changed-scope React Doctor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Review sessions now show their pull request links in the session header, while regular work sessions keep them in the composer. New route tests ensure links appear in the right place without duplication.

## Changes

- Updated pull request link handling to accept the active review item and configurable button sizes.
- Kept PR links in the composer for ordinary work sessions, hiding them when reviewing GitHub PRs.
- Added PR links to review session headers, including active and subscribed PRs.
- Added MSW route coverage for both review and ordinary session placements.
- Verified typechecking, regression tests, MSW tests, formatting, and React Doctor checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->