### PR TITLE
fix(factory): recover a reinstalled GitHub App without a manual DB edit

### DIFF
--- a/.changeset/odd-impalas-enjoy.md
+++ b/.changeset/odd-impalas-enjoy.md
@@ -1,0 +1,9 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the Factory getting stuck after a GitHub App is uninstalled and reinstalled.
+
+GitHub assigns a new installation ID on reinstall, which left every token request failing against the old one — recovering it needed a manual database edit. The Factory already knew how to repoint a repository at the replacement installation, but only triggered that recovery when the platform reported the old installation as missing (404). A suspended or soft-deleted installation reports as a conflict (409) instead, so the recovery never ran. It now covers both.
+
+A failed token mint that could equally be a transient GitHub outage (502) still surfaces as an error rather than repointing the repository, so a passing incident never migrates a healthy repository.

--- a/mastracode/factory-ui/src/hooks/__tests__/useFactoryData.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useFactoryData.msw.test.tsx
@@ -12,7 +12,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { server } from '../../../e2e/ui/msw-server';
 import { renderHookWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
 import type { GithubIssue, GithubPullRequest } from '../../ui/domains/factory/services/factory';
-import { INTAKE_POLL_MS, useProjectIssuesQuery, useProjectPullRequestsQuery } from '../useFactoryData';
+import {
+  INTAKE_ERROR_POLL_MS,
+  INTAKE_POLL_MS,
+  useProjectIssuesQuery,
+  useProjectPullRequestsQuery,
+} from '../useFactoryData';
 
 const PROJECT_ID = 'github-project-1';
 const ISSUES_URL = `${TEST_BASE_URL}/web/github/projects/${PROJECT_ID}/issues`;
@@ -134,6 +139,31 @@ describe('useProjectIssuesQuery', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.error).toBeInstanceOf(Error);
     expect((result.current.error as Error).message).toBe('boom');
+  });
+
+  it('given the feed keeps failing, when the normal poll interval elapses, then it backs off instead of hammering', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      let hits = 0;
+      server.use(
+        http.get(ISSUES_URL, () => {
+          hits += 1;
+          return HttpResponse.json({ error: 'github_error', message: 'installation unavailable' }, { status: 502 });
+        }),
+      );
+
+      const { result } = renderHookWithProviders(() => useProjectIssuesQuery(PROJECT_ID));
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(hits).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(INTAKE_POLL_MS + 1_000);
+      expect(hits).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(INTAKE_ERROR_POLL_MS);
+      await waitFor(() => expect(hits).toBe(2));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/mastracode/factory-ui/src/hooks/useFactoryData.ts
+++ b/mastracode/factory-ui/src/hooks/useFactoryData.ts
@@ -13,6 +13,14 @@ import type { GithubIssue } from '../ui/domains/factory/services/factory';
  * server) — poll on a gentler cadence than the DB-backed work-items list. */
 export const INTAKE_POLL_MS = 30_000;
 
