### PR TITLE
fix(playground-ui): keep unbreakable text inside the Notice box

### DIFF
--- a/.changeset/icy-feet-flow.md
+++ b/.changeset/icy-feet-flow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed long unbreakable text in Notice, such as a git remote URL with an embedded token, spilling outside the notice box. Messages now wrap at any character and long titles truncate.

--- a/packages/playground-ui/src/ds/components/Notice/notice-root.test.tsx
+++ b/packages/playground-ui/src/ds/components/Notice/notice-root.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, assert, describe, expect, it } from 'vitest';
+
+import { Notice } from './Notice';
+
+// jsdom has no layout engine, so scrollWidth cannot prove the overflow here.
+// These assert the guards that keep an unbreakable token inside the box:
+// `min-w-0` down the flex chain and `wrap-anywhere` on the text.
+const gitRemoteFailure =
+  "could not set 'remote.origin.url' to 'https://x-access-token:ghs_EXAMPLEtokenaGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9@github.com/mastra-ai/mastra.git'";
+
+const classesOf = (element: Element | null, label: string) => {
+  assert(element, `Expected ${label}`);
+  return [...element.classList];
+};
+
+afterEach(cleanup);
+
+describe('NoticeRoot', () => {
+  it('lets a message with no break opportunity wrap inside the box', () => {
+    render(<Notice variant="destructive">{gitRemoteFailure}</Notice>);
+
+    const message = screen.getByText(gitRemoteFailure);
+    expect(classesOf(message, 'the message')).toEqual(expect.arrayContaining(['wrap-anywhere', 'min-w-0']));
+    expect(classesOf(message.parentElement, 'the icon/message row')).toContain('min-w-0');
+  });
+
+  it('applies the same guard to the titled variant', () => {
+    render(
+      <Notice variant="destructive" title="Workspace unavailable">
+        <Notice.Message>{gitRemoteFailure}</Notice.Message>
+      </Notice>,
+    );
+
+    const body = screen.getByText(gitRemoteFailure).parentElement;
+    expect(classesOf(body, 'the message body')).toEqual(expect.arrayContaining(['wrap-anywhere', 'min-w-0']));
+  });
+
+  it('truncates a long title instead of wrapping it out of the fixed-height row', () => {
+    const title = 'A title long enough to outgrow the notice width on its own';
+    render(<Notice variant="warning" title={title} />);
+
+    expect(classesOf(screen.getByText(title), 'the title')).toContain('truncate');
+  });
+});

--- a/packages/playground-ui/src/ds/components/Notice/notice-root.tsx
+++ b/packages/playground-ui/src/ds/components/Notice/notice-root.tsx
@@ -51,9 +51,10 @@ export function NoticeRoot({ variant, title, icon, action, children, className }
         )}
       >
         <div className="flex flex-col gap-3 @md:flex-row @md:items-start @md:gap-2">
-          <div className="flex flex-1 items-start gap-2 [&>svg]:size-4">
+          <div className="flex min-w-0 flex-1 items-start gap-2 [&>svg]:size-4">
             <span className="flex h-[1lh] shrink-0 items-center [&>svg]:size-4">{resolvedIcon}</span>
-            {children && <div className="flex-1">{children}</div>}
+            {/* wrap-anywhere — messages carry URLs and tokens with no break opportunity */}
+            {children && <div className="min-w-0 flex-1 wrap-anywhere">{children}</div>}
           </div>
           {action && <div className="@md:-my-1 [&>button]:w-full @md:[&>button]:w-auto">{action}</div>}
         </div>
@@ -70,13 +71,14 @@ export function NoticeRoot({ variant, title, icon, action, children, className }
         className,
       )}
     >
-      <div className="flex h-4 items-center gap-2 [&>svg]:size-4">
+      <div className="flex h-4 min-w-0 items-center gap-2 [&>svg]:size-4">
         {resolvedIcon}
