### PR TITLE
fix(core): stop RegexFilterProcessor's redact strategy from discarding its matches

### DIFF
--- a/.changeset/good-flowers-exist.md
+++ b/.changeset/good-flowers-exist.md
@@ -1,0 +1,34 @@
+---
+'@mastra/core': minor
+---
+
+`RegexFilterProcessor` now reports what the `redact` strategy rewrote, through the existing `Processor.onViolation` callback.
+
+Redaction used to be silent. The processor found its matches, replaced the text, and dropped the match list, leaving nothing downstream to audit. It now reports once per redacted message, message part, or stream chunk, with offsets relative to that piece of text.
+
+```ts
+const filter = new RegexFilterProcessor({
+  presets: ['pii'],
+  strategy: 'redact',
+});
+
+filter.onViolation = async ({ detail }) => {
+  const redaction = detail as RegexRedactionDetail;
+
+  for (const entry of redaction.redactions) {
+    await auditLog.write({
+      phase: redaction.phase, // processInput | processOutputStream | processOutputResult
+      messageId: redaction.messageId,
+      rule: entry.rule, // 'credit-card'
+      offset: entry.index,
+      length: entry.length,
+    });
+  }
+};
+```
+
+Async callbacks are awaited. When no callback is attached the redact path stays synchronous, so nothing changes for existing callers. When two rules match the same span, the winning rule is reported as `rule` and every rule that matched is listed in `overlappingRules`.
+
+**Values are withheld by default**
+
+Reports carry offsets and rule names, not the matched text. An audit trail that copies the data it protects widens the exposure it was added to narrow, which is why the `block` strategy already withholds matched text from its `TripWire` metadata. Set `includeRedactedValues: true` to add a `value` field when the destination is as protected as the original.

--- a/.changeset/sunny-friends-write.md
+++ b/.changeset/sunny-friends-write.md
@@ -1,0 +1,23 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `RegexFilterProcessor` leaving part of a matched value in the output when two rules match overlapping text.
+
+**What was wrong**
+
+Rules were applied one at a time with `String.replace`, so an earlier rule could consume the start of a longer match and leave the rest in the clear. With the `pii` preset, `phone` runs before `credit-card`, so a card number written without separators lost only its first ten digits:
+
+```ts
+const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+
+// Before: "card [PHONE]111111"
+// After:  "card [CREDIT_CARD]"
+```
+
+Overlapping matches are now combined into one region and replaced once, using the replacement of the longest match.
+
+**Two smaller changes to redaction**
+
+- A replacement that references capture groups (`$1`, `$&`) now falls back to the replacement string as written when the rule cannot match the text it matched in isolation, which happens with a lookbehind or lookahead. The region is still redacted.
+- A rule that only matches empty strings no longer inserts its replacement between every character.

--- a/docs/src/content/en/reference/processors/regex-filter-processor.mdx
+++ b/docs/src/content/en/reference/processors/regex-filter-processor.mdx
@@ -58,14 +58,12 @@ const agent = new Agent({
   id: 'my-agent',
   name: 'my-agent',
   model: '__GATEWAY_OPENAI_MODEL_NANO__',
-  processors: {
-    input: [
-      new RegexFilterProcessor({
-        presets: ['pii', 'secrets'],
-        strategy: 'block',
-      }),
-    ],
-  },
+  inputProcessors: [
+    new RegexFilterProcessor({
+      presets: ['pii', 'secrets'],
+      strategy: 'block',
+    }),
+  ],
 })
 ```
 
@@ -127,6 +125,14 @@ const agent = new Agent({
       "Phases to apply the filter. 'input' filters input messages. 'output' filters output stream and result. 'all' filters both.",
     isOptional: true,
     defaultValue: "'all'",
+  },
+  {
+    name: 'includeRedactedValues',
+    type: 'boolean',
+    description:
+      'Include the text that was redacted in each report entry. Off by default, because the values are the data the processor removes.',
+    isOptional: true,
+    defaultValue: 'false',
   },
 ]}
 />
@@ -200,3 +206,117 @@ const filter = new RegexFilterProcessor({
 ```
 
 A replacement string can reference capture groups with `$1` or `$&`. Those references resolve for a single match whose pattern also matches the matched text on its own. In a combined region, or for a rule anchored on its surroundings with a lookbehind or lookahead, the replacement string is inserted as written. The region is redacted either way.
