### PR TITLE
fix(playground-ui): preserve browser sidebar shortcuts

### DIFF
--- a/.changeset/smooth-sides-ring.md
+++ b/.changeset/smooth-sides-ring.md
@@ -2,4 +2,8 @@
 '@mastra/playground-ui': patch
 ---
 
-Preserved browser shortcuts by making the MainSidebar Command+B toggle opt-in.
+Preserved browser shortcuts by making the MainSidebar Command+B toggle opt-in. Consumers that want the previous shortcut can enable it explicitly:
+
+```tsx
+<MainSidebarProvider disableKeyboardShortcut={false}>{children}</MainSidebarProvider>
+```

--- a/.changeset/smooth-sides-ring.md
+++ b/.changeset/smooth-sides-ring.md
@@ -1,9 +1,18 @@
 ---
-'@mastra/playground-ui': patch
+'@mastra/playground-ui': minor
 ---
 
 Preserved browser shortcuts by making the MainSidebar Command+B toggle opt-in. Consumers that want the previous shortcut can enable it explicitly:
 
 ```tsx
 <MainSidebarProvider disableKeyboardShortcut={false}>{children}</MainSidebarProvider>
+```
+
+Added selective hooks for consumers that only need sidebar state or mobile drawer state:
+
+```tsx
+import { useMaybeSidebarState, useMobileDrawer } from '@mastra/playground-ui/components/MainSidebar';
+
+const sidebar = useMaybeSidebarState();
+const { openMobile } = useMobileDrawer();
 ```

--- a/.changeset/smooth-sides-ring.md
+++ b/.changeset/smooth-sides-ring.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Preserved browser shortcuts by making the MainSidebar Command+B toggle opt-in.

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-context.ts
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-context.ts
@@ -23,21 +23,20 @@ type MainSidebarContextValue = {
   LinkComponent?: LinkComponent;
 };
 
-// Split: drawer open-state lives in its own context so NavLink/NavLabel
+// Split: drawer open-state lives in its own context so navigation rows
 // do not re-render when the mobile drawer toggles.
 export type MobileDrawerContextValue = {
   openMobile: boolean;
   setOpenMobile: (open: boolean) => void;
 };
 
-export const MainSidebarContext = React.createContext<Omit<
-  MainSidebarContextValue,
-  'openMobile' | 'setOpenMobile'
-> | null>(null);
+export type MainSidebarStateContextValue = Omit<MainSidebarContextValue, 'openMobile' | 'setOpenMobile'>;
+
+export const MainSidebarContext = React.createContext<MainSidebarStateContextValue | null>(null);
 export const MobileDrawerContext = React.createContext<MobileDrawerContextValue | null>(null);
 
 /** Reads sidebar state and actions without subscribing to mobile drawer state. */
