### PR TITLE
fix(core): reuse terminal nested snapshots on parallel restart

### DIFF
--- a/.changeset/calm-parallel-nested-restart.md
+++ b/.changeset/calm-parallel-nested-restart.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed boot-time recovery so nested workflows that already finished inside a parent `.parallel()` are reused instead of restarted. Parent `activeStepsPath` can still list completed children after a crash; restarting those terminal snapshots no longer throws "This workflow run was not active". Fixes https://github.com/mastra-ai/mastra/issues/20225
+Fixed boot-time recovery so nested workflows that already finished inside a parent `.parallel()` are reused instead of restarted. Parent `activeStepsPath` can still list completed children after a crash; restarting those terminal snapshots no longer throws "This workflow run was not active". As part of this, calling `restart()` on a run whose snapshot is already `success`, `failed`, or `tripwire` now returns the stored result without re-executing any steps (it previously threw). Fixes https://github.com/mastra-ai/mastra/issues/20225

--- a/.changeset/calm-parallel-nested-restart.md
+++ b/.changeset/calm-parallel-nested-restart.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed boot-time recovery so nested workflows that already finished inside a parent `.parallel()` are reused instead of restarted. Parent `activeStepsPath` can still list completed children after a crash; restarting those terminal snapshots no longer throws "This workflow run was not active". Fixes https://github.com/mastra-ai/mastra/issues/20225

--- a/packages/core/src/workflows/parallel-nested-restart.test.ts
+++ b/packages/core/src/workflows/parallel-nested-restart.test.ts
@@ -258,6 +258,10 @@ describe('parallel nested workflow restart recovery (issue #20225)', () => {
             status: 'success',
             output: { done: true },
             endedAt: Date.now(),
+            // Internal bookkeeping that fmtReturnValue strips from live results —
+            // the reconstructed terminal result must strip it too.
+            __state: { internal: true },
+            metadata: { nestedRunId: 'internal-nested-run-id', userField: 'kept' },
           },
         },
         serializedStepGraph: (workflow as any).serializedStepGraph,
@@ -274,5 +278,10 @@ describe('parallel nested workflow restart recovery (issue #20225)', () => {
     expect(result.status).toBe('success');
     expect(result).toMatchObject({ status: 'success', result: { done: true } });
     expect(mockStep).toHaveBeenCalledTimes(0);
+
+    // Reconstructed steps must strip internal bookkeeping, matching fmtReturnValue.
+    const doneStep = result.steps['done-step'] as Record<string, unknown>;
+    expect(doneStep).not.toHaveProperty('__state');
+    expect(doneStep.metadata).toEqual({ userField: 'kept' });
   });
 });

