### PR TITLE
fix(memory): retry schema working memory extraction on empty object

### DIFF
--- a/packages/memory/src/processors/observational-memory/__tests__/extractor.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/extractor.test.ts
@@ -410,6 +410,37 @@ describe('Extractor', () => {
     expect(generate.mock.calls[1][1].structuredOutput.jsonPromptInjection).toBe('inline');
   });
 
+  it('retries schema working-memory extraction when native output is an empty object', async () => {
+    const memory = {
+      getMergedThreadConfig: vi.fn(() => ({ workingMemory: { enabled: true, schema: {} } })),
+      getWorkingMemoryTemplate: vi.fn(async () => ({ format: 'json', content: '{"type":"object"}' })),
+      getWorkingMemory: vi.fn(async () => '{"preferences":{}}'),
+    } as any;
+    const extractor = new WorkingMemoryExtractor();
+    const [resolved] = await resolveExtractors([extractor], {
+      source: 'observer',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      memory,
+    });
+    const generate = vi
+      .fn()
+      .mockResolvedValueOnce({ object: {} })
+      .mockResolvedValueOnce({ object: { 'working-memory': { preferences: { responseStyle: 'concise' } } } });
+
+    const result = await extractStructuredValues({
+      agent: { generate } as unknown as Agent<any, any, any, any>,
+      source: 'observer',
+      extractors: [resolved!],
+    });
+
+    expect(result.values).toEqual({ 'working-memory': { preferences: { responseStyle: 'concise' } } });
+    expect(result.failures).toEqual([]);
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(generate.mock.calls[0][1].structuredOutput.jsonPromptInjection).toBeUndefined();
+    expect(generate.mock.calls[1][1].structuredOutput.jsonPromptInjection).toBe('inline');
+  });
+
   it('falls back to system json prompt injection when inline support is not advertised', async () => {
     const priority = new Extractor({ name: 'Priority', instructions: 'Extract priority.', schema: z.string() });
     const generate = vi

--- a/packages/memory/src/processors/observational-memory/extraction-runner.ts
+++ b/packages/memory/src/processors/observational-memory/extraction-runner.ts
@@ -20,6 +20,16 @@ function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
   );
 }
 
