### PR TITLE
feat(factory): allow model switching in review sessions

### DIFF
--- a/.changeset/gold-hounds-feel.md
+++ b/.changeset/gold-hounds-feel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Added model switching to Factory review sessions so work can continue during a model outage.

--- a/.changeset/openai-pack-supported-model.md
+++ b/.changeset/openai-pack-supported-model.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed the OpenAI pack to use its supported default model ID.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/ActiveModel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/ActiveModel.tsx
@@ -1,9 +1,12 @@
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@mastra/playground-ui/components/Select';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { useState } from 'react';
 
 import { useAvailableModelsQuery } from '../../../../../hooks/useAvailableModels';
 
 import { useChatConnection } from '../../context/useChatConnection';
 import { useChatModels } from '../../context/useChatModels';
+import { useChatSessionContext } from '../../context/useChatSessionContext';
 
 function titleCase(value: string): string {
   return value ? `${value[0]?.toUpperCase()}${value.slice(1).toLowerCase()}` : value;
@@ -35,9 +38,11 @@ function formatModelName(id: string): string {
 
 /** Current model id and whether its provider has usable credentials. */
 export function ActiveModel() {
-  const { activeModelId } = useChatModels();
+  const { kind } = useChatSessionContext();
+  const { activeModelId, setModel } = useChatModels();
   const { status } = useChatConnection();
   const modelsQuery = useAvailableModelsQuery();
+  const [pendingModelId, setPendingModelId] = useState<string>();
 
   // While the connection is still resolving there is no model id yet — show a
   // placeholder instead of a misleading "No model" label.
@@ -45,9 +50,45 @@ export function ActiveModel() {
     return <Skeleton aria-label="Loading model" className="h-3.5 w-24" />;
   }
 
+  const selectedModelId = pendingModelId ?? activeModelId;
   const label = activeModelId ? formatModelName(activeModelId) : 'No model';
   const notConfigured =
     Boolean(activeModelId) && modelsQuery.isSuccess && !modelsQuery.data.some(model => model.id === activeModelId);
+
+  if (kind === 'factory' && modelsQuery.data?.length) {
+    return (
+      <Select
+        value={selectedModelId}
+        disabled={Boolean(pendingModelId)}
+        onValueChange={modelId => {
+          if (pendingModelId || modelId === activeModelId) return;
+          setPendingModelId(modelId);
+          void setModel(modelId).then(
+            () => setPendingModelId(undefined),
+            () => setPendingModelId(undefined),
+          );
+        }}
+      >
+        <SelectTrigger
+          variant="ghost"
+          size="xs"
+          aria-label="Session model"
+          aria-busy={Boolean(pendingModelId)}
+          className={notConfigured ? 'text-accent2 w-auto' : 'text-neutral3 w-auto'}
+          title={activeModelId}
+        >
+          {selectedModelId ? formatModelName(selectedModelId) : 'No model'}
+        </SelectTrigger>
+        <SelectContent>
+          {modelsQuery.data.map(model => (
+            <SelectItem key={model.id} value={model.id}>
+              {model.provider} / {model.modelName}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
 
   return (
     <span

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/ActiveModel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/ActiveModel.tsx
@@ -1,5 +1,6 @@
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@mastra/playground-ui/components/Select';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { toast } from '@mastra/playground-ui/components/Toaster';
 import { useState } from 'react';
 
 import { useAvailableModelsQuery } from '../../../../../hooks/useAvailableModels';
@@ -51,9 +52,9 @@ export function ActiveModel() {
   }
 
   const selectedModelId = pendingModelId ?? activeModelId;
-  const label = activeModelId ? formatModelName(activeModelId) : 'No model';
+  const label = selectedModelId ? formatModelName(selectedModelId) : 'No model';
   const notConfigured =
-    Boolean(activeModelId) && modelsQuery.isSuccess && !modelsQuery.data.some(model => model.id === activeModelId);
+    Boolean(selectedModelId) && modelsQuery.isSuccess && !modelsQuery.data.some(model => model.id === selectedModelId);
 
   if (kind === 'factory' && modelsQuery.data?.length) {
     return (
@@ -65,19 +66,26 @@ export function ActiveModel() {
           setPendingModelId(modelId);
           void setModel(modelId).then(
             () => setPendingModelId(undefined),
-            () => setPendingModelId(undefined),
+            (cause: unknown) => {
+              setPendingModelId(undefined);
+              // failed switch must be loud — label alone just snaps back
+              toast.error(cause instanceof Error ? cause.message : 'Failed to switch model');
+            },
           );
         }}
       >
         <SelectTrigger
           variant="ghost"
           size="xs"
-          aria-label="Session model"
+          aria-label={notConfigured ? `Session model, ${label} is not configured` : 'Session model'}
           aria-busy={Boolean(pendingModelId)}
           className={notConfigured ? 'text-accent2 w-auto' : 'text-neutral3 w-auto'}
-          title={activeModelId}
+          title={selectedModelId}
         >
-          {selectedModelId ? formatModelName(selectedModelId) : 'No model'}
+          <span>
+            {label}
+            {notConfigured ? ' · not configured' : null}
+          </span>
         </SelectTrigger>
         <SelectContent>
           {modelsQuery.data.map(model => (

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ActiveModel.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ActiveModel.msw.test.tsx
@@ -6,29 +6,46 @@
  * flags models whose provider has no usable credentials.
  */
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { server } from '../../../../../../../e2e/ui/msw-server';
 import { TEST_BASE_URL, renderWithProviders } from '../../../../../../../e2e/ui/render';
 import { ChatConnectionContext } from '../../../context/ChatConnectionContext';
 import type { ChatConnectionApi } from '../../../context/ChatConnectionContext';
 import { ChatModelsContext } from '../../../context/ChatModelsContext';
+import { ChatSessionContext } from '../../../context/ChatSessionContext';
+import type { ChatSessionContextApi } from '../../../context/ChatSessionContext';
 import { ActiveModel } from '../ActiveModel';
+
+const factorySession: ChatSessionContextApi = {
+  resourceId: 'session-1',
+  sessionEnabled: true,
+  resourceEnabled: true,
+  baseUrl: TEST_BASE_URL,
+  kind: 'factory',
+};
 
 function renderActiveModel({
   activeModelId,
   status,
+  kind = 'user',
+  setModel = () => Promise.resolve(),
 }: {
   activeModelId: string | undefined;
   status: ChatConnectionApi['status'];
+  kind?: ChatSessionContextApi['kind'];
+  setModel?: (modelId: string) => Promise<void>;
 }) {
   return renderWithProviders(
-    <ChatConnectionContext.Provider value={{ status }}>
-      <ChatModelsContext.Provider value={{ activeModelId, setModel: () => Promise.resolve() }}>
-        <ActiveModel />
-      </ChatModelsContext.Provider>
-    </ChatConnectionContext.Provider>,
+    <ChatSessionContext.Provider value={{ ...factorySession, kind }}>
+      <ChatConnectionContext.Provider value={{ status }}>
+        <ChatModelsContext.Provider value={{ activeModelId, setModel }}>
+          <ActiveModel />
+        </ChatModelsContext.Provider>
+      </ChatConnectionContext.Provider>
+    </ChatSessionContext.Provider>,
   );
 }
 
@@ -43,7 +60,7 @@ function stubModelCatalog(ids: string[]) {
 }
 
 describe('ActiveModel', () => {
-  describe('given the connection is still resolving and no model id is known yet', () => {
+  describe('when the connection is still resolving and no model id is known yet', () => {
     it('shows a loading skeleton instead of a "No model" label', () => {
       renderActiveModel({ activeModelId: undefined, status: 'connecting' });
 
@@ -52,7 +69,7 @@ describe('ActiveModel', () => {
     });
   });
 
-  describe('given the connection is ready but reports no model', () => {
+  describe('when the connection is ready but reports no model', () => {
     it('falls back to the explicit "No model" label', () => {
       renderActiveModel({ activeModelId: undefined, status: 'ready' });
 
@@ -61,7 +78,7 @@ describe('ActiveModel', () => {
     });
   });
 
-  describe('given a connected session with a credentialed model', () => {
+  describe('when a connected session has a credentialed model', () => {
     it('renders the formatted model name without a warning', async () => {
       stubModelCatalog(['anthropic/claude-sonnet-4-5']);
       renderActiveModel({ activeModelId: 'anthropic/claude-sonnet-4-5', status: 'ready' });
@@ -71,12 +88,50 @@ describe('ActiveModel', () => {
     });
   });
 
-  describe('given the active model is missing from the credentialed catalog', () => {
+  describe('when the active model is missing from the credentialed catalog', () => {
     it('flags the model as not configured', async () => {
       stubModelCatalog(['openai/gpt-5']);
       renderActiveModel({ activeModelId: 'anthropic/claude-sonnet-4-5', status: 'ready' });
 
       expect(await screen.findByLabelText('Claude Sonnet 4.5 is not configured')).toBeInTheDocument();
+    });
+  });
+
+  describe('when a factory review session has multiple credentialed models', () => {
+    it('switches the session model selected from the status line', async () => {
+      const user = userEvent.setup();
+      const setModel = vi.fn<(modelId: string) => Promise<void>>().mockResolvedValue();
+      stubModelCatalog(['anthropic/claude-sonnet-4-5', 'openai/gpt-5.6-sol']);
+      renderActiveModel({
+        activeModelId: 'anthropic/claude-sonnet-4-5',
+        status: 'ready',
+        kind: 'factory',
+        setModel,
+      });
+
+      await user.click(await screen.findByLabelText('Session model'));
+      await user.click(await screen.findByRole('option', { name: 'openai / openai/gpt-5.6-sol' }));
+
+      expect(setModel).toHaveBeenCalledWith('openai/gpt-5.6-sol');
+    });
+
+    it('disables further model changes while a switch is pending', async () => {
+      const user = userEvent.setup();
+      const setModel = vi.fn<(modelId: string) => Promise<void>>(() => new Promise(() => {}));
+      stubModelCatalog(['anthropic/claude-sonnet-4-5', 'openai/gpt-5.6-sol']);
+      renderActiveModel({
+        activeModelId: 'anthropic/claude-sonnet-4-5',
+        status: 'ready',
+        kind: 'factory',
+        setModel,
+      });
+
+      const trigger = await screen.findByLabelText('Session model');
+      await user.click(trigger);
+      await user.click(await screen.findByRole('option', { name: 'openai / openai/gpt-5.6-sol' }));
+
+      expect(trigger).toHaveAttribute('aria-busy', 'true');
+      expect(trigger).toBeDisabled();
     });
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ActiveModel.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ActiveModel.msw.test.tsx
@@ -5,6 +5,7 @@
  * "No model" label; once connected it renders the formatted model name and
  * flags models whose provider has no usable credentials.
  */
+import { Toaster } from '@mastra/playground-ui/components/Toaster';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
@@ -43,6 +44,7 @@ function renderActiveModel({
       <ChatConnectionContext.Provider value={{ status }}>
         <ChatModelsContext.Provider value={{ activeModelId, setModel }}>
           <ActiveModel />
+          <Toaster position="bottom-right" />
         </ChatModelsContext.Provider>
       </ChatConnectionContext.Provider>
     </ChatSessionContext.Provider>,
@@ -53,7 +55,10 @@ function stubModelCatalog(ids: string[]) {
   server.use(
     http.get(`${TEST_BASE_URL}/web/config/models`, () =>
       HttpResponse.json({
-        models: ids.map(id => ({ id, provider: id.split('/')[0], modelName: id, hasApiKey: true })),
+        models: ids.map(id => {
+          const [provider, modelName] = id.split('/');
+          return { id, provider, modelName, hasApiKey: true };
+        }),
       }),
     ),
   );
@@ -110,7 +115,7 @@ describe('ActiveModel', () => {
       });
 
       await user.click(await screen.findByLabelText('Session model'));
-      await user.click(await screen.findByRole('option', { name: 'openai / openai/gpt-5.6-sol' }));
+      await user.click(await screen.findByRole('option', { name: 'openai / gpt-5.6-sol' }));
 
       expect(setModel).toHaveBeenCalledWith('openai/gpt-5.6-sol');
     });
@@ -128,10 +133,40 @@ describe('ActiveModel', () => {
 
       const trigger = await screen.findByLabelText('Session model');
       await user.click(trigger);
-      await user.click(await screen.findByRole('option', { name: 'openai / openai/gpt-5.6-sol' }));
+      await user.click(await screen.findByRole('option', { name: 'openai / gpt-5.6-sol' }));
 
       expect(trigger).toHaveAttribute('aria-busy', 'true');
       expect(trigger).toBeDisabled();
+    });
+
+    it('surfaces a failed switch and keeps the control usable', async () => {
+      const user = userEvent.setup();
+      const setModel = vi
+        .fn<(modelId: string) => Promise<void>>()
+        .mockRejectedValue(new Error('Provider is unavailable'));
+      stubModelCatalog(['anthropic/claude-sonnet-4-5', 'openai/gpt-5.6-sol']);
+      renderActiveModel({
+        activeModelId: 'anthropic/claude-sonnet-4-5',
+        status: 'ready',
+        kind: 'factory',
+        setModel,
+      });
+
+      const trigger = await screen.findByLabelText('Session model');
+      await user.click(trigger);
+      await user.click(await screen.findByRole('option', { name: 'openai / gpt-5.6-sol' }));
+
+      expect(await screen.findByText('Provider is unavailable')).toBeInTheDocument();
+      expect(trigger).toBeEnabled();
+      expect(trigger).toHaveTextContent('Claude Sonnet 4.5');
+    });
+
+    it('flags an active model the catalog no longer credentials', async () => {
+      stubModelCatalog(['openai/gpt-5.6-sol']);
+      renderActiveModel({ activeModelId: 'anthropic/claude-sonnet-4-5', status: 'ready', kind: 'factory' });
+
+      const trigger = await screen.findByLabelText('Session model, Claude Sonnet 4.5 is not configured');
+      expect(trigger).toHaveTextContent('not configured');
     });
   });
 });

--- a/mastracode/sdk/src/auth/storage.ts
+++ b/mastracode/sdk/src/auth/storage.ts
@@ -24,7 +24,7 @@ import type {
  */
 export const PROVIDER_DEFAULT_MODELS: Record<OAuthProviderId, string> = {
   anthropic: 'anthropic/claude-fable-5',
-  'openai-codex': 'openai/gpt-5.6',
+  'openai-codex': 'openai/gpt-5.6-sol',
   // gpt-4.1 routes through `/chat/completions` (which our OpenAI-compatible
   // adapter handles); Anthropic-shaped Copilot models (Claude on `/v1/messages`)
   // are not yet wired up, so picking one as the post-login default would error.

--- a/mastracode/sdk/src/onboarding/__tests__/packs.test.ts
+++ b/mastracode/sdk/src/onboarding/__tests__/packs.test.ts
@@ -33,8 +33,8 @@ describe('getAvailableModePacks', () => {
     });
 
     expect(packs.find(pack => pack.id === 'openai')?.models).toEqual({
-      plan: 'openai/gpt-5.6',
-      build: 'openai/gpt-5.6',
+      plan: 'openai/gpt-5.6-sol',
+      build: 'openai/gpt-5.6-sol',
       fast: 'openai/gpt-5.4-mini',
     });
   });

--- a/mastracode/sdk/src/onboarding/packs.ts
+++ b/mastracode/sdk/src/onboarding/packs.ts
@@ -67,7 +67,7 @@ export function getAvailableModePacks(
 ): ModePack[] {
   const packs: ModePack[] = [];
 
-  const openaiCodex = 'openai/gpt-5.6';
+  const openaiCodex = 'openai/gpt-5.6-sol';
   const openaiFast = 'openai/gpt-5.4-mini';
   const anthropicBuild = 'anthropic/claude-fable-5';
 


### PR DESCRIPTION
Factory review sessions can now switch between configured models from the existing status-line model control, allowing review work to continue during a provider or model outage.

The OpenAI onboarding pack also uses the supported default model ID.

Test plan:
- `pnpm vitest run src/ui/domains/chat/components/StatusLine/__tests__/ActiveModel.msw.test.tsx` in `mastracode/factory-ui`
- `pnpm vitest run src/onboarding/__tests__/packs.test.ts` in `mastracode/sdk`
- `pnpm vitest run src/integrations/github/sandbox.test.ts` in `mastracode/factory`
- `pnpm build` in `mastracode/factory-ui`
- `pnpm build:lib` in `mastracode/sdk`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Factory review sessions can keep working even if a provider/model is having trouble by letting you switch to another pre-configured model on the status line. OpenAI onboarding now points to the supported default “sol” model, so new setups match what the system actually supports.

## Changes
- Updated the Factory session status line “ActiveModel” UI to enable async model switching (with skeleton/loading and a disabled `aria-busy` selector while switching).
- On failed model switches, the UI now shows an error toast and keeps the selector usable.
- Preserved the “not configured” label/accessibility behavior, including reflecting the pending model during a switch (for better UI + a11y correctness).
- Expanded/updated tests to cover Factory-session model switching, pending states, failure handling, and “not credentialed” behavior in the model catalog.
- Updated OpenAI Codex default model IDs from `openai/gpt-5.6` to `openai/gpt-5.6-sol` across SDK defaults, onboarding packs, and onboarding pack tests.
- Added patch changesets for both `@mastra/factory` and `@mastra/code-sdk`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->