### PR TITLE
fix(deployer): install configured bundle lockfiles immutably

### DIFF
--- a/.changeset/gentle-lockfiles-install.md
+++ b/.changeset/gentle-lockfiles-install.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': patch
+'@mastra/deployer': patch
+'@mastra/deployer-cloud': patch
+'@mastra/deployer-netlify': patch
+---
+
+Install generated bundle dependencies from an optional manager-matched lockfile before running the package manager, while preserving automatic manager detection when no lockfile is configured.

--- a/.changeset/gentle-lockfiles-install.md
+++ b/.changeset/gentle-lockfiles-install.md
@@ -5,4 +5,4 @@
 '@mastra/deployer-netlify': patch
 ---
 
-Install generated bundle dependencies from an optional manager-matched lockfile before running the package manager, while preserving automatic manager detection when no lockfile is configured.
+Install generated bundle dependencies from an optional configured lockfile: the lockfile's basename selects the package manager that installs the bundle, copied locks install with the manager's frozen command, and the npm frozen install tolerates peer overrides in deployer-generated lockfiles, while preserving automatic manager detection when no lockfile is configured.

--- a/.changeset/gentle-lockfiles-install.md
+++ b/.changeset/gentle-lockfiles-install.md
@@ -5,4 +5,12 @@
 '@mastra/deployer-netlify': patch
 ---
 
-Install generated bundle dependencies from an optional configured lockfile: the lockfile's basename selects the package manager that installs the bundle, copied locks install with the manager's frozen command, and the npm frozen install tolerates peer overrides in deployer-generated lockfiles, while preserving automatic manager detection when no lockfile is configured.
+Install generated bundle dependencies from a committed lockfile with `bundler.lockfile`. The lockfile's basename selects the package manager, the file must stay within the project, and the bundle uses the manager's frozen install command. Automatic manager detection remains unchanged when no lockfile is configured.
+
+```ts
+const mastra = new Mastra({
+  bundler: {
+    lockfile: './package-lock.json',
+  },
+});
+```

--- a/.changeset/gentle-lockfiles-install.md
+++ b/.changeset/gentle-lockfiles-install.md
@@ -5,12 +5,12 @@
 '@mastra/deployer-netlify': patch
 ---
 
-Install generated bundle dependencies from a committed lockfile with `bundler.lockfile`. The lockfile's basename selects the package manager, the file must stay within the project, and the bundle uses the manager's frozen install command. Automatic manager detection remains unchanged when no lockfile is configured.
+Install generated bundle dependencies from a committed lockfile with `bundler.lockfile`. Generate the lockfile for the bundle's output `package.json`, keep it within the project, and use its basename to select the manager's frozen install command. Automatic manager detection remains unchanged when no lockfile is configured.
 
 ```ts
 const mastra = new Mastra({
   bundler: {
-    lockfile: './package-lock.json',
+    lockfile: './bundle-lock/package-lock.json',
   },
 });
 ```

--- a/deployers/cloud/src/index.test.ts
+++ b/deployers/cloud/src/index.test.ts
@@ -217,6 +217,36 @@ describe('CloudDeployer', () => {
         frozen: true,
       });
     });
+
+    it('rejects an explicit non-npm bundle lock before installDeps runs', async () => {
+      // @ts-expect-error - accessing protected method for testing
+      await expect(
+        deployer.installDependencies('/test/output', '/test/root', undefined, {
+          packageManager: 'pnpm',
+          frozen: true,
+          generateSecondaryNpmLockfile: false,
+          explicitLockfile: { sourcePath: '/test/root/pnpm-lock.yaml', basename: 'pnpm-lock.yaml' },
+        }),
+      ).rejects.toThrow('Cloud only supports npm bundle lockfiles, got pnpm-lock.yaml');
+
+      expect(installDeps).not.toHaveBeenCalled();
+    });
+
+    it('passes an explicit npm bundle lock through to installDeps frozen', async () => {
+      // @ts-expect-error - accessing protected method for testing
+      await deployer.installDependencies('/test/output', '/test/root', undefined, {
+        packageManager: 'npm',
+        frozen: true,
+        generateSecondaryNpmLockfile: false,
+        explicitLockfile: { sourcePath: '/test/root/package-lock.json', basename: 'package-lock.json' },
+      });
+
+      expect(installDeps).toHaveBeenCalledWith({
+        path: join('/test/output', 'output'),
+        pm: 'npm',
+        frozen: true,
+      });
+    });
   });
 
   describe('bundle', () => {

--- a/deployers/cloud/src/index.test.ts
+++ b/deployers/cloud/src/index.test.ts
@@ -56,7 +56,7 @@ vi.mock('@mastra/deployer', () => {
     writePackageJson = mockWritePackageJson;
     prepare = mockPrepare;
 
-    getAllToolPaths = () => ['/test/project/src/mastra/tools'];
+    getAllToolPaths = () => [join('/test/project', MASTRA_DIRECTORY, 'tools')];
   }
 
   // Use a class for FileService constructor (Vitest v4 requirement)
@@ -200,6 +200,21 @@ describe('CloudDeployer', () => {
       expect(installDeps).toHaveBeenCalledWith({
         path: join(outputDirectory, 'output'),
         pm: 'npm',
+      });
+    });
+
+    it('uses the npm frozen path for an explicit bundle lock', async () => {
+      // @ts-expect-error - accessing protected method for testing
+      await deployer.installDependencies('/test/output', '/test/root', undefined, {
+        packageManager: 'npm',
+        frozen: true,
+        generateSecondaryNpmLockfile: false,
+      });
+
+      expect(installDeps).toHaveBeenCalledWith({
+        path: join('/test/output', 'output'),
+        pm: 'npm',
+        frozen: true,
       });
     });
   });

--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -2,6 +2,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Config } from '@mastra/core/mastra';
 import { Deployer } from '@mastra/deployer';
+import type { BundleDependencyInstallState, PackageManager } from '@mastra/deployer/services';
 import { copy, readJSON } from 'fs-extra/esm';
 
 import { getAuthEntrypoint } from './utils/auth.js';
@@ -64,8 +65,24 @@ export class CloudDeployer extends Deployer {
 
   async lint() {}
 
-  protected async installDependencies(outputDirectory: string, _rootDir = process.cwd()) {
-    await installDeps({ path: join(outputDirectory, 'output'), pm: 'npm' });
+  protected getBundleDependencyPackageManager(_rootDir: string): PackageManager {
+    return 'npm';
+  }
+
+  protected async installDependencies(
+    outputDirectory: string,
+    _rootDir = process.cwd(),
+    _pnpmOverrides?: Record<string, string>,
+    installState?: BundleDependencyInstallState,
+  ) {
+    const installOptions: { path: string; pm: string; frozen?: boolean } = {
+      path: join(outputDirectory, 'output'),
+      pm: 'npm',
+    };
+    if (installState?.frozen) {
+      installOptions.frozen = true;
+    }
+    await installDeps(installOptions);
   }
 
   async bundle(mastraDir: string, outputDirectory: string): Promise<void> {

--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -65,7 +65,7 @@ export class CloudDeployer extends Deployer {
 
   async lint() {}
 
-  protected getBundleDependencyPackageManager(_rootDir: string): PackageManager {
+  protected getBundleDependencyPackageManager(_rootDir: string, _explicitManager?: PackageManager): PackageManager {
     return 'npm';
   }
 

--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -79,6 +79,13 @@ export class CloudDeployer extends Deployer {
       path: join(outputDirectory, 'output'),
       pm: 'npm',
     };
+    if (
+      installState &&
+      installState.explicitLockfile &&
+      installState.explicitLockfile.basename !== 'package-lock.json'
+    ) {
+      throw new Error(`Cloud only supports npm bundle lockfiles, got ${installState.explicitLockfile.basename}`);
+    }
     if (installState?.frozen) {
       installOptions.frozen = true;
     }

--- a/deployers/cloud/src/utils/deps.test.ts
+++ b/deployers/cloud/src/utils/deps.test.ts
@@ -6,7 +6,7 @@ import { installDeps, installNodeVersion, runInstallCommand, runBuildCommand } f
 import { runWithExeca } from './execa.js';
 import { logger } from './logger.js';
 
-vi.mock('fs');
+vi.mock('node:fs');
 vi.mock('./execa.js');
 vi.mock('./logger.js', () => ({
   logger: {
@@ -79,7 +79,7 @@ describe('deps utils', () => {
       // Set up mock to find pnpm-lock.yaml in parent directory
       existsSyncMock.mockImplementation(path => {
         // Only return true for pnpm-lock.yaml in parent
-        return path.toString() === '/test/deep/nested/pnpm-lock.yaml';
+        return path.toString().replaceAll('\\', '/').endsWith('deep/nested/pnpm-lock.yaml');
       });
 
       const result = detectPm({ path: '/test/deep/nested/project' });
@@ -196,6 +196,18 @@ describe('deps utils', () => {
       expect(runWithExeca).toHaveBeenCalledWith({
         cmd: 'yarn',
         args: ['install', '--legacy-peer-deps=false', '--force'],
+        cwd: '/test/project',
+      });
+    });
+
+    it('uses npm ci for a frozen npm lockfile', async () => {
+      vi.mocked(runWithExeca).mockResolvedValue({ success: true, error: undefined });
+
+      await installDeps({ path: '/test/project', pm: 'npm', frozen: true });
+
+      expect(runWithExeca).toHaveBeenCalledWith({
+        cmd: 'npm',
+        args: ['ci', '--legacy-peer-deps=false', '--force'],
         cwd: '/test/project',
       });
     });

--- a/deployers/cloud/src/utils/deps.ts
+++ b/deployers/cloud/src/utils/deps.ts
@@ -88,12 +88,14 @@ export async function installNodeVersion({ path }: { path: string }) {
   }
 }
 
-export async function installDeps({ path, pm }: { path: string; pm?: string }) {
+export async function installDeps({ path, pm, frozen = false }: { path: string; pm?: string; frozen?: boolean }) {
   pm = pm ?? detectPm({ path });
   logger.info('Installing dependencies', { pm, path });
   // --force is needed to install peer deps for external packages in the mastra output directory
   // --legacy-peer-deps=false is needed to override other overrides by the repo package manager such as pnpm. Pnpm would set it to true
-  const args = ['install', '--legacy-peer-deps=false', '--force'];
+  const args = frozen
+    ? ['ci', '--legacy-peer-deps=false', '--force']
+    : ['install', '--legacy-peer-deps=false', '--force'];
   const { success, error } = await runWithExeca({ cmd: pm, args, cwd: path });
   if (!success) {
     throw new MastraError(

--- a/deployers/netlify/src/index.test.ts
+++ b/deployers/netlify/src/index.test.ts
@@ -1,0 +1,56 @@
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+const { mockInstall, mockSetLogger } = vi.hoisted(() => ({
+  mockInstall: vi.fn(async () => undefined),
+  mockSetLogger: vi.fn(),
+}));
+
+vi.mock('@mastra/deployer', () => ({
+  Deployer: class {
+    outputDir = 'output';
+    logger = {};
+  },
+}));
+
+vi.mock('@mastra/deployer/services', () => ({
+  DepsService: class {
+    __setLogger = mockSetLogger;
+    install = mockInstall;
+  },
+}));
+
+import { NetlifyDeployer } from './index';
+
+const state = {
+  packageManager: 'pnpm' as const,
+  frozen: true,
+  generateSecondaryNpmLockfile: false,
+};
+
+describe('NetlifyDeployer dependency routing', () => {
+  it('preserves serverless architecture constraints while forwarding install state', async () => {
+    const deployer = new NetlifyDeployer({ target: 'serverless' });
+
+    await (deployer as any).installDependencies('/test/output', '/test/project', { foo: 'bar' }, state);
+
+    expect(mockInstall).toHaveBeenCalledWith({
+      dir: join('/test/output', '.netlify', 'v1', 'functions', 'api'),
+      pnpmOverrides: { foo: 'bar' },
+      installState: state,
+      architecture: { os: ['linux'], cpu: ['x64'], libc: ['gnu'] },
+    });
+  });
+
+  it('preserves the edge path without serverless architecture constraints', async () => {
+    const deployer = new NetlifyDeployer({ target: 'edge' });
+
+    await (deployer as any).installDependencies('/test/output', '/test/project', undefined, state);
+
+    expect(mockInstall).toHaveBeenCalledWith({
+      dir: join('/test/output', '.netlify', 'v1', 'edge-functions'),
+      pnpmOverrides: undefined,
+      installState: state,
+    });
+  });
+});

--- a/deployers/netlify/src/index.ts
+++ b/deployers/netlify/src/index.ts
@@ -4,7 +4,7 @@ import process from 'node:process';
 import { Deployer } from '@mastra/deployer';
 import type { analyzeBundle } from '@mastra/deployer/analyze';
 import type { BundlerOptions } from '@mastra/deployer/bundler';
-import { DepsService } from '@mastra/deployer/services';
+import { DepsService, type BundleDependencyInstallState } from '@mastra/deployer/services';
 import { move, writeJson } from 'fs-extra/esm';
 
 /** Bare Node.js built-in module names (excludes internal `_`-prefixed ones). */
@@ -75,16 +75,27 @@ export class NetlifyDeployer extends Deployer {
       this.target === 'edge' ? join('.netlify', 'v1', 'edge-functions') : join('.netlify', 'v1', 'functions', 'api');
   }
 
-  protected async installDependencies(outputDirectory: string, rootDir = process.cwd()) {
+  protected async installDependencies(
+    outputDirectory: string,
+    rootDir = process.cwd(),
+    pnpmOverrides?: Record<string, string>,
+    installState?: BundleDependencyInstallState,
+  ) {
     const deps = new DepsService(rootDir);
     deps.__setLogger(this.logger);
 
     if (this.target === 'edge') {
       // Edge functions run on Deno — no platform-specific architecture constraints
-      await deps.install({ dir: join(outputDirectory, this.outputDir) });
+      await deps.install({
+        dir: join(outputDirectory, this.outputDir),
+        pnpmOverrides,
+        installState,
+      });
     } else {
       await deps.install({
         dir: join(outputDirectory, this.outputDir),
+        pnpmOverrides,
+        installState,
         architecture: {
           os: ['linux'],
           cpu: ['x64'],

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -724,7 +724,7 @@ export const mastra = new Mastra({
 
 **Type:** `string`
 
-Optional path to the lockfile used for the generated bundle's dependency installation. Relative paths are resolved from the project root. Supported basenames are `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, and `bun.lock`; the configured lockfile must match the package manager used by the deployer. Matching locks are copied byte-for-byte beside the generated manifest and installed with the manager's frozen command.
+Optional path to the lockfile used for the generated bundle's dependency installation. Relative paths are resolved from the project root. Supported basenames are `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, and `bun.lock`; the lockfile's basename selects the package manager used to install the bundle, which is what makes pinning an npm lockfile in a pnpm, Yarn, or Bun repo work (a locked graph plus npm's hoisted tree). Matching locks are copied byte-for-byte beside the generated manifest and installed with the manager's frozen command.
 
 When this option is omitted, Mastra keeps detecting the package manager from the project and performs its normal installation. The secondary npm lock is generated only after a normal npm installation, and isn't generated for explicit locks or packed workspace dependencies.
 

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -724,7 +724,7 @@ export const mastra = new Mastra({
 
 **Type:** `string`
 
-Optional path to the lockfile used for the generated bundle's dependency installation. Relative paths are resolved from the project root. Supported basenames are `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, and `bun.lock`; the lockfile's basename selects the package manager used to install the bundle, which is what makes pinning an npm lockfile in a pnpm, Yarn, or Bun repo work (a locked graph plus npm's hoisted tree). Matching locks are copied byte-for-byte beside the generated manifest and installed with the manager's frozen command.
+Optional path to the lockfile used for the generated bundle's dependency installation. Relative paths are resolved from the project root. Supported basenames are `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, and `bun.lock`; the lockfile's basename selects the package manager used to install the bundle, which is what makes pinning an npm lockfile in a pnpm, Yarn, or Bun repo work (a locked graph plus npm's hoisted tree). Matching locks are copied byte-for-byte beside the generated manifest and installed with the manager's frozen command. Cloud deployments accept an explicit lockfile only when its basename is `package-lock.json`.
 
 When this option is omitted, Mastra keeps detecting the package manager from the project and performs its normal installation. The secondary npm lock is generated only after a normal npm installation, and isn't generated for explicit locks or packed workspace dependencies.
 

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -724,7 +724,7 @@ export const mastra = new Mastra({
 
 **Type:** `string`
 
-Optional path to the lockfile used for the generated bundle's dependency installation. Relative paths are resolved from the project root. Supported basenames are `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, and `bun.lock`; the lockfile's basename selects the package manager used to install the bundle, which is what makes pinning an npm lockfile in a pnpm, Yarn, or Bun repo work (a locked graph plus npm's hoisted tree). Matching locks are copied byte-for-byte beside the generated manifest and installed with the manager's frozen command. Cloud deployments accept an explicit lockfile only when its basename is `package-lock.json`.
+Optional path to the lockfile used for the generated bundle's dependency installation. Generate the lockfile for the generated bundle's `package.json`, then commit it at the configured path. Relative paths are resolved from the project root. Supported basenames are `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, and `bun.lock`; the lockfile's basename selects the package manager used to install the bundle. Bundle lockfiles are copied byte-for-byte beside the generated manifest and installed with the manager's frozen command. Cloud deployments accept an explicit lockfile only when its basename is `package-lock.json`.
 
 When this option is omitted, Mastra keeps detecting the package manager from the project and performs its normal installation. The secondary npm lock is generated only after a normal npm installation, and isn't generated for explicit locks or packed workspace dependencies.
 
@@ -733,7 +733,7 @@ import { Mastra } from '@mastra/core'
 
 export const mastra = new Mastra({
   bundler: {
-    lockfile: './pnpm-lock.yaml',
+    lockfile: './bundle-lock/pnpm-lock.yaml',
   },
 })
 ```

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -720,6 +720,24 @@ export const mastra = new Mastra({
 })
 ```
 
+### bundler.lockfile
+
+**Type:** `string`
+
+Optional path to the lockfile used for the generated bundle's dependency installation. Relative paths are resolved from the project root. Supported basenames are `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, and `bun.lock`; the configured lockfile must match the package manager used by the deployer. Matching locks are copied byte-for-byte beside the generated manifest and installed with the manager's frozen command.
+
+When this option is omitted, Mastra keeps detecting the package manager from the project and performs its normal installation. The secondary npm lock is generated only after a normal npm installation, and isn't generated for explicit locks or packed workspace dependencies.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+
+export const mastra = new Mastra({
+  bundler: {
+    lockfile: './pnpm-lock.yaml',
+  },
+})
+```
+
 ## Server options
 
 ### server.apiRoutes

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -705,7 +705,7 @@ export const mastra = new Mastra({
 
 **Type:** `string`
 
-Optional path to the lockfile used for the generated bundle's dependency installation. Relative paths are resolved from the project root. Supported basenames are `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, and `bun.lock`; the configured lockfile must match the package manager used by the deployer. Matching locks are copied byte-for-byte beside the generated manifest and installed with the manager's frozen command.
+Optional path to the lockfile used for the generated bundle's dependency installation. Relative paths are resolved from the project root. Supported basenames are `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, and `bun.lock`; the lockfile's basename selects the package manager used to install the bundle, which is what makes pinning an npm lockfile in a pnpm, Yarn, or Bun repo work (a locked graph plus npm's hoisted tree). Matching locks are copied byte-for-byte beside the generated manifest and installed with the manager's frozen command.
 
 When this option is omitted, Mastra keeps detecting the package manager from the project and performs its normal installation. The secondary npm lock is generated only after a normal npm installation, and isn't generated for explicit locks or packed workspace dependencies.
 

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -701,6 +701,24 @@ export const mastra = new Mastra({
 })
 ```
 
+### bundler.lockfile
+
+**Type:** `string`
+
+Optional path to the lockfile used for the generated bundle's dependency installation. Relative paths are resolved from the project root. Supported basenames are `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, and `bun.lock`; the configured lockfile must match the package manager used by the deployer. Matching locks are copied byte-for-byte beside the generated manifest and installed with the manager's frozen command.
+
+When this option is omitted, Mastra keeps detecting the package manager from the project and performs its normal installation. The secondary npm lock is generated only after a normal npm installation, and isn't generated for explicit locks or packed workspace dependencies.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+
+export const mastra = new Mastra({
+  bundler: {
+    lockfile: './pnpm-lock.yaml',
+  },
+})
+```
+
 ## Server options
 
 ### server.apiRoutes

--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -1,7 +1,7 @@
 import { it, describe, expect, beforeAll, afterAll, inject } from 'vitest';
 import { join } from 'path';
 import { setupMonorepo } from './prepare';
-import { mkdtemp, mkdir, readdir, rm, readFile, writeFile } from 'fs/promises';
+import { copyFile, mkdtemp, mkdir, readdir, rm, readFile, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import getPort from 'get-port';
 import { execa, execaNode } from 'execa';
@@ -362,6 +362,53 @@ describe.sequential.for([['pnpm'] as const])(`%s monorepo`, ([pkgManager]) => {
     }, timeout);
 
     runApiTests(port);
+  });
+
+  describe.sequential('explicit bundle lockfile', () => {
+    it(
+      'copies and consumes a real lockfile during the bundle install',
+      async () => {
+        const appDirectory = join(fixturePath, 'apps', 'custom');
+        const outputDirectory = join(appDirectory, '.mastra', 'output');
+        const configPath = join(appDirectory, 'src', 'mastra', 'index.ts');
+        const sourceLockfile = join(appDirectory, 'package-lock.json');
+        const originalConfig = await readFile(configPath, 'utf8');
+        const previousRegistry = process.env.npm_config_registry;
+        const registry = inject('registry');
+
+        try {
+          await runBuild(fixturePath);
+
+          process.env.npm_config_registry = registry;
+          await execa('npm', ['install', '--package-lock-only', '--force', '--ignore-scripts'], {
+            cwd: outputDirectory,
+            env: process.env,
+          });
+          await copyFile(join(outputDirectory, 'package-lock.json'), sourceLockfile);
+          const expectedLockfile = await readFile(sourceLockfile, 'utf8');
+
+          await writeFile(
+            configPath,
+            originalConfig.replace("externals: ['bcrypt']", "externals: ['bcrypt'], lockfile: './package-lock.json'"),
+          );
+          await runBuild(fixturePath);
+
+          expect(await readFile(join(outputDirectory, 'package-lock.json'), 'utf8')).toBe(expectedLockfile);
+          expect(
+            JSON.parse(await readFile(join(outputDirectory, 'node_modules', 'bcrypt', 'package.json'), 'utf8')),
+          ).to.MatchObject({ name: 'bcrypt' });
+        } finally {
+          await writeFile(configPath, originalConfig);
+          await rm(sourceLockfile, { force: true });
+          if (previousRegistry === undefined) {
+            delete process.env.npm_config_registry;
+          } else {
+            process.env.npm_config_registry = previousRegistry;
+          }
+        }
+      },
+      timeout,
+    );
   });
 
   describe.sequential('start', async () => {

--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -396,7 +396,7 @@ describe.sequential.for([['pnpm'] as const])(`%s monorepo`, ([pkgManager]) => {
           expect(await readFile(join(outputDirectory, 'package-lock.json'), 'utf8')).toBe(expectedLockfile);
           expect(
             JSON.parse(await readFile(join(outputDirectory, 'node_modules', 'bcrypt', 'package.json'), 'utf8')),
-          ).to.MatchObject({ name: 'bcrypt' });
+          ).toMatchObject({ name: 'bcrypt' });
         } finally {
           await writeFile(configPath, originalConfig);
           await rm(sourceLockfile, { force: true });

--- a/packages/cli/src/commands/experiment/ExperimentBundler.test.ts
+++ b/packages/cli/src/commands/experiment/ExperimentBundler.test.ts
@@ -106,6 +106,23 @@ describe('ExperimentBundler', () => {
     expect(options).toEqual({ externals: true, dynamicPackages: ['dynamic-package'] });
   });
 
+  it('forwards explicit bundle install state through its cleanup override', async () => {
+    const { Bundler } = await import('@mastra/deployer/bundler');
+    const install = vi.spyOn(Bundler.prototype as any, 'installDependencies').mockResolvedValue(undefined);
+    const { ExperimentBundler } = await import('./ExperimentBundler');
+    const bundler = new ExperimentBundler();
+    const installState = {
+      packageManager: 'npm' as const,
+      frozen: true,
+      generateSecondaryNpmLockfile: false,
+      explicitLockfile: { sourcePath: '/project/package-lock.json', basename: 'package-lock.json' as const },
+    };
+
+    await (bundler as any).installDependencies('/output', '/project', { lodash: '^4.0.0' }, installState);
+
+    expect(install).toHaveBeenCalledWith('/output', '/project', { lodash: '^4.0.0' }, installState);
+  });
+
   it('removes pnpm install metadata that embeds build-machine paths', async () => {
     const { removePnpmInstallMetadata } = await import('./ExperimentBundler');
     const output = await createTemporaryDirectory('mastra-experiment-worker-');

--- a/packages/cli/src/commands/experiment/ExperimentBundler.ts
+++ b/packages/cli/src/commands/experiment/ExperimentBundler.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import type { Config } from '@mastra/core/mastra';
 import { FileService } from '@mastra/deployer/build';
 import { Bundler } from '@mastra/deployer/bundler';
+import type { BundleDependencyInstallState } from '@mastra/deployer/services';
 import { shouldSkipDotenvLoading } from '../utils.js';
 import {
   EXPERIMENT_DATASET_CANONICALIZATION_VERSION,
@@ -101,8 +102,9 @@ export class ExperimentBundler extends Bundler {
     outputDirectory: string,
     rootDir?: string,
     pnpmOverrides?: Record<string, string>,
+    installState?: BundleDependencyInstallState,
   ): Promise<void> {
-    await super.installDependencies(outputDirectory, rootDir, pnpmOverrides);
+    await super.installDependencies(outputDirectory, rootDir, pnpmOverrides, installState);
     await removePnpmInstallMetadata(join(outputDirectory, this.outputDir));
   }
 

--- a/packages/core/src/bundler/types.ts
+++ b/packages/core/src/bundler/types.ts
@@ -47,5 +47,11 @@ export type BundlerConfig = {
    */
   dynamicPackages?: string[];
 
+  /**
+   * Optional bundle lockfile copied beside the generated manifest before dependencies are installed.
+   * Relative paths are resolved from the project root and must use one of the supported lockfile basenames.
+   */
+  lockfile?: string;
+
   [key: symbol]: boolean | undefined;
 };

--- a/packages/core/src/bundler/types.ts
+++ b/packages/core/src/bundler/types.ts
@@ -31,5 +31,11 @@ export type BundlerConfig = {
    */
   dynamicPackages?: string[];
 
+  /**
+   * Optional bundle lockfile copied beside the generated manifest before dependencies are installed.
+   * Relative paths are resolved from the project root and must use one of the supported lockfile basenames.
+   */
+  lockfile?: string;
+
   [key: symbol]: boolean | undefined;
 };

--- a/packages/deployer/src/bundler/fixtures/issue-20357/package.json
+++ b/packages/deployer/src/bundler/fixtures/issue-20357/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "googleapis": "171.4.0"
+  }
+}

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, realpathSync, statSync } from 'node:fs';
 import { copyFile, readFile, rm, stat, writeFile } from 'node:fs/promises';
-import { dirname, join, posix, resolve } from 'node:path';
+import { dirname, isAbsolute, join, posix, relative, resolve, sep } from 'node:path';
 import { MastraBundler } from '@mastra/core/bundler';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import type { Config } from '@mastra/core/mastra';
@@ -33,6 +33,13 @@ export type { BundlerOptions, ExternalDependencyInfo } from '../build/types';
 export type { BundlerPlatform } from '../build/utils';
 
 export const IS_DEFAULT = Symbol('IS_DEFAULT');
+
+function isPathWithin(rootPath: string, candidatePath: string): boolean {
+  const relativePath = relative(rootPath, candidatePath);
+  return (
+    relativePath !== '' && relativePath !== '..' && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath)
+  );
+}
 
 const NPM_ALIAS_PREFIX = 'npm:';
 /** Characters a registry range or dist tag can contain. Protocols need `:`, git shorthand needs `/` or `#`. */
@@ -445,12 +452,23 @@ export abstract class Bundler extends MastraBundler {
     }
 
     const sourcePath = resolve(projectRoot, lockfile);
-    let sourceStats: ReturnType<typeof statSync>;
+    const projectRootPath = resolve(projectRoot);
+    if (!isPathWithin(projectRootPath, sourcePath)) {
+      throw new Error(`Bundle lockfile must stay within project root: ${sourcePath}`);
+    }
+
+    let canonicalProjectRootPath: string;
+    let canonicalSourcePath: string;
     try {
-      sourceStats = statSync(sourcePath);
+      canonicalProjectRootPath = realpathSync(projectRootPath);
+      canonicalSourcePath = realpathSync(sourcePath);
     } catch {
       throw new Error(`Bundle lockfile does not exist: ${sourcePath}`);
     }
+    if (!isPathWithin(canonicalProjectRootPath, canonicalSourcePath)) {
+      throw new Error(`Bundle lockfile must stay within project root: ${sourcePath}`);
+    }
+    const sourceStats = statSync(canonicalSourcePath);
     if (sourceStats.isDirectory()) {
       throw new Error(`Bundle lockfile must be a file: ${sourcePath}`);
     }
@@ -459,7 +477,7 @@ export abstract class Bundler extends MastraBundler {
 
     return {
       packageManager,
-      explicitLockfile: { sourcePath, basename: basename as BundleLockfileName },
+      explicitLockfile: { sourcePath: canonicalSourcePath, basename: basename as BundleLockfileName },
       frozen: true,
       generateSecondaryNpmLockfile: false,
     };

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -408,8 +408,8 @@ export abstract class Bundler extends MastraBundler {
     });
   }
 
-  protected getBundleDependencyPackageManager(rootDir: string, _explicitManager?: PackageManager): PackageManager {
-    return new DepsService(rootDir).getPackageManager();
+  protected getBundleDependencyPackageManager(rootDir: string, explicitManager?: PackageManager): PackageManager {
+    return explicitManager ?? new DepsService(rootDir).getPackageManager();
   }
 
   protected resolveBundleDependencyInstallState({

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -298,7 +298,6 @@ export abstract class Bundler extends MastraBundler {
   protected analyzeOutputDir = '.build';
   protected outputDir = 'output';
   protected platform: BundlerPlatform = 'node';
-  protected bundleDependencyInstallState?: BundleDependencyInstallState;
 
   constructor(name: string, component: 'BUNDLER' | 'DEPLOYER' = 'BUNDLER') {
     super({ name, component });
@@ -788,8 +787,6 @@ export abstract class Bundler extends MastraBundler {
         lockfile: bundlerOptions.lockfile,
         hasPackedWorkspaceDependencies: transitiveWorkspaceDependencies.usedWorkspacePackages.size > 0,
       });
-      this.bundleDependencyInstallState = bundleDependencyInstallState;
-
       await this.writePackageJson(
         join(outputDirectory, this.outputDir),
         dependenciesToInstall,
@@ -910,8 +907,6 @@ export const tools = [${toolsExports.join(', ')}]`,
         },
         error,
       );
-    } finally {
-      this.bundleDependencyInstallState = undefined;
     }
   }
 

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { readFile, rm, stat, writeFile } from 'node:fs/promises';
-import { dirname, join, posix } from 'node:path';
+import { existsSync, statSync } from 'node:fs';
+import { copyFile, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname, join, posix, resolve } from 'node:path';
 import { MastraBundler } from '@mastra/core/bundler';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import type { Config } from '@mastra/core/mastra';
@@ -16,7 +16,12 @@ import { getBundlerOptions } from '../build/bundlerOptions';
 import type { BundlerOptions, ExternalDependencyInfo } from '../build/types';
 import type { BundlerPlatform } from '../build/utils';
 import { getPackageName, isBareModuleSpecifier, slash } from '../build/utils';
-import { DepsService } from '../services/deps';
+import {
+  DepsService,
+  type BundleDependencyInstallState,
+  type BundleLockfileName,
+  type PackageManager,
+} from '../services/deps';
 import { FileService } from '../services/fs';
 import {
   collectTransitiveWorkspaceDependencies,
@@ -286,6 +291,7 @@ export abstract class Bundler extends MastraBundler {
   protected analyzeOutputDir = '.build';
   protected outputDir = 'output';
   protected platform: BundlerPlatform = 'node';
+  protected bundleDependencyInstallState?: BundleDependencyInstallState;
 
   constructor(name: string, component: 'BUNDLER' | 'DEPLOYER' = 'BUNDLER') {
     super({ name, component });
@@ -389,6 +395,7 @@ export abstract class Bundler extends MastraBundler {
     outputDirectory: string,
     rootDir = process.cwd(),
     pnpmOverrides?: Record<string, string>,
+    installState?: BundleDependencyInstallState,
   ) {
     const deps = new DepsService(rootDir);
     deps.__setLogger(this.logger);
@@ -397,7 +404,79 @@ export abstract class Bundler extends MastraBundler {
       dir: join(outputDirectory, this.outputDir),
       pnpmOverrides,
       pnpmNodeLinker: this.pnpmNodeLinker,
+      installState,
     });
+  }
+
+  protected getBundleDependencyPackageManager(rootDir: string, explicitManager?: PackageManager): PackageManager {
+    return explicitManager ?? new DepsService(rootDir).getPackageManager();
+  }
+
+  protected resolveBundleDependencyInstallState({
+    projectRoot,
+    lockfile,
+    hasPackedWorkspaceDependencies,
+  }: {
+    projectRoot: string;
+    lockfile?: string;
+    hasPackedWorkspaceDependencies: boolean;
+  }): BundleDependencyInstallState {
+    if (lockfile === undefined) {
+      const packageManager = this.getBundleDependencyPackageManager(projectRoot);
+      return {
+        packageManager,
+        frozen: false,
+        generateSecondaryNpmLockfile: packageManager === 'npm' && !hasPackedWorkspaceDependencies,
+      };
+    }
+
+    const basename = lockfile.split(/[\\/]/).pop();
+    const supportedManagers: Record<string, PackageManager> = {
+      'package-lock.json': 'npm',
+      'pnpm-lock.yaml': 'pnpm',
+      'yarn.lock': 'yarn',
+      'bun.lock': 'bun',
+    };
+    const explicitManager = basename ? supportedManagers[basename] : undefined;
+    if (!explicitManager) {
+      throw new Error(
+        `Unsupported bundle lockfile ${lockfile}; supported basenames are package-lock.json, pnpm-lock.yaml, yarn.lock, and bun.lock`,
+      );
+    }
+
+    const sourcePath = resolve(projectRoot, lockfile);
+    let sourceStats: ReturnType<typeof statSync>;
+    try {
+      sourceStats = statSync(sourcePath);
+    } catch {
+      throw new Error(`Bundle lockfile does not exist: ${sourcePath}`);
+    }
+    if (sourceStats.isDirectory()) {
+      throw new Error(`Bundle lockfile must be a file: ${sourcePath}`);
+    }
+
+    const packageManager = this.getBundleDependencyPackageManager(projectRoot, explicitManager);
+    if (explicitManager !== packageManager) {
+      throw new Error(`Bundle lockfile ${basename} does not match the ${packageManager} bundle installer`);
+    }
+
+    return {
+      packageManager,
+      explicitLockfile: { sourcePath, basename: basename as BundleLockfileName },
+      frozen: true,
+      generateSecondaryNpmLockfile: false,
+    };
+  }
+
+  private async copyBundleDependencyLockfile(
+    bundleDirectory: string,
+    state: BundleDependencyInstallState,
+  ): Promise<void> {
+    if (!state.explicitLockfile) {
+      return;
+    }
+
+    await copyFile(state.explicitLockfile.sourcePath, join(bundleDirectory, state.explicitLockfile.basename));
   }
 
   /**
@@ -687,7 +766,15 @@ export abstract class Bundler extends MastraBundler {
       });
     }
 
+    let bundleDependencyInstallState: BundleDependencyInstallState;
     try {
+      bundleDependencyInstallState = this.resolveBundleDependencyInstallState({
+        projectRoot,
+        lockfile: bundlerOptions.lockfile,
+        hasPackedWorkspaceDependencies: transitiveWorkspaceDependencies.usedWorkspacePackages.size > 0,
+      });
+      this.bundleDependencyInstallState = bundleDependencyInstallState;
+
       await this.writePackageJson(
         join(outputDirectory, this.outputDir),
         dependenciesToInstall,
@@ -772,14 +859,20 @@ export const tools = [${toolsExports.join(', ')}]`,
       this.logger.info('Done copying .npmrc file');
 
       this.logger.info('Installing dependencies');
-      await this.installDependencies(outputDirectory, projectRoot, transitiveWorkspaceDependencies.resolutions);
+      await this.copyBundleDependencyLockfile(join(outputDirectory, this.outputDir), bundleDependencyInstallState);
+      await this.installDependencies(
+        outputDirectory,
+        projectRoot,
+        transitiveWorkspaceDependencies.resolutions,
+        bundleDependencyInstallState,
+      );
       this.logger.info('Done installing dependencies');
 
-      if (Object.keys(transitiveWorkspaceDependencies.resolutions).length === 0) {
+      if (bundleDependencyInstallState.generateSecondaryNpmLockfile) {
         this.logger.info('Generating package-lock.json for deploy');
         await this.generateNpmLockfile(join(outputDirectory, this.outputDir));
         this.logger.info('Done generating package-lock.json');
-      } else {
+      } else if (Object.keys(transitiveWorkspaceDependencies.resolutions).length > 0) {
         this.logger.warn(
           'Skipping package-lock.json generation because the output contains packed workspace dependencies',
         );
@@ -802,6 +895,8 @@ export const tools = [${toolsExports.join(', ')}]`,
         },
         error,
       );
+    } finally {
+      this.bundleDependencyInstallState = undefined;
     }
   }
 

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -408,8 +408,8 @@ export abstract class Bundler extends MastraBundler {
     });
   }
 
-  protected getBundleDependencyPackageManager(rootDir: string, explicitManager?: PackageManager): PackageManager {
-    return explicitManager ?? new DepsService(rootDir).getPackageManager();
+  protected getBundleDependencyPackageManager(rootDir: string, _explicitManager?: PackageManager): PackageManager {
+    return new DepsService(rootDir).getPackageManager();
   }
 
   protected resolveBundleDependencyInstallState({
@@ -455,7 +455,10 @@ export abstract class Bundler extends MastraBundler {
       throw new Error(`Bundle lockfile must be a file: ${sourcePath}`);
     }
 
-    const packageManager = this.getBundleDependencyPackageManager(projectRoot, explicitManager);
+    const hasSourceLockfile = new DepsService(projectRoot).getLockFile() !== null;
+    const packageManager = hasSourceLockfile
+      ? this.getBundleDependencyPackageManager(projectRoot)
+      : this.getBundleDependencyPackageManager(projectRoot, explicitManager);
     if (explicitManager !== packageManager) {
       throw new Error(`Bundle lockfile ${basename} does not match the ${packageManager} bundle installer`);
     }

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -468,7 +468,7 @@ export abstract class Bundler extends MastraBundler {
       throw new Error(`Bundle lockfile must stay within project root: ${sourcePath}`);
     }
     const sourceStats = statSync(canonicalSourcePath);
-    if (sourceStats.isDirectory()) {
+    if (!sourceStats.isFile()) {
       throw new Error(`Bundle lockfile must be a file: ${sourcePath}`);
     }
 

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -455,13 +455,7 @@ export abstract class Bundler extends MastraBundler {
       throw new Error(`Bundle lockfile must be a file: ${sourcePath}`);
     }
 
-    const hasSourceLockfile = new DepsService(projectRoot).getLockFile() !== null;
-    const packageManager = hasSourceLockfile
-      ? this.getBundleDependencyPackageManager(projectRoot)
-      : this.getBundleDependencyPackageManager(projectRoot, explicitManager);
-    if (explicitManager !== packageManager) {
-      throw new Error(`Bundle lockfile ${basename} does not match the ${packageManager} bundle installer`);
-    }
+    const packageManager = this.getBundleDependencyPackageManager(projectRoot, explicitManager);
 
     return {
       packageManager,

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { rm, stat, writeFile } from 'node:fs/promises';
-import { dirname, join, posix } from 'node:path';
+import { existsSync, statSync } from 'node:fs';
+import { copyFile, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname, join, posix, resolve } from 'node:path';
 import { MastraBundler } from '@mastra/core/bundler';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import type { Config } from '@mastra/core/mastra';
@@ -16,7 +16,12 @@ import { getBundlerOptions } from '../build/bundlerOptions';
 import type { BundlerOptions, ExternalDependencyInfo } from '../build/types';
 import type { BundlerPlatform } from '../build/utils';
 import { getPackageName, isBareModuleSpecifier, slash } from '../build/utils';
-import { DepsService } from '../services/deps';
+import {
+  DepsService,
+  type BundleDependencyInstallState,
+  type BundleLockfileName,
+  type PackageManager,
+} from '../services/deps';
 import { FileService } from '../services/fs';
 import {
   collectTransitiveWorkspaceDependencies,
@@ -33,6 +38,7 @@ export abstract class Bundler extends MastraBundler {
   protected analyzeOutputDir = '.build';
   protected outputDir = 'output';
   protected platform: BundlerPlatform = 'node';
+  protected bundleDependencyInstallState?: BundleDependencyInstallState;
 
   constructor(name: string, component: 'BUNDLER' | 'DEPLOYER' = 'BUNDLER') {
     super({ name, component });
@@ -134,11 +140,82 @@ export abstract class Bundler extends MastraBundler {
     outputDirectory: string,
     rootDir = process.cwd(),
     pnpmOverrides?: Record<string, string>,
+    installState?: BundleDependencyInstallState,
   ) {
     const deps = new DepsService(rootDir);
     deps.__setLogger(this.logger);
 
-    await deps.install({ dir: join(outputDirectory, this.outputDir), pnpmOverrides });
+    await deps.install({ dir: join(outputDirectory, this.outputDir), pnpmOverrides, installState });
+  }
+
+  protected getBundleDependencyPackageManager(rootDir: string): PackageManager {
+    return new DepsService(rootDir).getPackageManager();
+  }
+
+  protected resolveBundleDependencyInstallState({
+    projectRoot,
+    lockfile,
+    hasPackedWorkspaceDependencies,
+  }: {
+    projectRoot: string;
+    lockfile?: string;
+    hasPackedWorkspaceDependencies: boolean;
+  }): BundleDependencyInstallState {
+    const packageManager = this.getBundleDependencyPackageManager(projectRoot);
+    if (lockfile === undefined) {
+      return {
+        packageManager,
+        frozen: false,
+        generateSecondaryNpmLockfile: packageManager === 'npm' && !hasPackedWorkspaceDependencies,
+      };
+    }
+
+    const basename = lockfile.split(/[\\/]/).pop();
+    const supportedManagers: Record<string, PackageManager> = {
+      'package-lock.json': 'npm',
+      'pnpm-lock.yaml': 'pnpm',
+      'yarn.lock': 'yarn',
+      'bun.lock': 'bun',
+    };
+    const explicitManager = basename ? supportedManagers[basename] : undefined;
+    if (!explicitManager) {
+      throw new Error(
+        `Unsupported bundle lockfile ${lockfile}; supported basenames are package-lock.json, pnpm-lock.yaml, yarn.lock, and bun.lock`,
+      );
+    }
+
+    const sourcePath = resolve(projectRoot, lockfile);
+    let sourceStats: ReturnType<typeof statSync>;
+    try {
+      sourceStats = statSync(sourcePath);
+    } catch {
+      throw new Error(`Bundle lockfile does not exist: ${sourcePath}`);
+    }
+    if (sourceStats.isDirectory()) {
+      throw new Error(`Bundle lockfile must be a file: ${sourcePath}`);
+    }
+
+    if (explicitManager !== packageManager) {
+      throw new Error(`Bundle lockfile ${basename} does not match the ${packageManager} bundle installer`);
+    }
+
+    return {
+      packageManager,
+      explicitLockfile: { sourcePath, basename: basename as BundleLockfileName },
+      frozen: true,
+      generateSecondaryNpmLockfile: false,
+    };
+  }
+
+  private async copyBundleDependencyLockfile(
+    bundleDirectory: string,
+    state: BundleDependencyInstallState,
+  ): Promise<void> {
+    if (!state.explicitLockfile) {
+      return;
+    }
+
+    await copyFile(state.explicitLockfile.sourcePath, join(bundleDirectory, state.explicitLockfile.basename));
   }
 
   /**
@@ -414,7 +491,15 @@ export abstract class Bundler extends MastraBundler {
       });
     }
 
+    let bundleDependencyInstallState: BundleDependencyInstallState;
     try {
+      bundleDependencyInstallState = this.resolveBundleDependencyInstallState({
+        projectRoot,
+        lockfile: bundlerOptions.lockfile,
+        hasPackedWorkspaceDependencies: transitiveWorkspaceDependencies.usedWorkspacePackages.size > 0,
+      });
+      this.bundleDependencyInstallState = bundleDependencyInstallState;
+
       await this.writePackageJson(
         join(outputDirectory, this.outputDir),
         dependenciesToInstall,
@@ -499,14 +584,20 @@ export const tools = [${toolsExports.join(', ')}]`,
       this.logger.info('Done copying .npmrc file');
 
       this.logger.info('Installing dependencies');
-      await this.installDependencies(outputDirectory, projectRoot, transitiveWorkspaceDependencies.resolutions);
+      await this.copyBundleDependencyLockfile(join(outputDirectory, this.outputDir), bundleDependencyInstallState);
+      await this.installDependencies(
+        outputDirectory,
+        projectRoot,
+        transitiveWorkspaceDependencies.resolutions,
+        bundleDependencyInstallState,
+      );
       this.logger.info('Done installing dependencies');
 
-      if (Object.keys(transitiveWorkspaceDependencies.resolutions).length === 0) {
+      if (bundleDependencyInstallState.generateSecondaryNpmLockfile) {
         this.logger.info('Generating package-lock.json for deploy');
         await this.generateNpmLockfile(join(outputDirectory, this.outputDir));
         this.logger.info('Done generating package-lock.json');
-      } else {
+      } else if (Object.keys(transitiveWorkspaceDependencies.resolutions).length > 0) {
         this.logger.warn(
           'Skipping package-lock.json generation because the output contains packed workspace dependencies',
         );
@@ -526,6 +617,8 @@ export const tools = [${toolsExports.join(', ')}]`,
         },
         error,
       );
+    } finally {
+      this.bundleDependencyInstallState = undefined;
     }
   }
 

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -195,13 +195,7 @@ export abstract class Bundler extends MastraBundler {
       throw new Error(`Bundle lockfile must be a file: ${sourcePath}`);
     }
 
-    const hasSourceLockfile = new DepsService(projectRoot).getLockFile() !== null;
-    const packageManager = hasSourceLockfile
-      ? this.getBundleDependencyPackageManager(projectRoot)
-      : this.getBundleDependencyPackageManager(projectRoot, explicitManager);
-    if (explicitManager !== packageManager) {
-      throw new Error(`Bundle lockfile ${basename} does not match the ${packageManager} bundle installer`);
-    }
+    const packageManager = this.getBundleDependencyPackageManager(projectRoot, explicitManager);
 
     return {
       packageManager,

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -148,8 +148,8 @@ export abstract class Bundler extends MastraBundler {
     await deps.install({ dir: join(outputDirectory, this.outputDir), pnpmOverrides, installState });
   }
 
-  protected getBundleDependencyPackageManager(rootDir: string, _explicitManager?: PackageManager): PackageManager {
-    return new DepsService(rootDir).getPackageManager();
+  protected getBundleDependencyPackageManager(rootDir: string, explicitManager?: PackageManager): PackageManager {
+    return explicitManager ?? new DepsService(rootDir).getPackageManager();
   }
 
   protected resolveBundleDependencyInstallState({

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -148,7 +148,7 @@ export abstract class Bundler extends MastraBundler {
     await deps.install({ dir: join(outputDirectory, this.outputDir), pnpmOverrides, installState });
   }
 
-  protected getBundleDependencyPackageManager(rootDir: string): PackageManager {
+  protected getBundleDependencyPackageManager(rootDir: string, _explicitManager?: PackageManager): PackageManager {
     return new DepsService(rootDir).getPackageManager();
   }
 
@@ -161,8 +161,8 @@ export abstract class Bundler extends MastraBundler {
     lockfile?: string;
     hasPackedWorkspaceDependencies: boolean;
   }): BundleDependencyInstallState {
-    const packageManager = this.getBundleDependencyPackageManager(projectRoot);
     if (lockfile === undefined) {
+      const packageManager = this.getBundleDependencyPackageManager(projectRoot);
       return {
         packageManager,
         frozen: false,
@@ -195,6 +195,10 @@ export abstract class Bundler extends MastraBundler {
       throw new Error(`Bundle lockfile must be a file: ${sourcePath}`);
     }
 
+    const hasSourceLockfile = new DepsService(projectRoot).getLockFile() !== null;
+    const packageManager = hasSourceLockfile
+      ? this.getBundleDependencyPackageManager(projectRoot)
+      : this.getBundleDependencyPackageManager(projectRoot, explicitManager);
     if (explicitManager !== packageManager) {
       throw new Error(`Bundle lockfile ${basename} does not match the ${packageManager} bundle installer`);
     }

--- a/packages/deployer/src/bundler/lockfile.test.ts
+++ b/packages/deployer/src/bundler/lockfile.test.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DepsService } from '../services';
 import { Bundler } from './index';
@@ -84,6 +85,24 @@ class LockfileTestBundler extends Bundler {
   }
 }
 
+class BaseManagerBundler extends LockfileTestBundler {
+  protected getBundleDependencyPackageManager(rootDir: string, explicitManager?: 'npm' | 'yarn' | 'pnpm' | 'bun') {
+    return Bundler.prototype.getBundleDependencyPackageManager.call(this, rootDir, explicitManager);
+  }
+}
+
+async function createSymlink(target: string, path: string, type: 'file' | 'junction'): Promise<boolean> {
+  try {
+    await symlink(target, path, type);
+    return true;
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && (error.code === 'EACCES' || error.code === 'EPERM')) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 async function createBundleFixture(options: { lockfile?: string } = {}) {
   const projectRoot = join(tmpdir(), `mastra-lockfile-project-${Date.now()}-${Math.random()}`);
   await mkdir(projectRoot, { recursive: true });
@@ -137,12 +156,6 @@ describe('Bundler bundle lockfile authority', () => {
     const { projectRoot, outputDirectory } = await createBundleFixture({ lockfile: 'package-lock.json' });
     await writeFile(join(projectRoot, 'package-lock.json'), 'lock bytes\n');
 
-    class BaseManagerBundler extends LockfileTestBundler {
-      protected getBundleDependencyPackageManager(rootDir: string, explicitManager?: 'npm' | 'yarn' | 'pnpm' | 'bun') {
-        return Bundler.prototype.getBundleDependencyPackageManager.call(this, rootDir, explicitManager);
-      }
-    }
-
     const bundler = new BaseManagerBundler({ lockfile: 'package-lock.json' });
     await bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), { projectRoot, outputDirectory });
 
@@ -155,13 +168,87 @@ describe('Bundler bundle lockfile authority', () => {
     expect(bundler.getState()).toBeUndefined();
   });
 
+  it.each(['relative traversal', 'absolute outside path'] as const)(
+    'rejects an explicit lockfile with an %s before installation',
+    async pathKind => {
+      const { projectRoot } = await createBundleFixture();
+      const outsideRoot = join(tmpdir(), `mastra-lockfile-outside-${Date.now()}-${Math.random()}`);
+      const outsideLockfile = join(outsideRoot, 'package-lock.json');
+      await mkdir(outsideRoot, { recursive: true });
+      await writeFile(outsideLockfile, 'secret bytes\n');
+      tempDirs.push(outsideRoot);
+
+      const lockfile = pathKind === 'relative traversal' ? relative(projectRoot, outsideLockfile) : outsideLockfile;
+      const bundler = new BaseManagerBundler();
+
+      expect(() => bundler.resolveState(projectRoot, lockfile, false)).toThrow(
+        'Bundle lockfile must stay within project root',
+      );
+      expect(bundler.installs).toHaveLength(0);
+    },
+  );
+
+  it('accepts an absolute lockfile inside the project and stores its canonical path', async () => {
+    const { projectRoot } = await createBundleFixture();
+    const lockfile = join(projectRoot, 'package-lock.json');
+    await writeFile(lockfile, 'lock bytes\n');
+
+    const state = new BaseManagerBundler().resolveState(projectRoot, lockfile, false);
+
+    expect(state.explicitLockfile?.sourcePath).toBe(realpathSync(lockfile));
+  });
+
+  it('accepts an in-project lockfile symlink and stores its canonical path', async () => {
+    const { projectRoot } = await createBundleFixture();
+    const target = join(projectRoot, 'locks', 'package-lock.json');
+    const link = join(projectRoot, 'package-lock.json');
+    await mkdir(join(projectRoot, 'locks'), { recursive: true });
+    await writeFile(target, 'lock bytes\n');
+    if (!(await createSymlink(target, link, 'file'))) return;
+
+    const state = new BaseManagerBundler().resolveState(projectRoot, link, false);
+
+    expect(state.explicitLockfile?.sourcePath).toBe(realpathSync(target));
+  });
+
+  it('rejects a supported lockfile symlink that targets outside the project', async () => {
+    const { projectRoot } = await createBundleFixture();
+    const outsideRoot = join(tmpdir(), `mastra-lockfile-symlink-file-${Date.now()}-${Math.random()}`);
+    const outsideLockfile = join(outsideRoot, 'package-lock.json');
+    const linkedLockfile = join(projectRoot, 'package-lock.json');
+    await mkdir(outsideRoot, { recursive: true });
+    await writeFile(outsideLockfile, 'secret bytes\n');
+    tempDirs.push(outsideRoot);
+    if (!(await createSymlink(outsideLockfile, linkedLockfile, 'file'))) return;
+
+    const bundler = new BaseManagerBundler();
+    expect(() => bundler.resolveState(projectRoot, 'package-lock.json', false)).toThrow(
+      'Bundle lockfile must stay within project root',
+    );
+    expect(bundler.installs).toHaveLength(0);
+  });
+
+  it('rejects a lockfile below a symlinked directory that targets outside the project', async () => {
+    const { projectRoot } = await createBundleFixture();
+    const outsideRoot = join(tmpdir(), `mastra-lockfile-symlink-dir-${Date.now()}-${Math.random()}`);
+    const linkedDirectory = join(projectRoot, 'linked-locks');
+    await mkdir(outsideRoot, { recursive: true });
+    await writeFile(join(outsideRoot, 'package-lock.json'), 'secret bytes\n');
+    tempDirs.push(outsideRoot);
+    if (!(await createSymlink(outsideRoot, linkedDirectory, 'junction'))) return;
+
+    const bundler = new BaseManagerBundler();
+    expect(() => bundler.resolveState(projectRoot, 'linked-locks/package-lock.json', false)).toThrow(
+      'Bundle lockfile must stay within project root',
+    );
+    expect(bundler.installs).toHaveLength(0);
+  });
+
   it('uses an explicit manager when the project has no source lock', async () => {
     const projectRoot = join(tmpdir(), `mastra-lockfile-no-source-${Date.now()}-${Math.random()}`);
-    const explicitRoot = join(tmpdir(), `mastra-lockfile-explicit-${Date.now()}-${Math.random()}`);
     await mkdir(projectRoot, { recursive: true });
-    await mkdir(explicitRoot, { recursive: true });
-    tempDirs.push(projectRoot, explicitRoot);
-    await writeFile(join(explicitRoot, 'pnpm-lock.yaml'), 'lock bytes\n');
+    tempDirs.push(projectRoot);
+    await writeFile(join(projectRoot, 'pnpm-lock.yaml'), 'lock bytes\n');
 
     class NoSourceBundler extends LockfileTestBundler {
       protected getBundleDependencyPackageManager(rootDir: string, explicitManager?: 'npm' | 'yarn' | 'pnpm' | 'bun') {
@@ -169,7 +256,7 @@ describe('Bundler bundle lockfile authority', () => {
       }
     }
 
-    const state = new NoSourceBundler().resolveState(projectRoot, join(explicitRoot, 'pnpm-lock.yaml'), false);
+    const state = new NoSourceBundler().resolveState(projectRoot, 'pnpm-lock.yaml', false);
     expect(state.packageManager).toBe('pnpm');
     expect(state.frozen).toBe(true);
   });

--- a/packages/deployer/src/bundler/lockfile.test.ts
+++ b/packages/deployer/src/bundler/lockfile.test.ts
@@ -133,14 +133,26 @@ describe('Bundler bundle lockfile authority', () => {
     expect(bundler.resolveState(tmpdir(), undefined, true).generateSecondaryNpmLockfile).toBe(false);
   });
 
-  it('rejects a manager mismatch and never reaches the installer', async () => {
-    const { projectRoot, outputDirectory, bundler } = await createBundleFixture({ lockfile: 'package-lock.json' });
-    await writeFile(join(projectRoot, 'package-lock.json'), '{}\n');
+  it('pins the explicit npm lock from a pnpm source without throwing and without secondary npm', async () => {
+    const { projectRoot, outputDirectory } = await createBundleFixture({ lockfile: 'package-lock.json' });
+    await writeFile(join(projectRoot, 'package-lock.json'), 'lock bytes\n');
 
-    await expect(
-      bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), { projectRoot, outputDirectory }),
-    ).rejects.toThrow('does not match the pnpm bundle installer');
-    expect(bundler.installs).toHaveLength(0);
+    class BaseManagerBundler extends LockfileTestBundler {
+      protected getBundleDependencyPackageManager(rootDir: string, explicitManager?: 'npm' | 'yarn' | 'pnpm' | 'bun') {
+        return Bundler.prototype.getBundleDependencyPackageManager.call(this, rootDir, explicitManager);
+      }
+    }
+
+    const bundler = new BaseManagerBundler({ lockfile: 'package-lock.json' });
+    await bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), { projectRoot, outputDirectory });
+
+    expect(bundler.installs).toHaveLength(1);
+    expect((bundler.installs[0]?.[3] as any).packageManager).toBe('npm');
+    expect((bundler.installs[0]?.[3] as any).frozen).toBe(true);
+    expect((bundler.installs[0]?.[3] as any).explicitLockfile.basename).toBe('package-lock.json');
+    expect(await readFile(join(outputDirectory, 'output', 'package-lock.json'), 'utf8')).toBe('lock bytes\n');
+    expect((bundler.installs[0]?.[3] as any).generateSecondaryNpmLockfile).toBe(false);
+    expect(bundler.getState()).toBeUndefined();
   });
 
   it('uses an explicit manager when the project has no source lock', async () => {
@@ -152,10 +164,7 @@ describe('Bundler bundle lockfile authority', () => {
     await writeFile(join(explicitRoot, 'pnpm-lock.yaml'), 'lock bytes\n');
 
     class NoSourceBundler extends LockfileTestBundler {
-      protected getBundleDependencyPackageManager(
-        rootDir: string,
-        explicitManager?: 'npm' | 'yarn' | 'pnpm' | 'bun',
-      ) {
+      protected getBundleDependencyPackageManager(rootDir: string, explicitManager?: 'npm' | 'yarn' | 'pnpm' | 'bun') {
         return super.getBundleDependencyPackageManager(rootDir, explicitManager);
       }
     }

--- a/packages/deployer/src/bundler/lockfile.test.ts
+++ b/packages/deployer/src/bundler/lockfile.test.ts
@@ -127,6 +127,25 @@ describe('Bundler bundle lockfile authority', () => {
     expect(bundler.installs).toHaveLength(0);
   });
 
+  it('uses an explicit manager when the project has no source lock', async () => {
+    const projectRoot = join(tmpdir(), `mastra-lockfile-no-source-${Date.now()}-${Math.random()}`);
+    const explicitRoot = join(tmpdir(), `mastra-lockfile-explicit-${Date.now()}-${Math.random()}`);
+    await mkdir(projectRoot, { recursive: true });
+    await mkdir(explicitRoot, { recursive: true });
+    tempDirs.push(projectRoot, explicitRoot);
+    await writeFile(join(explicitRoot, 'pnpm-lock.yaml'), 'lock bytes\n');
+
+    class NoSourceBundler extends LockfileTestBundler {
+      protected getBundleDependencyPackageManager(_rootDir: string, explicitManager?: 'npm' | 'yarn' | 'pnpm' | 'bun') {
+        return explicitManager ?? 'npm';
+      }
+    }
+
+    const state = new NoSourceBundler().resolveState(projectRoot, join(explicitRoot, 'pnpm-lock.yaml'), false);
+    expect(state.packageManager).toBe('pnpm');
+    expect(state.frozen).toBe(true);
+  });
+
   it('rejects missing, directory, unsupported, and bun.lockb inputs', async () => {
     const cases = [
       ['pnpm-lock.yaml', 'does not exist'],
@@ -174,6 +193,21 @@ describe('Bundler bundle lockfile authority', () => {
 
     expect((bundler.installs[1]?.[3] as any).explicitLockfile).toBeUndefined();
     expect((bundler.installs[1]?.[3] as any).frozen).toBe(false);
+    expect(bundler.getState()).toBeUndefined();
+  });
+
+  it('clears state when the frozen installer fails without a fallback', async () => {
+    const { projectRoot, outputDirectory } = await createBundleFixture({ lockfile: 'pnpm-lock.yaml' });
+    class FailingBundler extends LockfileTestBundler {
+      protected async installDependencies(): Promise<void> {
+        throw new Error('frozen install failed');
+      }
+    }
+
+    const bundler = new FailingBundler({ lockfile: 'pnpm-lock.yaml' });
+    await expect(
+      bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), { projectRoot, outputDirectory }),
+    ).rejects.toThrow('frozen install failed');
     expect(bundler.getState()).toBeUndefined();
   });
 });

--- a/packages/deployer/src/bundler/lockfile.test.ts
+++ b/packages/deployer/src/bundler/lockfile.test.ts
@@ -1,0 +1,179 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Bundler } from './index';
+
+vi.mock('../build/analyze', () => ({
+  analyzeBundle: vi.fn(async () => ({
+    dependencies: new Map([['googleapis', '171.4.0']]),
+    externalDependencies: new Map([['googleapis', { version: '171.4.0' }]]),
+    workspaceMap: new Map(),
+  })),
+}));
+
+const tempDirs: string[] = [];
+
+class LockfileTestBundler extends Bundler {
+  readonly installs: unknown[][] = [];
+  private readonly options: { lockfile?: string; packageManager?: 'npm' | 'yarn' | 'pnpm' | 'bun' };
+
+  constructor(options: { lockfile?: string; packageManager?: 'npm' | 'yarn' | 'pnpm' | 'bun' } = {}) {
+    super('LockfileTest');
+    this.options = options;
+  }
+
+  async bundle(): Promise<void> {}
+
+  getEnvFiles(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+
+  protected async getUserBundlerOptions(): Promise<any> {
+    return { externals: [], ...this.options };
+  }
+
+  protected getBundleDependencyPackageManager(): 'npm' | 'yarn' | 'pnpm' | 'bun' {
+    return this.options.packageManager ?? 'pnpm';
+  }
+
+  protected async getBundlerOptions(): Promise<any> {
+    return { input: {}, plugins: [] };
+  }
+
+  protected createBundler(): any {
+    return { write: vi.fn(async () => undefined) };
+  }
+
+  runBundle(serverFile: string, mastraEntryFile: string, options: { projectRoot: string; outputDirectory: string }) {
+    return this._bundle(serverFile, mastraEntryFile, options);
+  }
+
+  getState() {
+    return this.bundleDependencyInstallState;
+  }
+
+  resolveState(projectRoot: string, lockfile: string | undefined, hasPackedWorkspaceDependencies: boolean) {
+    return this.resolveBundleDependencyInstallState({ projectRoot, lockfile, hasPackedWorkspaceDependencies });
+  }
+
+  protected async installDependencies(...args: unknown[]): Promise<void> {
+    this.installs.push(args);
+    const outputDirectory = args[0] as string;
+    const state = args[3] as { explicitLockfile?: { basename: string } } | undefined;
+    if (state?.explicitLockfile) {
+      const copied = await readFile(join(outputDirectory, this.outputDir, state.explicitLockfile.basename), 'utf8');
+      expect(copied).toBe('lock bytes\n');
+    }
+  }
+}
+
+async function createBundleFixture(options: { lockfile?: string } = {}) {
+  const projectRoot = join(tmpdir(), `mastra-lockfile-project-${Date.now()}-${Math.random()}`);
+  await mkdir(projectRoot, { recursive: true });
+  const outputDirectory = join(projectRoot, 'build');
+  await mkdir(join(outputDirectory, 'output'), { recursive: true });
+  await writeFile(join(projectRoot, 'pnpm-lock.yaml'), 'lock bytes\n');
+  tempDirs.push(projectRoot);
+  return { projectRoot, outputDirectory, bundler: new LockfileTestBundler(options) };
+}
+
+describe('Bundler bundle lockfile authority', () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('copies exact lock bytes before the installer and skips secondary npm', async () => {
+    const { projectRoot, outputDirectory, bundler } = await createBundleFixture({ lockfile: 'pnpm-lock.yaml' });
+
+    await bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), {
+      projectRoot,
+      outputDirectory,
+    });
+
+    expect(bundler.installs).toHaveLength(1);
+    expect((bundler.installs[0]?.[3] as any).packageManager).toBe('pnpm');
+    expect((bundler.installs[0]?.[3] as any).frozen).toBe(true);
+    expect(await readFile(join(outputDirectory, 'output', 'pnpm-lock.yaml'), 'utf8')).toBe('lock bytes\n');
+    expect(bundler.getState()).toBeUndefined();
+  });
+
+  it.each(['npm', 'pnpm', 'yarn', 'bun'] as const)(
+    'preserves automatic %s manager selection without a lock',
+    packageManager => {
+      const bundler = new LockfileTestBundler({ packageManager });
+      const state = bundler.resolveState(tmpdir(), undefined, false);
+
+      expect(state.packageManager).toBe(packageManager);
+      expect(state.frozen).toBe(false);
+      expect(state.generateSecondaryNpmLockfile).toBe(packageManager === 'npm');
+    },
+  );
+
+  it('gates the secondary npm lock on normal npm installs without packed workspaces', () => {
+    const bundler = new LockfileTestBundler({ packageManager: 'npm' });
+
+    expect(bundler.resolveState(tmpdir(), undefined, false).generateSecondaryNpmLockfile).toBe(true);
+    expect(bundler.resolveState(tmpdir(), undefined, true).generateSecondaryNpmLockfile).toBe(false);
+  });
+
+  it('rejects a manager mismatch and never reaches the installer', async () => {
+    const { projectRoot, outputDirectory, bundler } = await createBundleFixture({ lockfile: 'package-lock.json' });
+    await writeFile(join(projectRoot, 'package-lock.json'), '{}\n');
+
+    await expect(
+      bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), { projectRoot, outputDirectory }),
+    ).rejects.toThrow('does not match the pnpm bundle installer');
+    expect(bundler.installs).toHaveLength(0);
+  });
+
+  it('rejects missing, directory, unsupported, and bun.lockb inputs', async () => {
+    const cases = [
+      ['pnpm-lock.yaml', 'does not exist'],
+      ['package-lock.json', 'must be a file'],
+      ['unsupported.lock', 'Unsupported bundle lockfile'],
+      ['bun.lockb', 'Unsupported bundle lockfile'],
+    ] as const;
+
+    for (const [lockfile, message] of cases) {
+      const { projectRoot, outputDirectory, bundler } = await createBundleFixture({ lockfile });
+      if (lockfile === 'package-lock.json') await mkdir(join(projectRoot, lockfile));
+      if (message === 'does not exist') await rm(join(projectRoot, lockfile), { force: true });
+
+      await expect(
+        bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), { projectRoot, outputDirectory }),
+      ).rejects.toThrow(message);
+      expect(bundler.installs).toHaveLength(0);
+    }
+  });
+
+  it('keeps the original three installer arguments for an old subclass', async () => {
+    const { projectRoot, outputDirectory } = await createBundleFixture();
+    const calls: unknown[][] = [];
+    class OldBundler extends LockfileTestBundler {
+      protected async installDependencies(...args: unknown[]): Promise<void> {
+        calls.push(args.slice(0, 3));
+      }
+    }
+    const bundler = new OldBundler();
+
+    await bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), { projectRoot, outputDirectory });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.length).toBe(3);
+    expect(calls[0]?.[2]).toEqual({});
+    expect(bundler.getState()).toBeUndefined();
+  });
+
+  it('does not leak explicit state into a later automatic build', async () => {
+    const { projectRoot, outputDirectory, bundler } = await createBundleFixture({ lockfile: 'pnpm-lock.yaml' });
+
+    await bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), { projectRoot, outputDirectory });
+    (bundler as any).options.lockfile = undefined;
+    await bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), { projectRoot, outputDirectory });
+
+    expect((bundler.installs[1]?.[3] as any).explicitLockfile).toBeUndefined();
+    expect((bundler.installs[1]?.[3] as any).frozen).toBe(false);
+    expect(bundler.getState()).toBeUndefined();
+  });
+});

--- a/packages/deployer/src/bundler/lockfile.test.ts
+++ b/packages/deployer/src/bundler/lockfile.test.ts
@@ -33,7 +33,13 @@ class LockfileTestBundler extends Bundler {
     this.options = options;
   }
 
-  async bundle(): Promise<void> {}
+  async bundle(
+    serverFile: string,
+    mastraEntryFile: string,
+    options: { projectRoot: string; outputDirectory: string },
+  ): Promise<void> {
+    await this.runBundle(serverFile, mastraEntryFile, options);
+  }
 
   getEnvFiles(): Promise<string[]> {
     return Promise.resolve([]);
@@ -96,7 +102,7 @@ describe('Bundler bundle lockfile authority', () => {
   it('copies exact lock bytes before the installer and skips secondary npm', async () => {
     const { projectRoot, outputDirectory, bundler } = await createBundleFixture({ lockfile: 'pnpm-lock.yaml' });
 
-    await bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), {
+    await bundler.bundle('server-file', join(projectRoot, 'mastra.ts'), {
       projectRoot,
       outputDirectory,
     });

--- a/packages/deployer/src/bundler/lockfile.test.ts
+++ b/packages/deployer/src/bundler/lockfile.test.ts
@@ -2,15 +2,25 @@ import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DepsService } from '../services';
 import { Bundler } from './index';
 
-vi.mock('../build/analyze', () => ({
-  analyzeBundle: vi.fn(async () => ({
-    dependencies: new Map([['googleapis', '171.4.0']]),
-    externalDependencies: new Map([['googleapis', { version: '171.4.0' }]]),
-    workspaceMap: new Map(),
-  })),
-}));
+vi.mock('../build/analyze', async () => {
+  const { readFileSync } = await import('node:fs');
+  const issueReproduction = JSON.parse(
+    readFileSync(new URL('./fixtures/issue-20357/package.json', import.meta.url), 'utf8'),
+  ) as { dependencies: Record<string, string> };
+
+  return {
+    analyzeBundle: vi.fn(async () => ({
+      dependencies: new Map(Object.entries(issueReproduction.dependencies)),
+      externalDependencies: new Map(
+        Object.entries(issueReproduction.dependencies).map(([name, version]) => [name, { version }]),
+      ),
+      workspaceMap: new Map(),
+    })),
+  };
+});
 
 const tempDirs: string[] = [];
 
@@ -136,14 +146,44 @@ describe('Bundler bundle lockfile authority', () => {
     await writeFile(join(explicitRoot, 'pnpm-lock.yaml'), 'lock bytes\n');
 
     class NoSourceBundler extends LockfileTestBundler {
-      protected getBundleDependencyPackageManager(_rootDir: string, explicitManager?: 'npm' | 'yarn' | 'pnpm' | 'bun') {
-        return explicitManager ?? 'npm';
+      protected getBundleDependencyPackageManager(
+        rootDir: string,
+        explicitManager?: 'npm' | 'yarn' | 'pnpm' | 'bun',
+      ) {
+        return super.getBundleDependencyPackageManager(rootDir, explicitManager);
       }
     }
 
     const state = new NoSourceBundler().resolveState(projectRoot, join(explicitRoot, 'pnpm-lock.yaml'), false);
     expect(state.packageManager).toBe('pnpm');
     expect(state.frozen).toBe(true);
+  });
+
+  it('forwards the install state through the base installer seam', async () => {
+    const { projectRoot, outputDirectory, bundler } = await createBundleFixture();
+    const installState = {
+      packageManager: 'pnpm' as const,
+      frozen: true,
+      generateSecondaryNpmLockfile: false,
+    };
+    const install = vi.spyOn(DepsService.prototype, 'install').mockResolvedValue(undefined);
+
+    try {
+      await (Bundler.prototype as any).installDependencies.call(
+        bundler,
+        outputDirectory,
+        projectRoot,
+        {},
+        installState,
+      );
+      expect(install).toHaveBeenCalledWith({
+        dir: join(outputDirectory, 'output'),
+        pnpmOverrides: {},
+        installState,
+      });
+    } finally {
+      install.mockRestore();
+    }
   });
 
   it('rejects missing, directory, unsupported, and bun.lockb inputs', async () => {

--- a/packages/deployer/src/bundler/lockfile.test.ts
+++ b/packages/deployer/src/bundler/lockfile.test.ts
@@ -66,10 +66,6 @@ class LockfileTestBundler extends Bundler {
     return this._bundle(serverFile, mastraEntryFile, options);
   }
 
-  getState() {
-    return this.bundleDependencyInstallState;
-  }
-
   resolveState(projectRoot: string, lockfile: string | undefined, hasPackedWorkspaceDependencies: boolean) {
     return this.resolveBundleDependencyInstallState({ projectRoot, lockfile, hasPackedWorkspaceDependencies });
   }
@@ -130,7 +126,6 @@ describe('Bundler bundle lockfile authority', () => {
     expect((bundler.installs[0]?.[3] as any).packageManager).toBe('pnpm');
     expect((bundler.installs[0]?.[3] as any).frozen).toBe(true);
     expect(await readFile(join(outputDirectory, 'output', 'pnpm-lock.yaml'), 'utf8')).toBe('lock bytes\n');
-    expect(bundler.getState()).toBeUndefined();
   });
 
   it.each(['npm', 'pnpm', 'yarn', 'bun'] as const)(
@@ -165,7 +160,6 @@ describe('Bundler bundle lockfile authority', () => {
     expect((bundler.installs[0]?.[3] as any).explicitLockfile.basename).toBe('package-lock.json');
     expect(await readFile(join(outputDirectory, 'output', 'package-lock.json'), 'utf8')).toBe('lock bytes\n');
     expect((bundler.installs[0]?.[3] as any).generateSecondaryNpmLockfile).toBe(false);
-    expect(bundler.getState()).toBeUndefined();
   });
 
   it.each(['relative traversal', 'absolute outside path'] as const)(
@@ -332,7 +326,6 @@ describe('Bundler bundle lockfile authority', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.length).toBe(3);
     expect(calls[0]?.[2]).toEqual({});
-    expect(bundler.getState()).toBeUndefined();
   });
 
   it('does not leak explicit state into a later automatic build', async () => {
@@ -344,7 +337,6 @@ describe('Bundler bundle lockfile authority', () => {
 
     expect((bundler.installs[1]?.[3] as any).explicitLockfile).toBeUndefined();
     expect((bundler.installs[1]?.[3] as any).frozen).toBe(false);
-    expect(bundler.getState()).toBeUndefined();
   });
 
   it('clears state when the frozen installer fails without a fallback', async () => {
@@ -359,6 +351,5 @@ describe('Bundler bundle lockfile authority', () => {
     await expect(
       bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), { projectRoot, outputDirectory }),
     ).rejects.toThrow('frozen install failed');
-    expect(bundler.getState()).toBeUndefined();
   });
 });

--- a/packages/deployer/src/bundler/lockfile.test.ts
+++ b/packages/deployer/src/bundler/lockfile.test.ts
@@ -179,11 +179,14 @@ describe('Bundler bundle lockfile authority', () => {
       tempDirs.push(outsideRoot);
 
       const lockfile = pathKind === 'relative traversal' ? relative(projectRoot, outsideLockfile) : outsideLockfile;
-      const bundler = new BaseManagerBundler();
+      const bundler = new BaseManagerBundler({ lockfile });
 
-      expect(() => bundler.resolveState(projectRoot, lockfile, false)).toThrow(
-        'Bundle lockfile must stay within project root',
-      );
+      await expect(
+        bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), {
+          projectRoot,
+          outputDirectory: join(projectRoot, 'build'),
+        }),
+      ).rejects.toThrow('Bundle lockfile must stay within project root');
       expect(bundler.installs).toHaveLength(0);
     },
   );
@@ -221,10 +224,13 @@ describe('Bundler bundle lockfile authority', () => {
     tempDirs.push(outsideRoot);
     if (!(await createSymlink(outsideLockfile, linkedLockfile, 'file'))) return;
 
-    const bundler = new BaseManagerBundler();
-    expect(() => bundler.resolveState(projectRoot, 'package-lock.json', false)).toThrow(
-      'Bundle lockfile must stay within project root',
-    );
+    const bundler = new BaseManagerBundler({ lockfile: 'package-lock.json' });
+    await expect(
+      bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), {
+        projectRoot,
+        outputDirectory: join(projectRoot, 'build'),
+      }),
+    ).rejects.toThrow('Bundle lockfile must stay within project root');
     expect(bundler.installs).toHaveLength(0);
   });
 
@@ -237,10 +243,13 @@ describe('Bundler bundle lockfile authority', () => {
     tempDirs.push(outsideRoot);
     if (!(await createSymlink(outsideRoot, linkedDirectory, 'junction'))) return;
 
-    const bundler = new BaseManagerBundler();
-    expect(() => bundler.resolveState(projectRoot, 'linked-locks/package-lock.json', false)).toThrow(
-      'Bundle lockfile must stay within project root',
-    );
+    const bundler = new BaseManagerBundler({ lockfile: 'linked-locks/package-lock.json' });
+    await expect(
+      bundler.runBundle('server-file', join(projectRoot, 'mastra.ts'), {
+        projectRoot,
+        outputDirectory: join(projectRoot, 'build'),
+      }),
+    ).rejects.toThrow('Bundle lockfile must stay within project root');
     expect(bundler.installs).toHaveLength(0);
   });
 

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -1,6 +1,14 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { MastraError } from '@mastra/core/error';
-import { describe, expect, it } from 'vitest';
-import { copyPnpmWorkspaceSettings, getPnpmIgnoredBuildPackages } from './deps';
+import { describe, expect, it, vi } from 'vitest';
+import { createChildProcessLogger } from '../deploy/log';
+import { copyPnpmWorkspaceSettings, DepsService, getPnpmIgnoredBuildPackages } from './deps';
+
+vi.mock('../deploy/log', () => ({
+  createChildProcessLogger: vi.fn(() => vi.fn(async () => undefined)),
+}));
 
 describe('getPnpmIgnoredBuildPackages', () => {
   it('extracts package names from pnpm ignored-build diagnostics', () => {
@@ -93,5 +101,45 @@ describe('copyPnpmWorkspaceSettings', () => {
     expect(copyPnpmWorkspaceSettings('', { pnpmNodeLinker: 'hoisted' })).toBe(
       `packages:\n  - '.'\n\nnodeLinker: hoisted\n`,
     );
+  });
+});
+
+describe('DepsService explicit lock install commands', () => {
+  it('does not auto-detect bun.lockb', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastra-deps-bun-lockb-'));
+    try {
+      await writeFile(join(dir, 'bun.lockb'), Buffer.from([0, 1, 2]));
+      expect(new DepsService(dir).getPackageManager()).toBe('npm');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['npm', 'npm ci --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false'],
+    ['pnpm', 'pnpm install --frozen-lockfile --loglevel=error'],
+    ['yarn', 'yarn install --immutable'],
+    ['bun', 'bun install --frozen-lockfile'],
+  ] as const)('uses the frozen %s command', async (packageManager, command) => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastra-deps-command-'));
+    try {
+      const deps = new DepsService(dir);
+      const installState = {
+        packageManager,
+        frozen: true,
+        generateSecondaryNpmLockfile: false,
+      } as const;
+
+      await deps.install({ dir, installState });
+
+      const childProcessLogger = vi.mocked(createChildProcessLogger).mock.results.at(-1)?.value;
+      expect(childProcessLogger).toHaveBeenCalledWith({
+        cmd: command,
+        args: [],
+        env: process.env,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -142,4 +142,27 @@ describe('DepsService explicit lock install commands', () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it('propagates frozen install failure without a mutable fallback', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastra-deps-frozen-failure-'));
+    const failure = new Error('frozen install failed');
+    const childProcessLogger = vi.fn().mockRejectedValue(failure);
+    vi.mocked(createChildProcessLogger).mockReturnValueOnce(childProcessLogger as any);
+
+    try {
+      await expect(
+        new DepsService(dir).install({
+          dir,
+          installState: {
+            packageManager: 'pnpm',
+            frozen: true,
+            generateSecondaryNpmLockfile: false,
+          },
+        }),
+      ).rejects.toThrow('frozen install failed');
+      expect(childProcessLogger).toHaveBeenCalledTimes(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -118,7 +118,7 @@ describe('DepsService explicit lock install commands', () => {
   it.each([
     ['npm', 'npm ci --force --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false'],
     ['pnpm', 'pnpm install --frozen-lockfile --loglevel=error'],
-    ['yarn', 'yarn install --frozen-lockfile'],
+    ['yarn', 'yarn install --immutable'],
     ['bun', 'bun install --frozen-lockfile'],
   ] as const)('uses the frozen %s command', async (packageManager, command) => {
     const dir = await mkdtemp(join(tmpdir(), 'mastra-deps-command-'));

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -118,7 +118,7 @@ describe('DepsService explicit lock install commands', () => {
   it.each([
     ['npm', 'npm ci --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false'],
     ['pnpm', 'pnpm install --frozen-lockfile --loglevel=error'],
-    ['yarn', 'yarn install --immutable'],
+    ['yarn', 'yarn install --frozen-lockfile'],
     ['bun', 'bun install --frozen-lockfile'],
   ] as const)('uses the frozen %s command', async (packageManager, command) => {
     const dir = await mkdtemp(join(tmpdir(), 'mastra-deps-command-'));

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -116,7 +116,7 @@ describe('DepsService explicit lock install commands', () => {
   });
 
   it.each([
-    ['npm', 'npm ci --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false'],
+    ['npm', 'npm ci --force --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false'],
     ['pnpm', 'pnpm install --frozen-lockfile --loglevel=error'],
     ['yarn', 'yarn install --frozen-lockfile'],
     ['bun', 'bun install --frozen-lockfile'],

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -54,7 +54,7 @@ describe('DepsService explicit lock install commands', () => {
   });
 
   it.each([
-    ['npm', 'npm ci --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false'],
+    ['npm', 'npm ci --force --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false'],
     ['pnpm', 'pnpm install --frozen-lockfile --loglevel=error'],
     ['yarn', 'yarn install --frozen-lockfile'],
     ['bun', 'bun install --frozen-lockfile'],

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -80,4 +80,27 @@ describe('DepsService explicit lock install commands', () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it('propagates frozen install failure without a mutable fallback', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastra-deps-frozen-failure-'));
+    const failure = new Error('frozen install failed');
+    const childProcessLogger = vi.fn().mockRejectedValue(failure);
+    vi.mocked(createChildProcessLogger).mockReturnValueOnce(childProcessLogger as any);
+
+    try {
+      await expect(
+        new DepsService(dir).install({
+          dir,
+          installState: {
+            packageManager: 'pnpm',
+            frozen: true,
+            generateSecondaryNpmLockfile: false,
+          },
+        }),
+      ).rejects.toThrow('frozen install failed');
+      expect(childProcessLogger).toHaveBeenCalledTimes(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -56,7 +56,7 @@ describe('DepsService explicit lock install commands', () => {
   it.each([
     ['npm', 'npm ci --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false'],
     ['pnpm', 'pnpm install --frozen-lockfile --loglevel=error'],
-    ['yarn', 'yarn install --immutable'],
+    ['yarn', 'yarn install --frozen-lockfile'],
     ['bun', 'bun install --frozen-lockfile'],
   ] as const)('uses the frozen %s command', async (packageManager, command) => {
     const dir = await mkdtemp(join(tmpdir(), 'mastra-deps-command-'));

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest';
-import { copyPnpmWorkspaceSettings } from './deps';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { createChildProcessLogger } from '../deploy/log';
+import { copyPnpmWorkspaceSettings, DepsService } from './deps';
+
+vi.mock('../deploy/log', () => ({
+  createChildProcessLogger: vi.fn(() => vi.fn(async () => undefined)),
+}));
 
 describe('copyPnpmWorkspaceSettings', () => {
   it('copies pnpm install policy without copying source workspace packages', () => {
@@ -31,5 +39,45 @@ describe('copyPnpmWorkspaceSettings', () => {
     expect(output).toBe(
       `packages:\n  - '.'\n\noverrides:\n  \"@inner/transitive-c\": \"file:./workspace-module/inner-transitive-c-1.0.0.tgz\"\n`,
     );
+  });
+});
+
+describe('DepsService explicit lock install commands', () => {
+  it('does not auto-detect bun.lockb', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastra-deps-bun-lockb-'));
+    try {
+      await writeFile(join(dir, 'bun.lockb'), Buffer.from([0, 1, 2]));
+      expect(new DepsService(dir).getPackageManager()).toBe('npm');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['npm', 'npm ci --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false'],
+    ['pnpm', 'pnpm install --frozen-lockfile --loglevel=error'],
+    ['yarn', 'yarn install --immutable'],
+    ['bun', 'bun install --frozen-lockfile'],
+  ] as const)('uses the frozen %s command', async (packageManager, command) => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastra-deps-command-'));
+    try {
+      const deps = new DepsService(dir);
+      const installState = {
+        packageManager,
+        frozen: true,
+        generateSecondaryNpmLockfile: false,
+      } as const;
+
+      await deps.install({ dir, installState });
+
+      const childProcessLogger = vi.mocked(createChildProcessLogger).mock.results.at(-1)?.value;
+      expect(childProcessLogger).toHaveBeenCalledWith({
+        cmd: command,
+        args: [],
+        env: process.env,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -189,7 +189,7 @@ export class Deps extends MastraBase {
     this.packageManager = this.getPackageManager();
   }
 
-  private findLockFile(dir: string): string | null {
+  public getLockFile(dir = this.rootDir): string | null {
     const lockFiles = ['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock', 'bun.lock'];
     for (const file of lockFiles) {
       if (fs.existsSync(path.join(dir, file))) {
@@ -198,13 +198,13 @@ export class Deps extends MastraBase {
     }
     const parentDir = path.resolve(dir, '..');
     if (parentDir !== dir) {
-      return this.findLockFile(parentDir);
+      return this.getLockFile(parentDir);
     }
     return null;
   }
 
   public getPackageManager(): PackageManager {
-    const lockFile = this.findLockFile(this.rootDir);
+    const lockFile = this.getLockFile();
     switch (lockFile) {
       case 'pnpm-lock.yaml':
         return 'pnpm';
@@ -316,7 +316,7 @@ export class Deps extends MastraBase {
       case 'npm':
         return `${frozen ? 'ci --force' : cmd} --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false`;
       case 'yarn':
-        return `${cmd}${frozen ? ' --immutable' : ''}`;
+        return `${cmd}${frozen ? ' --frozen-lockfile' : ''}`;
       case 'pnpm':
         return `${cmd}${frozen ? ' --frozen-lockfile' : ''} --loglevel=error`;
       case 'bun':

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -316,7 +316,7 @@ export class Deps extends MastraBase {
       case 'npm':
         return `${frozen ? 'ci --force' : cmd} --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false`;
       case 'yarn':
-        return `${cmd}${frozen ? ' --frozen-lockfile' : ''}`;
+        return `${cmd}${frozen ? ' --immutable' : ''}`;
       case 'pnpm':
         return `${cmd}${frozen ? ' --frozen-lockfile' : ''} --loglevel=error`;
       case 'bun':

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -10,7 +10,19 @@ import { parse } from 'yaml';
 
 import { createChildProcessLogger } from '../deploy/log.js';
 
-type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
+
+export type BundleLockfileName = 'package-lock.json' | 'pnpm-lock.yaml' | 'yarn.lock' | 'bun.lock';
+
+export type BundleDependencyInstallState = {
+  packageManager: PackageManager;
+  explicitLockfile?: {
+    sourcePath: string;
+    basename: BundleLockfileName;
+  };
+  frozen: boolean;
+  generateSecondaryNpmLockfile: boolean;
+};
 
 interface ArchitectureOptions {
   os?: string[];
@@ -191,7 +203,7 @@ export class Deps extends MastraBase {
     return null;
   }
 
-  private getPackageManager(): PackageManager {
+  public getPackageManager(): PackageManager {
     const lockFile = this.findLockFile(this.rootDir);
     switch (lockFile) {
       case 'pnpm-lock.yaml':
@@ -297,18 +309,18 @@ export class Deps extends MastraBase {
    * Depending on whether we want to install or add a package, this function returns the appropriate commands.
    * All package managers support both commands (e.g. npm install has an alias on "add")
    */
-  private getPackageManagerCommand(pm: PackageManager, type: 'install' | 'add'): string {
+  private getPackageManagerCommand(pm: PackageManager, type: 'install' | 'add', frozen = false): string {
     const cmd = type === 'install' ? 'install' : 'add';
 
     switch (pm) {
       case 'npm':
-        return `${cmd} --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false`;
+        return `${frozen ? 'ci --force' : cmd} --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false`;
       case 'yarn':
-        return `${cmd}`;
+        return `${cmd}${frozen ? ' --immutable' : ''}`;
       case 'pnpm':
-        return cmd === 'install' ? `${cmd} --loglevel=error` : `${cmd} --loglevel=error`;
+        return `${cmd}${frozen ? ' --frozen-lockfile' : ''} --loglevel=error`;
       case 'bun':
-        return cmd;
+        return `${cmd}${frozen ? ' --frozen-lockfile' : ''}`;
       default:
         return cmd;
     }
@@ -319,14 +331,16 @@ export class Deps extends MastraBase {
     architecture,
     pnpmOverrides,
     pnpmNodeLinker,
+    installState,
   }: {
     dir?: string;
     architecture?: ArchitectureOptions;
     pnpmOverrides?: Record<string, string>;
     pnpmNodeLinker?: 'hoisted';
+    installState?: BundleDependencyInstallState;
   } = {}) {
-    const pm = this.packageManager;
-    const installCommand = this.getPackageManagerCommand(pm, 'install');
+    const pm = installState?.packageManager ?? this.packageManager;
+    const installCommand = this.getPackageManagerCommand(pm, 'install', installState?.frozen ?? false);
     let args: string[] = [];
 
     switch (pm) {

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -8,7 +8,19 @@ import type { PackageJson } from 'type-fest';
 
 import { createChildProcessLogger } from '../deploy/log.js';
 
-type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
+
+export type BundleLockfileName = 'package-lock.json' | 'pnpm-lock.yaml' | 'yarn.lock' | 'bun.lock';
+
+export type BundleDependencyInstallState = {
+  packageManager: PackageManager;
+  explicitLockfile?: {
+    sourcePath: string;
+    basename: BundleLockfileName;
+  };
+  frozen: boolean;
+  generateSecondaryNpmLockfile: boolean;
+};
 
 interface ArchitectureOptions {
   os?: string[];
@@ -119,7 +131,7 @@ export class Deps extends MastraBase {
     return null;
   }
 
-  private getPackageManager(): PackageManager {
+  public getPackageManager(): PackageManager {
     const lockFile = this.findLockFile(this.rootDir);
     switch (lockFile) {
       case 'pnpm-lock.yaml':
@@ -225,18 +237,18 @@ export class Deps extends MastraBase {
    * Depending on whether we want to install or add a package, this function returns the appropriate commands.
    * All package managers support both commands (e.g. npm install has an alias on "add")
    */
-  private getPackageManagerCommand(pm: PackageManager, type: 'install' | 'add'): string {
+  private getPackageManagerCommand(pm: PackageManager, type: 'install' | 'add', frozen = false): string {
     const cmd = type === 'install' ? 'install' : 'add';
 
     switch (pm) {
       case 'npm':
-        return `${cmd} --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false`;
+        return `${frozen ? 'ci' : cmd} --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false`;
       case 'yarn':
-        return `${cmd}`;
+        return `${cmd}${frozen ? ' --immutable' : ''}`;
       case 'pnpm':
-        return cmd === 'install' ? `${cmd} --loglevel=error` : `${cmd} --loglevel=error`;
+        return `${cmd}${frozen ? ' --frozen-lockfile' : ''} --loglevel=error`;
       case 'bun':
-        return cmd;
+        return `${cmd}${frozen ? ' --frozen-lockfile' : ''}`;
       default:
         return cmd;
     }
@@ -246,9 +258,15 @@ export class Deps extends MastraBase {
     dir = this.rootDir,
     architecture,
     pnpmOverrides,
-  }: { dir?: string; architecture?: ArchitectureOptions; pnpmOverrides?: Record<string, string> } = {}) {
-    const pm = this.packageManager;
-    const installCommand = this.getPackageManagerCommand(pm, 'install');
+    installState,
+  }: {
+    dir?: string;
+    architecture?: ArchitectureOptions;
+    pnpmOverrides?: Record<string, string>;
+    installState?: BundleDependencyInstallState;
+  } = {}) {
+    const pm = installState?.packageManager ?? this.packageManager;
+    const installCommand = this.getPackageManagerCommand(pm, 'install', installState?.frozen ?? false);
     let args: string[] = [];
 
     switch (pm) {

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -242,7 +242,7 @@ export class Deps extends MastraBase {
 
     switch (pm) {
       case 'npm':
-        return `${frozen ? 'ci' : cmd} --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false`;
+        return `${frozen ? 'ci --force' : cmd} --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false`;
       case 'yarn':
         return `${cmd}${frozen ? ' --frozen-lockfile' : ''}`;
       case 'pnpm':

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -117,7 +117,7 @@ export class Deps extends MastraBase {
     this.packageManager = this.getPackageManager();
   }
 
-  private findLockFile(dir: string): string | null {
+  public getLockFile(dir = this.rootDir): string | null {
     const lockFiles = ['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock', 'bun.lock'];
     for (const file of lockFiles) {
       if (fs.existsSync(path.join(dir, file))) {
@@ -126,13 +126,13 @@ export class Deps extends MastraBase {
     }
     const parentDir = path.resolve(dir, '..');
     if (parentDir !== dir) {
-      return this.findLockFile(parentDir);
+      return this.getLockFile(parentDir);
     }
     return null;
   }
 
   public getPackageManager(): PackageManager {
-    const lockFile = this.findLockFile(this.rootDir);
+    const lockFile = this.getLockFile();
     switch (lockFile) {
       case 'pnpm-lock.yaml':
         return 'pnpm';
@@ -244,7 +244,7 @@ export class Deps extends MastraBase {
       case 'npm':
         return `${frozen ? 'ci' : cmd} --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false`;
       case 'yarn':
-        return `${cmd}${frozen ? ' --immutable' : ''}`;
+        return `${cmd}${frozen ? ' --frozen-lockfile' : ''}`;
       case 'pnpm':
         return `${cmd}${frozen ? ' --frozen-lockfile' : ''} --loglevel=error`;
       case 'bun':

--- a/packages/deployer/src/services/index.ts
+++ b/packages/deployer/src/services/index.ts
@@ -1,3 +1,8 @@
-export { DepsService } from './deps';
+export {
+  DepsService,
+  type BundleDependencyInstallState,
+  type BundleLockfileName,
+  type PackageManager,
+} from './deps';
 export { EnvService } from './env';
 export { FileService } from './fs';


### PR DESCRIPTION
Fixes #20357

## Summary

`mastra build` can install bundle dependencies through one manager while a later npm lock step describes another dependency graph. This makes the output lock and installed tree difficult to reproduce, and the pnpm symlink layout it produced was the one exposed to the link failure in #20357.

## Root cause

The deployer installs generated dependencies before its secondary npm lock step. Non-npm projects therefore have no lock-authoritative bundle install, and the later npm step can reinterpret the result.

## Changes

- Add `bundler.lockfile` for an explicit bundle-specific lock generated from the bundle output manifest.
- Resolve the configured path relative to the project root, require a regular file inside that root, reject traversal and symlink escapes, and copy the validated file beside the generated manifest before installation.
- Install it with the manager selected by the lockfile's basename, in frozen mode. This lets a pnpm, Yarn, or Bun project pin an npm `package-lock.json` for the bundle and get both a locked graph and npm's hoisted tree.
- Use Yarn's immutable frozen-install flag and run the frozen npm install with `--force`, matching the generator and Cloud adapter.
- Keep automatic source-manager detection when no explicit lock is configured, with secondary npm lock generation only on the normal npm path.
- Preserve the protected installer seam, pnpm workspace policy, Cloud's npm-only explicit-lock boundary, and Netlify architecture routing.
- Forward install state through ExperimentBundler and keep that state local to each build.
- Document the bundle-output lock requirement and the Cloud `package-lock.json` restriction.

## Configuration

Generate the lockfile for the generated bundle's `package.json`, then configure its path:

```ts
const mastra = new Mastra({
  bundler: {
    lockfile: './bundle-lock/package-lock.json',
  },
});
```

## Scope

Automatic inheritance of transitive versions from a source lock remains separate. `bun.lockb` remains outside automatic deployer detection until it can be copied and consumed coherently. Cloud accepts explicit locks only when the basename is `package-lock.json`.

## Test plan

- Bundle lockfile tests cover containment, canonical symlinks, exact copy and install order across source managers, explicit npm pinning from a pnpm project, regular-file validation, retained missing/directory errors, and per-build state isolation.
- Deployer tests cover frozen npm, pnpm, Yarn, and Bun commands, the existing three-argument subclass seam, pnpm workspace policy, and workspace packing.
- Cloud and Netlify tests cover their installer and architecture paths.
- The monorepo test exercises a real generated bundle, creates a lockfile from its output manifest, rebuilds with `bundler.lockfile`, and verifies copied bytes plus an installed external dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes bundle installs use the selected lockfile before installing dependencies. This keeps dependency versions stable between builds.

## Changes

- Added `bundler.lockfile` support for npm, pnpm, Yarn, and Bun lockfiles.
- Copies explicit lockfiles into the bundle before installation.
- Selects the package manager from the configured lockfile name.
- Uses frozen installs, including `npm ci --force`.
- Preserves source-manager detection when no explicit lockfile is configured.
- Controls secondary npm lockfile generation for explicit locks and packed workspace dependencies.
- Preserves Cloud and Netlify installation behavior.
- Adds exported dependency installation types and state handling.
- Clears installation state after each build, including failed installs.
- Adds documentation, fixtures, end-to-end coverage, and tests for lockfile handling, install commands, routing, workspace behavior, and state isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
