### PR TITLE
feat(core): allow creating a Session without a workspace

### DIFF
--- a/.changeset/smart-windows-help.md
+++ b/.changeset/smart-windows-help.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Session no longer requires a workspace. `AgentController` already allowed running without one, but `Session` threw an error if no workspace was configured or resolved. `getWorkspace()` now returns `Workspace | undefined` to match this.

--- a/.changeset/smart-windows-help.md
+++ b/.changeset/smart-windows-help.md
@@ -2,4 +2,5 @@
 '@mastra/core': minor
 ---
 
-Session no longer requires a workspace. `AgentController` already allowed running without one, but `Session` threw an error if no workspace was configured or resolved. `getWorkspace()` now returns `Workspace | undefined` to match this.
+Sessions can run without a workspace. `getWorkspace()` returns `undefined` when no workspace is configured.
+

--- a/docs/src/content/en/reference/agent-controller/session.mdx
+++ b/docs/src/content/en/reference/agent-controller/session.mdx
@@ -113,14 +113,14 @@ The session is organized into sub-objects, each owning one domain of per-convers
 
 #### `getWorkspace()`
 
-Return the workspace resolved for this session. This preserves session-level overrides and workspaces selected from the session scope.
+Return the workspace resolved for this session. This preserves session-level overrides and workspaces selected from the session scope. Returns `undefined` when the session was created without a workspace.
 
 ```typescript
 const workspace = agentController.session.getWorkspace()
-const skill = await workspace.skills?.get('code-review')
+const skill = await workspace?.skills?.get('code-review')
 ```
 
-Returns: `Workspace`
+Returns: `Workspace | undefined`
 
 ### Permissions
 

--- a/docs/src/content/en/reference/agent-controller/session.mdx
+++ b/docs/src/content/en/reference/agent-controller/session.mdx
@@ -115,10 +115,10 @@ The session is organized into sub-objects, each owning one domain of per-convers
 
 Return the workspace resolved for this session. This preserves session-level overrides and workspaces selected from the session scope. Returns `undefined` when the session was created without a workspace.
 
-```typescript
-const workspace = agentController.session.getWorkspace()
+await agentController.init()
+const session = await agentController.createSession()
+const workspace = session.getWorkspace()
 const skill = await workspace?.skills?.get('code-review')
-```
 
 Returns: `Workspace | undefined`
 

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -522,7 +522,7 @@ export class AgentController<TState = {}> {
           initialState,
           stateSchema: this.config.stateSchema,
         },