-        <span className="text-ui-sm leading-none font-medium tracking-wide uppercase">{title}</span>
+        {/* truncate, not wrap — the row is 1rem tall, a wrapped title would spill out of it */}
+        <span className="text-ui-sm truncate leading-none font-medium tracking-wide uppercase">{title}</span>
       </div>
       {action && <div className="absolute top-2 right-2 hidden @md:block">{action}</div>}
       {(children || action) && (
-        <div className="flex flex-col gap-5">
+        <div className="flex min-w-0 flex-col gap-5 wrap-anywhere">
           {children}
           {action && <div className="self-start @md:hidden">{action}</div>}
         </div>

--- a/packages/playground-ui/src/ds/components/Notice/notice.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Notice/notice.stories.tsx
@@ -137,6 +137,32 @@ export const MessageOnlyWithActionLong: Story = {
   ),
 };
 
+const gitRemoteFailure =
+  "Failed to prepare the workspace: Failed to set git remote: error: could not lock config file .git/config: File exists fatal: could not set 'remote.origin.url' to 'https://x-access-token:ghs_EXAMPLEtokenaGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9eyJhdWQiOiJhdXRobiIsImRpZ2VzdCI6IlF2QzJWbmNsIjNkbFZtbFBNUXJleDhxdnl2d1RMZ0Z2N2FQbXVlTnJ1TGVn@github.com/mastra-ai/mastra.git'";
+
+export const MessageWithUnbreakableToken: Story = {
+  render: () => (
+    <Notice
+      variant="destructive"
+      action={
+        <Notice.Button>
+          Retry <RefreshCwIcon />
+        </Notice.Button>
+      }
+    >
+      {gitRemoteFailure}
+    </Notice>
+  ),
+};
+
+export const TitledWithUnbreakableToken: Story = {
+  render: () => (
+    <Notice variant="destructive" title="Workspace unavailable">
+      <Notice.Message>{gitRemoteFailure}</Notice.Message>
+    </Notice>
+  ),
+};
+
 export const CustomIcon: Story = {
   render: () => (
     <Notice variant="success" title="Achievement unlocked" icon={<TrophyIcon />}>


### PR DESCRIPTION
A destructive `Notice` in the chat feed was spilling its text several hundred pixels outside its own rounded border. The message came from a failed workspace setup and contained a git remote URL with an embedded access token — one 260-character run with no space, hyphen, or slash to break on.

The cause is not the line clamp; `Notice` has none. The icon/message row is a flex item with `flex-1` but no `min-w-0`, so its automatic minimum size stays at min-content, and min-content of that token is wider than any column we hand it. Even once constrained, the default `overflow-wrap: normal` refuses to break inside a word, so the text keeps going. I added `min-w-0` down the flex chain and `wrap-anywhere` on both message containers, in the titled and titleless variants. No `overflow-hidden` — the text has to stay readable, it just needs to wrap.

The title is the exception and keeps `truncate`. Its row is `h-4`, so a title that wrapped would spill vertically out of the row instead of horizontally out of the box.

I measured the before and after in Chrome with the message at the chat column width (80ch, 806px): before, the notice reported `scrollWidth` 1300 against `clientWidth` 804, with the text's right edge at 1301 while the box ended at 806. After, `scrollWidth` and `clientWidth` are both 804 and the text ends at 793, wrapping onto one extra line.

That measurement is not in the test suite. jsdom has no layout engine, so `scrollWidth` reads 0 there, and playground-ui has no browser-mode runner today. The unit test I did add asserts the guards on the real render — `wrap-anywhere` plus `min-w-0` on the message, `min-w-0` on the row, `truncate` on the title — which catches a removed guard but proves nothing about pixels. Two Storybook stories (`MessageWithUnbreakableToken`, `TitledWithUnbreakableToken`) carry the offending string so the layout can be checked by eye.

Ran the playground-ui unit suite (700 tests), typecheck, and the formatter. Unrelated: the error message itself surfaces a GitHub `ghs_` token to the user. This PR only makes it wrap; masking credentials in the remote URL before the error reaches the UI is a separate fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Long messages could push a `Notice` outside its box. This change makes those messages wrap safely, keeps long titles on one line, and adds tests and Storybook examples to verify the fix.

## Changes

- Added `min-w-0` across the relevant flex containers.
- Added `wrap-anywhere` to titled and titleless message content.
- Preserved title truncation with `truncate`.
- Added unit assertions for layout classes.
- Added Storybook stories with unbreakable token-like Git URLs.
- Added a patch changeset for `@mastra/playground-ui`.

## Testing

- Playground UI unit suite
- Typecheck
- Formatter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->