### PR TITLE
fix(core): never execute tools declined after approval suspend

### DIFF
--- a/.changeset/quiet-tools-decline.md
+++ b/.changeset/quiet-tools-decline.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `declineToolCall` / `declineToolCallGenerate` executing tools that were declined when approval was gated only by agent-level `requireToolApproval` (and the live policy was lost on resume). Resume now honors the outer approval suspend payload so declines short-circuit without running the tool. Fixes https://github.com/mastra-ai/mastra/issues/20470

--- a/.changeset/quiet-tools-decline.md
+++ b/.changeset/quiet-tools-decline.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed `declineToolCall` / `declineToolCallGenerate` executing tools that were declined when approval was gated only by agent-level `requireToolApproval` (and the live policy was lost on resume). Resume now honors the outer approval suspend payload so declines short-circuit without running the tool. Fixes https://github.com/mastra-ai/mastra/issues/20470
+Fixed `declineToolCall` and `declineToolCallGenerate` so declined approval-gated tools no longer execute or cause side effects after resume. Fixes https://github.com/mastra-ai/mastra/issues/20470

--- a/packages/core/src/loop/test-utils/aimock/scenarios/generate-approval-path.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/generate-approval-path.scenario.test.ts
@@ -135,6 +135,62 @@ describe('Generate() approval path scenario', () => {
     expect(result2).toBeDefined();
   });
 
+  it('declineToolCallGenerate never executes when gated only by requireToolApproval (#20470)', async () => {
+    // Reproduction shape from https://github.com/mastra-ai/mastra/issues/20470:
+    // tool has no requireApproval flag; gating is only agent-level requireToolApproval.
+    // declineToolCallGenerate does not re-pass that option on resume.
+    const llm = getMock();
+    let toolExecuted = false;
+
+    const dangerTool = createTool({
+      id: 'do_the_thing',
+      description: 'Performs an irreversible action',
+      inputSchema: z.object({
+        label: z.string(),
+      }),
+      execute: async () => {
+        toolExecuted = true;
+        return { done: true };
+      },
+    });
+
+    llm.on(
+      { endpoint: 'chat', hasToolResult: false },
+      {
+        toolCalls: [
+          {
+            id: 'call-20470-gen',
+            name: 'do_the_thing',
+            arguments: { label: 'alpha' },
+          },
+        ],
+      },
+    );
+    // After the decline is reported, the model wraps up without re-issuing the tool call.
+    llm.on({ endpoint: 'chat', hasToolResult: true }, { content: 'Declined.' });
+
+    const { agent } = await createSharedAgent(llm, {
+      tools: { do_the_thing: dangerTool },
+      memory: new MockMemory(),
+    });
+
+    const result1 = await agent.generate('Use the label "alpha".', {
+      requireToolApproval: ({ toolName }) => toolName === 'do_the_thing',
+      maxSteps: 5,
+    });
+
+    expect(result1.finishReason).toBe('suspended');
+    expect(toolExecuted).toBe(false);
+
+    const result2 = await agent.declineToolCallGenerate({
+      runId: result1.runId!,
+      toolCallId: result1.suspendPayload!.toolCallId,
+    });
+
+    expect(toolExecuted).toBe(false);
+    expect(result2).toBeDefined();
+  });
+
   it('should handle multiple sequential approval decisions', async () => {
     const llm = getMock();
     const executionLog: number[] = [];

--- a/packages/core/src/loop/test-utils/aimock/scenarios/tool-approval.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/tool-approval.scenario.test.ts
@@ -94,4 +94,38 @@ describe('AIMock loop scenario: tool approval suspend/resume', () => {
     const text = await output.text;
     expect(text).toContain('will not look that up');
   });
+
+  it('declineToolCall never executes when gated only by function requireToolApproval (#20470)', async () => {
+    let executions = 0;
+    const dangerTool = createTool({
+      id: 'do_the_thing',
+      description: 'Performs an irreversible action',
+      inputSchema: z.object({ label: z.string() }),
+      outputSchema: z.object({ done: z.boolean() }),
+      execute: async () => {
+        executions += 1;
+        return { done: true };
+      },
+    });
+
+    const { approvals, requests } = await runApprovalScenario({
+      llm: getMock(),
+      prompt: 'Use the label "beta".',
+      tools: { do_the_thing: dangerTool },
+      stopWhen: stepCountIs(5),
+      requireToolApproval: ({ toolName }) => toolName === 'do_the_thing',
+      decision: () => false,
+      fixtures: llm => {
+        llm.on(
+          { endpoint: 'chat', hasToolResult: false },
+          { toolCalls: [{ id: 'call_20470_stream', name: 'do_the_thing', arguments: { label: 'beta' } }] },
+        );
+        llm.on({ endpoint: 'chat', hasToolResult: true }, { content: 'Declined.' });
+      },
+    });
+
+    expect(approvals).toEqual(['decline:call_20470_stream']);
+    expect(executions).toBe(0);
+    expect(JSON.stringify(requests[1]?.body?.messages ?? [])).not.toContain('"done":true');
+  });
 });

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -443,6 +443,91 @@ describe('createToolCallStep tool approval workflow', () => {
     expectNoToolExecution();
   });
 
