### PR TITLE
fix(ai-sdk): stream agent step deltas

### DIFF
--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
@@ -1,6 +1,7 @@
+import { ChunkFrom } from '@mastra/core/stream';
 import { describe, expect, it } from 'vitest';
 
-import { transformAgent } from '../transformers';
+import { AgentStreamToAISDKTransformer, transformAgent } from '../transformers';
 
 /**
  * Regression test for https://github.com/mastra-ai/mastra/issues/14932
@@ -31,7 +32,11 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
     const emissions: any[] = [];
 
     function collect(result: any) {
-      if (result) emissions.push(result);
+      if (Array.isArray(result)) {
+        emissions.push(...result);
+      } else if (result) {
+        emissions.push(result);
+      }
     }
 
     for (let step = 0; step < numSteps; step++) {
@@ -180,6 +185,113 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
     );
 
     expect(bufferedSteps.get(runId).object).toEqual({ key: 'value', nested: { a: 1 } });
+  });
+
+  it('emits full completed steps as data-tool-agent-step deltas', () => {
+    const { emissions } = simulateMultiStepAgentRun(3);
+    const stepChunks = emissions.filter(emission => emission.type === 'data-tool-agent-step');
+
+    expect(stepChunks).toHaveLength(3);
+    expect(stepChunks[0]).toMatchObject({
+      id: 'test-run:step-0',
+      data: {
+        runId: 'test-run',
+        stepIndex: 0,
+        step: {
+          text: expect.stringContaining('Step 0 response text.'),
+          toolResults: [
+            expect.objectContaining({
+              result: { output: `Result from step 0. `.repeat(50) },
+            }),
+          ],
+        },
+      },
+    });
+  });
+
+  it('emits data-tool-agent-step deltas through the nested tool-output transformer route', async () => {
+    const stream = new ReadableStream<any>({
+      start(controller) {
+        controller.enqueue({
+          type: 'tool-output',
+          runId: 'supervisor-run',
+          from: ChunkFrom.AGENT,
+          payload: {
+            toolCallId: 'agent-subAgent',
+            output: {
+              type: 'start',
+              runId: 'sub-agent-run',
+              from: ChunkFrom.AGENT,
+              payload: { id: 'agent-1' },
+            },
+          },
+        });
+        controller.enqueue({
+          type: 'tool-output',
+          runId: 'supervisor-run',
+          from: ChunkFrom.AGENT,
+          payload: {
+            toolCallId: 'agent-subAgent',
+            output: {
+              type: 'tool-result',
+              runId: 'sub-agent-run',
+              from: ChunkFrom.AGENT,
+              payload: {
+                toolCallId: 'call-1',
+                toolName: 'search',
+                result: { output: 'large result '.repeat(20) },
+              },
+            },
+          },
+        });
+        controller.enqueue({
+          type: 'tool-output',
+          runId: 'supervisor-run',
+          from: ChunkFrom.AGENT,
+          payload: {
+            toolCallId: 'agent-subAgent',
+            output: {
+              type: 'step-finish',
+              runId: 'sub-agent-run',
+              from: ChunkFrom.AGENT,
+              payload: {
+                id: 'step-0',
+                stepResult: { reason: 'tool-calls', warnings: [] },
+                output: { usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+                metadata: { timestamp: new Date(), modelId: 'test-model' },
+              },
+            },
+          },
+        });
+        controller.close();
+      },
+    });
+
+    const chunks: any[] = [];
+    for await (const chunk of stream.pipeThrough(
+      AgentStreamToAISDKTransformer({ sendStart: false, sendFinish: false }),
+    )) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.some(chunk => chunk.type === 'data-tool-agent-step')).toBe(true);
+  });
+
+  it('keeps intermediate data-tool-agent snapshots from repeating completed step payloads', () => {
+    const { emissions } = simulateMultiStepAgentRun(3);
+    const snapshots = emissions.filter(emission => emission.type === 'data-tool-agent');
+
+    for (const snapshot of snapshots) {
+      for (const step of snapshot.data.steps) {
+        expect(step.text).toBe('');
+        expect(step.reasoning).toEqual([]);
+        expect(step.toolCalls).toEqual([]);
+        expect(step.toolResults).toEqual([]);
+        expect(step.sources).toEqual([]);
+        expect(step.files).toEqual([]);
+        expect(step.response.messages).toEqual([]);
+      }
+    }
   });
 
   it('payload size should grow linearly, not super-quadratically', () => {

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-tool-input-streaming.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-tool-input-streaming.test.ts
@@ -268,8 +268,11 @@ describe('transformAgent tool input streaming (issue #16422)', () => {
       }),
       bufferedSteps,
     );
+    const stepFinishSnapshot = Array.isArray(stepFinish)
+      ? stepFinish.find(chunk => chunk.type === 'data-tool-agent')
+      : stepFinish;
 
-    expect(stepFinish).toMatchObject({
+    expect(stepFinishSnapshot).toMatchObject({
       data: {
         pendingToolCalls: [],
         steps: [

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -108,6 +108,16 @@ export type AgentDataPart = {
   data: LLMStepResult;
 };
 
+export type AgentStepDataPart = {
+  type: 'data-tool-agent-step';
+  id: string;
+  data: {
+    runId: string;
+    stepIndex: number;
+    step: LLMStepResult;
+  };
+};
+
 // used so it's not serialized to JSON
 const PRIMITIVE_CACHE_SYMBOL = Symbol('primitive-cache');
 
@@ -391,7 +401,13 @@ export function createAgentStreamToAISDKTransformer<OUTPUT>(
           if (transformedChunk.type === 'tool-agent') {
             const payload = transformedChunk.payload;
             const agentTransformed = transformAgent<OUTPUT>(payload, bufferedSteps);
-            if (agentTransformed) controller.enqueue(agentTransformed);
+            if (Array.isArray(agentTransformed)) {
+              for (const item of agentTransformed) {
+                controller.enqueue(item);
+              }
+            } else if (agentTransformed) {
+              controller.enqueue(agentTransformed);
+            }
           } else if (transformedChunk.type === 'tool-workflow') {
             const payload = transformedChunk.payload;
             const workflowChunk = transformWorkflow(
@@ -601,7 +617,61 @@ function removePendingToolCall(pendingToolCalls: PendingAgentToolCall[] = [], to
   return pendingToolCalls.filter(call => call.toolCallId !== toolCallId);
 }
 
-export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps: Map<string, any>) {
+function cloneAgentStepForSnapshot(step: any) {
+  const { request: _request, response, ...rest } = step;
+
+  return {
+    ...rest,
+    text: '',
+    reasoning: [],
+    reasoningText: '',
+    sources: [],
+    files: [],
+    toolCalls: [],
+    pendingToolCalls: [],
+    toolResults: [],
+    staticToolCalls: [],
+    dynamicToolCalls: [],
+    staticToolResults: [],
+    dynamicToolResults: [],
+    object: null,
+    response: response ? { ...response, messages: [] } : response,
+  };
+}
+
+function createAgentDataPart(runId: string, data: any, { includeStepDetails }: { includeStepDetails: boolean }) {
+  const { _textOffset: _to, _reasoningOffset: _ro, ...serializableData } = data;
+
+  return {
+    type: 'data-tool-agent',
+    id: runId,
+    data: {
+      ...serializableData,
+      steps: includeStepDetails ? serializableData.steps : serializableData.steps.map(cloneAgentStepForSnapshot),
+    },
+  } satisfies AgentDataPart;
+}
+
+function createAgentStepDataPart(runId: string, data: any): AgentStepDataPart | null {
+  const stepIndex = data.steps.length - 1;
+  const step = data.steps[stepIndex];
+
+  if (!step) {
+    return null;
+  }
+
+  return {
+    type: 'data-tool-agent-step',
+    id: `${runId}:step-${stepIndex}`,
+    data: {
+      runId,
+      stepIndex,
+      step,
+    },
+  };
+}
+
+export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps: Map<string, any>): any {
   let hasChanged = false;
   switch (payload.type) {
     case 'start':
@@ -851,13 +921,15 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
   }
 
   if (hasChanged) {
-    // Strip internal offset trackers so they don't leak over the wire.
-    const { _textOffset: _to, _reasoningOffset: _ro, ...data } = bufferedSteps.get(payload.runId!)!;
-    return {
-      type: 'data-tool-agent',
-      id: payload.runId!,
-      data,
-    } satisfies AgentDataPart;
+    const data = bufferedSteps.get(payload.runId!)!;
+    const agentDataPart = createAgentDataPart(payload.runId!, data, { includeStepDetails: payload.type === 'finish' });
+
+    if (payload.type === 'step-finish') {
+      const stepDataPart = createAgentStepDataPart(payload.runId!, data);
+      return stepDataPart ? ([agentDataPart, stepDataPart] as const) : agentDataPart;
+    }
+
+    return agentDataPart;
   }
   return null;
 }
@@ -1396,8 +1468,9 @@ export function transformNetwork(
 
         step[PRIMITIVE_CACHE_SYMBOL] = step[PRIMITIVE_CACHE_SYMBOL] || new Map();
         const result = transformAgent(payload.payload as ChunkType<any>, step[PRIMITIVE_CACHE_SYMBOL]);
-        if (result) {
-          const { request, response, ...data } = result.data;
+        const agentResult = Array.isArray(result) ? result.find(item => item.type === 'data-tool-agent') : result;
+        if (agentResult) {
+          const { request, response, ...data } = agentResult.data;
           step.task = data;
         }
 


### PR DESCRIPTION
## Summary

Fixes #20440. Stream incremental agent step deltas from the AI SDK transformer instead of re-emitting cumulative nested state on each chunk. This keeps long nested agent streams from growing quadratically.

## Validation

- Not completed locally: `pnpm --filter @mastra/ai-sdk test transform-agent-cumulative-growth.test.ts transform-agent-tool-input-streaming.test.ts` triggered `pnpm install`, which timed out while downloading native packages. CI should run the added tests.