### PR TITLE
fix(core): resume parallel durable delegated approvals in any order

### DIFF
--- a/.changeset/cyan-chefs-stay.md
+++ b/.changeset/cyan-chefs-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed durable agents losing track of parallel sub-agent approvals. When a durable supervisor delegated to multiple sub-agents in parallel and more than one required approval, only the first approval was persisted — the rest disappeared from the conversation metadata. Also fixed listSuspendedRuns() never returning suspended durable agent runs. Both parallel approvals now persist, the suspended run is discoverable, and the approvals can be resumed in any order.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -133,6 +133,10 @@ import type {
   DelegationStartContext,
   DelegationCompleteContext,
 } from './agent.types';
+// Value import of durable constants is safe: constants.ts is a leaf module
+// with no imports, so it cannot create the runtime cycle `agent →
+// agent/durable → agent`.
+import { DurableStepIds } from './durable/constants';
 // Type-only imports from the durable module: erased at build time so they
 // don't create the runtime cycle `agent → agent/durable → agent`.
 import type {
@@ -6394,6 +6398,15 @@ export class Agent<
       }
     }
 
+    // Durable agentic-loop snapshots don't embed `__streamState` in suspend
+    // payloads; their thread/resource info lives on the serialized workflow
+    // input's message-list state instead.
+    const durableMemoryInfo = (existingSnapshot?.context as Record<string, any> | undefined)?.input?.messageListState
+      ?.memoryInfo;
+    if (durableMemoryInfo && typeof durableMemoryInfo === 'object') {
+      return durableMemoryInfo as AgentSnapshotMemoryInfo;
+    }
+
     return undefined;
   }
 
@@ -6403,6 +6416,13 @@ export class Agent<
       if (step && step.status === 'suspended' && step.suspendPayload?.__agentId) {
         return step.suspendPayload.__agentId;
       }
+    }
+
+    // Durable agentic-loop snapshots persist the owning agent id on the
+    // serialized workflow input instead of in suspend payloads.
+    const durableAgentId = (existingSnapshot?.context as Record<string, any> | undefined)?.input?.agentId;
+    if (typeof durableAgentId === 'string') {
+      return durableAgentId;
     }
 
     return undefined;
@@ -7658,13 +7678,19 @@ export class Agent<
 
     // threadId/resourceId live inside the snapshot state rather than in storage
     // columns, so fetch all matching rows and filter/paginate here to keep
