### PR TITLE
fix(cli): Correct --no-install flag

### DIFF
--- a/.changeset/clear-friends-retire.md
+++ b/.changeset/clear-friends-retire.md
@@ -1,0 +1,6 @@
+---
+'mastra': patch
+'create-mastra': patch
+---
+
+Add `--no-install` flag to create command. It allows you to skip dependency installation.

--- a/docs/src/content/en/reference/cli/create-mastra.mdx
+++ b/docs/src/content/en/reference/cli/create-mastra.mdx
@@ -113,6 +113,12 @@ Invalid input is rejected before templates are fetched or files are created.
     isOptional: true,
   },
   {
+    name: '--no-install',
+    type: 'boolean',
+    description: 'Skip dependency installation.',
+    isOptional: true,
+  },
+  {
     name: '-t, --template [template]',
     type: 'string',
     description: 'Use a template slug or public GitHub URL. Omit the value to select interactively.',

--- a/packages/cli/src/commands/create/command.test.ts
+++ b/packages/cli/src/commands/create/command.test.ts
@@ -23,7 +23,7 @@ function createOptions(overrides: Partial<NormalizedCreateOptions> = {}): Normal
     git: true,
     template: undefined,
     timeout: 60_000,
-    skipInstall: false,
+    install: true,
     ...overrides,
   };
 }
@@ -158,7 +158,7 @@ describe('shared create Commander wiring', () => {
       git: true,
       template: undefined,
       timeout: 60_000,
-      skipInstall: false,
+      install: true,
     });
   });
 
@@ -189,14 +189,14 @@ describe('shared create Commander wiring', () => {
       git: false,
       template: undefined,
       timeout: 12_345,
-      skipInstall: false,
+      install: true,
     });
     expect(subAction.mock.calls[0]?.[0]).toEqual(rootAction.mock.calls[0]?.[0]);
   });
 
-  it('parses --skip-install option', async () => {
+  it('parses --no-install option', async () => {
     const action = vi.fn();
-    await parseRoot(['project', '--skip-install'], action);
+    await parseRoot(['project', '--no-install'], action);
 
     expect(action).toHaveBeenCalledWith({
       projectName: 'project',
@@ -207,7 +207,7 @@ describe('shared create Commander wiring', () => {
       git: true,
       template: undefined,
       timeout: 60_000,
-      skipInstall: true,
+      install: false,
     });
   });
 });

--- a/packages/cli/src/commands/create/command.ts
+++ b/packages/cli/src/commands/create/command.ts
@@ -83,7 +83,6 @@ export function normalizeCreateCommandOptions(
   projectName: string | undefined,
   options: CreateCommandOptions,
 ): NormalizedCreateOptions {
-  console.log(options);
   return {
     projectName,
     empty: options.empty ?? false,

--- a/packages/cli/src/commands/create/command.ts
+++ b/packages/cli/src/commands/create/command.ts
@@ -20,7 +20,7 @@ export interface CreateCommandOptions {
   git: boolean;
   template?: string | boolean;
   timeout: number;
-  skipInstall?: boolean;
+  install: boolean;
 }
 
 export interface NormalizedCreateOptions {
@@ -32,7 +32,7 @@ export interface NormalizedCreateOptions {
   git: boolean;
   template?: string | boolean;
   timeout: number;
-  skipInstall: boolean;
+  install: boolean;
 }
 
 export function parseCreateLLMProvider(value: string): CreateLLMProvider {
@@ -71,18 +71,19 @@ export function configureCreateCommand(command: Command) {
     .option('-k, --llm-api-key <key>', 'API key for the model provider')
     .option('--no-skills', 'Do not install Mastra skills')
     .option('--no-git', 'Do not initialize a git repository')
+    .option('--no-install', 'Skip installing dependencies')
     .option(
       '-t, --template [template]',
       'Create from a template slug or public GitHub URL, or select interactively when omitted',
     )
-    .option('--timeout <milliseconds>', 'Package installation timeout in milliseconds', parseCreateTimeout, 60_000)
-    .option('--skip-install', 'Skip installing dependencies');
+    .option('--timeout <milliseconds>', 'Package installation timeout in milliseconds', parseCreateTimeout, 60_000);
 }
 
 export function normalizeCreateCommandOptions(
   projectName: string | undefined,
   options: CreateCommandOptions,
 ): NormalizedCreateOptions {
+  console.log(options);
   return {
     projectName,
     empty: options.empty ?? false,
@@ -92,7 +93,7 @@ export function normalizeCreateCommandOptions(
     git: options.git,
     template: options.template,
     timeout: options.timeout,
-    skipInstall: options.skipInstall ?? false,
+    install: options.install,
   };
 }
 

--- a/packages/cli/src/commands/create/create.test.ts
+++ b/packages/cli/src/commands/create/create.test.ts
@@ -835,14 +835,14 @@ describe('create materialization lifecycle', () => {
     }
   });
 
-  it('skips dependency installation when skipInstall is true', async () => {
+  it('skips dependency installation when install is false', async () => {
     const { create } = await import('./create');
     const { installDependencies } = await import('../../utils/clone-template');
 
     await create({
       projectName: 'my-project',
       empty: true,
-      skipInstall: true,
+      install: false,
       resolveVersionTag: vi.fn().mockResolvedValue('latest'),
     });
 

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -89,7 +89,7 @@ export interface CreateOptions {
   timeout?: number;
   analytics?: PosthogAnalytics;
   resolveVersionTag?: () => Promise<string | undefined>;
-  skipInstall?: boolean;
+  install?: boolean;
 }
 
 type PlatformSetupResult =
@@ -219,7 +219,7 @@ function normalizeDirectCreateOptions(args: CreateOptions): NormalizedCreateOpti
     git: args.git ?? true,
     template: args.template,
     timeout: args.timeout ?? 60_000,
-    skipInstall: args.skipInstall ?? false,
+    install: args.install ?? true,
   };
 }
 
@@ -370,7 +370,7 @@ export const create = async (args: CreateOptions): Promise<void> => {
       }
     }
 
-    if (!options.skipInstall) {
+    if (options.install) {
       if (observabilityEnabled) {
         await installDependencies(
           staging.projectPath,
@@ -423,9 +423,9 @@ export const create = async (args: CreateOptions): Promise<void> => {
     p.log.info('Skipping Mastra platform setup.');
   } else if (observabilityEnabled) {
     p.log.success(
-      options.skipInstall
-        ? 'Default template cloned. Dependency installation was skipped.'
-        : 'Default template cloned and dependencies installed.',
+      options.install
+        ? 'Default template cloned and dependencies installed.'
+        : 'Default template cloned. Dependency installation was skipped.',
     );
   }
 


### PR DESCRIPTION
## Description

Fixes the incorrect https://github.com/mastra-ai/mastra/pull/20588 PR. The option should be `--no-install` instead of `--skip-install`. The PR was also missing a changeset and docs change.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The CLI now uses the correct `--no-install` option when users want to skip dependency installation. The PR also updates tests, documentation, and release notes.

## Changes

- Replaced `skipInstall` with `install` in the create command options.
- Added support for `--no-install`.
- Updated dependency-installation behavior and success messages.
- Updated CLI tests for the new option and default behavior.
- Added documentation for `--no-install`.
- Added changesets for `mastra` and `create-mastra`.
- Removed a stale log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->