### PR TITLE
docs(memory): add context window diagram and fix Observational Memory accuracy

### DIFF
--- a/docs/src/components/MemoryContextWindowImage.tsx
+++ b/docs/src/components/MemoryContextWindowImage.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { useColorMode } from '@docusaurus/theme-common'
+
+export const MemoryContextWindowImage = () => {
+  const { colorMode } = useColorMode()
+
+  return (
+    <div className="mt-4">
+      <img
+        src={
+          colorMode === 'dark'
+            ? '/img/memory/memory-context-window-dark.svg'
+            : '/img/memory/memory-context-window-light.svg'
+        }
+        alt="Diagram showing how Mastra assembles the model context: system messages containing agent instructions, call-time system messages, working memory, cross-thread semantic recall, and Observational Memory, followed by conversation messages where message history and same-thread semantic recall interleave by timestamp, then call-time context messages, and finally the new user message"
+        width={760}
+        height={614}
+      />
+    </div>
+  )
+}
+
+export default MemoryContextWindowImage

--- a/docs/src/components/OmContextOverTimeImage.tsx
+++ b/docs/src/components/OmContextOverTimeImage.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { useColorMode } from '@docusaurus/theme-common'
+
+export const OmContextOverTimeImage = () => {
+  const { colorMode } = useColorMode()
+
+  return (
+    <div className="mt-4">
+      <img
+        src={
+          colorMode === 'dark'
+            ? '/img/memory/om-context-over-time-dark.svg'
+            : '/img/memory/om-context-over-time-light.svg'
+        }
+        alt="Chart of context tokens over the course of a conversation with Observational Memory enabled: message history repeatedly grows toward the 30,000 token observation threshold, then shrinks back to around 6,000 tokens as observations activate, while the observation log steps up with each cycle until it reaches the 40,000 token reflection threshold and the Reflector condenses it into reflections"
+        width={760}
+        height={500}
+      />
+    </div>
+  )
+}
+
+export default OmContextOverTimeImage

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Observational Memory | Memory"
+title: 'Observational Memory | Memory'
 description: "Learn how Observational Memory keeps your agent's context window small while preserving long-term memory across conversations."
 packages:
