### PR TITLE
fix(core): rewrite memory reminders for Azure

### DIFF
--- a/.changeset/kind-beers-cheat.md
+++ b/.changeset/kind-beers-cheat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Rewrite system-reminder tags in Azure-bound user text and system instructions to avoid content moderation refusals while preserving stored history.

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -18,7 +18,7 @@ You can use individual [`Processor`](/reference/processors/processor-interface) 
 
 Some processors implement both input and output logic and can be used in either array depending on where the transformation should occur.
 
-Some built-in processors also send hidden system reminder signals. These signals are persisted in raw memory history and converted to `<system-reminder>...</system-reminder>` context before the next model call, but standard UI-facing message conversions and default memory recall hide them unless you explicitly opt in.
+Some built-in processors also send hidden system reminder signals. These signals are persisted in raw memory history and converted to `<system-reminder>...</system-reminder>` context before the next model call, but standard UI-facing message conversions and default memory recall hide them unless you explicitly opt in. For Azure OpenAI agents, see [`ProviderHistoryCompat`](/reference/processors/provider-history-compat) for a wire-only rename that avoids content moderation of these tags.
 
 ## When to use processors
 

--- a/docs/src/content/en/reference/processors/provider-history-compat.mdx
+++ b/docs/src/content/en/reference/processors/provider-history-compat.mdx
@@ -99,6 +99,7 @@ Mastra agents don't add this processor automatically. Add it explicitly when you
 | `anthropic-tool-id-format` | Anthropic | Reactive API error recovery | Rewrites tool call IDs that contain characters outside `[a-zA-Z0-9_-]` and retries the request. |
 | `cerebras-strip-reasoning-content` | Cerebras | Preemptive prompt rewrite | Removes assistant `reasoning` parts from the outbound prompt so they're not serialized as unsupported `reasoning_content` fields. |
 | `anthropic-strip-foreign-reasoning-content` | Anthropic | Preemptive prompt rewrite | Removes non-Anthropic assistant `reasoning` parts from the outbound prompt. Anthropic-native thinking history is preserved. |
+| `azure-system-reminder-transform` | Azure OpenAI | Preemptive prompt rewrite | Renames `<system-reminder>` wrappers to `<memory-context>` in Azure-bound user text and in system-role instructions that reference the tag, to avoid content moderation refusals. Persisted history is unchanged. |
 
 Preemptive rules run through `processLLMRequest` after Mastra converts messages to the model prompt format and before the prompt is sent to the provider. These rewrites affect only the current provider call.
 

--- a/packages/core/src/processors/provider-history-compat.test.ts
+++ b/packages/core/src/processors/provider-history-compat.test.ts
@@ -392,7 +392,7 @@ const TEMPORAL_GAP_REMINDER =
 
 function promptWithAzureReminders(): LanguageModelV2Prompt {
   return [
-    { role: 'system', content: [{ type: 'text', text: TEMPORAL_GAP_REMINDER }] },
+    { role: 'system', content: TEMPORAL_GAP_REMINDER },
     { role: 'assistant', content: [{ type: 'text', text: TEMPORAL_GAP_REMINDER }] },
     {
       role: 'user',
@@ -405,7 +405,8 @@ function promptWithAzureReminders(): LanguageModelV2Prompt {
         { type: 'image', image: 'image-data' } as any,
       ],
     },
-    { role: 'user', content: TEMPORAL_GAP_REMINDER },
+    // string-content user shape cannot be produced by to-prompt; verifies the rule skips non-array user content
+    { role: 'user', content: TEMPORAL_GAP_REMINDER } as any,
   ];
 }
 
@@ -432,7 +433,9 @@ describe('azureSystemReminderTransform', () => {
     });
     expect(prompt).toEqual(sourcePrompt);
     expect(JSON.stringify(messageList.get.all.db())).toBe(sourceHistory);
