### PR TITLE
fix(core): resolve structured object after an output-processor retry

### DIFF
--- a/.changeset/stale-object-after-retry.md
+++ b/.changeset/stale-object-after-retry.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `result.object` staying stale after a successful output-processor retry. When an `OutputProcessor` rejected a structured-output attempt with `abort(reason, { retry: true })`, the retried model call emitted a fresh `object-result` chunk, but `object` had already been resolved from the rejected first attempt and kept that value. `result.text` advanced to the retried response while `result.object` silently did not, with no warning to signal the divergence — so consumers reading `result.object` received the answer the processor had just rejected.
+
+`object-result` chunks are now buffered and the promise is resolved once on `finish`, from the last chunk received. Resolving per chunk could not be fixed by simply preferring the latest value: any consumer that reads `result.object` before the stream drains materializes the underlying promise, and a settled promise ignores every later `resolve`. A validation rejection is still never overwritten. Fixes https://github.com/mastra-ai/mastra/issues/20570

--- a/.changeset/stale-object-after-retry.md
+++ b/.changeset/stale-object-after-retry.md
@@ -2,6 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed `result.object` staying stale after a successful output-processor retry. When an `OutputProcessor` rejected a structured-output attempt with `abort(reason, { retry: true })`, the retried model call emitted a fresh `object-result` chunk, but `object` had already been resolved from the rejected first attempt and kept that value. `result.text` advanced to the retried response while `result.object` silently did not, with no warning to signal the divergence — so consumers reading `result.object` received the answer the processor had just rejected.
-
-`object-result` chunks are now buffered and the promise is resolved once on `finish`, from the last chunk received. Resolving per chunk could not be fixed by simply preferring the latest value: any consumer that reads `result.object` before the stream drains materializes the underlying promise, and a settled promise ignores every later `resolve`. A validation rejection is still never overwritten. Fixes https://github.com/mastra-ai/mastra/issues/20570
+Fixed `result.object` staying stale after a successful output-processor retry. When an `OutputProcessor` rejected a structured-output attempt with `abort(reason, { retry: true })`, `result.text` advanced to the retried response but `result.object` kept the rejected first attempt. `result.object` now resolves to the retried response. Fixes https://github.com/mastra-ai/mastra/issues/20570

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -1,5 +1,6 @@
 import { ReadableStream } from 'node:stream/web';
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import { MessageList } from '../../agent/message-list';
 import type { Processor, ProcessorStreamWriter } from '../../processors';
 import { ChunkFrom } from '../types';
@@ -1355,5 +1356,81 @@ describe('MastraModelOutput', () => {
       expect(aClosed).toBe(true);
       expect(receivedByA.map(c => c.type)).toEqual(['text-delta', 'text-delta', 'step-finish', 'finish']);
     }, 5000);
+  });
+  describe('structured output object after an output-processor retry', () => {
+    const createObjectResultChunk = (runId: string, object: unknown): ChunkType =>
+      ({ type: 'object-result', runId, from: ChunkFrom.AGENT, object }) as ChunkType;
+
+    it('resolves object with the retried attempt, not the rejected first one', async () => {
+      const runId = 'run-retry-object';
+      const rejected = { answer: 'first, rejected by the output processor' };
+      const retried = { answer: 'second, accepted' };
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream: createChunkStream([
+          createObjectResultChunk(runId, rejected),
+          createObjectResultChunk(runId, retried),
+          createStepFinishChunk(runId),
+          createFinishChunk(runId),
+        ]),
+        messageList: new MessageList(),
+        messageId: 'msg-retry-object',
+        options: { runId },
+      });
+
+      await output.consumeStream();
+
+      expect(await output.object).toEqual(retried);
+    });
+
+    it('keeps the final object when several retries occur', async () => {
+      const runId = 'run-multi-retry-object';
+      const final = { answer: 'third, accepted' };
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream: createChunkStream([
+          createObjectResultChunk(runId, { answer: 'first' }),
+          createObjectResultChunk(runId, { answer: 'second' }),
+          createObjectResultChunk(runId, final),
+          createStepFinishChunk(runId),
+          createFinishChunk(runId),
+        ]),
+        messageList: new MessageList(),
+        messageId: 'msg-multi-retry-object',
+        options: { runId },
+      });
+
+      await output.consumeStream();
+
+      expect(await output.object).toEqual(final);
+    });
+
+    it('gets the retried value even when object is read before the stream drains', async () => {
+      const runId = 'run-late-read-object';
+      const retried = { answer: 'second, accepted' };
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream: createChunkStream([
+          createObjectResultChunk(runId, { answer: 'first, rejected by the output processor' }),
+          createObjectResultChunk(runId, retried),
+          createStepFinishChunk(runId),
+          createFinishChunk(runId),
+        ]),
+        messageList: new MessageList(),
+        messageId: 'msg-late-read-object',
+        options: { runId, structuredOutput: { schema: z.object({ answer: z.string() }) } },
+      });
+
+      // The consumer-facing path: reading `.object` here materializes the underlying
+      // promise, so resolving per `object-result` chunk would settle it on the first,
+      // discarded attempt and ignore the retry.
+      const objectPromise = output.object;
+      await output.consumeStream();
+
+      expect(await objectPromise).toEqual(retried);
+    });
   });
 });

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -542,11 +542,13 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               }
               break;
             case 'object-result':
