### PR TITLE
feat(agent-browser): support cdpHeaders for authenticated CDP connections

### DIFF
--- a/.changeset/agent-browser-cdp-headers.md
+++ b/.changeset/agent-browser-cdp-headers.md
@@ -1,0 +1,5 @@
+---
+'@mastra/agent-browser': minor
+---
+
+Add optional `cdpHeaders` on AgentBrowser for authenticated CDP connections (e.g. Cloudflare Browser Rendering Authorization). Headers are forwarded to agent-browser `launch({ cdpHeaders })` → `connectOverCDP`. Requires an agent-browser build that honors `cdpHeaders` on the generic CDP path.

--- a/.changeset/agent-browser-cdp-headers.md
+++ b/.changeset/agent-browser-cdp-headers.md
@@ -2,4 +2,5 @@
 '@mastra/agent-browser': minor
 ---
 
-Add optional `cdpHeaders` on AgentBrowser for authenticated CDP connections (e.g. Cloudflare Browser Rendering Authorization). Headers are forwarded to agent-browser `launch({ cdpHeaders })` → `connectOverCDP`. Requires an agent-browser build that honors `cdpHeaders` on the generic CDP path.
+Added support for authenticated CDP connections in `AgentBrowser`.
+

--- a/browser/agent-browser/src/__tests__/agent-browser.test.ts
+++ b/browser/agent-browser/src/__tests__/agent-browser.test.ts
@@ -311,6 +311,34 @@ describe('AgentBrowser', () => {
       // Should have re-launched
       expect(mockManager.launch).toHaveBeenCalledTimes(2);
     });
