### PR TITLE
fix(factory-ui): open Intake candidates in their provider

### DIFF
--- a/.changeset/polite-tigers-open.md
+++ b/.changeset/polite-tigers-open.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed Factory Intake issue menus so open issues can be opened in their connected provider.

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -425,6 +425,38 @@ describe('Board card pending states', () => {
     expect(linearLink).toHaveAttribute('target', '_blank');
   });
 
+  it('offers "Open in GitHub" on unfiled Intake candidates', async () => {
+    stubBoardEndpoints();
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/issues`, ({ request }) =>
+        HttpResponse.json({
+          issues: new URL(request.url).searchParams.has('label')
+            ? []
+            : [
+                {
+                  number: 43,
+                  title: 'Unfiled GitHub intake issue',
+                  url: 'https://github.com/acme/app/issues/43',
+                  author: 'octocat',
+                  labels: [],
+                  comments: 0,
+                  createdAt: '2026-07-28T00:00:00.000Z',
+                  updatedAt: '2026-07-28T00:00:00.000Z',
+                },
+              ],
+          nextPage: null,
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWorkBoard();
+
+    await user.click(await screen.findByRole('button', { name: 'More actions for Unfiled GitHub intake issue' }));
+    const githubLink = await screen.findByRole('menuitem', { name: 'Open in GitHub' });
+    expect(githubLink).toHaveAttribute('href', 'https://github.com/acme/app/issues/43');
+    expect(githubLink).toHaveAttribute('target', '_blank');
+  });
+
   it('identifies Slack-created work items as Slack instead of Manual', async () => {
     stubBoardEndpoints();
     server.use(

--- a/mastracode/factory-ui/src/ui/domains/factory/components/CandidateCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/CandidateCard.tsx
@@ -95,6 +95,10 @@ export function CandidateCard({
           onRunPrompt={prompt => onRun(defaultAction, prompt)}
           menuExtras={
             <>
+              <DropdownMenu.Item render={<a href={candidate.url} target="_blank" rel="noreferrer" />}>
+                <ArrowUpRight aria-hidden />
+                <span>{externalLinkLabel(candidate.source)}</span>
+              </DropdownMenu.Item>
               {showTriage && (
                 <DropdownMenu.Item disabled={triageStarting} onClick={onTriage}>
                   <Stethoscope aria-hidden />


### PR DESCRIPTION
Candidate cards now include the connected provider link in More actions, matching persisted work items while keeping the existing title icon.

Before: `More actions → Investigate, Custom prompt, Triage issue, Add to board`
After: `More actions → Investigate, Custom prompt, Open in GitHub/Linear, Triage issue, Add to board`

The board MSW test covers opening an unfiled GitHub candidate menu and verifies the external issue URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory Intake candidate cards now show a direct link to the connected GitHub or Linear issue in the More actions menu. The existing title icon remains available.

## Changes

- Added provider-specific actions:
  - “Open in GitHub”
  - “Open in Linear”
- Opened provider issues in a new browser tab.
- Added a board MSW test for an unfiled GitHub candidate.
- Added a patch changeset for `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->