### PR TITLE
fix(stores): raise stale @mastra/core peer floors on nine storage adapters

### DIFF
--- a/.changeset/store-core-peer-floors.md
+++ b/.changeset/store-core-peer-floors.md
@@ -1,0 +1,21 @@
+---
+'@mastra/cloudflare': patch
+'@mastra/convex': patch
+'@mastra/dsql': patch
+'@mastra/dynamodb': patch
+'@mastra/lance': patch
+'@mastra/mongodb': patch
+'@mastra/pg': patch
+'@mastra/redis': patch
+'@mastra/upstash': patch
+---
+
+Fixed nine storage adapters declaring a `@mastra/core` peer range that permitted core versions too old to load them. Each adapter imports `storageMessageMatchesMetadataFilter` from `@mastra/core/storage`, which core only exports from 1.53.0, but every one of them still advertised a floor below that — as low as `>=1.0.0-0`. Package managers accepted the incompatible pair without a warning and the install then failed at import time:
+
+```
+SyntaxError: The requested module '@mastra/core/storage' does not provide an export named 'storageMessageMatchesMetadataFilter'
+```
+
+All nine now declare `>=1.53.0-0 <2.0.0-0`, so npm and pnpm surface a peer conflict at install time instead of letting the project break on first import.
+
+Fixes [#20586](https://github.com/mastra-ai/mastra/issues/20586).

--- a/stores/cloudflare/package.json
+++ b/stores/cloudflare/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.20240919.0",
-    "@mastra/core": ">=1.34.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/stores/convex/package.json
+++ b/stores/convex/package.json
@@ -66,7 +66,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.50.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/dsql/package.json
+++ b/stores/dsql/package.json
@@ -49,7 +49,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/dynamodb/package.json
+++ b/stores/dynamodb/package.json
@@ -43,7 +43,7 @@
     "electrodb": "^3.9.1"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/stores/lance/package.json
+++ b/stores/lance/package.json
@@ -46,7 +46,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/mongodb/package.json
+++ b/stores/mongodb/package.json
@@ -51,7 +51,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.51.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -64,7 +64,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.51.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/redis/package.json
+++ b/stores/redis/package.json
@@ -51,7 +51,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/upstash/package.json
+++ b/stores/upstash/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.5-0 <2.0.0-0"
+    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Fixes #20586.

## Problem

#20586 reports that `@mastra/mongodb` >=1.15.0 imports `storageMessageMatchesMetadataFilter` from `@mastra/core/storage` — an export core only added in 1.53.0 — while still declaring a peer floor of `>=1.51.0-0`. npm and pnpm accept the pair, and the project dies on first import:

```
SyntaxError: The requested module '@mastra/core/storage' does not provide an export named 'storageMessageMatchesMetadataFilter'
```

I confirmed every fact in that report against the published tarballs, and then checked the reporter's closing note — *"Other storage adapters may have the same drift — we didn't audit them."*

**They do. It is nine adapters, not one, and all nine are broken in their currently published versions on npm.**

## Root cause

Two separate things:

**1. Nine stores import the symbol; none declared a floor high enough.**

```
$ grep -rl storageMessageMatchesMetadataFilter stores/*/src
stores/cloudflare  stores/convex  stores/dsql  stores/dynamodb  stores/lance
stores/mongodb     stores/pg      stores/redis stores/upstash
```

`@mastra/mongodb` — the one reported — actually had one of the *tightest* floors. Five sat at `>=1.0.0-0`, 53 minors below what the code needs:

| store | latest on npm | declared floor | imports symbol | broken today |
|---|---|---|---|---|
| `@mastra/cloudflare` | 1.6.0 | `>=1.34.0-0` | yes | **yes** |
| `@mastra/convex` | 1.5.1 | `>=1.50.0-0` | yes | **yes** |
| `@mastra/dsql` | 1.2.1 | `>=1.0.0-0` | yes | **yes** |
| `@mastra/dynamodb` | 1.2.1 | `>=1.0.0-0` | yes | **yes** |
| `@mastra/lance` | 1.2.1 | `>=1.0.0-0` | yes | **yes** |
| `@mastra/mongodb` | 1.15.1 | `>=1.51.0-0` | yes | **yes** (reported) |
| `@mastra/pg` | 1.18.1 | `>=1.51.0-0` | yes | **yes** |
| `@mastra/redis` | 1.3.0 | `>=1.0.0-0` | yes | **yes** |
| `@mastra/upstash` | 1.3.0 | `>=1.0.5-0` | yes | **yes** |

Verified against published tarballs — `storageMessageMatchesMetadataFilter` is absent from core 1.51.0 and 1.52.1 and first appears in 1.53.0:

```
core@1.51.0: exported=NO   core@1.52.1: exported=NO
core@1.53.0: exported=YES  (dist/storage/index.js, dist/storage/utils.d.ts)
```

**2. `scripts/validate-peerdeps.mjs` structurally cannot catch this.**

```js
// scripts/validate-peerdeps.mjs:100
const isValid = semver.satisfies(coreVersion, corePeerDep, { includePrerelease: true });
```

That asserts the *current* core version falls inside the declared range. A floor of `>=1.0.0-0 <2.0.0-0` satisfies core 1.56.0-alpha.5 trivially — so the looser and more wrong the floor is, the more certainly it passes. The check catches ranges that *exclude* core; it can never catch a floor that is too *low*. On the unmodified tree it reports:

```
Version summary: 108 valid, 0 invalid
All peer dependencies are valid!
```

That is why nine packages drifted silently.

## Fix

All nine now declare `>=1.53.0-0 <2.0.0-0`, so package managers surface a peer conflict at install time instead of letting the project break on first import. Nine one-line changes plus a changeset:

```diff
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
```

## Scope — deliberately left out

- **I did not change `validate-peerdeps.mjs`.** Making it verify floors means mapping each imported core symbol to the release that introduced it, which needs npm history and is a real design decision about what belongs in a fast CI lint. Happy to add it in a follow-up if you want it — say which shape you'd prefer.
- **`@mastra/mongodb` and `@mastra/pg` will need another bump.** At HEAD they also import `TABLE_WORKFLOW_DEFINITIONS`, `CreateWorkflowDefinitionInput`, `ListWorkflowDefinitionsInput/Output` and `UpdateWorkflowDefinitionInput`, which exist in `packages/core/src/storage/constants.ts` but are **not in any published core 1.x**. Their floor must move again when that core ships. I left it at 1.53.0 because I can't pin an unreleased version — flagging it rather than guessing.
- I did not touch the 18 stores that don't import the symbol.

## Verification

**Before/after, using the repo's own `semver`** — does each declared range still admit a core release that lacks the export?

```
store       admits a core without the symbol?
cloudflare  before: YES ["1.51.0","1.52.0","1.52.1"]  after: no
convex      before: YES ["1.51.0","1.52.0","1.52.1"]  after: no
dsql        before: YES ["1.51.0","1.52.0","1.52.1"]  after: no
dynamodb    before: YES ["1.51.0","1.52.0","1.52.1"]  after: no
lance       before: YES ["1.51.0","1.52.0","1.52.1"]  after: no
mongodb     before: YES ["1.51.0","1.52.0","1.52.1"]  after: no
pg          before: YES ["1.51.0","1.52.0","1.52.1"]  after: no
redis       before: YES ["1.51.0","1.52.0","1.52.1"]  after: no
upstash     before: YES ["1.51.0","1.52.0","1.52.1"]  after: no

PASS: no store admits a core lacking the symbol
```

`node scripts/validate-peerdeps.mjs` — **108 valid, 0 invalid, exit 0 both before and after**. It stays green either way, which is the point of the root-cause section above; it also confirms the raised floors introduce no transitive `propagatedPeerErrors` against the packages that depend on these stores.

Diff is 9 changed lines across 9 `package.json` files, plus one changeset. No source changes, so there is nothing to build or unit-test.

Happy to split this per-adapter, drop the changeset, or reshape the floor if 1.53.0 isn't the number you want.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Nine storage adapters now require a compatible `@mastra/core` version. This prevents installations that would later fail because the adapters use a feature added in core 1.53.0.

## Changes

- Raised the `@mastra/core` peer dependency floor to `>=1.53.0-0 <2.0.0-0` for:
  - cloudflare
  - convex
  - dsql
  - dynamodb
  - lance
  - mongodb
  - pg
  - redis
  - upstash
- Added a changeset for patch releases.
- Did not change source code or peer dependency validation logic.

## Verification

- Confirmed that the updated ranges exclude core versions without `storageMessageMatchesMetadataFilter`.
- Peer dependency validation passes: `108 valid, 0 invalid`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->