### PR TITLE
fix(playground-ui): re-anchor Sankey edge column headers

### DIFF
--- a/.changeset/young-falcons-change.md
+++ b/.changeset/young-falcons-change.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed the last column header in Sankey charts (for example SENTIMENT on the Trace Intelligence page) rendering right up against the chart's edge. It now keeps the same spacing as the first column's header.

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.stories.tsx
@@ -142,6 +142,35 @@ export const ClickableCurves: Story = {
   },
 };
 
+// mirrors the Intelligence page: four uppercased signal columns inside a full-bleed card
+const signalData = [
+  { goal: 'Resolve billing issue', outcome: 'Resolved', behavior: 'Escalated', sentiment: 'Frustrated' },
+  { goal: 'Resolve billing issue', outcome: 'Abandoned', behavior: 'Retried', sentiment: 'Frustrated' },
+  { goal: 'Find documentation', outcome: 'Resolved', behavior: 'Self-served', sentiment: 'Neutral' },
+  { goal: 'Find documentation', outcome: 'Resolved', behavior: 'Retried', sentiment: 'Satisfied' },
+  { goal: 'Configure integration', outcome: 'Deflected', behavior: 'Escalated', sentiment: 'Neutral' },
+  { goal: 'Configure integration', outcome: 'Resolved', behavior: 'Self-served', sentiment: 'Satisfied' },
+];
+
+const signalColumns = [
+  { id: 'goal', label: 'GOAL' },
+  { id: 'outcome', label: 'OUTCOME' },
+  { id: 'behavior', label: 'BEHAVIOR' },
+  { id: 'sentiment', label: 'SENTIMENT' },
+];
+
+export const SignalColumnHeaders: Story = {
+  render: () => (
+    <div className="w-full p-8">
+      <div className="border-border1 rounded-lg border">
+        <Sankey data={signalData} columns={signalColumns}>
+          <SankeyChart height={420} margin={{ top: 64, right: 32, bottom: 24, left: 32 }} />
+        </Sankey>
+      </div>
+    </div>
+  ),
+};
+
 export const Empty: Story = {
   render: () => (
     <div className="w-full p-8">

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -346,9 +346,12 @@ describe('SankeyChart', () => {
 
     expect(chartLabels).toEqual(expect.arrayContaining(['Channel', 'Region', 'Outcome']));
     const channelLabel = [...container.querySelectorAll('svg text')].find(element => element.textContent === 'Channel');
+    const regionLabel = [...container.querySelectorAll('svg text')].find(element => element.textContent === 'Region');
     const outcomeLabel = [...container.querySelectorAll('svg text')].find(element => element.textContent === 'Outcome');
-    expect(channelLabel?.getAttribute('text-anchor')).toBe('middle');
-    expect(outcomeLabel?.getAttribute('text-anchor')).toBe('middle');
+    // edge headers anchor to their node like the node labels do, so they stay inside the margin
+    expect(channelLabel?.getAttribute('text-anchor')).toBe('start');
+    expect(regionLabel?.getAttribute('text-anchor')).toBe('middle');
+    expect(outcomeLabel?.getAttribute('text-anchor')).toBe('end');
     const nodes = [...container.querySelectorAll('svg rect[rx="3"]')];
     const node = nodes[0];
     const nextNode = nodes.find(
@@ -360,7 +363,7 @@ describe('SankeyChart', () => {
     expect(
       Number(nextNode?.getAttribute('y')) - Number(node?.getAttribute('y')) - Number(node?.getAttribute('height')),
     ).toBeCloseTo(56);
-    expect(channelLabel?.getAttribute('x')).toBe('163.5');
+    expect(channelLabel?.getAttribute('x')).toBe(node?.getAttribute('x'));
     const searchLabel = [...container.querySelectorAll('svg text')].find(element => element.textContent === 'Search');
     expect(searchLabel?.getAttribute('font-size')).toBe('11');
     expect(searchLabel?.getAttribute('text-anchor')).toBe('start');

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -364,6 +364,11 @@ describe('SankeyChart', () => {
       Number(nextNode?.getAttribute('y')) - Number(node?.getAttribute('y')) - Number(node?.getAttribute('height')),
     ).toBeCloseTo(56);
     expect(channelLabel?.getAttribute('x')).toBe(node?.getAttribute('x'));
+    const columnXs = [...new Set(nodes.map(rect => Number(rect.getAttribute('x'))))].sort((a, b) => a - b);
+    expect(columnXs).toHaveLength(3);
+    const nodeWidth = Number(node?.getAttribute('width'));
+    expect(Number(regionLabel?.getAttribute('x'))).toBeCloseTo(columnXs[1] + nodeWidth / 2);
+    expect(Number(outcomeLabel?.getAttribute('x'))).toBeCloseTo(columnXs[2] + nodeWidth);
     const searchLabel = [...container.querySelectorAll('svg text')].find(element => element.textContent === 'Search');
     expect(searchLabel?.getAttribute('font-size')).toBe('11');
     expect(searchLabel?.getAttribute('text-anchor')).toBe('start');

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -215,7 +215,7 @@ function SankeyNode({
     maxCharacters: NODE_LABEL_MAX_CHARACTERS,
   });
   const visibleColumnLabel = columnLabel
-    ? truncateSankeyLabel(columnLabel, { fontSize: COLUMN_LABEL_FONT_SIZE, maxWidth: labelWidths.centered })
+    ? truncateSankeyLabel(columnLabel, { fontSize: COLUMN_LABEL_FONT_SIZE, maxWidth: nodeLabelWidth })
     : undefined;
   const tooltipId = useId();
   const [isHovered, setIsHovered] = useState(false);
@@ -232,7 +232,6 @@ function SankeyNode({
   const visibleY = y + (height - visibleHeight) / 2;
   const textAnchor = isFirstColumn ? 'start' : isLastColumn ? 'end' : 'middle';
   const labelX = isFirstColumn ? x : isLastColumn ? x + width : x + width / 2;
-  const columnLabelX = x + width / 2;
   const hue = hueMap[name] ?? 0;
   const isTooltipVisible = Boolean(description && tooltipPosition && (isHovered || isFocused));
   const showTooltipAt = (target: SVGGElement) => {
@@ -283,9 +282,9 @@ function SankeyNode({
         <title>{displayLabel}</title>
         {showColumnLabel && visibleColumnLabel ? (
           <text
-            x={columnLabelX}
+            x={labelX}
             y={18}
-            textAnchor="middle"
+            textAnchor={textAnchor}
             fill={nodeColor(hue)}
             fontSize={COLUMN_LABEL_FONT_SIZE}
             fontWeight={600}


### PR DESCRIPTION
## Description

On the Trace Intelligence page, the last Sankey column's header (e.g. SENTIMENT) rendered flush against the chart's edge, while the first column's header (e.g. GOAL) had a visible gap. Column headers were always horizontally centered on their node regardless of position. That was fine at the chart's original 160px side margins, but #19871 tightened margins to 32px to give the chart more room and never revisited header positioning — so a header on the last column now centers past its node and spills to within ~0.1px of the container edge.

## Before
<img width="1280" height="752" alt="image" src="https://github.com/user-attachments/assets/e89f848b-c2cb-435b-a547-ea1ee5ce29f0" />

## After
<img width="1280" height="446" alt="image" src="https://github.com/user-attachments/assets/3a287bb2-82d7-40d3-959d-0ed657ef1562" />

## Related Issue(s)

N/A — found via direct investigation of a UI screenshot; no GitHub issue was filed for this.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The Sankey chart headers now align with the chart edges. The first header starts at the left edge, the last header ends at the right edge, and middle headers remain centered.

## Changes

- Updated Sankey column headers to use `start`, `middle`, and `end` anchoring.
- Reused the existing edge-column truncation budget.
- Updated layout tests for header anchors and dynamic node positioning.
- Added the `SignalColumnHeaders` Storybook story for the 32px-margin layout.
- Added a patch changeset for `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->