### PR TITLE
chore(docs): Add Vale to CI

### DIFF
--- a/.claude/skills/mastra-docs/SKILL.md
+++ b/.claude/skills/mastra-docs/SKILL.md
@@ -11,28 +11,29 @@ Use this skill when you create or update Mastra docs. Keep the docs clear and co
 
 Start with references/STYLEGUIDE.md for all docs. Then use the guide that matches the content:
 
-- references/DOC.md - General docs that do not fit the categories below
+- references/DOC.md: General docs that do not fit the categories below
 - Choose the right guide for the file's content:
-  - references/GUIDE_QUICKSTART.md - Quickstarts that help readers get working fast with a specific library or framework
-  - references/GUIDE_TUTORIAL.md - Tutorials that teach readers how to build something with Mastra
-  - references/GUIDE_INTEGRATION.md - Integration guides for using Mastra with an external library or ecosystem
-  - references/GUIDE_DEPLOYMENT.md - Deployment guides for shipping a Mastra app to a platform
-- references/REFERENCE.md - Reference and API docs
+  - references/GUIDE_QUICKSTART.md: Quickstarts that help readers get working fast with a specific library or framework
+  - references/GUIDE_TUTORIAL.md: Tutorials that teach readers how to build something with Mastra
+  - references/GUIDE_INTEGRATION.md: Integration guides for using Mastra with an external library or ecosystem
+  - references/GUIDE_DEPLOYMENT.md: Deployment guides for shipping a Mastra app to a platform
+- references/REFERENCE.md: Reference and API docs
 
 ## Linting
 
 Use these tools to keep docs consistent:
 
-- oxfmt - Formats docs code, Markdown, config, and style files through the docs-local config.
-- prettier - Formats MDX through the docs-local custom parser so admonitions, JSX expressions, and fenced code blocks remain supported.
-- remark - Checks markdown issues like heading levels, list styles, and formatting consistency. This is the middle layer.
-- vale - Checks grammar, style, and wording. This is the top layer.
+- oxfmt: Formats docs code, Markdown, config, and style files through the docs-local config.
+- oxfmt-mdx: Formats MDX through the docs-local custom parser so admonitions, JSX expressions, and fenced code blocks remain supported.
+- remark: Checks markdown issues like heading levels, list styles, and formatting consistency. This is the middle layer.
+- vale: Checks grammar, style, and wording. This is the top layer.
+  - In order to use Vale, you must download the Vale binary and install `mdx2vast` globally. `pnpm run vale:download`, `npm install -g mdx2vast`.
 
 Run these commands in docs/:
 
-- pnpm run format - Format docs files with oxfmt and docs-local Prettier for MDX.
-- pnpm run format:check - Check docs formatting with oxfmt and docs-local Prettier for MDX.
-- pnpm run lint:remark - Check markdown with Remark
-- pnpm run lint:vale:ai - Check prose with Vale using the error alert level
-- pnpm run validate - Check frontmatter values and if all sidebars are valid
-- pnpm run generate-vercel-redirects - Generate vercel.json redirects after editing vercel.redirects.json
+- pnpm run format: Format docs files with oxfmt and docs-local oxfmt-mdx
+- pnpm run format:check: Check docs formatting with oxfmt and docs-local oxfmt-mdx
+- pnpm run lint:remark: Check MDX with Remark
+- pnpm run lint:vale:ai: Check prose with Vale using the error alert level
+- pnpm run validate: Check frontmatter values and if all sidebars are valid
+- pnpm run generate-vercel-redirects: Generate vercel.json redirects after editing vercel.redirects.json

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -198,13 +198,16 @@ jobs:
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
 
+      - name: Install mdx2vast
+        run: npm install -g mdx2vast
+
       - name: Check formatting
         working-directory: ./docs
         run: pnpm format:check
 
-      - name: Lint with remark
+      - name: Validate reference sidebar sort order
         working-directory: ./docs
-        run: pnpm lint:remark
+        run: pnpm validate:reference-sidebar
 
       - name: Check for MDX changes
         id: mdx-changes
@@ -220,11 +223,20 @@ jobs:
         working-directory: ./docs
         run: pnpm dlx tsx scripts/validate-frontmatter.ts
 
-      - name: Validate reference sidebar sort order
-        working-directory: ./docs
-        run: pnpm validate:reference-sidebar
-
       - name: Check for docs not linked in sidebars
         if: steps.mdx-changes.outputs.has_changes == 'true'
         working-directory: ./docs
         run: pnpm validate:sidebar-docs
+
+      - name: Lint with remark
+        if: steps.mdx-changes.outputs.has_changes == 'true'
+        working-directory: ./docs
+        run: pnpm lint:remark
+
+      - name: Lint with Vale
+        if: steps.mdx-changes.outputs.has_changes == 'true'
+        uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a
+        with:
+          files: '["docs/src/content/en/docs", "docs/src/content/en/guides", "docs/src/content/en/reference"]'
+          vale_flags: '--config=docs/.vale.ini --minAlertLevel=error'
+          fail_on_error: true

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -199,7 +199,7 @@ jobs:
         uses: ./.github/actions/setup-pnpm-node
 
       - name: Install mdx2vast
-        run: npm install -g mdx2vast
+        run: npm install -g --ignore-scripts mdx2vast@0.3.1
 
       - name: Check formatting
         working-directory: ./docs

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -245,6 +245,7 @@ jobs:
         if: steps.mdx-changes.outputs.has_changes == 'true'
         uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a
         with:
+          version: 3.13.1 # TODO: Update to newer version
           files: '["docs/src/content/en/docs", "docs/src/content/en/guides", "docs/src/content/en/reference"]'
           vale_flags: '--config=.vale-ci.ini --minAlertLevel=error'
           fail_on_error: true

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -233,10 +233,18 @@ jobs:
         working-directory: ./docs
         run: pnpm lint:remark
 
+      - name: Prepare Vale CI config
+        if: steps.mdx-changes.outputs.has_changes == 'true'
+        run: |
+          sed \
+            -e '/^Packages =/d' \
+            -e 's#^StylesPath = styles#StylesPath = docs/styles#' \
+            docs/.vale.ini > .vale-ci.ini
+
       - name: Lint with Vale
         if: steps.mdx-changes.outputs.has_changes == 'true'
         uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a
         with:
           files: '["docs/src/content/en/docs", "docs/src/content/en/guides", "docs/src/content/en/reference"]'
