### PR TITLE
fix(platform-workspace): preserve checkpointName across PlatformSandbox.clone()

### DIFF
--- a/.changeset/petite-views-grin.md
+++ b/.changeset/petite-views-grin.md
@@ -1,0 +1,23 @@
+---
+'@mastra/platform-workspace': patch
+---
+
+Fixed `PlatformSandbox.clone()` silently dropping `checkpointName`, which prevented every sandbox from restoring from its captured checkpoint. `clone({ checkpointName })` now stabilizes the clone's sandbox id (the recovery key the platform hashes on `POST /sandbox`), so subsequent boots of the same session hit their prior checkpoint instead of always paying a fresh template build.
+
+**Before**
+
+```ts
+// checkpointName was accepted but never stored — cloned sandbox got a
+// random id, so the platform never found a matching checkpoint.
+const child = template.clone({ checkpointName: 'mastra-recovery-session-42' });
+await child.start(); // body.id: 'platform-sandbox-<random>' → 30–60 s build every time
+```
+
+**After**
+
+```ts
+const child = template.clone({ checkpointName: 'mastra-recovery-session-42' });
+await child.start(); // body.id: 'mastra-recovery-session-42' → 5–10 s checkpoint restore
+```
+
+An explicit `id` still wins over `checkpointName` when both are passed.

--- a/.changeset/petite-views-grin.md
+++ b/.changeset/petite-views-grin.md
@@ -2,22 +2,11 @@
 '@mastra/platform-workspace': patch
 ---
 
-Fixed `PlatformSandbox.clone()` silently dropping `checkpointName`, which prevented every sandbox from restoring from its captured checkpoint. `clone({ checkpointName })` now stabilizes the clone's sandbox id (the recovery key the platform hashes on `POST /sandbox`), so subsequent boots of the same session hit their prior checkpoint instead of always paying a fresh template build.
-
-**Before**
-
-```ts
-// checkpointName was accepted but never stored — cloned sandbox got a
-// random id, so the platform never found a matching checkpoint.
-const child = template.clone({ checkpointName: 'mastra-recovery-session-42' });
-await child.start(); // body.id: 'platform-sandbox-<random>' → 30–60 s build every time
-```
-
-**After**
+Fixed `PlatformSandbox.clone()` silently ignoring `checkpointName`. Clones created with `clone({ checkpointName })` now reuse a matching captured checkpoint on `start()` instead of always provisioning a fresh sandbox, so repeated boots of the same session start much faster.
 
 ```ts
 const child = template.clone({ checkpointName: 'mastra-recovery-session-42' });
-await child.start(); // body.id: 'mastra-recovery-session-42' → 5–10 s checkpoint restore
+await child.start(); // Reuses the captured checkpoint when one is available.
 ```
 
-An explicit `id` still wins over `checkpointName` when both are passed.
+An explicit `id` still takes precedence over `checkpointName` when both are passed.

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -778,5 +778,43 @@ describe('PlatformSandbox', () => {
         env: { BASE: '1' },
       });
     });
+
+    it('forwards checkpointName as the create body id so the platform keys recovery on it', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_child', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const template = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+
+      const child = template.clone({ checkpointName: 'mastra-recovery-session-42' });
+      await child._start();
+
+      const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
+      // Recovery-key stability is the whole point: the proxy hashes body.id to
+      // look up prior checkpoints, so a session-stable checkpointName MUST
+      // round-trip to body.id on start().
+      expect(body.id).toBe('mastra-recovery-session-42');
+      expect(child.id).toBe('mastra-recovery-session-42');
+    });
+
+    it('prefers an explicit id over checkpointName when both are passed to clone', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_child', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const template = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+
+      const child = template.clone({ id: 'explicit-id', checkpointName: 'ignored-name' });
+      await child._start();
+
+      const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
+      expect(body.id).toBe('explicit-id');
+    });
   });
 });

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -236,8 +236,15 @@ export class PlatformSandbox extends MastraSandbox {
    * (e.g. one per project).
    */
   clone(options: SandboxCloneOptions = {}): PlatformSandbox {
+    // The proxy hashes `body.id` on POST /sandbox to look up a prior
+    // checkpoint. A stable `checkpointName` is only useful if it round-trips
+    // to `body.id`, so route it through the sandbox id when the caller
+    // didn't pick one explicitly. Without this, every clone gets a random
+    // id and no boot ever hits its captured checkpoint (see
+    // issue-platform-sandbox-clone-drops-checkpoint-name.md).
+    const id = options.id ?? options.checkpointName;
     return new PlatformSandbox({
-      ...(options.id !== undefined && { id: options.id }),
+      ...(id !== undefined && { id }),
       accessToken: this._client.accessToken,
       projectId: this._client.projectId,
       fetch: this._client.fetch,


### PR DESCRIPTION
## Summary

`PlatformSandbox.clone()` accepted `options.checkpointName` in its type signature but never stored or forwarded it. The cloned sandbox fell back to `generateId()` and sent that random id as `body.id` on `POST /sandbox` — which the workspace proxy hashes into the recovery lookup key. No boot ever hit a checkpoint captured by a prior boot, because the recovery key at capture time was never the key any subsequent boot looked up under.

Fix: route `options.checkpointName` through the clone's `id` when the caller didn't set one explicitly. `body.id` is now stable per session, so the proxy's recovery hash resolves to the previously captured checkpoint and boots take the fast restore path.

An explicit `options.id` still wins over `options.checkpointName`.

## Impact (from prod observations, 24 h ending 2026-07-30 15:49 UTC on shipyard)

- `Railway sandbox recovery create started`: 61
- `Railway sandbox recovery create completed`: **0**
- `Railway sandbox recovery checkpoint captured` (post-boot, orphan): 64

Every session was paying a 30–60 s template build instead of a 5–10 s checkpoint restore, and each boot wrote a fresh checkpoint under a name no future boot would ever look up — burning through the 100-checkpoint plan cap on garbage. After this fix, `body.id` for a given session is stable across container restarts and the proxy's recovery lookup resolves.

## Change

- `workspaces/platform-workspace/src/sandbox.ts` — `clone()` now uses `options.id ?? options.checkpointName` as the child sandbox's id.

## Tests

Two new unit tests in `workspaces/platform-workspace/src/sandbox.test.ts`:

1. `clone({ checkpointName })` round-trips the name to `body.id` on `start()` (the exact wire assertion the proxy hash consumes).
2. An explicit `id` still overrides `checkpointName` when both are passed.

Written TDD-style — the first test failed against `main`, then passed after the two-line fix. All 56 existing tests still pass. Typecheck and lint clean.

## Related

- `issue-platform-sandbox-clone-drops-checkpoint-name.md`
- `issue-railway-checkpoint-quota-exhaustion.md` (same root cause; this PR + PR #1796 GC together resolve it)
- `issue-sandbox-fleet-per-key-provision-coalescing.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
If you clone a sandbox that’s meant to restart from a saved checkpoint, the clone now keeps using the checkpoint’s name as its stable `id`, so restart can find the saved work. If you pass an explicit `id`, that one wins.

## Changes
- Fixed `PlatformSandbox.clone()` to set the clone `id` to `options.id ?? options.checkpointName`, ensuring the POST `/sandbox` `body.id` matches the captured checkpoint for recovery.
- Added unit tests to verify:
  - `clone({ checkpointName })` forwards `checkpointName` into the create request `body.id` (and the resulting `child.id`).
  - An explicit `clone({ id })` takes precedence over `checkpointName`.
- Updated the `@mastra/platform-workspace` changeset to document the `checkpointName` forwarding and `id` precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->