### PR TITLE
fix(factory-ui): remove duplicate PR link

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/factory/components/FactoryReviewPullRequestLinks.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/FactoryReviewPullRequestLinks.tsx
@@ -1,0 +1,41 @@
+import { useFactoryQuery } from '../../../../hooks/useFactories';
+import { PullRequestLinks } from '../../chat/components/PullRequestLinks';
+import { useChatSessionContext } from '../../chat/context/useChatSessionContext';
+import { useChatTranscript } from '../../chat/context/useChatTranscript';
+import type { WorkItem } from '../services/workItems';
+
+interface FactoryReviewPullRequestLinksProps {
+  factoryId: string;
+  projectRepositoryId: string | undefined;
+  reviewItem: WorkItem;
+  threadId: string;
+}
+
+export function FactoryReviewPullRequestLinks({
+  factoryId,
+  projectRepositoryId,
+  reviewItem,
+  threadId,
+}: FactoryReviewPullRequestLinksProps) {
+  const factoryQuery = useFactoryQuery(factoryId);
+  const { baseUrl, resourceId, projectPath } = useChatSessionContext();
+  const { transcript, busy } = useChatTranscript();
+  const repository = factoryQuery.data?.repositories.find(
+    candidate => candidate.projectRepositoryId === projectRepositoryId,
+  );
+
+  return (
+    <PullRequestLinks
+      baseUrl={baseUrl}
+      resourceId={resourceId}
+      projectPath={projectPath}
+      projectRepositoryId={projectRepositoryId}
+      reviewItem={reviewItem}
+      repositorySlug={repository?.slug}
+      threadId={threadId}
+      transcriptEntries={transcript.entries}
+      busy={busy}
+      size="sm"
+    />
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
@@ -2,14 +2,11 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { ExternalLink, Link2 } from 'lucide-react';
 import { Link, useNavigate, useParams } from 'react-router';
 
-import { useFactoryQuery } from '../../../../hooks/useFactories';
 import { useUserSessionQuery, useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
 import { useWorkItemsQuery } from '../../../../hooks/useWorkItems';
-import { PullRequestLinks } from '../../chat/components/PullRequestLinks';
-import { useChatSessionContext } from '../../chat/context/useChatSessionContext';
-import { useChatTranscript } from '../../chat/context/useChatTranscript';
 import { relatedWorkItems, relationshipLabel, relationshipPath } from '../services/relationships';
 import type { WorkItem, WorkItemSessionRef } from '../services/workItems';
+import { FactoryReviewPullRequestLinks } from './FactoryReviewPullRequestLinks';
 
 function latestLiveSession(item: WorkItem, livePaths: ReadonlySet<string>): WorkItemSessionRef | undefined {
   return Object.values(item.sessions)
@@ -47,12 +44,6 @@ export function FactorySessionHeader() {
   const projectRepositoryId = sessionQuery.data?.projectRepositoryId;
   const items = useWorkItemsQuery(factoryId);
   const workspaces = useWorkspacesQuery(projectRepositoryId);
-  const factoryQuery = useFactoryQuery(factoryId);
-  const { baseUrl, resourceId, projectPath } = useChatSessionContext();
-  const { transcript, busy } = useChatTranscript();
-  const repository = factoryQuery.data?.repositories.find(
-    candidate => candidate.projectRepositoryId === projectRepositoryId,
-  );
 
   if (!threadId || !factoryId || !sessionId) return null;
 
@@ -71,8 +62,9 @@ export function FactorySessionHeader() {
   const isReview = currentItem.source === 'github-pr';
   const section = isReview ? 'Review' : 'Work';
   const sectionPath = isReview ? `/factories/${factoryId}/review` : `/factories/${factoryId}/work`;
+  const externalItemUrl = isReview ? undefined : (currentItem.url ?? undefined);
   const externalItemLabel = externalWorkItemLabel(currentItem);
-  const hasHeaderActions = Boolean(currentItem.url) || destinations.length > 0;
+  const hasHeaderActions = Boolean(externalItemUrl) || destinations.length > 0;
 
   const openSession = (session: WorkItemSessionRef) => {
     void navigate(`/factories/${factoryId}/workspaces/${session.sessionId}/threads/${session.threadId}`);
@@ -92,12 +84,12 @@ export function FactorySessionHeader() {
         </nav>
         {hasHeaderActions || isReview ? (
           <div className="flex shrink-0 flex-wrap items-center gap-1">
-            {currentItem.url ? (
+            {externalItemUrl ? (
               <Button
                 as="a"
                 variant="ghost"
                 size="sm"
-                href={currentItem.url}
+                href={externalItemUrl}
                 target="_blank"
                 rel="noreferrer"
                 aria-label={`Open ${externalItemLabel}`}
@@ -136,17 +128,11 @@ export function FactorySessionHeader() {
               );
             })}
             {isReview ? (
-              <PullRequestLinks
-                baseUrl={baseUrl}
-                resourceId={resourceId}
-                projectPath={projectPath}
+              <FactoryReviewPullRequestLinks
+                factoryId={factoryId}
                 projectRepositoryId={projectRepositoryId}
                 reviewItem={currentItem}
-                repositorySlug={repository?.slug}
                 threadId={threadId}
-                transcriptEntries={transcript.entries}
-                busy={busy}
-                size="sm"
               />
             ) : null}
           </div>

--- a/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
@@ -6,6 +6,7 @@ import { useUserSessionQuery, useWorkspacesQuery } from '../../../../hooks/useWo
 import { useWorkItemsQuery } from '../../../../hooks/useWorkItems';
 import { relatedWorkItems, relationshipLabel, relationshipPath } from '../services/relationships';
 import type { WorkItem, WorkItemSessionRef } from '../services/workItems';
+import { genericExternalWorkItemUrl } from '../services/workItemPresentation';
 import { FactoryReviewPullRequestLinks } from './FactoryReviewPullRequestLinks';
 
 function latestLiveSession(item: WorkItem, livePaths: ReadonlySet<string>): WorkItemSessionRef | undefined {
@@ -62,7 +63,7 @@ export function FactorySessionHeader() {
   const isReview = currentItem.source === 'github-pr';
   const section = isReview ? 'Review' : 'Work';
   const sectionPath = isReview ? `/factories/${factoryId}/review` : `/factories/${factoryId}/work`;
-  const externalItemUrl = isReview ? undefined : (currentItem.url ?? undefined);
+  const externalItemUrl = genericExternalWorkItemUrl(currentItem);
   const externalItemLabel = externalWorkItemLabel(currentItem);
   const hasHeaderActions = Boolean(externalItemUrl) || destinations.length > 0;
 

--- a/mastracode/factory-ui/src/ui/domains/factory/services/workItemPresentation.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/workItemPresentation.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { genericExternalWorkItemUrl } from './workItemPresentation';
+
+describe('genericExternalWorkItemUrl', () => {
+  it('leaves pull request links to the review-specific header action', () => {
+    expect(
+      genericExternalWorkItemUrl({
+        source: 'github-pr',
+        url: 'https://github.com/mastra-ai/mastra/pull/20384',
+      }),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ['github-issue' as const, 'https://github.com/mastra-ai/mastra/issues/20384'],
+    ['linear-issue' as const, 'https://linear.app/mastra/issue/MASTRA-20384'],
+  ])('keeps the generic external link for %s work items', (source, url) => {
+    expect(genericExternalWorkItemUrl({ source, url })).toBe(url);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/factory/services/workItemPresentation.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/workItemPresentation.ts
@@ -1,0 +1,5 @@
+import type { WorkItem } from './workItems';
+
+export function genericExternalWorkItemUrl(item: Pick<WorkItem, 'source' | 'url'>): string | undefined {
+  return item.source === 'github-pr' ? undefined : (item.url ?? undefined);
+}

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageReviewPullRequestLink.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageReviewPullRequestLink.msw.test.tsx
@@ -177,6 +177,18 @@ describe('ThreadPage pull request link placement', () => {
       expect(link).toHaveAttribute('href', PULL_REQUEST_URL);
       expect(within(composer).queryByRole('link', { name: PULL_REQUEST_ACCESSIBLE_NAME })).not.toBeInTheDocument();
     });
+
+    it('shows one link to the reviewed pull request', async () => {
+      stubThreadRoute(createWireWorkItem('pull-request'), pullRequestSubscriptions);
+      renderThreadRoute();
+
+      const factorySession = await screen.findByRole('region', { name: 'Factory session' });
+      const pullRequestLinks = within(factorySession)
+        .getAllByRole('link')
+        .filter(link => link.getAttribute('href') === PULL_REQUEST_URL);
+
+      expect(pullRequestLinks).toHaveLength(1);
+    });
   });
 
   describe('when the current Factory session is ordinary work', () => {


### PR DESCRIPTION
Factory review sessions rendered the same pull request twice in the thread header.

This keeps review links in the status-aware PR component, leaves issue and Linear links unchanged, and adds an MSW regression asserting one link per reviewed PR.

Verified with the focused Factory UI tests, typecheck, build, formatting and lint checks, and React Doctor.

<img width="874" alt="Factory review header showing one pull request link" src="https://github.com/user-attachments/assets/edb45d20-1c92-48d5-9262-4abc91938782" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory review headers were showing the same pull request link twice. This change keeps just one link, while preserving issue and Linear links, and adds tests to prevent the problem from returning.

## Changes

- Added a dedicated component for pull request links in Factory review sessions.
- Updated session headers to use generic external work-item links.
- Added coverage confirming exactly one link appears for reviewed pull requests.
- Added unit tests confirming GitHub issue and Linear links remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->