### PR TITLE
fix(factory): improve work item composer readability

### DIFF
--- a/mastracode/factory-ui/src/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -519,6 +519,7 @@ describe('Board card pending states', () => {
     const composer = await within(planningColumn).findByRole('form', { name: 'New work item in Planning' });
     expect(planningColumn).toHaveAccessibleName('Planning');
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(within(composer).getByText('Manual · new')).toBeInTheDocument();
     expect(within(composer).getByRole('textbox', { name: 'Work item title' })).toHaveFocus();
 
     await user.keyboard('{Escape}');

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardIcons.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardIcons.tsx
@@ -4,6 +4,7 @@ import type { ComponentType } from 'react';
 
 import type { WorkItemSource } from '../services/workItems';
 import type { BoardStageId } from '../stages';
+import { IntakeIcon } from './IntakeIcon';
 
 export const SOURCE_ICONS: Record<
   WorkItemSource,
@@ -22,7 +23,7 @@ const STAGE_ICON_SOURCES: Partial<Record<BoardStageId, string>> = {
 };
 
 export function BoardStageIcon({ stage }: { stage: BoardStageId }) {
-  if (stage === 'intake') return <ArrowRightCircleIcon className="shrink-0 text-[#939393]" />;
+  if (stage === 'intake') return <IntakeIcon className="text-icon3 shrink-0" />;
   if (stage === 'review') return <GitPullRequest size={16} className="text-icon3 shrink-0" aria-hidden />;
   const source = STAGE_ICON_SOURCES[stage];
   if (source) return <img src={source} alt="" aria-hidden className="size-4 shrink-0" />;
@@ -30,27 +31,6 @@ export function BoardStageIcon({ stage }: { stage: BoardStageId }) {
   return <Icon size={16} className="text-icon3 shrink-0" aria-hidden />;
 }
 
-function ArrowRightCircleIcon({ size = 16, className }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 16 16"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      className={className}
-      aria-hidden
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M8 14.67C11.68 14.67 14.67 11.68 14.67 8C14.67 4.32 11.68 1.33 8 1.33C4.32 1.33 1.33 4.32 1.33 8C1.33 11.68 4.32 14.67 8 14.67ZM9.14 5.53C8.88 5.27 8.46 5.27 8.2 5.53C7.93 5.79 7.93 6.21 8.2 6.47L9.06 7.33H5.33C4.97 7.33 4.67 7.63 4.67 8C4.67 8.37 4.97 8.67 5.33 8.67H9.06L8.2 9.53C7.93 9.79 7.93 10.21 8.2 10.47C8.46 10.73 8.88 10.73 9.14 10.47L11.14 8.47C11.4 8.21 11.4 7.79 11.14 7.53L9.14 5.53Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-}
-
 export function IssueSourceIcon({ size = 16, className }: { size?: number; className?: string }) {
-  return <ArrowRightCircleIcon size={size} className={cn('text-[#6CCDFB]', className)} />;
+  return <IntakeIcon size={size} className={cn('text-[#6CCDFB]', className)} />;
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/components/InlineWorkItemComposer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/InlineWorkItemComposer.tsx
@@ -1,15 +1,13 @@
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from '@mastra/playground-ui/components/InputGroup';
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Input } from '@mastra/playground-ui/components/Input';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
-import { Check, FileText, X } from 'lucide-react';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import { Check, X } from 'lucide-react';
 import type { FormEvent } from 'react';
 import { useRef, useState } from 'react';
 
 import type { BoardStageId } from '../stages';
+import { IntakeIcon } from './IntakeIcon';
 
 interface InlineWorkItemComposerProps {
   stage: BoardStageId;
@@ -51,18 +49,22 @@ export function InlineWorkItemComposer({ stage, stageLabel, onCreate, onClose }:
       id={`new-work-item-${stage}`}
       aria-label={`New work item in ${stageLabel}`}
       aria-busy={submitting}
-      className="flex flex-col gap-1"
+      className={cn(
+        'relative flex flex-col gap-3 rounded-xl border border-border1/50 bg-neutral6/5 p-3 outline-none transition-colors focus-within:border-neutral5/50 motion-reduce:transition-none',
+        error !== undefined && 'border-error',
+      )}
       onSubmit={event => void submit(event)}
     >
-      <InputGroup variant="outline">
-        <InputGroupAddon>
-          <FileText aria-hidden />
-        </InputGroupAddon>
-        <InputGroupInput
+      <span className="text-ui-xs text-icon2 truncate pr-14">Manual · new</span>
+      <div className="flex min-w-0 items-center gap-1.5">
+        <IntakeIcon className="text-icon3 shrink-0" />
+        <Input
           ref={inputRef}
+          variant="unstyled"
           autoFocus
           aria-label="Work item title"
           autoComplete="off"
+          className="text-ui-smd text-icon6 placeholder:text-icon4 h-auto min-w-0 flex-1 p-0 font-semibold"
           value={title}
           onChange={event => {
             setTitle(event.target.value);
@@ -77,21 +79,30 @@ export function InlineWorkItemComposer({ stage, stageLabel, onCreate, onClose }:
           readOnly={submitting}
           error={error !== undefined}
         />
-        <InputGroupAddon align="inline-end">
-          <InputGroupButton type="button" aria-label="Cancel new work item" onClick={close} disabled={submitting}>
-            <X aria-hidden />
-          </InputGroupButton>
-          <InputGroupButton
-            type="submit"
-            aria-label={`Add work item to ${stageLabel}`}
-            disabled={!trimmedTitle || submitting}
-          >
-            {submitting ? <Spinner size="sm" aria-hidden className="size-3" /> : <Check aria-hidden />}
-          </InputGroupButton>
-        </InputGroupAddon>
-      </InputGroup>
+      </div>
+      <div className="absolute top-2 right-2 flex items-center">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Cancel new work item"
+          onClick={close}
+          disabled={submitting}
+        >
+          <X aria-hidden />
+        </Button>
+        <Button
+          type="submit"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={`Add work item to ${stageLabel}`}
+          disabled={!trimmedTitle || submitting}
+        >
+          {submitting ? <Spinner size="sm" aria-hidden className="size-3" /> : <Check aria-hidden />}
+        </Button>
+      </div>
       {error ? (
-        <p className="text-ui-xs text-notice-destructive-fg m-0 px-2" role="alert">
+        <p className="text-ui-xs text-notice-destructive-fg m-0" role="alert">
           {error}
         </p>
       ) : null}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/IntakeIcon.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/IntakeIcon.tsx
@@ -1,0 +1,25 @@
+interface IntakeIconProps {
+  size?: number;
+  className?: string;
+}
+
+export function IntakeIcon({ size = 16, className }: IntakeIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8 14.67C11.68 14.67 14.67 11.68 14.67 8C14.67 4.32 11.68 1.33 8 1.33C4.32 1.33 1.33 4.32 1.33 8C1.33 11.68 4.32 14.67 8 14.67ZM9.14 5.53C8.88 5.27 8.46 5.27 8.2 5.53C7.93 5.79 7.93 6.21 8.2 6.47L9.06 7.33H5.33C4.97 7.33 4.67 7.63 4.67 8C4.67 8.37 4.97 8.67 5.33 8.67H9.06L8.2 9.53C7.93 9.79 7.93 10.21 8.2 10.47C8.46 10.73 8.88 10.73 9.14 10.47L11.14 8.47C11.4 8.21 11.4 7.79 11.14 7.53L9.14 5.53Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/c7703e88-a7c9-4f0a-83bc-f34b1b270fe9" />

The inline work item composer inherited disabled opacity from InputGroup whenever its empty submit action was disabled, making the icon and placeholder hard to read. This gives it the same visual hierarchy as a saved work item and reuses the Intake icon, while only dimming the unavailable submit action.

Validated with the focused Board pending-state MSW suite (11 tests), Factory UI typecheck, production build, formatting, and React Doctor (98/100 with one existing BoardIcons mixed-export warning).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The composer is now easier to read when submitting isn’t available: only the submit button looks disabled, while the icon and placeholder stay clear. It also uses the same Intake icon as saved work items.

## Changes

- Refined the inline composer layout, controls, loading state, cancel action, and error styling.
- Added a reusable `IntakeIcon` and used it for board stages and issue sources.
- Updated pending-state coverage for the “Manual · new” indicator.
- Validation included the focused MSW suite, UI typecheck, production build, formatting, and React Doctor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->