### PR TITLE
fix(core): resolve slugify default import interop-safely for CommonJS

### DIFF
--- a/.changeset/moody-buckets-smile.md
+++ b/.changeset/moody-buckets-smile.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix `MCPServer` construction throwing `(0 , import_slugify.default) is not a function` under CommonJS. `@sindresorhus/slugify` is ESM-only, and the bundler's CJS interop bridge (`__toESM(mod, 1)`) shadows the namespace's own `default` export, so the generated `slugify.default(...)` call was not callable. `slugify` is now resolved through an interop-safe helper shared by `MCPServerBase` and schedule id canonicalization.
+Fixed `MCPServer` construction so it no longer throws `(0 , import_slugify.default) is not a function` when `@mastra/core` is consumed from CommonJS. Server ids and schedule ids now slugify correctly in both ESM and CJS projects. The underlying cause was the ESM-only `@sindresorhus/slugify` arriving double-wrapped through the CJS interop bridge; it is now resolved through an interop-safe helper.

--- a/.changeset/moody-buckets-smile.md
+++ b/.changeset/moody-buckets-smile.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `MCPServer` construction throwing `(0 , import_slugify.default) is not a function` under CommonJS. `@sindresorhus/slugify` is ESM-only, and the bundler's CJS interop bridge (`__toESM(mod, 1)`) shadows the namespace's own `default` export, so the generated `slugify.default(...)` call was not callable. `slugify` is now resolved through an interop-safe helper shared by `MCPServerBase` and schedule id canonicalization.

--- a/.changeset/moody-buckets-smile.md
+++ b/.changeset/moody-buckets-smile.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed `MCPServer` construction so it no longer throws `(0 , import_slugify.default) is not a function` when `@mastra/core` is consumed from CommonJS. Server ids and schedule ids now slugify correctly in both ESM and CJS projects. The underlying cause was the ESM-only `@sindresorhus/slugify` arriving double-wrapped through the CJS interop bridge; it is now resolved through an interop-safe helper.
+Fixed `MCPServer` construction so it no longer throws `(0 , import_slugify.default) is not a function` when `@mastra/core` is consumed from CommonJS. Server ids and schedule ids now slugify correctly in both ESM and CJS projects.

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import slugify from '@sindresorhus/slugify';
 import type { ToolsInput } from '../agent';
 import { MastraBase } from '../base';
 import { MastraError } from '../error';
@@ -7,6 +6,7 @@ import { RegisteredLogger } from '../logger';
 import type { Mastra } from '../mastra';
 import type { RequestContext } from '../request-context';
 import type { InternalCoreTool, MCPToolType } from '../tools';