-  - "@mastra/core"
-  - "@mastra/memory"
+  - '@mastra/core'
+  - '@mastra/memory'
 ---
 
 # Observational Memory

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -107,7 +107,7 @@ For an AI SDK example, see [Using Mastra Memory](/guides/build-your-ui/ai-sdk-ui
 
 :::note
 
-OM currently only supports `@mastra/pg`, `@mastra/libsql`, `@mastra/mongodb`, and `@mastra/convex` storage adapters.
+OM currently only supports `@mastra/pg`, `@mastra/libsql`, `@mastra/mysql`, `@mastra/mongodb`, and `@mastra/convex` storage adapters.
 It uses background agents for managing memory. When no model is set, the default model is `google/gemini-2.5-flash`.
 
 :::
@@ -394,7 +394,7 @@ new Agent({
 })
 ```
 
-You can also pass an allowlist of mimeType globs (for example `['image/*']`) to forward only the kinds the Observer can handle.
+You can also pass an allowlist of mimeType globs (for example `['image/*']`) to forward only the kinds the Observer can handle. Alternatively, set `observeAttachments: 'auto'` to let Mastra decide from the provider capabilities registry: attachments are forwarded when the Observer model supports multimodal input and dropped otherwise, falling back to `true` when no capability data is available for the model.
 
 ```md
 Date: 2026-01-15
@@ -420,6 +420,19 @@ The result is a three-tier system:
 1. **Recent messages**: Exact conversation history for the current task
 1. **Observations**: A log of what the Observer has seen
 1. **Reflections**: Condensed observations when memory becomes too long
+
+### Context over time
+
+With default settings, the context window doesn't grow unbounded. It oscillates through an observe-and-shrink cycle:
+
+1. **0 → 30k tokens**: Message history grows normally. In the background, the Observer buffers observations every \~6k tokens (`bufferTokens: 0.2`).
+1. **30k reached**: Buffered observations activate instantly. Observed messages are removed from the context window and only \~6k tokens of recent history remain (`bufferActivation: 0.8` retains 20% of the threshold). The \~24k tokens of removed messages become roughly 1-5k tokens of observations at typical 5-40x compression.
+1. **Repeat**: History grows from \~6k back toward 30k and shrinks again. Each cycle appends to the observation log, which grows much more slowly than raw history.
+1. **Observations reach 40k**: The Reflector condenses the observation log into reflections, shrinking it as well.
+
+The result: in the normal buffered cycle, raw history oscillates between roughly 6k and 30k tokens and the observation log stays around 40k tokens, however long the conversation runs. These are activation thresholds rather than hard caps — if background buffering falls behind, history can grow past the threshold until `blockAfter` (default `1.2`) forces a synchronous observation at \~36k tokens (\~48k for reflection) as a safety ceiling.
+
+With [`shareTokenBudget`](/reference/memory/observational-memory#shared-token-budget) enabled, the two budgets pool together: while the observation log is small, message history can expand into the unused observation space (up to \~70k tokens with the defaults) before observation triggers, then shrinks back as observations accumulate.
 
 ### Retrieval mode
 
@@ -706,7 +719,7 @@ Reflection works similarly, the Reflector runs in the background when observatio
 | - | - | - |
 | `observation.bufferTokens` | `0.2` | How often to buffer. `0.2` means every 20% of `messageTokens`. With the default 30k threshold, that's roughly every 6k tokens. Can also be an absolute token count (e.g. `5000`). |
 | `observation.bufferActivation` | `0.8` | How aggressively to clear the message window on activation. `0.8` means remove enough messages to keep only 20% of `messageTokens` remaining. Lower values keep more message history. |
-| `observation.blockAfter` | `1.2` | Safety threshold as a multiplier of `messageTokens`. At `1.2`, synchronous observation is forced at 36k tokens (1.2 × 30k). Only matters if buffering can't keep up. |
+| `observation.blockAfter` | `1.2` | Safety net if buffering can't keep up. Values from 1 up to (but not including) 100 multiply `messageTokens`: at `1.2`, synchronous observation is forced at 36k tokens (1.2 × 30k). Values of 100 or more are absolute token counts (e.g. `50_000`). |
 | `activateAfterIdle` | none | Forces buffered observations to activate after a period of inactivity, even before `observation.messageTokens` is reached. Accepts a numeric millisecond value such as `300_000`, duration strings like `"5m"` or `"1hr"`, or `"auto"` for a provider-aware prompt cache TTL. |
 | `activateOnProviderChange` | `false` | Forces buffered observations to activate when the next step uses a different `provider/model` than the one that produced the latest assistant step. Use this when switching providers or models would invalidate prompt cache reuse. |
 | `reflection.bufferActivation` | `0.5` | When to start background reflection. `0.5` means reflection begins when observations reach 50% of the `observationTokens` threshold. |
@@ -726,7 +739,7 @@ With `"auto"`, Mastra chooses an idle activation TTL from the active model provi
 | Groq | 2 hours |
 | OpenAI with `providerOptions.openai.promptCacheRetention: "24h"` | 1 hour |
 | OpenAI with `providerOptions.openai.promptCacheRetention: "in_memory"` | 5 minutes |
-| OpenAI `gpt-4*`, `gpt-5`, `gpt-5-*`, `gpt-5.1*`, `gpt-5.2*`, `gpt-5.3*`, and `gpt-5.4*` | 5 minutes |
+| OpenAI `gpt-4*`, `gpt-5`, `gpt-5-*`, and `gpt-5.1` through `gpt-5.4` (including `-` suffixed variants) | 5 minutes |
 | Other OpenAI models | 1 hour |
 
 ```typescript

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -6,6 +6,8 @@ packages:
   - '@mastra/memory'
 ---
 
+import OmContextOverTimeImage from '@site/src/components/OmContextOverTimeImage'
+
 # Observational Memory
 
 **Added in:** `@mastra/memory@1.1.0`
@@ -415,6 +417,8 @@ Example: An agent using Playwright MCP might see 50,000+ tokens per page snapsho
 
 When observations exceed their threshold (default: 40,000 tokens), the Reflector condenses them and combines related items, plus reflects on patterns.
 
+Reflections don't accumulate as a separate, ever-growing layer. Each reflection rewrites the entire observation log: the Reflector's output becomes the new log, and new observations append after it. When the log next hits the threshold, the Reflector re-processes everything — including earlier reflections — condensing older information more aggressively while keeping recent detail. Memory stays bounded around the reflection threshold no matter how long the conversation runs.
+
 The result is a three-tier system:
 
 1. **Recent messages**: Exact conversation history for the current task
@@ -425,10 +429,12 @@ The result is a three-tier system:
 
 With default settings, the context window doesn't grow unbounded. It oscillates through an observe-and-shrink cycle:
 
+<OmContextOverTimeImage />
+
 1. **0 → 30k tokens**: Message history grows normally. In the background, the Observer buffers observations every \~6k tokens (`bufferTokens: 0.2`).
 1. **30k reached**: Buffered observations activate instantly. Observed messages are removed from the context window and only \~6k tokens of recent history remain (`bufferActivation: 0.8` retains 20% of the threshold). The \~24k tokens of removed messages become roughly 1-5k tokens of observations at typical 5-40x compression.
 1. **Repeat**: History grows from \~6k back toward 30k and shrinks again. Each cycle appends to the observation log, which grows much more slowly than raw history.
-1. **Observations reach 40k**: The Reflector condenses the observation log into reflections, shrinking it as well.
+1. **Observations reach 40k**: The Reflector condenses the observation log — including any earlier reflections — into a new, smaller log.
 
 The result: in the normal buffered cycle, raw history oscillates between roughly 6k and 30k tokens and the observation log stays around 40k tokens, however long the conversation runs. These are activation thresholds rather than hard caps — if background buffering falls behind, history can grow past the threshold until `blockAfter` (default `1.2`) forces a synchronous observation at \~36k tokens (\~48k for reflection) as a safety ceiling.
 

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -170,7 +170,7 @@ See [Observational Memory](../memory/observational-memory) for details on how ob
 
 ## What the model sees
 
-Each memory feature lands in one of two places in the request sent to the model: the system messages or the conversation messages. Which layers are present depends on which features you've enabled — working memory, semantic recall, and Observational Memory only appear when configured, while message history is on by default. On every agent call, Mastra assembles the enabled layers in this order:
+Each memory feature lands in one of two places in the request sent to the model: the system messages or the conversation messages. Which layers are present depends on which features you've enabled — working memory, semantic recall, and Observational Memory only appear when configured, while message history is on by default. The diagram shows where each enabled layer is placed in the request; the list below describes what each layer contributes:
 
 <MemoryContextWindowImage />
 

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -9,6 +9,7 @@ packages:
 
 import Steps from "@site/src/components/Steps";
 import StepItem from "@site/src/components/StepItem";
+import MemoryContextWindowImage from "@site/src/components/MemoryContextWindowImage";
 
 # Memory
 
@@ -166,6 +167,20 @@ export const memoryAgent = new Agent({
 ```
 
 See [Observational Memory](../memory/observational-memory) for details on how observations and reflections work, and [the reference](/reference/memory/observational-memory) for all configuration options.
+
+## What the model sees
+
+Each memory feature lands in one of two places in the request sent to the model: the system messages or the conversation messages. Which layers are present depends on which features you've enabled — working memory, semantic recall, and Observational Memory only appear when configured, while message history is on by default. On every agent call, Mastra assembles the enabled layers in this order:
+
+<MemoryContextWindowImage />
+
+- [Working memory](../memory/working-memory) is injected as a system message containing the template and the stored data. With `useStateSignals`, it's delivered as a state signal instead.
+- [Semantic recall](../memory/semantic-recall) matches from the current thread are inserted as regular messages and interleave with message history by timestamp. Matches from other threads are formatted into a system message instead.
+- [Message history](../memory/message-history) adds the last N messages in chronological order. Your new message always comes last.
+- [Observational Memory](../memory/observational-memory) replaces old raw history: reflections and observations live in a system message, and only messages that haven't been observed yet remain in the conversation. A short continuation reminder is placed at the start of the conversation messages.
+- Context messages are the optional `context` array passed on a call, for example `agent.generate(msg, { context: [...] })`. Use them for one-off background such as app state or your own RAG results. They appear as regular conversation messages for that request only and are never saved to memory.
+
+Conversation messages are ordered by timestamp and deduplicated by message ID, so recalled older messages appear before recent history. Context messages passed at call time are stamped with the current time, which places them after history and recall but before your new message. To inspect the exact context for a real request, use [Tracing](/docs/observability/tracing/overview) and open the LLM call spans, see [Observability](#observability) below.
 
 ## Memory in multi-agent systems
 

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -33,7 +33,7 @@ export const agent = new Agent({
 
 ## Configuration
 
-The `observationalMemory` option accepts `true`, a configuration object, or `false`. Setting `true` enables OM with `google/gemini-2.5-flash` as the default model. When passing a config object, a `model` must be explicitly set: either at the top level or on `observation.model` and/or `reflection.model`.
+The `observationalMemory` option accepts `true`, a configuration object, or `false`. Setting `true` enables OM with `__GATEWAY_GOOGLE_MODEL_FLASH__` as the default model. When passing a config object, set `model` at the top level or on `observation.model` and/or `reflection.model`; when all model fields are omitted, OM falls back to `__GATEWAY_GOOGLE_MODEL_FLASH__`.
 
 Observer input is multimodal-aware. OM keeps text placeholders like `[Image #1: screenshot.png]` in the transcript it builds for the Observer, and also sends the underlying image parts when possible. This applies to both single-thread observation and batched multi-thread observation. Non-image files appear as placeholders only.
 
@@ -53,9 +53,9 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
     name: 'model',
     type: 'string | LanguageModel | DynamicModel | ModelByInputTokens | ModelWithRetries[]',
     description:
-      'Model for both the Observer and Reflector agents. Sets the model for both at once. Cannot be used together with `observation.model` or `reflection.model` — an error will be thrown if both are set. When using `observationalMemory: true`, defaults to `google/gemini-2.5-flash`. When passing a config object, this or `observation.model`/`reflection.model` must be set. Use `"default"` to explicitly use the default model (`google/gemini-2.5-flash`).',
+      'Model for both the Observer and Reflector agents. Sets the model for both at once. Cannot be used together with `observation.model` or `reflection.model` — an error will be thrown if both are set. When this and `observation.model`/`reflection.model` are all omitted, OM falls back to `google/gemini-2.5-flash`. Use `"default"` to explicitly use the default model (`google/gemini-2.5-flash`).',
     isOptional: true,
-    defaultValue: "'google/gemini-2.5-flash' (when using observationalMemory: true)",
+    defaultValue: "'google/gemini-2.5-flash'",
   },
   {
     name: 'scope',
@@ -100,7 +100,7 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
     name: 'retrieval',
     type: "boolean | { vector?: boolean; scope?: 'thread' | 'resource' }",
     description:
-      "Enable retrieval-mode observation groups as durable pointers to raw message history. `true` enables cross-thread browsing by default. `{ vector: true }` also enables semantic search using Memory's vector store and embedder. `{ scope: 'thread' }` restricts the recall tool to the current thread only. Default scope is `'resource'`.",
+      "Let the agent look up the raw message history behind its observations. Observation groups keep durable pointers to the original messages, and a `recall` tool is registered so the agent can browse them. `true` enables cross-thread browsing by default. `{ vector: true }` also enables semantic search using Memory's vector store and embedder. `{ scope: 'thread' }` restricts the recall tool to the current thread only. Default scope is `'resource'`.",
     isOptional: true,
     defaultValue: 'false',
   },
@@ -143,10 +143,18 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             isOptional: true,
           },
           {
-            name: 'observeAttachments',
-            type: 'boolean | string[]',
+            name: 'manageWorkingMemory',
+            type: 'boolean',
             description:
-              "Controls which image/file attachments are forwarded to the Observer model alongside their placeholder text lines. `true` (default) forwards all attachments. `false` drops all attachments while keeping placeholders visible. An array is a case-insensitive mimeType allowlist supporting exact matches (`'application/pdf'`), wildcard subtypes (`'image/*'`), and bare `'*'` for everything. Useful when the Observer model is text-only (e.g. some DeepSeek endpoints) while the main agent uses a multimodal model. Tool-result attachments are filtered using the same rule.",
+              'Let the Observer manage working memory through OM extraction. Adds `WorkingMemoryExtractor`, defaults `workingMemory.agentManaged` to `false`, and defaults `workingMemory.useStateSignals` to `true`. See [Working memory updates](#working-memory-updates).',
+            isOptional: true,
+            defaultValue: 'false',
+          },
+          {
+            name: 'observeAttachments',
+            type: "'auto' | boolean | string[]",
+            description:
+              "Controls which image/file attachments are forwarded to the Observer model alongside their placeholder text lines. `true` (default) forwards all attachments. `false` drops all attachments while keeping placeholders visible. `'auto'` uses the provider capabilities registry to decide: attachments are forwarded when the Observer model supports multimodal input, dropped otherwise, and forwarded when no capability data is available for the model. An array is a case-insensitive mimeType allowlist supporting exact matches (`'application/pdf'`), wildcard subtypes (`'image/*'`), and bare `'*'` for everything. Useful when the Observer model is text-only (e.g. some DeepSeek endpoints) while the main agent uses a multimodal model. Tool-result attachments are filtered using the same rule.",
             isOptional: true,
             defaultValue: 'true',
           },
@@ -169,9 +177,10 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
           {
             name: 'modelSettings',
             type: 'ObservationalMemoryModelSettings',
-            description: 'Model settings for the Observer agent.',
+            description:
+              'Model settings for the Observer agent. The `maxOutputTokens: 100_000` default is only applied with default model selection (no model set, `"default"`, or a `ModelByInputTokens` selector). Custom models get no `maxOutputTokens` default.',
             isOptional: true,
-            defaultValue: '{ temperature: 0.3, maxOutputTokens: 100_000 }',
+            defaultValue: '{ temperature: 0.3, maxOutputTokens: 100_000 (default model selection only) }',
             properties: [
               {
                 type: 'ObservationalMemoryModelSettings',
@@ -186,19 +195,28 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
                   {
                     name: 'maxOutputTokens',
                     type: 'number',
-                    description: 'Maximum output tokens. Set high to prevent truncation of observations.',
+                    description:
+                      'Maximum output tokens. Set high to prevent truncation of observations. The `100000` default is only applied with default model selection; custom models get no default.',
                     isOptional: true,
-                    defaultValue: '100000',
+                    defaultValue: '100000 (default model selection only)',
                   },
                 ],
               },
             ],
           },
           {
+            name: 'providerOptions',
+            type: 'ProviderOptions',
+            description:
+              'Provider-specific options passed to the Observer agent, such as Google thinking configuration.',
+            isOptional: true,
+            defaultValue: '{ google: { thinkingConfig: { thinkingBudget: 215 } } }',
+          },
+          {
             name: 'bufferTokens',
             type: 'number | false',
             description:
-              'Token interval for async background observation buffering. Can be an absolute token count (e.g. `5000`) or a fraction of `messageTokens` (e.g. `0.25` = buffer every 25% of threshold). When set, observations run in the background at this interval, storing results in a buffer. When the main `messageTokens` threshold is reached, buffered observations activate instantly without a blocking LLM call. Must resolve to less than `messageTokens`. Set to `false` to explicitly disable all async buffering (both observation and reflection).',
+              'How often background observation buffering runs. Values between `0` and `1` are fractions of `messageTokens`: `0.25` buffers every 25% of the threshold (7.5k tokens with the default 30k). Values of `1` or more are absolute token counts: `5000` buffers every 5k tokens. Buffered observations are stored until the `messageTokens` threshold is reached, then activate instantly without a blocking LLM call. Must resolve to less than `messageTokens`. Set to `false` to disable all async buffering (both observation and reflection).',
             isOptional: true,
             defaultValue: '0.2',
           },
@@ -214,7 +232,7 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             name: 'bufferActivation',
             type: 'number',
             description:
-              'Controls how much of the message window to retain after activation. Accepts a ratio (0-1) or an absolute token count (≥ 1000). For example, `0.8` means: activate enough buffers to remove 80% of `messageTokens` and leave 20% as active message history. An absolute token count like `4000` targets a goal of keeping ~4k message tokens remaining after activation. Higher values remove more message history per activation when using a ratio. Higher values keep more message history when using a token count.',
+              'How much of the message window to clear when buffered observations activate. Values between `0` and `1` are the fraction of `messageTokens` to remove: `0.8` removes ~80% of the message history and keeps ~20% (6k tokens with the default 30k). Values of `1000` or more are the token count to keep: `4000` keeps ~4k message tokens after activation. Note the direction flips: a higher ratio removes more history, while a higher token count keeps more.',
             isOptional: true,
             defaultValue: '0.8',
           },
@@ -222,21 +240,21 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             name: 'activateAfterIdle',
             type: 'number | string | false | "auto"',
             description:
-              'Time before buffered observations are forced to activate after inactivity. Accepts milliseconds, a duration string, `"auto"` for a provider-aware prompt cache TTL, or `false`. If unset, the top-level `activateAfterIdle` value is used for observations. Set `false` to disable the top-level idle setting for observations.',
+              'Time before buffered observations are forced to activate after inactivity. Accepts milliseconds, a duration string, `"auto"` for a provider-aware prompt cache TTL, or `false`. If unset, the top-level `activateAfterIdle` value is used for observations. Set `false` to disable the top-level idle setting for observations. Currently only applied when using the standalone `ObservationalMemory` class; `new Memory(...)` applies the top-level `activateAfterIdle` only.',
             isOptional: true,
           },
           {
             name: 'activateOnProviderChange',
             type: 'boolean',
             description:
-              'Force buffered observations to activate when the actor provider or model changes. If unset, the top-level `activateOnProviderChange` value is used for observations.',
+              'Force buffered observations to activate when the actor provider or model changes. If unset, the top-level `activateOnProviderChange` value is used for observations. Currently only applied when using the standalone `ObservationalMemory` class; `new Memory(...)` applies the top-level `activateOnProviderChange` only.',
             isOptional: true,
           },
           {
             name: 'blockAfter',
             type: 'number',
             description:
-              'Token threshold above which synchronous (blocking) observation is forced. Between `messageTokens` and `blockAfter`, only async buffering/activation is used. Above `blockAfter`, a synchronous observation runs as a last resort, while buffered activation still preserves a minimum remaining context (min(1000, retention floor)). Accepts a multiplier (1 < value < 2, multiplied by `messageTokens`) or an absolute token count (≥ 2, must be greater than `messageTokens`). Only relevant when `bufferTokens` is set. Defaults to `1.2` when async buffering is enabled.',
+              "Safety net that forces a synchronous (blocking) observation when background buffering can't keep up. Values from `1` up to (but not including) `100` are multipliers of `messageTokens`: `1.2` forces a blocking observation at 120% of the threshold (36k tokens with the default 30k). Values of `100` or more are absolute token counts and must be greater than `messageTokens`. Between `messageTokens` and `blockAfter`, only async buffering and activation run; buffered activation still preserves a minimum remaining context (the smaller of 1000 tokens or the retention floor). Only relevant when `bufferTokens` is set. Defaults to `1.2` when async buffering is enabled.",
             isOptional: true,
             defaultValue: '1.2 (when bufferTokens is set)',
           },
