### PR TITLE
fix(memory): handle pending tool approvals in token counting

### DIFF
--- a/.changeset/vast-cows-hammer.md
+++ b/.changeset/vast-cows-hammer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed Observational Memory token counting for pending tool approvals.

--- a/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
@@ -1279,6 +1279,30 @@ describe('TokenCounter', () => {
     });
   });
 
+  describe('tool approval (approval-requested)', () => {
+    it('counts a pending approval as zero content tokens instead of throwing', () => {
+      const counter = new TokenCounter();
+      const message = createMessage({
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'approval-requested',
+              toolCallId: 'tool-1',
+              toolName: 'deleteFile',
+              args: { path: 'fixture.txt' },
+              approval: { id: 'approval-1' },
+            },
+          },
+        ],
+      });
+      const emptyMessage = createMessage({ format: 2, parts: [] });
+
+      expect(counter.countMessage(message)).toBe(counter.countMessage(emptyMessage));
+    });
+  });
+
   describe('countObservations', () => {
     it('delegates to countString', () => {
       const counter = new TokenCounter();

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -1759,6 +1759,11 @@ export class TokenCounter {
         return { tokens, overheadDelta, toolResultDelta };
       }
 
+      if (invocation.state === 'approval-requested') {
+        // A pending approval is control metadata and has no model-visible tool output.
+        return { tokens, overheadDelta, toolResultDelta };
+      }
+
       if (invocation.state === 'output-denied') {
         // A declined approval carries no tool result; count its denial reason like a small result
         // so token accounting stays consistent (and doesn't throw on the new state).


### PR DESCRIPTION
Treat approval-requested tool invocations as control metadata with zero content tokens so Observational Memory does not abort while a conversation waits for human approval. Add a regression test and patch changeset.

## Description

Treats persisted `approval-requested` tool invocations as control metadata with zero content tokens.

This prevents Observational Memory from aborting token counting while a conversation is waiting for human approval. It also adds a regression test covering the persisted pending-approval message shape.

A patch changeset for `@mastra/memory` is included.
## Related issue(s)

Fixes #20607

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a conversation waits for human approval, the system now treats the pending tool request as having no message content. This prevents token counting from failing and allows processing to continue.

## Changes

- Updated `TokenCounter` to handle `approval-requested` tool invocations as control metadata with zero content tokens.
- Added a regression test for persisted assistant messages with pending tool approvals.
- Added a patch changeset for `@mastra/memory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->