+import { slugify } from '../utils/slugify';
 import type {
   MCPServerConfig,
   MCPServerHonoSSEOptions,

--- a/packages/core/src/mcp/mcp-cjs-interop.test.ts
+++ b/packages/core/src/mcp/mcp-cjs-interop.test.ts
@@ -1,0 +1,113 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { MCPServerBase } from '.';
+import type { MCPServerConfig } from '.';
+
+class MockMCPServer extends MCPServerBase {
+  constructor(config: MCPServerConfig) {
+    super(config);
+  }
+
+  convertTools(_tools: any) {
+    return {};
+  }
+  async startStdio() {}
+  async startSSE() {}
+  async startHonoSSE() {
+    return undefined;
+  }
+  async startHTTP() {}
+  async close() {}
+  getServerInfo() {
+    return {
+      id: this.id,
+      name: this.name,
+      description: this.description,
+      repository: this.repository,
+      version_detail: {
+        version: this.version,
+        release_date: this.releaseDate,
+        is_latest: this.isLatest,
+      },
+    };
+  }
+  getServerDetail() {
+    return {
+      ...this.getServerInfo(),
+      package_canonical: this.packageCanonical,
+      packages: this.packages,
+      remotes: this.remotes,
+    };
+  }
+  getToolListInfo() {
+    return { tools: [] };
+  }
+  getToolInfo() {
+    return undefined;
+  }
+  async executeTool() {
+    return {};
+  }
+  async readResource() {
+    return { contents: [] };
+  }
+  async listResources() {
+    return { resources: [] };
+  }
+}
+
+describe('MCPServerBase id slugification', () => {
+  it('slugifies a caller-supplied id', () => {
+    const server = new MockMCPServer({ id: 'My Server ID', name: 'test', version: '1.0.0', tools: {} });
+    expect(server.id).toBe('my-server-id');
+  });
+
+  it('falls back to a generated id when none is supplied', () => {
+    const server = new MockMCPServer({ name: 'test', version: '1.0.0', tools: {} });
+    expect(server.id).toBeTruthy();
+  });
+});
+
+const distEntry = join(dirname(fileURLToPath(import.meta.url)), '../../dist/mcp/index.cjs');
+
+/**
+ * Guards the CommonJS consumption path: `@mastra/core` is bundled to both ESM
+ * and CJS, and only the CJS output goes through the rolldown `__toESM` interop
+ * bridge that broke `slugify` in 1.54.0. Requires the package to be built, so
+ * it is skipped when `dist/` is absent.
+ */
+describe.skipIf(!existsSync(distEntry))('MCPServerBase under require()', () => {
+  it('constructs and slugifies its id from the built CJS bundle', () => {
+    const script = `
+      const { MCPServerBase } = require(${JSON.stringify(distEntry)});
+      class S extends MCPServerBase {
+        convertTools() { return {}; }
+        async startStdio() {}
+        async startSSE() {}
+        async startHonoSSE() {}
+        async startHTTP() {}
+        async close() {}
+        getServerInfo() { return {}; }
+        getServerDetail() { return {}; }
+        getToolListInfo() { return { tools: [] }; }
+        getToolInfo() { return undefined; }
+        async executeTool() { return {}; }
+        async readResource() { return { contents: [] }; }
+        async listResources() { return { resources: [] }; }
+      }
+      process.stdout.write(new S({ id: 'My Server ID', name: 'test', version: '1.0.0', tools: {} }).id);
+    `;
+
+    const require = createRequire(import.meta.url);
+    const output = execFileSync(process.execPath, ['-e', script], {
+      encoding: 'utf8',
+      cwd: dirname(require.resolve('../../package.json')),
+    });
+
+    expect(output).toBe('my-server-id');
+  });
+});

--- a/packages/core/src/schedules/schedules.ts
+++ b/packages/core/src/schedules/schedules.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
-import slugify from '@sindresorhus/slugify';
 import type { AgentSignalAttributes, AgentSignalType } from '../agent/signals';
 import { ErrorCategory, ErrorDomain, MastraError } from '../error';
 import type { Mastra } from '../mastra';
 import type { Schedule, SchedulesStorage } from '../storage/domains/schedules/base';
+import { slugify } from '../utils/slugify';
 import { computeNextFireAt, validateCron } from '../workflows/scheduler/cron';
 import type { ScheduleIfActive, ScheduleIfIdle } from './types';
 import { AGENT_SCHEDULE_PREFIX, WORKFLOW_SCHEDULE_PREFIX } from './types';

--- a/packages/core/src/utils/slugify.test.ts
+++ b/packages/core/src/utils/slugify.test.ts
@@ -54,6 +54,14 @@ describe('slugify interop', () => {
     expect(resolved('My Server ID')).toBe('my-server-id');
   });
 
+  it('resolves a double-wrapped default export', () => {
+    const fn = (value: string) => value.toLowerCase().replace(/\s+/g, '-');
+    const resolved = resolveSlugify({ default: { default: fn } });
+
+    expect(resolved).toBe(fn);
+    expect(resolved('My Server ID')).toBe('my-server-id');
+  });
+
   it('passes a plain function through unchanged', () => {
     const fn = (value: string) => value.toUpperCase();
     expect(resolveSlugify(fn)).toBe(fn);

--- a/packages/core/src/utils/slugify.test.ts
+++ b/packages/core/src/utils/slugify.test.ts
@@ -1,0 +1,61 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+import { resolveSlugify, slugify } from './slugify';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Verbatim copy of the rolldown CommonJS interop helper emitted into
+ * `packages/core/dist/rolldown-runtime-*.cjs`. The bundled output calls it as
+ * `__toESM(require('@sindresorhus/slugify'), 1)`, which is what breaks the
+ * plain `slugify.default(...)` call under `require()`.
+ */
+function __toESM(mod: any, isNodeMode?: number, target?: any) {
+  target = mod != null ? Object.create(Object.getPrototypeOf(mod)) : {};
+  const copyProps = (to: any, from: any, except?: string) => {
+    if ((from && typeof from === 'object') || typeof from === 'function') {
+      for (const key of Object.getOwnPropertyNames(from)) {
+        if (!Object.prototype.hasOwnProperty.call(to, key) && key !== except) {
+          const desc = Object.getOwnPropertyDescriptor(from, key);
+          Object.defineProperty(to, key, {
+            get: () => from[key],
+            enumerable: !desc || desc.enumerable,
+          });
+        }
+      }
+    }
+    return to;
+  };
+  return copyProps(
+    isNodeMode || !mod || !mod.__esModule
+      ? Object.defineProperty(target, 'default', { value: mod, enumerable: true })
+      : target,
+    mod,
+  );
+}
+
+describe('slugify interop', () => {
+  it('slugifies under the ESM import path', () => {
+    expect(slugify('My Server ID')).toBe('my-server-id');
+  });
+
+  it('reproduces the rolldown bridge that shadows the real default export', () => {
+    const bridged = __toESM(require('@sindresorhus/slugify'), 1);
+
+    // This is the exact value the generated CJS calls: `(0, mod.default)(id)`.
+    expect(typeof bridged.default).not.toBe('function');
+  });
+
+  it('resolves a callable through the rolldown bridge', () => {
+    const bridged = __toESM(require('@sindresorhus/slugify'), 1);
+    const resolved = resolveSlugify(bridged.default);
+
+    expect(typeof resolved).toBe('function');
+    expect(resolved('My Server ID')).toBe('my-server-id');
+  });
+
+  it('passes a plain function through unchanged', () => {
+    const fn = (value: string) => value.toUpperCase();
+    expect(resolveSlugify(fn)).toBe(fn);
+  });
+});

--- a/packages/core/src/utils/slugify.ts
+++ b/packages/core/src/utils/slugify.ts
@@ -1,0 +1,34 @@
+import slugifyImport from '@sindresorhus/slugify';
+
+type SlugifyFn = typeof slugifyImport;
+
+/**
+ * `@sindresorhus/slugify` is ESM-only, so under CommonJS the bundled output
+ * reaches it through the rolldown interop bridge:
+ *
+ * ```js
+ * let mod = require('@sindresorhus/slugify');
+ * mod = __toESM(mod, 1); // isNodeMode = 1
+ * // ...
+ * (0, mod.default)(id);
+ * ```
+ *
+ * With `isNodeMode` set, `__toESM` unconditionally defines `default` as the
+ * whole module object, shadowing the namespace's own `default` export. The
+ * generated `mod.default` is therefore the namespace, not the callable, and
+ * every call site throws `(0 , import_slugify.default) is not a function`.
+ *
+ * Resolving the callable defensively keeps both module systems working: under
+ * ESM the imported binding is already the function, under the CJS bridge we
+ * step through the extra `default` hop.
+ */
+export function resolveSlugify(mod: unknown): SlugifyFn {
+  let candidate = mod;
+  for (let hops = 0; hops < 2 && candidate && typeof candidate !== 'function'; hops++) {
+    candidate = (candidate as { default?: unknown }).default;
+  }
+  return (typeof candidate === 'function' ? candidate : mod) as SlugifyFn;
+}
+
+/** Interop-safe `@sindresorhus/slugify`, callable from both ESM and CommonJS builds. */
+export const slugify: SlugifyFn = resolveSlugify(slugifyImport);


### PR DESCRIPTION
## Description

`new MCPServer({ id: ... })` throws `TypeError: (0 , import_slugify.default) is not a function` when `@mastra/core` is consumed from CommonJS.

Root cause is in the generated CJS bundle, not in the source logic. `@sindresorhus/slugify` is ESM-only, so `packages/core/dist/mcp/index.cjs` reaches it through the rolldown interop bridge:

```js
let _sindresorhus_slugify = require("@sindresorhus/slugify");
_sindresorhus_slugify = require_rolldown_runtime.__toESM(_sindresorhus_slugify, 1);
// ...
this._id = (0, _sindresorhus_slugify.default)(config.id);
```

Under Node's `require(esm)` the required value is already the module namespace (`{ __esModule: true, default: [Function], slugifyWithCounter }`). `__toESM` is called with `isNodeMode = 1`, and that branch unconditionally does `__defProp(target, "default", { value: mod })` — so `default` becomes the namespace object itself and shadows the namespace's own `default` export. The call site then invokes an object.

This PR stops relying on the bundler bridge producing a callable. `slugify` is resolved defensively in one place, `packages/core/src/utils/slugify.ts`, and both static call sites import from there:

- `packages/core/src/mcp/index.ts` — `MCPServerBase` id slugification
- `packages/core/src/schedules/schedules.ts` — `canonicalizeScheduleId`, which is bundled through the identical bridge in `dist/schedules-*.cjs` and had the same latent failure

The ESM path is unchanged (the imported binding is already a function and passes straight through). `agent.ts` uses a genuine runtime `await import()` whose namespace is not rewritten by the bundler, so it is left alone.

Note for maintainers: any other ESM-only default import that gets bundled the same way shares this hazard, so a lint rule or a bundler-level interop setting would be a broader fix than this call-site one.

### Verification

Reproduced and fixed against the real build (`pnpm build --filter @mastra/core`), requiring `packages/core/dist/mcp/index.cjs` from a `.cjs` script:

- before: `TypeError: (0 , _sindresorhus_slugify.default) is not a function` at `dist/mcp/index.cjs:121`
- after: `OK id = my-server-id`, and the emitted CJS now reads `this._id = require_slugify.slugify(config.id)`

Gates run in `packages/core`:

- `vitest run src/utils/slugify.test.ts src/mcp/mcp-cjs-interop.test.ts src/mcp/mcp-versioning.test.ts` — 18 passed (the new CJS smoke test fails against a pre-fix bundle and passes after)
- `vitest run src/schedules` — 65 passed
- `tsc --noEmit -p tsconfig.build.json` — clean
- `oxlint` + `eslint` on the changed files — clean
- `oxfmt` applied

### Tests added

- `packages/core/src/utils/slugify.test.ts` — replicates rolldown's `__toESM` helper verbatim, asserts that the bridged `default` is not callable (pinning the hazard) and that the resolver recovers the real function
- `packages/core/src/mcp/mcp-cjs-interop.test.ts` — `MCPServerBase` id slugification unit test, plus a `require()`-based smoke test that constructs `MCPServerBase` from the built `dist/mcp/index.cjs` so the CommonJS bridge is exercised rather than only the ESM path. It is `describe.skipIf`-guarded on `dist/` existing, so it is inert when the package has not been built.

## Related issue(s)

Fixes #20354

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
If you use `@mastra/core` from CommonJS, it used to crash when it tried to turn an MCP server ID into a slug. This PR adds a helper that safely resolves `slugify`, so MCP server IDs and schedule IDs work in both CommonJS and ESM.

## Changes
- Added the interop-safe `resolveSlugify` helper.
- Updated MCP server ID normalization to use the shared helper.
- Updated schedule ID canonicalization to use the shared helper.
- Added tests for resolver behavior, MCP server IDs, and the built CommonJS bundle.
- Added a patch changeset for the CommonJS `MCPServer` construction fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->