### PR TITLE
fix(server): keep experiment name, description and metadata on trigger

### DIFF
--- a/.changeset/experiment-trigger-metadata.md
+++ b/.changeset/experiment-trigger-metadata.md
@@ -1,0 +1,15 @@
+---
+'@mastra/server': patch
+---
+
+Fixed `POST /datasets/:datasetId/experiments` silently discarding `name`, `description` and `metadata`. The request schema left the fields out, so they were stripped during validation and the experiment was created with those columns empty even though the request returned 200. They are now accepted and stored, matching what the experiment read routes already return.
+
+```jsonc
+// POST /datasets/<id>/experiments
+{
+  "targetType": "workflow",
+  "targetId": "my-workflow",
+  "name": "Nightly baseline",
+  "metadata": { "model": "claude-haiku-4-5" }, // before: dropped, now: stored
+}
+```

--- a/packages/server/src/server/handlers/datasets.test.ts
+++ b/packages/server/src/server/handlers/datasets.test.ts
@@ -2,15 +2,18 @@ import { Mastra } from '@mastra/core/mastra';
 import { InMemoryStore } from '@mastra/core/storage';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { HTTPException } from '../http-exception';
+import { triggerExperimentBodySchema } from '../schemas/datasets';
 import {
   ADD_ITEM_ROUTE,
   BATCH_INSERT_ITEMS_ROUTE,
   DELETE_DATASET_ROUTE,
   GET_DATASET_ROUTE,
+  GET_EXPERIMENT_ROUTE,
   GET_ITEM_ROUTE,
   GET_ITEM_VERSION_ROUTE,
   LIST_DATASETS_ROUTE,
   LIST_ITEM_VERSIONS_ROUTE,
+  TRIGGER_EXPERIMENT_ROUTE,
   UPDATE_DATASET_ROUTE,
   UPDATE_ITEM_ROUTE,
 } from './datasets';
@@ -625,6 +628,55 @@ describe('Datasets Handlers', () => {
       expect(byInput.get('selected')?.scorerIds).toEqual(['quality']);
       expect(byInput.get('disabled')?.scorerIds).toEqual([]);
       expect(byInput.get('inherited')?.scorerIds).toBeUndefined();
+    });
+  });
+
+  describe('experiment metadata', () => {
+    it('keeps name, description and metadata on the trigger body', () => {
+      const parsed = triggerExperimentBodySchema.parse({
+        targetType: 'agent',
+        targetId: 'my-agent',
+        name: 'Baseline run',
+        description: 'Haiku baseline',
+        metadata: { model: 'claude-haiku-4-5' },
+      });
+
+      expect(parsed).toMatchObject({
+        name: 'Baseline run',
+        description: 'Haiku baseline',
+        metadata: { model: 'claude-haiku-4-5' },
+      });
+    });
+
+    it('persists name, description and metadata on the triggered experiment', async () => {
+      const dataset = await mastra.datasets.create({ name: 'Experiment DS' });
+      await ADD_ITEM_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        datasetId: dataset.id,
+        input: { q: 'first' },
+      } as any);
+
+      const triggered = (await TRIGGER_EXPERIMENT_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        datasetId: dataset.id,
+        targetType: 'agent',
+        targetId: 'my-agent',
+        name: 'Baseline run',
+        description: 'Haiku baseline',
+        metadata: { model: 'claude-haiku-4-5' },
+      } as any)) as any;
+
+      const experiment = (await GET_EXPERIMENT_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        datasetId: dataset.id,
+        experimentId: triggered.experimentId,
+      } as any)) as any;
+
+      expect(experiment).toMatchObject({
+        name: 'Baseline run',
+        description: 'Haiku baseline',
+        metadata: { model: 'claude-haiku-4-5' },
+      });
     });
   });
 });

--- a/packages/server/src/server/handlers/datasets.ts
+++ b/packages/server/src/server/handlers/datasets.ts
@@ -696,6 +696,9 @@ export const TRIGGER_EXPERIMENT_ROUTE = createRoute({
       const {
         targetType,
         targetId,
+        name,
+        description,
+        metadata,
         scorerIds,
         version,
         agentVersion,
@@ -705,6 +708,9 @@ export const TRIGGER_EXPERIMENT_ROUTE = createRoute({
       } = params as {
         targetType: 'agent' | 'workflow' | 'scorer';
         targetId: string;
+        name?: string;
+        description?: string;
+        metadata?: Record<string, unknown>;
         scorerIds?: string[];
         version?: number;
         agentVersion?: string;
@@ -719,6 +725,9 @@ export const TRIGGER_EXPERIMENT_ROUTE = createRoute({
       const result = await ds.startExperimentAsync({
         targetType,
         targetId,
+        name,
+        description,
+        metadata,
         scorers: scorerIds,
         version,
         agentVersion,

--- a/packages/server/src/server/schemas/datasets.ts
+++ b/packages/server/src/server/schemas/datasets.ts
@@ -330,6 +330,9 @@ export const updateItemBodySchema = z.object({
 export const triggerExperimentBodySchema = z.object({
   targetType: z.enum(['agent', 'workflow', 'scorer']).describe('Type of target to run against'),
   targetId: z.string().describe('ID of the target'),
+  name: z.string().optional().describe('Name of the experiment, used for display and grouping'),
+  description: z.string().optional().describe('Description of the experiment'),
+  metadata: z.record(z.string(), z.unknown()).optional().describe('Additional metadata'),
   scorerIds: z.array(z.string()).optional().describe('IDs of scorers to apply'),
   version: z.coerce.number().int().optional().describe('Pin to specific dataset version'),
   agentVersion: z.string().optional().describe('Agent version ID to use for experiment'),


### PR DESCRIPTION
## Description

`POST /datasets/:datasetId/experiments` accepted `name`, `description` and `metadata` and then threw them away.

`triggerExperimentBodySchema` (`packages/server/src/server/schemas/datasets.ts`) never declared the three fields, and a plain `z.object()` strips unknown keys instead of rejecting them, so validation dropped them before the handler ran. The request still returned 200 and the experiment still executed, just with those columns empty, which is why it reads as "it worked".

Everything downstream already supports them:

- `ExperimentConfig` declares `name?`, `description?` and `metadata?`
- `Dataset.startExperimentAsync` passes all three to `createExperiment` (`packages/core/src/datasets/dataset.ts`)
- `experimentResponseSchema` returns all three

So the write path was the only place they were missing. This adds them to the trigger body schema and forwards them from the route handler to `startExperimentAsync`. Nothing else changes: all three stay optional, and a request that omits them behaves exactly as before.

## Tests

Two in `packages/server/src/server/handlers/datasets.test.ts`, both failing on `main`:

- the schema-level one shows `triggerExperimentBodySchema.parse()` keeping the fields rather than stripping them
- the route-level one triggers an experiment with a name, description and metadata and reads it back through `GET_EXPERIMENT_ROUTE`, which returned `undefined` for all three before this change

The rest of that file has three failures on my machine (`item tool mocks`, `item scorer IDs`) that reproduce identically on clean `main` from a stale prebuilt `@mastra/core` in `node_modules`, so they are unrelated to this change.

## Related issue(s)

Fixes #20539

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The experiment creation request now keeps its name, description, and metadata. This lets users label and group experiments instead of losing these values.

## Changes

- Added optional `name`, `description`, and `metadata` fields to `triggerExperimentBodySchema`.
- Forwarded these fields from `POST /datasets/:datasetId/experiments` to `startExperimentAsync`.
- Added schema and route tests for validation, persistence, and experiment retrieval.
- Added a patch changeset for `@mastra/server`.
- Preserved existing behavior when these fields are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->