### PR TITLE
fix(vercel): reattach MicroVM sandboxes through the fleet reuse pool

### DIFF
--- a/.changeset/vercel-microvm-fleet-pool-parity.md
+++ b/.changeset/vercel-microvm-fleet-pool-parity.md
@@ -1,0 +1,11 @@
+---
+'@mastra/vercel': patch
+'@mastra/factory': patch
+---
+
+`VercelSandbox` (MicroVM) now participates correctly in fleet reuse pools. Two changes:
+
+- `clone({ sandboxId })` now maps `sandboxId` to `sandboxName`, so a sandbox pulled from a pool resumes via `Sandbox.getOrCreate({ name })` instead of provisioning a fresh one.
+- `getInfo().metadata.sandboxId` now publishes the Vercel-assigned sandbox name, so the fleet has a reattach handle to persist on release.
+
+Every other pool-compatible provider (`docker`, `e2b`, `modal`, `daytona`, `blaxel`, `apple-container`) already reattaches through its logical `id` inside `start()`; no changes were needed there. `readProviderSandboxId`'s jsdoc has been updated to reflect that id-fallback is the norm, not an edge case.

--- a/mastracode/factory/src/sandbox/fleet.ts
+++ b/mastracode/factory/src/sandbox/fleet.ts
@@ -181,10 +181,11 @@ function toMaterializationSandbox(
 }
 
 /**
- * The provider's reattach id for a started sandbox. For Railway this is the
- * underlying `railwaySandboxId` in `getInfo().metadata`. Providers without a
- * provider-native id (e.g. local) reattach by construction id, so fall back
- * to the sandbox's own logical id.
+ * The provider's reattach id for a started sandbox. Providers publish this as
+ * `metadata.sandboxId` (or historically `metadata.railwaySandboxId`); when
+ * absent, we fall back to the sandbox's own logical id, which every current
+ * provider except Vercel MicroVM already uses as its reattach key inside
+ * `start()`. Vercel MicroVM publishes its assigned name as `metadata.sandboxId`.
  */
 async function readProviderSandboxId(sandbox: MaterializationSandbox): Promise<string | undefined> {
   const info = await sandbox.getInfo();

--- a/workspaces/vercel/src/microvm/index.test.ts
+++ b/workspaces/vercel/src/microvm/index.test.ts
@@ -334,6 +334,19 @@ describe('VercelSandbox', () => {
       expect(info.metadata?.timeout).toBe(120_000);
       expect(info.metadata?.domains).toEqual({ 8080: 'https://port-8080.vercel.run' });
     });
+
+    it('publishes the Vercel-assigned name as sandboxId so fleet pools can reattach', async () => {
+      const fake = makeFakeSandbox();
+      createMock.mockResolvedValue(fake);
+
+      const sandbox = new VercelSandbox();
+      await sandbox._start();
+
+      // fake sandbox's `.name` becomes the reattach handle the fleet pool
+      // serializes and later hands back via `clone({ sandboxId })`.
+      const info = sandbox.getInfo();
+      expect(info.metadata?.sandboxId).toBe(fake.name);
+    });
   });
 
   describe('getInstructions()', () => {
@@ -538,5 +551,20 @@ describe('VercelSandbox.clone', () => {
 
     expect(child.id).not.toBe(template.id);
     expect(child['_constructorOptions']).toMatchObject({ token: 'vc-tok', timeout: 120_000, env: { BASE: '1' } });
+  });
+
+  it('honors options.sandboxId as the reattach name so pooled sandboxes resume', () => {
+    // Vercel sandboxes reattach by `name`, not `id`. Fleet pools serialize a
+    // reattach handle as `sandboxId`; on clone we must map that back to
+    // `sandboxName` so `start()` calls `Sandbox.getOrCreate({ name })` and
+    // resumes the pooled sandbox instead of provisioning a fresh one.
+    const template = new VercelSandbox({ token: 'vc-tok', teamId: 'team-1', projectId: 'proj-1' });
+
+    const child = template.clone({ id: 'session-42', sandboxId: 'vercel-pooled-abc' });
+
+    expect(child['_constructorOptions']).toMatchObject({
+      id: 'session-42',
+      sandboxName: 'vercel-pooled-abc',
+    });
   });
 });