-        workspace: workspaceToConnect as Workspace,
+        workspace: workspaceToConnect,
         browser: browserToConnect,
       }),
     );

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -2646,7 +2646,7 @@ export class Session<TState = unknown> {
    * filtered back to the session's scope. Empty when the session is unscoped.
    */
   readonly #tags: Record<string, string>;
-  readonly #workspace: Workspace;
+  readonly #workspace?: Workspace;
   browser?: MastraBrowser;
 
   constructor({
@@ -2663,7 +2663,7 @@ export class Session<TState = unknown> {
     id: string;
     ownerId: string;
     tags?: Record<string, string>;
-    workspace: Workspace;
+    workspace?: Workspace;
     browser?: MastraBrowser;
   }) {
     this.#tags = tags && Object.keys(tags).length > 0 ? { ...tags } : {};
@@ -2678,7 +2678,7 @@ export class Session<TState = unknown> {
     this.#bus.setDisplayState(this.displayState);
     this.state = new SessionState(state ?? { initialState: {} as TState }, this.#bus);
 
-    if (!workspace || !(workspace instanceof Workspace)) {
+    if (workspace && !(workspace instanceof Workspace)) {
       throw new Error(`A session requires a valid workspace instance.`);
     }
 
@@ -2701,7 +2701,7 @@ export class Session<TState = unknown> {
    * is created. Use this accessor for operations that must stay bound to the
    * session's workspace rather than resolving through controller-global state.
    */
-  getWorkspace(): Workspace {
+  getWorkspace(): Workspace | undefined {
     return this.#workspace;
   }
 

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -2678,7 +2678,7 @@ export class Session<TState = unknown> {
     this.#bus.setDisplayState(this.displayState);
     this.state = new SessionState(state ?? { initialState: {} as TState }, this.#bus);
 
-    if (workspace && !(workspace instanceof Workspace)) {
+    if (workspace !== undefined && !(workspace instanceof Workspace)) {
       throw new Error(`A session requires a valid workspace instance.`);
     }
 

--- a/packages/core/src/agent-controller/workspace-resolution.test.ts
+++ b/packages/core/src/agent-controller/workspace-resolution.test.ts
@@ -114,7 +114,7 @@ describe('AgentController workspace — dynamic factory', () => {
     expect(factory).toHaveBeenCalledTimes(2);
   });
 
-  it('createSession throws when factory returns undefined', async () => {
+  it('createSession succeeds with no workspace when factory returns undefined', async () => {
     const nullFactory = vi.fn().mockResolvedValue(undefined);
     const controller = new AgentController({
       id: 'test',
@@ -124,9 +124,9 @@ describe('AgentController workspace — dynamic factory', () => {
     });
     await controller.init();
 
-    await expect(controller.createSession({ id: 'test-session', ownerId: 'test-owner' })).rejects.toThrow(
-      'A session requires a valid workspace instance.',
-    );
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    expect(session).toBeDefined();
+    expect(session.getWorkspace()).toBeUndefined();
   });
 
   it('resolveWorkspace provides session state to the factory', async () => {
@@ -165,7 +165,7 @@ describe('AgentController workspace — dynamic factory', () => {
 // ===========================================================================
 
 describe('AgentController workspace — none configured', () => {
-  it('createSession throws when no workspace is configured', async () => {
+  it('createSession succeeds when no workspace is configured', async () => {
     const controller = new AgentController({
       id: 'test',
       storage: new InMemoryStore(),
@@ -173,9 +173,9 @@ describe('AgentController workspace — none configured', () => {
     });
     await controller.init();
 
-    await expect(controller.createSession({ id: 'test-session', ownerId: 'test-owner' })).rejects.toThrow(
-      'A session requires a valid workspace instance.',
-    );
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    expect(session).toBeDefined();
+    expect(session.getWorkspace()).toBeUndefined();
   });
 });
 
@@ -309,17 +309,17 @@ describe('AgentController createSession — workspace isolation', () => {
       workspace: wsA,
     });
 
-    // Session B has no workspace override — should throw because no workspace is available
-    await expect(
-      controller.createSession({
-        id: 'session-b',
-        ownerId: 'test-owner',
-        resourceId: 'resource-b',
-      }),
-    ).rejects.toThrow('A session requires a valid workspace instance.');
+    // Session B has no workspace override and no controller-level workspace —
+    // it should not inherit session A's override.
+    const sessionB = await controller.createSession({
+      id: 'session-b',
+      ownerId: 'test-owner',
+      resourceId: 'resource-b',
+    });
 
-    // Session A still has its own workspace (init was called)
     expect(sessionA).toBeDefined();
+    expect(sessionA.getWorkspace()).toBe(wsA);
+    expect(sessionB.getWorkspace()).toBeUndefined();
     expect(initSpyA).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description

Session previously required a workspace instance and threw when none was provided, even though AgentController already treats workspace as optional. Make the workspace parameter and #workspace field optional, only validate the Workspace instance type when one is passed, and update getWorkspace() to return Workspace | undefined to match AgentController.getWorkspace().

the related issue is #20594.

Close #20594.

## Related issue(s)

#20594

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

A `Session` can now work without a workspace. When no workspace exists, `getWorkspace()` returns `undefined`.

## Changes

- Made the `Session` workspace optional.
- Validate the workspace only when one is provided.
- Updated `getWorkspace()` to return `Workspace | undefined`.
- Updated session creation and workspace-isolation tests.
- Updated session reference documentation.
- Added a minor changeset for `@mastra/core`.
- Related issue: `#20594`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->