+function shouldRetryEmptyStructuredObject(
+  object: Record<string, unknown>,
+  extractors: readonly Extractor<any>[],
+): boolean {
+  return (
+    Object.keys(object).length === 0 &&
+    extractors.some(extractor => extractor.retryStructuredExtractionOnEmptyObject)
+  );
+}
+
 export async function extractStructuredValues(opts: {
   agent: Agent<any, any, any, any>;
   source: ExtractorSource;
@@ -76,13 +86,32 @@ ${extractorInstructions}${priorLines.length > 0 ? `\n\n## Prior Extracted Values
   };
 
   let object: Record<string, unknown>;
+  let retryEmptyObject = false;
   try {
     object = await generateWithStructuredOutput();
+    retryEmptyObject = shouldRetryEmptyStructuredObject(object, structuredExtractors);
   } catch (error) {
     if (isAbortError(error, opts.abortSignal)) {
       throw error;
     }
 
+    try {
+      const fallbackJsonPromptInjection = coreFeatures.has('json-prompt-injection:inline') ? 'inline' : true;
+      object = await generateWithStructuredOutput(fallbackJsonPromptInjection);
+    } catch (fallbackError) {
+      if (isAbortError(fallbackError, opts.abortSignal)) {
+        throw fallbackError;
+      }
+
+      const message = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+      return {
+        values,
+        failures: structuredExtractors.map(extractor => ({ slug: extractor.slug, error: message })),
+      };
+    }
+  }
+
+  if (retryEmptyObject) {
     try {
       const fallbackJsonPromptInjection = coreFeatures.has('json-prompt-injection:inline') ? 'inline' : true;
       object = await generateWithStructuredOutput(fallbackJsonPromptInjection);

--- a/packages/memory/src/processors/observational-memory/extractor.ts
+++ b/packages/memory/src/processors/observational-memory/extractor.ts
@@ -40,6 +40,8 @@ export interface ExtractorConfig<T = unknown> {
   metadataKeyPath?: string | false;
   /** Optional lifecycle hook invoked after a value is parsed and before it is persisted. */
   onExtracted?: (context: ExtractorOnExtractedContext<T>) => Promise<T | void | undefined> | T | void | undefined;
+  /** Retry with JSON prompt injection when native structured output returns an empty object. */
+  retryStructuredExtractionOnEmptyObject?: boolean;
 }
 
 const BUILT_IN_SLUGS = new Set(['current-task', 'suggested-response', 'thread-title']);
@@ -120,6 +122,7 @@ export class Extractor<T = unknown> {
   readonly includePreviousExtraction: boolean;
   readonly metadataKeyPath: string | false;
   readonly onExtracted?: ExtractorConfig<T>['onExtracted'];
+  readonly retryStructuredExtractionOnEmptyObject: boolean;
   /** @internal */
   readonly internal: boolean;
   private readonly instructionsConfig: ExtractorConfigValue<string>;
@@ -151,6 +154,7 @@ export class Extractor<T = unknown> {
     this.includePreviousExtraction = config.includePreviousExtraction ?? true;
     this.metadataKeyPath = config.metadataKeyPath ?? `extracted.${slug}`;
     this.onExtracted = config.onExtracted;
+    this.retryStructuredExtractionOnEmptyObject = config.retryStructuredExtractionOnEmptyObject ?? false;
     this.internal = internal;
   }
 
@@ -172,6 +176,7 @@ export class Extractor<T = unknown> {
         includePreviousExtraction: this.includePreviousExtraction,
         metadataKeyPath: this.metadataKeyPath,
         onExtracted: this.onExtracted,
+        retryStructuredExtractionOnEmptyObject: this.retryStructuredExtractionOnEmptyObject,
       },
       this.internal,
     );

--- a/packages/memory/src/processors/observational-memory/working-memory-extractor.ts
+++ b/packages/memory/src/processors/observational-memory/working-memory-extractor.ts
@@ -64,6 +64,7 @@ export class WorkingMemoryExtractor extends Extractor<string | Record<string, un
       name: 'Working Memory',
       includePreviousExtraction: false,
       metadataKeyPath: false,
+      retryStructuredExtractionOnEmptyObject: true,
       instructions: async context => buildWorkingMemoryInstructions(await getWorkingMemoryDetails(context)),
       schema: async context => {
         const details = await getWorkingMemoryDetails(context);


### PR DESCRIPTION
Fixes #20503.

Summary:
- adds an opt-in retry for structured extractors when native structured output returns an empty object
- enables that retry for WorkingMemoryExtractor only
- retries with JSON prompt injection so schema working-memory output keeps the required top-level working-memory wrapper
- adds coverage for the native-empty-object retry path

Verification:
- git diff --check
- attempted: pnpm --filter @mastra/memory test -- src/processors/observational-memory/__tests__/extractor.test.ts, but pnpm started dependency installation and repeatedly stalled on registry retries, so I interrupted it
- attempted: pnpm --filter @mastra/memory check, same dependency install/network blocker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a model returns useful Working Memory data in the wrong shape, the system no longer silently ignores it. It asks the model once more for the required format and then applies the recovered update.

## Changes

- Added an opt-in `retryStructuredExtractionOnEmptyObject` extractor option.
- Added retry handling when native structured output returns `{}`.
- Enabled the option for `WorkingMemoryExtractor`.
- Used JSON prompt injection to preserve the top-level `working-memory` wrapper.
- Added regression coverage for the retry path.
- Preserved support for genuine no-update responses.

## Verification

- `git diff --check` passed.
- Package tests and checks were attempted but interrupted because dependency installation stalled during registry retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->