### PR TITLE
fix(factory): coalesce concurrent sandbox provisions per binding

### DIFF
--- a/.changeset/khaki-facts-sniff.md
+++ b/.changeset/khaki-facts-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed a boot-time provisioning storm where several concurrent requests for the same cold session (for example multiple open browser tabs polling right after a server restart) each provisioned their own sandbox. Concurrent sandbox opens for the same session now share one in-flight provision, so only a single sandbox is created per session.

--- a/mastracode/factory/src/sandbox/fleet.test.ts
+++ b/mastracode/factory/src/sandbox/fleet.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { WorkspaceSandbox } from '@mastra/core/workspace';
 import { describe, expect, it, vi } from 'vitest';
 import { resolveContainedLocalWorkdir, SandboxFleet } from './fleet.js';
-import type { MaterializationSandbox } from './fleet.js';
+import type { MaterializationSandbox, SandboxBindingStore } from './fleet.js';
 
 /** Minimal cloneable template sandbox standing in for Railway/Local instances. */
 function templateSandbox(
@@ -239,5 +239,134 @@ describe('sandbox option forwarding', () => {
     expect(executeCommand).toHaveBeenNthCalledWith(3, 'gh repo view', undefined, {
       env: { GH_TOKEN: 'fresh-token' },
     });
+  });
+});
+
+describe('provision coalescing', () => {
+  function bindingStore(checkpointName?: string): SandboxBindingStore & { sandboxId: string | null } {
+    const store = {
+      sandboxId: null as string | null,
+      ...(checkpointName ? { checkpointName } : {}),
+      setSandboxId: vi.fn(async (id: string | null) => {
+        store.sandboxId = id;
+      }),
+      clear: vi.fn(async () => {
+        store.sandboxId = null;
+      }),
+    };
+    return store;
+  }
+
+  /** Sandbox whose `start()` stays pending until released, to hold calls in flight. */
+  function slowSandbox(id: string) {
+    let release!: () => void;
+    let fail!: (error: Error) => void;
+    const gate = new Promise<void>((resolve, reject) => {
+      release = resolve;
+      fail = reject;
+    });
+    const sandbox: MaterializationSandbox = {
+      id,
+      start: vi.fn(() => gate),
+      getInfo: vi.fn(async () => ({ metadata: { sandboxId: id } })),
+      executeCommand: vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })),
+      stop: vi.fn(async () => {}),
+    };
+    return { sandbox, release, fail };
+  }
+
+  it('coalesces concurrent ensureSandbox calls for the same binding into one provision', async () => {
+    const { sandbox, release } = slowSandbox('sb-1');
+    const factory = vi.fn(() => sandbox);
+    const subject = fleet();
+    subject.setFactory(factory);
+    const store = bindingStore('mastracode-session-a');
+
+    const first = subject.ensureSandbox(store, { GH_TOKEN: 'token' });
+    const second = subject.ensureSandbox(store, { GH_TOKEN: 'token' });
+    release();
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toBe(sandbox);
+    expect(b).toBe(sandbox);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(sandbox.start).toHaveBeenCalledTimes(1);
+    expect(store.setSandboxId).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not block provisioning across different bindings', async () => {
+    const one = slowSandbox('sb-1');
+    const two = slowSandbox('sb-2');
+    const sandboxes = [one.sandbox, two.sandbox];
+    const factory = vi.fn(() => sandboxes.shift()!);
+    const subject = fleet();
+    subject.setFactory(factory);
+
+    const first = subject.ensureSandbox(bindingStore('mastracode-session-a'));
+    const second = subject.ensureSandbox(bindingStore('mastracode-session-b'));
+    one.release();
+    two.release();
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toBe(one.sandbox);
+    expect(b).toBe(two.sandbox);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not coalesce bindings without a stable key', async () => {
+    const one = slowSandbox('sb-1');
+    const two = slowSandbox('sb-2');
+    const sandboxes = [one.sandbox, two.sandbox];
+    const factory = vi.fn(() => sandboxes.shift()!);
+    const subject = fleet();
+    subject.setFactory(factory);
+
+    // No checkpointName and no stored sandbox id — two distinct bindings must
+    // each get their own sandbox instead of sharing one.
+    const first = subject.ensureSandbox(bindingStore());
+    const second = subject.ensureSandbox(bindingStore());
+    one.release();
+    two.release();
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toBe(one.sandbox);
+    expect(b).toBe(two.sandbox);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries fresh after a failed provision instead of caching the rejection', async () => {
+    const failed = slowSandbox('sb-fail');
+    const ok = slowSandbox('sb-ok');
+    const sandboxes = [failed.sandbox, ok.sandbox];
+    const factory = vi.fn(() => sandboxes.shift()!);
+    const subject = fleet();
+    subject.setFactory(factory);
+    const store = bindingStore('mastracode-session-a');
+
+    const first = subject.ensureSandbox(store);
+    failed.fail(new Error('boom'));
+    await expect(first).rejects.toThrow('boom');
+
+    const second = subject.ensureSandbox(store);
+    ok.release();
+    await expect(second).resolves.toBe(ok.sandbox);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('tears down a coalesced sandbox regardless of which caller holds the handle', async () => {
+    const { sandbox, release } = slowSandbox('sb-1');
+    const subject = fleet();
+    subject.setFactory(() => sandbox);
+    const store = bindingStore('mastracode-session-a');
+
+    const first = subject.ensureSandbox(store);
+    const second = subject.ensureSandbox(store);
+    release();
+    const [, shared] = await Promise.all([first, second]);
+
+    await subject.teardownSandbox(store, shared);
+    expect(sandbox.stop).toHaveBeenCalledTimes(1);
+    expect(store.clear).toHaveBeenCalledTimes(1);
+    expect(store.sandboxId).toBeNull();
   });
 });

