### PR TITLE
fix(factory-ui): clarify pull request status icons

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/chat/components/PullRequestLinks.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/PullRequestLinks.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { useQuery } from '@tanstack/react-query';
-import { CircleDot, CircleX, GitMerge } from 'lucide-react';
+import { GitMerge, GitPullRequest, GitPullRequestClosed } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
 import type { WorkItem } from '../../factory/services/workItems';
@@ -19,12 +19,14 @@ interface PullRequestSubscriptionsResponse {
 }
 
 function PullRequestIcon({ status }: { status: PullRequestSubscription['status'] }) {
-  if (status === 'merged') return <GitMerge size={13} aria-hidden />;
-  if (status === 'closed') return <CircleX size={13} aria-hidden />;
-  return <CircleDot size={13} aria-hidden />;
+  const className = statusIconColor(status);
+
+  if (status === 'merged') return <GitMerge size={13} className={className} aria-hidden />;
+  if (status === 'closed') return <GitPullRequestClosed size={13} className={className} aria-hidden />;
+  return <GitPullRequest size={13} className={className} aria-hidden />;
 }
 
-function statusColor(status: PullRequestSubscription['status']): string {
+function statusIconColor(status: PullRequestSubscription['status']): string {
   if (status === 'merged') return 'text-accent3';
   if (status === 'closed') return 'text-error';
   return 'text-accent1';
@@ -136,7 +138,7 @@ export function PullRequestLinks({
           aria-label={`Open ${subscription.status} ${subscription.repoFullName} pull request ${subscription.pullRequestNumber}`}
         >
           <PullRequestIcon status={subscription.status} />
-          <span className={statusColor(subscription.status)}>PR #{subscription.pullRequestNumber}</span>
+          <span>PR #{subscription.pullRequestNumber}</span>
         </Button>
       ))}
     </div>


### PR DESCRIPTION
Open and closed pull requests now use dedicated PR glyphs, while merged pull requests keep the merge glyph. Status color is limited to the icon so the PR label keeps the neutral button text color.

Validated with Factory UI typecheck, 78 unit tests, production build, `pnpm lint`, React Doctor, and dark/light browser checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Pull request links now show clearer icons for open, closed, and merged states. Only the icons change color, so the “PR #…” labels remain easy to read.

## Changes

- Added dedicated Lucide icons for open and closed pull requests.
- Retained the merge icon for merged pull requests.
- Applied status colors to icons only.
- Removed status-based styling from pull request labels.

## Validation

- Typecheck
- 78 unit tests
- Production build
- Linting
- React Doctor
- Dark/light browser checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->