@@ -293,9 +311,10 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
           {
             name: 'modelSettings',
             type: 'ObservationalMemoryModelSettings',
-            description: 'Model settings for the Reflector agent.',
+            description:
+              'Model settings for the Reflector agent. The `maxOutputTokens: 100_000` default is only applied with default model selection (no model set, `"default"`, or a `ModelByInputTokens` selector). Custom models get no `maxOutputTokens` default.',
             isOptional: true,
-            defaultValue: '{ temperature: 0, maxOutputTokens: 100_000 }',
+            defaultValue: '{ temperature: 0, maxOutputTokens: 100_000 (default model selection only) }',
             properties: [
               {
                 type: 'ObservationalMemoryModelSettings',
@@ -310,19 +329,28 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
                   {
                     name: 'maxOutputTokens',
                     type: 'number',
-                    description: 'Maximum output tokens. Set high to prevent truncation of observations.',
+                    description:
+                      'Maximum output tokens. Set high to prevent truncation of observations. The `100000` default is only applied with default model selection; custom models get no default.',
                     isOptional: true,
-                    defaultValue: '100000',
+                    defaultValue: '100000 (default model selection only)',
                   },
                 ],
               },
             ],
           },
           {
+            name: 'providerOptions',
+            type: 'ProviderOptions',
+            description:
+              'Provider-specific options passed to the Reflector agent, such as Google thinking configuration.',
+            isOptional: true,
+            defaultValue: '{ google: { thinkingConfig: { thinkingBudget: 1024 } } }',
+          },
+          {
             name: 'bufferActivation',
             type: 'number',
             description:
-              'Ratio (0-1) controlling when async reflection buffering starts. When observation tokens reach `observationTokens * bufferActivation`, reflection runs in the background. On activation at the full threshold, the buffered reflection replaces the observations it covers, preserving any new observations appended after that range.',
+              'When background reflection starts, as a ratio (0-1) of `observationTokens`: `0.5` starts reflecting in the background once observations reach 50% of the threshold (20k tokens with the default 40k). When the full threshold is reached, the buffered reflection replaces the observations it covers, preserving any new observations appended after that range.',
             isOptional: true,
             defaultValue: '0.5',
           },
