### PR TITLE
fix(factory): enforce pattern comparison in reviews

### DIFF
--- a/.changeset/lovely-walls-listen.md
+++ b/.changeset/lovely-walls-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved Factory pull-request reviews by requiring comparison with analogous codebase patterns.

--- a/mastracode/factory/factory-skills/factory-review/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-review/SKILL.md
@@ -80,6 +80,8 @@ For each significantly changed file: `git log --oneline -20 -- <file>`, `git bla
 
 Read around the changed lines: the module architecture, the contracts the changed code participates in, callers and data flow, and any AGENTS.md/README conventions in the touched packages. Then judge the approach: does it fit the existing design, or fight it? If the history shows a simpler or more consistent approach, flag it.
 
+For behavior-changing code, find the nearest analogous implementation and compare where it lives and how it follows existing abstractions, APIs, and test patterns. Flag deviations that are not justified by the codebase or its history.
+
 ## Phase 5: Verdict
 
 Weigh the findings — yours and the confirmed ones inherited from existing reviewers — and commit to one verdict:


### PR DESCRIPTION
Factory reviews now compare behavior-changing hunks with analogous implementations before approving. This helps catch code placed outside established usage-specific adapters or bypassing an existing abstraction.

Before, a reviewer could assess a diff without locating the existing implementation pattern. After, reviewers compare placement, control flow, API shape, callers, and tests, and need evidence for deliberate deviations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR asks reviewers to compare important code changes with similar code before approval. This helps catch changes that do not match existing patterns or tests.

## Changes

- Added a required analog-check procedure for behavior-changing hunks.
- The procedure covers:
  - Similar implementations
  - Callers
  - Tests
  - Evidence for deliberate deviations
- Reviewers must evaluate placement, control flow, API shape, callers, and tests.
- Added a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->