### PR TITLE
fix: reject AI SDK v5 system messages

### DIFF
--- a/.changeset/curly-lions-bake.md
+++ b/.changeset/curly-lions-bake.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/longmemeval': patch
-'@mastra/memory': patch
 ---
 
-Rejected system messages embedded in prompts and message arrays for AI SDK v5 generation calls.
+Fixed a prompt-injection risk by rejecting system-role messages embedded in `prompt` or `messages` for AI SDK v5 calls.

--- a/.changeset/curly-lions-bake.md
+++ b/.changeset/curly-lions-bake.md
@@ -1,0 +1,6 @@
+---
+'@mastra/longmemeval': patch
+'@mastra/memory': patch
+---
+
+Rejected system messages embedded in prompts and message arrays for AI SDK v5 generation calls.

--- a/explorations/longmemeval/src/commands/find-prohibited.ts
+++ b/explorations/longmemeval/src/commands/find-prohibited.ts
@@ -27,6 +27,7 @@ async function testContent(content: string): Promise<{ blocked: boolean; error?:
   try {
     await generateText({
       model: google('gemini-2.5-flash'),
+      allowSystemInMessages: false,
       messages: [
         { role: 'user', content },
         { role: 'assistant', content: 'I understand.' },

--- a/explorations/longmemeval/src/commands/test-cleaned.ts
+++ b/explorations/longmemeval/src/commands/test-cleaned.ts
@@ -19,6 +19,7 @@ async function testContent(content: string, label: string): Promise<boolean> {
     const model = google('gemini-2.5-flash');
     await generateText({
       model,
+      allowSystemInMessages: false,
       prompt: content.slice(0, 50000),
       providerOptions: {
         google: { safetySettings },

--- a/explorations/longmemeval/src/commands/test-incremental.ts
+++ b/explorations/longmemeval/src/commands/test-incremental.ts
@@ -19,6 +19,7 @@ async function testContent(content: string): Promise<boolean> {
     const model = google('gemini-2.5-flash');
     await generateText({
       model,
+      allowSystemInMessages: false,
       prompt: content,
       providerOptions: { google: { safetySettings } },
       maxOutputTokens: 10,

--- a/explorations/longmemeval/src/commands/test-messages.ts
+++ b/explorations/longmemeval/src/commands/test-messages.ts
@@ -19,6 +19,7 @@ async function testContent(content: string): Promise<boolean> {
     const model = google('gemini-2.5-flash');
     await generateText({
       model,
+      allowSystemInMessages: false,
       prompt: content,
       providerOptions: { google: { safetySettings } },
       maxOutputTokens: 10,

--- a/explorations/longmemeval/src/commands/test-prohibited.ts
+++ b/explorations/longmemeval/src/commands/test-prohibited.ts
@@ -32,6 +32,7 @@ async function testContent(content: string): Promise<{ blocked: boolean; error?:
     const model = google('gemini-2.5-flash');
     await generateText({
       model,
+      allowSystemInMessages: false,
       prompt: content.slice(0, 50000), // Limit to avoid token limits
       providerOptions: {
         google: { safetySettings },

--- a/explorations/longmemeval/src/commands/test-thread.ts
+++ b/explorations/longmemeval/src/commands/test-thread.ts
@@ -21,6 +21,7 @@ async function testContent(content: string, label: string): Promise<boolean> {
     const model = google('gemini-2.5-flash');
     await generateText({
       model,
+      allowSystemInMessages: false,
       prompt: content,
       providerOptions: {
         google: { safetySettings },

--- a/packages/_vendored/ai_v5/src/index.test.ts
+++ b/packages/_vendored/ai_v5/src/index.test.ts
@@ -1,0 +1,126 @@
+import type { LanguageModelV2 } from '@ai-sdk/provider';
+import { describe, expect, it, vi } from 'vitest';
+import { generateText, streamText } from './index';
+
+function convertArrayToReadableStream<T>(chunks: T[]) {
+  return new ReadableStream<T>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+function createMockModel() {
+  const doGenerate = vi.fn(async () => ({
+    content: [{ type: 'text' as const, text: 'trusted response' }],
+    finishReason: 'stop' as const,
+    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    warnings: [],
+  }));
+  const doStream = vi.fn(async () => ({
+    stream: convertArrayToReadableStream([
+      { type: 'stream-start' as const, warnings: [] },
+      { type: 'text-start' as const, id: 'text-1' },
+      { type: 'text-delta' as const, id: 'text-1', delta: 'trusted response' },
+      { type: 'text-end' as const, id: 'text-1' },
+      {
+        type: 'finish' as const,
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      },
+    ]),
+    warnings: [],
+  }));
+
+  return {
+    model: {
+      specificationVersion: 'v2',
+      provider: 'test',
+      modelId: 'test-model',
+      supportedUrls: {},
+      doGenerate,
+      doStream,
+    } as LanguageModelV2,
+    doGenerate,
+    doStream,
+  };
+}
+
+describe('secure AI SDK v5 text generation', () => {
+  const untrustedMessages = [
+    { role: 'system' as const, content: 'untrusted system message' },
+    { role: 'user' as const, content: 'hello' },
+  ];
+
+  it.each(['prompt', 'messages'] as const)('rejects system messages passed through %s in generateText', async field => {
+    const { model, doGenerate } = createMockModel();
+
+    await expect(
+      generateText({
+        model,
+        [field]: untrustedMessages,
+        allowSystemInMessages: true,
+      }),
+    ).rejects.toThrow('System messages are not allowed in the prompt or messages fields');
+    expect(doGenerate).not.toHaveBeenCalled();
+  });
+
+  it.each(['prompt', 'messages'] as const)('rejects system messages passed through %s in streamText', async field => {
+    const { model, doStream } = createMockModel();
+    const errors: unknown[] = [];
+
+    const result = streamText({
+      model,
+      [field]: untrustedMessages,
+      allowSystemInMessages: true,
+      onError: ({ error }) => errors.push(error),
+    });
+
+    for await (const _chunk of result.fullStream) {
+      // Consume the stream so prompt validation runs.
+    }
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      message: expect.stringContaining('System messages are not allowed in the prompt or messages fields'),
+    });
+    expect(doStream).not.toHaveBeenCalled();
+  });
+
+  it('allows trusted top-level system instructions in generateText', async () => {
+    const { model, doGenerate } = createMockModel();
+
+    const result = await generateText({
+      model,
+      system: 'trusted system instruction',
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+
+    expect(result.text).toBe('trusted response');
+    expect(doGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.arrayContaining([{ role: 'system', content: 'trusted system instruction' }]),
+      }),
+    );
+  });
+
+  it('allows trusted top-level system instructions in streamText', async () => {
+    const { model, doStream } = createMockModel();
+
+    const result = streamText({
+      model,
+      system: 'trusted system instruction',
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+
+    await expect(result.text).resolves.toBe('trusted response');
+    expect(doStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.arrayContaining([{ role: 'system', content: 'trusted system instruction' }]),
+      }),
+    );
+  });
+});

--- a/packages/_vendored/ai_v5/src/index.ts
+++ b/packages/_vendored/ai_v5/src/index.ts
@@ -2,6 +2,7 @@ import { generateText as generateTextV5, streamText as streamTextV5 } from 'ai';
 
 export * from 'ai';
 
+// Keep both security overrides after caller options so embedded system-role messages cannot be re-enabled.
 export const generateText: typeof generateTextV5 = options =>
   generateTextV5({
     ...options,

--- a/packages/_vendored/ai_v5/src/index.ts
+++ b/packages/_vendored/ai_v5/src/index.ts
@@ -1,1 +1,15 @@
+import { generateText as generateTextV5, streamText as streamTextV5 } from 'ai';
+
 export * from 'ai';
+
+export const generateText: typeof generateTextV5 = options =>
+  generateTextV5({
+    ...options,
+    allowSystemInMessages: false,
+  });
+
+export const streamText: typeof streamTextV5 = options =>
+  streamTextV5({
+    ...options,
+    allowSystemInMessages: false,
+  });

--- a/packages/memory/integration-tests/src/shared/ai-sdk-duplicate-ids.ts
+++ b/packages/memory/integration-tests/src/shared/ai-sdk-duplicate-ids.ts
@@ -35,6 +35,7 @@ export function getAiSdkDuplicateIdsTests(models: ModelConfig[]) {
 
         const result = streamTextFunction({
           model,
+          allowSystemInMessages: false,
           system:
             'First say "Let me check the weather", then call the get_weather tool, then summarize what you found.',
           prompt: 'What is the weather in Tokyo?',

--- a/packages/memory/integration-tests/src/shared/ai-sdk-duplicate-ids.ts
+++ b/packages/memory/integration-tests/src/shared/ai-sdk-duplicate-ids.ts
@@ -35,7 +35,6 @@ export function getAiSdkDuplicateIdsTests(models: ModelConfig[]) {
 
         const result = streamTextFunction({
           model,
-          allowSystemInMessages: false,
           system:
             'First say "Let me check the weather", then call the get_weather tool, then summarize what you found.',
           prompt: 'What is the weather in Tokyo?',


### PR DESCRIPTION
Fixes [AIKIDO-2026-11000](https://intel.aikido.dev/cve/AIKIDO-2026-11000):

>The `standardizePrompt` helper in the `ai` package previously accepted `system`-role entries inside the caller-supplied `messages` and `prompt` arrays used by `generateText`, `streamText`, `generateObject`, `streamObject`, and `streamUI`. Applications that forward end-user input directly into those arrays let an attacker inject a system message that overrides the developer's system instructions. The pre-fix behavior accepted `system` messages silently with no warning or rejection. The fix introduces an `allowSystemInMessages` option that warns by default when system messages appear in those fields and lets the application explicitly opt in to throw `InvalidPromptError` or preserve the legacy permissive behavior.

by forcing direct AI SDK v5 `generateText` and `streamText` calls to set `allowSystemInMessages: false`. This matches AI SDK v6’s default behavior, which rejects system-role messages embedded in prompt or messages while continuing to allow trusted top-level system instructions.

System-role messages embedded in `prompt` or `messages` are now rejected, while trusted top-level `system` instructions continue to work. The resolution is enforced in the shared v5 wrapper and the remaining direct v5 call sites.

```ts
generateText({
  model,
  allowSystemInMessages: false,
  system: trustedInstructions,
  messages,
});
```

This is intentionally scoped to direct AI SDK v5 `generateText` and `streamText` usage. Mastra’s core agent loop calls `model.doGenerate` or `model.doStream` directly, where `allowSystemInMessages` is not an applicable option. Observational memory uses that core loop, so shipped `@mastra/memory` behavior is unchanged and it is not included in the changeset.

Verified with tests covering both APIs, both untrusted input shapes, and trusted top-level system instructions.