+
+## Redaction reporting
+
+The `redact` strategy rewrites text in place, so nothing downstream can tell what changed. Assign `onViolation` to record it. The processor calls it once per redacted message, message part, or stream chunk, and offsets are relative to that piece of text. Async callbacks are awaited, and errors are caught so an unavailable audit sink cannot fail the request.
+
+```typescript
+import { RegexFilterProcessor, type RegexRedactionDetail } from '@mastra/core/processors'
+
+const filter = new RegexFilterProcessor({
+  presets: ['pii'],
+  strategy: 'redact',
+})
+
+filter.onViolation = async ({ detail }) => {
+  const redaction = detail as RegexRedactionDetail
+
+  for (const entry of redaction.redactions) {
+    await auditLog.write({
+      phase: redaction.phase,
+      messageId: redaction.messageId,
+      rule: entry.rule,
+      offset: entry.index,
+      length: entry.length,
+    })
+  }
+}
+```
+
+The callback is awaited, including in `processOutputStream`, where it runs for every chunk that contains a match. Keep the callback fast, or hand the work to a queue, so a slow audit sink doesn't stall a streaming response. With no callback attached, the `redact` path stays synchronous.
+
+The `block` strategy reports through the same callback. There the processor runner invokes it when it catches the `TripWire`, so `detail` holds the tripwire metadata described under [Error behavior](#error-behavior) rather than the shape below.
+
+`detail` for a redaction is a `RegexRedactionDetail`:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'strategy',
+    type: "'redact'",
+    description: 'Distinguishes a redaction report from the block strategy payload.',
+    isOptional: false,
+  },
+  {
+    name: 'phase',
+    type: "'processInput' | 'processOutputStream' | 'processOutputResult'",
+    description: 'Processor method that applied the redactions.',
+    isOptional: false,
+  },
+  {
+    name: 'messageId',
+    type: 'string',
+    description: 'Id of the message the text came from. Absent for stream chunks.',
+    isOptional: true,
+  },
+  {
+    name: 'partIndex',
+    type: 'number',
+    description:
+      "Index of the redacted part in the message's parts array, which also contains non-text parts. Absent for string content and stream chunks.",
+    isOptional: true,
+  },
+  {
+    name: 'redactions',
+    type: 'RegexRedaction[]',
+    description: 'Redactions in the order they appear in the text.',
+    isOptional: false,
+    properties: [
+      {
+        type: 'RegexRedaction',
+        parameters: [
+          {
+            name: 'rule',
+            type: 'string',
+            description: 'Name of the rule whose replacement was used.',
+            isOptional: false,
+          },
+          {
+            name: 'index',
+            type: 'number',
+            description: 'Start offset of the redacted span in the text.',
+            isOptional: false,
+          },
+          {
+            name: 'length',
+            type: 'number',
+            description: 'Length of the redacted span.',
+            isOptional: false,
+          },
+          {
+            name: 'replacement',
+            type: 'string',
+            description: 'Text that replaced the span.',
+            isOptional: false,
+          },
+          {
+            name: 'overlappingRules',
+            type: 'string[]',
+            description: 'Names of all rules that matched this span, set only when more than one overlapped.',
+            isOptional: true,
+          },
+          {
+            name: 'value',
+            type: 'string',
+            description: 'The text that was redacted. Set only when includeRedactedValues is enabled.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+Values are left out by default. An audit trail that copies the data it protects widens the exposure it was added to narrow. Set `includeRedactedValues` only when the destination is as protected as the original, and note that the `block` strategy also withholds matched text from its `TripWire` metadata for the same reason.

--- a/docs/src/content/en/reference/processors/regex-filter-processor.mdx
+++ b/docs/src/content/en/reference/processors/regex-filter-processor.mdx
@@ -185,3 +185,18 @@ When the `block` strategy is active (default), `RegexFilterProcessor` throws a `
 | `pii` | Emails, phone numbers, SSNs, credit card numbers | `[EMAIL]`, `[PHONE]`, `[SSN]`, `[CREDIT_CARD]` |
 | `secrets` | API keys, bearer tokens, AWS access keys | `[API_KEY]`, `[BEARER_TOKEN]`, `[AWS_KEY]` |
 | `urls` | HTTP/HTTPS URLs | `[URL]` |
+
+## Redaction behavior
+
+Every rule is matched independently, so two rules can claim text that overlaps. A card number written without separators matches both `phone` and `credit-card`, for example. Overlapping matches are combined into a single region and replaced once, using the replacement of the longest match.
+
+```typescript
+const filter = new RegexFilterProcessor({
+  presets: ['pii'],
+  strategy: 'redact',
+})
+
+// "Charge 4111111111111111 today" becomes "Charge [CREDIT_CARD] today"
+```
+
+A replacement string can reference capture groups with `$1` or `$&`. Those references resolve for a single match whose pattern also matches the matched text on its own. In a combined region, or for a rule anchored on its surroundings with a lookbehind or lookahead, the replacement string is inserted as written. The region is redacted either way.

--- a/packages/core/src/processors/processors/index.ts
+++ b/packages/core/src/processors/processors/index.ts
@@ -58,6 +58,8 @@ export {
   type RegexMatch,
   type RegexPreset,
   type RegexFilterTripwireMetadata,
+  type RegexRedaction,
+  type RegexRedactionDetail,
 } from './regex-filter';
 export { ToolCallFilter } from './tool-call-filter';
 

--- a/packages/core/src/processors/processors/regex-filter.test.ts
+++ b/packages/core/src/processors/processors/regex-filter.test.ts
@@ -386,6 +386,13 @@ describe('RegexFilterProcessor', () => {
       );
     });
 
+    it('falls back when the pattern covers less of the region on its own', () => {
+      const text = redactWith([{ name: 'lead', pattern: /\d+(?=\d)/g, replacement: '<$&>' }], '1234');
+
+      expect(text).toBe('<$&>4');
+      expect(text).not.toContain('12');
+    });
+
     it('leaves text untouched for a rule that only matches empty strings', () => {
       expect(redactWith([{ name: 'empty', pattern: /x*/g, replacement: '[Z]' }], 'abc')).toBe('abc');
     });

--- a/packages/core/src/processors/processors/regex-filter.test.ts
+++ b/packages/core/src/processors/processors/regex-filter.test.ts
@@ -208,6 +208,197 @@ describe('RegexFilterProcessor', () => {
     });
   });
 
+  describe('overlapping matches - redact strategy', () => {
+    function redactedText(text: string): string {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+      const result = filter.processInput(createInputArgs([createMessage(text)])) as MastraDBMessage[];
+      return (result[0].content as any).parts[0].text;
+    }
+
+    it('does not leave part of a bare card number in the clear', () => {
+      const text = redactedText('card 4111111111111111');
+
+      expect(text).toBe('card [CREDIT_CARD]');
+      expect(text).not.toContain('1111');
+    });
+
+    it('redacts a bare card number surrounded by text', () => {
+      expect(redactedText('pay 4111111111111111 now')).toBe('pay [CREDIT_CARD] now');
+    });
+
+    it('still redacts a separated card number', () => {
+      expect(redactedText('card 4111-1111-1111-1111')).toBe('card [CREDIT_CARD]');
+      expect(redactedText('card 4111 1111 1111 1111')).toBe('card [CREDIT_CARD]');
+    });
+
+    it('redacts non-overlapping matches independently', () => {
+      expect(redactedText('ssn 123-45-6789 card 4111111111111111')).toBe('ssn [SSN] card [CREDIT_CARD]');
+    });
+
+    it('redacts a contained match as a single region', () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii', 'urls'], strategy: 'redact' });
+      const result = filter.processInput(
+        createInputArgs([createMessage('see https://x.com/u/a@b.com now')]),
+      ) as MastraDBMessage[];
+
+      expect((result[0].content as any).parts[0].text).toBe('see [URL] now');
+    });
+
+    it('redacts overlapping matches in streaming chunks', async () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+      const part = {
+        type: 'text-delta',
+        runId: 'r',
+        from: 'AGENT',
+        payload: { id: 't1', text: 'card 4111111111111111' },
+      } as unknown as ChunkType;
+      const result = await filter.processOutputStream(createStreamArgs(part));
+
+      expect((result as any).payload.text).toBe('card [CREDIT_CARD]');
+    });
+
+    it('keeps capture groups in custom replacements', () => {
+      const filter = new RegexFilterProcessor({
+        rules: [{ name: 'order', pattern: /ID-(\d+)/g, replacement: '<$1>' }],
+        strategy: 'redact',
+      });
+
+      const result = filter.processInput(createInputArgs([createMessage('Your order ID-12345')])) as MastraDBMessage[];
+
+      expect((result[0].content as any).parts[0].text).toBe('Your order <12345>');
+    });
+
+    it('merges a partial overlap and keeps the longest rule', () => {
+      const filter = new RegexFilterProcessor({
+        rules: [
+          { name: 'short', pattern: /ab/g, replacement: '[SHORT]' },
+          { name: 'long', pattern: /bcdef/g, replacement: '[LONG]' },
+        ],
+        strategy: 'redact',
+      });
+
+      const result = filter.processInput(createInputArgs([createMessage('xabcdefy')])) as MastraDBMessage[];
+
+      expect((result[0].content as any).parts[0].text).toBe('x[LONG]y');
+    });
+
+    it('does not merge matches that only touch', () => {
+      const filter = new RegexFilterProcessor({
+        rules: [
+          { name: 'first', pattern: /ab/g, replacement: '[A]' },
+          { name: 'second', pattern: /cd/g, replacement: '[B]' },
+        ],
+        strategy: 'redact',
+      });
+
+      const result = filter.processInput(createInputArgs([createMessage('abcd')])) as MastraDBMessage[];
+
+      expect((result[0].content as any).parts[0].text).toBe('[A][B]');
+    });
+
+    it('redacts several overlap groups in one message', () => {
+      expect(redactedText('card 4111111111111111 and card 4222222222222222')).toBe(
+        'card [CREDIT_CARD] and card [CREDIT_CARD]',
+      );
+    });
+
+    it('keeps offsets correct after multi-byte characters', () => {
+      expect(redactedText('💳 4111111111111111 ✅')).toBe('💳 [CREDIT_CARD] ✅');
+    });
+
+    it('reports every overlapping match when blocking', () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'block' });
+
+      try {
+        filter.processInput(createInputArgs([createMessage('card 4111111111111111')]));
+        expect.fail('Expected TripWire');
+      } catch (error) {
+        const rules = (error as TripWire<any>).options.metadata.matches.map((m: any) => m.rule);
+        expect(rules).toContain('phone');
+        expect(rules).toContain('credit-card');
+      }
+    });
+
+    it('redacts overlapping matches in output results', () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+      const result = filter.processOutputResult(
+        createOutputResultArgs([createMessage('card 4111111111111111', 'assistant')]),
+      ) as MastraDBMessage[];
+
+      expect((result[0].content as any).parts[0].text).toBe('card [CREDIT_CARD]');
+    });
+
+    it('redacts overlapping matches in string-form content', () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+      const message = { ...createMessage('placeholder'), content: 'card 4111111111111111' } as any;
+      const result = filter.processInput(createInputArgs([message])) as MastraDBMessage[];
+
+      expect(result[0].content).toBe('card [CREDIT_CARD]');
+    });
+
+    it('redacts each text part independently', () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+      const message: MastraDBMessage = {
+        id: 'msg-parts',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [
+            { type: 'text' as const, text: 'card 4111111111111111' },
+            { type: 'text' as const, text: 'clean text' },
+            { type: 'text' as const, text: 'ssn 123-45-6789' },
+          ],
+        },
+        createdAt: new Date(),
+      } as MastraDBMessage;
+
+      const result = filter.processInput(createInputArgs([message])) as MastraDBMessage[];
+      const parts = (result[0].content as any).parts;
+
+      expect(parts[0].text).toBe('card [CREDIT_CARD]');
+      expect(parts[1].text).toBe('clean text');
+      expect(parts[2].text).toBe('ssn [SSN]');
+    });
+  });
+
+  describe('replacement resolution', () => {
+    function redactWith(rules: any[], text: string): string {
+      const filter = new RegexFilterProcessor({ rules, strategy: 'redact' });
+      const result = filter.processInput(createInputArgs([createMessage(text)])) as MastraDBMessage[];
+      return (result[0].content as any).parts[0].text;
+    }
+
+    it('expands the whole-match reference', () => {
+      expect(redactWith([{ name: 'order', pattern: /ID-\d+/g, replacement: '<$&>' }], 'order ID-12345')).toBe(
+        'order <ID-12345>',
+      );
+    });
+
+    it('redacts a rule anchored on its surroundings', () => {
+      expect(redactWith([{ name: 'ctx', pattern: /(?<=card )\d{4}/g, replacement: '[X]' }], 'card 1234')).toBe(
+        'card [X]',
+      );
+    });
+
+    it('falls back to the literal replacement when a match cannot be re-resolved', () => {
+      expect(redactWith([{ name: 'ctx', pattern: /(?<=card )\d{4}/g, replacement: '<$&>' }], 'card 1234')).toBe(
+        'card <$&>',
+      );
+    });
+
+    it('leaves text untouched for a rule that only matches empty strings', () => {
+      expect(redactWith([{ name: 'empty', pattern: /x*/g, replacement: '[Z]' }], 'abc')).toBe('abc');
+    });
+
+    it('redacts only the first match for a non-global pattern', () => {
+      expect(redactWith([{ name: 'num', pattern: /\d+/, replacement: '[N]' }], 'a1 b2')).toBe('a[N] b2');
+    });
+
+    it('uses the default replacement when a rule omits one', () => {
+      expect(redactWith([{ name: 'num', pattern: /\d+/g }], 'a1 b2')).toBe('a[REDACTED] b[REDACTED]');
+    });
+  });
+
   describe('processInput - warn strategy', () => {
     it('logs warning and passes through', () => {
       const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/core/src/processors/processors/regex-filter.test.ts
+++ b/packages/core/src/processors/processors/regex-filter.test.ts
@@ -399,6 +399,205 @@ describe('RegexFilterProcessor', () => {
     });
   });
 
+  describe('onViolation reporting', () => {
+    function createFilter(options: Partial<Record<string, unknown>> = {}) {
+      const violations: any[] = [];
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact', ...options } as any);
+      filter.onViolation = violation => {
+        violations.push(violation);
+      };
+      return { filter, violations };
+    }
+
+    it('reports the rule, offset, length, and replacement', async () => {
+      const { filter, violations } = createFilter();
+
+      await filter.processInput(createInputArgs([createMessage('Contact user@example.com please')]));
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].processorId).toBe('regex-filter');
+      expect(violations[0].message).toContain('email');
+      expect(violations[0].detail).toMatchObject({ strategy: 'redact', phase: 'processInput' });
+      expect(violations[0].detail.redactions).toEqual([
+        { rule: 'email', index: 8, length: 16, replacement: '[EMAIL]' },
+      ]);
+    });
+
+    it('reports offsets into the original text, in document order', async () => {
+      const { filter, violations } = createFilter();
+
+      const text = 'ssn 123-45-6789 mail a@b.com';
+      await filter.processInput(createInputArgs([createMessage(text)]));
+
+      const [first, second] = violations[0].detail.redactions;
+      expect(first.rule).toBe('ssn');
+      expect(text.slice(first.index, first.index + first.length)).toBe('123-45-6789');
+      expect(second.rule).toBe('email');
+      expect(text.slice(second.index, second.index + second.length)).toBe('a@b.com');
+    });
+
+    it('lists the overlapping rules for a merged region', async () => {
+      const { filter, violations } = createFilter();
+
+      await filter.processInput(createInputArgs([createMessage('card 4111111111111111')]));
+
+      const [redaction] = violations[0].detail.redactions;
+      expect(redaction.rule).toBe('credit-card');
+      expect(redaction.overlappingRules).toEqual(expect.arrayContaining(['phone', 'credit-card']));
+    });
+
+    it('omits overlappingRules when only one rule matched', async () => {
+      const { filter, violations } = createFilter();
+
+      await filter.processInput(createInputArgs([createMessage('mail a@b.com')]));
+
+      expect(violations[0].detail.redactions[0]).not.toHaveProperty('overlappingRules');
+    });
+
+    it('omits the redacted value by default', async () => {
+      const { filter, violations } = createFilter();
+
+      await filter.processInput(createInputArgs([createMessage('mail a@b.com')]));
+
+      expect(violations[0].detail.redactions[0]).not.toHaveProperty('value');
+    });
+
+    it('includes the redacted value when opted in', async () => {
+      const { filter, violations } = createFilter({ includeRedactedValues: true });
+
+      await filter.processInput(createInputArgs([createMessage('mail a@b.com')]));
+
+      expect(violations[0].detail.redactions[0].value).toBe('a@b.com');
+    });
+
+    it('identifies the message and part a redaction came from', async () => {
+      const { filter, violations } = createFilter();
+
+      const message: MastraDBMessage = {
+        id: 'msg-fixed',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [
+            { type: 'text' as const, text: 'clean text' },
+            { type: 'text' as const, text: 'mail a@b.com' },
+          ],
+        },
+        createdAt: new Date(),
+      } as MastraDBMessage;
+
+      await filter.processInput(createInputArgs([message]));
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].detail.messageId).toBe('msg-fixed');
+      expect(violations[0].detail.partIndex).toBe(1);
+    });
+
+    it('identifies the message but no part for string content', async () => {
+      const { filter, violations } = createFilter();
+
+      const message = { ...createMessage('placeholder'), id: 'msg-string', content: 'mail a@b.com' } as any;
+      await filter.processInput(createInputArgs([message]));
+
+      expect(violations[0].detail.messageId).toBe('msg-string');
+      expect(violations[0].detail).not.toHaveProperty('partIndex');
+    });
+
+    it('reports stream chunks without a message or part', async () => {
+      const { filter, violations } = createFilter();
+
+      const part = {
+        type: 'text-delta',
+        runId: 'r',
+        from: 'AGENT',
+        payload: { id: 't1', text: 'mail a@b.com' },
+      } as unknown as ChunkType;
+      await filter.processOutputStream(createStreamArgs(part));
+
+      expect(violations[0].detail.phase).toBe('processOutputStream');
+      expect(violations[0].detail).not.toHaveProperty('messageId');
+      expect(violations[0].detail).not.toHaveProperty('partIndex');
+    });
+
+    it('reports output results with the matching phase', async () => {
+      const { filter, violations } = createFilter();
+
+      await filter.processOutputResult(createOutputResultArgs([createMessage('mail a@b.com', 'assistant')]));
+
+      expect(violations[0].detail.phase).toBe('processOutputResult');
+    });
+
+    it('waits for an async callback before returning', async () => {
+      const order: string[] = [];
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+      filter.onViolation = async () => {
+        await new Promise(resolve => setTimeout(resolve, 5));
+        order.push('callback');
+      };
+
+      await filter.processInput(createInputArgs([createMessage('mail a@b.com')]));
+      order.push('after');
+
+      expect(order).toEqual(['callback', 'after']);
+    });
+
+    it('stays synchronous when no callback is attached', () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+
+      const result = filter.processInput(createInputArgs([createMessage('mail a@b.com')]));
+
+      expect(result).not.toBeInstanceOf(Promise);
+      expect(((result as MastraDBMessage[])[0].content as any).parts[0].text).toBe('mail [EMAIL]');
+    });
+
+    it('is not called by the processor for the warn strategy', () => {
+      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { filter, violations } = createFilter({ strategy: 'warn' });
+
+      filter.processInput(createInputArgs([createMessage('mail a@b.com')]));
+
+      expect(violations).toHaveLength(0);
+      spy.mockRestore();
+    });
+
+    it('is not called by the processor for the block strategy', () => {
+      const { filter, violations } = createFilter({ strategy: 'block' });
+
+      expect(() => filter.processInput(createInputArgs([createMessage('mail a@b.com')]))).toThrow(TripWire);
+      expect(violations).toHaveLength(0);
+    });
+
+    it('is not called when nothing matched', async () => {
+      const { filter, violations } = createFilter();
+
+      await filter.processInput(createInputArgs([createMessage('nothing sensitive here')]));
+
+      expect(violations).toHaveLength(0);
+    });
+
+    it('still redacts when the callback throws', async () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+      filter.onViolation = () => {
+        throw new Error('audit sink down');
+      };
+
+      const result = (await filter.processInput(createInputArgs([createMessage('mail a@b.com')]))) as MastraDBMessage[];
+
+      expect((result[0].content as any).parts[0].text).toBe('mail [EMAIL]');
+    });
+
+    it('still redacts when an async callback rejects', async () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+      filter.onViolation = async () => {
+        throw new Error('audit sink down');
+      };
+
+      const result = (await filter.processInput(createInputArgs([createMessage('mail a@b.com')]))) as MastraDBMessage[];
+
+      expect((result[0].content as any).parts[0].text).toBe('mail [EMAIL]');
+    });
+  });
+
   describe('processInput - warn strategy', () => {
     it('logs warning and passes through', () => {
       const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/core/src/processors/processors/regex-filter.ts
+++ b/packages/core/src/processors/processors/regex-filter.ts
@@ -359,11 +359,12 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
    * Resolve the text that replaces a region.
    *
    * Replacements containing `$` may reference capture groups, so those are
-   * resolved by re-running the rule against the matched slice. That only works
-   * when the pattern still matches in isolation — a rule anchored on its
-   * surroundings (lookbehind, lookahead) will not — and a merged region no
-   * longer corresponds to a single pattern at all. Both fall back to the
-   * replacement string as written, so a region is always redacted.
+   * resolved by re-running the rule against the matched slice. That requires the
+   * pattern to still cover the whole slice on its own, which it will not when the
+   * rule is anchored on its surroundings or when its match length depended on
+   * text outside the region. A merged region does not correspond to a single
+   * pattern at all. Every one of those falls back to the replacement string as
+   * written, so the region is replaced whole and no part of it survives.
    */
   private resolveReplacement(text: string, region: RedactionRegion): string {
     const { rule } = region.owner;
@@ -371,7 +372,8 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
     if (region.matches.length > 1 || !replacement.includes('$')) return replacement;
 
     const matched = text.slice(region.start, region.end);
-    if (!compilePattern(rule).test(matched)) return replacement;
+    const isolated = compilePattern(rule).exec(matched);
+    if (!isolated || isolated.index !== 0 || isolated[0].length !== matched.length) return replacement;
 
     return matched.replace(compilePattern(rule), replacement);
   }

--- a/packages/core/src/processors/processors/regex-filter.ts
+++ b/packages/core/src/processors/processors/regex-filter.ts
@@ -74,8 +74,12 @@ interface RedactionRegion {
   end: number;
   /** Longest match contributing to this region; supplies the replacement */
   owner: RuleMatch;
-  /** Every match merged into this region, including the owner */
-  matches: RuleMatch[];
+  /**
+   * Rule names of every match merged into this region, set only once a second
+   * match joins. Left undefined for the common one-match region so a region
+   * costs no extra allocation.
+   */
+  overlappingRules?: string[];
 }
 
 /**
@@ -335,7 +339,7 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
    * the clear, so overlapping ranges are unioned and redacted once.
    */
   private buildRedactionRegions(matches: RuleMatch[]): RedactionRegion[] {
-    const ordered = [...matches]
+    const ordered = matches
       .filter(match => matchLength(match) > 0)
       .sort((a, b) => a.start - b.start || matchLength(b) - matchLength(a));
 
@@ -344,12 +348,12 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
       const current = regions.at(-1);
       if (current && match.start < current.end) {
         current.end = Math.max(current.end, match.end);
-        current.matches.push(match);
+        (current.overlappingRules ??= [current.owner.rule.name]).push(match.rule.name);
         if (matchLength(match) > matchLength(current.owner)) {
           current.owner = match;
         }
       } else {
-        regions.push({ start: match.start, end: match.end, owner: match, matches: [match] });
+        regions.push({ start: match.start, end: match.end, owner: match });
       }
     }
     return regions;
@@ -369,7 +373,7 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
   private resolveReplacement(text: string, region: RedactionRegion): string {
     const { rule } = region.owner;
     const replacement = rule.replacement ?? '[REDACTED]';
-    if (region.matches.length > 1 || !replacement.includes('$')) return replacement;
+    if (region.overlappingRules || !replacement.includes('$')) return replacement;
 
     const matched = text.slice(region.start, region.end);
     const isolated = compilePattern(rule).exec(matched);
@@ -394,13 +398,13 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
       result += text.slice(cursor, region.start) + replacement;
       cursor = region.end;
 
-      const overlappingRules = [...new Set(region.matches.map(match => match.rule.name))];
+      const overlappingRules = region.overlappingRules && [...new Set(region.overlappingRules)];
       redactions.push({
         rule: region.owner.rule.name,
         index: region.start,
         length: region.end - region.start,
         replacement,
-        ...(overlappingRules.length > 1 ? { overlappingRules } : {}),
+        ...(overlappingRules && overlappingRules.length > 1 ? { overlappingRules } : {}),
         ...(this.includeRedactedValues ? { value: text.slice(region.start, region.end) } : {}),
       });
     }

--- a/packages/core/src/processors/processors/regex-filter.ts
+++ b/packages/core/src/processors/processors/regex-filter.ts
@@ -35,6 +35,49 @@ export interface RegexMatch {
 }
 
 /**
+ * Internal match that keeps a reference to the originating rule and both
+ * offsets. `RegexMatch` only carries the rule name, which is ambiguous when two
+ * rules share a name, and no end offset.
+ */
+interface RuleMatch {
+  /** The rule that produced this match */
+  rule: RegexRule;
+  /** Start offset of the match in the text */
+  start: number;
+  /** End offset (exclusive) of the match in the text */
+  end: number;
+}
+
+/**
+ * Width of a match in characters, used to pick the winner among overlaps.
+ */
+function matchLength(match: RuleMatch): number {
+  return match.end - match.start;
+}
+
+/**
+ * Rules are matched with a fresh RegExp each time so a `lastIndex` left over
+ * from a previous pass can never skip part of the next text.
+ */
+function compilePattern(rule: RegexRule): RegExp {
+  return new RegExp(rule.pattern.source, rule.pattern.flags);
+}
+
+/**
+ * A span of text to replace, built by unioning overlapping matches.
+ */
+interface RedactionRegion {
+  /** Start offset of the region in the text */
+  start: number;
+  /** End offset (exclusive) of the region in the text */
+  end: number;
+  /** Longest match contributing to this region; supplies the replacement */
+  owner: RuleMatch;
+  /** How many matches were merged into this region */
+  mergedCount: number;
+}
+
+/**
  * Metadata attached to the TripWire when the regex filter blocks
  */
 export interface RegexFilterTripwireMetadata {
@@ -193,13 +236,18 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
     this.phase = options.phase ?? 'all';
   }
 
-  private findMatches(text: string): RegexMatch[] {
-    const matches: RegexMatch[] = [];
+  /**
+   * Run every rule over the text and collect all matches, grouped by rule in
+   * declaration order. Matches may overlap; callers that rewrite text must
+   * de-overlap them first.
+   */
+  private collectMatches(text: string): RuleMatch[] {
+    const matches: RuleMatch[] = [];
     for (const rule of this.rules) {
-      const regex = new RegExp(rule.pattern.source, rule.pattern.flags);
+      const regex = compilePattern(rule);
       let m: RegExpExecArray | null;
       while ((m = regex.exec(text)) !== null) {
-        matches.push({ rule: rule.name, match: m[0], index: m.index });
+        matches.push({ rule, start: m.index, end: m.index + m[0].length });
         if (!regex.global) break;
         if (m[0].length === 0) {
           regex.lastIndex++;
@@ -209,13 +257,80 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
     return matches;
   }
 
-  private redactText(text: string): string {
-    let result = text;
-    for (const rule of this.rules) {
-      const regex = new RegExp(rule.pattern.source, rule.pattern.flags);
-      result = result.replace(regex, rule.replacement ?? '[REDACTED]');
+  /**
+   * Public-shaped view of the matches, used for block and warn reporting.
+   */
+  private findMatches(text: string): RegexMatch[] {
+    return this.collectMatches(text).map(({ rule, start, end }) => ({
+      rule: rule.name,
+      match: text.slice(start, end),
+      index: start,
+    }));
+  }
+
+  /**
+   * Collapses the raw matches into disjoint regions, merging any that overlap.
+   * Each rule is matched independently, so two rules can claim intersecting
+   * ranges (a bare 16-digit card number matches both `phone` and `credit-card`).
+   * Replacing them one rule at a time leaves the tail of the longer match in
+   * the clear, so overlapping ranges are unioned and redacted once.
+   */
+  private buildRedactionRegions(matches: RuleMatch[]): RedactionRegion[] {
+    const ordered = [...matches]
+      .filter(match => matchLength(match) > 0)
+      .sort((a, b) => a.start - b.start || matchLength(b) - matchLength(a));
+
+    const regions: RedactionRegion[] = [];
+    for (const match of ordered) {
+      const current = regions.at(-1);
+      if (current && match.start < current.end) {
+        current.end = Math.max(current.end, match.end);
+        current.mergedCount += 1;
+        if (matchLength(match) > matchLength(current.owner)) {
+          current.owner = match;
+        }
+      } else {
+        regions.push({ start: match.start, end: match.end, owner: match, mergedCount: 1 });
+      }
     }
-    return result;
+    return regions;
+  }
+
+  /**
+   * Resolve the text that replaces a region.
+   *
+   * Replacements containing `$` may reference capture groups, so those are
+   * resolved by re-running the rule against the matched slice. That only works
+   * when the pattern still matches in isolation — a rule anchored on its
+   * surroundings (lookbehind, lookahead) will not — and a merged region no
+   * longer corresponds to a single pattern at all. Both fall back to the
+   * replacement string as written, so a region is always redacted.
+   */
+  private resolveReplacement(text: string, region: RedactionRegion): string {
+    const { rule } = region.owner;
+    const replacement = rule.replacement ?? '[REDACTED]';
+    if (region.mergedCount > 1 || !replacement.includes('$')) return replacement;
+
+    const matched = text.slice(region.start, region.end);
+    if (!compilePattern(rule).test(matched)) return replacement;
+
+    return matched.replace(compilePattern(rule), replacement);
+  }
+
+  /**
+   * Replace every matched region of the text with its rule's replacement.
+   */
+  private redactText(text: string): string {
+    const regions = this.buildRedactionRegions(this.collectMatches(text));
+    if (regions.length === 0) return text;
+
+    let result = '';
+    let cursor = 0;
+    for (const region of regions) {
+      result += text.slice(cursor, region.start) + this.resolveReplacement(text, region);
+      cursor = region.end;
+    }
+    return result + text.slice(cursor);
   }
 
   private extractSegments(messages: MastraDBMessage[]): string[] {

--- a/packages/core/src/processors/processors/regex-filter.ts
+++ b/packages/core/src/processors/processors/regex-filter.ts
@@ -7,6 +7,7 @@ import type {
   ProcessOutputResultArgs,
   ProcessOutputStreamArgs,
   ProcessorMessageResult,
+  ProcessorViolation,
   Processor,
 } from '../index';
 
@@ -73,8 +74,46 @@ interface RedactionRegion {
   end: number;
   /** Longest match contributing to this region; supplies the replacement */
   owner: RuleMatch;
-  /** How many matches were merged into this region */
-  mergedCount: number;
+  /** Every match merged into this region, including the owner */
+  matches: RuleMatch[];
+}
+
+/**
+ * One span of text that the `redact` strategy rewrote.
+ */
+export interface RegexRedaction {
+  /** Name of the rule whose replacement was used */
+  rule: string;
+  /** Start offset of the redacted span in the text */
+  index: number;
+  /** Length of the redacted span */
+  length: number;
+  /** Text that replaced the span */
+  replacement: string;
+  /** Names of all rules that matched this span, when more than one overlapped */
+  overlappingRules?: string[];
+  /** The text that was redacted. Only set when `includeRedactedValues` is enabled */
+  value?: string;
+}
+
+/**
+ * `ProcessorViolation.detail` for a redaction. Reports the redactions applied to
+ * one piece of text, so the offsets always refer to a single message, message
+ * part, or stream chunk.
+ */
+export interface RegexRedactionDetail {
+  strategy: 'redact';
+  /** Processor method that applied the redactions */
+  phase: 'processInput' | 'processOutputStream' | 'processOutputResult';
+  /** Id of the message the text came from. Absent for stream chunks */
+  messageId?: string;
+  /**
+   * Index of the redacted part in the message's `parts` array, which also
+   * contains non-text parts. Absent for string content and stream chunks.
+   */
+  partIndex?: number;
+  /** Redactions in the order they appear in the text */
+  redactions: RegexRedaction[];
 }
 
 /**
@@ -124,6 +163,15 @@ export interface RegexFilterOptions {
    * - 'all': Filter both input and output (default)
    */
   phase?: 'input' | 'output' | 'all';
+
+  /**
+   * Include the text that was redacted in `RegexRedaction.value`.
+   *
+   * Off by default: the values are the data the processor exists to remove, so
+   * an audit trail should not become a second copy of them. Turn it on only
+   * when the destination is as protected as the original.
+   */
+  includeRedactedValues?: boolean;
 }
 
 const PII_RULES: RegexRule[] = [
@@ -223,6 +271,16 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
   private rules: RegexRule[];
   private strategy: 'block' | 'redact' | 'warn';
   private phase: 'input' | 'output' | 'all';
+  private includeRedactedValues: boolean;
+
+  /**
+   * Invoked when the `redact` strategy rewrites a piece of text, once per
+   * redacted message, message part, or stream chunk, with a
+   * {@link RegexRedactionDetail} as `detail`. The `block` strategy reports
+   * through the same callback, driven by the processor runner when it catches
+   * the TripWire.
+   */
+  public onViolation?: (violation: ProcessorViolation) => void | Promise<void>;
 
   constructor(options: RegexFilterOptions) {
     const presetRules = (options.presets ?? []).flatMap(preset => PRESET_MAP[preset] ?? []);
@@ -234,6 +292,7 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
 
     this.strategy = options.strategy ?? 'block';
     this.phase = options.phase ?? 'all';
+    this.includeRedactedValues = options.includeRedactedValues ?? false;
   }
 
   /**
@@ -285,12 +344,12 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
       const current = regions.at(-1);
       if (current && match.start < current.end) {
         current.end = Math.max(current.end, match.end);
-        current.mergedCount += 1;
+        current.matches.push(match);
         if (matchLength(match) > matchLength(current.owner)) {
           current.owner = match;
         }
       } else {
-        regions.push({ start: match.start, end: match.end, owner: match, mergedCount: 1 });
+        regions.push({ start: match.start, end: match.end, owner: match, matches: [match] });
       }
     }
     return regions;
@@ -309,7 +368,7 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
   private resolveReplacement(text: string, region: RedactionRegion): string {
     const { rule } = region.owner;
     const replacement = rule.replacement ?? '[REDACTED]';
-    if (region.mergedCount > 1 || !replacement.includes('$')) return replacement;
+    if (region.matches.length > 1 || !replacement.includes('$')) return replacement;
 
     const matched = text.slice(region.start, region.end);
     if (!compilePattern(rule).test(matched)) return replacement;
@@ -318,19 +377,68 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
   }
 
   /**
-   * Replace every matched region of the text with its rule's replacement.
+   * Replace every matched region of the text with its rule's replacement, and
+   * describe each replacement so callers can report it.
    */
-  private redactText(text: string): string {
+  private redactText(text: string): { text: string; redactions: RegexRedaction[] } {
     const regions = this.buildRedactionRegions(this.collectMatches(text));
-    if (regions.length === 0) return text;
+    if (regions.length === 0) return { text, redactions: [] };
 
+    const redactions: RegexRedaction[] = [];
     let result = '';
     let cursor = 0;
     for (const region of regions) {
-      result += text.slice(cursor, region.start) + this.resolveReplacement(text, region);
+      const replacement = this.resolveReplacement(text, region);
+      result += text.slice(cursor, region.start) + replacement;
       cursor = region.end;
+
+      const overlappingRules = [...new Set(region.matches.map(match => match.rule.name))];
+      redactions.push({
+        rule: region.owner.rule.name,
+        index: region.start,
+        length: region.end - region.start,
+        replacement,
+        ...(overlappingRules.length > 1 ? { overlappingRules } : {}),
+        ...(this.includeRedactedValues ? { value: text.slice(region.start, region.end) } : {}),
+      });
     }
-    return result + text.slice(cursor);
+    return { text: result + text.slice(cursor), redactions };
+  }
+
+  /**
+   * Hand a redaction to `onViolation`, if one is set and anything changed.
+   * Returns nothing when there is no callback, so the redact path stays
+   * synchronous unless a caller actually attached one.
+   */
+  private reportRedaction(
+    phase: RegexRedactionDetail['phase'],
+    redactions: RegexRedaction[],
+    location?: { messageId?: string; partIndex?: number },
+  ): void | Promise<void> {
+    if (!this.onViolation || redactions.length === 0) return;
+
+    const ruleNames = [...new Set(redactions.map(redaction => redaction.rule))].join(', ');
+    const detail: RegexRedactionDetail = {
+      strategy: 'redact',
+      phase,
+      ...(location?.messageId !== undefined ? { messageId: location.messageId } : {}),
+      ...(location?.partIndex !== undefined ? { partIndex: location.partIndex } : {}),
+      redactions,
+    };
+
+    try {
+      return Promise.resolve(
+        this.onViolation({
+          processorId: this.id,
+          message: `Regex filter: redacted content matching patterns: ${ruleNames}`,
+          detail,
+        }),
+      ).catch(() => {
+        // onViolation errors are silently caught
+      });
+    } catch {
+      // onViolation errors are silently caught
+    }
   }
 
   private extractSegments(messages: MastraDBMessage[]): string[] {
@@ -392,20 +500,39 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
     }
   }
 
-  private redactMessages(messages: MastraDBMessage[]): MastraDBMessage[] {
-    return messages.map(msg => {
+  /**
+   * Redact every text segment of every message, reporting each segment
+   * separately so the offsets in a report always refer to one piece of text.
+   *
+   * Returns the messages directly when nothing is awaiting a report, keeping the
+   * common case synchronous, and a promise once `onViolation` is set.
+   */
+  private redactMessages(
+    messages: MastraDBMessage[],
+    phase: RegexRedactionDetail['phase'],
+  ): MastraDBMessage[] | Promise<MastraDBMessage[]> {
+    const pending: Promise<void>[] = [];
+    const collect = (report: void | Promise<void>) => {
+      if (report) pending.push(report);
+    };
+
+    const redactedMessages = messages.map(msg => {
       if (typeof msg.content === 'string') {
         // At runtime, content may be a plain string even though MastraDBMessage types it as MastraMessageContentV2.
         // Redact the string and preserve the original shape.
-        return { ...msg, content: this.redactText(msg.content) } as unknown as MastraDBMessage;
+        const redacted = this.redactText(msg.content);
+        collect(this.reportRedaction(phase, redacted.redactions, { messageId: msg.id }));
+        return { ...msg, content: redacted.text } as unknown as MastraDBMessage;
       }
       if (!msg.content || typeof msg.content !== 'object' || !('parts' in msg.content) || !msg.content.parts) {
         return msg;
       }
 
-      const newParts = msg.content.parts.map(part => {
+      const newParts = msg.content.parts.map((part, partIndex) => {
         if (part.type === 'text' && 'text' in part) {
-          return { ...part, text: this.redactText((part as { type: 'text'; text: string }).text) };
+          const redacted = this.redactText((part as { type: 'text'; text: string }).text);
+          collect(this.reportRedaction(phase, redacted.redactions, { messageId: msg.id, partIndex }));
+          return { ...part, text: redacted.text };
         }
         return part;
       });
@@ -415,6 +542,9 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
         content: { ...msg.content, parts: newParts },
       };
     });
+
+    if (pending.length === 0) return redactedMessages;
+    return Promise.all(pending).then(() => redactedMessages);
   }
 
   processInput(args: ProcessInputArgs<RegexFilterTripwireMetadata>): ProcessInputResult | Promise<ProcessInputResult> {
@@ -427,7 +557,7 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
     this.handleMatches(matches, 'content');
 
     if (this.strategy === 'redact') {
-      return this.redactMessages(args.messages);
+      return this.redactMessages(args.messages, 'processInput');
     }
 
     return args.messages;
@@ -445,7 +575,9 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
           this.blockWithTripWire(matches, 'streaming content');
         }
         if (this.strategy === 'redact') {
-          return { ...args.part, payload: { ...args.part.payload, text: this.redactText(args.part.payload.text) } };
+          const redacted = this.redactText(args.part.payload.text);
+          await this.reportRedaction('processOutputStream', redacted.redactions);
+          return { ...args.part, payload: { ...args.part.payload, text: redacted.text } };
         }
         if (this.strategy === 'warn') {
           const ruleNames = [...new Set(matches.map(m => m.rule))].join(', ');
@@ -466,7 +598,7 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
     this.handleMatches(matches, 'content');
 
     if (this.strategy === 'redact') {
-      return this.redactMessages(args.messages);
+      return this.redactMessages(args.messages, 'processOutputResult');
     }
 
     return args.messages;


### PR DESCRIPTION
## Description

`RegexFilterProcessor`'s `redact` strategy found its matches, dropped them, and rewrote the text by running every rule again as a plain `String.replace`. Two problems came out of that one cause, so they're fixed together in two commits.

**Commit 1 — overlapping matches no longer leak** (`fix`, patch)

Rules ran one at a time, each over whatever the previous one left behind. In the `pii` preset `phone` is declared before `credit-card`, so a card number with no separators lost only its first ten digits:

```ts
new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });

// before: "card 4111111111111111"  ->  "card [PHONE]111111"
// after:  "card 4111111111111111"  ->  "card [CREDIT_CARD]"
```

Matches are now collapsed into disjoint regions, unioning any that overlap, and each region is replaced once using the longest match's replacement.

**Commit 2 — `redact` reports what it rewrote** (`feat`, minor)

Reporting goes through the existing `Processor.onViolation`, the same callback `block` already reaches when the runner catches its `TripWire`, and the one `CostGuardProcessor` calls itself on its non-block path.

```ts
import { RegexFilterProcessor, type RegexRedactionDetail } from '@mastra/core/processors';

const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });

filter.onViolation = async ({ detail }) => {
  const redaction = detail as RegexRedactionDetail;

  for (const entry of redaction.redactions) {
    await auditLog.write({
      phase: redaction.phase, // processInput | processOutputStream | processOutputResult
      messageId: redaction.messageId,
      rule: entry.rule, // 'credit-card'
      offset: entry.index,
      length: entry.length,
    });
  }
};
```

One report per redacted message, message part, or stream chunk, so offsets always refer to a single piece of text. When several rules matched the same span, the winning rule is `rule` and every rule that matched is listed in `overlappingRules`.

Async callbacks are awaited. With no callback attached the `redact` path stays synchronous, so nothing changes for existing callers.

**Values are withheld by default.** Reports carry offsets and rule names, not the matched text. An audit trail that copies the data it protects widens the exposure it was added to narrow, which is why `block` already replaces `match` with `'[REDACTED_MATCH]'` in its `TripWire` metadata. `includeRedactedValues: true` opts in for callers whose sink is as protected as the original.

### Two smaller behaviour changes to redaction

- A replacement referencing capture groups (`$1`, `$&`) falls back to the replacement string as written when the rule cannot match the text it matched in isolation, which happens with a lookbehind or lookahead. The region is still redacted either way — the previous code silently left such a region untouched under the new span logic, so this path is explicit and covered by a test.
- A rule that only matches empty strings no longer inserts its replacement between every character.

### Two things worth calling out

- **`warn` still only logs.** This PR wires `redact`. `CostGuardProcessor` does report through `onViolation` on its `warn` path, so wiring `warn` the same way would be consistent — happy to do it here or as a follow-up, whichever you prefer.
- **The `redact` path still scans the text twice**, once to decide whether anything matched and once inside the rewrite. That predates this PR and is unchanged; consolidating it seemed like separate work.

### Verification

- `pnpm --filter ./packages/core vitest run src/processors` — 39 files, 1042 passed, 1 skipped
- `pnpm --filter ./packages/core check` and `oxlint` / `eslint` on the changed files — clean
- `pnpm validate` in `docs` — 585 files pass. `lint:prose` could not run locally: `scripts/vale/bin/vale` fails with `mdx2vast not found` on untouched files too.

Two checks on the span rewrite specifically, since it changes a code path that had no overlap coverage:

- **Behaviour preserved.** Every string literal in `regex-filter.test.ts` (107 of them) produces byte-identical output under the old sequential `replace` and the new span logic. No existing literal contained overlapping matches, so the only behaviour that changes is the buggy case.
- **Tests actually catch the bug.** 13 of the 21 tests added in commit 1 fail against the pre-fix implementation. The other 8 are regression guards that pass both before and after (separated card numbers, capture groups, non-global patterns, default replacement, touching-but-not-overlapping spans).

Also corrects the agent example on the reference page, which used a `processors: { input: [...] }` option that does not exist — `Agent` takes `inputProcessors` and `outputProcessors`. `cost-guard-processor.mdx` has the same mistake but is left alone as out of scope.

## Related issue(s)

Fixes #20444

Context: #20234 asked for deterministic, LLM-free PII redaction and #20236 proposed a separate processor, which the team declined in favour of improving `RegexFilterProcessor`. This is that, narrowed to the two defects in the existing processor. #20234 stays open for the broader proposal.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
If two regex “redact” rules overlap, the old code could redact only part of the sensitive text—leaving other pieces visible. Now it redacts the whole overlapping region in one go and also tells you exactly what was removed and where.

## What changed
- Merges overlapping regex matches into disjoint spans and applies redaction once per span, using the replacement from the longest match (prevents partial redaction/leakage).
- Fixes `$` capture-group replacement resolution: only expands captures when the matched slice can be fully and safely re-covered; otherwise falls back to a full-region replacement strategy.
- Prevents rules that match only empty strings from inserting replacements between characters.
- Reports `redact` activity via `Processor.onViolation`, including:
  - processor phase and message/unit context (part vs chunk/stream),
  - message ID,
  - rule name(s),
  - offsets/lengths for the affected region,
  - replacement details,
  - `overlappingRules` when multiple rules overlap the same span.
- Excludes matched/redacted values from violation details by default; adds `includeRedactedValues` option (opt-in) to include the value in `RegexRedactionDetail`.
- Awaits async `onViolation` handlers, while keeping behavior synchronous when no callback is provided.
- Adds/updates documentation, types, and tests for overlapping redaction, streaming/structured reporting, and replacement-resolution edge cases.
- Updates an agent documentation example to use `inputProcessors`/`outputProcessors`.
- Re-exports `RegexRedaction` and `RegexRedactionDetail` types and extends `RegexFilterOptions` with `includeRedactedValues`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->