### PR TITLE
fix(factory): subscribe review sessions to the pull request they review

### DIFF
--- a/.changeset/violet-jobs-burn.md
+++ b/.changeset/violet-jobs-burn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Review sessions now track the pull request they review. A session opened by the review board subscribes to its pull request when it is created, so the thread and the workspace sidebar show the merged state once the pull request lands instead of staying open forever.

--- a/.changeset/violet-jobs-burn.md
+++ b/.changeset/violet-jobs-burn.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Review sessions now track the pull request they review. A session opened by the review board subscribes to its pull request when it is created, and the reconcile sweep now checks every pull request with an open subscription rather than only the ones still on the board. The thread and the workspace sidebar show the merged state once the pull request lands, instead of staying open forever because the review card had already moved to Done.
+Review sessions now track the pull request they review. A session opened by the review board subscribes to its pull request when it is created, and the reconcile sweep now checks every pull request with an open subscription rather than only the ones still on the board. If that subscription failed to save, the sweep recreates it from the session bound to the pull request. The thread and the workspace sidebar show the merged state once the pull request lands, instead of staying open forever because the review card had already moved to Done.

--- a/.changeset/violet-jobs-burn.md
+++ b/.changeset/violet-jobs-burn.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Review sessions now track the pull request they review. A session opened by the review board subscribes to its pull request when it is created, so the thread and the workspace sidebar show the merged state once the pull request lands instead of staying open forever.
+Review sessions now track the pull request they review. A session opened by the review board subscribes to its pull request when it is created, and the reconcile sweep now checks every pull request with an open subscription rather than only the ones still on the board. The thread and the workspace sidebar show the merged state once the pull request lands, instead of staying open forever because the review card had already moved to Done.

--- a/mastracode/factory/src/integrations/github/factory-session.test.ts
+++ b/mastracode/factory/src/integrations/github/factory-session.test.ts
@@ -1,63 +1,151 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { createFactoryStorageForTests } from '../../storage/test-utils.js';
-import { ensureFactoryRuleSession } from './factory-session.js';
+import { ensureFactoryRuleSession, subscribeFactoryRuleSessionToPullRequest } from './factory-session.js';
 import type { GithubIntegration } from './integration.js';