@@ -330,14 +358,14 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             name: 'activateAfterIdle',
             type: 'number | string | false | "auto"',
             description:
-              'Time before buffered reflections are forced to activate after inactivity. Accepts milliseconds, a duration string, `"auto"` for a provider-aware prompt cache TTL, or `false`. Reflections do not inherit top-level `activateAfterIdle`; set this explicitly to opt reflections into idle activation.',
+              'Time before buffered reflections are forced to activate after inactivity. Accepts milliseconds, a duration string, `"auto"` for a provider-aware prompt cache TTL, or `false`. Reflections do not inherit top-level `activateAfterIdle`; set this explicitly to opt reflections into idle activation. Currently only applied when using the standalone `ObservationalMemory` class; this setting has no effect through `new Memory(...)`.',
             isOptional: true,
           },
           {
             name: 'activateOnProviderChange',
             type: 'boolean',
             description:
-              'Force buffered reflections to activate when the actor provider or model changes. Reflections do not inherit top-level `activateOnProviderChange`; set this explicitly to opt reflections into provider-change activation.',
+              'Force buffered reflections to activate when the actor provider or model changes. Reflections do not inherit top-level `activateOnProviderChange`; set this explicitly to opt reflections into provider-change activation. Currently only applied when using the standalone `ObservationalMemory` class; this setting has no effect through `new Memory(...)`.',
             isOptional: true,
             defaultValue: 'false',
           },
@@ -345,7 +373,7 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             name: 'blockAfter',
             type: 'number',
             description:
-              'Token threshold above which synchronous (blocking) reflection is forced. Between `observationTokens` and `blockAfter`, only async buffering/activation is used. Above `blockAfter`, a synchronous reflection runs as a last resort. Accepts a multiplier (1 < value < 2, multiplied by `observationTokens`) or an absolute token count (≥ 2, must be greater than `observationTokens`). Only relevant when `bufferActivation` is set. Defaults to `1.2` when async reflection is enabled.',
+              "Safety net that forces a synchronous (blocking) reflection when background reflection can't keep up. Values from `1` up to (but not including) `100` are multipliers of `observationTokens`: `1.2` forces a blocking reflection at 120% of the threshold (48k tokens with the default 40k). Values of `100` or more are absolute token counts and must be greater than `observationTokens`. Between `observationTokens` and `blockAfter`, only async buffering and activation run. Only relevant when `bufferActivation` is set. Defaults to `1.2` when async reflection is enabled.",
             isOptional: true,
             defaultValue: '1.2 (when bufferActivation is set)',
           },
@@ -407,7 +435,7 @@ const memory = new Memory({
     name: 'slug',
     type: 'string',
     description:
-      'Generated stable identifier for persisted values and XML tags. Slugs use lowercase letters, numbers, and hyphens. Built-in slugs and reserved XML tags cannot be used by custom extractors.',
+      'Read-only property derived from `name` — not a constructor option. Generated stable identifier for persisted values and XML tags. Slugs use lowercase letters, numbers, and hyphens. Built-in slugs and reserved XML tags cannot be used by custom extractors.',
   },
   {
     name: 'instructions',
@@ -429,6 +457,14 @@ const memory = new Memory({
       'Controls whether the previous extraction is shown to the extractor on future OM runs. Set to `false` for values that should only come from the current OM run.',
     isOptional: true,
     defaultValue: 'true',
+  },
+  {
+    name: 'metadataKeyPath',
+    type: 'string | false',
+    description:
+      'Dot-separated OM metadata path used to persist the extracted value. Set to `false` to skip OM metadata persistence entirely.',
+    isOptional: true,
+    defaultValue: "'extracted.<slug>'",
   },
   {
     name: 'onExtracted',
@@ -974,9 +1010,63 @@ Emitted when buffered observations or reflections are activated (moved into the 
   { name: 'messagesActivated', type: 'number', description: 'Number of messages that were observed via activation.' },
   { name: 'generationCount', type: 'number', description: 'Current reflection generation count.' },
   { name: 'observations', type: 'string', description: 'The activated observations text.', isOptional: true },
+  {
+    name: 'triggeredBy',
+    type: "'threshold' | 'ttl' | 'provider_change'",
+    description:
+      'Whether activation was triggered by threshold crossing, `activateAfterIdle` expiry, or a model/provider change.',
+    isOptional: true,
+  },
+  {
+    name: 'lastActivityAt',
+    type: 'number',
+    description: 'Unix-ms timestamp of the last assistant message part used for TTL checks.',
+    isOptional: true,
+  },
+  {
+    name: 'ttlExpiredMs',
+    type: 'number',
+    description: 'How long `activateAfterIdle` had been exceeded when activation fired.',
+    isOptional: true,
+  },
+  {
+    name: 'previousModel',
+    type: 'string',
+    description: 'Previous assistant model identifier that triggered activation (e.g. `openai/gpt-4o`).',
+    isOptional: true,
+  },
+  {
+    name: 'currentModel',
+    type: 'string',
+    description: 'Current actor model identifier that triggered activation.',
+    isOptional: true,
+  },
   { name: 'recordId', type: 'string', description: 'The OM record ID.' },
   { name: 'threadId', type: 'string', description: "This thread's ID." },
   { name: 'config', type: 'ObservationMarkerConfig', description: 'Snapshot of config at activation time.' },
+]}
+/>
+
+### `data-om-thread-update`
+
+Emitted when the Observer updates the thread title. Only emitted when `observation.threadTitle` is enabled.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'cycleId',
+    type: 'string',
+    description: 'Unique ID for this observation cycle — shared with observation markers.',
+  },
+  { name: 'threadId', type: 'string', description: 'The thread ID that was updated.' },
+  {
+    name: 'oldTitle',
+    type: 'string',
+    description: 'The previous thread title. Undefined if the thread had no title.',
+    isOptional: true,
+  },
+  { name: 'newTitle', type: 'string', description: 'The new thread title.' },
+  { name: 'timestamp', type: 'string', description: 'When this update occurred.' },
 ]}
 />
 
