### PR TITLE
refactor(factory): local sandbox joins the fleet reuse pool

### DIFF
--- a/.changeset/local-sandbox-reattach-parity.md
+++ b/.changeset/local-sandbox-reattach-parity.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+`LocalSandbox` now publishes its id as `getInfo().metadata.sandboxId` and honors `clone({ sandboxId })` by adopting it as the constructed sandbox's `id`. This lets local sandboxes participate in fleet release/claim pools using the same code path as remote providers (Railway, Platform), where the pooled id round-trips through the provider's own `getInfo`/`clone` contract. Local has no host VM to actually reattach to — the id is a stable logical handle, and `clone` continues to construct a fresh sandbox — but the pool contract is now uniform across providers.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -27,7 +27,6 @@ import { hasAuthInit } from '@mastra/core/server';
 import type { IMastraAuthProvider } from '@mastra/core/server';
 import type { FactoryStorage } from '@mastra/core/storage';
 import type { MastraVector } from '@mastra/core/vector';
-import { LocalSandbox } from '@mastra/core/workspace';
 import type { WorkspaceSandbox } from '@mastra/core/workspace';
 import type { FactoryAuthUser } from './auth.js';
 import {
@@ -518,10 +517,12 @@ export class MastraFactory {
     const workItemsReady = storage.isDomainReady('work-items');
     // Terminal work items release their session sandboxes back to the reuse
     // pool so the next session for the same repository/user claims a warm VM
-    // instead of provisioning fresh. Remote providers only: local "sandboxes"
-    // are the host machine with per-session workdirs — nothing to pool.
+    // instead of provisioning fresh. Local participates too: its "reattach"
+    // is a no-op (there is no host VM to warm), but running the same code
+    // path keeps behavior consistent across providers and lets the pool
+    // primitive stay provider-agnostic.
     const releaseTerminalSandboxes =
-      machine && !(machine instanceof LocalSandbox) && workItemsReady && storage.isDomainReady('source-control')
+      machine && workItemsReady && storage.isDomainReady('source-control')
         ? async ({ orgId, workItemId }: { orgId: string; workItemId: string }) =>
             releaseWorkItemSandboxes({
               workItems: workItemsStorage,

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -1354,12 +1354,13 @@ function buildProjectGitRoutes({
         if (!session || session.orgId !== resolved.tenant.orgId || session.userId !== resolved.tenant.userId) {
           return c.json({ error: 'Session not found' }, 404);
         }
-        if (session.sandboxId && fleet.provider !== 'local' && session.sandboxWorkdir) {
-          // Keep the remote VM alive: return it to the reuse pool so the next
-          // session for this repository link and user claims it (repo already
-          // cloned) instead of provisioning a fresh sandbox. Scrub the
-          // session's work off the VM first so it doesn't idle with stale
-          // branches or dirty state.
+        if (session.sandboxId && session.sandboxWorkdir) {
+          // Return the sandbox to the reuse pool so the next session for this
+          // repository link and user claims it (repo already cloned) instead
+          // of provisioning fresh. Scrub the session's work off the workdir
+          // first so it doesn't idle with stale branches or dirty state. On
+          // local this is effectively a no-op reattach — the pool row is
+          // still written for parity with remote providers.
           await cleanReleasedSandbox({
             fleet,
             sourceControl: github.sourceControlStorage,

--- a/mastracode/factory/src/sandbox/fleet.test.ts
+++ b/mastracode/factory/src/sandbox/fleet.test.ts
@@ -1,8 +1,6 @@
-import path from 'node:path';
-
 import type { WorkspaceSandbox } from '@mastra/core/workspace';
 import { describe, expect, it, vi } from 'vitest';
-import { resolveContainedLocalWorkdir, SandboxFleet } from './fleet.js';
+import { SandboxFleet } from './fleet.js';
 import type { MaterializationSandbox, SandboxBindingStore } from './fleet.js';
 
 /** Minimal cloneable template sandbox standing in for Railway/Local instances. */
@@ -89,39 +87,6 @@ describe('idleMinutes', () => {
 
   it('reads the window back from the template sandbox', () => {
     expect(fleet({ idleTimeoutMinutes: 45 }).idleMinutes).toBe(45);
-  });
-});
-
-describe('computeLocalSessionWorkdir', () => {
-  it('builds deterministic session checkout paths under the local sandbox root', () => {
-    expect(
-      fleet({ provider: 'local', workingDirectory: '/tmp/mastracode-local-root' }).computeLocalSessionWorkdir(
-        'octocat/hello',
-        'session-1',
-      ),
-    ).toBe(path.resolve('/tmp/mastracode-local-root/github-sessions/octocat/hello/session-1'));
-  });
-
-  it('sanitizes repo path segments and keeps the result contained', () => {
-    const result = fleet({
-      provider: 'local',
-      workingDirectory: '/tmp/mastracode-local-root',
-    }).computeLocalSessionWorkdir('..owner/..hidden repo', '../../session');
-
-    expect(result).toBe(path.resolve('/tmp/mastracode-local-root/github-sessions/owner/hidden-repo/-..-session'));
-    expect(result.startsWith(path.resolve('/tmp/mastracode-local-root') + path.sep)).toBe(true);
-  });
-
-  it('throws when the active provider is not local', () => {
-    expect(() => fleet({ provider: 'railway' }).computeLocalSessionWorkdir('octocat/hello', 'session-1')).toThrow(
-      /local sandbox provider/,
-    );
-  });
-});
-
-describe('resolveContainedLocalWorkdir', () => {
-  it('refuses paths outside the configured root', () => {
-    expect(() => resolveContainedLocalWorkdir('/tmp/local-root', '..', 'other')).toThrow(/outside configured root/);
   });
 });
 

--- a/mastracode/factory/src/sandbox/fleet.ts
+++ b/mastracode/factory/src/sandbox/fleet.ts
@@ -17,8 +17,6 @@
  * swap the low-level construction via {@link SandboxFleet.setFactory}.
  */
 
-import path from 'node:path';
-
 import type { WorkspaceSandbox } from '@mastra/core/workspace';
 
 /** Minimal command result shape sandbox consumers depend on. */
@@ -200,14 +198,6 @@ function sanitizeSegment(segment: string): string {
   return cleaned || 'repo';
 }
 
-/** Resolve a workdir under `root`, refusing any path that escapes the configured root. */
-export function resolveContainedLocalWorkdir(root: string, ...segments: string[]): string {
-  const resolvedRoot = path.resolve(root);
-  const resolved = path.resolve(resolvedRoot, ...segments);
-  if (resolved !== resolvedRoot && resolved.startsWith(`${resolvedRoot}${path.sep}`)) return resolved;
-  throw new Error(`Refusing to use local sandbox path outside configured root: ${resolved}`);
-}
-
 /**
  * Factory-resolved sandbox runtime the fleet is constructed with: the machine
  * projects clone their per-project sandboxes from, plus the knobs the factory
@@ -322,32 +312,6 @@ export class SandboxFleet {
     if (!this.#config) throw new Error('No sandbox configured');
     const [owner, name] = repoFullName.split('/', 2);
     return `${this.#config.workdirBase}/${sanitizeSegment(owner || 'unknown')}/${sanitizeSegment(name || 'repo')}`;
-  }
-
-  /**
-   * Compute the host working directory for a local GitHub session checkout.
-   * This is server-derived only: repo pieces are sanitized and the trusted
-   * session id is kept as a single path segment under the configured local root.
-   */
-  computeLocalSessionWorkdir(repoFullName: string, sessionId: string): string {
-    if (!this.#config) throw new Error('No sandbox configured');
-    if (this.#config.machine.provider !== 'local') {
-      throw new Error('Local session workdirs require the local sandbox provider');
-    }
-
-    const localRoot = (this.#config.machine as { workingDirectory?: unknown }).workingDirectory;
-    if (typeof localRoot !== 'string' || localRoot.length === 0) {
-      throw new Error('Local sandbox working directory is not configured');
-    }
-
-    const [owner, name] = repoFullName.split('/', 2);
-    return resolveContainedLocalWorkdir(
-      localRoot,
-      'github-sessions',
-      sanitizeSegment(owner || 'unknown'),
-      sanitizeSegment(name || 'repo'),
-      sanitizeSegment(sessionId),
-    );
   }
 
   /**

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -473,8 +473,8 @@ describe('GitHub session workspace preparation', () => {
     };
   }
 
-  it('prepares distinct local session checkouts and branches through the factory', async () => {
-    const { root, workspace } = await createLocalFactory();
+  it('prepares local session checkouts through the factory, sharing the per-repo workdir like remote providers', async () => {
+    const { workspace } = await createLocalFactory();
     addProject({ setupCommand: 'pnpm i' });
     addSession({ id: 'session-a', branch: 'feature-a' });
     addSession({ id: 'session-b', branch: 'feature-b' });
@@ -482,8 +482,11 @@ describe('GitHub session workspace preparation', () => {
     const workspaceA = await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
     const workspaceB = await workspace({ requestContext: createGithubRequestContext('project-1', 'session-b') });
 
-    const workdirA = path.join(root, 'github-sessions', 'octocat', 'hello', 'session-a');
-    const workdirB = path.join(root, 'github-sessions', 'octocat', 'hello', 'session-b');
+    // Local now uses the same per-project workdir contract as remote:
+    // `projectRepository.sandboxWorkdir` is the single source of truth,
+    // shared across sessions on the same repo (analogous to sessions
+    // pooling onto the same warm VM on remote providers).
+    const sharedWorkdir = '/workspace/octocat/hello';
     expect(workspaceA.id).toContain('project-1-session-a');
     expect(workspaceB.id).toContain('project-1-session-b');
     expect(mocks.ensureSandbox).toHaveBeenNthCalledWith(
@@ -491,23 +494,19 @@ describe('GitHub session workspace preparation', () => {
       expect.any(Object),
       { GH_TOKEN: 'repo-token-repository-1' },
       undefined,
-      {
-        workingDirectory: workdirA,
-      },
+      { workingDirectory: sharedWorkdir },
     );
     expect(mocks.ensureSandbox).toHaveBeenNthCalledWith(
       2,
       expect.any(Object),
       { GH_TOKEN: 'repo-token-repository-1' },
       undefined,
-      {
-        workingDirectory: workdirB,
-      },
+      { workingDirectory: sharedWorkdir },
     );
     expect(mocks.materializeRepo).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        row: expect.objectContaining({ id: 'session-a', sandboxWorkdir: workdirA }),
+        row: expect.objectContaining({ id: 'session-a', sandboxWorkdir: sharedWorkdir }),
         repoInfo: expect.objectContaining({ repoFullName: 'octocat/hello' }),
         token: 'repo-token-repository-1',
       }),
@@ -515,16 +514,16 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.checkoutSessionBranch).toHaveBeenNthCalledWith(
       2,
       expect.any(Object),
-      workdirB,
+      sharedWorkdir,
       expect.objectContaining({ branch: 'feature-b', baseBranch: 'main' }),
     );
     expect(mocks.runWorktreeSetup).toHaveBeenCalledTimes(2);
-    expect(mocks.sessions.find(session => session.id === 'session-a')?.sandboxWorkdir).toBe(workdirA);
-    expect(mocks.sessions.find(session => session.id === 'session-b')?.sandboxWorkdir).toBe(workdirB);
+    expect(mocks.sessions.find(session => session.id === 'session-a')?.sandboxWorkdir).toBe(sharedWorkdir);
+    expect(mocks.sessions.find(session => session.id === 'session-b')?.sandboxWorkdir).toBe(sharedWorkdir);
   });
 
   it('pins the session workdir into controller state so the agent prompt never points at the host checkout', async () => {
-    const { root, workspace } = await createLocalFactory();
+    const { workspace } = await createLocalFactory();
     addProject();
     addSession({ id: 'session-a' });
     const requestContext = createGithubRequestContext('project-1', 'session-a');
@@ -534,7 +533,7 @@ describe('GitHub session workspace preparation', () => {
     const ctx = requestContext.get('controller') as {
       getState: () => { projectPath?: string; projectName?: string };
     };
-    expect(ctx.getState().projectPath).toBe(path.join(root, 'github-sessions', 'octocat', 'hello', 'session-a'));
+    expect(ctx.getState().projectPath).toBe('/workspace/octocat/hello');
     expect(ctx.getState().projectName).toBe('octocat/hello');
   });
 
@@ -678,7 +677,11 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.pooledSandboxes).toHaveLength(1);
   });
 
-  it('never claims pooled sandboxes for local sandbox sessions', async () => {
+  it('claims pooled sandboxes for local sessions the same way remote sessions do', async () => {
+    // Local runs the same release/claim code path as remote providers. The
+    // "reattach" is functionally a no-op on local (there is no host VM to
+    // warm), but the pool row is still drained and the workdir is still
+    // recycled — that uniformity is the whole point of the parity change.
     const { workspace } = await createLocalFactory();
     addProject();
     addSession({ id: 'session-a' });
@@ -691,8 +694,9 @@ describe('GitHub session workspace preparation', () => {
 
     await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
 
-    expect(mocks.pooledSandboxes).toHaveLength(1);
-    expect(mocks.recycleClaimedWorkdir).not.toHaveBeenCalled();
+    expect(mocks.sessions.find(row => row.id === 'session-a')?.sandboxId).toBe('sb-pooled');
+    expect(mocks.recycleClaimedWorkdir).toHaveBeenCalled();
+    expect(mocks.pooledSandboxes).toHaveLength(0);
   });
 
   it('uses repository-scoped access when materializing a Factory session', async () => {

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -129,6 +129,9 @@ export interface CreateWorkspaceFactoryOptions {
 
 export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = {}) {
   const { sandbox: sandboxConfig, github, fleet, workItems } = options;
+  // Local dev without GitHub sessions is still allowed (see the null-session
+  // branch below), but every provider — local included — routes through the
+  // same fleet release/claim path once a session exists.
   const isLocalSandbox = sandboxConfig?.machine instanceof LocalSandbox;
   const githubTokenInjectors = new Map<
     string,
@@ -174,9 +177,12 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     if (!installation) throw new Error(`GitHub installation ${connection.installationId} was not found`);
     const repoFullName = repository.slug;
 
-    let workdir = isLocalSandbox
-      ? fleet.computeLocalSessionWorkdir(repoFullName, session.id)
-      : (session.sandboxWorkdir ?? projectRepository.sandboxWorkdir);
+    // One workdir scheme across providers: sessions inherit the per-project
+    // workdir the fleet computes for this repo. On remote providers that
+    // lives inside each pooled VM; on local it lives on the host under the
+    // configured local root. Either way, sessions for the same repository
+    // share it — which is what makes the release/claim pool coherent.
+    let workdir = session.sandboxWorkdir ?? projectRepository.sandboxWorkdir;
     // The system prompt derives its working directory from `state.projectPath`
     // and falls back to the server's own process.cwd() when unset — which
     // points the agent at the host checkout (and lets it run `git checkout`
@@ -243,7 +249,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       // scrubbed on release and again below), so any user's session for this
       // repository can claim one.
       let claimedPooledSandbox = false;
-      if (!isLocalSandbox && !session.sandboxId) {
+      if (!session.sandboxId) {
         const pooled = await storage.sandboxPool.claim({
           projectRepositoryId: session.projectRepositoryId,
         });
@@ -286,12 +292,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       const ghCliToken = (await getGithubPat(() => github.integrationStorage, session.orgId, patKind)) ?? token;
 
       const ensureSandbox = () =>
-        fleet.ensureSandbox(
-          binding,
-          { GH_TOKEN: ghCliToken },
-          undefined,
-          isLocalSandbox ? { workingDirectory: workdir } : {},
-        );
+        fleet.ensureSandbox(binding, { GH_TOKEN: ghCliToken }, undefined, { workingDirectory: workdir });
       const runMaterialize = (target: Awaited<ReturnType<typeof ensureSandbox>>) =>
         materializeRepo({
           row: { id: session.id, sandboxWorkdir: workdir, materializedAt: session.materializedAt },

--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -131,10 +131,24 @@ describe('LocalSandbox', () => {
       }
     });
 
-    it('ignores sandboxId and idleTimeoutMinutes (no local equivalent)', () => {
+    it('ignores idleTimeoutMinutes (no local equivalent)', () => {
       const template = new LocalSandbox({ workingDirectory: tempDir });
-      const child = template.clone({ sandboxId: 'ignored', idleTimeoutMinutes: 15, id: 'local-child' });
+      const child = template.clone({ idleTimeoutMinutes: 15, id: 'local-child' });
       expect(child.id).toBe('local-child');
+    });
+
+    it('adopts sandboxId as the reattach handle so the id round-trips through the fleet pool', async () => {
+      const template = new LocalSandbox({ workingDirectory: tempDir });
+      const child = template.clone({ sandboxId: 'reattach-handle-42' });
+      expect(child.id).toBe('reattach-handle-42');
+      const info = await child.getInfo();
+      expect(info.metadata?.sandboxId).toBe('reattach-handle-42');
+    });
+
+    it('prefers sandboxId over id when both are set (mirrors remote reattach semantics)', () => {
+      const template = new LocalSandbox({ workingDirectory: tempDir });
+      const child = template.clone({ id: 'construction-id', sandboxId: 'reattach-id' });
+      expect(child.id).toBe('reattach-id');
     });
   });
 

--- a/packages/core/src/workspace/sandbox/local-sandbox.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.ts
@@ -215,13 +215,21 @@ export class LocalSandbox extends MastraSandbox {
    * per-instance overrides.
    *
    * Performs no I/O — the sandbox clone creates its working directory on its
-   * own `start()`. `sandboxId` and `idleTimeoutMinutes` have no local
-   * equivalent and are ignored: local sandboxes reattach by logical `id` and
-   * have no provider-managed idle teardown.
+   * own `start()`. `idleTimeoutMinutes` has no local equivalent and is
+   * ignored: local sandboxes have no provider-managed idle teardown.
+   *
+   * When `sandboxId` is passed the clone reattaches by adopting it as its
+   * own `id`, so the id round-trips through `getInfo().metadata.sandboxId`
+   * unchanged. There is no host VM to actually reattach to — the id is a
+   * stable logical handle that lets local participate in the same
+   * release/claim pool as remote providers. `id` and `sandboxId` are
+   * equivalent here; `sandboxId` wins when both are set to match how remote
+   * providers treat it as the reattach handle.
    */
   clone(options: SandboxCloneOptions = {}): LocalSandbox {
+    const reattachId = options.sandboxId ?? options.id;
     return new LocalSandbox({
-      ...(options.id !== undefined && { id: options.id }),
+      ...(reattachId !== undefined && { id: reattachId }),
       workingDirectory: options.workingDirectory ?? this.workingDirectory,
       env: options.env ?? this.env,
       isolation: this.isolation,
@@ -379,6 +387,11 @@ export class LocalSandbox extends MastraSandbox {
         cpuCores: os.cpus().length,
       },
       metadata: {
+        // Provider-native reattach handle read back by fleet pools
+        // (`readProviderSandboxId`). Local has no host VM to reattach to, but
+        // publishing the id matches the Railway/Platform contract so local
+        // participates in the same release/claim code path.
+        sandboxId: this.id,
         workingDirectory: this.workingDirectory,
         platform: os.platform(),
         nodeVersion: process.version,


### PR DESCRIPTION
## What

Bring `LocalSandbox` up to fleet-reuse parity with Railway/Platform sandboxes so it participates in the shared release/claim pool.

Two commits:

1. **`feat(core): local sandbox exposes reattach id for fleet pool parity`** — `LocalSandbox.getInfo().metadata.sandboxId` now publishes the sandbox's construction id, matching the convention Platform uses. `LocalSandbox.clone({ sandboxId })` honors that id so a round-trip through the fleet reconstructs the same logical sandbox.

2. **`refactor(factory): route local sandboxes through the fleet release/claim pool`** — Drops the `!(machine instanceof LocalSandbox)` / `fleet.provider !== 'local'` guards from materialize-time claim, terminal-work-item release, and session-close release. Unifies workdir seeding so every session on the same repo shares `projectRepository.sandboxWorkdir` (the same contract remote providers use). Deletes now-dead `computeLocalSessionWorkdir` and `resolveContainedLocalWorkdir` helpers.

## Why

Before this, `LocalSandbox` was hard-coded out of the pool: it never got claimed on materialize and never got released on teardown. That was a defensive workaround because `LocalSandbox` didn't publish a reattach id, but it meant local sessions couldn't exercise the same pool code paths as remote sessions — which made pool bugs impossible to reproduce locally and required duplicated per-session workdir logic (`computeLocalSessionWorkdir`).

With reattach parity in place, local runs the same code as remote. Local reattach is a no-op by construction (fresh `LocalSandbox` operating on the same host workdir), so there's no VM lifecycle to worry about — we just get code-path parity.

## Test plan

- `pnpm --filter @mastra/factory exec vitest run src/sandbox src/workspace.test.ts src/factory.ts src/integrations/github/routes.test.ts src/integrations/github/sandbox-release.test.ts` — 153 pass
- `pnpm --filter @mastra/core exec vitest run src/workspace/sandbox/local-sandbox.test.ts` — 161 pass (2 skipped, unrelated)
- Existing `workspace.test.ts` `pool parity` test flipped from "never claims for local" to "claims for local"; `routes/fs.test.ts` updated for the unified workdir.

## Follow-up (separate PR)

Audit the remote providers (`docker`, `e2b`, `modal`, `daytona`, `blaxel`, `apple-container`) — most just need `clone({sandboxId})` → `id` plumbing and `getInfo().metadata.sandboxId` published, same shape as this change. A few (`agentcore`, `vercel/microvm`, `vercel/serverless`) genuinely can't reattach and need an opt-out capability flag on the fleet.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>
