### PR TITLE
fix(cli): Pin exact versions on project creation

### DIFF
--- a/.changeset/exact-channel-versions-create.md
+++ b/.changeset/exact-channel-versions-create.md
@@ -1,0 +1,5 @@
+---
+'create-mastra': patch
+---
+
+Generated projects now pin every Mastra dependency to the exact version published on the invoked release channel instead of writing the channel tag (for example `alpha`) verbatim. If the CLI cannot resolve exact versions, it warns and falls back to the channel tag.

--- a/.changeset/exact-channel-versions-mastra.md
+++ b/.changeset/exact-channel-versions-mastra.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+`mastra create` now pins every Mastra dependency in generated default and empty projects to the exact version published on the invoked release channel instead of writing the channel tag (for example `alpha`) verbatim. If the CLI cannot resolve exact versions, it warns and falls back to the channel tag.

--- a/docs/src/content/en/reference/cli/create-mastra.mdx
+++ b/docs/src/content/en/reference/cli/create-mastra.mdx
@@ -57,6 +57,8 @@ npx create-mastra@latest my-empty-project --empty
 
 ## Automatic setup
 
+Default starter and empty scaffold projects pin generated Mastra dependencies to exact versions from the invoked release channel (for example, the exact `alpha` version rather than the `alpha` tag). If the CLI can't resolve exact versions, it warns and uses the channel tag instead. Custom templates remain template-owned — their dependencies are not modified.
+
 After installing dependencies, the command:
 
 1. Detects supported coding assistants on `PATH` and installs Mastra skills. If none are detected, it installs universal skills.

--- a/docs/src/content/en/reference/cli/create-mastra.mdx
+++ b/docs/src/content/en/reference/cli/create-mastra.mdx
@@ -57,8 +57,6 @@ npx create-mastra@latest my-empty-project --empty
 
 ## Automatic setup
 
-Default starter and empty scaffold projects pin generated Mastra dependencies to exact versions from the invoked release channel (for example, the exact `alpha` version rather than the `alpha` tag). If the CLI can't resolve exact versions, it warns and uses the channel tag instead. Custom templates remain template-owned — their dependencies are not modified.
-
 After installing dependencies, the command:
 
 1. Detects supported coding assistants on `PATH` and installs Mastra skills. If none are detected, it installs universal skills.

--- a/packages/cli/src/commands/create/provider-adapter.test.ts
+++ b/packages/cli/src/commands/create/provider-adapter.test.ts
@@ -3,11 +3,16 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { execa } from 'execa';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CreateLLMProvider } from './command';
 import { adaptDefaultTemplate, MANAGED_PROVIDER_CONFIGS } from './provider-adapter';
 import { PNPM_WORKSPACE } from './utils';
+
+vi.mock('execa');
+
+const mockedExeca = vi.mocked(execa);
 
 const templatePath = fileURLToPath(new URL('../../../../../templates/template-agent-harness', import.meta.url));
 const temporaryDirectories: string[] = [];
@@ -38,6 +43,12 @@ afterEach(async () => {
   await Promise.all(
     temporaryDirectories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })),
   );