+  it('declines without a live requireToolApproval policy when suspendData marks approval (#20470)', async () => {
+    // Mirrors declineToolCall after agent-level requireToolApproval (boolean/function) gated
+    // the original suspend: resume helpers do not re-pass the policy, and function policies
+    // do not survive RequestContext serialization. The suspend payload still records the wait.
+    const inputData = makeInputData();
+    const toolsWithoutFlag = {
+      'test-tool': {
+        execute: vi.fn().mockResolvedValue({ leaked: true }),
+      },
+    };
+    const step = createToolCallStep({
+      tools: toolsWithoutFlag,
+      messageList,
+      controller,
+      runId: 'test-run',
+      streamState,
+      // intentionally no requireToolApproval — lost on resume
+    });
+
+    const result = await step.execute(
+      makeExecuteParams({
+        inputData,
+        resumeData: { approved: false },
+        suspendData: {
+          requireToolApproval: {
+            toolCallId: inputData.toolCallId,
+            toolName: inputData.toolName,
+            args: inputData.args,
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      approval: {
+        id: inputData.toolCallId,
+        approved: false,
+        reason: 'Tool call was not approved by the user',
+      },
+      ...inputData,
+    });
+    expect(toolsWithoutFlag['test-tool'].execute).not.toHaveBeenCalled();
+  });
+
+  it('approves exactly once when live policy is gone but suspendData marks approval', async () => {
+    const inputData = makeInputData();
+    const toolResult = { success: true };
+    const toolsWithoutFlag = {
+      'test-tool': {
+        execute: vi.fn().mockResolvedValue(toolResult),
+      },
+    };
+    const step = createToolCallStep({
+      tools: toolsWithoutFlag,
+      messageList,
+      controller,
+      runId: 'test-run',
+      streamState,
+    });
+
+    const result = await step.execute(
+      makeExecuteParams({
+        inputData,
+        resumeData: { approved: true },
+        suspendData: {
+          requireToolApproval: {
+            toolCallId: inputData.toolCallId,
+            toolName: inputData.toolName,
+            args: inputData.args,
+          },
+        },
+      }),
+    );
+
+    expect(toolsWithoutFlag['test-tool'].execute).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      result: toolResult,
+      ...inputData,
+      approval: {
+        id: inputData.toolCallId,
+        approved: true,
+      },
+    });
+  });
+
   it('should return inputData as-is for provider-executed tools (no client execution)', async () => {
     // Provider-executed tools are handled by the stream path (tool-call + tool-result chunks
     // in llm-execution-step), so tool-call-step just passes through inputData unchanged.

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -575,6 +575,53 @@ describe('createToolCallStep tool approval workflow', () => {
     );
   });
 
+  it('forwards delegated decline even when a live requireToolApproval policy is present', async () => {
+    // Live outer policy must not re-gate nested resumes: with requireToolApproval still
+    // set, suspendedToolRunId + { approved: false } must reach the nested tool.
+    const inputData = makeInputData();
+    const toolsWithoutFlag = {
+      'test-tool': {
+        execute: vi.fn().mockResolvedValue({ forwarded: true }),
+      },
+    };
+    const step = createToolCallStep({
+      tools: toolsWithoutFlag,
+      messageList,
+      controller,
+      requireToolApproval: true,
+      runId: 'test-run',
+      streamState,
+    });
+
+    const resumeData = { approved: false };
+    const result = await step.execute(
+      makeExecuteParams({
+        inputData,
+        resumeData,
+        suspendData: {
+          requireToolApproval: {
+            toolCallId: inputData.toolCallId,
+            toolName: inputData.toolName,
+            args: inputData.args,
+          },
+          suspendedToolRunId: 'nested-run-id',
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      result: { forwarded: true },
+      ...inputData,
+    });
+    expect(toolsWithoutFlag['test-tool'].execute).toHaveBeenCalledWith(
+      inputData.args,
+      expect.objectContaining({
+        toolCallId: inputData.toolCallId,
+        resumeData,
+      }),
+    );
+  });
+
   it('should return inputData as-is for provider-executed tools (no client execution)', async () => {
     // Provider-executed tools are handled by the stream path (tool-call + tool-result chunks
     // in llm-execution-step), so tool-call-step just passes through inputData unchanged.

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -528,6 +528,53 @@ describe('createToolCallStep tool approval workflow', () => {
     });
   });
 
+  it('does not outer-gate decline when suspendData has suspendedToolRunId (delegated approval)', async () => {
+    // Nested sub-agent/workflow approval suspends also write requireToolApproval on the
+    // outer payload, but they set suspendedToolRunId. Decline must reach the nested tool
+    // (resumeData forwarded), not the outer output-denied short-circuit.
+    const inputData = makeInputData();
+    const toolsWithoutFlag = {
+      'test-tool': {
+        execute: vi.fn().mockResolvedValue({ forwarded: true }),
+      },
+    };
+    const step = createToolCallStep({
+      tools: toolsWithoutFlag,
+      messageList,
+      controller,
+      runId: 'test-run',
+      streamState,
+    });
+
+    const resumeData = { approved: false };
+    const result = await step.execute(
+      makeExecuteParams({
+        inputData,
+        resumeData,
+        suspendData: {
+          requireToolApproval: {
+            toolCallId: inputData.toolCallId,
+            toolName: inputData.toolName,
+            args: inputData.args,
+          },
+          suspendedToolRunId: 'nested-run-id',
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      result: { forwarded: true },
+      ...inputData,
+    });
+    expect(toolsWithoutFlag['test-tool'].execute).toHaveBeenCalledWith(
+      inputData.args,
+      expect.objectContaining({
+        toolCallId: inputData.toolCallId,
+        resumeData,
+      }),
+    );
+  });
+
   it('should return inputData as-is for provider-executed tools (no client execution)', async () => {
     // Provider-executed tools are handled by the stream path (tool-call + tool-result chunks
     // in llm-execution-step), so tool-call-step just passes through inputData unchanged.

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -513,14 +513,19 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         // helpers typically only pass `{ runId, toolCallId }` — not the original option.
         // The suspend payload still records that this step waited for approval, so treat
         // that as authoritative for the resume decision (especially declines).
+        //
+        // Nested sub-agent/workflow approvals also write `requireToolApproval` on the
+        // outer suspend payload, but they additionally set `suspendedToolRunId`. Those
+        // must resume into the nested tool path — not the outer approval short-circuit.
         const suspendedForApproval = Boolean(
           suspendData &&
           typeof suspendData === 'object' &&
-          (suspendData as { requireToolApproval?: unknown }).requireToolApproval,
+          (suspendData as { requireToolApproval?: unknown }).requireToolApproval &&
+          !(suspendData as { suspendedToolRunId?: unknown }).suspendedToolRunId,
         );
         const isApprovalResume =
           resumeData != null && typeof resumeData === 'object' && 'approved' in (resumeData as Record<string, unknown>);
-        // Gate the resume branch on either a live policy or a prior approval suspend.
+        // Gate the resume branch on either a live policy or a prior outer approval suspend.
         // Without this, `declineToolCall` falls through to `execute` when the policy was
         // lost (#20470). Do not key only on `approved` in resumeData — generic tool
         // resumes can carry that field for unrelated reasons (same guard as durable).

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -508,6 +508,24 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           }
         }
 
+        // On resume, the live `requireToolApproval` policy may be gone: function-form
+        // policies do not survive RequestContext serialization, and decline/approve
+        // helpers typically only pass `{ runId, toolCallId }` — not the original option.
+        // The suspend payload still records that this step waited for approval, so treat
+        // that as authoritative for the resume decision (especially declines).
+        const suspendedForApproval = Boolean(
+          suspendData &&
+          typeof suspendData === 'object' &&
+          (suspendData as { requireToolApproval?: unknown }).requireToolApproval,
+        );
+        const isApprovalResume =
+          resumeData != null && typeof resumeData === 'object' && 'approved' in (resumeData as Record<string, unknown>);
+        // Gate the resume branch on either a live policy or a prior approval suspend.
+        // Without this, `declineToolCall` falls through to `execute` when the policy was
+        // lost (#20470). Do not key only on `approved` in resumeData — generic tool
+        // resumes can carry that field for unrelated reasons (same guard as durable).
+        const approvalGated = toolRequiresApproval || (suspendedForApproval && isApprovalResume);
+
         // Schema for tool call approval - used for both streaming and metadata
         const approvalSchema = toStandardSchema(
           z.object({
@@ -519,7 +537,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           }),
         );
 
-        if (toolRequiresApproval) {
+        if (approvalGated) {
           if (!resumeData) {
             await stopGoalActivity({
               agentId,
@@ -595,8 +613,9 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
 
         // When an approval-gated tool is approved on resume, tag the resolved output with the
         // approval decision so it round-trips through persistence as `approval: { approved: true }`.
+        // Use `approvalGated` (not only the live policy) so approve-after-policy-loss still tags.
         const approvalGrant =
-          toolRequiresApproval && resumeData && (resumeData as { approved?: boolean }).approved === true
+          approvalGated && resumeData && (resumeData as { approved?: boolean }).approved === true
             ? ({ approval: { id: inputData.toolCallId, approved: true as const } } as const)
             : undefined;
 
@@ -606,7 +625,11 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         const isAgentTool = inputData.toolName?.startsWith('agent-');
         const isWorkflowTool = inputData.toolName?.startsWith('workflow-');
         const resumeDataToPassToToolOptions =
-          !isAgentTool && toolRequiresApproval && Object.keys(resumeData).length === 1 && 'approved' in resumeData
+          !isAgentTool &&
+          approvalGated &&
+          resumeData &&
+          Object.keys(resumeData).length === 1 &&
+          'approved' in resumeData
             ? undefined
             : resumeData;
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -516,12 +516,18 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         //
         // Nested sub-agent/workflow approvals also write `requireToolApproval` on the
         // outer suspend payload, but they additionally set `suspendedToolRunId`. Those
-        // must resume into the nested tool path — not the outer approval short-circuit.
+        // must resume into the nested tool path — not the outer approval short-circuit —
+        // even when a live outer `requireToolApproval` policy is still present.
+        const isDelegatedApproval = Boolean(
+          suspendData &&
+          typeof suspendData === 'object' &&
+          (suspendData as { suspendedToolRunId?: unknown }).suspendedToolRunId,
+        );
         const suspendedForApproval = Boolean(
           suspendData &&
           typeof suspendData === 'object' &&
           (suspendData as { requireToolApproval?: unknown }).requireToolApproval &&
-          !(suspendData as { suspendedToolRunId?: unknown }).suspendedToolRunId,
+          !isDelegatedApproval,
         );
         const isApprovalResume =
           resumeData != null && typeof resumeData === 'object' && 'approved' in (resumeData as Record<string, unknown>);
@@ -529,7 +535,8 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         // Without this, `declineToolCall` falls through to `execute` when the policy was
         // lost (#20470). Do not key only on `approved` in resumeData — generic tool
         // resumes can carry that field for unrelated reasons (same guard as durable).
-        const approvalGated = toolRequiresApproval || (suspendedForApproval && isApprovalResume);
+        const approvalGated =
+          !isDelegatedApproval && (toolRequiresApproval || (suspendedForApproval && isApprovalResume));
 
         // Schema for tool call approval - used for both streaming and metadata
         const approvalSchema = toStandardSchema(


### PR DESCRIPTION
## Summary

- **Problem:** `declineToolCall()` / `declineToolCallGenerate()` could execute the tool they were declining when approval was gated only by agent-level `requireToolApproval` (boolean or function) and the tool itself did not set `requireApproval: true`.
- **Root cause:** On resume, the live `requireToolApproval` policy is usually absent: function-form policies do not survive `RequestContext` serialization, and the decline/approve helpers only pass `{ runId, toolCallId }`. The decline short-circuit lived behind `if (toolRequiresApproval)`, so a lost policy fell through to `execute`. Approve often worked by accident because fall-through still runs the tool.
- **Solution:** When resuming, treat `suspendData.requireToolApproval` (written at suspend time) plus an `approved` resume payload as approval-gated — same durable-path idea of not trusting a bare `approved` field alone. Declines still return `approval: { approved: false, ... }` with no execution; approve still executes exactly once and keeps approval tagging.

Fixes #20470

## Root cause (detail)

Suspend correctly records:

`	s
suspend({ requireToolApproval: { toolCallId, toolName, args }, ... })
`

Resume via `declineToolCall({ runId, toolCallId })` rebuilds the loop **without** re-supplying `requireToolApproval`. With no tool-level `requireApproval`, `toolRequiresApproval` became `false`, the denial branch was skipped, and `execute` ran.

## Risks

- Low: change is confined to the approval resume branch in `tool-call-step`.
- Guard requires both a prior approval suspend payload **and** an `approved` resume field, matching the durable step's caution against misreading unrelated `approved` resume data.
- No new public APIs; existing approve/decline behavior for `requireApproval: true` tools is unchanged.

## Testing

- Unit: decline with lost live policy + `suspendData.requireToolApproval` never executes; approve in the same shape executes exactly once and tags approval.
- Scenario (generate): `declineToolCallGenerate` with function-form `requireToolApproval` and no tool `requireApproval` — tool never runs.
- Scenario (stream): `declineToolCall` with the same gating shape — tool never runs.
- Existing approval suites still pass: `tool-call-step.test.ts`, `generate-approval-path`, `tool-approval`, `resume-after-decline`, `concurrent-approval`, durable/recall roundtrip tests (43 tests in the affected set).

## Test plan

- [x] Unit regression for decline-without-live-policy
- [x] Approve-once still holds when policy is lost on resume
- [x] Stream + generate decline paths
- [x] Existing approval / resume-after-decline scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Sometimes a tool won’t run until you say “yes” or “no.” This PR makes sure that if you say **decline**, the tool still **never runs** when the system later resumes—even if the original “require approval” rule is no longer available—while **approved** calls still run exactly once.

## Changes

- Fixed `declineToolCall()` / `declineToolCallGenerate()` so resumed, approval-gated tool calls resolve as **declined/unapproved** without invoking `tool.execute` (preventing side effects).
- Updated `createToolCallStep` resume gating to detect approval-gated calls via `suspendData.requireToolApproval` plus the resume payload’s `approved` value, so declines still work when the live policy is unavailable.
- Prevented the outer decline logic from short-circuiting delegated/nested approvals (using `suspendedToolRunId` to avoid blocking the nested tool’s own approval handling).
- Ensured approved resumed calls still tag their results with approval metadata so the decision survives round-trips.
- Added regression coverage for:
  - stream/generate + decline paths where only agent-level `requireToolApproval` gates the tool (`#20470`),
  - resume behavior when `requireToolApproval` is “lost” across serialization,
  - delegated/nested approval cases to confirm decline reaches (or doesn’t block) the correct tool.
- Added a patch changeset for `@mastra/core` referencing `#20470`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->