### PR TITLE
fix(mastracode): only show scheduled retry timing

### DIFF
--- a/.changeset/calm-timers-render.md
+++ b/.changeset/calm-timers-render.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed retry timing in Mastra Code so the TUI only shows a retry delay when a retry is actually scheduled.

--- a/mastracode/tui/src/tui/display.test.ts
+++ b/mastracode/tui/src/tui/display.test.ts
@@ -1,0 +1,48 @@
+import { Container } from '@earendil-works/pi-tui';
+import stripAnsi from 'strip-ansi';
+import { describe, expect, it, vi } from 'vitest';
+
+import { showFormattedError } from './display.js';
+import type { TUIState } from './state.js';
+
+function createState(): TUIState {
+  return {
+    chatContainer: new Container(),
+    ui: { requestRender: vi.fn() },
+    session: {
+      om: {
+        observer: { modelId: vi.fn(() => undefined) },
+        reflector: { modelId: vi.fn(() => undefined) },
+      },
+    },
+  } as unknown as TUIState;
+}
+
+function renderedText(state: TUIState): string {
+  return stripAnsi(state.chatContainer.render(120).join('\n'));
+}
+
+describe('showFormattedError', () => {
+  it('does not show retry timing when no retry was scheduled', () => {
+    const state = createState();
+
+    showFormattedError(state, new Error('Server error. The API may be experiencing issues.'));
+
+    expect(renderedText(state)).toContain('Server error. The API may be experiencing issues.');
+    expect(renderedText(state)).not.toContain('retry in 5s');
+  });
+
+  it('shows retry timing when the event explicitly schedules a retry', () => {
+    const state = createState();
+
+    showFormattedError(state, {
+      error: new Error('Server error. The API may be experiencing issues.'),
+      retryable: true,
+      retryDelay: 500,
+      retryAttempt: 1,
+      maxRetries: 10,
+    });
+
+    expect(renderedText(state)).toContain('retry 1/10 in 0.5s');
+  });
+});

--- a/mastracode/tui/src/tui/display.ts
+++ b/mastracode/tui/src/tui/display.ts
@@ -61,9 +61,9 @@ export function showFormattedError(
     errorText += theme.fg('muted', ` [url: ${parsed.requestUrl}]`);
   }
 
-  // Add retry info if applicable
-  const retryable = 'retryable' in event ? event.retryable : parsed.retryable;
-  const retryDelay = 'retryDelay' in event ? event.retryDelay : parsed.retryDelay;
+  // Retry timing is only shown when the controller explicitly scheduled a retry.
+  const retryable = 'error' in event && event.retryable === true;
+  const retryDelay = 'error' in event ? event.retryDelay : undefined;
   if (retryable && retryDelay) {
     const seconds = retryDelay / 1000;
     const retryAttempt = 'retryAttempt' in event ? event.retryAttempt : undefined;


### PR DESCRIPTION
## Description

Mastra Code previously allowed `showFormattedError()` to fall back to retry metadata inferred by `parseError()`. That could display `(retry in 5s)` for an error classified as retryable even when the controller had not scheduled a retry and the run was terminating.

This change renders retry timing only when an error event explicitly includes scheduled-retry metadata. It adds focused TUI tests covering both an unscheduled server error and a controller-scheduled retry.

Verification:

- TUI display tests: 2 passed
- TUI typecheck and lint passed
- Prettier, changeset status, and `git diff --check` passed

## Related issue(s)

Fixes #20390

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The TUI no longer says a retry is coming unless the system actually scheduled one. Tests cover both failed runs without retries and errors with scheduled retries.

## Changes

- Updated retry display logic to use only explicit controller-provided retry metadata.
- Added tests for unscheduled server errors and scheduled retry rendering.
- Added patch release changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->