### PR TITLE
fix(factory): fix issue intake pagination

### DIFF
--- a/.changeset/open-games-join.md
+++ b/.changeset/open-games-join.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed GitHub issue intake pagination when platform responses contain fewer issues after filtering pull requests.

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -173,7 +173,7 @@ describe('PlatformGithubIntegration', () => {
           labels: ['bug'],
         }),
       ],
-      nextCursor: null,
+      nextCursor: '2',
     });
     await expect(
       integration.versionControl.listPullRequests({ connection: installationConnection, sourceId: 'acme/app' }),
@@ -182,6 +182,29 @@ describe('PlatformGithubIntegration', () => {
       nextCursor: null,
     });
     expect(String(fetchImpl.mock.calls[0]?.[0])).toContain('label=bug%2Curgent');
+  });
+
+  it('continues platform issue pagination after a short filtered page and stops on an empty page', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      return json({ issues: url.searchParams.get('page') === '1' ? [issue] : [] });
+    });
+    const integration = createIntegration(fetchImpl);
+    const connection = { type: 'app-installation' as const, installationId: 7 };
+
+    const firstPage = await integration.intake.listIssues({
+      connection,
+      sourceIds: ['acme/app'],
+      cursor: '1',
+    });
+    const secondPage = await integration.intake.listIssues({
+      connection,
+      sourceIds: ['acme/app'],
+      cursor: firstPage.nextCursor ?? undefined,
+    });
+
+    expect(firstPage).toMatchObject({ issues: [expect.objectContaining({ id: '12' })], nextCursor: '2' });
+    expect(secondPage).toEqual({ issues: [], nextCursor: null });
   });
 
   it('fetches issue details, creates comments, and preserves not-found semantics', async () => {

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -887,7 +887,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     const result = await this.#client.request<{ issues: GithubIssue[] }>('GET', `${path}?${query}`);
     return {
       issues: result.issues.map(issue => parseIntakeIssue(sourceId, issue)),
-      nextCursor: result.issues.length === PAGE_SIZE ? String(page + 1) : null,
+      nextCursor: result.issues.length > 0 ? String(page + 1) : null,
     };
   }
 


### PR DESCRIPTION
## Problem

The Factory Work intake stopped loading GitHub issues after the first page, while Review pull request pagination continued working.

GitHub's repository issues API returns issues and pull requests together. The platform filters pull requests from that response before returning the issue list to Factory. Factory treated any filtered page containing fewer than 30 issues as the final page, even when GitHub had returned a full mixed page with more pages available.

## Fix

Continue issue pagination after every non-empty platform response. Pagination now stops when the platform returns an empty issue page.

Added regression coverage for a short filtered issue page followed by an empty page.

## Long-term solution

The platform issues endpoint should return pagination metadata derived from GitHub's raw response before pull requests are filtered, such as `nextPage` or `hasNextPage`. Factory should consume that metadata instead of inferring continuation from the filtered issue count.

The current fallback fixes the reproduced failure, but it can still stop early if a raw GitHub page contains only pull requests while later pages contain issues.

## Verification

- Platform GitHub integration tests: 34 passed
- Factory typecheck: passed
- Factory lint: passed with zero errors or warnings
- Manually verified that Work intake loads additional issue pages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

GitHub sends issues and pull requests in the same list. Factory removes pull requests, but it previously stopped too early when that left a short page. This fix continues to the next page and adds tests for this case.

## Changes

- Continue GitHub issue pagination when a filtered page contains any issues.
- Add regression coverage for a short filtered page followed by an empty page.
- Update the expected pagination cursor.
- Add a patch changeset for `@mastra/factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->