### PR TITLE
feat(mastracode): retry transient provider server errors

### DIFF
--- a/.changeset/brave-servers-retry.md
+++ b/.changeset/brave-servers-retry.md
@@ -1,0 +1,6 @@
+---
+'@mastra/code-sdk': patch
+'mastracode': patch
+---
+
+Extended Mastra Code's transient retry policy to cover provider server errors with up to 10 retries and exponential backoff starting at 500ms.

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -547,8 +547,7 @@ describe('createMastraCode', () => {
     });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      | { memory?: unknown; initialState?: Record<string, unknown> }
-      | undefined;
+      { memory?: unknown; initialState?: Record<string, unknown> } | undefined;
     expect(agentControllerConfig?.memory).toBe(customMemory);
     expect(agentControllerConfig?.initialState?.configDir).toBe('.acme-code');
     expect(getDynamicMemoryMock).not.toHaveBeenCalled();
@@ -590,8 +589,7 @@ describe('createMastraCode', () => {
     await createMastraCode({ pluginManager: pluginManager as any });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      | { modes?: Array<{ id: string; availableTools?: string[] }>; initialState?: Record<string, unknown> }
-      | undefined;
+      { modes?: Array<{ id: string; availableTools?: string[] }>; initialState?: Record<string, unknown> } | undefined;
     expect(agentControllerConfig?.modes?.find(mode => mode.id === 'plan')?.availableTools).toContain('plugin_tool');
     expect(agentControllerConfig?.modes?.find(mode => mode.id === 'fast')?.availableTools).toContain('plugin_tool');
     expect(agentControllerConfig?.initialState?.pluginInstructions).toEqual(['Use plugin policy.']);
@@ -634,8 +632,7 @@ describe('createMastraCode', () => {
     });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      | { modes?: { id: string; default?: boolean; defaultModelId: string }[] }
-      | undefined;
+      { modes?: { id: string; default?: boolean; defaultModelId: string }[] } | undefined;
     expect(agentControllerConfig?.modes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'review', default: true, defaultModelId: '__GATEWAY_OPENAI_MODEL__' }),
@@ -659,8 +656,7 @@ describe('createMastraCode', () => {
     await createMastraCode({ cwd: projectPath });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      | { initialState?: Record<string, unknown> }
-      | undefined;
+      { initialState?: Record<string, unknown> } | undefined;
     expect(agentControllerConfig?.initialState?.projectPath).toBe(projectPath);
   });
 
@@ -687,8 +683,7 @@ describe('createMastraCode', () => {
     expect(createMcpManagerMock).toHaveBeenCalledWith(projectPath, '.acme-code', undefined);
     expect(hookManagerConstructorMock).toHaveBeenCalledWith(projectPath, 'session-init', '.acme-code', undefined);
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      | { initialState?: Record<string, unknown> }
-      | undefined;
+      { initialState?: Record<string, unknown> } | undefined;
     expect(agentControllerConfig?.initialState?.configDir).toBe('.acme-code');
   });
 
@@ -735,8 +730,7 @@ describe('createMastraCode', () => {
     await createMastraCode({ pubsub, unixSocketPubSub: true });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls.at(-1)?.[0] as
-      | { pubsub?: unknown; threadLock?: unknown }
-      | undefined;
+      { pubsub?: unknown; threadLock?: unknown } | undefined;
     expect(agentControllerConfig?.pubsub).toBe(pubsub);
     expect(agentControllerConfig?.threadLock).toBeDefined();
   });
@@ -748,8 +742,7 @@ describe('createMastraCode', () => {
     await createMastraCode({ pubsub, crossProcessPubSub: true });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls.at(-1)?.[0] as
-      | { pubsub?: unknown; threadLock?: unknown }
-      | undefined;
+      { pubsub?: unknown; threadLock?: unknown } | undefined;
     expect(agentControllerConfig?.pubsub).toBe(pubsub);
     expect(agentControllerConfig?.threadLock).toBeUndefined();
   });
@@ -788,8 +781,7 @@ describe('createMastraCode', () => {
     await createMastraCode();
 
     const agentControllerCall = controllerConstructorMock.mock.calls[0]?.[0] as
-      | { initialState?: Record<string, unknown> }
-      | undefined;
+      { initialState?: Record<string, unknown> } | undefined;
     expect(agentControllerCall?.initialState?.observeAttachments).toBe(false);
   });
 
@@ -799,8 +791,7 @@ describe('createMastraCode', () => {
     await createMastraCode();
 
     const agentControllerCall = controllerConstructorMock.mock.calls[0]?.[0] as
-      | { initialState?: Record<string, unknown> }
-      | undefined;
+      { initialState?: Record<string, unknown> } | undefined;
     expect(agentControllerCall?.initialState?.observeAttachments).toBe('auto');
   });
 
@@ -824,8 +815,7 @@ describe('createMastraCode', () => {
 
     expect(agentConstructorMock).toHaveBeenCalled();
     const agentConfig = agentConstructorMock.mock.calls[0]?.[0] as
-      | { errorProcessors?: Array<{ id?: string }> }
-      | undefined;
+      { errorProcessors?: Array<{ id?: string }> } | undefined;
     expect(agentConfig?.errorProcessors?.map(processor => processor.id)).toEqual([
       'provider-history-compat',
       'stream-error-retry-processor',
@@ -840,9 +830,8 @@ describe('createMastraCode', () => {
 
     expect(streamErrorRetryProcessorConstructorMock).toHaveBeenCalledTimes(1);
     const options = streamErrorRetryProcessorConstructorMock.mock.calls[0]?.[0] as
-      | { matchers?: Array<{ match?: unknown; maxRetries?: number; delayMs?: unknown; onRetry?: unknown }> }
-      | undefined;
-    expect(options?.matchers).toHaveLength(2);
+      { matchers?: Array<{ match?: unknown; maxRetries?: number; delayMs?: unknown; onRetry?: unknown }> } | undefined;
+    expect(options?.matchers).toHaveLength(3);
 
     // First matcher: Bad Request (400) with maxRetries 1 and 2s delay.
     const badRequestPolicy = options!.matchers![0]!;
@@ -890,6 +879,15 @@ describe('createMastraCode', () => {
     expect(transientConnectionPolicy.delayMs!({ retryCount: 2 })).toBe(2000);
     // High retry counts are capped at the max delay (30000ms).
     expect(transientConnectionPolicy.delayMs!({ retryCount: 10 })).toBe(30000);
+
+    // Third matcher: provider server failures use the same retry budget and visible status.
+    const serverErrorPolicy = options!.matchers![2] as typeof transientConnectionPolicy;
+    expect(typeof serverErrorPolicy.match).toBe('function');
+    expect(serverErrorPolicy.match!(new Error('Server error. The API may be experiencing issues.'))).toBe(true);
+    expect(serverErrorPolicy.match!(Object.assign(new Error('Bad gateway'), { status: 502 }))).toBe(true);
+    expect(serverErrorPolicy.maxRetries).toBe(10);
+    expect(serverErrorPolicy.delayMs!({ retryCount: 0 })).toBe(500);
+    expect(typeof serverErrorPolicy.onRetry).toBe('function');
   });
 
   it('prepends embedding input processors without replacing mandatory built-ins', async () => {
@@ -899,8 +897,7 @@ describe('createMastraCode', () => {
     await createMastraCode({ inputProcessors: [customProcessor] });
 
     const agentConfig = agentConstructorMock.mock.calls[0]?.[0] as
-      | { inputProcessors?: Array<{ id?: string }> }
-      | undefined;
+      { inputProcessors?: Array<{ id?: string }> } | undefined;
     const processors = agentConfig?.inputProcessors ?? [];
     expect(processors[0]).toBe(customProcessor);
     expect(processors.map(processor => processor.id)).toEqual([
@@ -918,8 +915,7 @@ describe('createMastraCode', () => {
 
     expect(agentConstructorMock).toHaveBeenCalled();
     const agentConfig = agentConstructorMock.mock.calls[0]?.[0] as
-      | { inputProcessors?: Array<{ id?: string }>; errorProcessors?: Array<{ id?: string }> }
-      | undefined;
+      { inputProcessors?: Array<{ id?: string }>; errorProcessors?: Array<{ id?: string }> } | undefined;
     expect(agentConfig?.inputProcessors?.map(processor => processor.id)).toContain('provider-history-compat');
     expect(agentConfig?.errorProcessors?.map(processor => processor.id)).toContain('provider-history-compat');
   });

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -108,9 +108,9 @@ import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
 
 const CODE_AGENT_ID = 'code-agent';
 
-// Global retry policy for transient connection failures (e.g. provider sockets dropping mid-stream).
+// Global retry policy for transient provider failures (e.g. dropped sockets and server errors).
 // Applied centrally to every model call via StreamErrorRetryProcessor, independent of model-pack
-// settings, so all modes/subagents benefit from a short wait before retrying a dropped connection.
+// settings, so all modes/subagents benefit from a short wait before retrying a transient failure.
 // Delay uses exponential backoff: initialDelay * 2^retryCount, capped at maxDelay.
 const MASTRACODE_TRANSIENT_CONNECTION_MAX_RETRIES = 10;
 const MASTRACODE_TRANSIENT_CONNECTION_RETRY_INITIAL_DELAY_MS = 500;
@@ -118,6 +118,8 @@ const MASTRACODE_TRANSIENT_CONNECTION_RETRY_MAX_DELAY_MS = 30000;
 
 const TRANSIENT_CONNECTION_ERROR_CODES = new Set(['ECONNRESET', 'EPIPE']);
 const TRANSIENT_CONNECTION_MESSAGE_PATTERN = /econnreset|socket hang up|write epipe|other side closed/i;
+const TRANSIENT_SERVER_ERROR_STATUSES = new Set([500, 502, 503]);
+const TRANSIENT_SERVER_ERROR_MESSAGE_PATTERN = /internal server|server error|api may be experiencing issues/i;
 
 /**
  * Matcher for transient connection failures. Cause-chain traversal is handled
@@ -136,7 +138,29 @@ function isTransientConnectionError(error: unknown): boolean {
   return false;
 }
 
-function emitTransientConnectionRetry(
+function isTransientServerError(error: unknown): boolean {
+  if (!error) return false;
+
+  const errorObj = typeof error === 'object' ? (error as { status?: unknown; statusCode?: unknown }) : undefined;
+  if (
+    (typeof errorObj?.status === 'number' && TRANSIENT_SERVER_ERROR_STATUSES.has(errorObj.status)) ||
+    (typeof errorObj?.statusCode === 'number' && TRANSIENT_SERVER_ERROR_STATUSES.has(errorObj.statusCode))
+  ) {
+    return true;
+  }
+
+  const message = error instanceof Error ? error.message : undefined;
+  return typeof message === 'string' && TRANSIENT_SERVER_ERROR_MESSAGE_PATTERN.test(message);
+}
+
+function getTransientRetryDelay(retryCount: number): number {
+  return Math.min(
+    MASTRACODE_TRANSIENT_CONNECTION_RETRY_INITIAL_DELAY_MS * Math.pow(2, retryCount),
+    MASTRACODE_TRANSIENT_CONNECTION_RETRY_MAX_DELAY_MS,
+  );
+}
+
+function emitTransientRetry(
   error: unknown,
   retryCount: number,
   delayMs: number,
@@ -716,8 +740,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
       new AgentsMDInjector({
         getIgnoredInstructionPaths: ({ requestContext }) => {
           const agentControllerContext = requestContext?.get('controller') as
-            | AgentControllerRequestContext<{ projectPath?: string }>
-            | undefined;
+            AgentControllerRequestContext<{ projectPath?: string }> | undefined;
           const state = agentControllerContext?.getState();
           return getStaticallyLoadedInstructionPaths(state?.projectPath ?? project.rootPath);
         },
@@ -738,13 +761,16 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
           {
             match: isTransientConnectionError,
             maxRetries: MASTRACODE_TRANSIENT_CONNECTION_MAX_RETRIES,
-            delayMs: ({ retryCount }) =>
-              Math.min(
-                MASTRACODE_TRANSIENT_CONNECTION_RETRY_INITIAL_DELAY_MS * Math.pow(2, retryCount),
-                MASTRACODE_TRANSIENT_CONNECTION_RETRY_MAX_DELAY_MS,
-              ),
+            delayMs: ({ retryCount }) => getTransientRetryDelay(retryCount),
             onRetry: ({ error, retryCount, delayMs, requestContext }) =>
-              emitTransientConnectionRetry(error, retryCount, delayMs, requestContext),
+              emitTransientRetry(error, retryCount, delayMs, requestContext),
+          },
+          {
+            match: isTransientServerError,
+            maxRetries: MASTRACODE_TRANSIENT_CONNECTION_MAX_RETRIES,
+            delayMs: ({ retryCount }) => getTransientRetryDelay(retryCount),
+            onRetry: ({ error, retryCount, delayMs, requestContext }) =>
+              emitTransientRetry(error, retryCount, delayMs, requestContext),
           },
         ],
       }),

--- a/mastracode/tui/e2e/tui/stream-error-retry.ts
+++ b/mastracode/tui/e2e/tui/stream-error-retry.ts
@@ -23,11 +23,16 @@ export const streamErrorRetryScenario = {
   async inProcessApp({ startMastraCodeApp }): Promise<McE2eInProcessApp> {
     const patches = createGlobalPatchScope();
     const originalFetch = globalThis.fetch.bind(globalThis);
-    let failedOnce = false;
+    let failedAttempts = 0;
     patches.setProperty(globalThis, 'fetch', async (input, init) => {
-      if (!failedOnce && requestUrl(input).includes('/responses')) {
-        failedOnce = true;
-        throw Object.assign(new Error('Cannot connect to API: write EPIPE'), { code: 'EPIPE' });
+      if (requestUrl(input).includes('/responses')) {
+        failedAttempts++;
+        if (failedAttempts === 1) {
+          throw Object.assign(new Error('Cannot connect to API: write EPIPE'), { code: 'EPIPE' });
+        }
+        if (failedAttempts === 2) {
+          throw Object.assign(new Error('Server error. The API may be experiencing issues.'), { status: 503 });
+        }
       }
       return originalFetch(input, init);
     });
@@ -52,6 +57,7 @@ export const streamErrorRetryScenario = {
 
     terminal.submit(PROMPT);
     await runtime.waitForScreenText(/write EPIPE.*retry 1\/10 in 0\.5s/i, terminal);
+    await runtime.waitForScreenText(/Server error.*retry 2\/10 in 1s/i, terminal);
     await runtime.waitForScreenText(new RegExp(RESPONSE), terminal, 30_000);
 
     terminal.keyCtrlC();


### PR DESCRIPTION
## Description

Mastra Code's visible transient retry policy covered dropped connections but not temporary provider server failures. HTTP 500/502/503 responses could therefore terminate a run instead of using the same recovery behavior.

This change extends the configured policy to provider server statuses and recognized server-error messages. These failures receive up to 10 retries with exponential backoff beginning at 500ms and capped at 30 seconds, while the existing retry callback displays attempt and delay progress.

The deterministic real-TUI scenario now injects an `EPIPE` failure followed by a provider 503 failure against the OpenAI Responses endpoint, verifies `retry 1/10 in 0.5s` and `retry 2/10 in 1s`, and confirms recovery.

Verification:

- Code SDK focused tests: 33 passed
- Real-TUI stream retry scenario: 1 passed
- Mastra Code build: 29/29 tasks passed
- SDK and TUI typechecks and lint passed
- Prettier, changeset status, and `git diff --check` passed

## Related issue(s)

Closes #20391

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a temporary provider problem happens, Mastra Code now waits and tries again instead of failing immediately. It retries common server outages with increasing delays and shows progress in the TUI.

## Changes

- Added retry handling for provider HTTP 500, 502, and 503 responses and recognized server-error messages.
- Retries up to 10 times with exponential backoff starting at 500 ms, capped at 30 seconds.
- Reused the existing visible retry progress callbacks.
- Centralized retry delay calculation for connection and server errors.
- Updated SDK tests to validate the new server-error matcher.
- Expanded the real-TUI scenario to test `EPIPE`, followed by provider 503, and successful recovery.
- Added patch changesets for `@mastra/code-sdk` and `mastracode`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->