### PR TITLE
Add mastra api learning commands for Trace Intelligence

### DIFF
--- a/.changeset/loud-chicken-jam.md
+++ b/.changeset/loud-chicken-jam.md
@@ -1,0 +1,18 @@
+---
+'mastra': minor
+---
+
+Added `mastra api learning` commands for querying Trace Intelligence (private beta) from the CLI. You can now list entities with theme output, browse analysis snapshots, read cross-signal theme flows and per-trace paths, and drill into individual themes, examples, history, and noise buckets — without writing curl requests against the platform API.
+
+```bash
+# Discover agents with Trace Intelligence output
+mastra api learning entities '{"entityType":"agent"}'
+
+# List analysis snapshots for an agent
+mastra api learning snapshots my-agent '{"entityType":"agent","signalNames":"goal,outcome,behavior,sentiment"}'
+
+# List themes for one trace signal in one snapshot
+mastra api learning theme list my-agent '{"entityType":"agent","signalName":"goal","snapshotId":"<snapshotId>"}'
+```
+
+The commands target the hosted Trace Intelligence service and resolve credentials the same way as other observability commands.

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -1026,6 +1026,8 @@ For observability commands (`trace`, `log`, `score`, and `metric`), the CLI targ
 1. Project metadata from `.mastra-project.json` for the project ID.
 1. Your Mastra CLI login token as an auth fallback.
 
+Learning commands also send `X-Mastra-Organization-Id`, resolved from an explicit `--header`, `MASTRA_ORGANIZATION_ID` in your environment, or `.mastra-project.json`, in that order.
+
 Use `--url` and `--header` when you need to override the default hosted observability target or credentials.
 
 ### Flags

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -1019,7 +1019,7 @@ For runtime commands, the command resolves the target server in this order:
 
 Automatic platform auth is only used when the CLI resolves a Mastra platform target from `.mastra-project.json`. Localhost targets and explicit `--url` targets don't receive automatic credentials. Headers passed with `--header` are sent to any target, including localhost.
 
-For observability commands (`trace`, `log`, `score`, and `metric`), the CLI targets `https://observability.mastra.ai` by default instead of a project deployment URL. It resolves credentials in this order:
+For observability commands (`trace`, `log`, `score`, and `metric`), the CLI targets `https://observability.mastra.ai` by default instead of a project deployment URL. Trace Intelligence commands (`learning`) work the same way but target `https://output.signals.mastra.ai`. Both resolve credentials in this order:
 
 1. Explicit `Authorization` and `X-Mastra-Project-Id` headers passed with `--header`.
 1. `MASTRA_PLATFORM_ACCESS_TOKEN` and `MASTRA_PROJECT_ID` from your environment.
@@ -1552,6 +1552,86 @@ Lists results for an experiment. Pass optional JSON input for route-supported fi
 
 ```bash
 mastra api experiment results <datasetId> <experimentId> [input]
+```
+
+#### `mastra api learning entities`
+
+Lists entities (agents) with Trace Intelligence output, including which trace signals are available per entity. Requires enrollment in the Trace Intelligence private beta.
+
+```bash
+mastra api learning entities '{"entityType":"agent"}'
+```
+
+#### `mastra api learning snapshots`
+
+Lists analysis snapshots for an entity and an ordered, comma-separated list of trace signals. Later commands need a `snapshotId` from this list.
+
+```bash
+mastra api learning snapshots <entityId> '{"entityType":"agent","signalNames":"goal,outcome,behavior,sentiment","limit":10}'
+```
+
+#### `mastra api learning flow`
+
+Gets the cross-signal theme flow for one snapshot: stages and links for a Sankey-style view where counts are distinct traces.
+
+```bash
+mastra api learning flow <entityId> '{"entityType":"agent","signalNames":"goal,outcome","snapshotId":"<snapshotId>"}'
+```
+
+#### `mastra api learning paths`
+
+Gets per-trace theme assignments across the ordered trace signals in one snapshot. Paginate with `limit` and `offset`.
+
+```bash
+mastra api learning paths <entityId> '{"entityType":"agent","signalNames":"goal,outcome","snapshotId":"<snapshotId>","limit":100}'
+```
+
+#### `mastra api learning theme list`
+
+Lists themes for one trace signal in one snapshot.
+
+```bash
+mastra api learning theme list <entityId> '{"entityType":"agent","signalName":"goal","snapshotId":"<snapshotId>"}'
+```
+
+#### `mastra api learning theme get`
+
+Gets one theme in one snapshot by its numeric theme ID.
+
+```bash
+mastra api learning theme get <entityId> <themeId> '{"entityType":"agent","signalName":"goal","snapshotId":"<snapshotId>"}'
+```
+
+#### `mastra api learning theme examples`
+
+Lists trace examples for one theme in one snapshot. Paginate with `limit` and `offset`.
+
+```bash
+mastra api learning theme examples <entityId> <themeId> '{"entityType":"agent","signalName":"goal","snapshotId":"<snapshotId>","limit":10}'
+```
+
+#### `mastra api learning theme history`
+
+Gets the lifecycle history for one durable theme across snapshots, including split and merge relationships. Takes no `snapshotId`.
+
+```bash
+mastra api learning theme history <entityId> <themeId> '{"entityType":"agent","signalName":"goal"}'
+```
+
+#### `mastra api learning noise get`
+
+Gets the unclustered (noise) bucket for one trace signal in one snapshot.
+
+```bash
+mastra api learning noise get <entityId> '{"entityType":"agent","signalName":"goal","snapshotId":"<snapshotId>"}'
+```
+
+#### `mastra api learning noise examples`
+
+Lists trace examples for the noise bucket in one snapshot. Paginate with `limit` and `offset`.
+
+```bash
+mastra api learning noise examples <entityId> '{"entityType":"agent","signalName":"goal","snapshotId":"<snapshotId>","limit":10}'
 ```
 
 ## Common flags

