### PR TITLE
fix(hono): propagate fetch-to-node cancel as Node response close

### DIFF
--- a/.changeset/fetch-to-node-cancel-close.md
+++ b/.changeset/fetch-to-node-cancel-close.md
@@ -1,0 +1,5 @@
+---
+'@mastra/hono': patch
+---
+
+Prevent MCP Streamable-HTTP disconnects from crashing the server 15s later by propagating ReadableStream cancellation into the fetch-to-node simulated Node response (and shipping the patched bridge inside @mastra/hono).

--- a/patches/fetch-to-node@2.1.0.patch
+++ b/patches/fetch-to-node@2.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/fetch-to-node/http-server.js b/dist/fetch-to-node/http-server.js
-index d29281cd05bfa88150c3c7c9be8c66b3ccb99391..8b09548c7f5ccab83e27c5b65df1a36add335596 100644
+index d29281cd05bfa88150c3c7c9be8c66b3ccb99391..1b7ace8e6709a426cdceae36e5067a18168ac174 100644
 --- a/dist/fetch-to-node/http-server.js
 +++ b/dist/fetch-to-node/http-server.js
 @@ -317,6 +317,7 @@ export class FetchServerResponse extends FetchOutgoingMessage {
@@ -10,7 +10,7 @@ index d29281cd05bfa88150c3c7c9be8c66b3ccb99391..8b09548c7f5ccab83e27c5b65df1a36a
          let body = this._hasBody
              ? new ReadableStream({
                  start(controller) {
-@@ -328,18 +329,22 @@ export class FetchServerResponse extends FetchOutgoingMessage {
+@@ -328,18 +329,24 @@ export class FetchServerResponse extends FetchOutgoingMessage {
                      }
                      else {
                          _this.on("finish", () => {
@@ -32,6 +32,8 @@ index d29281cd05bfa88150c3c7c9be8c66b3ccb99391..8b09548c7f5ccab83e27c5b65df1a36a
                  },
 +                cancel() {
 +                    cancelled = true;
++                    // Propagate cancel to nested Node bridges (MCP SSE keepalive).
++                    _this.emit("close");
 +                },
              })
              : null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,7 @@ packageExtensionsChecksum: sha256-xGYNP5bHLPlbBT+RiHXWlNCiUtPhW6W9ntBiVM/duy4=
 patchedDependencies:
   '@changesets/get-dependents-graph@2.1.4': eb65c5cbf43c61ce6dcb0c77fa30d9aebcdffa3a70dee1faefc4cde4125f28fa
   '@earendil-works/pi-tui@0.80.6': 88572df39a8452647fa073db5bc0907de3f1cb04c52c4559c8cc6e662973818b
+  fetch-to-node@2.1.0: a1bf6459123fc3b9bede346d5c5457a2cbc5f3194686cfe497ce9eab19fefd80
 
 importers:
 
@@ -4734,7 +4735,7 @@ importers:
         version: 10.7.0(jiti@2.7.0)
       fetch-to-node:
         specifier: ^2.1.0
-        version: 2.1.0
+        version: 2.1.0(patch_hash=a1bf6459123fc3b9bede346d5c5457a2cbc5f3194686cfe497ce9eab19fefd80)
       hono-openapi:
         specifier: ^1.3.1
         version: 1.3.1(@hono/standard-validator@0.3.0(@standard-schema/spec@1.1.0)(hono@4.12.30))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3)))(arktype@2.2.0)(quansync@0.2.11)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3)))(arktype@2.2.0)(quansync@0.2.11)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(arktype@2.2.0)(openapi-types@12.1.3)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.30)(openapi-types@12.1.3)
@@ -6319,7 +6320,7 @@ importers:
         version: link:../../packages/server
       fetch-to-node:
         specifier: ^2.1.0
-        version: 2.1.0
+        version: 2.1.0(patch_hash=a1bf6459123fc3b9bede346d5c5457a2cbc5f3194686cfe497ce9eab19fefd80)
       ws:
         specifier: ^8.21.0
         version: 8.21.0(bufferutil@4.1.0)
@@ -48372,7 +48373,7 @@ snapshots:
       to-arraybuffer: 1.0.1
       tough-cookie: 4.1.4
 
-  fetch-to-node@2.1.0: {}
+  fetch-to-node@2.1.0(patch_hash=a1bf6459123fc3b9bede346d5c5457a2cbc5f3194686cfe497ce9eab19fefd80): {}
 
   fflate@0.4.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,6 +51,9 @@ catalog:
 patchedDependencies:
   '@changesets/get-dependents-graph@2.1.4': patches/@changesets__get-dependents-graph@2.1.4.patch
   '@earendil-works/pi-tui@0.80.6': patches/@earendil-works__pi-tui@0.80.6.patch
