### PR TITLE
Add My account settings to Factory

### DIFF
--- a/.changeset/quiet-accounts-open.md
+++ b/.changeset/quiet-accounts-open.md
@@ -1,0 +1,5 @@
+---
+mastra: patch
+---
+
+Added a My account settings page with signed-in identity details and an explicit log out action.

--- a/.changeset/quiet-accounts-open.md
+++ b/.changeset/quiet-accounts-open.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/factory': patch
+mastra: patch
 ---
 
 Added a My account settings page with signed-in identity details and an explicit logout action.

--- a/.changeset/quiet-accounts-open.md
+++ b/.changeset/quiet-accounts-open.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Added a My account settings page with signed-in identity details and an explicit log out action.
+Added a My account settings page with signed-in identity details and an explicit logout action.

--- a/.changeset/quiet-accounts-open.md
+++ b/.changeset/quiet-accounts-open.md
@@ -1,5 +1,5 @@
 ---
-mastra: patch
+'@mastra/factory': patch
 ---
 
 Added a My account settings page with signed-in identity details and an explicit log out action.

--- a/mastracode/factory-ui/src/ui/Sidebar.tsx
+++ b/mastracode/factory-ui/src/ui/Sidebar.tsx
@@ -1,16 +1,16 @@
 import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
-import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
-import { CircleUserRound, Settings } from 'lucide-react';
+import { Settings } from 'lucide-react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 
-import { useApiConfig } from '../api/config';
-import { clearMastraCodeStorage, redirectToLogout, useFactoryAuth } from './domains/auth';
-import { FactorySection } from './domains/factory';
+import { SidebarAccountLink } from './domains/auth/components/SidebarAccountLink';
+import { FactorySection } from './domains/factory/components/FactorySection';
 import { SettingsNavigation } from './domains/settings/components/SettingsNavigation';
 import { useCloseSettings } from './domains/settings/hooks/useCloseSettings';
 import { settingsSectionPath } from './domains/settings/settingsSections';
