### PR TITLE
fix(ci): open a PR instead of pushing providers/docs regen straight to main

### DIFF
--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -41,6 +41,7 @@ jobs:
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
@@ -116,27 +117,43 @@ jobs:
 
       - name: Commit and push changes
         if: steps.git-check.outputs.changed == 'true'
+        env:
+          # main is protected by a ruleset that rejects direct pushes (#20609),
+          # so this pushes to a dedicated bot branch and opens/updates a PR
+          # instead of pushing straight to main. The branch is force-pushed
+          # fresh from the just-checked-out main tip on every run, so it never
+          # accumulates history or needs a rebase, and reusing the same branch
+          # name means a still-open PR is simply updated in place rather than
+          # spawning a new PR every 6 hours.
+          GH_TOKEN: ${{ steps.app-auth.outputs.token }}
         run: |
+          BRANCH="automated/regenerate-providers-docs"
           git add packages/core/src/llm/model/provider-registry.json
           git add packages/core/src/llm/model/provider-types.generated.d.ts
           # The generator rewrites and adds per-provider capability files. These
           # must be staged too; otherwise they linger as unstaged/untracked
-          # changes that abort the rebase below and never make it onto main.
+          # changes.
           git add packages/core/src/llm/model/capabilities/
           git add docs/src/content/en/models/
           if [ -n "${CHANGESET_FILE}" ]; then
             git add "${CHANGESET_FILE}"
           fi
-          git commit -m "chore: regenerate providers and docs [skip ci]"
-          # Use --autostash as a safeguard so any unexpected leftover unstaged
-          # changes don't abort the rebase with "cannot pull with rebase: You
-          # have unstaged changes." Autostash safely stashes and restores them.
-          git pull --rebase --autostash
-          git push
+          git commit -m "chore: regenerate providers and docs"
+          git push --force origin "HEAD:${BRANCH}"
+
+          if [ -n "$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number')" ]; then
+            echo "Existing PR for ${BRANCH} updated by the force-push above."
+          else
+            gh pr create \
+              --title "chore: regenerate providers and docs" \
+              --body "Automated update to the provider registry and generated model documentation from models.dev. This branch is force-pushed with a fresh snapshot every 6 hours, so this PR is updated in place rather than duplicated on each run." \
+              --base main \
+              --head "${BRANCH}"
+          fi
 
       - name: Log summary
         if: steps.git-check.outputs.changed == 'true'
-        run: echo "✅ Providers and documentation updated with changeset and committed to main"
+        run: echo "✅ Providers and documentation updated with changeset; opened/updated PR against main"
 
       - name: Log no changes
         if: steps.git-check.outputs.changed != 'true'


### PR DESCRIPTION
## Description

The scheduled `regenerate-provider-registry.yml` workflow has failed on every run since ~Aug 1: the final push to `main` is rejected with `GH013` repository rule violations now that `main`'s ruleset blocks direct pushes, even from the Dane app. Generation itself still succeeds, so `provider-registry.json` and the generated model docs have been stale since Jul 31.

The issue names two possible fixes: exempting the bot in the ruleset, or switching the workflow to a PR-based flow. This PR implements the second option, since a ruleset exemption is a repo-settings change outside this codebase that only a maintainer with admin access can make. **If a ruleset exemption is actually the preferred fix, this PR can simply be closed instead** — the two aren't mutually exclusive, and I don't have visibility into why the ruleset was tightened, so I can't say which option better fits the intent behind it.

What this PR does: instead of pushing straight to `main`, the workflow now pushes its commit to a dedicated `automated/regenerate-providers-docs` branch and opens a PR against `main`, going through the same merge path as any other change. The branch is force-pushed fresh from the just-checked-out `main` tip on every run, so it never accumulates history and doesn't need the previous `--rebase --autostash` workaround. Reusing the same branch name means a still-open PR is updated in place instead of spawning a new one every 6 hours. `[skip ci]` was removed from the commit message so the PR gets normal CI coverage before a maintainer merges it.

This mirrors `backport-auto.yml`'s existing pattern (force-push a dedicated branch with the same Dane App token, then create a PR via the same permission set), which already proves this exact combination of permissions and push/PR flow works in this repo today — so this isn't a new, unproven automation pattern.

### Verification
- Confirmed `permission-pull-requests: write` is already granted to the Dane App at the installation level, since `backport-auto.yml` requests the identical permission combination (`permission-contents: write` + `permission-pull-requests: write`) with the same credentials.
- Confirmed the force-push-to-branch + PR-creation flow works with this token today, since `backport.ts` (invoked by `backport-auto.yml`) does `git push origin +branch --force` followed by `octokit.pulls.create(...)` using the same Dane App auth.
- Validated YAML syntax and ran `prettier --check` on the changed file — no formatting issues.
- Can't execute the actual scheduled workflow itself outside `mastra-ai/mastra`'s real environment, so this is reviewed carefully rather than tested end-to-end; happy to address anything CI or a maintainer surfaces.

## Related issue(s)

Fixes #20609

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The workflow now prepares provider updates in a branch and opens a pull request instead of pushing directly to `main`. This avoids repository rule failures and lets normal CI checks run.

## Changes

- Reset `automated/regenerate-providers-docs` from the latest `main` commit on each run.
- Force-push generated provider registry and documentation updates to the branch.
- Create or update a pull request against `main`.
- Grant the app token pull-request write permission.
- Remove `[skip ci]` from the commit message.
- Update success logs for the pull-request flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->