### PR TITLE
feat(factory-ui): add shared thread rail

### DIFF
--- a/.changeset/loose-windows-join.md
+++ b/.changeset/loose-windows-join.md
@@ -2,4 +2,10 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed thread rail browser imports and active-turn tracking after older history is prepended.
+Fixed three problems with the conversation rail in chat threads.
+
+**The rail now marks the turn you are reading after older history loads.** Scrolling up to load earlier messages used to leave the oldest message highlighted as the current turn, so the marker jumped to the top of the thread instead of following the transcript.
+
+**Scrolling stays responsive in long threads.** The rail re-derived the order of every message on each scroll event. It now does that only when messages are added or removed.
+
+**The rail can be used in a browser-only app.** Importing it no longer drags the whole `@mastra/react` entry point into the bundle.

--- a/.changeset/loose-windows-join.md
+++ b/.changeset/loose-windows-join.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed thread rail browser imports and active-turn tracking after older history is prepended.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ThreadRailLayer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ThreadRailLayer.tsx
@@ -10,7 +10,7 @@ export function ThreadRailLayer() {
   if (turns.length === 0) return null;
 
   return (
-    <div className="pointer-events-none absolute inset-y-0 left-4 z-20 hidden @[58rem]:block">
+    <div className="pointer-events-none absolute inset-y-0 left-4 z-20">
       <ThreadRail turns={turns} className="pointer-events-auto sticky top-1/2 -translate-y-1/2" />
     </div>
   );

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ThreadRailLayer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ThreadRailLayer.tsx
@@ -2,7 +2,6 @@ import { buildThreadRailTurns, ThreadRail } from '@mastra/playground-ui/componen
 
 import { useChatTranscript } from '../context/useChatTranscript';
 
-/** Positions the shared conversation rail without owning its presentation or interaction behavior. */
 export function ThreadRailLayer() {
   const { transcript } = useChatTranscript();
   const messages = transcript.entries.flatMap(entry => (entry.kind === 'message' ? [entry.message] : []));

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ThreadRailLayer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ThreadRailLayer.tsx
@@ -1,0 +1,18 @@
+import { buildThreadRailTurns, ThreadRail } from '@mastra/playground-ui/components/ThreadRail';
+
+import { useChatTranscript } from '../context/useChatTranscript';
+
+/** Positions the shared conversation rail without owning its presentation or interaction behavior. */
+export function ThreadRailLayer() {
+  const { transcript } = useChatTranscript();
+  const messages = transcript.entries.flatMap(entry => (entry.kind === 'message' ? [entry.message] : []));
+  const turns = buildThreadRailTurns(messages);
+
+  if (turns.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-y-0 left-4 z-20 hidden @[58rem]:block">
+      <ThreadRail turns={turns} className="pointer-events-auto sticky top-1/2 -translate-y-1/2" />
+    </div>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/layout.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/layout.ts
@@ -2,8 +2,13 @@
 const CHAT_COLUMN_REM = 44;
 const CARD_REM = 21;
 const GUTTER_REM = 1.5;
+const RAIL_LANE_REM = 7;
 
 export const DOCK_MIN_REM = CHAT_COLUMN_REM + CARD_REM + GUTTER_REM * 2;
+
+// Measured on the padded scroller, not the shell: the docked card's inset is room the rail
+// cannot use, and below this the ticks land on the messages.
+export const RAIL_MIN_REM = CHAT_COLUMN_REM + RAIL_LANE_REM * 2;
 
 // Tailwind scans literals, so the rem values below can't interpolate the constants — keep in sync.
 export const chatColumnClass = '[--chat-column:44rem]';

--- a/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
@@ -19,6 +19,7 @@ import { GoalPanel } from '../domains/chat/components/GoalPanel';
 import { TaskPanel } from '../domains/chat/components/TaskPanel';
 import { Transcript } from '../domains/chat/components/Transcript';
 import { TranscriptHistoryLoader } from '../domains/chat/components/TranscriptHistoryLoader';
+import { ThreadRailLayer } from '../domains/chat/components/ThreadRailLayer';
 import { WorkingIndicator } from '../domains/chat/components/WorkingIndicator';
 import { ChatMessageBoundary, ChatSessionBoundary } from '../domains/chat/context/ChatSessionProvider';
 import { useChatTranscript } from '../domains/chat/context/useChatTranscript';
@@ -79,23 +80,26 @@ function ThreadPageMain({ workspacePath }: { workspacePath: string | undefined }
       </ChatShell.Bar>
       <ChatShell.Stage>
         <ChatShell.Viewport>
-          <ChatShell.Content className="gap-0 pt-6">
-            <ChatShell.Column className="flex-1">
-              <ConnectionNotice />
-              <ChatMessageBoundary>
-                <ThreadTranscript />
-              </ChatMessageBoundary>
-            </ChatShell.Column>
-          </ChatShell.Content>
-          <ChatShell.Dock>
-            <ChatShell.ScrollButton aria-label="Jump to latest message" />
-            <ChatShell.Column className="gap-2">
-              <TaskPanel />
-              <div role="region" aria-label="Thread composer">
-                <ComposerPanel />
-              </div>
-            </ChatShell.Column>
-          </ChatShell.Dock>
+          <div className="relative flex min-h-full min-w-0 flex-1 flex-col">
+            <ThreadRailLayer />
+            <ChatShell.Content className="gap-0 pt-6">
+              <ChatShell.Column className="flex-1">
+                <ConnectionNotice />
+                <ChatMessageBoundary>
+                  <ThreadTranscript />
+                </ChatMessageBoundary>
+              </ChatShell.Column>
+            </ChatShell.Content>
+            <ChatShell.Dock>
+              <ChatShell.ScrollButton aria-label="Jump to latest message" />
+              <ChatShell.Column className="gap-2">
+                <TaskPanel />
+                <div role="region" aria-label="Thread composer">
+                  <ComposerPanel />
+                </div>
+              </ChatShell.Column>
+            </ChatShell.Dock>
+          </div>
         </ChatShell.Viewport>
         <WorkspaceFilesSurface />
       </ChatShell.Stage>

--- a/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
@@ -1,6 +1,7 @@
 import { ChatShell } from '@mastra/playground-ui/components/ChatShell';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import type { ReactNode } from 'react';
+import { useRef } from 'react';
 import { useParams } from 'react-router';
 
 import { Sidebar } from '../Sidebar';
@@ -8,7 +9,8 @@ import { ChatLayout } from '../layouts/ChatLayout';
 import { useThreadWorkspacePath } from '../domains/workspace-viewer/hooks/useThreadWorkspacePath';
 import { WorkspaceFilesProvider } from '../domains/workspace-viewer/context/WorkspaceFilesProvider';
 import { WorkspaceFilesSurface } from '../domains/workspace-viewer/components/WorkspaceFilesSurface';
-import { chatColumnClass } from '../domains/workspace-viewer/layout';
+import { chatColumnClass, RAIL_MIN_REM } from '../domains/workspace-viewer/layout';
+import { useWiderThan } from '../domains/workspace-viewer/hooks/useWiderThan';
 import { useInvalidateWorkspaceChangesOnRunCompletion } from '../domains/workspace-viewer/useInvalidateWorkspaceChangesOnRunCompletion';
 import { ChatHeader } from '../domains/chat/components/ChatHeader';
 import { FactorySessionHeader } from '../domains/factory/components/RelatedFactorySessions';
@@ -69,6 +71,8 @@ function ThreadPageMain({ workspacePath }: { workspacePath: string | undefined }
   useGlobalShortcuts();
   useRouteThreadSync();
   useThreadPageKickoffs();
+  const railBoxRef = useRef<HTMLDivElement>(null);
+  const railFits = useWiderThan(railBoxRef, RAIL_MIN_REM);
 
   return (
     <ThreadShell workspacePath={workspacePath}>
@@ -80,8 +84,8 @@ function ThreadPageMain({ workspacePath }: { workspacePath: string | undefined }
       </ChatShell.Bar>
       <ChatShell.Stage>
         <ChatShell.Viewport>
-          <div className="relative flex min-h-full min-w-0 flex-1 flex-col">
-            <ThreadRailLayer />
+          <div ref={railBoxRef} className="relative flex min-h-full min-w-0 flex-1 flex-col">
+            {railFits && <ThreadRailLayer />}
             <ChatShell.Content className="gap-0 pt-6">
               <ChatShell.Column className="flex-1">
                 <ConnectionNotice />

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageRail.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageRail.msw.test.tsx
@@ -2,7 +2,7 @@ import type { MastraDBMessage } from '@mastra/client-js';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { server } from '../../../../e2e/ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '../../../../e2e/ui/render';
@@ -115,7 +115,29 @@ function renderThreadRoute(path: string) {
   return renderWithProviders(<RouterProvider router={router} />);
 }
 
+const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+
+/** jsdom reports every box as 0×0, so the rail threshold needs a width to measure against. */
+function stubScrollerWidth(width: number) {
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width,
+    height: 800,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: 800,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  });
+}
+
+beforeEach(() => {
+  stubScrollerWidth(1200);
+});
+
 afterEach(() => {
+  HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
   window.localStorage.removeItem(SIDEBAR_STATE_KEY);
 });
 
@@ -126,6 +148,19 @@ describe('ThreadPage conversation rail', () => {
       renderThreadRoute(`/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${SESSION_ID}`);
 
       expect(await screen.findByText('There are no user turns in this thread.')).toBeInTheDocument();
+      expect(screen.queryByRole('navigation', { name: 'Conversation timeline' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when the docked workspace card leaves no room beside the column', () => {
+    it('does not render conversation navigation', async () => {
+      // 704px = the 44rem column with zero gutter, what the scroller is left with
+      // once the workspace card claims its inset.
+      stubScrollerWidth(704);
+      stubThreadRoute(threadRailMessages);
+      renderThreadRoute(`/factories/${FACTORY_ID}/user/threads/${SESSION_ID}`);
+
+      expect(await screen.findByText('Run the focused checks')).toBeInTheDocument();
       expect(screen.queryByRole('navigation', { name: 'Conversation timeline' })).not.toBeInTheDocument();
     });
   });

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageRail.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageRail.msw.test.tsx
@@ -1,0 +1,198 @@
+import type { MastraDBMessage } from '@mastra/client-js';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../../e2e/ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../e2e/ui/render';
+import { createAppRoutes } from '../../router';
+import { assistantOnlyThreadMessages, threadRailMessages } from './fixtures/thread-rail';
+
+const FACTORY_ID = 'factory-thread-rail';
+const REPOSITORY_ID = 'repository-thread-rail';
+const SESSION_ID = 'session-thread-rail';
+const AGENT_CONTROLLER_API = `${TEST_BASE_URL}/api/agent-controller/code`;
+const SIDEBAR_STATE_KEY = 'mastracode-web:sidebar:state';
+
+const workspaceSession = {
+  id: 'workspace-session-row',
+  sessionId: SESSION_ID,
+  projectRepositoryId: REPOSITORY_ID,
+  orgId: 'org-1',
+  userId: 'user-1',
+  branch: 'factory/thread-rail',
+  baseBranch: 'main',
+  sandboxId: 'sandbox-1',
+  sandboxWorkdir: '/workspace/acme',
+  materializedAt: '2026-08-03T09:00:00.000Z',
+  createdAt: '2026-08-03T09:00:00.000Z',
+  updatedAt: '2026-08-03T09:00:00.000Z',
+};
+
+function stubThreadRoute(messages: MastraDBMessage[]) {
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'connection-1',
+            installationId: 'installation-1',
+            repositories: [
+              {
+                id: REPOSITORY_ID,
+                branch: 'main',
+                sandboxWorkdir: '/workspace/acme',
+                repository: { slug: 'acme/app', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+      HttpResponse.json({ workItems: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPOSITORY_ID}/sessions`, () =>
+      HttpResponse.json({ sessions: [workspaceSession] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/subscriptions`, () => HttpResponse.json({ subscriptions: [] })),
+    http.get(`${TEST_BASE_URL}/web/user-sessions/${SESSION_ID}`, () =>
+      HttpResponse.json({ session: workspaceSession }),
+    ),
+    http.post(`${TEST_BASE_URL}/web/github/projects/${REPOSITORY_ID}/ensure`, () =>
+      HttpResponse.json({
+        resourceId: SESSION_ID,
+        factoryProjectId: FACTORY_ID,
+        projectRepositoryId: REPOSITORY_ID,
+        sandboxId: 'sandbox-1',
+        sandboxWorkdir: '/workspace/acme',
+      }),
+    ),
+    http.post(`${AGENT_CONTROLLER_API}/sessions`, () =>
+      HttpResponse.json({ controllerId: 'code', resourceId: SESSION_ID, threadId: SESSION_ID }),
+    ),
+    http.get(`${AGENT_CONTROLLER_API}/sessions/:resourceId`, () =>
+      HttpResponse.json({
+        controllerId: 'code',
+        resourceId: SESSION_ID,
+        modeId: 'build',
+        modelId: 'openai/gpt-4o-mini',
+        threadId: SESSION_ID,
+        settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+      }),
+    ),
+    http.put(`${AGENT_CONTROLLER_API}/sessions/:resourceId/state`, () => HttpResponse.json({ ok: true })),
+    http.get(
+      `${AGENT_CONTROLLER_API}/sessions/:resourceId/stream`,
+      () =>
+        new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    ),
+    http.get(`${AGENT_CONTROLLER_API}/sessions/:resourceId/permissions`, () => HttpResponse.json({})),
+    http.get(`${AGENT_CONTROLLER_API}/sessions/:resourceId/threads`, () =>
+      HttpResponse.json({ threads: [{ id: SESSION_ID, title: 'Factory thread' }] }),
+    ),
+    http.get(`${AGENT_CONTROLLER_API}/sessions/:resourceId/threads/:threadId/messages`, () =>
+      HttpResponse.json({ messages }),
+    ),
+    http.get(`${AGENT_CONTROLLER_API}/modes`, () => HttpResponse.json({ modes: [] })),
+    http.get(`${TEST_BASE_URL}/web/workspace/rendered/list`, () =>
+      HttpResponse.json({ workspacePath: `/workspace/${SESSION_ID}`, root: '.artifacts', rootPath: '', entries: [] }),
+    ),
+  );
+}
+
+function renderThreadRoute(path: string) {
+  const router = createMemoryRouter(createAppRoutes(), { initialEntries: [path] });
+  return renderWithProviders(<RouterProvider router={router} />);
+}
+
+afterEach(() => {
+  window.localStorage.removeItem(SIDEBAR_STATE_KEY);
+});
+
+describe('ThreadPage conversation rail', () => {
+  describe('when a workspace thread contains no user turns', () => {
+    it('does not render conversation navigation', async () => {
+      stubThreadRoute(assistantOnlyThreadMessages);
+      renderThreadRoute(`/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${SESSION_ID}`);
+
+      expect(await screen.findByText('There are no user turns in this thread.')).toBeInTheDocument();
+      expect(screen.queryByRole('navigation', { name: 'Conversation timeline' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when a user-session thread contains multiple user turns', () => {
+    it('renders one jump control per user turn and marks the latest turn', async () => {
+      stubThreadRoute(threadRailMessages);
+      renderThreadRoute(`/factories/${FACTORY_ID}/user/threads/${SESSION_ID}`);
+
+      const rail = await screen.findByRole('navigation', { name: 'Conversation timeline' });
+      const jumpControls = within(rail).getAllByRole('button', { name: /Jump to/ });
+
+      expect(jumpControls).toHaveLength(2);
+      expect(within(rail).getByRole('button', { name: 'Jump to Review the implementation plan' })).toBeInTheDocument();
+      await waitFor(() =>
+        expect(within(rail).getByRole('button', { name: 'Jump to Run the focused checks' })).toHaveAttribute(
+          'aria-current',
+          'location',
+        ),
+      );
+    });
+
+    it('shows the same turn preview for hover and keyboard focus', async () => {
+      stubThreadRoute(threadRailMessages);
+      renderThreadRoute(`/factories/${FACTORY_ID}/user/threads/${SESSION_ID}`);
+
+      const firstTurn = await screen.findByRole('button', { name: 'Jump to Review the implementation plan' });
+      fireEvent.mouseEnter(firstTurn);
+
+      const preview = within(screen.getByTestId('thread-rail-preview-current'));
+      expect(preview.getByText('The implementation is ready to review.')).toBeInTheDocument();
+      expect(preview.getByText('plan.md')).toBeInTheDocument();
+
+      const secondTurn = screen.getByRole('button', { name: 'Jump to Run the focused checks' });
+      fireEvent.focus(secondTurn);
+      await waitFor(() =>
+        expect(
+          within(screen.getByTestId('thread-rail-preview-current')).getByText('Run the focused checks'),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it('scrolls the transcript to the selected user turn', async () => {
+      const originalScrollTo = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollTo');
+      const scrollTo = vi.fn();
+      Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+        configurable: true,
+        writable: true,
+        value: scrollTo,
+      });
+
+      try {
+        stubThreadRoute(threadRailMessages);
+        renderThreadRoute(`/factories/${FACTORY_ID}/user/threads/${SESSION_ID}`);
+
+        const firstTurn = await screen.findByRole('button', { name: 'Jump to Review the implementation plan' });
+        scrollTo.mockClear();
+        fireEvent.click(firstTurn);
+
+        expect(scrollTo).toHaveBeenCalledTimes(1);
+      } finally {
+        if (originalScrollTo) {
+          Object.defineProperty(HTMLElement.prototype, 'scrollTo', originalScrollTo);
+        } else {
+          Reflect.deleteProperty(HTMLElement.prototype, 'scrollTo');
+        }
+      }
+    });
+  });
+});

--- a/mastracode/factory-ui/src/ui/pages/__tests__/fixtures/thread-rail.ts
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/fixtures/thread-rail.ts
@@ -1,0 +1,52 @@
+import type { MastraDBMessage } from '@mastra/client-js';
+
+const createdAt = new Date('2026-08-03T09:00:00.000Z');
+
+export const assistantOnlyThreadMessages: MastraDBMessage[] = [
+  {
+    id: 'assistant-only',
+    role: 'assistant',
+    createdAt,
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text: 'There are no user turns in this thread.' }],
+    },
+  },
+];
+
+export const threadRailMessages: MastraDBMessage[] = [
+  {
+    id: 'user-plan',
+    role: 'user',
+    createdAt,
+    content: {
+      format: 2,
+      parts: [
+        { type: 'text', text: 'Review the implementation plan' },
+        {
+          type: 'file',
+          mimeType: 'text/markdown',
+          data: 'https://files.example.com/plan.md',
+        },
+      ],
+    },
+  },
+  {
+    id: 'assistant-review',
+    role: 'assistant',
+    createdAt,
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text: 'The implementation is ready to review.' }],
+    },
+  },
+  {
+    id: 'user-checks',
+    role: 'user',
+    createdAt,
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text: 'Run the focused checks' }],
+    },
+  },
+];

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
@@ -405,6 +405,29 @@ const HistoryHarness = ({
   </MessageScrollerProvider>
 );
 
+const HistoryRailHarness = ({ messageIds }: { messageIds: string[] }) => (
+  <MessageScrollerProvider>
+    <MessageScrollerViewport data-testid="history-rail-viewport">
+      <MessageScrollerContent>
+        {messageIds.map(messageId => (
+          <MessageScrollerItem key={messageId} messageId={messageId} scrollAnchor>
+            <div>{messageId}</div>
+          </MessageScrollerItem>
+        ))}
+      </MessageScrollerContent>
+    </MessageScrollerViewport>
+    <ThreadRail
+      turns={messageIds.map(messageId => ({
+        key: messageId,
+        messageId,
+        prompt: messageId,
+        files: [],
+        hiddenFileCount: 0,
+      }))}
+    />
+  </MessageScrollerProvider>
+);
+
 const contentResizeObserver = () => {
   const content = document.querySelector<HTMLElement>('[data-slot="message-scroller-content"]');
   if (!content) throw new Error('No scroller content');
@@ -414,6 +437,33 @@ const contentResizeObserver = () => {
 };
 
 describe('MessageScroller older history', () => {
+  it('tracks the active anchor in document order after older messages are prepended', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined);
+    const { rerender } = render(<HistoryRailHarness messageIds={['message-3', 'message-4']} />);
+    const viewport = screen.getByTestId('history-rail-viewport');
+    installScrollTo(viewport);
+    setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 200 });
+    setTop(viewport, 100);
+    setTop(getItem('message-3'), 80);
+    setTop(getItem('message-4'), 180);
+    fireEvent.scroll(viewport);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Jump to message-3' }).getAttribute('aria-current')).toBe('location');
+    });
+
+    rerender(<HistoryRailHarness messageIds={['message-1', 'message-2', 'message-3', 'message-4']} />);
+    setTop(getItem('message-1'), -120);
+    setTop(getItem('message-2'), -20);
+    setTop(getItem('message-3'), 80);
+    setTop(getItem('message-4'), 180);
+    fireEvent.scroll(viewport);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Jump to message-3' }).getAttribute('aria-current')).toBe('location');
+    });
+  });
+
   it('does not request older history before the transcript has settled at the end', () => {
     const onReachStart = vi.fn();
     render(<HistoryHarness messageIds={['message-1']} onReachStart={onReachStart} />);

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
@@ -64,6 +64,14 @@ const visibilityMatches = (left: MessageScrollerVisibility, right: MessageScroll
   left.visibleMessageIds.length === right.visibleMessageIds.length &&
   left.visibleMessageIds.every((messageId, index) => messageId === right.visibleMessageIds[index]);
 
+const orderItemsByDocumentPosition = (items: Array<readonly [string, MessageScrollerItemRecord]>) =>
+  items.sort(([, left], [, right]) => {
+    const position = left.element.compareDocumentPosition(right.element);
+    if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+    if (position & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+    return 0;
+  });
+
 const getContentPadding = (contentElement: HTMLElement | null) => {
   if (!contentElement) return { start: 0, end: 0 };
   const styles = window.getComputedStyle(contentElement);
@@ -249,7 +257,10 @@ export function MessageScrollerProvider({
   }, [publishScrollable, scrollEdgeThreshold, viewportElement]);
 
   const updateVisibility = React.useCallback(() => {
-    const items = Array.from(itemsRegistry.entries());
+    // Items are registered in mount order, which differs from document order
+    // after older history is prepended. Anchor tracking must follow the rendered
+    // transcript or a newly prepended oldest item can incorrectly stay active.
+    const items = orderItemsByDocumentPosition(Array.from(itemsRegistry.entries()));
     const fallbackAnchorId = items.filter(([, item]) => item.scrollAnchor).at(-1)?.[0] ?? items.at(-1)?.[0];
 
     if (items.length === 0) {

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
@@ -195,6 +195,8 @@ export function MessageScrollerProvider({
   const itemsRef = React.useRef<Map<string, MessageScrollerItemRecord> | null>(null);
   itemsRef.current ??= new Map<string, MessageScrollerItemRecord>();
   const itemsRegistry = itemsRef.current;
+  // Rebuilt on register/unregister only — scroll runs this too often to sort per event.
+  const orderedItemsRef = React.useRef<Array<readonly [string, MessageScrollerItemRecord]> | null>(null);
   const visibleMessageIdsRef = React.useRef<Set<string> | null>(null);
   visibleMessageIdsRef.current ??= new Set<string>();
   const intersectingMessageIds = visibleMessageIdsRef.current;
@@ -257,10 +259,9 @@ export function MessageScrollerProvider({
   }, [publishScrollable, scrollEdgeThreshold, viewportElement]);
 
   const updateVisibility = React.useCallback(() => {
-    // Items are registered in mount order, which differs from document order
-    // after older history is prepended. Anchor tracking must follow the rendered
-    // transcript or a newly prepended oldest item can incorrectly stay active.
-    const items = orderItemsByDocumentPosition(Array.from(itemsRegistry.entries()));
+    // Registration is mount order, not document order, once history is prepended.
+    orderedItemsRef.current ??= orderItemsByDocumentPosition(Array.from(itemsRegistry.entries()));
+    const items = orderedItemsRef.current;
     const fallbackAnchorId = items.filter(([, item]) => item.scrollAnchor).at(-1)?.[0] ?? items.at(-1)?.[0];
 
     if (items.length === 0) {
@@ -416,6 +417,7 @@ export function MessageScrollerProvider({
   const registerItem = React.useCallback(
     (messageId: string, element: HTMLElement, scrollAnchor: boolean) => {
       itemsRegistry.set(messageId, { element, scrollAnchor });
+      orderedItemsRef.current = null;
       setItemsVersion(version => version + 1);
 
       return () => {
@@ -423,6 +425,7 @@ export function MessageScrollerProvider({
         if (current?.element !== element) return;
         itemsRegistry.delete(messageId);
         intersectingMessageIds.delete(messageId);
+        orderedItemsRef.current = null;
         setItemsVersion(version => version + 1);
       };
     },

--- a/packages/playground-ui/src/ds/components/ThreadRail/thread-rail-turns.test.ts
+++ b/packages/playground-ui/src/ds/components/ThreadRail/thread-rail-turns.test.ts
@@ -1,5 +1,4 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
-import { CLIENT_MESSAGE_ID_KEY } from '@mastra/react';
 import { describe, expect, it } from 'vitest';
 
 import { buildThreadRailTurns } from './thread-rail-turns';
@@ -29,7 +28,7 @@ const signalMessage = (id: string, signalType: string, text: string): MastraDBMe
 describe('buildThreadRailTurns', () => {
   it('creates one turn per displayable user message with stable client keys and assistant previews', () => {
     const turns = buildThreadRailTurns([
-      userMessage('server-user-1', 'first question', { [CLIENT_MESSAGE_ID_KEY]: 'client-user-1' }),
+      userMessage('server-user-1', 'first question', { clientMessageId: 'client-user-1' }),
       assistantMessage('assistant-1', 'first answer'),
       userMessage('server-user-2', 'second question'),
     ]);

--- a/packages/playground-ui/src/ds/components/ThreadRail/thread-rail-turns.ts
+++ b/packages/playground-ui/src/ds/components/ThreadRail/thread-rail-turns.ts
@@ -1,8 +1,8 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
-import { CLIENT_MESSAGE_ID_KEY } from '@mastra/react';
 
 const SUMMARY_MAX_LENGTH = 120;
 const FILE_PREVIEW_LIMIT = 2;
+const CLIENT_MESSAGE_ID_KEY = 'clientMessageId';
 
 export interface ThreadRailTurn {
   key: string;

--- a/packages/playground-ui/src/ds/components/ThreadRail/thread-rail-turns.ts
+++ b/packages/playground-ui/src/ds/components/ThreadRail/thread-rail-turns.ts
@@ -1,8 +1,10 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+import type { MastraDBMessageMetadata } from '@mastra/react';
 
 const SUMMARY_MAX_LENGTH = 120;
 const FILE_PREVIEW_LIMIT = 2;
-const CLIENT_MESSAGE_ID_KEY = 'clientMessageId';
+// Inlined, not imported: the value export sits behind a barrel this browser bundle must not pull.
+const CLIENT_MESSAGE_ID_KEY = 'clientMessageId' satisfies keyof MastraDBMessageMetadata;
 
 export interface ThreadRailTurn {
   key: string;


### PR DESCRIPTION
Adds the shared playground-ui thread rail to Factory workspace and user-session chats. It derives turns from the Factory transcript, keeps the rail inside the existing message scroller, and hides it below the 58rem container breakpoint or when there are no user turns.

This also removes a server-only barrel import from the shared turn builder and fixes active-turn tracking after older messages are prepended, so browser consumers stay aligned with the visible transcript.

Validated with Factory MSW tests (409), playground-ui tests (717), both package typechecks and builds, root lint, changed-scope React Doctor, and wide/narrow browser checks with zero console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a side rail that helps users move between conversation turns in Factory chats. It hides when there are no user messages or when the screen is too narrow, and it stays accurate when older messages load.

## Changes

- Added `ThreadRailLayer` to Factory thread routes.
- Derived rail turns from the Factory transcript.
- Kept the rail inside the existing message scroller.
- Hid the rail below the 58rem breakpoint or when no user turns exist.
- Measured the padded scroller to prevent overlap with docked cards.
- Fixed active-turn tracking after older messages are prepended.
- Cached document-ordered scroller items to improve scroll performance.
- Removed the server-only `CLIENT_MESSAGE_ID_KEY` barrel import.
- Added Factory MSW tests for rail visibility, selection, hover, keyboard focus, and scrolling.
- Added `MessageScroller` regression coverage for prepended history.
- Added a patch changeset for `@mastra/playground-ui`.

## Validation

- Factory MSW tests passed.
- `playground-ui` tests passed.
- Package typechecks and builds passed.
- Root lint passed.
- Changed-scope React Doctor checks passed.
- Wide and narrow browser checks passed with zero console errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->