### PR TITLE
feat(factory): async skill dispatch and project default model for rule-triggered sessions

### DIFF
--- a/.changeset/orange-kiwis-dream.md
+++ b/.changeset/orange-kiwis-dream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Improved stage transitions to complete immediately. Transitions from intake to triage, planning, or review now return right away, with skill activation happening asynchronously in the background instead of blocking the transition.

--- a/.changeset/thick-pillows-sing.md
+++ b/.changeset/thick-pillows-sing.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed rule-triggered factory sessions ignoring the project default model. Sessions created by stage-transition rules now correctly use the project's configured default model instead of falling back to the controller default.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -713,6 +713,7 @@ export class MastraFactory {
                 controller,
                 transitionService: runtimeTransitionService,
                 storage: storage.getDomain<WorkItemsStorage>('work-items'),
+                projectsStorage: storage.getDomain<FactoryProjectsStorage>('projects'),
                 reconcileToolResults: () => factoryProcessor?.reconcileAllBoundThreads() ?? Promise.resolve(),
                 prepareBinding,
                 primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -157,10 +157,12 @@ describe('GithubRules', () => {
       rules,
     });
     const deliveredSignals: Array<{ id: string; contents: string; threadId: string; user: unknown }> = [];
+    const deliveredNotifications: Array<{ kind: string; summary: string; threadId: string; user: unknown }> = [];
     const sessions = new Map<string, ReturnType<typeof makeSession>>();
 
     function makeSession(key: string, initialThreadId?: string) {
       let threadId: string | undefined = initialThreadId;
+      const consumeStream = vi.fn(async () => {});
       const session = {
         thread: {
           list: vi.fn(async () => []),
@@ -194,7 +196,19 @@ describe('GithubRules', () => {
         ),
         state: { set: vi.fn(async () => {}) },
         sendMessage: vi.fn(async () => {}),
-        sendNotificationSignal: vi.fn(async () => ({ persisted: Promise.resolve(), accepted: Promise.resolve() })),
+        sendNotificationSignal: vi.fn(
+          (
+            input: { kind: string; summary: string },
+            options: { requestContext: { get(key: string): unknown } },
+          ) => {
+            if (!threadId) throw new Error('Notification delivered before thread persistence.');
+            deliveredNotifications.push({ ...input, threadId, user: options.requestContext.get('user') });
+            return {
+              persisted: Promise.resolve(),
+              accepted: Promise.resolve({ action: 'wake', output: { consumeStream } }),
+            };
+          },
+        ),
       };
       sessions.set(key, session);
       return session;
@@ -220,7 +234,7 @@ describe('GithubRules', () => {
       storage: workItems,
       ownerId: 'worker-1',
       primeCredentials,
-      prepareBinding: async ({ record, item, role }) => {
+      prepareBinding: async ({ record, item, role, invocation }) => {
         await coordinator.prepare({
           orgId: record.orgId,
           userId: 'user-1',
@@ -230,13 +244,18 @@ describe('GithubRules', () => {
           kickoffKey: record.idempotencyKey,
           destinationStage: 'triage',
           workItem: { id: item.id, role, input: item },
+          ...(invocation ? { invocation } : {}),
         });
       },
     });
 
     await service.ingest(issueOpened('delivery-full-flow'));
+    // Cycle 1: upsertLinkedWorkItem → transition to triage → invokeSkill deferred
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+    // Cycle 2: invokeSkill → prepareBinding (with invocation) → pending start created
     await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
+    // Cycle 3: pending start → sendNotificationSignal with run-kickoff
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:02Z'));
 
     const [item] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
     expect(item).toMatchObject({
@@ -251,10 +270,12 @@ describe('GithubRules', () => {
       },
     });
     expect(primeCredentials).toHaveBeenCalledWith({ orgId: 'org-1', userId: 'user-1' });
-    expect(deliveredSignals).toEqual([
+    // Skill kickoff delivered via pending start notification (not inline sendSignal)
+    expect(deliveredNotifications).toEqual([
       expect.objectContaining({
+        kind: 'run-kickoff',
         threadId: 'session-issue-42',
-        contents: expect.stringContaining('<skill name="factory-triage">'),
+        summary: expect.stringContaining('<skill name="factory-triage">'),
         user: { workosId: 'user-1', organizationId: 'org-1' },
       }),
     ]);
@@ -272,6 +293,7 @@ describe('GithubRules', () => {
 
     await dispatcher.runOnce(new Date('2030-01-01T00:00:02Z'));
     await dispatcher.runOnce(new Date('2030-01-01T00:00:03Z'));
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:04Z'));
 
     const [rematerialized] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
     expect(rematerialized).toMatchObject({
@@ -279,7 +301,12 @@ describe('GithubRules', () => {
       stages: ['triage'],
     });
     expect(rematerialized?.id).not.toBe(item?.id);
-    expect(deliveredSignals).toHaveLength(2);
+    expect(deliveredNotifications).toHaveLength(2);
+    expect((await workItems.listDeferredDecisions('org-1', project.id)).map(decision => decision.status)).toEqual([
+      'succeeded',
+      'succeeded',
+      'succeeded',
+    ]);
   });
 
   it('prefers canonical board identities over legacy GitHub rows during ingress', async () => {

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -232,9 +232,10 @@ describe('GithubRules', () => {
       controller: controller as never,
       transitionService,
       storage: workItems,
+      projectsStorage: projects,
       ownerId: 'worker-1',
       primeCredentials,
-      prepareBinding: async ({ record, item, role, invocation }) => {
+      prepareBinding: async ({ record, item, role, invocation, defaultModelId }) => {
         await coordinator.prepare({
           orgId: record.orgId,
           userId: 'user-1',
@@ -245,6 +246,7 @@ describe('GithubRules', () => {
           destinationStage: 'triage',
           workItem: { id: item.id, role, input: item },
           ...(invocation ? { invocation } : {}),
+          ...(defaultModelId ? { defaultModelId } : {}),
         });
       },
     });

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -190,6 +190,7 @@ async function prepareFactoryRuleBinding(
       },
     },
     ...(input.invocation ? { invocation: input.invocation } : {}),
+    ...(input.defaultModelId ? { defaultModelId: input.defaultModelId } : {}),
   });
 }
 

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -189,6 +189,7 @@ async function prepareFactoryRuleBinding(
         metadata: input.item.metadata,
       },
     },
+    ...(input.invocation ? { invocation: input.invocation } : {}),
   });
 }
 

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -10,12 +10,12 @@ import type { FactoryCommitDecision } from './types.js';
 
 const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
 
-async function createItem(storage: WorkItemsStorage, sourceKey = 'github-issue:1') {
+async function createItem(storage: WorkItemsStorage, sourceKey = 'github-issue:1', factoryProjectId = PROJECT_ID) {
   return (
     await storage.upsert({
       orgId: 'org-1',
       userId: 'user-1',
-      factoryProjectId: PROJECT_ID,
+      factoryProjectId,
       input: {
         externalSource: { integrationId: 'github', type: 'issue', externalId: sourceKey },
         title: 'Fix issue',
@@ -79,9 +79,9 @@ function createSession(accepted?: Promise<unknown>) {
 async function queueDecision(
   storage: WorkItemsStorage,
   decision: FactoryCommitDecision,
-  options?: { sourceKey?: string; ingress?: string },
+  options?: { sourceKey?: string; ingress?: string; factoryProjectId?: string },
 ) {
-  const item = await createItem(storage, options?.sourceKey);
+  const item = await createItem(storage, options?.sourceKey, options?.factoryProjectId);
   const rules = defaultFactoryRules({
     version: 'rules-v1',
     overrides: { work: { execute: { issue: { onEnter: () => decision } } } },
@@ -89,7 +89,7 @@ async function queueDecision(
   const transitionService = new FactoryTransitionService({ storage, rules });
   const result = await transitionService.transition({
     orgId: 'org-1',
-    factoryProjectId: PROJECT_ID,
+    factoryProjectId: options?.factoryProjectId ?? PROJECT_ID,
     workItemId: item.id,
     board: 'work',
     stage: 'execute',
@@ -1018,6 +1018,159 @@ describe('FactoryDecisionDispatcher', () => {
       expect.objectContaining({
         ifActive: { behavior: 'deliver' },
         ifIdle: { behavior: 'wake' },
+      }),
+    );
+  });
+
+  it('does not re-send a rule-driven skill inline when the deferred decision fails after prepareBinding', async () => {
+    const { workItems: storage, projects } = await createFactoryStorageForTests();
+    const { item, transitionService } = await queueDecision(storage, {
+      type: 'invokeSkill',
+      role: 'triage',
+      skillName: 'understand-issue',
+      idempotencyKey: 'skill-durable-kickoff',
+    });
+    // Make completeDeferredDecision return null on the first call so the
+    // dispatcher fails after prepareBinding created the pending start.
+    const realComplete = storage.completeDeferredDecision.bind(storage);
+    let completeCalls = 0;
+    storage.completeDeferredDecision = vi.fn(async (...args: Parameters<typeof realComplete>) => {
+      completeCalls += 1;
+      if (completeCalls === 1) return null;
+      return realComplete(...args);
+    });
+    const { controller, session } = createSession();
+    // First sendNotificationSignal call (cycle-1 preceding-message or kickoff
+    // attempt) throws so the dispatcher records a retry. Subsequent calls
+    // succeed normally.
+    const realSend = session.sendNotificationSignal;
+    let sendCalls = 0;
+    session.sendNotificationSignal = vi.fn(async (...args: Parameters<typeof realSend>) => {
+      sendCalls += 1;
+      if (sendCalls === 1) throw new Error('notification persist failed');
+      return realSend(...args);
+    });
+    const prepareBinding = vi.fn(async (input: { record: { id: string }; invocation?: { skillName: string } }) => {
+      const kickoffMessage = input.invocation ? `<skill name="${input.invocation.skillName}">\n</skill>` : null;
+      await storage.prepareRunStart({
+        orgId: 'org-1',
+        userId: 'user-1',
+        factoryProjectId: PROJECT_ID,
+        workItem: {
+          id: item.id,
+          input: {
+            externalSource: item.externalSource,
+            title: item.title,
+            stages: ['intake'],
+            sessions: {},
+            metadata: item.metadata,
+          },
+        },
+        role: 'triage',
+        session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-1' },
+        resourceId: PROJECT_ID,
+        kickoffKey: input.record.id,
+        kickoffMessage,
+      });
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      projectsStorage: projects,
+      ownerId: 'worker-1',
+      prepareBinding,
+    });
+
+    // Cycle 1: invokeSkill → prepareBinding creates pending start → fails
+    // before completion. The decision enters retry.
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+
+    const [recordAfterCycle1] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(recordAfterCycle1?.status).toBe('retry');
+    expect(session.sendSignal).not.toHaveBeenCalled();
+
+    // Cycle 2: claimPendingStarts picks up the pending start from cycle 1
+    // and dispatches it (delivering run-kickoff). Then the retry of
+    // invokeSkill runs: #requireOrPrepareBinding sees the pending start
+    // record for this kickoff key and returns prepared: true, so the
+    // dispatcher must NOT fall through to inline sendSignal().
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
+
+    expect(session.sendSignal).not.toHaveBeenCalled();
+    expect(prepareBinding).toHaveBeenCalledTimes(1); // not called again
+
+    expect(session.sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'run-kickoff',
+        summary: expect.stringContaining('<skill name="understand-issue">'),
+      }),
+      expect.objectContaining({
+        ifActive: { behavior: 'deliver' },
+        ifIdle: { behavior: 'wake' },
+      }),
+    );
+
+    const [recordAfterCycle2] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(recordAfterCycle2?.status).toBe('succeeded');
+  });
+
+  it('passes the project default model to prepareBinding so rule-driven sessions use the configured default', async () => {
+    const { workItems: storage, projects } = await createFactoryStorageForTests();
+    const project = await projects.create({
+      orgId: 'org-1',
+      userId: 'user-1',
+      input: { name: 'Test project', defaultModelId: 'openai/gpt-5.6-sol' },
+    });
+    const { item, transitionService } = await queueDecision(
+      storage,
+      {
+        type: 'invokeSkill',
+        role: 'triage',
+        skillName: 'understand-issue',
+        idempotencyKey: 'skill-default-model',
+      },
+      { factoryProjectId: project.id },
+    );
+    const { controller } = createSession();
+    const prepareBinding = vi.fn(async (input: { record: { id: string }; invocation?: { skillName: string } }) => {
+      const kickoffMessage = input.invocation ? `<skill name="${input.invocation.skillName}">\n</skill>` : null;
+      await storage.prepareRunStart({
+        orgId: 'org-1',
+        userId: 'user-1',
+        factoryProjectId: project.id,
+        workItem: {
+          id: item.id,
+          input: {
+            externalSource: item.externalSource,
+            title: item.title,
+            stages: ['intake'],
+            sessions: {},
+            metadata: item.metadata,
+          },
+        },
+        role: 'triage',
+        session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-1' },
+        resourceId: project.id,
+        kickoffKey: input.record.id,
+        kickoffMessage,
+      });
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      projectsStorage: projects,
+      ownerId: 'worker-1',
+      prepareBinding,
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+
+    expect(prepareBinding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultModelId: 'openai/gpt-5.6-sol',
+        invocation: { type: 'skill', skillName: 'understand-issue', arguments: '' },
       }),
     );
   });

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -1039,17 +1039,7 @@ describe('FactoryDecisionDispatcher', () => {
       if (completeCalls === 1) return null;
       return realComplete(...args);
     });
-    const { controller, session } = createSession();
-    // First sendNotificationSignal call (cycle-1 preceding-message or kickoff
-    // attempt) throws so the dispatcher records a retry. Subsequent calls
-    // succeed normally.
-    const realSend = session.sendNotificationSignal;
-    let sendCalls = 0;
-    session.sendNotificationSignal = vi.fn(async (...args: Parameters<typeof realSend>) => {
-      sendCalls += 1;
-      if (sendCalls === 1) throw new Error('notification persist failed');
-      return realSend(...args);
-    });
+    const { controller, session, delivered } = createSession();
     const prepareBinding = vi.fn(async (input: { record: { id: string }; invocation?: { skillName: string } }) => {
       const kickoffMessage = input.invocation ? `<skill name="${input.invocation.skillName}">\n</skill>` : null;
       await storage.prepareRunStart({
@@ -1088,6 +1078,7 @@ describe('FactoryDecisionDispatcher', () => {
 
     const [recordAfterCycle1] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
     expect(recordAfterCycle1?.status).toBe('retry');
+    expect(recordAfterCycle1).toBeDefined();
     expect(session.sendSignal).not.toHaveBeenCalled();
 
     // Cycle 2: claimPendingStarts picks up the pending start from cycle 1
@@ -1110,6 +1101,14 @@ describe('FactoryDecisionDispatcher', () => {
         ifIdle: { behavior: 'wake' },
       }),
     );
+
+    // Verify the kickoff was delivered (not just attempted)
+    const kickoffDedupeKey = `factory-kickoff:${recordAfterCycle1!.id}`;
+    expect(delivered).toContain(kickoffDedupeKey);
+
+    // Verify the pending start is marked as 'sent'
+    const [pendingStart] = await storage.listPendingStarts('org-1', PROJECT_ID);
+    expect(pendingStart?.status).toBe('sent');
 
     const [recordAfterCycle2] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
     expect(recordAfterCycle2?.status).toBe('succeeded');

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -874,7 +874,8 @@ describe('FactoryDecisionDispatcher', () => {
       idempotencyKey: 'skill-auto-start',
     });
     const { controller, session } = createSession();
-    const prepareBinding = vi.fn(async () => {
+    const prepareBinding = vi.fn(async (input: { invocation?: { skillName: string } }) => {
+      const kickoffMessage = input.invocation ? `<skill name="${input.invocation.skillName}">\n</skill>` : null;
       await storage.prepareRunStart({
         orgId: 'org-1',
         userId: 'user-1',
@@ -893,7 +894,7 @@ describe('FactoryDecisionDispatcher', () => {
         session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-1' },
         resourceId: PROJECT_ID,
         kickoffKey: 'skill-auto-start',
-        kickoffMessage: null,
+        kickoffMessage,
       });
     });
     const dispatcher = new FactoryDecisionDispatcher({
@@ -904,14 +905,31 @@ describe('FactoryDecisionDispatcher', () => {
       prepareBinding,
     });
 
+    // Cycle 1: invokeSkill → prepareBinding (with invocation) → pending start created
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
 
     expect(prepareBinding).toHaveBeenCalledWith(
-      expect.objectContaining({ item: expect.objectContaining({ id: item.id }), role: 'triage' }),
+      expect.objectContaining({
+        item: expect.objectContaining({ id: item.id }),
+        role: 'triage',
+        invocation: { type: 'skill', skillName: 'understand-issue', arguments: '' },
+      }),
     );
-    expect(session.sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({ contents: expect.stringContaining('<skill name="understand-issue">') }),
-      { requestContext: expect.anything(), requireDelivery: true },
+    // Inline skill sending should NOT happen — pending start handles it
+    expect(session.sendSignal).not.toHaveBeenCalled();
+
+    // Cycle 2: pending start → sendNotificationSignal with run-kickoff
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
+
+    expect(session.sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'run-kickoff',
+        summary: expect.stringContaining('<skill name="understand-issue">'),
+      }),
+      expect.objectContaining({
+        ifActive: { behavior: 'deliver' },
+        ifIdle: { behavior: 'wake' },
+      }),
     );
   });
 
@@ -945,7 +963,8 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const { controller, session } = createSession();
     controller.getSessionByResource.mockResolvedValueOnce(undefined as never).mockResolvedValue(session);
-    const prepareBinding = vi.fn(async () => {
+    const prepareBinding = vi.fn(async (input: { invocation?: { skillName: string } }) => {
+      const kickoffMessage = input.invocation ? `<skill name="${input.invocation.skillName}">\n</skill>` : null;
       await storage.prepareRunStart({
         orgId: 'org-1',
         userId: 'user-1',
@@ -964,7 +983,7 @@ describe('FactoryDecisionDispatcher', () => {
         session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-2' },
         resourceId: PROJECT_ID,
         kickoffKey: 'skill-session-recovery-replacement',
-        kickoffMessage: null,
+        kickoffMessage,
       });
     });
     const dispatcher = new FactoryDecisionDispatcher({
@@ -975,15 +994,31 @@ describe('FactoryDecisionDispatcher', () => {
       prepareBinding,
     });
 
+    // Cycle 1: invokeSkill → existing binding but no session → prepareBinding → pending start created
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
 
     expect(prepareBinding).toHaveBeenCalledWith(
-      expect.objectContaining({ item: expect.objectContaining({ id: item.id }), role: 'triage' }),
+      expect.objectContaining({
+        item: expect.objectContaining({ id: item.id }),
+        role: 'triage',
+        invocation: { type: 'skill', skillName: 'understand-issue', arguments: '' },
+      }),
     );
+    expect(session.sendSignal).not.toHaveBeenCalled();
+
+    // Cycle 2: pending start → sendNotificationSignal with run-kickoff
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
+
     expect(session.thread.switch).toHaveBeenCalledWith({ threadId: 'thread-2' });
-    expect(session.sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({ contents: expect.stringContaining('<skill name="understand-issue">') }),
-      { requestContext: expect.anything(), requireDelivery: true },
+    expect(session.sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'run-kickoff',
+        summary: expect.stringContaining('<skill name="understand-issue">'),
+      }),
+      expect.objectContaining({
+        ifActive: { behavior: 'deliver' },
+        ifIdle: { behavior: 'wake' },
+      }),
     );
   });
 

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -46,6 +46,7 @@ export interface FactoryBindingPreparationInput {
   record: FactoryDeferredDecisionRecord;
   item: WorkItemRow;
   role: string;
+  invocation?: { type: 'skill'; skillName: string; arguments: string };
 }
 
 export interface FactoryDecisionDispatcherOptions {
@@ -317,7 +318,49 @@ export class FactoryDecisionDispatcher {
         return;
       }
       case 'invokeSkill': {
-        const binding = await this.#requireOrPrepareBinding(record, decision.role);
+        const invocation = {
+          type: 'skill' as const,
+          skillName: decision.skillName,
+          arguments: decision.arguments ?? '',
+        };
+        const { binding, prepared } = await this.#requireOrPrepareBinding(record, decision.role, invocation);
+        if (prepared) {
+          // The pending start has the skill kickoff message. It will be
+          // dispatched by #dispatchPendingStart in the next dispatch cycle.
+          // Only send the preceding message here (if any) so it arrives before
+          // the kickoff.
+          const item = record.workItemId
+            ? await this.#storage.get({ orgId: record.orgId, id: record.workItemId })
+            : null;
+          const startedBy = item?.sessions[binding.role]?.startedBy;
+          if (!startedBy) throw new Error(`Factory binding ${binding.id} has no authenticated session owner.`);
+          await this.#primeCredentials?.({ orgId: record.orgId, userId: startedBy });
+          const requestContext = new RequestContext();
+          requestContext.set('user', { workosId: startedBy, organizationId: record.orgId });
+          if (decision.precedingMessage) {
+            const session = await this.#requireSession(binding);
+            await awaitNotification(
+              await session.sendNotificationSignal(
+                {
+                  source: 'factory',
+                  kind: 'stage-transition',
+                  summary: decision.precedingMessage,
+                  priority: 'medium',
+                  payload: { message: decision.precedingMessage },
+                  sourceId: `${record.id}:stage-transition`,
+                  dedupeKey: `${record.idempotencyKey}:stage-transition`,
+                },
+                {
+                  ifActive: { behavior: 'deliver' },
+                  ifIdle: { behavior: 'persist' },
+                  requestContext,
+                },
+              ),
+            );
+          }
+          return;
+        }
+        // Existing binding found — resolve and send the skill inline.
         const item = record.workItemId ? await this.#storage.get({ orgId: record.orgId, id: record.workItemId }) : null;
         const startedBy = item?.sessions[binding.role]?.startedBy;
         if (!startedBy) throw new Error(`Factory binding ${binding.id} has no authenticated session owner.`);
@@ -377,7 +420,7 @@ export class FactoryDecisionDispatcher {
       }
       case 'sendMessage': {
         const binding = decision.prepareBinding
-          ? await this.#requireOrPrepareBinding(record, decision.role)
+          ? (await this.#requireOrPrepareBinding(record, decision.role)).binding
           : await this.#requireBinding(record, decision.role);
         const item = record.workItemId ? await this.#storage.get({ orgId: record.orgId, id: record.workItemId }) : null;
         const startedBy = item?.sessions[binding.role]?.startedBy;
@@ -516,18 +559,20 @@ export class FactoryDecisionDispatcher {
   async #requireOrPrepareBinding(
     record: FactoryDeferredDecisionRecord,
     role: string,
-  ): Promise<FactoryRunBindingRecord> {
+    invocation?: { type: 'skill'; skillName: string; arguments: string },
+  ): Promise<{ binding: FactoryRunBindingRecord; prepared: boolean }> {
     const binding = await this.#findBinding(record, role);
     if (binding) {
       const session = await this.#controller.getSessionByResource(binding.resourceId);
-      if (session) return binding;
+      if (session) return { binding, prepared: false };
     }
     if (!this.#prepareBinding) {
       throw new Error(binding ? 'Bound Factory session not found.' : `No active Factory binding for role ${role}.`);
     }
     const item = await this.#requireItem(record);
-    await this.#prepareBinding({ record, item, role });
-    return this.#requireBinding(record, role);
+    await this.#prepareBinding({ record, item, role, ...(invocation ? { invocation } : {}) });
+    const newBinding = await this.#requireBinding(record, role);
+    return { binding: newBinding, prepared: true };
   }
 
   async #requireSession(binding: FactoryRunBindingRecord): Promise<DispatcherSession> {

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -6,6 +6,7 @@ import { RequestContext } from '@mastra/core/request-context';
 
 import { resolveSkillInvocation } from '../skills/service.js';
 import type { SkillSession } from '../skills/service.js';
+import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type {
   FactoryDeferredDecisionRecord,
   FactoryPendingStartRecord,
@@ -47,12 +48,14 @@ export interface FactoryBindingPreparationInput {
   item: WorkItemRow;
   role: string;
   invocation?: { type: 'skill'; skillName: string; arguments: string };
+  defaultModelId?: string;
 }
 
 export interface FactoryDecisionDispatcherOptions {
   controller: FactoryController;
   transitionService: Pick<FactoryTransitionService, 'transition'>;
   storage: WorkItemsStorage;
+  projectsStorage?: FactoryProjectsStorage;
   ownerId?: string;
   reconcileToolResults?: () => Promise<void>;
   prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
@@ -132,6 +135,7 @@ export class FactoryDecisionDispatcher {
   readonly #controller: FactoryController;
   readonly #transitionService: Pick<FactoryTransitionService, 'transition'>;
   readonly #storage: WorkItemsStorage;
+  readonly #projectsStorage?: FactoryProjectsStorage;
   readonly #ownerId: string;
   readonly #reconcileToolResults?: () => Promise<void>;
   readonly #prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
@@ -145,6 +149,7 @@ export class FactoryDecisionDispatcher {
     this.#controller = options.controller;
     this.#transitionService = options.transitionService;
     this.#storage = options.storage;
+    this.#projectsStorage = options.projectsStorage;
     this.#ownerId = options.ownerId ?? `factory-dispatcher:${randomUUID()}`;
     this.#reconcileToolResults = options.reconcileToolResults;
     this.#prepareBinding = options.prepareBinding;
@@ -570,7 +575,18 @@ export class FactoryDecisionDispatcher {
       throw new Error(binding ? 'Bound Factory session not found.' : `No active Factory binding for role ${role}.`);
     }
     const item = await this.#requireItem(record);
-    await this.#prepareBinding({ record, item, role, ...(invocation ? { invocation } : {}) });
+    let defaultModelId: string | undefined;
+    if (this.#projectsStorage) {
+      const project = await this.#projectsStorage.get({ orgId: record.orgId, id: record.factoryProjectId });
+      defaultModelId = project?.defaultModelId ?? undefined;
+    }
+    await this.#prepareBinding({
+      record,
+      item,
+      role,
+      ...(invocation ? { invocation } : {}),
+      ...(defaultModelId ? { defaultModelId } : {}),
+    });
     const newBinding = await this.#requireBinding(record, role);
     return { binding: newBinding, prepared: true };
   }

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -569,7 +569,16 @@ export class FactoryDecisionDispatcher {
     const binding = await this.#findBinding(record, role);
     if (binding) {
       const session = await this.#controller.getSessionByResource(binding.resourceId);
-      if (session) return { binding, prepared: false };
+      if (session) {
+        // Check if a pending start already exists for this kickoff key.
+        // If it does, the skill kickoff is already represented durably —
+        // either #dispatchPendingStart will deliver it (pending/leased/retry)
+        // or it already did (sent). Returning prepared: true in both cases
+        // prevents duplicate inline sending on retry.
+        const pendingStarts = await this.#storage.listPendingStarts(record.orgId, record.factoryProjectId);
+        const hasKickoff = pendingStarts.some(ps => ps.kickoffKey === record.id);
+        return { binding, prepared: hasKickoff };
+      }
     }
     if (!this.#prepareBinding) {
       throw new Error(binding ? 'Bound Factory session not found.' : `No active Factory binding for role ${role}.`);

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -575,8 +575,11 @@ export class FactoryDecisionDispatcher {
         // either #dispatchPendingStart will deliver it (pending/leased/retry)
         // or it already did (sent). Returning prepared: true in both cases
         // prevents duplicate inline sending on retry.
-        const pendingStarts = await this.#storage.listPendingStarts(record.orgId, record.factoryProjectId);
-        const hasKickoff = pendingStarts.some(ps => ps.kickoffKey === record.id);
+        const hasKickoff = await this.#storage.hasPendingStartForKickoff(
+          record.orgId,
+          record.factoryProjectId,
+          record.id,
+        );
         return { binding, prepared: hasKickoff };
       }
     }

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -1388,6 +1388,15 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     ).map(toPendingStart);
   }
 
+  async hasPendingStartForKickoff(orgId: string, factoryProjectId: string, kickoffKey: string): Promise<boolean> {
+    const row = await this.#db.findOne<GovernanceDbRow>('factory_pending_starts', {
+      org_id: orgId,
+      factory_project_id: factoryProjectId,
+      kickoff_key: kickoffKey,
+    });
+    return row !== null;
+  }
+
   async claimPendingStarts(input: FactoryLeaseClaimInput): Promise<FactoryPendingStartRecord[]> {
     return this.#claimLeases('factory_pending_starts', input, toPendingStart);
   }


### PR DESCRIPTION
Two fixes to the factory dispatcher's `invokeSkill` path:

**Async skill dispatch**

Stage transitions that trigger skills (intake → triage, planning, review) no longer block the dispatcher. The skill activation is baked into the pending-start kickoff record so the transition returns immediately and the skill runs as a side-effect in the next dispatch cycle.

**Project default model**

Sessions created by stage-transition rules now pick up the project's configured default model. Previously the dispatcher's `prepareBinding` path skipped the model, causing sessions to fall back to the controller default (e.g. Qwen 3.7 Max instead of the project's OpenAI Sol 5.6).

```ts
// Before: dispatcher resolved and sent the skill inline, blocking
await resolveSkillInvocation(...);
await session.sendSignal({ requireDelivery: true });

// After: skill lives in the pending start kickoff, dispatched async
await coordinator.prepare({ invocation, defaultModelId });
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a factory changes stage, it finishes the change immediately and starts the related skill in the background. Rule-triggered sessions use the model configured for their project.

## What changed

- Added asynchronous skill kickoff handling for stage-transition activations.
- Prevented duplicate delivery by checking the kickoff-specific pending-start record.
- Preserved inline skill delivery for existing bindings.
- Passed skill invocation details through binding preparation.
- Applied each project’s `defaultModelId` to rule-triggered sessions.
- Added project storage access to `FactoryDecisionDispatcher`.
- Updated dispatcher and GitHub integration tests for pending-start delivery, retry handling, and notification deduplication.
- Added changesets for the factory releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->