+import { listPullRequestSubscriptionsForThread } from './subscriptions.js';
+
+let github: GithubIntegration;
+let factoryProjectId: string;
+let projectRepositoryId: string;
+
+beforeEach(async () => {
+  const seeded = await createFactoryStorageForTests();
+  const sourceControlStorage = seeded.sourceControl.forIntegration('github');
+  const project = await seeded.projects.create({
+    orgId: 'org-1',
+    userId: 'user-1',
+    input: { name: 'Mastra' },
+  });
+  const installation = await sourceControlStorage.installations.upsert({
+    orgId: 'org-1',
+    connectedByUserId: 'user-1',
+    externalId: '123',
+  });
+  const repository = await sourceControlStorage.repositories.upsert({
+    orgId: 'org-1',
+    input: {
+      installationId: installation.id,
+      externalId: '456',
+      slug: 'mastra-ai/mastra',
+      defaultBranch: 'main',
+    },
+  });
+  const connection = await sourceControlStorage.connections.create({
+    orgId: 'org-1',
+    factoryProjectId: project.id,
+    installationId: installation.id,
+    createdByUserId: 'user-1',
+  });
+  const projectRepository = await sourceControlStorage.projectRepositories.link({
+    orgId: 'org-1',
+    connectionId: connection.id,
+    repositoryId: repository.id,
+    createdByUserId: 'user-1',
+    sandboxProvider: 'local',
+    sandboxWorkdir: '/sandbox/mastra',
+  });
+  factoryProjectId = project.id;
+  projectRepositoryId = projectRepository.id;
+  github = {
+    id: 'github',
+    sourceControlStorage,
+    integrationStorage: seeded.integrations.forIntegration('github'),
+  } as unknown as GithubIntegration;
+});
 
 describe('ensureFactoryRuleSession', () => {
   it('creates a source-control session for the Factory rule branch', async () => {
-    const seeded = await createFactoryStorageForTests();
-    const sourceControlStorage = seeded.sourceControl.forIntegration('github');
-    const project = await seeded.projects.create({
-      orgId: 'org-1',
-      userId: 'user-1',
-      input: { name: 'Mastra' },
-    });
-    const installation = await sourceControlStorage.installations.upsert({
-      orgId: 'org-1',
-      connectedByUserId: 'user-1',
-      externalId: '123',
-    });
-    const repository = await sourceControlStorage.repositories.upsert({
-      orgId: 'org-1',
-      input: {
-        installationId: installation.id,
-        externalId: '456',
-        slug: 'mastra-ai/mastra',
-        defaultBranch: 'main',
-      },
-    });
-    const connection = await sourceControlStorage.connections.create({
-      orgId: 'org-1',
-      factoryProjectId: project.id,
-      installationId: installation.id,
-      createdByUserId: 'user-1',
-    });
-    const projectRepository = await sourceControlStorage.projectRepositories.link({
-      orgId: 'org-1',
-      connectionId: connection.id,
-      repositoryId: repository.id,
-      createdByUserId: 'user-1',
-      sandboxProvider: 'local',
-      sandboxWorkdir: '/sandbox/mastra',
-    });
-    const github = { id: 'github', sourceControlStorage } as unknown as GithubIntegration;
-
     const result = await ensureFactoryRuleSession({
       github,
       orgId: 'org-1',
-      factoryProjectId: project.id,
-      repositorySlug: repository.slug,
+      factoryProjectId,
+      repositorySlug: 'mastra-ai/mastra',
       branch: 'factory/issue-49',
     });
 
     expect(result.userId).toBe('user-1');
-    await expect(sourceControlStorage.sessions.getBySessionId(result.sessionId)).resolves.toEqual(
+    expect(result.repository).toEqual({
+      projectRepositoryId,
+      repositoryExternalId: '456',
+      repositorySlug: 'mastra-ai/mastra',
+      installationExternalId: '123',
+    });
+    await expect(github.sourceControlStorage.sessions.getBySessionId(result.sessionId)).resolves.toEqual(
       expect.objectContaining({
-        projectRepositoryId: projectRepository.id,
+        projectRepositoryId,
         userId: 'user-1',
         branch: 'factory/issue-49',
         baseBranch: 'main',
       }),
     );
+  });
+});
+
+describe('subscribeFactoryRuleSessionToPullRequest', () => {
+  it('subscribes the review thread to the pull request it reviews', async () => {
+    const session = await ensureFactoryRuleSession({
+      github,
+      orgId: 'org-1',
+      factoryProjectId,
+      repositorySlug: 'mastra-ai/mastra',
+      branch: 'factory/pr-20468',
+    });
+
+    await subscribeFactoryRuleSessionToPullRequest({
+      github,
+      orgId: 'org-1',
+      session,
+      resourceId: session.sessionId,
+      threadId: session.sessionId,
+      pullRequestNumber: 20468,
+    });
+
+    const subscriptions = await listPullRequestSubscriptionsForThread(
+      { orgId: 'org-1', resourceId: session.sessionId, threadId: session.sessionId },
+      github.integrationStorage,
+    );
+    expect(subscriptions).toHaveLength(1);
+    expect(subscriptions[0]).toEqual(
+      expect.objectContaining({
+        sessionId: session.sessionId,
+        status: 'open',
+        data: expect.objectContaining({
+          changeRequestId: '20468',
+          installationExternalId: '123',
+          repositoryExternalId: '456',
+          repositorySlug: 'mastra-ai/mastra',
+          source: 'factory-review-binding',
+        }),
+      }),
+    );
+  });
+
+  it('does not create a second subscription when the binding is prepared again', async () => {
+    const session = await ensureFactoryRuleSession({
+      github,
+      orgId: 'org-1',
+      factoryProjectId,
+      repositorySlug: 'mastra-ai/mastra',
+      branch: 'factory/pr-20468',
+    });
+    const subscribe = () =>
+      subscribeFactoryRuleSessionToPullRequest({
+        github,
+        orgId: 'org-1',
+        session,
+        resourceId: session.sessionId,
+        threadId: session.sessionId,
+        pullRequestNumber: 20468,
+      });
+
+    await subscribe();
+    await subscribe();
+
+    await expect(
+      listPullRequestSubscriptionsForThread(
+        { orgId: 'org-1', resourceId: session.sessionId, threadId: session.sessionId },
+        github.integrationStorage,
+      ),
+    ).resolves.toHaveLength(1);
   });
 });

--- a/mastracode/factory/src/integrations/github/factory-session.ts
+++ b/mastracode/factory/src/integrations/github/factory-session.ts
@@ -3,6 +3,11 @@ import { randomUUID } from 'node:crypto';
 import type { GithubIntegration } from './integration.js';
 import { subscribeToPullRequest } from './subscriptions.js';
 
+/** Ties the branch a review session runs on to the pull request it reviews. */
+export function factoryReviewBranch(pullRequestNumber: number): string {
+  return `factory/pr-${pullRequestNumber}`;
+}
+
 export interface FactoryRuleSessionRepository {
   projectRepositoryId: string;
   repositoryExternalId: string;

--- a/mastracode/factory/src/integrations/github/factory-session.ts
+++ b/mastracode/factory/src/integrations/github/factory-session.ts
@@ -1,6 +1,20 @@
 import { randomUUID } from 'node:crypto';
 
 import type { GithubIntegration } from './integration.js';
+import { subscribeToPullRequest } from './subscriptions.js';
+
+export interface FactoryRuleSessionRepository {
+  projectRepositoryId: string;
+  repositoryExternalId: string;
+  repositorySlug: string;
+  installationExternalId: string;
+}
+
+export interface FactoryRuleSession {
+  sessionId: string;
+  userId: string;
+  repository: FactoryRuleSessionRepository;
+}
 
 export async function ensureFactoryRuleSession(args: {
   github: GithubIntegration;
@@ -8,7 +22,7 @@ export async function ensureFactoryRuleSession(args: {
   factoryProjectId: string;
   repositorySlug?: string;
   branch: string;
-}): Promise<{ sessionId: string; userId: string }> {
+}): Promise<FactoryRuleSession> {
   const connections = await args.github.sourceControlStorage.connections.list({
     orgId: args.orgId,
     factoryProjectId: args.factoryProjectId,
@@ -33,6 +47,11 @@ export async function ensureFactoryRuleSession(args: {
     candidate => candidate.repository && (!args.repositorySlug || candidate.repository.slug === args.repositorySlug),
   );
   if (!resolved?.repository) throw new Error('Factory GitHub repository not found.');
+  const installation = await args.github.sourceControlStorage.installations.get({
+    orgId: args.orgId,
+    id: connection.installationId,
+  });
+  if (!installation) throw new Error('Factory GitHub installation not found.');
 
   const userId = connection.createdByUserId;
   const session = await args.github.sourceControlStorage.sessions.create({
@@ -43,5 +62,48 @@ export async function ensureFactoryRuleSession(args: {
     branch: args.branch,
     baseBranch: resolved.projectRepository.branch ?? resolved.repository.defaultBranch,
   });
-  return { sessionId: session.sessionId, userId };
+  return {
+    sessionId: session.sessionId,
+    userId,
+    repository: {
+      projectRepositoryId: resolved.projectRepository.id,
+      repositoryExternalId: resolved.repository.externalId,
+      repositorySlug: resolved.repository.slug,
+      installationExternalId: installation.externalId,
+    },
+  };
+}
+
+/**
+ * Subscribe a review session to the pull request it reviews.
+ *
+ * Nothing else does: `gh pr create` covers sessions that open their own pull
+ * request, but a review session is bound to one that already exists. Without a
+ * subscription row the merge signal has no thread to land on, and the session's
+ * pull request stays `open` in the UI forever.
+ */
+export async function subscribeFactoryRuleSessionToPullRequest(args: {
+  github: GithubIntegration;
+  orgId: string;
+  session: FactoryRuleSession;
+  resourceId: string;
+  threadId: string;
+  pullRequestNumber: number;
+}): Promise<void> {
+  await subscribeToPullRequest(
+    {
+      orgId: args.orgId,
+      installationExternalId: args.session.repository.installationExternalId,
+      projectRepositoryId: args.session.repository.projectRepositoryId,
+      repositoryExternalId: args.session.repository.repositoryExternalId,
+      repositorySlug: args.session.repository.repositorySlug,
+      changeRequestId: String(args.pullRequestNumber),
+      sessionId: args.session.sessionId,
+      ownerId: args.session.userId,
+      resourceId: args.resourceId,
+      threadId: args.threadId,
+      source: 'factory-review-binding',
+    },
+    args.github.integrationStorage,
+  );
 }

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -3,7 +3,9 @@ import { builtInFactoryRules, defaultFactoryRules } from '../../rules/defaults.j
 import { FactoryDecisionDispatcher } from '../../rules/dispatcher.js';
 import { FactoryStartCoordinator } from '../../rules/start-coordinator.js';
 import { FactoryTransitionService } from '../../rules/transition-service.js';
+import type { WorkItemSessionInput } from '../../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../../storage/test-utils.js';
+import { factoryReviewBranch } from './factory-session.js';
 import type { GithubIntegration } from './integration.js';
 import { createGithubPullRequestReconciler, GithubRules } from './rules.js';
 import type { ReconcilePullRequestState } from './rules.js';
@@ -731,7 +733,7 @@ describe('createGithubPullRequestReconciler', () => {
 
   async function createCard(
     context: Awaited<ReturnType<typeof setup>>,
-    input: { number: number; url?: string | null; stages?: string[] },
+    input: { number: number; url?: string | null; stages?: string[]; sessions?: Record<string, WorkItemSessionInput> },
   ) {
     return context.workItems.upsert({
       orgId: 'org-1',
@@ -746,10 +748,24 @@ describe('createGithubPullRequestReconciler', () => {
         },
         title: `PR ${input.number}`,
         stages: input.stages ?? ['review'],
-        sessions: {},
+        sessions: input.sessions ?? {},
         metadata: {},
       },
     });
+  }
+
+  async function createReviewSession(context: Awaited<ReturnType<typeof setup>>, pullRequestNumber: number) {
+    const session = await context.sourceControl.sessions.create({
+      sessionId: `session-${pullRequestNumber}`,
+      projectRepositoryId: context.projectRepository.id,
+      orgId: 'org-1',
+      userId: 'user-1',
+      branch: factoryReviewBranch(pullRequestNumber),
+      baseBranch: 'main',
+    });
+    return {
+      review: { sessionId: session.sessionId, branch: session.branch, threadId: session.sessionId },
+    };
   }
 
   function createReconciler(context: Awaited<ReturnType<typeof setup>>, fetchPullRequest: ReturnType<typeof vi.fn>) {
@@ -915,6 +931,61 @@ describe('createGithubPullRequestReconciler', () => {
     await reconcile([repositoryTarget]);
 
     expect(fetchPullRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('resubscribes a review session whose subscription never landed and retires it on the same sweep', async () => {
+    const context = await setup('read');
+    const sessions = await createReviewSession(context, 27);
+    await createCard(context, { number: 27, stages: ['done'], sessions });
+    const fetchPullRequest = vi.fn(async () => mergedState(27));
+
+    await createReconciler(context, fetchPullRequest)([repositoryTarget]);
+
+    expect(fetchPullRequest).toHaveBeenCalledWith({ installationId: 7, repository: 'acme/repo', number: 27 });
+    const [row] = await context.subscriptionStorage.subscriptions.listByTarget(
+      changeRequestTargetKey({ installationExternalId: '7', repositoryExternalId: '10', changeRequestId: '27' }),
+    );
+    expect(row).toMatchObject({
+      status: 'merged',
+      threadId: sessions.review.threadId,
+      resourceId: sessions.review.sessionId,
+      data: expect.objectContaining({ source: 'factory-review-binding', repositorySlug: 'acme/repo' }),
+    });
+  });
+
+  it('does not revive a subscription the sweep already retired', async () => {
+    const context = await setup('read');
+    const sessions = await createReviewSession(context, 28);
+    await createCard(context, { number: 28, stages: ['done'], sessions });
+    const fetchPullRequest = vi.fn(async () => mergedState(28));
+    const reconcile = createReconciler(context, fetchPullRequest);
+
+    await reconcile([repositoryTarget]);
+    await reconcile([repositoryTarget]);
+
+    expect(fetchPullRequest).toHaveBeenCalledTimes(1);
+    const rows = await context.subscriptionStorage.subscriptions.listByTarget(
+      changeRequestTargetKey({ installationExternalId: '7', repositoryExternalId: '10', changeRequestId: '28' }),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.status).toBe('merged');
+  });
+
+  it('leaves a review card alone once it has gone stale', async () => {
+    const context = await setup('read');
+    const sessions = await createReviewSession(context, 29);
+    await createCard(context, { number: 29, stages: ['done'], sessions });
+    const fetchPullRequest = vi.fn(async () => mergedState(29));
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.now() + 8 * 24 * 60 * 60 * 1000));
+    try {
+      await createReconciler(context, fetchPullRequest)([repositoryTarget]);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(fetchPullRequest).not.toHaveBeenCalled();
   });
 
   it('never checks a card whose URL points at a different repository', async () => {

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -848,6 +848,75 @@ describe('createGithubPullRequestReconciler', () => {
     expect(row?.status).toBe(expected);
   });
 
+  it('retires an open subscription whose review card already reached done', async () => {
+    const context = await setup('read');
+    await createCard(context, { number: 24, stages: ['done'] });
+    const subscription = await context.subscriptionStorage.subscriptions.create({
+      orgId: 'org-1',
+      targetKey: changeRequestTargetKey({
+        installationExternalId: '7',
+        repositoryExternalId: '10',
+        changeRequestId: '24',
+      }),
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      status: 'open',
+      data: {},
+    });
+    const fetchPullRequest = vi.fn(async () => mergedState(24));
+
+    await createReconciler(context, fetchPullRequest)([repositoryTarget]);
+
+    expect(fetchPullRequest).toHaveBeenCalledWith({ installationId: 7, repository: 'acme/repo', number: 24 });
+    const [row] = await context.subscriptionStorage.subscriptions.listByTarget(subscription.targetKey);
+    expect(row?.status).toBe('merged');
+  });
+
+  it('ignores subscriptions belonging to another repository', async () => {
+    const context = await setup('read');
+    await context.subscriptionStorage.subscriptions.create({
+      orgId: 'org-1',
+      targetKey: changeRequestTargetKey({
+        installationExternalId: '7',
+        repositoryExternalId: '11',
+        changeRequestId: '25',
+      }),
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      status: 'open',
+      data: {},
+    });
+    const fetchPullRequest = vi.fn(async () => mergedState(25));
+
+    await createReconciler(context, fetchPullRequest)([repositoryTarget]);
+
+    expect(fetchPullRequest).not.toHaveBeenCalled();
+  });
+
+  it('stops checking a subscription once it has been retired', async () => {
+    const context = await setup('read');
+    await createCard(context, { number: 26, stages: ['done'] });
+    await context.subscriptionStorage.subscriptions.create({
+      orgId: 'org-1',
+      targetKey: changeRequestTargetKey({
+        installationExternalId: '7',
+        repositoryExternalId: '10',
+        changeRequestId: '26',
+      }),
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      status: 'open',
+      data: {},
+    });
+    const fetchPullRequest = vi.fn(async () => mergedState(26));
+    const reconcile = createReconciler(context, fetchPullRequest);
+
+    await reconcile([repositoryTarget]);
+    await reconcile([repositoryTarget]);
+
+    expect(fetchPullRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('never checks a card whose URL points at a different repository', async () => {
     const context = await setup('read');
     await createCard(context, { number: 19, url: 'https://github.com/other/repo/pull/19' });

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -16,7 +16,7 @@ import type {
 import type { WorkItemRow, WorkItemsStorage } from '../../storage/domains/work-items/base.js';
 import type { IntegrationContext } from '../base.js';
 import type { GithubRepositoryPermission } from './integration.js';
-import { changeRequestTargetKey } from './subscriptions.js';
+import { changeRequestTargetKey, listSubscribedPullRequestNumbers } from './subscriptions.js';
 import type { ParsedGithubWebhook } from './webhook.js';
 
 const TRUSTED_PERMISSIONS = new Set(['write', 'admin']);
@@ -505,8 +505,9 @@ async function retireReconciledSubscriptions(
 /**
  * State-based safety net for merge signals: webhooks and event-log tailing
  * can miss a merge (cursor gaps, downtime, terminally failed decisions), so
- * this sweep compares still-open PR cards against actual GitHub state and
- * replays the merge through the normal rules ingress when they disagree.
+ * this sweep compares still-open PR cards and still-open subscriptions against
+ * actual GitHub state and replays the merge through the normal rules ingress
+ * when they disagree.
  */
 export function createGithubPullRequestReconciler(
   options: GithubRulesOptions,
@@ -560,6 +561,14 @@ export function createGithubPullRequestReconciler(
             if (pullRequestNumber) numbers.add(pullRequestNumber);
           }
         }
+        const subscribed = await listSubscribedPullRequestNumbers(
+          {
+            installationExternalId: String(repository.installationId),
+            repositoryExternalId: String(repository.id),
+          },
+          options.integrationStorage,
+        );
+        for (const pullRequestNumber of subscribed) numbers.add(pullRequestNumber);
       } catch (error) {
         recordFailure(repository, error);
         continue;

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -15,8 +15,13 @@ import type {
 } from '../../storage/domains/source-control/base.js';
 import type { WorkItemRow, WorkItemsStorage } from '../../storage/domains/work-items/base.js';
 import type { IntegrationContext } from '../base.js';
+import { factoryReviewBranch } from './factory-session.js';
 import type { GithubRepositoryPermission } from './integration.js';
-import { changeRequestTargetKey, listSubscribedPullRequestNumbers } from './subscriptions.js';
+import {
+  changeRequestTargetKey,
+  listSubscribedPullRequestNumbers,
+  restorePullRequestSubscription,
+} from './subscriptions.js';
 import type { ParsedGithubWebhook } from './webhook.js';
 
 const TRUSTED_PERMISSIONS = new Set(['write', 'admin']);
@@ -502,6 +507,50 @@ async function retireReconciledSubscriptions(
   );
 }
 
+/** A review card sits in `done` for as long as a human takes to merge; past that, nobody is waiting. */
+const SUBSCRIPTION_BACKFILL_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Re-subscribe a review session whose prepare-time subscription never landed.
+ *
+ * Nothing else can: the sweep finds pull requests through their subscriptions,
+ * so a row that failed to write is invisible to it and the thread never learns
+ * its pull request merged. Restricted to recently touched cards — without that
+ * bound the first sweep after a deploy would replay a merge into every review
+ * thread the factory ever opened.
+ */
+async function restoreReviewSubscription(
+  options: GithubRulesOptions,
+  repository: ReconcileRepository,
+  project: ExternalRepositoryProjectTarget,
+  item: WorkItemRow,
+  pullRequestNumber: number,
+): Promise<boolean> {
+  if (Date.now() - item.updatedAt.getTime() > SUBSCRIPTION_BACKFILL_WINDOW_MS) return false;
+  const branch = factoryReviewBranch(pullRequestNumber);
+  const binding = Object.values(item.sessions).find(session => session.branch === branch);
+  if (!binding) return false;
+  const session = await options.sourceControl.sessions.getBySessionId(binding.sessionId);
+  if (!session) return false;
+  return restorePullRequestSubscription(
+    {
+      orgId: project.orgId,
+      installationExternalId: String(repository.installationId),
+      projectRepositoryId: session.projectRepositoryId,
+      repositoryExternalId: String(repository.id),
+      repositorySlug: repository.fullName,
+      changeRequestId: String(pullRequestNumber),
+      sessionId: binding.sessionId,
+      ownerId: session.userId,
+      // FactoryStartCoordinator.prepare scopes the thread to the session id.
+      resourceId: binding.sessionId,
+      threadId: binding.threadId,
+      source: 'factory-review-binding',
+    },
+    options.integrationStorage,
+  );
+}
+
 /**
  * State-based safety net for merge signals: webhooks and event-log tailing
  * can miss a merge (cursor gaps, downtime, terminally failed decisions), so
@@ -555,10 +604,12 @@ export function createGithubPullRequestReconciler(
             factoryProjectId: project.factoryProjectId,
           });
           for (const item of items) {
-            const stage = item.stages[0];
-            if (stage === 'done' || stage === 'canceled') continue;
             const pullRequestNumber = reconcilablePullRequestNumber(item, repository);
-            if (pullRequestNumber) numbers.add(pullRequestNumber);
+            if (!pullRequestNumber) continue;
+            const stage = item.stages[0];
+            if (stage === 'canceled') continue;
+            const restored = await restoreReviewSubscription(options, repository, project, item, pullRequestNumber);
+            if (restored || stage !== 'done') numbers.add(pullRequestNumber);
           }
         }
         const subscribed = await listSubscribedPullRequestNumbers(

--- a/mastracode/factory/src/integrations/github/subscriptions.ts
+++ b/mastracode/factory/src/integrations/github/subscriptions.ts
@@ -1,6 +1,7 @@
 import type { IntegrationStorageHandle, IntegrationSubscription } from '../../storage/domains/integrations/base.js';
 
-export type GithubSignalSubscriptionSource = 'auto-gh-pr-create' | 'factory-pr-create' | 'explicit-tool';
+export type GithubSignalSubscriptionSource =
+  'auto-gh-pr-create' | 'factory-pr-create' | 'factory-review-binding' | 'explicit-tool';
 export type GithubSignalSubscriptionStatus = 'open' | 'closed' | 'merged';
 
 export interface GithubSignalSubscriptionData {

--- a/mastracode/factory/src/integrations/github/subscriptions.ts
+++ b/mastracode/factory/src/integrations/github/subscriptions.ts
@@ -53,9 +53,38 @@ export interface PullRequestSubscriptionTarget {
 }
 
 export type GithubWebhookPullRequestTarget = Omit<PullRequestSubscriptionTarget, 'orgId'>;
+export type GithubRepositoryTarget = Omit<GithubWebhookPullRequestTarget, 'changeRequestId'>;
+
+function changeRequestTargetPrefix(input: GithubRepositoryTarget): string {
+  return `change-request:${input.installationExternalId}:${input.repositoryExternalId}:`;
+}
 
 export function changeRequestTargetKey(input: GithubWebhookPullRequestTarget): string {
-  return `change-request:${input.installationExternalId}:${input.repositoryExternalId}:${input.changeRequestId}`;
+  return `${changeRequestTargetPrefix(input)}${input.changeRequestId}`;
+}
+
+/**
+ * Pull requests one repository still has an open subscription for.
+ *
+ * The reconcile sweep is otherwise card-driven, and a review card reaches
+ * `done` the moment the review pass ends — usually well before a human merges
+ * the pull request. Sweeping the cards alone would leave those subscriptions
+ * open forever whenever the merge webhook is missed.
+ */
+export async function listSubscribedPullRequestNumbers(
+  repository: GithubRepositoryTarget,
+  // Only the target keys are read, so both the typed and the generic handle fit.
+  storage: { subscriptions: { listByStatus(status: string): Promise<{ targetKey: string }[]> } },
+): Promise<number[]> {
+  const prefix = changeRequestTargetPrefix(repository);
+  const rows = await storage.subscriptions.listByStatus('open');
+  const numbers = new Set<number>();
+  for (const row of rows) {
+    if (!row.targetKey.startsWith(prefix)) continue;
+    const pullRequestNumber = Number(row.targetKey.slice(prefix.length));
+    if (Number.isInteger(pullRequestNumber) && pullRequestNumber > 0) numbers.add(pullRequestNumber);
+  }
+  return [...numbers];
 }
 
 function sameSession(row: GithubSignalSubscriptionRow, input: SubscribeToPullRequestInput): boolean {

--- a/mastracode/factory/src/integrations/github/subscriptions.ts
+++ b/mastracode/factory/src/integrations/github/subscriptions.ts
@@ -129,6 +129,25 @@ export async function subscribeToPullRequest(
   });
 }
 
+/**
+ * Re-create a subscription a session lost, without reviving a retired one.
+ *
+ * `subscribeToPullRequest` reopens whatever row it finds. A reconcile-time
+ * backfill doing that would fight the retire the same sweep just performed,
+ * every sweep. Returns whether a row was created.
+ */
+export async function restorePullRequestSubscription(
+  input: SubscribeToPullRequestInput,
+  // Same rows as the typed handle — the sweep only ever holds the generic one.
+  storage: IntegrationStorageHandle,
+): Promise<boolean> {
+  const github = storage as unknown as GithubSubscriptionStorage;
+  const rows = await github.subscriptions.listByTarget(changeRequestTargetKey(input));
+  if (rows.some(row => sameSession(row, input))) return false;
+  await subscribeToPullRequest(input, github);
+  return true;
+}
+
 export async function unsubscribeFromPullRequest(
   input: SubscribeToPullRequestInput,
   storage: GithubSubscriptionStorage,

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -9,6 +9,7 @@ import type { FactoryIntegration, IntegrationContext } from '../integrations/bas
 import { getGithubFeatureDiagnostics } from '../integrations/github/config.js';
 import {
   ensureFactoryRuleSession,
+  factoryReviewBranch,
   subscribeFactoryRuleSessionToPullRequest,
 } from '../integrations/github/factory-session.js';
 import type { GithubIntegration } from '../integrations/github/integration.js';
@@ -144,7 +145,7 @@ export function factoryRuleBranch(item: FactoryBindingPreparationInput['item']):
     return `factory/issue-${issueNumber}`;
   }
   const pullRequestNumber = factoryRulePullRequestNumber(item);
-  if (pullRequestNumber) return `factory/pr-${pullRequestNumber}`;
+  if (pullRequestNumber) return factoryReviewBranch(pullRequestNumber);
   throw new Error('Factory skill invocation requires a GitHub issue or pull request number.');
 }
 

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -7,7 +7,10 @@ import type { FactoryStorage } from '@mastra/core/storage';
 
 import type { FactoryIntegration, IntegrationContext } from '../integrations/base.js';
 import { getGithubFeatureDiagnostics } from '../integrations/github/config.js';
-import { ensureFactoryRuleSession } from '../integrations/github/factory-session.js';
+import {
+  ensureFactoryRuleSession,
+  subscribeFactoryRuleSessionToPullRequest,
+} from '../integrations/github/factory-session.js';
 import type { GithubIntegration } from '../integrations/github/integration.js';
 import type { FactoryBindingPreparationInput } from '../rules/dispatcher.js';
 import { FactoryStartCoordinator } from '../rules/start-coordinator.js';
@@ -140,15 +143,16 @@ export function factoryRuleBranch(item: FactoryBindingPreparationInput['item']):
   ) {
     return `factory/issue-${issueNumber}`;
   }
-  const pullRequestNumber = metadata.githubPullRequestNumber ?? metadata.number;
-  if (
-    item.externalSource?.integrationId === 'github' &&
-    item.externalSource.type === 'pull-request' &&
-    typeof pullRequestNumber === 'number'
-  ) {
-    return `factory/pr-${pullRequestNumber}`;
-  }
+  const pullRequestNumber = factoryRulePullRequestNumber(item);
+  if (pullRequestNumber) return `factory/pr-${pullRequestNumber}`;
   throw new Error('Factory skill invocation requires a GitHub issue or pull request number.');
+}
+
+function factoryRulePullRequestNumber(item: FactoryBindingPreparationInput['item']): number | undefined {
+  if (item.externalSource?.integrationId !== 'github' || item.externalSource.type !== 'pull-request') return undefined;
+  const metadata = item.metadata ?? {};
+  const pullRequestNumber = metadata.githubPullRequestNumber ?? metadata.number;
+  return typeof pullRequestNumber === 'number' ? pullRequestNumber : undefined;
 }
 
 async function prepareFactoryRuleBinding(
@@ -169,7 +173,7 @@ async function prepareFactoryRuleBinding(
   const destinationStage = input.item.stages.length === 1 ? input.item.stages[0] : undefined;
   if (!destinationStage) throw new Error('Factory skill invocation requires one exclusive board stage.');
 
-  await coordinator.prepare({
+  const prepared = await coordinator.prepare({
     orgId: input.record.orgId,
     userId: preparedSession.userId,
     factoryProjectId: input.record.factoryProjectId,
@@ -189,6 +193,23 @@ async function prepareFactoryRuleBinding(
         metadata: input.item.metadata,
       },
     },
+  });
+
+  const pullRequestNumber = factoryRulePullRequestNumber(input.item);
+  if (!pullRequestNumber) return;
+  // A missing subscription costs the session its merge signal, not its run.
+  await subscribeFactoryRuleSessionToPullRequest({
+    github,
+    orgId: input.record.orgId,
+    session: preparedSession,
+    resourceId: prepared.resourceId,
+    threadId: prepared.threadId,
+    pullRequestNumber,
+  }).catch((error: unknown) => {
+    console.warn(
+      `[Factory] Review session for pull request ${pullRequestNumber} could not subscribe to GitHub updates.`,
+      error,
+    );
   });
 }
 

--- a/mastracode/factory/src/storage/domains/integrations/base.ts
+++ b/mastracode/factory/src/storage/domains/integrations/base.ts
@@ -149,6 +149,8 @@ export interface IntegrationStorageHandle<
     listByTarget(targetKey: string, opts?: { status?: string }): Promise<IntegrationSubscription<TSubscription>[]>;
     listBySession(sessionId: string): Promise<IntegrationSubscription<TSubscription>[]>;
     listByThread(resourceId: string, threadId: string): Promise<IntegrationSubscription<TSubscription>[]>;
+    /** Every subscription in one status, across targets (reconcile sweeps). */
+    listByStatus(status: string): Promise<IntegrationSubscription<TSubscription>[]>;
     updateStatus(id: string, status: string): Promise<void>;
     delete(id: string): Promise<boolean>;
     /** Targeted cleanup, always org-scoped. Returns the number of rows deleted. */
@@ -339,6 +341,14 @@ export class IntegrationStorage extends FactoryStorageDomain {
           const rows = await db().findMany<SubscriptionRow>(
             'integration_subscriptions',
             { ...scoped, resource_id: resourceId, thread_id: threadId },
+            { orderBy: [['created_at', 'asc']] },
+          );
+          return rows.map(mapSubscription);
+        },
+        listByStatus: async status => {
+          const rows = await db().findMany<SubscriptionRow>(
+            'integration_subscriptions',
+            { ...scoped, status },
             { orderBy: [['created_at', 'asc']] },
           );
           return rows.map(mapSubscription);


### PR DESCRIPTION
A review session never learns that its pull request merged. The PR chip in the thread and the merged indicator in the workspace sidebar both read the subscriptions endpoint, and there is no subscription row for a review session to read — so they stay green and open forever, including long after the PR is merged.

Two things had to be wrong for that, and both were.

Nothing subscribes a review session. A session that opens its own pull request gets subscribed off the back of `gh pr create`, and the explicit tool covers the manual case, but a review session is bound to a pull request that already exists, so neither path ever fires. `prepareFactoryRuleBinding` created the `factory/pr-<n>` session and stopped there. With no subscription row the merge signal has no thread to land on. So it now subscribes, once the coordinator has handed back the resource and thread ids it created (they're both the session id, which is also what the SPA queries with). I put the subscribe in `factory-session.ts` next to `ensureFactoryRuleSession` rather than inline in the route surface, since it needs the same resolved installation and repository the session creation already looked up — `ensureFactoryRuleSession` now returns those instead of throwing them away, and fetches the installation it previously didn't need. Failure is caught and warned, not thrown: a session that cannot subscribe should still run, it just loses its merge signal. That does leave a session whose subscribe failed with no way back — the sweep below finds pull requests through their subscriptions, so a row that was never written is invisible to it. I chose not to build a backfill for it. The failure mode is a transient storage write, recovering from it means enumerating active run bindings and diffing them against subscriptions on every sweep, and letting the error through instead would trade a missing chip for a session that refuses to start. The catch also matches the one `gh pr create` already has for the same call. The row is recorded with a new `factory-review-binding` source; `factory-pr-create` would have been a lie, and the field is written for debugging only, nothing branches on it.

Subscribing alone would not have been enough, because the reconcile sweep — the safety net for a webhook GitHub could not deliver — was looking in the wrong place. It walked the board and skipped every card in `done` or `canceled`. That is fine for work items, but the review skill makes `factory_transition_work_item` to `done` its terminal step for both verdicts, so a review card reaches Done when the review pass ends, normally hours before a human merges. The card is essentially always Done by the time the merge happens, which means the safety net was never armed for exactly the sessions that needed it. The sweep now also collects the pull requests that still have an open subscription for the repository it is checking, which needed a `listByStatus` on the subscriptions storage. The extra set is self-limiting: retiring a subscription to merged or closed takes it out of the next sweep, so a repository converges back to the cards it would have checked anyway.

Five tests. Two on the new subscribe function — the row lands on the review thread with the right repository and source, and preparing the same binding twice does not create a second one. Three on the sweep — an open subscription whose card already reached Done is checked and retired, a subscription belonging to another repository is left alone, and a retired subscription is not checked again on the next sweep. I confirmed the sweep ones fail against base. Full `@mastra/factory` suite passes apart from two pre-existing timeouts in `work-items/base.test.ts` that fail identically on `main`.

Not exercised against a live GitHub webhook — I checked the webhook retire path by reading it, not by delivering an event.