-    expect(transformedPrompt[0]).toBe(prompt[0]);
+    expect(transformedPrompt[0]).not.toBe(prompt[0]);
+    expect((transformedPrompt[0] as any).content).not.toMatch(/<system-reminder/);
+    expect((transformedPrompt[0] as any).content).toContain('<memory-context');
     expect(transformedPrompt[1]).toBe(prompt[1]);
     expect(transformedPrompt[2]).not.toBe(prompt[2]);
     expect((transformedPrompt[2]!.content as any[])[1]).toBe((prompt[2]!.content as any[])[1]);

--- a/packages/core/src/processors/provider-history-compat.test.ts
+++ b/packages/core/src/processors/provider-history-compat.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it } from 'vitest';
 import { MessageList } from '../agent/message-list';
 import {
   anthropicStripForeignReasoningContent,
+  azureSystemReminderTransform,
   cerebrasStripReasoningContent,
+  isMaybeAzure,
   isMaybeAnthropic,
   isMaybeCerebras,
   ProviderHistoryCompat,
@@ -362,9 +364,223 @@ describe('isMaybeCerebras', () => {
   });
 });
 
+describe('isMaybeAzure', () => {
+  it('matches Azure gateway strings and provider objects', () => {
+    expect(isMaybeAzure('azure-openai/my-deployment')).toBe(true);
+    expect(isMaybeAzure('azure/my-deployment')).toBe(true);
+    expect(isMaybeAzure({ provider: 'azure.chat', modelId: 'my-deployment' })).toBe(true);
+    expect(isMaybeAzure({ provider: 'azure-openai.chat', modelId: 'my-deployment' })).toBe(true);
+    expect(isMaybeAzure({ provider: 'openai-compatible.chat', modelId: 'azure-openai/my-deployment' })).toBe(true);
+  });
+
+  it('does not match non-Azure provider boundaries', () => {
+    expect(isMaybeAzure('openai.chat')).toBe(false);
+    expect(isMaybeAzure('anthropic/claude-opus-4-6')).toBe(false);
+    expect(isMaybeAzure('azure-foo')).toBe(false);
+    expect(isMaybeAzure({ provider: 'azure-foo', modelId: 'my-deployment' })).toBe(false);
+    expect(isMaybeAzure(undefined)).toBe(false);
+    expect(isMaybeAzure(() => 'azure/my-deployment')).toBe(false);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // cerebrasStripReasoningContent rule + ProviderHistoryCompat.processLLMRequest
 // ---------------------------------------------------------------------------
+
+const TEMPORAL_GAP_REMINDER =
+  '<system-reminder type="temporal-gap" gapText="10 minutes later" gapMs="600000" timestamp="9:10 AM" timestampMs="1710000000000" precedesMessageId="input-1">10 minutes later — 9:10 AM</system-reminder>';
+
+function promptWithAzureReminders(): LanguageModelV2Prompt {
+  return [
+    { role: 'system', content: [{ type: 'text', text: TEMPORAL_GAP_REMINDER }] },
+    { role: 'assistant', content: [{ type: 'text', text: TEMPORAL_GAP_REMINDER }] },
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: `${TEMPORAL_GAP_REMINDER} ${TEMPORAL_GAP_REMINDER}`,
+          providerOptions: { test: { preserved: true } },
+        },
+        { type: 'image', image: 'image-data' } as any,
+      ],
+    },
+    { role: 'user', content: TEMPORAL_GAP_REMINDER },
+  ];
+}
+
+describe('azureSystemReminderTransform', () => {
+  it('rewrites issue-shaped temporal-gap user text at the production hook', async () => {
+    const handler = new ProviderHistoryCompat();
+    const prompt = promptWithAzureReminders();
+    const sourcePrompt = JSON.parse(JSON.stringify(prompt));
+    const messageList = new MessageList({ threadId: 'azure-reminder' });
+    messageList.add([createUserMessage(TEMPORAL_GAP_REMINDER)], 'input');
+    const sourceHistory = JSON.stringify(messageList.get.all.db());
+
+    const result = await handler.processLLMRequest(makeRequestArgs(prompt, 'azure-openai/my-deployment'));
+
+    expect(result).toEqual({ prompt: expect.any(Array) });
+    const transformedPrompt = (result as { prompt: LanguageModelV2Prompt }).prompt;
+    const transformedText = (transformedPrompt[2]!.content as any[])[0]!.text;
+    expect(transformedText).toBe(
+      '<memory-context type="temporal-gap" gapText="10 minutes later" gapMs="600000" timestamp="9:10 AM" timestampMs="1710000000000" precedesMessageId="input-1">10 minutes later — 9:10 AM</memory-context> <memory-context type="temporal-gap" gapText="10 minutes later" gapMs="600000" timestamp="9:10 AM" timestampMs="1710000000000" precedesMessageId="input-1">10 minutes later — 9:10 AM</memory-context>',
+    );
+    expect(transformedText).not.toMatch(/<system-reminder(?:\s|>)/);
+    expect((transformedPrompt[2]!.content as any[])[0]!.providerOptions).toEqual({
+      test: { preserved: true },
+    });
+    expect(prompt).toEqual(sourcePrompt);
+    expect(JSON.stringify(messageList.get.all.db())).toBe(sourceHistory);
+    expect(transformedPrompt[0]).toBe(prompt[0]);
+    expect(transformedPrompt[1]).toBe(prompt[1]);
+    expect(transformedPrompt[2]).not.toBe(prompt[2]);
+    expect((transformedPrompt[2]!.content as any[])[1]).toBe((prompt[2]!.content as any[])[1]);
+    expect(transformedPrompt[3]).toBe(prompt[3]);
+  });
+
+  it('preserves attributes and contents while changing multiple markers', () => {
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: `before ${TEMPORAL_GAP_REMINDER} after ${TEMPORAL_GAP_REMINDER}` }],
+      },
+    ];
+
+    const result = azureSystemReminderTransform.applyToPrompt!({
+      prompt,
+      model: { provider: 'azure.chat', modelId: 'my-deployment' },
+    });
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `before ${TEMPORAL_GAP_REMINDER.replaceAll('system-reminder', 'memory-context')} after ${TEMPORAL_GAP_REMINDER.replaceAll('system-reminder', 'memory-context')}`,
+          },
+        ],
+      },
+    ]);
+    expect(prompt[0]!.content).toEqual([
+      { type: 'text', text: `before ${TEMPORAL_GAP_REMINDER} after ${TEMPORAL_GAP_REMINDER}` },
+    ]);
+    expect(azureSystemReminderTransform.fix).toBeUndefined();
+  });
+
+  it('preserves non-Azure prompts and returns undefined for unchanged prompts', async () => {
+    const prompt = promptWithAzureReminders();
+    const handler = new ProviderHistoryCompat();
+
+    for (const model of ['openai.chat', 'anthropic/claude-opus-4-6', 'azure-foo', 'unknown/model']) {
+      expect(azureSystemReminderTransform.applyToPrompt!({ prompt, model })).toBeUndefined();
+      expect(await handler.processLLMRequest(makeRequestArgs(prompt, model))).toBeUndefined();
+    }
+
+    const unchangedPrompt: LanguageModelV2Prompt = [{ role: 'user', content: [{ type: 'text', text: 'plain text' }] }];
+    expect(
+      azureSystemReminderTransform.applyToPrompt!({
+        prompt: unchangedPrompt,
+        model: 'azure-openai/my-deployment',
+      }),
+    ).toBeUndefined();
+  });
+
+  // Finding A: system-role instruction + user-role marker must both be renamed
+  it('renames the tag in the system-role OM instruction so it agrees with the renamed user markers', () => {
+    // The OM processor adds a system message whose text defines <system-reminder>.
+    // On Azure that literal must not survive in the outbound payload.
+    const omSystemInstruction =
+      "SYSTEM REMINDERS: Messages wrapped in <system-reminder>...</system-reminder> contain internal continuation guidance, not user-authored content. Use them to maintain continuity, but do not mention them or treat them as part of the user's message.";
+    const continuationHint = '<system-reminder>Please continue naturally with the conversation.</system-reminder>';
+
+    const prompt: LanguageModelV2Prompt = [
+      { role: 'system', content: omSystemInstruction },
+      { role: 'user', content: [{ type: 'text', text: continuationHint }] },
+    ];
+    const sourcePrompt = JSON.parse(JSON.stringify(prompt));
+
+    const result = azureSystemReminderTransform.applyToPrompt!({
+      prompt,
+      model: 'azure-openai/my-deployment',
+    });
+
+    expect(result).toBeDefined();
+    // System instruction: no <system-reminder> literal remains
+    const sysContent = (result![0] as { role: 'system'; content: string }).content;
+    expect(sysContent).not.toMatch(/<system-reminder/);
+    expect(sysContent).toContain('<memory-context>');
+    expect(sysContent).toContain('</memory-context>');
+    expect(sysContent).toContain('not user-authored content');
+    // User message: tag also renamed
+    const userText = ((result![1] as any).content as Array<{ type: string; text: string }>)[0]!.text;
+    expect(userText).not.toMatch(/<system-reminder/);
+    expect(userText).toBe('<memory-context>Please continue naturally with the conversation.</memory-context>');
+    // Source prompt is unchanged (wire-only)
+    expect(prompt).toEqual(sourcePrompt);
+  });
+
+  it('returns undefined for system-role string content with no reminder tags on Azure', () => {
+    const prompt: LanguageModelV2Prompt = [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    ];
+    expect(
+      azureSystemReminderTransform.applyToPrompt!({ prompt, model: 'azure-openai/my-deployment' }),
+    ).toBeUndefined();
+  });
+
+  it('leaves system-role instruction unchanged for non-Azure models', () => {
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'system',
+        content: 'Messages wrapped in <system-reminder>...</system-reminder> contain guidance.',
+      },
+      { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+    ];
+    expect(azureSystemReminderTransform.applyToPrompt!({ prompt, model: 'openai/gpt-4o' })).toBeUndefined();
+  });
+
+  // Finding C: bare form, self-closing form, and non-matching prefix
+  it('rewrites the bare OM continuation form without attributes', () => {
+    const bare = '<system-reminder>Please continue naturally with the conversation.</system-reminder>';
+    const prompt: LanguageModelV2Prompt = [{ role: 'user', content: [{ type: 'text', text: bare }] }];
+    const result = azureSystemReminderTransform.applyToPrompt!({
+      prompt,
+      model: 'azure-openai/my-deployment',
+    });
+    expect(result).toBeDefined();
+    const text = ((result![0] as any).content as Array<{ type: string; text: string }>)[0]!.text;
+    expect(text).toBe('<memory-context>Please continue naturally with the conversation.</memory-context>');
+    expect(text).not.toMatch(/<system-reminder/);
+  });
+
+  it('rewrites the self-closing form', () => {
+    const prompt: LanguageModelV2Prompt = [
+      { role: 'user', content: [{ type: 'text', text: 'before <system-reminder/> after' }] },
+    ];
+    const result = azureSystemReminderTransform.applyToPrompt!({
+      prompt,
+      model: 'azure-openai/my-deployment',
+    });
+    expect(result).toBeDefined();
+    const text = ((result![0] as any).content as Array<{ type: string; text: string }>)[0]!.text;
+    expect(text).toBe('before <memory-context/> after');
+  });
+
+  it('does not rewrite a tag whose name only starts with system-reminder', () => {
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: '<system-reminderX>should not change</system-reminderX>' }],
+      },
+    ];
+    expect(
+      azureSystemReminderTransform.applyToPrompt!({ prompt, model: 'azure-openai/my-deployment' }),
+    ).toBeUndefined();
+  });
+});
 
 function promptWithReasoning(): LanguageModelV2Prompt {
   return [

--- a/packages/core/src/processors/provider-history-compat.ts
+++ b/packages/core/src/processors/provider-history-compat.ts
@@ -221,6 +221,88 @@ export function isMaybeAnthropic(
   return matchesProviderPrefix(model, 'anthropic');
 }
 
+export function isMaybeAzure(
+  model:
+    | string
+    | { provider?: string; modelId?: string }
+    | ((...args: any[]) => any)
+    | { model: any; enabled?: boolean }[]
+    | unknown,
+): boolean {
+  if (Array.isArray(model)) {
+    return model.some(entry => isMaybeAzure((entry as { model?: unknown }).model ?? entry));
+  }
+
+  if (model && typeof model === 'object') {
+    const { provider, modelId } = model as { provider?: unknown; modelId?: unknown };
+    if (typeof provider === 'string' && /^(?:azure|azure-openai)(?:\.[a-z0-9_-]+)?$/i.test(provider)) {
+      return true;
+    }
+
+    return (
+      typeof modelId === 'string' &&
+      (matchesProviderPrefix(modelId, 'azure') || matchesProviderPrefix(modelId, 'azure-openai'))
+    );
+  }
+
+  return matchesProviderPrefix(model, 'azure') || matchesProviderPrefix(model, 'azure-openai');
+}
+
+const SYSTEM_REMINDER_OPEN_TAG = /<system-reminder(?=\s|\/?>)([^>]*)>/g;
+const SYSTEM_REMINDER_CLOSE_TAG = /<\/system-reminder>/g;
+
+/**
+ * Azure OpenAI can moderate the system-reminder wrapper in user text and in
+ * system-role instructions that reference it. Rename it only in the outbound
+ * prompt so persisted history stays provider-neutral.
+ *
+ * System messages have `content: string`; user messages have array content.
+ * Both forms are handled so the tag name in the system instruction and in the
+ * user-role markers agree, and no `<system-reminder>` literal remains in the
+ * Azure-bound payload.
+ */
+export const azureSystemReminderTransform: CompatRule = {
+  name: 'azure-system-reminder-transform',
+  applyToPrompt({ prompt, model }) {
+    if (!isMaybeAzure(model)) return undefined;
+
+    let promptMutated = false;
+    const next = prompt.map(message => {
+      // System messages carry string content; rename the tag there too so the
+      // instruction and the user-role markers agree.
+      if (message.role === 'system') {
+        if (typeof message.content !== 'string') return message;
+        const text = message.content
+          .replace(SYSTEM_REMINDER_OPEN_TAG, '<memory-context$1>')
+          .replace(SYSTEM_REMINDER_CLOSE_TAG, '</memory-context>');
+        if (text === message.content) return message;
+        promptMutated = true;
+        return { ...message, content: text };
+      }
+
+      if (message.role !== 'user' || !Array.isArray(message.content)) return message;
+
+      let messageMutated = false;
+      const content = message.content.map(part => {
+        if (part.type !== 'text') return part;
+
+        const text = part.text
+          .replace(SYSTEM_REMINDER_OPEN_TAG, '<memory-context$1>')
+          .replace(SYSTEM_REMINDER_CLOSE_TAG, '</memory-context>');
+        if (text === part.text) return part;
+
+        messageMutated = true;
+        promptMutated = true;
+        return { ...part, text };
+      });
+
+      return messageMutated ? { ...message, content } : message;
+    });
+
+    return promptMutated ? next : undefined;
+  },
+};
+
 /**
  * Returns a copy of the prompt with selected `reasoning` parts stripped from
  * assistant messages. Returns `undefined` if no changes were necessary.
@@ -317,6 +399,7 @@ export const DEFAULT_COMPAT_RULES: CompatRule[] = [
   anthropicToolIdFormat,
   cerebrasStripReasoningContent,
   anthropicStripForeignReasoningContent,
+  azureSystemReminderTransform,
 ];
 
 // ---------------------------------------------------------------------------
@@ -343,6 +426,10 @@ export const DEFAULT_COMPAT_RULES: CompatRule[] = [
  * - **anthropic-strip-foreign-reasoning-content** — strips non-Anthropic
  *   `reasoning` parts from assistant messages in the outbound prompt when the
  *   resolved model is Anthropic. Anthropic-native reasoning parts are kept.
+ * - **azure-system-reminder-transform** — renames `system-reminder` wrappers
+ *   in Azure-bound user text and in system-role instructions that reference
+ *   the tag, so the instruction and the markers agree in the outbound payload.
+ *   Persisted history is unchanged.
  *
  * To add custom rules, pass them to the constructor:
  * ```ts


### PR DESCRIPTION
## Description

Azure OpenAI can reject Observational Memory continuation and temporal-gap reminders because their user text contains `<system-reminder>` markup. The provider-history compatibility layer now rewrites that wrapper only in Azure-bound requests, covering both user-role markers and the system-role instruction that defines the wrapper.

## Related issue(s)

Fixes #16531

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

---

## Root cause

Mastra intentionally stores reminder markup in message history, then converts it into the outbound prompt. `ProviderHistoryCompat` already provides a preemptive wire-only rewrite hook, but no default rule handled Azure's content moderation behavior. The Observational Memory system instruction also carries `<system-reminder>` literals: leaving them while renaming the user-role markers would leave the instruction referencing a tag the model never sees.

## Changes

- `packages/core/src/processors/provider-history-compat.ts`: detect `azure` and canonical `azure-openai` model forms, then rename eligible tags to `<memory-context>` in both user-role text and system-role string content without changing contents or attributes.
- `packages/core/src/processors/provider-history-compat.test.ts`: cover the production hook, canonical model detection, temporal-gap attributes, the OM system instruction + user-role marker pair, the bare continuation form, the self-closing form, the `<system-reminderX>` negative case, non-Azure and non-user boundaries, and immutability.
- `docs/src/content/en/reference/processors/provider-history-compat.mdx`: add the `azure-system-reminder-transform` row to the Built-in rules table.
- `.changeset/*`: patch release note for `@mastra/core`.

The transform follows the wire-only direction in [the issue discussion](https://github.com/mastra-ai/mastra/issues/16531#issuecomment-4461953465) and the closed prior implementation in [#16653](https://github.com/mastra-ai/mastra/pull/16653). Attribution for the reported workaround: [issue comment](https://github.com/mastra-ai/mastra/issues/16531#issuecomment-4439310999).

## Compatibility

Persisted messages remain unchanged. Non-Azure prompts, assistant messages, non-text parts, reminder contents, attributes, and existing provider rules are unchanged.

`ProviderHistoryCompat` is opt-in and must be registered explicitly on each agent where the fix should apply:

```ts
import { Agent } from '@mastra/core/agent'
import { ProviderHistoryCompat } from '@mastra/core/processors'

const agent = new Agent({
  model: 'azure-openai/my-deployment',
  inputProcessors: [new ProviderHistoryCompat()],
  // ...
})
```

Agents that do not include `ProviderHistoryCompat` in `inputProcessors` are not affected by this change. Making the processor a default for Azure agents would be a separate product decision.

## Test plan

- `pnpm --filter ./packages/core test src/processors/provider-history-compat.test.ts`, covering the issue-shaped Azure prompt, canonical `azure-openai/*` detection, attribute preservation, the OM system instruction + user-marker pair, the bare continuation form, the self-closing form, the `<system-reminderX>` negative case, non-Azure and role/part negative space, immutability, and existing rule composition.
- `pnpm --filter ./packages/core lint`
- `npx oxfmt --check` on changed `.ts` files

The focused tests prove the outbound prompt shape. Live Azure moderation remains provider-owned; the tag substitution is the workaround recorded in the issue thread.