-import { FactorySwitcher, UserSessionsSection, WorkspacesSection } from './domains/workspaces';
+import { FactorySwitcher } from './domains/workspaces/components/FactorySwitcher';
+import { UserSessionsSection } from './domains/workspaces/components/UserSessionsSection';
+import { WorkspacesSection } from './domains/workspaces/components/WorkspacesSection';
 
 function useSettingsOpen() {
   const { pathname } = useLocation();
@@ -110,7 +110,7 @@ function SidebarFooter() {
 
   return (
     <MainSidebar.NavList>
-      <SidebarAuth />
+      <SidebarAccountLink />
       <MainSidebar.NavLink
         asChild
         link={{
@@ -132,50 +132,5 @@ function SidebarFooter() {
         </button>
       </MainSidebar.NavLink>
     </MainSidebar.NavList>
-  );
-}
-
-function SidebarAuth() {
-  const auth = useFactoryAuth();
-  const { baseUrl } = useApiConfig();
-
-  if (auth.isLoading) {
-    return (
-      <li role="status" aria-label="Checking sign-in" className="flex h-9 items-center gap-2 px-3">
-        <Skeleton className="size-4 rounded-full" />
-        <Skeleton className="h-3 w-24" />
-      </li>
-    );
-  }
-
-  // Unauthenticated sessions never reach the app (the router bounces them to
-  // `/signin`), so the sidebar only renders the signed-in identity.
-  const state = auth.data;
-  if (!state?.authEnabled || !state.authenticated) return null;
-
-  const identity = state.user?.name ?? state.user?.email ?? 'User';
-
-  return (
-    <MainSidebar.NavLink
-      asChild
-      link={{
-        name: 'User',
-        url: '#',
-        icon: <CircleUserRound />,
-      }}
-    >
-      <button
-        type="button"
-        onClick={() => {
-          clearMastraCodeStorage();
-          redirectToLogout(baseUrl);
-        }}
-        aria-label="Sign out"
-        title={identity}
-      >
-        <CircleUserRound />
-        <MainSidebar.NavLabel>{identity}</MainSidebar.NavLabel>
-      </button>
-    </MainSidebar.NavLink>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/auth/components/SidebarAccountLink.tsx
+++ b/mastracode/factory-ui/src/ui/domains/auth/components/SidebarAccountLink.tsx
@@ -1,0 +1,48 @@
+import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
+import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { CircleUserRound } from 'lucide-react';
+import { Link, useLocation, useParams } from 'react-router';
+
+import { useFactoryAuth } from '../../../../hooks/useFactoryAuth';
+import { settingsSectionPath } from '../../settings/settingsSections';
+
+export function SidebarAccountLink() {
+  const auth = useFactoryAuth();
+  const { factoryId } = useParams<{ factoryId: string }>();
+  const location = useLocation();
+
+  if (auth.isLoading) {
+    return (
+      <li role="status" aria-label="Checking sign-in" className="flex h-9 items-center gap-2 px-3">
+        <Skeleton className="size-4 rounded-full" />
+        <Skeleton className="h-3 w-24" />
+      </li>
+    );
+  }
+
+  const state = auth.data;
+  if (!factoryId || !state?.authEnabled || !state.authenticated) return null;
+
+  const identity = state.user?.name ?? state.user?.email ?? 'User';
+
+  return (
+    <MainSidebar.NavLink
+      asChild
+      link={{
+        name: 'My account',
+        url: settingsSectionPath(factoryId, 'account'),
+        icon: <CircleUserRound />,
+      }}
+    >
+      <Link
+        to={settingsSectionPath(factoryId, 'account')}
+        state={{ from: location }}
+        aria-label="My account"
+        title={identity}
+      >
+        <CircleUserRound aria-hidden="true" />
+        <MainSidebar.NavLabel>{identity}</MainSidebar.NavLabel>
+      </Link>
+    </MainSidebar.NavLink>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/auth/components/__tests__/SidebarAccountLink.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/auth/components/__tests__/SidebarAccountLink.msw.test.tsx
@@ -1,0 +1,58 @@
+import { MainSidebarProvider } from '@mastra/playground-ui/components/MainSidebar';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../e2e/ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../../../e2e/ui/render';
+import { SidebarAccountLink } from '../SidebarAccountLink';
+
+function CurrentPath() {
+  return <output aria-label="Current path">{useLocation().pathname}</output>;
+}
+
+function renderAccountLink() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/factories/fp-1/work']}>
+      <MainSidebarProvider storageKey="sidebar-account-link-test" mobileBreakpoint={0}>
+        <Routes>
+          <Route
+            path="/factories/:factoryId/*"
+            element={
+              <>
+                <SidebarAccountLink />
+                <CurrentPath />
+              </>
+            }
+          />
+        </Routes>
+      </MainSidebarProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('SidebarAccountLink', () => {
+  it('opens My account instead of logging out', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get(`${TEST_BASE_URL}/auth/me`, () =>
+        HttpResponse.json({
+          authenticated: true,
+          user: { userId: 'user-1', email: 'dev@mastra.ai', name: 'Dev' },
+          provider: 'workos',
+        }),
+      ),
+    );
+
+    renderAccountLink();
+
+    const accountLink = await screen.findByRole('link', { name: 'My account' });
+    expect(accountLink).toHaveTextContent('Dev');
+
+    await user.click(accountLink);
+
+    expect(screen.getByRole('status', { name: 'Current path' })).toHaveTextContent('/factories/fp-1/settings/account');
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/auth/services/auth.ts
+++ b/mastracode/factory-ui/src/ui/domains/auth/services/auth.ts
@@ -19,7 +19,7 @@ export interface FactoryAuthState {
   /** Whether the server has web auth configured (any provider). */
   authEnabled: boolean;
   authenticated: boolean;
-  user?: { userId?: string; email?: string; name?: string };
+  user?: { userId?: string; email?: string; name?: string; organizationId?: string };
   /** Active identity provider: 'workos' | 'better-auth' | custom adapter kind. */
   provider?: string;
   /** True when the provider hosts credential forms and sign-up is disabled. */
@@ -128,7 +128,7 @@ export async function fetchAuthState(baseUrl: string): Promise<FactoryAuthState>
   }
   const data = (await res.json()) as {
     authenticated?: boolean;
-    user?: { userId?: string; email?: string; name?: string } | null;
+    user?: { userId?: string; email?: string; name?: string; organizationId?: string } | null;
     provider?: string;
     signUpDisabled?: boolean;
   };

--- a/mastracode/factory-ui/src/ui/domains/settings/components/AccountSettingsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/AccountSettingsSection.tsx
@@ -1,0 +1,133 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { Notice } from '@mastra/playground-ui/components/Notice';
+import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { LogOut } from 'lucide-react';
+
+import { useApiConfig } from '../../../../api/config';
+import { useFactoryAuth } from '../../../../hooks/useFactoryAuth';
+import { clearMastraCodeStorage, redirectToLogout } from '../../auth/services/auth';
+import { SettingsCard, SettingsRow } from './SettingsCard';
+import { SettingsSubsection } from './SettingsSubsection';
+
+const AUTH_PROVIDER_LABELS: Record<string, string> = {
+  workos: 'WorkOS',
+  'better-auth': 'Email and password',
+  'mastra-studio': 'Mastra Studio',
+};
+
+function authProviderLabel(provider: string | undefined): string {
+  if (!provider) return 'Unknown';
+  return (
+    AUTH_PROVIDER_LABELS[provider] ??
+    provider
+      .split('-')
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ')
+  );
+}
+
+function AccountValue({ children, mono = false }: { children: string; mono?: boolean }) {
+  return (
+    <Txt as="span" variant="ui-sm" font={mono ? 'mono' : undefined} className="text-icon4 truncate">
+      {children}
+    </Txt>
+  );
+}
+
+function CopyableAccountValue({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="flex min-w-0 items-center gap-1">
+      <AccountValue mono>{value}</AccountValue>
+      <CopyButton content={value} size="icon-xs" variant="ghost" tooltip={`Copy ${label}`} />
+    </div>
+  );
+}
+
+function AccountSettingsSkeleton() {
+  return (
+    <SettingsCard>
+      <SettingsRow label="Name">
+        <Skeleton className="h-4 w-28" />
+      </SettingsRow>
+      <SettingsRow label="Email">
+        <Skeleton className="h-4 w-40" />
+      </SettingsRow>
+      <SettingsRow label="Authentication">
+        <Skeleton className="h-4 w-24" />
+      </SettingsRow>
+    </SettingsCard>
+  );
+}
+
+export function AccountSettingsSection() {
+  const auth = useFactoryAuth();
+  const { baseUrl } = useApiConfig();
+
+  if (auth.isPending) {
+    return (
+      <SettingsSubsection title="Profile">
+        <AccountSettingsSkeleton />
+      </SettingsSubsection>
+    );
+  }
+
+  if (auth.isError) {
+    return <Notice variant="destructive">Could not load your account details. Reload the page to try again.</Notice>;
+  }
+
+  const state = auth.data;
+  if (!state?.authEnabled) {
+    return <Notice variant="info">Authentication is not enabled for this deployment.</Notice>;
+  }
+
+  if (!state.authenticated) {
+    return <Notice variant="info">Sign in to view your account details.</Notice>;
+  }
+
+  const user = state.user;
+
+  const logOut = () => {
+    clearMastraCodeStorage();
+    redirectToLogout(baseUrl);
+  };
+
+  return (
+    <div className="flex flex-col gap-8">
+      <SettingsSubsection title="Profile" description="Your signed-in identity for this MastraCode deployment.">
+        <SettingsCard>
+          <SettingsRow label="Name">
+            <AccountValue>{user?.name ?? 'Not provided'}</AccountValue>
+          </SettingsRow>
+          <SettingsRow label="Email">
+            <AccountValue>{user?.email ?? 'Not provided'}</AccountValue>
+          </SettingsRow>
+          <SettingsRow label="Authentication">
+            <AccountValue>{authProviderLabel(state.provider)}</AccountValue>
+          </SettingsRow>
+          {user?.userId && (
+            <SettingsRow label="Account ID" hint="Useful when contacting support.">
+              <CopyableAccountValue value={user.userId} label="account ID" />
+            </SettingsRow>
+          )}
+          {user?.organizationId && (
+            <SettingsRow label="Organization ID" hint="The organization that owns this Factory.">
+              <CopyableAccountValue value={user.organizationId} label="organization ID" />
+            </SettingsRow>
+          )}
+        </SettingsCard>
+      </SettingsSubsection>
+      <SettingsSubsection title="Session">
+        <SettingsCard>
+          <SettingsRow label="Log out" hint="End your MastraCode session on this device.">
+            <Button type="button" variant="outline" size="sm" aria-label="Log out of MastraCode" onClick={logOut}>
+              <LogOut aria-hidden="true" />
+              Log out
+            </Button>
+          </SettingsRow>
+        </SettingsCard>
+      </SettingsSubsection>
+    </div>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsNavigation.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsNavigation.tsx
@@ -1,7 +1,18 @@
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@mastra/playground-ui/components/InputGroup';
 import { MainSidebar, useMainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { ArrowLeft, Bot, Building2, Cable, GitBranch, Inbox, Palette, Search, SlidersHorizontal } from 'lucide-react';
+import {
+  ArrowLeft,
+  Bot,
+  Building2,
+  Cable,
+  CircleUserRound,
+  GitBranch,
+  Inbox,
+  Palette,
+  Search,
+  SlidersHorizontal,
+} from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useLocation, useParams } from 'react-router';
@@ -26,6 +37,12 @@ const SETTINGS_GROUPS: SettingsNavGroup[] = [
   {
     id: 'preferences',
     items: [
+      {
+        id: 'account',
+        label: SETTINGS_SECTION_LABELS.account,
+        icon: CircleUserRound,
+        searchText: 'my account profile identity email authentication session log out sign out user',
+      },
       {
         id: 'preferences',
         label: SETTINGS_SECTION_LABELS.preferences,

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../../hooks/useUpdateAgentControllerSettingsMutation';
 import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 import { ConnectedAccountsSection } from './ConnectedAccountsSection';
+import { AccountSettingsSection } from './AccountSettingsSection';
 import { CustomProvidersSection } from './CustomProvidersSection';
 import { SettingsHeader } from './SettingsHeader';
 import { FactoryManagementSection } from './FactoryManagementSection';
@@ -69,6 +70,7 @@ export function SettingsPanel() {
     <section aria-label="Settings" className="flex flex-1 flex-col px-5 pb-5">
       <div className="mx-auto grid w-full max-w-4xl py-3">
         {!isMobile && <SettingsHeader autoFocus placement="desktop" />}
+        {section === 'account' && <AccountSettingsSection />}
         {section === 'preferences' && <GeneralSettings theme={theme} onThemeChange={setTheme} />}
         {section === 'factory' && <FactoryManagementSection />}
         {section === 'connections' && (

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/AccountSettingsSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/AccountSettingsSection.msw.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../e2e/ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../../../e2e/ui/render';
+import { AccountSettingsSection } from '../AccountSettingsSection';
+
+function stubAuthenticatedAccount() {
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({
+        authenticated: true,
+        user: {
+          userId: 'user-1',
+          email: 'dev@mastra.ai',
+          name: 'Dev',
+          organizationId: 'org-1',
+        },
+        provider: 'workos',
+      }),
+    ),
+  );
+}
+
+describe('AccountSettingsSection', () => {
+  describe('when the user is signed in', () => {
+    it('shows the profile returned by the auth endpoint', async () => {
+      stubAuthenticatedAccount();
+
+      renderWithProviders(<AccountSettingsSection />);
+
+      expect(await screen.findByText('Dev')).toBeInTheDocument();
+      expect(screen.getByText('dev@mastra.ai')).toBeInTheDocument();
+      expect(screen.getByText('WorkOS')).toBeInTheDocument();
+      expect(screen.getByText('user-1')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Copy account ID' })).toBeInTheDocument();
+      expect(screen.getByText('org-1')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Copy organization ID' })).toBeInTheDocument();
+    });
+
+    it('offers logout as an explicit session action', async () => {
+      stubAuthenticatedAccount();
+
+      renderWithProviders(<AccountSettingsSection />);
+
+      expect(await screen.findByRole('button', { name: 'Log out of MastraCode' })).toBeInTheDocument();
+    });
+  });
+
+  describe('when authentication is disabled', () => {
+    it('explains why account actions are unavailable', async () => {
+      server.use(
+        http.get(`${TEST_BASE_URL}/auth/me`, () => HttpResponse.json({ error: 'not_found' }, { status: 404 })),
+      );
+
+      renderWithProviders(<AccountSettingsSection />);
+
+      expect(await screen.findByText('Authentication is not enabled for this deployment.')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Log out of MastraCode' })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsNavigation.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsNavigation.msw.test.tsx
@@ -24,6 +24,15 @@ function renderNavigation() {
 afterEach(() => window.localStorage.removeItem(STORAGE_KEY));
 
 describe('SettingsNavigation', () => {
+  it('links to My account settings', () => {
+    renderNavigation();
+
+    expect(screen.getByRole('link', { name: 'My account' })).toHaveAttribute(
+      'href',
+      '/factories/fp-1/settings/account',
+    );
+  });
+
   it('separates code repositories, work intake, and agent settings into named groups', () => {
     renderNavigation();
     expect(screen.getByRole('link', { name: 'Factory' })).toHaveAttribute('href', '/factories/fp-1/settings/factory');

--- a/mastracode/factory-ui/src/ui/domains/settings/settingsSections.ts
+++ b/mastracode/factory-ui/src/ui/domains/settings/settingsSections.ts
@@ -1,4 +1,5 @@
 export type SettingsSection =
+  | 'account'
   | 'preferences'
   | 'factory'
   | 'connections'
@@ -8,6 +9,7 @@ export type SettingsSection =
   | 'behavior';
 
 export const SETTINGS_SECTION_LABELS: Record<SettingsSection, string> = {
+  account: 'My account',
   preferences: 'Preferences',
   factory: 'Factory',
   connections: 'Connections',


### PR DESCRIPTION
## What changed

- open My account settings from the sidebar identity instead of immediately logging out
- show profile and authentication details, copyable account identifiers, and an explicit logout action
- cover the account route, authenticated profile, and auth-disabled state with focused MSW tests

## Why

The identity control looked like navigation but acted as an immediate logout. Moving logout into account settings makes the behavior clear and avoids accidental sign-outs.

## Checks

- focused Factory UI MSW tests
- Factory UI typecheck
- repository lint
- React Doctor 100/100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

In Factory, clicking your name no longer logs you out right away—instead it opens your “My account” page. That page shows your signed-in details and IDs you can copy, plus a clear “Log out” button when you actually want to leave.

## What changed

- Added a new **My account** settings page at `/factories/:factoryId/settings/account`:
  - Shows **profile** + **authentication/provider** details
  - Provides copyable **Account ID** and **Organization ID** (when available)
  - Includes an explicit **Log out** action (clears MastraCode storage and redirects)
  - Handles friendly UI states for loading, errors, signed-out users, and when auth is disabled for the deployment
- Updated the sidebar identity area to link to the account settings page via a new `SidebarAccountLink` component (replacing the old in-sidebar auth/loading/logout behavior).
- Extended auth typing to support `organizationId` in the user auth state.
- Extended settings navigation/routing to support the new `account` section and label it “My account”.
- Updated/added focused release note and MSW tests around the sidebar link, the account settings page (authenticated), and the auth-disabled state.

## Tests / validation

- Added focused Factory UI MSW tests for:
  - The sidebar “My account” link navigation
  - The authenticated account settings profile view (including copy actions/fields)
  - The authentication-disabled state (logout not shown)
- Factory UI typechecking, repository lint, and React Doctor (100/100).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->