### PR TITLE
fix(factory): register factory-materialized workspace with Mastra registry

### DIFF
--- a/.changeset/silly-ways-start.md
+++ b/.changeset/silly-ways-start.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed a critical bug where `createWorkspaceFactory` never registered the workspace it built with the Mastra instance. Any HTTP handler that resolved a factory workspace synchronously via `mastra.getWorkspaceById(id)` (file tree, permissions probe, MCP/tool routes) threw `MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND`, surfacing as sustained `Workspace with id ... not found` / `Error calling handler` log noise on live Factory sessions. The factory now registers the workspace with the Mastra registry before returning it, so sync lookups succeed on the first request and reuse the same instance on later ones.

--- a/.changeset/silly-ways-start.md
+++ b/.changeset/silly-ways-start.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed a critical bug where `createWorkspaceFactory` never registered the workspace it built with the Mastra instance. Any HTTP handler that resolved a factory workspace synchronously via `mastra.getWorkspaceById(id)` (file tree, permissions probe, MCP/tool routes) threw `MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND`, surfacing as sustained `Workspace with id ... not found` / `Error calling handler` log noise on live Factory sessions. The factory now registers the workspace with the Mastra registry before returning it, so sync lookups succeed on the first request and reuse the same instance on later ones.
+Fix Factory workspaces not being available to HTTP routes immediately after creation. Sessions now consistently reuse the same workspace across requests.

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -791,4 +791,109 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.ensureSandbox).not.toHaveBeenCalled();
     expect(mocks.materializeRepo).not.toHaveBeenCalled();
   });
+
+  // The factory used to construct a Workspace and return it without ever
+  // adding it to the Mastra registry, so any HTTP handler that resolved the
+  // workspace synchronously via `mastra.getWorkspaceById(id)` (file tree,
+  // permissions probe, MCP/tool routes) threw `MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND`.
+  // Register the workspace before returning so those sync lookups succeed.
+  describe('registers the freshly materialized workspace with Mastra', () => {
+    // Minimal Mastra stub that mirrors addWorkspace's key-dedupe behavior and
+    // exposes the exact shape the factory reuse path expects.
+    function createMastraStub() {
+      const workspaces = new Map<string, unknown>();
+      const addWorkspace = vi.fn((workspace: { id: string }, key?: string, _metadata?: unknown) => {
+        const workspaceKey = key || workspace.id;
+        if (workspaces.has(workspaceKey)) return;
+        workspaces.set(workspaceKey, workspace);
+      });
+      const getWorkspaceById = vi.fn((id: string) => {
+        const workspace = workspaces.get(id);
+        if (!workspace) throw new Error(`Workspace with id ${id} not found`);
+        return workspace;
+      });
+      return { addWorkspace, getWorkspaceById, workspaces };
+    }
+
+    it('calls mastra.addWorkspace exactly once with the expected id shape and agent metadata', async () => {
+      const { workspace } = await createLocalFactory();
+      addProject();
+      addSession({ id: 'session-a' });
+      const mastra = createMastraStub();
+
+      const built = await workspace({
+        requestContext: createGithubRequestContext('project-1', 'session-a'),
+        mastra: mastra as any,
+      });
+
+      expect(built.id).toBe('mfw-project-1-session-a-web-factory');
+      expect(mastra.addWorkspace).toHaveBeenCalledTimes(1);
+      expect(mastra.addWorkspace).toHaveBeenCalledWith(
+        built,
+        'mfw-project-1-session-a-web-factory',
+        expect.objectContaining({ source: 'mastra' }),
+      );
+    });
+
+    it('makes mastra.getWorkspaceById return the same instance the factory returned', async () => {
+      const { workspace } = await createLocalFactory();
+      addProject();
+      addSession({ id: 'session-a' });
+      const mastra = createMastraStub();
+
+      const built = await workspace({
+        requestContext: createGithubRequestContext('project-1', 'session-a'),
+        mastra: mastra as any,
+      });
+
+      expect(mastra.getWorkspaceById('mfw-project-1-session-a-web-factory')).toBe(built);
+    });
+
+    it('short-circuits on the second call for the same session without re-registering', async () => {
+      const { workspace } = await createLocalFactory();
+      addProject();
+      addSession({ id: 'session-a' });
+      const mastra = createMastraStub();
+
+      const first = await workspace({
+        requestContext: createGithubRequestContext('project-1', 'session-a'),
+        mastra: mastra as any,
+      });
+      const second = await workspace({
+        requestContext: createGithubRequestContext('project-1', 'session-a'),
+        mastra: mastra as any,
+      });
+
+      expect(second).toBe(first);
+      expect(mastra.addWorkspace).toHaveBeenCalledTimes(1);
+      // Reuse path found the existing workspace instead of re-provisioning.
+      expect(mocks.ensureSandbox).toHaveBeenCalledTimes(1);
+      expect(mocks.materializeRepo).toHaveBeenCalledTimes(1);
+    });
+
+    it('registers exactly one workspace under inflight materialization coalescing', async () => {
+      const { workspace } = await createLocalFactory();
+      addProject();
+      addSession({ id: 'session-a' });
+      const mastra = createMastraStub();
+      // Hold materialization open so the follower arrives before the leader
+      // registers, matching the race the fix targets.
+      mocks.materializeRepo.mockImplementationOnce(() => new Promise(resolve => setTimeout(resolve, 20)));
+
+      const [first, second] = await Promise.all([
+        workspace({
+          requestContext: createGithubRequestContext('project-1', 'session-a'),
+          mastra: mastra as any,
+        }),
+        workspace({
+          requestContext: createGithubRequestContext('project-1', 'session-a'),
+          mastra: mastra as any,
+        }),
+      ]);
+
+      expect(second).toBe(first);
+      expect(mastra.addWorkspace).toHaveBeenCalledTimes(1);
+      expect(mastra.workspaces.size).toBe(1);
+    });
+  });
 });

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -351,7 +351,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       const filesystem = new SandboxFilesystem({ sandbox, workdir });
       const projectSkillPaths = [path.join(configDir, 'skills'), '.claude/skills', '.agents/skills'];
       const skillPaths = [...(effectiveSkillExtension?.paths ?? []), ...projectSkillPaths];
