### PR TITLE
fix(memory): retry malformed structured extractor output

### DIFF
--- a/.changeset/fast-beers-stay.md
+++ b/.changeset/fast-beers-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory silently skipping structured extractor values when models omit the extractor wrapper.

--- a/packages/memory/src/processors/observational-memory/__tests__/extractor.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/extractor.test.ts
@@ -410,6 +410,101 @@ describe('Extractor', () => {
     expect(generate.mock.calls[1][1].structuredOutput.jsonPromptInjection).toBe('inline');
   });
 
+  it('retries structured extraction when native output omits the extractor slug wrapper', async () => {
+    const workingMemory = new Extractor({
+      name: 'Working Memory',
+      instructions: 'Extract working memory.',
+      schema: z.object({
+        preferences: z.object({
+          responseStyle: z.string(),
+        }),
+      }),
+    });
+    let generateCalls = 0;
+    const agent = new Agent({
+      id: 'structured-extraction-wrapper-test',
+      name: 'Structured Extraction Wrapper Test',
+      instructions: 'Extract values.',
+      model: new MockLanguageModelV2({
+        doGenerate: async () => {
+          generateCalls += 1;
+          const text =
+            generateCalls === 1
+              ? '{"preferences":{"responseStyle":"concise"}}'
+              : '{"working-memory":{"preferences":{"responseStyle":"concise"}}}';
+
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            content: [{ type: 'text', text }],
+            warnings: [],
+          };
+        },
+      }),
+    });
+    const generate = vi.spyOn(agent, 'generate');
+
+    const result = await extractStructuredValues({
+      agent,
+      source: 'observer',
+      extractors: [workingMemory],
+    });
+
+    expect(generateCalls).toBe(2);
+    expect(generate.mock.calls[1]?.[1]?.structuredOutput?.jsonPromptInjection).toBe('inline');
+    expect(result).toEqual({
+      values: {
+        'working-memory': {
+          preferences: {
+            responseStyle: 'concise',
+          },
+        },
+      },
+      failures: [],
+    });
+  });
+
+  it('accepts an empty structured extraction without retrying', async () => {
+    const workingMemory = new Extractor({
+      name: 'Working Memory',
+      instructions: 'Extract working memory.',
+      schema: z.object({
+        preferences: z.object({
+          responseStyle: z.string(),
+        }),
+      }),
+    });
+    let generateCalls = 0;
+    const agent = new Agent({
+      id: 'empty-structured-extraction-test',
+      name: 'Empty Structured Extraction Test',
+      instructions: 'Extract values.',
+      model: new MockLanguageModelV2({
+        doGenerate: async () => {
+          generateCalls += 1;
+
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            content: [{ type: 'text', text: '{}' }],
+            warnings: [],
+          };
+        },
+      }),
+    });
+
+    const result = await extractStructuredValues({
+      agent,
+      source: 'observer',
+      extractors: [workingMemory],
+    });
+
+    expect(generateCalls).toBe(1);
+    expect(result).toEqual({ values: {}, failures: [] });
+  });
+
   it('falls back to system json prompt injection when inline support is not advertised', async () => {
     const priority = new Extractor({ name: 'Priority', instructions: 'Extract priority.', schema: z.string() });
     const generate = vi

--- a/packages/memory/src/processors/observational-memory/extraction-runner.ts
+++ b/packages/memory/src/processors/observational-memory/extraction-runner.ts
@@ -35,12 +35,13 @@ export async function extractStructuredValues(opts: {
     return { values: {}, failures: [] };
   }
 
-  const schema = z.object(
-    Object.fromEntries(structuredExtractors.map(extractor => [extractor.slug, extractor.schema.optional()])) as Record<
-      string,
-      z.ZodTypeAny
-    >,
-  );
+  const schema = z
+    .object(
+      Object.fromEntries(
+        structuredExtractors.map(extractor => [extractor.slug, extractor.schema.optional()]),
+      ) as Record<string, z.ZodTypeAny>,
+    )
+    .strict();
   const priorLines = buildExtractorPriorLines(structuredExtractors, opts.priorExtractedValues);
   const extractorInstructions = structuredExtractors
     .map(extractor => `- ${extractor.slug}: ${extractor.instructions}`)


### PR DESCRIPTION
## Description

Observational Memory combines configured structured extractors into one top-level schema. Previously, unknown top-level keys were stripped, so a model response containing the correct inner Working Memory object without the `working-memory` wrapper became `{}` and silently skipped the existing fallback.

This makes only the combined extractor wrapper schema strict. A wrapperless response now fails Agent structured-output validation and enters the existing `jsonPromptInjection: 'inline'` fallback. Configured extractor slugs remain optional, so a valid `{}` still represents no extracted values and does not retry.

The regression tests use a real `Agent` with `MockLanguageModelV2`: the first response omits the wrapper, the second returns it, and the test verifies the inline fallback succeeds. A separate test verifies that `{}` remains a one-call no-op. This adds no public API and no custom retry path.

## Related issue(s)

Fixes #20503

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Verification

- `pnpm --filter ./packages/memory exec vitest run src/processors/observational-memory/__tests__/extractor.test.ts --reporter=dot --bail=1` (30 passed)
- `pnpm --filter ./packages/memory check`
- `pnpm --filter ./packages/memory lint`

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] Documentation is not required for this internal bug fix
- [x] I have added tests that prove my fix is effective
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Models sometimes return useful data in the wrong format. This change detects that format error, retries with a correction prompt, and still accepts a truly empty `{}` response as a valid no-op.

## Changes

- Made the combined extractor wrapper schema strict.
- Triggered the existing inline JSON prompt fallback when the expected extractor wrapper is missing.
- Preserved optional extractor slugs, so `{}` does not trigger a retry.
- Added regression tests with `Agent` and `MockLanguageModelV2` for fallback recovery and one-call no-op behavior.
- Added a patch changeset for `@mastra/memory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->