### PR TITLE
perf(pg): reduce warm init from ~350 round trips to 6

### DIFF
--- a/.changeset/loud-mirrors-mate.md
+++ b/.changeset/loud-mirrors-mate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Improved PostgresStore startup: init now reads the schema catalog up front (3 read-only queries) instead of issuing hundreds of per-object existence checks and no-op DDL statements. On an already-migrated database this cuts init from ~350 serialized queries to 6, dropping init time on a 50ms connection from ~18.5s to ~0.5s. Fixed init failing for roles without CREATE privileges when the schema already exists, and removed a table lock that could block writers while init re-created triggers that were already in place. Fresh and partially-migrated databases are set up exactly as before.

--- a/stores/pg/docker-compose.benchmark.yaml
+++ b/stores/pg/docker-compose.benchmark.yaml
@@ -9,6 +9,11 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
+    # pg_stat_statements powers the warm-mode statement counting in
+    # scripts/init-benchmark.ts. max is raised so the many distinct
+    # schema-qualified DDL statements the cold iterations generate don't
+    # evict entries between the warm-mode before/after snapshots.
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.max=10000
 
   # Toxiproxy sits between the benchmark client and Postgres so we can
   # measure init() at multiple round-trip latencies. The fix's worst case

--- a/stores/pg/scripts/init-benchmark.ts
+++ b/stores/pg/scripts/init-benchmark.ts
@@ -18,6 +18,16 @@
  * Each iteration uses a fresh schema, so init() always does the full
  * createTable/alterTable/createIndex chain (no fast-path).
  *
+ * After the cold modes, a "warm" mode measures init() against an
+ * already-converged schema (converged once, then NOT dropped between
+ * iterations) — the steady-state cost every restart pays. Warm
+ * iterations also count the SQL statements each init() issues, using
+ * pg_stat_statements (enabled via shared_preload_libraries in
+ * docker-compose.benchmark.yaml), broken down by statement class.
+ * Counting is database-scoped (pg_stat_statements joined to pg_database
+ * on dbid, filtered to the benchmark database) and diff-based — never a
+ * cluster-wide pg_stat_statements_reset().
+ *
  * Run via: `pnpm bench:init`
  */
 
@@ -132,6 +142,215 @@ async function timeOnce(mode: 'pinned' | 'parallel'): Promise<number> {
   return (timeOnce as any)._last as number;
 }
 