-    // `total` accurate.
-    const { runs } = await workflowsStore.listWorkflowRuns({
-      workflowName: 'agentic-loop',
-      status: 'suspended',
-      fromDate,
-      toDate,
-    });
+    // `total` accurate. Durable agents persist their agentic loop under a
+    // separate workflow name, so query both — otherwise suspended durable runs
+    // are never discoverable.
+    const runs: Awaited<ReturnType<typeof workflowsStore.listWorkflowRuns>>['runs'] = [];
+    for (const workflowName of ['agentic-loop', DurableStepIds.AGENTIC_LOOP]) {
+      const { runs: workflowRuns } = await workflowsStore.listWorkflowRuns({
+        workflowName,
+        status: 'suspended',
+        fromDate,
+        toDate,
+      });
+      runs.push(...workflowRuns);
+    }
 
     const matchedRuns: AgentRun[] = [];
     for (const run of runs) {

--- a/packages/core/src/agent/durable/__tests__/parallel-delegation-approval-durable.test.ts
+++ b/packages/core/src/agent/durable/__tests__/parallel-delegation-approval-durable.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Durable parallel sub-agent delegation approvals.
+ *
+ * A durable supervisor delegates to two sub-agents in parallel (one tool-call
+ * turn with two tool calls) and each sub-agent's tool requires approval.
+ * Matching the default engine (#19450/#19645), the durable engine must:
+ *  1. surface approval requests for both delegations,
+ *  2. persist BOTH approvals in `pendingToolApprovals` with the outer runId
+ *     and each delegation's own inner `delegatedRunId`,
+ *  3. report the suspended run with both tool calls via `listSuspendedRuns()`,
+ *  4. resume the approvals in any order, executing each gated tool exactly
+ *     once and completing the run.
+ *
+ * Regressions covered:
+ *  - The second suspension's metadata write was silently lost: the first
+ *    suspension's pre-suspend flush drained the response messages, so the
+ *    sibling's `addToolMetadata` found no assistant message and dropped the
+ *    entry.
+ *  - `listSuspendedRuns()` only queried the regular `agentic-loop` workflow
+ *    name, so suspended durable runs (which persist under
+ *    `durable-agentic-loop`) were never discoverable.
+ */
+
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { z } from 'zod';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { Mastra } from '../../../mastra';
+import { MockMemory } from '../../../memory/mock';
+import { InMemoryStore } from '../../../storage/mock';
+import { createTool } from '../../../tools';
+import { Agent } from '../../agent';
+import { DurableStepIds } from '../constants';
+import { createDurableAgent } from '../create-durable-agent';
+import { globalRunRegistry } from '../run-registry';
+
+function makeSubAgentModel(label: string, resultToken: string) {
+  return new MockLanguageModelV2({
+    doStream: async ({ prompt }) => {
+      const hasToolResult = JSON.stringify(prompt).includes(resultToken);
+      if (!hasToolResult) {
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream<any>([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: `${label}-0`, modelId: 'mock-model', timestamp: new Date(0) },
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: `inner-${label}`,
+              toolName: 'gatedTool',
+              input: `{"query":"${label}"}`,
+              providerExecuted: false,
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+            },
+          ]),
+        };
+      }
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream<any>([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: `${label}-1`, modelId: 'mock-model', timestamp: new Date(0) },
+          { type: 'text-start', id: `${label}-text` },
+          { type: 'text-delta', id: `${label}-text`, delta: `${label} done.` },
+          { type: 'text-end', id: `${label}-text` },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 } },
+        ]),
+      };
+    },
+  });
+}
+
+/** Supervisor: one turn with TWO parallel delegations, then the final answer. */
+function makeSupervisorModel() {
+  return new MockLanguageModelV2({
+    doStream: async ({ prompt }) => {
+      const text = JSON.stringify(prompt);
+      const hasBoth = text.includes('alpha done') && text.includes('beta done');
+      if (!hasBoth) {
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream<any>([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'sup-0', modelId: 'mock-model', timestamp: new Date(0) },
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: 'sup-tc-A',
+              toolName: 'agent-subAlpha',
+              input: JSON.stringify({ prompt: 'do alpha' }),
+              providerExecuted: false,
+            },
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: 'sup-tc-B',
+              toolName: 'agent-subBeta',
+              input: JSON.stringify({ prompt: 'do beta' }),
+              providerExecuted: false,
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+        };
+      }
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream<any>([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'sup-1', modelId: 'mock-model', timestamp: new Date(0) },
+          { type: 'text-start', id: 'sup-text' },
+          { type: 'text-delta', id: 'sup-text', delta: 'Both delegations complete.' },
+          { type: 'text-end', id: 'sup-text' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+        ]),
+      };
+    },
+  });
+}
+
+/**
+ * Drain a stream until `stopWhen` returns true or the stream ends. Durable
+ * streams intentionally stay open while the run is suspended (so a later
+ * resume can keep streaming), so mid-flow legs stop at a condition instead of
+ * waiting for closure. Returns collected chunk types/approvals/text.
+ */
+async function drainUntil(stream: AsyncIterable<any>, stopWhen: (state: { types: string[] }) => boolean, ms = 15000) {
+  const types: string[] = [];
+  const approvals: any[] = [];
+  let text = '';
+  let timedOut = false;
+  const iterator = stream[Symbol.asyncIterator]();
+  const deadline = Date.now() + ms;
+  while (true) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      timedOut = true;
+      break;
+    }
+    const next = await Promise.race([
+      iterator.next(),
+      new Promise<'timeout'>(res => setTimeout(() => res('timeout'), remaining)),
+    ]);
+    if (next === 'timeout') {
+      timedOut = true;
+      break;
+    }
+    if (next.done) break;
+    const chunk = next.value;
+    types.push(chunk.type);
+    if (chunk.type === 'tool-call-approval') approvals.push(chunk.payload);
+    if (chunk.type === 'text-delta') text += chunk.payload?.text ?? '';
+    if (stopWhen({ types })) break;
+  }
+  return { types, approvals, text, timedOut };
+}
+
+describe('durable parallel delegation approvals', () => {
+  let pubsub: EventEmitterPubSub;
+
+  beforeEach(() => {
+    pubsub = new EventEmitterPubSub();
+  });
+
+  afterEach(async () => {
+    globalRunRegistry.clear();
+    await pubsub.close();
+  });
+
+  const setup = () => {
+    const storage = new InMemoryStore();
+    const mockMemory = new MockMemory();
+    const executions: string[] = [];
+
+    const buildGatedTool = () =>
+      createTool({
+        id: 'gatedTool',
+        description: 'Approval-gated tool',
+        inputSchema: z.object({ query: z.string() }),
+        requireApproval: true,
+        execute: async (input: { query: string }) => {
+          executions.push(input.query);
+          return { result: `${input.query} done` };
+        },
+      });
+
+    const subAlpha = new Agent({
+      id: 'subAlpha',
+      name: 'subAlpha',
+      description: 'Does alpha',
+      instructions: 'Use your tool.',
+      model: makeSubAgentModel('alpha', 'alpha done') as LanguageModelV2,
+      tools: { gatedTool: buildGatedTool() },
+    });
+    const subBeta = new Agent({
+      id: 'subBeta',
+      name: 'subBeta',
+      description: 'Does beta',
+      instructions: 'Use your tool.',
+      model: makeSubAgentModel('beta', 'beta done') as LanguageModelV2,
+      tools: { gatedTool: buildGatedTool() },
+    });
+    const supervisor = new Agent({
+      id: 'supervisor',
+      name: 'Supervisor',
+      instructions: 'Delegate to both sub-agents.',
+      model: makeSupervisorModel() as LanguageModelV2,
+      agents: { subAlpha, subBeta },
+      memory: mockMemory,
+    });
+
+    const durableAgent = createDurableAgent({ agent: supervisor, pubsub });
+    new Mastra({ agents: { durableAgent }, storage, logger: false });
+    return { storage, mockMemory, executions, durableAgent };
+  };
+
+  const runToBothApprovals = async (
+    durableAgent: ReturnType<typeof setup>['durableAgent'],
+    memory: { thread: string; resource: string },
+    storage: InMemoryStore,
+  ) => {
+    const result = await durableAgent.stream('Do alpha and beta', { memory, maxSteps: 5 });
+    const leg1 = await drainUntil(
+      result.fullStream,
+      ({ types }) => types.filter(t => t === 'tool-call-approval').length >= 2,
+    );
+    expect(
+      leg1.approvals.map(a => a?.toolCallId).sort(),
+      `both delegations should surface approval requests; chunks: ${leg1.types.join(', ')}`,
+    ).toEqual(['sup-tc-A', 'sup-tc-B']);
+
+    const workflows = (await storage.getStore('workflows'))!;
+    await vi.waitFor(async () => {
+      const persisted = await workflows.getWorkflowRunById({
+        runId: result.runId,
+        workflowName: DurableStepIds.AGENTIC_LOOP,
+      });
+      const snapshot = typeof persisted?.snapshot === 'string' ? JSON.parse(persisted.snapshot) : persisted?.snapshot;
+      expect(snapshot?.status).toBe('suspended');
+    });
+    return result.runId;
+  };
+
+  const getApprovalEntries = async (mockMemory: MockMemory, memory: { thread: string; resource: string }) => {
+    return vi.waitFor(async () => {
+      const { messages } = await mockMemory.recall({ threadId: memory.thread, resourceId: memory.resource });
+      const withApproval = [...messages]
+        .reverse()
+        .find(
+          (m: any) =>
+            m.role === 'assistant' && Object.keys((m.content as any)?.metadata?.pendingToolApprovals ?? {}).length >= 2,
+        );
+      const approvals = (withApproval as any)?.content?.metadata?.pendingToolApprovals as
+        | Record<string, any>
+        | undefined;
+      expect(approvals).toBeDefined();
+      return approvals!;
+    });
+  };
+
+  const approveAndDrainMiddleLeg = async (
+    durableAgent: ReturnType<typeof setup>['durableAgent'],
+    runId: string,
+    toolCallId: string,
+    memory: { thread: string; resource: string },
+  ) => {
+    // The run re-suspends afterwards (the sibling is still parked), so the
+    // stream stays open by design — stop at the delegation's tool-result.
+    const resumed = await durableAgent.approveToolCall({ runId, toolCallId, memory });
+    const leg = await drainUntil(resumed.fullStream, ({ types }) => types.includes('tool-result'));
+    expect(leg.timedOut, `approving ${toolCallId} should produce a tool-result; got: ${leg.types.join(', ')}`).toBe(
+      false,
+    );
+    expect(leg.types, `no errors after approving ${toolCallId}`).not.toContain('error');
+    expect(leg.types, `no tool errors after approving ${toolCallId}`).not.toContain('tool-error');
+  };
+
+  const approveAndDrainFinalLeg = async (
+    durableAgent: ReturnType<typeof setup>['durableAgent'],
+    runId: string,
+    toolCallId: string,
+    memory: { thread: string; resource: string },
+  ) => {
+    // The last approval completes the run, so the stream closes on finish.
+    const resumed = await durableAgent.approveToolCall({ runId, toolCallId, memory });
+    const leg = await drainUntil(resumed.fullStream, () => false);
+    expect(leg.timedOut, `final approval should complete the run; got: ${leg.types.join(', ')}`).toBe(false);
+    expect(leg.types, `no errors after approving ${toolCallId}`).not.toContain('error');
+    expect(leg.types, `no tool errors after approving ${toolCallId}`).not.toContain('tool-error');
+    expect(leg.types).toContain('finish');
+    expect(leg.text).toBe('Both delegations complete.');
+  };
+
+  const assertLeg1State = async (
+    runId: string,
+    mockMemory: MockMemory,
+    durableAgent: ReturnType<typeof setup>['durableAgent'],
+    memory: { thread: string; resource: string },
+    executions: string[],
+  ) => {
+    // Both approvals persist with the outer runId and their own inner run.
+    const entries = await getApprovalEntries(mockMemory, memory);
+    expect(Object.keys(entries).sort()).toEqual(['sup-tc-A', 'sup-tc-B']);
+    for (const toolCallId of ['sup-tc-A', 'sup-tc-B']) {
+      expect(entries[toolCallId]!.runId).toBe(runId);
+      expect(entries[toolCallId]!.delegatedRunId).toBeDefined();
+      expect(entries[toolCallId]!.delegatedRunId).not.toBe(runId);
+    }
+    expect(entries['sup-tc-A']!.delegatedRunId).not.toBe(entries['sup-tc-B']!.delegatedRunId);
+
+    // The suspended durable run is discoverable with both tool calls.
+    const discovered = await durableAgent.listSuspendedRuns({
+      threadId: memory.thread,
+      resourceId: memory.resource,
+    });
+    expect(discovered.total).toBe(1);
+    expect(discovered.runs[0]!.runId).toBe(runId);
+    expect(discovered.runs[0]!.toolCalls.map(tc => tc.toolCallId).sort()).toEqual(['sup-tc-A', 'sup-tc-B']);
+
+    // Nothing has executed before approval.
+    expect(executions).toEqual([]);
+  };
+
+  it('persists, discovers, and resumes both approvals in order (A then B)', async () => {
+    const { storage, mockMemory, executions, durableAgent } = setup();
+    const memory = { thread: 'parallel-a-first-thread', resource: 'parallel-a-first-resource' };
+
+    const runId = await runToBothApprovals(durableAgent, memory, storage);
+    await assertLeg1State(runId, mockMemory, durableAgent, memory, executions);
+
+    await approveAndDrainMiddleLeg(durableAgent, runId, 'sup-tc-A', memory);
+    await vi.waitFor(() => expect(executions).toContain('alpha'));
+
+    await approveAndDrainFinalLeg(durableAgent, runId, 'sup-tc-B', memory);
+    expect(executions.sort()).toEqual(['alpha', 'beta']);
+  }, 60000);
+
+  it('resumes the approvals out of order (B before A)', async () => {
+    const { storage, mockMemory, executions, durableAgent } = setup();
+    const memory = { thread: 'parallel-b-first-thread', resource: 'parallel-b-first-resource' };
+
+    const runId = await runToBothApprovals(durableAgent, memory, storage);
+    await assertLeg1State(runId, mockMemory, durableAgent, memory, executions);
+
+    await approveAndDrainMiddleLeg(durableAgent, runId, 'sup-tc-B', memory);
+    await vi.waitFor(() => expect(executions).toContain('beta'));
+
+    await approveAndDrainFinalLeg(durableAgent, runId, 'sup-tc-A', memory);
+    expect(executions.sort()).toEqual(['alpha', 'beta']);
+  }, 60000);
+});

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -486,22 +486,7 @@ export function createDurableToolCallStep() {
       }) => {
         if (!messageList) return;
         const metadataKey = opts.type === 'suspension' ? 'suspendedTools' : 'pendingToolApprovals';
-        const responseMessages = messageList.get.response.db();
-        const lastAssistantMessage = [...responseMessages].reverse().find(msg => msg.role === 'assistant');
-        if (!lastAssistantMessage?.content) return;
-
-        let metadata: Record<string, any>;
-        if (
-          typeof lastAssistantMessage.content.metadata === 'object' &&
-          lastAssistantMessage.content.metadata !== null
-        ) {
-          metadata = lastAssistantMessage.content.metadata as Record<string, any>;
-        } else {
-          metadata = {};
-          lastAssistantMessage.content.metadata = metadata;
-        }
-        metadata[metadataKey] = metadata[metadataKey] || {};
-        metadata[metadataKey][toolCallId] = {
+        const entry = {
           toolCallId,
           toolName,
           args,
@@ -515,6 +500,51 @@ export function createDurableToolCallStep() {
           ...(opts.type === 'suspension' ? { suspendPayload: opts.suspendPayload } : {}),
           ...(opts.resumeSchema ? { resumeSchema: opts.resumeSchema } : {}),
         };
+
+        const responseMessages = messageList.get.response.db();
+        const lastAssistantMessage = [...responseMessages].reverse().find(msg => msg.role === 'assistant');
+        if (lastAssistantMessage?.content) {
+          let metadata: Record<string, any>;
+          if (
+            typeof lastAssistantMessage.content.metadata === 'object' &&
+            lastAssistantMessage.content.metadata !== null
+          ) {
+            metadata = lastAssistantMessage.content.metadata as Record<string, any>;
+          } else {
+            metadata = {};
+            lastAssistantMessage.content.metadata = metadata;
+          }
+          metadata[metadataKey] = metadata[metadataKey] || {};
+          metadata[metadataKey][toolCallId] = entry;
+          return;
+        }
+
+        // The response view is empty: a sibling parallel tool call already
+        // suspended and its pre-suspension flush drained the unsaved response
+        // messages. Without a fallback this sibling's entry is silently lost
+        // and only the first suspension survives in persisted metadata. Merge
+        // the entry into the assistant message that carries this tool call via
+        // updateMessageMetadataByToolCallId, which also re-marks the message
+        // unsaved so the following flush persists this write too.
+        const allMessages = messageList.get.all.db();
+        const target = [...allMessages]
+          .reverse()
+          .find(
+            msg =>
+              msg.role === 'assistant' &&
+              (msg.content?.parts ?? []).some(
+                (part: any) => part?.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCallId,
+              ),
+          );
+        if (!target?.content) return;
+        const existingMeta =
+          typeof target.content.metadata === 'object' && target.content.metadata !== null
+            ? (target.content.metadata as Record<string, any>)
+            : {};
+        const existingEntries = (existingMeta[metadataKey] ?? {}) as Record<string, any>;
+        messageList.updateMessageMetadataByToolCallId(toolCallId, {
+          [metadataKey]: { ...existingEntries, [toolCallId]: entry },
+        });
       };
 
       // Remove suspended-tool / pending-approval metadata from the last

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -501,8 +501,14 @@ export function createDurableToolCallStep() {
           ...(opts.resumeSchema ? { resumeSchema: opts.resumeSchema } : {}),
         };
 
+        const carriesToolCall = (msg: any) =>
+          msg.role === 'assistant' &&
+          (msg.content?.parts ?? []).some(
+            (part: any) => part?.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCallId,
+          );
+
         const responseMessages = messageList.get.response.db();
-        const lastAssistantMessage = [...responseMessages].reverse().find(msg => msg.role === 'assistant');
+        const lastAssistantMessage = [...responseMessages].reverse().find(carriesToolCall);
         if (lastAssistantMessage?.content) {
           let metadata: Record<string, any>;
           if (
@@ -527,16 +533,13 @@ export function createDurableToolCallStep() {
         // updateMessageMetadataByToolCallId, which also re-marks the message
         // unsaved so the following flush persists this write too.
         const allMessages = messageList.get.all.db();
-        const target = [...allMessages]
-          .reverse()
-          .find(
-            msg =>
-              msg.role === 'assistant' &&
-              (msg.content?.parts ?? []).some(
-                (part: any) => part?.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCallId,
-              ),
+        const target = [...allMessages].reverse().find(carriesToolCall);
+        if (!target?.content) {
+          logger?.warn?.(
+            `[DurableAgent] addToolMetadata could not find an assistant message for tool call ${toolCallId} (${toolName}); ${metadataKey} entry was not persisted.`,
           );
-        if (!target?.content) return;
+          return;
+        }
         const existingMeta =
           typeof target.content.metadata === 'object' && target.content.metadata !== null
             ? (target.content.metadata as Record<string, any>)


### PR DESCRIPTION
When a durable supervisor delegates to multiple sub-agents in parallel and more than one requires approval, only the first approval survived. The second delegation's approval entry silently disappeared from persisted message metadata (the first suspension's pre-suspend flush drained the response messages, so the sibling's metadata write had nothing to attach to). On top of that, `listSuspendedRuns()` only queried the regular `agentic-loop` workflow name, so suspended durable runs were never discoverable at all.

Before:

```ts
const { runs } = await durableAgent.listSuspendedRuns({ threadId, resourceId });
// runs: [] — suspended durable run invisible

// persisted metadata after both delegations request approval:
// pendingToolApprovals: { 'sup-tc-A': {...} } — sup-tc-B lost
```

After:

```ts
const { runs } = await durableAgent.listSuspendedRuns({ threadId, resourceId });
// runs[0].toolCalls → ['sup-tc-A', 'sup-tc-B']

await durableAgent.approveToolCall({ runId, toolCallId: 'sup-tc-B' }); // any order works
await durableAgent.approveToolCall({ runId, toolCallId: 'sup-tc-A' });
// each gated tool runs exactly once, run completes
```

The fix has two parts: `addToolMetadata` in the durable tool-call step now falls back to merging the approval entry into the assistant message that carries the tool call (via `updateMessageMetadataByToolCallId`) when the response view is already drained, and `listSuspendedRuns()` now also queries the `durable-agentic-loop` workflow name, reading `agentId`/thread scoping from the durable snapshot's workflow input. Scoping stays default-deny.

Test plan: new regression test covers the full flow (both approvals surface, both persist with outer `runId` + distinct `delegatedRunId`, discovery returns both tool calls, resume works A-first and B-first with exactly-once execution). Both tests fail without the fix. Durable + discovery + delegation suites (76 files, 702 tests), typecheck, lint, and build:core all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When several delegated agents need approval at the same time, the system now remembers every approval. Users can find and approve them in any order without running an approval twice.

## Changes

- Preserve metadata for parallel suspended tool calls.
- Match metadata to the assistant message that contains the relevant tool call.
- Merge fallback metadata when response messages were already flushed.
- Log a warning when no matching assistant message exists.
- Discover suspended durable runs through the `durable-agentic-loop` workflow.
- Apply agent and thread scoping from the durable snapshot input.
- Add regression coverage for approval discovery, run IDs, approval order, and exactly-once execution.
- Add a patch changeset for `@mastra/core`.

## Validation

- Durable, discovery, and delegation test suites pass.
- Typecheck passes.
- Lint passes.
- `build:core` passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->