### PR TITLE
fix(core): resume persisted stream suspensions after restart

### DIFF
--- a/.changeset/great-pumas-guess.md
+++ b/.changeset/great-pumas-guess.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed sendStreamResume() to resume suspended agent runs from storage after a server restart or when requests reach another instance.

--- a/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
+++ b/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
@@ -196,6 +196,40 @@ function createSuspendedSetup({
   return { agent, mastra, storage };
 }
 
+function createToolSuspensionSetup({
+  storage,
+  toolCallOnFirstCall,
+  onResume,
+}: {
+  storage: InMemoryStore;
+  toolCallOnFirstCall: boolean;
+  onResume: (resumeData: { name: string }) => void;
+}) {
+  const askUserTool = createTool({
+    id: 'Ask user tool',
+    description: 'Asks the user for the name',
+    inputSchema: z.object({ name: z.string() }),
+    suspendSchema: z.object({ question: z.string() }),
+    resumeSchema: z.object({ name: z.string() }),
+    execute: async (_input, context) => {
+      if (!context?.agent?.resumeData) {
+        return await context?.agent?.suspend({ question: 'Which user?' });
+      }
+      onResume(context.agent.resumeData);
+      return { name: context.agent.resumeData.name, email: 'dero@mail.com' };
+    },
+  });
+  const agent = new Agent({
+    id: 'suspending-agent',
+    name: 'Suspending Agent',
+    instructions: 'You find users.',
+    model: createMockModel({ toolName: 'askUserTool', toolCallOnFirstCall }),
+    tools: { askUserTool },
+  });
+  const mastra = new Mastra({ agents: { agent }, logger: false, storage });
+  return { agent, mastra };
+}
+
 async function suspendRun(agent: Agent, threadId: string, resourceId: string) {
   const stream = await agent.stream('Find the user with name - Dero Israel', {
     requireToolApproval: true,
@@ -755,6 +789,69 @@ describe('suspended-run discovery', () => {
     }, 30000);
   });
 
+  describe('agent.sendStreamResume() storage fallback', () => {
+    it('resumes a tool-suspended run after a simulated restart', async () => {
+      const storage = new InMemoryStore();
+      const resumedTool = vi.fn();
+      const { agent } = createToolSuspensionSetup({ storage, toolCallOnFirstCall: true, onResume: resumedTool });
+      const stream = await agent.stream('Find the user', {
+        memory: { thread: 'thread-1', resource: 'resource-1' },
+      });
+      let toolCallId = '';
+      for await (const chunk of stream.fullStream) {
+        if (chunk.type === 'tool-call-suspended') {
+          toolCallId = chunk.payload.toolCallId;
+        }
+      }
+      expect(toolCallId).toBeTruthy();
+
+      const { agent: restartedAgent, mastra } = createToolSuspensionSetup({
+        storage,
+        toolCallOnFirstCall: false,
+        onResume: resumedTool,
+      });
+      expect(restartedAgent.getActiveThreadRunId({ threadId: 'thread-1', resourceId: 'resource-1' })).toBeUndefined();
+      expect((await restartedAgent.listSuspendedRuns({ threadId: 'thread-1', resourceId: 'resource-1' })).runs).toEqual(
+        [expect.objectContaining({ runId: stream.runId })],
+      );
+
+      const result = await restartedAgent.sendStreamResume({
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+        runId: stream.runId,
+        toolCallId,
+        resumeData: { name: 'Dero Israel' },
+      });
+      expect(result).toEqual({ accepted: true, runId: stream.runId, toolCallId });
+
+      const workflowsStore = (await mastra.getStorage()!.getStore('workflows'))!;
+      await vi.waitFor(
+        async () => {
+          expect(resumedTool).toHaveBeenCalledWith({ name: 'Dero Israel' });
+          expect((await workflowsStore.listWorkflowRuns({})).runs).toHaveLength(0);
+        },
+        { timeout: 10000 },
+      );
+    }, 30000);
+
+    it('rejects a toolCallId that does not belong to the stored run', async () => {
+      const storage = new InMemoryStore();
+      const { agent } = createSuspendedSetup({ storage });
+      const { runId } = await suspendRun(agent, 'thread-1', 'resource-1');
+      const { agent: restartedAgent } = createSuspendedSetup({ storage, toolCallOnFirstCall: false });
+
+      await expect(
+        restartedAgent.sendStreamResume({
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          runId,
+          toolCallId: 'wrong-tool-call',
+          resumeData: { approved: true },
+        }),
+      ).rejects.toMatchObject({ id: 'AGENT_SEND_STREAM_RESUME_NO_SUSPENDED_THREAD_RUN' });
+    }, 30000);
+  });
+
   describe('agent.sendToolApproval() storage fallback', () => {
     it('approves a suspended run after a simulated restart (in-memory state lost)', async () => {
       const storage = new InMemoryStore();
@@ -789,34 +886,8 @@ describe('suspended-run discovery', () => {
 
     it('matches a suspend()-parked run by toolCallId after a simulated restart', async () => {
       const resumedTool = vi.fn();
-      const makeAskUserAgent = (toolCallOnFirstCall: boolean) => {
-        const askUserTool = createTool({
-          id: 'Ask user tool',
-          description: 'Asks the user for the name',
-          inputSchema: z.object({ name: z.string() }),
-          suspendSchema: z.object({ question: z.string() }),
-          resumeSchema: z.object({ name: z.string() }),
-          execute: async (_input, context) => {
-            if (!context?.agent?.resumeData) {
-              return await context?.agent?.suspend({ question: 'Which user?' });
-            }
-            resumedTool(context.agent.resumeData);
-            return { name: context.agent.resumeData.name, email: 'dero@mail.com' };
-          },
-        });
-        const agent = new Agent({
-          id: 'suspending-agent',
-          name: 'Suspending Agent',
-          instructions: 'You find users.',
-          model: createMockModel({ toolName: 'askUserTool', toolCallOnFirstCall }),
-          tools: { askUserTool },
-        });
-        const mastra = new Mastra({ agents: { agent }, logger: false, storage });
-        return { agent, mastra };
-      };
-
       const storage = new InMemoryStore();
-      const { agent } = makeAskUserAgent(true);
+      const { agent } = createToolSuspensionSetup({ storage, toolCallOnFirstCall: true, onResume: resumedTool });
       const stream = await agent.stream('Find the user', {
         memory: { thread: 'thread-1', resource: 'resource-1' },
       });
@@ -830,7 +901,11 @@ describe('suspended-run discovery', () => {
 
       // Fresh process: the run must be resolved from storage, and the id taken
       // from the tool-call-suspended chunk has to match the discovered run.
-      const { agent: restartedAgent, mastra } = makeAskUserAgent(false);
+      const { agent: restartedAgent, mastra } = createToolSuspensionSetup({
+        storage,
+        toolCallOnFirstCall: false,
+        onResume: resumedTool,
+      });
       expect(restartedAgent.getActiveThreadRunId({ threadId: 'thread-1', resourceId: 'resource-1' })).toBeUndefined();
 
       const result = await restartedAgent.sendToolApproval({

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -8776,10 +8776,35 @@ export class Agent<
       });
     }
 
-    const resumableRun = agentThreadStreamRuntime.getResumableThreadRun(
+    const pubsub = this.getPubSub();
+    const hasLocalRun = agentThreadStreamRuntime.hasThreadRun(runId, pubsub);
+    let resumableRun = agentThreadStreamRuntime.getResumableThreadRun(
       { threadId, resourceId, runId, toolCallId },
-      this.getPubSub(),
+      pubsub,
     );
+
+    if (!resumableRun && !hasLocalRun) {
+      // The thread runtime only tracks runs seen by this process. Recover the
+      // explicitly targeted run from snapshot storage after a restart or when
+      // the resume request reaches another server instance.
+      let suspendedRuns: AgentRun[] = [];
+      try {
+        ({ runs: suspendedRuns } = await this.listSuspendedRuns({ threadId, resourceId }));
+      } catch (error) {
+        if (!(error instanceof MastraError) || error.id !== 'AGENT_LIST_SUSPENDED_RUNS_NO_STORAGE') {
+          throw error;
+        }
+      }
+
+      const storedRun = suspendedRuns.find(
+        run =>
+          run.runId === runId && (!toolCallId || run.toolCalls.some(toolCall => toolCall.toolCallId === toolCallId)),
+      );
+      if (storedRun) {
+        resumableRun = { runId, toolCallId };
+      }
+    }
+
     if (!resumableRun) {
       throw new MastraError({
         id: 'AGENT_SEND_STREAM_RESUME_NO_SUSPENDED_THREAD_RUN',
@@ -8854,9 +8879,8 @@ export class Agent<
 
     let runId = this.getActiveThreadRunId({ threadId, resourceId });
     // Tracks whether runId was recovered from storage (not the in-memory active-run
-    // map). Storage-discovered runs are not present in the in-memory thread runtime,
-    // so they must resume directly via resumeStream() rather than through
-    // sendStreamResume(), whose getResumableThreadRun() guard is in-memory only.
+    // map). This path resumes directly because the snapshot has already been
+    // discovered here, avoiding a second storage lookup in sendStreamResume().
     let resolvedFromStorage = false;
 
     if (!runId) {
@@ -8939,10 +8963,8 @@ export class Agent<
     };
 
     if (resolvedFromStorage) {
-      // The run was recovered from storage and is not tracked by the in-memory
-      // thread runtime, so sendStreamResume()'s getResumableThreadRun() guard would
-      // reject it. Resume directly from the persisted snapshot, mirroring the
-      // explicit-runId approveToolCall()/declineToolCall() entry points.
+      // Resume directly from the persisted snapshot, mirroring the explicit-runId
+      // approveToolCall()/declineToolCall() entry points.
       // @ts-expect-error - resumeStream overloads don't narrow cleanly here; matches
       // the same pattern used by approveToolCall()/declineToolCall() above.
       await this.resumeStream(resumeData, {

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -687,6 +687,10 @@ export class AgentThreadStreamRuntime {
     return activeRunId;
   }
 
+  hasThreadRun(runId: string, pubsub?: PubSub): boolean {
+    return this.#getState(pubsub).threadRunsById.has(runId);
+  }
+
   getResumableThreadRun(
     options: AgentSubscribeToThreadOptions & { runId: string; toolCallId?: string },
     pubsub?: PubSub,


### PR DESCRIPTION
Fixes `sendStreamResume()` so it can recover an explicitly targeted suspended run from workflow snapshot storage when the run is no longer present in the current process runtime.

The storage fallback matches the requested thread, resource, run ID, and optional tool-call ID before calling `resumeStream()`. Locally tracked runs do not use the fallback, which preserves duplicate-resume protection while a previously accepted resume is still completing.

Added regression coverage for resuming a tool-suspended run with a fresh agent instance sharing the same storage, as well as rejecting a mismatched tool-call ID.

## Related issue(s)

Fixes #20600

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A suspended run can now resume after a restart or from another server. The system finds the saved run, checks that it matches the request, and continues it safely.

## Changes

- Updated `sendStreamResume()` to recover suspended runs from workflow snapshot storage.
- Match recovered runs by:
  - `threadId`
  - `resourceId`
  - `runId`
  - Optional `toolCallId`
- Resume recovered runs with `resumeStream()`.
- Preserve the existing in-memory path for locally tracked runs and duplicate-resume protection.
- Added `hasThreadRun()` to `AgentThreadStreamRuntime`.
- Added regression tests for:
  - Resuming a tool-suspended run with a new agent instance.
  - Rejecting an unknown `toolCallId`.
  - Reusing shared suspension test setup.
- Added a patch changeset for `@mastra/core`.

## Verification

- Core build
- Targeted Vitest tests
- Package checks
- Linting
- Formatting checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->