### PR TITLE
fix(observability): persist bridged spans as trace roots

### DIFF
--- a/.changeset/sweet-pots-cough.md
+++ b/.changeset/sweet-pots-cough.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Store externally parented Mastra root spans as trace roots

--- a/observability/mastra/src/exporters/mastra-storage.test.ts
+++ b/observability/mastra/src/exporters/mastra-storage.test.ts
@@ -267,6 +267,34 @@ describe('MastraStorageExporter', () => {
           ]),
         });
       });
+
+      it('should store bridged root spans without their external parent', async () => {
+        mockObservabilityStore.observabilityStrategy = {
+          preferred: 'realtime',
+          supported: ['realtime', 'batch-with-updates', 'insert-only'],
+        };
+        const exporter = new MastraStorageExporter({ strategy: 'realtime', logger: mockLogger });
+        await exporter.init({ mastra: mockMastra });
+
+        const rootEvent = createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'root-span');
+        rootEvent.exportedSpan.isRootSpan = true;
+        rootEvent.exportedSpan.parentSpanId = 'external-parent';
+
+        const childEvent = createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'child-span');
+        childEvent.exportedSpan.isRootSpan = false;
+        childEvent.exportedSpan.parentSpanId = 'root-span';
+
+        await exporter.exportTracingEvent(rootEvent);
+        await exporter.exportTracingEvent(childEvent);
+
+        const records = mockObservabilityStore.batchCreateSpans.mock.calls.flatMap((call: any) => call[0].records);
+        expect(records).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ spanId: 'root-span', parentSpanId: null }),
+            expect.objectContaining({ spanId: 'child-span', parentSpanId: 'root-span' }),
+          ]),
+        );
+      });
     });
 
     describe('Batch-with-updates strategy', () => {

--- a/observability/mastra/src/exporters/mastra-storage.ts
+++ b/observability/mastra/src/exporters/mastra-storage.ts
@@ -487,7 +487,11 @@ export class MastraStorageExporter extends BaseExporter {
         this.#observabilityStorage!.batchCreateScores({ scores: events.map(s => buildScoreRecord(s)) }),
       ),
       this.flushCreates('tracing', createSpanEvents, async events => {
-        const records = events.map(t => buildCreateSpanRecord(t.exportedSpan));
+        const records = events.map(t =>
+          buildCreateSpanRecord(
+            t.exportedSpan.isRootSpan ? { ...t.exportedSpan, parentSpanId: undefined } : t.exportedSpan,
+          ),
+        );
         await this.#observabilityStorage!.batchCreateSpans({ records });
         this.#eventBuffer.addCreatedSpans({ records });
       }),


### PR DESCRIPTION
When a Mastra root span inherits an ambient OpenTelemetry parent, that parent is exported to external tracing but is not present in Mastra storage. Studio then cannot identify the stored span as the trace root.

This clears the external parent only when creating a storage record for a Mastra root span. Child spans continue to retain their Mastra parent IDs.

Before: `root -> external parent not in Mastra storage`

After: `root -> null`, while `child -> root`

Verified with the observability test suite, package lint, and package build.