### PR TITLE
fix(ai-sdk): compact nested agent stream snapshots

### DIFF
--- a/.changeset/major-spies-shave.md
+++ b/.changeset/major-spies-shave.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/ai-sdk': patch
+'@mastra/ai-sdk': minor
 ---
 
 Fixed nested agent streams to emit compact snapshots until each step completes, and added `data-tool-agent-step` as a new stream part type (exported as `AgentStepDataPart`) that carries the full completed-step detail for consumers that observe suspension without a finish event.

--- a/.changeset/major-spies-shave.md
+++ b/.changeset/major-spies-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed nested agent streams to emit compact snapshots until each step completes.

--- a/.changeset/major-spies-shave.md
+++ b/.changeset/major-spies-shave.md
@@ -2,4 +2,4 @@
 '@mastra/ai-sdk': patch
 ---
 
-Fixed nested agent streams to emit compact snapshots until each step completes.
+Fixed nested agent streams to emit compact snapshots until each step completes, and added `data-tool-agent-step` as a new stream part type (exported as `AgentStepDataPart`) that carries the full completed-step detail for consumers that observe suspension without a finish event.

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { AgentDataPart, AgentStepDataPart } from '../transformers';
 import { transformAgent } from '../transformers';
 
 /**
@@ -17,9 +18,14 @@ import { transformAgent } from '../transformers';
  * 3. text and reasoning were copied cumulatively into each step result,
  *    making steps[i].text contain text from steps 0..i (O(N²) storage).
  */
