### PR TITLE
fix(factory-ui): use issue icon for GitHub issue links

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/factory/__tests__/RelatedFactorySessions.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/__tests__/RelatedFactorySessions.msw.test.tsx
@@ -110,6 +110,7 @@ describe('FactorySessionHeader', () => {
       expect(link).toHaveAttribute('href', issueUrl);
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noreferrer');
+      expect(link.querySelector('.lucide-circle-dot')).toBeInTheDocument();
     });
   });
 
@@ -124,6 +125,7 @@ describe('FactorySessionHeader', () => {
       expect(link).toHaveAttribute('href', issueUrl);
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noreferrer');
+      expect(link.querySelector('.lucide-external-link')).toBeInTheDocument();
     });
   });
 

--- a/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@mastra/playground-ui/components/Button';
-import { ExternalLink, Link2 } from 'lucide-react';
+import { CircleDot, ExternalLink, Link2 } from 'lucide-react';
 import { Link, useNavigate, useParams } from 'react-router';
 
 import { useUserSessionQuery, useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
@@ -65,6 +65,7 @@ export function FactorySessionHeader() {
   const sectionPath = isReview ? `/factories/${factoryId}/review` : `/factories/${factoryId}/work`;
   const externalItemUrl = genericExternalWorkItemUrl(currentItem);
   const externalItemLabel = externalWorkItemLabel(currentItem);
+  const ExternalItemIcon = currentItem.source === 'github-issue' ? CircleDot : ExternalLink;
   const hasHeaderActions = Boolean(externalItemUrl) || destinations.length > 0;
 
   const openSession = (session: WorkItemSessionRef) => {
@@ -95,7 +96,7 @@ export function FactorySessionHeader() {
                 rel="noreferrer"
                 aria-label={`Open ${externalItemLabel}`}
               >
-                <ExternalLink size={13} aria-hidden />
+                <ExternalItemIcon size={13} aria-hidden />
                 {externalItemLabel}
               </Button>
             ) : null}


### PR DESCRIPTION
GitHub issue links in Factory session headers were using the generic external-link icon. This switches them to Lucide's `CircleDot` to match GitHub's issue visual, while Linear issue links keep `ExternalLink`.

Verified with the focused Factory UI MSW test, typecheck, and production build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

GitHub issue links now show a dot icon, making them easier to recognize. Linear links keep their existing external-link icon, with tests covering both.

## Changes

- Render Lucide `CircleDot` for GitHub issue links.
- Preserve `ExternalLink` for Linear issue links.
- Added MSW assertions for both icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->