### PR TITLE
fix(memory): delete observational vectors with threads

### DIFF
--- a/.changeset/better-lamps-work.md
+++ b/.changeset/better-lamps-work.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed thread deletion to remove observational memory vectors.

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -2407,7 +2407,12 @@ describe('Memory', () => {
     function createMemoryWithMockVector(indexSeparator = '_') {
       const mockVector = {
         deleteVectors: vi.fn(),
-        listIndexes: vi.fn().mockResolvedValue([`memory${indexSeparator}messages`]),
+        listIndexes: vi
+          .fn()
+          .mockResolvedValue([
+            `memory${indexSeparator}messages`,
+            `memory${indexSeparator}observations${indexSeparator}384`,
+          ]),
         query: vi.fn(),
         upsert: vi.fn(),
         createIndex: vi.fn(),
@@ -2439,6 +2444,7 @@ describe('Memory', () => {
       await memory.deleteMessages([messageId]);
 
       await vi.waitFor(() => {
+        expect(memory.mockVector.deleteVectors).toHaveBeenCalledTimes(1);
         expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
           indexName: 'memory_messages',
           filter: { message_id: { $in: [messageId] } },
@@ -2453,8 +2459,13 @@ describe('Memory', () => {
       await memory.deleteThread(threadId);
 
       await vi.waitFor(() => {
+        expect(memory.mockVector.deleteVectors).toHaveBeenCalledTimes(2);
         expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
           indexName: 'memory_messages',
+          filter: { thread_id: threadId },
+        });
+        expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
+          indexName: 'memory_observations_384',
           filter: { thread_id: threadId },
         });
       });
@@ -2467,6 +2478,7 @@ describe('Memory', () => {
       await memory.deleteMessages([messageId]);
 
       await vi.waitFor(() => {
+        expect(memory.mockVector.deleteVectors).toHaveBeenCalledTimes(1);
         expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
           indexName: 'memory-messages',
           filter: { message_id: { $in: [messageId] } },
@@ -2481,8 +2493,13 @@ describe('Memory', () => {
       await memory.deleteThread(threadId);
 
       await vi.waitFor(() => {
+        expect(memory.mockVector.deleteVectors).toHaveBeenCalledTimes(2);
         expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
           indexName: 'memory-messages',
+          filter: { thread_id: threadId },
+        });
+        expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
+          indexName: 'memory-observations-384',
           filter: { thread_id: threadId },
         });
       });

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -726,15 +726,18 @@ export class Memory extends MastraMemory {
   }
 
   /**
-   * Lists all vector indexes that match the memory messages prefix.
+   * Lists vector indexes managed by memory.
    * Handles separator differences across vector store backends (e.g. '_' vs '-').
    */
-  private async getMemoryVectorIndexes(): Promise<string[]> {
+  private async getMemoryVectorIndexes({ includeObservations = false } = {}): Promise<string[]> {
     if (!this.vector) return [];
     const separator = this.vector.indexSeparator ?? '_';
-    const prefix = `memory${separator}messages`;
+    const messagePrefix = `memory${separator}messages`;
+    const observationPrefix = `memory${separator}observations${separator}`;
     const indexes = await this.vector.listIndexes();
-    return indexes.filter(name => name.startsWith(prefix));
+    return indexes.filter(
+      name => name.startsWith(messagePrefix) || (includeObservations && name.startsWith(observationPrefix)),
+    );
   }
 
   /**
@@ -745,7 +748,7 @@ export class Memory extends MastraMemory {
    */
   private async deleteThreadVectors(threadId: string): Promise<void> {
     try {
-      const memoryIndexes = await this.getMemoryVectorIndexes();
+      const memoryIndexes = await this.getMemoryVectorIndexes({ includeObservations: true });
 
       await Promise.all(
         memoryIndexes.map(async (indexName: string) => {


### PR DESCRIPTION
## Description

Thread deletion currently cleans `memory_messages` indexes but leaves matching vectors in `memory_observations_<dimensions>`. This change includes observational-memory indexes in thread cleanup while keeping individual message deletion scoped to message indexes.

This preserves Mastra's existing fire-and-forget (non-blocking, best-effort) vector cleanup semantics; the change only expands thread cleanup to include observational-memory indexes.

The regression tests cover both underscore and dash index separators, and verify that message deletion does not touch observation indexes.

## Related issue(s)

Fixes #20509

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Verification

- `pnpm --filter ./packages/memory exec vitest run src/index.test.ts --reporter=dot --bail 1` — 94 passed
- `pnpm --filter ./packages/memory check` — passed
- `pnpm --filter ./packages/memory lint` — passed
- `pnpm build:memory` — passed
- `pnpm exec oxfmt --check packages/memory/src/index.ts packages/memory/src/index.test.ts .changeset/better-lamps-work.md` — passed

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable; no public API change)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a thread is deleted, its stored message and observation data are now removed. Deleting one message still removes only that message’s data.

## Changes

- Updated `Memory.deleteThread` to remove vectors from:
  - `memory_messages`
  - `memory_observations_<dimensions>`
- Preserved message-only behavior for individual message deletion.
- Added regression tests for underscore and dash index separators.
- Added a patch changeset for `@mastra/memory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->