### PR TITLE
Bound the RequestContext serializability probe

### DIFF
--- a/.changeset/tidy-panthers-count.md
+++ b/.changeset/tidy-panthers-count.md
@@ -1,0 +1,6 @@
+---
+'@internal/core': patch
+'@mastra/core': patch
+---
+
+Fixed `RequestContext.toJSON()` blocking the event loop when a stored value is an acyclic object graph with layered shared references. `JSON.stringify` expands shared references once per path, so a graph of ~30 heap objects with two-way sharing expands to 2^30 visited nodes: the serializability probe would burn 60-100 seconds of synchronous CPU, throw `RangeError` past V8's string-length cap, and silently filter the key anyway. The probe is now budgeted at 1M visited nodes — values that expand past the budget are filtered immediately, in milliseconds, with the same outcome. Handling of circular references, cross-context cycles, functions, and symbols is unchanged.

--- a/.changeset/tidy-panthers-count.md
+++ b/.changeset/tidy-panthers-count.md
@@ -3,4 +3,4 @@
 '@mastra/core': patch
 ---
 
-Fixed `RequestContext.toJSON()` blocking the event loop when a stored value is an acyclic object graph with layered shared references. `JSON.stringify` expands shared references once per path, so a graph of ~30 heap objects with two-way sharing expands to 2^30 visited nodes: the serializability probe would burn 60-100 seconds of synchronous CPU, throw `RangeError` past V8's string-length cap, and silently filter the key anyway. The probe is now budgeted at 1M visited nodes — values that expand past the budget are filtered immediately, in milliseconds, with the same outcome. Handling of circular references, cross-context cycles, functions, and symbols is unchanged.
+Fixed `RequestContext.toJSON()` so deeply shared object graphs no longer block the event loop during serialization. Values that exceed the serialization safety limit are filtered instead.

--- a/packages/_internal-core/src/request-context/index.ts
+++ b/packages/_internal-core/src/request-context/index.ts
@@ -136,6 +136,15 @@ let _toJSONDepth = 0;
  * value would do — a value that fails the budget would also be pathological
  * to persist. 1M visits keeps the worst-case probe in the tens of
  * milliseconds while remaining far above any reasonable context value.
