### PR TITLE
fix(core): deduplicate concurrent workflow resumes

### DIFF
--- a/.changeset/lovely-carpets-smell.md
+++ b/.changeset/lovely-carpets-smell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Prevent concurrent workflow resume calls from executing downstream steps more than once.

--- a/packages/core/src/workflows/concurrent-resume.test.ts
+++ b/packages/core/src/workflows/concurrent-resume.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage/mock';
+import { createWorkflow } from './create';
+import { createStep } from './workflow';
+
+describe('concurrent workflow resume', () => {
+  it('executes downstream steps at most once for the same suspended run', async () => {
+    let downstreamExecutions = 0;
+    let releaseDownstream!: () => void;
+    let downstreamStarted!: () => void;
+    const downstreamRelease = new Promise<void>(resolve => {
+      releaseDownstream = resolve;
+    });
+    const firstDownstreamExecution = new Promise<void>(resolve => {
+      downstreamStarted = resolve;
+    });
+
+    const suspendingStep = createStep({
+      id: 'suspending-step',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ resumed: z.boolean() }),
+      suspendSchema: z.object({ waiting: z.boolean() }),
+      resumeSchema: z.object({ approved: z.boolean() }),
+      execute: async ({ resumeData, suspend }) => {
+        if (!resumeData?.approved) {
+          await suspend({ waiting: true });
+        }
+        return { resumed: true };
+      },
+    });
+
+    const downstreamStep = createStep({
+      id: 'downstream-step',
+      inputSchema: z.object({ resumed: z.boolean() }),
+      outputSchema: z.object({ completed: z.boolean() }),
+      execute: async () => {
+        downstreamExecutions += 1;
+        downstreamStarted();
+        await downstreamRelease;
+        return { completed: true };
+      },
+    });
+
+    const workflow = createWorkflow({
+      id: 'concurrent-resume-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ completed: z.boolean() }),
+      steps: [suspendingStep, downstreamStep],
+    })
+      .then(suspendingStep)
+      .then(downstreamStep)
+      .commit();
+
+    new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: { 'concurrent-resume-workflow': workflow },
+    });
+
+    const run = await workflow.createRun({ runId: 'concurrent-resume-run' });
+    const suspended = await run.start({ inputData: {} });
+    expect(suspended.status).toBe('suspended');
+
+    const firstResume = run.resume({
+      step: 'suspending-step',
+      resumeData: { approved: true },
+    });
+    const secondResume = run.resume({
+      step: 'suspending-step',
+      resumeData: { approved: true },
+    });
+
+    await firstDownstreamExecution;
+    await new Promise(resolve => setTimeout(resolve, 25));
+    expect(downstreamExecutions).toBe(1);
+
+    releaseDownstream();
+    const results = await Promise.all([firstResume, secondResume]);
+
+    expect(results.map(result => result.status)).toEqual(['success', 'success']);
+    expect(downstreamExecutions).toBe(1);
+  });
+
+  it('allows another resume after an in-flight resume rejects', async () => {
+    const suspendingStep = createStep({
+      id: 'suspending-step',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ resumed: z.boolean() }),
+      suspendSchema: z.object({ waiting: z.boolean() }),
+      resumeSchema: z.object({ approved: z.literal(true) }),
+      execute: async ({ resumeData, suspend }) => {
+        if (!resumeData?.approved) {
+          await suspend({ waiting: true });
+        }
+        return { resumed: true };
+      },
+    });
+
+    const workflow = createWorkflow({
+      id: 'resume-rejection-cleanup-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ resumed: z.boolean() }),
+      steps: [suspendingStep],
+    })
+      .then(suspendingStep)
+      .commit();
+
+    new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: { 'resume-rejection-cleanup-workflow': workflow },
+    });
+
+    const run = await workflow.createRun({ runId: 'resume-rejection-cleanup-run' });
+    const suspended = await run.start({ inputData: {} });
+    expect(suspended.status).toBe('suspended');
+
+    await expect(
+      run.resume({
+        step: 'suspending-step',
+        resumeData: { approved: false } as { approved: true },
+      }),
+    ).rejects.toThrow();
+
+    const resumed = await run.resume({
+      step: 'suspending-step',
+      resumeData: { approved: true },
+    });
+
+    expect(resumed.status).toBe('success');
+  });
+});

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2996,6 +2996,47 @@ export class Workflow<
  * Represents a workflow run that can be executed
  */
 
