### PR TITLE
fix(core): skip agent schedule detection when disabled

### DIFF
--- a/.changeset/brave-things-hide.md
+++ b/.changeset/brave-things-hide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed scheduler-disabled instances querying storage for existing agent schedules during worker startup.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -5036,6 +5036,7 @@ export class Mastra<
    */
   async #detectExistingAgentSchedules(): Promise<void> {
     if (this.#schedulerRequested) return;
+    if (this.#schedulerConfig?.enabled === false) return;
     if (!this.#storage) return;
     try {
       const schedulesStore = await this.#storage.getStore('schedules');

--- a/packages/core/src/mastra/scheduler-integration.test.ts
+++ b/packages/core/src/mastra/scheduler-integration.test.ts
@@ -93,6 +93,26 @@ describe('Mastra — workflow scheduler integration', () => {
     await mastra.shutdown();
   });
 
+  it('does not query for existing agent schedules when the scheduler is explicitly disabled', async () => {
+    const storage = new MockStore();
+    const schedulesStore = (await storage.getStore('schedules'))!;
+    const listSchedules = vi.spyOn(schedulesStore, 'listSchedules');
+
+    const mastra = new Mastra({
+      logger: false,
+      ...withoutNotificationDispatch,
+      storage,
+      scheduler: { enabled: false },
+    });
+
+    await mastra.startWorkers();
+
+    expect(listSchedules).not.toHaveBeenCalled();
+    expect(mastra.scheduler).toBeUndefined();
+
+    await mastra.shutdown();
+  });
+
   it('does not instantiate the scheduler when only unscheduled workflows are registered', async () => {
     const storage = new MockStore();
 


### PR DESCRIPTION
Fixes #20550.

Mastra currently probes storage for persisted agent schedules during `startWorkers()` even when `scheduler.enabled` is explicitly `false`. The detection happens before the scheduler enablement check, which can produce boot warnings from storage adapters for a subsystem the application opted out of.

Before:

```ts
if (this.#schedulerRequested) return;
if (!this.#storage) return;
```

After:

```ts
if (this.#schedulerRequested) return;
if (this.#schedulerConfig?.enabled === false) return;
if (!this.#storage) return;
```

This adds regression coverage that verifies the schedules store is not queried and the scheduler is not created when disabled. It also includes a patch changeset for `@mastra/core`.

Validated with the full scheduler integration test file, the Core TypeScript check, ESLint, Oxlint, the Core build, and `git diff --check`.