+/**
+ * Statement classes for warm-mode counting. The classification rule is
+ * the shared vocabulary for reasoning about init cost:
+ *
+ * - "information_schema probes"  — per-column existence checks
+ * - "pg_indexes probes"          — per-index existence checks
+ *                                  (FROM pg_indexes + indexname = ...)
+ * - "snapshot catalog reads"     — schema-scoped catalog snapshot reads
+ *                                  (pg_catalog.pg_tables / pg_class+
+ *                                  pg_attribute / pg_catalog.pg_indexes
+ *                                  WITHOUT an indexname predicate)
+ * - "ALTER TABLE" / "CREATE TABLE" / "CREATE INDEX" — DDL
+ * - "other"                      — everything else the init issued
+ */
+const STATEMENT_CLASSES = [
+  'information_schema probes',
+  'pg_indexes probes',
+  'snapshot catalog reads',
+  'ALTER TABLE',
+  'CREATE TABLE',
+  'CREATE INDEX',
+  'other',
+] as const;
+type StatementClass = (typeof STATEMENT_CLASSES)[number];
+
+function classifyStatement(query: string): StatementClass {
+  const q = query.replace(/\s+/g, ' ');
+  if (/information_schema\./i.test(q)) return 'information_schema probes';
+  // Per-index existence probe: pg_indexes with an indexname predicate.
+  if (/from\s+pg_indexes/i.test(q) && /indexname\s*=/i.test(q)) return 'pg_indexes probes';
+  // Schema-scoped catalog snapshot reads.
+  if (/from\s+pg_catalog\.pg_tables\s+where\s+schemaname\s*=/i.test(q)) return 'snapshot catalog reads';
+  if (/pg_catalog\.pg_class/i.test(q) && /pg_attribute/i.test(q)) return 'snapshot catalog reads';
+  if (/from\s+pg_catalog\.pg_indexes/i.test(q) && !/indexname\s*=/i.test(q)) return 'snapshot catalog reads';
+  if (/^\s*alter\s+table/i.test(q)) return 'ALTER TABLE';
+  if (/^\s*create\s+table/i.test(q)) return 'CREATE TABLE';
+  if (/^\s*create\s+(unique\s+)?index/i.test(q)) return 'CREATE INDEX';
+  return 'other';
+}
+
+interface WarmResult {
+  latencyMs: number;
+  samplesMs: number[];
+  meanMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  minMs: number;
+  maxMs: number;
+  /** Per-init statement counts by class, averaged across iterations. */
+  perClass: Record<StatementClass, number>;
+  /** Per-init total statements, averaged across iterations. */
+  totalStatements: number;
+}
+
+type StatementSnapshot = Map<string, number>;
+
+/**
+ * Snapshot pg_stat_statements call counts, scoped to the benchmark
+ * database (dbid join — NOT cluster-wide). The snapshot query itself is
+ * excluded via the pg_stat_statements text filter so counting doesn't
+ * observe itself.
+ */
+async function snapshotStatements(stats: Pool): Promise<StatementSnapshot> {
+  const { rows } = await stats.query<{ key: string; query: string; calls: string }>(
+    `SELECT s.queryid::text || ':' || md5(s.query) AS key, s.query, s.calls::text AS calls
+     FROM pg_stat_statements s
+     JOIN pg_database d ON d.oid = s.dbid
+     WHERE d.datname = current_database()
+       AND s.query NOT LIKE '%pg_stat_statements%'`,
+  );
+  const snap: StatementSnapshot = new Map();
+  for (const row of rows) {
+    snap.set(`${row.key}|${row.query}`, Number(row.calls));
+  }
+  return snap;
+}
+
+function diffStatements(before: StatementSnapshot, after: StatementSnapshot): Record<StatementClass, number> {
+  const counts = Object.fromEntries(STATEMENT_CLASSES.map(c => [c, 0])) as Record<StatementClass, number>;
+  for (const [key, callsAfter] of after) {
+    const callsBefore = before.get(key) ?? 0;
+    const delta = callsAfter - callsBefore;
+    if (delta <= 0) continue;
+    const query = key.slice(key.indexOf('|') + 1);
+    counts[classifyStatement(query)] += delta;
+  }
+  return counts;
+}
+
+let warmRunSeq = 0;
+
+/** One pinned init() against an existing (converged) schema. */
+async function warmInitOnce(schema: string): Promise<number> {
+  const pool = new Pool({
+    host: PROXY_LISTEN_HOST,
+    port: PROXY_LISTEN_PORT,
+    user: 'postgres',
+    password: 'postgres',
+    database: 'postgres',
+    max: POOL_MAX,
+  });
+  const store = new PostgresStore({
+    id: `bench-warm-${schema}-${warmRunSeq++}`,
+    pool,
+    schemaName: schema,
+  });
+  const start = performance.now();
+  try {
+    await store.init();
+    return performance.now() - start;
+  } finally {
+    await store.close().catch(() => {});
+    await pool.end().catch(() => {});
+  }
+}
+
+/**
+ * Warm-mode benchmark for one latency tier: converge a schema once
+ * (discarded from measurement), then measure repeated init() runs
+ * against it, counting statements per init via pg_stat_statements
+ * snapshots taken over the direct (latency-free) connection.
+ */
+async function runWarmBench(latencyMs: number, stats: Pool): Promise<WarmResult | null> {
+  const schema = `bench_warm_${Date.now()}_${Math.floor(Math.random() * 1e9)}`;
+  const samples: number[] = [];
+  const perIterCounts: Record<StatementClass, number>[] = [];
+  try {
+    const convergeMs = await warmInitOnce(schema);
+    console.info(`  warm converge: ${formatMs(convergeMs)} (discarded)`);
+
+    for (let i = 0; i < ITERATIONS; i++) {
+      try {
+        const before = await snapshotStatements(stats);
+        const ms = await warmInitOnce(schema);
+        const after = await snapshotStatements(stats);
+        const counts = diffStatements(before, after);
+        const total = STATEMENT_CLASSES.reduce((acc, c) => acc + counts[c], 0);
+        samples.push(ms);
+        perIterCounts.push(counts);
+        console.info(`  warm iter ${i + 1}: ${formatMs(ms)} (${total} statements)`);
+      } catch (err) {
+        console.error(`  warm iter ${i + 1} failed: ${(err as Error).message}`);
+      }
+    }
+  } catch (err) {
+    console.error(`  warm converge failed: ${(err as Error).message}`);
+  } finally {
+    await dropSchema(schema).catch(() => {});
+  }
+
+  if (samples.length === 0) return null;
+
+  const perClass = Object.fromEntries(
+    STATEMENT_CLASSES.map(c => [
+      c,
+      Math.round(perIterCounts.reduce((acc, counts) => acc + counts[c], 0) / perIterCounts.length),
+    ]),
+  ) as Record<StatementClass, number>;
+  const totalStatements = STATEMENT_CLASSES.reduce((acc, c) => acc + perClass[c], 0);
+
+  const base = summarize(latencyMs, 'pinned', samples);
+  return {
+    latencyMs,
+    samplesMs: samples,
+    meanMs: base.meanMs,
+    p50Ms: base.p50Ms,
+    p95Ms: base.p95Ms,
+    minMs: base.minMs,
+    maxMs: base.maxMs,
+    perClass,
+    totalStatements,
+  };
+}
+
+function printWarmResults(warmResults: WarmResult[]): void {
+  if (warmResults.length === 0) return;
+
+  console.info('=== warm init() — already-converged schema, pinned path ===');
+  console.info(`iterations per cell: ${ITERATIONS} (schema converged once, then reused)\n`);
+
+  const header = ['latency', 'mean', 'p50', 'p95', 'min', 'max', 'stmts/init'];
+  const rows: string[][] = [header];
+  for (const r of [...warmResults].sort((a, b) => a.latencyMs - b.latencyMs)) {
+    rows.push([
+      `${r.latencyMs}ms`,
+      formatMs(r.meanMs),
+      formatMs(r.p50Ms),
+      formatMs(r.p95Ms),
+      formatMs(r.minMs),
+      formatMs(r.maxMs),
+      `${r.totalStatements}`,
+    ]);
+  }
+  const widths = header.map((_, i) => Math.max(...rows.map(row => (row[i] ?? '').length)));
+  for (const row of rows) {
+    console.info(row.map((cell, i) => cell.padEnd(widths[i] ?? 0)).join('  '));
+  }
+
+  console.info('\nWarm init statement classes (per init, mean across iterations):');
+  for (const r of [...warmResults].sort((a, b) => a.latencyMs - b.latencyMs)) {
+    console.info(`  ${r.latencyMs}ms latency:`);
+    for (const cls of STATEMENT_CLASSES) {
+      console.info(`    ${`${cls}:`.padEnd(28)}${r.perClass[cls]}`);
+    }
+    console.info(`    ${'total:'.padEnd(28)}${r.totalStatements}`);
+  }
+  console.info('');
+}
+
 function summarize(latencyMs: number, mode: 'pinned' | 'parallel', samples: number[]): Result {
   const sorted = [...samples].sort((a, b) => a - b);
   const sum = sorted.reduce((acc, v) => acc + v, 0);
@@ -199,38 +418,58 @@ function printResults(results: Result[]): void {
 
 async function main(): Promise<void> {
   const results: Result[] = [];
+  const warmResults: WarmResult[] = [];
 
-  for (const latencyMs of LATENCIES_MS) {
-    console.info(`\n--- ${latencyMs}ms one-way latency ---`);
-    await setLatency(latencyMs);
+  // Direct (latency-free) connection for pg_stat_statements snapshots.
+  const stats = new Pool({ connectionString: CLEANUP_CONNECTION });
+  try {
+    await stats.query('CREATE EXTENSION IF NOT EXISTS pg_stat_statements');
+    await stats.query('SELECT 1 FROM pg_stat_statements LIMIT 1');
+  } catch (err) {
+    throw new Error(
+      `warm-mode statement counting needs pg_stat_statements (shared_preload_libraries in docker-compose.benchmark.yaml): ${(err as Error).message}`,
+    );
+  }
 
-    for (const mode of ['parallel', 'pinned'] as const) {
-      const samples: number[] = [];
-      // Warm up once so JIT/connection-establishment cost isn't charged
-      // to the first measured iteration.
-      try {
-        await timeOnce(mode);
-      } catch (err) {
-        console.error(`  warmup ${mode} failed: ${(err as Error).message}`);
-      }
+  try {
+    for (const latencyMs of LATENCIES_MS) {
+      console.info(`\n--- ${latencyMs}ms one-way latency ---`);
+      await setLatency(latencyMs);
 
-      for (let i = 0; i < ITERATIONS; i++) {
+      for (const mode of ['parallel', 'pinned'] as const) {
+        const samples: number[] = [];
+        // Warm up once so JIT/connection-establishment cost isn't charged
+        // to the first measured iteration.
         try {
-          const ms = await timeOnce(mode);
-          samples.push(ms);
-          console.info(`  ${mode} iter ${i + 1}: ${formatMs(ms)}`);
+          await timeOnce(mode);
         } catch (err) {
-          console.error(`  ${mode} iter ${i + 1} failed: ${(err as Error).message}`);
+          console.error(`  warmup ${mode} failed: ${(err as Error).message}`);
+        }
+
+        for (let i = 0; i < ITERATIONS; i++) {
+          try {
+            const ms = await timeOnce(mode);
+            samples.push(ms);
+            console.info(`  ${mode} iter ${i + 1}: ${formatMs(ms)}`);
+          } catch (err) {
+            console.error(`  ${mode} iter ${i + 1} failed: ${(err as Error).message}`);
+          }
+        }
+
+        if (samples.length > 0) {
+          results.push(summarize(latencyMs, mode, samples));
         }
       }
 
-      if (samples.length > 0) {
-        results.push(summarize(latencyMs, mode, samples));
-      }
+      const warm = await runWarmBench(latencyMs, stats);
+      if (warm) warmResults.push(warm);
     }
+  } finally {
+    await stats.end().catch(() => {});
   }
 
   printResults(results);
+  printWarmResults(warmResults);
 }
 
 main().catch(err => {

--- a/stores/pg/scripts/init-benchmark.ts
+++ b/stores/pg/scripts/init-benchmark.ts
@@ -151,8 +151,9 @@ async function timeOnce(mode: 'pinned' | 'parallel'): Promise<number> {
  *                                  (FROM pg_indexes + indexname = ...)
  * - "snapshot catalog reads"     — schema-scoped catalog snapshot reads
  *                                  (pg_catalog.pg_tables / pg_class+
- *                                  pg_attribute / pg_catalog.pg_indexes
- *                                  WITHOUT an indexname predicate)
+ *                                  pg_attribute / pg_index or
+ *                                  pg_catalog.pg_indexes WITHOUT an
+ *                                  indexname predicate)
  * - "ALTER TABLE" / "CREATE TABLE" / "CREATE INDEX" — DDL
  * - "other"                      — everything else the init issued
  */
@@ -176,6 +177,7 @@ function classifyStatement(query: string): StatementClass {
   if (/from\s+pg_catalog\.pg_tables\s+where\s+schemaname\s*=/i.test(q)) return 'snapshot catalog reads';
   if (/pg_catalog\.pg_class/i.test(q) && /pg_attribute/i.test(q)) return 'snapshot catalog reads';
   if (/from\s+pg_catalog\.pg_indexes/i.test(q) && !/indexname\s*=/i.test(q)) return 'snapshot catalog reads';
+  if (/pg_catalog\.pg_index\b/i.test(q) && /indisreplident/i.test(q)) return 'snapshot catalog reads';
   if (/^\s*alter\s+table/i.test(q)) return 'ALTER TABLE';
   if (/^\s*create\s+table/i.test(q)) return 'CREATE TABLE';
   if (/^\s*create\s+(unique\s+)?index/i.test(q)) return 'CREATE INDEX';

--- a/stores/pg/src/storage/client.ts
+++ b/stores/pg/src/storage/client.ts
@@ -1,4 +1,5 @@
 import type { Pool, PoolClient, QueryResult } from 'pg';
+import type { SchemaSnapshot, SchemaSnapshotHost } from './db/schema-snapshot';
 
 // Re-export pg types for consumers
 export type { Pool, PoolClient, QueryResult } from 'pg';
@@ -378,12 +379,30 @@ export class PinnedClientAdapter implements DbClient {
  * During PostgresStore.init() we temporarily pin a single-client adapter
  * so every domain's DDL flows through one backend connection.
  */
-export class RoutingDbClient implements DbClient {
+export class RoutingDbClient implements DbClient, SchemaSnapshotHost {
   #base: DbClient;
   #pinned: DbClient | null = null;
+  #schemaSnapshot: SchemaSnapshot | null = null;
 
   constructor(base: DbClient) {
     this.#base = base;
+  }
+
+  /**
+   * Catalog snapshot for the current init window, or `null` outside it.
+   *
+   * It lives here rather than on `PgDB` because every storage domain builds its
+   * own `PgDB` over this one shared client — hanging the snapshot off the
+   * client means one load serves all of them, and its lifetime lines up exactly
+   * with the pinned-init window that `pin()`/`unpin()` already delimit.
+   */
+  get schemaSnapshot(): SchemaSnapshot | null {
+    return this.#schemaSnapshot;
+  }
+
+  /** Install (or clear, with `null`) the init-window catalog snapshot. */
+  setSchemaSnapshot(snapshot: SchemaSnapshot | null): void {
+    this.#schemaSnapshot = snapshot;
   }
 
   /** Returns the currently active client (pinned if set, otherwise base). */

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -615,6 +615,17 @@ export class PgDB extends MastraBase {
       return;
     }
 
+    // During the init window, a snapshot holding tables for this schema proves
+    // the schema exists (the snapshot queries are scoped to it), so the
+    // `information_schema.schemata` probe below would be a warm init's one
+    // remaining per-process round trip. Skip it and mark setup complete. A
+    // cold schema yields an empty snapshot and falls through to the probe.
+    const snapshot = this.schemaSnapshot;
+    if (snapshot && snapshot.tables.size > 0) {
+      schemaSetupRegistry.set(this.schemaName, { promise: null, complete: true });
+      return;
+    }
+
     const quotedSchemaName = getSchemaName(this.schemaName);
 
     if (!registryEntry?.promise) {

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -489,6 +489,61 @@ export class PgDB extends MastraBase {
   }
 
   /**
+   * Records an out-of-band `ALTER TABLE … RENAME TO` in the init snapshot.
+   *
+   * Init-time migrations that issue raw DDL on `this.client` (instead of going
+   * through createTable/alterTable/createIndex, which maintain the snapshot
+   * themselves) MUST report it through these `note*` methods. A snapshot that
+   * still lists a renamed-away table makes a later createTable() in the same
+   * init skip the rebuild the migration depends on — stranding data. No-op
+   * outside the init window.
+   *
+   * Indexes riding along with a rename keep their names, so the snapshot's
+   * index set stays accurate without changes here.
+   */
+  noteTableRenamed(oldName: string, newName: string): void {
+    const snapshot = this.schemaSnapshot;
+    if (snapshot) {
+      if (snapshot.tables.delete(oldName)) snapshot.tables.add(newName);
+      const columns = snapshot.columns.get(oldName);
+      if (columns) {
+        snapshot.columns.delete(oldName);
+        snapshot.columns.set(newName, columns);
+      }
+    }
+    this.tableColumnsCache.delete(oldName);
+    this.tableColumnsCache.delete(newName);
+  }
+
+  /**
+   * Records an out-of-band `DROP TABLE` in the init snapshot. See
+   * {@link noteTableRenamed} for why raw-DDL migrations must call this.
+   *
+   * The dropped table's indexes vanish with it, but the snapshot's flat index
+   * set cannot map names back to tables. Stale entries only make a later
+   * createIndex() skip a recreate until the next init re-reads the catalog —
+   * the same self-healing bound the rest of the snapshot design accepts.
+   */
+  noteTableDropped(tableName: string): void {
+    const snapshot = this.schemaSnapshot;
+    if (snapshot) {
+      snapshot.tables.delete(tableName);
+      snapshot.columns.delete(tableName);
+    }
+    this.tableColumnsCache.delete(tableName);
+  }
+
+  /**
+   * Records an out-of-band `ALTER TABLE … ADD COLUMN` in the init snapshot.
+   * See {@link noteTableRenamed} for why raw-DDL migrations must call this.
+   */
+  noteColumnAdded(tableName: string, column: string): void {
+    const snapshot = this.schemaSnapshot;
+    if (snapshot) this.snapshotColumns(snapshot, tableName).add(column);
+    this.tableColumnsCache.delete(tableName);
+  }
+
+  /**
    * Gets the set of column names that actually exist in the database table.
    * Results are cached; the cache is invalidated when alterTable() adds new columns.
    */
@@ -946,6 +1001,7 @@ export class PgDB extends MastraBase {
           const alterSql =
             `ALTER TABLE ${fullTableName} ADD COLUMN IF NOT EXISTS "${parsedColumnName}" ${sqlType} ${nullable} ${defaultValue}`.trim();
           await this.client.none(alterSql);
+          this.noteColumnAdded(TABLE_SPANS, columnName);
           this.logger?.debug?.(`Added column '${columnName}' to ${fullTableName}`);
 
           // For timestamp columns, also add the timezone-aware version
@@ -954,6 +1010,7 @@ export class PgDB extends MastraBase {
             const timestampZSql =
               `ALTER TABLE ${fullTableName} ADD COLUMN IF NOT EXISTS "${parsedColumnName}Z" TIMESTAMPTZ DEFAULT NOW()`.trim();
             await this.client.none(timestampZSql);
+            this.noteColumnAdded(TABLE_SPANS, `${columnName}Z`);
             this.logger?.debug?.(`Added timezone column '${columnName}Z' to ${fullTableName}`);
           }
         }
@@ -970,6 +1027,7 @@ export class PgDB extends MastraBase {
             const timestampZSql =
               `ALTER TABLE ${fullTableName} ADD COLUMN IF NOT EXISTS "${parsedTzColumnName}" TIMESTAMPTZ DEFAULT NOW()`.trim();
             await this.client.none(timestampZSql);
+            this.noteColumnAdded(TABLE_SPANS, tzColumnName);
             this.logger?.debug?.(`Added timezone column '${tzColumnName}' to ${fullTableName}`);
           }
         }
@@ -1122,6 +1180,11 @@ export class PgDB extends MastraBase {
     const snapshot = this.schemaSnapshot;
     if (snapshot) return snapshot.primaryKeyIndexes.has(constraintName.toLowerCase());
 
+    return this.spansPrimaryKeyExistsLive(constraintName, schemaFilter);
+  }
+
+  /** Live-catalog variant of {@link spansPrimaryKeyExists}, bypassing the snapshot. */
+  private async spansPrimaryKeyExistsLive(constraintName: string, schemaFilter: string): Promise<boolean> {
     const result = await this.client.oneOrNone<{ exists: boolean }>(
       `SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = lower($1) AND connamespace = (SELECT oid FROM pg_namespace WHERE nspname = $2)) as exists`,
       [constraintName, schemaFilter],
@@ -1176,9 +1239,15 @@ export class PgDB extends MastraBase {
       // isDuplicateRelationError can also match on unrelated name collisions
       // (e.g. a stale index with the same name), so the post-check prevents
       // silently swallowing errors when the constraint is still missing.
+      //
+      // The confirm must hit the live catalog: in this path the init snapshot
+      // (if live) just said the constraint was ABSENT — that is why the ALTER
+      // ran — so re-asking it would deterministically contradict the
+      // concurrent creator and turn a benign race into a thrown error.
       if (isDuplicateRelationError(error)) {
-        const confirmed = await this.spansPrimaryKeyExists();
+        const confirmed = await this.spansPrimaryKeyExistsLive(constraintName, schemaFilter);
         if (confirmed) {
+          this.schemaSnapshot?.primaryKeyIndexes.add(constraintName.toLowerCase());
           this.logger?.debug?.(`PRIMARY KEY constraint ${constraintName} was created by another process`);
           return;
         }

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -22,6 +22,8 @@ import type { DbClient, QueryValues, TxClient } from '../client';
 import { PoolAdapter } from '../client';
 import { buildConstraintName } from './constraint-utils';
 import { isDuplicateRelationError, isDuplicateSchemaError } from './pg-errors';
+import { getSchemaSnapshot } from './schema-snapshot';
+import type { SchemaSnapshot } from './schema-snapshot';
 
 // Re-export DbClient for external use
 export type { DbClient } from '../client';
@@ -408,6 +410,52 @@ export class PgDB extends MastraBase {
   }
 
   /**
+   * Catalog snapshot for the current init window, or `null` outside it.
+   *
+   * When non-null, the init-path methods below answer existence questions from
+   * it instead of round-tripping to the server, and record the objects they
+   * create so later callers in the same init see them. See
+   * {@link SchemaSnapshot} for why it is scoped to init only.
+   */
+  private get schemaSnapshot(): SchemaSnapshot | null {
+    return getSchemaSnapshot(this.client, this.schemaName);
+  }
+
+  /**
+   * Whether the snapshot proves `generateTableSQL` would be a no-op for this
+   * table — i.e. the CREATE statement can be skipped.
+   *
+   * For most tables that is just "the table exists". `workflow_snapshot` is the
+   * exception: its generated SQL also carries a DO block that back-fills the
+   * `(workflow_name, run_id)` unique constraint and promotes it to the table's
+   * replica identity, so a table created by an older version still needs the
+   * statement to run.
+   */
+  private snapshotShowsTableConverged(snapshot: SchemaSnapshot, tableName: TABLE_NAMES): boolean {
+    if (!snapshot.tables.has(tableName)) return false;
+
+    if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      const constraintName = buildConstraintName({
+        baseName: 'mastra_workflow_snapshot_workflow_name_run_id_key',
+        schemaName: this.schemaName ? parseSqlIdentifier(this.schemaName, 'schema name') : undefined,
+      }).toLowerCase();
+      return snapshot.indexes.has(constraintName) && snapshot.replicaIdentityIndexes.has(constraintName);
+    }
+
+    return true;
+  }
+
+  /** Column set for `tableName` in the snapshot, created empty if absent. */
+  private snapshotColumns(snapshot: SchemaSnapshot, tableName: string): Set<string> {
+    let columns = snapshot.columns.get(tableName);
+    if (!columns) {
+      columns = new Set<string>();
+      snapshot.columns.set(tableName, columns);
+    }
+    return columns;
+  }
+
+  /**
    * Gets the set of column names that actually exist in the database table.
    * Results are cached; the cache is invalidated when alterTable() adds new columns.
    */
@@ -451,6 +499,13 @@ export class PgDB extends MastraBase {
 
   async hasColumn(table: string, column: string): Promise<boolean> {
     const schema = this.schemaName || 'public';
+
+    const snapshot = this.schemaSnapshot;
+    if (snapshot) {
+      const columns = snapshot.columns.get(table);
+      if (!columns) return false;
+      return columns.has(column) || columns.has(column.toLowerCase());
+    }
 
     const result = await this.client.oneOrNone(
       `SELECT 1 FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND (column_name = $3 OR column_name = $4)`,
@@ -705,15 +760,38 @@ export class PgDB extends MastraBase {
         await this.setupSchema();
       }
 
-      const sql = generateTableSQL({ tableName, schema, schemaName: this.schemaName, compositePrimaryKey });
+      const snapshot = this.schemaSnapshot;
+      // Skipping the statement when everything it would create is already there
+      // is not only a saved round trip: `CREATE TABLE IF NOT EXISTS` requires
+      // CREATE on the schema, so on a converged schema this is also what lets a
+      // least-privilege role finish init instead of failing with
+      // "permission denied".
+      if (!snapshot || !this.snapshotShowsTableConverged(snapshot, tableName)) {
+        const sql = generateTableSQL({ tableName, schema, schemaName: this.schemaName, compositePrimaryKey });
 
-      try {
-        await this.client.none(sql);
-      } catch (error) {
-        // `CREATE TABLE IF NOT EXISTS` is not atomic across concurrent
-        // backends. Two processes can both pass the existence probe and one
-        // surfaces a catalog duplicate error. Treat it as "already created".
-        if (!isDuplicateRelationError(error)) throw error;
+        try {
+          await this.client.none(sql);
+        } catch (error) {
+          // `CREATE TABLE IF NOT EXISTS` is not atomic across concurrent
+          // backends. Two processes can both pass the existence probe and one
+          // surfaces a catalog duplicate error. Treat it as "already created".
+          if (!isDuplicateRelationError(error)) throw error;
+        }
+
+        if (snapshot) {
+          snapshot.tables.add(tableName);
+          // generateTableSQL emits the declared columns plus a `Z` twin for
+          // every timestamp column; record both so the alterTable pass below
+          // and later domains don't re-probe for them.
+          const created = this.snapshotColumns(snapshot, tableName);
+          for (const [name, def] of Object.entries(schema)) {
+            const parsedName = parseSqlIdentifier(name, 'column name');
+            created.add(parsedName);
+            if (def.type === 'timestamp') {
+              created.add(`${parsedName}Z`);
+            }
+          }
+        }
       }
 
       await this.alterTable({
@@ -1172,6 +1250,11 @@ export class PgDB extends MastraBase {
     ifNotExists: string[];
   }): Promise<void> {
     const fullTableName = getTableName({ indexName: tableName, schemaName: getSchemaName(this.schemaName) });
+    const snapshot = this.schemaSnapshot;
+    // Every ALTER below is `ADD COLUMN IF NOT EXISTS`, so on a converged schema
+    // they are all no-ops the server still has to parse and acknowledge. When a
+    // snapshot is live, only issue the ones that will actually change something.
+    const knownColumns = snapshot ? this.snapshotColumns(snapshot, tableName) : null;
 
     try {
       for (const columnName of ifNotExists) {
@@ -1185,12 +1268,19 @@ export class PgDB extends MastraBase {
           const alterSql =
             `ALTER TABLE ${fullTableName} ADD COLUMN IF NOT EXISTS "${parsedColumnName}" ${sqlType} ${nullable} ${defaultValue}`.trim();
 
-          await this.client.none(alterSql);
+          if (!knownColumns?.has(parsedColumnName)) {
+            await this.client.none(alterSql);
+            knownColumns?.add(parsedColumnName);
+          }
 
           if (sqlType === 'TIMESTAMP') {
-            const timestampZSql =
-              `ALTER TABLE ${fullTableName} ADD COLUMN IF NOT EXISTS "${parsedColumnName}Z" TIMESTAMPTZ DEFAULT NOW()`.trim();
-            await this.client.none(timestampZSql);
+            const tzColumnName = `${parsedColumnName}Z`;
+            if (!knownColumns?.has(tzColumnName)) {
+              const timestampZSql =
+                `ALTER TABLE ${fullTableName} ADD COLUMN IF NOT EXISTS "${tzColumnName}" TIMESTAMPTZ DEFAULT NOW()`.trim();
+              await this.client.none(timestampZSql);
+              knownColumns?.add(tzColumnName);
+            }
           }
 
           this.logger?.debug?.(`Ensured column ${parsedColumnName} exists in table ${fullTableName}`);

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -337,7 +337,14 @@ export function generateTimestampTriggerSQL(tableName: string, schemaName?: stri
   const quotedSchemaName = getSchemaName(schemaName);
   const fullTableName = getTableName({ indexName: tableName, schemaName: quotedSchemaName });
   const functionName = `${quotedSchemaName}.trigger_set_timestamps`;
-  const triggerName = `"${parseSqlIdentifier(`${tableName}_timestamps`, 'trigger name')}"`;
+  const parsedTriggerName = parseSqlIdentifier(`${tableName}_timestamps`, 'trigger name');
+  const triggerName = `"${parsedTriggerName}"`;
+
+  // Literals for the pg_trigger guard below. The identifiers are already
+  // validated by parseSqlIdentifier, so they cannot carry a quote.
+  const triggerNameLiteral = `'${parsedTriggerName}'`;
+  const tableNameLiteral = `'${parseSqlIdentifier(tableName, 'table name')}'`;
+  const schemaNameLiteral = schemaName ? `'${parseSqlIdentifier(schemaName, 'schema name')}'` : `'public'`;
 
   return `CREATE OR REPLACE FUNCTION ${functionName}()
 RETURNS TRIGGER AS $$
@@ -357,12 +364,38 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS ${triggerName} ON ${fullTableName};
+DO $mastra_timestamps_trigger$
+BEGIN
+    -- Recreating the trigger unconditionally would take an ACCESS EXCLUSIVE
+    -- lock on the table (DROP TRIGGER does, even when nothing changes), and
+    -- init runs on every process start. Skip when the trigger is already
+    -- exactly what the CREATE below would produce.
+    --
+    -- tgtype 23 = ROW (1) | BEFORE (2) | INSERT (4) | UPDATE (16), so a trigger
+    -- whose timing or events differ still falls through and gets rebuilt. The
+    -- behaviour itself lives in the function, which is replaced above on every
+    -- init, so an upgraded function body lands without touching the trigger.
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_trigger tg
+        JOIN pg_catalog.pg_class c ON c.oid = tg.tgrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE tg.tgname = ${triggerNameLiteral}
+          AND c.relname = ${tableNameLiteral}
+          AND n.nspname = ${schemaNameLiteral}
+          AND NOT tg.tgisinternal
+          AND tg.tgtype = 23
+          AND tg.tgfoid = '${functionName}()'::regprocedure
+    ) THEN
+        DROP TRIGGER IF EXISTS ${triggerName} ON ${fullTableName};
 
-CREATE TRIGGER ${triggerName}
-    BEFORE INSERT OR UPDATE ON ${fullTableName}
-    FOR EACH ROW
-    EXECUTE FUNCTION ${functionName}();`;
+        CREATE TRIGGER ${triggerName}
+            BEFORE INSERT OR UPDATE ON ${fullTableName}
+            FOR EACH ROW
+            EXECUTE FUNCTION ${functionName}();
+    END IF;
+END
+$mastra_timestamps_trigger$;`;
 }
 
 /**

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -1073,6 +1073,11 @@ export class PgDB extends MastraBase {
     });
     const schemaFilter = this.schemaName || 'public';
 
+    // A primary key is always backed by an index of the same name, so the init
+    // snapshot already answers this without a round trip.
+    const snapshot = this.schemaSnapshot;
+    if (snapshot) return snapshot.primaryKeyIndexes.has(constraintName.toLowerCase());
+
     const result = await this.client.oneOrNone<{ exists: boolean }>(
       `SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = lower($1) AND connamespace = (SELECT oid FROM pg_namespace WHERE nspname = $2)) as exists`,
       [constraintName, schemaFilter],
@@ -1116,6 +1121,7 @@ export class PgDB extends MastraBase {
         ADD CONSTRAINT ${constraintName}
         PRIMARY KEY ("traceId", "spanId")
       `);
+      this.schemaSnapshot?.primaryKeyIndexes.add(constraintName.toLowerCase());
 
       this.logger?.info?.(`Added PRIMARY KEY constraint ${constraintName} to ${fullTableName}`);
     } catch (error) {
@@ -1410,15 +1416,20 @@ export class PgDB extends MastraBase {
         schemaName: getSchemaName(this.schemaName),
       });
 
-      const indexExists = await this.client.oneOrNone(
-        `SELECT 1 FROM pg_indexes
+      const snapshot = this.schemaSnapshot;
+      if (snapshot) {
+        if (snapshot.indexes.has(name)) return;
+      } else {
+        const indexExists = await this.client.oneOrNone(
+          `SELECT 1 FROM pg_indexes
          WHERE indexname = $1
          AND schemaname = $2`,
-        [name, schemaName],
-      );
+          [name, schemaName],
+        );
 
-      if (indexExists) {
-        return;
+        if (indexExists) {
+          return;
+        }
       }
 
       const uniqueStr = unique ? 'UNIQUE ' : '';
@@ -1455,6 +1466,7 @@ export class PgDB extends MastraBase {
       const sql = `CREATE ${uniqueStr}INDEX ${concurrentStr}${quotedIndexName} ON ${fullTableName} ${methodStr}(${columnsStr})${withStr}${tablespaceStr}${whereStr}`;
 
       await this.client.none(sql);
+      snapshot?.indexes.add(name);
     } catch (error) {
       if (error instanceof Error && error.message.includes('CONCURRENTLY')) {
         const retryOptions = { ...options, concurrent: false };
@@ -1476,23 +1488,46 @@ export class PgDB extends MastraBase {
     }
   }
 
+  /**
+   * Runs a caller-built `CREATE INDEX IF NOT EXISTS` statement, unless the init
+   * snapshot already proves `indexName` exists.
+   *
+   * `createIndex` covers the indexes described by {@link CreateIndexOptions};
+   * this is for the two init paths that hand-write their statement (a partial
+   * or otherwise non-standard index) and would otherwise send a no-op DDL on
+   * every warm init.
+   */
+  async createIndexFromStatement(indexName: string, sql: string): Promise<void> {
+    const snapshot = this.schemaSnapshot;
+    if (snapshot?.indexes.has(indexName)) return;
+
+    await this.client.none(sql);
+    snapshot?.indexes.add(indexName);
+  }
+
   async dropIndex(indexName: string): Promise<void> {
     try {
       const schemaName = this.schemaName || 'public';
-      const indexExists = await this.client.oneOrNone(
-        `SELECT 1 FROM pg_indexes
+      const snapshot = this.schemaSnapshot;
+      if (snapshot) {
+        if (!snapshot.indexes.has(indexName)) return;
+      } else {
+        const indexExists = await this.client.oneOrNone(
+          `SELECT 1 FROM pg_indexes
          WHERE indexname = $1
          AND schemaname = $2`,
-        [indexName, schemaName],
-      );
+          [indexName, schemaName],
+        );
 
-      if (!indexExists) {
-        return;
+        if (!indexExists) {
+          return;
+        }
       }
 
       const quotedIndexName = `"${parseSqlIdentifier(indexName, 'index name')}"`;
       const sql = `DROP INDEX IF EXISTS ${getSchemaName(this.schemaName)}.${quotedIndexName}`;
       await this.client.none(sql);
+      snapshot?.indexes.delete(indexName);
     } catch (error) {
       throw new MastraError(
         {

--- a/stores/pg/src/storage/db/schema-snapshot.stress.test.ts
+++ b/stores/pg/src/storage/db/schema-snapshot.stress.test.ts
@@ -1,0 +1,245 @@
+import { Client, Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { PostgresStore } from '..';
+import { TEST_CONFIG, connectionString } from '../test-utils';
+
+/**
+ * The init-window catalog snapshot under stress: several processes starting at
+ * once, a role that may read the schema but not change it, and a store whose
+ * init is called more than once.
+ */
+
+const RESTRICTED_ROLE = 'mastra_snapshot_restricted';
+const RESTRICTED_PASSWORD = 'test123';
+
+let adminPool: Pool;
+const schemasToDrop: string[] = [];
+const storesToClose: PostgresStore[] = [];
+
+function uniqueSchema(prefix: string): string {
+  const name = `${prefix}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+  schemasToDrop.push(name);
+  return name;
+}
+
+function newStore(schemaName: string, overrides: Record<string, unknown> = {}): PostgresStore {
+  const store = new PostgresStore({
+    ...TEST_CONFIG,
+    id: `stress-${schemaName}-${Math.random().toString(36).slice(2, 6)}`,
+    schemaName,
+    ...overrides,
+  } as any);
+  storesToClose.push(store);
+  return store;
+}
+
+/** Records every statement the pg driver sends while `fn` runs, and any that fail. */
+async function captureStatements(fn: () => Promise<void>): Promise<{ sent: string[]; failed: string[] }> {
+  const sent: string[] = [];
+  const failed: string[] = [];
+  const original = Client.prototype.query;
+
+  (Client.prototype as any).query = function (this: any, ...args: any[]) {
+    const first = args[0];
+    const text = typeof first === 'string' ? first : first?.text;
+    if (typeof text === 'string') sent.push(text);
+    const result = (original as any).apply(this, args);
+    if (result && typeof result.then === 'function' && typeof text === 'string') {
+      return result.catch((error: any) => {
+        failed.push(`${error?.message}  <<  ${text.replace(/\s+/g, ' ').slice(0, 80)}`);
+        throw error;
+      });
+    }
+    return result;
+  };
+
+  try {
+    await fn();
+  } finally {
+    (Client.prototype as any).query = original;
+  }
+
+  return { sent, failed };
+}
+
+function count(statements: string[], pattern: RegExp): number {
+  return statements.filter(s => pattern.test(s)).length;
+}
+
+const SNAPSHOT_READ = /FROM pg_catalog\.pg_(tables|class|index)\b/i;
+const WRITE_DDL = /^\s*(CREATE|ALTER|DROP)\s+(TABLE|INDEX|UNIQUE INDEX)/im;
+
+async function tableCount(schema: string): Promise<number> {
+  const { rows } = await adminPool.query(`SELECT count(*)::int AS n FROM pg_catalog.pg_tables WHERE schemaname = $1`, [
+    schema,
+  ]);
+  return rows[0].n;
+}
+
+async function columnsOf(schema: string): Promise<string[]> {
+  const { rows } = await adminPool.query(
+    `SELECT c.relname || '.' || a.attname AS col
+       FROM pg_catalog.pg_class c
+       JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+       JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+      WHERE n.nspname = $1 AND c.relkind = 'r' AND a.attnum > 0 AND NOT a.attisdropped
+      ORDER BY 1`,
+    [schema],
+  );
+  return rows.map(r => r.col);
+}
+
+beforeAll(async () => {
+  adminPool = new Pool({ connectionString });
+}, 30000);
+
+afterAll(async () => {
+  for (const store of storesToClose) {
+    try {
+      await store.close();
+    } catch {}
+  }
+  for (const schema of schemasToDrop) {
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+  }
+  await adminPool.end();
+}, 120000);
+
+describe('init snapshot under stress', () => {
+  /**
+   * Scoped to warm concurrent init on purpose. Cold concurrent init — several
+   * processes racing to build an empty schema — is broken independently of the
+   * snapshot: `CREATE INDEX IF NOT EXISTS` and `CREATE TABLE IF NOT EXISTS`
+   * are not atomic against a concurrent backend, so the losers get a duplicate
+   * `pg_class` key or a deadlock. Measured on this test database, 5 rounds of
+   * 2 racing cold inits: 10/10 failed before the snapshot work, 5/10 after.
+   * That is a pre-existing bug and is not this change's to fix; asserting a
+   * cold race here would be asserting someone else's fix.
+   *
+   * Warm concurrent init is the case this change is about — every process
+   * after the first, which is the serverless shape — and it is clean: 0/20
+   * failures on both revisions.
+   */
+  it('converges correctly when several stores init a converged schema at once', async () => {
+    const schema = uniqueSchema('stress_race');
+    await adminPool.query(`CREATE SCHEMA "${schema}"`);
+
+    await newStore(schema).init();
+    const settledTables = await tableCount(schema);
+    const settledColumns = await columnsOf(schema);
+
+    // Four processes start together against the converged schema. Each loads
+    // its own snapshot; none of them may decide to write anything.
+    const stores = [newStore(schema), newStore(schema), newStore(schema), newStore(schema)];
+    const { sent, failed } = await captureStatements(async () => {
+      const results = await Promise.allSettled(stores.map(s => s.init()));
+      const rejected = results.filter(r => r.status === 'rejected') as PromiseRejectedResult[];
+      expect(rejected.map(r => String((r.reason as any)?.cause?.message ?? r.reason))).toEqual([]);
+    });
+
+    // `CREATE OR REPLACE FUNCTION` for the timestamp trigger is deliberately
+    // unconditional so an upgraded function body lands, and Postgres does not
+    // serialize it — racing backends get "tuple concurrently updated". That is
+    // pre-existing and harmless: init logs it and carries on, and the function
+    // the losers failed to rewrite is already the one they wanted. Nothing
+    // else may fail.
+    expect(failed.filter(s => !/CREATE OR REPLACE FUNCTION/i.test(s))).toEqual([]);
+    expect(count(sent, WRITE_DDL)).toBe(0);
+    // One snapshot per store, not one per domain.
+    expect(count(sent, SNAPSHOT_READ)).toBe(3 * stores.length);
+
+    // The schema is untouched by the stampede.
+    expect(await tableCount(schema)).toBe(settledTables);
+    expect(await columnsOf(schema)).toEqual(settledColumns);
+  }, 180000);
+
+  it('initializes a converged schema as a role that may read it but not change it', async () => {
+    const schema = uniqueSchema('stress_restricted');
+    await adminPool.query(`CREATE SCHEMA "${schema}"`);
+
+    // A privileged deploy step converges the schema first.
+    const owner = newStore(schema);
+    await owner.init();
+    await owner.close();
+
+    await adminPool.query(
+      `DO $$ BEGIN
+         IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${RESTRICTED_ROLE}') THEN
+           CREATE USER ${RESTRICTED_ROLE} WITH PASSWORD '${RESTRICTED_PASSWORD}' NOCREATEDB;
+         END IF;
+       END $$;`,
+    );
+    // Exactly enough to use the schema: connect, look at it, read and write
+    // rows. No CREATE on the schema, no ownership of the tables.
+    await adminPool.query(`GRANT CONNECT ON DATABASE "${(TEST_CONFIG as any).database}" TO ${RESTRICTED_ROLE}`);
+    await adminPool.query(`GRANT USAGE ON SCHEMA "${schema}" TO ${RESTRICTED_ROLE}`);
+    await adminPool.query(
+      `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA "${schema}" TO ${RESTRICTED_ROLE}`,
+    );
+    await adminPool.query(`REVOKE CREATE ON SCHEMA "${schema}" FROM ${RESTRICTED_ROLE}, PUBLIC`);
+
+    try {
+      const restricted = newStore(schema, { user: RESTRICTED_ROLE, password: RESTRICTED_PASSWORD });
+
+      const { sent, failed } = await captureStatements(async () => {
+        await restricted.init();
+      });
+
+      // The snapshot answers every existence question, so init never reaches
+      // for a privilege it does not have. Before the snapshot, the very first
+      // unconditional `CREATE TABLE IF NOT EXISTS` aborted init here.
+      expect(count(sent, WRITE_DDL)).toBe(0);
+      expect(count(sent, SNAPSHOT_READ)).toBe(3);
+
+      // `CREATE OR REPLACE FUNCTION` for the timestamp trigger stays
+      // unconditional so function-body upgrades land, and it is the one
+      // statement a non-owner cannot run. init already treats that as a
+      // warning rather than a failure, and nothing else is denied.
+      expect(failed.filter(s => !/CREATE OR REPLACE FUNCTION/i.test(s))).toEqual([]);
+
+      // Storage is actually usable afterwards.
+      const id = `restricted-${Date.now()}`;
+      const at = new Date();
+      await restricted.stores.memory!.saveThread({
+        thread: { id, resourceId: 'r1', title: 'restricted', createdAt: at, updatedAt: at, metadata: {} },
+      });
+      expect((await restricted.stores.memory!.getThreadById({ threadId: id }))?.id).toBe(id);
+    } finally {
+      await adminPool.query(`REVOKE ALL ON ALL TABLES IN SCHEMA "${schema}" FROM ${RESTRICTED_ROLE}`);
+      await adminPool.query(`REVOKE ALL ON SCHEMA "${schema}" FROM ${RESTRICTED_ROLE}`);
+    }
+  }, 180000);
+
+  it('does not re-read the catalog on a repeated init, and never reuses a stale snapshot', async () => {
+    const schema = uniqueSchema('stress_repeat');
+    await adminPool.query(`CREATE SCHEMA "${schema}"`);
+
+    const store = newStore(schema);
+    await store.init();
+
+    // Same instance: init is already done, so it costs nothing at all.
+    const second = await captureStatements(async () => {
+      await store.init();
+    });
+    expect(second.sent).toEqual([]);
+
+    // A fresh instance re-reads the catalog rather than trusting anything
+    // cached — drop a table behind its back and it must come back.
+    const before = await tableCount(schema);
+    await adminPool.query(`DROP TABLE "${schema}"."mastra_favorites"`);
+    expect(await tableCount(schema)).toBe(before - 1);
+
+    const reopened = newStore(schema);
+    const third = await captureStatements(async () => {
+      await reopened.init();
+    });
+    expect(count(third.sent, SNAPSHOT_READ)).toBe(3);
+    expect(count(third.sent, /CREATE TABLE IF NOT EXISTS/i)).toBe(1);
+    expect(await tableCount(schema)).toBe(before);
+    const { rows } = await adminPool.query(
+      `SELECT to_regclass(format('%I.%I', $1::text, 'mastra_favorites')) IS NOT NULL AS present`,
+      [schema],
+    );
+    expect(rows[0].present).toBe(true);
+  }, 180000);
+});

--- a/stores/pg/src/storage/db/schema-snapshot.test.ts
+++ b/stores/pg/src/storage/db/schema-snapshot.test.ts
@@ -234,6 +234,56 @@ describe('init catalog snapshot', () => {
     expect(await tablesIn(fresh)).toEqual(await tablesIn(converged));
   }, 90000);
 
+  it('ignores unrelated tables, columns, and indexes sharing the schema', async () => {
+    // A plugin (or anything else) is free to put its own objects in the schema
+    // Mastra was pointed at. The snapshot is read for the whole schema, so this
+    // pins that it stays a lookup table: unknown objects are never enumerated,
+    // never touched, and never satisfy a Mastra object's existence check.
+    const schema = uniqueSchema('snapshot_coexist');
+    await admin(`CREATE SCHEMA "${schema}"`);
+
+    const cold = await newStore(schema);
+    await cold.init();
+    await cold.close();
+
+    await admin(`CREATE TABLE "${schema}".plugin_widgets (id text PRIMARY KEY, payload jsonb)`);
+    await admin(`CREATE INDEX plugin_widgets_payload_idx ON "${schema}".plugin_widgets USING gin (payload)`);
+    await admin(`ALTER TABLE "${schema}".mastra_threads ADD COLUMN plugin_tenant_id text`);
+    await admin(`CREATE INDEX plugin_threads_tenant_idx ON "${schema}".mastra_threads (plugin_tenant_id)`);
+
+    const mastraTablesBefore = (await tablesIn(schema)).filter(t => t !== 'plugin_widgets');
+
+    const warm = await newStore(schema);
+    const statements = await captureStatements(() => warm.init());
+
+    // Same capture-hook guard as the warm-init test above.
+    expect(count(statements, /pg_catalog\.pg_tables/i)).toBe(1);
+
+    // The extra objects neither reintroduce probes nor provoke DDL.
+    expect(count(statements, INFORMATION_SCHEMA_COLUMN_PROBE)).toBe(0);
+    expect(count(statements, INDEX_PROBE)).toBe(0);
+    expect(count(statements, CREATE_TABLE)).toBe(0);
+    expect(count(statements, CREATE_INDEX)).toBe(0);
+    expect(count(statements, NO_OP_ALTER)).toBe(0);
+
+    // Nothing of the plugin's was dropped, altered, or recreated.
+    expect(await tablesIn(schema)).toContain('plugin_widgets');
+    expect(await indexesIn(schema)).toEqual(
+      expect.arrayContaining(['plugin_widgets_payload_idx', 'plugin_threads_tenant_idx']),
+    );
+    expect((await columnsIn(schema, 'mastra_threads')).has('plugin_tenant_id')).toBe(true);
+    expect((await tablesIn(schema)).filter(t => t !== 'plugin_widgets')).toEqual(mastraTablesBefore);
+
+    // And drift in a Mastra table still heals with the plugin's column present.
+    await admin(`ALTER TABLE "${schema}".mastra_threads DROP COLUMN "createdAtZ"`);
+    const healer = await newStore(schema);
+    await healer.init();
+
+    const columns = await columnsIn(schema, 'mastra_threads');
+    expect(columns.has('createdAtZ')).toBe(true);
+    expect(columns.has('plugin_tenant_id')).toBe(true);
+  }, 90000);
+
   it('stops using the snapshot once init has returned', async () => {
     const schema = uniqueSchema('snapshot_cleared');
     await admin(`CREATE SCHEMA "${schema}"`);

--- a/stores/pg/src/storage/db/schema-snapshot.test.ts
+++ b/stores/pg/src/storage/db/schema-snapshot.test.ts
@@ -1,0 +1,205 @@
+import { TABLE_SCHEMAS } from '@mastra/core/storage';
+import type { TABLE_NAMES } from '@mastra/core/storage';
+import { Client, Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { PostgresStore } from '..';
+import { TEST_CONFIG, connectionString } from '../test-utils';
+import { PgDB } from '.';
+
+/**
+ * Covers the init-window catalog snapshot: on an already-converged schema,
+ * init() must stop re-asking the server what it already knows, while still
+ * converging a cold or drifted schema exactly as before.
+ */
+
+let adminPool: Pool;
+const schemasToDrop: string[] = [];
+const storesToClose: PostgresStore[] = [];
+
+function uniqueSchema(prefix: string): string {
+  const name = `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  schemasToDrop.push(name);
+  return name;
+}
+
+async function admin(sql: string, values?: unknown[]): Promise<any[]> {
+  const result = await adminPool.query(sql, values as any);
+  return result.rows;
+}
+
+async function newStore(schemaName: string): Promise<PostgresStore> {
+  const store = new PostgresStore({ ...TEST_CONFIG, id: `snapshot-test-${schemaName}`, schemaName });
+  storesToClose.push(store);
+  return store;
+}
+
+/** Records every statement the pg driver sends while `fn` runs. */
+async function captureStatements(fn: () => Promise<void>): Promise<string[]> {
+  const statements: string[] = [];
+  const original = Client.prototype.query;
+
+  (Client.prototype as any).query = function (this: any, ...args: any[]) {
+    const first = args[0];
+    const text = typeof first === 'string' ? first : first?.text;
+    if (typeof text === 'string') statements.push(text);
+    return (original as any).apply(this, args);
+  };
+
+  try {
+    await fn();
+  } finally {
+    (Client.prototype as any).query = original;
+  }
+
+  return statements;
+}
+
+function count(statements: string[], pattern: RegExp): number {
+  return statements.filter(s => pattern.test(s)).length;
+}
+
+const INFORMATION_SCHEMA_COLUMN_PROBE = /information_schema\.columns/i;
+const NO_OP_ALTER = /ALTER TABLE[\s\S]*ADD COLUMN IF NOT EXISTS/i;
+const CREATE_TABLE = /CREATE TABLE IF NOT EXISTS/i;
+
+async function tablesIn(schemaName: string): Promise<string[]> {
+  const rows = await admin(`SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = $1 ORDER BY tablename`, [
+    schemaName,
+  ]);
+  return rows.map(r => r.tablename);
+}
+
+async function columnsIn(schemaName: string, tableName: string): Promise<Set<string>> {
+  const rows = await admin(
+    `SELECT column_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2`,
+    [schemaName, tableName],
+  );
+  return new Set(rows.map(r => r.column_name));
+}
+
+beforeAll(async () => {
+  adminPool = new Pool({ connectionString });
+}, 30000);
+
+afterAll(async () => {
+  for (const store of storesToClose) {
+    try {
+      await store.close();
+    } catch {}
+  }
+  for (const schema of schemasToDrop) {
+    await admin(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+  }
+  await adminPool.end();
+}, 60000);
+
+describe('init catalog snapshot', () => {
+  it('issues no column probes, no-op ALTERs, or CREATE TABLEs on a warm init', async () => {
+    const schema = uniqueSchema('snapshot_warm');
+    await admin(`CREATE SCHEMA "${schema}"`);
+
+    const cold = await newStore(schema);
+    await cold.init();
+    await cold.close();
+
+    const warm = await newStore(schema);
+    const statements = await captureStatements(() => warm.init());
+
+    // Guards the capture hook itself: the three snapshot reads must show up, or
+    // the zero-counts below would be vacuously true.
+    expect(count(statements, /pg_catalog\.pg_tables/i)).toBe(1);
+    expect(count(statements, /pg_catalog\.pg_attribute/i)).toBe(1);
+    expect(count(statements, /pg_catalog\.pg_index\b/i)).toBe(1);
+
+    expect(count(statements, INFORMATION_SCHEMA_COLUMN_PROBE)).toBe(0);
+    expect(count(statements, NO_OP_ALTER)).toBe(0);
+    expect(count(statements, CREATE_TABLE)).toBe(0);
+  }, 60000);
+
+  it('converges a cold schema to the same tables and columns as another cold init', async () => {
+    const schemaA = uniqueSchema('snapshot_cold_a');
+    const schemaB = uniqueSchema('snapshot_cold_b');
+    await admin(`CREATE SCHEMA "${schemaA}"`);
+    await admin(`CREATE SCHEMA "${schemaB}"`);
+
+    const storeA = await newStore(schemaA);
+    const storeB = await newStore(schemaB);
+    await storeA.init();
+    await storeB.init();
+
+    const tablesA = await tablesIn(schemaA);
+    expect(tablesA.length).toBeGreaterThan(0);
+    expect(await tablesIn(schemaB)).toEqual(tablesA);
+
+    for (const table of tablesA) {
+      const actual = await columnsIn(schemaA, table);
+      expect(await columnsIn(schemaB, table)).toEqual(actual);
+
+      // Every column the table's schema declares must exist, plus the `Z` twin
+      // of each timestamp column.
+      const declared = TABLE_SCHEMAS[table as TABLE_NAMES];
+      if (!declared) continue;
+      for (const [name, def] of Object.entries(declared)) {
+        expect(actual.has(name), `${table}.${name} missing after cold init`).toBe(true);
+        if (def.type === 'timestamp') {
+          expect(actual.has(`${name}Z`), `${table}.${name}Z missing after cold init`).toBe(true);
+        }
+      }
+    }
+  }, 90000);
+
+  it('heals a dropped column and a dropped table on the next init', async () => {
+    const schema = uniqueSchema('snapshot_drift');
+    await admin(`CREATE SCHEMA "${schema}"`);
+
+    const first = await newStore(schema);
+    await first.init();
+    await first.close();
+
+    const before = await tablesIn(schema);
+    const droppedTable = before.find(t => t !== 'mastra_threads')!;
+
+    await admin(`ALTER TABLE "${schema}".mastra_threads DROP COLUMN "createdAtZ"`);
+    await admin(`DROP TABLE "${schema}"."${droppedTable}" CASCADE`);
+
+    expect((await columnsIn(schema, 'mastra_threads')).has('createdAtZ')).toBe(false);
+    expect(await tablesIn(schema)).not.toContain(droppedTable);
+
+    const second = await newStore(schema);
+    await second.init();
+
+    expect((await columnsIn(schema, 'mastra_threads')).has('createdAtZ')).toBe(true);
+    expect(await tablesIn(schema)).toContain(droppedTable);
+  }, 90000);
+
+  it('does not let one schema\u2019s snapshot satisfy another schema\u2019s init', async () => {
+    const converged = uniqueSchema('snapshot_scope_converged');
+    const fresh = uniqueSchema('snapshot_scope_fresh');
+    await admin(`CREATE SCHEMA "${converged}"`);
+    await admin(`CREATE SCHEMA "${fresh}"`);
+
+    const convergedStore = await newStore(converged);
+    await convergedStore.init();
+
+    const freshStore = await newStore(fresh);
+    await freshStore.init();
+
+    expect(await tablesIn(fresh)).toEqual(await tablesIn(converged));
+  }, 90000);
+
+  it('stops using the snapshot once init has returned', async () => {
+    const schema = uniqueSchema('snapshot_cleared');
+    await admin(`CREATE SCHEMA "${schema}"`);
+
+    const store = await newStore(schema);
+    await store.init();
+
+    const db = new PgDB({ client: store.db, schemaName: schema });
+    expect(await db.hasColumn('mastra_threads', 'createdAtZ')).toBe(true);
+
+    await admin(`ALTER TABLE "${schema}".mastra_threads DROP COLUMN "createdAtZ"`);
+
+    // A snapshot that outlived init() would still report the column present.
+    expect(await db.hasColumn('mastra_threads', 'createdAtZ')).toBe(false);
+  }, 60000);
+});

--- a/stores/pg/src/storage/db/schema-snapshot.test.ts
+++ b/stores/pg/src/storage/db/schema-snapshot.test.ts
@@ -339,4 +339,85 @@ describe('init catalog snapshot', () => {
     // A snapshot that outlived init() would still report the column present.
     expect(await db.hasColumn('mastra_threads', 'createdAtZ')).toBe(false);
   }, 60000);
+
+  it('migrates a legacy flat agents schema with the snapshot live', async () => {
+    const schema = uniqueSchema('snapshot_legacy');
+    await admin(`CREATE SCHEMA "${schema}"`);
+
+    // A database last touched by a pre-versioning release: agent config fields
+    // live directly on mastra_agents. The legacy migration renames this table
+    // and recreates it in the new shape via raw DDL — every step of which must
+    // keep the init snapshot honest, or later createTable/alterTable calls
+    // skip work the rename just un-did.
+    await admin(`
+      CREATE TABLE "${schema}".mastra_agents (
+        id TEXT PRIMARY KEY,
+        name TEXT,
+        description TEXT,
+        instructions TEXT,
+        model JSONB,
+        metadata JSONB,
+        "createdAt" TIMESTAMP DEFAULT NOW(),
+        "updatedAt" TIMESTAMP DEFAULT NOW()
+      )
+    `);
+    await admin(`INSERT INTO "${schema}".mastra_agents (id, name, instructions, model) VALUES ($1, $2, $3, $4)`, [
+      'legacy-agent-1',
+      'Legacy Agent',
+      'be legacy',
+      JSON.stringify({ provider: 'openai', name: 'gpt-4o' }),
+    ]);
+
+    const store = await newStore(schema);
+    await store.init();
+
+    const tables = await tablesIn(schema);
+    expect(tables).toContain('mastra_agents');
+    expect(tables).toContain('mastra_agent_versions');
+    expect(tables).not.toContain('mastra_agents_legacy');
+
+    // The table was rebuilt in the new thin shape…
+    const agentColumns = await columnsIn(schema, 'mastra_agents');
+    expect(agentColumns.has('activeVersionId')).toBe(true);
+    expect(agentColumns.has('name')).toBe(false);
+
+    // …and the legacy row's data survived the trip into the versions table.
+    const agents = await admin(`SELECT id, "activeVersionId" FROM "${schema}".mastra_agents`);
+    expect(agents).toHaveLength(1);
+    expect(agents[0].id).toBe('legacy-agent-1');
+    const versions = await admin(`SELECT "agentId", name FROM "${schema}".mastra_agent_versions`);
+    expect(versions).toHaveLength(1);
+    expect(versions[0].agentId).toBe('legacy-agent-1');
+    expect(versions[0].name).toBe('Legacy Agent');
+  }, 60000);
+
+  it('migrates a snapshot-column agent_versions schema with the snapshot live', async () => {
+    const schema = uniqueSchema('snapshot_versions');
+    await admin(`CREATE SCHEMA "${schema}"`);
+
+    const first = await newStore(schema);
+    await first.init();
+    await first.close();
+
+    // A database from the intermediate era: agents already thin, but versions
+    // still store one opaque snapshot blob per row. The migration drops the
+    // table outright and relies on init() to recreate it — which only happens
+    // if the drop is reflected in the init snapshot.
+    await admin(`DROP TABLE "${schema}".mastra_agent_versions`);
+    await admin(`
+      CREATE TABLE "${schema}".mastra_agent_versions (
+        id TEXT PRIMARY KEY,
+        "agentId" TEXT,
+        snapshot JSONB
+      )
+    `);
+
+    const store = await newStore(schema);
+    await store.init();
+
+    const versionColumns = await columnsIn(schema, 'mastra_agent_versions');
+    expect(versionColumns.has('snapshot')).toBe(false);
+    expect(versionColumns.has('name')).toBe(true);
+    expect(versionColumns.has('instructions')).toBe(true);
+  }, 60000);
 });

--- a/stores/pg/src/storage/db/schema-snapshot.test.ts
+++ b/stores/pg/src/storage/db/schema-snapshot.test.ts
@@ -61,6 +61,16 @@ function count(statements: string[], pattern: RegExp): number {
 const INFORMATION_SCHEMA_COLUMN_PROBE = /information_schema\.columns/i;
 const NO_OP_ALTER = /ALTER TABLE[\s\S]*ADD COLUMN IF NOT EXISTS/i;
 const CREATE_TABLE = /CREATE TABLE IF NOT EXISTS/i;
+const INDEX_PROBE = /FROM pg_indexes\b[\s\S]*indexname\s*=/i;
+const CREATE_INDEX = /CREATE (UNIQUE )?INDEX/i;
+const CONSTRAINT_PROBE = /FROM pg_constraint\b[\s\S]*conname\s*=/i;
+
+async function indexesIn(schemaName: string): Promise<string[]> {
+  const rows = await admin(`SELECT indexname FROM pg_catalog.pg_indexes WHERE schemaname = $1 ORDER BY indexname`, [
+    schemaName,
+  ]);
+  return rows.map(r => r.indexname);
+}
 
 async function tablesIn(schemaName: string): Promise<string[]> {
   const rows = await admin(`SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = $1 ORDER BY tablename`, [
@@ -114,6 +124,10 @@ describe('init catalog snapshot', () => {
     expect(count(statements, INFORMATION_SCHEMA_COLUMN_PROBE)).toBe(0);
     expect(count(statements, NO_OP_ALTER)).toBe(0);
     expect(count(statements, CREATE_TABLE)).toBe(0);
+    expect(count(statements, INDEX_PROBE)).toBe(0);
+    expect(count(statements, CREATE_INDEX)).toBe(0);
+    // The spans PRIMARY KEY is index-backed, so the snapshot answers it too.
+    expect(count(statements, CONSTRAINT_PROBE)).toBe(0);
   }, 60000);
 
   it('converges a cold schema to the same tables and columns as another cold init', async () => {
@@ -170,6 +184,39 @@ describe('init catalog snapshot', () => {
 
     expect((await columnsIn(schema, 'mastra_threads')).has('createdAtZ')).toBe(true);
     expect(await tablesIn(schema)).toContain(droppedTable);
+  }, 90000);
+
+  it('recreates indexes dropped out of band on the next init', async () => {
+    // Deliberately short: default index names are schema-prefixed, and a long
+    // schema pushes them past Postgres' 63-byte identifier limit, at which
+    // point the domain logs and skips them.
+    const schema = `sidx_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+    schemasToDrop.push(schema);
+    await admin(`CREATE SCHEMA "${schema}"`);
+
+    const first = await newStore(schema);
+    await first.init();
+    await first.close();
+
+    const before = await indexesIn(schema);
+    // One index from the createIndex() path and one from the hand-written
+    // CREATE INDEX path, so both snapshot readers are covered. The default
+    // index's name is schema-prefixed and then truncated to 63 bytes by
+    // Postgres, so it is located by definition rather than by name.
+    const viaCreateIndex = `${schema}_mastra_threads_resourceid_createdat_idx`;
+    expect(before).toContain(viaCreateIndex);
+    expect(before).toContain('idx_favorites_entity');
+
+    await admin(`DROP INDEX "${schema}"."${viaCreateIndex}"`);
+    await admin(`DROP INDEX "${schema}".idx_favorites_entity`);
+
+    const second = await newStore(schema);
+    await second.init();
+
+    const after = await indexesIn(schema);
+    expect(after).toContain(viaCreateIndex);
+    expect(after).toContain('idx_favorites_entity');
+    expect(after).toEqual(before);
   }, 90000);
 
   it('does not let one schema\u2019s snapshot satisfy another schema\u2019s init', async () => {

--- a/stores/pg/src/storage/db/schema-snapshot.test.ts
+++ b/stores/pg/src/storage/db/schema-snapshot.test.ts
@@ -1,7 +1,7 @@
 import { TABLE_SCHEMAS } from '@mastra/core/storage';
 import type { TABLE_NAMES } from '@mastra/core/storage';
 import { Client, Pool } from 'pg';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { PostgresStore } from '..';
 import { TEST_CONFIG, connectionString } from '../test-utils';
 import { PgDB } from '.';
@@ -129,6 +129,46 @@ describe('init catalog snapshot', () => {
     // The spans PRIMARY KEY is index-backed, so the snapshot answers it too.
     expect(count(statements, CONSTRAINT_PROBE)).toBe(0);
   }, 60000);
+
+  it('skips the schemata existence probe on a warm init in a fresh process', async () => {
+    const schema = uniqueSchema('snapshot_fresh');
+    await admin(`CREATE SCHEMA "${schema}"`);
+
+    const cold = await newStore(schema);
+    await cold.init();
+    await cold.close();
+
+    // The per-process schemaSetupRegistry hides the `information_schema.schemata`
+    // probe from same-process re-inits, which is how it went unmeasured: a fresh
+    // process (a CLI invocation, a serverless cold start) pays it on every warm
+    // init. Reset the module graph so the registry starts empty, like a fresh
+    // process would.
+    vi.resetModules();
+    const { PostgresStore: FreshPostgresStore } = await import('..');
+    const warm = new FreshPostgresStore({ ...TEST_CONFIG, id: `snapshot-fresh-${schema}`, schemaName: schema });
+
+    const statements = await captureStatements(() => warm.init());
+    await warm.close();
+
+    // Snapshot reads present (capture hook sanity), schemata probe absent: the
+    // snapshot's tables prove the schema exists.
+    expect(count(statements, /pg_catalog\.pg_tables/i)).toBe(1);
+    expect(count(statements, /information_schema\.schemata/i)).toBe(0);
+
+    // A cold schema in a fresh process still probes and creates it.
+    vi.resetModules();
+    const { PostgresStore: ColdFreshStore } = await import('..');
+    const coldSchema = uniqueSchema('snapshot_fresh_cold');
+    const coldFresh = new ColdFreshStore({
+      ...TEST_CONFIG,
+      id: `snapshot-fresh-${coldSchema}`,
+      schemaName: coldSchema,
+    });
+    const coldStatements = await captureStatements(() => coldFresh.init());
+    await coldFresh.close();
+    expect(count(coldStatements, /information_schema\.schemata/i)).toBe(1);
+    expect((await tablesIn(coldSchema)).length).toBeGreaterThan(0);
+  }, 120000);
 
   it('converges a cold schema to the same tables and columns as another cold init', async () => {
     const schemaA = uniqueSchema('snapshot_cold_a');

--- a/stores/pg/src/storage/db/schema-snapshot.ts
+++ b/stores/pg/src/storage/db/schema-snapshot.ts
@@ -1,0 +1,129 @@
+import type { DbClient } from '../client';
+
+/**
+ * A read-only picture of one Postgres schema's catalog, taken once at the start
+ * of `PostgresStore.init()`.
+ *
+ * Before this existed, every domain's init converged its own tables by asking
+ * the server: an `information_schema.columns` probe per column, a `pg_indexes`
+ * probe per index, plus an unconditional `CREATE TABLE IF NOT EXISTS` and a
+ * no-op `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` per column. On an
+ * already-converged schema that is ~350 statements that change nothing, and
+ * because init pins every domain to a single backend connection (issue #17679)
+ * they are strictly serialized — warm init cost is ~350 x RTT.
+ *
+ * The snapshot answers all of those questions locally instead, from three
+ * catalog reads.
+ *
+ * **Init-scoped by design.** The snapshot is installed on the store's
+ * `RoutingDbClient` for exactly the pinned-init window and cleared in the same
+ * `finally` that unpins, so staleness is bounded to a single init() call and
+ * runtime code paths keep querying the live catalog. It is deliberately *not* a
+ * process-global cache (that shape was proposed in PR #13960 and closed
+ * unmerged): every init re-reads the catalog, so a schema that drifted out of
+ * band between inits is still detected and healed.
+ *
+ * **Why `pg_catalog` and not `information_schema`.** `information_schema` views
+ * are privilege-filtered: a role with USAGE on the schema but no grants on a
+ * table sees the table but none of its columns, which would make the snapshot
+ * report "table present, zero columns" and skip DDL that is genuinely needed.
+ * The `pg_catalog` views used here are not privilege-filtered, so all three
+ * queries share one visibility rule.
+ */
+export interface SchemaSnapshot {
+  /** Schema the snapshot was taken from (`public` when the store has none). */
+  readonly schemaName: string;
+  /** Unqualified names of tables present in the schema. */
+  tables: Set<string>;
+  /** table name -> column names present on that table. */
+  columns: Map<string, Set<string>>;
+  /** Lowercased index names present in the schema. */
+  indexes: Set<string>;
+  /** Lowercased names of indexes that are the replica identity of their table. */
+  replicaIdentityIndexes: Set<string>;
+}
+
+/**
+ * Implemented by `RoutingDbClient` so the `PgDB` instances that share it (one
+ * per storage domain) can all read the single snapshot loaded for the current
+ * init window.
+ */
+export interface SchemaSnapshotHost {
+  readonly schemaSnapshot: SchemaSnapshot | null;
+}
+
+/**
+ * Returns the snapshot currently installed on `client`, but only when it was
+ * taken from the schema the caller operates on. A store configured for another
+ * schema (or a client with no snapshot at all) gets `null` and falls back to
+ * probing the live catalog.
+ */
+export function getSchemaSnapshot(client: unknown, schemaName: string | undefined): SchemaSnapshot | null {
+  const snapshot = (client as Partial<SchemaSnapshotHost> | null | undefined)?.schemaSnapshot;
+  if (!snapshot) return null;
+  return snapshot.schemaName === (schemaName || 'public') ? snapshot : null;
+}
+
+/**
+ * Reads the catalog for `schemaName` in three queries. Must be called on the
+ * pinned init client so the snapshot reflects what that connection will see.
+ */
+export async function loadSchemaSnapshot(client: DbClient, schemaName: string | undefined): Promise<SchemaSnapshot> {
+  const schema = schemaName || 'public';
+
+  const [tableRows, columnRows, indexRows] = await Promise.all([
+    client.manyOrNone<{ tablename: string }>(`SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = $1`, [
+      schema,
+    ]),
+    client.manyOrNone<{ table_name: string; column_name: string }>(
+      `SELECT c.relname AS table_name, a.attname AS column_name
+         FROM pg_catalog.pg_class c
+         JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+         JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+        WHERE n.nspname = $1
+          AND c.relkind IN ('r', 'p')
+          AND a.attnum > 0
+          AND NOT a.attisdropped`,
+      [schema],
+    ),
+    // pg_index rather than the pg_indexes view: same names, but it also carries
+    // indisreplident, which createTable needs to know whether the
+    // workflow_snapshot unique index is already the table's replica identity.
+    client.manyOrNone<{ indexname: string; is_replica_identity: boolean }>(
+      `SELECT c.relname AS indexname, i.indisreplident AS is_replica_identity
+         FROM pg_catalog.pg_index i
+         JOIN pg_catalog.pg_class c ON c.oid = i.indexrelid
+         JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = $1`,
+      [schema],
+    ),
+  ]);
+
+  const columns = new Map<string, Set<string>>();
+  for (const row of columnRows) {
+    let set = columns.get(row.table_name);
+    if (!set) {
+      set = new Set<string>();
+      columns.set(row.table_name, set);
+    }
+    set.add(row.column_name);
+  }
+
+  const indexes = new Set<string>();
+  const replicaIdentityIndexes = new Set<string>();
+  for (const row of indexRows) {
+    const name = row.indexname.toLowerCase();
+    indexes.add(name);
+    if (row.is_replica_identity) {
+      replicaIdentityIndexes.add(name);
+    }
+  }
+
+  return {
+    schemaName: schema,
+    tables: new Set(tableRows.map(r => r.tablename)),
+    columns,
+    indexes,
+    replicaIdentityIndexes,
+  };
+}

--- a/stores/pg/src/storage/db/schema-snapshot.ts
+++ b/stores/pg/src/storage/db/schema-snapshot.ts
@@ -37,10 +37,17 @@ export interface SchemaSnapshot {
   tables: Set<string>;
   /** table name -> column names present on that table. */
   columns: Map<string, Set<string>>;
-  /** Lowercased index names present in the schema. */
+  /** Index names present in the schema, exactly as the catalog stores them. */
   indexes: Set<string>;
-  /** Lowercased names of indexes that are the replica identity of their table. */
+  /** Names of indexes that are the replica identity of their table. */
   replicaIdentityIndexes: Set<string>;
+  /**
+   * Lowercased names of PRIMARY KEY indexes. A primary key is always backed by
+   * an index of the same name, so this answers "does constraint X exist?" for
+   * primary keys without a `pg_constraint` probe. Lowercased because the
+   * queries it replaces compare `conname = lower($1)`.
+   */
+  primaryKeyIndexes: Set<string>;
 }
 
 /**
@@ -88,9 +95,10 @@ export async function loadSchemaSnapshot(client: DbClient, schemaName: string | 
     ),
     // pg_index rather than the pg_indexes view: same names, but it also carries
     // indisreplident, which createTable needs to know whether the
-    // workflow_snapshot unique index is already the table's replica identity.
-    client.manyOrNone<{ indexname: string; is_replica_identity: boolean }>(
-      `SELECT c.relname AS indexname, i.indisreplident AS is_replica_identity
+    // workflow_snapshot unique index is already the table's replica identity,
+    // and indisprimary, which answers primary-key constraint existence.
+    client.manyOrNone<{ indexname: string; is_replica_identity: boolean; is_primary: boolean }>(
+      `SELECT c.relname AS indexname, i.indisreplident AS is_replica_identity, i.indisprimary AS is_primary
          FROM pg_catalog.pg_index i
          JOIN pg_catalog.pg_class c ON c.oid = i.indexrelid
          JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
@@ -111,11 +119,14 @@ export async function loadSchemaSnapshot(client: DbClient, schemaName: string | 
 
   const indexes = new Set<string>();
   const replicaIdentityIndexes = new Set<string>();
+  const primaryKeyIndexes = new Set<string>();
   for (const row of indexRows) {
-    const name = row.indexname.toLowerCase();
-    indexes.add(name);
+    indexes.add(row.indexname);
     if (row.is_replica_identity) {
-      replicaIdentityIndexes.add(name);
+      replicaIdentityIndexes.add(row.indexname);
+    }
+    if (row.is_primary) {
+      primaryKeyIndexes.add(row.indexname.toLowerCase());
     }
   }
 
@@ -125,5 +136,6 @@ export async function loadSchemaSnapshot(client: DbClient, schemaName: string | 
     columns,
     indexes,
     replicaIdentityIndexes,
+    primaryKeyIndexes,
   };
 }

--- a/stores/pg/src/storage/db/timestamp-trigger.test.ts
+++ b/stores/pg/src/storage/db/timestamp-trigger.test.ts
@@ -1,0 +1,163 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { PostgresStore } from '..';
+import { TEST_CONFIG, connectionString } from '../test-utils';
+
+/**
+ * The spans timestamp trigger is (re)established on every init. Recreating it
+ * unconditionally means a `DROP TRIGGER` — and therefore an ACCESS EXCLUSIVE
+ * lock on a hot table — every time any process starts. These cover that init
+ * leaves the trigger alone when it is already correct, and still repairs it
+ * when it is not.
+ */
+
+let adminPool: Pool;
+const schemasToDrop: string[] = [];
+const storesToClose: PostgresStore[] = [];
+
+function uniqueSchema(prefix: string): string {
+  const name = `${prefix}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+  schemasToDrop.push(name);
+  return name;
+}
+
+async function newStore(schemaName: string): Promise<PostgresStore> {
+  const store = new PostgresStore({ ...TEST_CONFIG, id: `trigger-test-${schemaName}`, schemaName });
+  storesToClose.push(store);
+  return store;
+}
+
+async function spansTrigger(schema: string): Promise<{ tgname: string; tgtype: number; fn: string } | undefined> {
+  const { rows } = await adminPool.query(
+    `SELECT tg.tgname, tg.tgtype, tg.tgfoid::regprocedure::text AS fn
+       FROM pg_catalog.pg_trigger tg
+      WHERE tg.tgrelid = format('%I.%I', $1::text, 'mastra_ai_spans')::regclass
+        AND NOT tg.tgisinternal`,
+    [schema],
+  );
+  return rows[0];
+}
+
+beforeAll(async () => {
+  adminPool = new Pool({ connectionString });
+}, 30000);
+
+afterAll(async () => {
+  for (const store of storesToClose) {
+    try {
+      await store.close();
+    } catch {}
+  }
+  for (const schema of schemasToDrop) {
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+  }
+  await adminPool.end();
+}, 60000);
+
+describe('spans timestamp trigger', () => {
+  it('does not take an exclusive lock on the spans table during a warm init', async () => {
+    const schema = uniqueSchema('trg_lock');
+    await adminPool.query(`CREATE SCHEMA "${schema}"`);
+
+    const cold = await newStore(schema);
+    await cold.init();
+    await cold.close();
+
+    // Hold an ordinary read lock from another session. An ACCESS EXCLUSIVE
+    // request has to queue behind it, so an init that wants one cannot finish.
+    const holder = await adminPool.connect();
+    await holder.query('BEGIN');
+    await holder.query(`SELECT count(*) FROM "${schema}"."mastra_ai_spans"`);
+
+    try {
+      const warm = await newStore(schema);
+      const init = warm.init();
+
+      const outcome = await Promise.race([
+        init.then(() => 'completed' as const),
+        new Promise<'blocked'>(resolve => setTimeout(() => resolve('blocked'), 5000)),
+      ]);
+
+      const { rows: waiting } = await adminPool.query(
+        `SELECT mode FROM pg_locks
+          WHERE relation = format('%I.%I', $1::text, 'mastra_ai_spans')::regclass
+            AND NOT granted`,
+        [schema],
+      );
+
+      expect(waiting.map(r => r.mode)).toEqual([]);
+      expect(outcome).toBe('completed');
+      await init;
+    } finally {
+      await holder.query('ROLLBACK');
+      holder.release();
+    }
+  }, 90000);
+
+  it('leaves an already-correct trigger in place and keeps it firing', async () => {
+    const schema = uniqueSchema('trg_keep');
+    await adminPool.query(`CREATE SCHEMA "${schema}"`);
+
+    const cold = await newStore(schema);
+    await cold.init();
+    await cold.close();
+
+    const before = await spansTrigger(schema);
+    expect(before?.tgname).toBe('mastra_ai_spans_timestamps');
+
+    const warm = await newStore(schema);
+    await warm.init();
+
+    // Same trigger row, not a rebuilt one.
+    expect(await spansTrigger(schema)).toEqual(before);
+
+    await adminPool.query(
+      `INSERT INTO "${schema}"."mastra_ai_spans" ("traceId","spanId","name","spanType","startedAt","isEvent")
+       VALUES ('t1','s1','n','agent_run', NOW(), false)`,
+    );
+    const { rows } = await adminPool.query(
+      `SELECT "createdAt" IS NOT NULL AS stamped, "updatedAtZ" IS NOT NULL AS stamped_z
+         FROM "${schema}"."mastra_ai_spans" WHERE "spanId" = 's1'`,
+    );
+    expect(rows[0]).toEqual({ stamped: true, stamped_z: true });
+  }, 90000);
+
+  it('rebuilds a trigger whose timing or events have drifted', async () => {
+    const schema = uniqueSchema('trg_drift');
+    await adminPool.query(`CREATE SCHEMA "${schema}"`);
+
+    const cold = await newStore(schema);
+    await cold.init();
+    await cold.close();
+
+    // Replace it with one that fires on INSERT only (tgtype 7, not 23). The
+    // guard keys on the exact timing/events, so this must not be mistaken for
+    // a correct trigger.
+    await adminPool.query(`DROP TRIGGER mastra_ai_spans_timestamps ON "${schema}"."mastra_ai_spans"`);
+    await adminPool.query(
+      `CREATE TRIGGER mastra_ai_spans_timestamps
+         BEFORE INSERT ON "${schema}"."mastra_ai_spans"
+         FOR EACH ROW EXECUTE FUNCTION "${schema}".trigger_set_timestamps()`,
+    );
+    expect((await spansTrigger(schema))?.tgtype).toBe(7);
+
+    const healer = await newStore(schema);
+    await healer.init();
+
+    expect((await spansTrigger(schema))?.tgtype).toBe(23);
+
+    // And UPDATE stamping works again, which the drifted trigger had lost.
+    await adminPool.query(
+      `INSERT INTO "${schema}"."mastra_ai_spans" ("traceId","spanId","name","spanType","startedAt","isEvent")
+       VALUES ('t1','s1','n','agent_run', NOW(), false)`,
+    );
+    const { rows: inserted } = await adminPool.query(
+      `SELECT "updatedAt" FROM "${schema}"."mastra_ai_spans" WHERE "spanId" = 's1'`,
+    );
+    await adminPool.query(`UPDATE "${schema}"."mastra_ai_spans" SET name = 'n2' WHERE "spanId" = 's1'`);
+    const { rows: updated } = await adminPool.query(
+      `SELECT "updatedAt" FROM "${schema}"."mastra_ai_spans" WHERE "spanId" = 's1'`,
+    );
+    expect(updated[0].updatedAt.getTime()).toBeGreaterThan(inserted[0].updatedAt.getTime());
+  }, 90000);
+});

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -143,9 +143,15 @@ export class AgentsPG extends AgentsStorage {
     const hasLegacyColumns = await this.#db.hasColumn(TABLE_AGENTS, 'name');
 
     if (hasLegacyColumns) {
-      // Current table has legacy schema — rename it and drop old versions table
+      // Current table has legacy schema — rename it and drop old versions table.
+      // Raw DDL bypasses the snapshot-maintaining createTable/alterTable paths,
+      // so each statement reports itself to the init snapshot: otherwise the
+      // createTable() calls below would skip rebuilding the tables this just
+      // renamed away or dropped.
       await this.#db.client.none(`ALTER TABLE ${fullTableName} RENAME TO "${TABLE_AGENTS}_legacy"`);
+      this.#db.noteTableRenamed(TABLE_AGENTS, `${TABLE_AGENTS}_legacy`);
       await this.#db.client.none(`DROP TABLE IF EXISTS ${fullVersionsTableName}`);
+      this.#db.noteTableDropped(TABLE_AGENT_VERSIONS);
     }
 
     // Check if legacy table exists (either just renamed, or left behind by a previous partial migration)
@@ -216,6 +222,7 @@ export class AgentsPG extends AgentsStorage {
 
     // Drop legacy table only after all inserts succeed
     await this.#db.client.none(`DROP TABLE IF EXISTS ${legacyTableName}`);
+    this.#db.noteTableDropped(`${TABLE_AGENTS}_legacy`);
   }
 
   /**
@@ -236,11 +243,14 @@ export class AgentsPG extends AgentsStorage {
       schemaName: getSchemaName(this.#schema),
     });
 
-    // Drop the old versions table - the new schema will be created by init()
+    // Drop the old versions table - the new schema will be created by init(),
+    // which only happens if the snapshot reflects the drop.
     await this.#db.client.none(`DROP TABLE IF EXISTS ${fullVersionsTableName}`);
+    this.#db.noteTableDropped(TABLE_AGENT_VERSIONS);
 
     // Also clean up any lingering legacy table from a partial migration
     await this.#db.client.none(`DROP TABLE IF EXISTS ${legacyTableName}`);
+    this.#db.noteTableDropped(`${TABLE_AGENTS}_legacy`);
   }
 
   /**

--- a/stores/pg/src/storage/domains/datasets/index.ts
+++ b/stores/pg/src/storage/domains/datasets/index.ts
@@ -118,6 +118,9 @@ export class DatasetsPG extends DatasetsStorage {
     if (!exists) {
       const fullTableName = getTableName({ indexName: table, schemaName: getSchemaName(this.#schema) });
       await this.#db.client.none(`ALTER TABLE ${fullTableName} ADD COLUMN "${column}" ${sqlType}`);
+      // Raw DDL bypasses alterTable's snapshot maintenance — report it so later
+      // init-path checks in the same window see the column.
+      this.#db.noteColumnAdded(table, column);
     }
   }
 

--- a/stores/pg/src/storage/domains/favorites/index.ts
+++ b/stores/pg/src/storage/domains/favorites/index.ts
@@ -71,7 +71,8 @@ export class FavoritesPG extends FavoritesStorage {
 
     // Lookup index for entity-scoped queries (cascade delete, count rebuild).
     const fullTableName = getTableName({ indexName: TABLE_FAVORITES, schemaName: getSchemaName(this.#schema) });
-    await this.#db.client.none(
+    await this.#db.createIndexFromStatement(
+      'idx_favorites_entity',
       `CREATE INDEX IF NOT EXISTS idx_favorites_entity ON ${fullTableName} ("entityType", "entityId")`,
     );
   }

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -225,7 +225,10 @@ export class MemoryPG extends MemoryStorage {
         indexName: OM_TABLE,
         schemaName: getSchemaName(this.#schema),
       });
-      await this.#db.client.none(`CREATE INDEX IF NOT EXISTS idx_om_lookup_key ON ${omTableName} ("lookupKey")`);
+      await this.#db.createIndexFromStatement(
+        'idx_om_lookup_key',
+        `CREATE INDEX IF NOT EXISTS idx_om_lookup_key ON ${omTableName} ("lookupKey")`,
+      );
     }
     await this.createDefaultIndexes();
     await this.createCustomIndexes();

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -17,6 +17,7 @@ import { PinnedClientAdapter, PoolAdapter, RoutingDbClient } from './client';
 import type { DbClient, PoolClient } from './client';
 import type { PgDomainClientConfig } from './db';
 import { getSchemaName } from './db';
+import { loadSchemaSnapshot } from './db/schema-snapshot';
 import { AgentsPG } from './domains/agents';
 import { BackgroundTasksPG } from './domains/background-tasks';
 import { BlobsPG } from './domains/blobs';
@@ -336,6 +337,11 @@ export class PostgresStore extends MastraCompositeStore {
       pinnedClient = await this.#pool.connect();
       const pinned = new PinnedClientAdapter(this.#pool, pinnedClient);
       this.#db.pin(pinned);
+      // Read the schema's catalog once, up front, so the domains below can
+      // answer "does this table/column/index already exist?" locally instead of
+      // asking the server ~350 times over this one serialized connection.
+      // Cleared in the finally: the snapshot never outlives init().
+      this.#db.setSchemaSnapshot(await loadSchemaSnapshot(pinned, this.schema));
       await super.init();
       // Only mark initialized after schema creation actually finishes so a
       // racing second init() caller can't return early and issue runtime
@@ -359,6 +365,10 @@ export class PostgresStore extends MastraCompositeStore {
         error,
       );
     } finally {
+      // Drop the snapshot unconditionally — including when loading it or
+      // super.init() threw — so no code path can read a stale catalog picture
+      // after init returns.
+      this.#db.setSchemaSnapshot(null);
       // Only unpin/release when connect() actually handed us a client; on a
       // failed connect() pinnedClient is undefined and pin() never ran.
       if (pinnedClient) {


### PR DESCRIPTION
## Description

`PostgresStore.init()` on an already-migrated database re-verifies every table, column, and index with its own serialized query — ~350 round trips that are all no-ops on a converged schema. On a 50ms-RTT connection (serverless + managed PG in another region) that's ~18.5s of pure latency on every cold start.

This PR loads one schema-wide catalog snapshot at the start of init (3 read-only `pg_catalog` queries on the already-pinned client) and answers all existence checks from it, skipping DDL the snapshot proves is a no-op. The probe-then-act behavior is unchanged for anything the snapshot says is missing — cold init, drift healing, and multi-schema scoping behave exactly as before, just proven by tests now.

Before (warm init, 50ms RTT):

```
~350 serialized statements, ~18.5s wall time
```

After:

```
6 driver round trips (3 snapshot reads + trigger DDL + 2 runtime queries), ~0.5s wall time
```

Two behavioral fixes fell out of the same work:

- warm init no longer rebuilds the timestamp trigger, which was taking an `ACCESS EXCLUSIVE` lock on `mastra_ai_spans` on every boot (measured: a concurrent reader blocked init for 6.2s; now 54ms beside the same reader)
- init now works for a least-privilege role (USAGE-only, no CREATE) on a converged schema — before, it aborted on the first `CREATE OR REPLACE FUNCTION`

Raw-DDL migration paths (legacy agents migration, datasets column adds, spans PK) update the snapshot as they go, with regression tests covering table rename/drop mid-init, concurrent init, restricted roles, out-of-band drift, and repeated init. The included `init-benchmark.ts` script reproduces the red/green numbers against a latency-injected PG.

## Related issue(s)

Fixes #20344

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Starting the database used to involve hundreds of small checks, even when everything was already set up. This change takes one quick snapshot of the database first, skips unnecessary work, and still repairs missing or changed pieces.

## Summary

- Reduced warm `PostgresStore.init()` from roughly 350 serialized database round trips to 6 catalog queries.
- Added schema snapshots covering tables, columns, indexes, replica identity indexes, and primary keys.
- Skipped no-op DDL and existence checks when the snapshot confirms the schema is current.
- Preserved drift repair for dropped or changed tables, columns, indexes, and legacy schemas.
- Avoided unnecessary timestamp-trigger replacement and its table lock.
- Improved initialization for restricted roles on already-converged schemas.
- Kept snapshots synchronized across raw DDL migrations and cleared them after initialization.
- Added benchmark support and extensive tests for warm and cold initialization, drift healing, concurrency, permissions, multiple schemas, migrations, and trigger behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->