@@ -984,8 +1074,11 @@ Emitted when buffered observations or reflections are activated (moved into the 
 
 Most users should use the `Memory` class above. Using `ObservationalMemory` directly is mainly useful for benchmarking, experimentation, or when you need to control processor ordering with other processors (like [guardrails](/docs/agents/guardrails)).
 
+The `ObservationalMemory` class is the engine; to attach it to an agent, wrap it in an `ObservationalMemoryProcessor`, which needs a `Memory` instance for loading and persisting messages. Note that `stores.memory` is typed as optional on storage adapters, so a non-null assertion (or a runtime check) is needed:
+
 ```typescript title="src/mastra/agents/agent.ts"
-import { ObservationalMemory } from '@mastra/memory/processors'
+import { ObservationalMemory, ObservationalMemoryProcessor } from '@mastra/memory/processors'
+import { Memory } from '@mastra/memory'
 import { Agent } from '@mastra/core/agent'
 import { LibSQLStore } from '@mastra/libsql'
 
@@ -994,9 +1087,12 @@ const storage = new LibSQLStore({
   url: 'file:./memory.db',
 })
 
+const memory = new Memory({ storage })
+
 const om = new ObservationalMemory({
-  storage: storage.stores.memory,
-  model: 'google/gemini-2.5-flash',
+  storage: storage.stores.memory!,
+  memory,
+  model: '__GATEWAY_GOOGLE_MODEL_FLASH__',
   scope: 'resource',
   observation: {
     messageTokens: 20_000,
@@ -1006,13 +1102,15 @@ const om = new ObservationalMemory({
   },
 })
 
+const omProcessor = new ObservationalMemoryProcessor(om, memory)
+
 export const agent = new Agent({
   id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL_MINI__',
-  inputProcessors: [om],
-  outputProcessors: [om],
+  inputProcessors: [omProcessor],
+  outputProcessors: [omProcessor],
 })
 ```
 
@@ -1075,14 +1173,22 @@ When `retrieval` is set (any truthy value), a `recall` tool is registered so the
     type: 'string',
     isOptional: true,
     description:
-      'A message ID to anchor the recall query. Required for `mode: "messages"` when browsing the current thread. Extract the start or end ID from an observation group range (e.g. from `_range: \\`startId:endId\\`_`, use either `startId` or `endId`). If a range string is passed directly, the tool returns a hint explaining how to extract the correct ID. Can be omitted when `threadId` is provided to start reading from the beginning of that thread.',
+      'A message ID to anchor the recall query. Extract the start or end ID from an observation group range (e.g. from `_range: \\`startId:endId\\`_`, use either `startId` or `endId`). If a range string is passed directly, the tool returns a hint explaining how to extract the correct ID. When both `cursor` and `threadId` are omitted for `mode: "messages"`, the tool browses the current thread from the position set by `anchor`.',
   },
   {
     name: 'threadId',
     type: 'string',
     isOptional: true,
     description:
-      'Browse a different thread by its ID. Use `mode: "threads"` first to discover thread IDs. When provided without a `cursor`, reading starts from the beginning of the thread.',
+      'Browse a different thread by its ID, or pass `"current"` for the active thread. Use `mode: "threads"` first to discover thread IDs. When provided without a `cursor`, reading starts from the beginning of the thread.',
+  },
+  {
+    name: 'anchor',
+    type: "'start' | 'end'",
+    isOptional: true,
+    defaultValue: "'start'",
+    description:
+      'For `mode: "messages"` without a `cursor`, page from the start (oldest-first) or end (newest-first) of the thread.',
   },
   {
     name: 'page',
@@ -1106,6 +1212,19 @@ When `retrieval` is set (any truthy value), a `recall` tool is registered so the
     defaultValue: "'low'",
     description:
       "Controls how much content is shown per message part. `'low'` shows truncated text and tool names with positional indices (`[p0]`, `[p1]`). `'high'` shows full content including tool arguments and results, clamped to one part per call with continuation hints.",
+  },
+  {
+    name: 'partType',
+    type: "'text' | 'tool-call' | 'tool-result' | 'reasoning' | 'image' | 'file'",
+    isOptional: true,
+    description: 'Filter results to only include message parts of this type. Only applies to `mode: "messages"`.',
+  },
+  {
+    name: 'toolName',
+    type: 'string',
+    isOptional: true,
+    description:
+      'Filter results to only include tool-call and tool-result parts matching this tool name. Only applies to `mode: "messages"`.',
   },
   {
     name: 'partIndex',
@@ -1159,6 +1278,11 @@ When `retrieval` is set (any truthy value), a `recall` tool is registered so the
     name: 'limit',
     type: 'number',
     description: 'The limit used for this query.',
+  },
+  {
+    name: 'detail',
+    type: "'low' | 'high'",
+    description: 'The detail level used for this query.',
   },
   {
     name: 'hasNextPage',

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Reference: Observational Memory | Memory"
-description: "API reference for Observational Memory in Mastra: a three-tier memory system that uses Observer and Reflector agents to maintain long-term memory across conversations."
+title: 'Reference: Observational Memory | Memory'
+description: 'API reference for Observational Memory in Mastra: a three-tier memory system that uses Observer and Reflector agents to maintain long-term memory across conversations.'
 packages:
-  - "@mastra/core"
-  - "@mastra/memory"
+  - '@mastra/core'
+  - '@mastra/memory'
 ---
 
 # Observational Memory
@@ -870,7 +870,12 @@ Emitted when observation or reflection fails. The system falls back to synchrono
   { name: 'durationMs', type: 'number', description: 'Duration until failure in milliseconds.' },
   { name: 'tokensAttempted', type: 'number', description: 'Message tokens (input) that were attempted.' },
   { name: 'error', type: 'string', description: 'Error message.' },
-  { name: 'observations', type: 'string', description: 'Any partial content available for display.', isOptional: true },
+  {
+    name: 'observations',
+    type: 'string',
+    description: 'Any partial content available for display.',
+    isOptional: true,
+  },
   { name: 'recordId', type: 'string', description: 'The OM record ID.' },
   { name: 'threadId', type: 'string', description: "This thread's ID." },
 ]}