-      return new Workspace({
+      const workspace = new Workspace({
         id: workspaceId,
         name: 'Mastra Code Factory Session Workspace',
         filesystem,
@@ -360,6 +360,16 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         skills: skillPaths,
         skillSource: effectiveSkillExtension?.createSource(filesystem, projectSkillPaths) ?? filesystem,
       });
+      // Register with the Mastra instance so sync HTTP handlers that resolve
+      // the workspace via `mastra.getWorkspaceById(id)` (file tree, permissions
+      // probe, MCP/tool routes) find it instead of throwing
+      // `MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND`. `addWorkspace` is idempotent on
+      // key collision, so the inflight coalescing and reuse paths above stay
+      // race-safe. Registration happens synchronously with the return so a
+      // concurrent lookup on another request cannot observe an unregistered
+      // workspace.
+      mastra?.addWorkspace(workspace, workspaceId, { source: 'mastra' });
+      return workspace;
     };
 
     // Dedupe concurrent materializations of the same workspace: followers


### PR DESCRIPTION
## Summary

`createWorkspaceFactory` in `@mastra/factory` constructed and returned a new `Workspace` without ever calling `mastra.addWorkspace(...)`. The Mastra registry never held an entry for the factory session's workspace id, so any HTTP handler that resolved the workspace synchronously via `mastra.getWorkspaceById(id)` (file tree, permissions probe, MCP/tool routes) threw `MASTRA_GET_WORKSPACE_BY_ID_NOT_FOUND`.

This surfaced on `shipyard.studio.mastra.cloud` as a sustained ~1/s stream of:

```
Workspace with id mfw-<projectRepoId>-<sessionId>-web-factory not found
Error calling handler
```

on containers that had been live for hours — sessions were live and agents/tools worked, but every sync `getWorkspaceById` route 404'd.

The fix registers the workspace on the `Mastra` instance before returning it. `Mastra.addWorkspace` is idempotent on key collision, so the existing inflight-materialization coalescing and the pre-existing `try { mastra?.getWorkspaceById(workspaceId) } catch {}` reuse path stay race-safe. That reuse block (which the original author added knowing the lookup would throw) now actually finds the registered workspace on later calls and short-circuits, avoiding a repeated provision.

## Test plan

New `describe('registers the freshly materialized workspace with Mastra', …)` block in `mastracode/factory/src/workspace.test.ts` with four scenarios matching the issue's TDD checklist:

- **Test A** — factory calls `mastra.addWorkspace` exactly once with the expected id shape `mfw-<projectRepoId>-<sessionId>-web-factory` and workspace metadata.
- **Test B** — `mastra.getWorkspaceById(workspaceId)` returns the same instance the factory returned (no throw).
- **Test C** — a second invocation for the same session short-circuits via the existing reuse path; `addWorkspace` is called at most once and no re-provision happens.
- **Test D** — under inflight-materialization coalescing (two callers race for the same workspace id), exactly one `addWorkspace` and one `Workspace` instance are produced.

Verified locally:

- `pnpm --filter ./mastracode/factory exec vitest run src/workspace.test.ts` → 33 passed.
- `pnpm --filter ./mastracode/factory check` → clean.
- `pnpm --filter ./mastracode/factory lint` → clean.

The 4 unrelated `src/storage/domains/work-items/base.test.ts` timeout failures reproduce on `main` at the same commit and are not touched by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the factory creates a new “workspace” for a session, it now immediately tells Mastra about it before handing it back. That way, Mastra can look it up right away (even on the very next call) instead of mistakenly saying it doesn’t exist. Repeated and simultaneous requests still share the same workspace.

## Summary

- Fix `createWorkspaceFactory` to register newly materialized factory workspaces with the Mastra registry (`mastra.addWorkspace(...)`) before returning them.
- Ensure synchronous `mastra.getWorkspaceById(id)` can resolve factory-session workspaces immediately, instead of throwing “not found”.
- Preserve:
  - inflight materialization coalescing (concurrent calls register only once)
  - workspace reuse short-circuiting (subsequent calls reuse the already-registered workspace)
- Add tests validating registration, lookup, repeated invocation reuse, and concurrent coalescing behavior in `workspace.test.ts`.
- Add a changeset entry for a patch release describing the consistent workspace reuse behavior across requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->