### PR TITLE
fix: handle both usage paths in convertMastraChunkToAISDKBase

### DIFF
--- a/.changeset/fix-usage-path.md
+++ b/.changeset/fix-usage-path.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+fix: handle both usage paths for persisted signal chunks

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -171,11 +171,14 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
       };
 
     case 'finish': {
+      // Normal model runs carry usage at payload.output.usage (full FinishPayload).
+      // Synthesized finish chunks from #broadcastPersistedSignal carry usage directly
+      // at payload.usage without an output wrapper. Resolve defensively to support both.
       return {
         type: 'finish',
         finishReason: normalizeFinishReason(chunk.payload.stepResult.reason) as FinishReason,
         ...(includeRawFinishReason ? { rawFinishReason: chunk.payload.stepResult.reason } : {}),
-        totalUsage: normalizeUsage(chunk.payload.output.usage),
+        totalUsage: normalizeUsage(chunk.payload.output?.usage ?? chunk.payload.usage),
       };
     }
     case 'reasoning-start':
@@ -319,7 +322,9 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
         providerMetadata: chunk.payload.providerMetadata,
       };
     case 'step-finish': {
-      const { request: _request, providerMetadata, ...rest } = chunk.payload.metadata;
+      // Defensive: synthesized chunks (e.g. from #broadcastPersistedSignal) may omit
+      // payload.metadata and carry usage at payload.usage instead of payload.output.usage.
+      const { request: _request, providerMetadata, ...rest } = chunk.payload.metadata ?? {};
       return {
         type: 'finish-step',
         response: {
@@ -328,7 +333,7 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
           modelId: (rest.modelId as string) || '',
           ...rest,
         },
-        usage: normalizeUsage(chunk.payload.output.usage),
+        usage: normalizeUsage(chunk.payload.output?.usage ?? chunk.payload.usage),
         finishReason: normalizeFinishReason(chunk.payload.stepResult.reason) as FinishReason,
         ...(includeRawFinishReason ? { rawFinishReason: chunk.payload.stepResult.reason } : {}),
         providerMetadata,


### PR DESCRIPTION
## Problem

Fixes #19721

The  function does not correctly handle usage signal chunks when they arrive through the persisted signal path. This causes usage information to be silently dropped for certain streaming configurations.

## Solution

Updated  to handle both the inline and persisted signal chunk paths, ensuring usage data is correctly extracted regardless of how it arrives.

## Changes

- : Added handling for the persisted signal chunk path
- Added changeset for patch release of 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When saved messages are replayed, usage details can appear in a different location. This change reads both locations so streams continue to work without errors.

## Changes

- Updated `convertMastraChunkToAISDKBase` to support usage from:
  - `payload.output.usage` for standard `finish` chunks.
  - `payload.usage` for persisted signal `finish` chunks.
- Prevented `TypeError` when persisted signal chunks omit `payload.output`.
- Defaulted missing step-finish metadata to an empty object.
- Added a patch changeset for `@mastra/ai-sdk`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->