### PR TITLE
docs: show approval-bound tool calls

### DIFF
--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -121,36 +121,17 @@ Function-based `requireToolApproval` is only available on regular `stream()` / `
 
 #### Bind approval to the exact tool arguments
 
-For sensitive tools, avoid treating approval as a reusable session flag. The
-approval should apply to the exact tool name and arguments that were shown to
-the reviewer. If those arguments drift before execution, the tool should not
-run under the old approval.
+For sensitive tools, bind the approval to the exact tool name and arguments that were shown to the reviewer. If those arguments drift before execution, the tool shouldn't run under the old approval.
 
-The `tool-call-approval` chunk already includes `toolName`, `toolCallId`, and
-`args`. You can fingerprint those fields when the approval request is shown,
-store the approved fingerprint, and consume it in a `beforeToolCall` hook before
-the tool runs:
+The `tool-call-approval` chunk already includes `toolName`, `toolCallId`, and `args`. You can fingerprint those fields when the approval request is shown. Store the approved fingerprint and consume it in a `beforeToolCall` hook before the tool runs:
 
 ```typescript title="src/mastra/agents/approval-bound-agent.ts"
-import { createHash } from 'node:crypto'
-
 import { Agent } from '@mastra/core/agent'
 
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize)
-  if (value && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([key, val]) => [key, canonicalize(val)]),
-    )
-  }
-  return value
-}
-
+// For your production usecase, build a stable hash of the tool name and args
 function actionFingerprint(toolName: string, args: unknown) {
-  const payload = JSON.stringify({ toolName, args: canonicalize(args) })
-  return createHash('sha256').update(payload).digest('hex')
+  const payload = JSON.stringify({ toolName, args })
+  return `fingerprint-${payload}`
 }
 
 const sensitiveTools = new Set(['issue_refund', 'delete_record'])
@@ -175,7 +156,9 @@ export const approvalBoundAgent = new Agent({
     },
   },
 })
+```
 
+```typescript
 const stream = await approvalBoundAgent.stream('Refund order ord-1042', {
   requireToolApproval: ({ toolName }) => sensitiveTools.has(toolName),
 })
