### PR TITLE
fix(mastracode): notify when user input is requested

### DIFF
--- a/.changeset/all-cars-reply.md
+++ b/.changeset/all-cars-reply.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed notifications for assistant questions and plan approvals so configured hooks run as soon as Mastra Code waits for user input.

--- a/mastracode/tui/src/tui/__tests__/mastra-tui-hooks.test.ts
+++ b/mastracode/tui/src/tui/__tests__/mastra-tui-hooks.test.ts
@@ -338,6 +338,33 @@ describe('MastraTUI hook wiring', () => {
     expect(runPermissionRequest).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['ask_user', 'ask_question', { question: 'Continue?' }, 'Continue?'],
+    ['submit_plan', 'plan_approval', { path: '.mastracode/plans/change.md' }, 'Plan requires your approval'],
+  ] as const)('notifies immediately when %s requests user input', async (toolName, reason, suspendPayload, message) => {
+    let releaseDispatch!: () => void;
+    mocks.dispatchEvent.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          releaseDispatch = resolve;
+        }),
+    );
+    const tui = createBareTui();
+
+    const handling = tui.handleEvent({
+      type: 'tool_suspended',
+      toolCallId: 'call-input',
+      toolName,
+      args: suspendPayload,
+      suspendPayload,
+    });
+
+    expect(mocks.notify).toHaveBeenCalledWith(tui.state, reason, message);
+
+    releaseDispatch();
+    await handling;
+  });
+
   it('does not fire PostToolUse from TUI tool_end events', async () => {
     const runPostToolUse = vi.fn().mockResolvedValue(createHookResult());
     const tui = createBareTui({ runPostToolUse });

--- a/mastracode/tui/src/tui/handlers/prompts.ts
+++ b/mastracode/tui/src/tui/handlers/prompts.ts
@@ -212,8 +212,6 @@ export async function handleAskQuestion(
       showModalOverlay(state.ui, dialog, { widthPercent: 0.7 });
       dialog.focused = true;
     }
-
-    ctx.notify('ask_question', question);
   });
 }
 
@@ -482,7 +480,5 @@ export async function handlePlanApproval(
     state.ui.requestRender();
     state.chatContainer.invalidate();
     state.ui.setFocus(approvalComponent);
-
-    ctx.notify('plan_approval', `Plan "${resolvedTitle}" requires approval`);
   });
 }

--- a/mastracode/tui/src/tui/mastra-tui.ts
+++ b/mastracode/tui/src/tui/mastra-tui.ts
@@ -799,6 +799,14 @@ export class MastraTUI {
 
     try {
       this.fireLifecycleHooksForEvent(event);
+      if (event.type === 'tool_suspended') {
+        if (event.toolName === 'ask_user') {
+          const payload = (event.suspendPayload ?? {}) as { question?: string };
+          notify(this.state, 'ask_question', payload.question);
+        } else if (event.toolName === 'submit_plan') {
+          notify(this.state, 'plan_approval', 'Plan requires your approval');
+        }
+      }
       await dispatchEvent(event, this.getEventContext(), this.state);
       this.captureAgentControllerAnalytics(event);
 


### PR DESCRIPTION
## Description

Notify users as soon as Mastra Code receives an interactive input request instead of waiting for the suspended prompt handler to finish.

The TUI now sends `ask_question` and `plan_approval` notifications before dispatching `ask_user` and `submit_plan` suspension events. The existing handler-level calls were removed to avoid duplicate notifications. Regression coverage keeps the dispatcher unresolved and verifies that notification already occurred, proving the hook runs while Mastra Code is waiting for the user.

## Related issue(s)

Closes #20398

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Verification

- Focused TUI hook and prompt tests: 83 passed
- TUI typecheck: passed
- TUI lint: 0 warnings, 0 errors
- Mastra Code build: 29/29 tasks passed
- Full SDK tests: 1,145 passed, 2 skipped
- Formatting and `git diff --check`: passed

The full TUI suite has 4 pre-existing failures in `goal.test.ts` and `shell-output.test.ts`; 1,057/1,061 tests passed. The focused tests covering this change pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When Mastra Code asks the user something (or asks approval for a plan), it now sends the notification *immediately*—before it waits for the user’s reply. This makes “configured notification hooks” run reliably and prevents duplicate notifications.

## Changes

- Updated `MastraTUI.handleEvent` to send pre-dispatch notifications for `tool_suspended` events:
  - `ask_user` → `ask_question` (using an optional `question` from the suspension payload)
  - `submit_plan` → `plan_approval`
- Removed handler-side `ctx.notify(...)` emissions from:
  - `handleAskQuestion`
  - `handlePlanApproval`
- Added regression coverage to ensure notifications fire while the dispatcher is still blocked/unresolved.
- Added a patch changeset for `mastracode` describing the notification fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->