### PR TITLE
fix(factory-ui): route changed tests to Vitest projects

### DIFF
--- a/mastracode/factory-ui/e2e/ui/vitest.config.ts
+++ b/mastracode/factory-ui/e2e/ui/vitest.config.ts
@@ -26,6 +26,8 @@ export default defineConfig({
     dedupe: ['react', 'react-dom', '@tanstack/react-query'],
   },
   test: {
+    name: 'msw:factory-ui',
+    root: pkgRoot,
     environment: 'jsdom',
     globals: true,
     // playground-ui ships `.css` imports in its ESM dist; when installed from

--- a/mastracode/factory-ui/package.json
+++ b/mastracode/factory-ui/package.json
@@ -9,9 +9,9 @@
     "web": "MASTRACODE_ENV_DIR=../web MASTRACODE_API_TARGET=${MASTRACODE_API_TARGET:-http://localhost:4111} MASTRACODE_UI_PORT=${MASTRACODE_UI_PORT:-5173} vite --config src/vite.config.ts",
     "build": "vite --config src/vite.config.ts build",
     "typecheck": "tsc --noEmit -p src/ui/tsconfig.json",
-    "test": "vitest run && vitest run --config e2e/ui/vitest.config.ts",
-    "test:unit": "vitest run",
-    "test:msw": "vitest run --config e2e/ui/vitest.config.ts"
+    "test": "vitest run",
+    "test:unit": "vitest run --project unit:factory-ui",
+    "test:msw": "vitest run --project msw:factory-ui"
   },
   "dependencies": {
     "@fontsource-variable/mona-sans": "5.3.0",

--- a/mastracode/factory-ui/vitest.config.ts
+++ b/mastracode/factory-ui/vitest.config.ts
@@ -1,15 +1,21 @@
 import { defineConfig } from 'vitest/config';
 
 /**
- * Unit tests colocated under `src/**`. The MSW UI suite lives under
- * `e2e/ui/` with its own explicit `--config`; its globs are disjoint from
- * this one.
+ * Unit and MSW UI projects share this entrypoint so targeted test runs can
+ * select the right environment from the changed test file path.
  */
 export default defineConfig({
   test: {
-    name: 'unit:factory-ui',
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
+    projects: [
+      {
+        test: {
+          name: 'unit:factory-ui',
+          environment: 'node',
+          include: ['src/**/*.test.ts'],
+          exclude: ['**/node_modules/**', '**/dist/**'],
+        },
+      },
+      './e2e/ui/vitest.config.ts',
+    ],
   },
 });


### PR DESCRIPTION
Factory UI's changed MSW tests were being run through its unit-only Vitest config, so the changed-test gate collected zero tests. This registers the unit and MSW suites under the package root and keeps the package scripts scoped through named projects.

Verified with the gate-shaped SettingsNavigation invocation and the full Factory UI suite: 82 files and 419 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory UI now sends each test to the right test setup automatically, so unit tests and browser-style MSW tests run reliably without special configuration commands.

## What changed

- Converted Factory UI’s Vitest configuration to named projects:
  - `unit:factory-ui`
  - `msw:factory-ui`
- Registered the MSW configuration with the package root.
- Updated package scripts to select projects with `--project`.
- Simplified the default test command to run Vitest through the shared configuration.

## Verification

- `SettingsNavigation` gate-shaped invocation passed.
- Full Factory UI suite passed: **82 files, 419 tests**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->