-describe('transformAgent cumulative growth (issue #14932)', () => {
+describe('transformAgent cumulative growth', () => {
   function makePayload(type: string, runId: string, payload: any) {
     return { type, runId, payload } as any;
+  }
+
+  function flattenAgentParts(result: any) {
+    if (!result) return [];
+    return Array.isArray(result) ? result : [result];
   }
 
   function simulateMultiStepAgentRun(numSteps: number) {
@@ -31,7 +37,7 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
     const emissions: any[] = [];
 
     function collect(result: any) {
-      if (result) emissions.push(result);
+      emissions.push(...flattenAgentParts(result));
     }
 
     for (let step = 0; step < numSteps; step++) {
@@ -93,13 +99,49 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
             stepResult: { reason: 'tool-calls', warnings: [] },
             output: { usage: { inputTokens: 100, outputTokens: 100, totalTokens: 200 } },
             metadata: { timestamp: new Date(), modelId: 'test-model' },
+            response: {
+              messages: [
+                {
+                  role: 'assistant',
+                  content: [{ type: 'text', text: `Completed response for step ${step}. `.repeat(15) }],
+                },
+              ],
+            },
           }),
           bufferedSteps,
         ),
       );
     }
 
+    collect(
+      transformAgent(
+        makePayload('finish', runId, {
+          stepResult: { reason: 'stop', warnings: [] },
+          output: { usage: { inputTokens: 1000, outputTokens: 1000, totalTokens: 2000 } },
+          response: {
+            id: 'response-1',
+            modelId: 'test-model',
+            messages: [
+              {
+                role: 'assistant',
+                content: [{ type: 'text', text: 'Final response'.repeat(20) }],
+              },
+            ],
+          },
+        }),
+        bufferedSteps,
+      ),
+    );
+
     return { emissions, bufferedSteps, runId };
+  }
+
+  function getAgentSnapshots(emissions: any[]) {
+    return emissions.filter(chunk => chunk.type === 'data-tool-agent') as AgentDataPart[];
+  }
+
+  function getAgentStepDeltas(emissions: any[]) {
+    return emissions.filter(chunk => chunk.type === 'data-tool-agent-step') as AgentStepDataPart[];
   }
 
   it('stepResults should not contain nested copies of prior steps', () => {
@@ -196,8 +238,180 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
     const { emissions } = simulateMultiStepAgentRun(3);
 
     for (const emission of emissions) {
+      if ('step' in emission.data) {
+        expect(emission.data.step).not.toHaveProperty('_textOffset');
+        expect(emission.data.step).not.toHaveProperty('_reasoningOffset');
+        continue;
+      }
+
       expect(emission.data).not.toHaveProperty('_textOffset');
       expect(emission.data).not.toHaveProperty('_reasoningOffset');
     }
+  });
+
+  it('emits compact data-tool-agent snapshots, one full data-tool-agent-step delta per step, and a full terminal data-tool-agent snapshot', () => {
+    const { emissions } = simulateMultiStepAgentRun(3);
+    const snapshots = getAgentSnapshots(emissions);
+    const stepDeltas = getAgentStepDeltas(emissions);
+
+    expect(stepDeltas).toHaveLength(3);
+    expect(stepDeltas.map(part => part.id)).toEqual(['test-run:0', 'test-run:1', 'test-run:2']);
+    expect(stepDeltas.map(part => part.data.stepIndex)).toEqual([0, 1, 2]);
+    expect(stepDeltas[1]?.data.step.text).toContain('Step 1 response text.');
+    expect(stepDeltas[1]?.data.step.toolResults[0]?.result).toEqual({
+      output: `Result from step 1. `.repeat(50),
+    });
+    expect(stepDeltas[1]?.data.step.response.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: `Completed response for step 1. `.repeat(15) }],
+      },
+    ]);
+
+    for (const snapshot of snapshots.slice(0, -1)) {
+      for (const step of snapshot.data.steps as any[]) {
+        expect(step.text).toBe('');
+        expect(step.reasoning).toEqual([]);
+        expect(step.toolCalls).toEqual([]);
+        expect(step.toolResults).toEqual([]);
+        expect(step.sources).toEqual([]);
+        expect(step.files).toEqual([]);
+        expect(step.response.messages).toEqual([]);
+      }
+    }
+
+    const finalSnapshot = snapshots[snapshots.length - 1]!;
+    expect(finalSnapshot.data.finishReason).toBe('stop');
+    expect(finalSnapshot.data.response.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Final response'.repeat(20) }],
+      },
+    ]);
+    expect(finalSnapshot.data.steps).toHaveLength(3);
+    expect(finalSnapshot.data.steps[2]?.text).toContain('Step 2 response text.');
+    expect(finalSnapshot.data.steps[2]?.toolResults[0]?.result).toEqual({
+      output: `Result from step 2. `.repeat(50),
+    });
+    expect(finalSnapshot.data.steps[2]?.response.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: `Completed response for step 2. `.repeat(15) }],
+      },
+    ]);
+  });
+
+  it('total serialized bytes grow sub-quadratically when doubling step count', () => {
+    // Completed step descriptors and run-level cumulative text/reasoning are still
+    // re-emitted in every intermediate snapshot, so growth is ~O(N^1.74) rather than
+    // O(N) or O(N²). A bound of 4.0 rejects a pure O(N²) regression (which would give
+    // exactly 4x for 2x steps) while accepting the current behavior.
+    const { emissions: emissionsN } = simulateMultiStepAgentRun(10);
+    const { emissions: emissions2N } = simulateMultiStepAgentRun(20);
+
+    const bytesN = emissionsN.reduce((sum, p) => sum + JSON.stringify(p).length, 0);
+    const bytes2N = emissions2N.reduce((sum, p) => sum + JSON.stringify(p).length, 0);
+    const ratio = bytes2N / bytesN;
+
+    expect(ratio, `2x steps gave ${ratio.toFixed(2)}x bytes (expected < 4.0, would be 4.0 for O(N²))`).toBeLessThan(
+      4.0,
+    );
+  });
+
+  it('completed-step deltas carry full detail on aborted runs (no finish event)', () => {
+    // When a run terminates without a finish event (abort, tripwire, transport error),
+    // intermediate snapshots are compact and carry no completed-step detail, but each
+    // data-tool-agent-step delta emitted at step-finish carries the full step. A consumer
+    // reading both parts loses nothing even without the terminal snapshot.
+    const bufferedSteps = new Map<string, any>();
+    const runId = 'aborted-run';
+    const emissions: any[] = [];
+
+    function collect(result: any) {
+      if (!result) return;
+      const parts = Array.isArray(result) ? result : [result];
+      emissions.push(...parts);
+    }
+
+    function makePayload(type: string, payload: any) {
+      return { type, runId, payload } as any;
+    }
+
+    collect(transformAgent(makePayload('start', { id: 'agent-1' }), bufferedSteps));
+
+    collect(
+      transformAgent(
+        makePayload('tool-call', {
+          type: 'tool-call',
+          toolCallId: 'call-0',
+          toolName: 'search',
+          args: { query: 'abort test' },
+          payload: { dynamic: false },
+        }),
+        bufferedSteps,
+      ),
+    );
+
+    collect(
+      transformAgent(
+        makePayload('tool-result', {
+          type: 'tool-result',
+          toolCallId: 'call-0',
+          toolName: 'search',
+          result: { data: 'result that only arrives in step delta' },
+          payload: { dynamic: false },
+        }),
+        bufferedSteps,
+      ),
+    );
+
+    collect(
+      transformAgent(
+        makePayload('step-finish', {
+          id: 'step-0',
+          stepResult: { reason: 'tool-calls', warnings: [] },
+          output: { usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+          metadata: { timestamp: new Date(), modelId: 'test-model' },
+        }),
+        bufferedSteps,
+      ),
+    );
+
+    // Simulate abort: no finish event follows.
+    const stepDeltas = emissions.filter(e => e?.type === 'data-tool-agent-step');
+    const snapshots = emissions.filter(e => e?.type === 'data-tool-agent');
+
+    // The step delta carries the full completed step.
+    expect(stepDeltas).toHaveLength(1);
+    expect(stepDeltas[0]!.data.step.toolResults[0]?.result).toEqual({
+      data: 'result that only arrives in step delta',
+    });
+
+    // All intermediate snapshots are compact: the completed step has no detail.
+    for (const snapshot of snapshots) {
+      if (snapshot.data.steps.length > 0) {
+        expect(snapshot.data.steps[0]!.toolResults).toEqual([]);
+      }
+    }
+  });
+
+  it('keeps later data-tool-agent snapshots free of prior completed-step payloads and bounds total serialized bytes', () => {
+    const { emissions } = simulateMultiStepAgentRun(3);
+    const snapshots = getAgentSnapshots(emissions);
+    const totalBytes = emissions.reduce((sum, part) => sum + JSON.stringify(part).length, 0);
+    const finalSnapshot = snapshots[snapshots.length - 1]!;
+    const laterIntermediateSnapshot = snapshots.find(
+      snapshot => snapshot.data.steps.length === 2 && snapshot.data.text.includes('Step 2 response text.'),
+    );
+
+    // Calibrated against the restored full fixture (text repeat(10), toolResult repeat(50)).
+    // Base emits ~200 000+ bytes for the same 3-step run; this ceiling proves the fix works.
+    expect(totalBytes).toBeLessThan(75000);
+    expect(laterIntermediateSnapshot).toBeDefined();
+    expect(JSON.stringify(laterIntermediateSnapshot)).not.toContain(`Result from step 0. `.repeat(50));
+    expect(JSON.stringify(laterIntermediateSnapshot)).not.toContain(`Completed response for step 0. `.repeat(15));
+    expect(finalSnapshot.data.steps[0]?.toolResults[0]?.result).toEqual({
+      output: `Result from step 0. `.repeat(50),
+    });
   });
 });

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
@@ -304,8 +304,9 @@ describe('transformAgent cumulative growth', () => {
   it('total serialized bytes grow sub-quadratically when doubling step count', () => {
     // Completed step descriptors and run-level cumulative text/reasoning are still
     // re-emitted in every intermediate snapshot, so growth is ~O(N^1.74) rather than
-    // O(N) or O(N²). A bound of 4.0 rejects a pure O(N²) regression (which would give
-    // exactly 4x for 2x steps) while accepting the current behavior.
+    // O(N) or O(N²). The bound of 3.8 is derived from the measured head ratio
+    // (~3.33 for this fixture) with a 14% margin; it rejects the base O(N²) shape
+    // (~4.05) while accepting the compacted head behavior.
     const { emissions: emissionsN } = simulateMultiStepAgentRun(10);
     const { emissions: emissions2N } = simulateMultiStepAgentRun(20);
 
@@ -313,8 +314,8 @@ describe('transformAgent cumulative growth', () => {
     const bytes2N = emissions2N.reduce((sum, p) => sum + JSON.stringify(p).length, 0);
     const ratio = bytes2N / bytesN;
 
-    expect(ratio, `2x steps gave ${ratio.toFixed(2)}x bytes (expected < 4.0, would be 4.0 for O(N²))`).toBeLessThan(
-      4.0,
+    expect(ratio, `2x steps gave ${ratio.toFixed(2)}x bytes (expected < 3.8, head ~3.33, base ~4.05)`).toBeLessThan(
+      3.8,
     );
   });
 

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-tool-input-streaming.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-tool-input-streaming.test.ts
@@ -8,6 +8,10 @@ describe('transformAgent tool input streaming (issue #16422)', () => {
     return { type, runId, payload } as any;
   }
 
+  function getSnapshot(result: any) {
+    return Array.isArray(result) ? result[0] : result;
+  }
+
   it('emits data-tool-agent updates while a sub-agent tool input is streaming', () => {
     const bufferedSteps = new Map<string, any>();
     const runId = 'sub-agent-run';
@@ -269,7 +273,7 @@ describe('transformAgent tool input streaming (issue #16422)', () => {
       bufferedSteps,
     );
 
-    expect(stepFinish).toMatchObject({
+    expect(getSnapshot(stepFinish)).toMatchObject({
       data: {
         pendingToolCalls: [],
         steps: [
@@ -281,7 +285,7 @@ describe('transformAgent tool input streaming (issue #16422)', () => {
     });
   });
 
-  it('emits pending tool input updates through the nested tool-output transformer route', async () => {
+  it('emits pending data-tool-agent tool input updates through the nested tool-output transformer route', async () => {
     const stream = new ReadableStream<any>({
       start(controller) {
         controller.enqueue({

--- a/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
@@ -1027,7 +1027,7 @@ describe('WorkflowStreamToAISDKTransformer', () => {
 });
 
 describe('AgentNetworkToAISDKTransformer', () => {
-  it('should return NetworkDataPart on each agent-execution-event and workflow-execution-event', async () => {
+  it('should keep data-network output and leak no data-tool-agent-step parts on agent-execution-event and workflow-execution-event', async () => {
     const mockStream = new ReadableStream({
       async start(controller) {
         // Network start
@@ -1129,6 +1129,7 @@ describe('AgentNetworkToAISDKTransformer', () => {
 
     // Find all NetworkDataPart chunks
     const networkChunks = chunks.filter(chunk => chunk.type === 'data-network' || chunk.type === 'data-tool-network');
+    const agentStepChunks = chunks.filter(chunk => chunk.type === 'data-tool-agent-step');
 
     // Should have NetworkDataPart chunks for:
     // 1. routing-agent-start
@@ -1138,6 +1139,7 @@ describe('AgentNetworkToAISDKTransformer', () => {
     // 5. workflow-execution-event-workflow-start (our new behavior - returns NetworkDataPart)
     // 6. network-execution-event-finish
     expect(networkChunks.length).toBeGreaterThanOrEqual(6);
+    expect(agentStepChunks).toHaveLength(0);
 
     // Verify that agent-execution-event-start returns a NetworkDataPart
     // The chunk should have the step with updated task from transformAgent
@@ -1173,6 +1175,139 @@ describe('AgentNetworkToAISDKTransformer', () => {
     expect(workflowStep).toBeDefined();
     expect(workflowStep?.task).toBeDefined();
     expect(workflowStep?.task.name).toBe('test-workflow'); // From transformWorkflow
+  });
+
+  it('preserves task.steps[0].toolResults on the network path after agent-execution-event-finish', async () => {
+    // After step-finish the network adapter holds a compact snapshot (toolResults stripped).
+    // The finish event must produce a full snapshot so that the terminal task is complete.
+    const mockStream = new ReadableStream({
+      async start(controller) {
+        controller.enqueue({
+          type: 'routing-agent-start',
+          runId: 'net-run-1',
+          payload: {
+            networkId: 'test-net',
+            agentId: 'worker-agent',
+            runId: 'agent-run-1',
+            inputData: { iteration: 0, task: null, threadId: 'thread-1', threadResourceId: 'res-1' },
+          },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-start',
+          runId: 'net-run-1',
+          payload: { agentId: 'worker-agent', runId: 'agent-run-1', args: { prompt: 'do work', iteration: 0 } },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-event-start',
+          runId: 'net-run-1',
+          payload: { type: 'start', runId: 'agent-run-1', from: 'AGENT', payload: { id: 'worker-agent' } },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-event-tool-call',
+          runId: 'net-run-1',
+          payload: {
+            type: 'tool-call',
+            runId: 'agent-run-1',
+            from: 'AGENT',
+            payload: {
+              type: 'tool-call',
+              toolCallId: 'call-net-0',
+              toolName: 'search',
+              args: { q: 'test' },
+              payload: { dynamic: false },
+            },
+          },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-event-tool-result',
+          runId: 'net-run-1',
+          payload: {
+            type: 'tool-result',
+            runId: 'agent-run-1',
+            from: 'AGENT',
+            payload: {
+              type: 'tool-result',
+              toolCallId: 'call-net-0',
+              toolName: 'search',
+              result: { answer: 'network-path result preserved' },
+              payload: { dynamic: false },
+            },
+          },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-event-step-finish',
+          runId: 'net-run-1',
+          payload: {
+            type: 'step-finish',
+            runId: 'agent-run-1',
+            from: 'AGENT',
+            payload: {
+              id: 'step-net-0',
+              stepResult: { reason: 'tool-calls', warnings: [] },
+              output: { usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 } },
+              metadata: { timestamp: new Date(), modelId: 'test-model' },
+            },
+          },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-event-finish',
+          runId: 'net-run-1',
+          payload: {
+            type: 'finish',
+            runId: 'agent-run-1',
+            from: 'AGENT',
+            payload: {
+              stepResult: { reason: 'stop', warnings: [] },
+              output: { usage: { inputTokens: 50, outputTokens: 50, totalTokens: 100 } },
+              response: { id: 'resp-1', modelId: 'test-model', messages: [] },
+            },
+          },
+        });
+
+        controller.enqueue({
+          type: 'network-execution-event-finish',
+          runId: 'net-run-1',
+          payload: { result: 'done', usage: { inputTokens: 50, outputTokens: 50, totalTokens: 100 } },
+        });
+
+        controller.close();
+      },
+    });
+
+    const aiSdkStream = toAISdkV5Stream(mockStream as unknown as MastraAgentNetworkStream, { from: 'network' });
+
+    const chunks: any[] = [];
+    for await (const chunk of aiSdkStream) {
+      chunks.push(chunk);
+    }
+
+    const networkChunks = chunks.filter(chunk => chunk.type === 'data-network' || chunk.type === 'data-tool-network');
+    const agentStepChunks = chunks.filter(chunk => chunk.type === 'data-tool-agent-step');
+
+    // No data-tool-agent-step must leak onto the network wire.
+    expect(agentStepChunks).toHaveLength(0);
+
+    // Find the chunk produced by agent-execution-event-finish.
+    // It is the last network chunk before network-execution-event-finish.
+    const finishChunk = networkChunks.at(-2);
+    expect(finishChunk).toBeDefined();
+
+    // The routing-agent step is the first with id='agent-run-1'; agent-execution-event-*
+    // updates it in place. Find by task presence to avoid ambiguity with the second step.
+    const agentStep = finishChunk?.data?.steps?.find((s: any) => s.name === 'worker-agent' && s.task);
+    expect(agentStep).toBeDefined();
+
+    // Terminal task must carry the completed step's toolResults after finish.
+    expect(agentStep?.task?.steps).toHaveLength(1);
+    expect(agentStep?.task?.steps?.[0]?.toolResults?.[0]?.result).toEqual({
+      answer: 'network-path result preserved',
+    });
   });
 });
 

--- a/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
@@ -1389,9 +1389,61 @@ describe('AgentNetworkToAISDKTransformer', () => {
           },
         });
 
-        // A text-delta for step 1 arrives after step-finish. Without the
-        // accumulated-detail fix this overwrites step.task with a fresh compact
-        // snapshot that has empty toolResults, demonstrating the regression.
+        // A second tool-call / tool-result / step-finish pair exercises the
+        // multi-entry branch of the re-application loop (completedSteps.size > 1).
+        controller.enqueue({
+          type: 'agent-execution-event-tool-call',
+          runId: 'sus-net-1',
+          payload: {
+            type: 'tool-call',
+            runId: 'sus-agent-run-1',
+            from: 'AGENT',
+            payload: {
+              type: 'tool-call',
+              toolCallId: 'call-sus-1',
+              toolName: 'lookup',
+              args: { q: 'suspended-query-2' },
+              payload: { dynamic: false },
+            },
+          },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-event-tool-result',
+          runId: 'sus-net-1',
+          payload: {
+            type: 'tool-result',
+            runId: 'sus-agent-run-1',
+            from: 'AGENT',
+            payload: {
+              type: 'tool-result',
+              toolCallId: 'call-sus-1',
+              toolName: 'lookup',
+              result: { answer: 'suspension-path result-2 preserved' },
+              payload: { dynamic: false },
+            },
+          },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-event-step-finish',
+          runId: 'sus-net-1',
+          payload: {
+            type: 'step-finish',
+            runId: 'sus-agent-run-1',
+            from: 'AGENT',
+            payload: {
+              id: 'step-sus-1',
+              stepResult: { reason: 'tool-calls', warnings: [] },
+              output: { usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+              metadata: { timestamp: new Date(), modelId: 'test-model' },
+            },
+          },
+        });
+
+        // A text-delta arrives after both step-finishes. Without the fix this
+        // overwrites step.task with a compact snapshot that has empty toolResults
+        // for both completed steps, demonstrating the regression.
         controller.enqueue({
           type: 'agent-execution-event-text-delta',
           runId: 'sus-net-1',
@@ -1399,7 +1451,7 @@ describe('AgentNetworkToAISDKTransformer', () => {
             type: 'text-delta',
             runId: 'sus-agent-run-1',
             from: 'AGENT',
-            payload: { text: 'step-1 text' },
+            payload: { text: 'step-2 text' },
           },
         });
 
@@ -1427,19 +1479,27 @@ describe('AgentNetworkToAISDKTransformer', () => {
     // No data-tool-agent-step must leak onto the network wire.
     expect(agentStepChunks).toHaveLength(0);
 
-    // Assert against the last agent-event chunk (before network-execution-event-finish)
-    // so the assertion observes terminal state after all events, not just the
-    // step-finish chunk that existed before the regression was introduced.
+    // Assert on the last chunk produced before network-execution-event-finish.
+    // In production each chunk is serialized at emit time, so the last
+    // pre-termination chunk is the one that carries the final merged step state.
+    // Here all chunks share the same in-memory step object (shallow spread), so
+    // every chunk reads the final state; the at(-2) position is what matters in
+    // production and is kept for accuracy.
     const lastAgentChunk = networkChunks.at(-2);
     expect(lastAgentChunk).toBeDefined();
 
     const agentStep = lastAgentChunk?.data?.steps?.find((s: any) => s.name === 'sus-agent' && s.task);
     expect(agentStep).toBeDefined();
 
-    // Full step detail must be present even without a finish event.
-    expect(agentStep?.task?.steps).toHaveLength(1);
+    // Both completed steps' full detail must be present even without a finish event.
+    // This exercises the multi-entry branch (completedSteps.size > 1) of the
+    // re-application loop.
+    expect(agentStep?.task?.steps).toHaveLength(2);
     expect(agentStep?.task?.steps?.[0]?.toolResults?.[0]?.result).toEqual({
       answer: 'suspension-path result preserved',
+    });
+    expect(agentStep?.task?.steps?.[1]?.toolResults?.[0]?.result).toEqual({
+      answer: 'suspension-path result-2 preserved',
     });
   });
 });

--- a/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
@@ -1309,6 +1309,125 @@ describe('AgentNetworkToAISDKTransformer', () => {
       answer: 'network-path result preserved',
     });
   });
+
+  it('preserves task.steps[0].toolResults on the network path when the agent terminates without finish (suspended)', async () => {
+    // Suspended/failed sub-agents never emit a finish event, so the only opportunity
+    // to capture full step detail is at step-finish via the completed-step delta.
+    const mockStream = new ReadableStream({
+      async start(controller) {
+        controller.enqueue({
+          type: 'routing-agent-start',
+          runId: 'sus-net-1',
+          payload: {
+            networkId: 'test-net-sus',
+            agentId: 'sus-agent',
+            runId: 'sus-agent-run-1',
+            inputData: { iteration: 0, task: null, threadId: 'thread-sus', threadResourceId: 'res-sus' },
+          },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-start',
+          runId: 'sus-net-1',
+          payload: { agentId: 'sus-agent', runId: 'sus-agent-run-1', args: { prompt: 'do work', iteration: 0 } },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-event-start',
+          runId: 'sus-net-1',
+          payload: { type: 'start', runId: 'sus-agent-run-1', from: 'AGENT', payload: { id: 'sus-agent' } },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-event-tool-call',
+          runId: 'sus-net-1',
+          payload: {
+            type: 'tool-call',
+            runId: 'sus-agent-run-1',
+            from: 'AGENT',
+            payload: {
+              type: 'tool-call',
+              toolCallId: 'call-sus-0',
+              toolName: 'lookup',
+              args: { q: 'suspended-query' },
+              payload: { dynamic: false },
+            },
+          },
+        });
+
+        controller.enqueue({
+          type: 'agent-execution-event-tool-result',
+          runId: 'sus-net-1',
+          payload: {
+            type: 'tool-result',
+            runId: 'sus-agent-run-1',
+            from: 'AGENT',
+            payload: {
+              type: 'tool-result',
+              toolCallId: 'call-sus-0',
+              toolName: 'lookup',
+              result: { answer: 'suspension-path result preserved' },
+              payload: { dynamic: false },
+            },
+          },
+        });
+
+        // step-finish but no subsequent finish (suspended termination)
+        controller.enqueue({
+          type: 'agent-execution-event-step-finish',
+          runId: 'sus-net-1',
+          payload: {
+            type: 'step-finish',
+            runId: 'sus-agent-run-1',
+            from: 'AGENT',
+            payload: {
+              id: 'step-sus-0',
+              stepResult: { reason: 'tool-calls', warnings: [] },
+              output: { usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+              metadata: { timestamp: new Date(), modelId: 'test-model' },
+            },
+          },
+        });
+
+        // Network finishes without a sub-agent finish (mirrors suspension)
+        controller.enqueue({
+          type: 'network-execution-event-finish',
+          runId: 'sus-net-1',
+          payload: { result: 'suspended', usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+        });
+
+        controller.close();
+      },
+    });
+
+    const aiSdkStream = toAISdkV5Stream(mockStream as unknown as MastraAgentNetworkStream, { from: 'network' });
+
+    const chunks: any[] = [];
+    for await (const chunk of aiSdkStream) {
+      chunks.push(chunk);
+    }
+
+    const networkChunks = chunks.filter(chunk => chunk.type === 'data-network' || chunk.type === 'data-tool-network');
+    const agentStepChunks = chunks.filter(chunk => chunk.type === 'data-tool-agent-step');
+
+    // No data-tool-agent-step must leak onto the network wire.
+    expect(agentStepChunks).toHaveLength(0);
+
+    // Find the chunk produced by agent-execution-event-step-finish.
+    const stepFinishChunk = networkChunks.find(chunk =>
+      chunk.data?.steps?.some((s: any) => s.name === 'sus-agent' && s.task?.steps?.length > 0),
+    );
+    expect(stepFinishChunk).toBeDefined();
+
+    const agentStep = stepFinishChunk?.data?.steps?.find((s: any) => s.name === 'sus-agent' && s.task);
+    expect(agentStep).toBeDefined();
+
+    // Full step detail must be present even without a finish event.
+    expect(agentStep?.task?.steps).toHaveLength(1);
+    expect(agentStep?.task?.steps?.[0]?.toolResults?.[0]?.result).toEqual({
+      answer: 'suspension-path result preserved',
+    });
+  });
 });
 
 describe('Network stream - core fix (text events from core)', () => {

--- a/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
@@ -1389,6 +1389,20 @@ describe('AgentNetworkToAISDKTransformer', () => {
           },
         });
 
+        // A text-delta for step 1 arrives after step-finish. Without the
+        // accumulated-detail fix this overwrites step.task with a fresh compact
+        // snapshot that has empty toolResults, demonstrating the regression.
+        controller.enqueue({
+          type: 'agent-execution-event-text-delta',
+          runId: 'sus-net-1',
+          payload: {
+            type: 'text-delta',
+            runId: 'sus-agent-run-1',
+            from: 'AGENT',
+            payload: { text: 'step-1 text' },
+          },
+        });
+
         // Network finishes without a sub-agent finish (mirrors suspension)
         controller.enqueue({
           type: 'network-execution-event-finish',
@@ -1413,13 +1427,13 @@ describe('AgentNetworkToAISDKTransformer', () => {
     // No data-tool-agent-step must leak onto the network wire.
     expect(agentStepChunks).toHaveLength(0);
 
-    // Find the chunk produced by agent-execution-event-step-finish.
-    const stepFinishChunk = networkChunks.find(chunk =>
-      chunk.data?.steps?.some((s: any) => s.name === 'sus-agent' && s.task?.steps?.length > 0),
-    );
-    expect(stepFinishChunk).toBeDefined();
+    // Assert against the last agent-event chunk (before network-execution-event-finish)
+    // so the assertion observes terminal state after all events, not just the
+    // step-finish chunk that existed before the regression was introduced.
+    const lastAgentChunk = networkChunks.at(-2);
+    expect(lastAgentChunk).toBeDefined();
 
-    const agentStep = stepFinishChunk?.data?.steps?.find((s: any) => s.name === 'sus-agent' && s.task);
+    const agentStep = lastAgentChunk?.data?.steps?.find((s: any) => s.name === 'sus-agent' && s.task);
     expect(agentStep).toBeDefined();
 
     // Full step detail must be present even without a finish event.

--- a/client-sdks/ai-sdk/src/index.ts
+++ b/client-sdks/ai-sdk/src/index.ts
@@ -12,7 +12,7 @@ export type { WorkflowDataPart, WorkflowStepDataPart } from './transformers';
 export { networkRoute, handleNetworkStream } from './network-route';
 export type { NetworkRouteOptions, NetworkStreamHandlerParams, NetworkStreamHandlerOptions } from './network-route';
 export type { NetworkDataPart } from './transformers';
-export type { AgentDataPart } from './transformers';
+export type { AgentDataPart, AgentStepDataPart } from './transformers';
 
 export { toAISdkStream, toAISdkV5Stream } from './convert-streams';
 export { workflowSnapshotToStream } from './convert-snapshot';

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -658,7 +658,7 @@ function createAgentResponseState() {
   };
 }
 
-function createAgentRunState(id = '') {
+function createAgentRunState(id: unknown = '') {
   return {
     id,
     object: null,
@@ -792,8 +792,7 @@ export function transformAgent<OUTPUT>(
   let completedStep: { stepIndex: number; step: Record<string, any> } | null = null;
   switch (payload.type) {
     case 'start': {
-      const startState = createAgentRunState();
-      startState.id = payload.payload.id;
+      const startState = createAgentRunState(payload.payload.id);
       bufferedSteps.set(payload.runId!, startState);
       hasChanged = true;
       break;
@@ -1582,6 +1581,15 @@ export function transformNetwork(
         if (snapshot) {
           const { request, response, ...data } = snapshot.data;
           step.task = data;
+          // Merge full step detail from the completed-step delta so that
+          // suspended/failed terminations (no finish) still carry toolResults etc.
+          if (Array.isArray(result)) {
+            const { stepIndex, step: completedStepDetail } = result[1].data;
+            const taskSteps = data.steps;
+            if (Array.isArray(taskSteps) && stepIndex < taskSteps.length) {
+              taskSteps[stepIndex] = { ...taskSteps[stepIndex], ...completedStepDetail };
+            }
+          }
         }
 
         bufferedNetworks.set(payload.runId!, current);

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -1580,6 +1580,11 @@ export function transformNetwork(
         }
 
         step[PRIMITIVE_CACHE_SYMBOL] = step[PRIMITIVE_CACHE_SYMBOL] || new Map();
+        // When the nested agent restarts (start event) discard stale step detail
+        // so a new run doesn't merge prior-run completedStepDetail into its steps.
+        if ((payload.payload as AgentChunkType).type === 'start') {
+          delete step[COMPLETED_STEPS_SYMBOL];
+        }
         const result = transformAgent(payload.payload as ChunkType<any>, step[PRIMITIVE_CACHE_SYMBOL]);
         const snapshot = Array.isArray(result) ? result[0] : result;
         if (snapshot) {

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -108,6 +108,18 @@ export type AgentDataPart = {
   data: LLMStepResult;
 };
 
+export type AgentStepDataPart = {
+  type: 'data-tool-agent-step';
+  id: string;
+  data: {
+    runId: string;
+    stepIndex: number;
+    step: LLMStepResult;
+  };
+};
+
+type TransformAgentResult = AgentDataPart | readonly [AgentDataPart, AgentStepDataPart];
+
 // used so it's not serialized to JSON
 const PRIMITIVE_CACHE_SYMBOL = Symbol('primitive-cache');
 
@@ -397,7 +409,15 @@ export function createAgentStreamToAISDKTransformer<OUTPUT>(
         if (transformedChunk.type === 'tool-agent') {
           const payload = transformedChunk.payload;
           const agentTransformed = transformAgent<OUTPUT>(payload, bufferedSteps);
-          if (agentTransformed) controller.enqueue(agentTransformed);
+          if (agentTransformed) {
+            if (Array.isArray(agentTransformed)) {
+              for (const part of agentTransformed) {
+                controller.enqueue(part);
+              }
+            } else {
+              controller.enqueue(agentTransformed);
+            }
+          }
         } else if (transformedChunk.type === 'tool-workflow') {
           const payload = transformedChunk.payload;
           const workflowChunk = transformWorkflow(
@@ -555,30 +575,7 @@ export function AgentStreamToAISDKV6Transformer<OUTPUT>({
 
 function ensureAgentRunState(bufferedSteps: Map<string, any>, runId: string) {
   if (!bufferedSteps.has(runId)) {
-    bufferedSteps.set(runId, {
-      id: '',
-      object: null,
-      finishReason: null,
-      usage: null,
-      warnings: [],
-      text: '',
-      reasoning: [],
-      sources: [],
-      files: [],
-      toolCalls: [],
-      pendingToolCalls: [],
-      toolResults: [],
-      request: {},
-      response: {
-        id: '',
-        timestamp: new Date(),
-        modelId: '',
-        messages: [],
-      },
-      providerMetadata: undefined,
-      steps: [],
-      status: 'running',
-    });
+    bufferedSteps.set(runId, createAgentRunState());
   }
 
   return bufferedSteps.get(runId)!;
@@ -652,36 +649,155 @@ function removePendingToolCall(pendingToolCalls: PendingAgentToolCall[] = [], to
   return pendingToolCalls.filter(call => call.toolCallId !== toolCallId);
 }
 
-export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps: Map<string, any>) {
+function createAgentResponseState() {
+  return {
+    id: '',
+    timestamp: new Date(),
+    modelId: '',
+    messages: [],
+  };
+}
+
+function createAgentRunState(id = '') {
+  return {
+    id,
+    object: null,
+    finishReason: null,
+    usage: null,
+    warnings: [],
+    text: '',
+    reasoning: [],
+    sources: [],
+    files: [],
+    toolCalls: [],
+    pendingToolCalls: [],
+    toolResults: [],
+    request: {},
+    response: createAgentResponseState(),
+    providerMetadata: undefined,
+    steps: [],
+    status: 'running',
+  };
+}
+
+function cloneAgentResponse(
+  response: Record<string, any> | undefined,
+  { includeMessages }: { includeMessages: boolean },
+) {
+  if (!response) return response;
+
+  return {
+    ...response,
+    ...(Object.prototype.hasOwnProperty.call(response, 'messages')
+      ? { messages: includeMessages ? response.messages : [] }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(response, 'dbMessages')
+      ? { dbMessages: includeMessages ? response.dbMessages : [] }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(response, 'uiMessages')
+      ? { uiMessages: includeMessages ? response.uiMessages : [] }
+      : {}),
+  };
+}
+
+function cloneAgentStep(step: Record<string, any>, { includeDetails }: { includeDetails: boolean }) {
+  if (includeDetails) {
+    return {
+      ...step,
+      response: cloneAgentResponse(step.response, { includeMessages: true }),
+    };
+  }
+
+  return {
+    ...step,
+    object: null,
+    files: [],
+    sources: [],
+    toolCalls: [],
+    pendingToolCalls: [],
+    toolResults: [],
+    dynamicToolCalls: [],
+    dynamicToolResults: [],
+    staticToolCalls: [],
+    staticToolResults: [],
+    text: '',
+    reasoning: [],
+    content: Array.isArray(step.content) ? [] : step.content,
+    reasoningText: typeof step.reasoningText === 'string' ? '' : step.reasoningText,
+    response: cloneAgentResponse(step.response, { includeMessages: false }),
+  };
+}
+
+function serializeAgentRun(
+  current: Record<string, any>,
+  {
+    includeCompletedStepDetails,
+    includeResponseMessages,
+  }: { includeCompletedStepDetails: boolean; includeResponseMessages: boolean },
+) {
+  const { _textOffset: _to, _reasoningOffset: _ro, ...data } = current;
+
+  return {
+    ...data,
+    response: cloneAgentResponse(data.response, { includeMessages: includeResponseMessages }),
+    steps: data.steps.map((step: Record<string, any>) =>
+      cloneAgentStep(step, {
+        includeDetails: includeCompletedStepDetails,
+      }),
+    ),
+  };
+}
+
+function createAgentDataPart(args: {
+  current: Record<string, any>;
+  runId: string;
+  includeCompletedStepDetails: boolean;
+  includeResponseMessages: boolean;
+}): AgentDataPart {
+  const { current, runId, includeCompletedStepDetails, includeResponseMessages } = args;
+
+  return {
+    type: 'data-tool-agent',
+    id: runId,
+    data: serializeAgentRun(current, {
+      includeCompletedStepDetails,
+      includeResponseMessages,
+    }) as unknown as LLMStepResult,
+  };
+}
+
+function createAgentStepDataPart(args: {
+  runId: string;
+  stepIndex: number;
+  step: Record<string, any>;
+}): AgentStepDataPart {
+  const { runId, stepIndex, step } = args;
+
+  return {
+    type: 'data-tool-agent-step',
+    id: `${runId}:${stepIndex}`,
+    data: {
+      runId,
+      stepIndex,
+      step: cloneAgentStep(step, { includeDetails: true }) as unknown as LLMStepResult,
+    },
+  };
+}
+
+export function transformAgent<OUTPUT>(
+  payload: ChunkType<OUTPUT>,
+  bufferedSteps: Map<string, any>,
+): TransformAgentResult | null {
   let hasChanged = false;
+  let completedStep: { stepIndex: number; step: Record<string, any> } | null = null;
   switch (payload.type) {
-    case 'start':
-      bufferedSteps.set(payload.runId!, {
-        id: payload.payload.id,
-        object: null,
-        finishReason: null,
-        usage: null,
-        warnings: [],
-        text: '',
-        reasoning: [],
-        sources: [],
-        files: [],
-        toolCalls: [],
-        pendingToolCalls: [],
-        toolResults: [],
-        request: {},
-        response: {
-          id: '',
-          timestamp: new Date(),
-          modelId: '',
-          messages: [],
-        },
-        providerMetadata: undefined,
-        steps: [],
-        status: 'running',
-      });
+    case 'start': {
+      const startState = createAgentRunState();
+      startState.id = payload.payload.id;
+      bufferedSteps.set(payload.runId!, startState);
       hasChanged = true;
       break;
+    }
     case 'tool-call-input-streaming-start': {
       const toolInputStartRun = ensureAgentRunState(bufferedSteps, payload.runId!);
       const existing = toolInputStartRun.pendingToolCalls?.find(
@@ -828,6 +944,7 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
       break;
     case 'step-finish': {
       const stepRun = ensureAgentRunState(bufferedSteps, payload.runId!);
+      const stepIndex = stepRun.steps.length;
       // Exclude `steps` and internal offset trackers from the stepResult to
       // avoid recursive nesting where each stepResult embeds copies of all
       // prior stepResults (issue #14932).
@@ -894,6 +1011,7 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
         _textOffset: stepRun.text.length,
         _reasoningOffset: stepRun.reasoning.length,
       });
+      completedStep = { stepIndex, step: stepResult };
       hasChanged = true;
       break;
     }
@@ -902,13 +1020,26 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
   }
 
   if (hasChanged) {
-    // Strip internal offset trackers so they don't leak over the wire.
-    const { _textOffset: _to, _reasoningOffset: _ro, ...data } = bufferedSteps.get(payload.runId!)!;
-    return {
-      type: 'data-tool-agent',
-      id: payload.runId!,
-      data,
-    } satisfies AgentDataPart;
+    const current = bufferedSteps.get(payload.runId!)!;
+    const snapshot = createAgentDataPart({
+      current,
+      runId: payload.runId!,
+      includeCompletedStepDetails: payload.type === 'finish',
+      includeResponseMessages: payload.type === 'finish',
+    });
+
+    if (completedStep) {
+      return [
+        snapshot,
+        createAgentStepDataPart({
+          runId: payload.runId!,
+          stepIndex: completedStep.stepIndex,
+          step: completedStep.step,
+        }),
+      ] as const;
+    }
+
+    return snapshot;
   }
   return null;
 }
@@ -1447,8 +1578,9 @@ export function transformNetwork(
 
         step[PRIMITIVE_CACHE_SYMBOL] = step[PRIMITIVE_CACHE_SYMBOL] || new Map();
         const result = transformAgent(payload.payload as ChunkType<any>, step[PRIMITIVE_CACHE_SYMBOL]);
-        if (result) {
-          const { request, response, ...data } = result.data;
+        const snapshot = Array.isArray(result) ? result[0] : result;
+        if (snapshot) {
+          const { request, response, ...data } = snapshot.data;
           step.task = data;
         }
 

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -122,6 +122,8 @@ type TransformAgentResult = AgentDataPart | readonly [AgentDataPart, AgentStepDa
 
 // used so it's not serialized to JSON
 const PRIMITIVE_CACHE_SYMBOL = Symbol('primitive-cache');
+// persists completed-step details on the network step across subsequent events
+const COMPLETED_STEPS_SYMBOL = Symbol('completed-steps-cache');
 
 type ConvertMastraChunkToAISDK = <OUTPUT>(args: { chunk: ChunkType<OUTPUT>; mode?: 'generate' | 'stream' }) => any;
 
@@ -290,6 +292,7 @@ export function createAgentNetworkToAISDKTransformer<UI_CHUNK>() {
         task: null | Record<string, unknown>;
         input: StepResult['input'];
         [PRIMITIVE_CACHE_SYMBOL]: Map<string, any>;
+        [COMPLETED_STEPS_SYMBOL]?: Map<number, Record<string, any>>;
       })[];
       usage: LanguageModelV2Usage | null;
       output: unknown | null;
@@ -1224,6 +1227,7 @@ export function transformNetwork(
         task: null | Record<string, unknown>;
         input: StepResult['input'];
         [PRIMITIVE_CACHE_SYMBOL]: Map<string, any>;
+        [COMPLETED_STEPS_SYMBOL]?: Map<number, Record<string, any>>;
       })[];
       usage: LanguageModelV2Usage | null;
       output: unknown | null;
@@ -1580,14 +1584,22 @@ export function transformNetwork(
         const snapshot = Array.isArray(result) ? result[0] : result;
         if (snapshot) {
           const { request, response, ...data } = snapshot.data;
-          step.task = data;
-          // Merge full step detail from the completed-step delta so that
-          // suspended/failed terminations (no finish) still carry toolResults etc.
+          // If this event carries a completed-step delta, persist its full detail
+          // on the network step so subsequent events can re-apply it.
           if (Array.isArray(result)) {
             const { stepIndex, step: completedStepDetail } = result[1].data;
-            const taskSteps = data.steps;
-            if (Array.isArray(taskSteps) && stepIndex < taskSteps.length) {
-              taskSteps[stepIndex] = { ...taskSteps[stepIndex], ...completedStepDetail };
+            step[COMPLETED_STEPS_SYMBOL] = step[COMPLETED_STEPS_SYMBOL] || new Map();
+            step[COMPLETED_STEPS_SYMBOL].set(stepIndex, completedStepDetail);
+          }
+          step.task = data;
+          // Re-apply ALL persisted completed-step details after every assignment so
+          // later events (text-delta etc.) don't overwrite the merged toolResults.
+          const completedSteps = step[COMPLETED_STEPS_SYMBOL];
+          if (completedSteps && completedSteps.size > 0 && Array.isArray(data.steps)) {
+            for (const [stepIndex, completedStepDetail] of completedSteps) {
+              if (stepIndex < data.steps.length) {
+                data.steps[stepIndex] = { ...data.steps[stepIndex], ...completedStepDetail };
+              }
             }
           }
         }

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -409,7 +409,8 @@ Mastra streams data to the frontend as "parts" within messages. Each part has a 
 | `data-workflow` | `workflowRoute()` | Workflow execution state snapshots with step status and final outputs |
 | `data-workflow-step` | `workflowRoute()` | Workflow step delta with the full payload for the changed step |
 | `data-network` | `networkRoute()` | Agent network execution with ordered steps and outputs |
-| `data-tool-agent` | Nested agent in tool | Agent output streamed from within a tool's `execute()` |
+| `data-tool-agent` | Nested agent in tool | Compact nested-agent snapshot while the current step is still running |
+| `data-tool-agent-step` | Nested agent in tool | Full nested-agent step payload emitted when a nested step finishes |
 | `data-tool-workflow` | Nested workflow in tool | Workflow output streamed from within a tool's `execute()` |
 | `data-tool-network` | Nested network in tool | Network output streamed from within a tool's `execute()` |
 | `data-{custom}` | `writer.custom()` | Custom events for progress indicators, status updates, etc. |
@@ -1290,7 +1291,7 @@ For a complete implementation, see the [workflow-suspend-resume example](https:/
 
 ### Nested agent streams in tools
 
-Tools can call agents internally and stream the agent's output back to the UI. This creates `data-tool-agent` parts that can be rendered alongside the tool's final output.
+Tools can call agents internally and stream the agent's output back to the UI. This creates compact `data-tool-agent` snapshots while the nested step is still running, `data-tool-agent-step` parts when a nested step finishes, and one full `data-tool-agent` snapshot when the nested run finishes.
 
 The pattern uses:
 
@@ -1349,13 +1350,13 @@ The pattern uses:
   </TabItem>
 
   <TabItem value="frontend" label="Frontend">
-    Handle `data-tool-agent` parts to display the nested agent's streamed output.
+    Handle `data-tool-agent` parts for the live snapshot and `data-tool-agent-step` parts for the completed nested step payload.
 
     ```typescript title="src/components/nested-agent-chat.tsx"
     import { useChat } from '@ai-sdk/react'
     import { DefaultChatTransport } from 'ai'
     import { useState } from 'react'
-    import type { AgentDataPart } from '@mastra/ai-sdk'
+    import type { AgentDataPart, AgentStepDataPart } from '@mastra/ai-sdk'
 
     export function NestedAgentChat() {
       const [input, setInput] = useState('')
@@ -1395,6 +1396,15 @@ The pattern uses:
                     </div>
                   )
                 }
+                if (part.type === 'data-tool-agent-step') {
+                  const { data } = part as AgentStepDataPart
+                  return (
+                    <div key={index} className="nested-agent-step">
+                      <strong>Completed nested step {data.stepIndex + 1}</strong>
+                      {data.step.text && <p>{data.step.text}</p>}
+                    </div>
+                  )
+                }
                 return null
               })}
             </div>
@@ -1409,7 +1419,8 @@ The pattern uses:
 Key points:
 
 - Piping `fullStream` to `context.writer` creates `data-tool-agent` parts
-- The `AgentDataPart` has `id` (on the part) and `data.text` (the agent's streamed text)
+- Read `data-tool-agent-step` when you need the full payload for the nested step that just finished
+- The `AgentDataPart` has `id` (on the part) and `data.text` (the current nested-agent text snapshot)
 - The tool still returns its own output after the stream completes
 
 For a complete implementation, see the [tool-nested-streams example](https://github.com/mastra-ai/ui-dojo/blob/main/src/pages/ai-sdk/tool-nested-streams.tsx) in UI Dojo.


### PR DESCRIPTION
## Description

Nested agent streams repeat completed step output in every `data-tool-agent` update. `transformAgent` keeps a complete run state for the final result and serializes it after every nested chunk, so each intermediate snapshot carries the full history of completed steps and `response.messages`.

This change stops completed-step detail and `response.messages` from being repeated in intermediate snapshots. Instead, each completed step is emitted once as a `data-tool-agent-step` delta at `step-finish`, and intermediate `data-tool-agent` snapshots carry only lightweight completed-step descriptors (identity and metadata; no `text`, `toolResults`, `response.messages`, or `sources`). A single complete `data-tool-agent` snapshot is emitted at `finish` with all fields intact.

Cumulative `data.text` and `data.reasoning` in intermediate snapshots remain unchanged: they accumulate across steps as before, so live text rendering and consumers that read `data.text` see no behavior change.

## Related issue(s)

Fixes #20440

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Compatibility

`data.text`, `data.reasoning`, current-step tool state, final `data-tool-agent`, workflow parts, and network parts remain available. The network adapter consumes the complete snapshot and does not add `data-tool-agent-step` to `data-network` or `data-tool-network` streams. Consumers that need completed-step detail during a live run should read `data-tool-agent-step`; the terminal snapshot remains complete. Cumulative `data.text` and `data.reasoning` re-emission in intermediate snapshots is not changed by this fix.

## Test plan

- `pnpm --filter ./client-sdks/ai-sdk test src/__tests__/transform-agent-cumulative-growth.test.ts src/__tests__/transform-agent-tool-input-streaming.test.ts src/__tests__/transform-agent-a2a-stream.test.ts src/__tests__/transformers.test.ts src/__tests__/resume-stream.test.ts src/__tests__/transform-workflow-cumulative-growth.test.ts src/__tests__/convert-snapshot.test.ts`, covering bounded intermediate snapshots, one completed-step delta per step, terminal full state, tool-input streaming, resumed/A2A streams, network preservation, and workflow regressions.
- `pnpm --filter ./client-sdks/ai-sdk exec tsc --noEmit`
- `pnpm --filter ./client-sdks/ai-sdk run build:lib`
- `pnpm --filter ./client-sdks/ai-sdk lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Nested agent streams no longer repeat all previous details in every update. They send compact updates while work is in progress and send complete step details separately, which reduces stream size without changing the final result.

## What changed

- Added compact intermediate `data-tool-agent` snapshots.
- Added `data-tool-agent-step` events for completed-step details.
- Preserved complete terminal snapshots and reconnect behavior.
- Preserved cumulative `data.text` and `data.reasoning`.
- Preserved network, workflow, current-step tool, resumed-stream, and suspended-stream behavior.
- Added the public `AgentStepDataPart` type export.
- Updated network transformations to cache and restore completed-step details.
- Added handling for array results in agent tool transformations.
- Updated documentation with frontend handling for `data-tool-agent-step`.
- Added regression tests for stream-size growth, terminal data, aborted runs, suspended runs, nested agents, and network snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->