+});
+
+beforeEach(() => {
+  mockedExeca.mockReset();
+  // Default: resolution fails so existing structural tests fall back to channel tags.
+  mockedExeca.mockRejectedValue(new Error('npm unavailable') as never);
 });
 
 const expectedAdaptations = {
@@ -76,6 +87,7 @@ const expectedAdaptations = {
 describe('adaptDefaultTemplate', () => {
   for (const provider of Object.keys(MANAGED_PROVIDER_CONFIGS) as CreateLLMProvider[]) {
     it(`adapts the default template completely for ${provider}`, async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const projectPath = await createFixture();
       const agentPath = path.join(projectPath, 'src/mastra/agents/agent.ts');
       const manifestPath = path.join(projectPath, 'package.json');
@@ -151,6 +163,7 @@ describe('adaptDefaultTemplate', () => {
         expect(functionalFiles).not.toContain(otherConfig.apiKeyEnv);
         expect(functionalFiles).not.toContain(`${otherConfig.providerIdentifier}.tools`);
       }
+      errorSpy.mockRestore();
     });
   }
 
@@ -284,5 +297,83 @@ describe('adaptDefaultTemplate', () => {
     await expect(
       adaptFixture({ projectPath: noReadmeProject, provider: 'google', versionTag: 'latest' }),
     ).resolves.toBeDefined();
+  });
+
+  it('resolves each Mastra dependency to its independently exact version on success', async () => {
+    mockedExeca.mockImplementation(((_cmd: string, args: string[]) => {
+      const pkg = args?.[1];
+      if (pkg === '@mastra/core') return Promise.resolve({ stdout: '1.55.0-alpha.0\n' }) as never;
+      if (pkg === '@mastra/duckdb') return Promise.resolve({ stdout: '1.5.2-alpha.0\n' }) as never;
+      if (pkg === '@mastra/libsql') return Promise.resolve({ stdout: '1.18.0-alpha.1\n' }) as never;
+      if (pkg === 'mastra') return Promise.resolve({ stdout: '1.21.0-alpha.0\n' }) as never;
+      if (pkg === '@mastra/memory') return Promise.resolve({ stdout: '1.24.0-alpha.0\n' }) as never;
+      if (pkg === '@mastra/observability') return Promise.resolve({ stdout: '1.16.3-alpha.0\n' }) as never;
+      return Promise.reject(new Error('unexpected')) as never;
+    }) as never);
+
+    const projectPath = await createFixture();
+    const manifestPath = path.join(projectPath, 'package.json');
+
+    await adaptFixture({ projectPath, provider: 'openai', versionTag: 'alpha' });
+
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+    for (const section of [manifest.dependencies, manifest.devDependencies]) {
+      for (const [packageName, version] of Object.entries(section)) {
+        if (packageName === 'mastra' || packageName.startsWith('@mastra/')) {
+          expect(version).not.toBe('alpha');
+          expect(version).not.toBe('latest');
+        }
+      }
+    }
+    expect(manifest.dependencies['@mastra/core']).toBe('1.55.0-alpha.0');
+    expect(manifest.dependencies['@mastra/libsql']).toBe('1.18.0-alpha.1');
+    expect(manifest.dependencies['@mastra/duckdb']).toBe('1.5.2-alpha.0');
+    expect(manifest.dependencies['@mastra/memory']).toBe('1.24.0-alpha.0');
+    expect(manifest.dependencies['@mastra/observability']).toBe('1.16.3-alpha.0');
+    expect(manifest.devDependencies.mastra).toBe('1.21.0-alpha.0');
+  });
+
+  it('warns once and preserves the channel tag for all Mastra packages on resolution failure', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockedExeca.mockRejectedValue(new Error('npm error') as never);
+
+    const projectPath = await createFixture();
+    const manifestPath = path.join(projectPath, 'package.json');
+    const originalManifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+
+    await adaptFixture({ projectPath, provider: 'openai', versionTag: 'snapshot-channel' });
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+    for (const section of [manifest.dependencies, manifest.devDependencies]) {
+      for (const [packageName, version] of Object.entries(section)) {
+        if (packageName === 'mastra' || packageName.startsWith('@mastra/')) {
+          expect(version).toBe('snapshot-channel');
+        }
+      }
+    }
+    expect(manifest.dependencies.zod).toBe(originalManifest.dependencies.zod);
+  });
+
+  it('performs no resolver lookup and no warning when the manifest has no Mastra packages', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const projectPath = await createFixture();
+    const manifestPath = path.join(projectPath, 'package.json');
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+
+    for (const section of ['dependencies', 'devDependencies'] as const) {
+      for (const key of Object.keys(manifest[section] ?? {})) {
+        if (key === 'mastra' || key.startsWith('@mastra/')) delete manifest[section][key];
+      }
+    }
+    await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+    await adaptFixture({ projectPath, provider: 'openai', versionTag: 'latest' });
+
+    expect(mockedExeca).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/packages/cli/src/commands/create/provider-adapter.test.ts
+++ b/packages/cli/src/commands/create/provider-adapter.test.ts
@@ -334,7 +334,7 @@ describe('adaptDefaultTemplate', () => {
   });
 
   it('warns once and preserves the channel tag for all Mastra packages on resolution failure', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     mockedExeca.mockRejectedValue(new Error('npm error') as never);
 
     const projectPath = await createFixture();
@@ -343,8 +343,8 @@ describe('adaptDefaultTemplate', () => {
 
     await adaptFixture({ projectPath, provider: 'openai', versionTag: 'snapshot-channel' });
 
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    errorSpy.mockRestore();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
 
     const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
     for (const section of [manifest.dependencies, manifest.devDependencies]) {

--- a/packages/cli/src/commands/create/provider-adapter.ts
+++ b/packages/cli/src/commands/create/provider-adapter.ts
@@ -345,7 +345,7 @@ export async function adaptDefaultTemplate({
   const mastraPackages = collectMastraPackages(packageJsonSource);
   const resolvedVersions = await resolveMastraPackageVersions(mastraPackages, versionTag);
   if (resolvedVersions === undefined && mastraPackages.length > 0) {
-    console.error(
+    console.warn(
       `We could not resolve exact Mastra package versions for the "${versionTag}" channel, using the channel tag instead`,
     );
   }

--- a/packages/cli/src/commands/create/provider-adapter.ts
+++ b/packages/cli/src/commands/create/provider-adapter.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 import type { PackageManager } from '../../utils/package-manager';
 import type { CreateLLMProvider } from './command';
 import { PNPM_WORKSPACE } from './utils';
+import type { ResolvedMastraVersions } from './version-resolver';
+import { resolveMastraPackageVersions } from './version-resolver';
 
 export interface ManagedProviderConfig {
   displayName: string;
@@ -107,10 +109,30 @@ function getDependencyMap(manifest: Record<string, unknown>, section: 'dependenc
   return value as Record<string, unknown>;
 }
 
+function collectMastraPackages(manifestSource: string): string[] {
+  let manifest: Record<string, unknown>;
+  try {
+    manifest = JSON.parse(manifestSource) as Record<string, unknown>;
+  } catch {
+    return [];
+  }
+  const names = new Set<string>();
+  for (const section of ['dependencies', 'devDependencies'] as const) {
+    const deps = manifest[section];
+    if (deps && typeof deps === 'object' && !Array.isArray(deps)) {
+      for (const name of Object.keys(deps as Record<string, unknown>)) {
+        if (name === 'mastra' || name.startsWith('@mastra/')) names.add(name);
+      }
+    }
+  }
+  return [...names];
+}
+
 function normalizeManagedManifest(
   content: string,
   provider: ManagedProviderConfig,
-  versionTag: string,
+  mastraVersions: ResolvedMastraVersions | undefined,
+  fallbackTag: string,
 ): { content: string; sdkVersion: string } {
   let manifest: Record<string, unknown>;
   try {
@@ -151,7 +173,9 @@ function normalizeManagedManifest(
 
   for (const section of dependencySections) {
     for (const packageName of Object.keys(section)) {
-      if (packageName === 'mastra' || packageName.startsWith('@mastra/')) section[packageName] = versionTag;
+      if (packageName === 'mastra' || packageName.startsWith('@mastra/')) {
+        section[packageName] = mastraVersions?.[packageName] ?? fallbackTag;
+      }
     }
   }
 
@@ -318,7 +342,14 @@ export async function adaptDefaultTemplate({
 
   const readmeSource = await fs.readFile(readmePath, 'utf8').catch(() => undefined);
   const nextAgent = adaptAgentSource(agentSource, provider, config);
-  const normalizedManifest = normalizeManagedManifest(packageJsonSource, config, versionTag);
+  const mastraPackages = collectMastraPackages(packageJsonSource);
+  const resolvedVersions = await resolveMastraPackageVersions(mastraPackages, versionTag);
+  if (resolvedVersions === undefined && mastraPackages.length > 0) {
+    console.error(
+      `We could not resolve exact Mastra package versions for the "${versionTag}" channel, using the channel tag instead`,
+    );
+  }
+  const normalizedManifest = normalizeManagedManifest(packageJsonSource, config, resolvedVersions, versionTag);
   const nextEnvExample = replaceEnvKey(envExampleSource, config.apiKeyEnv);
   const nextEnv = apiKey ? setEnvValue(nextEnvExample, config.apiKeyEnv, apiKey) : undefined;
   const nextReadme =

--- a/packages/cli/src/commands/create/scaffold.test.ts
+++ b/packages/cli/src/commands/create/scaffold.test.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { execa } from 'execa';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   cleanupOwnedStagingDirectory,
@@ -13,6 +14,10 @@ import {
   publishStagedProject,
   writeEmptyScaffold,
 } from './utils';
+
+vi.mock('execa');
+
+const mockedExeca = vi.mocked(execa);
 
 const temporaryDirectories: string[] = [];
 
@@ -40,6 +45,12 @@ afterEach(async () => {
   await Promise.all(
     temporaryDirectories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })),
   );
+});
+
+beforeEach(() => {
+  mockedExeca.mockReset();
+  // Default: resolution fails so structural tests fall back to channel tags.
+  mockedExeca.mockRejectedValue(new Error('npm unavailable') as never);
 });
 
 describe('empty scaffold', () => {
@@ -159,6 +170,77 @@ describe('empty scaffold', () => {
     ).not.toBe(
       JSON.parse(await fs.readFile(path.join(staging.projectPath, 'node_modules/mastra/package.json'), 'utf8')).version,
     );
+  });
+
+  it('writes exact resolved Mastra package versions on successful resolution', async () => {
+    mockedExeca.mockImplementation(((_cmd: string, args: string[]) => {
+      const pkg = args?.[1];
+      if (pkg === '@mastra/core') return Promise.resolve({ stdout: '1.55.0-alpha.0\n' }) as never;
+      if (pkg === 'mastra') return Promise.resolve({ stdout: '1.21.0-alpha.0\n' }) as never;
+      return Promise.reject(new Error('unexpected')) as never;
+    }) as never);
+
+    const invocationCwd = await createInvocationDirectory();
+    const staging = await createOwnedStagingDirectory(invocationCwd, 'exact-project');
+
+    await writeEmptyScaffold({
+      projectPath: staging.projectPath,
+      projectName: 'exact-project',
+      versionTag: 'alpha',
+      packageManager: 'npm',
+    });
+
+    const manifest = JSON.parse(await fs.readFile(path.join(staging.projectPath, 'package.json'), 'utf8'));
+    expect(manifest.dependencies['@mastra/core']).toBe('1.55.0-alpha.0');
+    expect(manifest.devDependencies.mastra).toBe('1.21.0-alpha.0');
+  });
+
+  it('warns once and falls back to the channel tag when resolution fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const invocationCwd = await createInvocationDirectory();
+    const staging = await createOwnedStagingDirectory(invocationCwd, 'fallback-project');
+
+    await writeEmptyScaffold({
+      projectPath: staging.projectPath,
+      projectName: 'fallback-project',
+      versionTag: 'alpha',
+      packageManager: 'npm',
+    });
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+
+    const manifest = JSON.parse(await fs.readFile(path.join(staging.projectPath, 'package.json'), 'utf8'));
+    expect(manifest.dependencies['@mastra/core']).toBe('alpha');
+    expect(manifest.devDependencies.mastra).toBe('alpha');
+  });
+
+  it('never produces a partial mixture of exact versions and channel tags', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let callCount = 0;
+    mockedExeca.mockImplementation((() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve({ stdout: '1.55.0-alpha.0\n' }) as never;
+      return Promise.reject(new Error('npm error')) as never;
+    }) as never);
+
+    const invocationCwd = await createInvocationDirectory();
+    const staging = await createOwnedStagingDirectory(invocationCwd, 'partial-project');
+
+    await writeEmptyScaffold({
+      projectPath: staging.projectPath,
+      projectName: 'partial-project',
+      versionTag: 'alpha',
+      packageManager: 'npm',
+    });
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+
+    const manifest = JSON.parse(await fs.readFile(path.join(staging.projectPath, 'package.json'), 'utf8'));
+    expect(manifest.dependencies['@mastra/core']).toBe('alpha');
+    expect(manifest.devDependencies.mastra).toBe('alpha');
   });
 });
 

--- a/packages/cli/src/commands/create/scaffold.test.ts
+++ b/packages/cli/src/commands/create/scaffold.test.ts
@@ -196,7 +196,7 @@ describe('empty scaffold', () => {
   });
 
   it('warns once and falls back to the channel tag when resolution fails', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const invocationCwd = await createInvocationDirectory();
     const staging = await createOwnedStagingDirectory(invocationCwd, 'fallback-project');
@@ -208,8 +208,8 @@ describe('empty scaffold', () => {
       packageManager: 'npm',
     });
 
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    errorSpy.mockRestore();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
 
     const manifest = JSON.parse(await fs.readFile(path.join(staging.projectPath, 'package.json'), 'utf8'));
     expect(manifest.dependencies['@mastra/core']).toBe('alpha');
@@ -217,7 +217,7 @@ describe('empty scaffold', () => {
   });
 
   it('never produces a partial mixture of exact versions and channel tags', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     let callCount = 0;
     mockedExeca.mockImplementation((() => {
       callCount++;
@@ -235,8 +235,8 @@ describe('empty scaffold', () => {
       packageManager: 'npm',
     });
 
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    errorSpy.mockRestore();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
 
     const manifest = JSON.parse(await fs.readFile(path.join(staging.projectPath, 'package.json'), 'utf8'));
     expect(manifest.dependencies['@mastra/core']).toBe('alpha');

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import type { PackageManager } from '../../utils/package-manager';
+import { resolveMastraPackageVersions } from './version-resolver';
 
 export const EMPTY_TSCONFIG = {
   compilerOptions: {
@@ -103,6 +104,16 @@ export async function writeEmptyScaffold({
 }): Promise<void> {
   await fs.mkdir(path.join(projectPath, 'src/mastra'), { recursive: true });
 
+  const mastraPackages = ['@mastra/core', 'mastra'];
+  const resolved = await resolveMastraPackageVersions(mastraPackages, versionTag);
+  if (resolved === undefined) {
+    console.error(
+      `We could not resolve exact Mastra package versions for the "${versionTag}" channel, using the channel tag instead`,
+    );
+  }
+  const coreVersion = resolved?.['@mastra/core'] ?? versionTag;
+  const mastraVersion = resolved?.mastra ?? versionTag;
+
   const packageJson = {
     name: projectName,
     version: '1.0.0',
@@ -117,10 +128,10 @@ export async function writeEmptyScaffold({
       start: 'mastra start',
     },
     dependencies: {
-      '@mastra/core': versionTag,
+      '@mastra/core': coreVersion,
     },
     devDependencies: {
-      mastra: versionTag,
+      mastra: mastraVersion,
       typescript: '^6.0.3',
       '@types/node': 'latest',
     },

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -107,7 +107,7 @@ export async function writeEmptyScaffold({
   const mastraPackages = ['@mastra/core', 'mastra'];
   const resolved = await resolveMastraPackageVersions(mastraPackages, versionTag);
   if (resolved === undefined) {
-    console.error(
+    console.warn(
       `We could not resolve exact Mastra package versions for the "${versionTag}" channel, using the channel tag instead`,
     );
   }

--- a/packages/cli/src/commands/create/version-resolver.test.ts
+++ b/packages/cli/src/commands/create/version-resolver.test.ts
@@ -1,0 +1,120 @@
+import { execa } from 'execa';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveMastraPackageVersions } from './version-resolver';
+
+vi.mock('execa');
+
+const mockedExeca = vi.mocked(execa);
+
+beforeEach(() => {
+  mockedExeca.mockReset();
+});
+
+describe('resolveMastraPackageVersions', () => {
+  it('resolves independent exact versions for packages with different numbering', async () => {
+    mockedExeca.mockImplementation(((_cmd: string, args: string[]) => {
+      const pkg = args?.[1];
+      if (pkg === '@mastra/core') return Promise.resolve({ stdout: '1.55.0-alpha.0\n' }) as never;
+      if (pkg === 'mastra') return Promise.resolve({ stdout: '1.21.0-alpha.0\n' }) as never;
+      if (pkg === '@mastra/libsql') return Promise.resolve({ stdout: '1.18.0-alpha.1\n' }) as never;
+      return Promise.reject(new Error('unexpected')) as never;
+    }) as never);
+
+    const result = await resolveMastraPackageVersions(['mastra', '@mastra/core', '@mastra/libsql'], 'alpha');
+
+    expect(result).toEqual({
+      '@mastra/core': '1.55.0-alpha.0',
+      '@mastra/libsql': '1.18.0-alpha.1',
+      mastra: '1.21.0-alpha.0',
+    });
+  });
+
+  it('dedupes and sorts package requests deterministically', async () => {
+    const calls: string[] = [];
+    mockedExeca.mockImplementation(((_cmd: string, args: string[]) => {
+      const pkg = args?.[1];
+      calls.push(pkg);
+      return Promise.resolve({ stdout: '1.0.0\n' }) as never;
+    }) as never);
+
+    await resolveMastraPackageVersions(['mastra', '@mastra/core', 'mastra', '@mastra/core'], 'latest');
+
+    expect(calls).toEqual(['@mastra/core', 'mastra']);
+  });
+
+  it('returns an empty map without invoking npm for an empty package set', async () => {
+    const result = await resolveMastraPackageVersions([], 'latest');
+
+    expect(result).toEqual({});
+    expect(mockedExeca).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when a dist-tag lookup command rejects', async () => {
+    mockedExeca.mockRejectedValue(new Error('npm error') as never);
+
+    const result = await resolveMastraPackageVersions(['mastra'], 'alpha');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when the dist-tag output is empty', async () => {
+    mockedExeca.mockResolvedValue({ stdout: '\n' } as never);
+
+    const result = await resolveMastraPackageVersions(['mastra'], 'alpha');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('fails the complete operation when only a subset resolves', async () => {
+    let callCount = 0;
+    mockedExeca.mockImplementation((() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve({ stdout: '1.0.0\n' }) as never;
+      return Promise.reject(new Error('npm error')) as never;
+    }) as never);
+
+    const result = await resolveMastraPackageVersions(['@mastra/core', 'mastra'], 'alpha');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('accepts a valid exact stable version', async () => {
+    mockedExeca.mockResolvedValue({ stdout: '1.50.2\n' } as never);
+
+    const result = await resolveMastraPackageVersions(['@mastra/core'], 'latest');
+
+    expect(result).toEqual({ '@mastra/core': '1.50.2' });
+  });
+
+  it('accepts a valid exact prerelease version', async () => {
+    mockedExeca.mockResolvedValue({ stdout: '1.55.0-alpha.0\n' } as never);
+
+    const result = await resolveMastraPackageVersions(['@mastra/core'], 'alpha');
+
+    expect(result).toEqual({ '@mastra/core': '1.55.0-alpha.0' });
+  });
+
+  const invalidValues: Array<[string, string]> = [
+    ['a dist-tag name', 'latest'],
+    ['a caret range', '^1.2.3'],
+    ['a tilde range', '~1.2.3'],
+    ['a noncanonical version', 'v1.2.3'],
+    ['invalid semver', 'not-a-version'],
+    ['an x-range', '1.x'],
+    ['empty string', ''],
+    ['npm diagnostic text', 'npm ERR! code E404\nnpm ERR! 404 Not Found'],
+    ['multiline output', '1.2.3\n1.2.4'],
+    ['whitespace-only', '   '],
+  ];
+
+  for (const [description, value] of invalidValues) {
+    it(`rejects ${description}`, async () => {
+      mockedExeca.mockResolvedValue({ stdout: `${value}\n` } as never);
+
+      const result = await resolveMastraPackageVersions(['mastra'], 'alpha');
+
+      expect(result).toBeUndefined();
+    });
+  }
+});

--- a/packages/cli/src/commands/create/version-resolver.ts
+++ b/packages/cli/src/commands/create/version-resolver.ts
@@ -1,0 +1,54 @@
+import { execa } from 'execa';
+import semver from 'semver';
+
+export type ResolvedMastraVersions = Record<string, string>;
+
+/**
+ * Resolve the exact published version for each requested Mastra package via its
+ * `dist-tags.<versionTag>` entry. Returns a complete map of exact versions only
+ * when every package resolves successfully; otherwise returns `undefined`.
+ *
+ * The low-level resolver never logs — the calling boundary owns the fallback
+ * warning.
+ */
+export async function resolveMastraPackageVersions(
+  packageNames: string[],
+  versionTag: string,
+): Promise<ResolvedMastraVersions | undefined> {
+  const uniqueNames = [...new Set(packageNames)].sort();
+  if (uniqueNames.length === 0) return {};
+
+  const resolved: ResolvedMastraVersions = {};
+
+  for (const packageName of uniqueNames) {
+    const result = await resolveSinglePackageVersion(packageName, versionTag);
+    if (result === undefined) return undefined;
+    resolved[packageName] = result;
+  }
+
+  return resolved;
+}
+
+async function resolveSinglePackageVersion(packageName: string, versionTag: string): Promise<string | undefined> {
+  let stdout: string;
+  try {
+    const { stdout: output } = await execa('npm', ['view', packageName, `dist-tags.${versionTag}`]);
+    stdout = output;
+  } catch {
+    return undefined;
+  }
+
+  const trimmed = stdout.trim();
+  if (!trimmed) return undefined;
+
+  // Require exactly one non-empty output line.
+  if (trimmed.includes('\n')) return undefined;
+
+  // Require the raw value to equal its semver-normalized form. This rejects
+  // tags (e.g. "latest"), ranges (e.g. "^1.2.3"), noncanonical forms (e.g.
+  // "v1.2.3"), and invalid semver, while accepting valid prerelease versions.
+  const normalized = semver.valid(trimmed);
+  if (normalized === null || normalized !== trimmed) return undefined;
+
+  return normalized;
+}

--- a/packages/cli/src/commands/create/version-resolver.ts
+++ b/packages/cli/src/commands/create/version-resolver.ts
@@ -29,10 +29,14 @@ export async function resolveMastraPackageVersions(
   return resolved;
 }
 
+const NPM_VIEW_TIMEOUT_MS = 15_000;
+
 async function resolveSinglePackageVersion(packageName: string, versionTag: string): Promise<string | undefined> {
   let stdout: string;
   try {
-    const { stdout: output } = await execa('npm', ['view', packageName, `dist-tags.${versionTag}`]);
+    const { stdout: output } = await execa('npm', ['view', packageName, `dist-tags.${versionTag}`], {
+      timeout: NPM_VIEW_TIMEOUT_MS,
+    });
     stdout = output;
   } catch {
     return undefined;


### PR DESCRIPTION
## Description

Instead of using tags we now use exact versions during project creation of create-mastra. If lookup fails we still fall back to tag

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you run `mastra create`, it now pins Mastra dependencies to the *exact* versions that were published for the selected release channel (like “alpha”), so installs don’t unexpectedly drift. If the CLI can’t look up those exact versions, it falls back to the old channel-tag behavior and prints a warning.

## What changed

- Added `resolveMastraPackageVersions` to look up exact Mastra (`mastra`, `@mastra/*`) versions via `npm view <pkg> dist-tags.<channel>`, with:
  - a 15s timeout,
  - strict validation of the returned semver (including canonicalization),
  - “all-or-nothing” behavior (if any package fails, version resolution returns `undefined`).
- Updated project scaffolding to pin Mastra dependency versions to the resolved exact versions for:
  - default projects,
  - empty projects,
  - managed-provider template adaptation.
- Implemented fallback behavior:
  - if exact resolution fails and Mastra packages are present, emit a single `console.warn` and use the channel tag for those Mastra packages,
  - if there are no Mastra packages in the manifest, skip resolution entirely (no warning/error).
- Expanded/adjusted tests to cover successful resolution, resolver failure, partial resolution behavior (no mixed results), deduping/sorting of resolution requests, timeout/invalid dist-tag handling, and the “no Mastra packages” case.
- Added changesets for the `create-mastra` entry points to document the new exact-version pinning behavior with the fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->