### PR TITLE
fix(factory-ui): give the thread page a single header

### DIFF
--- a/.changeset/tame-bobcats-laugh.md
+++ b/.changeset/tame-bobcats-laugh.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed the MainSidebar mobile menu button staying visible on desktop. Its hide rule used a zero-specificity selector, so an app stylesheet loaded after the design system's could win and leave the hamburger next to the desktop sidebar.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ChatHeader.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ChatHeader.tsx
@@ -3,32 +3,27 @@ import { cn } from '@mastra/playground-ui/utils/cn';
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 
 type ChatHeaderProps = ComponentPropsWithoutRef<'header'> & {
-  /** Rendered on mobile only — pages gate it on their own viewport check. */
   mobileContent?: ReactNode;
 };
 
-/**
- * The one header bar of a page: the sidebar trigger for the current viewport
- * plus optional page content. Contentless chrome collapses away, so an expanded
- * desktop sidebar (which carries its own toggle) leaves no dead bar behind.
- */
+/** The single header bar of a page. Renders nothing when it would hold neither a trigger nor content. */
 export function ChatHeader({ mobileContent, children, className, ...props }: ChatHeaderProps) {
-  // Both triggers off the same `isMobile`, never a `md:` media query: the
-  // provider's breakpoint is px and `md:` is rem, so a moved rem base would
-  // open a band with two toggles or none.
+  // both triggers off one signal — px matchMedia vs rem `md:` drifts into two toggles or none
   const { isMobile, desktopState } = useMainSidebar();
+
   const trigger = isMobile ? (
     <MainSidebar.MobileTrigger id="mobile-navigation-trigger" />
   ) : desktopState === 'collapsed' ? (
     <MainSidebar.Trigger className="mx-0 shrink-0" />
   ) : null;
+  const content = isMobile ? mobileContent : null;
 
-  if (!trigger && !mobileContent && !children) return null;
+  if (!trigger && !content && !children) return null;
 
   return (
     <header className={cn('flex min-w-0 shrink-0 items-center gap-2 px-3 py-2', className)} {...props}>
       {trigger}
-      {mobileContent}
+      {content}
       {children}
     </header>
   );

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ChatHeader.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ChatHeader.tsx
@@ -1,20 +1,35 @@
 import { MainSidebar, useMainSidebar } from '@mastra/playground-ui/components/MainSidebar';
-import type { ReactNode } from 'react';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 
-export function ChatHeader({ mobileContent }: { mobileContent?: ReactNode }) {
-  const { desktopState } = useMainSidebar();
+type ChatHeaderProps = ComponentPropsWithoutRef<'header'> & {
+  /** Rendered on mobile only — pages gate it on their own viewport check. */
+  mobileContent?: ReactNode;
+};
+
+/**
+ * The one header bar of a page: the sidebar trigger for the current viewport
+ * plus optional page content. Contentless chrome collapses away, so an expanded
+ * desktop sidebar (which carries its own toggle) leaves no dead bar behind.
+ */
+export function ChatHeader({ mobileContent, children, className, ...props }: ChatHeaderProps) {
+  // Both triggers off the same `isMobile`, never a `md:` media query: the
+  // provider's breakpoint is px and `md:` is rem, so a moved rem base would
+  // open a band with two toggles or none.
+  const { isMobile, desktopState } = useMainSidebar();
+  const trigger = isMobile ? (
+    <MainSidebar.MobileTrigger id="mobile-navigation-trigger" />
+  ) : desktopState === 'collapsed' ? (
+    <MainSidebar.Trigger className="mx-0 shrink-0" />
+  ) : null;
+
+  if (!trigger && !mobileContent && !children) return null;
 
   return (
-    <>
-      <header className="flex items-center gap-2 px-3 py-2 md:hidden">
-        <MainSidebar.MobileTrigger id="mobile-navigation-trigger" />
-        {mobileContent}
-      </header>
-      {desktopState === 'collapsed' && (
-        <header className="hidden shrink-0 items-center px-3 py-2 md:flex">
-          <MainSidebar.Trigger className="mx-0" />
-        </header>
-      )}
-    </>
+    <header className={cn('flex min-w-0 shrink-0 items-center gap-2 px-3 py-2', className)} {...props}>
+      {trigger}
+      {mobileContent}
+      {children}
+    </header>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ChatHeader.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ChatHeader.msw.test.tsx
@@ -90,7 +90,6 @@ describe('ChatHeader', () => {
 
     expect(screen.getByTestId('desktop-sidebar-state')).toHaveTextContent('default');
     expect(screen.queryByRole('button', { name: 'Toggle sidebar' })).not.toBeInTheDocument();
-    // Nothing left to host: no dead bar above the page.
     expect(screen.queryByRole('banner')).not.toBeInTheDocument();
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ChatHeader.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ChatHeader.msw.test.tsx
@@ -55,6 +55,7 @@ describe('ChatHeader', () => {
     const mobileHeader = screen.getByRole('banner');
     expect(within(mobileHeader).getByRole('heading', { name: 'Preferences' })).toHaveFocus();
     expect(within(mobileHeader).getByRole('button', { name: 'Close settings' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Toggle sidebar' })).not.toBeInTheDocument();
   });
 
   it('opens the design-system mobile sidebar', async () => {
@@ -83,10 +84,13 @@ describe('ChatHeader', () => {
     const trigger = screen.getByRole('button', { name: 'Toggle sidebar' });
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(screen.getByTestId('desktop-sidebar-state')).toHaveTextContent('collapsed');
+    expect(screen.queryByLabelText('Open navigation menu')).not.toBeInTheDocument();
 
     await userEvent.click(trigger);
 
     expect(screen.getByTestId('desktop-sidebar-state')).toHaveTextContent('default');
     expect(screen.queryByRole('button', { name: 'Toggle sidebar' })).not.toBeInTheDocument();
+    // Nothing left to host: no dead bar above the page.
+    expect(screen.queryByRole('banner')).not.toBeInTheDocument();
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/factory/__tests__/RelatedFactorySessions.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/__tests__/RelatedFactorySessions.msw.test.tsx
@@ -1,3 +1,4 @@
+import { MainSidebarProvider } from '@mastra/playground-ui/components/MainSidebar';
 import { screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter, Route, Routes } from 'react-router';
@@ -89,16 +90,18 @@ function stubHeader(item: ReturnType<typeof workItem> | ReturnType<typeof linear
 function renderHeader() {
   return renderWithProviders(
     <MemoryRouter initialEntries={[`/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${THREAD_ID}`]}>
-      <Routes>
-        <Route
-          path="/factories/:factoryId/workspaces/:sessionId/threads/:threadId"
-          element={
-            <WorkspaceFilesProvider>
-              <FactorySessionHeader />
-            </WorkspaceFilesProvider>
-          }
-        />
-      </Routes>
+      <MainSidebarProvider storageKey="related-factory-sessions-test">
+        <Routes>
+          <Route
+            path="/factories/:factoryId/workspaces/:sessionId/threads/:threadId"
+            element={
+              <WorkspaceFilesProvider>
+                <FactorySessionHeader />
+              </WorkspaceFilesProvider>
+            }
+          />
+        </Routes>
+      </MainSidebarProvider>
     </MemoryRouter>,
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
@@ -1,9 +1,11 @@
 import { Button } from '@mastra/playground-ui/components/Button';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { CircleDot, ExternalLink, Link2 } from 'lucide-react';
 import { Link, useNavigate, useParams } from 'react-router';
 
 import { useUserSessionQuery, useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
 import { useWorkItemsQuery } from '../../../../hooks/useWorkItems';
+import { ChatHeader } from '../../chat/components/ChatHeader';
 import { WorkspaceFilesToggle } from '../../workspace-viewer/components/WorkspaceFilesToggle';
 import { useWorkspaceFiles } from '../../workspace-viewer/context/useWorkspaceFiles';
 import { relatedWorkItems, relationshipLabel, relationshipPath } from '../services/relationships';
@@ -52,6 +54,7 @@ function activeWorkItem(
   );
 }
 
+/** The thread column's only header: the shared bar with the session content inside it. */
 export function FactorySessionHeader() {
   const { factoryId, sessionId, threadId } = useParams<{ factoryId: string; sessionId: string; threadId: string }>();
   const sessionQuery = useUserSessionQuery(sessionId);
@@ -62,32 +65,30 @@ export function FactorySessionHeader() {
 
   const allItems = items.data ?? [];
   const currentItem = activeWorkItem(allItems, factoryId, sessionId, threadId);
-
-  if (!currentItem && !workspacePath) return null;
-
+  const hasSession = Boolean(currentItem || workspacePath);
   const livePaths = new Set((workspaces.data?.workspaces ?? []).map(workspace => workspace.sessionId));
 
   return (
-    <header
-      role="region"
-      className="border-border1 flex w-full min-w-0 items-center gap-2 border-b px-3 py-2 md:px-5"
-      aria-label="Factory session"
-    >
-      {currentItem ? <WorkItemBreadcrumb item={currentItem} factoryId={factoryId} /> : null}
-      <div className="ml-auto flex shrink-0 items-center gap-1">
-        {currentItem && factoryId && threadId ? (
-          <WorkItemActions
-            item={currentItem}
-            allItems={allItems}
-            livePaths={livePaths}
-            factoryId={factoryId}
-            threadId={threadId}
-            projectRepositoryId={projectRepositoryId}
-          />
-        ) : null}
-        <WorkspaceFilesToggle />
-      </div>
-    </header>
+    <ChatHeader className={cn(hasSession && 'border-border1 border-b md:px-5')}>
+      {hasSession ? (
+        <div role="region" aria-label="Factory session" className="flex min-w-0 flex-1 items-center gap-2">
+          {currentItem ? <WorkItemBreadcrumb item={currentItem} factoryId={factoryId} /> : null}
+          <div className="ml-auto flex shrink-0 items-center gap-1">
+            {currentItem && factoryId && threadId ? (
+              <WorkItemActions
+                item={currentItem}
+                allItems={allItems}
+                livePaths={livePaths}
+                factoryId={factoryId}
+                threadId={threadId}
+                projectRepositoryId={projectRepositoryId}
+              />
+            ) : null}
+            <WorkspaceFilesToggle />
+          </div>
+        </div>
+      ) : null}
+    </ChatHeader>
   );
 }
 

--- a/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
@@ -54,7 +54,6 @@ function activeWorkItem(
   );
 }
 
-/** The thread column's only header: the shared bar with the session content inside it. */
 export function FactorySessionHeader() {
   const { factoryId, sessionId, threadId } = useParams<{ factoryId: string; sessionId: string; threadId: string }>();
   const sessionQuery = useUserSessionQuery(sessionId);

--- a/mastracode/factory-ui/src/ui/pages/SettingsPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/SettingsPage.tsx
@@ -43,7 +43,7 @@ function SettingsPageContent() {
   return (
     <PageLayout
       sidebar={<Sidebar />}
-      header={<ChatHeader mobileContent={isMobile ? <SettingsHeader autoFocus placement="mobile" /> : undefined} />}
+      header={<ChatHeader mobileContent={<SettingsHeader autoFocus placement="mobile" />} />}
     >
       <SettingsPanel />
     </PageLayout>

--- a/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
@@ -33,8 +33,7 @@ export function ThreadPage() {
       sidebar={<Sidebar />}
       main={
         resolvingSession ? (
-          // The session header owns the sidebar toggle but needs the workspace
-          // provider, so the bare bar stands in until the session resolves.
+          // bare bar stands in — the session header needs WorkspaceFilesProvider
           <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden">
             <ChatHeader />
             <div className="grid min-h-0 place-items-center">
@@ -57,7 +56,7 @@ function ThreadPageMain() {
   useGlobalShortcuts();
 
   return (
-    // minmax(0,1fr) col — implicit auto col sizes to max-content, long breadcrumb widens the column
+    // explicit col — implicit auto col sizes to max-content, long breadcrumb widens the column
     <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)_auto_auto] overflow-hidden">
       <FactorySessionHeader />
       {/* Flex, not block — ChatMessageBoundary's loading state sizes itself with flex-1. */}

--- a/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
@@ -31,11 +31,15 @@ export function ThreadPage() {
   return (
     <ChatLayout
       sidebar={<Sidebar />}
-      header={<ChatHeader />}
       main={
         resolvingSession ? (
-          <div className="grid h-full min-h-0 place-items-center">
-            <Spinner aria-label="Loading session" className="text-icon3" />
+          // The session header owns the sidebar toggle but needs the workspace
+          // provider, so the bare bar stands in until the session resolves.
+          <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden">
+            <ChatHeader />
+            <div className="grid min-h-0 place-items-center">
+              <Spinner aria-label="Loading session" className="text-icon3" />
+            </div>
           </div>
         ) : (
           <ChatSessionBoundary threadId={threadId}>
@@ -53,7 +57,8 @@ function ThreadPageMain() {
   useGlobalShortcuts();
 
   return (
-    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)_auto_auto] overflow-hidden">
+    // minmax(0,1fr) col — implicit auto col sizes to max-content, long breadcrumb widens the column
+    <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)_auto_auto] overflow-hidden">
       <FactorySessionHeader />
       {/* Flex, not block — ChatMessageBoundary's loading state sizes itself with flex-1. */}
       <div className="relative flex min-h-0 flex-col overflow-hidden">

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageHeader.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageHeader.msw.test.tsx
@@ -1,9 +1,3 @@
-/**
- * Regression coverage for the thread route's header chrome: the sidebar toggle
- * and the session breadcrumb used to live in two stacked bars. They must share
- * one header, and a toggle must already be there while the session resolves —
- * a fully collapsed sidebar has no other way back.
- */
 import { screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
@@ -66,7 +60,6 @@ function deferred() {
   return { promise, resolve };
 }
 
-/** Stubs the thread routes, optionally holding the session lookup that drives the loading shell. */
 function stubThreadRoute({ gateSession = false } = {}) {
   const sessionGate = deferred();
 

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageHeader.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageHeader.msw.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Regression coverage for the thread route's header chrome: the sidebar toggle
+ * and the session breadcrumb used to live in two stacked bars. They must share
+ * one header, and a toggle must already be there while the session resolves —
+ * a fully collapsed sidebar has no other way back.
+ */
+import { screen, waitFor, within } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { server } from '../../../../e2e/ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../e2e/ui/render';
+import { createAppRoutes } from '../../router';
+
+const FACTORY_ID = 'fp-1';
+const REPO_ID = 'ghp-1';
+const SESSION_ID = 'sess-1';
+const AC = `${TEST_BASE_URL}/api/agent-controller/code`;
+const SIDEBAR_STATE_KEY = 'mastracode-web:sidebar:state';
+
+const workspaceSession = {
+  id: 'row-1',
+  sessionId: SESSION_ID,
+  projectRepositoryId: REPO_ID,
+  orgId: 'org-1',
+  userId: 'user-1',
+  branch: 'factory/issue-42',
+  baseBranch: 'main',
+  sandboxId: 'sb-1',
+  sandboxWorkdir: '/local/acme/app',
+  materializedAt: '2026-07-29T00:00:00.000Z',
+  createdAt: '2026-07-29T00:00:00.000Z',
+  updatedAt: '2026-07-29T00:00:00.000Z',
+};
+
+const workItem = {
+  id: 'wi-1',
+  orgId: 'org-1',
+  createdBy: 'user-1',
+  factoryProjectId: FACTORY_ID,
+  externalSource: {
+    integrationId: 'github',
+    type: 'issue',
+    externalId: '42',
+    url: 'https://github.com/acme/app/issues/42',
+  },
+  parentWorkItemId: null,
+  title: 'Fix the flaky login test',
+  stages: ['execute'],
+  stageHistory: [],
+  sessions: {
+    [SESSION_ID]: { sessionId: SESSION_ID, branch: 'factory/issue-42', threadId: SESSION_ID, startedBy: 'user-1' },
+  },
+  metadata: { number: 42 },
+  revision: 1,
+  createdAt: '2026-07-29T00:00:00.000Z',
+  updatedAt: '2026-07-29T00:00:00.000Z',
+};
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(r => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** Stubs the thread routes, optionally holding the session lookup that drives the loading shell. */
+function stubThreadRoute({ gateSession = false } = {}) {
+  const sessionGate = deferred();
+
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'conn-1',
+            installationId: 'inst-1',
+            repositories: [
+              {
+                id: REPO_ID,
+                branch: 'main',
+                sandboxWorkdir: '/local/acme/app',
+                repository: { slug: 'acme/app', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+      HttpResponse.json({ workItems: [workItem] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+      HttpResponse.json({ sessions: [workspaceSession] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/subscriptions`, () => HttpResponse.json({ subscriptions: [] })),
+    http.get(`${TEST_BASE_URL}/web/user-sessions/${SESSION_ID}`, async () => {
+      if (gateSession) await sessionGate.promise;
+      return HttpResponse.json({ session: workspaceSession });
+    }),
+    http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () =>
+      HttpResponse.json({
+        resourceId: SESSION_ID,
+        factoryProjectId: FACTORY_ID,
+        projectRepositoryId: REPO_ID,
+        sandboxId: 'sb-1',
+        sandboxWorkdir: '/local/acme/app',
+      }),
+    ),
+    http.post(`${AC}/sessions`, () =>
+      HttpResponse.json({ controllerId: 'code', resourceId: SESSION_ID, threadId: SESSION_ID }),
+    ),
+    http.get(`${AC}/sessions/:resourceId`, () =>
+      HttpResponse.json({
+        controllerId: 'code',
+        resourceId: SESSION_ID,
+        modeId: 'build',
+        modelId: 'openai/gpt-4o-mini',
+        threadId: SESSION_ID,
+        settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+      }),
+    ),
+    http.put(`${AC}/sessions/:resourceId/state`, () => HttpResponse.json({ ok: true })),
+    http.get(
+      `${AC}/sessions/:resourceId/stream`,
+      () =>
+        new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    ),
+    http.get(`${AC}/sessions/:resourceId/permissions`, () => HttpResponse.json({})),
+    http.get(`${AC}/sessions/:resourceId/threads`, () => HttpResponse.json({ threads: [] })),
+    http.get(`${AC}/sessions/:resourceId/threads/:threadId/messages`, () => HttpResponse.json({ messages: [] })),
+    http.get(`${AC}/modes`, () => HttpResponse.json({ modes: [] })),
+    http.get(`${TEST_BASE_URL}/web/workspace/rendered/list`, () =>
+      HttpResponse.json({ workspacePath: `/ws/${SESSION_ID}`, root: '.artifacts', rootPath: '', entries: [] }),
+    ),
+  );
+
+  return { sessionGate };
+}
+
+function renderRoute(path: string) {
+  const router = createMemoryRouter(createAppRoutes(), { initialEntries: [path] });
+  return renderWithProviders(<RouterProvider router={router} />);
+}
+
+afterEach(() => {
+  window.localStorage.removeItem(SIDEBAR_STATE_KEY);
+});
+
+describe('ThreadPage header', () => {
+  it('keeps the sidebar toggle and the session breadcrumb in a single header', async () => {
+    window.localStorage.setItem(SIDEBAR_STATE_KEY, 'collapsed');
+    stubThreadRoute();
+    renderRoute(`/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${SESSION_ID}`);
+
+    const breadcrumb = await screen.findByRole('navigation', { name: 'Factory session breadcrumb' });
+    const header = breadcrumb.closest('header');
+    expect(header).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Toggle sidebar' }).closest('header')).toBe(header);
+    expect(screen.queryByLabelText('Open navigation menu')).not.toBeInTheDocument();
+    expect(within(header!).getByText('Issue #42: Fix the flaky login test')).toBeInTheDocument();
+    expect(within(header!).getByRole('link', { name: 'Work' })).toBeInTheDocument();
+  });
+
+  it('carries the sidebar toggle while the session resolves', async () => {
+    window.localStorage.setItem(SIDEBAR_STATE_KEY, 'collapsed');
+    const { sessionGate } = stubThreadRoute({ gateSession: true });
+    renderRoute(`/factories/${FACTORY_ID}/user/threads/${SESSION_ID}`);
+
+    expect(await screen.findByLabelText('Loading session')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Toggle sidebar' })).toBeInTheDocument();
+
+    sessionGate.resolve();
+    await waitFor(() => expect(screen.queryByLabelText('Loading session')).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Toggle sidebar' })).toBeInTheDocument();
+  });
+});

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-mobile-trigger.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-mobile-trigger.tsx
@@ -32,9 +32,7 @@ export function MainSidebarMobileTrigger({
       }}
       className={cn(
         'inline-flex size-10 items-center justify-center rounded-md',
-        // Compound selector, not `in-*`: that variant wraps the ancestor in
-        // `:where()`, so an app stylesheet loaded after ours wins with a plain
-        // `.inline-flex` and the trigger stays visible on desktop.
+        // compound selector, not `in-*` — its `:where()` ties with a consumer's later `.inline-flex`
         "[[data-sidebar-mobile='false']_&]:hidden",
         'text-neutral4 hover:bg-sidebar-nav-hover hover:text-neutral6',
         'focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:outline-hidden',

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-mobile-trigger.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-mobile-trigger.tsx
@@ -32,7 +32,10 @@ export function MainSidebarMobileTrigger({
       }}
       className={cn(
         'inline-flex size-10 items-center justify-center rounded-md',
-        'in-data-[sidebar-mobile=false]:hidden',
+        // Compound selector, not `in-*`: that variant wraps the ancestor in
+        // `:where()`, so an app stylesheet loaded after ours wins with a plain
+        // `.inline-flex` and the trigger stays visible on desktop.
+        "[[data-sidebar-mobile='false']_&]:hidden",
         'text-neutral4 hover:bg-sidebar-nav-hover hover:text-neutral6',
         'focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:outline-hidden',
         className,


### PR DESCRIPTION
Open a Factory session in MastraCode web and you got two header bars stacked on top of each other: the chat header, plus the Factory session header with the breadcrumb. The chat header looks pointless at first — on desktop with the sidebar expanded it renders zero pixels tall — but it is the only host for the sidebar toggle when the sidebar is fully collapsed (`collapsedWidth={0}`), which is why the board page needs it and why the thread route ended up with a duplicate.

So `ChatHeader` is now the one header primitive: sidebar trigger plus an optional content slot, and it returns nothing when it would have neither. `FactorySessionHeader` composes it with the breadcrumb and the session actions as children, and `ThreadPage` no longer passes its own `header` to `ChatLayout`. During session resolution the bare bar still stands in, because the session header needs `WorkspaceFilesProvider` and cannot mount before the session resolves — without that the toggle would vanish for the duration of the load, and a fully collapsed sidebar has no other way back.

Two more things came out of putting the two bars into one.

The two sidebar triggers disagreed about what "mobile" means. The design system's burger is hidden by a JS `matchMedia` breakpoint in px (`mobileBreakpoint={768}`), while my desktop toggle used Tailwind's `md:`, which is 48rem. Those are only the same number while the rem base is 16px; move it and you get a band showing both toggles, or — worse — neither. Both now derive from the provider's `isMobile`, so they are mutually exclusive by construction and there is no media query in the component at all. Since the header knows the viewport, it also gates its own `mobileContent` slot — the settings page used to make that same call a second time before passing the prop.

The breadcrumb also could not truncate. `ThreadPageMain`'s grid declared rows but no column, so the implicit `auto` column sized itself to max-content: a long session title widened the whole thread column instead of clipping, and the action pills got pushed past the right edge (clipped by the container's `overflow-hidden`, so they were simply gone). Both grids now declare `grid-cols-[minmax(0,1fr)]`, the header carries `min-w-0`, and the session region is `flex-1` rather than `w-full` — with a trigger present, `w-full` made it 100% *plus* the trigger. I checked this against a running dev server: with a 3000px title the breadcrumb caps at the available width and ellipsizes while the actions stay put, and at a 390px column the title truncates to ~140px with no overflow.

One fix lands in `@mastra/playground-ui` rather than the app. `MainSidebar`'s mobile trigger hides itself on desktop with `in-data-[sidebar-mobile=false]:hidden`, which Tailwind compiles to `:where([data-sidebar-mobile="false"]) .in-…\:hidden`. `:where()` contributes no specificity, so that rule is (0,1,0) — a tie with a plain `.inline-flex`, and ties go to whichever stylesheet loads last. MastraCode web imports the design system stylesheet before its own Tailwind entry, so `.inline-flex` won and the hamburger sat next to an expanded desktop sidebar. It only became visible now because the header used to be `display: none` on desktop entirely. The rule is now a compound descendant selector, (0,2,0), immune to load order.

Known limits, and things I did not touch:

- The action group is `shrink-0`, so on a very narrow column the breadcrumb squeezes down to roughly 140px of title. Making the pills icon-only below the breakpoint would buy ~100px but touches `PullRequestLinks`, which is shared, so I left it.
- The toggle stays outside the `role="region"` labelled "Factory session", by choice: `region` is not an allowed role on `<header>`, and a global navigation control does not belong inside a session landmark.
- Pre-existing, not from this branch: with the sidebar expanded there is no visible collapse control anywhere in the app — only ⌘B and dragging the sidebar below its minimum width.

Tested with the factory-ui MSW suite (74 files, 356 tests) and the design system's `MainSidebar` tests, plus typecheck on both packages. The new `ThreadPageHeader.msw.test.tsx` covers the two regressions that matter: breadcrumb and toggle in the same `<header>` element, and a toggle present while the session resolves. `ChatHeader.msw.test.tsx` gained the exclusivity assertions (no burger on desktop, no toggle on mobile, no bar at all when there is nothing to host). The CSS specificity fix is not observable in jsdom — I verified it by rebuilding `dist/style.css` and reading the emitted selector, and by checking both pages in a browser at a few widths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR makes the thread page use one “top bar” (header) instead of multiple competing ones. It also ensures the sidebar button shows the right way on phones vs. desktops, and that long breadcrumb text doesn’t shove the other session controls out of the way.

## Changes
- Consolidated thread header composition: `ChatHeader` now owns the sidebar trigger and an optional mobile content slot, while `FactorySessionHeader` composes it with breadcrumb + session actions.
- Updated `ThreadPage` so it no longer passes a separate `header`; during session resolution it shows a bare header/placeholder with loading UI instead.
- Sidebar trigger visibility is now driven by the provider’s `isMobile` state to prevent both mobile/desktop controls from appearing at the same time.
- Improved layout behavior for long breadcrumbs via updated grid sizing, `min-w-0`, and flexible column handling so session actions keep space.
- Strengthened design-system styling for `MainSidebarMobileTrigger` to avoid stylesheet load-order overrides that previously kept it visible on desktop.
- Enhanced `ChatHeader` to accept native `<header>` props (and `children`) alongside `mobileContent`, and to render `null` when there’s no usable trigger/content.
- Updated/added tests covering header composition, session-loading states, trigger exclusivity, and the no-content case (plus related Factory UI + design system coverage and CSS/type/browser verification).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->