--- a/mastracode/factory/src/sandbox/fleet.ts
+++ b/mastracode/factory/src/sandbox/fleet.ts
@@ -127,6 +127,21 @@ export interface SandboxBindingStore {
 }
 
 /**
+ * Stable identity for one binding's in-flight provision work, used to coalesce
+ * concurrent `ensureSandbox` calls. Prefer `checkpointName` — it is a pure
+ * function of the owning session and is set before the first provision, which
+ * is exactly when the herd forms (the stored `sandboxId` is still null then).
+ * Fall back to the stored provider id, and skip coalescing entirely for
+ * bindings with neither: keying those on a shared constant would wrongly
+ * funnel *different* bindings onto one sandbox.
+ */
+function coalesceKey(store: SandboxBindingStore): string | undefined {
+  if (store.checkpointName) return `checkpoint:${store.checkpointName}`;
+  if (store.sandboxId) return `sandbox:${store.sandboxId}`;
+  return undefined;
+}
+
+/**
  * Adapt a cloned `WorkspaceSandbox` to the minimal surface this module needs.
  * Lifecycle goes through the `_`-prefixed wrappers when present (they add
  * status tracking and concurrency safety on `MastraSandbox` subclasses),
@@ -217,6 +232,8 @@ export class SandboxFleet {
   readonly #config: SandboxFleetConfig | undefined;
   #factory: SandboxFactory | undefined;
   #liveCount = 0;
+  /** In-flight `ensureSandbox` work, keyed per binding so concurrent callers coalesce. */
+  readonly #inflight = new Map<string, Promise<MaterializationSandbox>>();
 
   constructor(config?: SandboxFleetConfig) {
     this.#config = config;
@@ -352,6 +369,13 @@ export class SandboxFleet {
   /**
    * Provision a new sandbox (persisting its provider id on first open) or
    * reattach to the stored one. Returns a started, live sandbox.
+   *
+   * Concurrent calls for the same binding coalesce onto one in-flight
+   * provision/reattach and share its sandbox handle — N simultaneous requests
+   * for one cold session (e.g. several browser tabs polling right after boot)
+   * must not each fire their own `POST /sandbox` against the provider.
+   * Failures are not cached: once the shared attempt settles, the next call
+   * starts fresh.
    */
   async ensureSandbox(store: SandboxBindingStore, onProgress?: ProgressFn): Promise<MaterializationSandbox>;
   async ensureSandbox(
@@ -373,6 +397,28 @@ export class SandboxFleet {
       typeof envOrProgress === 'function'
         ? ((progressOrOptions as EnsureSandboxOptions | undefined) ?? {})
         : maybeOptions;
+
+    const key = coalesceKey(store);
+    if (!key) return this.#ensureSandboxUncoalesced(store, env, onProgress, options);
+
+    const existing = this.#inflight.get(key);
+    if (existing) return existing;
+
+    const promise = this.#ensureSandboxUncoalesced(store, env, onProgress, options).finally(() => {
+      // Only clear when this is still the entry we own.
+      if (this.#inflight.get(key) === promise) this.#inflight.delete(key);
+    });
+    this.#inflight.set(key, promise);
+    return promise;
+  }
+
+  /** The single provision/reattach attempt behind {@link ensureSandbox}. */
+  async #ensureSandboxUncoalesced(
+    store: SandboxBindingStore,
+    env: Record<string, string> | undefined,
+    onProgress: ProgressFn | undefined,
+    options: EnsureSandboxOptions,
+  ): Promise<MaterializationSandbox> {
     const idleTimeoutMinutes = this.idleMinutes;
     const checkpointName = store.checkpointName;
 


### PR DESCRIPTION
On a fresh container boot, N concurrent requests for the same cold session (stored `sandbox_id = NULL` — e.g. several browser tabs polling right after a deploy) each ran the full provision path in `SandboxFleet.ensureSandbox`, firing N parallel `POST /sandbox` calls against the provider. In prod this showed up as 8 "Railway sandbox recovery create started" lines within 534 ms, followed by parallel template builds and Railway 429s that surfaced to users as proxy failures.

`ensureSandbox` now coalesces concurrent calls for the same binding onto one shared in-flight promise, so all callers share a single provision/reattach and get the same sandbox handle.

```ts
// before: each call provisions independently
const [a, b] = await Promise.all([fleet.ensureSandbox(binding), fleet.ensureSandbox(binding)]);
// -> two POST /sandbox calls, two VMs

// after: concurrent calls for the same binding share one provision
const [a, b] = await Promise.all([fleet.ensureSandbox(binding), fleet.ensureSandbox(binding)]);
// -> one POST /sandbox call, a === b
```

The coalescing key prefers the binding's `checkpointName` (a pure function of the session, present before the first provision — exactly when the herd forms), falls back to the stored sandbox id, and skips coalescing entirely for bindings with neither so distinct keyless bindings never wrongly share a sandbox. Failed provisions are not cached — the in-flight entry clears on settle so the next call retries fresh. Different sessions still provision in parallel, and the scope is per-fleet-instance (per process), which is where the herd forms; cross-replica coordination is a separate workspace-proxy concern.

Tested with new unit tests in `fleet.test.ts` covering same-binding coalescing, cross-binding independence, keyless bindings, failure retry, and teardown of a shared handle. `pnpm --filter ./mastracode/factory test`, `check`, and `lint` pass (the 4 `routes/fs.test.ts` failures are pre-existing on a clean tree).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If multiple requests all ask for the same sandbox at the same time, this change makes them share one “in-progress setup” instead of creating several identical sandboxes. If setup fails, the failure isn’t shared forever—later calls will try again.  

## Changes

- Updated `SandboxFleet.ensureSandbox` to coalesce concurrent provisioning for the same binding onto a shared in-flight promise (scoped per fleet instance).
- Coalescing key logic:
  - Uses the binding’s `checkpointName` first
  - Falls back to the stored sandbox ID
  - Skips coalescing when neither is available
- Added per-binding coalescing storage (`#inflight` map) and ensured settled/failed provisions don’t stay cached, so retries work.
- Kept different bindings provisioning independently (no cross-binding coalescing).
- Improved shared-handle teardown so the coalesced sandbox is cleared/stopped exactly once across concurrent callers.

## Tests

- Added unit tests covering:
  - Same-binding concurrent coalescing
  - Cross-binding independence
  - Keyless bindings (no coalescing)
  - Retry after provisioning failure
  - Shared-handle teardown behavior

- Added/updated a patch changeset for `@mastra/factory`.

## Validation

- FACTORY tests, checks, and lint pass.
- Four `routes/fs.test.ts` failures remain pre-existing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->