### PR TITLE
Fix oxfmt formatting on main (unblocks Lint CI)

### DIFF
--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -547,7 +547,8 @@ describe('createMastraCode', () => {
     });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      { memory?: unknown; initialState?: Record<string, unknown> } | undefined;
+      | { memory?: unknown; initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerConfig?.memory).toBe(customMemory);
     expect(agentControllerConfig?.initialState?.configDir).toBe('.acme-code');
     expect(getDynamicMemoryMock).not.toHaveBeenCalled();
@@ -589,7 +590,8 @@ describe('createMastraCode', () => {
     await createMastraCode({ pluginManager: pluginManager as any });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      { modes?: Array<{ id: string; availableTools?: string[] }>; initialState?: Record<string, unknown> } | undefined;
+      | { modes?: Array<{ id: string; availableTools?: string[] }>; initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerConfig?.modes?.find(mode => mode.id === 'plan')?.availableTools).toContain('plugin_tool');
     expect(agentControllerConfig?.modes?.find(mode => mode.id === 'fast')?.availableTools).toContain('plugin_tool');
     expect(agentControllerConfig?.initialState?.pluginInstructions).toEqual(['Use plugin policy.']);
@@ -632,7 +634,8 @@ describe('createMastraCode', () => {
     });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      { modes?: { id: string; default?: boolean; defaultModelId: string }[] } | undefined;
+      | { modes?: { id: string; default?: boolean; defaultModelId: string }[] }
+      | undefined;
     expect(agentControllerConfig?.modes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'review', default: true, defaultModelId: '__GATEWAY_OPENAI_MODEL__' }),
@@ -656,7 +659,8 @@ describe('createMastraCode', () => {
     await createMastraCode({ cwd: projectPath });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      { initialState?: Record<string, unknown> } | undefined;
+      | { initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerConfig?.initialState?.projectPath).toBe(projectPath);
   });
 
@@ -683,7 +687,8 @@ describe('createMastraCode', () => {
     expect(createMcpManagerMock).toHaveBeenCalledWith(projectPath, '.acme-code', undefined);
     expect(hookManagerConstructorMock).toHaveBeenCalledWith(projectPath, 'session-init', '.acme-code', undefined);
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      { initialState?: Record<string, unknown> } | undefined;
+      | { initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerConfig?.initialState?.configDir).toBe('.acme-code');
   });
 
@@ -730,7 +735,8 @@ describe('createMastraCode', () => {
     await createMastraCode({ pubsub, unixSocketPubSub: true });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls.at(-1)?.[0] as
-      { pubsub?: unknown; threadLock?: unknown } | undefined;
+      | { pubsub?: unknown; threadLock?: unknown }
+      | undefined;
     expect(agentControllerConfig?.pubsub).toBe(pubsub);
     expect(agentControllerConfig?.threadLock).toBeDefined();
   });
@@ -742,7 +748,8 @@ describe('createMastraCode', () => {
     await createMastraCode({ pubsub, crossProcessPubSub: true });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls.at(-1)?.[0] as
-      { pubsub?: unknown; threadLock?: unknown } | undefined;
+      | { pubsub?: unknown; threadLock?: unknown }
+      | undefined;
     expect(agentControllerConfig?.pubsub).toBe(pubsub);
     expect(agentControllerConfig?.threadLock).toBeUndefined();
   });
@@ -781,7 +788,8 @@ describe('createMastraCode', () => {
     await createMastraCode();
 
     const agentControllerCall = controllerConstructorMock.mock.calls[0]?.[0] as
-      { initialState?: Record<string, unknown> } | undefined;
+      | { initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerCall?.initialState?.observeAttachments).toBe(false);
   });
 
@@ -791,7 +799,8 @@ describe('createMastraCode', () => {
     await createMastraCode();
 
     const agentControllerCall = controllerConstructorMock.mock.calls[0]?.[0] as
-      { initialState?: Record<string, unknown> } | undefined;
+      | { initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerCall?.initialState?.observeAttachments).toBe('auto');
   });
 
@@ -815,7 +824,8 @@ describe('createMastraCode', () => {
 
     expect(agentConstructorMock).toHaveBeenCalled();
     const agentConfig = agentConstructorMock.mock.calls[0]?.[0] as
-      { errorProcessors?: Array<{ id?: string }> } | undefined;
+      | { errorProcessors?: Array<{ id?: string }> }
+      | undefined;
     expect(agentConfig?.errorProcessors?.map(processor => processor.id)).toEqual([
       'provider-history-compat',
       'stream-error-retry-processor',
@@ -830,7 +840,8 @@ describe('createMastraCode', () => {
 
     expect(streamErrorRetryProcessorConstructorMock).toHaveBeenCalledTimes(1);
     const options = streamErrorRetryProcessorConstructorMock.mock.calls[0]?.[0] as
-      { matchers?: Array<{ match?: unknown; maxRetries?: number; delayMs?: unknown; onRetry?: unknown }> } | undefined;
+      | { matchers?: Array<{ match?: unknown; maxRetries?: number; delayMs?: unknown; onRetry?: unknown }> }
+      | undefined;
     expect(options?.matchers).toHaveLength(3);
 
     // First matcher: Bad Request (400) with maxRetries 1 and 2s delay.
@@ -897,7 +908,8 @@ describe('createMastraCode', () => {
     await createMastraCode({ inputProcessors: [customProcessor] });
 
     const agentConfig = agentConstructorMock.mock.calls[0]?.[0] as
-      { inputProcessors?: Array<{ id?: string }> } | undefined;
+      | { inputProcessors?: Array<{ id?: string }> }
+      | undefined;
     const processors = agentConfig?.inputProcessors ?? [];
     expect(processors[0]).toBe(customProcessor);
     expect(processors.map(processor => processor.id)).toEqual([
@@ -915,7 +927,8 @@ describe('createMastraCode', () => {
 
     expect(agentConstructorMock).toHaveBeenCalled();
     const agentConfig = agentConstructorMock.mock.calls[0]?.[0] as
-      { inputProcessors?: Array<{ id?: string }>; errorProcessors?: Array<{ id?: string }> } | undefined;
+      | { inputProcessors?: Array<{ id?: string }>; errorProcessors?: Array<{ id?: string }> }
+      | undefined;
     expect(agentConfig?.inputProcessors?.map(processor => processor.id)).toContain('provider-history-compat');
     expect(agentConfig?.errorProcessors?.map(processor => processor.id)).toContain('provider-history-compat');
   });

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -740,7 +740,8 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
       new AgentsMDInjector({
         getIgnoredInstructionPaths: ({ requestContext }) => {
           const agentControllerContext = requestContext?.get('controller') as
-            AgentControllerRequestContext<{ projectPath?: string }> | undefined;
+            | AgentControllerRequestContext<{ projectPath?: string }>
+            | undefined;
           const state = agentControllerContext?.getState();
           return getStaticallyLoadedInstructionPaths(state?.projectPath ?? project.rootPath);
         },


### PR DESCRIPTION
## Summary

Fixes `lint:format` on main. #20393 landed with two unformatted files (`mastracode/sdk/src/index.ts`, `mastracode/sdk/src/__tests__/index.test.ts`), so every PR's Lint job now fails at the root `oxfmt --check` step. This is a formatting-only change (`oxfmt` write mode, no code edits).

## Test plan

- `oxfmt --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*' '!observability/_examples/**/*'` passes locally at this commit (10488 files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR tidies up two SDK files so the formatting check passes again. It only changes how the code is laid out, not what it does.

## Changes

- Formatted `mastracode/sdk/src/index.ts`.
- Reformatted equivalent TypeScript type assertions in `mastracode/sdk/src/__tests__/index.test.ts`.
- Verified formatting across 10,488 files with the required exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->