### PR TITLE
fix(cli): Track observability decisions

### DIFF
--- a/.changeset/observability-outcome-analytics.md
+++ b/.changeset/observability-outcome-analytics.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Track Mastra platform observability setup outcome (skipped, cancelled, completed, failed) in create command telemetry.

--- a/packages/cli/src/commands/create/create.test.ts
+++ b/packages/cli/src/commands/create/create.test.ts
@@ -510,6 +510,10 @@ describe('managed observability', () => {
       answer: 'yes',
       selection_method: 'interactive',
     });
+    expect(trackEvent).toHaveBeenCalledWith('cli_observability_outcome', {
+      command: 'create',
+      outcome: 'completed',
+    });
     expect(JSON.stringify(trackEvent.mock.calls)).not.toContain('auth-token');
     expect(JSON.stringify(trackEvent.mock.calls)).not.toContain('org-id');
     expect(JSON.stringify(trackEvent.mock.calls)).not.toContain('platform-project-id');
@@ -521,6 +525,7 @@ describe('managed observability', () => {
     const observability = await import('../init/observability-provision');
     const initUtils = await import('../init/utils.js');
     const { publishStagedProject } = await import('./utils');
+    const trackEvent = vi.fn();
 
     vi.mocked(prompts.select)
       .mockResolvedValueOnce('openai')
@@ -529,13 +534,21 @@ describe('managed observability', () => {
     vi.mocked(observability.provisionObservabilityProject).mockRejectedValueOnce(new Error('platform unavailable'));
 
     await expect(
-      create({ projectName: 'my-project', resolveVersionTag: vi.fn().mockResolvedValue('latest') }),
+      create({
+        projectName: 'my-project',
+        resolveVersionTag: vi.fn().mockResolvedValue('latest'),
+        analytics: { trackEvent } as never,
+      }),
     ).resolves.toBeUndefined();
 
     expect(publishStagedProject).toHaveBeenCalledOnce();
     expect(initUtils.writeObservabilityEnv).toHaveBeenCalledWith({ projectPath: path.resolve('my-project') });
     expect(prompts.note).toHaveBeenCalledWith(expect.stringContaining('platform unavailable'));
     expect(prompts.note).toHaveBeenCalledWith(expect.stringContaining('projects.mastra.ai'));
+    expect(trackEvent).toHaveBeenCalledWith('cli_observability_outcome', {
+      command: 'create',
+      outcome: 'failed',
+    });
     expect(prompts.outro).toHaveBeenCalledOnce();
   });
 
@@ -544,16 +557,19 @@ describe('managed observability', () => {
     const prompts = await import('@clack/prompts');
     const credentials = await import('../auth/credentials.js');
     const observability = await import('../init/observability-provision');
+    const trackEvent = vi.fn();
 
     await create({
       projectName: 'my-project',
       llmProvider: 'anthropic',
       resolveVersionTag: vi.fn().mockResolvedValue('latest'),
+      analytics: { trackEvent } as never,
     });
 
     expect(prompts.select).not.toHaveBeenCalled();
     expect(credentials.getToken).not.toHaveBeenCalled();
     expect(observability.provisionObservabilityProject).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalledWith('cli_observability_outcome', expect.anything());
   });
 
   it.each([
@@ -618,6 +634,7 @@ describe('managed observability', () => {
     const credentials = await import('../auth/credentials.js');
     const observability = await import('../init/observability-provision');
     const { publishStagedProject } = await import('./utils');
+    const trackEvent = vi.fn();
 
     vi.mocked(prompts.select)
       .mockResolvedValueOnce('openai')
@@ -629,6 +646,7 @@ describe('managed observability', () => {
       create({
         projectName: 'my-project',
         resolveVersionTag: vi.fn().mockResolvedValue('latest'),
+        analytics: { trackEvent } as never,
       }),
     ).resolves.toBeUndefined();
 
@@ -637,6 +655,10 @@ describe('managed observability', () => {
     expect(publishStagedProject).toHaveBeenCalledOnce();
     expect(observability.provisionObservabilityProject).not.toHaveBeenCalled();
     expect(prompts.cancel).not.toHaveBeenCalled();
+    expect(trackEvent).toHaveBeenCalledWith('cli_observability_outcome', {
+      command: 'create',
+      outcome: 'skipped',
+    });
     expect(prompts.outro).toHaveBeenCalledOnce();
   });
 
@@ -648,6 +670,7 @@ describe('managed observability', () => {
     const commandUtils = await import('../utils.js');
     const { installDependencies } = await import('../../utils/clone-template');
     const { publishStagedProject } = await import('./utils');
+    const trackEvent = vi.fn();
     let finishInstall: (() => void) | undefined;
 
     vi.mocked(prompts.select)
@@ -670,6 +693,7 @@ describe('managed observability', () => {
     const createPromise = create({
       projectName: 'my-project',
       resolveVersionTag: vi.fn().mockResolvedValue('latest'),
+      analytics: { trackEvent } as never,
     });
 
     await vi.waitFor(() => {
@@ -684,6 +708,10 @@ describe('managed observability', () => {
     expect(publishStagedProject).not.toHaveBeenCalled();
     expect(skills.installMastraSkills).not.toHaveBeenCalled();
     expect(commandUtils.gitInit).not.toHaveBeenCalled();
+    expect(trackEvent).toHaveBeenCalledWith('cli_observability_outcome', {
+      command: 'create',
+      outcome: 'cancelled',
+    });
     expect(prompts.outro).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -401,10 +401,16 @@ export const create = async (args: CreateOptions): Promise<void> => {
   process.removeListener('SIGINT', handleSigint);
   process.removeListener('SIGTERM', handleSigterm);
 
-  if (interruptionSignal === 'SIGINT') cancelCreate();
+  if (interruptionSignal === 'SIGINT') {
+    if (observabilityEnabled) {
+      analytics?.trackEvent('cli_observability_outcome', { command: 'create', outcome: 'cancelled' });
+    }
+    cancelCreate();
+  }
   if (interruptionSignal === 'SIGTERM') throw new Error('Operation terminated by SIGTERM');
   if (materializationError) throw materializationError;
   if (platformSetup?.status === 'cancelled') {
+    analytics?.trackEvent('cli_observability_outcome', { command: 'create', outcome: 'skipped' });
     p.log.info('Skipping Mastra platform setup.');
   } else if (observabilityEnabled) {
     p.log.success('Default template cloned and dependencies installed.');
@@ -444,12 +450,14 @@ export const create = async (args: CreateOptions): Promise<void> => {
       });
       platformEnvWritten = true;
       observabilitySummary = `${color.green('Mastra platform enabled.')}\n\nProject: ${color.cyan(result.projectName)} (${result.orgName})\nWrote ${color.cyan('MASTRA_PLATFORM_ACCESS_TOKEN')} and ${color.cyan('MASTRA_PROJECT_ID')} to ${color.cyan('.env')}.`;
+      analytics?.trackEvent('cli_observability_outcome', { command: 'create', outcome: 'completed' });
     } catch (error) {
       platformError = error;
     }
   }
 
   if (platformError !== undefined) {
+    analytics?.trackEvent('cli_observability_outcome', { command: 'create', outcome: 'failed' });
     const message = platformError instanceof Error ? platformError.message : 'Unknown error';
     try {
       await writeObservabilityEnv({ projectPath: targetPath });


### PR DESCRIPTION
## Description

Track Mastra platform observability setup outcome (skipped, cancelled, completed, failed) in create command telemetry.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When users set up Mastra platform monitoring during `create`, the CLI now records whether setup was skipped, cancelled, completed, or failed. This helps understand how often setup succeeds or encounters issues.

## Changes

- Added `cli_observability_outcome` telemetry for managed-mode projects.
- Covered cancelled, skipped, completed, and failed setup outcomes.
- Added tests for each outcome and ensured prompt-free flows emit no event.
- Added a patch changeset for the `mastra` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->