### PR TITLE
fix(mcp): coordinate concurrent reconnects

### DIFF
--- a/.changeset/brave-rice-yawn.md
+++ b/.changeset/brave-rice-yawn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed concurrent MCP tool calls failing while the client reconnects after a dropped connection.

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -3564,10 +3564,16 @@ describe('InternalMastraMCPClient - stale SDK transport detach (issue #19862)', 
   let httpServer: HttpServer;
   let baseUrl: URL;
   let failing = false;
+  let initializeCount = 0;
+  let dropConcurrentToolCalls = false;
+  let pendingToolCallSockets: Array<{ destroy(): void }> = [];
   let client: InternalMastraMCPClient;
 
   beforeEach(async () => {
     failing = false;
+    initializeCount = 0;
+    dropConcurrentToolCalls = false;
+    pendingToolCallSockets = [];
     httpServer = createServer(async (req, res) => {
       if (failing || req.method === 'GET') {
         res.writeHead(req.method === 'GET' ? 405 : 404).end();
@@ -3592,6 +3598,7 @@ describe('InternalMastraMCPClient - stale SDK transport detach (issue #19862)', 
           .end(JSON.stringify({ jsonrpc: '2.0', id: body.id, result }));
       };
       if (body?.method === 'initialize') {
+        initializeCount++;
         reply({
           protocolVersion: body.params?.protocolVersion ?? '2025-03-26',
           capabilities: { tools: {} },
@@ -3602,6 +3609,14 @@ describe('InternalMastraMCPClient - stale SDK transport detach (issue #19862)', 
       } else if (body.method === 'tools/list') {
         reply({ tools: [{ name: 'ping', description: 'ping', inputSchema: { type: 'object', properties: {} } }] });
       } else if (body.method === 'tools/call') {
+        if (dropConcurrentToolCalls) {
+          pendingToolCallSockets.push(req.socket);
+          if (pendingToolCallSockets.length === 2) {
+            dropConcurrentToolCalls = false;
+            pendingToolCallSockets.forEach(socket => socket.destroy());
+          }
+          return;
+        }
         reply({ content: [{ type: 'text', text: 'pong' }] });
       } else {
         reply({});
@@ -3757,4 +3772,206 @@ describe('InternalMastraMCPClient - stale SDK transport detach (issue #19862)', 
       content: [{ type: 'text', text: 'pong' }],
     });
   }, 20000);
+
+  it('shares one real HTTP reconnect when concurrent tool calls lose the same transport', async () => {
+    client = new InternalMastraMCPClient({
+      name: 'concurrent-http-reconnect',
+      server: { url: baseUrl },
+    });
+    await client.connect();
+    const tools = await client.tools();
+
+    dropConcurrentToolCalls = true;
+    const results = await Promise.all([
+      tools['ping'].execute!({ context: {} }),
+      tools['ping'].execute!({ context: {} }),
+    ]);
+
+    expect(results).toEqual([
+      { content: [{ type: 'text', text: 'pong' }] },
+      { content: [{ type: 'text', text: 'pong' }] },
+    ]);
+    expect(initializeCount).toBe(2);
+  }, 20000);
+});
+
+describe('InternalMastraMCPClient - concurrent tool reconnects', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function createToolClient() {
+    const client = new InternalMastraMCPClient({
+      name: 'concurrent-reconnect-client',
+      server: { url: new URL('http://localhost:1234/mcp') },
+    });
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [{ name: 'ping', description: 'ping', inputSchema: { type: 'object' as const } }],
+    });
+    return { client, sdkClient };
+  }
+
+  it('shares one reconnect when concurrent calls fail on the same transport', async () => {
+    const { client, sdkClient } = createToolClient();
+    const staleTransport = { close: vi.fn().mockResolvedValue(undefined) };
+    const replacementTransport = { close: vi.fn().mockResolvedValue(undefined) };
+    (client as any).transport = staleTransport;
+
+    let rejectFirst!: (error: Error) => void;
+    let rejectSecond!: (error: Error) => void;
+    const callTool = vi
+      .spyOn(sdkClient, 'callTool')
+      .mockImplementationOnce(
+        () => new Promise((_, reject) => (rejectFirst = reject)) as ReturnType<Client['callTool']>,
+      )
+      .mockImplementationOnce(
+        () => new Promise((_, reject) => (rejectSecond = reject)) as ReturnType<Client['callTool']>,
+      )
+      .mockResolvedValue({ content: [{ type: 'text', text: 'pong' }] });
+    const connect = vi.spyOn(client, 'connect').mockImplementation(async () => {
+      (client as any).transport = replacementTransport;
+      return true;
+    });
+
+    const tool = (await client.tools())['ping'];
+    const firstCall = tool.execute?.({});
+    const secondCall = tool.execute?.({});
+    await vi.waitFor(() => expect(callTool).toHaveBeenCalledTimes(2));
+
+    rejectFirst(new Error('Connection closed'));
+    rejectSecond(new Error('Connection closed'));
+
+    await expect(Promise.all([firstCall, secondCall])).resolves.toEqual([
+      { content: [{ type: 'text', text: 'pong' }] },
+      { content: [{ type: 'text', text: 'pong' }] },
+    ]);
+    expect(staleTransport.close).toHaveBeenCalledOnce();
+    expect(connect).toHaveBeenCalledOnce();
+    expect((client as any).transport).toBe(replacementTransport);
+  });
+
+  it('does not replace a healthy transport after a late failure from an older one', async () => {
+    const { client, sdkClient } = createToolClient();
+    const staleTransport = { close: vi.fn().mockResolvedValue(undefined) };
+    const replacementTransport = { close: vi.fn().mockResolvedValue(undefined) };
+    (client as any).transport = staleTransport;
+
+    let rejectToolCall!: (error: Error) => void;
+    const callTool = vi
+      .spyOn(sdkClient, 'callTool')
+      .mockImplementationOnce(
+        () => new Promise((_, reject) => (rejectToolCall = reject)) as ReturnType<Client['callTool']>,
+      )
+      .mockResolvedValue({ content: [{ type: 'text', text: 'pong' }] });
+    const connect = vi.spyOn(client, 'connect').mockResolvedValue(true);
+
+    const tool = (await client.tools())['ping'];
+    const result = tool.execute?.({});
+    await vi.waitFor(() => expect(callTool).toHaveBeenCalledOnce());
+
+    (client as any).transport = replacementTransport;
+    rejectToolCall(new Error('Connection closed'));
+
+    await expect(result).resolves.toEqual({ content: [{ type: 'text', text: 'pong' }] });
+    expect(staleTransport.close).not.toHaveBeenCalled();
+    expect(replacementTransport.close).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
+    expect((client as any).transport).toBe(replacementTransport);
+  });
+
+  it('reconnects again when the replacement transport fails while an earlier reconnect is settling', async () => {
+    const { client, sdkClient } = createToolClient();
+    const firstTransport = { close: vi.fn().mockResolvedValue(undefined) };
+    const secondTransport = { close: vi.fn().mockResolvedValue(undefined) };
+    const thirdTransport = { close: vi.fn().mockResolvedValue(undefined) };
+    (client as any).transport = firstTransport;
+
+    let replacementPublished!: () => void;
+    const replacementWasPublished = new Promise<void>(resolve => (replacementPublished = resolve));
+    let finishFirstReconnect!: () => void;
+    const firstReconnectCanFinish = new Promise<void>(resolve => (finishFirstReconnect = resolve));
+    const connect = vi
+      .spyOn(client, 'connect')
+      .mockImplementationOnce(async () => {
+        (client as any).transport = secondTransport;
+        replacementPublished();
+        await firstReconnectCanFinish;
+        return true;
+      })
+      .mockImplementationOnce(async () => {
+        (client as any).transport = thirdTransport;
+        return true;
+      });
+    const callTool = vi
+      .spyOn(sdkClient, 'callTool')
+      .mockRejectedValueOnce(new Error('Connection closed'))
+      .mockRejectedValueOnce(new Error('Connection closed'))
+      .mockResolvedValue({ content: [{ type: 'text', text: 'pong' }] });
+
+    const tool = (await client.tools())['ping'];
+    const firstCall = tool.execute?.({});
+    await replacementWasPublished;
+
+    const secondCall = tool.execute?.({});
+    await vi.waitFor(() => expect(callTool).toHaveBeenCalledTimes(2));
+    finishFirstReconnect();
+
+    await expect(Promise.all([firstCall, secondCall])).resolves.toEqual([
+      { content: [{ type: 'text', text: 'pong' }] },
+      { content: [{ type: 'text', text: 'pong' }] },
+    ]);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(firstTransport.close).toHaveBeenCalledOnce();
+    expect(secondTransport.close).toHaveBeenCalledOnce();
+    expect((client as any).transport).toBe(thirdTransport);
+  });
+
+  it('does not leave a replacement transport connected when disconnect starts during reconnect', async () => {
+    const { client } = createToolClient();
+    const firstTransport = { close: vi.fn().mockResolvedValue(undefined) };
+    const replacementTransport = { close: vi.fn().mockResolvedValue(undefined) };
+    (client as any).transport = firstTransport;
+
+    let finishConnect!: () => void;
+    const connectCanFinish = new Promise<void>(resolve => (finishConnect = resolve));
+    const connect = vi.spyOn(client, 'connect').mockImplementation(async () => {
+      (client as any).transport = replacementTransport;
+      await connectCanFinish;
+      return true;
+    });
+
+    const reconnect = client.forceReconnect();
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledOnce());
+    const disconnect = client.disconnect();
+    finishConnect();
+
+    await expect(reconnect).resolves.toBeUndefined();
+    await expect(disconnect).resolves.toBeUndefined();
+    expect(firstTransport.close).toHaveBeenCalledOnce();
+    expect(replacementTransport.close).toHaveBeenCalledOnce();
+    expect((client as any).transport).toBeUndefined();
+  });
+
+  it('does not reconnect a tool call that fails after an explicit disconnect', async () => {
+    const { client, sdkClient } = createToolClient();
+    const transport = { close: vi.fn().mockResolvedValue(undefined) };
+    (client as any).transport = transport;
+
+    let rejectToolCall!: (error: Error) => void;
+    const callTool = vi.spyOn(sdkClient, 'callTool').mockImplementationOnce(
+      () => new Promise((_, reject) => (rejectToolCall = reject)) as ReturnType<Client['callTool']>,
+    );
+    const connect = vi.spyOn(client, 'connect');
+    const tool = (await client.tools())['ping'];
+    const result = tool.execute?.({});
+    await vi.waitFor(() => expect(callTool).toHaveBeenCalledOnce());
+
+    await client.disconnect();
+    rejectToolCall(new Error('Connection closed'));
+
+    await expect(result).rejects.toThrow('Connection closed');
+    expect(connect).not.toHaveBeenCalled();
+    expect(transport.close).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -647,6 +647,8 @@ export class InternalMastraMCPClient extends MastraBase {
   }
 
   private isConnected: Promise<boolean> | null = null;
+  private reconnectPromise: Promise<void> | null = null;
+  private lifecycleGeneration = 0;
 
   /**
    * Connects to the MCP server using the configured transport.
@@ -792,6 +794,17 @@ export class InternalMastraMCPClient extends MastraBase {
   }
 
   async disconnect() {
+    // Invalidate tool calls that started before this explicit teardown. Their
+    // recovery path must not establish a replacement connection afterwards.
+    this.lifecycleGeneration++;
+
+    // A reconnect that started first may publish a replacement transport.
+    // Wait for it, then tear down whichever transport is current.
+    const reconnectPromise = this.reconnectPromise;
+    if (reconnectPromise) {
+      await reconnectPromise.catch(() => {});
+    }
+
     // Release any transport left pending from an unfinished authorization flow,
     // even when there is no live transport to tear down.
     this.closePendingAuthTransport();
@@ -847,36 +860,83 @@ export class InternalMastraMCPClient extends MastraBase {
    * @internal
    */
   async forceReconnect(): Promise<void> {
-    this.log('debug', 'Forcing reconnection to MCP server...');
-
-    // Release any transport left pending from an unfinished authorization flow
-    // before rebuilding the connection.
-    this.closePendingAuthTransport();
-
-    // Disconnect current connection (ignore errors as connection may already be broken)
-    const disconnectedTransport = this.transport;
-    try {
-      if (disconnectedTransport) {
-        await disconnectedTransport.close();
-      }
-    } catch (e) {
-      this.log('debug', 'Error during force disconnect (ignored)', {
-        error: e instanceof Error ? e.message : String(e),
-      });
-    } finally {
-      if (disconnectedTransport) {
-        this.severClientTransportLink(disconnectedTransport);
-      }
+    if (this.reconnectPromise) {
+      this.log('debug', 'Reconnection already in progress; waiting for it to complete');
+      return await this.reconnectPromise;
     }
 
-    // Reset connection state
-    this.transport = undefined;
-    this.isConnected = null;
-    this.serverInstructions = undefined;
+    const reconnectPromise = (async () => {
+      this.log('debug', 'Forcing reconnection to MCP server...');
 
-    // Reconnect
-    await this.connect();
-    this.log('debug', 'Successfully reconnected to MCP server');
+      // Release any transport left pending from an unfinished authorization flow
+      // before rebuilding the connection.
+      this.closePendingAuthTransport();
+
+      // Disconnect current connection (ignore errors as connection may already be broken)
+      const disconnectedTransport = this.transport;
+      try {
+        if (disconnectedTransport) {
+          await disconnectedTransport.close();
+        }
+      } catch (e) {
+        this.log('debug', 'Error during force disconnect (ignored)', {
+          error: e instanceof Error ? e.message : String(e),
+        });
+      } finally {
+        if (disconnectedTransport) {
+          this.severClientTransportLink(disconnectedTransport);
+        }
+      }
+
+      // Reset connection state only when it still belongs to the transport that
+      // this reconnect attempt disconnected. A close callback may have already
+      // cleared it, but must not let us erase a replacement transport.
+      if (!disconnectedTransport || this.transport === disconnectedTransport) {
+        this.transport = undefined;
+        this.isConnected = null;
+        this.serverInstructions = undefined;
+      }
+
+      await this.connect();
+      this.log('debug', 'Successfully reconnected to MCP server');
+    })();
+    this.reconnectPromise = reconnectPromise;
+
+    try {
+      await reconnectPromise;
+    } finally {
+      if (this.reconnectPromise === reconnectPromise) {
+        this.reconnectPromise = null;
+      }
+    }
+  }
+
+  private async reconnectAfterTransportFailure(failedTransport: Transport | undefined, lifecycleGeneration: number) {
+    while (true) {
+      if (this.lifecycleGeneration !== lifecycleGeneration) {
+        throw new Error('MCP client was disconnected while recovering the failed transport');
+      }
+
+      const reconnectPromise = this.reconnectPromise;
+      if (reconnectPromise) {
+        await reconnectPromise;
+        // Re-evaluate after the owner clears the settled promise. The transport
+        // that failed may itself be the replacement created by that reconnect.
+        continue;
+      }
+
+      if (failedTransport && this.transport && this.transport !== failedTransport) {
+        this.log('debug', 'Connection was already replaced after the failed operation; skipping reconnect');
+        return;
+      }
+
+      await this.forceReconnect();
+
+      if (this.lifecycleGeneration !== lifecycleGeneration) {
+        throw new Error('MCP client was disconnected while recovering the failed transport');
+      }
+      return;
+    }
   }
 
   async listResources(): Promise<ListResourcesResult> {
@@ -1157,6 +1217,8 @@ export class InternalMastraMCPClient extends MastraBase {
                 return res;
               };
 
+              const failedTransport = this.transport;
+              const lifecycleGeneration = this.lifecycleGeneration;
               try {
                 return await executeToolCall();
               } catch (e) {
@@ -1168,7 +1230,7 @@ export class InternalMastraMCPClient extends MastraBase {
 
                   try {
                     // Force reconnection
-                    await this.forceReconnect();
+                    await this.reconnectAfterTransportFailure(failedTransport, lifecycleGeneration);
 
                     // Retry the tool call with fresh connection
                     this.log('debug', `Retrying tool ${tool.name} after reconnection...`);


### PR DESCRIPTION
## Description

Coordinates MCP recovery so concurrent tool calls that lose the same transport share one reconnect. A late failure from an older transport no longer replaces a newer healthy connection, and an explicit disconnect tears down a reconnect that was already in flight.

The public reproduction at https://github.com/rares04/mastra-mcp-reconnect-repro consistently leaves one call rejected and one pending on `@mastra/mcp@1.15.0`. The packed package from this branch completes both calls through one replacement connection. The PR also adds that real Streamable HTTP regression and focused tests for stale failures and lifecycle interleavings.

## Related issue(s)

Fixes #20526.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR
