### PR TITLE
feat(factory-ui): Jira intake settings and board surface

### DIFF
--- a/mastracode/factory-ui/e2e/ui/msw-server.ts
+++ b/mastracode/factory-ui/e2e/ui/msw-server.ts
@@ -20,6 +20,10 @@ export const server = setupServer(
   // Ambient provider catalog (read by the NewPage credential guard wherever
   // it renders); credential-specific tests override it with `server.use(...)`.
   http.get('*/web/config/providers', () => HttpResponse.json({ providers: [] })),
+  // Ambient Jira feature status (read wherever the intake surface renders).
+  // 404 mirrors a deployment without the JIRA_* env group — routes not
+  // mounted, the service degrades to disabled. Jira tests override it.
+  http.get('*/web/jira/status', () => HttpResponse.json(null, { status: 404 })),
   http.get('*/web/factory/projects', () => HttpResponse.json({ projects: [] })),
   http.get('*/web/factory/projects/:id/source-control-connections', () => HttpResponse.json({ connections: [] })),
   http.get('*/web/github/projects/:projectRepositoryId/worktrees', () => HttpResponse.json({ worktrees: [] })),

--- a/mastracode/factory-ui/src/api/keys.ts
+++ b/mastracode/factory-ui/src/api/keys.ts
@@ -34,6 +34,11 @@ export const queryKeys = {
   linearIssuesAll: () => ['linear', 'issues'] as const,
   linearIssues: (githubProjectId: string | undefined) =>
     [...queryKeys.linearIssuesAll(), githubProjectId ?? null] as const,
+  jiraStatus: () => ['jira', 'status'] as const,
+  jiraProjects: () => ['jira', 'projects'] as const,
+  // The Jira issues request carries no project scoping (the server applies the
+  // org's intake selection), so one cache entry covers the feed.
+  jiraIssues: () => ['jira', 'issues'] as const,
   intakeConfig: () => ['intake', 'config'] as const,
   channelAccounts: () => ['channel-accounts'] as const,
   workItems: (factoryProjectId: string | undefined) => ['factory', 'work-items', factoryProjectId ?? null] as const,

--- a/mastracode/factory-ui/src/hooks/__tests__/useJiraData.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useJiraData.msw.test.tsx
@@ -166,6 +166,34 @@ describe('intake config with the jira key', () => {
     expect(result.current.data?.jira).toEqual({ enabled: false, sourceIds: null });
   });
 
+  it('given the deployment registers only github and jira, when the config is saved, then unregistered keys are not sent', async () => {
+    // The server rejects keys for unregistered integrations (invalid_config),
+    // so the save must trim the fixed client shape down to the GET's keys.
+    const registered = { github: { enabled: true, sourceIds: null }, jira: { enabled: false, sourceIds: null } };
+    let putBody: unknown;
+    server.use(
+      http.get(CONFIG_URL, () => HttpResponse.json({ config: registered })),
+      http.put(CONFIG_URL, async ({ request }) => {
+        putBody = await request.json();
+        return HttpResponse.json({ config: putBody });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useSaveIntakeConfigMutation());
+
+    result.current.mutate({
+      github: { enabled: true, sourceIds: null },
+      linear: { enabled: false, sourceIds: null },
+      jira: { enabled: true, sourceIds: ['10001'] },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(putBody).toEqual({
+      github: { enabled: true, sourceIds: null },
+      jira: { enabled: true, sourceIds: ['10001'] },
+    });
+  });
+
   it('given a jira selection is saved, when it succeeds, then the config cache updates and jira issues invalidate', async () => {
     const initial: IntakeConfig = {
       github: { enabled: true, sourceIds: null },

--- a/mastracode/factory-ui/src/hooks/__tests__/useJiraData.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useJiraData.msw.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * BDD coverage for the Jira intake data hooks and the `jira` intake-config key.
+ *
+ * Drives the real services + React Query cache; only the network is mocked
+ * (MSW). Handlers register on the ApiConfig base URL the test providers inject
+ * (`TEST_BASE_URL`), matching how the app wires it.
+ */
+import { waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../e2e/ui/msw-server';
+import { renderHookWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import type { IntakeConfig } from '../../ui/domains/factory/services/intake';
+import type { JiraIssue, JiraProject, JiraStatus } from '../../ui/domains/factory/services/jira';
+import { isJiraAuthError } from '../../ui/domains/factory/services/jira';
+import { useIntakeConfigQuery, useSaveIntakeConfigMutation } from '../useIntakeConfig';
+import { useJiraIssuesQuery, useJiraProjectsQuery, useJiraStatusQuery } from '../useJiraData';
+
+const STATUS_URL = `${TEST_BASE_URL}/web/jira/status`;
+const ISSUES_URL = `${TEST_BASE_URL}/web/jira/issues`;
+const PROJECTS_URL = `${TEST_BASE_URL}/web/jira/projects`;
+const CONFIG_URL = `${TEST_BASE_URL}/web/intake/config`;
+
+const issue: JiraIssue = {
+  id: '20001',
+  identifier: 'ENG-1',
+  title: 'Login button unresponsive on Safari',
+  url: 'https://acme.atlassian.net/browse/ENG-1',
+  state: 'To Do',
+  stateType: 'unstarted',
+  priorityLabel: 'High',
+  assignee: 'Ada Lovelace',
+  project: 'ENG',
+  labels: ['bug'],
+  createdAt: '2026-07-01T00:00:00Z',
+  updatedAt: '2026-07-02T00:00:00Z',
+};
+
+const projects: JiraProject[] = [
+  { id: '10001', name: 'Engineering', key: 'ENG' },
+  { id: '10002', name: 'Operations', key: 'OPS' },
+];
+
+const readyStatus: JiraStatus = {
+  enabled: true,
+  configured: true,
+  site: 'acme.atlassian.net',
+  reason: 'ready',
+};
+
+describe('useJiraStatusQuery', () => {
+  it('given a configured deployment, when the hook resolves, then it exposes the status', async () => {
+    server.use(http.get(STATUS_URL, () => HttpResponse.json(readyStatus)));
+
+    const { result } = renderHookWithProviders(() => useJiraStatusQuery());
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data).toEqual(readyStatus);
+  });
+
+  it('given the routes are not mounted (no env group), when the hook resolves, then it degrades to disabled instead of erroring', async () => {
+    server.use(http.get(STATUS_URL, () => HttpResponse.json({ error: 'not_found' }, { status: 404 })));
+
+    const { result } = renderHookWithProviders(() => useJiraStatusQuery());
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data).toMatchObject({ enabled: false, configured: false });
+  });
+});
+
+describe('useJiraIssuesQuery', () => {
+  it('given cursor pages, when fetchNextPage is called, then pages accumulate in order', async () => {
+    const pageTwoIssue: JiraIssue = { ...issue, id: '20002', identifier: 'ENG-2', title: 'Page two issue' };
+    const requestedCursors: Array<string | null> = [];
+    server.use(
+      http.get(ISSUES_URL, ({ request }) => {
+        const after = new URL(request.url).searchParams.get('after');
+        requestedCursors.push(after);
+        return after === 'cursor-2'
+          ? HttpResponse.json({ issues: [pageTwoIssue], nextCursor: null })
+          : HttpResponse.json({ issues: [issue], nextCursor: 'cursor-2' });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useJiraIssuesQuery(true));
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data).toEqual([issue]);
+    expect(result.current.hasNextPage).toBe(true);
+
+    await result.current.fetchNextPage();
+
+    await waitFor(() => expect(result.current.data).toHaveLength(2));
+    expect(result.current.data).toEqual([issue, pageTwoIssue]);
+    expect(result.current.hasNextPage).toBe(false);
+    expect(requestedCursors).toEqual([null, 'cursor-2']);
+  });
+
+  it('given the hook is disabled, when it mounts, then no request is made', async () => {
+    const hit = vi.fn();
+    server.use(
+      http.get(ISSUES_URL, () => {
+        hit();
+        return HttpResponse.json({ issues: [issue], nextCursor: null });
+      }),
+    );
+
+    const { result, client } = renderHookWithProviders(() => useJiraIssuesQuery(false));
+
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(hit).not.toHaveBeenCalled();
+  });
+
+  it('given Jira rejects the credentials, when the hook errors, then isJiraAuthError recognizes the code', async () => {
+    server.use(
+      http.get(ISSUES_URL, () =>
+        HttpResponse.json({ error: 'jira_auth_failed', message: 'Jira rejected the configured credentials.' }, { status: 409 }),
+      ),
+    );
+
+    const { result } = renderHookWithProviders(() => useJiraIssuesQuery(true));
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as Error).message).toBe('Jira rejected the configured credentials.');
+    expect(isJiraAuthError(result.current.error)).toBe(true);
+  });
+
+  it('given the server fails, when the hook resolves, then it surfaces the server message without the auth code', async () => {
+    server.use(
+      http.get(ISSUES_URL, () => HttpResponse.json({ error: 'jira_fetch_failed', message: 'boom' }, { status: 502 })),
+    );
+
+    const { result } = renderHookWithProviders(() => useJiraIssuesQuery(true));
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as Error).message).toBe('boom');
+    expect(isJiraAuthError(result.current.error)).toBe(false);
+  });
+});
+
+describe('useJiraProjectsQuery', () => {
+  it('given a configured site, when the hook resolves, then it exposes the projects', async () => {
+    server.use(http.get(PROJECTS_URL, () => HttpResponse.json({ projects })));
+
+    const { result } = renderHookWithProviders(() => useJiraProjectsQuery(true));
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data).toEqual(projects);
+  });
+});
+
+describe('intake config with the jira key', () => {
+  it('given a server config without a jira key, when the query resolves, then jira defaults to disabled', async () => {
+    server.use(
+      http.get(CONFIG_URL, () =>
+        HttpResponse.json({ config: { github: { enabled: true, sourceIds: null } } }),
+      ),
+    );
+
+    const { result } = renderHookWithProviders(() => useIntakeConfigQuery());
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data?.jira).toEqual({ enabled: false, sourceIds: null });
+  });
+
+  it('given a jira selection is saved, when it succeeds, then the config cache updates and jira issues invalidate', async () => {
+    const initial: IntakeConfig = {
+      github: { enabled: true, sourceIds: null },
+      linear: { enabled: false, sourceIds: null },
+      jira: { enabled: false, sourceIds: null },
+    };
+    const updated: IntakeConfig = { ...initial, jira: { enabled: true, sourceIds: ['10001'] } };
+    let putBody: unknown;
+    const issueRequests = vi.fn();
+    server.use(
+      http.get(CONFIG_URL, () => HttpResponse.json({ config: initial })),
+      http.put(CONFIG_URL, async ({ request }) => {
+        putBody = await request.json();
+        return HttpResponse.json({ config: updated });
+      }),
+      http.get(ISSUES_URL, () => {
+        issueRequests();
+        return HttpResponse.json({ issues: [issue], nextCursor: null });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => ({
+      query: useIntakeConfigQuery(),
+      issues: useJiraIssuesQuery(true),
+      save: useSaveIntakeConfigMutation(),
+    }));
+
+    await waitFor(() => expect(result.current.query.data).toBeDefined());
+    await waitFor(() => expect(result.current.issues.data).toBeDefined());
+    const issueFetchesBeforeSave = issueRequests.mock.calls.length;
+
+    result.current.save.mutate(updated);
+
+    await waitFor(() => expect(result.current.query.data).toEqual(updated));
+    expect(putBody).toEqual(updated);
+    // The save invalidates the jira issues cache, triggering a refetch.
+    await waitFor(() => expect(issueRequests.mock.calls.length).toBeGreaterThan(issueFetchesBeforeSave));
+  });
+});

--- a/mastracode/factory-ui/src/hooks/__tests__/useLinearData.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useLinearData.msw.test.tsx
@@ -139,6 +139,7 @@ describe('useIntakeConfigQuery / useSaveIntakeConfigMutation', () => {
   const config: IntakeConfig = {
     github: { enabled: true, sourceIds: null },
     linear: { enabled: true, sourceIds: null },
+    jira: { enabled: false, sourceIds: null },
   };
 
   it('given a saved config, when the query resolves, then it exposes the config', async () => {
@@ -154,6 +155,7 @@ describe('useIntakeConfigQuery / useSaveIntakeConfigMutation', () => {
     const updated: IntakeConfig = {
       github: { enabled: false, sourceIds: null },
       linear: { enabled: true, sourceIds: ['proj-1'] },
+      jira: { enabled: false, sourceIds: null },
     };
     let putBody: unknown;
     server.use(

--- a/mastracode/factory-ui/src/hooks/__tests__/useLinearData.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useLinearData.msw.test.tsx
@@ -180,7 +180,11 @@ describe('useIntakeConfigQuery / useSaveIntakeConfigMutation', () => {
   });
 
   it('given the save fails, when it settles, then the mutation surfaces the server message', async () => {
-    server.use(http.put(CONFIG_URL, () => HttpResponse.json({ error: 'invalid_config' }, { status: 400 })));
+    server.use(
+      // The save first reads the registered keys, then PUTs.
+      http.get(CONFIG_URL, () => HttpResponse.json({ config })),
+      http.put(CONFIG_URL, () => HttpResponse.json({ error: 'invalid_config' }, { status: 400 })),
+    );
 
     const { result } = renderHookWithProviders(() => useSaveIntakeConfigMutation());
 

--- a/mastracode/factory-ui/src/hooks/useIntakeConfig.ts
+++ b/mastracode/factory-ui/src/hooks/useIntakeConfig.ts
@@ -17,8 +17,8 @@ export function useIntakeConfigQuery(enabled: boolean = true) {
 
 /**
  * Persist the intake config. On success the config cache is updated in place
- * and the Linear issue list is invalidated — the server applies the project
- * selection, so a config change can alter its results.
+ * and the Linear and Jira issue lists are invalidated — the server applies the
+ * project selection, so a config change can alter their results.
  */
 export function useSaveIntakeConfigMutation() {
   const { baseUrl } = useApiConfig();
@@ -28,6 +28,7 @@ export function useSaveIntakeConfigMutation() {
     onSuccess: saved => {
       queryClient.setQueryData(queryKeys.intakeConfig(), saved);
       void queryClient.invalidateQueries({ queryKey: queryKeys.linearIssuesAll() });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.jiraIssues() });
     },
   });
 }

--- a/mastracode/factory-ui/src/hooks/useJiraData.ts
+++ b/mastracode/factory-ui/src/hooks/useJiraData.ts
@@ -1,0 +1,51 @@
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+
+import { useApiConfig } from '../api/config';
+import { queryKeys } from '../api/keys';
+import { fetchJiraStatus, listJiraIssues, listJiraProjects } from '../ui/domains/factory/services/jira';
+import { INTAKE_POLL_MS } from './useFactoryData';
+
+/**
+ * Jira feature status through the shared React Query cache. The service
+ * degrades to a disabled status instead of throwing, so consumers read `data`,
+ * never `error`. Pass `enabled: false` to gate the request.
+ */
+export function useJiraStatusQuery(enabled: boolean = true) {
+  const { baseUrl } = useApiConfig();
+  return useQuery({
+    queryKey: queryKeys.jiraStatus(),
+    queryFn: () => fetchJiraStatus(baseUrl),
+    enabled,
+  });
+}
+
+/**
+ * The selected Jira projects' active issues, loaded one cursor page at a time
+ * as the list is scrolled. The server applies the caller's intake config
+ * (project selection); pass `enabled: false` until the Jira feed is active.
+ */
+export function useJiraIssuesQuery(enabled: boolean) {
+  const { baseUrl } = useApiConfig();
+  return useInfiniteQuery({
+    queryKey: queryKeys.jiraIssues(),
+    queryFn: ({ pageParam }) => listJiraIssues(baseUrl, pageParam || undefined),
+    initialPageParam: '',
+    getNextPageParam: lastPage => lastPage.nextCursor,
+    enabled,
+    select: data => data.pages.flatMap(page => page.issues),
+    // New intake must show up on the board without a reload; the endpoint
+    // proxies the Jira API, so poll on the gentle intake cadence.
+    refetchInterval: INTAKE_POLL_MS,
+    refetchOnWindowFocus: true,
+  });
+}
+
+/** The Jira site's projects (Settings intake-source picker). */
+export function useJiraProjectsQuery(enabled: boolean) {
+  const { baseUrl } = useApiConfig();
+  return useQuery({
+    queryKey: queryKeys.jiraProjects(),
+    queryFn: () => listJiraProjects(baseUrl),
+    enabled,
+  });
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCandidates.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCandidates.ts
@@ -3,11 +3,20 @@ import type { ComponentType } from 'react';
 
 import { relativeTime } from '../../../lib/date/relativeTime';
 import { AUTO_TRIAGED_LABEL, NEEDS_APPROVAL_LABEL, hasLabel } from './boardItems';
-import { LINEAR_FETCH_HINT, approvalRunAction, guidedPrompt, issueRunActions, reviewRunAction } from './boardRunSpecs';
+import {
+  JIRA_FETCH_HINT,
+  LINEAR_FETCH_HINT,
+  approvalRunAction,
+  guidedPrompt,
+  issueRunActions,
+  reviewRunAction,
+} from './boardRunSpecs';
 import type { RunAction } from './boardRunSpecs';
 import { itemAppearsInStage } from './boardStages';
+import { JiraIcon } from '../../ui/icons';
 import { IssueSourceIcon } from './components/BoardIcons';
 import type { GithubIssue, GithubPullRequest } from './services/factory';
+import type { JiraIssue } from './services/jira';
 import type { LinearIssue } from './services/linear';
 import type { WorkItem, WorkItemSource } from './services/workItems';
 import type { BoardStageId } from './stages';
@@ -21,6 +30,7 @@ export const INTAKE_SOURCES = [
   { id: 'github', label: 'Issues' },
   { id: 'github-prs', label: 'PRs' },
   { id: 'linear', label: 'Linear' },
+  { id: 'jira', label: 'Jira' },
 ] as const;
 
 export type IntakeSource = (typeof INTAKE_SOURCES)[number]['id'];
@@ -106,6 +116,25 @@ export function linearCandidate(issue: LinearIssue): BoardCandidate {
     branch: `factory/linear-${issue.identifier.toLowerCase()}`,
     threadTitle: `${issue.identifier}: ${issue.title}`,
     customPrompt: instructions => guidedPrompt(`Investigate ${ref}. ${LINEAR_FETCH_HINT}`, instructions),
+    metadata: { identifier: issue.identifier, state: issue.state, assignee: issue.assignee },
+  };
+}
+
+export function jiraCandidate(issue: JiraIssue): BoardCandidate {
+  const ref = `Jira issue ${issue.identifier} (${issue.url})`;
+  return {
+    sourceKey: `jira:${issue.identifier}`,
+    source: 'jira-issue',
+    title: issue.title,
+    url: issue.url,
+    meta: `${issue.identifier} · ${issue.state}${issue.assignee ? ` · ${issue.assignee}` : ''}`,
+    icon: JiraIcon,
+    iconClassName: 'text-[#2684FF]',
+    column: 'intake',
+    runActions: issueRunActions(ref, { context: JIRA_FETCH_HINT }),
+    branch: `factory/jira-${issue.identifier.toLowerCase()}`,
+    threadTitle: `${issue.identifier}: ${issue.title}`,
+    customPrompt: instructions => guidedPrompt(`Investigate ${ref}. ${JIRA_FETCH_HINT}`, instructions),
     metadata: { identifier: issue.identifier, state: issue.state, assignee: issue.assignee },
   };
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
@@ -9,6 +9,7 @@ export const SOURCE_LABELS: Record<WorkItemSource, string> = {
   'github-issue': 'Issue',
   'github-pr': 'PR Review',
   'linear-issue': 'Linear',
+  'jira-issue': 'Jira',
   'slack-thread': 'Slack',
   manual: 'Manual',
 };
@@ -41,6 +42,7 @@ export function candidateSourceKeyForItem(item: WorkItem): string | undefined {
 /** Aria label for the icon-only external link next to a card title. */
 export function externalLinkLabel(source: WorkItemSource): string {
   if (source === 'linear-issue') return 'Open in Linear';
+  if (source === 'jira-issue') return 'Open in Jira';
   if (source === 'slack-thread') return 'Open in Slack';
   if (source === 'manual') return 'Open link';
   return 'Open in GitHub';
@@ -51,7 +53,10 @@ export function workItemMeta(item: WorkItem): string {
   const age = `added ${relativeTime(item.createdAt)}`;
   const githubNumber = githubNumberForItem(item);
   if (githubNumber !== undefined) return `#${githubNumber}${author ? ` · ${author}` : ''} · ${age}`;
-  if (item.source === 'linear-issue' && typeof item.metadata.identifier === 'string') {
+  if (
+    (item.source === 'linear-issue' || item.source === 'jira-issue') &&
+    typeof item.metadata.identifier === 'string'
+  ) {
     return `${item.metadata.identifier}${author ? ` · ${author}` : ''} · ${age}`;
   }
   return `${SOURCE_LABELS[item.source]} · ${age}`;

--- a/mastracode/factory-ui/src/ui/domains/factory/boardRunSpecs.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardRunSpecs.ts
@@ -100,6 +100,8 @@ export function reviewRunAction(ref: string, checkout: string): RunAction {
 
 export const LINEAR_FETCH_HINT = `Start by fetching the issue's full details (description and comments) with the linear_get_issue tool.`;
 
+export const JIRA_FETCH_HINT = `Start by fetching the issue's full details (description and comments) with the jira_get_issue tool.`;
+
 /**
  * The runs a persisted card can start, derived from its source + metadata.
  * Issues can be investigated (→ Planning) or built (→ Building); PRs get a
@@ -124,6 +126,14 @@ export function itemRunSpec(item: WorkItem): ItemRunSpec | undefined {
       branch: `factory/linear-${meta.identifier.toLowerCase()}`,
       threadTitle: `${meta.identifier}: ${item.title}`,
       actions: issueRunActions(ref, { context: LINEAR_FETCH_HINT }),
+    };
+  }
+  if (item.source === 'jira-issue' && typeof meta.identifier === 'string') {
+    const ref = `Jira issue ${meta.identifier}${item.url ? ` (${item.url})` : ''}`;
+    return {
+      branch: `factory/jira-${meta.identifier.toLowerCase()}`,
+      threadTitle: `${meta.identifier}: ${item.title}`,
+      actions: issueRunActions(ref, { context: JIRA_FETCH_HINT }),
     };
   }
   if (item.source === 'github-pr' && githubNumber !== undefined) {

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardColumnEmptyState.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardColumnEmptyState.tsx
@@ -14,7 +14,7 @@ function boardColumnEmptyCopy(stage: BoardStageId, kind: BoardKind, hasIntakeSou
       if (!hasIntakeSource) {
         return {
           title: 'No intake sources',
-          description: 'Choose GitHub or Linear in Settings to feed this column.',
+          description: 'Choose GitHub, Linear, or Jira in Settings to feed this column.',
         };
       }
       return kind === 'review'

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardIcons.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardIcons.tsx
@@ -2,6 +2,7 @@ import { cn } from '@mastra/playground-ui/utils/cn';
 import { CheckCircle2, CircleDot, CircleX, GitCompareArrows, GitPullRequest } from 'lucide-react';
 import type { ComponentType } from 'react';
 
+import { JiraIcon } from '../../../ui/icons';
 import { SlackLogo } from '../../../ui/SlackLogo';
 import type { WorkItemSource } from '../services/workItems';
 import type { BoardStageId } from '../stages';
@@ -14,6 +15,7 @@ export const SOURCE_ICONS: Record<
   'github-issue': { icon: IssueSourceIcon, className: '' },
   'github-pr': { icon: GitCompareArrows, className: 'text-accent1' },
   'linear-issue': { icon: CircleDot, className: 'text-accent3' },
+  'jira-issue': { icon: JiraIcon, className: 'text-[#2684FF]' },
   'slack-thread': { icon: SlackLogo, className: '' },
   manual: { icon: CircleDot, className: 'text-icon3' },
 };

--- a/mastracode/factory-ui/src/ui/domains/factory/components/IntakeColumnExtras.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/IntakeColumnExtras.tsx
@@ -3,30 +3,35 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 
 import { useApiConfig } from '../../../../api/config';
 import type { useProjectIssuesQuery, useProjectPullRequestsQuery } from '../../../../hooks/useFactoryData';
+import type { useJiraIssuesQuery } from '../../../../hooks/useJiraData';
 import type { useLinearIssuesQuery } from '../../../../hooks/useLinearData';
 import type { IntakeSource } from '../boardCandidates';
+import { isJiraAuthError } from '../services/jira';
 import { connectLinear, isLinearReauthError } from '../services/linear';
 import { LoadMoreSentinel } from './LoadMoreSentinel';
 
 /**
  * Intake column tail for the ACTIVE candidate feed: loading state, Linear
- * reauth notice, and pagination. Only one feed is browsed at a time, so only
- * its states render.
+ * reauth / Jira credential notices, and pagination. Only one feed is browsed
+ * at a time, so only its states render.
  */
 export function IntakeColumnExtras({
   source,
   issues,
   pulls,
   linearIssues,
+  jiraIssues,
 }: {
   source?: IntakeSource;
   issues: ReturnType<typeof useProjectIssuesQuery>;
   pulls: ReturnType<typeof useProjectPullRequestsQuery>;
   linearIssues: ReturnType<typeof useLinearIssuesQuery>;
+  jiraIssues: ReturnType<typeof useJiraIssuesQuery>;
 }) {
   const { baseUrl } = useApiConfig();
   if (source === undefined) return null;
-  const feed = source === 'github' ? issues : source === 'github-prs' ? pulls : linearIssues;
+  const feed =
+    source === 'github' ? issues : source === 'github-prs' ? pulls : source === 'linear' ? linearIssues : jiraIssues;
 
   return (
     <>
@@ -38,6 +43,15 @@ export function IntakeColumnExtras({
           <Button size="xs" onClick={() => connectLinear(baseUrl)}>
             Connect Linear
           </Button>
+        </div>
+      )}
+      {source === 'jira' && jiraIssues.isError && isJiraAuthError(jiraIssues.error) && (
+        // Jira credentials are deployment env config — there is no reconnect
+        // flow, so point the operator at the env vars instead.
+        <div className="flex flex-col gap-2 p-1">
+          <Txt as="span" variant="ui-xs" className="text-icon3">
+            Jira rejected the configured credentials. Update JIRA_EMAIL and JIRA_API_TOKEN on the server.
+          </Txt>
         </div>
       )}
       <LoadMoreSentinel

--- a/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/RelatedFactorySessions.tsx
@@ -33,6 +33,9 @@ function externalWorkItemLabel(item: WorkItem): string {
   if (item.source === 'linear-issue') {
     return typeof item.metadata.identifier === 'string' ? item.metadata.identifier : (number ?? 'Linear issue');
   }
+  if (item.source === 'jira-issue') {
+    return typeof item.metadata.identifier === 'string' ? item.metadata.identifier : (number ?? 'Jira issue');
+  }
   return 'Work item';
 }
 

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/__tests__/useBoardIntake.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/__tests__/useBoardIntake.msw.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * BDD coverage for the board intake feed's Jira readiness + candidate mapping.
+ *
+ * Drives the real hooks + services through React Query; only the network is
+ * mocked (MSW). The Linear feed's behavior is covered indirectly by the board
+ * page tests — these specs pin down the Jira feed added alongside it.
+ */
+import { waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../../../../e2e/ui/msw-server';
+import { renderHookWithProviders, TEST_BASE_URL } from '../../../../../../e2e/ui/render';
+import type { IntakeConfig } from '../../services/intake';
+import type { JiraIssue, JiraStatus } from '../../services/jira';
+import type { LinkedRepositoryPayload } from '../../../workspaces/services/github';
+import { useBoardIntake } from '../useBoardIntake';
+
+const CONFIG_URL = `${TEST_BASE_URL}/web/intake/config`;
+const LINEAR_STATUS_URL = `${TEST_BASE_URL}/web/linear/status`;
+const JIRA_STATUS_URL = `${TEST_BASE_URL}/web/jira/status`;
+const JIRA_ISSUES_URL = `${TEST_BASE_URL}/web/jira/issues`;
+const GITHUB_ISSUES_URL = `${TEST_BASE_URL}/web/github/projects/ghp-1/issues`;
+
+const repository: LinkedRepositoryPayload = { projectRepositoryId: 'ghp-1', slug: 'acme/mastra' };
+
+const configuredJiraStatus: JiraStatus = {
+  enabled: true,
+  configured: true,
+  site: 'acme.atlassian.net',
+  reason: 'ready',
+};
+
+const jiraIssue: JiraIssue = {
+  id: '20001',
+  identifier: 'ENG-1',
+  title: 'Login button unresponsive on Safari',
+  url: 'https://acme.atlassian.net/browse/ENG-1',
+  state: 'To Do',
+  stateType: 'unstarted',
+  priorityLabel: 'High',
+  assignee: 'Ada Lovelace',
+  project: 'ENG',
+  labels: ['bug'],
+  createdAt: '2026-07-01T00:00:00Z',
+  updatedAt: '2026-07-02T00:00:00Z',
+};
+
+/** GitHub deselected so the Jira feed is the only one in play; jira selection configurable. */
+function jiraOnlyConfig(jira: IntakeConfig['jira']): IntakeConfig {
+  return {
+    github: { enabled: true, sourceIds: null },
+    linear: { enabled: false, sourceIds: null },
+    jira,
+  };
+}
+
+function useFeedHandlers({ config, jiraStatus }: { config: IntakeConfig; jiraStatus?: JiraStatus }) {
+  server.use(
+    http.get(CONFIG_URL, () => HttpResponse.json({ config })),
+    // Linear env group absent — routes not mounted, service degrades to disabled.
+    http.get(LINEAR_STATUS_URL, () => HttpResponse.json(null, { status: 404 })),
+    // The always-on triage feed (auto-triaged label) polls the GitHub issues route.
+    http.get(GITHUB_ISSUES_URL, () => HttpResponse.json({ issues: [], nextPage: null })),
+    ...(jiraStatus ? [http.get(JIRA_STATUS_URL, () => HttpResponse.json(jiraStatus))] : []),
+  );
+}
+
+function renderBoardIntake(knownSourceKeys: ReadonlySet<string> = new Set()) {
+  return renderHookWithProviders(() =>
+    useBoardIntake({ factoryProjectId: 'fp-1', repository, kind: 'work', knownSourceKeys }),
+  );
+}
+
+describe('useBoardIntake — Jira feed', () => {
+  it('given Jira is configured, enabled, and has selected projects, then the feed is available and maps candidates', async () => {
+    useFeedHandlers({
+      config: jiraOnlyConfig({ enabled: true, sourceIds: ['10001'] }),
+      jiraStatus: configuredJiraStatus,
+    });
+    server.use(http.get(JIRA_ISSUES_URL, () => HttpResponse.json({ issues: [jiraIssue], nextCursor: null })));
+
+    const { result } = renderBoardIntake();
+
+    await waitFor(() => expect(result.current.available).toContain('jira'));
+    expect(result.current.active).toBe('jira');
+
+    await waitFor(() => expect(result.current.candidates).toHaveLength(1));
+    const candidate = result.current.candidates[0]!;
+    expect(candidate.sourceKey).toBe('jira:ENG-1');
+    expect(candidate.source).toBe('jira-issue');
+    expect(candidate.title).toBe('Login button unresponsive on Safari');
+    expect(candidate.url).toBe('https://acme.atlassian.net/browse/ENG-1');
+    expect(candidate.meta).toBe('ENG-1 · To Do · Ada Lovelace');
+    expect(candidate.branch).toBe('factory/jira-eng-1');
+    expect(candidate.column).toBe('intake');
+  });
+
+  it('given the deployment has no Jira env group (status 404), then the feed never becomes available and no issues are fetched', async () => {
+    const hit = vi.fn();
+    // No jiraStatus handler — the ambient 404 stands in for unmounted routes.
+    useFeedHandlers({ config: jiraOnlyConfig({ enabled: true, sourceIds: ['10001'] }) });
+    server.use(
+      http.get(JIRA_ISSUES_URL, () => {
+        hit();
+        return HttpResponse.json({ issues: [jiraIssue], nextCursor: null });
+      }),
+    );
+
+    const { result, client } = renderBoardIntake();
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    expect(result.current.available).not.toContain('jira');
+    expect(hit).not.toHaveBeenCalled();
+  });
+
+  it('given no Jira projects are selected, then the feed is not available', async () => {
+    useFeedHandlers({
+      config: jiraOnlyConfig({ enabled: true, sourceIds: null }),
+      jiraStatus: configuredJiraStatus,
+    });
+
+    const { result, client } = renderBoardIntake();
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    expect(result.current.available).not.toContain('jira');
+  });
+
+  it('given an issue is already on the board, then its candidate is dropped from the feed', async () => {
+    useFeedHandlers({
+      config: jiraOnlyConfig({ enabled: true, sourceIds: ['10001'] }),
+      jiraStatus: configuredJiraStatus,
+    });
+    server.use(http.get(JIRA_ISSUES_URL, () => HttpResponse.json({ issues: [jiraIssue], nextCursor: null })));
+
+    const { result } = renderBoardIntake(new Set(['jira:ENG-1']));
+
+    await waitFor(() => expect(result.current.active).toBe('jira'));
+    await waitFor(() => expect(result.current.jiraIssues.data).toHaveLength(1));
+    expect(result.current.candidates).toHaveLength(0);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardIntake.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardIntake.ts
@@ -2,9 +2,10 @@ import { useMemo, useState } from 'react';
 
 import { useProjectIssuesQuery, useProjectPullRequestsQuery } from '../../../../hooks/useFactoryData';
 import { useIntakeConfigQuery } from '../../../../hooks/useIntakeConfig';
+import { useJiraIssuesQuery, useJiraStatusQuery } from '../../../../hooks/useJiraData';
 import { useLinearIssuesQuery, useLinearStatusQuery } from '../../../../hooks/useLinearData';
 import type { LinkedRepositoryPayload } from '../../workspaces/services/github';
-import { issueCandidate, linearCandidate, pullRequestCandidate } from '../boardCandidates';
+import { issueCandidate, jiraCandidate, linearCandidate, pullRequestCandidate } from '../boardCandidates';
 import type { BoardCandidate, IntakeSource } from '../boardCandidates';
 import { AUTO_TRIAGED_LABEL, hasLabel } from '../boardItems';
 import type { BoardKind } from '../boardStages';
@@ -32,6 +33,7 @@ export function useBoardIntake({
   const projectRepositoryId = repository.projectRepositoryId;
   const configQuery = useIntakeConfigQuery();
   const linearStatusQuery = useLinearStatusQuery();
+  const jiraStatusQuery = useJiraStatusQuery();
 
   const config = configQuery.data;
   const githubEnabled = config?.github.enabled ?? true;
@@ -40,6 +42,8 @@ export function useBoardIntake({
   const linearConnected = Boolean(linearFeature && linearStatusQuery.data?.connected);
   const linearReady =
     (config?.linear.enabled ?? false) && linearConnected && (config?.linear.sourceIds?.length ?? 0) > 0;
+  const jiraConfigured = Boolean(jiraStatusQuery.data?.enabled && jiraStatusQuery.data.configured);
+  const jiraReady = (config?.jira.enabled ?? false) && jiraConfigured && (config?.jira.sourceIds?.length ?? 0) > 0;
 
   // Work intake owns issues; Review intake owns pull requests. Keeping the
   // feeds on separate routes prevents review-producing PR work from being
@@ -47,7 +51,11 @@ export function useBoardIntake({
   const githubIntakeActive = githubEnabled && githubSelected;
   const available: IntakeSource[] = review
     ? ['github-prs']
-    : [...(githubIntakeActive ? (['github'] as const) : []), ...(linearReady ? (['linear'] as const) : [])];
+    : [
+        ...(githubIntakeActive ? (['github'] as const) : []),
+        ...(linearReady ? (['linear'] as const) : []),
+        ...(jiraReady ? (['jira'] as const) : []),
+      ];
   const [selected, setSelected] = useState<IntakeSource>(review ? 'github-prs' : 'github');
   const active: IntakeSource | undefined = available.includes(selected) ? selected : available[0];
 
@@ -56,6 +64,7 @@ export function useBoardIntake({
   const triageIssues = useProjectIssuesQuery(!review ? projectRepositoryId : undefined, AUTO_TRIAGED_LABEL);
   const pulls = useProjectPullRequestsQuery(active === 'github-prs' ? projectRepositoryId : undefined);
   const linearIssues = useLinearIssuesQuery(active === 'linear' ? factoryProjectId : undefined);
+  const jiraIssues = useJiraIssuesQuery(active === 'jira');
 
   const candidates = useMemo(() => {
     const intakeIssues = (active === 'github' ? (issues.data ?? []) : []).filter(
@@ -67,9 +76,10 @@ export function useBoardIntake({
           ...intakeIssues.map(issueCandidate),
           ...(triageIssues.data ?? []).map(issueCandidate),
           ...(active === 'linear' ? (linearIssues.data ?? []).map(linearCandidate) : []),
+          ...(active === 'jira' ? (jiraIssues.data ?? []).map(jiraCandidate) : []),
         ];
     return all.filter(candidate => !knownSourceKeys.has(candidate.sourceKey));
-  }, [knownSourceKeys, issues.data, triageIssues.data, pulls.data, linearIssues.data, active, review]);
+  }, [knownSourceKeys, issues.data, triageIssues.data, pulls.data, linearIssues.data, jiraIssues.data, active, review]);
 
   return {
     available,
@@ -80,11 +90,16 @@ export function useBoardIntake({
     issues,
     pulls,
     linearIssues,
+    jiraIssues,
     isPending:
-      (!review && (configQuery.isPending || ((config?.linear.enabled ?? false) && linearStatusQuery.isPending))) ||
+      (!review &&
+        (configQuery.isPending ||
+          ((config?.linear.enabled ?? false) && linearStatusQuery.isPending) ||
+          ((config?.jira.enabled ?? false) && jiraStatusQuery.isPending))) ||
       (active === 'github' && issues.isPending) ||
       (active === 'github-prs' && pulls.isPending) ||
-      (active === 'linear' && linearIssues.isPending),
+      (active === 'linear' && linearIssues.isPending) ||
+      (active === 'jira' && jiraIssues.isPending),
     isTriagePending: !review && triageIssues.isPending,
   };
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/index.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/index.ts
@@ -5,5 +5,6 @@ export * from '../../../hooks/useIntakeConfig';
 export * from '../../../hooks/useWorkItems';
 export * from './services/factory';
 export * from './services/linear';
+export * from './services/jira';
 export * from './services/intake';
 export * from './services/workItems';

--- a/mastracode/factory-ui/src/ui/domains/factory/services/intake.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/intake.ts
@@ -16,6 +16,7 @@ export interface IntakeSelection {
 export interface IntakeConfig {
   github: IntakeSelection;
   linear: IntakeSelection;
+  jira: IntakeSelection;
 }
 
 /**
@@ -23,13 +24,14 @@ export interface IntakeConfig {
  * only returns the integrations registered in the running deployment, so a key
  * is absent whenever that integration isn't connected. Fill the fixed shape the
  * UI relies on so reads like `config.github.enabled` never touch `undefined`.
- * GitHub defaults to enabled (issues sync once a repo is picked); Linear stays
- * off until it's connected and a project is selected.
+ * GitHub defaults to enabled (issues sync once a repo is picked); Linear and
+ * Jira stay off until they're configured and a project is selected.
  */
 function normalizeIntakeConfig(raw: Partial<Record<string, IntakeSelection>> | null | undefined): IntakeConfig {
   return {
     github: raw?.github ?? { enabled: true, sourceIds: null },
     linear: raw?.linear ?? { enabled: false, sourceIds: null },
+    jira: raw?.jira ?? { enabled: false, sourceIds: null },
   };
 }
 

--- a/mastracode/factory-ui/src/ui/domains/factory/services/intake.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/intake.ts
@@ -35,7 +35,10 @@ function normalizeIntakeConfig(raw: Partial<Record<string, IntakeSelection>> | n
   };
 }
 
-async function requestIntakeConfig(baseUrl: string, init?: RequestInit): Promise<IntakeConfig> {
+async function requestIntakeConfig(
+  baseUrl: string,
+  init?: RequestInit,
+): Promise<Partial<Record<string, IntakeSelection>>> {
   const res = await fetch(`${baseUrl}/web/intake/config`, {
     headers: { Accept: 'application/json', ...(init?.body ? { 'content-type': 'application/json' } : {}) },
     credentials: 'include',
@@ -53,15 +56,24 @@ async function requestIntakeConfig(baseUrl: string, init?: RequestInit): Promise
     throw new Error(message);
   }
   const { config } = (await res.json()) as { config?: Partial<Record<string, IntakeSelection>> };
-  return normalizeIntakeConfig(config);
+  return config ?? {};
 }
 
 /** Read the caller's intake config (server falls back to the defaults). */
 export async function fetchIntakeConfig(baseUrl: string): Promise<IntakeConfig> {
-  return requestIntakeConfig(baseUrl);
+  return normalizeIntakeConfig(await requestIntakeConfig(baseUrl));
 }
 
-/** Save the caller's intake config; resolves to the persisted config. */
+/**
+ * Save the caller's intake config; resolves to the persisted config.
+ *
+ * The server rejects keys for integrations that aren't registered in the
+ * running deployment (e.g. `jira` when the `JIRA_*` env group is absent), while
+ * the UI always works with the fixed normalized shape — so read the registered
+ * keys first and send only those.
+ */
 export async function saveIntakeConfig(baseUrl: string, config: IntakeConfig): Promise<IntakeConfig> {
-  return requestIntakeConfig(baseUrl, { method: 'PUT', body: JSON.stringify(config) });
+  const registered = await requestIntakeConfig(baseUrl);
+  const body = Object.fromEntries(Object.entries(config).filter(([integrationId]) => integrationId in registered));
+  return normalizeIntakeConfig(await requestIntakeConfig(baseUrl, { method: 'PUT', body: JSON.stringify(body) }));
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/services/jira.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/jira.ts
@@ -1,0 +1,122 @@
+/**
+ * Browser-side helpers for the Jira intake source.
+ *
+ * All requests go to the server's `/web/jira/*` routes, which sit behind the
+ * host auth gate and are scoped to the caller's organization. Jira credentials
+ * are deployment-global env config (`JIRA_BASE_URL` / `JIRA_EMAIL` /
+ * `JIRA_API_TOKEN`) — there is no per-org connect flow, so unlike Linear this
+ * service has no OAuth redirect helper; the disabled state points the operator
+ * at the env vars instead.
+ */
+
+export type JiraStatusReason = 'missing_config' | 'auth_required' | 'organization_required' | 'ready';
+
+export interface JiraStatus {
+  enabled: boolean;
+  /** True when the deployment has the complete `JIRA_*` env group. */
+  configured: boolean;
+  /** Jira site host, e.g. `mycompany.atlassian.net`. */
+  site: string | null;
+  reason?: JiraStatusReason;
+}
+
+export interface JiraIssue {
+  id: string;
+  /** Human key like `ENG-123`. */
+  identifier: string;
+  title: string;
+  url: string;
+  /** Status name, e.g. `In Progress`. */
+  state: string;
+  /** Status-category-derived type: `unstarted` / `started` / `completed`. */
+  stateType: string;
+  priorityLabel: string;
+  assignee: string | null;
+  /** Jira project key, e.g. `ENG`. */
+  project: string | null;
+  labels: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JiraIssuePage {
+  issues: JiraIssue[];
+  /** Opaque cursor for the next page, or `null` on the last page. */
+  nextCursor: string | null;
+}
+
+export interface JiraProject {
+  id: string;
+  name: string;
+  /** Short project key, e.g. `ENG`. */
+  key: string | null;
+}
+
+/**
+ * Read Jira feature status. Degrades to a disabled status on 404 (routes not
+ * mounted — env group absent), a network error, or when the feature is off —
+ * same contract as `fetchLinearStatus`, so consumers read `data`, never
+ * `error`.
+ */
+export async function fetchJiraStatus(baseUrl: string): Promise<JiraStatus> {
+  try {
+    const res = await fetch(`${baseUrl}/web/jira/status`, {
+      headers: { Accept: 'application/json' },
+      credentials: 'include',
+    });
+    if (res.status === 401) {
+      return { enabled: false, configured: false, site: null, reason: 'auth_required' };
+    }
+    if (!res.ok) return { enabled: false, configured: false, site: null };
+    return (await res.json()) as JiraStatus;
+  } catch {
+    return { enabled: false, configured: false, site: null };
+  }
+}
+
+/** GET helper for the read-only Jira endpoints; throws server messages. */
+async function getJiraResource<T>(baseUrl: string, path: string): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    headers: { Accept: 'application/json' },
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    let message = `Request failed (${res.status})`;
+    let code: string | undefined;
+    try {
+      const body = (await res.json()) as { error?: string; message?: string };
+      code = body.error;
+      if (body.message) message = body.message;
+      else if (body.error) message = body.error;
+    } catch {
+      /* ignore non-JSON */
+    }
+    const err = new Error(message);
+    (err as { code?: string }).code = code;
+    throw err;
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * True when the server reported that Jira rejected the deployment's
+ * credentials (revoked/expired API token) — the operator must fix the
+ * `JIRA_*` env vars.
+ */
+export function isJiraAuthError(err: unknown): boolean {
+  return (err as { code?: string } | null)?.code === 'jira_auth_failed';
+}
+
+/** List one cursor page of the selected projects' active issues. */
+export async function listJiraIssues(baseUrl: string, after?: string): Promise<JiraIssuePage> {
+  const params = new URLSearchParams();
+  if (after) params.set('after', after);
+  const query = params.toString();
+  return getJiraResource<JiraIssuePage>(baseUrl, `/web/jira/issues${query ? `?${query}` : ''}`);
+}
+
+/** List the site's projects (Settings intake-source picker). */
+export async function listJiraProjects(baseUrl: string): Promise<JiraProject[]> {
+  const { projects } = await getJiraResource<{ projects: JiraProject[] }>(baseUrl, '/web/jira/projects');
+  return projects;
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/services/workItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/workItems.ts
@@ -6,7 +6,7 @@
  * org-wide, so every member of the org reads and moves the same cards.
  */
 
-export type WorkItemSource = 'github-issue' | 'github-pr' | 'linear-issue' | 'slack-thread' | 'manual';
+export type WorkItemSource = 'github-issue' | 'github-pr' | 'linear-issue' | 'jira-issue' | 'slack-thread' | 'manual';
 
 export interface WorkItemSessionRef {
   sessionId: string;
@@ -82,6 +82,7 @@ function sourceFromExternalSource(source: ExternalWorkItemSource | null): WorkIt
   if (source.integrationId === 'github' && source.type === 'issue') return 'github-issue';
   if (source.integrationId === 'github' && source.type === 'pull-request') return 'github-pr';
   if (source.integrationId === 'linear' && source.type === 'issue') return 'linear-issue';
+  if (source.integrationId === 'jira' && source.type === 'issue') return 'jira-issue';
   if (source.integrationId === 'slack' && source.type === 'slack-thread') return 'slack-thread';
   return 'manual';
 }
@@ -96,6 +97,8 @@ function externalSourceTarget(
       return { integrationId: 'github', type: 'pull-request' };
     case 'linear-issue':
       return { integrationId: 'linear', type: 'issue' };
+    case 'jira-issue':
+      return { integrationId: 'jira', type: 'issue' };
     case 'slack-thread':
       return { integrationId: 'slack', type: 'slack-thread' };
   }

--- a/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
@@ -13,7 +13,9 @@ import type { ReactNode } from 'react';
 import { useApiConfig } from '../../../../api/config';
 import { SkeletonRows } from '../../../ui/SkeletonRows';
 import { useIntakeConfigQuery, useSaveIntakeConfigMutation } from '../../../../hooks/useIntakeConfig';
+import { useJiraProjectsQuery, useJiraStatusQuery } from '../../../../hooks/useJiraData';
 import { useLinearProjectsQuery, useLinearStatusQuery } from '../../../../hooks/useLinearData';
+import { isJiraAuthError } from '../../factory/services/jira';
 import { connectLinear, isLinearReauthError } from '../../factory/services/linear';
 import type { LinearProject } from '../../factory/services/linear';
 import type { IntakeConfig } from '../../factory/services/intake';
@@ -153,6 +155,11 @@ export function IntakeSection() {
   const linearConnected = Boolean(linearStatus?.enabled && linearStatus.connected);
   const linearProjectsQuery = useLinearProjectsQuery(linearConnected);
 
+  const jiraStatusQuery = useJiraStatusQuery();
+  const jiraStatus = jiraStatusQuery.data;
+  const jiraConfigured = Boolean(jiraStatus?.enabled && jiraStatus.configured);
+  const jiraProjectsQuery = useJiraProjectsQuery(jiraConfigured);
+
   const config = configQuery.data;
   const linkedRepositories = (factoriesQuery.data ?? []).flatMap(factory => factory.repositories);
 
@@ -286,6 +293,59 @@ export function IntakeSection() {
                       }
                     />
                   ))}
+                </SourcePickerGroup>
+              )}
+            </div>
+          )
+        )}
+
+        <SettingsRow label="Jira issues" hint="Active issues from the selected projects.">
+          <Switch
+            aria-label="Sync Jira issues"
+            checked={config.jira.enabled}
+            disabled={busy || !jiraConfigured}
+            onCheckedChange={enabled => update({ ...config, jira: { ...config.jira, enabled } })}
+          />
+        </SettingsRow>
+
+        {!jiraConfigured ? (
+          // Jira credentials are deployment env config — no per-org connect
+          // flow, so the disabled state points the operator at the env vars.
+          <div className="flex items-center gap-3 px-4 py-3">
+            <Txt as="span" variant="ui-sm" className="text-icon3">
+              Jira is not configured on this server. Set JIRA_BASE_URL, JIRA_EMAIL, and JIRA_API_TOKEN to enable it.
+            </Txt>
+          </div>
+        ) : config.jira.enabled && isJiraAuthError(jiraProjectsQuery.error) ? (
+          <div className="flex items-center gap-3 px-4 py-3">
+            <Txt as="span" variant="ui-sm" className="text-icon3">
+              Jira rejected the configured credentials. Update JIRA_EMAIL and JIRA_API_TOKEN on the server.
+            </Txt>
+          </div>
+        ) : (
+          config.jira.enabled && (
+            <div className="flex flex-col gap-2.5 px-4 py-3">
+              <Txt as="span" variant="ui-sm" className="text-icon3">
+                Connected to {jiraStatus?.site ?? 'a Jira site'}
+              </Txt>
+              {(jiraProjectsQuery.data ?? []).length > 0 && (
+                <SourcePickerGroup>
+                  <SourcePickerSection
+                    label="Projects"
+                    items={(jiraProjectsQuery.data ?? []).map(project => ({
+                      id: project.id,
+                      label: project.key ? `${project.key} · ${project.name}` : project.name,
+                    }))}
+                    selectedIds={config.jira.sourceIds}
+                    disabled={busy}
+                    pending={busy}
+                    onToggleItem={projectId =>
+                      update({
+                        ...config,
+                        jira: { ...config.jira, sourceIds: toggleId(config.jira.sourceIds, projectId) },
+                      })
+                    }
+                  />
                 </SourcePickerGroup>
               )}
             </div>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/IntakeSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/IntakeSection.msw.test.tsx
@@ -7,12 +7,15 @@ import { describe, expect, it } from 'vitest';
 import { server } from '../../../../../../e2e/ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '../../../../../../e2e/ui/render';
 import type { IntakeConfig } from '../../../factory/services/intake';
+import type { JiraProject, JiraStatus } from '../../../factory/services/jira';
 import type { LinearProject, LinearStatus } from '../../../factory/services/linear';
 import { IntakeSection } from '../IntakeSection';
 
 const CONFIG_URL = `${TEST_BASE_URL}/web/intake/config`;
 const LINEAR_STATUS_URL = `${TEST_BASE_URL}/web/linear/status`;
 const LINEAR_PROJECTS_URL = `${TEST_BASE_URL}/web/linear/projects`;
+const JIRA_STATUS_URL = `${TEST_BASE_URL}/web/jira/status`;
+const JIRA_PROJECTS_URL = `${TEST_BASE_URL}/web/jira/projects`;
 
 function baseConfig(): IntakeConfig {
   return {
@@ -37,6 +40,26 @@ const linearProjects: LinearProject[] = [
   { id: 'lproj-2', name: 'Design refresh', state: 'planned', teams: [] },
   { id: 'lproj-3', name: 'Shared initiative', state: 'started', teams: [engTeam, designTeam] },
 ];
+
+const configuredJiraStatus: JiraStatus = {
+  enabled: true,
+  configured: true,
+  site: 'acme.atlassian.net',
+  reason: 'ready',
+};
+
+const jiraProjects: JiraProject[] = [
+  { id: '10001', name: 'Engineering', key: 'ENG' },
+  { id: '10002', name: 'Operations', key: 'OPS' },
+];
+
+/** Register configured-Jira handlers on top of `useIntakeHandlers` (whose default is the ambient 404). */
+function useJiraHandlers(status: JiraStatus = configuredJiraStatus) {
+  server.use(
+    http.get(JIRA_STATUS_URL, () => HttpResponse.json(status)),
+    http.get(JIRA_PROJECTS_URL, () => HttpResponse.json({ projects: jiraProjects })),
+  );
+}
 
 function seedGithubProject() {
   server.use(
@@ -380,6 +403,90 @@ describe('IntakeSection', () => {
       // GitHub defaults to enabled; Linear stays off until it's connected here.
       expect(await screen.findByRole('switch', { name: 'Sync GitHub issues' })).toBeChecked();
       expect(screen.getByRole('switch', { name: 'Sync Linear issues' })).not.toBeChecked();
+    });
+  });
+
+  describe('given Jira is not configured on the server', () => {
+    it('explains the env vars and disables the toggle without a connect button', async () => {
+      // No Jira handlers registered — the ambient 404 mirrors a deployment
+      // without the JIRA_* env group (routes not mounted).
+      useIntakeHandlers();
+
+      renderIntakeSection();
+
+      expect(
+        await screen.findByText(
+          'Jira is not configured on this server. Set JIRA_BASE_URL, JIRA_EMAIL, and JIRA_API_TOKEN to enable it.',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('switch', { name: 'Sync Jira issues' })).toBeDisabled();
+      expect(screen.queryByRole('button', { name: /Connect Jira/ })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('given Jira is configured and enabled', () => {
+    it('shows the site and the project picker', async () => {
+      useIntakeHandlers({ config: { ...baseConfig(), jira: { enabled: true, sourceIds: null } } });
+      useJiraHandlers();
+
+      renderIntakeSection();
+
+      expect(await screen.findByText('Connected to acme.atlassian.net')).toBeInTheDocument();
+      const projects = await screen.findByRole('group', { name: 'Projects' });
+      await userEvent.click(within(projects).getByRole('button', { name: 'Projects' }));
+      expect(within(projects).getByRole('checkbox', { name: 'ENG · Engineering' })).toBeInTheDocument();
+      expect(within(projects).getByRole('checkbox', { name: 'OPS · Operations' })).toBeInTheDocument();
+    });
+
+    it('persists an explicit Jira project selection under the jira key', async () => {
+      const saved = useIntakeHandlers({ config: { ...baseConfig(), jira: { enabled: true, sourceIds: null } } });
+      useJiraHandlers();
+
+      renderIntakeSection();
+
+      const projects = await screen.findByRole('group', { name: 'Projects' });
+      await userEvent.click(within(projects).getByRole('button', { name: 'Projects' }));
+      await userEvent.click(within(projects).getByRole('checkbox', { name: 'ENG · Engineering' }));
+
+      await waitFor(() => expect(saved).toHaveLength(1));
+      expect(saved[0]!.jira.sourceIds).toEqual(['10001']);
+      expect(saved[0]!.jira.enabled).toBe(true);
+    });
+  });
+
+  describe('given Jira is configured but disabled', () => {
+    it('persists the config with jira enabled when the switch is toggled', async () => {
+      const saved = useIntakeHandlers();
+      useJiraHandlers();
+
+      renderIntakeSection();
+
+      const jiraSwitch = await screen.findByRole('switch', { name: 'Sync Jira issues' });
+      await waitFor(() => expect(jiraSwitch).toBeEnabled());
+      await userEvent.click(jiraSwitch);
+
+      await waitFor(() => expect(saved).toHaveLength(1));
+      expect(saved[0]!.jira.enabled).toBe(true);
+      expect(saved[0]!.github.enabled).toBe(true);
+    });
+  });
+
+  describe('given Jira rejects the configured credentials', () => {
+    it('explains the credential failure instead of an empty project picker', async () => {
+      useIntakeHandlers({ config: { ...baseConfig(), jira: { enabled: true, sourceIds: null } } });
+      server.use(
+        http.get(JIRA_STATUS_URL, () => HttpResponse.json(configuredJiraStatus)),
+        http.get(JIRA_PROJECTS_URL, () => HttpResponse.json({ error: 'jira_auth_failed' }, { status: 409 })),
+      );
+
+      renderIntakeSection();
+
+      expect(
+        await screen.findByText(
+          'Jira rejected the configured credentials. Update JIRA_EMAIL and JIRA_API_TOKEN on the server.',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('group', { name: 'Projects' })).not.toBeInTheDocument();
     });
   });
 

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/IntakeSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/IntakeSection.msw.test.tsx
@@ -18,6 +18,7 @@ function baseConfig(): IntakeConfig {
   return {
     github: { enabled: true, sourceIds: null },
     linear: { enabled: true, sourceIds: null },
+    jira: { enabled: false, sourceIds: null },
   };
 }
 
@@ -149,6 +150,7 @@ describe('IntakeSection', () => {
         config: {
           github: { enabled: true, sourceIds: ['mastra'] },
           linear: { enabled: true, sourceIds: ['lproj-1'] },
+          jira: { enabled: false, sourceIds: null },
         },
       });
 

--- a/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
@@ -244,6 +244,7 @@ function BoardContent({
                     issues={intake.issues}
                     pulls={intake.pulls}
                     linearIssues={intake.linearIssues}
+                    jiraIssues={intake.jiraIssues}
                   />
                 )}
               </BoardColumn>

--- a/mastracode/factory-ui/src/ui/pages/MetricsPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/MetricsPage.tsx
@@ -50,6 +50,7 @@ const SOURCE_LABELS: Record<string, string> = {
   'github:issue': 'GitHub issues',
   'github:pull-request': 'GitHub PRs',
   'linear:issue': 'Linear issues',
+  'jira:issue': 'Jira issues',
   manual: 'Manual',
 };
 

--- a/mastracode/factory-ui/src/ui/ui/icons.tsx
+++ b/mastracode/factory-ui/src/ui/ui/icons.tsx
@@ -184,6 +184,13 @@ export const LinearIcon = ({ size = 16, className }: IconProps) => (
   </svg>
 );
 
+/** Official Jira logomark (fill-based; inherits currentColor). */
+export const JiraIcon = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+    <path d="M11.571 11.513H0a5.218 5.218 0 0 0 5.232 5.215h2.13v2.057A5.215 5.215 0 0 0 12.575 24V12.518a1.005 1.005 0 0 0-1.005-1.005zm5.723-5.756H5.736a5.215 5.215 0 0 0 5.215 5.214h2.129v2.058a5.218 5.218 0 0 0 5.215 5.214V6.758a1.001 1.001 0 0 0-1.001-1.001zM23.013 0H11.455a5.215 5.215 0 0 0 5.215 5.215h2.129v2.057A5.215 5.215 0 0 0 24 12.483V1.005A1.001 1.001 0 0 0 23.013 0z" />
+  </svg>
+);
+
 export const BellIcon = ({ size = 15, className }: IconProps) =>
   svg(
     <>


### PR DESCRIPTION
## Summary

Second PR of the Jira Cloud intake feature (stacked on #20579, which adds the server-side `JiraIntegration`). This PR surfaces Jira in the Mastra Factory SPA so it works the same way Linear does today:

- **Settings → Work Intake**: a Jira row with an enable toggle and a project picker. When the deployment has no `JIRA_*` env group the toggle is disabled with a hint naming the three env vars; when configured it shows "Connected to {site}" and lists the site's projects (`KEY · Name`). Credential failures (`jira_auth_failed`) surface a notice pointing at the API token.
- **Work board intake feed**: a `Jira` feed pill appears once Jira is configured, enabled, and at least one project is selected. Selected projects' active issues stream into the Intake column with the Jira logomark, `KEY · Status · Assignee` meta, an "Open in Jira" link, and Investigate/run actions wired to the `jira_get_issue` agent tool.
- **Data layer**: `services/jira.ts` (status/projects/issues, 404 → disabled degradation, `jira_auth_failed` detection), React Query hooks with the standard intake polling cadence, `jira` key in the intake config shape, and a `'jira-issue'` work-item source mapping (`{integrationId: 'jira', type: 'issue'}`).
- **Fix**: `saveIntakeConfig` now trims the payload to the integration keys registered on the server — the PUT route rejects unregistered keys, so sending the fixed normalized shape would have broken Settings saves on deployments without a given integration.

No changes to Linear/GitHub behavior; all additions mirror the existing Linear patterns.

## Test plan

- `pnpm --filter ./mastracode/factory-ui test:msw` → 80 files, 418 passed (new: 5 IntakeSection Jira specs, 4 board-feed specs in `useBoardIntake.msw.test.tsx`, 10 `useJiraData` specs — MSW at the network boundary only)
- `pnpm --filter ./mastracode/factory-ui test:unit` → 15 files, 99 passed
- `pnpm --filter ./mastracode/factory-ui typecheck` → exit 0
- Stacked server gates re-run: factory Jira suite 62 passed, web entry 11 passed, factory typecheck exit 0
- Live demo: real web server + stub Jira Cloud API → curl transcript ends `PROOF: GREEN`; captioned browser recording of Settings picker → board feed against the same stack

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>