-          vale_flags: '--config=docs/.vale.ini --minAlertLevel=error'
+          vale_flags: '--config=.vale-ci.ini --minAlertLevel=error'
           fail_on_error: true

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -9,7 +9,7 @@ Packages = write-good, https://github.com/tbhb/vale-ai-tells/releases/download/v
 
 # Only lint English content (excluding auto-generated models)
 # Native MDX support via mdx2vast (must be installed globally: npm i -g mdx2vast)
-[src/content/en/{docs,guides,reference}/**/*.{md,mdx}]
+[**/src/content/en/{docs,guides,reference}/**/*.{md,mdx}]
 BasedOnStyles = Vale, write-good, Mastra, signs-of-ai-writing, ai-tells
 
 # Disable rules

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,9 +1,10 @@
-Use @styleguides/STYLEGUIDE.md first. @styleguides/ also includes guides for docs and reference docs
+Use @styleguides/STYLEGUIDE.md first.
 
 When working check src/content/en/docs/ and src/content/en/reference/ update existing docs or create new docs
 @CONTRIBUTING.md for setup, local development, and components / frontmatter
-When adding model name/ID to docs, use placeholder token from src/plugins/remark-model-tokens/models.ts (remark replaces them at build time)
-When deleting/renaming doc, redirect needs to be added to vercel.redirects.json. Use pnpm run generate-vercel-redirects to update generated vercel.json
+When adding model name/ID to docs, use placeholder token from src/plugins/remark-model-tokens/models.ts
+When moving doc, use scripts/move-doc.ts
+When deleting, add redirect to vercel.redirects.json. Use pnpm run generate-vercel-redirects to update generated vercel.json
 
 main documentation src/content/en/docs
 step by step guides src/content/en/guides
@@ -30,6 +31,6 @@ pnpm test:navigation # Navigation tests desktop + tablet + mobile
 
 Linting
 pnpm validate # Check frontmatter values & if all sidebars are valid
-pnpm lint:prose # Check prose with Vale & Remark
+pnpm lint:prose # Check prose with Vale & Remark, first time setup: pnpm vale:download \n npm install -g mdx2vast
 
 Tests live in tests/ helpers in tests/helpers/ & playwright.config.ts starts pnpm serve

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -52,11 +52,25 @@ Before submitting a PR, make sure to:
    pnpm run serve
    ```
 
-3. **Check for broken links** - The build process will warn you about broken links.
+3. **Check for broken links**: The build process will warn you about broken links.
 
-4. **Verify code examples** - If you've added code examples, test them if possible to ensure they work.
+4. **Verify code examples**: If you've added code examples, test them if possible to ensure they work.
 
-5. **Run linters**:
+5. **Run linters**: Install Vale and `mdx2vast`, then run the linting and validation commands.
+
+   Download Vale:
+
+   ```bash
+   pnpm run vale:download
+   ```
+
+   Install `mdx2vast` globally:
+
+   ```bash
+   npm install -g mdx2vast
+   ```
+
+   Run the validation scripts:
 
    ```shell
    pnpm run lint:prose && pnpm run validate
