### PR TITLE
fix(factory): slash-command menu never appears in the web chat composer

### DIFF
--- a/.changeset/composer-slash-suggestions.md
+++ b/.changeset/composer-slash-suggestions.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/factory': patch
+'mastra': patch
 ---
 
 Fixed the slash-command menu in the Factory web chat. Typing `/` in the composer now shows the list of available commands again; the menu was rendering but invisibly clipped by the composer box.

--- a/.changeset/composer-slash-suggestions.md
+++ b/.changeset/composer-slash-suggestions.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the slash-command menu in the Factory web chat. Typing `/` in the composer now shows the list of available commands again; the menu was rendering but invisibly clipped by the composer box.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
@@ -157,14 +157,12 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
     });
     if (accepted.length === 0) return;
     const additions = await Promise.all(
-      accepted.map(
-        async (file): Promise<PendingImage> => ({
-          id: `pending-image-${pendingImageSeq++}`,
-          data: await readFileAsBase64(file),
-          mediaType: file.type,
-          filename: file.name || undefined,
-        }),
-      ),
+      accepted.map(async (file): Promise<PendingImage> => ({
+        id: `pending-image-${pendingImageSeq++}`,
+        data: await readFileAsBase64(file),
+        mediaType: file.type,
+        filename: file.name || undefined,
+      })),
     );
     setImages(prev => [...prev, ...additions]);
   };
@@ -301,7 +299,29 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
   const disabled = status !== 'ready';
 
   return (
-    <ComposerRoot onSubmit={onSubmit} onDrop={onDrop} onDragOver={e => e.preventDefault()}>
+    <ComposerRoot onSubmit={onSubmit} onDrop={onDrop} onDragOver={e => e.preventDefault()} className="relative">
+      {/* Rendered outside ComposerBox: its overflow-hidden clips anything above the box. */}
+      {showSuggestions && (
+        <div className="border-border1 bg-surface3 absolute bottom-full left-0 right-0 z-20 mx-auto mb-2 w-full max-w-3xl rounded-md border p-1 shadow-lg">
+          {suggestions.map((cmd, index) => (
+            <button
+              key={cmd.name}
+              type="button"
+              className={cn(
+                'flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-ui-sm',
+                index === activeSuggestion ? 'bg-surface4 text-icon6' : 'text-icon3',
+              )}
+              onMouseDown={e => {
+                e.preventDefault();
+                applyCommand(cmd.name);
+              }}
+            >
+              <span>/{cmd.name}</span>
+              <span>{cmd.description}</span>
+            </button>
+          ))}
+        </div>
+      )}
       <ComposerBox ref={spotlightRef} className={cn('composer-spotlight', modeColorClass)}>
         <div aria-hidden="true" className="composer-spotlight-surface" />
         {images.length > 0 && (
@@ -340,27 +360,6 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
           aria-label="Message"
           aria-keyshortcuts="Shift+Tab"
         />
-        {showSuggestions && (
-          <div className="border-border1 bg-surface3 absolute bottom-full mb-2 w-full rounded-md border p-1 shadow-lg">
-            {suggestions.map((cmd, index) => (
-              <button
-                key={cmd.name}
-                type="button"
-                className={cn(
-                  'flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-ui-sm',
-                  index === activeSuggestion ? 'bg-surface4 text-icon6' : 'text-icon3',
-                )}
-                onMouseDown={e => {
-                  e.preventDefault();
-                  applyCommand(cmd.name);
-                }}
-              >
-                <span>/{cmd.name}</span>
-                <span>{cmd.description}</span>
-              </button>
-            ))}
-          </div>
-        )}
         <input
           ref={fileInputRef}
           type="file"

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
@@ -157,12 +157,14 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
     });
     if (accepted.length === 0) return;
     const additions = await Promise.all(
-      accepted.map(async (file): Promise<PendingImage> => ({
-        id: `pending-image-${pendingImageSeq++}`,
-        data: await readFileAsBase64(file),
-        mediaType: file.type,
-        filename: file.name || undefined,
-      })),
+      accepted.map(
+        async (file): Promise<PendingImage> => ({
+          id: `pending-image-${pendingImageSeq++}`,
+          data: await readFileAsBase64(file),
+          mediaType: file.type,
+          filename: file.name || undefined,
+        }),
+      ),
     );
     setImages(prev => [...prev, ...additions]);
   };
