### PR TITLE
fix(server): abort A2A streams when tasks are canceled

### DIFF
--- a/.changeset/quiet-rules-remember.md
+++ b/.changeset/quiet-rules-remember.md
@@ -2,4 +2,4 @@
 "@mastra/server": patch
 ---
 
-Prevent late A2A stream updates from overwriting canceled tasks.
+Abort active A2A streams when tasks are canceled or streaming requests disconnect, and prevent late updates from overwriting canceled tasks.

--- a/.changeset/quiet-rules-remember.md
+++ b/.changeset/quiet-rules-remember.md
@@ -1,0 +1,5 @@
+---
+"@mastra/server": patch
+---
+
+Prevent late A2A stream updates from overwriting canceled tasks.

--- a/packages/server/src/server/a2a/store.test.ts
+++ b/packages/server/src/server/a2a/store.test.ts
@@ -84,6 +84,45 @@ describe('InMemoryTaskStore', () => {
     });
   });
 
+  it('keeps a canceled task when an opt-in stale save tries to overwrite it', async () => {
+    const store = new InMemoryTaskStore();
+
+    await store.save({
+      agentId: 'agent-1',
+      data: createTask({
+        id: 'task-1',
+        status: {
+          state: 'canceled',
+          timestamp: '2025-05-08T11:48:38.458Z',
+        },
+      }),
+    });
+
+    const storedTask = await store.save({
+      agentId: 'agent-1',
+      skipIfCanceled: true,
+      data: createTask({
+        id: 'task-1',
+        status: {
+          state: 'completed',
+          timestamp: '2025-05-08T11:49:38.458Z',
+        },
+      }),
+    });
+
+    const canceledTask = createTask({
+      id: 'task-1',
+      status: {
+        state: 'canceled',
+        timestamp: '2025-05-08T11:48:38.458Z',
+      },
+    });
+
+    expect(storedTask).toEqual(canceledTask);
+    await expect(store.load({ agentId: 'agent-1', taskId: 'task-1' })).resolves.toEqual(canceledTask);
+    expect(store.getVersion({ agentId: 'agent-1', taskId: 'task-1' })).toBe(1);
+  });
+
   it('waitForNextUpdate removes listeners and rejects on abort', async () => {
     const store = new InMemoryTaskStore();
     const task = createTask();

--- a/packages/server/src/server/a2a/store.ts
+++ b/packages/server/src/server/a2a/store.ts
@@ -15,6 +15,7 @@ export class InMemoryTaskStore {
   private store: Map<string, Task> = new Map();
   private versions: Map<string, number> = new Map();
   private listeners: Map<string, Set<(update: { task: Task; version: number }) => void>> = new Map();
+  private abortControllers: Map<string, AbortController> = new Map();
   public activeCancellations = new Set<string>();
 
   private getKey(agentId: string, taskId: string) {
@@ -81,6 +82,33 @@ export class InMemoryTaskStore {
 
   getVersion({ agentId, taskId }: { agentId: string; taskId: string }): number {
     return this.versions.get(this.getKey(agentId, taskId)) ?? 0;
+  }
+
+  registerAbortController({
+    agentId,
+    taskId,
+    controller,
+  }: {
+    agentId: string;
+    taskId: string;
+    controller: AbortController;
+  }): () => void {
+    const key = this.getKey(agentId, taskId);
+    this.abortControllers.set(key, controller);
+
+    return () => {
+      if (this.abortControllers.get(key) === controller) {
+        this.abortControllers.delete(key);
+      }
+    };
+  }
+
+  abortTask({ agentId, taskId, reason }: { agentId: string; taskId: string; reason?: unknown }): void {
+    const controller = this.abortControllers.get(this.getKey(agentId, taskId));
+
+    if (controller && !controller.signal.aborted) {
+      controller.abort(reason);
+    }
   }
 
   async waitForNextUpdate({

--- a/packages/server/src/server/a2a/store.ts
+++ b/packages/server/src/server/a2a/store.ts
@@ -50,15 +50,23 @@ export class InMemoryTaskStore {
     agentId,
     data,
     expectedVersion,
+    skipIfCanceled = false,
   }: {
     agentId: string;
     data: Task;
     expectedVersion?: number;
-  }): Promise<void> {
+    skipIfCanceled?: boolean;
+  }): Promise<Task> {
     // Store copies to prevent internal mutation if caller reuses objects
     const key = this.getKey(agentId, data.id);
     if (!data.id) {
       throw new Error('Task ID is required');
+    }
+
+    const existingTask = this.store.get(key);
+
+    if (skipIfCanceled && existingTask?.status.state === 'canceled' && data.status.state !== 'canceled') {
+      return { ...existingTask };
     }
 
     const currentVersion = this.versions.get(key) ?? 0;
@@ -78,6 +86,8 @@ export class InMemoryTaskStore {
         listener({ task: { ...storedTask }, version: nextVersion });
       }
     }
+
+    return { ...storedTask };
   }
 
   getVersion({ agentId, taskId }: { agentId: string; taskId: string }): number {

--- a/packages/server/src/server/handlers/a2a.test.ts
+++ b/packages/server/src/server/handlers/a2a.test.ts
@@ -1958,7 +1958,9 @@ describe('A2A Handler', () => {
 
       await gen.next();
       const nextStreamEvent = gen.next();
-      await Promise.resolve();
+      await vi.waitFor(() => {
+        expect(streamAbortSignal).toBeDefined();
+      });
 
       const cancelResult = await handleTaskCancel({
         requestId: 'cancel-request-id',
@@ -1987,6 +1989,7 @@ describe('A2A Handler', () => {
 
       const savedTask = await mockTaskStore.load({ agentId, taskId });
       expect(savedTask?.status.state).toBe('canceled');
+      await gen.return(undefined);
     });
 
     it('should stream structured output as a data artifact part', async () => {

--- a/packages/server/src/server/handlers/a2a.test.ts
+++ b/packages/server/src/server/handlers/a2a.test.ts
@@ -1885,6 +1885,110 @@ describe('A2A Handler', () => {
       expect(done.done).toBe(true);
     });
 
+    it('passes request abortSignal to agent stream execution', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const requestAbortController = new AbortController();
+      let streamAbortSignal: AbortSignal | undefined;
+
+      const params: MessageSendParams = {
+        message: { messageId, kind: 'message', role: 'user', parts: [{ kind: 'text', text: 'Hello' }] },
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockImplementation is not available on the Agent class
+      mockAgent.stream.mockImplementation((_messages, options) => {
+        streamAbortSignal = options.abortSignal;
+        return createStreamResult({ chunks: ['Hello'] });
+      });
+
+      const gen = handleMessageStream({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agentId,
+        agent: mockAgent,
+        requestContext: new RequestContext(),
+        abortSignal: requestAbortController.signal,
+      });
+
+      await gen.next();
+      requestAbortController.abort('client disconnected');
+      await gen.next();
+
+      expect(streamAbortSignal?.aborted).toBe(true);
+      expect(streamAbortSignal?.reason).toBe('client disconnected');
+    });
+
+    it('aborts the active stream and does not let late chunks overwrite a canceled task', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const taskId = 'cancel-stream-task';
+      const continueStream = createDeferred<void>();
+      let streamAbortSignal: AbortSignal | undefined;
+
+      const params: MessageSendParams = {
+        message: { messageId, taskId, kind: 'message', role: 'user', parts: [{ kind: 'text', text: 'Hello' }] },
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockImplementation is not available on the Agent class
+      mockAgent.stream.mockImplementation((_messages, options) => {
+        streamAbortSignal = options.abortSignal;
+        return {
+          ...createStreamResult({ chunks: [], text: 'First second' }),
+          fullStream: (async function* () {
+            yield { type: 'text-delta', textDelta: 'First ' };
+            await continueStream.promise;
+            yield { type: 'text-delta', textDelta: 'second' };
+          })(),
+        };
+      });
+
+      const gen = handleMessageStream({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agentId,
+        agent: mockAgent,
+        requestContext: new RequestContext(),
+      });
+
+      await gen.next();
+      const nextStreamEvent = gen.next();
+      await Promise.resolve();
+
+      const cancelResult = await handleTaskCancel({
+        requestId: 'cancel-request-id',
+        taskStore: mockTaskStore,
+        agentId,
+        taskId,
+      });
+
+      expect(cancelResult.result?.status.state).toBe('canceled');
+      expect(streamAbortSignal?.aborted).toBe(true);
+
+      continueStream.resolve();
+      const canceledUpdate = await nextStreamEvent;
+      expect(canceledUpdate.value).toMatchObject({
+        id: requestId,
+        jsonrpc: '2.0',
+        result: {
+          final: true,
+          kind: 'status-update',
+          status: {
+            state: 'canceled',
+          },
+          taskId,
+        },
+      });
+
+      const savedTask = await mockTaskStore.load({ agentId, taskId });
+      expect(savedTask?.status.state).toBe('canceled');
+    });
+
     it('should stream structured output as a data artifact part', async () => {
       const requestId = 'test-request-id';
       const messageId = 'test-message-id';

--- a/packages/server/src/server/handlers/a2a.test.ts
+++ b/packages/server/src/server/handlers/a2a.test.ts
@@ -1933,6 +1933,8 @@ describe('A2A Handler', () => {
         message: { messageId, taskId, kind: 'message', role: 'user', parts: [{ kind: 'text', text: 'Hello' }] },
       };
 
+      await seedTask(mockTaskStore, taskId);
+
       const mockAgent = mockMastra.getAgentById(agentId);
       // @ts-expect-error - mockImplementation is not available on the Agent class
       mockAgent.stream.mockImplementation((_messages, options) => {

--- a/packages/server/src/server/handlers/a2a.test.ts
+++ b/packages/server/src/server/handlers/a2a.test.ts
@@ -1913,12 +1913,61 @@ describe('A2A Handler', () => {
         abortSignal: requestAbortController.signal,
       });
 
-      await gen.next();
+      const first = await gen.next();
       requestAbortController.abort('client disconnected');
-      await gen.next();
+      const canceled = await gen.next();
 
       expect(streamAbortSignal?.aborted).toBe(true);
       expect(streamAbortSignal?.reason).toBe('client disconnected');
+      expect(canceled.value).toMatchObject({
+        result: {
+          final: true,
+          status: { state: 'canceled' },
+        },
+      });
+      expect(await mockTaskStore.load({ agentId, taskId: (first.value?.result as { id: string }).id })).toMatchObject({
+        status: { state: 'canceled' },
+      });
+    });
+
+    it('does not mark request-driven abort errors as failed', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const requestAbortController = new AbortController();
+      const params: MessageSendParams = {
+        message: { messageId, kind: 'message', role: 'user', parts: [{ kind: 'text', text: 'Hello' }] },
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockImplementation is not available on the Agent class
+      mockAgent.stream.mockImplementation((_messages, options) => {
+        throw options.abortSignal?.reason;
+      });
+
+      const gen = handleMessageStream({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agentId,
+        agent: mockAgent,
+        requestContext: new RequestContext(),
+        abortSignal: requestAbortController.signal,
+      });
+
+      const first = await gen.next();
+      requestAbortController.abort(new DOMException('Client disconnected.', 'AbortError'));
+      const canceled = await gen.next();
+
+      expect(canceled.value).toMatchObject({
+        result: {
+          final: true,
+          status: { state: 'canceled' },
+        },
+      });
+      expect(await mockTaskStore.load({ agentId, taskId: (first.value?.result as { id: string }).id })).toMatchObject({
+        status: { state: 'canceled' },
+      });
     });
 
     it('aborts the active stream and does not let late chunks overwrite a canceled task', async () => {
@@ -3785,7 +3834,7 @@ describe('A2A Handler', () => {
         agentId: 'test-agent',
         requestContext: new RequestContext(),
         taskStore: mockTaskStore,
-        abortSignal: AbortSignal.abort(),
+        abortSignal: new AbortController().signal,
         id: 42,
         method: 'message/stream',
         params: {

--- a/packages/server/src/server/handlers/a2a.ts
+++ b/packages/server/src/server/handlers/a2a.ts
@@ -1436,9 +1436,11 @@ export async function* handleMessageStream({
     let streamCanceled = false;
 
     for await (const chunk of result.fullStream) {
-      const latestTask = await taskStore.load({ agentId, taskId: currentData.id });
-      if (latestTask?.status.state === 'canceled') {
-        currentData = latestTask;
+      if (taskAbortController.signal.aborted) {
+        const latestTask = await taskStore.load({ agentId, taskId: currentData.id });
+        if (latestTask) {
+          currentData = latestTask;
+        }
         streamCanceled = true;
         break;
       }
@@ -1486,6 +1488,35 @@ export async function* handleMessageStream({
       if (finalStructuredObject) {
         structuredData = finalStructuredObject;
       }
+    }
+
+    if (!streamCanceled && taskAbortController.signal.aborted) {
+      const latestTask = await taskStore.load({ agentId, taskId: currentData.id });
+      if (latestTask) {
+        currentData = latestTask;
+      }
+      streamCanceled = true;
+    }
+
+    if (streamCanceled && abortSignal?.aborted && currentData.status.state !== 'canceled') {
+      const previousTask = currentData;
+      currentData = applyUpdateToTask(currentData, {
+        state: 'canceled',
+        message: {
+          messageId: crypto.randomUUID(),
+          role: 'agent',
+          parts: [{ kind: 'text', text: 'Task canceled because the request was aborted.' }],
+          kind: 'message',
+        },
+      });
+      currentData = await saveTaskAndMaybeSendPushNotification({
+        taskStore,
+        pushNotificationSender: resolvedPushNotificationSender,
+        previousTask,
+        nextTask: currentData,
+        agentId,
+        logger,
+      });
     }
 
     if (!streamCanceled && suspended) {
@@ -1630,6 +1661,34 @@ export async function* handleMessageStream({
     const latestTask = await taskStore.load({ agentId, taskId: currentData.id });
     if (latestTask?.status.state === 'canceled') {
       currentData = latestTask;
+    } else if (taskAbortController.signal.aborted) {
+      currentData = latestTask ?? currentData;
+      if (abortSignal?.aborted) {
+        const previousTask = currentData;
+        currentData = applyUpdateToTask(currentData, {
+          state: 'canceled',
+          message: {
+            messageId: crypto.randomUUID(),
+            role: 'agent',
+            parts: [{ kind: 'text', text: 'Task canceled because the request was aborted.' }],
+            kind: 'message',
+          },
+        });
+
+        try {
+          currentData = await saveTaskAndMaybeSendPushNotification({
+            taskStore,
+            pushNotificationSender: resolvedPushNotificationSender,
+            previousTask,
+            nextTask: currentData,
+            agentId,
+            logger,
+          });
+        } catch (saveError) {
+          // @ts-expect-error saveError is an unknown error
+          logger?.error(`Failed to save task ${currentData.id} after request abort:`, saveError?.message);
+        }
+      }
     } else {
       currentData = latestTask ?? currentData;
       const previousTask = currentData;

--- a/packages/server/src/server/handlers/a2a.ts
+++ b/packages/server/src/server/handlers/a2a.ts
@@ -654,6 +654,31 @@ function shouldSendPushNotification(previousTask: Task | undefined, nextTask: Ta
   return previousTask?.status.state !== nextTask.status.state;
 }
 
+function createLinkedAbortController(abortSignal?: AbortSignal) {
+  const controller = new AbortController();
+
+  if (!abortSignal) {
+    return { controller, cleanup: () => {} };
+  }
+
+  const abortFromSignal = () => {
+    if (!controller.signal.aborted) {
+      controller.abort(abortSignal.reason);
+    }
+  };
+
+  if (abortSignal.aborted) {
+    abortFromSignal();
+  } else {
+    abortSignal.addEventListener('abort', abortFromSignal, { once: true });
+  }
+
+  return {
+    controller,
+    cleanup: () => abortSignal.removeEventListener('abort', abortFromSignal),
+  };
+}
+
 async function saveTaskAndMaybeSendPushNotification({
   taskStore,
   pushNotificationSender,
@@ -670,11 +695,11 @@ async function saveTaskAndMaybeSendPushNotification({
   agentId: string;
   expectedVersion?: number;
   logger?: IMastraLogger;
-}) {
+}): Promise<Task> {
   await taskStore.save({ agentId, data: nextTask, expectedVersion });
 
   if (!shouldSendPushNotification(previousTask, nextTask)) {
-    return;
+    return nextTask;
   }
 
   void pushNotificationSender
@@ -686,6 +711,8 @@ async function saveTaskAndMaybeSendPushNotification({
     .catch(error => {
       logger?.error('Failed to schedule A2A push notification', error);
     });
+
+  return nextTask;
 }
 
 function extractFullStreamTextDelta(value: unknown): string | null {
@@ -1303,6 +1330,7 @@ export async function* handleMessageStream({
   agentId,
   logger,
   requestContext,
+  abortSignal,
 }: {
   requestId: number | string;
   params: MessageSendParams;
@@ -1313,6 +1341,7 @@ export async function* handleMessageStream({
   agentId: string;
   logger?: IMastraLogger;
   requestContext: RequestContext;
+  abortSignal?: AbortSignal;
 }) {
   validateMessageSendParams(params);
 
@@ -1371,27 +1400,45 @@ export async function* handleMessageStream({
     logger,
   });
 
-  yield createSuccessResponse(requestId, currentData);
+  const { controller: taskAbortController, cleanup: cleanupLinkedAbortController } =
+    createLinkedAbortController(abortSignal);
+  const unregisterTaskAbortController = taskStore.registerAbortController({
+    agentId,
+    taskId,
+    controller: taskAbortController,
+  });
 
   try {
+    yield createSuccessResponse(requestId, currentData);
+
     const resourceId = (metadata?.resourceId as string) ?? (message.metadata?.resourceId as string) ?? agentId;
     const result = resume
       ? await agent.resumeStream(normalizeResumeData(extractResumeData(message), resume.requiresApproval), {
           runId: resume.runId,
           ...(resume.toolCallId ? { toolCallId: resume.toolCallId } : {}),
           requestContext,
+          abortSignal: taskAbortController.signal,
         })
       : await agent.stream([convertToCoreMessage(message)], {
           runId: taskId,
           requestContext,
+          abortSignal: taskAbortController.signal,
           ...(contextId ? { threadId: contextId, resourceId } : {}),
         });
     let sawTextArtifact = false;
     let pendingTextChunk: string | undefined;
     let structuredData: Record<string, unknown> | undefined;
     let suspended = false;
+    let streamCanceled = false;
 
     for await (const chunk of result.fullStream) {
+      const latestTask = await taskStore.load({ agentId, taskId: currentData.id });
+      if (latestTask?.status.state === 'canceled') {
+        currentData = latestTask;
+        streamCanceled = true;
+        break;
+      }
+
       if (isSuspensionChunk(chunk)) {
         suspended = true;
         continue;
@@ -1413,13 +1460,17 @@ export async function* handleMessageStream({
         });
 
         currentData = applyUpdateToTask(currentData, textUpdate);
-        await saveTaskAndMaybeSendPushNotification({
+        currentData = await saveTaskAndMaybeSendPushNotification({
           taskStore,
           pushNotificationSender: resolvedPushNotificationSender,
           nextTask: currentData,
           agentId,
           logger,
         });
+        if (currentData.status.state === 'canceled') {
+          streamCanceled = true;
+          break;
+        }
         yield createSuccessResponse(requestId, textUpdate);
 
         sawTextArtifact = true;
@@ -1433,7 +1484,7 @@ export async function* handleMessageStream({
       }
     }
 
-    if (suspended) {
+    if (!streamCanceled && suspended) {
       // Agent suspensions (tool approval, suspend()) surface as the A2A
       // `input-required` state so clients can provide the missing input and
       // continue the task (HITL per the A2A spec). Skip the completed path
@@ -1448,20 +1499,21 @@ export async function* handleMessageStream({
         });
 
         currentData = applyUpdateToTask(currentData, textUpdate);
-        await saveTaskAndMaybeSendPushNotification({
+        currentData = await saveTaskAndMaybeSendPushNotification({
           taskStore,
           pushNotificationSender: resolvedPushNotificationSender,
           nextTask: currentData,
           agentId,
           logger,
         });
-        yield createSuccessResponse(requestId, textUpdate);
+        if (currentData.status.state === 'canceled') {
+          streamCanceled = true;
+        } else {
+          yield createSuccessResponse(requestId, textUpdate);
+        }
       }
 
-      const previousTask = currentData;
-      // `suspendPayload`/`resumeSchema` resolve as soon as the suspension chunk
-      // is processed, so awaiting them here is safe and keeps the reported
-      // payload identical to the non-streaming path.
+      const suspensionTask = currentData;
       currentData = applySuspensionToTask({
         task: currentData,
         suspendPayload: await result.suspendPayload,
@@ -1470,15 +1522,20 @@ export async function* handleMessageStream({
         logger,
       });
 
-      await saveTaskAndMaybeSendPushNotification({
+      currentData = await saveTaskAndMaybeSendPushNotification({
         taskStore,
         pushNotificationSender: resolvedPushNotificationSender,
-        previousTask,
+        previousTask: suspensionTask,
         nextTask: currentData,
         agentId,
         logger,
       });
-    } else {
+      if (currentData.status.state === 'canceled') {
+        streamCanceled = true;
+      }
+    }
+
+    if (!streamCanceled && !suspended) {
       structuredData ??= (await result.object) as Record<string, unknown> | undefined;
 
       if (!pendingTextChunk && !sawTextArtifact) {
@@ -1498,20 +1555,24 @@ export async function* handleMessageStream({
         });
 
         currentData = applyUpdateToTask(currentData, textUpdate);
-        await saveTaskAndMaybeSendPushNotification({
+        currentData = await saveTaskAndMaybeSendPushNotification({
           taskStore,
           pushNotificationSender: resolvedPushNotificationSender,
           nextTask: currentData,
           agentId,
           logger,
         });
-        yield createSuccessResponse(requestId, textUpdate);
+        if (currentData.status.state === 'canceled') {
+          streamCanceled = true;
+        } else {
+          yield createSuccessResponse(requestId, textUpdate);
+        }
 
         sawTextArtifact = true;
         pendingTextChunk = undefined;
       }
 
-      if (structuredData) {
+      if (!streamCanceled && structuredData) {
         const dataUpdate = createDataArtifactUpdate({
           taskId: currentData.id,
           contextId: currentData.contextId,
@@ -1520,73 +1581,91 @@ export async function* handleMessageStream({
         });
 
         currentData = applyUpdateToTask(currentData, dataUpdate);
-        await saveTaskAndMaybeSendPushNotification({
+        currentData = await saveTaskAndMaybeSendPushNotification({
           taskStore,
           pushNotificationSender: resolvedPushNotificationSender,
           nextTask: currentData,
           agentId,
           logger,
         });
-        yield createSuccessResponse(requestId, dataUpdate);
+        if (currentData.status.state === 'canceled') {
+          streamCanceled = true;
+        } else {
+          yield createSuccessResponse(requestId, dataUpdate);
+        }
       }
 
-      const previousTask = currentData;
-      const completedTask = applyUpdateToTask(currentData, {
-        state: 'completed',
-        message: undefined,
-      });
+      if (!streamCanceled) {
+        const previousTask = currentData;
+        const completedTask = applyUpdateToTask(currentData, {
+          state: 'completed',
+          message: undefined,
+        });
 
-      completedTask.metadata = {
-        ...clearSuspensionMetadata(completedTask.metadata),
-        execution: {
-          toolCalls: await result.toolCalls,
-          toolResults: await result.toolResults,
-          usage: await result.usage,
-          finishReason: await result.finishReason,
-        },
-      };
+        completedTask.metadata = {
+          ...clearSuspensionMetadata(completedTask.metadata),
+          execution: {
+            toolCalls: await result.toolCalls,
+            toolResults: await result.toolResults,
+            usage: await result.usage,
+            finishReason: await result.finishReason,
+          },
+        };
 
-      currentData = completedTask;
-
-      await saveTaskAndMaybeSendPushNotification({
-        taskStore,
-        pushNotificationSender: resolvedPushNotificationSender,
-        previousTask,
-        nextTask: currentData,
-        agentId,
-        logger,
-      });
+        currentData = await saveTaskAndMaybeSendPushNotification({
+          taskStore,
+          pushNotificationSender: resolvedPushNotificationSender,
+          previousTask,
+          nextTask: completedTask,
+          agentId,
+          logger,
+        });
+      }
     }
   } catch (handlerError) {
-    const previousTask = currentData;
-    currentData = applyUpdateToTask(currentData, {
-      state: 'failed',
-      message: {
-        messageId: crypto.randomUUID(),
-        role: 'agent',
-        parts: [
-          {
-            kind: 'text',
-            text: `Handler failed: ${handlerError instanceof Error ? handlerError.message : String(handlerError)}`,
-          },
-        ],
-        kind: 'message',
-      },
-    });
-
-    try {
-      await saveTaskAndMaybeSendPushNotification({
-        taskStore,
-        pushNotificationSender: resolvedPushNotificationSender,
-        previousTask,
-        nextTask: currentData,
-        agentId,
-        logger,
+    const latestTask = await taskStore.load({ agentId, taskId: currentData.id });
+    if (latestTask?.status.state === 'canceled') {
+      currentData = latestTask;
+    } else {
+      currentData = latestTask ?? currentData;
+      const previousTask = currentData;
+      currentData = applyUpdateToTask(currentData, {
+        state: 'failed',
+        message: {
+          messageId: crypto.randomUUID(),
+          role: 'agent',
+          parts: [
+            {
+              kind: 'text',
+              text: `Handler failed: ${handlerError instanceof Error ? handlerError.message : String(handlerError)}`,
+            },
+          ],
+          kind: 'message',
+        },
       });
-    } catch (saveError) {
-      // @ts-expect-error saveError is an unknown error
-      logger?.error(`Failed to save task ${currentData.id} after handler error:`, saveError?.message);
+
+      try {
+        currentData = await saveTaskAndMaybeSendPushNotification({
+          taskStore,
+          pushNotificationSender: resolvedPushNotificationSender,
+          previousTask,
+          nextTask: currentData,
+          agentId,
+          logger,
+        });
+      } catch (saveError) {
+        // @ts-expect-error saveError is an unknown error
+        logger?.error(`Failed to save task ${currentData.id} after handler error:`, saveError?.message);
+      }
     }
+  } finally {
+    unregisterTaskAbortController();
+    cleanupLinkedAbortController();
+  }
+
+  const latestTask = await taskStore.load({ agentId, taskId: currentData.id });
+  if (latestTask?.status.state === 'canceled') {
+    currentData = latestTask;
   }
 
   yield createSuccessResponse(requestId, {
@@ -1751,6 +1830,11 @@ export async function handleTaskCancel({
     }
 
     taskStore.activeCancellations.add(taskId);
+    taskStore.abortTask({
+      agentId,
+      taskId,
+      reason: new DOMException('Task cancelled by request.', 'AbortError'),
+    });
 
     const cancelUpdate: Omit<TaskStatus, 'timestamp'> = {
       state: 'canceled',
@@ -1861,6 +1945,7 @@ export async function getAgentExecutionHandler({
           agentId,
           logger,
           requestContext,
+          abortSignal,
         });
         return result;
       }

--- a/packages/server/src/server/handlers/a2a.ts
+++ b/packages/server/src/server/handlers/a2a.ts
@@ -696,23 +696,27 @@ async function saveTaskAndMaybeSendPushNotification({
   expectedVersion?: number;
   logger?: IMastraLogger;
 }): Promise<Task> {
-  await taskStore.save({ agentId, data: nextTask, expectedVersion });
+  const storedTask = await taskStore.save({ agentId, data: nextTask, expectedVersion, skipIfCanceled: true });
 
-  if (!shouldSendPushNotification(previousTask, nextTask)) {
-    return nextTask;
+  if (storedTask.status.state === 'canceled' && nextTask.status.state !== 'canceled') {
+    return storedTask;
+  }
+
+  if (!shouldSendPushNotification(previousTask, storedTask)) {
+    return storedTask;
   }
 
   void pushNotificationSender
     .sendNotifications({
       agentId,
-      task: nextTask,
+      task: storedTask,
       logger,
     })
     .catch(error => {
       logger?.error('Failed to schedule A2A push notification', error);
     });
 
-  return nextTask;
+  return storedTask;
 }
 
 function extractFullStreamTextDelta(value: unknown): string | null {


### PR DESCRIPTION
Fixes #20447.

Summary:
- wires the A2A message/stream request abortSignal into agent.stream through a per-task AbortController
- registers the active same-process stream controller in InMemoryTaskStore so tasks/cancel can abort the underlying agent run
- prevents late stream artifact/completed/failed saves from overwriting a canceled task
- adds regression coverage for request abort propagation and late chunks after task cancellation

Verification:
- git diff --check
- attempted: vitest run packages/server/src/server/handlers/a2a.test.ts --testNamePattern "passes request abortSignal|aborts the active stream" using an existing package runner, but the local worktree dependency set is incomplete and failed to load vite
- attempted: tsc --noEmit --project packages/server/tsconfig.json; the worktree lacks built/linked internal monorepo packages, so it reports existing module resolution errors, with no new abortSignal argument error after correction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If a client disconnects or cancels a task, the A2A agent now stops its active stream when possible. Late results cannot change the task back from `canceled`.

## Changes

- Pass request abort signals to `agent.stream()` through per-task `AbortController` instances.
- Track active streams in `InMemoryTaskStore`.
- Abort active streams when `tasks/cancel` runs.
- Preserve `canceled` as the terminal task state.
- Prevent late stream updates from overwriting canceled tasks.
- Clean up abort-controller registrations after stream processing.
- Add regression tests for request-abort propagation, active stream cancellation, and stale saves.
- Add a patch changeset for `@mastra/server`.

## Verification

- `git diff --check` passed.
- Vitest and TypeScript checks were attempted but blocked by incomplete local dependencies and unresolved internal monorepo packages.
- Cancellation remains cooperative and best effort for providers and tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->