--- a/packages/cli/src/commands/api/api.test.ts
+++ b/packages/cli/src/commands/api/api.test.ts
@@ -595,12 +595,12 @@ describe('api command executor', () => {
     );
 
     await executeDescriptor(API_COMMANDS.learningEntities, [], '{"entityType":"agent"}', {
-      url: 'https://learning.example.com',
+      url: 'https://example.com',
       header: [],
       pretty: false,
     });
 
-    expect(fetchMock).toHaveBeenCalledWith('https://learning.example.com/api/learning/entities?entityType=agent', {
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/api/learning/entities?entityType=agent', {
       method: 'GET',
       headers: {},
       signal: expect.any(AbortSignal),
@@ -619,11 +619,11 @@ describe('api command executor', () => {
       API_COMMANDS.learningThemeGet,
       ['my-agent', '42'],
       '{"entityType":"agent","signalName":"goal","snapshotId":"snap"}',
-      { url: 'https://learning.example.com', header: [], pretty: false },
+      { url: 'https://example.com', header: [], pretty: false },
     );
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://learning.example.com/api/learning/entities/my-agent/themes/42?entityType=agent&signalName=goal&snapshotId=snap',
+      'https://example.com/api/learning/entities/my-agent/themes/42?entityType=agent&signalName=goal&snapshotId=snap',
       { method: 'GET', headers: {}, signal: expect.any(AbortSignal) },
     );
     expect(JSON.parse(stdout)).toEqual({
@@ -642,7 +642,7 @@ describe('api command executor', () => {
       'mastra',
       'api',
       '--url',
-      'https://learning.example.com',
+      'https://example.com',
       'learning',
       'snapshots',
       '--schema',

--- a/packages/cli/src/commands/api/api.test.ts
+++ b/packages/cli/src/commands/api/api.test.ts
@@ -587,6 +587,83 @@ describe('api command executor', () => {
     });
   });
 
+  it('queries learning entities and wraps the entities list', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        entities: [{ entityId: 'my-agent', entityType: 'agent', availableSignals: ['goal', 'outcome'] }],
+      }),
+    );
+
+    await executeDescriptor(API_COMMANDS.learningEntities, [], '{"entityType":"agent"}', {
+      url: 'https://learning.example.com',
+      header: [],
+      pretty: false,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://learning.example.com/api/learning/entities?entityType=agent', {
+      method: 'GET',
+      headers: {},
+      signal: expect.any(AbortSignal),
+    });
+    expect(JSON.parse(stdout)).toEqual({
+      data: [{ entityId: 'my-agent', entityType: 'agent', availableSignals: ['goal', 'outcome'] }],
+      page: { total: 1, page: 0, perPage: 1, hasMore: false },
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('sends learning theme requests with entity and theme positionals as path params', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ snapshot: { snapshotId: 'snap' }, theme: { themeId: '42' } }));
+
+    await executeDescriptor(
+      API_COMMANDS.learningThemeGet,
+      ['my-agent', '42'],
+      '{"entityType":"agent","signalName":"goal","snapshotId":"snap"}',
+      { url: 'https://learning.example.com', header: [], pretty: false },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://learning.example.com/api/learning/entities/my-agent/themes/42?entityType=agent&signalName=goal&snapshotId=snap',
+      { method: 'GET', headers: {}, signal: expect.any(AbortSignal) },
+    );
+    expect(JSON.parse(stdout)).toEqual({
+      data: { snapshot: { snapshotId: 'snap' }, theme: { themeId: '42' } },
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('returns local schemas for learning commands without fetching a manifest', async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerApiCommand(program);
+
+    await program.parseAsync([
+      'node',
+      'mastra',
+      'api',
+      '--url',
+      'https://learning.example.com',
+      'learning',
+      'snapshots',
+      '--schema',
+    ]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(JSON.parse(stdout)).toMatchObject({
+      command: 'mastra api learning snapshots <entityId> <input>',
+      method: 'GET',
+      path: '/learning/entities/:entityId/theme-snapshots',
+      positionals: [{ name: 'entityId', required: true }],
+      input: {
+        required: true,
+        source: 'query',
+        schema: { type: 'object', required: ['entityType', 'signalNames'] },
+      },
+    });
+    expect(stderr).toBe('');
+    expect(process.exitCode).toBeUndefined();
+  });
+
   it('allows schema discovery commands without identity positionals', async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({

--- a/packages/cli/src/commands/api/descriptors.test.ts
+++ b/packages/cli/src/commands/api/descriptors.test.ts
@@ -1,8 +1,7 @@
 import { Command } from 'commander';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { API_ROUTE_METADATA } from './route-metadata.generated';
 import type { ApiCommandDescriptor } from './types';
-import { API_COMMANDS, registerApiCommand } from './index';
+import { API_COMMANDS, CLI_ROUTE_METADATA, registerApiCommand } from './index';
 
 interface CommandLeaf {
   path: string;
@@ -39,8 +38,8 @@ function commandKey(name: string): string {
   return name.replace(/ ([a-z])/g, (_, letter: string) => letter.toUpperCase());
 }
 
-function routeKey(descriptor: ApiCommandDescriptor): keyof typeof API_ROUTE_METADATA {
-  return `${descriptor.method} ${descriptor.path}` as keyof typeof API_ROUTE_METADATA;
+function routeKey(descriptor: ApiCommandDescriptor): keyof typeof CLI_ROUTE_METADATA {
+  return `${descriptor.method} ${descriptor.path}` as keyof typeof CLI_ROUTE_METADATA;
 }
 
 function pathParams(path: string): string[] {
@@ -80,7 +79,7 @@ describe('api command descriptors', () => {
     expect(new Set(names).size).toBe(names.length);
 
     for (const descriptor of Object.values(API_COMMANDS)) {
-      const metadata = API_ROUTE_METADATA[routeKey(descriptor)];
+      const metadata = CLI_ROUTE_METADATA[routeKey(descriptor)];
       expect(metadata, descriptor.key).toBeDefined();
       expect(descriptor.method, descriptor.key).toBe(metadata.method);
       expect(descriptor.path, descriptor.key).toBe(metadata.path);

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -3,6 +3,7 @@ import { getAnalytics } from '../../analytics/index.js';
 import { requestApi } from './client.js';
 import { ApiCliError, errorEnvelope, toApiCliError } from './errors.js';
 import { parseInput, resolvePathParams, stripPathParamsFromInput } from './input.js';
+import { LEARNING_ROUTE_METADATA } from './learning-route-metadata.js';
 import { normalizeData } from './normalizers.js';
 import { normalizeSuccess, writeJson } from './output.js';
 import { normalizeResponse } from './response-normalizer.js';
@@ -13,6 +14,12 @@ import type { ApiGlobalOptions } from './target.js';
 import type { ApiCommandActionOptions, ApiCommandDescriptor, HttpMethod } from './types.js';
 
 const API_ANALYTICS_SHUTDOWN_TIMEOUT_MS = 1000;
+
+/**
+ * All route metadata addressable by CLI commands: generated `@mastra/server`
+ * routes plus hand-authored Mastra platform learning routes.
+ */
+export const CLI_ROUTE_METADATA = { ...API_ROUTE_METADATA, ...LEARNING_ROUTE_METADATA } as const;
 
 export const API_COMMANDS = {} as Record<string, ApiCommandDescriptor>;
 
@@ -405,6 +412,119 @@ export function registerApiCommand(program: CommanderCommand): void {
     input: 'optional',
     list: true,
   });
+
+  const learning = api
+    .command('learning')
+    .description('Query Trace Intelligence themes across agent traces (Mastra platform)');
+  addAction(learning, 'entities', 'GET /learning/entities', {
+    description: 'List entities with Trace Intelligence output',
+    input: 'required',
+    list: true,
+    examples: [
+      {
+        description: 'List agents with available trace signal themes',
+        command: `mastra api learning entities '{"entityType":"agent"}'`,
+      },
+    ],
+  });
+  addAction(learning, 'snapshots', 'GET /learning/entities/:entityId/theme-snapshots', {
+    description: 'List analysis snapshots for an entity and ordered trace signals',
+    input: 'required',
+    list: true,
+    examples: [
+      {
+        description: 'List snapshots for an agent across all four trace signals',
+        command: `mastra api learning snapshots my-agent '{"entityType":"agent","signalNames":"goal,outcome,behavior,sentiment"}'`,
+      },
+    ],
+  });
+  addAction(learning, 'flow', 'GET /learning/entities/:entityId/theme-flow', {
+    description: 'Get the cross-signal theme flow for one snapshot',
+    input: 'required',
+    examples: [
+      {
+        description: 'Get the goal-to-outcome flow for a snapshot',
+        command: `mastra api learning flow my-agent '{"entityType":"agent","signalNames":"goal,outcome","snapshotId":"snapshot_abc"}'`,
+      },
+    ],
+  });
+  addAction(learning, 'paths', 'GET /learning/entities/:entityId/theme-paths', {
+    description: 'Get per-trace theme assignments for one snapshot',
+    input: 'required',
+    examples: [
+      {
+        description: 'Map traces to themes across goal and outcome',
+        command: `mastra api learning paths my-agent '{"entityType":"agent","signalNames":"goal,outcome","snapshotId":"snapshot_abc","limit":100}'`,
+      },
+    ],
+  });
+
+  const learningTheme = learning.command('theme').description('List and inspect trace signal themes');
+  addAction(learningTheme, 'list', 'GET /learning/entities/:entityId/themes', {
+    description: 'List themes for one trace signal in one snapshot',
+    input: 'required',
+    list: true,
+    examples: [
+      {
+        description: 'List goal themes in a snapshot',
+        command: `mastra api learning theme list my-agent '{"entityType":"agent","signalName":"goal","snapshotId":"snapshot_abc"}'`,
+      },
+    ],
+  });
+  addAction(learningTheme, 'get', 'GET /learning/entities/:entityId/themes/:themeId', {
+    description: 'Get one theme in one snapshot',
+    input: 'required',
+    examples: [
+      {
+        description: 'Get one goal theme in a snapshot',
+        command: `mastra api learning theme get my-agent 42 '{"entityType":"agent","signalName":"goal","snapshotId":"snapshot_abc"}'`,
+      },
+    ],
+  });
+  addAction(learningTheme, 'examples', 'GET /learning/entities/:entityId/themes/:themeId/examples', {
+    description: 'List trace examples for one theme in one snapshot',
+    input: 'required',
+    list: true,
+    examples: [
+      {
+        description: 'List trace examples for a theme',
+        command: `mastra api learning theme examples my-agent 42 '{"entityType":"agent","signalName":"goal","snapshotId":"snapshot_abc","limit":10}'`,
+      },
+    ],
+  });
+  addAction(learningTheme, 'history', 'GET /learning/entities/:entityId/themes/:themeId/history', {
+    description: 'Get lifecycle history for one durable theme',
+    input: 'required',
+    examples: [
+      {
+        description: 'Get history for a theme across snapshots',
+        command: `mastra api learning theme history my-agent 42 '{"entityType":"agent","signalName":"goal"}'`,
+      },
+    ],
+  });
+
+  const learningNoise = learning.command('noise').description('Inspect unclustered (noise) traces');
+  addAction(learningNoise, 'get', 'GET /learning/entities/:entityId/noise', {
+    description: 'Get the noise bucket for one trace signal in one snapshot',
+    input: 'required',
+    examples: [
+      {
+        description: 'Get the goal noise bucket in a snapshot',
+        command: `mastra api learning noise get my-agent '{"entityType":"agent","signalName":"goal","snapshotId":"snapshot_abc"}'`,
+      },
+    ],
+  });
+  addAction(learningNoise, 'examples', 'GET /learning/entities/:entityId/noise/examples', {
+    description: 'List trace examples for the noise bucket in one snapshot',
+    input: 'required',
+    list: true,
+    examples: [
+      {
+        description: 'List noise trace examples',
+        command: `mastra api learning noise examples my-agent '{"entityType":"agent","signalName":"goal","snapshotId":"snapshot_abc","limit":10}'`,
+      },
+    ],
+  });
 }
 
 /**
@@ -420,7 +540,7 @@ export function registerApiCommand(program: CommanderCommand): void {
 function addAction(
   parent: CommanderCommand,
   name: string,
-  routeKey: keyof typeof API_ROUTE_METADATA,
+  routeKey: keyof typeof CLI_ROUTE_METADATA,
   options: ApiCommandActionOptions,
 ): void {
   const descriptor = buildDescriptor(parent, name, routeKey, options);
@@ -511,12 +631,12 @@ function looksLikeJsonObject(value: string): boolean {
 function buildDescriptor(
   parent: CommanderCommand,
   name: string,
-  routeKey: keyof typeof API_ROUTE_METADATA,
+  routeKey: keyof typeof CLI_ROUTE_METADATA,
   options: ApiCommandActionOptions,
 ): ApiCommandDescriptor {
-  const route = API_ROUTE_METADATA[routeKey];
+  const route = CLI_ROUTE_METADATA[routeKey];
   const verboseRoute = options.verboseRouteKey
-    ? API_ROUTE_METADATA[options.verboseRouteKey as keyof typeof API_ROUTE_METADATA]
+    ? CLI_ROUTE_METADATA[options.verboseRouteKey as keyof typeof CLI_ROUTE_METADATA]
     : undefined;
   const commandName = [...commandPath(parent), parseCommandName(name)].join(' ');
   const pathParamsFromInput = new Set(options.pathParamsFromInput ?? []);

--- a/packages/cli/src/commands/api/learning-route-metadata.ts
+++ b/packages/cli/src/commands/api/learning-route-metadata.ts
@@ -1,0 +1,291 @@
+/**
+ * Hand-authored route metadata for the Trace Intelligence (Agent Learning) read API.
+ *
+ * These routes are served by the Mastra platform learning endpoint
+ * (`https://output.signals.mastra.ai/api/learning/*`), not by `@mastra/server`,
+ * so they are not part of the generated server route metadata. The shapes here
+ * mirror the platform's learning HTTP schemas; update them together.
+ */
+
+const TRACE_SIGNAL_NAMES = ['goal', 'sentiment', 'behavior', 'outcome'] as const;
+
+const entityTypeSchema = {
+  type: 'string',
+  description: 'Entity type to query, e.g. "agent"',
+} as const;
+
+const signalNamesSchema = {
+  type: 'string',
+  description: `Ordered, comma-separated trace signal names (1-4 unique values of: ${TRACE_SIGNAL_NAMES.join(', ')}), e.g. "goal,outcome"`,
+} as const;
+
+const signalNameSchema = {
+  type: 'string',
+  enum: [...TRACE_SIGNAL_NAMES],
+  description: 'One trace signal name',
+} as const;
+
+const snapshotIdSchema = {
+  type: 'string',
+  description:
+    'Opaque snapshot ID from `learning snapshots`. Send it back unchanged with the same entity and signal selection.',
+} as const;
+
+const entityIdParamSchema = {
+  type: 'object',
+  properties: { entityId: { type: 'string', description: 'Entity ID from `learning entities`' } },
+  required: ['entityId'],
+} as const;
+
+const themeParamSchema = {
+  type: 'object',
+  properties: {
+    entityId: { type: 'string', description: 'Entity ID from `learning entities`' },
+    themeId: { type: 'string', description: 'Numeric durable theme ID' },
+  },
+  required: ['entityId', 'themeId'],
+} as const;
+
+export const LEARNING_ROUTE_METADATA = {
+  'GET /learning/entities': {
+    method: 'GET',
+    path: '/learning/entities',
+    pathParams: [],
+    queryParams: ['entityType', 'limit'],
+    bodyParams: [],
+    hasQuery: true,
+    hasBody: false,
+    responseShape: { kind: 'object-property', listProperty: 'entities' },
+  },
+  'GET /learning/entities/:entityId/theme-snapshots': {
+    method: 'GET',
+    path: '/learning/entities/:entityId/theme-snapshots',
+    pathParams: ['entityId'],
+    queryParams: ['cursor', 'entityType', 'from', 'limit', 'signalNames', 'to'],
+    bodyParams: [],
+    hasQuery: true,
+    hasBody: false,
+    responseShape: { kind: 'object-property', listProperty: 'snapshots' },
+  },
+  'GET /learning/entities/:entityId/theme-flow': {
+    method: 'GET',
+    path: '/learning/entities/:entityId/theme-flow',
+    pathParams: ['entityId'],
+    queryParams: ['entityType', 'signalNames', 'snapshotId', 'themeLimitPerStage'],
+    bodyParams: [],
+    hasQuery: true,
+    hasBody: false,
+    responseShape: { kind: 'single' },
+  },
+  'GET /learning/entities/:entityId/theme-paths': {
+    method: 'GET',
+    path: '/learning/entities/:entityId/theme-paths',
+    pathParams: ['entityId'],
+    queryParams: ['entityType', 'limit', 'offset', 'signalNames', 'snapshotId'],
+    bodyParams: [],
+    hasQuery: true,
+    hasBody: false,
+    responseShape: { kind: 'single' },
+  },
+  'GET /learning/entities/:entityId/themes': {
+    method: 'GET',
+    path: '/learning/entities/:entityId/themes',
+    pathParams: ['entityId'],
+    queryParams: ['entityType', 'signalName', 'snapshotId'],
+    bodyParams: [],
+    hasQuery: true,
+    hasBody: false,
+    responseShape: { kind: 'object-property', listProperty: 'themes' },
+  },
+  'GET /learning/entities/:entityId/themes/:themeId': {
+    method: 'GET',
+    path: '/learning/entities/:entityId/themes/:themeId',
+    pathParams: ['entityId', 'themeId'],
+    queryParams: ['entityType', 'signalName', 'snapshotId'],
+    bodyParams: [],
+    hasQuery: true,
+    hasBody: false,
+    responseShape: { kind: 'single' },
+  },
+  'GET /learning/entities/:entityId/themes/:themeId/examples': {
+    method: 'GET',
+    path: '/learning/entities/:entityId/themes/:themeId/examples',
+    pathParams: ['entityId', 'themeId'],
+    queryParams: ['entityType', 'limit', 'offset', 'signalName', 'snapshotId'],
+    bodyParams: [],
+    hasQuery: true,
+    hasBody: false,
+    responseShape: { kind: 'object-property', listProperty: 'examples' },
+  },
+  'GET /learning/entities/:entityId/themes/:themeId/history': {
+    method: 'GET',
+    path: '/learning/entities/:entityId/themes/:themeId/history',
+    pathParams: ['entityId', 'themeId'],
+    queryParams: ['cursor', 'entityType', 'limit', 'signalName'],
+    bodyParams: [],
+    hasQuery: true,
+    hasBody: false,
+    responseShape: { kind: 'single' },
+  },
+  'GET /learning/entities/:entityId/noise': {
+    method: 'GET',
+    path: '/learning/entities/:entityId/noise',
+    pathParams: ['entityId'],
+    queryParams: ['entityType', 'signalName', 'snapshotId'],
+    bodyParams: [],
+    hasQuery: true,
+    hasBody: false,
+    responseShape: { kind: 'single' },
+  },
+  'GET /learning/entities/:entityId/noise/examples': {
+    method: 'GET',
+    path: '/learning/entities/:entityId/noise/examples',
+    pathParams: ['entityId'],
+    queryParams: ['entityType', 'limit', 'offset', 'signalName', 'snapshotId'],
+    bodyParams: [],
+    hasQuery: true,
+    hasBody: false,
+    responseShape: { kind: 'object-property', listProperty: 'examples' },
+  },
+} as const;
+
+/**
+ * Local request schemas for learning commands, keyed by `METHOD /path`.
+ *
+ * The learning endpoint does not expose `/api/system/api-schema`, so `--schema`
+ * resolves these instead of fetching a manifest from the target server.
+ */
+export const LEARNING_ROUTE_SCHEMAS: Record<
+  keyof typeof LEARNING_ROUTE_METADATA,
+  { pathParamSchema?: unknown; queryParamSchema?: unknown }
+> = {
+  'GET /learning/entities': {
+    queryParamSchema: {
+      type: 'object',
+      properties: {
+        entityType: entityTypeSchema,
+        limit: { type: 'integer', minimum: 1, maximum: 500 },
+      },
+      required: ['entityType'],
+    },
+  },
+  'GET /learning/entities/:entityId/theme-snapshots': {
+    pathParamSchema: entityIdParamSchema,
+    queryParamSchema: {
+      type: 'object',
+      properties: {
+        entityType: entityTypeSchema,
+        signalNames: signalNamesSchema,
+        limit: { type: 'integer', minimum: 1, maximum: 100 },
+        cursor: { type: 'string', description: 'Opaque pagination cursor from a previous response' },
+        from: { type: 'string', format: 'date-time', description: 'Inclusive lower bound on snapshot cutoff' },
+        to: { type: 'string', format: 'date-time', description: 'Inclusive upper bound on snapshot cutoff' },
+      },
+      required: ['entityType', 'signalNames'],
+    },
+  },
+  'GET /learning/entities/:entityId/theme-flow': {
+    pathParamSchema: entityIdParamSchema,
+    queryParamSchema: {
+      type: 'object',
+      properties: {
+        entityType: entityTypeSchema,
+        signalNames: signalNamesSchema,
+        snapshotId: snapshotIdSchema,
+        themeLimitPerStage: { type: 'integer', minimum: 1, maximum: 100 },
+      },
+      required: ['entityType', 'signalNames', 'snapshotId'],
+    },
+  },
+  'GET /learning/entities/:entityId/theme-paths': {
+    pathParamSchema: entityIdParamSchema,
+    queryParamSchema: {
+      type: 'object',
+      properties: {
+        entityType: entityTypeSchema,
+        signalNames: signalNamesSchema,
+        snapshotId: snapshotIdSchema,
+        limit: { type: 'integer', minimum: 1, maximum: 500 },
+        offset: { type: 'integer', minimum: 0, maximum: 100000 },
+      },
+      required: ['entityType', 'signalNames', 'snapshotId'],
+    },
+  },
+  'GET /learning/entities/:entityId/themes': {
+    pathParamSchema: entityIdParamSchema,
+    queryParamSchema: {
+      type: 'object',
+      properties: {
+        entityType: entityTypeSchema,
+        signalName: signalNameSchema,
+        snapshotId: snapshotIdSchema,
+      },
+      required: ['entityType', 'signalName', 'snapshotId'],
+    },
+  },
+  'GET /learning/entities/:entityId/themes/:themeId': {
+    pathParamSchema: themeParamSchema,
+    queryParamSchema: {
+      type: 'object',
+      properties: {
+        entityType: entityTypeSchema,
+        signalName: signalNameSchema,
+        snapshotId: snapshotIdSchema,
+      },
+      required: ['entityType', 'signalName', 'snapshotId'],
+    },
+  },
+  'GET /learning/entities/:entityId/themes/:themeId/examples': {
+    pathParamSchema: themeParamSchema,
+    queryParamSchema: {
+      type: 'object',
+      properties: {
+        entityType: entityTypeSchema,
+        signalName: signalNameSchema,
+        snapshotId: snapshotIdSchema,
+        limit: { type: 'integer', minimum: 1, maximum: 100 },
+        offset: { type: 'integer', minimum: 0, maximum: 100000 },
+      },
+      required: ['entityType', 'signalName', 'snapshotId'],
+    },
+  },
+  'GET /learning/entities/:entityId/themes/:themeId/history': {
+    pathParamSchema: themeParamSchema,
+    queryParamSchema: {
+      type: 'object',
+      properties: {
+        entityType: entityTypeSchema,
+        signalName: signalNameSchema,
+        limit: { type: 'integer', minimum: 1, maximum: 500 },
+        cursor: { type: 'string', description: 'Opaque pagination cursor from a previous response' },
+      },
+      required: ['entityType', 'signalName'],
+    },
+  },
+  'GET /learning/entities/:entityId/noise': {
+    pathParamSchema: entityIdParamSchema,
+    queryParamSchema: {
+      type: 'object',
+      properties: {
+        entityType: entityTypeSchema,
+        signalName: signalNameSchema,
+        snapshotId: snapshotIdSchema,
+      },
+      required: ['entityType', 'signalName', 'snapshotId'],
+    },
+  },
+  'GET /learning/entities/:entityId/noise/examples': {
+    pathParamSchema: entityIdParamSchema,
+    queryParamSchema: {
+      type: 'object',
+      properties: {
+        entityType: entityTypeSchema,
+        signalName: signalNameSchema,
+        snapshotId: snapshotIdSchema,
+        limit: { type: 'integer', minimum: 1, maximum: 100 },
+        offset: { type: 'integer', minimum: 0, maximum: 100000 },
+      },
+      required: ['entityType', 'signalName', 'snapshotId'],
+    },
+  },
+};

--- a/packages/cli/src/commands/api/schema.ts
+++ b/packages/cli/src/commands/api/schema.ts
@@ -1,11 +1,23 @@
 import { fetchSchemaManifest } from './client.js';
 import { ApiCliError } from './errors.js';
+import { LEARNING_ROUTE_SCHEMAS } from './learning-route-metadata.js';
 import type { ResolvedTarget } from './target.js';
 import type { ApiCommandDescriptor, ApiCommandExample } from './types.js';
 
 export async function getCommandSchema(descriptor: ApiCommandDescriptor, target: ResolvedTarget): Promise<unknown> {
   if (!descriptor.acceptsInput) {
     throw new ApiCliError('SCHEMA_UNAVAILABLE', 'This command does not accept JSON input');
+  }
+
+  // Learning routes live on the Mastra platform learning endpoint, which does
+  // not expose a schema manifest; resolve their hand-authored schemas locally.
+  const learningSchema = (
+    LEARNING_ROUTE_SCHEMAS as Partial<
+      Record<string, (typeof LEARNING_ROUTE_SCHEMAS)[keyof typeof LEARNING_ROUTE_SCHEMAS]>
+    >
+  )[`${descriptor.method} ${descriptor.path}`];
+  if (learningSchema) {
+    return buildRouteSchema(descriptor, learningSchema);
   }
 
   const manifest = await fetchSchemaManifest(target.baseUrl, target.headers, target.timeoutMs, target.apiPrefix);
@@ -26,6 +38,13 @@ export async function getCommandSchema(descriptor: ApiCommandDescriptor, target:
     });
   }
 
+  return buildRouteSchema(descriptor, route);
+}
+
+function buildRouteSchema(
+  descriptor: ApiCommandDescriptor,
+  route: { pathParamSchema?: any; queryParamSchema?: any; bodySchema?: any; responseSchema?: any },
+): unknown {
   const source = descriptor.method === 'GET' ? 'query' : route.queryParamSchema ? 'query+body' : 'body';
   const inputSchema =
     descriptor.method === 'GET' ? route.queryParamSchema : mergeObjectSchemas(route.queryParamSchema, route.bodySchema);

--- a/packages/cli/src/commands/api/target.test.ts
+++ b/packages/cli/src/commands/api/target.test.ts
@@ -163,6 +163,59 @@ describe('resolveTarget', () => {
     expect(mocks.fetchServerProjects).not.toHaveBeenCalled();
   });
 
+  it('uses the hosted learning endpoint with env credentials for learning routes', async () => {
+    process.env.MASTRA_PLATFORM_ACCESS_TOKEN = 'env-token';
+    process.env.MASTRA_PROJECT_ID = 'env-project';
+
+    await expect(resolveTarget(options(), fetchMock as typeof fetch, '/learning/entities')).resolves.toEqual({
+      baseUrl: 'https://output.signals.mastra.ai',
+      headers: {
+        Authorization: 'Bearer env-token',
+        'X-Mastra-Project-Id': 'env-project',
+      },
+      fallbackHeaders: {
+        Authorization: 'Bearer platform-token',
+        'X-Mastra-Project-Id': 'env-project',
+      },
+      timeoutMs: 30_000,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.fetchServerProjects).not.toHaveBeenCalled();
+  });
+
+  it('uses CLI auth and project config when learning env credentials are unavailable', async () => {
+    mocks.loadProjectConfig.mockResolvedValueOnce(linkedProject);
+
+    await expect(
+      resolveTarget(options(), fetchMock as typeof fetch, '/learning/entities/agent_1/theme-snapshots'),
+    ).resolves.toEqual({
+      baseUrl: 'https://output.signals.mastra.ai',
+      headers: {
+        Authorization: 'Bearer platform-token',
+        'X-Mastra-Project-Id': 'project-1',
+      },
+      timeoutMs: 30_000,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.fetchServerProjects).not.toHaveBeenCalled();
+  });
+
+  it('uses explicit --url for learning paths instead of the hosted endpoint', async () => {
+    await expect(
+      resolveTarget(
+        options({ url: 'https://learning-dev.example.com', header: ['Authorization: Bearer custom'] }),
+        fetchMock as typeof fetch,
+        '/learning/entities',
+      ),
+    ).resolves.toEqual({
+      baseUrl: 'https://learning-dev.example.com',
+      headers: { Authorization: 'Bearer custom' },
+      timeoutMs: 30_000,
+    });
+  });
+
   it('uses explicit --url for observability paths instead of hosted endpoint', async () => {
     process.env.MASTRA_PLATFORM_ACCESS_TOKEN = 'env-token';
     process.env.MASTRA_PROJECT_ID = 'env-project';

--- a/packages/cli/src/commands/api/target.test.ts
+++ b/packages/cli/src/commands/api/target.test.ts
@@ -42,6 +42,7 @@ describe('resolveTarget', () => {
     vi.clearAllMocks();
     delete process.env.MASTRA_PLATFORM_ACCESS_TOKEN;
     delete process.env.MASTRA_PROJECT_ID;
+    delete process.env.MASTRA_ORGANIZATION_ID;
     fetchMock.mockRejectedValue(new Error('local unavailable'));
     mocks.getToken.mockResolvedValue('platform-token');
     mocks.loadProjectConfig.mockResolvedValue(null);
@@ -50,6 +51,7 @@ describe('resolveTarget', () => {
   afterEach(() => {
     delete process.env.MASTRA_PLATFORM_ACCESS_TOKEN;
     delete process.env.MASTRA_PROJECT_ID;
+    delete process.env.MASTRA_ORGANIZATION_ID;
     vi.unstubAllGlobals();
   });
 
@@ -191,6 +193,41 @@ describe('resolveTarget', () => {
       resolveTarget(options(), fetchMock as typeof fetch, '/learning/entities/agent_1/theme-snapshots'),
     ).resolves.toEqual({
       baseUrl: 'https://output.signals.mastra.ai',
+      headers: {
+        Authorization: 'Bearer platform-token',
+        'X-Mastra-Project-Id': 'project-1',
+        'X-Mastra-Organization-Id': 'org-1',
+      },
+      timeoutMs: 30_000,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.fetchServerProjects).not.toHaveBeenCalled();
+  });
+
+  it('prefers the env organization ID over project config for learning routes', async () => {
+    process.env.MASTRA_ORGANIZATION_ID = 'env-org';
+    mocks.loadProjectConfig.mockResolvedValueOnce(linkedProject);
+
+    await expect(resolveTarget(options(), fetchMock as typeof fetch, '/learning/entities')).resolves.toEqual({
+      baseUrl: 'https://output.signals.mastra.ai',
+      headers: {
+        Authorization: 'Bearer platform-token',
+        'X-Mastra-Project-Id': 'project-1',
+        'X-Mastra-Organization-Id': 'env-org',
+      },
+      timeoutMs: 30_000,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.fetchServerProjects).not.toHaveBeenCalled();
+  });
+
+  it('does not send the organization header for observability routes', async () => {
+    mocks.loadProjectConfig.mockResolvedValueOnce(linkedProject);
+
+    await expect(resolveTarget(options(), fetchMock as typeof fetch, '/observability/v1/traces')).resolves.toEqual({
+      baseUrl: 'https://observability.mastra.ai',
       headers: {
         Authorization: 'Bearer platform-token',
         'X-Mastra-Project-Id': 'project-1',

--- a/packages/cli/src/commands/api/target.ts
+++ b/packages/cli/src/commands/api/target.ts
@@ -12,6 +12,7 @@ const OBSERVABILITY_URL = 'https://observability.mastra.ai';
 const LEARNING_URL = 'https://output.signals.mastra.ai';
 const AUTHORIZATION_HEADER = 'Authorization';
 const PROJECT_ID_HEADER = 'X-Mastra-Project-Id';
+const ORGANIZATION_ID_HEADER = 'X-Mastra-Organization-Id';
 
 export interface ApiGlobalOptions {
   url?: string;
@@ -49,7 +50,7 @@ export async function resolveTarget(
   }
 
   if (isLearningPath(path)) {
-    return resolvePlatformServiceTarget(LEARNING_URL, customHeaders, timeoutMs);
+    return resolvePlatformServiceTarget(LEARNING_URL, customHeaders, timeoutMs, { includeOrganization: true });
   }
 
   if (await canReachLocal(timeoutMs, fetchFn, apiPrefix)) {
@@ -98,15 +99,18 @@ async function resolvePlatformServiceTarget(
   baseUrl: string,
   customHeaders: Record<string, string>,
   timeoutMs: number,
+  options: { includeOrganization?: boolean } = {},
 ): Promise<ResolvedTarget> {
   const env = loadDotenv(process.cwd());
   const explicitAuthorization = getHeader(customHeaders, AUTHORIZATION_HEADER);
   const explicitProjectId = getHeader(customHeaders, PROJECT_ID_HEADER);
+  const explicitOrganizationId = getHeader(customHeaders, ORGANIZATION_ID_HEADER);
   const envToken = process.env.MASTRA_PLATFORM_ACCESS_TOKEN || env.MASTRA_PLATFORM_ACCESS_TOKEN;
   const cliToken = explicitAuthorization ? undefined : await getOptionalToken();
   const envProjectId = process.env.MASTRA_PROJECT_ID || env.MASTRA_PROJECT_ID;
-  const configProjectId =
-    explicitProjectId || envProjectId ? undefined : (await loadProjectConfig(process.cwd()))?.projectId;
+  const envOrganizationId = process.env.MASTRA_ORGANIZATION_ID || env.MASTRA_ORGANIZATION_ID;
+  const projectConfig = await loadProjectConfig(process.cwd());
+  const configProjectId = explicitProjectId || envProjectId ? undefined : projectConfig?.projectId;
   const projectId = explicitProjectId || envProjectId || configProjectId;
   const headers = { ...customHeaders };
 
@@ -118,6 +122,14 @@ async function resolvePlatformServiceTarget(
 
   if (!explicitProjectId && projectId) {
     headers[PROJECT_ID_HEADER] = projectId;
+  }
+
+  // The learning endpoint binds tenant scope from the organization header.
+  if (options.includeOrganization && !explicitOrganizationId) {
+    const organizationId = envOrganizationId || projectConfig?.organizationId;
+    if (organizationId) {
+      headers[ORGANIZATION_ID_HEADER] = organizationId;
+    }
   }
 
   const fallbackHeaders =

--- a/packages/cli/src/commands/api/target.ts
+++ b/packages/cli/src/commands/api/target.ts
@@ -9,6 +9,7 @@ import { parseHeaders } from './headers.js';
 
 const LOCAL_URL = 'http://localhost:4111';
 const OBSERVABILITY_URL = 'https://observability.mastra.ai';
+const LEARNING_URL = 'https://output.signals.mastra.ai';
 const AUTHORIZATION_HEADER = 'Authorization';
 const PROJECT_ID_HEADER = 'X-Mastra-Project-Id';
 
@@ -44,7 +45,11 @@ export async function resolveTarget(
   }
 
   if (isObservabilityPath(path)) {
-    return resolveObservabilityTarget(customHeaders, timeoutMs);
+    return resolvePlatformServiceTarget(OBSERVABILITY_URL, customHeaders, timeoutMs);
+  }
+
+  if (isLearningPath(path)) {
+    return resolvePlatformServiceTarget(LEARNING_URL, customHeaders, timeoutMs);
   }
 
   if (await canReachLocal(timeoutMs, fetchFn, apiPrefix)) {
@@ -85,7 +90,12 @@ export async function resolveTarget(
   }
 }
 
-async function resolveObservabilityTarget(
+/**
+ * Resolves a hosted Mastra platform service target (observability or learning)
+ * with platform credentials instead of a project deployment URL.
+ */
+async function resolvePlatformServiceTarget(
+  baseUrl: string,
   customHeaders: Record<string, string>,
   timeoutMs: number,
 ): Promise<ResolvedTarget> {
@@ -116,7 +126,7 @@ async function resolveObservabilityTarget(
       : undefined;
 
   return {
-    baseUrl: OBSERVABILITY_URL,
+    baseUrl,
     headers,
     timeoutMs,
     fallbackHeaders,
@@ -125,6 +135,10 @@ async function resolveObservabilityTarget(
 
 function isObservabilityPath(path?: string): boolean {
   return path?.startsWith('/observability/') || path === '/observability';
+}
+
+function isLearningPath(path?: string): boolean {
+  return path?.startsWith('/learning/') || path === '/learning';
 }
 
 function loadDotenv(cwd: string): Record<string, string> {


### PR DESCRIPTION
## Summary

Adds a `mastra api learning` command group for querying Trace Intelligence (private beta) from the CLI. Ten read-only commands expose the hosted learning read API:

- `learning entities` — list entities (agents) with Trace Intelligence output
- `learning snapshots` — list analysis snapshots for an entity + ordered trace signals
- `learning flow` — cross-signal theme flow (Sankey) for one snapshot
- `learning paths` — per-trace theme assignments in one snapshot
- `learning theme list | get | examples | history` — theme inspection
- `learning noise get | examples` — unclustered traces

Learning routes are served by the platform learning endpoint (`https://output.signals.mastra.ai/api/learning/*`), not `@mastra/server`, so route metadata and request schemas are hand-authored in `learning-route-metadata.ts` (mirroring the platform's learning HTTP schemas). Target resolution routes `/learning/*` paths to the hosted learning endpoint using the same credential chain as the existing observability commands.

## Test plan

- `pnpm test:cli` — 853 tests pass (10 learning command tests cover input parsing, positional args, pagination, and response normalization)
- `pnpm build:cli` — clean build
- End-to-end: seeded a local Entity Signals stack with 129 traces and ran all 10 commands against the local output-service — all returned correctly shaped responses (entities, snapshots, flow, paths, themes, examples, history, noise)
- Note: the hosted endpoint currently rejects bearer tokens because the output-service `PLATFORM_API_URL` overlay points at the memory gateway; fixed in [mastra-ai/platform#1789](https://github.com/mastra-ai/platform/pull/1789). Once that deploys, these commands authenticate against production.