--- a/workspaces/vercel/src/microvm/index.ts
+++ b/workspaces/vercel/src/microvm/index.ts
@@ -186,6 +186,10 @@ export class VercelSandbox extends MastraSandbox {
       ...(options.id !== undefined && { id: options.id }),
       ...(options.env !== undefined && { env: options.env }),
       ...(options.idleTimeoutMinutes !== undefined && { timeout: options.idleTimeoutMinutes * 60_000 }),
+      // Reattach key: Vercel sandboxes are looked up by `name`, not `id`.
+      // Callers pooling sandboxes pass `sandboxId` — treat it as the sandbox
+      // name so `start()`'s `Sandbox.getOrCreate({ name })` resumes it.
+      ...(options.sandboxId !== undefined && { sandboxName: options.sandboxId }),
     });
   }
 
@@ -419,6 +423,9 @@ export class VercelSandbox extends MastraSandbox {
       metadata: {
         ...this._metadata,
         sandboxName: this._sandbox?.name,
+        // Reattach key surfaced for fleet pools: prefer the Vercel-assigned
+        // name (survives across sessions), fall back to the sandbox's own id.
+        sandboxId: this._sandbox?.name ?? this._sandboxName ?? this.id,
         runtime: this._runtime,
         timeout: this._timeout,
         ...(this._vcpus ? { vcpus: this._vcpus } : {}),


### PR DESCRIPTION
## Stacked on top of #20533

This PR is stacked on `fix/local-sandbox-fleet-parity` — merge that first, then GitHub will rebase this onto `main`.

## What

Fix Vercel MicroVM sandbox to actually reattach through the fleet reuse pool.

## Why

While auditing remote sandbox providers for pool compatibility (follow-up to #20533's local-parity work), I found every provider already reattaches through its logical `id` inside `start()` — **except Vercel MicroVM**, whose reattach key is `sandboxName`, not `id`.

Before this fix, when the fleet handed a pooled MicroVM sandbox back via `clone({ id, sandboxId })`, `_sandboxName` stayed unset, and `start()` fell through to the unnamed `Sandbox.create(params)` path — silently provisioning a fresh VM instead of resuming the pooled one. Not broken in the observable sense, just quietly negating the whole point of pooling for that provider.

## Changes

- `VercelSandbox.clone({ sandboxId })` now maps `sandboxId` → `sandboxName` so the pooled name flows into `_sandboxName`, and `start()` calls `Sandbox.getOrCreate({ name })`.
- `VercelSandbox.getInfo().metadata.sandboxId` publishes the Vercel-assigned sandbox name so the fleet has a reattach handle to persist on release. Matches the convention Platform/Local use.
- Fleet `readProviderSandboxId` jsdoc updated to reflect that id-fallback is the norm (every non-Railway/Platform provider today publishes no explicit reattach key and reattaches via logical `id`).

## What I confirmed *didn't* need changing

Every other pool-compatible provider already reattaches by logical `id`:

- **Docker** — `_findExistingContainer` labels by `this.id`
- **E2B** — `findExistingSandbox()` by `this.id` in metadata
- **Modal** — `client.sandboxes.fromName(appName, this.id)`
- **Daytona** — `findExistingSandbox()` by `this.id`
- **Blaxel** — `findExistingSandbox(this.toSandboxName(this.id))`
- **Apple Container** — `_inspectContainer()` by name derived from `this.id`

Since the pool serializes `sandbox.id` when no `metadata.sandboxId` is published, and the clone path threads that value back through `clone({ id })`, these providers reattach correctly with no changes.

## Not applicable

- **Vercel Serverless** and **AgentCore** — no `clone()` method, so they can't be used as a fleet template machine at all (the fleet already validates this at boot). No capability-flag needed.

## Test plan

- `pnpm --filter @mastra/vercel exec vitest run src/microvm/index.test.ts` — 40 pass (2 new: clone round-trip and getInfo publishes sandboxId)
- `pnpm --filter @mastra/factory exec vitest run src/sandbox/fleet.test.ts` — 21 pass (existing test at line 162-168 already asserts the `clone({ id, sandboxId })` contract, so this PR's fix satisfies it end-to-end)

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>
