### PR TITLE
fix(factory): require approval for work item transitions

### DIFF
--- a/.changeset/dry-fans-start.md
+++ b/.changeset/dry-fans-start.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Factory work item transitions now require explicit approval before execution.

--- a/mastracode/factory/src/rules/tools.test.ts
+++ b/mastracode/factory/src/rules/tools.test.ts
@@ -12,6 +12,7 @@ const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
 type ExecutableTool = {
   execute: (input: unknown, context: unknown) => Promise<unknown>;
   inputSchema: { safeParse: (input: unknown) => { success: boolean } };
+  requireApproval: boolean;
 };
 
 function requestContext(
@@ -102,6 +103,20 @@ describe('factory_transition_work_item', () => {
         transitionService: service,
       }),
     ).resolves.toEqual({});
+  });
+
+  it('requires approval before executing a bound transition', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const service = new FactoryTransitionService({ storage, rules: defaultFactoryRules({ version: 'rules-v1' }) });
+    await prepareBoundItem(storage);
+
+    const tools = await createFactoryTransitionTools({
+      requestContext: requestContext(),
+      storage,
+      transitionService: service,
+    });
+
+    expect((tools.factory_transition_work_item as ExecutableTool).requireApproval).toBe(true);
   });
 
   it('derives the item, board, actor, and immutable ingress from the binding and tool call', async () => {

--- a/mastracode/factory/src/rules/tools.ts
+++ b/mastracode/factory/src/rules/tools.ts
@@ -37,6 +37,7 @@ export async function createFactoryTransitionTools(options: {
       description:
         'Request a governed stage transition for the Factory work item exactly bound to this thread. Use the current revision from the factory-phase signal and explain why the transition is appropriate.',
       inputSchema: transitionInputSchema,
+      requireApproval: true,
       execute: async ({ stage, expectedRevision, rationale }, execution) => {
         const currentAddress = getFactorySessionAddress(execution.requestContext);
         const toolCallId = execution.agent?.toolCallId;


### PR DESCRIPTION
Factory agents could move a bound work item immediately once transition rules passed.

Now `factory_transition_work_item` pauses for approval before the transition service runs, while the existing binding, revision, and governance checks remain in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory work item transitions now wait for explicit approval before they run. This prevents a transition from starting before it passes the required review.

## Changes

- Set `requireApproval: true` for `factory_transition_work_item`.
- Added test coverage for approval requirements on bound transitions.
- Added a patch changeset for `@mastra/factory`.
- Existing binding, revision, and governance checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->