@@ -900,7 +905,11 @@ Emitted when async buffering completes. The content is stored but not yet activa
 <PropertiesTable
   content={[
   { name: 'cycleId', type: 'string', description: 'Matches the corresponding `buffering-start` marker.' },
-  { name: 'operationType', type: "'observation' | 'reflection'", description: 'Type of operation that was buffered.' },
+  {
+    name: 'operationType',
+    type: "'observation' | 'reflection'",
+    description: 'Type of operation that was buffered.',
+  },
   { name: 'completedAt', type: 'string', description: 'ISO timestamp when buffering completed.' },
   { name: 'durationMs', type: 'number', description: 'Duration in milliseconds.' },
   { name: 'tokensBuffered', type: 'number', description: 'Message tokens (input) that were buffered.' },

--- a/docs/static/img/memory/memory-context-window-dark.svg
+++ b/docs/static/img/memory/memory-context-window-dark.svg
@@ -1,0 +1,116 @@
+<svg width="760" height="614" viewBox="0 0 760 614" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="How Mastra assembles the model context from system messages and conversation messages">
+  <style>
+    text { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .header { font-size: 12px; font-weight: 700; letter-spacing: 0.1em; fill: #cfcfcf; }
+    .header-desc { font-size: 11px; fill: #8a8a8a; }
+    .section { font-size: 10.5px; font-weight: 600; letter-spacing: 0.09em; fill: #8a8a8a; }
+    .title { font-size: 13px; font-weight: 600; fill: #f2f2f2; }
+    .desc { font-size: 13px; fill: #9a9a9a; }
+    .num { font-size: 11px; font-weight: 600; fill: #a8a8a8; }
+    .num-mem { font-size: 11px; font-weight: 600; fill: #2aed73; }
+    .legend { font-size: 12px; fill: #9a9a9a; }
+    .flow-label { font-size: 10px; font-weight: 600; letter-spacing: 0.06em; fill: #7a7a7a; }
+    .bracket-label { font-size: 12px; font-weight: 600; fill: #2aed73; }
+    .opt { font-size: 11px; font-style: italic; fill: #6fae83; }
+    .outer { fill: #0e0e0e; stroke: #262626; }
+    .group { fill: #141414; stroke: #262626; }
+    .row { fill: #1c1c1c; stroke: #2c2c2c; }
+    .row-mem { fill: #0e2617; stroke: #1e4a2c; }
+    .chip { fill: #2c2c2c; }
+    .chip-mem { fill: #143621; }
+    .accent { fill: #2aed73; }
+    .flow { stroke: #4a4a4a; stroke-width: 1.5; fill: none; }
+    .bracket { stroke: #2aed73; stroke-width: 1.5; fill: none; }
+  </style>
+
+  <!-- Order-of-delivery arrow -->
+  <text x="28" y="56" text-anchor="middle" class="flow-label">FIRST</text>
+  <line x1="28" y1="66" x2="28" y2="504" class="flow"/>
+  <path d="M23 502 L28 512 L33 502" class="flow"/>
+  <text x="28" y="530" text-anchor="middle" class="flow-label">LAST</text>
+
+  <!-- Context window -->
+  <rect x="48" y="12" width="560" height="558" rx="16" class="outer"/>
+  <text x="68" y="40" class="header">CONTEXT WINDOW</text>
+  <text x="588" y="40" text-anchor="end" class="header-desc">one request to the model</text>
+
+  <!-- System messages group -->
+  <rect x="64" y="54" width="528" height="276" rx="12" class="group"/>
+  <text x="80" y="78" class="section">SYSTEM MESSAGES</text>
+
+  <!-- 1 Agent instructions -->
+  <rect x="80" y="88" width="496" height="40" rx="8" class="row"/>
+  <circle cx="102" cy="108" r="11" class="chip"/>
+  <text x="102" y="112" text-anchor="middle" class="num">1</text>
+  <text x="122" y="113"><tspan class="title">Agent instructions</tspan></text>
+
+  <!-- 2 Call-time system messages -->
+  <rect x="80" y="136" width="496" height="40" rx="8" class="row"/>
+  <circle cx="102" cy="156" r="11" class="chip"/>
+  <text x="102" y="160" text-anchor="middle" class="num">2</text>
+  <text x="122" y="161"><tspan class="title">System messages</tspan><tspan class="desc"> — passed at call time</tspan></text>
+
+  <!-- 3 Working memory -->
+  <rect x="80" y="184" width="496" height="40" rx="8" class="row-mem"/>
+  <rect x="80" y="191" width="3.5" height="26" rx="1.75" class="accent"/>
+  <circle cx="102" cy="204" r="11" class="chip-mem"/>
+  <text x="102" y="208" text-anchor="middle" class="num-mem">3</text>
+  <text x="122" y="209"><tspan class="title">Working memory</tspan><tspan class="desc"> — template + stored data</tspan></text>
+  <text x="564" y="209" text-anchor="end" class="opt">if enabled</text>
+
+  <!-- 4 Semantic recall (other threads) -->
+  <rect x="80" y="232" width="496" height="40" rx="8" class="row-mem"/>
+  <rect x="80" y="239" width="3.5" height="26" rx="1.75" class="accent"/>
+  <circle cx="102" cy="252" r="11" class="chip-mem"/>
+  <text x="102" y="256" text-anchor="middle" class="num-mem">4</text>
+  <text x="122" y="257"><tspan class="title">Semantic recall</tspan><tspan class="desc"> — matches from other threads</tspan></text>
+  <text x="564" y="257" text-anchor="end" class="opt">if enabled</text>
+
+  <!-- 5 Observational Memory -->
+  <rect x="80" y="280" width="496" height="40" rx="8" class="row-mem"/>
+  <rect x="80" y="287" width="3.5" height="26" rx="1.75" class="accent"/>
+  <circle cx="102" cy="300" r="11" class="chip-mem"/>
+  <text x="102" y="304" text-anchor="middle" class="num-mem">5</text>
+  <text x="122" y="305"><tspan class="title">Observational Memory</tspan><tspan class="desc"> — reflections + observations</tspan></text>
+  <text x="564" y="305" text-anchor="end" class="opt">if enabled</text>
+
+  <!-- Conversation messages group -->
+  <rect x="64" y="344" width="528" height="210" rx="12" class="group"/>
+  <text x="80" y="368" class="section">CONVERSATION MESSAGES · OLDEST → NEWEST</text>
+
+  <!-- 6 Message history + same-thread semantic recall (interleaved by timestamp) -->
+  <rect x="80" y="378" width="496" height="68" rx="8" class="row-mem"/>
+  <rect x="80" y="387" width="3.5" height="50" rx="1.75" class="accent"/>
+  <circle cx="102" cy="412" r="11" class="chip-mem"/>
+  <text x="102" y="416" text-anchor="middle" class="num-mem">6</text>
+  <text x="122" y="398"><tspan class="title">Message history + semantic recall</tspan><tspan class="desc"> — interleaved by timestamp</tspan></text>
+  <text x="122" y="416"><tspan class="desc">history on by default; recall matches merge in if enabled</tspan></text>
+  <text x="122" y="434"><tspan class="desc">only unobserved messages remain when Observational Memory is on</tspan></text>
+
+  <!-- 7 Call-time context messages -->
+  <rect x="80" y="454" width="496" height="40" rx="8" class="row"/>
+  <circle cx="102" cy="474" r="11" class="chip"/>
+  <text x="102" y="478" text-anchor="middle" class="num">7</text>
+  <text x="122" y="479"><tspan class="title">Context messages</tspan><tspan class="desc"> — passed at call time, never saved to memory</tspan></text>
+
+  <!-- 8 New user message -->
+  <rect x="80" y="502" width="496" height="40" rx="8" class="row"/>
+  <circle cx="102" cy="522" r="11" class="chip"/>
+  <text x="102" y="526" text-anchor="middle" class="num">8</text>
+  <text x="122" y="527"><tspan class="title">Your new message</tspan></text>
+
+  <!-- Memory brackets -->
+  <path d="M614 188 h4 q4 0 4 4 v120 q0 4 -4 4 h-4" class="bracket"/>
+  <text x="632" y="248" class="bracket-label">Mastra</text>
+  <text x="632" y="264" class="bracket-label">memory</text>
+
+  <path d="M614 382 h4 q4 0 4 4 v56 q0 4 -4 4 h-4" class="bracket"/>
+  <text x="632" y="405" class="bracket-label">Mastra</text>
+  <text x="632" y="421" class="bracket-label">memory</text>
+
+  <!-- Legend -->
+  <rect x="48" y="582" width="14" height="14" rx="4" class="row-mem"/>
+  <text x="70" y="593" class="legend">Injected by Mastra memory</text>
+  <rect x="270" y="582" width="14" height="14" rx="4" class="row"/>
+  <text x="292" y="593" class="legend">From your agent and the current call</text>
+</svg>

--- a/docs/static/img/memory/memory-context-window-light.svg
+++ b/docs/static/img/memory/memory-context-window-light.svg
@@ -1,0 +1,116 @@
+<svg width="760" height="614" viewBox="0 0 760 614" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="How Mastra assembles the model context from system messages and conversation messages">
+  <style>
+    text { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .header { font-size: 12px; font-weight: 700; letter-spacing: 0.1em; fill: #4b4b4b; }
+    .header-desc { font-size: 11px; fill: #8a8a8a; }
+    .section { font-size: 10.5px; font-weight: 600; letter-spacing: 0.09em; fill: #8a8a8a; }
+    .title { font-size: 13px; font-weight: 600; fill: #0a0a0a; }
+    .desc { font-size: 13px; fill: #616161; }
+    .num { font-size: 11px; font-weight: 600; fill: #5f5f5f; }
+    .num-mem { font-size: 11px; font-weight: 600; fill: #0d8020; }
+    .legend { font-size: 12px; fill: #5f5f5f; }
+    .flow-label { font-size: 10px; font-weight: 600; letter-spacing: 0.06em; fill: #9a9a9a; }
+    .bracket-label { font-size: 12px; font-weight: 600; fill: #0d8020; }
+    .opt { font-size: 11px; font-style: italic; fill: #6b9a77; }
+    .outer { fill: #ffffff; stroke: #e4e4e4; }
+    .group { fill: #f9f9f9; stroke: #ececec; }
+    .row { fill: #f0f0f0; stroke: #e2e2e2; }
+    .row-mem { fill: #eaf6ee; stroke: #cfe8d6; }
+    .chip { fill: #e2e2e2; }
+    .chip-mem { fill: #d5edda; }
+    .accent { fill: #0d8020; }
+    .flow { stroke: #b5b5b5; stroke-width: 1.5; fill: none; }
+    .bracket { stroke: #0d8020; stroke-width: 1.5; fill: none; }
+  </style>
+
+  <!-- Order-of-delivery arrow -->
+  <text x="28" y="56" text-anchor="middle" class="flow-label">FIRST</text>
+  <line x1="28" y1="66" x2="28" y2="504" class="flow"/>
+  <path d="M23 502 L28 512 L33 502" class="flow"/>
+  <text x="28" y="530" text-anchor="middle" class="flow-label">LAST</text>
+
+  <!-- Context window -->
+  <rect x="48" y="12" width="560" height="558" rx="16" class="outer"/>
+  <text x="68" y="40" class="header">CONTEXT WINDOW</text>
+  <text x="588" y="40" text-anchor="end" class="header-desc">one request to the model</text>
+
+  <!-- System messages group -->
+  <rect x="64" y="54" width="528" height="276" rx="12" class="group"/>
+  <text x="80" y="78" class="section">SYSTEM MESSAGES</text>
+
+  <!-- 1 Agent instructions -->
+  <rect x="80" y="88" width="496" height="40" rx="8" class="row"/>
+  <circle cx="102" cy="108" r="11" class="chip"/>
+  <text x="102" y="112" text-anchor="middle" class="num">1</text>
+  <text x="122" y="113"><tspan class="title">Agent instructions</tspan></text>
+
+  <!-- 2 Call-time system messages -->
+  <rect x="80" y="136" width="496" height="40" rx="8" class="row"/>
+  <circle cx="102" cy="156" r="11" class="chip"/>
+  <text x="102" y="160" text-anchor="middle" class="num">2</text>
+  <text x="122" y="161"><tspan class="title">System messages</tspan><tspan class="desc"> — passed at call time</tspan></text>
+
+  <!-- 3 Working memory -->
+  <rect x="80" y="184" width="496" height="40" rx="8" class="row-mem"/>
+  <rect x="80" y="191" width="3.5" height="26" rx="1.75" class="accent"/>
+  <circle cx="102" cy="204" r="11" class="chip-mem"/>
+  <text x="102" y="208" text-anchor="middle" class="num-mem">3</text>
+  <text x="122" y="209"><tspan class="title">Working memory</tspan><tspan class="desc"> — template + stored data</tspan></text>
+  <text x="564" y="209" text-anchor="end" class="opt">if enabled</text>
+
+  <!-- 4 Semantic recall (other threads) -->
+  <rect x="80" y="232" width="496" height="40" rx="8" class="row-mem"/>
+  <rect x="80" y="239" width="3.5" height="26" rx="1.75" class="accent"/>
+  <circle cx="102" cy="252" r="11" class="chip-mem"/>
+  <text x="102" y="256" text-anchor="middle" class="num-mem">4</text>
+  <text x="122" y="257"><tspan class="title">Semantic recall</tspan><tspan class="desc"> — matches from other threads</tspan></text>
+  <text x="564" y="257" text-anchor="end" class="opt">if enabled</text>
+
+  <!-- 5 Observational Memory -->
+  <rect x="80" y="280" width="496" height="40" rx="8" class="row-mem"/>
+  <rect x="80" y="287" width="3.5" height="26" rx="1.75" class="accent"/>
+  <circle cx="102" cy="300" r="11" class="chip-mem"/>
+  <text x="102" y="304" text-anchor="middle" class="num-mem">5</text>
+  <text x="122" y="305"><tspan class="title">Observational Memory</tspan><tspan class="desc"> — reflections + observations</tspan></text>
+  <text x="564" y="305" text-anchor="end" class="opt">if enabled</text>
+
+  <!-- Conversation messages group -->
+  <rect x="64" y="344" width="528" height="210" rx="12" class="group"/>
+  <text x="80" y="368" class="section">CONVERSATION MESSAGES · OLDEST → NEWEST</text>
+
+  <!-- 6 Message history + same-thread semantic recall (interleaved by timestamp) -->
+  <rect x="80" y="378" width="496" height="68" rx="8" class="row-mem"/>
+  <rect x="80" y="387" width="3.5" height="50" rx="1.75" class="accent"/>
+  <circle cx="102" cy="412" r="11" class="chip-mem"/>
+  <text x="102" y="416" text-anchor="middle" class="num-mem">6</text>
+  <text x="122" y="398"><tspan class="title">Message history + semantic recall</tspan><tspan class="desc"> — interleaved by timestamp</tspan></text>
+  <text x="122" y="416"><tspan class="desc">history on by default; recall matches merge in if enabled</tspan></text>
+  <text x="122" y="434"><tspan class="desc">only unobserved messages remain when Observational Memory is on</tspan></text>
+
+  <!-- 7 Call-time context messages -->
+  <rect x="80" y="454" width="496" height="40" rx="8" class="row"/>
+  <circle cx="102" cy="474" r="11" class="chip"/>
+  <text x="102" y="478" text-anchor="middle" class="num">7</text>
+  <text x="122" y="479"><tspan class="title">Context messages</tspan><tspan class="desc"> — passed at call time, never saved to memory</tspan></text>
+
+  <!-- 8 New user message -->
+  <rect x="80" y="502" width="496" height="40" rx="8" class="row"/>
+  <circle cx="102" cy="522" r="11" class="chip"/>
+  <text x="102" y="526" text-anchor="middle" class="num">8</text>
+  <text x="122" y="527"><tspan class="title">Your new message</tspan></text>
+
+  <!-- Memory brackets -->
+  <path d="M614 188 h4 q4 0 4 4 v120 q0 4 -4 4 h-4" class="bracket"/>
+  <text x="632" y="248" class="bracket-label">Mastra</text>
+  <text x="632" y="264" class="bracket-label">memory</text>
+
+  <path d="M614 382 h4 q4 0 4 4 v56 q0 4 -4 4 h-4" class="bracket"/>
+  <text x="632" y="405" class="bracket-label">Mastra</text>
+  <text x="632" y="421" class="bracket-label">memory</text>
+
+  <!-- Legend -->
+  <rect x="48" y="582" width="14" height="14" rx="4" class="row-mem"/>
+  <text x="70" y="593" class="legend">Injected by Mastra memory</text>
+  <rect x="270" y="582" width="14" height="14" rx="4" class="row"/>
+  <text x="292" y="593" class="legend">From your agent and the current call</text>
+</svg>

--- a/docs/static/img/memory/om-context-over-time-dark.svg
+++ b/docs/static/img/memory/om-context-over-time-dark.svg
@@ -1,0 +1,75 @@
+<svg width="760" height="500" viewBox="0 0 760 500" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="How the context window changes over time with Observational Memory enabled">
+  <style>
+    text { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .header { font-size: 12px; font-weight: 700; letter-spacing: 0.1em; fill: #cfcfcf; }
+    .header-desc { font-size: 11px; fill: #8a8a8a; }
+    .title { font-size: 13px; font-weight: 600; fill: #f2f2f2; }
+    .desc { font-size: 13px; fill: #9a9a9a; }
+    .num-mem { font-size: 11px; font-weight: 600; fill: #2aed73; }
+    .legend { font-size: 12px; fill: #9a9a9a; }
+    .flow-label { font-size: 10px; font-weight: 600; letter-spacing: 0.06em; fill: #7a7a7a; }
+    .axis-label { font-size: 11px; fill: #8a8a8a; }
+    .thresh-label { font-size: 10.5px; font-weight: 600; fill: #8a8a8a; }
+    .thresh-label-mem { font-size: 10.5px; font-weight: 600; fill: #2aed73; }
+    .outer { fill: #0e0e0e; stroke: #262626; }
+    .chip-mem { fill: #143621; }
+    .hist { stroke: #a8a8a8; stroke-width: 2; fill: none; stroke-linejoin: round; stroke-linecap: round; }
+    .obs { stroke: #2aed73; stroke-width: 2.25; fill: none; stroke-linejoin: round; stroke-linecap: round; }
+    .axis { stroke: #333333; stroke-width: 1; }
+    .thresh { stroke: #3a3a3a; stroke-width: 1.25; stroke-dasharray: 5 4; fill: none; }
+    .thresh-mem { stroke: #2e6b40; stroke-width: 1.25; stroke-dasharray: 5 4; fill: none; }
+    .leader { stroke: #6a6a6a; stroke-width: 1; }
+  </style>
+
+  <!-- Frame -->
+  <rect x="16" y="12" width="728" height="440" rx="16" class="outer"/>
+  <text x="36" y="40" class="header">CONTEXT OVER TIME</text>
+  <text x="724" y="40" text-anchor="end" class="header-desc">default settings · illustrative, not to scale</text>
+
+  <!-- Threshold lines -->
+  <line x1="96" y1="108" x2="704" y2="108" class="thresh-mem"/>
+  <text x="100" y="101" class="thresh-label-mem">reflection threshold · 40k</text>
+  <line x1="96" y1="168" x2="704" y2="168" class="thresh"/>
+  <text x="100" y="161" class="thresh-label">observation threshold · 30k</text>
+
+  <!-- Axes -->
+  <line x1="96" y1="348" x2="704" y2="348" class="axis"/>
+  <text x="86" y="112" text-anchor="end" class="axis-label">40k</text>
+  <text x="86" y="172" text-anchor="end" class="axis-label">30k</text>
+  <text x="86" y="316" text-anchor="end" class="axis-label">6k</text>
+  <text x="86" y="352" text-anchor="end" class="axis-label">0</text>
+
+  <!-- Observation log (green, stepped) -->
+  <polyline class="obs" points="96,348 240,348 240,276 360,276 360,204 480,204 480,144 600,144 600,108 620,108 620,264 704,264"/>
+
+  <!-- Message history (gray, sawtooth) -->
+  <polyline class="hist" points="96,348 240,168 246,312 360,168 366,312 480,168 486,312 600,168 606,312 704,222"/>
+
+  <!-- Marker 1: first activation -->
+  <circle cx="243" cy="138" r="10" class="chip-mem"/>
+  <text x="243" y="142" text-anchor="middle" class="num-mem">1</text>
+  <line x1="243" y1="148" x2="243" y2="164" class="leader"/>
+
+  <!-- Marker 2: reflection -->
+  <circle cx="610" cy="84" r="10" class="chip-mem"/>
+  <text x="610" y="88" text-anchor="middle" class="num-mem">2</text>
+  <line x1="610" y1="94" x2="610" y2="104" class="leader"/>
+
+  <!-- X axis label -->
+  <text x="400" y="374" text-anchor="middle" class="flow-label">CONVERSATION PROGRESSES →</text>
+
+  <!-- Marker explanations -->
+  <circle cx="45" cy="398" r="10" class="chip-mem"/>
+  <text x="45" y="402" text-anchor="middle" class="num-mem">1</text>
+  <text x="63" y="403"><tspan class="title">History hits 30k</tspan><tspan class="desc"> — observations activate and observed messages drop out; ~6k of recent history stays</tspan></text>
+
+  <circle cx="45" cy="426" r="10" class="chip-mem"/>
+  <text x="45" y="430" text-anchor="middle" class="num-mem">2</text>
+  <text x="63" y="431"><tspan class="title">Observation log hits 40k</tspan><tspan class="desc"> — the Reflector condenses it into reflections</tspan></text>
+
+  <!-- Legend -->
+  <line x1="24" y1="474" x2="56" y2="474" class="hist"/>
+  <text x="64" y="478" class="legend">Message history (raw tokens)</text>
+  <line x1="300" y1="474" x2="332" y2="474" class="obs"/>
+  <text x="340" y="478" class="legend">Observation log</text>
+</svg>

--- a/docs/static/img/memory/om-context-over-time-light.svg
+++ b/docs/static/img/memory/om-context-over-time-light.svg
@@ -1,0 +1,75 @@
+<svg width="760" height="500" viewBox="0 0 760 500" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="How the context window changes over time with Observational Memory enabled">
+  <style>
+    text { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .header { font-size: 12px; font-weight: 700; letter-spacing: 0.1em; fill: #4b4b4b; }
+    .header-desc { font-size: 11px; fill: #8a8a8a; }
+    .title { font-size: 13px; font-weight: 600; fill: #0a0a0a; }
+    .desc { font-size: 13px; fill: #616161; }
+    .num-mem { font-size: 11px; font-weight: 600; fill: #0d8020; }
+    .legend { font-size: 12px; fill: #5f5f5f; }
+    .flow-label { font-size: 10px; font-weight: 600; letter-spacing: 0.06em; fill: #9a9a9a; }
+    .axis-label { font-size: 11px; fill: #8a8a8a; }
+    .thresh-label { font-size: 10.5px; font-weight: 600; fill: #7a7a7a; }
+    .thresh-label-mem { font-size: 10.5px; font-weight: 600; fill: #0d8020; }
+    .outer { fill: #ffffff; stroke: #e4e4e4; }
+    .chip-mem { fill: #d5edda; }
+    .hist { stroke: #5f5f5f; stroke-width: 2; fill: none; stroke-linejoin: round; stroke-linecap: round; }
+    .obs { stroke: #0d8020; stroke-width: 2.25; fill: none; stroke-linejoin: round; stroke-linecap: round; }
+    .axis { stroke: #d9d9d9; stroke-width: 1; }
+    .thresh { stroke: #bdbdbd; stroke-width: 1.25; stroke-dasharray: 5 4; fill: none; }
+    .thresh-mem { stroke: #a9d4b4; stroke-width: 1.25; stroke-dasharray: 5 4; fill: none; }
+    .leader { stroke: #9a9a9a; stroke-width: 1; }
+  </style>
+
+  <!-- Frame -->
+  <rect x="16" y="12" width="728" height="440" rx="16" class="outer"/>
+  <text x="36" y="40" class="header">CONTEXT OVER TIME</text>
+  <text x="724" y="40" text-anchor="end" class="header-desc">default settings · illustrative, not to scale</text>
+
+  <!-- Threshold lines -->
+  <line x1="96" y1="108" x2="704" y2="108" class="thresh-mem"/>
+  <text x="100" y="101" class="thresh-label-mem">reflection threshold · 40k</text>
+  <line x1="96" y1="168" x2="704" y2="168" class="thresh"/>
+  <text x="100" y="161" class="thresh-label">observation threshold · 30k</text>
+
+  <!-- Axes -->
+  <line x1="96" y1="348" x2="704" y2="348" class="axis"/>
+  <text x="86" y="112" text-anchor="end" class="axis-label">40k</text>
+  <text x="86" y="172" text-anchor="end" class="axis-label">30k</text>
+  <text x="86" y="316" text-anchor="end" class="axis-label">6k</text>
+  <text x="86" y="352" text-anchor="end" class="axis-label">0</text>
+
+  <!-- Observation log (green, stepped) -->
+  <polyline class="obs" points="96,348 240,348 240,276 360,276 360,204 480,204 480,144 600,144 600,108 620,108 620,264 704,264"/>
+
+  <!-- Message history (gray, sawtooth) -->
+  <polyline class="hist" points="96,348 240,168 246,312 360,168 366,312 480,168 486,312 600,168 606,312 704,222"/>
+
+  <!-- Marker 1: first activation -->
+  <circle cx="243" cy="138" r="10" class="chip-mem"/>
+  <text x="243" y="142" text-anchor="middle" class="num-mem">1</text>
+  <line x1="243" y1="148" x2="243" y2="164" class="leader"/>
+
+  <!-- Marker 2: reflection -->
+  <circle cx="610" cy="84" r="10" class="chip-mem"/>
+  <text x="610" y="88" text-anchor="middle" class="num-mem">2</text>
+  <line x1="610" y1="94" x2="610" y2="104" class="leader"/>
+
+  <!-- X axis label -->
+  <text x="400" y="374" text-anchor="middle" class="flow-label">CONVERSATION PROGRESSES →</text>
+
+  <!-- Marker explanations -->
+  <circle cx="45" cy="398" r="10" class="chip-mem"/>
+  <text x="45" y="402" text-anchor="middle" class="num-mem">1</text>
+  <text x="63" y="403"><tspan class="title">History hits 30k</tspan><tspan class="desc"> — observations activate and observed messages drop out; ~6k of recent history stays</tspan></text>
+
+  <circle cx="45" cy="426" r="10" class="chip-mem"/>
+  <text x="45" y="430" text-anchor="middle" class="num-mem">2</text>
+  <text x="63" y="431"><tspan class="title">Observation log hits 40k</tspan><tspan class="desc"> — the Reflector condenses it into reflections</tspan></text>
+
+  <!-- Legend -->
+  <line x1="24" y1="474" x2="56" y2="474" class="hist"/>
+  <text x="64" y="478" class="legend">Message history (raw tokens)</text>
+  <line x1="300" y1="474" x2="332" y2="474" class="obs"/>
+  <text x="340" y="478" class="legend">Observation log</text>
+</svg>


### PR DESCRIPTION
This adds a "What the model sees" section to the memory overview with a light/dark diagram showing how Mastra assembles the model context — which layers are system messages vs conversation messages, their order, and which only appear when enabled.

It also fixes accuracy issues found while auditing the Observational Memory docs against source. The biggest one: the standalone usage example didn't typecheck because `ObservationalMemory` is the engine, not a processor. The example now shows the working pattern:

```ts
const om = new ObservationalMemory({ storage: storage.stores.memory!, memory, ... })
const omProcessor = new ObservationalMemoryProcessor(om, memory)

const agent = new Agent({ inputProcessors: [omProcessor], outputProcessors: [omProcessor], ... })
```

Smaller fixes: `blockAfter` multiplier semantics now match the implementation (values from 1 up to but not including 100 are multipliers), the worked token timeline distinguishes activation thresholds from the `blockAfter` safety ceiling, the reference documents previously missing options (`providerOptions`, `manageWorkingMemory`, `metadataKeyPath`), the `data-om-thread-update` stream part, extra `data-om-activation` fields, and the recall tool's full parameter set. Verified with docs build, remark, format checks, and a typecheck of the standalone example against a scaffolded project.

No changeset: docs-only change, `mastra-docs` is private and excluded from changesets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR updates Mastra’s memory docs to make it clearer what gets sent to the model (and in what order), using new light/dark diagrams. It also fixes Observational Memory docs so the examples, settings meanings, and documented event/tool details match the real behavior.

## Changes

- Added light/dark “What the model sees” diagrams to the memory overview, including assembled context ordering and where each memory layer lands in the request (plus pointers to tracing to inspect the exact context).
- Added a “Context over time” diagram and explanations for recursive/generational reflections, clarifying that observations are bounded by reflection thresholds and that each reflection rewrites/condenses the observation log.
- Corrected and expanded Observational Memory documentation:
  - Updated the standalone example to use `ObservationalMemory` with `ObservationalMemoryProcessor` and wired the processor into input/output pipelines.
  - Aligned `blockAfter` multiplier semantics with implementation; clarified activation thresholds vs the `blockAfter` safety ceiling.
  - Documented `providerOptions`, `manageWorkingMemory`, and `metadataKeyPath`.
  - Added/documented additional streaming event fields including `data-om-thread-update` and expanded `data-om-activation` fields.
  - Updated attachment handling docs (including an `'auto'`/capability-driven mode) and broadened storage adapter/model default details (e.g., `@mastra/mysql`, expanded OpenAI auto-TTL variants).
  - Expanded recall tool documentation to cover the complete parameter set and clarified returned fields (including `detail` in messages mode).
- Verified via documentation build, remark + formatting checks, and standalone example typechecking.
- Documentation-only change (no changeset included).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->