### PR TITLE
fix(platform-workspace): kill-switch direct exec after WS transport failure

### DIFF
--- a/.changeset/direct-exec-kill-switch.md
+++ b/.changeset/direct-exec-kill-switch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/platform-workspace': patch
+---
+
+Fix direct-exec fallback loop: when the WebSocket transport fails on a sandbox (Railway rejects the handshake, mid-stream drop, etc.), disable direct-exec permanently for that sandbox instead of re-minting a fresh lease on every subsequent exec. Also surface WebSocket close code, reason, and `opened` state in `DirectExecResult` and emit a diagnostic warning on transport failure so we can see why Railway is refusing the upgrade in production.

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -547,7 +547,8 @@ describe('createMastraCode', () => {
     });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      { memory?: unknown; initialState?: Record<string, unknown> } | undefined;
+      | { memory?: unknown; initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerConfig?.memory).toBe(customMemory);
     expect(agentControllerConfig?.initialState?.configDir).toBe('.acme-code');
     expect(getDynamicMemoryMock).not.toHaveBeenCalled();
@@ -589,7 +590,8 @@ describe('createMastraCode', () => {
     await createMastraCode({ pluginManager: pluginManager as any });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      { modes?: Array<{ id: string; availableTools?: string[] }>; initialState?: Record<string, unknown> } | undefined;
+      | { modes?: Array<{ id: string; availableTools?: string[] }>; initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerConfig?.modes?.find(mode => mode.id === 'plan')?.availableTools).toContain('plugin_tool');
     expect(agentControllerConfig?.modes?.find(mode => mode.id === 'fast')?.availableTools).toContain('plugin_tool');
     expect(agentControllerConfig?.initialState?.pluginInstructions).toEqual(['Use plugin policy.']);
@@ -632,7 +634,8 @@ describe('createMastraCode', () => {
     });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      { modes?: { id: string; default?: boolean; defaultModelId: string }[] } | undefined;
+      | { modes?: { id: string; default?: boolean; defaultModelId: string }[] }
+      | undefined;
     expect(agentControllerConfig?.modes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'review', default: true, defaultModelId: '__GATEWAY_OPENAI_MODEL__' }),
@@ -656,7 +659,8 @@ describe('createMastraCode', () => {
     await createMastraCode({ cwd: projectPath });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      { initialState?: Record<string, unknown> } | undefined;
+      | { initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerConfig?.initialState?.projectPath).toBe(projectPath);
   });
 
@@ -683,7 +687,8 @@ describe('createMastraCode', () => {
     expect(createMcpManagerMock).toHaveBeenCalledWith(projectPath, '.acme-code', undefined);
     expect(hookManagerConstructorMock).toHaveBeenCalledWith(projectPath, 'session-init', '.acme-code', undefined);
     const agentControllerConfig = controllerConstructorMock.mock.calls[0]?.[0] as
-      { initialState?: Record<string, unknown> } | undefined;
+      | { initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerConfig?.initialState?.configDir).toBe('.acme-code');
   });
 
@@ -730,7 +735,8 @@ describe('createMastraCode', () => {
     await createMastraCode({ pubsub, unixSocketPubSub: true });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls.at(-1)?.[0] as
-      { pubsub?: unknown; threadLock?: unknown } | undefined;
+      | { pubsub?: unknown; threadLock?: unknown }
+      | undefined;
     expect(agentControllerConfig?.pubsub).toBe(pubsub);
     expect(agentControllerConfig?.threadLock).toBeDefined();
   });
@@ -742,7 +748,8 @@ describe('createMastraCode', () => {
     await createMastraCode({ pubsub, crossProcessPubSub: true });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls.at(-1)?.[0] as
-      { pubsub?: unknown; threadLock?: unknown } | undefined;
+      | { pubsub?: unknown; threadLock?: unknown }
+      | undefined;
     expect(agentControllerConfig?.pubsub).toBe(pubsub);
     expect(agentControllerConfig?.threadLock).toBeUndefined();
   });
@@ -781,7 +788,8 @@ describe('createMastraCode', () => {
     await createMastraCode();
 
     const agentControllerCall = controllerConstructorMock.mock.calls[0]?.[0] as
-      { initialState?: Record<string, unknown> } | undefined;
+      | { initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerCall?.initialState?.observeAttachments).toBe(false);
   });
 
@@ -791,7 +799,8 @@ describe('createMastraCode', () => {
     await createMastraCode();
 
     const agentControllerCall = controllerConstructorMock.mock.calls[0]?.[0] as
-      { initialState?: Record<string, unknown> } | undefined;
+      | { initialState?: Record<string, unknown> }
+      | undefined;
     expect(agentControllerCall?.initialState?.observeAttachments).toBe('auto');
   });
 
@@ -815,7 +824,8 @@ describe('createMastraCode', () => {
 
     expect(agentConstructorMock).toHaveBeenCalled();
     const agentConfig = agentConstructorMock.mock.calls[0]?.[0] as
-      { errorProcessors?: Array<{ id?: string }> } | undefined;
+      | { errorProcessors?: Array<{ id?: string }> }
+      | undefined;
     expect(agentConfig?.errorProcessors?.map(processor => processor.id)).toEqual([
       'provider-history-compat',
       'stream-error-retry-processor',
@@ -830,7 +840,8 @@ describe('createMastraCode', () => {
 
     expect(streamErrorRetryProcessorConstructorMock).toHaveBeenCalledTimes(1);
     const options = streamErrorRetryProcessorConstructorMock.mock.calls[0]?.[0] as
-      { matchers?: Array<{ match?: unknown; maxRetries?: number; delayMs?: unknown; onRetry?: unknown }> } | undefined;
+      | { matchers?: Array<{ match?: unknown; maxRetries?: number; delayMs?: unknown; onRetry?: unknown }> }
+      | undefined;
     expect(options?.matchers).toHaveLength(3);
 
     // First matcher: Bad Request (400) with maxRetries 1 and 2s delay.
@@ -897,7 +908,8 @@ describe('createMastraCode', () => {
     await createMastraCode({ inputProcessors: [customProcessor] });
 
     const agentConfig = agentConstructorMock.mock.calls[0]?.[0] as
-      { inputProcessors?: Array<{ id?: string }> } | undefined;
+      | { inputProcessors?: Array<{ id?: string }> }
+      | undefined;
     const processors = agentConfig?.inputProcessors ?? [];
     expect(processors[0]).toBe(customProcessor);
     expect(processors.map(processor => processor.id)).toEqual([
@@ -915,7 +927,8 @@ describe('createMastraCode', () => {
 
     expect(agentConstructorMock).toHaveBeenCalled();
     const agentConfig = agentConstructorMock.mock.calls[0]?.[0] as
-      { inputProcessors?: Array<{ id?: string }>; errorProcessors?: Array<{ id?: string }> } | undefined;
+      | { inputProcessors?: Array<{ id?: string }>; errorProcessors?: Array<{ id?: string }> }
+      | undefined;
     expect(agentConfig?.inputProcessors?.map(processor => processor.id)).toContain('provider-history-compat');
     expect(agentConfig?.errorProcessors?.map(processor => processor.id)).toContain('provider-history-compat');
   });

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -740,7 +740,8 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
       new AgentsMDInjector({
         getIgnoredInstructionPaths: ({ requestContext }) => {
           const agentControllerContext = requestContext?.get('controller') as
-            AgentControllerRequestContext<{ projectPath?: string }> | undefined;
+            | AgentControllerRequestContext<{ projectPath?: string }>
+            | undefined;
           const state = agentControllerContext?.getState();
           return getStaticallyLoadedInstructionPaths(state?.projectPath ?? project.rootPath);
         },

--- a/workspaces/platform-workspace/src/direct-exec.test.ts
+++ b/workspaces/platform-workspace/src/direct-exec.test.ts
@@ -119,6 +119,7 @@ describe('execViaLease', () => {
       stderr: 'oops',
       truncated: false,
       timedOut: false,
+      opened: true,
     });
 
     const [init, stdinClose] = sockets[0]!.sent.map(s => JSON.parse(s));
@@ -204,6 +205,9 @@ describe('execViaLease', () => {
       stderr: '',
       truncated: false,
       timedOut: false,
+      closeCode: 1006,
+      closeReason: 'connection lost',
+      opened: true,
     });
   });
 
@@ -219,6 +223,9 @@ describe('execViaLease', () => {
       stderr: '',
       truncated: false,
       timedOut: false,
+      closeCode: 1006,
+      closeReason: 'handshake rejected',
+      opened: false,
     });
   });
 
@@ -239,12 +246,14 @@ describe('execViaLease', () => {
 
       // Handshake deadline is transport failure, NOT timeout — timedOut stays
       // false so the caller can distinguish "stalled connect" from "ran too long".
+      // No closeCode/closeReason because the socket never fired onclose.
       expect(result).toEqual({
         exitCode: null,
         stdout: '',
         stderr: '',
         truncated: false,
         timedOut: false,
+        opened: false,
       });
     } finally {
       vi.useRealTimers();
@@ -353,6 +362,7 @@ describe('execViaLease', () => {
       stderr: '',
       truncated: false,
       timedOut: false,
+      opened: true,
     });
     // Only one close() call should have originated from our side.
     expect(sockets[0]!.closeCalls).toEqual([{ code: 1000, reason: '' }]);

--- a/workspaces/platform-workspace/src/direct-exec.ts
+++ b/workspaces/platform-workspace/src/direct-exec.ts
@@ -89,6 +89,15 @@ export interface DirectExecResult {
   stderr: string;
   truncated: boolean;
   timedOut: boolean;
+  /**
+   * WebSocket close metadata. Populated on any close (normal or transport
+   * failure). `opened` distinguishes handshake failures (never opened) from
+   * mid-stream drops. Callers use this for diagnostic logging; not part of
+   * the CommandResult contract.
+   */
+  closeCode?: number;
+  closeReason?: string;
+  opened?: boolean;
 }
 
 const DEFAULT_WS_FACTORY: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
@@ -123,6 +132,8 @@ export function execViaLease(lease: ExecLease, options: DirectExecOptions): Prom
     let timedOut = false;
     let settled = false;
     let opened = false;
+    let closeCode: number | undefined;
+    let closeReason: string | undefined;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let handshakeTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -149,7 +160,16 @@ export function execViaLease(lease: ExecLease, options: DirectExecOptions): Prom
       } catch {
         /* already closed */
       }
-      resolve({ exitCode, stdout, stderr, truncated: false, timedOut });
+      resolve({
+        exitCode,
+        stdout,
+        stderr,
+        truncated: false,
+        timedOut,
+        ...(closeCode !== undefined && { closeCode }),
+        ...(closeReason !== undefined && { closeReason }),
+        opened,
+      });
     };
 
     // Arm the timeout BEFORE we open the socket so a stalled handshake can't
@@ -201,6 +221,8 @@ export function execViaLease(lease: ExecLease, options: DirectExecOptions): Prom
     };
 
     socket.onclose = event => {
+      closeCode = event.code;
+      closeReason = event.reason;
       if (!opened) {
         // Never opened — surface as a failure via exitCode=null,
         // truncated=false, timedOut=false so the caller can distinguish
@@ -211,7 +233,6 @@ export function execViaLease(lease: ExecLease, options: DirectExecOptions): Prom
       // Preserve any info captured before close; if the server sent an
       // `exit` frame this is a no-op because settle() already ran.
       settle();
-      void event; // eslint: intentionally observed for future logging
     };
 
     socket.onerror = () => {

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -574,36 +574,32 @@ describe('PlatformSandbox', () => {
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
-    it('drops the cached lease and falls through to /exec when the WS closes without an exit frame', async () => {
+    it('falls back to /exec permanently after a WS transport failure', async () => {
       // Simulates a mid-handshake drop / expired token / provider hiccup:
       // lease mint succeeds but the direct-exec socket closes before an exit
-      // frame arrives. We should discard the (possibly stale) lease, fall
-      // through to the proxy /exec path for THIS call, and re-mint on the
-      // next call so we don't fall through forever on a transient blip.
+      // frame arrives. We fall through to /exec for THIS call AND stay on
+      // /exec for every subsequent call on this sandbox — we don't want to
+      // pay a fresh mint + failed handshake on every exec when the transport
+      // is broken (see direct-exec production incident 2026-07-29).
       vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
         .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.first' }))
         .mockResolvedValueOnce(
-          json({ exitCode: 0, stdout: 'via-proxy', stderr: '', timedOut: false, truncated: false }),
+          json({ exitCode: 0, stdout: 'via-proxy-1', stderr: '', timedOut: false, truncated: false }),
         )
-        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.second' }));
+        .mockResolvedValueOnce(
+          json({ exitCode: 0, stdout: 'via-proxy-2', stderr: '', timedOut: false, truncated: false }),
+        );
       const sockets: FakeSocket[] = [];
-      let call = 0;
       const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
         const socket = new FakeSocket(endpoint, subprotocols);
         sockets.push(socket);
-        const isFirst = ++call === 1;
         queueMicrotask(() => {
           socket.onopen?.({});
-          if (isFirst) {
-            // First exec: close without an exit frame — transport failure.
-            socket.onclose?.({ code: 1006, reason: 'abnormal' });
-          } else {
-            // Second exec: normal exit.
-            socket.onmessage?.({ data: JSON.stringify({ type: 'exit', data: { exit_code: 0 } }) });
-          }
+          // Close without an exit frame — transport failure.
+          socket.onclose?.({ code: 1006, reason: 'abnormal' });
         });
         return socket;
       };
@@ -620,19 +616,17 @@ describe('PlatformSandbox', () => {
       const first = await sandbox.executeCommand('echo one');
       const second = await sandbox.executeCommand('echo two');
 
-      // First call fell through to /exec after the WS drop.
-      expect(first).toMatchObject({ exitCode: 0, stdout: 'via-proxy' });
-      // Second call re-minted a fresh lease (jwt.second) and succeeded direct.
-      expect(second).toMatchObject({ exitCode: 0 });
-      // Fetch sequence: provision, first lease, /exec fallback, second lease.
+      expect(first).toMatchObject({ exitCode: 0, stdout: 'via-proxy-1' });
+      expect(second).toMatchObject({ exitCode: 0, stdout: 'via-proxy-2' });
+      // Fetch sequence: provision, first lease, /exec fallback, /exec fallback (no re-mint).
       expect(fetchMock).toHaveBeenCalledTimes(4);
-      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec');
-      expect(String(fetchMock.mock.calls[3]![0])).toBe(
+      expect(String(fetchMock.mock.calls[1]![0])).toBe(
         'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
       );
-      // Two sockets opened (both direct-exec attempts); the second used the fresh JWT.
-      expect(sockets).toHaveLength(2);
-      expect(sockets[1]!.subprotocols[1]).toBe('jwt.second');
+      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec');
+      expect(String(fetchMock.mock.calls[3]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec');
+      // Only one WS attempt — kill switch prevents the second exec from retrying direct.
+      expect(sockets).toHaveLength(1);
     });
 
     it('coalesces concurrent lease mints on a cold cache into a single POST /exec-lease', async () => {

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -197,7 +197,8 @@ export class PlatformSandbox extends MastraSandbox {
    * Tri-state feature detection for the platform's exec-lease endpoint:
    *   undefined — not yet tried (default; try direct on first exec)
    *   true      — endpoint present, use direct exec
-   *   false     — endpoint returned 404 or 501, fall back permanently to /exec
+   *   false     — endpoint absent (404/501) OR the WebSocket transport failed
+   *               once; fall back permanently to /exec for this sandbox
    * Sticky per instance so we make the fallback decision once per sandbox
    * lifetime instead of paying an extra round-trip on every exec.
    */
@@ -402,12 +403,26 @@ export class PlatformSandbox extends MastraSandbox {
     });
     // `null` exitCode without `timedOut` means the socket closed without an
     // exit frame — i.e. a transport failure (handshake stalled, mid-stream
-    // drop, expired token). Drop the cached lease so the next call re-mints,
-    // and return `null` to let the caller fall through to the proxy /exec
-    // path. Timed-out and normal-exit results still return synthesised /
-    // real exit codes as before.
+    // drop, expired token). Drop the cached lease AND flip the feature bit
+    // so we don't burn a fresh mint + failed WS handshake on every subsequent
+    // exec; fall back permanently to /exec for this sandbox. Log the close
+    // metadata so we can diagnose why Railway refused the WebSocket. Timed-out
+    // and normal-exit results still return synthesised / real exit codes as
+    // before.
     if (result.exitCode === null && !result.timedOut) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[platform-workspace] direct-exec transport failed; falling back to /exec permanently for this sandbox',
+        {
+          sandboxId: this._sandboxId,
+          opened: result.opened,
+          closeCode: result.closeCode,
+          closeReason: result.closeReason,
+          wsEndpoint: lease.wsEndpoint,
+        },
+      );
       this._lease = null;
+      this._directExecAvailable = false;
       return null;
     }
     const exitCode = result.exitCode ?? 124;


### PR DESCRIPTION
## Problem

Direct exec is deployed but every exec is silently falling back to `/exec` after paying a wasted mint round-trip.

Observed pattern in shipyard production (workspace-proxy logs, 2026-07-29):
- `POST /exec-lease` → 200 (~400ms)
- `POST /exec` → 30s (legacy fallback)
- `POST /exec-lease` → 200 again
- `POST /exec` → 30s again
- (repeat for every exec)

Root cause: in `_tryDirectExec()`, when the WebSocket to Railway closes without an exit frame (Railway refused the upgrade / mid-stream drop / expired token), we dropped the cached lease but left `_directExecAvailable = true`. So every subsequent exec re-entered the direct path, minted a fresh lease, hit the same WS failure, and fell back to `/exec` — worse than pure legacy because we now paid **mint + failed handshake + legacy /exec** per call.

## Fix

Two changes:

1. **Kill switch.** On the first WS transport failure for a sandbox, flip `_directExecAvailable = false` and stay on `/exec` permanently for that sandbox's lifetime. Stops the mint-fail-fallback thrashing dead.
2. **Diagnostic logging.** Surface `closeCode`, `closeReason`, and `opened` on `DirectExecResult` and emit a `console.warn` on transport failure with the sandbox ID + close metadata + WS endpoint. This is how we'll actually diagnose WHY Railway is refusing the upgrade — the previous code threw the close code away.

## Verification

- All 54 tests pass (`pnpm --filter @mastra/platform-workspace test`)
- Build + lint + oxfmt clean
- Rewrote the "drops the cached lease" test to assert the new sticky-fallback behavior: only one `/exec-lease` mint, one WS attempt, subsequent execs go straight to `/exec` with no re-mint

## What we still don't know

Why Railway is refusing the WebSocket upgrade in the first place. This PR does NOT fix the underlying transport issue — it just stops us from bleeding latency while we diagnose it. Once this ships to shipyard, the next transport failure will log the close code + reason, which will tell us whether:
- Auth is being rejected (bad JWT / wrong claim / wrong audience)
- Subprotocol handshake is malformed
- Egress to `ssh.railway.com:2226` is blocked from Cloud Run
- Something else entirely

Follow-up PR will address the actual WS handshake once we have that data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If the client can’t connect to a sandbox using the direct WebSocket method, it now gives up on that unreliable path and permanently switches to the safer fallback. It also keeps better “why it failed” details so you can debug connection problems faster.

## Changes

- Permanently disables direct WebSocket execution for a given sandbox after a transport failure (“kill switch”).
- Prevents repeated exec lease minting, repeated WebSocket attempts, and looping fallback `/exec` calls.
- Extends `DirectExecResult` with optional diagnostic fields: `opened`, `closeCode`, and `closeReason`.
- Adds logging on transport failures including the sandbox ID, WebSocket close metadata, and the endpoint.
- Updates/adjusts tests to reflect the new fallback behavior and the expanded `DirectExecResult` shape.
- Adds a patch changeset for `@mastra/platform-workspace`.

## Verification

- 54 tests passing.
- Build, lint, and formatting checks clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->