### PR TITLE
fix(platform-workspace): remove /exec fallback; make direct-exec the only data plane

### DIFF
--- a/.changeset/five-parrots-lay.md
+++ b/.changeset/five-parrots-lay.md
@@ -2,13 +2,13 @@
 '@mastra/platform-workspace': minor
 ---
 
-Fixed `PlatformSandbox.executeCommand` permanently falling back to the slower HTTP `/exec` route after a single WebSocket hiccup. A dropped connection is now retried once with a fresh lease, and later commands keep using the direct WebSocket path.
+`PlatformSandbox.executeCommand` now retries a dropped connection once and continues using direct execution for later commands. Previously a single connection hiccup permanently downgraded the sandbox to a slower fallback route for the rest of its lifetime.
 
-The HTTP fallback has been removed. Errors from the exec-lease endpoint now surface directly instead of being swallowed:
+Execution failures now surface directly:
 
-- A 410 response throws the new `SandboxDestroyedError`. The cached sandbox id and lease are cleared, so the next call provisions a fresh sandbox.
-- Any other non-2xx response throws `PlatformApiError` (previously masked by the fallback).
+- A destroyed sandbox throws the new `SandboxDestroyedError`. The cached sandbox is cleared, so the next call provisions a fresh one.
 - Two connection failures in a row against a live sandbox throw the new `SandboxExecTransportError`, which carries `sandboxId`, `command`, `attempts`, `opened`, `closeCode`, `closeReason`, and `wsEndpoint` for diagnostics.
+- Other platform errors previously masked by the fallback now bubble out as `PlatformApiError`.
 
 ```ts
 import { SandboxDestroyedError, SandboxExecTransportError } from '@mastra/platform-workspace';

--- a/.changeset/five-parrots-lay.md
+++ b/.changeset/five-parrots-lay.md
@@ -2,17 +2,13 @@
 '@mastra/platform-workspace': minor
 ---
 
-Improved `PlatformSandbox.executeCommand`: commands now always run over the faster direct WebSocket connection. A single connection hiccup is retried once with a fresh lease instead of permanently downgrading the sandbox to the slower HTTP route. If the retry also fails, the call throws a typed error you can act on.
+Fixed `PlatformSandbox.executeCommand` permanently falling back to the slower HTTP `/exec` route after a single WebSocket hiccup. A dropped connection is now retried once with a fresh lease, and later commands keep using the direct WebSocket path.
 
-**New error types** exported from `@mastra/platform-workspace`:
+The HTTP fallback has been removed. Errors from the exec-lease endpoint now surface directly instead of being swallowed:
 
-- `SandboxDestroyedError` — thrown when the sandbox has been destroyed. The cached sandbox id and lease are cleared, so reusing the same instance will provision a fresh sandbox on the next call. Catch this to reprovision and retry.
-- `SandboxExecTransportError` — thrown when the connection fails twice in a row against a sandbox that is still alive. Carries `sandboxId`, `command`, `attempts`, and connection diagnostics (`opened`, `closeCode`, `closeReason`, `wsEndpoint`) so you can tell a broken connection apart from a failed command.
-
-**Behaviour changes callers should audit:**
-
-- `PlatformApiError` (status 404 / 500 / 501 when starting an exec) now bubbles out of `executeCommand` instead of being silently retried against the old HTTP route. Wrap calls that expect to survive platform errors accordingly.
-- A one-off connection failure no longer slows down the rest of the session. Later commands keep using the fast path.
+- A 410 response throws the new `SandboxDestroyedError`. The cached sandbox id and lease are cleared, so the next call provisions a fresh sandbox.
+- Any other non-2xx response throws `PlatformApiError` (previously masked by the fallback).
+- Two connection failures in a row against a live sandbox throw the new `SandboxExecTransportError`, which carries `sandboxId`, `command`, `attempts`, `opened`, `closeCode`, `closeReason`, and `wsEndpoint` for diagnostics.
 
 ```ts
 import { SandboxDestroyedError, SandboxExecTransportError } from '@mastra/platform-workspace';
@@ -21,13 +17,9 @@ try {
   await sandbox.executeCommand('pytest');
 } catch (err) {
   if (err instanceof SandboxDestroyedError) {
-    // Reprovision the sandbox and replay the command.
+    // Reprovision and retry.
   } else if (err instanceof SandboxExecTransportError) {
-    console.error('Sandbox connection failed', {
-      closeCode: err.closeCode,
-      closeReason: err.closeReason,
-      wsEndpoint: err.wsEndpoint,
-    });
+    // Connection failed twice; sandbox is still alive.
   }
 }
 ```

--- a/.changeset/five-parrots-lay.md
+++ b/.changeset/five-parrots-lay.md
@@ -1,0 +1,33 @@
+---
+'@mastra/platform-workspace': minor
+---
+
+Removed the `/exec` proxy fallback from `PlatformSandbox.executeCommand` so direct-exec (WebSocket to Railway) is now the only data plane. A single WebSocket handshake hiccup no longer permanently disables direct-exec for the sandbox's lifetime — the client now performs one in-flight retry with a fresh lease, and only escalates to a typed error when the retry also fails.
+
+**New error types** exported from `@mastra/platform-workspace`:
+
+- `SandboxDestroyedError` — thrown when `/exec-lease` returns 410. The sandbox has been destroyed; the client clears its cached sandbox id and lease so a reused instance re-provisions on the next call. Fleet-level code should catch this and reprovision + replay.
+- `SandboxExecTransportError` — thrown when both the initial WebSocket attempt and the retry close without an `exit` frame against a live sandbox. Carries `{ opened, closeCode, closeReason, wsEndpoint, sandboxId, command, attempts }` so operators can distinguish transport failures from command failures.
+
+**Behaviour changes callers should audit:**
+
+- `PlatformApiError` (status 404 / 500 / 501 on `/exec-lease`) now bubbles out of `executeCommand` instead of being silently swallowed by a fallback to `POST /sandbox/:id/exec`.
+- A transient WebSocket transport failure no longer disables direct-exec for the sandbox's lifetime — subsequent execs use direct-exec again, protecting per-session performance under the concurrent-exec burst patterns the fallback used to permanently punish.
+
+```ts
+import { SandboxDestroyedError, SandboxExecTransportError } from '@mastra/platform-workspace';
+
+try {
+  await sandbox.executeCommand('pytest');
+} catch (err) {
+  if (err instanceof SandboxDestroyedError) {
+    // fleet layer: clear stale binding, reprovision, replay
+  } else if (err instanceof SandboxExecTransportError) {
+    console.error('Railway data plane failure', {
+      closeCode: err.closeCode,
+      closeReason: err.closeReason,
+      wsEndpoint: err.wsEndpoint,
+    });
+  }
+}
+```

--- a/.changeset/five-parrots-lay.md
+++ b/.changeset/five-parrots-lay.md
@@ -2,17 +2,17 @@
 '@mastra/platform-workspace': minor
 ---
 
-Removed the `/exec` proxy fallback from `PlatformSandbox.executeCommand` so direct-exec (WebSocket to Railway) is now the only data plane. A single WebSocket handshake hiccup no longer permanently disables direct-exec for the sandbox's lifetime — the client now performs one in-flight retry with a fresh lease, and only escalates to a typed error when the retry also fails.
+Improved `PlatformSandbox.executeCommand`: commands now always run over the faster direct WebSocket connection. A single connection hiccup is retried once with a fresh lease instead of permanently downgrading the sandbox to the slower HTTP route. If the retry also fails, the call throws a typed error you can act on.
 
 **New error types** exported from `@mastra/platform-workspace`:
 
-- `SandboxDestroyedError` — thrown when `/exec-lease` returns 410. The sandbox has been destroyed; the client clears its cached sandbox id and lease so a reused instance re-provisions on the next call. Fleet-level code should catch this and reprovision + replay.
-- `SandboxExecTransportError` — thrown when both the initial WebSocket attempt and the retry close without an `exit` frame against a live sandbox. Carries `{ opened, closeCode, closeReason, wsEndpoint, sandboxId, command, attempts }` so operators can distinguish transport failures from command failures.
+- `SandboxDestroyedError` — thrown when the sandbox has been destroyed. The cached sandbox id and lease are cleared, so reusing the same instance will provision a fresh sandbox on the next call. Catch this to reprovision and retry.
+- `SandboxExecTransportError` — thrown when the connection fails twice in a row against a sandbox that is still alive. Carries `sandboxId`, `command`, `attempts`, and connection diagnostics (`opened`, `closeCode`, `closeReason`, `wsEndpoint`) so you can tell a broken connection apart from a failed command.
 
 **Behaviour changes callers should audit:**
 
-- `PlatformApiError` (status 404 / 500 / 501 on `/exec-lease`) now bubbles out of `executeCommand` instead of being silently swallowed by a fallback to `POST /sandbox/:id/exec`.
-- A transient WebSocket transport failure no longer disables direct-exec for the sandbox's lifetime — subsequent execs use direct-exec again, protecting per-session performance under the concurrent-exec burst patterns the fallback used to permanently punish.
+- `PlatformApiError` (status 404 / 500 / 501 when starting an exec) now bubbles out of `executeCommand` instead of being silently retried against the old HTTP route. Wrap calls that expect to survive platform errors accordingly.
+- A one-off connection failure no longer slows down the rest of the session. Later commands keep using the fast path.
 
 ```ts
 import { SandboxDestroyedError, SandboxExecTransportError } from '@mastra/platform-workspace';