+              // Buffer only. An output processor that aborts with `{ retry: true }` runs
+              // the model again and the retried attempt emits a fresh `object-result`, so
+              // resolving here would pin `object` to the attempt that was thrown away:
+              // a consumer that read `result.object` before the stream drained has already
+              // materialized the underlying promise, and a settled promise ignores every
+              // later `resolve`. The buffer is resolved once, on `finish`.
               self.#bufferedObject = chunk.object;
-              // Only resolve if not already rejected by validation error
-              if (self.#delayedPromises.object.status.type === 'pending') {
-                self.#delayedPromises.object.resolve(chunk.object);
-              }
               break;
             case 'source':
               self.#bufferedSources.push(chunk);
@@ -1070,6 +1072,14 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 if (self.#delayedPromises.object.status.type !== 'resolved') {
                   self.#delayedPromises.object.resolve(undefined as OUTPUT);
                 }
+              }
+
+              // Resolve the structured object from the last buffered `object-result`, so a
+              // retried attempt wins over the one it replaced. Left pending, `flush` still
+              // settles it as undefined; already rejected by validation, or already
+              // resolved as undefined by the error path above, it stays untouched.
+              if (self.#bufferedObject !== undefined && self.#delayedPromises.object.status.type === 'pending') {
+                self.#delayedPromises.object.resolve(self.#bufferedObject);
               }
 
               const reasoningText =


### PR DESCRIPTION
## Description

When an `OutputProcessor` rejects a structured-output attempt with `abort(reason, { retry: true })`, the retried model call emits a fresh `object-result` chunk. `result.object` was resolved from the **first** chunk, so it kept the attempt the processor had just rejected, while `result.text` advanced to the retried response. The two silently disagreed, with no warning to signal the divergence.

### Root cause

`object-result` resolved the `object` promise inline, guarded on `status.type === 'pending'` — first write wins:

```ts
case 'object-result':
  self.#bufferedObject = chunk.object;
  // Only resolve if not already rejected by validation error
  if (self.#delayedPromises.object.status.type === 'pending') {
    self.#delayedPromises.object.resolve(chunk.object);
  }
```

`#bufferedObject` did advance to the retried value, but the promise consumers actually await did not. `text` accumulates separately, which is why only `object` went stale.

### Fix

Buffer `object-result` chunks and resolve the promise once, on `finish`, from the last chunk received.

Relaxing the guard to "latest write wins" is **not** sufficient, and that is worth calling out. `DelayedPromise.resolve()` updates `status`, but if the underlying native promise has already been materialized it is already settled and ignores every later `resolve`:

```ts
resolve(value: T): void {
  this.status = { type: 'resolved', value };
  if (this._promise) {
    this._resolve?.(value);   // no-op once settled
  }
}
```

Reading `result.object` materializes that promise (the getter calls `promise.promise`), so any consumer that grabs it before the stream drains — the ordinary `const obj = await result.object` path — would still receive the discarded attempt. Deferring resolution to `finish` avoids the problem entirely, and matches how the object is already read back for the `onFinish` payload. A validation rejection is still never overwritten, and `flush` still settles a pending promise as `undefined`.

## Related issue(s)

Fixes #20570

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Testing

Three regression tests in `output.test.ts`, each verified to fail on `main` and pass with the fix:

1. `object` resolves to the retried attempt rather than the rejected first one
2. the final value wins across several retries
3. **the retried value is returned even when `object` is read before the stream drains** — this is the case the first-write-wins guard could not fix, and the one real consumers hit

Full `packages/core` unit suite is green (`vitest run --exclude '**/tool-builder/**'`, ~11.9k tests). The only failures on my machine are pre-existing and environmental — `src/events/__tests__/*multiprocess*` and a few workflow/storage files need a built `dist/`, and `docs/` needs `@docusaurus/tsconfig`. They reproduce unchanged on a clean checkout.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the system retries an invalid structured response, `result.object` now shows the corrected response instead of the rejected one. This keeps `result.object` and `result.text` consistent.

## Changes

- Buffer `object-result` chunks until stream completion.
- Resolve `result.object` with the latest value after retries.
- Preserve validation rejection behavior.
- Add regression tests for single retries, multiple retries, and early reads of `result.object`.
- Add a patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->