+  # Guards + close propagation for MCP Streamable-HTTP client disconnect (#20332 / #13904).
+  # Without emit('close'), MCP's 15s SSE keepalive keeps writing into a cancelled outer stream.
+  fetch-to-node@2.1.0: patches/fetch-to-node@2.1.0.patch
 
 packageExtensions:
   '@ai-sdk/provider-utils@3.0.25':

--- a/server-adapters/hono/src/__tests__/fetch-to-node-cancel-close.test.ts
+++ b/server-adapters/hono/src/__tests__/fetch-to-node-cancel-close.test.ts
@@ -1,0 +1,38 @@
+import { toFetchResponse, toReqRes } from 'fetch-to-node';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression for #20332: MCP Streamable-HTTP nests @hono/node-server inside a
+ * fetch-to-node simulated Node response. When the outer Web ReadableStream is
+ * cancelled (client disconnect), fetch-to-node must emit `close` on that
+ * response so the inner bridge cancels MCP's SSE keepalive. Guards alone stop
+ * the crash but leave the 15s keepalive orphaned.
+ */
+describe('fetch-to-node cancel close propagation (#20332)', () => {
+  it('emits close on the simulated Node response when the fetch body is cancelled', async () => {
+    const request = new Request('http://127.0.0.1/api/mcp/test-mcp/mcp', {
+      method: 'GET',
+      headers: { accept: 'text/event-stream' },
+    });
+    const { res } = toReqRes(request);
+
+    const closePromise = new Promise<void>(resolve => {
+      res.once('close', () => resolve());
+    });
+
+    // Headers + body start so _toFetchResponse builds a live ReadableStream.
+    res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+    res.write(': early\n\n');
+
+    const fetchResponse = await toFetchResponse(res);
+    expect(fetchResponse.body).not.toBeNull();
+
+    await fetchResponse.body!.cancel();
+    await expect(closePromise).resolves.toBeUndefined();
+
+    // Late write after cancel must not throw (guarded enqueue path).
+    expect(() => {
+      res.write(': keepalive\n\n');
+    }).not.toThrow();
+  });
+});

--- a/server-adapters/hono/tsdown.config.ts
+++ b/server-adapters/hono/tsdown.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
   dts: false,
   treeshake: true,
   sourcemap: true,
+  // Embed the workspace-patched fetch-to-node so published @mastra/hono
+  // (and user .mastra/output bundles) do not depend on unpatched npm 2.1.0.
+  // See #20332 / patches/fetch-to-node@2.1.0.patch.
+  noExternal: ['fetch-to-node'],
   onSuccess: async () => {
     await generateTypes(process.cwd());
   },


### PR DESCRIPTION
## Summary
- Re-wire `patches/fetch-to-node@2.1.0.patch` into `patchedDependencies` (it existed from #13904 but was dropped from the workspace patch list).
- Extend `ReadableStream.cancel()` to `emit('close')` on the simulated Node `ServerResponse`, so nested `@hono/node-server` / MCP Streamable-HTTP cancels and clears the 15s SSE keepalive.
- Keep the existing cancelled guards/try-catch around `close()` / `enqueue()` for in-flight write races.
- Bundle the patched `fetch-to-node` into `@mastra/hono` via `noExternal` so published packages / `.mastra/output` do not keep shipping unpatched npm `2.1.0`.

Fixes #20332

## Context
@roaminro isolated that client disconnect cancels the outer fetch-to-node stream, but without `close` propagation MCP's keepalive fires ~15s later and `controller.enqueue` on the already-cancelled stream kills the process. Guards alone stop the crash but leave the timer orphaned.

## Test plan
- [x] `vitest run src/__tests__/fetch-to-node-cancel-close.test.ts` in `@mastra/hono` (cancel emits `close`; late write does not throw)
- [ ] Optional: deterministic one-client / 17s repro from #20332 against a built server with this patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a client disconnects, the server now closes the related response safely. This prevents delayed writes from crashing the server.

## Changes

- Re-added the `fetch-to-node@2.1.0` patch.
- Propagated `ReadableStream` cancellation through the simulated Node `ServerResponse`.
- Emitted `close` when the response stream is cancelled.
- Prevented `finish` and `data` events after cancellation.
- Added error handling for `close()` and `enqueue()` races.
- Bundled `fetch-to-node` into `@mastra/hono`.
- Added a regression test for cancellation and late writes.
- Added a patch changeset for `@mastra/hono`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->