@@ -21,9 +21,9 @@ try {
   await sandbox.executeCommand('pytest');
 } catch (err) {
   if (err instanceof SandboxDestroyedError) {
-    // fleet layer: clear stale binding, reprovision, replay
+    // Reprovision the sandbox and replay the command.
   } else if (err instanceof SandboxExecTransportError) {
-    console.error('Railway data plane failure', {
+    console.error('Sandbox connection failed', {
       closeCode: err.closeCode,
       closeReason: err.closeReason,
       wsEndpoint: err.wsEndpoint,

--- a/docs/src/content/en/reference/workspace/platform-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/platform-sandbox.mdx
@@ -269,6 +269,28 @@ try {
 
 `code` and `proxyMessage` are `undefined` when the response body isn't JSON, for example an HTML 502 from a load balancer.
 
+`executeCommand` runs over the direct-exec data plane (a WebSocket to the Railway tcp-proxy) and can also throw two typed sandbox errors on unrecoverable failure:
+
+```typescript
+import { SandboxDestroyedError, SandboxExecTransportError } from '@mastra/platform-workspace'
+
+try {
+  await sandbox.executeCommand('pytest')
+} catch (err) {
+  if (err instanceof SandboxDestroyedError) {
+    // /exec-lease returned 410; the sandbox has been destroyed.
+    // The cached sandbox id and lease have already been cleared,
+    // so reusing the instance will reprovision on the next call.
+  } else if (err instanceof SandboxExecTransportError) {
+    // Both the initial WebSocket attempt and the built-in retry
+    // closed without an exit frame against a live sandbox.
+    console.error(err.closeCode, err.closeReason, err.wsEndpoint)
+  }
+}
+```
+
+`SandboxExecTransportError` carries diagnostic fields (`opened`, `closeCode`, `closeReason`, `wsEndpoint`, plus `sandboxId`, `command`, and `attempts`) so operators can distinguish a broken Railway data plane from a failed command.
+
 ## Related
 
 - [PlatformFilesystem reference](/reference/workspace/platform-filesystem)

--- a/workspaces/platform-workspace/README.md
+++ b/workspaces/platform-workspace/README.md
@@ -106,3 +106,12 @@ try {
 `code` / `proxyMessage` are `undefined` when the proxy returns a non-JSON body (e.g. an HTML 502 from a load balancer).
 
 Filesystem-specific errors (`FileNotFoundError`, `FileExistsError`, `WorkspaceReadOnlyError`) are re-exported from `@mastra/core`.
+
+### Sandbox exec errors
+
+`PlatformSandbox.executeCommand` runs over the direct-exec data plane (a WebSocket straight to the Railway tcp-proxy) and can throw two typed errors on unrecoverable failure:
+
+- `SandboxDestroyedError` — the platform returned 410 for `/exec-lease`, meaning the sandbox has been destroyed. The cached sandbox id and lease are cleared, so a reused `PlatformSandbox` instance will re-provision on the next call. Fleet-level code that owns a binding store should catch this, clear the stale sandbox id, and reprovision + replay.
+- `SandboxExecTransportError` — both the initial WebSocket attempt and the built-in retry closed without an `exit` frame against a live sandbox. Carries `{ opened, closeCode, closeReason, wsEndpoint }` diagnostics plus `sandboxId`, `command`, and `attempts` so upstream logs / alerts can distinguish "the Railway data plane is broken" from "your command failed".
+
+`PlatformApiError` (with status 404 / 500 / 501 on `/exec-lease`) can also bubble up from `executeCommand` — those are configuration or platform errors, not "reprovision me" signals, and are propagated as-is.

--- a/workspaces/platform-workspace/src/index.ts
+++ b/workspaces/platform-workspace/src/index.ts
@@ -1,4 +1,10 @@
 export { PlatformClient, PlatformApiError, type PlatformClientOptions, type PlatformProxyError } from './client.js';
 export { PlatformFilesystem, type PlatformFilesystemOptions } from './filesystem.js';
-export { PlatformSandbox, type PlatformSandboxOptions, type PlatformSandboxNetworkIsolation } from './sandbox.js';
+export {
+  PlatformSandbox,
+  SandboxExecTransportError,
+  SandboxDestroyedError,
+  type PlatformSandboxOptions,
+  type PlatformSandboxNetworkIsolation,
+} from './sandbox.js';
 export { platformFilesystemProvider, platformSandboxProvider } from './provider.js';

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -753,6 +753,11 @@ describe('PlatformSandbox', () => {
       for (const call of fetchMock.mock.calls) {
         expect(String(call[0])).not.toMatch(/\/exec$/);
       }
+
+      // The lease from the failed second attempt must be evicted so a caller
+      // that catches the transport error and re-runs the command doesn't
+      // waste its first WS attempt on the same implicated JWT.
+      expect((sandbox as unknown as { _lease: unknown })._lease).toBeNull();
     });
 
     it('coalesces concurrent execs during a transient WS failure into a single retry mint', async () => {

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -576,8 +576,7 @@ describe('PlatformSandbox', () => {
       // Sandbox id must be cleared so the caller's next executeCommand
       // triggers a fresh ensureRunning + provision cycle instead of picking
       // up the stale id.
-      const info = await sandbox.getInfo();
-      expect(info.metadata?.sandboxId).toBeUndefined();
+      expect((sandbox as unknown as { _sandboxId: unknown })._sandboxId).toBeUndefined();
     });
 
     it('propagates non-410 errors from the exec-lease mint instead of falling back silently', async () => {
@@ -698,8 +697,7 @@ describe('PlatformSandbox', () => {
       // open a second socket.
       expect(sockets).toHaveLength(1);
       // Sandbox id cleared — same invariant as the initial-410 case.
-      const info = await sandbox.getInfo();
-      expect(info.metadata?.sandboxId).toBeUndefined();
+      expect((sandbox as unknown as { _sandboxId: unknown })._sandboxId).toBeUndefined();
     });
 
     it('throws SandboxExecTransportError when both WS attempts fail against a live sandbox', async () => {
@@ -863,6 +861,76 @@ describe('PlatformSandbox', () => {
       expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(sockets).toHaveLength(3);
       expect(sockets[2]!.subprotocols[1]).toBe('jwt.second');
+    });
+
+    it('does not evict a concurrently-cached fresh lease when an older attempt fails late', async () => {
+      // Race scenario: exec A opens a WS with lease-1, exec B is scheduled
+      // after A retries and caches lease-2, THEN A's second-attempt WS fails
+      // late. A must clear only lease-1 (already gone); it must not blow
+      // away lease-2 which exec B legitimately cached. Without the identity
+      // guard on `_lease` eviction, A would null the cache and force the
+      // next exec into an avoidable extra `/exec-lease` mint.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.first' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.second' }));
+      const sockets: FakeSocket[] = [];
+      // Hand out a socket that never closes on demand, so we can drive the
+      // race deterministically from the test body instead of via
+      // queueMicrotask.
+      const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+        const socket = new FakeSocket(endpoint, subprotocols);
+        sockets.push(socket);
+        return socket;
+      };
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+
+      // Kick off exec A. It mints lease-1 and opens sockets[0].
+      const execA = sandbox.executeCommand('echo A').catch(err => err);
+      await vi.waitFor(() => expect(sockets).toHaveLength(1));
+      // A's first WS fails. It will now mint lease-2 for its retry attempt.
+      sockets[0]!.onopen?.({});
+      sockets[0]!.onclose?.({ code: 1006, reason: 'abnormal' });
+      await vi.waitFor(() => expect(sockets).toHaveLength(2));
+      // At this point A has cached lease-2 in `_lease` and is holding
+      // sockets[1] open. Fail sockets[1] to trigger A's final eviction
+      // path — but before that, "exec B" has *effectively* cached lease-2
+      // by being the one that owns it. When A's transport-failure throw
+      // clears the cache, an identity check must preserve lease-2 (still
+      // the currently-cached lease) so B (the next exec) reuses it.
+      const lease2 = (sandbox as unknown as { _lease: { jwt: string } | null })._lease;
+      expect(lease2?.jwt).toBe('jwt.second');
+
+      // Fail A's retry WS -> throws SandboxExecTransportError, tries to
+      // clear _lease. With the identity guard AND the fact that the still-
+      // cached lease IS the one that just failed, the cache is cleared;
+      // this test intentionally exercises the safe-clear branch by making
+      // no OTHER lease exist. The negative-race case is covered by the
+      // guarded assertion below: we manually inject a "concurrent fresh"
+      // lease before A's throw runs its eviction, and confirm A does NOT
+      // discard it.
+      const freshLease = { jwt: 'jwt.fresh', expiresAtMs: Date.now() + 60_000 } as const;
+      (sandbox as unknown as { _lease: unknown })._lease = freshLease;
+      sockets[1]!.onopen?.({});
+      sockets[1]!.onclose?.({ code: 1006, reason: 'abnormal' });
+      const err = await execA;
+      const { SandboxExecTransportError } = await import('./sandbox.js');
+      expect(err).toBeInstanceOf(SandboxExecTransportError);
+      // The freshLease we injected must survive A's eviction, because it
+      // is not the lease A failed on. Without the identity guard, this
+      // would be null.
+      expect((sandbox as unknown as { _lease: unknown })._lease).toBe(freshLease);
     });
 
     it('coalesces concurrent lease mints on a cold cache into a single POST /exec-lease', async () => {

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -372,12 +372,12 @@ describe('PlatformSandbox', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2); // no third fetch
   });
 
-  it('treats an explicit timeout: 0 as "no timeout" on the direct-exec path (matches proxy semantics)', async () => {
-    // On the fallback /exec path, timeout: 0 must be preserved (not dropped
-    // by a truthy check) so the proxy sees `timeoutSec: 0` and interprets it
-    // as no-timeout. On the direct-exec path, the client owns the timeout —
-    // "no timeout" is expressed by NOT arming a client-side timer, so the
-    // exec runs to completion regardless of wall-clock elapsed.
+  it('treats an explicit timeout: 0 as "no timeout" on the direct-exec path', async () => {
+    // The client owns the timeout on the direct-exec path — "no timeout" is
+    // expressed by NOT arming a client-side timer, so the exec runs to
+    // completion regardless of wall-clock elapsed. A truthy check that
+    // dropped `timeout: 0` would silently swap it for the default, which
+    // is exactly the bug this test guards against.
     vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
     const fetchMock = vi
       .fn()
@@ -514,20 +514,17 @@ describe('PlatformSandbox', () => {
       expect(fetchMock).toHaveBeenCalledTimes(3);
     });
 
-    it('falls back to the proxy /exec route when the exec-lease endpoint returns 404', async () => {
+    it('throws PlatformApiError when /exec-lease returns 404 (no /exec fallback)', async () => {
+      // Old proxy without /exec-lease is now a loud config error, not a
+      // silent fallback. Platform PR #1777 is deployed everywhere — a 404
+      // here means the proxy is genuinely misconfigured and should be seen.
       vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
-        // Older platform deployment: exec-lease not present.
-        .mockResolvedValueOnce(json({ error: { message: 'Not Found', type: 'not_found' } }, { status: 404 }))
-        .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '', timedOut: false, truncated: false }))
-        // Second exec should skip the mint attempt entirely — the fallback bit is sticky.
-        .mockResolvedValueOnce(json({ exitCode: 0, stdout: 'ok', stderr: '', timedOut: false, truncated: false }));
-      // If the fallback fails to trigger, we'd end up here and the test would blow up
-      // with an unhandled WS error. Passing a factory that throws makes that explicit.
+        .mockResolvedValueOnce(json({ error: { message: 'Not Found', type: 'not_found' } }, { status: 404 }));
       const factory: DirectExecWebSocketFactory = () => {
-        throw new Error('should not open a WebSocket after 404 fallback');
+        throw new Error('should not open a WebSocket when the lease mint 404s');
       };
 
       const sandbox = new PlatformSandbox({
@@ -539,21 +536,53 @@ describe('PlatformSandbox', () => {
       });
 
       await sandbox._start();
-      const first = await sandbox.executeCommand('echo one');
-      const second = await sandbox.executeCommand('echo two');
-
-      expect(first).toMatchObject({ exitCode: 0, stdout: 'ok' });
-      expect(second).toMatchObject({ exitCode: 0, stdout: 'ok' });
-      // Calls: provision, exec-lease (404), /exec (fallback), /exec (sticky fallback).
-      expect(fetchMock).toHaveBeenCalledTimes(4);
+      await expect(sandbox.executeCommand('echo one')).rejects.toThrow(/not_found/);
+      // Provision + failed mint only — no /exec request.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(String(fetchMock.mock.calls[1]![0])).toBe(
         'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
       );
-      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec');
-      expect(String(fetchMock.mock.calls[3]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec');
     });
 
-    it('propagates non-404/501 errors from the exec-lease mint instead of falling back silently', async () => {
+    it('throws SandboxDestroyedError when /exec-lease returns 410 and clears sandbox state', async () => {
+      // 410 = sandbox has been destroyed (Railway destroy, quota reclamation,
+      // etc.). The client cannot recover on its own — the fleet layer must
+      // clear the stale binding and reprovision. This test asserts the
+      // typed error surfaces + cached sandbox state is nulled so a reused
+      // instance re-provisions cleanly on the next call.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(json({ error: { message: 'Gone', type: 'gone' } }, { status: 410 }));
+      const factory: DirectExecWebSocketFactory = () => {
+        throw new Error('should not open a WebSocket when the sandbox is destroyed');
+      };
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      const { SandboxDestroyedError } = await import('./sandbox.js');
+      await expect(sandbox.executeCommand('echo one', ['arg'])).rejects.toBeInstanceOf(SandboxDestroyedError);
+      // Only provision + one failed mint. No /exec fallback, no retry mint —
+      // a 410 on the first attempt is terminal for this instance.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      // Sandbox id must be cleared so the caller's next executeCommand
+      // triggers a fresh ensureRunning + provision cycle instead of picking
+      // up the stale id.
+      const info = await sandbox.getInfo();
+      expect(info.metadata?.sandboxId).toBeUndefined();
+    });
+
+    it('propagates non-410 errors from the exec-lease mint instead of falling back silently', async () => {
+      // 500/501 are platform errors that must surface, not be masked by a
+      // silent fallback to /exec.
       vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
       const fetchMock = vi
         .fn()
@@ -569,36 +598,84 @@ describe('PlatformSandbox', () => {
 
       await sandbox._start();
       await expect(sandbox.executeCommand('echo hi')).rejects.toThrow(/internal_error/);
-      // Only provision + failed mint; no /exec fallback because 500 isn't a
-      // "endpoint not present" signal.
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
-    it('falls back to /exec permanently after a WS transport failure', async () => {
-      // Simulates a mid-handshake drop / expired token / provider hiccup:
-      // lease mint succeeds but the direct-exec socket closes before an exit
-      // frame arrives. We fall through to /exec for THIS call AND stay on
-      // /exec for every subsequent call on this sandbox — we don't want to
-      // pay a fresh mint + failed handshake on every exec when the transport
-      // is broken (see direct-exec production incident 2026-07-29).
+    it('recovers from a single transient WS transport failure by minting a fresh lease and retrying', async () => {
+      // First direct-exec WS closes without an exit frame (transport hiccup).
+      // The client must drop the cached lease, mint a fresh one, and retry
+      // on the same sandbox — one bad millisecond must NOT cost the entire
+      // session (this was the perf regression that motivated ripping the
+      // /exec fallback in the first place).
       vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
         .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.first' }))
-        .mockResolvedValueOnce(
-          json({ exitCode: 0, stdout: 'via-proxy-1', stderr: '', timedOut: false, truncated: false }),
-        )
-        .mockResolvedValueOnce(
-          json({ exitCode: 0, stdout: 'via-proxy-2', stderr: '', timedOut: false, truncated: false }),
-        );
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.second' }));
       const sockets: FakeSocket[] = [];
       const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
         const socket = new FakeSocket(endpoint, subprotocols);
         sockets.push(socket);
         queueMicrotask(() => {
           socket.onopen?.({});
-          // Close without an exit frame — transport failure.
+          if (sockets.length === 1) {
+            // First socket: transport failure (close without exit frame).
+            socket.onclose?.({ code: 1006, reason: 'abnormal' });
+          } else {
+            // Second socket: real exit frame — retry succeeds.
+            socket.fireBinary(1, 'ok');
+            socket.onmessage?.({ data: JSON.stringify({ type: 'exit', data: { exit_code: 0 } }) });
+          }
+        });
+        return socket;
+      };
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      const result = await sandbox.executeCommand('echo one');
+
+      expect(result).toMatchObject({ success: true, exitCode: 0, stdout: 'ok' });
+      // Fetch sequence: provision, first lease, second lease. No /exec call.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(String(fetchMock.mock.calls[1]![0])).toBe(
+        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
+      );
+      expect(String(fetchMock.mock.calls[2]![0])).toBe(
+        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
+      );
+      // Two WS attempts: the failed one and the successful retry, each with
+      // a distinct JWT proving the cached lease was dropped between them.
+      expect(sockets).toHaveLength(2);
+      expect(sockets[0]!.subprotocols[1]).toBe('jwt.first');
+      expect(sockets[1]!.subprotocols[1]).toBe('jwt.second');
+    });
+
+    it('throws SandboxDestroyedError when a transport failure is followed by 410 on the retry mint', async () => {
+      // The destroyed-mid-exec scenario: the cached lease's WS drops with
+      // no exit frame (looks like a transport failure), then the retry mint
+      // returns 410 (sandbox is actually gone). The error must be
+      // SandboxDestroyedError, not SandboxExecTransportError — the caller's
+      // recovery strategy is completely different (reprovision, not retry).
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.first' }))
+        .mockResolvedValueOnce(json({ error: { message: 'Gone', type: 'gone' } }, { status: 410 }));
+      const sockets: FakeSocket[] = [];
+      const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+        const socket = new FakeSocket(endpoint, subprotocols);
+        sockets.push(socket);
+        queueMicrotask(() => {
+          socket.onopen?.({});
           socket.onclose?.({ code: 1006, reason: 'abnormal' });
         });
         return socket;
@@ -613,20 +690,174 @@ describe('PlatformSandbox', () => {
       });
 
       await sandbox._start();
-      const first = await sandbox.executeCommand('echo one');
-      const second = await sandbox.executeCommand('echo two');
-
-      expect(first).toMatchObject({ exitCode: 0, stdout: 'via-proxy-1' });
-      expect(second).toMatchObject({ exitCode: 0, stdout: 'via-proxy-2' });
-      // Fetch sequence: provision, first lease, /exec fallback, /exec fallback (no re-mint).
-      expect(fetchMock).toHaveBeenCalledTimes(4);
-      expect(String(fetchMock.mock.calls[1]![0])).toBe(
-        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
-      );
-      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec');
-      expect(String(fetchMock.mock.calls[3]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec');
-      // Only one WS attempt — kill switch prevents the second exec from retrying direct.
+      const { SandboxDestroyedError } = await import('./sandbox.js');
+      await expect(sandbox.executeCommand('echo one')).rejects.toBeInstanceOf(SandboxDestroyedError);
+      // provision + first lease (used for failed WS) + retry mint (410).
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      // Only one WS attempt was made — the retry mint 410'd before we could
+      // open a second socket.
       expect(sockets).toHaveLength(1);
+      // Sandbox id cleared — same invariant as the initial-410 case.
+      const info = await sandbox.getInfo();
+      expect(info.metadata?.sandboxId).toBeUndefined();
+    });
+
+    it('throws SandboxExecTransportError when both WS attempts fail against a live sandbox', async () => {
+      // Persistent transport failure with a still-alive sandbox at the
+      // control plane (mint keeps succeeding). This is the "Railway data
+      // plane is broken" signal — a loud, typed error the platform team
+      // can act on, replacing the old silent kill-switch-and-fallback.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.first' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.second' }));
+      const sockets: FakeSocket[] = [];
+      const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+        const socket = new FakeSocket(endpoint, subprotocols);
+        sockets.push(socket);
+        queueMicrotask(() => {
+          socket.onopen?.({});
+          socket.onclose?.({ code: 1011, reason: 'server_error' });
+        });
+        return socket;
+      };
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      const { SandboxExecTransportError } = await import('./sandbox.js');
+      const promise = sandbox.executeCommand('echo one');
+      await expect(promise).rejects.toBeInstanceOf(SandboxExecTransportError);
+      const error = (await promise.catch(e => e)) as InstanceType<typeof SandboxExecTransportError>;
+      expect(error).toMatchObject({
+        sandboxId: 'sbx_1',
+        command: 'echo one',
+        attempts: 2,
+        opened: true,
+        closeCode: 1011,
+        closeReason: 'server_error',
+        wsEndpoint: 'wss://ssh.railway.com:2226/ws/exec',
+      });
+      // provision + two mints. No /exec request.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(sockets).toHaveLength(2);
+      // No /exec call was ever made.
+      for (const call of fetchMock.mock.calls) {
+        expect(String(call[0])).not.toMatch(/\/exec$/);
+      }
+    });
+
+    it('coalesces concurrent execs during a transient WS failure into a single retry mint', async () => {
+      // Under a normal agent burst (parallel find_files / view / etc), the
+      // second-attempt lease mint must be shared by all in-flight execs
+      // rather than fanning out into N mints. This is the pathological
+      // pattern from prod incident 2026-07-29 that the coalescing guards
+      // against.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      // Delay the retry-mint response so all 10 execs pile into _ensureLease
+      // simultaneously and share it.
+      let releaseRetryMint!: () => void;
+      const retryMintPromise = new Promise<Response>(resolve => {
+        releaseRetryMint = () => resolve(leaseResponse({ jwt: 'jwt.retry' }));
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.first' }))
+        .mockImplementationOnce(() => retryMintPromise);
+      const sockets: FakeSocket[] = [];
+      const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+        const socket = new FakeSocket(endpoint, subprotocols);
+        sockets.push(socket);
+        queueMicrotask(() => {
+          socket.onopen?.({});
+          if (subprotocols[1] === 'jwt.first') {
+            socket.onclose?.({ code: 1006, reason: 'abnormal' });
+          } else {
+            socket.fireBinary(1, 'ok');
+            socket.onmessage?.({ data: JSON.stringify({ type: 'exit', data: { exit_code: 0 } }) });
+          }
+        });
+        return socket;
+      };
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      // Fire 10 execs; all should share the retry mint after their first
+      // (cached-lease) WS fails.
+      const results = Promise.all(Array.from({ length: 10 }, (_, i) => sandbox.executeCommand(`echo ${i}`)));
+      // Let them all pile into _ensureLease after their first-attempt WS
+      // failure, then release the shared retry mint.
+      await new Promise(r => setTimeout(r, 0));
+      releaseRetryMint();
+      const finished = await results;
+
+      for (const result of finished) {
+        expect(result).toMatchObject({ success: true, exitCode: 0 });
+      }
+      // provision + first (cached) mint + exactly one retry mint (shared).
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not reuse a failed lease after a transport-failure retry succeeds', async () => {
+      // After the retry mint replaces the failed lease, the next exec must
+      // use the new lease's JWT — reusing the failed one would re-run the
+      // whole retry dance and defeat the point of the retry.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.first' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.second' }));
+      const sockets: FakeSocket[] = [];
+      const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+        const socket = new FakeSocket(endpoint, subprotocols);
+        sockets.push(socket);
+        queueMicrotask(() => {
+          socket.onopen?.({});
+          if (sockets.length === 1) {
+            socket.onclose?.({ code: 1006, reason: 'abnormal' });
+          } else {
+            socket.fireBinary(1, 'ok');
+            socket.onmessage?.({ data: JSON.stringify({ type: 'exit', data: { exit_code: 0 } }) });
+          }
+        });
+        return socket;
+      };
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      await sandbox.executeCommand('echo first');
+      await sandbox.executeCommand('echo second');
+
+      // provision + first mint + retry mint. Second exec must reuse the
+      // (now cached) jwt.second lease, not mint again and not reopen using
+      // jwt.first.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(sockets).toHaveLength(3);
+      expect(sockets[2]!.subprotocols[1]).toBe('jwt.second');
     });
 
     it('coalesces concurrent lease mints on a cold cache into a single POST /exec-lease', async () => {

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -125,10 +125,7 @@ export class SandboxDestroyedError extends Error {
   readonly command: string;
   readonly attempts: number;
 
-  constructor(
-    message: string,
-    diagnostics: { sandboxId?: string; command: string; attempts: number },
-  ) {
+  constructor(message: string, diagnostics: { sandboxId?: string; command: string; attempts: number }) {
     super(message);
     this.name = 'SandboxDestroyedError';
     this.sandboxId = diagnostics.sandboxId;
@@ -529,6 +526,10 @@ export class PlatformSandbox extends MastraSandbox {
     // broken."
     const result = lastResult!;
     const lease = lastLease!;
+    // The lease from the failed second attempt is still cached; drop it so
+    // the next `executeCommand` doesn't waste its first attempt on the same
+    // implicated JWT before minting fresh.
+    this._lease = null;
     throw new SandboxExecTransportError(
       `Direct-exec transport failed for sandbox ${this._sandboxId ?? '(unknown)'} after ${attemptsMade} attempt(s)` +
         (result.closeCode !== undefined

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -405,9 +405,9 @@ export class PlatformSandbox extends MastraSandbox {
 
     const started = Date.now();
     const fullCommand = buildCommand(command, args);
-    // Nullish check so an explicit `timeout: 0` is sent as `0` (interpreted as
-    // "no timeout" by the direct-exec transport) instead of being dropped by a
-    // truthy check.
+    // Nullish check so an explicit `timeout: 0` still overrides the instance
+    // default. `_runDirectExec` omits `timeoutMs` from the exec payload when
+    // the value is 0, which disables the client-side timer entirely.
     const effectiveTimeout = options?.timeout ?? this._timeout;
 
     // Direct-exec (WebSocket straight to Railway's tcp-proxy) is the only
@@ -474,11 +474,14 @@ export class PlatformSandbox extends MastraSandbox {
     let lastResult: Awaited<ReturnType<typeof execViaLease>> | undefined;
     let lastLease: (ExecLease & { expiresAtMs: number | null }) | undefined;
     let attemptsMade = 0;
-    // Two attempts: initial + one retry. On the second attempt we always
-    // drop the cached lease first so we don't reuse a JWT that may itself
-    // be the cause of the transport failure.
+    // Two attempts: initial + one retry. On the second attempt we drop the
+    // cached lease so we don't reuse a JWT that may itself be the cause of
+    // the transport failure — but only if the cache still holds the same
+    // lease we just failed against. A concurrent exec sharing this instance
+    // may have already cached a fresh, unrelated lease in between, and we
+    // must not discard that.
     for (let attempt = 0; attempt < 2; attempt++) {
-      if (attempt > 0) this._lease = null;
+      if (attempt > 0 && lastLease && this._lease === lastLease) this._lease = null;
       let lease: ExecLease & { expiresAtMs: number | null };
       try {
         lease = await this._ensureLease();
@@ -528,8 +531,10 @@ export class PlatformSandbox extends MastraSandbox {
     const lease = lastLease!;
     // The lease from the failed second attempt is still cached; drop it so
     // the next `executeCommand` doesn't waste its first attempt on the same
-    // implicated JWT before minting fresh.
-    this._lease = null;
+    // implicated JWT before minting fresh. Identity-check first so a
+    // concurrent exec that has already cached a fresh, unrelated lease
+    // isn't collateral-damaged.
+    if (this._lease === lease) this._lease = null;
     throw new SandboxExecTransportError(
       `Direct-exec transport failed for sandbox ${this._sandboxId ?? '(unknown)'} after ${attemptsMade} attempt(s)` +
         (result.closeCode !== undefined

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -66,12 +66,75 @@ const CREATE_MAX_ATTEMPTS = 3;
 /** Base delay between create retries; multiplied by the attempt number. */
 const CREATE_RETRY_BASE_DELAY_MS = 2_000;
 
-interface ExecResponse {
-  exitCode: number | null;
-  stdout: string;
-  stderr: string;
-  truncated?: boolean;
-  timedOut?: boolean;
+/**
+ * Diagnostic error thrown when the direct-exec WebSocket transport fails
+ * twice in a row (opening handshake refused or socket closed mid-stream
+ * without an `exit` frame). Distinguishes "the sandbox transport is broken"
+ * from "your command failed" so callers can decide whether to retry at a
+ * higher level (e.g. reprovision the sandbox) or surface the error.
+ *
+ * `opened` is `true` when the WebSocket completed its handshake at least
+ * once before closing; `false` when Railway refused the upgrade outright.
+ */
+export class SandboxExecTransportError extends Error {
+  readonly sandboxId: string | undefined;
+  readonly command: string;
+  readonly attempts: number;
+  readonly opened: boolean;
+  readonly closeCode: number | undefined;
+  readonly closeReason: string | undefined;
+  readonly wsEndpoint: string;
+
+  constructor(
+    message: string,
+    diagnostics: {
+      sandboxId?: string;
+      command: string;
+      attempts: number;
+      opened: boolean;
+      closeCode?: number;
+      closeReason?: string;
+      wsEndpoint: string;
+    },
+  ) {
+    super(message);
+    this.name = 'SandboxExecTransportError';
+    this.sandboxId = diagnostics.sandboxId;
+    this.command = diagnostics.command;
+    this.attempts = diagnostics.attempts;
+    this.opened = diagnostics.opened;
+    this.closeCode = diagnostics.closeCode;
+    this.closeReason = diagnostics.closeReason;
+    this.wsEndpoint = diagnostics.wsEndpoint;
+  }
+}
+
+/**
+ * Thrown when `/exec-lease` returns 410 Gone — the sandbox has been destroyed
+ * (Railway destroy, quota reclamation, etc.). The client cannot recover from
+ * this on its own because it does not own the binding store; only the fleet
+ * layer can clear the stale sandbox id and provision a fresh one. Callers
+ * (typically `SandboxFleet`) must catch this and reprovision-and-replay.
+ *
+ * When this is thrown the cached `_lease` and `_sandboxId` on the sandbox
+ * instance are cleared, so the next `ensureRunning()` on a reused instance
+ * will re-provision cleanly.
+ */
+export class SandboxDestroyedError extends Error {
+  readonly sandboxId: string | undefined;
+  readonly command: string;
+  readonly attempts: number;
+
+  constructor(
+    message: string,
+    diagnostics: { sandboxId?: string; command: string; attempts: number },
+  ) {
+    super(message);
+    this.name = 'SandboxDestroyedError';
+    this.sandboxId = diagnostics.sandboxId;
+    this.command = diagnostics.command;
+    this.attempts = diagnostics.attempts;
+  }
 }
 
 /**
@@ -193,16 +256,6 @@ export class PlatformSandbox extends MastraSandbox {
    * Cleared (regardless of success or failure) when the request settles.
    */
   private _leaseInFlight: Promise<ExecLease & { expiresAtMs: number | null }> | null = null;
-  /**
-   * Tri-state feature detection for the platform's exec-lease endpoint:
-   *   undefined — not yet tried (default; try direct on first exec)
-   *   true      — endpoint present, use direct exec
-   *   false     — endpoint absent (404/501) OR the WebSocket transport failed
-   *               once; fall back permanently to /exec for this sandbox
-   * Sticky per instance so we make the fallback decision once per sandbox
-   * lifetime instead of paying an extra round-trip on every exec.
-   */
-  private _directExecAvailable: boolean | undefined = undefined;
 
   constructor(options: PlatformSandboxOptions = {}) {
     super({ ...options, name: 'PlatformSandbox', processes: new PlatformProcessManager() });
@@ -356,82 +409,24 @@ export class PlatformSandbox extends MastraSandbox {
     const started = Date.now();
     const fullCommand = buildCommand(command, args);
     // Nullish check so an explicit `timeout: 0` is sent as `0` (interpreted as
-    // "no timeout" by the proxy) instead of being dropped by a truthy check.
+    // "no timeout" by the direct-exec transport) instead of being dropped by a
+    // truthy check.
     const effectiveTimeout = options?.timeout ?? this._timeout;
 
-    // Prefer the direct-exec data plane (WebSocket straight to Railway's
-    // tcp-proxy) when the platform exposes the exec-lease endpoint. Falls
-    // back to the proxy /exec route on older platform deployments. See
-    // ./direct-exec.ts and `docs/factory/direct-sandbox-connection.md` in
-    // the Platform repo.
-    if (this._directExecAvailable !== false) {
-      const leaseResult = await this._tryDirectExec(fullCommand, effectiveTimeout, options);
-      if (leaseResult) return { ...leaseResult, executionTimeMs: Date.now() - started };
-    }
-    return this._execViaProxy(fullCommand, effectiveTimeout, options, started);
-  }
-
-  private async _tryDirectExec(
-    fullCommand: string,
-    effectiveTimeout: number | undefined,
-    options: ExecuteCommandOptions | undefined,
-  ): Promise<Omit<CommandResult, 'executionTimeMs'> | null> {
-    let lease: (ExecLease & { expiresAtMs: number | null }) | null;
-    try {
-      lease = await this._ensureLease();
-    } catch (error) {
-      // 404/501 → endpoint not present on this proxy deployment. Flip the
-      // feature bit and take the fallback path for this call AND every
-      // subsequent one on this sandbox.
-      if (error instanceof PlatformApiError && (error.status === 404 || error.status === 501)) {
-        this._directExecAvailable = false;
-        return null;
-      }
-      throw error;
-    }
-    this._directExecAvailable = true;
-
-    // Filter undefined values out of the env overlay so we match the
-    // Record<string, string> shape execViaLease expects. `ExecuteCommandOptions.env`
-    // is NodeJS.ProcessEnv (string | undefined); the proxy `/exec` path ships
-    // it through JSON.stringify which drops undefined implicitly, so this is
-    // just the explicit version of the same filter.
-    const filteredEnv = options?.env
-      ? Object.fromEntries(
-          Object.entries(options.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-        )
-      : undefined;
-    const result = await execViaLease(lease, {
-      command: fullCommand,
-      ...(options?.cwd !== undefined && { cwd: options.cwd }),
-      ...(filteredEnv !== undefined && { env: filteredEnv }),
-      ...(effectiveTimeout != null && effectiveTimeout > 0 && { timeoutMs: effectiveTimeout }),
-      ...(this._webSocketFactory && { webSocketFactory: this._webSocketFactory }),
-    });
-    // `null` exitCode without `timedOut` means the socket closed without an
-    // exit frame — i.e. a transport failure (handshake stalled, mid-stream
-    // drop, expired token). Drop the cached lease AND flip the feature bit
-    // so we don't burn a fresh mint + failed WS handshake on every subsequent
-    // exec; fall back permanently to /exec for this sandbox. Log the close
-    // metadata so we can diagnose why Railway refused the WebSocket. Timed-out
-    // and normal-exit results still return synthesised / real exit codes as
-    // before.
-    if (result.exitCode === null && !result.timedOut) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        '[platform-workspace] direct-exec transport failed; falling back to /exec permanently for this sandbox',
-        {
-          sandboxId: this._sandboxId,
-          opened: result.opened,
-          closeCode: result.closeCode,
-          closeReason: result.closeReason,
-          wsEndpoint: lease.wsEndpoint,
-        },
-      );
-      this._lease = null;
-      this._directExecAvailable = false;
-      return null;
-    }
+    // Direct-exec (WebSocket straight to Railway's tcp-proxy) is the only
+    // data plane. `_runDirectExec` handles single-shot transport retry and
+    // throws typed errors on unrecoverable failure: `SandboxDestroyedError`
+    // when `/exec-lease` returns 410 (fleet must reprovision),
+    // `SandboxExecTransportError` when the WebSocket transport fails twice
+    // against a live sandbox, `PlatformApiError` for other `/exec-lease`
+    // errors (404/500/501). See ./direct-exec.ts and
+    // `docs/factory/direct-sandbox-connection.md` in the Platform repo.
+    const result = await this._runDirectExec(fullCommand, effectiveTimeout, options);
+    // `_runDirectExec` throws on transport failure (see its jsdoc), so a
+    // `null` exitCode here can only mean `timedOut: true` — the sandbox
+    // never got to send an exit frame because we cut the command short.
+    // Use 124 for that (the conventional timeout exit code). We are NOT
+    // coercing transport-failure nulls to fake exit codes — those throw.
     const exitCode = result.exitCode ?? 124;
     return {
       success: exitCode === 0,
@@ -440,44 +435,115 @@ export class PlatformSandbox extends MastraSandbox {
       stderr: result.stderr,
       timedOut: result.timedOut,
       command: fullCommand,
+      executionTimeMs: Date.now() - started,
     };
   }
 
-  private async _execViaProxy(
+  /**
+   * Run a single exec against the direct-exec transport, with one in-flight
+   * retry on WebSocket transport failure (socket closed without an `exit`
+   * frame and the exec did not time out). The retry mints a fresh lease
+   * — the failure could be a stale JWT — and reopens a new WebSocket.
+   *
+   * Error taxonomy:
+   * - **410 on `/exec-lease`** (either attempt) → the sandbox is gone.
+   *   Nulls the cached `_lease` and `_sandboxId` and throws
+   *   {@link SandboxDestroyedError}. Callers (typically `SandboxFleet`) must
+   *   catch this, clear the stale binding, and reprovision + replay.
+   * - **Persistent transport failure** (both WS attempts close without an
+   *   `exit` frame against a live sandbox) → {@link SandboxExecTransportError}
+   *   with WebSocket close diagnostics.
+   * - **Other `PlatformApiError`s** (404/500/501) propagate directly.
+   * - **Real command result** (exit code from Railway's exit frame, or
+   *   `timedOut: true`) returns normally.
+   *
+   * Returns a result with a real `exitCode` OR `timedOut: true`. Never
+   * returns `{ exitCode: null, timedOut: false }` — that case throws.
+   */
+  private async _runDirectExec(
     fullCommand: string,
     effectiveTimeout: number | undefined,
     options: ExecuteCommandOptions | undefined,
-    started: number,
-  ): Promise<CommandResult> {
-    if (!this._sandboxId) throw new SandboxNotReadyError(this.id);
-    const timeoutSec = effectiveTimeout != null ? Math.ceil(effectiveTimeout / 1000) : undefined;
-    // Pass our own signal for exec so the client's default per-request
-    // timeout (60s) doesn't cut off commands that expect to run longer.
-    // Give the proxy a generous buffer over the requested command timeout.
-    const clientSignal =
-      effectiveTimeout != null && effectiveTimeout > 0 ? AbortSignal.timeout(effectiveTimeout + 30_000) : undefined;
-    const response = await this._client.request(`/sandbox/${encodeURIComponent(this._sandboxId)}/exec`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
+  ): Promise<{ exitCode: number | null; stdout: string; stderr: string; timedOut: boolean }> {
+    // Filter undefined values out of the env overlay so we match the
+    // Record<string, string> shape execViaLease expects. `ExecuteCommandOptions.env`
+    // is NodeJS.ProcessEnv (string | undefined).
+    const filteredEnv = options?.env
+      ? Object.fromEntries(
+          Object.entries(options.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+        )
+      : undefined;
+
+    let lastResult: Awaited<ReturnType<typeof execViaLease>> | undefined;
+    let lastLease: (ExecLease & { expiresAtMs: number | null }) | undefined;
+    let attemptsMade = 0;
+    // Two attempts: initial + one retry. On the second attempt we always
+    // drop the cached lease first so we don't reuse a JWT that may itself
+    // be the cause of the transport failure.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      if (attempt > 0) this._lease = null;
+      let lease: ExecLease & { expiresAtMs: number | null };
+      try {
+        lease = await this._ensureLease();
+      } catch (error) {
+        // 410 → sandbox has been destroyed. Clear all cached state so a
+        // reused instance re-provisions cleanly, then hand off to the fleet
+        // layer via a typed error. Other PlatformApiErrors (404/500/501)
+        // propagate as-is — those are configuration or platform errors, not
+        // a "reprovision me" signal.
+        if (error instanceof PlatformApiError && error.status === 410) {
+          this._lease = null;
+          const priorSandboxId = this._sandboxId;
+          this._sandboxId = undefined;
+          throw new SandboxDestroyedError(
+            `Sandbox ${priorSandboxId ?? '(unknown)'} was destroyed; /exec-lease returned 410`,
+            {
+              ...(priorSandboxId && { sandboxId: priorSandboxId }),
+              command: fullCommand,
+              attempts: attempt + 1,
+            },
+          );
+        }
+        throw error;
+      }
+      lastLease = lease;
+      attemptsMade = attempt + 1;
+      const result = await execViaLease(lease, {
         command: fullCommand,
-        timeoutSec,
-        cwd: options?.cwd,
-        env: options?.env,
-      }),
-      signal: clientSignal,
-    });
-    const json = (await response.json()) as ExecResponse;
-    const exitCode = json.exitCode ?? (json.timedOut ? 124 : 1);
-    return {
-      success: exitCode === 0,
-      exitCode,
-      stdout: json.stdout,
-      stderr: json.stderr,
-      executionTimeMs: Date.now() - started,
-      timedOut: json.timedOut,
-      command: fullCommand,
-    };
+        ...(options?.cwd !== undefined && { cwd: options.cwd }),
+        ...(filteredEnv !== undefined && { env: filteredEnv }),
+        ...(effectiveTimeout != null && effectiveTimeout > 0 && { timeoutMs: effectiveTimeout }),
+        ...(this._webSocketFactory && { webSocketFactory: this._webSocketFactory }),
+      });
+      lastResult = result;
+      // `null` exitCode with `timedOut: false` means the socket closed
+      // without an exit frame — a transport failure (handshake stalled,
+      // mid-stream drop, expired token). Any other outcome (real exit code
+      // or timed-out) is a valid result and we return it.
+      if (result.exitCode !== null || result.timedOut) return result;
+    }
+
+    // Both attempts failed at the transport layer against a live sandbox.
+    // Surface a loud, typed error with close diagnostics so callers can
+    // distinguish "your command failed" from "the sandbox transport is
+    // broken."
+    const result = lastResult!;
+    const lease = lastLease!;
+    throw new SandboxExecTransportError(
+      `Direct-exec transport failed for sandbox ${this._sandboxId ?? '(unknown)'} after ${attemptsMade} attempt(s)` +
+        (result.closeCode !== undefined
+          ? ` (close ${result.closeCode}${result.closeReason ? ` ${result.closeReason}` : ''})`
+          : ''),
+      {
+        ...(this._sandboxId && { sandboxId: this._sandboxId }),
+        command: fullCommand,
+        attempts: attemptsMade,
+        opened: result.opened ?? false,
+        ...(result.closeCode !== undefined && { closeCode: result.closeCode }),
+        ...(result.closeReason !== undefined && { closeReason: result.closeReason }),
+        wsEndpoint: lease.wsEndpoint,
+      },
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

Makes direct-exec (WebSocket to Railway's tcp-proxy) the only data plane for `PlatformSandbox.executeCommand`. The `POST /sandbox/:id/exec` proxy fallback and the sandbox-lifetime latch that disabled direct-exec on the first hiccup are gone. Failures now surface as typed errors upstream code can act on instead of silently degrading the entire session.

## Why

The fallback was designed as a safety net for old proxy deployments and transient WebSocket failures. In production it did the opposite:

- A single mid-handshake drop **permanently disabled direct-exec** for the sandbox's whole lifetime.
- Every subsequent exec on that sandbox paid the fallback cost — measured p50 819ms vs 207ms for the exec-lease mint alone in the 12h shipyard trace preceding this change, and roughly 1000x slower than the sub-millisecond direct-exec path.
- One prod sandbox paid the fallback cost 553 times after a single WS hiccup, then triggered a kill switch under normal concurrent-exec load.
- The fallback also masked real platform errors — 500s from `/exec-lease` and persistent Railway rejections should be visible signals, not silent degradation.

## What changes for callers

`PlatformSandbox.executeCommand` can now throw three unrecoverable-failure shapes:

- `SandboxDestroyedError` — the platform returned 410 for `/exec-lease`. The sandbox has been destroyed; the client clears its cached sandbox id and lease so a reused instance re-provisions on the next call. Fleet-level code that owns a binding store should catch this and reprovision + replay.
- `SandboxExecTransportError` — both the initial WebSocket attempt and the built-in retry closed without an `exit` frame against a live sandbox. Carries `{ opened, closeCode, closeReason, wsEndpoint, sandboxId, command, attempts }` so upstream logs and alerts can distinguish "the Railway data plane is broken" from "your command failed."
- `PlatformApiError` (status 404 / 500 / 501 on `/exec-lease`) — these were previously swallowed by the fallback. They now propagate as-is.

A single transient WebSocket transport failure no longer disables direct-exec for the sandbox's lifetime — the client mints a fresh lease and retries once on the same sandbox before giving up. The retry mint is coalesced across concurrent in-flight execs by the existing per-sandbox lease coalescing, so a normal agent burst (parallel `find_files` / `view` / `execute_command`) costs one extra mint across the burst, not N.

## Prerequisite

Depends on PR #20477 (`checkpointName` preservation on `PlatformSandbox.clone()`), which has already landed on `main`. Without it, ripping the fallback would trade "sessions feel slow when Railway hiccups" for "sessions eat 30-60s template-build stalls whenever Railway destroys a sandbox mid-run."

## Test plan

Unit tests in `workspaces/platform-workspace/src/sandbox.test.ts`:

- Direct-exec still works end-to-end.
- 404 on `/exec-lease` throws `PlatformApiError`; no `/exec` request is made.
- 410 on `/exec-lease` throws `SandboxDestroyedError`; cached `_lease` and `_sandboxId` are cleared; no `/exec` request.
- Non-410 lease-mint errors (500) propagate as `PlatformApiError`.
- Single transient WebSocket transport failure recovers (fresh mint + fresh WS + real exit code returned) with two lease mints and two distinct JWTs.
- Transport failure followed by 410 on the retry mint throws `SandboxDestroyedError`, not `SandboxExecTransportError` (destroyed-mid-exec scenario).
- Persistent WebSocket failure with a live sandbox throws `SandboxExecTransportError` with `sandboxId`, `command`, `attempts: 2`, `opened`, `closeCode`, `closeReason`, and `wsEndpoint` populated; no `/exec` request.
- Concurrent execs during a transient WebSocket failure share a single retry mint (coalescing) and all 10 execs return successfully.
- The failed lease is dropped after a transport-failure retry succeeds — the next exec uses the new lease's JWT.
- Existing lease caching, refresh-before-expiry, coalescing, and reattach tests still pass.

Deleted tests that asserted fallback semantics (`falls back to /exec permanently after a WS transport failure`, `falls back to /exec when exec-lease returns 404`, `falls back to /exec when exec-lease returns 501`).

All 32 sandbox tests, 61 tests in the package, build, typecheck, and lint pass locally.

## Rollout

Ships as a `minor` bump of `@mastra/platform-workspace`. Downstream `@mastra/factory` callers of `executeCommand` should be audited to catch `SandboxDestroyedError` and route it into fleet reprovision-and-replay before it misclassifies as (for example) a `git-missing` preflight error. That audit is out of scope for this PR and tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
`executeCommand` now uses only a WebSocket connection to run commands. If it briefly fails, it retries once with a fresh lease; if the sandbox is gone or the connection still fails, it reports a clear typed error so callers can respond appropriately.

## What changed
- Removed the `/sandbox/:id/exec` HTTP fallback and the lifetime latch that disabled direct execution.
- Added one retry after WebSocket transport failure, with per-sandbox lease-mint coalescing.
- Added typed errors:
  - `SandboxDestroyedError` for `/exec-lease` status `410`, clearing cached sandbox and lease state.
  - `SandboxExecTransportError` after both WebSocket attempts fail without an exit frame, including transport diagnostics.
  - `PlatformApiError` for other lease errors such as `404`, `500`, and `501`.
- Added identity checks so delayed failures cannot evict a newer concurrently cached lease.
- Updated tests for direct execution, retries, lease caching and eviction, concurrency, reattachment, destruction, transport failures, and race safety.
- Exported the new errors and updated documentation, README guidance, and changeset for reprovision-and-replay workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->