### PR TITLE
fix(ai-sdk): preserve finish reasons in UI streams

### DIFF
--- a/.changeset/lemon-cloths-boil.md
+++ b/.changeset/lemon-cloths-boil.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed AI SDK UI finish chunks so consumers can distinguish why a stream ended.

--- a/client-sdks/ai-sdk/src/helpers.test.ts
+++ b/client-sdks/ai-sdk/src/helpers.test.ts
@@ -263,3 +263,35 @@ describe('finish usage conversion', () => {
     });
   });
 });
+
+describe('v6 finish UI conversion', () => {
+  it.each([
+    ['stop', 'stop'],
+    ['length', 'length'],
+    ['content-filter', 'content-filter'],
+    ['tool-calls', 'tool-calls'],
+    ['other', 'other'],
+    ['tripwire', 'other'],
+    ['retry', 'other'],
+  ] as const)('maps the %s finish reason to %s in the UI chunk', (reason, expectedFinishReason) => {
+    const part = convertMastraChunkToAISDKv6({
+      chunk: {
+        type: 'finish',
+        runId: 'run-1',
+        from: ChunkFrom.AGENT,
+        payload: { stepResult: { reason }, output: { usage: {} } },
+      } as any,
+    });
+
+    const uiChunk = convertFullStreamChunkToUIMessageStream({
+      part: part as any,
+      sendFinish: true,
+      onError: error => String(error),
+    });
+
+    expect(uiChunk).toEqual({
+      type: 'finish',
+      finishReason: expectedFinishReason,
+    });
+  });
+});

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -802,6 +802,7 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
       if (sendFinish) {
         return {
           type: 'finish' as const,
+          finishReason: part.finishReason,
           ...(messageMetadataValue != null ? { messageMetadata: messageMetadataValue } : {}),
         } as InferUIMessageChunk<UI_MESSAGE>;
       }


### PR DESCRIPTION
## Description

Mastra already normalizes each stream `finish` part before converting it to an AI SDK UI message chunk, but the UI conversion dropped `part.finishReason` and returned only `type` and optional `messageMetadata`.

This PR forwards the normalized `finishReason` on UI `finish` chunks and adds v6 coverage for `stop`, `length`, `content-filter`, `tool-calls`, `other`, plus Mastra-specific `tripwire` and `retry` reasons that normalize to `other`.

This change restores termination classification and observability for UI stream consumers. It does not attempt to diagnose or change model responses that end with `stop` and empty content, nor upstream clean EOF behavior. Raw provider reasons and usage remain on the full-stream finish part; they are not added to the UI chunk because the AI SDK UI finish contract only forwards `finishReason` and optional message metadata.

Validation:

- `pnpm --config.minimum-release-age=0 --filter @mastra/ai-sdk exec vitest run src/helpers.test.ts` (17 passed)
- `pnpm --config.minimum-release-age=0 --filter @mastra/ai-sdk lint`
- `pnpm --config.minimum-release-age=0 --filter @mastra/ai-sdk exec tsc --noEmit -p tsconfig.json`
- `pnpm --config.minimum-release-age=0 turbo build --filter ./client-sdks/ai-sdk` (18/18 tasks passed)

The full package test command additionally ran 180 passing tests. It also reported three suite-load failures on existing `ai/test` imports and one LibSQL observational-memory assertion outside the changed files; the focused tests, lint, typecheck, and package build above all pass.

## Related issue(s)

Fixes #20562

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR tells the UI why an AI response ended. Consumers can now distinguish normal stops, length limits, content filters, tool calls, and other termination reasons.

## Changes

- Forward normalized `finishReason` values to AI SDK v6 UI finish chunks.
- Normalize Mastra-specific `tripwire` and `retry` reasons to `other`.
- Preserve raw provider reasons and usage on the full-stream finish part.
- Add tests for standard and Mastra-specific finish reasons.
- Add a patch changeset for `@mastra/ai-sdk`.

## Scope

This PR does not address empty-content `stop` responses or streams that end without a finish part.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->