### PR TITLE
fix(factory): bound concurrent skill wakeups

### DIFF
--- a/.changeset/eager-pugs-call.md
+++ b/.changeset/eager-pugs-call.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed Factory rule dispatches so concurrent skill wakeups stay bounded until their agent runs finish.
+Fixed Factory rule dispatches so concurrent skill wakeups stay bounded until their agent runs finish or terminal observation times out.

--- a/.changeset/eager-pugs-call.md
+++ b/.changeset/eager-pugs-call.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory rule dispatches so concurrent skill wakeups stay bounded until their agent runs finish.

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -291,6 +291,7 @@ describe('GithubRules', () => {
 
     function makeSession(key: string, initialThreadId?: string) {
       let threadId: string | undefined = initialThreadId;
+      const agentEndListeners = new Set<(event: { type: string }) => void>();
       const session = {
         thread: {
           list: vi.fn(async () => []),
@@ -319,9 +320,16 @@ describe('GithubRules', () => {
           (input: { id: string; contents: string }, options: { requestContext: { get(key: string): unknown } }) => {
             if (!threadId) throw new Error('Signal delivered before thread persistence.');
             deliveredSignals.push({ ...input, threadId, user: options.requestContext.get('user') });
+            for (const listener of agentEndListeners) {
+              listener({ type: 'agent_end' });
+            }
             return { accepted: Promise.resolve({ accepted: true, action: 'wake' }) };
           },
         ),
+        subscribe: vi.fn((listener: (event: { type: string }) => void) => {
+          agentEndListeners.add(listener);
+          return () => agentEndListeners.delete(listener);
+        }),
         state: { set: vi.fn(async () => {}) },
         sendMessage: vi.fn(async () => {}),
         sendNotificationSignal: vi.fn(async () => ({ persisted: Promise.resolve(), accepted: Promise.resolve() })),

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import { defaultFactoryRules } from './defaults.js';
-import { FactoryDecisionDispatcher } from './dispatcher.js';
+import { FACTORY_DISPATCH_CONSTANTS, FactoryDecisionDispatcher } from './dispatcher.js';
 import { FactoryStartCoordinator } from './start-coordinator.js';
 import { FactoryTransitionService } from './transition-service.js';
 import type { FactoryCommitDecision } from './types.js';
@@ -729,6 +729,67 @@ describe('FactoryDecisionDispatcher', () => {
     expect(
       (await storage.listDeferredDecisions('org-1', PROJECT_ID)).find(d => d.idempotencyKey === 'blocked-by-wake'),
     ).toMatchObject({ status: 'succeeded' });
+  });
+
+  it('releases a wake dispatch when the terminal event is not observed before the deadline', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01T00:00:00Z'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const storage = (await createFactoryStorageForTests()).workItems;
+      const { item, transitionService } = await queueDecision(storage, {
+        type: 'invokeSkill',
+        role: 'work',
+        skillName: 'understand-issue',
+        idempotencyKey: 'wake-observation-timeout',
+      });
+      await storage.prepareRunStart({
+        orgId: 'org-1',
+        userId: 'user-1',
+        factoryProjectId: PROJECT_ID,
+        workItem: {
+          id: item.id,
+          input: {
+            externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:1' },
+            title: 'Fix issue',
+            stages: ['execute'],
+            sessions: {},
+            metadata: {},
+          },
+        },
+        role: 'work',
+        session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-1' },
+        resourceId: PROJECT_ID,
+        kickoffKey: 'kickoff-null',
+        kickoffMessage: null,
+      });
+      const { controller, session, getAgentEndListenerCount } = createSession(undefined, {
+        signalAccepted: Promise.resolve({ accepted: true, action: 'wake' }),
+      });
+      const dispatcher = new FactoryDecisionDispatcher({
+        controller: controller as never,
+        transitionService,
+        storage,
+        ownerId: 'worker-1',
+      });
+
+      const dispatch = dispatcher.runOnce();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(session.sendSignal).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(FACTORY_DISPATCH_CONSTANTS.skillCompletionObservationTimeoutMs);
+      await dispatch;
+
+      expect((await storage.listDeferredDecisions('org-1', PROJECT_ID))[0]).toMatchObject({ status: 'succeeded' });
+      expect(getAgentEndListenerCount()).toBe(0);
+      expect(warn).toHaveBeenCalledWith('Factory skill run terminal event was not observed before timeout', {
+        decisionId: expect.any(String),
+        runId: undefined,
+      });
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it('does not miss agent end emitted synchronously during the wake signal', async () => {

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -27,10 +27,22 @@ async function createItem(storage: WorkItemsStorage, sourceKey = 'github-issue:1
   ).item;
 }
 
-function createSession(accepted?: Promise<unknown>) {
+function createSession(
+  accepted?: Promise<unknown>,
+  options?: {
+    signalAccepted?: Promise<{ accepted: true; action?: string }>;
+    emitAgentEndDuringSignal?: boolean;
+  },
+) {
   let threadId = 'thread-1';
   const consumeStream = vi.fn(async () => {});
   const notificationAccepted = accepted ?? Promise.resolve({ action: 'wake', output: { consumeStream } });
+  const agentEndListeners = new Set<(event: { type: string }) => void>();
+  const emitAgentEnd = () => {
+    for (const listener of agentEndListeners) {
+      listener({ type: 'agent_end' });
+    }
+  };
   const deliveredKeys = new Set<string>();
   const deliveredSignals = new Set<string>();
   const delivered: string[] = [];
@@ -65,7 +77,14 @@ function createSession(accepted?: Promise<unknown>) {
     sendMessage: vi.fn(async () => {}),
     sendSignal: vi.fn((input: { id: string }, _options: { requestContext: { get(key: string): unknown } }) => {
       deliveredSignals.add(input.id);
-      return { accepted: Promise.resolve({ accepted: true, action: 'deliver' as string | undefined }) };
+      if (options?.emitAgentEndDuringSignal) {
+        emitAgentEnd();
+      }
+      return { accepted: options?.signalAccepted ?? Promise.resolve({ accepted: true, action: 'deliver' }) };
+    }),
+    subscribe: vi.fn((listener: (event: { type: string }) => void) => {
+      agentEndListeners.add(listener);
+      return () => agentEndListeners.delete(listener);
     }),
     sendNotificationSignal,
   };
@@ -73,7 +92,15 @@ function createSession(accepted?: Promise<unknown>) {
     createSession: vi.fn(async () => session),
     getSessionByResource: vi.fn(async (): Promise<typeof session | undefined> => session),
   };
-  return { controller, session, delivered, sendNotificationSignal, consumeStream };
+  return {
+    controller,
+    session,
+    delivered,
+    sendNotificationSignal,
+    consumeStream,
+    emitAgentEnd,
+    getAgentEndListenerCount: () => agentEndListeners.size,
+  };
 }
 
 async function queueDecision(
@@ -566,7 +593,7 @@ describe('FactoryDecisionDispatcher', () => {
       idempotencyKey: 'skill-1',
       precedingMessage: 'This work was moved from the planning stage to the execute stage.',
     });
-    const { controller, session, sendNotificationSignal } = createSession();
+    const { controller, session, sendNotificationSignal, getAgentEndListenerCount } = createSession();
     await storage.prepareRunStart({
       orgId: 'org-1',
       userId: 'user-1',
@@ -629,6 +656,124 @@ describe('FactoryDecisionDispatcher', () => {
     );
     const requestContext = session.sendSignal.mock.calls[0]?.[1]?.requestContext;
     expect(requestContext?.get('user')).toEqual({ workosId: 'user-1', organizationId: 'org-1' });
+    expect(session.subscribe).toHaveBeenCalledTimes(1);
+    expect(getAgentEndListenerCount()).toBe(0);
+  });
+
+  it('holds a wake dispatch slot until agent end before claiming another decision', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { item, transitionService } = await queueDecision(storage, {
+      type: 'invokeSkill',
+      role: 'work',
+      skillName: 'understand-issue',
+      idempotencyKey: 'wake-holds-capacity',
+    });
+    await storage.prepareRunStart({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: PROJECT_ID,
+      workItem: {
+        id: item.id,
+        input: {
+          externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:1' },
+          title: 'Fix issue',
+          stages: ['execute'],
+          sessions: {},
+          metadata: {},
+        },
+      },
+      role: 'work',
+      session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-1' },
+      resourceId: PROJECT_ID,
+      kickoffKey: 'kickoff-null',
+      kickoffMessage: null,
+    });
+    const { controller, session, emitAgentEnd, getAgentEndListenerCount } = createSession(undefined, {
+      signalAccepted: Promise.resolve({ accepted: true, action: 'wake' }),
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+      maxInFlight: 1,
+    });
+
+    const first = dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+    await vi.waitFor(() => expect(session.sendSignal).toHaveBeenCalledTimes(1));
+    await queueDecision(
+      storage,
+      {
+        type: 'upsertLinkedWorkItem',
+        idempotencyKey: 'blocked-by-wake',
+        board: 'work',
+        source: 'github-issue',
+        sourceKey: 'github-issue:99',
+        title: 'Linked issue',
+        url: null,
+        stage: 'intake',
+      },
+      { sourceKey: 'github-issue:2', ingress: 'move-2' },
+    );
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+    expect(
+      (await storage.listDeferredDecisions('org-1', PROJECT_ID)).find(d => d.idempotencyKey === 'blocked-by-wake'),
+    ).toMatchObject({ status: 'pending' });
+
+    emitAgentEnd();
+    await first;
+    expect(getAgentEndListenerCount()).toBe(0);
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+    expect(
+      (await storage.listDeferredDecisions('org-1', PROJECT_ID)).find(d => d.idempotencyKey === 'blocked-by-wake'),
+    ).toMatchObject({ status: 'succeeded' });
+  });
+
+  it('does not miss agent end emitted synchronously during the wake signal', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { item, transitionService } = await queueDecision(storage, {
+      type: 'invokeSkill',
+      role: 'work',
+      skillName: 'understand-issue',
+      idempotencyKey: 'synchronous-agent-end',
+    });
+    await storage.prepareRunStart({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: PROJECT_ID,
+      workItem: {
+        id: item.id,
+        input: {
+          externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:1' },
+          title: 'Fix issue',
+          stages: ['execute'],
+          sessions: {},
+          metadata: {},
+        },
+      },
+      role: 'work',
+      session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-1' },
+      resourceId: PROJECT_ID,
+      kickoffKey: 'kickoff-null',
+      kickoffMessage: null,
+    });
+    const { controller, getAgentEndListenerCount } = createSession(undefined, {
+      signalAccepted: Promise.resolve({ accepted: true, action: 'wake' }),
+      emitAgentEndDuringSignal: true,
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+
+    expect((await storage.listDeferredDecisions('org-1', PROJECT_ID))[0]).toMatchObject({ status: 'succeeded' });
+    expect(getAgentEndListenerCount()).toBe(0);
   });
 
   it('retries the skill kickoff when the wake signal is rejected instead of marking it succeeded', async () => {
@@ -640,7 +785,7 @@ describe('FactoryDecisionDispatcher', () => {
       arguments: 'Issue 42',
       idempotencyKey: 'skill-wake-fail',
     });
-    const { controller, session } = createSession();
+    const { controller, session, getAgentEndListenerCount } = createSession();
     await storage.prepareRunStart({
       orgId: 'org-1',
       userId: 'user-1',
@@ -679,6 +824,7 @@ describe('FactoryDecisionDispatcher', () => {
     const [afterFailure] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
     expect(afterFailure?.status).toBe('retry');
     expect(afterFailure?.lastError).toContain('Platform proxy request failed');
+    expect(getAgentEndListenerCount()).toBe(0);
 
     await dispatcher.runOnce(new Date(first.getTime() + 5_000));
 

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -24,10 +24,22 @@ const BATCH_SIZE = 10;
 const MAX_ATTEMPTS = 5;
 const MAX_ERROR_LENGTH = 512;
 const MAX_BACKOFF_MS = 60_000;
+const SKILL_COMPLETION_OBSERVATION_TIMEOUT_MS = 10 * 60_000;
 // Dispatches can legitimately run for minutes. Woken skill invocations hold
 // capacity until their agent run reaches a terminal state; binding preparation
 // also runs detached from the poll loop under this concurrency cap.
 const MAX_IN_FLIGHT = 2;
+
+function waitForAgentEndOrTimeout(agentEnd: Promise<void>): Promise<boolean> {
+  return new Promise(resolve => {
+    const timeout = setTimeout(() => resolve(false), SKILL_COMPLETION_OBSERVATION_TIMEOUT_MS);
+    timeout.unref?.();
+    void agentEnd.then(() => {
+      clearTimeout(timeout);
+      resolve(true);
+    });
+  });
+}
 
 interface DispatcherSession extends SkillSession {
   thread: {
@@ -386,7 +398,13 @@ export class FactoryDecisionDispatcher {
             throw new Error(`Factory skill invocation signal did not reach the agent (${String(settled.action)}).`);
           }
           if (settled.action === 'wake') {
-            await agentEnd;
+            const observed = await waitForAgentEndOrTimeout(agentEnd);
+            if (!observed) {
+              console.warn('Factory skill run terminal event was not observed before timeout', {
+                decisionId: record.id,
+                runId: settled.runId,
+              });
+            }
           }
         } finally {
           unsubscribe();
@@ -648,6 +666,7 @@ export const FACTORY_DISPATCH_CONSTANTS = {
   maxAttempts: MAX_ATTEMPTS,
   maxErrorLength: MAX_ERROR_LENGTH,
   maxBackoffMs: MAX_BACKOFF_MS,
+  skillCompletionObservationTimeoutMs: SKILL_COMPLETION_OBSERVATION_TIMEOUT_MS,
   maxInFlight: MAX_IN_FLIGHT,
   stages: FACTORY_RULE_STAGES,
 } as const;

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import type { MastraCodeState } from '@mastra/code-sdk/schema';
-import type { AgentController } from '@mastra/core/agent-controller';
+import type { AgentController, AgentControllerEventListener } from '@mastra/core/agent-controller';
 import { RequestContext } from '@mastra/core/request-context';
 
 import { resolveSkillInvocation } from '../skills/service.js';
@@ -24,10 +24,10 @@ const BATCH_SIZE = 10;
 const MAX_ATTEMPTS = 5;
 const MAX_ERROR_LENGTH = 512;
 const MAX_BACKOFF_MS = 60_000;
-// Dispatches can legitimately run for minutes (skill kickoffs consume the
-// agent's run stream; binding preparation clones repositories), so they run
-// detached from the poll loop under this concurrency cap.
-const MAX_IN_FLIGHT = 25;
+// Dispatches can legitimately run for minutes. Woken skill invocations hold
+// capacity until their agent run reaches a terminal state; binding preparation
+// also runs detached from the poll loop under this concurrency cap.
+const MAX_IN_FLIGHT = 2;
 
 interface DispatcherSession extends SkillSession {
   thread: {
@@ -38,6 +38,7 @@ interface DispatcherSession extends SkillSession {
     input: { id: string; type: 'user'; tagName: 'user'; contents: string },
     options: { requestContext: RequestContext; requireDelivery?: boolean },
   ): { accepted: Promise<{ accepted: true; runId?: string; action?: string }> };
+  subscribe(listener: AgentControllerEventListener): () => void;
 }
 
 type FactoryController = Pick<AgentController<MastraCodeState>, 'getSessionByResource'>;
@@ -353,25 +354,42 @@ export class FactoryDecisionDispatcher {
             ),
           );
         }
-        const result = session.sendSignal(
-          {
-            id: record.id,
-            type: 'user',
-            tagName: 'user',
-            contents: resolved.message,
-          },
-          // Without `requireDelivery` the session resolves `accepted` on the
-          // next tick and swallows wake failures, so a kickoff that never
-          // reached the agent would be marked succeeded and the thread would
-          // stay empty forever.
-          { requestContext, requireDelivery: true },
-        );
-        const settled = await result.accepted;
-        if (settled.action !== 'wake' && settled.action !== 'deliver') {
-          // An undefined action means the session did not verify delivery at
-          // all — with `requireDelivery` set that is a contract violation, not
-          // a success.
-          throw new Error(`Factory skill invocation signal did not reach the agent (${String(settled.action)}).`);
+        let resolveAgentEnd!: () => void;
+        const agentEnd = new Promise<void>(resolve => {
+          resolveAgentEnd = resolve;
+        });
+        const unsubscribe = session.subscribe(event => {
+          if (event.type === 'agent_end') {
+            resolveAgentEnd();
+          }
+        });
+
+        try {
+          const result = session.sendSignal(
+            {
+              id: record.id,
+              type: 'user',
+              tagName: 'user',
+              contents: resolved.message,
+            },
+            // Without `requireDelivery` the session resolves `accepted` on the
+            // next tick and swallows wake failures, so a kickoff that never
+            // reached the agent would be marked succeeded and the thread would
+            // stay empty forever.
+            { requestContext, requireDelivery: true },
+          );
+          const settled = await result.accepted;
+          if (settled.action !== 'wake' && settled.action !== 'deliver') {
+            // An undefined action means the session did not verify delivery at
+            // all — with `requireDelivery` set that is a contract violation, not
+            // a success.
+            throw new Error(`Factory skill invocation signal did not reach the agent (${String(settled.action)}).`);
+          }
+          if (settled.action === 'wake') {
+            await agentEnd;
+          }
+        } finally {
+          unsubscribe();
         }
         return;
       }

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -28,7 +28,7 @@ const SKILL_COMPLETION_OBSERVATION_TIMEOUT_MS = 10 * 60_000;
 // Dispatches can legitimately run for minutes. Woken skill invocations hold
 // capacity until their agent run reaches a terminal state; binding preparation
 // also runs detached from the poll loop under this concurrency cap.
-const MAX_IN_FLIGHT = 2;
+const MAX_IN_FLIGHT = 25;
 
 function waitForAgentEndOrTimeout(agentEnd: Promise<void>): Promise<boolean> {
   return new Promise(resolve => {


### PR DESCRIPTION
This bounds Factory skill wakeups so the dispatcher keeps a slot occupied until the agent run ends, rather than releasing it as soon as the signal is accepted. It also lowers the default limit to two active wakeups.

Before: `accepted -> slot released`
After: `wake accepted -> agent_end -> slot released`

Delivery signals still complete immediately. Added coverage for wake capacity, synchronous completion, cleanup after rejected delivery, and the GitHub triage flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Factory keeps a wakeup slot busy until the woken skill finishes. This prevents too many skill runs from running at the same time. The default limit is now two active wakeups.

## Changes

- Keep dispatcher capacity occupied until `agent_end`.
- Lower `FACTORY_DISPATCH_CONSTANTS.maxInFlight` from `25` to `2`.
- Complete delivery signals immediately.
- Release capacity after a bounded wait if `agent_end` is not observed.
- Remove session listeners after successful or rejected delivery.
- Handle synchronous `agent_end` events without leaking capacity.
- Add coverage for wake capacity, completion timeouts, cleanup, synchronous completion, and the GitHub triage flow.
- Add a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->