### PR TITLE
feat(factory): route invokeSkill through pending-start for async delivery

### DIFF
--- a/.changeset/orange-kiwis-dream.md
+++ b/.changeset/orange-kiwis-dream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Improved stage transitions to complete immediately. Transitions from intake to triage, planning, or review now return right away, with skill activation happening asynchronously in the background instead of blocking the transition.

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -157,10 +157,12 @@ describe('GithubRules', () => {
       rules,
     });
     const deliveredSignals: Array<{ id: string; contents: string; threadId: string; user: unknown }> = [];
+    const deliveredNotifications: Array<{ kind: string; summary: string; threadId: string; user: unknown }> = [];
     const sessions = new Map<string, ReturnType<typeof makeSession>>();
 
     function makeSession(key: string, initialThreadId?: string) {
       let threadId: string | undefined = initialThreadId;
+      const consumeStream = vi.fn(async () => {});
       const session = {
         thread: {
           list: vi.fn(async () => []),
@@ -194,7 +196,19 @@ describe('GithubRules', () => {
         ),
         state: { set: vi.fn(async () => {}) },
         sendMessage: vi.fn(async () => {}),
-        sendNotificationSignal: vi.fn(async () => ({ persisted: Promise.resolve(), accepted: Promise.resolve() })),
+        sendNotificationSignal: vi.fn(
+          (
+            input: { kind: string; summary: string },
+            options: { requestContext: { get(key: string): unknown } },
+          ) => {
+            if (!threadId) throw new Error('Notification delivered before thread persistence.');
+            deliveredNotifications.push({ ...input, threadId, user: options.requestContext.get('user') });
+            return {
+              persisted: Promise.resolve(),
+              accepted: Promise.resolve({ action: 'wake', output: { consumeStream } }),
+            };
+          },
+        ),
       };
       sessions.set(key, session);
       return session;
@@ -220,7 +234,7 @@ describe('GithubRules', () => {
       storage: workItems,
       ownerId: 'worker-1',
       primeCredentials,
-      prepareBinding: async ({ record, item, role }) => {
+      prepareBinding: async ({ record, item, role, invocation }) => {
         await coordinator.prepare({
           orgId: record.orgId,
           userId: 'user-1',
@@ -230,13 +244,18 @@ describe('GithubRules', () => {
           kickoffKey: record.idempotencyKey,
           destinationStage: 'triage',
           workItem: { id: item.id, role, input: item },
+          ...(invocation ? { invocation } : {}),
         });
       },
     });
 
     await service.ingest(issueOpened('delivery-full-flow'));
+    // Cycle 1: upsertLinkedWorkItem → transition to triage → invokeSkill deferred
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+    // Cycle 2: invokeSkill → prepareBinding (with invocation) → pending start created
     await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
+    // Cycle 3: pending start → sendNotificationSignal with run-kickoff
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:02Z'));
 
     const [item] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
     expect(item).toMatchObject({
@@ -251,10 +270,12 @@ describe('GithubRules', () => {
       },
     });
     expect(primeCredentials).toHaveBeenCalledWith({ orgId: 'org-1', userId: 'user-1' });
-    expect(deliveredSignals).toEqual([
+    // Skill kickoff delivered via pending start notification (not inline sendSignal)
+    expect(deliveredNotifications).toEqual([
       expect.objectContaining({
+        kind: 'run-kickoff',
         threadId: 'session-issue-42',
-        contents: expect.stringContaining('<skill name="factory-triage">'),
+        summary: expect.stringContaining('<skill name="factory-triage">'),
         user: { workosId: 'user-1', organizationId: 'org-1' },
       }),
     ]);
@@ -272,6 +293,7 @@ describe('GithubRules', () => {
 
     await dispatcher.runOnce(new Date('2030-01-01T00:00:02Z'));
     await dispatcher.runOnce(new Date('2030-01-01T00:00:03Z'));
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:04Z'));
 
     const [rematerialized] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
     expect(rematerialized).toMatchObject({
@@ -279,7 +301,12 @@ describe('GithubRules', () => {
       stages: ['triage'],
     });
     expect(rematerialized?.id).not.toBe(item?.id);
-    expect(deliveredSignals).toHaveLength(2);
+    expect(deliveredNotifications).toHaveLength(2);
+    expect((await workItems.listDeferredDecisions('org-1', project.id)).map(decision => decision.status)).toEqual([
+      'succeeded',
+      'succeeded',
+      'succeeded',
+    ]);
   });
 
   it('prefers canonical board identities over legacy GitHub rows during ingress', async () => {

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -189,6 +189,7 @@ async function prepareFactoryRuleBinding(
         metadata: input.item.metadata,
       },
     },
+    ...(input.invocation ? { invocation: input.invocation } : {}),
   });
 }
 

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -874,7 +874,8 @@ describe('FactoryDecisionDispatcher', () => {
       idempotencyKey: 'skill-auto-start',
     });
     const { controller, session } = createSession();
-    const prepareBinding = vi.fn(async () => {
+    const prepareBinding = vi.fn(async (input: { invocation?: { skillName: string } }) => {
+      const kickoffMessage = input.invocation ? `<skill name="${input.invocation.skillName}">\n</skill>` : null;
       await storage.prepareRunStart({
         orgId: 'org-1',
         userId: 'user-1',
@@ -893,7 +894,7 @@ describe('FactoryDecisionDispatcher', () => {
         session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-1' },
         resourceId: PROJECT_ID,
         kickoffKey: 'skill-auto-start',
-        kickoffMessage: null,
+        kickoffMessage,
       });
     });
     const dispatcher = new FactoryDecisionDispatcher({
@@ -904,14 +905,31 @@ describe('FactoryDecisionDispatcher', () => {
       prepareBinding,
     });
 
+    // Cycle 1: invokeSkill → prepareBinding (with invocation) → pending start created
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
 
     expect(prepareBinding).toHaveBeenCalledWith(
-      expect.objectContaining({ item: expect.objectContaining({ id: item.id }), role: 'triage' }),
+      expect.objectContaining({
+        item: expect.objectContaining({ id: item.id }),
+        role: 'triage',
+        invocation: { type: 'skill', skillName: 'understand-issue', arguments: '' },
+      }),
     );
-    expect(session.sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({ contents: expect.stringContaining('<skill name="understand-issue">') }),
-      { requestContext: expect.anything(), requireDelivery: true },
+    // Inline skill sending should NOT happen — pending start handles it
+    expect(session.sendSignal).not.toHaveBeenCalled();
+
+    // Cycle 2: pending start → sendNotificationSignal with run-kickoff
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
+
+    expect(session.sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'run-kickoff',
+        summary: expect.stringContaining('<skill name="understand-issue">'),
+      }),
+      expect.objectContaining({
+        ifActive: { behavior: 'deliver' },
+        ifIdle: { behavior: 'wake' },
+      }),
     );
   });
 
@@ -945,7 +963,8 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const { controller, session } = createSession();
     controller.getSessionByResource.mockResolvedValueOnce(undefined as never).mockResolvedValue(session);
-    const prepareBinding = vi.fn(async () => {
+    const prepareBinding = vi.fn(async (input: { invocation?: { skillName: string } }) => {
+      const kickoffMessage = input.invocation ? `<skill name="${input.invocation.skillName}">\n</skill>` : null;
       await storage.prepareRunStart({
         orgId: 'org-1',
         userId: 'user-1',
@@ -964,7 +983,7 @@ describe('FactoryDecisionDispatcher', () => {
         session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-2' },
         resourceId: PROJECT_ID,
         kickoffKey: 'skill-session-recovery-replacement',
-        kickoffMessage: null,
+        kickoffMessage,
       });
     });
     const dispatcher = new FactoryDecisionDispatcher({
@@ -975,15 +994,31 @@ describe('FactoryDecisionDispatcher', () => {
       prepareBinding,
     });
 
+    // Cycle 1: invokeSkill → existing binding but no session → prepareBinding → pending start created
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
 
     expect(prepareBinding).toHaveBeenCalledWith(
-      expect.objectContaining({ item: expect.objectContaining({ id: item.id }), role: 'triage' }),
+      expect.objectContaining({
+        item: expect.objectContaining({ id: item.id }),
+        role: 'triage',
+        invocation: { type: 'skill', skillName: 'understand-issue', arguments: '' },
+      }),
     );
+    expect(session.sendSignal).not.toHaveBeenCalled();
+
+    // Cycle 2: pending start → sendNotificationSignal with run-kickoff
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
+
     expect(session.thread.switch).toHaveBeenCalledWith({ threadId: 'thread-2' });
-    expect(session.sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({ contents: expect.stringContaining('<skill name="understand-issue">') }),
-      { requestContext: expect.anything(), requireDelivery: true },
+    expect(session.sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'run-kickoff',
+        summary: expect.stringContaining('<skill name="understand-issue">'),
+      }),
+      expect.objectContaining({
+        ifActive: { behavior: 'deliver' },
+        ifIdle: { behavior: 'wake' },
+      }),
     );
   });
 

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -46,6 +46,7 @@ export interface FactoryBindingPreparationInput {
   record: FactoryDeferredDecisionRecord;
   item: WorkItemRow;
   role: string;
+  invocation?: { type: 'skill'; skillName: string; arguments: string };
 }
 
 export interface FactoryDecisionDispatcherOptions {
@@ -317,7 +318,49 @@ export class FactoryDecisionDispatcher {
         return;
       }
       case 'invokeSkill': {
-        const binding = await this.#requireOrPrepareBinding(record, decision.role);
+        const invocation = {
+          type: 'skill' as const,
+          skillName: decision.skillName,
+          arguments: decision.arguments ?? '',
+        };
+        const { binding, prepared } = await this.#requireOrPrepareBinding(record, decision.role, invocation);
+        if (prepared) {
+          // The pending start has the skill kickoff message. It will be
+          // dispatched by #dispatchPendingStart in the next dispatch cycle.
+          // Only send the preceding message here (if any) so it arrives before
+          // the kickoff.
+          const item = record.workItemId
+            ? await this.#storage.get({ orgId: record.orgId, id: record.workItemId })
+            : null;
+          const startedBy = item?.sessions[binding.role]?.startedBy;
+          if (!startedBy) throw new Error(`Factory binding ${binding.id} has no authenticated session owner.`);
+          await this.#primeCredentials?.({ orgId: record.orgId, userId: startedBy });
+          const requestContext = new RequestContext();
+          requestContext.set('user', { workosId: startedBy, organizationId: record.orgId });
+          if (decision.precedingMessage) {
+            const session = await this.#requireSession(binding);
+            await awaitNotification(
+              await session.sendNotificationSignal(
+                {
+                  source: 'factory',
+                  kind: 'stage-transition',
+                  summary: decision.precedingMessage,
+                  priority: 'medium',
+                  payload: { message: decision.precedingMessage },
+                  sourceId: `${record.id}:stage-transition`,
+                  dedupeKey: `${record.idempotencyKey}:stage-transition`,
+                },
+                {
+                  ifActive: { behavior: 'deliver' },
+                  ifIdle: { behavior: 'persist' },
+                  requestContext,
+                },
+              ),
+            );
+          }
+          return;
+        }
+        // Existing binding found — resolve and send the skill inline.
         const item = record.workItemId ? await this.#storage.get({ orgId: record.orgId, id: record.workItemId }) : null;
         const startedBy = item?.sessions[binding.role]?.startedBy;
         if (!startedBy) throw new Error(`Factory binding ${binding.id} has no authenticated session owner.`);
@@ -377,7 +420,7 @@ export class FactoryDecisionDispatcher {
       }
       case 'sendMessage': {
         const binding = decision.prepareBinding
-          ? await this.#requireOrPrepareBinding(record, decision.role)
+          ? (await this.#requireOrPrepareBinding(record, decision.role)).binding
           : await this.#requireBinding(record, decision.role);
         const item = record.workItemId ? await this.#storage.get({ orgId: record.orgId, id: record.workItemId }) : null;
         const startedBy = item?.sessions[binding.role]?.startedBy;
@@ -516,18 +559,20 @@ export class FactoryDecisionDispatcher {
   async #requireOrPrepareBinding(
     record: FactoryDeferredDecisionRecord,
     role: string,
-  ): Promise<FactoryRunBindingRecord> {
+    invocation?: { type: 'skill'; skillName: string; arguments: string },
+  ): Promise<{ binding: FactoryRunBindingRecord; prepared: boolean }> {
     const binding = await this.#findBinding(record, role);
     if (binding) {
       const session = await this.#controller.getSessionByResource(binding.resourceId);
-      if (session) return binding;
+      if (session) return { binding, prepared: false };
     }
     if (!this.#prepareBinding) {
       throw new Error(binding ? 'Bound Factory session not found.' : `No active Factory binding for role ${role}.`);
     }
     const item = await this.#requireItem(record);
-    await this.#prepareBinding({ record, item, role });
-    return this.#requireBinding(record, role);
+    await this.#prepareBinding({ record, item, role, ...(invocation ? { invocation } : {}) });
+    const newBinding = await this.#requireBinding(record, role);
+    return { binding: newBinding, prepared: true };
   }
 
   async #requireSession(binding: FactoryRunBindingRecord): Promise<DispatcherSession> {


### PR DESCRIPTION
Stage transitions (intake → triage/planning/review) now complete immediately instead of blocking on skill delivery.

**Before:** The `invokeSkill` decision would block the dispatch cycle by resolving the skill and sending it inline with `requireDelivery: true`, waiting for the agent to wake and acknowledge delivery.

**After:** The skill activation is baked into the pending start record as the kickoff message, and the dispatcher returns immediately. Skill delivery happens asynchronously in the next dispatch cycle via `#dispatchPendingStart`.

For existing bindings (already-active sessions), the inline behavior is preserved.

**Impact:**
- Faster stage transitions — no waiting for skill execution
- Aligns rule-triggered skills with the HTTP API `/runs/start` endpoint
- No breaking changes
