### PR TITLE
feat(cli): add --skip-install option

### DIFF
--- a/packages/cli/src/commands/create/command.test.ts
+++ b/packages/cli/src/commands/create/command.test.ts
@@ -23,6 +23,7 @@ function createOptions(overrides: Partial<NormalizedCreateOptions> = {}): Normal
     git: true,
     template: undefined,
     timeout: 60_000,
+    skipInstall: false,
     ...overrides,
   };
 }
@@ -157,6 +158,7 @@ describe('shared create Commander wiring', () => {
       git: true,
       template: undefined,
       timeout: 60_000,
+      skipInstall: false,
     });
   });
 
@@ -187,8 +189,26 @@ describe('shared create Commander wiring', () => {
       git: false,
       template: undefined,
       timeout: 12_345,
+      skipInstall: false,
     });
     expect(subAction.mock.calls[0]?.[0]).toEqual(rootAction.mock.calls[0]?.[0]);
+  });
+
+  it('parses --skip-install option', async () => {
+    const action = vi.fn();
+    await parseRoot(['project', '--skip-install'], action);
+
+    expect(action).toHaveBeenCalledWith({
+      projectName: 'project',
+      empty: false,
+      llmProvider: undefined,
+      llmApiKey: undefined,
+      skills: true,
+      git: true,
+      template: undefined,
+      timeout: 60_000,
+      skipInstall: true,
+    });
   });
 });
 

--- a/packages/cli/src/commands/create/command.ts
+++ b/packages/cli/src/commands/create/command.ts
@@ -20,6 +20,7 @@ export interface CreateCommandOptions {
   git: boolean;
   template?: string | boolean;
   timeout: number;
+  skipInstall?: boolean;
 }
 
 export interface NormalizedCreateOptions {
@@ -31,6 +32,7 @@ export interface NormalizedCreateOptions {
   git: boolean;
   template?: string | boolean;
   timeout: number;
+  skipInstall: boolean;
 }
 
 export function parseCreateLLMProvider(value: string): CreateLLMProvider {
@@ -73,7 +75,8 @@ export function configureCreateCommand(command: Command) {
       '-t, --template [template]',
       'Create from a template slug or public GitHub URL, or select interactively when omitted',
     )
-    .option('--timeout <milliseconds>', 'Package installation timeout in milliseconds', parseCreateTimeout, 60_000);
+    .option('--timeout <milliseconds>', 'Package installation timeout in milliseconds', parseCreateTimeout, 60_000)
+    .option('--skip-install', 'Skip installing dependencies');
 }
 
 export function normalizeCreateCommandOptions(
@@ -89,6 +92,7 @@ export function normalizeCreateCommandOptions(
     git: options.git,
     template: options.template,
     timeout: options.timeout,
+    skipInstall: options.skipInstall ?? false,
   };
 }
 

--- a/packages/cli/src/commands/create/create.test.ts
+++ b/packages/cli/src/commands/create/create.test.ts
@@ -835,6 +835,20 @@ describe('create materialization lifecycle', () => {
     }
   });
 
+  it('skips dependency installation when skipInstall is true', async () => {
+    const { create } = await import('./create');
+    const { installDependencies } = await import('../../utils/clone-template');
+
+    await create({
+      projectName: 'my-project',
+      empty: true,
+      skipInstall: true,
+      resolveVersionTag: vi.fn().mockResolvedValue('latest'),
+    });
+
+    expect(installDependencies).not.toHaveBeenCalled();
+  });
+
   it('names the selected provider environment key in the completion note when the key is skipped', async () => {
     const { create } = await import('./create');
     const prompts = await import('@clack/prompts');

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -89,6 +89,7 @@ export interface CreateOptions {
   timeout?: number;
   analytics?: PosthogAnalytics;
   resolveVersionTag?: () => Promise<string | undefined>;
+  skipInstall?: boolean;
 }
 
 type PlatformSetupResult =
@@ -218,6 +219,7 @@ function normalizeDirectCreateOptions(args: CreateOptions): NormalizedCreateOpti
     git: args.git ?? true,
     template: args.template,
     timeout: args.timeout ?? 60_000,
+    skipInstall: args.skipInstall ?? false,
   };
 }
 
@@ -368,16 +370,23 @@ export const create = async (args: CreateOptions): Promise<void> => {
       }
     }
 
-    if (observabilityEnabled) {
-      await installDependencies(
-        staging.projectPath,
-        packageManager,
-        options.timeout,
-        materializationController.signal,
-        true,
-      );
-    } else {
-      await installDependencies(staging.projectPath, packageManager, options.timeout, materializationController.signal);
+    if (!options.skipInstall) {
+      if (observabilityEnabled) {
+        await installDependencies(
+          staging.projectPath,
+          packageManager,
+          options.timeout,
+          materializationController.signal,
+          true,
+        );
+      } else {
+        await installDependencies(
+          staging.projectPath,
+          packageManager,
+          options.timeout,
+          materializationController.signal,
+        );
+      }
     }
     materializationController.signal.throwIfAborted();
     await publishStagedProject({ projectPath: staging.projectPath, targetPath, projectName });
@@ -413,7 +422,11 @@ export const create = async (args: CreateOptions): Promise<void> => {
     analytics?.trackEvent('cli_observability_outcome', { command: 'create', outcome: 'skipped' });
     p.log.info('Skipping Mastra platform setup.');
   } else if (observabilityEnabled) {
-    p.log.success('Default template cloned and dependencies installed.');
+    p.log.success(
+      options.skipInstall
+        ? 'Default template cloned. Dependency installation was skipped.'
+        : 'Default template cloned and dependencies installed.',
+    );
   }
 
   const postSetup = await runPostCreateSetup({


### PR DESCRIPTION
## Description

Add a `--skip-install` option to the `mastra-create` CLI tool.

## Related issue(s)

Fixes #20587

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The `mastra-create` CLI can now create a project without installing dependencies. Use `--skip-install` when another tool or process manages installation.

## Changes

- Added the `--skip-install` CLI option.
- Defaulted `skipInstall` to `false`.
- Skipped dependency installation when `skipInstall` is `true`.
- Updated command option types and normalization.
- Changed the success message when installation is skipped.
- Added tests for option parsing, defaults, and skipped installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->