+/** Back-off once the feed fails: each poll burns the installation's mint budget,
+ * but the feed must still self-heal after the connection is repaired. */
+export const INTAKE_ERROR_POLL_MS = 5 * 60_000;
+
+function intakePollInterval(query: { state: { status: string } }): number {
+  return query.state.status === 'error' ? INTAKE_ERROR_POLL_MS : INTAKE_POLL_MS;
+}
+
 /**
  * Open issues for a GitHub project, loaded one page at a time as the list is
  * scrolled; disabled until a github project is active.
@@ -30,7 +38,7 @@ export function useProjectIssuesQuery(projectRepositoryId: string | undefined, l
     // New intake must show up on the board without a reload. The endpoint
     // proxies the live GitHub API (and a refetch replays every loaded page),
     // so poll gently and refresh when the user returns to the tab.
-    refetchInterval: INTAKE_POLL_MS,
+    refetchInterval: intakePollInterval,
     refetchOnWindowFocus: true,
   });
 }
@@ -75,7 +83,7 @@ export function useProjectPullRequestsQuery(projectRepositoryId: string | undefi
     getNextPageParam: lastPage => lastPage.nextPage,
     select: data => data.pages.flatMap(page => page.pullRequests),
     // Same intake-freshness contract as the issues feed above.
-    refetchInterval: INTAKE_POLL_MS,
+    refetchInterval: intakePollInterval,
     refetchOnWindowFocus: true,
   });
 }

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { defaultFactoryRules } from '../../../rules/defaults.js';
+import type { SourceControlStorageHandle } from '../../../storage/domains/source-control/base.js';
 import type { IntegrationContext } from '../../base.js';
 
 import { createPlatformStorageForTests, mountApiRoutes } from '../test-utils.js';
@@ -1162,6 +1163,85 @@ describe('PlatformGithubIntegration', () => {
       // Verify the repository's installation_id was migrated to the new installation
       const migratedRepository = await storage.repositories.get({ orgId: 'org-1', id: oldRepository.id });
       expect(migratedRepository?.installationId).toBe(newInstallation.id);
+    });
+
+    /** Old installation on `7`, new one on `456`, both owned by `acme`. */
+    async function seedReinstalledOrg(storage: SourceControlStorageHandle) {
+      const oldInstallation = await storage.installations.upsert({
+        orgId: 'org-1',
+        connectedByUserId: 'user-1',
+        externalId: '7',
+        accountName: 'acme',
+        accountType: 'Organization',
+      });
+      const oldRepository = await storage.repositories.upsert({
+        orgId: 'org-1',
+        input: { installationId: oldInstallation.id, externalId: '101', slug: 'acme/app', defaultBranch: 'main' },
+      });
+      const newInstallation = await storage.installations.upsert({
+        orgId: 'org-1',
+        connectedByUserId: 'user-1',
+        externalId: '456',
+        accountName: 'acme',
+        accountType: 'Organization',
+      });
+      return { oldInstallation, oldRepository, newInstallation };
+    }
+
+    it('recovers when Platform reports the installation as suspended or soft-deleted', async () => {
+      const { sourceControl } = await createPlatformStorageForTests();
+      const storage = sourceControl.forIntegration('github');
+      const { oldRepository, newInstallation } = await seedReinstalledOrg(storage);
+
+      // Platform answers 409 while its own row still exists but is unusable.
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ type: 'conflict', detail: 'GitHub App installation is not available.' }), {
+            status: 409,
+            headers: { 'content-type': 'application/json' },
+          }),
+        )
+        .mockResolvedValueOnce(json({ token: 'ghs_recovered', expiresAt: '2026-07-21T18:00:00Z' }));
+
+      const integration = createIntegration(fetchImpl);
+      integration.versionControl.initialize({ storage });
+
+      await expect(
+        integration.versionControl.getRepositoryAccess({ orgId: 'org-1', repositoryId: oldRepository.id }),
+      ).resolves.toEqual({
+        cloneUrl: 'https://github.com/acme/app.git',
+        authorization: { scheme: 'bearer', token: 'ghs_recovered' },
+      });
+
+      const migratedRepository = await storage.repositories.get({ orgId: 'org-1', id: oldRepository.id });
+      expect(migratedRepository?.installationId).toBe(newInstallation.id);
+    });
+
+    it('leaves the repository alone when the mint fails for a transient reason', async () => {
+      const { sourceControl } = await createPlatformStorageForTests();
+      const storage = sourceControl.forIntegration('github');
+      const { oldInstallation, oldRepository } = await seedReinstalledOrg(storage);
+
+      // A 502 covers a dead installation and a GitHub outage alike — migrating on it
+      // would repoint healthy repositories during an incident.
+      const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ type: 'github_app_token_mint_failed' }), {
+          status: 502,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+
+      const integration = createIntegration(fetchImpl);
+      integration.versionControl.initialize({ storage });
+
+      await expect(
+        integration.versionControl.getRepositoryAccess({ orgId: 'org-1', repositoryId: oldRepository.id }),
+      ).rejects.toThrow();
+
+      const repository = await storage.repositories.get({ orgId: 'org-1', id: oldRepository.id });
+      expect(repository?.installationId).toBe(oldInstallation.id);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -384,7 +384,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         // GitHub assigns a new installation ID. Platform creates a new installation row,
         // and Factory's intake.listSources creates a new local installation row with the
         // new externalId. Try to find the new installation by accountName.
-        if (!isNotFound(err) || !installation.accountName) throw err;
+        if (!isDeadInstallation(err) || !installation.accountName) throw err;
         const installations = await this.storage.installations.list({ orgId });
         const newInstallation = installations.find(
           inst => inst.accountName === installation.accountName && inst.id !== installation.id,
@@ -393,8 +393,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         const newInstallationId = parsePositiveInteger(newInstallation.externalId);
         if (newInstallationId === null) throw err;
 
-        // Persist the migration so we don't hit the 404 path on every call.
-        // This updates the repository's installation_id to the new installation.
+        // Persist the migration so we don't hit the recovery path on every call.
         await this.storage.repositories.migrateInstallation({
           orgId,
           id: repositoryId,
@@ -1399,4 +1398,10 @@ function reviewEvent(event: 'approve' | 'request-changes' | 'comment') {
 
 function isNotFound(error: unknown): boolean {
   return error instanceof PlatformApiError && error.status === 404;
+}
+
+// Platform answers 404 when the installation row is gone, 409 when it is suspended or soft-deleted.
+// A 502 also covers a dead installation but is indistinguishable from a transient GitHub outage.
+function isDeadInstallation(error: unknown): boolean {
+  return error instanceof PlatformApiError && (error.status === 404 || error.status === 409);
 }


### PR DESCRIPTION
Reinstalling a GitHub App hands it a new installation ID, and everything downstream of the stored one starts failing: session materialization can't mint a token to set the git remote, and intake quietly stops ingesting issues. Getting out of it needed a manual DB edit. Hit during live testing on 2026-07-23 (COR-1013).

The odd part is that the recovery already exists — on a failed mint we look for a replacement installation by account name and repoint the repository at it. It just never ran, because it was gated on Platform reporting the old installation as missing:

```ts
if (!isNotFound(err) || !installation.accountName) throw err;
```

Platform only answers 404 when its own installation row is gone. When the row is still there but suspended or soft-deleted — the common reinstall case — it answers 409, and the recovery was skipped. So the gate now covers both.

I deliberately left 502 out. Platform collapses every GitHub-side mint failure into a generic 502, which covers a dead installation and a transient GitHub outage equally well, and migrating on it would repoint healthy repositories mid-incident. There's a test pinning that behaviour so nobody widens it later without meaning to. Making the dead-installation case distinguishable is a change on the platform side, and I'd rather do it there than guess here.

While in there I also fixed the board intake polling every 30s no matter how badly it was failing, which taxes Platform's 30/min per-installation mint budget for nothing. It backs off to 5min while the feed is failing and returns to normal once it recovers — a back-off rather than a circuit break, so the board still heals itself after someone reconnects.

Two things worth knowing. None of this is verified against a real dead installation; I never reproduced the original incident, and the coverage is unit and MSW tests only. And I couldn't confirm whether the 2026-07-23 failure was a 409 or a 502 — the `github_app_installation_token_request_failed` logs would say. If it was a 502, this PR alone won't have fixed it and the platform change becomes the actual fix.

One correction to the issue while I'm here: the "installation resolution cached for process lifetime" theory doesn't hold up. Platform reads the installation from the DB on every mint, and the token cache in its GitHub App client sits on `getInstallationToken`, which the Factory-facing route bypasses. On our side the two caches are 5min and 30s. The restart that appeared to be required was most likely the 5min repository-access TTL expiring. So the acceptance criterion about not needing a restart should already hold today.

Tests: `@mastra/factory` 32/32, factory-ui MSW 396/396, typecheck on both packages, lint on `@mastra/factory`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

If Factory’s old GitHub connection stops working after an app is reinstalled, it can now find the new connection and fix the repository automatically. Intake polling also slows down during failures to avoid repeatedly contacting a broken service.

## What changed

- GitHub installation recovery now handles both `404` and `409` responses.
- Repositories are repointed to replacement installations automatically.
- `502` responses remain excluded from recovery to avoid masking temporary GitHub outages.
- Board intake polling backs off from 30 seconds to 5 minutes while errors persist, then returns to its normal interval.
- Added unit and MSW coverage for recovery and polling behavior.
- Added a patch Changesets entry for `@mastra/factory`.

## Validation

- Typechecks completed for both packages.
- Linting completed for `@mastra/factory`.
- Real dead-installation behavior has not been manually verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->