### PR TITLE
feat(core): support custom reason when declining tool calls

### DIFF
--- a/.changeset/ninety-goats-cry.md
+++ b/.changeset/ninety-goats-cry.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': minor
+---
+
+Added a `reason` parameter to the `declineToolCall` and `declineToolCallGenerate` options on `Agent` and `DurableAgent` to support custom rejection reasons when declining tool calls.
+
+**Usage Example:**
+
+```typescript
+// Decline a suspended tool call with a custom explanation
+await agent.declineToolCall({
+  runId: output.runId,
+  toolCallId: 'call-xyz',
+  reason: 'Declined due to insufficient user privileges',
+});
+```

--- a/packages/core/src/agent/agent-types.test-d.ts
+++ b/packages/core/src/agent/agent-types.test-d.ts
@@ -291,18 +291,28 @@ describe('Agent Type Tests', () => {
     // the fix these object literals fail excess-property checking.
     const agent = new Agent({ id: 'a', name: 'A', model: {} as any, instructions: 'hi' });
 
-    it('accepts `model` on approveToolCall / declineToolCall (stream)', () => {
+    it('accepts `model` and `reason` on approveToolCall / declineToolCall (stream)', () => {
       const approve: Parameters<typeof agent.approveToolCall>[0] = { runId: 'r', model: {} as any };
-      const decline: Parameters<typeof agent.declineToolCall>[0] = { runId: 'r', model: {} as any };
+      const decline: Parameters<typeof agent.declineToolCall>[0] = {
+        runId: 'r',
+        reason: 'rejection reason',
+        model: {} as any,
+      };
       assertType<string>(approve.runId);
       assertType<string>(decline.runId);
+      assertType<string | undefined>(decline.reason);
     });
 
-    it('accepts `model` on approveToolCallGenerate / declineToolCallGenerate (generate)', () => {
+    it('accepts `model` and `reason` on approveToolCallGenerate / declineToolCallGenerate (generate)', () => {
       const approve: Parameters<typeof agent.approveToolCallGenerate>[0] = { runId: 'r', model: {} as any };
-      const decline: Parameters<typeof agent.declineToolCallGenerate>[0] = { runId: 'r', model: {} as any };
+      const decline: Parameters<typeof agent.declineToolCallGenerate>[0] = {
+        runId: 'r',
+        reason: 'rejection reason',
+        model: {} as any,
+      };
       assertType<string>(approve.runId);
       assertType<string>(decline.runId);
+      assertType<string | undefined>(decline.reason);
     });
   });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1511,8 +1511,7 @@ export class Agent<
    * ```
    */
   public listAgents({ requestContext = new RequestContext() }: { requestContext?: RequestContext } = {}):
-    | Record<string, SubAgent<string, TRequestContext>>
-    | Promise<Record<string, SubAgent<string, TRequestContext>>> {
+    Record<string, SubAgent<string, TRequestContext>> | Promise<Record<string, SubAgent<string, TRequestContext>>> {
     const agentsToUse = this.#agents
       ? typeof this.#agents === 'function'
         ? this.#agents({ requestContext: requestContext as RequestContext<TRequestContext> })
@@ -2410,8 +2409,7 @@ export class Agent<
    * ```
    */
   public getInstructions({ requestContext = new RequestContext() }: { requestContext?: RequestContext } = {}):
-    | AgentInstructions
-    | Promise<AgentInstructions> {
+    AgentInstructions | Promise<AgentInstructions> {
     if (typeof this.#instructions === 'function') {
       const result = this.#instructions({
         requestContext: requestContext as RequestContext<TRequestContext>,
@@ -2529,9 +2527,7 @@ export class Agent<
    * ```
    */
   public getMetadata({ requestContext = new RequestContext() }: { requestContext?: RequestContext } = {}):
-    | Record<string, unknown>
-    | undefined
-    | Promise<Record<string, unknown> | undefined> {
+    Record<string, unknown> | undefined | Promise<Record<string, unknown> | undefined> {
     if (this.#metadata === undefined) {
       return undefined;
     }
@@ -2675,8 +2671,7 @@ export class Agent<
    * ```
    */
   public getDefaultOptions({ requestContext = new RequestContext() }: { requestContext?: RequestContext } = {}):
-    | AgentExecutionOptions<TOutput>
-    | Promise<AgentExecutionOptions<TOutput>> {
+    AgentExecutionOptions<TOutput> | Promise<AgentExecutionOptions<TOutput>> {
     if (typeof this.#defaultOptions !== 'function') {
       return this.#defaultOptions;
     }
@@ -2719,8 +2714,7 @@ export class Agent<
    * ```
    */
   public getDefaultNetworkOptions({ requestContext = new RequestContext() }: { requestContext?: RequestContext } = {}):
-    | NetworkOptions
-    | Promise<NetworkOptions> {
+    NetworkOptions | Promise<NetworkOptions> {
     if (typeof this.#defaultNetworkOptions !== 'function') {
       return this.#defaultNetworkOptions;
     }
@@ -6157,8 +6151,7 @@ export class Agent<
     requestContext: RequestContext;
     structuredOutput?: boolean;
     overrideScorers?:
-      | MastraScorers
-      | Record<string, { scorer: MastraScorer['name']; sampling?: ScoringSamplingConfig }>;
+      MastraScorers | Record<string, { scorer: MastraScorer['name']; sampling?: ScoringSamplingConfig }>;
     threadId?: string;
     resourceId?: string;
   } & ObservabilityContext) {
@@ -6870,8 +6863,7 @@ export class Agent<
       : undefined;
     const persistedTracingContext = isResume
       ? (resumeContext?.snapshot?.tracingContext as
-          | { traceId?: string; spanId?: string; parentSpanId?: string }
-          | undefined)
+          { traceId?: string; spanId?: string; parentSpanId?: string } | undefined)
       : undefined;
 
     // Only fall back to persisted traceId/parentSpanId when the caller didn't provide
@@ -8979,7 +8971,7 @@ export class Agent<
    * ```
    */
   async declineToolCall<OUTPUT = undefined>(
-    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string } & {
+    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string; reason?: string } & {
       model?: DynamicArgument<MastraModelConfig>;
     },
   ): Promise<MastraModelOutput<OUTPUT>> {
@@ -8991,7 +8983,7 @@ export class Agent<
     }
 
     // @ts-expect-error - the types here are wrong
-    return this.resumeStream({ approved: false }, options);
+    return this.resumeStream({ approved: false, reason: options.reason }, options);
   }
 
   /**
@@ -9036,12 +9028,12 @@ export class Agent<
    * ```
    */
   async declineToolCallGenerate<OUTPUT = undefined>(
-    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string } & {
+    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string; reason?: string } & {
       model?: DynamicArgument<MastraModelConfig>;
     },
   ): Promise<Awaited<ReturnType<MastraModelOutput<OUTPUT>['getFullOutput']>>> {
     // @ts-expect-error - the types here are wrong
-    return this.resumeGenerate({ approved: false }, options);
+    return this.resumeGenerate({ approved: false, reason: options.reason }, options);
   }
 
   /**

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -2050,9 +2050,9 @@ export class DurableAgent<
    * `resume()` path.
    */
   override async declineToolCall(
-    options: { runId: string; toolCallId?: string } & Record<string, any>,
+    options: { runId: string; toolCallId?: string; reason?: string } & Record<string, any>,
   ): Promise<MastraModelOutput<any>> {
-    return this.resumeStream({ approved: false }, options);
+    return this.resumeStream({ approved: false, reason: options.reason }, options);
   }
 
   override async approveToolCallGenerate<OUTPUT = undefined>(
@@ -2063,10 +2063,10 @@ export class DurableAgent<
   }
 
   override async declineToolCallGenerate<OUTPUT = undefined>(
-    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string },
+    options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string; reason?: string },
   ): Promise<Awaited<ReturnType<MastraModelOutput<OUTPUT>['getFullOutput']>>> {
     const { runId, ...resumeOptions } = options;
-    return this.resumeGenerate(runId, { approved: false }, resumeOptions as any) as any;
+    return this.resumeGenerate(runId, { approved: false, reason: options.reason }, resumeOptions as any) as any;
   }
 
   /**

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -2055,6 +2055,10 @@ export class DurableAgent<
     return this.resumeStream({ approved: false, reason: options.reason }, options);
   }
 
+  /**
+   * Override the inherited `approveToolCallGenerate()` to route through the durable
+   * `resume()` path.
+   */
   override async approveToolCallGenerate<OUTPUT = undefined>(
     options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string },
   ): Promise<Awaited<ReturnType<MastraModelOutput<OUTPUT>['getFullOutput']>>> {
@@ -2062,6 +2066,10 @@ export class DurableAgent<
     return this.resumeGenerate(runId, { approved: true }, resumeOptions as any) as any;
   }
 
+  /**
+   * Override the inherited `declineToolCallGenerate()` to route through the durable
+   * `resume()` path.
+   */
   override async declineToolCallGenerate<OUTPUT = undefined>(
     options: AgentExecutionOptions<OUTPUT> & { runId: string; toolCallId?: string; reason?: string },
   ): Promise<Awaited<ReturnType<MastraModelOutput<OUTPUT>['getFullOutput']>>> {

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -70,6 +70,15 @@ const durableToolCallOutputSchema = durableToolCallInputSchema.extend({
     .optional(),
 });
 
+const APPROVAL_RESUME_SCHEMA = JSON.stringify({
+  type: 'object',
+  properties: {
+    approved: { type: 'boolean' },
+    reason: { type: 'string' },
+  },
+  required: ['approved'],
+});
+
 /**
  * Flush messages to memory before suspending.
  * Mirrors the base Agent's flushMessagesBeforeSuspension() to ensure
@@ -595,14 +604,7 @@ export function createDurableToolCallStep() {
       };
 
       if (requiresApproval && !resumeData) {
-        const resumeSchema = JSON.stringify({
-          type: 'object',
-          properties: {
-            approved: { type: 'boolean' },
-            reason: { type: 'string' },
-          },
-          required: ['approved'],
-        });
+        const resumeSchema = APPROVAL_RESUME_SCHEMA;
 
         // Persist active goal time before exposing the approval wait.
         await stopGoalActivity({ agentId: initData.agentId, runId });
@@ -817,14 +819,7 @@ export function createDurableToolCallStep() {
               : undefined;
           if (suspendOptions?.requireToolApproval) {
             // Tool is requesting approval during execution
-            const approvalResumeSchema = JSON.stringify({
-              type: 'object',
-              properties: {
-                approved: { type: 'boolean' },
-                reason: { type: 'string' },
-              },
-              required: ['approved'],
-            });
+            const approvalResumeSchema = APPROVAL_RESUME_SCHEMA;
 
             await stopGoalActivity({ agentId: initData.agentId, runId });
 

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -599,6 +599,7 @@ export function createDurableToolCallStep() {
           type: 'object',
           properties: {
             approved: { type: 'boolean' },
+            reason: { type: 'string' },
           },
           required: ['approved'],
         });
@@ -673,7 +674,7 @@ export function createDurableToolCallStep() {
             approval: {
               id: toolCallId,
               approved: false,
-              reason: 'Tool call was not approved by the user',
+              reason: (resumeData as { reason?: string }).reason || 'Tool call was not approved by the user',
             },
           };
         }
@@ -820,6 +821,7 @@ export function createDurableToolCallStep() {
               type: 'object',
               properties: {
                 approved: { type: 'boolean' },
+                reason: { type: 'string' },
               },
               required: ['approved'],
             });

--- a/packages/core/src/loop/test-utils/aimock/scenarios/decline-tool-reason.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/decline-tool-reason.scenario.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { MockMemory } from '../../../../memory';
+import { createTool } from '../../../../tools';
+import { createSharedAgent, runLoopScenario, useLoopScenarioAimock, describeForAllEngines } from '../aimock-scenario';
+
+describeForAllEngines(
+  'AIMock loop scenario: decline tool call with custom reason',
+  engine => {
+    const getMock = useLoopScenarioAimock();
+
+    it('propagates custom reason when tool call is declined via declineToolCall()', async () => {
+      const sensitiveTool = createTool({
+        id: 'sensitive-op',
+        description: 'Performs a sensitive operation requiring approval',
+        inputSchema: z.object({
+          action: z.string(),
+        }),
+        requireApproval: true,
+        execute: async ({ action }) => {
+          return { performed: action, success: true };
+        },
+      });
+
+      const sharedMemory = new MockMemory();
+      const shared = await createSharedAgent(getMock(), {
+        tools: { sensitiveTool },
+        memory: sharedMemory,
+        engine,
+      });
+
+      const threadId = `decline-reason-stream-thread-${engine}`;
+      const resourceId = 'test-resource';
+
+      // Agent calls the tool, suspends
+      const { output, chunks } = await runLoopScenario({
+        engine,
+        llm: getMock(),
+        sharedAgent: shared,
+        prompt: 'Perform action-123',
+        memory: sharedMemory,
+        threadId,
+        resourceId,
+        fixtures: llm => {
+          llm.onMessage(/perform/i, {
+            toolCalls: [
+              {
+                id: `call-sens-1-${engine}`,
+                name: 'sensitive-op',
+                arguments: { action: 'action-123' },
+              },
+            ],
+          });
+        },
+        collectChunks: true,
+      });
+
+      // Find the approval chunk
+      const approvalChunks = chunks!.filter(c => c.type === 'tool-call-approval');
+      expect(approvalChunks.length).toBeGreaterThan(0);
+      const toolCallId = (approvalChunks[0] as any).payload.toolCallId;
+
+      // Decline via declineToolCall with a custom reason
+      const customReason = 'Declined due to policy restriction - user role is insufficient';
+      const declineResult = await shared.agent.declineToolCall({
+        runId: output.runId,
+        toolCallId,
+        reason: customReason,
+      });
+
+      // Drain the stream
+      for await (const _ of declineResult.fullStream) {
+        // no-op
+      }
+
+      // Verify the recalled invocation carries the custom reason
+      const { messages } = await sharedMemory.recall({ threadId, resourceId });
+      const declined = messages
+        .flatMap((m: any) => m.content?.parts ?? [])
+        .find((p: any) => p.type === 'tool-invocation' && p.toolInvocation?.toolName === 'sensitive-op')
+        ?.toolInvocation as { state?: string; approval?: { approved?: boolean; reason?: string } } | undefined;
+
+      expect(declined).toBeDefined();
+      expect(declined?.state).toBe('output-denied');
+      expect(declined?.approval?.approved).toBe(false);
+      expect(declined?.approval?.reason).toBe(customReason);
+    });
+
+    it('propagates custom reason when tool call is declined via declineToolCallGenerate()', async () => {
+      const sensitiveTool = createTool({
+        id: 'sensitive-op',
+        description: 'Performs a sensitive operation requiring approval',
+        inputSchema: z.object({
+          action: z.string(),
+        }),
+        requireApproval: true,
+        execute: async ({ action }) => {
+          return { performed: action, success: true };
+        },
+      });
+
+      const llm = getMock();
+      // Set up fixtures for the generate() calls
+      llm.onMessage(/perform/i, {
+        toolCalls: [
+          {
+            id: `call-sens-gen-${engine}`,
+            name: 'sensitive-op',
+            arguments: { action: 'action-123' },
+          },
+        ],
+      });
+      llm.on({ endpoint: 'chat', hasToolResult: true }, { content: 'Declined.' });
+
+      const sharedMemory = new MockMemory();
+      const shared = await createSharedAgent(llm, {
+        tools: { sensitiveTool },
+        memory: sharedMemory,
+        engine,
+      });
+
+      const threadId = `decline-reason-gen-thread-${engine}`;
+      const resourceId = 'test-resource';
+
+      // Agent calls the tool, suspends
+      const output = await shared.agent.generate('Perform action-123', {
+        requireToolApproval: true,
+        memory: { thread: threadId, resource: resourceId },
+      });
+
+      expect(output.finishReason).toBe('suspended');
+      expect(output.suspendPayload).toBeDefined();
+
+      const toolCallId = output.suspendPayload!.toolCallId;
+
+      // Decline via declineToolCallGenerate with a custom reason
+      const customReason = 'Declined due to security warning';
+      await shared.agent.declineToolCallGenerate({
+        runId: output.runId!,
+        toolCallId,
+        reason: customReason,
+        memory: { thread: threadId, resource: resourceId },
+      });
+
+      // Verify the recalled invocation carries the custom reason
+      const { messages } = await sharedMemory.recall({ threadId, resourceId });
+      console.log('RECALLED MESSAGES FOR GENERATE:', JSON.stringify(messages, null, 2));
+      const declined = messages
+        .flatMap((m: any) => m.content?.parts ?? [])
+        .find((p: any) => p.type === 'tool-invocation' && p.toolInvocation?.toolName === 'sensitive-op')
+        ?.toolInvocation as { state?: string; approval?: { approved?: boolean; reason?: string } } | undefined;
+
+      expect(declined).toBeDefined();
+      expect(declined?.state).toBe('output-denied');
+      expect(declined?.approval?.approved).toBe(false);
+      expect(declined?.approval?.reason).toBe(customReason);
+    });
+  },
+  { skip: ['fs'] },
+);

--- a/packages/core/src/loop/test-utils/aimock/scenarios/decline-tool-reason.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/decline-tool-reason.scenario.test.ts
@@ -144,7 +144,6 @@ describeForAllEngines(
 
       // Verify the recalled invocation carries the custom reason
       const { messages } = await sharedMemory.recall({ threadId, resourceId });
-      console.log('RECALLED MESSAGES FOR GENERATE:', JSON.stringify(messages, null, 2));
       const declined = messages
         .flatMap((m: any) => m.content?.parts ?? [])
         .find((p: any) => p.type === 'tool-invocation' && p.toolInvocation?.toolName === 'sensitive-op')

--- a/packages/core/src/loop/test-utils/aimock/scenarios/decline-tool-reason.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/decline-tool-reason.scenario.test.ts
@@ -4,11 +4,23 @@ import { MockMemory } from '../../../../memory';
 import { createTool } from '../../../../tools';
 import { createSharedAgent, runLoopScenario, useLoopScenarioAimock, describeForAllEngines } from '../aimock-scenario';
 
+/**
+ * Integration scenario test suite for declining tool calls with a custom reason.
+ * Evaluates behavior across both normal and durable execution engines.
+ */
 describeForAllEngines(
   'AIMock loop scenario: decline tool call with custom reason',
+  /**
+   * Runs tests for the specified execution engine.
+   * @param engine - The engine type under test.
+   */
   engine => {
     const getMock = useLoopScenarioAimock();
 
+    /**
+     * Test case verifying that the custom reason is correctly propagated and persisted
+     * when declining a tool call using the streaming `declineToolCall` API.
+     */
     it('propagates custom reason when tool call is declined via declineToolCall()', async () => {
       const sensitiveTool = createTool({
         id: 'sensitive-op',
@@ -17,6 +29,11 @@ describeForAllEngines(
           action: z.string(),
         }),
         requireApproval: true,
+        /**
+         * Simulates executing the sensitive tool call.
+         * @param params - Tool parameters.
+         * @returns Execution confirmation.
+         */
         execute: async ({ action }) => {
           return { performed: action, success: true };
         },
@@ -41,6 +58,10 @@ describeForAllEngines(
         memory: sharedMemory,
         threadId,
         resourceId,
+        /**
+         * Sets up mock LLM responses for the scenario run.
+         * @param llm - The mock LLM instance.
+         */
         fixtures: llm => {
           llm.onMessage(/perform/i, {
             toolCalls: [
@@ -86,6 +107,10 @@ describeForAllEngines(
       expect(declined?.approval?.reason).toBe(customReason);
     });
 
+    /**
+     * Test case verifying that the custom reason is correctly propagated and persisted
+     * when declining a tool call using the non-streaming `declineToolCallGenerate` API.
+     */
     it('propagates custom reason when tool call is declined via declineToolCallGenerate()', async () => {
       const sensitiveTool = createTool({
         id: 'sensitive-op',
@@ -94,6 +119,11 @@ describeForAllEngines(
           action: z.string(),
         }),
         requireApproval: true,
+        /**
+         * Simulates executing the sensitive tool call.
+         * @param params - Tool parameters.
+         * @returns Execution confirmation.
+         */
         execute: async ({ action }) => {
           return { performed: action, success: true };
         },

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -687,20 +687,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                     toolCallId: inputData.toolCallId,
                     toolName: inputData.toolName,
                     args: inputData.args,
-                    resumeSchema: JSON.stringify(
-                      standardSchemaToJSONSchema(
-                        toStandardSchema(
-                          z.object({
-                            approved: z
-                              .boolean()
-                              .describe(
-                                'Controls if the tool call is approved or not, should be true when approved and false when declined',
-                              ),
-                            reason: z.string().optional().describe('Reason for declining the tool call'),
-                          }),
-                        ),
-                      ),
-                    ),
+                    resumeSchema: JSON.stringify(standardSchemaToJSONSchema(approvalSchema)),
                   },
                 },
                 'approval',
@@ -718,20 +705,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                 args: inputData.args,
                 type: 'approval',
                 suspendedToolRunId: options.runId,
-                resumeSchema: JSON.stringify(
-                  standardSchemaToJSONSchema(
-                    toStandardSchema(
-                      z.object({
-                        approved: z
-                          .boolean()
-                          .describe(
-                            'Controls if the tool call is approved or not, should be true when approved and false when declined',
-                          ),
-                        reason: z.string().optional().describe('Reason for declining the tool call'),
-                      }),
-                    ),
-                  ),
-                ),
+                resumeSchema: JSON.stringify(standardSchemaToJSONSchema(approvalSchema)),
                 metadata: approvalChunk.metadata,
               });
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -546,6 +546,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               .describe(
                 'Controls if the tool call is approved or not, should be true when approved and false when declined',
               ),
+            reason: z.string().optional().describe('Reason for declining the tool call'),
           }),
         );
 
@@ -615,7 +616,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                 approval: {
                   id: inputData.toolCallId,
                   approved: false,
-                  reason: 'Tool call was not approved by the user',
+                  reason: resumeData.reason || 'Tool call was not approved by the user',
                 },
                 ...inputData,
               };
@@ -695,6 +696,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                               .describe(
                                 'Controls if the tool call is approved or not, should be true when approved and false when declined',
                               ),
+                            reason: z.string().optional().describe('Reason for declining the tool call'),
                           }),
                         ),
                       ),
@@ -725,6 +727,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                           .describe(
                             'Controls if the tool call is approved or not, should be true when approved and false when declined',
                           ),
+                        reason: z.string().optional().describe('Reason for declining the tool call'),
                       }),
                     ),
                   ),


