### PR TITLE
fix: handle both usage paths in convertMastraChunkToAISDKBase for persisted signal chunks

### DIFF
--- a/.changeset/fix-usage-path-mapping.md
+++ b/.changeset/fix-usage-path-mapping.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+fix: handle both usage paths in convertMastraChunkToAISDKBase for persisted signal chunks

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -171,11 +171,14 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
       };
 
     case 'finish': {
+      // Normal model runs carry usage at payload.output.usage (full FinishPayload).
+      // Synthesized finish chunks from #broadcastPersistedSignal carry usage directly
+      // at payload.usage without an output wrapper. Resolve defensively to support both.
       return {
         type: 'finish',
         finishReason: normalizeFinishReason(chunk.payload.stepResult.reason) as FinishReason,
         ...(includeRawFinishReason ? { rawFinishReason: chunk.payload.stepResult.reason } : {}),
-        totalUsage: normalizeUsage(chunk.payload.output.usage),
+        totalUsage: normalizeUsage(chunk.payload.output?.usage ?? chunk.payload.usage),
       };
     }
     case 'reasoning-start':
@@ -319,7 +322,9 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
         providerMetadata: chunk.payload.providerMetadata,
       };
     case 'step-finish': {
-      const { request: _request, providerMetadata, ...rest } = chunk.payload.metadata;
+      // Defensive: synthesized chunks (e.g. from #broadcastPersistedSignal) may omit
+      // payload.metadata and carry usage at payload.usage instead of payload.output.usage.
+      const { request: _request, providerMetadata, ...rest } = chunk.payload.metadata ?? {};
       return {
         type: 'finish-step',
         response: {
@@ -328,7 +333,7 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
           modelId: (rest.modelId as string) || '',
           ...rest,
         },
-        usage: normalizeUsage(chunk.payload.output.usage),
+        usage: normalizeUsage(chunk.payload.output?.usage ?? chunk.payload.usage),
         finishReason: normalizeFinishReason(chunk.payload.stepResult.reason) as FinishReason,
         ...(includeRawFinishReason ? { rawFinishReason: chunk.payload.stepResult.reason } : {}),
         providerMetadata,


### PR DESCRIPTION
## Problem

Fixes #19721

The  function in  does not correctly handle usage signal chunks when they arrive through the persisted signal path (as opposed to the inline path). This causes usage information to be silently dropped for certain streaming configurations.

## Root Cause

The function only checks for usage data in one code path. When the signal chunk arrives via the persisted path, the usage fields are not extracted, resulting in missing token counts in the AI SDK response.

## Solution

Updated  to handle both the inline and persisted signal chunk paths, ensuring usage data is correctly extracted regardless of how it arrives.

## Changes

- : Added handling for the persisted signal chunk path in the usage extraction logic
- Added changeset for patch release

## Testing

- Verified both code paths correctly extract usage data
- No breaking changes to the existing API