@@ -302,7 +304,7 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
     <ComposerRoot onSubmit={onSubmit} onDrop={onDrop} onDragOver={e => e.preventDefault()} className="relative">
       {/* Rendered outside ComposerBox: its overflow-hidden clips anything above the box. */}
       {showSuggestions && (
-        <div className="border-border1 bg-surface3 absolute bottom-full left-0 right-0 z-20 mx-auto mb-2 w-full max-w-3xl rounded-md border p-1 shadow-lg">
+        <div className="border-border1 bg-surface3 absolute right-0 bottom-full left-0 z-20 mx-auto mb-2 w-full max-w-3xl rounded-md border p-1 shadow-lg">
           {suggestions.map((cmd, index) => (
             <button
               key={cmd.name}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerSlashSuggestions.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerSlashSuggestions.msw.test.tsx
@@ -1,0 +1,73 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { renderWithProviders } from '../../../../../../e2e/ui/render';
+import { SLASH_COMMANDS } from '../../services/commands';
+import { Composer } from '../Composer';
+import { OverlayTestProviders, useOverlayControllerHandlers } from './overlay-test-utils';
+
+function renderComposer() {
+  return renderWithProviders(
+    <OverlayTestProviders>
+      <Composer />
+    </OverlayTestProviders>,
+  );
+}
+
+/** The input stays disabled until the controller connection is ready. */
+async function findReadyInput(): Promise<HTMLTextAreaElement> {
+  const input = (await screen.findByRole('textbox', { name: 'Message' })) as HTMLTextAreaElement;
+  await waitFor(() => expect(input).toBeEnabled());
+  return input;
+}
+
+beforeEach(useOverlayControllerHandlers);
+
+describe('Composer slash-command suggestions', () => {
+  describe('when the user types "/" in the composer', () => {
+    it('shows every registered slash command', async () => {
+      const user = userEvent.setup();
+      renderComposer();
+
+      const input = await findReadyInput();
+      await user.type(input, '/');
+
+      for (const command of SLASH_COMMANDS) {
+        expect(await screen.findByRole('button', { name: new RegExp(`^/${command.name}\\s`) })).toBeInTheDocument();
+      }
+    });
+
+    it('renders the suggestions outside the clipping composer box', async () => {
+      const user = userEvent.setup();
+      renderComposer();
+
+      const input = await findReadyInput();
+      await user.type(input, '/');
+
+      // ComposerBox uses overflow-hidden; a popover nested inside it would be
+      // invisibly clipped even though it exists in the DOM.
+      const suggestion = await screen.findByRole('button', { name: /^\/help\s/ });
+      expect(suggestion.closest('[data-slot="composer-box"]')).toBeNull();
+      expect(suggestion.closest('[data-slot="composer"]')).not.toBeNull();
+    });
+  });
+
+  describe('when the user narrows the command by typing', () => {
+    it('filters suggestions by prefix and completes with Tab', async () => {
+      const user = userEvent.setup();
+      renderComposer();
+
+      const input = await findReadyInput();
+      await user.type(input, '/goa');
+
+      expect(await screen.findByRole('button', { name: /^\/goal\s/ })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^\/help\s/ })).not.toBeInTheDocument();
+
+      await user.keyboard('{Tab}');
+      expect(input).toHaveValue('/goal ');
+      // Args phase: suggestions close once the command is complete.
+      expect(screen.queryByRole('button', { name: /^\/goal\s/ })).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Typing `/` in the Factory web chat composer is supposed to pop up an autocomplete menu of slash commands (`/model`, `/goal`, `/help`, …), but nothing showed up. The menu was actually rendering — it's positioned above the input with `bottom-full`, and `ComposerBox` has `overflow-hidden` (needed for the sending-pulse animation), so the whole popover was silently clipped out of view.

The fix moves the popover out of the clipping box and renders it from the form root instead, so it floats above the composer as intended.

Includes MSW tests covering: the full command list appearing on `/`, prefix filtering + Tab completion (`/goa` → `/goal `), and a structural guard asserting the popover is not nested inside the `overflow-hidden` box so this exact regression can't come back.

Test plan: `pnpm --filter ./mastracode/factory-ui test:msw` (380 passing), typecheck, and production build all green; verified manually that typing `/` shows the menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

In the chat composer, the “slash command” menu was being cut off by the box that holds the input. This change moves the menu to be rendered from a higher-level container so it’s always visible, with tests confirming it shows, filters, and tab-completes correctly.

## Changes

- Fixed the slash-command suggestions dropdown rendering by moving it outside the clipped `ComposerBox` (rendered from the form root / composer root positioning).
- Updated the dropdown positioning/z-index styling to match the new placement.
- Added an MSW/RTL test suite covering:
  - Showing all slash commands after typing `/`
  - Prefix filtering (e.g., `/goa`)
  - `Tab` completion (updates input and closes the menu)
  - A structural guard ensuring the popover isn’t nested under the clipping container (`[data-slot="composer-box"]` ancestor absent).
- Updated the changeset to target `mastra` (since Factory UI is bundled into the Mastra CLI) instead of `@mastra/factory`.
- Applied `oxfmt` formatting to `Composer.tsx`.
- Typecheck, production build, and 380 MSW tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->