@@ -149,14 +163,14 @@ function add(a: number, b: number) {
 ```
 ````
 
-#### Prettier formatting
+#### oxfmt-mdx formatting
 
-By default, Prettier will format code blocks in all Markdown/MDX files. If you want to disable Prettier for a specific code block, add `prettier:false` to the code block's metadata.
+By default, oxfmt-mdx will format code blocks in all Markdown/MDX files. If you want to disable oxfmt-mdx for a specific code block, add `oxfmt:false` to the code block's metadata.
 
-**Important:** This is an anti-pattern! This is an escape hatch for edge cases where Prettier's formatting produces undesirable results. In general, you should strive to write code that can be formatted by Prettier to maintain a consistent style across the documentation.
+**Important:** This is an anti-pattern! This is an escape hatch for edge cases where oxfmt-mdx's formatting produces undesirable results. In general, you should strive to write code that can be formatted by oxfmt-mdx to maintain a consistent style across the documentation.
 
 ````md
-```typescript prettier:false
+```typescript oxfmt:false
 function add(a: number, b: number) {
   return a + b
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ Here's a quick start to run the docs locally
   pnpm run dev
   ```
 
-## Optional: Linting
+## Linting
 
 ### Remark
 

--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -123,7 +123,7 @@ Function-based `requireToolApproval` is only available on regular `stream()` / `
 
 For sensitive tools, bind the approval to the exact tool name and arguments that were shown to the reviewer. If those arguments drift before execution, the tool shouldn't run under the old approval.
 
-The `tool-call-approval` chunk already includes `toolName`, `toolCallId`, and `args`. You can fingerprint those fields when the approval request is shown. The example below uses a simple JSON string as the fingerprint, but in production you should use a stable hash of the tool name and arguments:
+The `tool-call-approval` chunk already includes `toolName`, `toolCallId`, and `args`. You can fingerprint those fields when the approval request is shown. The example below uses a JSON string as the fingerprint, but in production you should use a stable hash of the tool name and arguments:
 
 ```typescript title="src/mastra/agents/approval-bound-agent.ts"
 import { Agent } from '@mastra/core/agent'
@@ -189,7 +189,7 @@ async function approveReviewedToolCall(runId: string, toolCallId: string, finger
 await consumeApprovalStream(stream)
 ```
 
-In production, store the approved fingerprint in durable storage scoped to the user, run, tool call, and policy version. The `Set` above is intentionally small so the boundary is easy to see: the approval is consumed once, and only for the same canonical tool arguments that were reviewed.
+In production, store the approved fingerprint in durable storage scoped to the user, run, tool call, and policy version. The `Set` above is intentionally small so the boundary is clear: the approval is consumed once, and only for the same canonical tool arguments that were reviewed.
 
 ### Runtime suspension with `suspend()`
 

--- a/docs/src/content/en/docs/deployment/workers.mdx
+++ b/docs/src/content/en/docs/deployment/workers.mdx
@@ -49,11 +49,11 @@ The orchestration worker requires a PubSub backend that supports pull mode (e.g.
 
 ### Scheduler worker
 
-Polls storage for due cron schedules and publishes `workflow.start` events. It is a producer only, meaning it creates work for the orchestration worker to pick up.
+Polls storage for due cron schedules and publishes `workflow.start` events. It's a producer only, meaning it creates work for the orchestration worker to pick up.
 
 The scheduler reads declarative `schedule` fields from your workflow definitions automatically. See [Scheduled workflows](/docs/workflows/scheduled-workflows) for how to declare schedules.
 
-**Do not run more than one scheduler instance.** Multiple schedulers polling the same storage would fire duplicate events for the same schedule.
+**Don't run more than one scheduler instance.** Multiple schedulers polling the same storage would fire duplicate events for the same schedule.
 
 ### Background task worker
 
@@ -118,7 +118,7 @@ To run workers separately, configure a distributed [PubSub](/docs/server/pubsub)
   </TabItem>
 </Tabs>
 
-Any [supported storage backend](/reference/workers/overview#supported-storage-backends) works — swap the storage adapter for your preferred database.
+Any [supported storage backend](/reference/workers/overview#supported-storage-backends) works. Swap the storage adapter for your preferred database.
 
 Run the same build artifact in multiple containers, each with a different [`MASTRA_WORKERS`](/reference/workers/overview#mastra_workers) value to control which worker starts in each process.
 
@@ -128,13 +128,13 @@ The [worker deployment guide](/guides/deployment/mastra-workers) walks through t
 
 ## Network architecture
 
-Workers are internal infrastructure. They are not exposed to end users and do not need their own subdomain, public URL, or inbound HTTP route.
+Workers are internal infrastructure. They're not exposed to end users and don't need their own subdomain, public URL, or inbound HTTP route.
 
 In a split deployment:
 
-- **The API server is the only public-facing process.** It serves all client HTTP requests — REST endpoints, agent interactions, workflow triggers, and any custom routes.
-- **Workers connect outbound only.** They pull events from the distributed PubSub backend and read/write to the shared storage database. They do not accept inbound traffic from clients.
-- **The orchestration worker calls the API internally.** It sends step execution requests to the API over the container network using `MASTRA_STEP_EXECUTION_URL`. This is internal service-to-service communication, not a public endpoint.
+- **The API server is the only public-facing process**: It serves all client HTTP requests, including REST endpoints, agent interactions, workflow triggers, and any custom routes.
+- **Workers connect outbound only**: They pull events from the distributed PubSub backend and read/write to the shared storage database. They don't accept inbound traffic from clients.
+- **The orchestration worker calls the API internally**: It sends step execution requests to the API over the container network using `MASTRA_STEP_EXECUTION_URL`. This is internal service-to-service communication, not a public endpoint.
 
 All three worker types (orchestration, scheduler, background task) sit behind the API on a private network. They share access to the PubSub backend and storage database but never receive traffic directly from clients. If a worker-related feature needs an HTTP route (for example, token minting for a voice integration), that route runs on the API server, not on the worker process.
 
@@ -149,7 +149,7 @@ All three worker types (orchestration, scheduler, background task) sit behind th
 
 - [Worker deployment guide](/guides/deployment/mastra-workers): Docker Compose example and topology options
 - [Worker authentication](/docs/server/auth/workers): Secure worker-to-API communication
-- [Workers reference](/reference/workers/overview): Environment variables, worker types, and storage backends
+- [Workers reference](/reference/workers/overview): Details about worker environment variables and types, with a list of supported storage backends
 - [CLI reference](/reference/cli/mastra#mastra-worker-build): `mastra worker build` and `mastra worker start`
 - [PubSub](/docs/server/pubsub): Event delivery backends
 - [Scheduled workflows](/docs/workflows/scheduled-workflows): Declare cron schedules on workflows

--- a/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
+++ b/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
@@ -145,7 +145,7 @@ Visit the [Scorers overview](/docs/evals/overview) for details on available and 
 
 ## Tool mocks
 
-When an experiment runs an agent that calls side-effecting tools, you can make the run deterministic by attaching static tool mocks to individual dataset items. During the experiment, a mocked tool returns its declared output instead of executing. By default, tools that have no mock on the item run live.
+When an experiment runs an agent that calls side-effecting tools, attach static tool mocks to individual dataset items to make the run deterministic. During the experiment, a mocked tool returns its declared output instead of executing. Tools without a mock on the item run live by default.
 
 Mocks live on the dataset item, so they version with the row and travel with the test case. Each mock declares a tool name, the arguments it expects, and the output to return:
 

--- a/docs/src/content/en/docs/index.mdx
+++ b/docs/src/content/en/docs/index.mdx
@@ -174,6 +174,6 @@ Browse [templates](https://mastra.ai/templates) for complete Mastra projects you
 
 :::note
 
-New to Mastra? Read [What is Mastra?](/docs/what-is-mastra) for an overview of the framework, its capabilities, and what you can build with it.
+New to Mastra? Read [What's Mastra?](/docs/what-is-mastra) for an overview of the framework, its capabilities, and what you can build with it.
 
 :::

--- a/docs/src/content/en/docs/index.mdx
+++ b/docs/src/content/en/docs/index.mdx
@@ -21,8 +21,6 @@ Mastra is a TypeScript framework for building AI agents and applications. Create
 
 ## Quickstart
 
-I hope this helps with stuff. despite its challenges.
-
 Run this command to create a general-purpose agent harness with a local workspace, shell tools, memory, task tracking, web access, and recurring schedules. It also installs Mastra skills for your installed coding agent, so you can start prompting and editing it:
 
 ```bash npm2yarn

--- a/docs/src/content/en/docs/index.mdx
+++ b/docs/src/content/en/docs/index.mdx
@@ -21,6 +21,8 @@ Mastra is a TypeScript framework for building AI agents and applications. Create
 
 ## Quickstart
 
+I hope this helps with stuff. despite its challenges.
+
 Run this command to create a general-purpose agent harness with a local workspace, shell tools, memory, task tracking, web access, and recurring schedules. It also installs Mastra skills for your installed coding agent, so you can start prompting and editing it:
 
 ```bash npm2yarn

--- a/docs/src/content/en/docs/long-running-agents/durable-agents.mdx
+++ b/docs/src/content/en/docs/long-running-agents/durable-agents.mdx
@@ -259,7 +259,7 @@ Recovery re-runs the agentic loop from the last snapshot, which re-issues LLM ca
 
 ### Manual recovery
 
-If you need finer control — for example gating recovery behind a leader election or running it on a schedule — call the methods directly:
+If you need finer control, such as gating recovery behind a leader election or running it on a schedule, call the methods directly:
 
 ```typescript
 // Recover all durable agents
@@ -275,7 +275,7 @@ await durableAgent.recoverActiveRuns({ runId: 'run-abc-123' })
 
 ### Multi-instance deployments
 
-There is no distributed lease or lock yet. In multi-replica deployments, every replica that starts with `recovery.durableAgents: 'auto'` will race to recover the same runs. For now, either gate recovery behind your own leader election or run it from a single replica.
+Mastra doesn't provide a distributed lease or lock yet. In multi-replica deployments, every replica that starts with `recovery.durableAgents: 'auto'` will race to recover the same runs. For now, either gate recovery behind your own leader election or run it from a single replica.
 
 ## Related
 

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -417,7 +417,7 @@ Example: An agent using Playwright MCP might see 50,000+ tokens per page snapsho
 
 When observations exceed their threshold (default: 40,000 tokens), the Reflector condenses them and combines related items, plus reflects on patterns.
 
-Reflections don't accumulate as a separate, ever-growing layer. Each reflection rewrites the entire observation log: the Reflector's output becomes the new log, and new observations append after it. When the log next hits the threshold, the Reflector re-processes everything — including earlier reflections — condensing older information more aggressively while keeping recent detail. Memory stays bounded around the reflection threshold no matter how long the conversation runs.
+Reflections don't accumulate as a separate, ever-growing layer. Each reflection rewrites the entire observation log. The Reflector's output becomes the new log, and new observations append after it. When the log next hits the threshold, the Reflector re-processes everything, including earlier reflections. It condenses older information more aggressively while keeping recent detail. Memory stays bounded around the reflection threshold no matter how long the conversation runs.
 
 The result is a three-tier system:
 
@@ -425,7 +425,7 @@ The result is a three-tier system:
 1. **Observations**: A log of what the Observer has seen
 1. **Reflections**: Condensed observations when memory becomes too long
 
-### Context over time
+### How context changes over time
 
 With default settings, the context window doesn't grow unbounded. It oscillates through an observe-and-shrink cycle:
 
@@ -434,11 +434,11 @@ With default settings, the context window doesn't grow unbounded. It oscillates 
 1. **0 → 30k tokens**: Message history grows normally. In the background, the Observer buffers observations every \~6k tokens (`bufferTokens: 0.2`).
 1. **30k reached**: Buffered observations activate instantly. Observed messages are removed from the context window and only \~6k tokens of recent history remain (`bufferActivation: 0.8` retains 20% of the threshold). The \~24k tokens of removed messages become roughly 1-5k tokens of observations at typical 5-40x compression.
 1. **Repeat**: History grows from \~6k back toward 30k and shrinks again. Each cycle appends to the observation log, which grows much more slowly than raw history.
-1. **Observations reach 40k**: The Reflector condenses the observation log — including any earlier reflections — into a new, smaller log.
+1. **Observations reach 40k**: The Reflector creates a smaller log from the current observations and any earlier reflections.
 
-The result: in the normal buffered cycle, raw history oscillates between roughly 6k and 30k tokens and the observation log stays around 40k tokens, however long the conversation runs. These are activation thresholds rather than hard caps — if background buffering falls behind, history can grow past the threshold until `blockAfter` (default `1.2`) forces a synchronous observation at \~36k tokens (\~48k for reflection) as a safety ceiling.
+In the normal buffered cycle, raw history oscillates between roughly 6k and 30k tokens. The observation log stays around 40k tokens, however long the conversation runs. These are activation thresholds rather than hard caps. If background buffering doesn't keep pace, history can grow past the threshold until `blockAfter` (default `1.2`) forces a synchronous observation at \~36k tokens (\~48k for reflection) as a safety ceiling.
 
-With [`shareTokenBudget`](/reference/memory/observational-memory#shared-token-budget) enabled, the two budgets pool together: while the observation log is small, message history can expand into the unused observation space (up to \~70k tokens with the defaults) before observation triggers, then shrinks back as observations accumulate.
+With [`shareTokenBudget`](/reference/memory/observational-memory#shared-token-budget) enabled, the two budgets pool together. While the observation log is small, message history can expand into the unused observation space (up to \~70k tokens with the defaults) before observation triggers. It then shrinks as observations accumulate.
 
 ### Retrieval mode
 

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -170,7 +170,7 @@ See [Observational Memory](../memory/observational-memory) for details on how ob
 
 ## What the model sees
 
-Each memory feature lands in one of two places in the request sent to the model: the system messages or the conversation messages. Which layers are present depends on which features you've enabled — working memory, semantic recall, and Observational Memory only appear when configured, while message history is on by default. The diagram shows where each enabled layer is placed in the request; the list below describes what each layer contributes:
+Each memory feature is added to either the system messages or the conversation messages in the request sent to the model. The layers depend on the features you've enabled. Working memory and semantic recall only appear when configured. The same applies to Observational Memory, while message history is on by default. The diagram shows where each enabled layer is placed in the request. The list below describes what each layer contributes:
 
 <MemoryContextWindowImage />
 

--- a/docs/src/content/en/docs/what-is-mastra.mdx
+++ b/docs/src/content/en/docs/what-is-mastra.mdx
@@ -1,15 +1,15 @@
 ---
-title: 'What is Mastra?'
+title: "What's Mastra?"
 description: 'Learn what Mastra is: an open-source TypeScript framework for building everything from AI-powered applications to autonomous AI systems.'
 packages:
   - '@mastra/core'
 ---
 
-# What is Mastra?
+# What's Mastra?
 
-Mastra is an open-source TypeScript framework for building AI applications and autonomous AI systems. Use it for anything from an AI feature inside an existing product to long-running agents that run entire processes on their own, such as a software factory that plans, builds, reviews, and ships code.
+Mastra is an open-source TypeScript framework for building AI applications and autonomous AI systems. Use it for anything from an AI feature inside an existing product to long-running agents that run entire processes on their own, such as a software factory that plans, builds, reviews, and releases code.
 
-Mastra gives you everything you need to build an agent harness out of the box. It's built on established patterns, so you make fewer integration decisions and spend more time on your product. And, as you'd expect from an AI framework, it includes a [skill and CLI](/docs/getting-started/build-with-ai) that help your coding agent write accurate, up-to-date Mastra code.
+Mastra gives you everything you need to build an agent harness out of the box. It's built on established patterns, so you make fewer integration decisions and spend more time on your product. It also includes a [skill and CLI](/docs/getting-started/build-with-ai) that help your coding agent write accurate, up-to-date Mastra code.
 
 Run Mastra standalone or inside your existing web server, and call your agents from your own code, over HTTP using the [Mastra client](/docs/server/mastra-client), or from channels (for example, Slack).
 
@@ -38,10 +38,10 @@ export const supportAgent = new Agent({
 
 Then add the capabilities your agent needs:
 
-- **Act in real environments**: Use [workspaces](/docs/workspace/overview) so agents can read and write files, run commands, and work inside a sandbox.
+- **Act in real environments**: Use [workspaces](/docs/workspace/overview) so agents can read and write files or run commands. They can also work inside a sandbox.
 - **Bring the right context**: Use tools, [memory](/docs/memory/observational-memory), [skills](/docs/agents/skills), and domain knowledge so agents remember what matters and stay within the context window.
 - **Coordinate complex work**: Run typed [workflows](/docs/workflows/overview), [tasks](/docs/agents/using-tools#task-tracking), and [subagents](/docs/agents/supervisor-agents) when work needs multiple steps or parallel execution.
-- **Control the agent loop**: [Suspend](/docs/agents/agent-approval) for human approval, steer an in-flight loop with [signals](/docs/long-running-agents/signals), or queue input for the next turn.
+- **Control the agent loop**: [Suspend](/docs/agents/agent-approval) for human approval or steer an in-flight loop with [signals](/docs/long-running-agents/signals). You can also queue input for the next turn.
 - **Meet users where they work**: Connect agents to Slack, Discord, GitHub, and other [channels](/docs/capabilities/channels/overview).
 - **Manage risk and cost**: Configure authentication, multi-tenant isolation, and [guardrails](/docs/agents/guardrails), including [`CostGuardProcessor`](/reference/processors/cost-guard-processor).
 
@@ -51,13 +51,13 @@ See the left-hand sidebar for the full menu of features.
 
 ![Agents page in Mastra Studio. A sidebar lists primitives like agents, workflows, and tools, a middle panel lists recent chats, and a chat panel shows the agent responding to a prompt with collapsible tool calls and a task list tracking progress. Below the chat is a message box with a model picker.](/img/studio-agent-chat.png)
 
-[Studio](/docs/studio/overview) is usually the first place you go after creating a Mastra app. It gives you a live environment for testing agents, inspecting runs, and iterating quickly.
+[Studio](/docs/studio/overview) is usually the first place you go after creating a Mastra app. It gives you a live environment where you can test agents and inspect runs as you iterate.
 
-Studio isn't just for engineers. Deploy it and share it with your team, so collaborators can try an agent before it ships. With the [Editor](/docs/editor/overview) and [Agent Builder](/docs/agent-builder/overview), non-technical teammates can create and iterate on agents themselves, with every change versioned in code.
+Studio isn't limited to engineers. Deploy it and share it with your team, so collaborators can try an agent before it goes to production. With the [Editor](/docs/editor/overview) and [Agent Builder](/docs/agent-builder/overview), non-technical teammates can create and iterate on agents themselves, with every change versioned in code.
 
 ## Observability and evals
 
-![Traces page in Mastra Studio. A table lists recent agent runs with timestamps and inputs. A details panel shows the selected trace as an expandable tree of model, tool, and workspace spans with per-span timings, plus actions to evaluate the trace or save it as a dataset item.](/img/studio-traces.png)
+![Traces page in Mastra Studio. A table lists recent agent runs with timestamps and inputs. Beside it, a details panel shows the selected trace as an expandable tree of model, tool, and workspace spans with per-span timings, plus actions to evaluate the trace or save it as a dataset item.](/img/studio-traces.png)
 
 Mastra has built-in logs, traces, and metrics, so you can understand every run in development and production. See [Observability](/docs/observability/overview).
 
@@ -68,9 +68,9 @@ Evals close the loop. Score outputs with rule-based or LLM-as-judge [scorers](/d
 Some agents finish in a single request. Others run for hours or days, like a sales agent that watches for signups or an SRE agent that handles incidents. Mastra supports [long-running agents](/docs/long-running-agents/durable-agents) with these capabilities:
 
 - **Survive restarts and disconnects**: [Durable agents](/docs/long-running-agents/durable-agents) persist run state so work resumes and clients reconnect.
-- **Wake and steer agents mid-run**: Send [messages and signals](/docs/long-running-agents/signals) to wake an agent, add context, or queue input.
+- **Wake and steer agents mid-run**: Send [messages and signals](/docs/long-running-agents/signals) to wake an agent or add context. You can also queue input.
 - **Keep working toward a goal**: [Goals](/docs/long-running-agents/goals) persist an objective until it's met or the run budget is spent.
-- **Run work outside the request**: Use [schedules](/docs/long-running-agents/schedules) and [background tasks](/docs/long-running-agents/background-tasks) for recurring jobs, slow tools, and work that shouldn't block the agent loop.
+- **Run work outside the request**: Use [schedules](/docs/long-running-agents/schedules) and [background tasks](/docs/long-running-agents/background-tasks) for recurring jobs or slow tools. They also handle work that shouldn't block the agent loop.
 
 For long-running interactive applications, [AgentController](/docs/agent-controller/overview) manages threads, modes, tool approvals, and model switching. It powers [Mastra Code](https://code.mastra.ai/) and lets you build a Claude Code-style experience for your own domain.
 

--- a/docs/src/content/en/reference/agents/durable-agent.mdx
+++ b/docs/src/content/en/reference/agents/durable-agent.mdx
@@ -274,7 +274,7 @@ const { output, cleanup } = await durableAgent.observe(runId, {
 await output.text
 ```
 
-By default `observe()` waits indefinitely for events. If the process running the run stops unexpectedly, the run stops producing events but never emits a completion event, so the observed stream would wait forever. Pass `idleTimeoutMs` to bound that wait: after that many milliseconds of silence the stream ends. An optional `isAlive` check is consulted first — return `true` while the run is still being worked on (for example a long-running tool call, or a run paused waiting for human input) to keep waiting; returning `false`, or omitting `isAlive`, ends the stream with an error. A transient throw from `isAlive` is treated as "still alive", so a momentary check failure never ends a live stream.
+By default `observe()` waits indefinitely for events. If the process running the run stops unexpectedly, the run stops producing events but never emits a completion event, so the observed stream would wait forever. Pass `idleTimeoutMs` to bound that wait: after that many milliseconds of silence the stream ends. An optional `isAlive` check is consulted first. Return `true` while the run is still being worked on (for example a long-running tool call, or a run paused waiting for human input) to keep waiting. Returning `false`, or omitting `isAlive`, ends the stream with an error. A transient throw from `isAlive` is treated as "still alive", so a momentary check failure never ends a live stream.
 
 ```typescript
 const { output } = await durableAgent.observe(runId, {
@@ -283,7 +283,7 @@ const { output } = await durableAgent.observe(runId, {
 })
 ```
 
-Ending a run on idle timeout runs the same cleanup as a run that errors (see the warning below), so its cached state is released rather than retained. Both options are opt-in; omit them for the previous wait-indefinitely behavior.
+Ending a run on idle timeout runs the same cleanup as a run that errors (see the warning below), so its cached state is released rather than retained. Both options are opt-in. Omit them for the previous wait-indefinitely behavior.
 
 Returns: `Promise<DurableAgentStreamResult>`
 

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -181,7 +181,7 @@ Comma-separated list of custom arguments to pass to the Node.js process, e.g. `-
 
 ## `mastra worker build`
 
-Bundles your Mastra application for worker deployment. Produces the same output as `mastra build` — a self-contained `.mastra/output/` directory.
+Bundles your Mastra application for worker deployment. Produces the same output as `mastra build`: a self-contained `.mastra/output/` directory.
 
 ```bash
 mastra worker build [options]

--- a/docs/src/content/en/reference/core/mastra-class.mdx
+++ b/docs/src/content/en/reference/core/mastra-class.mdx
@@ -393,7 +393,7 @@ Visit the [Configuration reference](/reference/configuration) for detailed docum
 
 Re-drives every orphaned `running` durable-agent run across all registered durable agents. Called automatically on boot when `recovery.durableAgents` is `'auto'`. You can also call it directly for manual recovery or from a scheduled task.
 
-Requires persistent storage — with an in-memory store there is nothing to recover after a process restart.
+Requires persistent storage. With an in-memory store, there's nothing to recover after a process restart.
 
 ```typescript
 const result = await mastra.recoverAllDurableAgents()

--- a/docs/src/content/en/reference/evals/summarization.mdx
+++ b/docs/src/content/en/reference/evals/summarization.mdx
@@ -10,7 +10,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 # Summarization scorer
 
-The `createSummarizationScorer()` function creates a scorer that evaluates a summary on two axes: whether every claim it makes is supported by the source text, and whether it preserves the information the source states. The final score is the lower of the two, so a summary cannot pass by being faithful but empty, or thorough but wrong.
+The `createSummarizationScorer()` function creates a scorer that evaluates a summary on two axes: whether every claim it makes is supported by the source text, and whether it preserves the information the source states. The final score is the lower of the two, so a summary can't pass by being faithful but empty, or thorough but wrong.
 
 The summary is the agent's last message that carries text, and the source text defaults to the first user message of the run input. Pass `source` or `sourceExtractor` when the text being summarized lives somewhere else, such as a tool result.
 
@@ -182,13 +182,13 @@ These ranges assume the default `scale` of 1. When using a custom scale, multipl
 
 - **0.9-1.0**: Excellent summary, faithful to the source and covering its main points
 - **0.7-0.8**: Good summary with a small omission or an unsupported detail
-- **0.4-0.6**: Moderate summary, either missing significant information or drifting from the source
+- **0.4-0.6**: Moderate summary, either missing important information or drifting from the source
 - **0.1-0.3**: Poor summary, most of the source is lost or contradicted
-- **0.0**: The summary supports no claims, answers no questions, or produced nothing to judge
+- **0.0**: The summary produced nothing to judge, or it failed to support any claims. A summary that answers no questions also receives this score
 
 ### Reading the two axes
 
-Both axes leave their verdicts on the run result: the alignment verdicts on the preprocess step, and the coverage verdicts on the analyze step. Each verdict carries the claim or question it belongs to and the reason behind it. The two failure modes look different:
+Both axes leave their verdicts on the run result: the alignment verdicts on the preprocess step, and the coverage verdicts on the analyze step. Each verdict carries the claim or question it belongs to and the reason behind it. A low alignment score has a different meaning from a low coverage score:
 
 - A low alignment score with high coverage means the summary invents or distorts detail
 - A low coverage score with high alignment means the summary is accurate but leaves too much out
@@ -201,7 +201,7 @@ Length plays no part in the score. A summary that repeats the source word for wo
 
 ### Cost
 
-Each evaluation makes three model calls. `maxQuestions` bounds the coverage half of the work, which otherwise grows with source length. Raise it for long documents where ten questions cannot represent the content.
+Each evaluation makes three model calls. `maxQuestions` bounds the coverage half of the work, which otherwise grows with source length. Raise it for long documents where ten questions can't represent the content.
 
 ## Scorer configuration
 

--- a/docs/src/content/en/reference/processors/regex-filter-processor.mdx
+++ b/docs/src/content/en/reference/processors/regex-filter-processor.mdx
@@ -209,7 +209,7 @@ A replacement string can reference capture groups with `$1` or `$&`. Those refer
 
 ## Redaction reporting
 
-The `redact` strategy rewrites text in place, so nothing downstream can tell what changed. Assign `onViolation` to record it. The processor calls it once per redacted message, message part, or stream chunk, and offsets are relative to that piece of text. Async callbacks are awaited, and errors are caught so an unavailable audit sink cannot fail the request.
+The `redact` strategy rewrites text in place, so nothing downstream can tell what changed. Assign `onViolation` to record it. The processor calls it once per redacted message, message part, or stream chunk, and offsets are relative to that piece of text. Async callbacks are awaited, and errors are caught so an unavailable audit sink can't fail the request.
 
 ```typescript
 import { RegexFilterProcessor, type RegexRedactionDetail } from '@mastra/core/processors'

--- a/docs/src/content/en/reference/tools/isolated-vm-transport.mdx
+++ b/docs/src/content/en/reference/tools/isolated-vm-transport.mdx
@@ -23,7 +23,7 @@ Compared to the default `StdioCodeModeTransport`, this transport spawns no proce
 npm install @mastra/isolated-vm
 ```
 
-`isolated-vm` is a native addon. It ships prebuilt binaries for common platforms, so installation usually needs no extra setup. A C++ toolchain is only needed on platforms without a matching prebuild, where it falls back to compiling from source.
+`isolated-vm` is a native addon. It provides prebuilt binaries for common platforms, so installation usually needs no extra setup. A C++ toolchain is only needed on platforms without a matching prebuild, where it falls back to compiling from source.
 
 On Node.js 20 and later, the host process must be started with the `--no-node-snapshot` flag, otherwise creating an isolate crashes the process. The constructor throws an error when the flag is missing. Pass the flag when starting your server, or set it through `NODE_OPTIONS`:
 

--- a/docs/src/content/en/reference/vectors/mongodb.mdx
+++ b/docs/src/content/en/reference/vectors/mongodb.mdx
@@ -177,7 +177,7 @@ Waits for an index to become ready after creation. Useful when you need to ensur
 
 ### `upsert()`
 
-Adds or updates vectors and their metadata in the collection. On a bring-your-own index this requires `allowWrites: true` at `createIndex()` time — BYO collections are read-only by default.
+Adds or updates vectors and their metadata in the collection. On a bring-your-own index, this requires `allowWrites: true` at `createIndex()` time because BYO collections are read-only by default.
 
 <PropertiesTable
   content={[
@@ -280,12 +280,12 @@ Provisions an Atlas Search (BM25/full-text) index on the collection backing an i
 **Managed vs. bring-your-own collections:**
 
 - For a **managed** index (created without `collectionName`), `createIndex()` already provisions a _dynamic_ full-text index named `${collectionName}_search_index` (covering all string fields). `createSearchIndex()` is therefore only needed when you want a **field-restricted** mapping or a **custom index name**.
-- For a **bring-your-own** index (created with `collectionName`), `createIndex()` does **not** auto-create any full-text index — enabling `textQuery()`/`hybridQuery()` on a caller-owned operational collection is **opt-in**. Call `createSearchIndex()` explicitly to provision the (billable) text index; until you do, `textQuery()`/`hybridQuery()` throw a clear error rather than querying a non-existent index.
+- For a **bring-your-own** index (created with `collectionName`), `createIndex()` doesn't auto-create any full-text index. Enabling `textQuery()`/`hybridQuery()` on a caller-owned operational collection is opt-in. Call `createSearchIndex()` explicitly to provision the (billable) text index. Until you do, `textQuery()`/`hybridQuery()` throw a clear error rather than querying a non-existent index.
 
 Naming:
 
-- When `fields` is provided **without** an explicit `searchIndexName`, the field-mapped index is created under a **distinct** default name (`${collectionName}_${indexName}_search_fields_index`, unique per logical index) so it does not collide with — and get silently ignored by — a managed collection's auto-created dynamic index. This distinct index is persisted as the text-search index, so `textQuery()`/`hybridQuery()` use the restricted mapping automatically.
-- When `searchIndexName` is provided, that exact name is used and persisted. `textQuery()`/`hybridQuery()` resolve the persisted name automatically; you can also override the name per call via their `searchIndexName` / `textSearchIndexName` parameters.
+- When `fields` is provided **without** an explicit `searchIndexName`, the field-mapped index is created under a **distinct** default name (`${collectionName}_${indexName}_search_fields_index`, unique per logical index) so it doesn't collide with a managed collection's auto-created dynamic index and get silently ignored. This distinct index is persisted as the text-search index, so `textQuery()`/`hybridQuery()` use the restricted mapping automatically.
+- When `searchIndexName` is provided, that exact name is used and persisted. `textQuery()`/`hybridQuery()` resolve the persisted name automatically. You can also override the name per call via their `searchIndexName` / `textSearchIndexName` parameters.
 
 <PropertiesTable
   content={[
@@ -327,7 +327,7 @@ await store.createSearchIndex({
 })
 ```
 
-> **Note:** The field-mapped index name includes the logical `indexName`, so two logical indexes on the same collection get distinct text indexes. Recreating the _same_ logical index with different `fields` still requires dropping the existing index first (`IndexAlreadyExists`).
+The field-mapped index name includes the logical `indexName`, so two logical indexes on the same collection get distinct text indexes. Recreating the _same_ logical index with different `fields` still requires dropping the existing index first (`IndexAlreadyExists`).
 
 ### `waitForSearchIndexReady()`
 
@@ -372,7 +372,7 @@ await store.waitForSearchIndexReady({ indexName: 'precedents' })
 
 Runs a full-text (BM25) search against an Atlas Search index. By default it targets the text-search index recorded for this index (set by `createSearchIndex()`, or the dynamic `${collectionName}_search_index` auto-created by `createIndex()`). Pass `searchIndexName` to target a specific index for this call.
 
-**Note:** metadata filters here (like `hybridQuery()`) are applied via a `$match` stage. For the vector branch of `hybridQuery()`, filters on fields not declared via `filterFields` at index creation are transparently materialised as candidate `_id`s (the same fallback `query()` uses), so undeclared-field filters do not error.
+Metadata filters here (like `hybridQuery()`) are applied via a `$match` stage. For the vector branch of `hybridQuery()`, filters on fields not declared via `filterFields` at index creation are transparently materialised as candidate `_id`s (the same fallback `query()` uses), so undeclared-field filters don't error.
 
 <PropertiesTable
   content={[
@@ -433,7 +433,7 @@ const results = await store.textQuery({
 
 ### `hybridQuery()`
 
-Runs a hybrid search that fuses vector similarity and full-text results using MongoDB's server-side `$rankFusion` (requires MongoDB >= 8.0; generally available from 8.1, and on 8.0.x it may need a MongoDB support case to enable — it runs where enabled, e.g. Atlas 8.0.x). A full-text search index must exist: it is auto-created for managed indexes, but for a bring-your-own collection you must call `createSearchIndex()` first (opt-in).
+Runs a hybrid search that fuses vector similarity and full-text results using MongoDB's server-side `$rankFusion`. It requires MongoDB >= 8.0 and is generally available from 8.1. On 8.0.x, it may need a MongoDB support case to enable, and it runs where enabled, such as Atlas 8.0.x. A full-text search index must exist: it's auto-created for managed indexes, but for a bring-your-own collection you must call `createSearchIndex()` first (opt-in).
 
 <PropertiesTable
   content={[
@@ -512,7 +512,7 @@ const results = await store.hybridQuery({
 })
 ```
 
-**Note:** `hybridQuery()` requires MongoDB >= 8.0 for the `$rankFusion` stage (generally available from 8.1; on 8.0.x it may need a MongoDB support case to enable, and runs where enabled, such as Atlas 8.0.x). If you're running an older version, or `$rankFusion` is not enabled on your 8.0.x deployment, use `query()` and `textQuery()` separately and merge the results client-side.
+`hybridQuery()` requires MongoDB >= 8.0 for the `$rankFusion` stage. The stage is generally available from 8.1. On 8.0.x, it may need a MongoDB support case to enable and runs where enabled, such as Atlas 8.0.x. If you're running an older version, or `$rankFusion` isn't enabled on your 8.0.x deployment, use `query()` and `textQuery()` separately and merge the results client-side.
 
 ### `describeIndex()`
 
@@ -543,9 +543,9 @@ interface IndexStats {
 Deletes a vector index. Behavior depends on how the index was created:
 
 - **Managed index** (created without `collectionName`): drops the entire collection and all its data.
-- **Bring-your-own index** (created with `collectionName`): drops the Atlas vectorSearch index **and**, if one was provisioned via `createSearchIndex()`, the companion full-text search index. The caller's operational collection and its documents are **preserved** — this store never drops a collection it did not create.
+- **Bring-your-own index** (created with `collectionName`): drops the Atlas vectorSearch index and, if one was provisioned via `createSearchIndex()`, the companion full-text search index. The caller's operational collection and its documents are preserved. This store never drops a collection it didn't create.
 
-The BYO classification is recorded durably when the index is created, so it is applied correctly even by a different process (e.g. an index created by a setup job and later deleted by a long-lived service). Always pass the **logical index name** (the `indexName` used at `createIndex`), not the physical collection name.
+The BYO classification is recorded durably when the index is created, so it's applied correctly even by a different process (e.g. an index created by a setup job and later deleted by a long-lived service). Always pass the **logical index name** (the `indexName` used at `createIndex`), not the physical collection name.
 
 <PropertiesTable
   content={[
@@ -559,7 +559,7 @@ The BYO classification is recorded durably when the index is created, so it is a
 
 ### `listIndexes()`
 
-Lists the **logical** Mastra index names (the `indexName` values passed to `createIndex`), not physical collection names. For a bring-your-own index whose data lives in an operational collection, the logical index name is returned — never the physical collection name — so the value can be passed straight back into `deleteIndex()` / `describeIndex()`. Managed indexes created before durable metadata was introduced are still discovered via their `${name}_vector_index` search index. The internal registry collection is never listed.
+Lists the **logical** Mastra index names (the `indexName` values passed to `createIndex`), not physical collection names. For a bring-your-own index whose data lives in an operational collection, the logical index name is returned instead of the physical collection name. The value can be passed straight back into `deleteIndex()` / `describeIndex()`. Managed indexes created before durable metadata was introduced are still discovered via their `${name}_vector_index` search index. The internal registry collection is never listed.
 
 Returns: `Promise<string[]>`
 
@@ -737,12 +737,12 @@ await store.createSearchIndex({ indexName: 'precedents', fields: ['note'] })
 
 - The collection must already exist and contain documents with an `embedding` field (or the custom `embeddingFieldPath` you configured)
 - The collection is never created or dropped when using `collectionName`
-- **A BYO index is read-only by default.** `upsert()`, `updateVector()`, `deleteVector()`, and `deleteVectors()` throw a clear error rather than mutating caller-owned operational documents. To let the store write embeddings into (or delete documents from) your collection, opt in explicitly with `createIndex({ ..., allowWrites: true })`. The policy is persisted and survives restarts; entries written by older versions without the flag are treated as read-only (fail closed).
+- **A BYO index is read-only by default.** `upsert()`, `updateVector()`, `deleteVector()`, and `deleteVectors()` throw a clear error rather than mutating caller-owned operational documents. To let the store write embeddings into (or delete documents from) your collection, opt in explicitly with `createIndex({ ..., allowWrites: true })`. The policy is persisted and survives restarts. Entries written by older versions without the flag are treated as read-only (fail closed).
 - Use `metadataMode: 'document'` when querying to retrieve the full source document as `metadata`
 - In `'document'` mode the embedding is omitted from `metadata` by default; pass `includeVector: true` to retain it (and also expose it as a top-level `vector`)
 - **Filtering in `'document'` mode operates on root document fields**, not a nested `metadata.` subdocument. `filter: { lane: 'fraud' }` matches the top-level `lane` field of your operational documents (in the default `'field'` mode, bare fields are rewritten to `metadata.<field>` for managed collections). Both the pushdown and `$match` fallback paths honor this.
 - **Native `ObjectId` `_id`s are supported.** Operational collections commonly key on `ObjectId`; query results coerce `_id` to a string (the `QueryResult.id` contract), and `deleteVector()`/`updateVector()`/`deleteVectors()` accept that string and match the underlying `ObjectId` document. Managed collections (string `_id`s) are unaffected.
-- Full-text and hybrid search on a BYO collection are **opt-in**: no full-text index is auto-created, so call `createSearchIndex()` before `textQuery()`/`hybridQuery()`. The full-text index builds asynchronously — call `waitForSearchIndexReady()` (or pass `waitUntilReady: true`) before an immediate text/hybrid query.
+- Full-text and hybrid search on a BYO collection are **opt-in**: no full-text index is auto-created, so call `createSearchIndex()` before `textQuery()`/`hybridQuery()`. The full-text index builds asynchronously. Call `waitForSearchIndexReady()` (or pass `waitUntilReady: true`) before an immediate text/hybrid query.
 - `deleteIndex()` on a BYO index drops the vector index (and the text index if one was created) but **preserves** the collection and its documents
 
 ## Best practices


### PR DESCRIPTION
## Description

Enable Vale linting in CI. Adjust agent instructions so it also runs locally.

<img width="1450" height="759" alt="CleanShot 2026-07-31 at 11 53 58" src="https://github.com/user-attachments/assets/bd97b0ea-71b7-45af-ab90-870758e71d6c" />
<img width="754" height="684" alt="CleanShot 2026-07-31 at 11 54 10" src="https://github.com/user-attachments/assets/6ef5e6c9-dd34-4e50-889f-aa429a307ce4" />


## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds Vale documentation checks to CI. It also updates contributor instructions so developers can run the same checks locally and improves documentation wording.

## Changes

- Added Vale linting with Reviewdog to the documentation CI workflow.
- Added setup and local validation instructions for Vale and `mdx2vast`.
- Updated Vale file matching for English documentation.
- Replaced Prettier guidance with `oxfmt-mdx`.
- Added checks for broken links, code examples, and sidebar ordering.
- Updated documentation wording, formatting, and technical details across agent, deployment, memory, evals, reference, and vector-store pages.

## Testing

- No tests were added.
- Documentation linting now fails CI when Vale reports errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->