+ *
+ * Two caveats to that bound. The budget is per `JSON.stringify` call, and a
+ * nested value's `toJSON()` runs before the replacer sees it — so a stored
+ * graph that reaches a nested `RequestContext` through N shared paths
+ * re-runs that context's probes with a fresh budget on every visit
+ * (tracked in #20446). And `Buffer.prototype.toJSON` materializes a
+ * `{ type, data }` object before the replacer, so Buffers charge one budget
+ * unit per byte rather than the arithmetic typed-array fast path — a Buffer
+ * past the budget is filtered.
  */
 const SERIALIZATION_PROBE_BUDGET = 1_000_000;
 

--- a/packages/_internal-core/src/request-context/index.ts
+++ b/packages/_internal-core/src/request-context/index.ts
@@ -322,12 +322,14 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
         // the budget arithmetically instead of materializing every element
         // through the replacer.
         if (ArrayBuffer.isView(probed)) {
-          // Detect BigInt element types via the cross-realm-safe brand tag —
-          // `instanceof` fails for views from another realm — and pass them
-          // through so the engine still throws TypeError on their BigInt
-          // elements, matching the unbudgeted probe's verdict.
-          const tag = Object.prototype.toString.call(probed);
-          if (tag === '[object BigInt64Array]' || tag === '[object BigUint64Array]') {
+          // Detect BigInt element types by reading element 0 — integer-indexed
+          // access on a typed array is unspoofable and realm-independent,
+          // unlike `instanceof` (fails cross-realm) or the brand tag (an own
+          // `Symbol.toStringTag` shadows it). Pass BigInt views through so the
+          // engine still throws TypeError on their elements, matching the
+          // unbudgeted probe's verdict. (An empty BigInt view has no elements
+          // to throw on and stringifies to '{}' either way.)
+          if (typeof (probed as ArrayLike<unknown>)[0] === 'bigint') {
             return probed;
           }
           budget -= (probed as { length?: number }).length ?? 0;

--- a/packages/_internal-core/src/request-context/index.ts
+++ b/packages/_internal-core/src/request-context/index.ts
@@ -148,6 +148,15 @@ let _toJSONDepth = 0;
  */
 const SERIALIZATION_PROBE_BUDGET = 1_000_000;
 
+/**
+ * The intrinsic `%TypedArray%.prototype.length` getter. Reads the element
+ * count from internal slots, so it cannot be shadowed by an own `length`
+ * property, works across realms, and throws `TypeError` for `DataView` —
+ * which makes it double as the discriminator between typed arrays (intrinsic
+ * indexed elements) and other `ArrayBuffer` views (plain-object semantics).
+ */
+const _typedArrayLength = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(Int8Array.prototype), 'length')!.get!;
+
 export class RequestContext<Values extends Record<string, any> | unknown = unknown> {
   private registry = new Map<string, unknown>();
 
@@ -322,6 +331,19 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
         // the budget arithmetically instead of materializing every element
         // through the replacer.
         if (ArrayBuffer.isView(probed)) {
+          // The fast path is only sound for typed arrays, whose index-shaped
+          // own keys are always intrinsic elements (out-of-bounds index
+          // definition throws). `DataView` has no intrinsic elements — an
+          // index-named own property on one is ordinary data that a real
+          // serialization walks — so it must pass through with plain-object
+          // semantics. The intrinsic length getter discriminates: it throws
+          // for anything without typed-array internal slots.
+          let elementCount: number;
+          try {
+            elementCount = _typedArrayLength.call(probed) as number;
+          } catch {
+            return probed;
+          }
           // Detect BigInt element types by reading element 0 — integer-indexed
           // access on a typed array is unspoofable and realm-independent,
           // unlike `instanceof` (fails cross-realm) or the brand tag (an own
@@ -332,7 +354,9 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
           if (typeof (probed as ArrayLike<unknown>)[0] === 'bigint') {
             return probed;
           }
-          budget -= (probed as { length?: number }).length ?? 0;
+          // Charge the intrinsic element count — an own `length` data
+          // property can shadow the prototype getter and lie.
+          budget -= elementCount;
           if (budget < 0) {
             throw new RangeError('RequestContext.isSerializable: value expands past the serialization probe budget');
           }

--- a/packages/_internal-core/src/request-context/index.ts
+++ b/packages/_internal-core/src/request-context/index.ts
@@ -310,16 +310,35 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
           throw new RangeError('RequestContext.isSerializable: value expands past the serialization probe budget');
         }
         // Typed arrays serialize one element per index; charge them against
-        // the budget arithmetically and skip them so the probe doesn't
-        // materialize every element through the replacer. BigInt64Array /
-        // BigUint64Array fall through so the engine still throws TypeError
-        // on their BigInt elements, matching the unbudgeted probe's verdict.
-        if (ArrayBuffer.isView(probed) && !(probed instanceof BigInt64Array) && !(probed instanceof BigUint64Array)) {
+        // the budget arithmetically instead of materializing every element
+        // through the replacer.
+        if (ArrayBuffer.isView(probed)) {
+          // Detect BigInt element types via the cross-realm-safe brand tag —
+          // `instanceof` fails for views from another realm — and pass them
+          // through so the engine still throws TypeError on their BigInt
+          // elements, matching the unbudgeted probe's verdict.
+          const tag = Object.prototype.toString.call(probed);
+          if (tag === '[object BigInt64Array]' || tag === '[object BigUint64Array]') {
+            return probed;
+          }
           budget -= (probed as { length?: number }).length ?? 0;
           if (budget < 0) {
             throw new RangeError('RequestContext.isSerializable: value expands past the serialization probe budget');
           }
-          return undefined;
+          // Preserve probe semantics for non-index own enumerable properties
+          // (a getter that throws, or a value that leads back into a cycle,
+          // must still fail the probe the way it fails a real serialization):
+          // stand in a surrogate carrying only those properties. Reading a
+          // throwing getter here propagates into the catch below, exactly as
+          // the engine's own property read would have.
+          const surrogate: Record<string, unknown> = {};
+          for (const key of Object.keys(probed)) {
+            const index = Number(key);
+            if (!(Number.isInteger(index) && index >= 0 && String(index) === key)) {
+              surrogate[key] = (probed as unknown as Record<string, unknown>)[key];
+            }
+          }
+          return surrogate;
         }
         return probed;
       });

--- a/packages/_internal-core/src/request-context/index.ts
+++ b/packages/_internal-core/src/request-context/index.ts
@@ -330,8 +330,10 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
           // must still fail the probe the way it fails a real serialization):
           // stand in a surrogate carrying only those properties. Reading a
           // throwing getter here propagates into the catch below, exactly as
-          // the engine's own property read would have.
-          const surrogate: Record<string, unknown> = {};
+          // the engine's own property read would have. Null prototype so an
+          // own enumerable `__proto__` key copies as data instead of hitting
+          // the inherited setter.
+          const surrogate: Record<string, unknown> = Object.create(null);
           for (const key of Object.keys(probed)) {
             const index = Number(key);
             if (!(Number.isInteger(index) && index >= 0 && String(index) === key)) {

--- a/packages/_internal-core/src/request-context/index.ts
+++ b/packages/_internal-core/src/request-context/index.ts
@@ -119,6 +119,26 @@ const _toJSONInProgress = new WeakSet<RequestContext<any>>();
  */
 let _toJSONDepth = 0;
 
+/**
+ * Maximum number of nodes the `isSerializable` probe lets `JSON.stringify`
+ * visit for a single stored value.
+ *
+ * `JSON.stringify` expands shared (non-circular) references once per path,
+ * not once per object: an acyclic graph where every level shares one child
+ * (`{ a: n, b: n }` nested `d` times) holds `d + 1` heap objects but expands
+ * to `2^d` visited nodes. Around `2^26` the output also exceeds V8's string
+ * length cap and stringify throws `RangeError` — but only after doing the
+ * traversal work, which keeps doubling past the cap. Unbounded, a ~30-object
+ * value can block the event loop for minutes and then be silently filtered.
+ *
+ * The budget counts node *visits* (shared references count once per path)
+ * because that is exactly the work any real downstream serialization of the
+ * value would do — a value that fails the budget would also be pathological
+ * to persist. 1M visits keeps the worst-case probe in the tens of
+ * milliseconds while remaining far above any reasonable context value.
+ */
+const SERIALIZATION_PROBE_BUDGET = 1_000_000;
+
 export class RequestContext<Values extends Record<string, any> | unknown = unknown> {
   private registry = new Map<string, unknown>();
 
@@ -265,6 +285,12 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
   /**
    * Check if a value can be safely serialized to JSON.
    *
+   * The probe is budgeted (see `SERIALIZATION_PROBE_BUDGET`): a value whose
+   * serialization would visit an unbounded number of nodes — an acyclic
+   * graph with layered shared references expands as 2^depth — is treated as
+   * non-serializable and filtered instead of blocking the event loop for
+   * the full expansion.
+   *
    * Re-throws `CyclicRequestContextToJSONError` when called from a nested
    * `toJSON()` (`_toJSONDepth > 1`), so the marker propagates up to the
    * outermost `toJSON()`'s `isSerializable`, which then swallows it and
@@ -278,7 +304,25 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
     if (typeof value !== 'object') return true;
 
     try {
-      JSON.stringify(value);
+      let budget = SERIALIZATION_PROBE_BUDGET;
+      JSON.stringify(value, (_key, probed) => {
+        if (--budget < 0) {
+          throw new RangeError('RequestContext.isSerializable: value expands past the serialization probe budget');
+        }
+        // Typed arrays serialize one element per index; charge them against
+        // the budget arithmetically and skip them so the probe doesn't
+        // materialize every element through the replacer. BigInt64Array /
+        // BigUint64Array fall through so the engine still throws TypeError
+        // on their BigInt elements, matching the unbudgeted probe's verdict.
+        if (ArrayBuffer.isView(probed) && !(probed instanceof BigInt64Array) && !(probed instanceof BigUint64Array)) {
+          budget -= (probed as { length?: number }).length ?? 0;
+          if (budget < 0) {
+            throw new RangeError('RequestContext.isSerializable: value expands past the serialization probe budget');
+          }
+          return undefined;
+        }
+        return probed;
+      });
       return true;
     } catch (e) {
       if (e instanceof CyclicRequestContextToJSONError && _toJSONDepth > 1) {

--- a/packages/_internal-core/src/request-context/index.ts
+++ b/packages/_internal-core/src/request-context/index.ts
@@ -351,7 +351,7 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
           // engine still throws TypeError on their elements, matching the
           // unbudgeted probe's verdict. (An empty BigInt view has no elements
           // to throw on and stringifies to '{}' either way.)
-          if (typeof (probed as ArrayLike<unknown>)[0] === 'bigint') {
+          if (typeof (probed as unknown as ArrayLike<unknown>)[0] === 'bigint') {
             return probed;
           }
           // Charge the intrinsic element count — an own `length` data

--- a/packages/core/src/request-context/index.test.ts
+++ b/packages/core/src/request-context/index.test.ts
@@ -362,6 +362,25 @@ describe('RequestContext', () => {
       expect(json).toEqual({ serializable: 'value' });
       expect(json).not.toHaveProperty('cyclicTyped');
     });
+
+    it('should skip typed arrays whose own enumerable __proto__ property leads back into a cycle', () => {
+      // An own enumerable `__proto__` data property is serialized by
+      // JSON.stringify; a plain-object surrogate would swallow it through
+      // the inherited setter and let the probe pass a value that a real
+      // serialization rejects.
+      const typed = new Uint8Array([1]);
+      const holder: Record<string, unknown> = { typed };
+      Object.defineProperty(typed, '__proto__', { enumerable: true, value: holder });
+
+      const ctx = new RequestContext();
+      ctx.set('protoCyclicTyped', typed);
+      ctx.set('serializable', 'value');
+
+      const json = ctx.toJSON();
+
+      expect(json).toEqual({ serializable: 'value' });
+      expect(json).not.toHaveProperty('protoCyclicTyped');
+    });
   });
 
   describe('serializeForSpan', () => {

--- a/packages/core/src/request-context/index.test.ts
+++ b/packages/core/src/request-context/index.test.ts
@@ -244,6 +244,70 @@ describe('RequestContext', () => {
       const parsed = JSON.parse(serialized);
       expect(parsed).toEqual({ serializable: 'value' });
     });
+
+    it('should skip acyclic shared-reference values that expand past the serialization budget, in bounded time', () => {
+      // JSON.stringify expands shared references once per path: this value
+      // holds 31 heap objects but expands to 2^30 visited nodes. Without the
+      // probe budget the stringify probe burns 60-100s of synchronous CPU,
+      // throws RangeError past V8's string cap, and the key is filtered
+      // anyway — after blocking the event loop for the full expansion.
+      let node: unknown = { leaf: true };
+      for (let i = 0; i < 30; i++) node = { a: node, b: node };
+
+      const ctx = new RequestContext();
+      ctx.set('sharedDag', node);
+      ctx.set('serializable', 'value');
+
+      const start = Date.now();
+      const json = ctx.toJSON();
+      const elapsed = Date.now() - start;
+
+      // The unbudgeted probe takes minutes here; the budgeted one bails in
+      // tens of milliseconds. Loose threshold to assert "bounded", not "fast".
+      expect(elapsed).toBeLessThan(2000);
+      expect(json).toEqual({ serializable: 'value' });
+      expect(json).not.toHaveProperty('sharedDag');
+    });
+
+    it('should keep acyclic shared-reference values that stay within the serialization budget', () => {
+      // Same shape, but 2^10 expanded nodes — far under the budget.
+      let node: unknown = { leaf: true };
+      for (let i = 0; i < 10; i++) node = { a: node, b: node };
+
+      const ctx = new RequestContext();
+      ctx.set('smallDag', node);
+
+      const json = ctx.toJSON();
+
+      expect(json).toHaveProperty('smallDag');
+    });
+
+    it('should skip oversized typed arrays without materializing their elements, and keep small ones', () => {
+      const ctx = new RequestContext();
+      ctx.set('bigTyped', new Float64Array(8 * 1024 * 1024));
+      ctx.set('smallTyped', new Uint8Array(16));
+      ctx.set('smallBuffer', Buffer.alloc(64));
+
+      const start = Date.now();
+      const json = ctx.toJSON();
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(2000);
+      expect(json).not.toHaveProperty('bigTyped');
+      expect(json).toHaveProperty('smallTyped');
+      expect(json).toHaveProperty('smallBuffer');
+    });
+
+    it('should still skip BigInt-element typed arrays like the unbudgeted probe did', () => {
+      const ctx = new RequestContext();
+      ctx.set('bigIntArray', new BigInt64Array([1n]));
+      ctx.set('serializable', 'value');
+
+      const json = ctx.toJSON();
+
+      expect(json).toEqual({ serializable: 'value' });
+      expect(json).not.toHaveProperty('bigIntArray');
+    });
   });
 
   describe('serializeForSpan', () => {

--- a/packages/core/src/request-context/index.test.ts
+++ b/packages/core/src/request-context/index.test.ts
@@ -308,6 +308,60 @@ describe('RequestContext', () => {
       expect(json).toEqual({ serializable: 'value' });
       expect(json).not.toHaveProperty('bigIntArray');
     });
+
+    it('should skip BigInt-element typed arrays created in another realm', async () => {
+      // A foreign-realm BigInt64Array passes ArrayBuffer.isView but fails
+      // `instanceof BigInt64Array`, so the fast path must detect it via the
+      // cross-realm brand tag — JSON.stringify still throws on its elements.
+      const vm = await import('node:vm');
+      const foreign = vm.runInNewContext('new BigInt64Array([1n])');
+
+      const ctx = new RequestContext();
+      ctx.set('foreignBigIntArray', foreign);
+      ctx.set('serializable', 'value');
+
+      const json = ctx.toJSON();
+
+      expect(json).toEqual({ serializable: 'value' });
+      expect(json).not.toHaveProperty('foreignBigIntArray');
+    });
+
+    it('should skip typed arrays whose custom enumerable getter throws', () => {
+      // The element fast path must not hide non-index properties from the
+      // probe: a throwing getter fails a real JSON.stringify, so it must
+      // fail the probe too.
+      const typed = new Uint8Array([1]);
+      Object.defineProperty(typed, 'boom', {
+        enumerable: true,
+        get() {
+          throw new Error('getter invoked');
+        },
+      });
+
+      const ctx = new RequestContext();
+      ctx.set('throwingTyped', typed);
+      ctx.set('serializable', 'value');
+
+      const json = ctx.toJSON();
+
+      expect(json).toEqual({ serializable: 'value' });
+      expect(json).not.toHaveProperty('throwingTyped');
+    });
+
+    it('should skip typed arrays whose custom property leads back into a cycle', () => {
+      const typed = new Uint8Array([1]);
+      const holder: Record<string, unknown> = { typed };
+      Object.defineProperty(typed, 'back', { enumerable: true, value: holder });
+
+      const ctx = new RequestContext();
+      ctx.set('cyclicTyped', typed);
+      ctx.set('serializable', 'value');
+
+      const json = ctx.toJSON();
+
+      expect(json).toEqual({ serializable: 'value' });
+      expect(json).not.toHaveProperty('cyclicTyped');
+    });
   });
 
   describe('serializeForSpan', () => {

--- a/packages/core/src/request-context/index.test.ts
+++ b/packages/core/src/request-context/index.test.ts
@@ -391,6 +391,51 @@ describe('RequestContext', () => {
       expect(json).not.toHaveProperty('cyclicTyped');
     });
 
+    it('should keep plain DataViews, matching JSON.stringify', () => {
+      // A DataView has no intrinsic elements; JSON.stringify renders it '{}'.
+      const ctx = new RequestContext();
+      ctx.set('dataView', new DataView(new ArrayBuffer(8)));
+
+      const json = ctx.toJSON();
+
+      expect(json).toHaveProperty('dataView');
+    });
+
+    it('should skip DataViews whose own index-named property leads back into a cycle', () => {
+      // Unlike a typed array, an index-named own property on a DataView is
+      // ordinary data that a real serialization walks — the probe must not
+      // treat it as a skippable element.
+      const dataView = new DataView(new ArrayBuffer(8));
+      const holder: Record<string, unknown> = { dataView };
+      (dataView as unknown as Record<number, unknown>)[0] = holder;
+
+      const ctx = new RequestContext();
+      ctx.set('cyclicDataView', dataView);
+      ctx.set('serializable', 'value');
+
+      const json = ctx.toJSON();
+
+      expect(json).toEqual({ serializable: 'value' });
+      expect(json).not.toHaveProperty('cyclicDataView');
+    });
+
+    it('should budget typed-array elements by intrinsic length even when an own length property lies', () => {
+      const big = new Float64Array(8 * 1024 * 1024);
+      Object.defineProperty(big, 'length', { value: 0 });
+
+      const ctx = new RequestContext();
+      ctx.set('lyingLength', big);
+      ctx.set('serializable', 'value');
+
+      const start = Date.now();
+      const json = ctx.toJSON();
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(2000);
+      expect(json).toEqual({ serializable: 'value' });
+      expect(json).not.toHaveProperty('lyingLength');
+    });
+
     it('should skip typed arrays whose own enumerable __proto__ property leads back into a cycle', () => {
       // An own enumerable `__proto__` data property is serialized by
       // JSON.stringify; a plain-object surrogate would swallow it through

--- a/packages/core/src/request-context/index.test.ts
+++ b/packages/core/src/request-context/index.test.ts
@@ -309,6 +309,34 @@ describe('RequestContext', () => {
       expect(json).not.toHaveProperty('bigIntArray');
     });
 
+    it('should skip BigInt-element typed arrays whose brand tag is spoofed', () => {
+      // An own Symbol.toStringTag shadows the built-in typed-array tag, so
+      // detection must not rely on it — the elements are still BigInt and a
+      // real JSON.stringify still throws.
+      const spoofed = new BigInt64Array([1n]);
+      Object.defineProperty(spoofed, Symbol.toStringTag, { value: 'Uint8Array' });
+
+      const ctx = new RequestContext();
+      ctx.set('spoofedBigIntArray', spoofed);
+      ctx.set('serializable', 'value');
+
+      const json = ctx.toJSON();
+
+      expect(json).toEqual({ serializable: 'value' });
+      expect(json).not.toHaveProperty('spoofedBigIntArray');
+    });
+
+    it('should keep empty BigInt-element typed arrays, matching JSON.stringify', () => {
+      // No elements to throw on: JSON.stringify(new BigInt64Array(0)) is '{}',
+      // so the unbudgeted probe kept it and the budgeted probe must too.
+      const ctx = new RequestContext();
+      ctx.set('emptyBigIntArray', new BigInt64Array(0));
+
+      const json = ctx.toJSON();
+
+      expect(json).toHaveProperty('emptyBigIntArray');
+    });
+
     it('should skip BigInt-element typed arrays created in another realm', async () => {
       // A foreign-realm BigInt64Array passes ArrayBuffer.isView but fails
       // `instanceof BigInt64Array`, so the fast path must detect it via the


### PR DESCRIPTION

## Description

`RequestContext.isSerializable()` ran a bare `JSON.stringify(value)` as a throw/no-throw probe. `JSON.stringify` expands shared (non-circular) references once per path, so an acyclic value graph with layered two-way sharing costs `2^depth`: ~30 heap objects expand to a billion node visits, blocking the event loop for 60–100 s before the `RangeError` (past V8's string-length cap) lands in the catch and the key is silently filtered — the same verdict, minutes later, with no error surfaced. Full mechanism, production evidence, and measurements in the linked issue. The cross-context cycle guard from #16686 doesn't cover this: a DAG is not a cycle.

This PR budgets the probe at 1,000,000 visited node paths using a `JSON.stringify` replacer:

- **Counting visits (not unique objects) is deliberate** — it models exactly the work any real downstream serialization of the value would do. A value that fails the budget would be equally pathological to persist, so "over budget ⇒ not serializable" is the honest verdict, delivered in milliseconds instead of minutes.
- **Typed arrays are charged arithmetically** (`budget -= view.length`) and skipped by the replacer, so the probe doesn't materialize every element as a JS number. `BigInt64Array`/`BigUint64Array` fall through to the engine so it still throws `TypeError` on their BigInt elements, matching the unbudgeted probe's verdict.
- **All existing filtering semantics are preserved**: functions, symbols, in-value circular references (engine `TypeError`), cross-context cycles (`CyclicRequestContextToJSONError` re-throw contract from #16686, untouched), and throwing `toJSON`/getter values behave exactly as before. The full existing request-context suite passes unchanged — including the four timing-based cycle tests.

Behavior change, stated honestly: values whose serialization visits more than 1M node paths (or typed arrays with more than 1M elements) were previously *kept* if they managed to stringify under V8's caps (paying seconds of blocking time per probe, per step) and are now **filtered**. Values under the budget are unaffected. The budget lives in one documented constant (`SERIALIZATION_PROBE_BUDGET`); happy to tune the number or wire an override if the team wants one. There is also a small constant-factor cost on legitimate values (the replacer makes stringify ~2–3× slower per probe) — for typical contexts this is micro/milliseconds, and it buys the bound.

New tests: the 2^30 DAG is filtered in ~40 ms with sibling keys kept (was ~66 s); a 2^10 DAG under the budget is kept; an 8M-element `Float64Array` is filtered without materializing elements while small typed arrays and Buffers are kept; `BigInt64Array` still filtered. With the bound in place the request-context suite drops from 66 s to ~150 ms wall clock (the pre-existing cycle tests were already exercising multi-second stringify work).

Changeset covers `@internal/core` (implementation) and `@mastra/core` (user-visible surface).

## Related issue(s)

Fixes #20366. Related: #16685/#16686 (cycles — different mechanism, guard preserved), #20308 (probe cost noted among span-path findings).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable) — n/a, internal serialization path
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Some object graphs can make a JSON safety check run for too long. This PR limits the work to 1,000,000 visited paths and safely handles typed arrays without expanding all their elements.

## Summary
- Adds a bounded `JSON.stringify` probe to `RequestContext.isSerializable()`.
- Filters values when the probe exceeds its 1,000,000-path budget.
- Preserves existing behavior for functions, symbols, circular references, cross-context cycles, getters, throwing `toJSON()` methods, and nested `RequestContext.toJSON()` errors.
- Charges non-BigInt typed arrays by intrinsic length without materializing elements.
- Preserves enumerable custom properties and their getter and cycle behavior during typed-array probing.
- Rejects oversized typed arrays and Buffers without blocking the event loop.
- Detects BigInt typed arrays by inspecting element `0`, including cross-realm views, and rejects spoofed `Symbol.toStringTag` values.
- Preserves empty BigInt typed arrays and ordinary `DataView` serialization behavior.
- Uses `Object.create(null)` for typed-array surrogates so enumerable `__proto__` properties remain data properties.
- Documents budget amplification from nested `toJSON()` calls and Buffer materialization before the replacer.
- Expands tests for shared graphs, typed arrays, Buffers, BigInt typed arrays, DataViews, custom properties, getters, cycles, and `__proto__`.
- Adds patch changesets for `@internal/core` and `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->