### PR TITLE
fix(mongodb-store): improve IndexKeySpecsConflict error with migration steps

### DIFF
--- a/.changeset/swift-parts-drop.md
+++ b/.changeset/swift-parts-drop.md
@@ -2,12 +2,12 @@
 '@mastra/mongodb': patch
 ---
 
-When `MongoDBStore.init()` fails because an existing non-unique index conflicts with Mastra's required unique index, the error now includes step-by-step migration commands instead of a generic failure message.
+When MongoDB storage initialization fails because an existing non-unique index conflicts with Mastra's required unique index, the error now includes step-by-step migration commands instead of a generic failure message.
 
 **Before:** `Failed to create default index on collection "mastra_threads". Set skipDefaultIndexes to manage indexes yourself.`
 
 **After:**
-```
+```text
 Index conflict on collection "mastra_threads": an existing non-unique index on { id: 1 }
 conflicts with Mastra's required unique index.
 

--- a/.changeset/swift-parts-drop.md
+++ b/.changeset/swift-parts-drop.md
@@ -1,0 +1,20 @@
+---
+'@mastra/mongodb': patch
+---
+
+When `MongoDBStore.init()` fails because an existing non-unique index conflicts with Mastra's required unique index, the error now includes step-by-step migration commands instead of a generic failure message.
+
+**Before:** `Failed to create default index on collection "mastra_threads". Set skipDefaultIndexes to manage indexes yourself.`
+
+**After:**
+```
+Index conflict on collection "mastra_threads": an existing non-unique index on { id: 1 }
+conflicts with Mastra's required unique index.
+
+To migrate:
+  1. Check for duplicates:  db.mastra_threads.aggregate([{ $group: { _id: "$id", n: { $sum: 1 } } }, { $match: { n: { $gt: 1 } } }])
+  2. Drop the old index:    db.mastra_threads.dropIndex("id_1")
+  3. Recreate as unique:    db.mastra_threads.createIndex({ id: 1 }, { unique: true })
+
+Alternatively, set skipDefaultIndexes: true to manage indexes yourself.
+```

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -153,12 +153,26 @@ export class MemoryStorageMongoDB extends MemoryStorage {
       } catch (error) {
         // Fail loud: a silently missing index degrades query performance at scale.
         // Users who manage their own indexes can set skipDefaultIndexes.
+        const mongoCode = (error as any)?.code;
+        const isUniqueConflict = mongoCode === 86 && indexDef.options?.unique === true;
+        const field = Object.keys(indexDef.keys)[0] ?? 'id';
+        const indexName = Object.entries(indexDef.keys)
+          .map(([k, v]) => `${k}_${v}`)
+          .join('_');
+        const text = isUniqueConflict
+          ? `Index conflict on collection "${indexDef.collection}": an existing non-unique index on { ${field}: 1 } conflicts with Mastra's required unique index.\n\n` +
+            `To migrate:\n` +
+            `  1. Check for duplicates:  db.${indexDef.collection}.aggregate([{ $group: { _id: "$${field}", n: { $sum: 1 } } }, { $match: { n: { $gt: 1 } } }])\n` +
+            `  2. Drop the old index:    db.${indexDef.collection}.dropIndex("${indexName}")\n` +
+            `  3. Recreate as unique:    db.${indexDef.collection}.createIndex({ ${field}: 1 }, { unique: true })\n\n` +
+            `Alternatively, set skipDefaultIndexes: true to manage indexes yourself.`
+          : `Failed to create default index on collection "${indexDef.collection}". Set skipDefaultIndexes to manage indexes yourself.`;
         throw new MastraError(
           {
             id: createStorageErrorId('MONGODB', 'CREATE_DEFAULT_INDEXES', 'FAILED'),
             domain: ErrorDomain.STORAGE,
             category: ErrorCategory.THIRD_PARTY,
-            text: `Failed to create default index on collection "${indexDef.collection}". Set skipDefaultIndexes to manage indexes yourself.`,
+            text,
             details: { collection: indexDef.collection },
           },
           error,

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -154,7 +154,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
         // Fail loud: a silently missing index degrades query performance at scale.
         // Users who manage their own indexes can set skipDefaultIndexes.
         const mongoCode = (error as any)?.code;
-        const isUniqueConflict = mongoCode === 86 && indexDef.options?.unique === true;
+        const isUniqueConflict = mongoCode === 85 && indexDef.options?.unique === true;
         const field = Object.keys(indexDef.keys)[0] ?? 'id';
         const indexName = Object.entries(indexDef.keys)
           .map(([k, v]) => `${k}_${v}`)

--- a/stores/mongodb/src/storage/domains/memory/memory-data-modeling.test.ts
+++ b/stores/mongodb/src/storage/domains/memory/memory-data-modeling.test.ts
@@ -142,6 +142,48 @@ describe('MemoryStorageMongoDB — index definitions and metadata storage', () =
     expect(String(err.id)).toContain('CREATE_DEFAULT_INDEXES');
   });
 
+  test('createDefaultIndexes emits migration steps on IndexKeySpecsConflict (code 86)', async () => {
+    const conflict = Object.assign(new Error('index conflict'), { code: 86 });
+    const throwingMemory = new MemoryStorageMongoDB({
+      connectorHandler: {
+        getCollection: async () =>
+          ({
+            createIndex: async () => {
+              throw conflict;
+            },
+          }) as any,
+        close: async () => {},
+      },
+    });
+
+    const err = await throwingMemory.createDefaultIndexes().catch(e => e);
+    expect(err).toBeInstanceOf(MastraError);
+    expect(err.message).toContain('non-unique');
+    expect(err.message).toContain('dropIndex');
+    expect(err.message).toContain('createIndex');
+    expect(err.message).toContain('skipDefaultIndexes');
+  });
+
+  test('createDefaultIndexes emits generic message for non-conflict errors', async () => {
+    const otherError = Object.assign(new Error('disk full'), { code: 28 });
+    const throwingMemory = new MemoryStorageMongoDB({
+      connectorHandler: {
+        getCollection: async () =>
+          ({
+            createIndex: async () => {
+              throw otherError;
+            },
+          }) as any,
+        close: async () => {},
+      },
+    });
+
+    const err = await throwingMemory.createDefaultIndexes().catch(e => e);
+    expect(err).toBeInstanceOf(MastraError);
+    expect(err.message).not.toContain('non-unique');
+    expect(err.message).toContain('skipDefaultIndexes');
+  });
+
   test('createDefaultIndexes resolves when index creation succeeds', async () => {
     const okMemory = new MemoryStorageMongoDB({
       connectorHandler: {

--- a/stores/mongodb/src/storage/domains/memory/memory-data-modeling.test.ts
+++ b/stores/mongodb/src/storage/domains/memory/memory-data-modeling.test.ts
@@ -142,8 +142,8 @@ describe('MemoryStorageMongoDB — index definitions and metadata storage', () =
     expect(String(err.id)).toContain('CREATE_DEFAULT_INDEXES');
   });
 
-  test('createDefaultIndexes emits migration steps on IndexKeySpecsConflict (code 86)', async () => {
-    const conflict = Object.assign(new Error('index conflict'), { code: 86 });
+  test('createDefaultIndexes emits migration steps on IndexOptionsConflict (code 85)', async () => {
+    const conflict = Object.assign(new Error('index conflict'), { code: 85 });
     const throwingMemory = new MemoryStorageMongoDB({
       connectorHandler: {
         getCollection: async () =>


### PR DESCRIPTION
## Summary

- Detects MongoDB error code 86 (`IndexKeySpecsConflict`) in `createDefaultIndexes` and emits a step-by-step migration guide instead of a generic failure message
- Non-conflict errors still receive the short `skipDefaultIndexes` hint
- Adds two unit tests covering both the conflict and non-conflict branches

## Background

Closes #20420. Users upgrading from older versions may have a pre-existing non-unique `{ id: 1 }` index that conflicts with the unique index Mastra requires. PR #18393 changed the error handling from warn-and-continue to throw, surfacing this conflict as a fatal but previously-silent error. The fix makes the error message actionable.

## Test plan

- [ ] `pnpm --filter ./stores/mongodb exec vitest run src/storage/domains/memory/memory-data-modeling.test.ts` — new unit tests pass without Docker
- [ ] Existing integration tests unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If MongoDB can’t create the indexes Mastra needs because an old index is shaped differently, Mastra now tells you exactly how to fix it. If it’s some other index problem, it still tells you to use `skipDefaultIndexes` instead.

## Changes

- Improved MongoDB default index conflict handling:
  - Detects the “same index fields, different options” unique-index conflict (MongoDB error code `85` / `IndexOptionsConflict`) instead of a generic failure.
  - Error message now includes step-by-step migration commands to:
    - Find duplicate `id` values in `mastra_threads` / `mastra_messages`.
    - Drop the legacy non-unique `id_1` index (`dropIndex("id_1")`).
    - Recreate it as unique (`createIndex({ id: 1 }, { unique: true })`).
  - Keeps the `skipDefaultIndexes: true` option as an alternative when indexes are managed externally.
- Preserved the existing generic guidance (including the `skipDefaultIndexes` hint) for non-conflict index errors.
- Updated/added unit tests to cover both branches:
  - Migration guidance is emitted for code `85`.
  - Generic message behavior remains for a different failure code (`28`).
- Added/updated a patch changeset for `@mastra/mongodb` describing the new improved error guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->