### PR TITLE
docs: move web search tool docs

### DIFF
--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -75,31 +75,6 @@ export const weatherAgent = new Agent({
 })
 ```
 
-## Use provider web search
-
-Import `webSearchTool` from `@mastra/core/tools` when you want the model provider to run its native web search tool. The tool has no local `execute` function. Mastra resolves it at run time from the active model, then passes the provider-managed tool to the model.
-
-```typescript {2,14} title="src/mastra/agents/research-agent.ts"
-import { Agent } from '@mastra/core/agent'
-import { webSearchTool } from '@mastra/core/tools'
-
-export const researchAgent = new Agent({
-  id: 'research-agent',
-  name: 'Research Agent',
-  instructions: `
-    You are a helpful research assistant.
-    Use web search when you need current information.`,
-  model: '__GATEWAY_OPENAI_MODEL__',
-  tools: {
-    webSearch: webSearchTool,
-  },
-})
-```
-
-`webSearchTool` supports OpenAI, Anthropic, Google Gemini, and xAI models. If Mastra can't infer one of those providers from the active model, the agent run fails with a `MastraError`.
-
-Only the `webSearchTool` value triggers provider web search. Custom tools with the names `webSearch` or `web_search` stay unchanged.
-
 ## Define schemas
 
 You can define the tool's `inputSchema` and `outputSchema` with any library that supports [Standard JSON Schema](https://standardschema.dev/json-schema). This includes libraries like [Zod](https://zod.dev/), [Valibot](https://valibot.dev/), and [ArkType](https://arktype.io/).
@@ -518,6 +493,32 @@ Mastra includes agent-agnostic built-in tools in `@mastra/core/tools` that add i
 | `task_update` | Update one tracked task by ID |
 | `task_complete` | Mark one tracked task completed |
 | `task_check` | Check task list completion status |
+| `webSearchTool` | Run provider-native web search with the active model |
+
+### Use provider web search
+
+Import `webSearchTool` from `@mastra/core/tools` when you want the model provider to run its native web search tool. The tool has no local `execute` function. Mastra resolves it at run time from the active model, then passes the provider-managed tool to the model.
+
+```typescript {2,14} title="src/mastra/agents/research-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { webSearchTool } from '@mastra/core/tools'
+
+export const researchAgent = new Agent({
+  id: 'research-agent',
+  name: 'Research Agent',
+  instructions: `
+    You are a helpful research assistant.
+    Use web search when you need current information.`,
+  model: '__GATEWAY_OPENAI_MODEL__',
+  tools: {
+    webSearch: webSearchTool,
+  },
+})
+```
+
+`webSearchTool` supports OpenAI, Anthropic, Google Gemini, and xAI models. If Mastra can't infer one of those providers from the active model, the agent run fails with a `MastraError`.
+
+Only the `webSearchTool` value triggers provider web search. Custom tools with the names `webSearch` or `web_search` stay unchanged.
 
 ### Ask the user a question
 

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -497,28 +497,26 @@ Mastra includes agent-agnostic built-in tools in `@mastra/core/tools` that add i
 
 ### Use provider web search
 
-Import `webSearchTool` from `@mastra/core/tools` when you want the model provider to run its native web search tool. The tool has no local `execute` function. Mastra resolves it at run time from the active model, then passes the provider-managed tool to the model.
+Import `webSearchTool` from `@mastra/core/tools` when you want the model provider to run its native web search tool. Mastra resolves it at run time from the active model, then passes the provider-managed tool to the model.
 
-```typescript {2,14} title="src/mastra/agents/research-agent.ts"
+```typescript {2,10} title="src/mastra/agents/research-agent.ts"
 import { Agent } from '@mastra/core/agent'
 import { webSearchTool } from '@mastra/core/tools'
 
 export const researchAgent = new Agent({
   id: 'research-agent',
   name: 'Research Agent',
-  instructions: `
-    You are a helpful research assistant.
-    Use web search when you need current information.`,
-  model: '__GATEWAY_OPENAI_MODEL__',
+  instructions: 'Use web search when you need current information.',
+  model: 'openai/gpt-5.6-sol',
   tools: {
-    webSearch: webSearchTool,
+    search: webSearchTool,
   },
 })
 ```
 
 `webSearchTool` supports OpenAI, Anthropic, Google Gemini, and xAI models. If Mastra can't infer one of those providers from the active model, the agent run fails with a `MastraError`.
 
-Only the `webSearchTool` value triggers provider web search. Custom tools with the names `webSearch` or `web_search` stay unchanged.
+The `search` key is only the agent-local tool name. Use any key. The `webSearchTool` value tells Mastra to use provider web search.
 
 ### Ask the user a question
 


### PR DESCRIPTION
## Summary
- Move provider web search guidance under the Built-in tools section
- Add webSearchTool to the built-in tools table

## Checks
- pnpm validate
- pnpm format:mdx:check
- Targeted Vale and Remark checks for docs/src/content/en/docs/agents/using-tools.mdx

Note: Full pnpm lint:prose runs but fails on existing unrelated docs issues outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR puts the web search instructions where users expect them: alongside the other built-in tools. It also explains the example more clearly and adds web search to the built-in tools table.

## Changes

- Relocated provider web search guidance under **Built-in tools**.
- Added `webSearchTool` to the built-in tools table.
- Clarified that the tool key (such as `search`) is agent-local, while `webSearchTool` enables provider-native search.
- Updated and reformatted the example configuration.
- Added validation checks; full prose linting still reports unrelated existing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->