+type WorkflowRunResumeParams<TResume, TEngineType, TRequestContext extends Record<string, any> | unknown> = {
+  resumeData?: TResume;
+  step?:
+    | Step<string, any, any, TResume, any, any, TEngineType, any>
+    | [
+        ...Step<string, any, any, any, any, any, TEngineType, any>[],
+        Step<string, any, any, TResume, any, any, TEngineType, any>,
+      ]
+    | string
+    | string[];
+  label?: string;
+  requestContext?: RequestContext<TRequestContext>;
+  retryCount?: number;
+  tracingOptions?: TracingOptions;
+  outputWriter?: OutputWriter;
+  format?: 'legacy' | 'vnext' | undefined;
+  isVNext?: boolean;
+  outputOptions?: {
+    includeState?: boolean;
+    includeResumeLabels?: boolean;
+  };
+  forEachIndex?: number;
+  perStep?: boolean;
+  actor?: ActorSignal;
+} & Partial<ObservabilityContext>;
+
+function getWorkflowRunResumeKey<TResume, TEngineType, TRequestContext extends Record<string, any> | unknown>(
+  params: WorkflowRunResumeParams<TResume, TEngineType, TRequestContext>,
+) {
+  if (params.label) {
+    return `label:${params.label}:foreach:${params.forEachIndex ?? 'none'}`;
+  }
+
+  const stepPath = (Array.isArray(params.step) ? params.step : [params.step])
+    .filter(step => step !== undefined)
+    .map(step => (typeof step === 'string' ? step : step.id))
+    .join('.');
+
+  return `step:${stepPath || 'auto'}:foreach:${params.forEachIndex ?? 'none'}`;
+}
+
 export class Run<
   TEngineType = DefaultEngineType,
   TSteps extends Step<string, any, any, any, any, any, TEngineType, any>[] = Step<
@@ -3088,6 +3129,7 @@ export class Run<
   streamOutput?: WorkflowRunOutput<WorkflowResult<TState, TInput, TOutput, TSteps>>;
   protected closeStreamAction?: () => Promise<void>;
   protected executionResults?: Promise<WorkflowResult<TState, TInput, TOutput, TSteps>>;
+  #resumeExecutions = new Map<string, Promise<WorkflowResult<TState, TInput, TOutput, TSteps>>>();
   protected stateSchema?: StandardSchemaWithJSON<TState>;
   protected inputSchema?: StandardSchemaWithJSON<TInput>;
   protected requestContextSchema?: StandardSchemaWithJSON<any>;
@@ -3972,32 +4014,30 @@ export class Run<
     return this._restart(args);
   }
 
-  protected async _resume<TResume>(
-    params: {
-      resumeData?: TResume;
-      step?:
-        | Step<string, any, any, TResume, any, any, TEngineType, any>
-        | [
-            ...Step<string, any, any, any, any, any, TEngineType, any>[],
-            Step<string, any, any, TResume, any, any, TEngineType, any>,
-          ]
-        | string
-        | string[];
-      label?: string;
-      requestContext?: RequestContext<TRequestContext>;
-      retryCount?: number;
-      tracingOptions?: TracingOptions;
-      outputWriter?: OutputWriter;
-      format?: 'legacy' | 'vnext' | undefined;
-      isVNext?: boolean;
-      outputOptions?: {
-        includeState?: boolean;
-        includeResumeLabels?: boolean;
-      };
-      forEachIndex?: number;
-      perStep?: boolean;
-      actor?: ActorSignal;
-    } & Partial<ObservabilityContext>,
+  protected _resume<TResume>(
+    params: WorkflowRunResumeParams<TResume, TEngineType, TRequestContext>,
+  ): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+    const key = getWorkflowRunResumeKey(params);
+    const inFlightExecution = this.#resumeExecutions.get(key);
+    if (inFlightExecution) {
+      return inFlightExecution;
+    }
+
+    const execution = this.#executeResume(params);
+    this.#resumeExecutions.set(key, execution);
+
+    const clearExecution = () => {
+      if (this.#resumeExecutions.get(key) === execution) {
+        this.#resumeExecutions.delete(key);
+      }
+    };
+    void execution.then(clearExecution, clearExecution);
+
+    return execution;
+  }
+
+  async #executeResume<TResume>(
+    params: WorkflowRunResumeParams<TResume, TEngineType, TRequestContext>,
   ): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
     const observabilityContext = resolveObservabilityContext(params);
     const workflowsStore = await this.#mastra?.getStorage()?.getStore('workflows');


### PR DESCRIPTION
Two concurrent `resume()` calls for the same suspended target can both load the suspended snapshot before either call advances execution. That allows downstream steps and external side effects to run twice.

Before this change, awaiting two concurrent resumes could execute the downstream step twice:

```ts
await Promise.all([run.resume(resumeOptions), run.resume(resumeOptions)])
```

After this change, callers for the same step or label and `forEachIndex` join the same in-flight execution and receive the same result. The entry is cleared after success or failure, so a later suspension lifecycle can still resume normally. Different resume targets keep independent keys.

This fixes the reported reproduction and the normal cached `Run` path. It does not add a storage-backed claim across independent Mastra processes; distributed resume ownership still requires a storage contract.

The regression test failed on `main` with two downstream executions and passes with one after this change. I also verified rejection cleanup, nested resume labels, foreach suspend payloads, agent approval resume behavior, core type checking, and `pnpm build:core`.

Fixes #20443