-export function useMaybeSidebarState(): Omit<MainSidebarContextValue, 'openMobile' | 'setOpenMobile'> | null {
+export function useMaybeSidebarState(): MainSidebarStateContextValue | null {
   return React.useContext(MainSidebarContext);
 }
 

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-context.ts
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-context.ts
@@ -1,0 +1,60 @@
+import React from 'react';
+import type { LinkComponent } from '@/ds/types/link-component';
+
+export type SidebarState = 'default' | 'collapsed';
+
+type MainSidebarContextValue = {
+  state: SidebarState;
+  desktopState: SidebarState;
+  width: number;
+  minWidth: number;
+  maxWidth: number;
+  collapseBelow: number;
+  collapsedWidth: number;
+  isMobile: boolean;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  toggleSidebar: () => void;
+  setWidth: (width: number) => void;
+  collapse: () => void;
+  expand: () => void;
+  commit: () => void;
+  setGestureActive: (active: boolean) => void;
+  LinkComponent?: LinkComponent;
+};
+
+// Split: drawer open-state lives in its own context so NavLink/NavHeader
+// do not re-render when the mobile drawer toggles.
+export type MobileDrawerContextValue = {
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+};
+
+export const MainSidebarContext = React.createContext<Omit<
+  MainSidebarContextValue,
+  'openMobile' | 'setOpenMobile'
+> | null>(null);
+export const MobileDrawerContext = React.createContext<MobileDrawerContextValue | null>(null);
+
+export function useMainSidebar(): MainSidebarContextValue {
+  const ctx = React.useContext(MainSidebarContext);
+  const drawer = React.useContext(MobileDrawerContext);
+  if (!ctx || !drawer) {
+    throw new Error('useMainSidebar must be used within a MainSidebarProvider.');
+  }
+  return { ...ctx, ...drawer };
+}
+
+export function useMaybeSidebar(): MainSidebarContextValue | null {
+  const ctx = React.useContext(MainSidebarContext);
+  const drawer = React.useContext(MobileDrawerContext);
+  if (!ctx || !drawer) return null;
+  return { ...ctx, ...drawer };
+}
+
+/** Reads only mobile drawer state. Cheap — no re-renders on sidebar resize. */
+export function useMobileDrawer(): MobileDrawerContextValue {
+  const drawer = React.useContext(MobileDrawerContext);
+  if (!drawer) throw new Error('useMobileDrawer must be used within a MainSidebarProvider.');
+  return drawer;
+}

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-context.ts
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-context.ts
@@ -23,7 +23,7 @@ type MainSidebarContextValue = {
   LinkComponent?: LinkComponent;
 };
 
-// Split: drawer open-state lives in its own context so NavLink/NavHeader
+// Split: drawer open-state lives in its own context so NavLink/NavLabel
 // do not re-render when the mobile drawer toggles.
 export type MobileDrawerContextValue = {
   openMobile: boolean;
@@ -35,6 +35,11 @@ export const MainSidebarContext = React.createContext<Omit<
   'openMobile' | 'setOpenMobile'
 > | null>(null);
 export const MobileDrawerContext = React.createContext<MobileDrawerContextValue | null>(null);
+
+/** Reads sidebar state and actions without subscribing to mobile drawer state. */
+export function useMaybeSidebarState(): Omit<MainSidebarContextValue, 'openMobile' | 'setOpenMobile'> | null {
+  return React.useContext(MainSidebarContext);
+}
 
 export function useMainSidebar(): MainSidebarContextValue {
   const ctx = React.useContext(MainSidebarContext);

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-context.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-context.tsx
@@ -1,3 +1,5 @@
+/* oxlint-disable react/only-export-components -- Provider hooks intentionally share private context instances with the provider. */
+/* eslint-disable react-refresh/only-export-components -- Provider hooks intentionally share private context instances with the provider. */
 import React from 'react';
 import type { CSSProperties } from 'react';
 import type { LinkComponent } from '@/ds/types/link-component';
@@ -76,7 +78,7 @@ export type MainSidebarProviderProps = {
   collapseBelow?: number;
   /** Width in px when collapsed. Defaults to `64`. Set to `0` for fully hidden. */
   collapsedWidth?: number;
-  /** Disable the global ⌘B / Ctrl+B toggle shortcut. Defaults to `false`. */
+  /** Disable the global ⌘B / Ctrl+B toggle shortcut. Defaults to `true` so browser shortcuts are preserved. */
   disableKeyboardShortcut?: boolean;
   /** Scope-key for localStorage. Allows multiple independent sidebars per app. */
   storageKey?: string;
@@ -100,7 +102,7 @@ export function MainSidebarProvider({
   maxWidth = 480,
   collapseBelow,
   collapsedWidth = 64,
-  disableKeyboardShortcut = false,
+  disableKeyboardShortcut = true,
   storageKey,
   mobileBreakpoint = 1024,
   mobileWidth = 360,

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-header.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-header.tsx
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef } from 'react';
 import type { SidebarState } from './main-sidebar-context';
-import { useMaybeSidebar } from './main-sidebar-context';
+import { useMaybeSidebarState } from './main-sidebar-context';
 import { VisuallyHidden } from '@/ds/primitives/visually-hidden';
 import type { LinkComponent } from '@/ds/types/link-component';
 import { cn } from '@/lib/utils';
@@ -22,7 +22,7 @@ export function MainSidebarNavHeader({
   LinkComponent: LinkProp,
   ...props
 }: MainSidebarNavHeaderProps) {
-  const ctx = useMaybeSidebar();
+  const ctx = useMaybeSidebarState();
   const state: SidebarState = stateProp ?? ctx?.state ?? 'default';
   const isMobile = ctx?.isMobile ?? false;
   const Link: LinkComponent = LinkProp ?? ctx?.LinkComponent ?? 'a';

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-label.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-label.tsx
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef } from 'react';
 import type { SidebarState } from './main-sidebar-context';
-import { useMaybeSidebar } from './main-sidebar-context';
+import { useMaybeSidebarState } from './main-sidebar-context';
 import { VisuallyHidden } from '@/ds/primitives/visually-hidden';
 import { cn } from '@/lib/utils';
 
@@ -21,7 +21,7 @@ export type MainSidebarNavLabelProps = ComponentPropsWithoutRef<'span'> & {
  * own children, so the label needs to opt into the collapse-aware rendering.
  */
 export function MainSidebarNavLabel({ children, className, state: stateProp, ...rest }: MainSidebarNavLabelProps) {
-  const ctx = useMaybeSidebar();
+  const ctx = useMaybeSidebarState();
   const state: SidebarState = stateProp ?? ctx?.state ?? 'default';
   if (state === 'collapsed') {
     return <VisuallyHidden>{children}</VisuallyHidden>;

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, assert, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { useMobileDrawer } from './main-sidebar-context';
+import { MainSidebarNavHeader } from './main-sidebar-nav-header';
 import { MainSidebarNavLink } from './main-sidebar-nav-link';
 import { MainSidebarProvider } from './main-sidebar-provider';
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/ds/components/Tooltip';
@@ -57,20 +58,21 @@ afterEach(() => cleanup());
 //     producing an arrow stranded in the middle of empty space.
 
 describe('MainSidebarNavLink (collapsed) — tooltip regression', () => {
-  it('does not re-render when only the mobile drawer state changes', () => {
+  it('does not re-render navigation rows when only the mobile drawer state changes', () => {
     const Link = vi.fn(({ children, ...props }: LinkComponentProps) => <a {...props}>{children}</a>);
     render(
       <MainSidebarProvider LinkComponent={Link}>
         <DrawerToggle />
+        <MainSidebarNavHeader href="/workspace">Workspace</MainSidebarNavHeader>
         <ul>
           <MainSidebarNavLink link={{ name: 'Agents', url: '/agents' }} />
         </ul>
       </MainSidebarProvider>,
     );
 
-    expect(Link).toHaveBeenCalledTimes(1);
+    expect(Link).toHaveBeenCalledTimes(2);
     fireEvent.click(screen.getByRole('button', { name: 'Toggle drawer' }));
-    expect(Link).toHaveBeenCalledTimes(1);
+    expect(Link).toHaveBeenCalledTimes(2);
   });
 
   it('applies a pointer cursor to sidebar nav items', () => {

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
@@ -4,8 +4,8 @@ import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, assert, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { MainSidebarProvider } from './main-sidebar-context';
 import { MainSidebarNavLink } from './main-sidebar-nav-link';
+import { MainSidebarProvider } from './main-sidebar-provider';
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/ds/components/Tooltip';
 
 const getTooltipPopup = () => {

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.test.tsx
@@ -4,14 +4,21 @@ import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, assert, beforeAll, describe, expect, it, vi } from 'vitest';
 
+import { useMobileDrawer } from './main-sidebar-context';
 import { MainSidebarNavLink } from './main-sidebar-nav-link';
 import { MainSidebarProvider } from './main-sidebar-provider';
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/ds/components/Tooltip';
+import type { LinkComponentProps } from '@/ds/types/link-component';
 
 const getTooltipPopup = () => {
   const popup = document.querySelector<HTMLElement>('.bg-surface3');
   assert(popup, 'Expected tooltip popup');
   return popup;
+};
+
+const DrawerToggle = () => {
+  const { openMobile, setOpenMobile } = useMobileDrawer();
+  return <button onClick={() => setOpenMobile(!openMobile)}>Toggle drawer</button>;
 };
 
 // MainSidebarProvider reads matchMedia at mount to decide mobile vs desktop.
@@ -50,6 +57,22 @@ afterEach(() => cleanup());
 //     producing an arrow stranded in the middle of empty space.
 
 describe('MainSidebarNavLink (collapsed) — tooltip regression', () => {
+  it('does not re-render when only the mobile drawer state changes', () => {
+    const Link = vi.fn(({ children, ...props }: LinkComponentProps) => <a {...props}>{children}</a>);
+    render(
+      <MainSidebarProvider LinkComponent={Link}>
+        <DrawerToggle />
+        <ul>
+          <MainSidebarNavLink link={{ name: 'Agents', url: '/agents' }} />
+        </ul>
+      </MainSidebarProvider>,
+    );
+
+    expect(Link).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle drawer' }));
+    expect(Link).toHaveBeenCalledTimes(1);
+  });
+
   it('applies a pointer cursor to sidebar nav items', () => {
     render(
       <ul>

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
 import type { SidebarState } from './main-sidebar-context';
-import { useMaybeSidebar } from './main-sidebar-context';
+import { useMaybeSidebarState } from './main-sidebar-context';
 import { navItemClasses } from './main-sidebar-nav-item-classes';
 import type { MainSidebarNavItemSize } from './main-sidebar-nav-item-classes';
 import { MainSidebarNavLabel } from './main-sidebar-nav-label';
@@ -70,7 +70,7 @@ export function MainSidebarNavLink({
   ...props
 }: MainSidebarNavLinkProps) {
   // Auto-inherit state + LinkComponent from context; explicit props still win.
-  const ctx = useMaybeSidebar();
+  const ctx = useMaybeSidebarState();
   const state: SidebarState = stateProp ?? ctx?.state ?? 'default';
   const Link: LinkComponent = LinkProp ?? ctx?.LinkComponent ?? 'a';
   const isCollapsed = state === 'collapsed';

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-provider.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-provider.tsx
@@ -1,68 +1,17 @@
-/* oxlint-disable react/only-export-components -- Provider hooks intentionally share private context instances with the provider. */
-/* eslint-disable react-refresh/only-export-components -- Provider hooks intentionally share private context instances with the provider. */
 import React from 'react';
 import type { CSSProperties } from 'react';
+import {
+  MainSidebarContext,
+  MobileDrawerContext,
+  type MobileDrawerContextValue,
+  type SidebarState,
+} from './main-sidebar-context';
 import type { LinkComponent } from '@/ds/types/link-component';
 
 const SIDEBAR_STATE_KEY = 'sidebar:state';
 const SIDEBAR_WIDTH_KEY = 'sidebar:width';
 
 const SIDEBAR_WIDTH_VAR = '--sidebar-width';
-
-export type SidebarState = 'default' | 'collapsed';
-
-type MainSidebarContext = {
-  state: SidebarState;
-  desktopState: SidebarState;
-  width: number;
-  minWidth: number;
-  maxWidth: number;
-  collapseBelow: number;
-  collapsedWidth: number;
-  isMobile: boolean;
-  openMobile: boolean;
-  setOpenMobile: (open: boolean) => void;
-  toggleSidebar: () => void;
-  setWidth: (width: number) => void;
-  collapse: () => void;
-  expand: () => void;
-  commit: () => void;
-  setGestureActive: (active: boolean) => void;
-  LinkComponent?: LinkComponent;
-};
-
-// Split: drawer open-state lives in its own context so NavLink/NavHeader
-// do not re-render when the mobile drawer toggles.
-type MobileDrawerContext = {
-  openMobile: boolean;
-  setOpenMobile: (open: boolean) => void;
-};
-
-const MainSidebarContext = React.createContext<Omit<MainSidebarContext, 'openMobile' | 'setOpenMobile'> | null>(null);
-const MobileDrawerContext = React.createContext<MobileDrawerContext | null>(null);
-
-export function useMainSidebar(): MainSidebarContext {
-  const ctx = React.useContext(MainSidebarContext);
-  const drawer = React.useContext(MobileDrawerContext);
-  if (!ctx || !drawer) {
-    throw new Error('useMainSidebar must be used within a MainSidebarProvider.');
-  }
-  return { ...ctx, ...drawer };
-}
-
-export function useMaybeSidebar(): MainSidebarContext | null {
-  const ctx = React.useContext(MainSidebarContext);
-  const drawer = React.useContext(MobileDrawerContext);
-  if (!ctx || !drawer) return null;
-  return { ...ctx, ...drawer };
-}
-
-/** Reads only mobile drawer state. Cheap — no re-renders on sidebar resize. */
-export function useMobileDrawer(): MobileDrawerContext {
-  const drawer = React.useContext(MobileDrawerContext);
-  if (!drawer) throw new Error('useMobileDrawer must be used within a MainSidebarProvider.');
-  return drawer;
-}
 
 export type MainSidebarProviderProps = {
   children: React.ReactNode;
@@ -298,7 +247,7 @@ export function MainSidebarProvider({
     ],
   );
 
-  const drawerValue = React.useMemo<MobileDrawerContext>(() => ({ openMobile, setOpenMobile }), [openMobile]);
+  const drawerValue = React.useMemo<MobileDrawerContextValue>(() => ({ openMobile, setOpenMobile }), [openMobile]);
 
   // CSS var owned exclusively by writeCssVar (single source of truth).
   // SSR seeds the initial value here; post-mount writeCssVar takes over.

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.test.tsx
@@ -101,6 +101,54 @@ describe('MainSidebar resize handle gesture', () => {
   });
 });
 
+describe('MainSidebar keyboard behavior', () => {
+  it('leaves Command+B available to the browser by default', () => {
+    mockMatchMedia(false);
+    render(
+      <MainSidebarProvider>
+        <MainSidebar>
+          <MainSidebar.Nav />
+        </MainSidebar>
+      </MainSidebarProvider>,
+    );
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      code: 'KeyB',
+      key: 'b',
+      metaKey: true,
+    });
+
+    fireEvent(window, event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(document.querySelector('[data-sidebar-scope]')?.getAttribute('data-sidebar-state')).toBe('default');
+  });
+
+  it('toggles the sidebar when a consumer explicitly opts in', () => {
+    mockMatchMedia(false);
+    render(
+      <MainSidebarProvider disableKeyboardShortcut={false}>
+        <MainSidebar>
+          <MainSidebar.Nav />
+        </MainSidebar>
+      </MainSidebarProvider>,
+    );
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      code: 'KeyB',
+      key: 'b',
+      metaKey: true,
+    });
+
+    fireEvent(window, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.querySelector('[data-sidebar-scope]')?.getAttribute('data-sidebar-state')).toBe('collapsed');
+  });
+});
+
 describe('MainSidebar mobile drawer', () => {
   it('opens as an accessible dialog on mobile', () => {
     mockMatchMedia(true);

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.test.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MainSidebar } from './main-sidebar';
-import { MainSidebarProvider } from './main-sidebar-context';
+import { MainSidebarProvider } from './main-sidebar-provider';
 
 const mockMatchMedia = (matches: boolean) => {
   Object.defineProperty(window, 'matchMedia', {

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-trigger.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-trigger.tsx
@@ -1,4 +1,4 @@
-import { KeyboardIcon, PanelRightIcon } from 'lucide-react';
+import { PanelRightIcon } from 'lucide-react';
 import type { ComponentPropsWithoutRef } from 'react';
 import { useMainSidebar } from './main-sidebar-context';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
@@ -45,12 +45,7 @@ export function MainSidebarTrigger({ className, onClick, ...props }: MainSidebar
         }
       />
 
-      <TooltipContent>
-        Toggle Sidebar
-        <div className="flex items-center gap-1 [&>svg]:size-[1em]">
-          <KeyboardIcon /> Ctrl+B
-        </div>
-      </TooltipContent>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
     </Tooltip>
   );
 }

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
@@ -66,8 +66,7 @@ const HelperCopy = () => (
   <>
     <p className="text-ui-md text-neutral5 font-medium">Main content area</p>
     <p className="text-ui-sm text-neutral4 mt-2 max-w-[40ch]">
-      Hover the sidebar edge to reveal the handle. Drag to resize, click to toggle, or hit{' '}
-      <kbd className="bg-surface5 text-neutral4 rounded px-1 font-mono text-[0.65rem]">⌘B</kbd>.
+      Hover the sidebar edge to reveal the handle. Drag to resize, or click to toggle.
     </p>
   </>
 );
@@ -510,7 +509,7 @@ export const Resizable: Story = {
     docs: {
       description: {
         story:
-          'Drag the right edge to resize between min and max width. Width is persisted to `localStorage` under `sidebar:width`. Dragging below `collapseBelow` snaps the sidebar to its collapsed state; the toggle (or `Ctrl+B`) restores the last expanded width.',
+          'Drag the right edge to resize between min and max width. Width is persisted to `localStorage` under `sidebar:width`. Dragging below `collapseBelow` snaps the sidebar to its collapsed state; the toggle restores the last expanded width.',
       },
     },
   },
@@ -527,7 +526,7 @@ export const Collapsed: Story = {
     docs: {
       description: {
         story:
-          'Icon-only mode. `NavLink` and `NavHeader` both render compact when their `state` prop (or context state) is `"collapsed"`. Use the trigger or `Ctrl+B` to expand.',
+          'Icon-only mode. `NavLink` and `NavHeader` both render compact when their `state` prop (or context state) is `"collapsed"`. Use the trigger to expand.',
       },
     },
   },
@@ -552,7 +551,7 @@ export const FullyCollapsible: Story = {
     docs: {
       description: {
         story:
-          'Set `collapsedWidth: 0` for a fully hidden sidebar. The drag handle persists at the edge so users can re-open it. Drag below `collapseBelow` to snap closed; click the handle (or `Ctrl+B`) to restore the previous width.',
+          'Set `collapsedWidth: 0` for a fully hidden sidebar. The drag handle persists at the edge so users can re-open it. Drag below `collapseBelow` to snap closed; click the handle to restore the previous width.',
       },
     },
   },

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.ts
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.ts
@@ -11,8 +11,9 @@ import { MainSidebarRoot } from './main-sidebar-root';
 import { MainSidebarSections } from './main-sidebar-sections';
 import { MainSidebarTrigger } from './main-sidebar-trigger';
 
-export { MainSidebarProvider, type SidebarState, type MainSidebarProviderProps } from './main-sidebar-context';
+export type { SidebarState } from './main-sidebar-context';
 export { useMainSidebar, useMaybeSidebar } from './main-sidebar-context';
+export { MainSidebarProvider, type MainSidebarProviderProps } from './main-sidebar-provider';
 export { navItemClasses } from './main-sidebar-nav-item-classes';
 export { type MainSidebarNavItemSize } from './main-sidebar-nav-item-classes';
 export { type NavLink } from './main-sidebar-nav-link';

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.ts
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.ts
@@ -11,8 +11,8 @@ import { MainSidebarRoot } from './main-sidebar-root';
 import { MainSidebarSections } from './main-sidebar-sections';
 import { MainSidebarTrigger } from './main-sidebar-trigger';
 
-export type { SidebarState } from './main-sidebar-context';
-export { useMainSidebar, useMaybeSidebar } from './main-sidebar-context';
+export type { MainSidebarStateContextValue, MobileDrawerContextValue, SidebarState } from './main-sidebar-context';
+export { useMainSidebar, useMaybeSidebar, useMaybeSidebarState, useMobileDrawer } from './main-sidebar-context';
 export { MainSidebarProvider, type MainSidebarProviderProps } from './main-sidebar-provider';
 export { navItemClasses } from './main-sidebar-nav-item-classes';
 export { type MainSidebarNavItemSize } from './main-sidebar-nav-item-classes';

--- a/packages/playground/src/lib/command/navigation-command.tsx
+++ b/packages/playground/src/lib/command/navigation-command.tsx
@@ -9,9 +9,7 @@ import {
   CommandPaletteResults,
   CommandPaletteScope,
 } from '@mastra/playground-ui/components/CommandPalette';
-import { Kbd } from '@mastra/playground-ui/components/Kbd';
 import { useMaybeSidebar } from '@mastra/playground-ui/components/MainSidebar';
-import { useKeyboardShortcutLabel } from '@mastra/playground-ui/hooks/use-keyboard-shortcut-label';
 import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
 import { McpServerIcon } from '@mastra/playground-ui/icons/McpServerIcon';
 import { ToolsIcon } from '@mastra/playground-ui/icons/ToolsIcon';
@@ -122,23 +120,21 @@ const CommandRail = ({
   </CommandPaletteRail>
 );
 
-const ShortcutResults = ({
+const CommandResults = ({
   sidebar,
   activeScope,
-  sidebarShortcutLabel,
   closeCommand,
 }: {
   sidebar: SidebarContextValue | null;
   activeScope: CommandScope;
-  sidebarShortcutLabel: string;
   closeCommand: () => void;
 }) => {
   if (!sidebar || (activeScope !== 'all' && activeScope !== 'settings')) return null;
 
   return (
-    <CommandGroup heading="Shortcuts">
+    <CommandGroup heading="Commands">
       <CommandPaletteItem
-        value="toggle sidebar collapse expand layout panel shortcut command b ctrl b"
+        value="toggle sidebar collapse expand layout panel"
         onSelect={() => {
           sidebar.toggleSidebar();
           closeCommand();
@@ -146,8 +142,6 @@ const ShortcutResults = ({
         icon={<PanelLeftIcon />}
         title="Toggle Sidebar"
         subtitle="Studio layout"
-        badge="Shortcut"
-        shortcut={<Kbd size="sm">{sidebarShortcutLabel}</Kbd>}
       />
     </CommandGroup>
   );
@@ -473,7 +467,6 @@ export const NavigationCommand = () => {
   const { navigate, paths } = useLinkComponent();
   const { isMastraPlatform } = useMastraPlatform();
   const sidebar = useMaybeSidebar();
-  const sidebarShortcutLabel = useKeyboardShortcutLabel('B');
   const [activeScope, setActiveScope] = React.useState<CommandScope>('all');
 
   const { data: agents = {} } = useAgents();
@@ -599,12 +592,7 @@ export const NavigationCommand = () => {
         <CommandRail scopeOptions={scopeOptions} activeScope={activeScope} onScopeChange={setActiveScope} />
         <CommandPaletteResults aria-label="Search results" footer={<CommandPaletteFooter label="Studio search" />}>
           <CommandEmpty>No matching results.</CommandEmpty>
-          <ShortcutResults
-            sidebar={sidebar}
-            activeScope={activeScope}
-            sidebarShortcutLabel={sidebarShortcutLabel}
-            closeCommand={closeCommand}
-          />
+          <CommandResults sidebar={sidebar} activeScope={activeScope} closeCommand={closeCommand} />
           <PathSectionResults sections={visiblePathSections} handleSelect={handleSelect} />
           <AgentResults visible={showAgents} entries={agentEntries} paths={paths} handleSelect={handleSelect} />
           <WorkflowResults

--- a/packages/playground/src/lib/command/navigation-command.tsx
+++ b/packages/playground/src/lib/command/navigation-command.tsx
@@ -9,7 +9,7 @@ import {
   CommandPaletteResults,
   CommandPaletteScope,
 } from '@mastra/playground-ui/components/CommandPalette';
-import { useMaybeSidebar } from '@mastra/playground-ui/components/MainSidebar';
+import { useMaybeSidebarState } from '@mastra/playground-ui/components/MainSidebar';
 import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
 import { McpServerIcon } from '@mastra/playground-ui/icons/McpServerIcon';
 import { ToolsIcon } from '@mastra/playground-ui/icons/ToolsIcon';
@@ -71,7 +71,7 @@ type NavigationSection = {
 };
 
 type NavigationPaths = ReturnType<typeof useLinkComponent>['paths'];
-type SidebarContextValue = NonNullable<ReturnType<typeof useMaybeSidebar>>;
+type SidebarContextValue = NonNullable<ReturnType<typeof useMaybeSidebarState>>;
 type HandleSelect = (path: string) => void;
 type AgentEntry = [string, { name: string }];
 type WorkflowEntry = [string, { name: string }];
@@ -466,7 +466,7 @@ export const NavigationCommand = () => {
   const { open, setOpen } = useNavigationCommand();
   const { navigate, paths } = useLinkComponent();
   const { isMastraPlatform } = useMastraPlatform();
-  const sidebar = useMaybeSidebar();
+  const sidebar = useMaybeSidebarState();
   const [activeScope, setActiveScope] = React.useState<CommandScope>('all');
 
   const { data: agents = {} } = useAgents();


### PR DESCRIPTION
Makes the shared MainSidebar Cmd/Ctrl+B binding opt-in so browser shortcuts keep working by default.

The sidebar button and Studio command-palette action still toggle the sidebar. Stale shortcut labels were removed, and regression coverage verifies both the browser-safe default and explicit opt-in behavior.

The MainSidebar provider now has a clean Fast Refresh boundary, with context and hooks in a separate non-component module instead of lint suppressions. Navigation headers, labels, and links subscribe only to sidebar state, avoiding re-renders when the mobile drawer toggles. The selective state and drawer hooks are public, and Studio's command palette now uses the state-only hook.

The changeset is minor because it adds public hooks and changes the default shortcut behavior on the current alpha line.

Tested:
- Playground UI tests (719), lint-staged checks, typecheck, and build
- Playground and Factory UI typechecks
- React Doctor changed-scope check with no diagnostics
- Storybook browser verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The sidebar no longer uses Command+B by default, so it does not interfere with browser shortcuts. Users can still toggle it with the sidebar button, the command palette, or by explicitly enabling the shortcut.

## Changes

- Made `MainSidebar` Command+B support opt-in.
- Added state-only and mobile-drawer-only hooks to reduce unnecessary navigation re-renders.
- Improved the `MainSidebarProvider` Fast Refresh boundary.
- Removed outdated shortcut labels from tooltips, stories, and the command palette.
- Added regression tests for shortcut behavior and render isolation.
- Added a minor changeset for `@mastra/playground-ui`.

## Validation

- Ran Playground UI tests.
- Ran lint, typechecks, builds, and React Doctor checks.
- Verified Storybook behavior in a browser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