+
+    it('forwards cdpUrl and cdpHeaders to BrowserManager.launch', async () => {
+      const cdpHeaders = { Authorization: 'Bearer test-token' };
+      const browserWithCdp = new AgentBrowser({
+        scope: 'shared',
+        cdpUrl: 'wss://example.com/cdp',
+        cdpHeaders,
+      });
+
+      try {
+        await browserWithCdp.ensureReady();
+        expect(mockManager.launch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cdpUrl: 'wss://example.com/cdp',
+            cdpHeaders,
+          }),
+        );
+      } finally {
+        await browserWithCdp.close();
+      }
+    });
+
+    it('omits cdpHeaders from launch options when not configured', async () => {
+      await browser.ensureReady();
+      const launchOptions = mockManager.launch.mock.calls[0]?.[0];
+      expect(launchOptions).toBeDefined();
+      expect(launchOptions).not.toHaveProperty('cdpHeaders');
+    });
   });
 
   describe('isBrowserRunning', () => {

--- a/browser/agent-browser/src/__tests__/thread-manager.test.ts
+++ b/browser/agent-browser/src/__tests__/thread-manager.test.ts
@@ -203,6 +203,38 @@ describe('AgentBrowserThreadManager', () => {
       expect(mockManager.launch).toHaveBeenCalledTimes(2);
     });
 
+    it('forwards cdpHeaders to BrowserManager.launch for thread-scoped browsers', async () => {
+      const cdpHeaders = { Authorization: 'Bearer test-token' };
+      const threadManager = new AgentBrowserThreadManager({
+        scope: 'thread',
+        browserConfig: {
+          headless: true,
+          cdpHeaders,
+        },
+      });
+
+      await threadManager.getManagerForThread('thread-1');
+
+      expect(mockManager.launch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cdpHeaders,
+        }),
+      );
+    });
+
+    it('omits cdpHeaders from thread launch options when not configured', async () => {
+      const threadManager = new AgentBrowserThreadManager({
+        scope: 'thread',
+        browserConfig: { headless: true },
+      });
+
+      await threadManager.getManagerForThread('thread-1');
+
+      const launchOptions = mockManager.launch.mock.calls[0]?.[0];
+      expect(launchOptions).toBeDefined();
+      expect(launchOptions).not.toHaveProperty('cdpHeaders');
+    });
+
     it('hasActiveThreadManagers returns true when browsers exist', async () => {
       const threadManager = new AgentBrowserThreadManager({
         scope: 'thread',

--- a/browser/agent-browser/src/agent-browser.ts
+++ b/browser/agent-browser/src/agent-browser.ts
@@ -183,7 +183,7 @@ export class AgentBrowser extends MastraBrowser {
     this.sharedManager = new BrowserManager();
 
     const localConfig = this.config as BrowserConfig;
-    const launchOptions: BrowserLaunchOptions = {
+    const launchOptions: BrowserLaunchOptions & { cdpHeaders?: Record<string, string> } = {
       headless: this.headless,
       viewport: localConfig.viewport,
       profile: localConfig.profile,
@@ -194,6 +194,9 @@ export class AgentBrowser extends MastraBrowser {
     // Resolve CDP URL if provided (can be string or function)
     if (localConfig.cdpUrl) {
       launchOptions.cdpUrl = await this.resolveCdpUrl(localConfig.cdpUrl);
+    }
+    if (localConfig.cdpHeaders) {
+      launchOptions.cdpHeaders = localConfig.cdpHeaders;
     }
 
     await this.sharedManager.launch(launchOptions);

--- a/browser/agent-browser/src/thread-manager.ts
+++ b/browser/agent-browser/src/thread-manager.ts
@@ -82,7 +82,7 @@ export class AgentBrowserThreadManager extends ThreadManager<BrowserManager> {
       // Thread scope - create a new browser manager for this thread
       const manager = new BrowserManager();
 
-      const launchOptions: BrowserLaunchOptions = {
+      const launchOptions: BrowserLaunchOptions & { cdpHeaders?: Record<string, string> } = {
         headless: this.browserConfig.headless,
         viewport: this.browserConfig.viewport,
         profile: this.browserConfig.profile,
@@ -92,6 +92,9 @@ export class AgentBrowserThreadManager extends ThreadManager<BrowserManager> {
 
       if (this.browserConfig.cdpUrl && this.resolveCdpUrl) {
         launchOptions.cdpUrl = await this.resolveCdpUrl(this.browserConfig.cdpUrl);
+      }
+      if (this.browserConfig.cdpHeaders) {
+        launchOptions.cdpHeaders = this.browserConfig.cdpHeaders;
       }
 
       try {

--- a/browser/agent-browser/src/types.ts
+++ b/browser/agent-browser/src/types.ts
@@ -6,6 +6,12 @@ import type { BrowserToolName } from './tools/constants';
  */
 export interface AgentBrowserConfigExtensions {
   /**
+   * Headers passed to chromium.connectOverCDP when using `cdpUrl`.
+   * Required for providers like Cloudflare Browser Rendering (Authorization bearer token).
+   * Distinct from page `extraHTTPHeaders` / navigation headers.
+   */
+  cdpHeaders?: Record<string, string>;
+  /**
    * Path to a Playwright storage state file (JSON) containing cookies and localStorage.
    * This is a lighter-weight alternative to `profile` — it only persists
    * authentication state, not the full browser profile.


### PR DESCRIPTION
Fixes #20605.

## Problem

`AgentBrowser` can connect to a remote browser via `cdpUrl`, but it cannot pass **WebSocket connect headers** into Playwright's `chromium.connectOverCDP`.

Cloudflare Browser Rendering requires an Authorization header on the CDP connection:

```ts
await chromium.connectOverCDP(browserWSEndpoint, {
  headers: {
    Authorization: `Bearer ${API_TOKEN}`,
  },
});
```

Docs: https://developers.cloudflare.com/browser-run/cdp/playwright/

Today the only public option is:

```ts
new AgentBrowser({
  cdpUrl: 'wss://api.cloudflare.com/client/v4/accounts/.../browser-rendering/devtools/browser?keep_alive=600000',
});
```

`@mastra/agent-browser` forwards only `cdpUrl` into `agent-browser`'s `BrowserManager.launch()`. There is no way to supply connect headers. (Page-level `extraHTTPHeaders` are a different concern.)

## Solution

Add optional `cdpHeaders` on the AgentBrowser config and pass it through both launch paths (shared + thread manager):

```ts
new AgentBrowser({
  cdpUrl: 'wss://api.cloudflare.com/.../devtools/browser?keep_alive=600000',
  cdpHeaders: {
    Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
  },
});
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## Dependency note

`@mastra/agent-browser` depends on `agent-browser@0.19.0`. That package's generic CDP path currently calls `connectOverCDP(url, { timeout })` without headers. A companion fix adds `cdpHeaders` there:

- Issue: https://github.com/vercel-labs/agent-browser/issues/1642  
- PR: https://github.com/vercel-labs/agent-browser/pull/1643  

Until a release of `agent-browser` that honors `cdpHeaders` is available and this package bumps to it, the field is plumbed in Mastra and is a no-op at connect time on stock `0.19.0`. Happy to follow up with a dependency bump PR once #1643 (or equivalent) lands.

## Checklist

- [x] I have linked the related issue(s) in the description above (`Fixes #20605`)
- [ ] I have made corresponding changes to the documentation (happy to add a docs note if maintainers want it in this PR)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Verification

- Source change is limited to config typing + launch option forwarding in:
  - `browser/agent-browser/src/types.ts`
  - `browser/agent-browser/src/agent-browser.ts`
  - `browser/agent-browser/src/thread-manager.ts`
- Added a changeset for `@mastra/agent-browser` (minor).
- Locally used the same option shape successfully against Cloudflare Browser Rendering with a patched `agent-browser@0.19.0` that forwards headers to `connectOverCDP`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This change lets users provide login headers when connecting to an existing browser. It helps authenticated CDP services, such as Cloudflare Browser Rendering, accept the connection.

## Changes

- Added optional `cdpHeaders?: Record<string, string>` to `AgentBrowserConfigExtensions`.
- Forwarded `cdpHeaders` through shared and thread browser launch paths.
- Added tests for configured and omitted headers.
- Added a minor changeset.
- Requires an `agent-browser` version that supports CDP headers. With `agent-browser@0.19.0`, the option has no effect at connection time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->