@@ -206,10 +189,7 @@ async function approveReviewedToolCall(runId: string, toolCallId: string, finger
 await consumeApprovalStream(stream)
 ```
 
-In production, store the approved fingerprint in durable storage scoped to the
-user, run, tool call, and policy version. The `Set` above is intentionally small
-so the boundary is easy to see: the approval is consumed once, and only for the
-same canonical tool arguments that were reviewed.
+In production, store the approved fingerprint in durable storage scoped to the user, run, tool call, and policy version. The `Set` above is intentionally small so the boundary is easy to see: the approval is consumed once, and only for the same canonical tool arguments that were reviewed.
 
 ### Runtime suspension with `suspend()`
 

--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -123,7 +123,7 @@ Function-based `requireToolApproval` is only available on regular `stream()` / `
 
 For sensitive tools, bind the approval to the exact tool name and arguments that were shown to the reviewer. If those arguments drift before execution, the tool shouldn't run under the old approval.
 
-The `tool-call-approval` chunk already includes `toolName`, `toolCallId`, and `args`. You can fingerprint those fields when the approval request is shown. Store the approved fingerprint and consume it in a `beforeToolCall` hook before the tool runs:
+The `tool-call-approval` chunk already includes `toolName`, `toolCallId`, and `args`. You can fingerprint those fields when the approval request is shown. The example below uses a simple JSON string as the fingerprint, but in production you should use a stable hash of the tool name and arguments:
 
 ```typescript title="src/mastra/agents/approval-bound-agent.ts"
 import { Agent } from '@mastra/core/agent'

--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -119,6 +119,98 @@ Function-based `requireToolApproval` is only available on regular `stream()` / `
 
 :::
 
+#### Bind approval to the exact tool arguments
+
+For sensitive tools, avoid treating approval as a reusable session flag. The
+approval should apply to the exact tool name and arguments that were shown to
+the reviewer. If those arguments drift before execution, the tool should not
+run under the old approval.
+
+The `tool-call-approval` chunk already includes `toolName`, `toolCallId`, and
+`args`. You can fingerprint those fields when the approval request is shown,
+store the approved fingerprint, and consume it in a `beforeToolCall` hook before
+the tool runs:
+
+```typescript title="src/mastra/agents/approval-bound-agent.ts"
+import { createHash } from 'node:crypto'
+
+import { Agent } from '@mastra/core/agent'
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, val]) => [key, canonicalize(val)]),
+    )
+  }
+  return value
+}
+
+function actionFingerprint(toolName: string, args: unknown) {
+  const payload = JSON.stringify({ toolName, args: canonicalize(args) })
+  return createHash('sha256').update(payload).digest('hex')
+}
+
+const sensitiveTools = new Set(['issue_refund', 'delete_record'])
+const approvedFingerprints = new Set<string>()
+
+export const approvalBoundAgent = new Agent({
+  id: 'approval-bound-agent',
+  name: 'Approval Bound Agent',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  tools: { issueRefundTool, deleteRecordTool },
+  hooks: {
+    beforeToolCall: ({ toolName, input }) => {
+      if (!sensitiveTools.has(toolName)) return
+
+      const fingerprint = actionFingerprint(toolName, input)
+      if (!approvedFingerprints.delete(fingerprint)) {
+        return {
+          proceed: false,
+          output: `Tool call blocked: approval did not match ${toolName} arguments.`,
+        }
+      }
+    },
+  },
+})
+
+const stream = await approvalBoundAgent.stream('Refund order ord-1042', {
+  requireToolApproval: ({ toolName }) => sensitiveTools.has(toolName),
+})
+
+async function consumeApprovalStream(currentStream: typeof stream) {
+  for await (const chunk of currentStream.fullStream) {
+    if (chunk.type === 'tool-call-approval') {
+      const { toolName, toolCallId, args } = chunk.payload
+      const fingerprint = actionFingerprint(toolName, args)
+
+      // Present toolName, args, and fingerprint to your approval UI.
+      const approved = await showApprovalDialog({ toolName, args, fingerprint })
+
+      const nextStream = approved
+        ? await approveReviewedToolCall(currentStream.runId, toolCallId, fingerprint)
+        : await approvalBoundAgent.declineToolCall({ runId: currentStream.runId, toolCallId })
+
+      await consumeApprovalStream(nextStream)
+    }
+  }
+}
+
+async function approveReviewedToolCall(runId: string, toolCallId: string, fingerprint: string) {
+  approvedFingerprints.add(fingerprint)
+  return approvalBoundAgent.approveToolCall({ runId, toolCallId })
+}
+
+await consumeApprovalStream(stream)
+```
+
+In production, store the approved fingerprint in durable storage scoped to the
+user, run, tool call, and policy version. The `Set` above is intentionally small
+so the boundary is easy to see: the approval is consumed once, and only for the
+same canonical tool arguments that were reviewed.
+
 ### Runtime suspension with `suspend()`
 
 A tool can also pause _during_ its `execute` function by calling `suspend()`. This is useful when the tool starts running and then discovers it needs additional user input or confirmation before it can finish.


### PR DESCRIPTION
## Summary

Adds a section to the Agent approval guide showing how to bind an approval to the exact tool name and arguments shown to the reviewer.

The example uses existing Mastra primitives only:

- tool-call-approval chunks expose toolName and args
- a stable fingerprint is computed over those fields
- a beforeToolCall hook consumes a one-time approved fingerprint before a sensitive tool runs
- if the runtime tool arguments drift, the hook returns proceed: false instead of executing the tool

This is intended as an application-side pattern for sensitive tools such as refunds, deletes, deployments, or data exports. It does not add new framework APIs.

## Test plan

- git diff --check
- lightweight content check confirmed the new section and one-time fingerprint consumption are present

I could not run the docs oxfmt-mdx check locally because docs/node_modules is not installed in this clone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR updates the Agent approval docs with an example that “locks” an approval to the exact tool name and input values that the reviewer saw. If the inputs change before the agent runs the tool, the system blocks it so the old approval can’t be reused.

## Summary
- Updated the **“Bind approval to the exact tool arguments”** subsection with a simplified end-to-end example.
- The example now fingerprints **`toolName` + raw `args`** using `JSON.stringify` (instead of canonicalizing `args` and hashing with `node:crypto`).
- Shows consuming the one-time approved fingerprint in a `beforeToolCall` hook and returning `proceed: false` when runtime arguments don’t match what was approved.
- Keeps the approval-stream walkthrough using existing Mastra primitives (`tool-call-approval`, `approveToolCall`, `declineToolCall`) and calls out durable storage for production.
- Mentions the pattern for sensitive operations (refunds, deletes, deployments, data exports) without adding any framework APIs.
- Includes validation notes (`git diff --check` + lightweight content check); `oxfmt-mdx` couldn’t run because `docs/node_modules` was unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->