### PR TITLE
docs(observability): add telemetry.dev OTLP provider

### DIFF
--- a/docs/src/content/en/docs/observability/integrations/exporters/otel.mdx
+++ b/docs/src/content/en/docs/observability/integrations/exporters/otel.mdx
@@ -8,7 +8,7 @@ packages:
 
 # OpenTelemetry exporter
 
-The OpenTelemetry (OTEL) exporter sends your traces and logs to any OTEL-compatible observability platform using standardized [OpenTelemetry Semantic Conventions for GenAI](https://opentelemetry.io/docs/specs/semconv/gen-ai/). This ensures broad compatibility with platforms like Datadog, New Relic, SigNoz, MLflow, Latitude, Dash0, Traceloop, Laminar, and more.
+The OpenTelemetry (OTEL) exporter sends your traces and logs to any OTEL-compatible observability platform using standardized [OpenTelemetry Semantic Conventions for GenAI](https://opentelemetry.io/docs/specs/semconv/gen-ai/). This ensures broad compatibility with platforms like Datadog, New Relic, SigNoz, MLflow, Latitude, Dash0, Traceloop, Laminar, telemetry.dev, and more.
 
 :::info Looking for bidirectional OTEL integration?
 
@@ -20,7 +20,7 @@ If you have existing OpenTelemetry instrumentation and want Mastra traces to inh
 
 Each provider requires specific protocol packages. Install the base exporter plus the protocol package for your provider:
 
-### For HTTP/Protobuf Providers (SigNoz, New Relic, Laminar, MLflow, Latitude)
+### For HTTP/Protobuf Providers (SigNoz, New Relic, Laminar, MLflow, Latitude, telemetry.dev)
 
 ```bash npm2yarn
 npm install @mastra/otel-exporter@latest @opentelemetry/exporter-trace-otlp-proto
@@ -90,6 +90,28 @@ new OtelExporter({
 ```
 
 Sign up at [console.latitude.so](https://console.latitude.so/login), or self-host and point the endpoint at your own ingestion host.
+
+### telemetry.dev
+
+[telemetry.dev](https://telemetry.dev) ingests OTLP/HTTP protobuf traces and normalizes OpenTelemetry GenAI semantic conventions into model, provider, token, latency, and cost fields. Use the `custom` provider with your project API key:
+
+```bash title=".env"
+TELEMETRY_DEV_API_KEY=td_live_...
+```
+
+```typescript title="src/mastra/index.ts"
+new OtelExporter({
+  provider: {
+    custom: {
+      endpoint: 'https://ingest.telemetry.dev/v1/traces',
+      protocol: 'http/protobuf',
+      headers: {
+        Authorization: `Bearer ${process.env.TELEMETRY_DEV_API_KEY}`,
+      },
+    },
+  },
+})
+```
 
 ### Dash0
 


### PR DESCRIPTION
This adds telemetry.dev to the OpenTelemetry exporter guide using the existing `custom` HTTP/protobuf provider path, the same way other generic OTLP providers are documented. The example sends traces to telemetry.dev's OTLP endpoint with bearer auth from `TELEMETRY_DEV_API_KEY` and notes that GenAI semantic-convention attributes are normalized server-side. Docs-only, no new package.

Disclosure: I built telemetry.dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This adds instructions for sending tracing information to telemetry.dev. It shows how to securely connect using an API key, with no code or package changes.

## Summary

- Added telemetry.dev to the supported OpenTelemetry platforms.
- Documented its custom HTTP/Protobuf OTLP configuration.
- Added bearer authentication using `TELEMETRY_DEV_API_KEY`.
- Noted that telemetry.dev normalizes GenAI semantic-convention attributes server-side.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->