### PR TITLE
docs(playground): add changeset for Studio dataset item timeouts

### DIFF
--- a/.changeset/studio-dataset-item-timeouts.md
+++ b/.changeset/studio-dataset-item-timeouts.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Studio now lets you configure a per-item execution timeout on dataset items. Set an optional timeout when creating an item, edit it later from the item detail panel or the item versions page, and see the saved override in the item details. Timeouts are whole milliseconds from 1 to 1,800,000 (30 minutes) and override the experiment-level fallback for that item.


### PR DESCRIPTION
## Summary

Mastra publishes a combined changelog generated from changeset files. Every package that is not explicitly ignored needs a changeset entry so its user-facing changes appear in a release.

The per-item dataset timeout work adds a new capability across several packages. The stack already documents the programmatic side of it — `@mastra/core`, `@mastra/server`, `@mastra/client-js`, and the storage adapters each have a changeset. What is missing is the Studio user interface change that actually exposes the feature to people who do not call the API directly: setting, editing, and reading a per-item timeout from Studio.

Studio (`@internal/playground`) is explicitly un-ignored in `.changeset/config.json` and is version-locked with the `mastra` and `create-mastra` packages, so its changes are expected to carry their own release notes. This adds that missing entry so the Studio-facing behaviour appears in the changelog alongside the API-level notes.

No product code is touched — this adds a single markdown file under `.changeset/`.

## Test plan

- No runtime code changed, so no behavioural tests apply.
- The added file follows the same frontmatter and wording conventions as existing Studio changesets in the repository.
- The repository changeset check on this branch should now report an entry instead of "no changesets".

Follow-up to the review of #20003.
