### PR TITLE
fix(deployer-vercel): keep custom api routes reachable with studio

### DIFF
--- a/.changeset/late-houses-hug.md
+++ b/.changeset/late-houses-hug.md
@@ -19,4 +19,4 @@ export const mastra = new Mastra({
 
 `POST /my/webhook` now returns `{"ok":true}` instead of Studio's `index.html`.
 
-This also fixes Studio deployments that set a custom `server.apiPrefix`, which previously lost the entire built-in API to the same fallback.
+Requests to a custom `server.apiPrefix` now reach your server too, instead of being answered with the Studio page. Studio's own UI still calls `/api`, so pointing Studio at a custom prefix is not supported yet.

--- a/.changeset/late-houses-hug.md
+++ b/.changeset/late-houses-hug.md
@@ -1,0 +1,22 @@
+---
+'@mastra/deployer-vercel': patch
+---
+
+Fixed custom API routes being unreachable when deploying to Vercel with `studio: true`.
+
+Routes registered with `registerApiRoute()` are mounted at the root of the server, but the generated Vercel route table only forwarded `/api/*` and `/health` to your app. Every other path fell through to Studio's `index.html`, so a request to a custom route returned the Studio HTML page and the handler never ran. Moving the route under `/api` was not an option either, since that prefix is reserved for built-in routes.
+
+The route table now serves the paths Studio owns from the CDN and sends everything else to your server, so custom routes behave the same as they do with `mastra dev` and `studio: false`. Studio and its assets are still served as static files with no function invocations.
+
+```ts
+export const mastra = new Mastra({
+  deployer: new VercelDeployer({ studio: true }),
+  server: {
+    apiRoutes: [registerApiRoute('/my/webhook', { method: 'POST', handler: c => c.json({ ok: true }) })],
+  },
+});
+```
+
+`POST /my/webhook` now returns `{"ok":true}` instead of Studio's `index.html`.
+
+This also fixes Studio deployments that set a custom `server.apiPrefix`, which previously lost the entire built-in API to the same fallback.

--- a/deployers/vercel/src/index.ts
+++ b/deployers/vercel/src/index.ts
@@ -44,13 +44,17 @@ export class VercelDeployer extends Deployer {
   async prepare(outputDirectory: string): Promise<void> {
     await super.prepare(outputDirectory);
 
-    this.writeVercelJSON(join(outputDirectory, this.outputDir, '..', '..'));
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const studioSource = join(dirname(__dirname), 'dist', 'studio');
+
+    this.writeVercelJSON(
+      join(outputDirectory, this.outputDir, '..', '..'),
+      this.studio ? this.readStudioRouteRoots(studioSource) : [],
+    );
 
     if (this.studio) {
-      const __filename = fileURLToPath(import.meta.url);
-      const __dirname = dirname(__filename);
-
-      const studioSource = join(dirname(__dirname), 'dist', 'studio');
       const staticDir = join(outputDirectory, '.vercel', 'output', 'static');
 
       try {
@@ -62,6 +66,27 @@ export class VercelDeployer extends Deployer {
       }
 
       this.injectStudioConfig(staticDir);
+    }
+  }
+
+  /**
+   * Studio's top-level route segments, emitted by the Studio build alongside index.html.
+   * The Vercel route table needs them explicitly: custom `registerApiRoute()` paths are mounted
+   * at the root of the server, so the function has to own every path Studio doesn't claim.
+   */
+  private readStudioRouteRoots(studioSource: string): string[] {
+    const manifestPath = join(studioSource, 'routes-manifest.json');
+
+    try {
+      const roots = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+      if (!Array.isArray(roots) || roots.some(root => typeof root !== 'string')) {
+        throw new Error('expected an array of route segments');
+      }
+      return roots;
+    } catch (err) {
+      throw new Error(
+        `Failed to read studio routes manifest at "${manifestPath}": ${err instanceof Error ? err.message : err}`,
+      );
     }
   }
 
@@ -120,10 +145,10 @@ export const HEAD = handle(app);
     writeFileSync(indexPath, html);
   }
 
-  private writeVercelJSON(outputDirectory: string) {
+  private writeVercelJSON(outputDirectory: string, studioRouteRoots: string[]) {
     writeFileSync(
       join(outputDirectory, 'config.json'),
-      JSON.stringify({ version: 3, routes: getVercelRoutes({ studio: this.studio }) }),
+      JSON.stringify({ version: 3, routes: getVercelRoutes({ studio: this.studio, studioRouteRoots }) }),
     );
   }
 

--- a/deployers/vercel/src/routes.test.ts
+++ b/deployers/vercel/src/routes.test.ts
@@ -2,17 +2,42 @@ import { describe, expect, it } from 'vitest';
 import { getVercelRoutes } from './routes';
 
 describe('getVercelRoutes', () => {
-  const findRouteIndex = (
-    routes: ReturnType<typeof getVercelRoutes>,
-    predicate: (route: ReturnType<typeof getVercelRoutes>[number]) => boolean,
-  ) => {
+  const studioRouteRoots = ['agents', 'agent-builder', 'workflows'];
+
+  type Routes = ReturnType<typeof getVercelRoutes>;
+
+  const findRouteIndex = (routes: Routes, predicate: (route: Routes[number]) => boolean) => {
     const index = routes.findIndex(predicate);
     expect(index).toBeGreaterThanOrEqual(0);
     return index;
   };
 
+  /**
+   * Mirrors Vercel's Build Output API route matching: sources are checked in order, and the
+   * routes after `handle: filesystem` only apply once the static filesystem misses.
+   * https://vercel.com/docs/build-output-api/configuration
+   */
+  const resolve = (routes: Routes, path: string) => {
+    const filesystemIndex = routes.findIndex(route => 'handle' in route);
+    const phases = [
+      routes.slice(0, filesystemIndex === -1 ? routes.length : filesystemIndex),
+      routes.slice(filesystemIndex + 1),
+    ];
+
+    for (const phase of phases) {
+      for (const route of phase) {
+        if (!('src' in route)) continue;
+        if (new RegExp(route.src).test(path)) {
+          return route.dest === '/' ? 'function' : route.dest;
+        }
+      }
+    }
+
+    return 'filesystem';
+  };
+
   it('routes the studio root to the static index before filesystem matching', () => {
-    const routes = getVercelRoutes({ studio: true });
+    const routes = getVercelRoutes({ studio: true, studioRouteRoots });
     const rootIndex = findRouteIndex(
       routes,
       route => 'src' in route && route.src === '^/$' && route.dest === '/index.html',
@@ -22,14 +47,61 @@ describe('getVercelRoutes', () => {
     expect(rootIndex).toBeLessThan(filesystemIndex);
   });
 
-  it('keeps server endpoints routed to the function before filesystem matching', () => {
-    const routes = getVercelRoutes({ studio: true });
+  it('serves studio SPA routes from the static index', () => {
+    const routes = getVercelRoutes({ studio: true, studioRouteRoots });
+
+    for (const path of ['/agents', '/agents/weather-agent/chat', '/agent-builder', '/workflows']) {
+      expect(resolve(routes, path)).toBe('/index.html');
+    }
+  });
+
+  it('routes custom api routes to the function instead of the studio SPA', () => {
+    const routes = getVercelRoutes({ studio: true, studioRouteRoots });
+
+    for (const path of ['/my/webhook', '/inngest/api', '/chat']) {
+      expect(resolve(routes, path)).toBe('function');
+    }
+  });
+
+  it('keeps server endpoints routed to the function', () => {
+    const routes = getVercelRoutes({ studio: true, studioRouteRoots });
+
+    for (const path of ['/api/agents', '/health']) {
+      expect(resolve(routes, path)).toBe('function');
+    }
+  });
+
+  it('routes a non-default apiPrefix to the function', () => {
+    const routes = getVercelRoutes({ studio: true, studioRouteRoots });
+
+    expect(resolve(routes, '/mastra/agents')).toBe('function');
+  });
+
+  it('leaves static assets to filesystem matching', () => {
+    const routes = getVercelRoutes({ studio: true, studioRouteRoots });
     const filesystemIndex = findRouteIndex(routes, route => 'handle' in route && route.handle === 'filesystem');
 
-    for (const src of ['/api/(.*)', '/health']) {
-      const routeIndex = findRouteIndex(routes, route => 'src' in route && route.src === src && route.dest === '/');
-      expect(routeIndex).toBeLessThan(filesystemIndex);
+    for (const path of ['/assets/index-egSSWNcT.js', '/mastra.svg']) {
+      const matchedBeforeFilesystem = routes
+        .slice(0, filesystemIndex)
+        .some(route => 'src' in route && new RegExp(route.src).test(path));
+
+      expect(matchedBeforeFilesystem).toBe(false);
     }
+  });
+
+  it('escapes regex characters in studio route segments', () => {
+    const routes = getVercelRoutes({ studio: true, studioRouteRoots: ['a.b'] });
+
+    expect(resolve(routes, '/a.b')).toBe('/index.html');
+    expect(resolve(routes, '/axb')).toBe('function');
+  });
+
+  it('sends everything to the function when no studio routes are known', () => {
+    const routes = getVercelRoutes({ studio: true, studioRouteRoots: [] });
+
+    expect(resolve(routes, '/my/webhook')).toBe('function');
+    expect(resolve(routes, '/')).toBe('/index.html');
   });
 
   it('routes all requests to the function when studio is disabled', () => {

--- a/deployers/vercel/src/routes.ts
+++ b/deployers/vercel/src/routes.ts
@@ -1,15 +1,26 @@
 type VercelRoutesOptions = {
   studio: boolean;
+  /** Studio's top-level route segments, read from the Studio build's routes-manifest.json. */
+  studioRouteRoots?: string[];
 };
 
-export function getVercelRoutes({ studio }: VercelRoutesOptions) {
-  return studio
-    ? [
-        { src: '^/$', dest: '/index.html' },
-        { src: '/api/(.*)', dest: '/' },
-        { src: '/health', dest: '/' },
-        { handle: 'filesystem' as const },
-        { src: '/(.*)', dest: '/index.html', check: true },
-      ]
-    : [{ src: '/(.*)', dest: '/' }];
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export function getVercelRoutes({ studio, studioRouteRoots = [] }: VercelRoutesOptions) {
+  if (!studio) {
+    return [{ src: '/(.*)', dest: '/' }];
+  }
+
+  // Studio owns a known set of SPA paths; everything else belongs to the server function.
+  // The function has to be the catch-all because custom `registerApiRoute()` paths are mounted
+  // at the root of the server (never under `apiPrefix`), so the CDN cannot tell them apart from
+  // an unknown path — an SPA catch-all would swallow every one of them.
+  const spaRoots = studioRouteRoots.map(escapeRegExp).join('|');
+
+  return [
+    { src: '^/$', dest: '/index.html' },
+    ...(spaRoots ? [{ src: `^/(?:${spaRoots})(?:/.*)?$`, dest: '/index.html' }] : []),
+    { handle: 'filesystem' as const },
+    { src: '/(.*)', dest: '/' },
+  ];
 }

--- a/docs/src/content/en/guides/deployment/vercel.mdx
+++ b/docs/src/content/en/guides/deployment/vercel.mdx
@@ -95,6 +95,8 @@ export const mastra = new Mastra({
 
 After deploying, Studio is available at the root URL (`https://<your-project>.vercel.app/`) and the API remains at `/api/*`. Studio automatically connects to the API on the same origin, so you don't need additional environment variables.
 
+Studio serves its own pages from the CDN, and every other path goes to your server, so routes you add with [`registerApiRoute()`](/docs/server/custom-api-routes) stay reachable at their own paths. Avoid giving a custom route a path that Studio already uses (for example `/agents` or `/workflows`), since Studio claims those first.
+
 :::warning
 Once Studio is connected to your Mastra server, it has full access to your agents, workflows, and tools. Be sure to secure it properly in production (e.g. behind authentication, VPN, etc.) to prevent unauthorized access.
 :::


### PR DESCRIPTION
## Description

`VercelDeployer({ studio: true })` made every route registered with `registerApiRoute()` unreachable. The generated Vercel route table forwarded only `/api/*` and `/health` to the server function and sent everything else to Studio's `index.html`, so custom routes were served the Studio HTML page and their handlers never ran. Moving a route under `/api` was not a workaround either, since `validateCustomRoutePaths()` reserves that prefix and throws at startup — there was no path that satisfied both constraints.

The route table now enumerates the paths Studio owns and makes the server function the catch-all, so custom routes respond exactly as they do with `mastra dev` and `studio: false`.

- Inverted the studio route table in `getVercelRoutes()`: `^/$` and the Studio route roots rewrite to `/index.html`, then `handle: filesystem`, then `/(.*)` to the function
- Read Studio's top-level route segments from `routes-manifest.json`, which the Studio build already emits alongside `index.html` (added in #15152 and unused until now)
- Dropped the hardcoded `/api` literal, so requests to a custom `server.apiPrefix` reach the function instead of the Studio page — those previously lost the entire built-in API to the same fallback. Note this covers routing only: `injectStudioConfig()` still injects a hardcoded `'/api'`, so Studio's own UI cannot target a custom prefix yet. Threading the real prefix through needs `getServerOptions()`, which requires the entry file that only `bundle()` receives, so it is left as a follow-up rather than a lifecycle refactor here
- Reworked `routes.test.ts` to resolve paths through Vercel's documented phase matching instead of asserting array positions, so the tests cover routing outcomes
- `studio: false` output is unchanged

Verified against a real `mastra build`: `POST /my/webhook` returns `{"ok":true}` (previously `text/html`), while `/`, Studio pages and hashed assets are still served as static files with no function invocations.

## Related Issue(s)

Fixes #20511

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When Studio is enabled, custom routes now reach their handlers instead of showing Studio’s page. Studio pages and static files continue to work, including deployments with a custom API prefix.

## Changes

- Reworked Vercel routing to:
  - Rewrite the root and known Studio route roots to `/index.html`.
  - Serve matching files from the filesystem.
  - Forward all remaining paths to the server function.
- Read Studio route roots from `routes-manifest.json`.
- Support custom `server.apiPrefix` values by removing the hardcoded `/api` fallback.
- Preserve `studio: false` behavior.
- Document route precedence and conflicts with Studio paths.
- Add tests for custom routes, Studio pages, static assets, SPA routes, custom API prefixes, regex escaping, and empty route configurations.
- Add a patch changeset for `@mastra/deployer-vercel`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
