### PR TITLE
fix(core): persist null output in collectToolMocks for steps without toolResult

### DIFF
--- a/.changeset/tidy-wasps-repeat.md
+++ b/.changeset/tidy-wasps-repeat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `collectToolMocks` emitting `output: undefined` for tool-call trajectory steps without a recorded `toolResult` (e.g. failed or suspended calls). `JSON.stringify` drops `undefined` keys, so saving a dataset item from such a trace failed server-side validation with `400 Invalid request body: toolMocks.N.output — expected nonoptional, received undefined`. Missing results are now persisted as `null`.

--- a/packages/core/src/evals/collect-tool-mocks.test.ts
+++ b/packages/core/src/evals/collect-tool-mocks.test.ts
@@ -94,6 +94,19 @@ describe('collectToolMocks', () => {
     expect(collectToolMocks(steps)).toEqual([{ toolName: 'noArgs', args: {}, output: { ok: true } }]);
   });
 
+  it('defaults a missing toolResult to null so the mock survives JSON serialization', () => {
+    // `toolResult` is optional on tool_call steps (failed/suspended calls or
+    // non-record outputs). `JSON.stringify` drops `undefined` keys and the
+    // server schema requires `output` (zod v4: missing key fails with
+    // "expected nonoptional, received undefined"), so we persist `null`.
+    const steps: TrajectoryStep[] = [{ name: "tool: 'flaky'", stepType: 'tool_call', toolArgs: { id: 1 } }];
+
+    const [mock] = collectToolMocks(steps);
+    expect(mock).toEqual({ toolName: 'flaky', args: { id: 1 }, output: null });
+    expect('output' in mock!).toBe(true);
+    expect(JSON.parse(JSON.stringify(mock))).toEqual({ toolName: 'flaky', args: { id: 1 }, output: null });
+  });
+
   it('returns an empty array for undefined or empty steps', () => {
     expect(collectToolMocks(undefined)).toEqual([]);
     expect(collectToolMocks([])).toEqual([]);

--- a/packages/core/src/evals/collect-tool-mocks.ts
+++ b/packages/core/src/evals/collect-tool-mocks.ts
@@ -50,7 +50,11 @@ function collectToolMocksInto(steps: TrajectoryStep[] | undefined, acc: DatasetI
       acc.push({
         toolName,
         args: toolArgs ?? {},
-        output: toolResult,
+        // `toolResult` is optional on the step (e.g. failed/suspended calls, or
+        // non-record outputs). `JSON.stringify` drops `undefined` keys, and the
+        // server schema requires `output` (zod v4 rejects a missing key with
+        // "expected nonoptional, received undefined"), so persist `null`.
+        output: toolResult ?? null,
         // Sub-agent delegation args are LLM-authored + runtime-injected; default
         // to ignore-args matching so the saved mock matches on replay.
         ...(isSubAgentDelegation(toolName) ? { matchArgs: 'ignore' as const } : {}),


### PR DESCRIPTION
Fixes #20568

## Problem

Saving a dataset item from a trace fails with HTTP 400 when the trace contains a tool-call step without a recorded `toolResult`:

```
Failed to save item: HTTP error! status: 400 -
{"error":"Invalid request body","issues":[{"field":"toolMocks.11.output",
"message":"Invalid input: expected nonoptional, received undefined"}]}
```

**Root cause:** `toolResult` is optional on tool-call trajectory steps (failed/suspended calls, or outputs that are not records — see `toRecordOrUndefined`). `collectToolMocks` emitted `output: toolResult` verbatim, i.e. `output: undefined` for those steps. `JSON.stringify` drops `undefined` keys, so the key never reaches the server, and the dataset-item request schema (`output: z.unknown()`, non-optional for missing keys under zod v4) rejects the request.

## Fix

Persist `output: toolResult ?? null` in `collectToolMocks`. A mock with `output: null` faithfully records "the tool produced no result" and passes server validation.

## Testing

- Added a regression test in `packages/core/src/evals/collect-tool-mocks.test.ts` asserting a step without `toolResult` yields `output: null` and that the key survives a `JSON.stringify`/`JSON.parse` round-trip.
- `npx vitest run src/evals/collect-tool-mocks.test.ts` — 8/8 tests pass.

## Repro (before the fix)

1. Run an agent where a tool call fails or is suspended (no recorded result).
2. In Studio, open the trace → "Save as Dataset Item" (or "Add tool mocks to item").
3. The generated `toolMocks` include an entry without `output` → server responds 400 as above.