### PR DESCRIPTION
## Description

This PR adds the ability to provide a custom `reason` string when declining a suspended tool call via the `declineToolCall` and `declineToolCallGenerate` methods on `Agent` and `DurableAgent`.

- Extends the `declineToolCall` and `declineToolCallGenerate` options to accept an optional `reason` parameter.
- Propagates this custom reason during the execution resume phase for both standard and durable workflow engines.
- Updates the internal tool call validation schemas (both JSON schemas and Zod schemas) to allow `reason` as an optional parameter.
- Recalls and persists the custom reason under `approval.reason` (falling back to the default message when not provided) so that it is properly recorded in memory/database for downstream agentic loop consumers and streams.
- Added typecheck tests and integration scenario tests verifying the propagation of the decline reason in both engine paths.

## Related issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/20495

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a tool call is declined, callers can provide a reason. The system returns and stores this reason in standard and durable workflows.

## Changes

- Added optional `reason` support to `declineToolCall` and `declineToolCallGenerate` on `Agent` and `DurableAgent`.
- Propagated the reason during streaming and generation workflow resumption.
- Updated JSON and Zod approval schemas.
- Stored the reason under `approval.reason`.
- Used the default decline message when no reason is provided.
- Centralized approval schema definitions.
- Added type tests and integration tests for supported engine paths.
- Added JSDoc comments and a minor changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->