--- a/packages/core/src/workflows/parallel-nested-restart.test.ts
+++ b/packages/core/src/workflows/parallel-nested-restart.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Regression for https://github.com/mastra-ai/mastra/issues/20225
+ *
+ * Boot-time recovery of a parent `.parallel([nested…])` must treat terminal
+ * child snapshots as authoritative. Parent activeStepsPath can still list
+ * completed branches as running after a crash; restarting those children
+ * previously threw "This workflow run was not active".
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage/mock';
+import { createWorkflow } from './create';
+import { createStep } from './workflow';
+
+describe('parallel nested workflow restart recovery (issue #20225)', () => {
+  it('reuses terminal nested parallel branches on parent restart', async () => {
+    const storage = new MockStore();
+    const mastra = new Mastra({ logger: false, storage });
+
+    const inputSchema = z.object({ value: z.string() });
+    const outputSchema = z.object({ branch: z.string(), value: z.string() });
+
+    const mockFastA = vi.fn().mockResolvedValue({ branch: 'fastBranchA', value: 'repro' });
+    const mockSlow = vi.fn().mockResolvedValue({ branch: 'slowBranch', value: 'repro' });
+    const mockFastC = vi.fn().mockResolvedValue({ branch: 'fastBranchC', value: 'repro' });
+
+    const makeBranch = (id: string, execute: typeof mockFastA) => {
+      const step = createStep({
+        id: `${id}Step`,
+        execute,
+        inputSchema,
+        outputSchema,
+      });
+      return createWorkflow({
+        id,
+        inputSchema,
+        outputSchema,
+        steps: [step],
+      })
+        .then(step)
+        .commit();
+    };
+
+    const fastBranchA = makeBranch('fastBranchA', mockFastA);
+    const slowBranch = makeBranch('slowBranch', mockSlow);
+    const fastBranchC = makeBranch('fastBranchC', mockFastC);
+
+    const parentWorkflow = createWorkflow({
+      id: 'parallelNestedParent',
+      inputSchema,
+      outputSchema: z.any(),
+    })
+      .parallel([fastBranchA, slowBranch, fastBranchC])
+      .commit();
+
+    parentWorkflow.__registerMastra(mastra);
+    fastBranchA.__registerMastra(mastra);
+    slowBranch.__registerMastra(mastra);
+    fastBranchC.__registerMastra(mastra);
+
+    const workflowsStore = await storage.getStore('workflows');
+    expect(workflowsStore).toBeTruthy();
+
+    const runId = `parallel-nested-recovery-${Date.now()}`;
+    const startedAt = Date.now();
+    const input = { value: 'repro' };
+
+    // Parent crash window: every parallel nested branch still looks active.
+    await workflowsStore!.persistWorkflowSnapshot({
+      workflowName: parentWorkflow.id,
+      runId,
+      snapshot: {
+        runId,
+        status: 'running',
+        activePaths: [0],
+        activeStepsPath: {
+          fastBranchA: [0, 0],
+          slowBranch: [0, 1],
+          fastBranchC: [0, 2],
+        },
+        value: {},
+        context: {
+          input,
+          fastBranchA: {
+            payload: input,
+            startedAt,
+            status: 'running',
+          },
+          slowBranch: {
+            payload: input,
+            startedAt,
+            status: 'running',
+          },
+          fastBranchC: {
+            payload: input,
+            startedAt,
+            status: 'running',
+          },
+        },
+        serializedStepGraph: (parentWorkflow as any).serializedStepGraph,
+        suspendedPaths: {},
+        waitingPaths: {},
+        resumeLabels: {},
+        timestamp: Date.now(),
+      },
+    });
+
+    const fastResultA = { branch: 'fastBranchA', value: 'repro' };
+    const fastResultC = { branch: 'fastBranchC', value: 'repro' };
+
+    await workflowsStore!.persistWorkflowSnapshot({
+      workflowName: fastBranchA.id,
+      runId,
+      snapshot: {
+        runId,
+        status: 'success',
+        result: fastResultA,
+        activePaths: [],
+        activeStepsPath: {},
+        value: {},
+        context: {
+          input,
+          fastBranchAStep: {
+            payload: input,
+            startedAt,
+            status: 'success',
+            output: fastResultA,
+            endedAt: startedAt + 150,
+          },
+        },
+        serializedStepGraph: (fastBranchA as any).serializedStepGraph,
+        suspendedPaths: {},
+        waitingPaths: {},
+        resumeLabels: {},
+        timestamp: Date.now(),
+      },
+    });
+
+    await workflowsStore!.persistWorkflowSnapshot({
+      workflowName: fastBranchC.id,
+      runId,
+      snapshot: {
+        runId,
+        status: 'success',
+        result: fastResultC,
+        activePaths: [],
+        activeStepsPath: {},
+        value: {},
+        context: {
+          input,
+          fastBranchCStep: {
+            payload: input,
+            startedAt,
+            status: 'success',
+            output: fastResultC,
+            endedAt: startedAt + 250,
+          },
+        },
+        serializedStepGraph: (fastBranchC as any).serializedStepGraph,
+        suspendedPaths: {},
+        waitingPaths: {},
+        resumeLabels: {},
+        timestamp: Date.now(),
+      },
+    });
+
+    await workflowsStore!.persistWorkflowSnapshot({
+      workflowName: slowBranch.id,
+      runId,
+      snapshot: {
+        runId,
+        status: 'running',
+        activePaths: [0],
+        activeStepsPath: { slowBranchStep: [0] },
+        value: {},
+        context: {
+          input,
+          slowBranchStep: {
+            payload: input,
+            startedAt,
+            status: 'running',
+          },
+        },
+        serializedStepGraph: (slowBranch as any).serializedStepGraph,
+        suspendedPaths: {},
+        waitingPaths: {},
+        resumeLabels: {},
+        timestamp: Date.now(),
+      },
+    });
+
+    const run = await parentWorkflow.createRun({ runId });
+    const restartResult = await run.restart();
+
+    expect(restartResult.status).toBe('success');
+    expect(restartResult).toMatchObject({
+      status: 'success',
+      result: {
+        fastBranchA: fastResultA,
+        slowBranch: { branch: 'slowBranch', value: 'repro' },
+        fastBranchC: fastResultC,
+      },
+    });
+
+    // Terminal children must not re-execute; only the still-active slow branch may.
+    expect(mockFastA).toHaveBeenCalledTimes(0);
+    expect(mockFastC).toHaveBeenCalledTimes(0);
+    expect(mockSlow).toHaveBeenCalledTimes(1);
+
+    const parentSnap = await workflowsStore!.loadWorkflowSnapshot({
+      workflowName: parentWorkflow.id,
+      runId,
+    });
+    expect(parentSnap?.status).toBe('success');
+  });
+
+  it('returns terminal snapshot from restart without re-executing steps', async () => {
+    const storage = new MockStore();
+    const mastra = new Mastra({ logger: false, storage });
+
+    const mockStep = vi.fn().mockResolvedValue({ done: true });
+    const step = createStep({
+      id: 'done-step',
+      execute: mockStep,
+      inputSchema: z.object({ value: z.number() }),
+      outputSchema: z.object({ done: z.boolean() }),
+    });
+    const workflow = createWorkflow({
+      id: 'already-complete-wf',
+      inputSchema: z.object({ value: z.number() }),
+      outputSchema: z.object({ done: z.boolean() }),
+      steps: [step],
+    })
+      .then(step)
+      .commit();
+
+    workflow.__registerMastra(mastra);
+    const workflowsStore = await storage.getStore('workflows');
+    const runId = `terminal-restart-${Date.now()}`;
+
+    await workflowsStore!.persistWorkflowSnapshot({
+      workflowName: workflow.id,
+      runId,
+      snapshot: {
+        runId,
+        status: 'success',
+        result: { done: true },
+        activePaths: [],
+        activeStepsPath: {},
+        value: {},
+        context: {
+          input: { value: 1 },
+          'done-step': {
+            payload: { value: 1 },
+            startedAt: Date.now(),
+            status: 'success',
+            output: { done: true },
+            endedAt: Date.now(),
+          },
+        },
+        serializedStepGraph: (workflow as any).serializedStepGraph,
+        suspendedPaths: {},
+        waitingPaths: {},
+        resumeLabels: {},
+        timestamp: Date.now(),
+      },
+    });
+
+    const run = await workflow.createRun({ runId });
+    const result = await run.restart();
+
+    expect(result.status).toBe('success');
+    expect(result).toMatchObject({ status: 'success', result: { done: true } });
+    expect(mockStep).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -4240,7 +4240,12 @@ export class Run<
       this.cleanup?.();
       // Match fmtReturnValue: context keeps `input` alongside step results, and `input`
       // is also surfaced as a top-level field on the returned WorkflowResult.
-      const steps = hydrateSerializedStepErrors({ ...(snapshot.context ?? {}) }) ?? {};
+      const hydratedSteps = hydrateSerializedStepErrors({ ...(snapshot.context ?? {}) }) ?? {};
+      // Strip internal bookkeeping (__state, metadata.nestedRunId) from step results so the
+      // reconstructed result matches what a live run would have returned via fmtReturnValue.
+      const steps = Object.fromEntries(
+        Object.entries(hydratedSteps).map(([stepId, stepResult]) => [stepId, cleanStepResult(stepResult)]),
+      ) as typeof hydratedSteps;
       const input = (snapshot.context as { input?: TInput } | undefined)?.input as TInput;
       const base = {
         steps,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -15,7 +15,7 @@ import { MastraFGAPermissions } from '../auth/ee';
 import type { ActorSignal } from '../auth/ee';
 import { MastraBase } from '../base';
 import { RequestContext } from '../di';
-import { ErrorCategory, ErrorDomain, MastraError } from '../error';
+import { ErrorCategory, ErrorDomain, MastraError, getErrorFromUnknown } from '../error';
 import type { MastraScorers } from '../evals';
 import { EventEmitterPubSub } from '../events/event-emitter';
 import type { PubSub } from '../events/pubsub';
@@ -97,7 +97,12 @@ import type {
   WorkflowRunStartOptions,
   ForeachOptions,
 } from './types';
-import { cleanStepResult, createRestartExecutionParams, createTimeTravelExecutionParams } from './utils';
+import {
+  cleanStepResult,
+  createRestartExecutionParams,
+  createTimeTravelExecutionParams,
+  hydrateSerializedStepErrors,
+} from './utils';
 
 // Options that can be passed when wrapping an agent with createStep
 // These work for both stream() (v2) and streamLegacy() (v1) methods
@@ -4221,6 +4226,51 @@ export class Run<
 
     if (!snapshot) {
       throw new Error(`Snapshot not found for run ${this.runId}`);
+    }
+
+    // Parent parallel activeStepsPath can lag behind nested child completion after a crash:
+    // children may already be terminal while the parent still lists them as active and
+    // re-invokes restart(). Treat terminal snapshots as authoritative and reuse them.
+    // See https://github.com/mastra-ai/mastra/issues/20225
+    const terminalStatuses: WorkflowRunStatus[] = ['success', 'failed', 'canceled', 'bailed', 'tripwire'];
+    if (terminalStatuses.includes(snapshot.status)) {
+      this.cleanup?.();
+      const steps = hydrateSerializedStepErrors({ ...(snapshot.context ?? {}) }) ?? {};
+      const input = (snapshot.context as { input?: TInput } | undefined)?.input as TInput;
+      const base = {
+        status: snapshot.status,
+        steps,
+        input,
+        runId: this.runId,
+        ...(snapshot.value && Object.keys(snapshot.value).length > 0 ? { state: snapshot.value as TState } : {}),
+        ...(snapshot.stepExecutionPath ? { stepExecutionPath: snapshot.stepExecutionPath } : {}),
+        ...(snapshot.resumeLabels ? { resumeLabels: snapshot.resumeLabels } : {}),
+      };
+
+      if (snapshot.status === 'success') {
+        return { ...base, status: 'success', result: snapshot.result as TOutput } as WorkflowResult<
+          TState,
+          TInput,
+          TOutput,
+          TSteps
+        >;
+      }
+      if (snapshot.status === 'failed') {
+        return {
+          ...base,
+          status: 'failed',
+          error: getErrorFromUnknown(snapshot.error, { serializeStack: false }),
+        } as WorkflowResult<TState, TInput, TOutput, TSteps>;
+      }
+      if (snapshot.status === 'tripwire') {
+        return { ...base, status: 'tripwire', tripwire: snapshot.tripwire } as WorkflowResult<
+          TState,
+          TInput,
+          TOutput,
+          TSteps
+        >;
+      }
+      return base as WorkflowResult<TState, TInput, TOutput, TSteps>;
     }
 
     const restartData = createRestartExecutionParams({ snapshot, graph: this.executionGraph });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -4232,13 +4232,17 @@ export class Run<
     // children may already be terminal while the parent still lists them as active and
     // re-invokes restart(). Treat terminal snapshots as authoritative and reuse them.
     // See https://github.com/mastra-ai/mastra/issues/20225
-    const terminalStatuses: WorkflowRunStatus[] = ['success', 'failed', 'canceled', 'bailed', 'tripwire'];
-    if (terminalStatuses.includes(snapshot.status)) {
+    //
+    // Only statuses already represented on WorkflowResult are reconstructed here.
+    // Other terminal statuses (canceled/bailed) keep the existing createRestartExecutionParams
+    // "was not active" behavior — expanding WorkflowResult is out of scope for this fix.
+    if (snapshot.status === 'success' || snapshot.status === 'failed' || snapshot.status === 'tripwire') {
       this.cleanup?.();
+      // Match fmtReturnValue: context keeps `input` alongside step results, and `input`
+      // is also surfaced as a top-level field on the returned WorkflowResult.
       const steps = hydrateSerializedStepErrors({ ...(snapshot.context ?? {}) }) ?? {};
       const input = (snapshot.context as { input?: TInput } | undefined)?.input as TInput;
       const base = {
-        status: snapshot.status,
         steps,
         input,
         runId: this.runId,
@@ -4262,15 +4266,12 @@ export class Run<
           error: getErrorFromUnknown(snapshot.error, { serializeStack: false }),
         } as WorkflowResult<TState, TInput, TOutput, TSteps>;
       }
-      if (snapshot.status === 'tripwire') {
-        return { ...base, status: 'tripwire', tripwire: snapshot.tripwire } as WorkflowResult<
-          TState,
-          TInput,
-          TOutput,
-          TSteps
-        >;
-      }
-      return base as WorkflowResult<TState, TInput, TOutput, TSteps>;
+      return { ...base, status: 'tripwire', tripwire: snapshot.tripwire } as WorkflowResult<
+        TState,
+        TInput,
+        TOutput,
+        TSteps
+      >;
     }
 
     const restartData = createRestartExecutionParams({ snapshot, graph: this.executionGraph });


### PR DESCRIPTION
## Summary

- Boot-time recovery via `restart()` / `restartAllActiveWorkflowRuns()` failed for parents interrupted inside `.parallel([nestedWorkflow…])` when some nested branches had already persisted `success` while the parent snapshot still listed every branch as active (`activeStepsPath` lag after a crash).
- Nested `restart()` then hit `createRestartExecutionParams` and threw `This workflow run was not active` for the completed children.
- Fix: treat terminal child snapshots (`success` / `failed` / `canceled` / `bailed` / `tripwire`) as authoritative in `Run._restart` and return them without re-execution. Still-running siblings continue through the normal restart path.

Fixes #20225

## Design

| | |
|---|---|
| **Root cause** | Parent parallel persistence lags nested child completion. After a crash, parent `activeStepsPath` still marks completed nested workflows as active, so recovery calls `restart()` on terminal snapshots. |
| **Invariant** | A terminal nested snapshot must never be re-executed; child truth wins over stale parent intent. |
| **Chosen fix** | Early-return terminal snapshots from `_restart` (minimal, preserves other recovery semantics). |
| **Alternatives considered** | (A) Filter `activeStepsPath` before parallel restart — also needs fixing `break` vs `continue` in `executeParallel`; (B) Persist parent branch status synchronously on child completion — larger surface / still racy on hard kill; (C) Bundle/patch packaging — N/A. |

## Test plan

- [x] Red/green: `packages/core/src/workflows/parallel-nested-restart.test.ts`
  - Parent `.parallel` with two terminal nested snapshots + one running nested snapshot → parent `restart()` succeeds; terminal branch steps not re-executed; slow branch runs once
  - Direct `restart()` on an already-successful run returns the stored result without re-executing steps
- [x] `tsc --noEmit -p tsconfig.build.json` in `packages/core`
- [ ] CI unit workflows

## Notes

- Diff is intentionally small: one early-return path in `_restart` + focused regression + changeset.
- Does not change how parent snapshots are written during live parallel execution (follow-up possible, out of scope).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If a workflow stops while some parallel tasks are complete, recovery keeps the completed results and resumes only the unfinished tasks. This prevents errors caused by trying to run completed tasks again.

## Changes

- Updated `Run._restart` to reuse `success`, `failed`, and `tripwire` snapshots without re-executing steps.
- Hydrated serialized step errors and removed internal fields with `cleanStepResult`.
- Preserved normal restart behavior for still-running nested workflows and other terminal statuses.
- Added regression tests for mixed branch recovery and terminal workflow restart.
- Added a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->