### PR TITLE
Improve Trace Intelligence onboarding feedback

### DIFF
--- a/.changeset/three-foxes-tickle.md
+++ b/.changeset/three-foxes-tickle.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/client-js': patch
+---
+
+Added Trace Intelligence progress types and improved the onboarding state with processing progress, clearer copy, accessible markup, mobile polish, and the dedicated documentation link.

--- a/client-sdks/client-js/src/agent-learning.ts
+++ b/client-sdks/client-js/src/agent-learning.ts
@@ -1,5 +1,14 @@
 export type TraceSignalName = 'goal' | 'sentiment' | 'behavior' | 'outcome';
 
+export type EntityLearningProgressStatus = 'collecting' | 'processing' | 'ready';
+
+export interface EntityLearningProgressResponse {
+  status: EntityLearningProgressStatus;
+  traceCount: number;
+  signals: Record<TraceSignalName, { generated: number; embedded: number }>;
+  availableSignals: TraceSignalName[];
+}
+
 export interface ThemeLearningEntity {
   entityId: string;
   entityType: string;

--- a/packages/playground-ui/src/ee/signals/components/__tests__/signals-overview-page.test.tsx
+++ b/packages/playground-ui/src/ee/signals/components/__tests__/signals-overview-page.test.tsx
@@ -69,7 +69,7 @@ describe('SignalsOverviewPage', () => {
     it('links to the Trace Intelligence documentation', () => {
       render(<SignalsOverviewPage />);
 
-      expect(screen.getByRole('link', { name: 'Read the docs (opens in new tab)' }).getAttribute('href')).toBe(
+      expect(screen.getByRole('link', { name: /Read the docs/ }).getAttribute('href')).toBe(
         'https://mastra.ai/en/docs/mastra-platform/trace-intelligence',
       );
     });

--- a/packages/playground-ui/src/ee/signals/components/__tests__/signals-overview-page.test.tsx
+++ b/packages/playground-ui/src/ee/signals/components/__tests__/signals-overview-page.test.tsx
@@ -8,8 +8,8 @@ import { SignalsOverviewPage } from '../signals-overview-page';
 afterEach(() => cleanup());
 
 describe('SignalsOverviewPage', () => {
-  describe('when trace intelligence has not launched yet', () => {
-    it('explains the purpose of trace intelligence', () => {
+  describe('when Trace Intelligence has not launched yet', () => {
+    it('explains the purpose of Trace Intelligence', () => {
       render(<SignalsOverviewPage />);
 
       expect(screen.getByRole('heading', { name: 'Understand what drives every agent interaction' })).not.toBeNull();
@@ -18,67 +18,59 @@ describe('SignalsOverviewPage', () => {
     it('shows the ordered trace analysis pipeline', () => {
       render(<SignalsOverviewPage />);
 
-      const pipeline = screen.getByRole('list', { name: 'Trace intelligence pipeline' });
+      const pipeline = screen.getByRole('list', { name: 'Trace Intelligence analysis pipeline' });
       const stageHeadings = within(pipeline)
         .getAllByRole('heading')
         .map(heading => heading.textContent);
 
-      expect(stageHeadings).toEqual(['Traces', 'Mastra Engine', 'Trace signals']);
+      expect(stageHeadings).toEqual(['Traces', 'Trace Intelligence', 'Theme analysis']);
     });
 
     it('shows representative trace inputs', () => {
       render(<SignalsOverviewPage />);
 
-      const pipeline = screen.getByRole('list', { name: 'Trace intelligence pipeline' });
+      const pipeline = screen.getByRole('list', { name: 'Trace Intelligence analysis pipeline' });
       expect(within(pipeline).getByText('chat.completion')).not.toBeNull();
       expect(within(pipeline).getByText('tool.search_docs')).not.toBeNull();
       expect(within(pipeline).getByText('workflow.support')).not.toBeNull();
     });
 
-    it('shows the four supported signal dimensions', () => {
+    it('shows the four supported trace signal dimensions', () => {
       render(<SignalsOverviewPage />);
 
-      const pipeline = screen.getByRole('list', { name: 'Trace intelligence pipeline' });
+      const pipeline = screen.getByRole('list', { name: 'Trace Intelligence analysis pipeline' });
       for (const signal of ['Outcome', 'Goal', 'Behavior', 'Sentiment']) {
         expect(within(pipeline).getByText(signal)).not.toBeNull();
       }
     });
 
-    it('defines each supported signal in plain language', () => {
+    it('defines each supported trace signal in plain language', () => {
       render(<SignalsOverviewPage />);
 
       const definitions = screen.getByRole('list', { name: 'Trace signal definitions' });
-      expect(within(definitions).getByText(/what the user is trying to achieve or have completed/i)).not.toBeNull();
-      expect(within(definitions).getByText(/the user's emotional state or attitude/i)).not.toBeNull();
+      expect(within(definitions).getByText(/what the user is trying to achieve/i)).not.toBeNull();
+      expect(
+        within(definitions).getByText(/whether the interaction was completed, unresolved, or blocked/i),
+      ).not.toBeNull();
       expect(
         within(definitions).getByText(
-          /observable actions and patterns, including tool use, omissions, retries, failures, and recovery/i,
+          /observable actions and patterns in the trace, including tool use, retries, failures, and recovery/i,
         ),
       ).not.toBeNull();
-      expect(within(definitions).getByText(/the final completed, unresolved, or blocked state/i)).not.toBeNull();
+      expect(within(definitions).getByText(/the user's emotional state or attitude/i)).not.toBeNull();
     });
 
-    it('previews where grouped trace relationships will appear', () => {
+    it('shows that Trace Intelligence is collecting traces', () => {
       render(<SignalsOverviewPage />);
 
-      expect(
-        screen.getByText(
-          /grouped trace relationships will appear after traces contain at least two trace signal types/i,
-        ),
-      ).not.toBeNull();
+      expect(screen.getByText('Collecting traces for Trace Intelligence.')).not.toBeNull();
     });
 
-    it('shows that the analysis is waiting for traces', () => {
+    it('links to the Trace Intelligence documentation', () => {
       render(<SignalsOverviewPage />);
 
-      expect(screen.getByText('Waiting for traces.')).not.toBeNull();
-    });
-
-    it('links to the tracing documentation', () => {
-      render(<SignalsOverviewPage />);
-
-      expect(screen.getByRole('link', { name: 'Read the docs' }).getAttribute('href')).toBe(
-        'https://mastra.ai/en/docs/observability/tracing/overview',
+      expect(screen.getByRole('link', { name: 'Read the docs (opens in new tab)' }).getAttribute('href')).toBe(
+        'https://mastra.ai/en/docs/mastra-platform/trace-intelligence',
       );
     });
 
@@ -91,6 +83,31 @@ describe('SignalsOverviewPage', () => {
 });
 
 describe('SignalsEmptyState', () => {
+  describe('when progress is available', () => {
+    it('shows trace and trace signal processing progress', () => {
+      render(
+        <SignalsEmptyState
+          progress={{
+            status: 'processing',
+            traceCount: 87,
+            signals: {
+              goal: { generated: 87, embedded: 84 },
+              outcome: { generated: 87, embedded: 40 },
+              behavior: { generated: 52, embedded: 12 },
+              sentiment: { generated: 0, embedded: 0 },
+            },
+            availableSignals: ['goal'],
+          }}
+        />,
+      );
+
+      expect(screen.getByText('Analyzing traces for Trace Intelligence.')).not.toBeNull();
+      expect(screen.getByText('87')).not.toBeNull();
+      expect(screen.getByText('1 of 4')).not.toBeNull();
+      expect(screen.getByText('87 generated · 84 embedded')).not.toBeNull();
+    });
+  });
+
   describe('when a custom action is supplied', () => {
     it('renders the custom action', () => {
       render(<SignalsEmptyState actionSlot={<button type="button">Choose an agent</button>} />);

--- a/packages/playground-ui/src/ee/signals/components/signals-empty-state.tsx
+++ b/packages/playground-ui/src/ee/signals/components/signals-empty-state.tsx
@@ -1,3 +1,4 @@
+import type { TraceSignalName } from '@mastra/client-js';
 import { CpuIcon } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
 
@@ -8,15 +9,22 @@ import { nodeColor } from '../../../ds/components/SankeyChart/sankeyColor';
 import type { LinkComponent } from '../../../ds/types/link-component';
 import { getSignalHue } from '../signal-colors';
 
-const signalDefinitions = [
-  { label: 'Goal', description: 'What the user is trying to achieve or have completed.' },
-  { label: 'Sentiment', description: "The user's emotional state or attitude." },
+type SignalDefinition = {
+  key: TraceSignalName;
+  label: string;
+  description: string;
+};
+
+const signalDefinitions: SignalDefinition[] = [
+  { key: 'goal', label: 'Goal', description: 'What the user is trying to achieve.' },
+  { key: 'outcome', label: 'Outcome', description: 'Whether the interaction was completed, unresolved, or blocked.' },
   {
+    key: 'behavior',
     label: 'Behavior',
     description:
-      "The entity's observable actions and patterns, including tool use, omissions, retries, failures, and recovery.",
+      'The observable actions and patterns in the trace, including tool use, retries, failures, and recovery.',
   },
-  { label: 'Outcome', description: 'The final completed, unresolved, or blocked state.' },
+  { key: 'sentiment', label: 'Sentiment', description: "The user's emotional state or attitude." },
 ];
 const signalLabels = signalDefinitions.map(signal => signal.label);
 
@@ -37,30 +45,127 @@ const PipelineConnector = () => (
   </div>
 );
 
+export type TraceIntelligenceProgress = {
+  status: 'collecting' | 'processing' | 'ready';
+  traceCount: number;
+  signals: Record<TraceSignalName, { generated: number; embedded: number }>;
+  availableSignals: TraceSignalName[];
+};
+
 export type SignalsEmptyStateProps = {
   actionSlot?: ReactNode;
   LinkComponent?: LinkComponent;
+  progress?: TraceIntelligenceProgress;
+  isRangeEmpty?: boolean;
 };
 
-export const SignalsEmptyState = ({ actionSlot, LinkComponent = 'a' }: SignalsEmptyStateProps) => {
+function formatNumber(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function statusCopy(progress?: TraceIntelligenceProgress, isRangeEmpty?: boolean) {
+  if (isRangeEmpty) {
+    return {
+      title: 'No Trace Intelligence themes in this date range.',
+      body: 'Choose a wider snapshot date range, or wait for newly processed traces to form recurring themes.',
+    };
+  }
+  if (!progress || progress.status === 'collecting') {
+    return {
+      title: 'Collecting traces for Trace Intelligence.',
+      body: 'Trace Intelligence starts grouping recurring patterns after your deployed agents send enough completed traces.',
+    };
+  }
+  if (progress.status === 'ready') {
+    return {
+      title: 'Trace Intelligence themes are ready.',
+      body: 'Select at least two available trace signal types to see how goals, outcomes, behaviors, and sentiment connect.',
+    };
+  }
+  return {
+    title: 'Analyzing traces for Trace Intelligence.',
+    body: 'Trace signals have started processing. Themes appear after enough generated and embedded trace signals form recurring patterns.',
+  };
+}
+
+function ProgressSummary({ progress }: { progress: TraceIntelligenceProgress }) {
+  return (
+    <dl className="mt-4 grid gap-2 sm:grid-cols-3">
+      <div className="border-border1 bg-surface3 rounded-md border px-3 py-2">
+        <dt className="text-neutral3 text-xs">Traces analyzed</dt>
+        <dd className="text-neutral6 mt-1 text-lg font-semibold">{formatNumber(progress.traceCount)}</dd>
+      </div>
+      <div className="border-border1 bg-surface3 rounded-md border px-3 py-2">
+        <dt className="text-neutral3 text-xs">Trace signal types ready</dt>
+        <dd className="text-neutral6 mt-1 text-lg font-semibold">{progress.availableSignals.length} of 4</dd>
+      </div>
+      <div className="border-border1 bg-surface3 rounded-md border px-3 py-2">
+        <dt className="text-neutral3 text-xs">Status</dt>
+        <dd className="text-neutral6 mt-1 text-lg font-semibold capitalize">{progress.status}</dd>
+      </div>
+    </dl>
+  );
+}
+
+function SignalProgressList({ progress }: { progress?: TraceIntelligenceProgress }) {
+  if (!progress) return null;
+
+  return (
+    <ul aria-label="Trace signal processing progress" className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+      {signalDefinitions.map(signal => {
+        const value = progress.signals[signal.key];
+        const isReady = progress.availableSignals.includes(signal.key);
+        return (
+          <li className="border-border1 bg-surface2 rounded-md border px-3 py-2" key={signal.label}>
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-sm font-semibold" style={signalStyle(signal.label)}>
+                {signal.label}
+              </span>
+              <span className="text-neutral4 text-xs">{isReady ? 'Themes ready' : 'Processing'}</span>
+            </div>
+            <p className="text-neutral3 mt-1 text-xs">
+              {formatNumber(value.generated)} generated · {formatNumber(value.embedded)} embedded
+            </p>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export const SignalsEmptyState = ({
+  actionSlot,
+  LinkComponent = 'a',
+  progress,
+  isRangeEmpty,
+}: SignalsEmptyStateProps) => {
+  const copy = statusCopy(progress, isRangeEmpty);
+
   return (
     <section className="bg-surface1 min-h-full w-full p-6 md:px-10 lg:px-12 xl:px-[4.375rem]">
       <div className="mx-auto w-full max-w-260">
         <header>
-          <h1 className="text-header-xl text-neutral6 font-medium tracking-tight">
+          <p className="text-neutral4 flex items-center gap-2 font-mono text-xs tracking-wider uppercase">
+            <span aria-hidden="true" className="bg-accent1 size-2 rounded-full" />
+            Trace Intelligence
+          </p>
+          <h1 className="text-header-xl text-neutral6 mt-2 font-medium tracking-tight">
             Understand what drives every agent interaction
           </h1>
+          <p className="text-neutral3 mt-2 max-w-180 text-sm leading-5">
+            Trace Intelligence groups recurring goals, outcomes, behaviors, and sentiment across completed traces.
+          </p>
         </header>
 
         <div
-          aria-label="Trace intelligence pipeline"
-          className="mt-14 grid gap-4 lg:grid-cols-[17.5rem_4.5rem_17.5rem_4.5rem_minmax(0,1fr)] lg:gap-0"
           role="list"
+          aria-label="Trace Intelligence analysis pipeline"
+          className="mt-14 grid gap-4 lg:grid-cols-[17.5rem_4.5rem_17.5rem_4.5rem_minmax(0,1fr)] lg:gap-0"
         >
-          <article className="h-50 p-5" role="listitem">
+          <div role="listitem" className="min-h-50 p-5">
             <h2 className="text-neutral6 text-lg font-semibold">Traces</h2>
             <p className="text-neutral3 mt-0.5 text-xs">Every agent interaction</p>
-            <p className="text-neutral2 mt-5 font-mono text-[0.5625rem] tracking-[0.24em] uppercase">Input</p>
+            <p className="text-neutral3 mt-5 font-mono text-[0.6875rem] tracking-[0.18em] uppercase">Input</p>
             <div className="mt-2.5 space-y-2">
               {traceRows.map(([name, duration]) => (
                 <div
@@ -68,39 +173,39 @@ export const SignalsEmptyState = ({ actionSlot, LinkComponent = 'a' }: SignalsEm
                   key={name}
                 >
                   <span className="text-neutral4">{name}</span>
-                  <span className="text-neutral2">{duration}</span>
+                  <span className="text-neutral3">{duration}</span>
                 </div>
               ))}
             </div>
-          </article>
+          </div>
 
           <PipelineConnector />
 
           <Card
-            as="article"
-            className="flex h-50 flex-col items-center p-5 text-center"
-            elevation="elevated"
+            as="div"
             role="listitem"
+            className="flex min-h-50 flex-col items-center p-5 text-center"
+            elevation="elevated"
           >
-            <h2 className="text-neutral6 text-lg font-semibold">Mastra Engine</h2>
-            <p className="text-neutral3 mt-0.5 text-xs">Clusters recurring patterns</p>
+            <h2 className="text-neutral6 text-lg font-semibold">Trace Intelligence</h2>
+            <p className="text-neutral3 mt-0.5 text-xs">Finds recurring themes</p>
             <div aria-hidden="true" className="relative mt-5 flex size-20 items-center justify-center">
               <span className="signals-engine-pulse border-positive1/15 absolute size-20 rounded-full border" />
               <span className="border-positive1/25 absolute size-14 rounded-full border" />
               <span className="border-positive1/40 bg-positive1/5 absolute size-9 rounded-full border shadow-[0_0_24px_var(--color-positive1)]" />
               <CpuIcon className="text-positive1 relative size-4" />
             </div>
-            <p className="text-ui-xs text-neutral2 mt-3 max-w-40 leading-4">
-              Finds relationships across conversations, tools, and workflows
+            <p className="text-ui-xs text-neutral3 mt-3 max-w-40 leading-4">
+              Clusters similar trace signals into themes for each dimension
             </p>
           </Card>
 
           <PipelineConnector />
 
-          <article className="h-50 p-5" role="listitem">
-            <h2 className="text-neutral6 text-lg font-semibold">Trace signals</h2>
-            <p className="text-neutral3 mt-0.5 text-xs">What your users actually do</p>
-            <p className="text-neutral2 mt-5 font-mono text-[0.5625rem] tracking-[0.24em] uppercase">Output</p>
+          <div role="listitem" className="min-h-50 p-5">
+            <h2 className="text-neutral6 text-lg font-semibold">Theme analysis</h2>
+            <p className="text-neutral3 mt-0.5 text-xs">How recurring patterns connect</p>
+            <p className="text-neutral3 mt-5 font-mono text-[0.6875rem] tracking-[0.18em] uppercase">Output</p>
             <div className="mt-3 flex flex-wrap gap-2">
               {signalLabels.map(label => (
                 <span
@@ -113,62 +218,50 @@ export const SignalsEmptyState = ({ actionSlot, LinkComponent = 'a' }: SignalsEm
                 </span>
               ))}
             </div>
-          </article>
+          </div>
         </div>
 
         <section className="mt-10" aria-labelledby="signal-definitions-heading">
           <h2 id="signal-definitions-heading" className="text-neutral6 text-lg font-semibold">
             What each trace signal means
           </h2>
-          <div aria-label="Trace signal definitions" className="mt-4 grid gap-3 sm:grid-cols-2" role="list">
+          <ul aria-label="Trace signal definitions" className="mt-4 grid gap-3 sm:grid-cols-2">
             {signalDefinitions.map(signal => (
-              <article className="px-1 py-2" key={signal.label} role="listitem">
+              <li className="px-1 py-2" key={signal.label}>
                 <h3 className="text-sm font-semibold" style={signalStyle(signal.label)}>
                   {signal.label}
                 </h3>
                 <p className="text-neutral3 mt-1.5 text-xs leading-5">{signal.description}</p>
-              </article>
+              </li>
             ))}
-          </div>
+          </ul>
         </section>
 
-        <section className="mt-10" aria-label="Trace signal relationship preview">
-          <p className="text-neutral2 font-mono text-[0.5625rem] tracking-[0.2em] uppercase">
-            Grouped trace relationships will appear after traces contain at least two trace signal types
-          </p>
-          <div aria-hidden="true" className="mt-3 grid h-18 grid-cols-3 gap-5 opacity-35">
-            {[0, 1, 2].map(index => (
-              <div className="border-border1 bg-surface2/30 rounded-md border border-dashed p-4" key={index}>
-                <div className="bg-neutral1 h-1.5 w-16 rounded-full" />
-                <div className="bg-neutral1/60 mt-3 h-1 w-full rounded-full" />
-                <div className="bg-neutral1/40 mt-2 h-1 w-2/3 rounded-full" />
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <aside className="border-border1 bg-surface2 mt-9 flex min-h-16 flex-col gap-4 rounded-md border px-5 py-3.5 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex min-w-0 items-start gap-3 sm:items-center">
+        <aside className="border-border1 bg-surface2 mt-9 rounded-md border px-5 py-4">
+          <div className="flex min-w-0 items-start gap-3">
             <span
               aria-hidden="true"
-              className="bg-warning1 mt-1.5 size-2 shrink-0 rounded-full shadow-[0_0_9px_currentColor] sm:mt-0"
+              className="bg-warning1 mt-1.5 size-2 shrink-0 rounded-full shadow-[0_0_9px_currentColor]"
             />
-            <p className="text-neutral3 text-xs leading-5">
-              <strong className="text-neutral5 font-semibold">Waiting for traces.</strong> Trace intelligence activates
-              automatically once your agents start receiving traffic.
-            </p>
+            <div className="min-w-0 flex-1">
+              <p className="text-neutral3 text-xs leading-5">
+                <strong className="text-neutral5 font-semibold">{copy.title}</strong> {copy.body}
+              </p>
+              {progress ? <ProgressSummary progress={progress} /> : null}
+              <SignalProgressList progress={progress} />
+            </div>
           </div>
-          <div className="flex shrink-0 flex-wrap items-center gap-2">
+          <div className="mt-4 flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
             {actionSlot}
             <Button
               as="a"
-              href="https://mastra.ai/en/docs/observability/tracing/overview"
+              href="https://mastra.ai/en/docs/mastra-platform/trace-intelligence"
               target="_blank"
               rel="noopener noreferrer"
               variant="outline"
               size="sm"
             >
-              Read the docs
+              Read the docs<span className="sr-only"> (opens in new tab)</span>
             </Button>
             <Button as={LinkComponent} href="/observability" variant="primary" size="sm">
               View incoming traces

--- a/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
+++ b/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
@@ -1,6 +1,24 @@
-import type { ThemeEntitiesResponse, ThemeFlowResponse, ThemeNode, ThemeSnapshotsResponse } from '@mastra/client-js';
+import type {
+  EntityLearningProgressResponse,
+  ThemeEntitiesResponse,
+  ThemeFlowResponse,
+  ThemeNode,
+  ThemeSnapshotsResponse,
+} from '@mastra/client-js';
 
 export const emptyThemeEntitiesResponse: ThemeEntitiesResponse = { entities: [] };
+
+export const processingProgressResponse: EntityLearningProgressResponse = {
+  status: 'processing',
+  traceCount: 87,
+  signals: {
+    goal: { generated: 87, embedded: 84 },
+    outcome: { generated: 87, embedded: 40 },
+    behavior: { generated: 52, embedded: 12 },
+    sentiment: { generated: 0, embedded: 0 },
+  },
+  availableSignals: ['goal'],
+};
 
 export const populatedThemeEntitiesResponse: ThemeEntitiesResponse = {
   entities: [

--- a/packages/playground/src/ee/signals/__tests__/index.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/index.test.tsx
@@ -22,6 +22,7 @@ import {
   multiAgentThemeEntitiesResponse,
   multiEligibleThemeEntitiesResponse,
   populatedThemeEntitiesResponse,
+  processingProgressResponse,
   themeFlowResponse,
   themeSnapshotsResponse,
 } from './fixtures/theme-flow';
@@ -65,9 +66,9 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('Signals page', () => {
+describe('Trace Intelligence page', () => {
   describe('when the entities request is pending', () => {
-    it('shows the Signals loading state', async () => {
+    it('shows the Trace Intelligence loading state', async () => {
       server.use(
         http.get(`${BASE_URL}/api/learning/entities`, async () => {
           await new Promise(() => {});
@@ -91,7 +92,7 @@ describe('Signals page', () => {
 
       renderSignalsPage();
 
-      expect(await screen.findByText('Unable to load trace intelligence entities.')).not.toBeNull();
+      expect(await screen.findByText('Unable to load trace signal entities.')).not.toBeNull();
     });
   });
 
@@ -115,7 +116,7 @@ describe('Signals page', () => {
 
       renderSignalsPage();
 
-      expect(await screen.findByText('Unable to load trace intelligence entities.')).not.toBeNull();
+      expect(await screen.findByText('Unable to load trace signal entities.')).not.toBeNull();
       fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
 
       expect(await screen.findByRole('combobox', { name: 'Agent' })).not.toBeNull();
@@ -124,12 +125,12 @@ describe('Signals page', () => {
   });
 
   describe('when no Agent Learning entities exist', () => {
-    it('shows that the analysis is waiting for traces', async () => {
+    it('shows that Trace Intelligence is collecting traces', async () => {
       server.use(http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(emptyThemeEntitiesResponse)));
 
       renderSignalsPage();
 
-      expect(await screen.findByText('Waiting for traces.')).not.toBeNull();
+      expect(await screen.findByText('Collecting traces for Trace Intelligence.')).not.toBeNull();
     });
   });
 
@@ -146,12 +147,11 @@ describe('Signals page', () => {
       );
     });
 
-    it('labels the populated analysis', async () => {
+    it('labels the populated analysis with snapshot context', async () => {
       renderSignalsPage();
 
-      expect(
-        await screen.findByRole('heading', { name: 'Understand what drives every agent interaction' }),
-      ).not.toBeNull();
+      expect(await screen.findByText(/support-agent · Snapshot 4 of 4/)).not.toBeNull();
+      expect(screen.queryByRole('heading', { name: 'Understand what drives every agent interaction' })).toBeNull();
     });
 
     it('exposes the theme flow as a named region', async () => {
@@ -160,7 +160,7 @@ describe('Signals page', () => {
       expect(await screen.findByRole('region', { name: 'Trace signal theme flow' })).not.toBeNull();
     });
 
-    it('keeps exactly one trace intelligence documentation action across the shell and page', async () => {
+    it('keeps exactly one Trace intelligence documentation action across the shell and page', async () => {
       renderSignalsPageWithShell();
       await screen.findByRole('region', { name: 'Trace signal theme flow' });
 
@@ -212,10 +212,13 @@ describe('Signals page', () => {
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
           HttpResponse.json(emptyThemeSnapshotsResponse),
         ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/progress`, () =>
+          HttpResponse.json(processingProgressResponse),
+        ),
       );
       renderSignalsPage();
 
-      expect(await screen.findByText('Waiting for traces.')).not.toBeNull();
+      expect(await screen.findByText('No Trace Intelligence themes in this date range.')).not.toBeNull();
       expect(screen.getByRole('button', { name: 'Last 7 days' })).not.toBeNull();
     });
   });
@@ -343,7 +346,7 @@ describe('Signals page', () => {
     });
   });
 
-  describe('when a low-signal agent is returned before an eligible agent', () => {
+  describe('when a low-trace-signal agent is returned before an eligible agent', () => {
     it('defaults to the first agent that can render a flow', async () => {
       server.use(
         http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(lowSignalFirstThemeEntitiesResponse)),
@@ -362,7 +365,7 @@ describe('Signals page', () => {
     });
   });
 
-  describe('when multiple agents have different signal coverage', () => {
+  describe('when multiple agents have different trace signal coverage', () => {
     beforeEach(() => {
       server.use(
         http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(multiAgentThemeEntitiesResponse)),
@@ -371,6 +374,9 @@ describe('Signals page', () => {
         ),
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () =>
           HttpResponse.json(themeFlowResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/triage-agent/progress`, () =>
+          HttpResponse.json(processingProgressResponse),
         ),
       );
     });
@@ -393,9 +399,12 @@ describe('Signals page', () => {
       fireEvent.pointerDown(triageAgent, { pointerType: 'mouse' });
       fireEvent.click(triageAgent, { detail: 1 });
 
-      expect(await screen.findByText('Not enough trace signal data yet')).not.toBeNull();
-      expect(screen.getByText('Available trace signals: Goal')).not.toBeNull();
+      expect(await screen.findByText('Analyzing traces for Trace Intelligence.')).not.toBeNull();
+      expect(screen.getByText('87')).not.toBeNull();
+      expect(screen.getByText('1 of 4')).not.toBeNull();
       expect(screen.getByRole('combobox', { name: 'Agent' })).not.toBeNull();
+      expect(screen.queryByText('Snapshot date')).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Last 7 days' })).toBeNull();
     });
   });
 
@@ -440,11 +449,14 @@ describe('Signals page', () => {
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
           HttpResponse.json({ snapshots: [] }),
         ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/progress`, () =>
+          HttpResponse.json(processingProgressResponse),
+        ),
       );
 
       renderSignalsPage();
 
-      expect(await screen.findByText('Waiting for traces.')).not.toBeNull();
+      expect(await screen.findByText('No Trace Intelligence themes in this date range.')).not.toBeNull();
     });
   });
 });

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -88,7 +88,7 @@ async function reorderOutcomeAfterBehavior(beforeDrop?: () => void) {
   );
   distributionCards.forEach((card, index) => {
     const draggable = card.parentElement;
-    if (!draggable) throw new Error('Signal distribution draggable was not rendered');
+    if (!draggable) throw new Error('Trace signal distribution draggable was not rendered');
     vi.spyOn(draggable, 'getBoundingClientRect').mockReturnValue(rectangle(index * 250, 240, 300));
   });
   vi.spyOn(screen.getByRole('region', { name: 'Trace signal distributions' }), 'getBoundingClientRect').mockReturnValue(
@@ -179,7 +179,7 @@ describe('stabilizeThemeFlow', () => {
 
 describe('SankeySignals', () => {
   describe('when the snapshot request is pending', () => {
-    it('shows the Signals loading state', async () => {
+    it('shows the Trace Intelligence loading state', async () => {
       server.use(
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, async () => {
           await new Promise(() => {});
@@ -194,7 +194,7 @@ describe('SankeySignals', () => {
   });
 
   describe('when the flow request is pending', () => {
-    it('shows the Signals loading state', async () => {
+    it('shows the Trace Intelligence loading state', async () => {
       server.use(
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
           HttpResponse.json(themeSnapshotsResponse),
@@ -238,7 +238,7 @@ describe('SankeySignals', () => {
   });
 
   describe('when the snapshot request fails', () => {
-    it('shows the signal flow error state', async () => {
+    it('shows the trace signal flow error state', async () => {
       server.use(
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
           HttpResponse.json({ error: 'Snapshot unavailable' }, { status: 500 }),
@@ -286,7 +286,7 @@ describe('SankeySignals', () => {
     });
   });
 
-  describe('when a snapshot contains four populated signal stages', () => {
+  describe('when a snapshot contains four populated trace signal stages', () => {
     beforeEach(() => {
       server.use(
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
@@ -298,12 +298,12 @@ describe('SankeySignals', () => {
       );
     });
 
-    it('renders the page identity without duplicating the shell documentation action', async () => {
+    it('renders the analysis context without duplicating onboarding copy or shell documentation action', async () => {
       renderSankeySignals();
 
-      expect(await screen.findByText('TRACE INTELLIGENCE')).not.toBeNull();
-      expect(screen.getByRole('heading', { name: 'Understand what drives every agent interaction' })).not.toBeNull();
-      expect(screen.getByText(/Trace intelligence groups recurring patterns across traces/)).not.toBeNull();
+      await screen.findByText('support-agent · Snapshot 4 of 4 · Jul 1–8, 2026');
+      expect(screen.queryByRole('heading', { name: 'Understand what drives every agent interaction' })).toBeNull();
+      expect(screen.queryByText(/Trace intelligence groups recurring patterns across traces/)).toBeNull();
       expect(screen.queryByRole('link', { name: 'Trace intelligence documentation' })).toBeNull();
     });
 
@@ -317,7 +317,7 @@ describe('SankeySignals', () => {
     it('shows exactly three metrics derived from the loaded flow', async () => {
       renderSankeySignals();
 
-      const metrics = await screen.findByRole('list', { name: 'Trace intelligence metrics' });
+      const metrics = await screen.findByRole('list', { name: 'Trace signal metrics' });
       expect(within(metrics).getAllByRole('listitem')).toHaveLength(3);
       expect(within(metrics).getByText('50 traces analyzed')).not.toBeNull();
       expect(within(metrics).getByText('9 themes')).not.toBeNull();
@@ -339,7 +339,7 @@ describe('SankeySignals', () => {
       const column = columns[0];
       expect(record).toBeDefined();
       expect(column).toBeDefined();
-      if (!record || !column) throw new Error('Expected a signal flow record and column');
+      if (!record || !column) throw new Error('Expected a trace signal flow record and column');
       expect(getSignalRecordNodeLabel(record, column)).toBe(
         'Resolve support request\nThe user wants help resolving a support issue.',
       );
@@ -413,7 +413,7 @@ describe('SankeySignals', () => {
     });
   });
 
-  describe('when a signal distribution is reordered', () => {
+  describe('when a trace signal distribution is reordered', () => {
     it('keeps the selected snapshot range on the perspective request', async () => {
       const snapshotRanges: Array<[string | null, string | null]> = [];
       const reorderedSnapshot = {
@@ -554,7 +554,7 @@ describe('SankeySignals', () => {
 
       await reorderOutcomeAfterBehavior();
 
-      expect(await screen.findByText('Reloading snapshots for new signal perspective…')).not.toBeNull();
+      expect(await screen.findByText('Reloading snapshots for new trace signal perspective…')).not.toBeNull();
       expect(screen.queryByTestId('signals-loading-skeleton')).toBeNull();
       expect(
         within(screen.getByRole('region', { name: 'Trace signal distributions' }))
@@ -762,7 +762,7 @@ describe('SankeySignals', () => {
     it('uses the authoritative snapshot total in the header badge', async () => {
       renderSankeySignals();
 
-      const metrics = await screen.findByRole('list', { name: 'Trace intelligence metrics' });
+      const metrics = await screen.findByRole('list', { name: 'Trace signal metrics' });
       expect(within(metrics).getByText('80 traces analyzed')).not.toBeNull();
       expect(within(metrics).queryByText('50 traces analyzed')).toBeNull();
     });
@@ -817,7 +817,7 @@ describe('SankeySignals', () => {
     });
   });
 
-  describe('when themes in one signal stage share a display label', () => {
+  describe('when themes in one trace signal stage share a display label', () => {
     beforeEach(() => {
       server.use(
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
@@ -851,7 +851,7 @@ describe('SankeySignals', () => {
       );
     });
 
-    it('renders the flow with the signal and theme labels', async () => {
+    it('renders the flow with the trace signal and theme labels', async () => {
       renderSankeySignals();
 
       expect(await screen.findByRole('region', { name: 'Trace signal theme flow' })).not.toBeNull();
@@ -868,7 +868,7 @@ describe('SankeySignals', () => {
       ).toEqual(['Goal', 'Outcome']);
     });
 
-    it('preserves the API-defined signal order', () => {
+    it('preserves the API-defined trace signal order', () => {
       const { columns } = themeFlowToSankeyData(themeFlowResponse);
 
       expect(columns).toEqual([

--- a/packages/playground/src/ee/signals/__tests__/theme-drilldown.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/theme-drilldown.test.tsx
@@ -269,7 +269,7 @@ describe('Agent Learning theme drilldown hooks', () => {
   });
 
   describe('when a drill-in starts', () => {
-    it('fetches every paths page with the opaque snapshot and ordered signals', async () => {
+    it('fetches every paths page with the opaque snapshot and ordered trace signals', async () => {
       const observedOffsets: string[] = [];
       server.use(
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-paths`, ({ request }) => {
@@ -413,7 +413,7 @@ describe('SankeySignals drill-in', () => {
       fireEvent.click(detailsRow);
 
       expect(await screen.findByRole('dialog', { name: 'Add transcript' })).not.toBeNull();
-      expect(screen.getByRole('heading', { name: 'Understand what drives every agent interaction' })).not.toBeNull();
+      expect(screen.queryByRole('heading', { name: 'Understand what drives every agent interaction' })).toBeNull();
       expect(await screen.findByText('Users want to add a transcript to their workspace.')).not.toBeNull();
       expect(await screen.findByText('Add this transcript to my workspace.')).not.toBeNull();
       expect(await screen.findByText(/^birth$/i)).not.toBeNull();
@@ -424,7 +424,7 @@ describe('SankeySignals drill-in', () => {
   });
 
   describe('when a Noise row is selected', () => {
-    it('shows Noise for every signal and opens its definition and summary examples', async () => {
+    it('shows Noise for every trace signal and opens its definition and summary examples', async () => {
       useFlowHandlers();
       server.use(
         http.get(`${BASE_URL}/api/learning/entities/support-agent/noise`, ({ request }) => {

--- a/packages/playground/src/ee/signals/entity-learning-api.ts
+++ b/packages/playground/src/ee/signals/entity-learning-api.ts
@@ -2,6 +2,7 @@ import type {
   NoiseExamplesResponse,
   NoiseResponse,
   ThemeDetailResponse,
+  EntityLearningProgressResponse,
   ThemeEntitiesResponse,
   ThemeExamplesResponse,
   ThemeFlowResponse,
@@ -14,6 +15,13 @@ import type {
 export function fetchThemeEntities(entityType: string) {
   const query = new URLSearchParams({ entityType });
   return learningJson<ThemeEntitiesResponse>(`/api/learning/entities?${query}`);
+}
+
+export function fetchEntityLearningProgress(entityId: string, entityType: string) {
+  const query = new URLSearchParams({ entityType });
+  return learningJson<EntityLearningProgressResponse>(
+    `/api/learning/entities/${encodeURIComponent(entityId)}/progress?${query}`,
+  );
 }
 
 export function fetchThemeSnapshots(

--- a/packages/playground/src/ee/signals/hooks/index.ts
+++ b/packages/playground/src/ee/signals/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useNoise } from './use-noise';
 export { useNoiseExamples } from './use-noise-examples';
+export { useEntityLearningProgress } from './use-entity-learning-progress';
 export { useThemeDetail } from './use-theme-detail';
 export { useThemeEntities } from './use-theme-entities';
 export { useThemeExamples } from './use-theme-examples';

--- a/packages/playground/src/ee/signals/hooks/use-entity-learning-progress.ts
+++ b/packages/playground/src/ee/signals/hooks/use-entity-learning-progress.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchEntityLearningProgress } from '../entity-learning-api';
+
+export function useEntityLearningProgress(entityId: string | undefined, entityType: string, enabled = true) {
+  return useQuery({
+    queryKey: ['entity-learning', entityType, entityId, 'progress'],
+    queryFn: () => fetchEntityLearningProgress(entityId ?? '', entityType),
+    enabled: enabled && Boolean(entityId),
+  });
+}

--- a/packages/playground/src/ee/signals/hooks/use-noise-examples.ts
+++ b/packages/playground/src/ee/signals/hooks/use-noise-examples.ts
@@ -14,7 +14,7 @@ export function useNoiseExamples(
   return useQuery({
     queryKey: ['entity-learning', entityType, entityId, 'noise-examples', signalName, snapshotId, limit, offset],
     queryFn: () => {
-      if (!signalName || !snapshotId) throw new Error('Noise example queries require a signal and snapshot');
+      if (!signalName || !snapshotId) throw new Error('Noise example queries require a trace signal and snapshot');
       return fetchNoiseExamples(entityId, entityType, signalName, snapshotId, limit, offset);
     },
     enabled: signalName !== undefined && snapshotId !== undefined,

--- a/packages/playground/src/ee/signals/hooks/use-noise.ts
+++ b/packages/playground/src/ee/signals/hooks/use-noise.ts
@@ -12,7 +12,7 @@ export function useNoise(
   return useQuery({
     queryKey: ['entity-learning', entityType, entityId, 'noise', signalName, snapshotId],
     queryFn: () => {
-      if (!signalName || !snapshotId) throw new Error('Noise queries require a signal and snapshot');
+      if (!signalName || !snapshotId) throw new Error('Noise queries require a trace signal and snapshot');
       return fetchNoise(entityId, entityType, signalName, snapshotId);
     },
     enabled: signalName !== undefined && snapshotId !== undefined,

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -11,6 +11,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 
 import { fetchThemeFlow, fetchThemePaths, fetchThemeSnapshots } from './entity-learning-api';
+import { useEntityLearningProgress } from './hooks/use-entity-learning-progress';
 import { useSnapshotPlayback } from './hooks/use-snapshot-playback';
 import { useThemeFlows } from './hooks/use-theme-flows';
 import { useThemePaths } from './hooks/use-theme-paths';
@@ -172,6 +173,12 @@ export function SankeySignals({
     return stabilizeThemeFlow(drilledFlow, [stableUnfilteredFlow, drilledFlow]);
   }, [drillIn, pathsQuery.data, stableUnfilteredFlow]);
   const graphSummary = useMemo(() => (flow ? buildSignalGraphSummary(flow) : undefined), [flow]);
+  const populatedStageCount = currentFlow?.stages.filter(stage => stage.nodes.length > 0).length ?? 0;
+  const shouldLoadProgress =
+    snapshotsQuery.isSuccess &&
+    !snapshotsQuery.isError &&
+    (!snapshot || Boolean(currentFlow && (!flow || !graphSummary || populatedStageCount < 2)));
+  const progressQuery = useEntityLearningProgress(entityId, entityType, shouldLoadProgress);
   const isPlaybackBlockedByDrillIn = drillIn !== undefined && (pathsQuery.isFetching || pathsQuery.isError);
   const hasActivePathsError = drillIn !== undefined && pathsQuery.isError;
 
@@ -236,7 +243,7 @@ export function SankeySignals({
     );
   }
 
-  if (!snapshot) return <SignalsEmptyState LinkComponent={Link} />;
+  if (!snapshot) return <SignalsEmptyState LinkComponent={Link} progress={progressQuery.data} isRangeEmpty />;
 
   if (isFlowPending) {
     return (
@@ -253,10 +260,8 @@ export function SankeySignals({
     );
   }
 
-  const populatedStageCount = currentFlow?.stages.filter(stage => stage.nodes.length > 0).length ?? 0;
-
   if (!currentFlow || !flow || !graphSummary || populatedStageCount < 2) {
-    return <SignalsEmptyState LinkComponent={Link} />;
+    return <SignalsEmptyState LinkComponent={Link} progress={progressQuery.data} />;
   }
 
   const stages = flow.stages;
@@ -296,22 +301,11 @@ export function SankeySignals({
   return (
     <main className="min-w-0 space-y-5 p-4 lg:p-6">
       <header className="max-w-3xl" data-testid="signals-page-header">
-        <div className="text-neutral4 flex items-center gap-2 font-mono text-xs font-semibold tracking-widest">
-          <span aria-hidden="true" className="bg-accent1 size-2 rounded-full" />
-          TRACE INTELLIGENCE
-        </div>
-        <h1 className="text-neutral6 mt-2 text-xl font-semibold sm:text-2xl">
-          Understand what drives every agent interaction
-        </h1>
-        <p className="text-neutral3 mt-1.5 text-sm leading-5">
-          Trace intelligence groups recurring patterns across traces so you can see how goal, outcome, behavior, and
-          sentiment trace signals connect.
-        </p>
-        <p className="text-neutral4 mt-2 font-mono text-xs">
+        <p className="text-neutral4 font-mono text-xs">
           {entityId} · Snapshot {flow.snapshot.ordinal} of {flow.snapshot.total} ·{' '}
           {formatSnapshotWindow(flow.snapshot.startedAt, flow.snapshot.endedAt)}
         </p>
-        <ul aria-label="Trace intelligence metrics" className="mt-3 flex flex-wrap gap-2">
+        <ul aria-label="Trace signal metrics" className="mt-3 flex flex-wrap gap-2">
           <li className="border-border1 bg-surface2 text-neutral4 rounded-md border px-3 py-1.5 text-xs">
             {traceLabel(flow.snapshot.traceCount)} analyzed
           </li>
@@ -377,12 +371,12 @@ export function SankeySignals({
         <>
           {perspectiveMutation.isPending ? (
             <p className="text-neutral3 font-mono text-xs" role="status">
-              Reloading snapshots for new signal perspective…
+              Reloading snapshots for new trace signal perspective…
             </p>
           ) : null}
           {perspectiveMutation.isError ? (
             <p className="text-xs text-red-500" role="alert">
-              Unable to load that signal perspective. Try reordering the columns again.
+              Unable to load that trace signal perspective. Try reordering the columns again.
             </p>
           ) : null}
           <SignalDistributions

--- a/packages/playground/src/ee/signals/signals-overview-page.tsx
+++ b/packages/playground/src/ee/signals/signals-overview-page.tsx
@@ -5,7 +5,7 @@ import { SignalsOverviewPage as SignalsEmptyState } from '@mastra/playground-ui/
 import { useState } from 'react';
 
 import { Link } from '../../lib/link';
-import { useThemeEntities } from './hooks';
+import { useEntityLearningProgress, useThemeEntities } from './hooks';
 import { SankeySignals } from './sankey-signals';
 import { SignalsErrorState } from './signals-error-state';
 import { SignalsLoadingSkeleton } from './signals-loading-skeleton';
@@ -13,14 +13,11 @@ import type { ThemeLearningEntity, TraceSignalName } from './types';
 
 const SIGNAL_ORDER: TraceSignalName[] = ['goal', 'outcome', 'behavior', 'sentiment'];
 
-function formatSignalName(signalName: TraceSignalName) {
-  return signalName.charAt(0).toUpperCase() + signalName.slice(1);
-}
-
 function SignalsControls({
   entities,
   selectedEntityId,
   onEntityChange,
+  showDatePicker,
   datePreset,
   dateFrom,
   dateTo,
@@ -30,6 +27,7 @@ function SignalsControls({
   entities: ThemeLearningEntity[];
   selectedEntityId: string;
   onEntityChange: (entityId: string) => void;
+  showDatePicker: boolean;
   datePreset: DateRangePreset;
   dateFrom?: Date;
   dateTo?: Date;
@@ -37,7 +35,7 @@ function SignalsControls({
   onDateChange: (value: Date | undefined, type: 'from' | 'to') => void;
 }) {
   return (
-    <div className="flex min-w-0 flex-wrap items-center gap-3 px-4 pt-4 lg:px-6 lg:pt-6">
+    <div className="flex min-w-0 flex-wrap items-center gap-3 px-6 pt-6 pb-8 md:px-10 lg:px-12 lg:pt-8 lg:pb-10 xl:px-[4.375rem]">
       <label className="text-neutral4 text-xs font-medium" htmlFor="signals-agent-selector">
         Agent
       </label>
@@ -53,16 +51,20 @@ function SignalsControls({
           ))}
         </SelectContent>
       </Select>
-      <span className="text-neutral4 text-xs font-medium">Snapshot date</span>
-      <DateTimeRangePicker
-        preset={datePreset}
-        onPresetChange={onDatePresetChange}
-        dateFrom={dateFrom}
-        dateTo={dateTo}
-        onDateChange={onDateChange}
-        presets={['last-24h', 'last-3d', 'last-7d', 'last-14d', 'last-30d', 'custom']}
-        size="sm"
-      />
+      {showDatePicker ? (
+        <>
+          <span className="text-neutral4 text-xs font-medium">Snapshot date</span>
+          <DateTimeRangePicker
+            preset={datePreset}
+            onPresetChange={onDatePresetChange}
+            dateFrom={dateFrom}
+            dateTo={dateTo}
+            onDateChange={onDateChange}
+            presets={['last-24h', 'last-3d', 'last-7d', 'last-14d', 'last-30d', 'custom']}
+            size="sm"
+          />
+        </>
+      ) : null}
     </div>
   );
 }
@@ -77,6 +79,17 @@ export function SignalsOverviewPage() {
     if (type === 'from') setDateFrom(value);
     else setDateTo(value);
   };
+  const entities = entitiesQuery.data?.entities ?? [];
+  const entity =
+    entities.find(currentEntity => currentEntity.entityId === selectedEntityId) ??
+    entities.find(currentEntity => currentEntity.availableSignals.length >= 2) ??
+    entities[0];
+  const signalNames = entity ? SIGNAL_ORDER.filter(signalName => entity.availableSignals.includes(signalName)) : [];
+  const progressQuery = useEntityLearningProgress(
+    entity?.entityId,
+    entity?.entityType ?? 'agent',
+    !entitiesQuery.isPending && !entitiesQuery.isError && signalNames.length < 2,
+  );
 
   if (entitiesQuery.isPending) {
     return <SignalsLoadingSkeleton />;
@@ -84,24 +97,13 @@ export function SignalsOverviewPage() {
 
   if (entitiesQuery.isError) {
     return (
-      <SignalsErrorState
-        message="Unable to load trace intelligence entities."
-        onRetry={() => void entitiesQuery.refetch()}
-      />
+      <SignalsErrorState message="Unable to load trace signal entities." onRetry={() => void entitiesQuery.refetch()} />
     );
   }
-
-  const entities = entitiesQuery.data?.entities ?? [];
-  const entity =
-    entities.find(currentEntity => currentEntity.entityId === selectedEntityId) ??
-    entities.find(currentEntity => currentEntity.availableSignals.length >= 2) ??
-    entities[0];
 
   if (!entity) {
     return <SignalsEmptyState LinkComponent={Link} />;
   }
-
-  const signalNames = SIGNAL_ORDER.filter(signalName => entity.availableSignals.includes(signalName));
 
   return (
     <>
@@ -109,6 +111,7 @@ export function SignalsOverviewPage() {
         entities={entities}
         selectedEntityId={entity.entityId}
         onEntityChange={setSelectedEntityId}
+        showDatePicker={signalNames.length >= 2}
         datePreset={datePreset}
         dateFrom={dateFrom}
         dateTo={dateTo}
@@ -125,20 +128,7 @@ export function SignalsOverviewPage() {
           dateTo={dateTo}
         />
       ) : (
-        <section
-          className="border-border1 bg-surface2 m-4 rounded-lg border p-6 lg:m-6"
-          aria-labelledby="signals-data-heading"
-        >
-          <h1 className="text-neutral6 text-lg font-semibold" id="signals-data-heading">
-            Not enough trace signal data yet
-          </h1>
-          <p className="text-neutral3 mt-2 text-sm">
-            At least two trace signal types are needed to show how themes connect across traces.
-          </p>
-          <p className="text-neutral4 mt-4 text-xs">
-            Available trace signals: {signalNames.length > 0 ? signalNames.map(formatSignalName).join(', ') : 'None'}
-          </p>
-        </section>
+        <SignalsEmptyState LinkComponent={Link} progress={progressQuery.data} />
       )}
     </>
   );

--- a/packages/playground/src/ee/signals/types.ts
+++ b/packages/playground/src/ee/signals/types.ts
@@ -1,4 +1,5 @@
 export type {
+  EntityLearningProgressResponse,
   NoiseExamplesResponse,
   NoiseResponse,
   ThemeDetailResponse,

--- a/packages/playground/src/lib/nav/nav-items.tsx
+++ b/packages/playground/src/lib/nav/nav-items.tsx
@@ -48,7 +48,10 @@ const signalsNavItem: NavItem = {
   url: '/intelligence',
   activePaths: ['/intelligence'],
   Icon: LayoutGrid,
-  docs: { href: 'https://mastra.ai/en/docs/observability/tracing/overview', label: 'Trace intelligence documentation' },
+  docs: {
+    href: 'https://mastra.ai/en/docs/mastra-platform/trace-intelligence',
+    label: 'Trace intelligence documentation',
+  },
   isOnMastraPlatform: true,
   // Kept in the registry so /intelligence routes and breadcrumbs always resolve, but
   // only surfaced in the sidebar/command palette when the flag is enabled.


### PR DESCRIPTION
## Summary
- Show Trace Intelligence processing progress for agents that have traces but are still waiting on enough signal data to form themes.
- Keep the agent selector visible during onboarding, hide the snapshot date picker until theme data can render, and scope onboarding copy to empty states only.
- Align the empty-state language and docs link with the Trace Intelligence docs while cleaning up accessibility, mobile spacing, and visual placeholders.

## Test plan
- pnpm build:playground-ui
- pnpm --filter ./packages/playground-ui test -- --run src/ee/signals/components/__tests__/signals-overview-page.test.tsx
- pnpm --filter ./packages/playground test -- --run src/ee/signals/__tests__/index.test.tsx
- pnpm --filter ./packages/playground test -- --run src/ee/signals/__tests__/index.test.tsx src/ee/signals/__tests__/sankey-signals.test.tsx src/ee/signals/__tests__/theme-drilldown.test.tsx
- pnpm --filter ./packages/playground typecheck
- pnpm --filter @mastra/client-js test:unit -- --run src/agent-learning.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Trace Intelligence now tells you what stage it’s in (“collecting” vs “processing”) while it gathers enough trace data to find patterns. The onboarding UI is cleaner too: you always see the agent dropdown, but the date picker only appears when there’s enough data to analyze.

## What changed

- Added typed “learning progress” for Trace Intelligence:
  - `EntityLearningProgressStatus` + `EntityLearningProgressResponse` in `@mastra/client-js`
  - new `fetchEntityLearningProgress(...)` and `useEntityLearningProgress(...)`
  - added a `processingProgressResponse` test fixture
- Improved the Trace Intelligence onboarding/empty states:
  - Show a progress-driven empty state when there isn’t enough signal data yet (collecting/processing/ready), including per-trace-signal generated/embedded counts
  - Limited onboarding copy to empty-state rendering (replaced prior inline explanations with `SignalsEmptyState`)
  - Kept the agent selector visible during onboarding; only the snapshot date picker is conditional
  - Hid the snapshot date picker until at least two trace signal types are available (`showDatePicker={signalNames.length >= 2}`)
- Aligned copy and documentation links with Trace Intelligence docs:
  - updated nav/docs target to the `/trace-intelligence` docs page
  - updated “Read the docs” link assertions to match the Trace Intelligence URL
- Accessibility + UI polish:
  - updated empty-state semantics/labels and added progress UI placeholders
  - improved spacing/mobile presentation in the onboarding surfaces
- Tests + release note updates:
  - updated/extended Signals UI tests to reflect new Trace Intelligence wording and progress behaviors (including a new progress-prop empty-state test)
  - added a patch changeset for `@mastra/playground-ui` and `@mastra/client-js`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->