### PR TITLE
fix(factory): bound skill wakeups and feature triage

### DIFF
--- a/.changeset/wacky-beers-love.md
+++ b/.changeset/wacky-beers-love.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Updated Factory triage to keep new features in Intake until manually advanced.

--- a/mastracode/factory/factory-skills/factory-triage/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-triage/SKILL.md
@@ -83,6 +83,7 @@ Set `COMMENT_BODY` to the marker followed by the handoff. Update the oldest mark
 Post the same handoff as your final conversation message. Take the current stage and `expectedRevision` from the `factory-phase` signal.
 
 - When the current stage is **Intake** or **Triage**, make the terminal `factory_transition_work_item` call: valid/actionable issues go to `planning`; issues that should be closed go to `done` with the close rationale.
+- When the item is marked as a new feature, DO NOT MOVE TO planning. Keep the issue open until manually moved to planning.
 - When the item is already in **Planning** or a later stage, this is a webhook-driven refresh: update the GitHub handoff but do **not** request a stage transition. Report the updated verdict and stop.
 
 `rationale` (max 1000 chars) — the triage verdict and headline understanding in a few sentences (e.g. "Genuine regression from <commit>; root cause understood; ready to plan a fix").


### PR DESCRIPTION
Fixes Factory dispatch so a woken skill keeps its dispatcher slot until the agent run finishes, avoiding unbounded simultaneous runs. New feature work items now remain in Intake instead of being automatically advanced to Planning.

Before: accepted wake signals released capacity immediately, and new features could advance automatically.
After: capacity releases when the agent run ends, and new features wait for a manual move to Planning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR prevents too many skill runs from starting at the same time. It also keeps new feature requests in Intake until someone moves them to Planning.

## Changes

- Keeps a woken skill’s dispatcher slot occupied until its agent run ends.
- Releases dispatcher capacity at `agent_end`.
- Prevents new feature work items from moving to `planning` automatically.
- Adds a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->