### PR TITLE
MASTRA-4507: feat(core): add per-run experiment persistence policy

### DIFF
--- a/.changeset/metal-pugs-cheer.md
+++ b/.changeset/metal-pugs-cheer.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': minor
+---
+
+Added per-run controls for experiment and score persistence. Targets and scorers continue to run, while callers can keep results in memory without writing selected record types to storage.
+
+```typescript
+const summary = await dataset.startExperiment({
+  targetType: 'agent',
+  targetId: 'my-agent',
+  scorers: ['accuracy'],
+  persistence: { experiments: 'none', scores: 'none' },
+});
+```

--- a/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
+++ b/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
@@ -12,7 +12,7 @@ import TabItem from "@theme/TabItem";
 
 **Added in:** `@mastra/core@1.4.0`
 
-An experiment runs every item in a dataset through a target (an agent, a workflow, or a scorer) and then optionally scores the outputs. Use a scorer as the target when you want to evaluate an LLM judge itself. Results are persisted to storage so you can compare runs across different prompts, models, or code changes.
+An experiment runs every item in a dataset through a target (an agent, a workflow, or a scorer) and then optionally scores the outputs. Use a scorer as the target when you want to evaluate an LLM judge itself. By default, results are persisted to storage so you can compare runs across different prompts, models, or code changes.
 
 <Inject>
   **For AI agents:** Run `npx mastra api experiment run dataset_123 '{"name":"translation-baseline"}'` to start an experiment directly instead of opening Studio or writing a temporary script. Use a dataset ID returned by `npx mastra api dataset list` in place of the sample ID. The command requires a running Mastra server with dataset storage and registered experiment targets; start the local server with `npx mastra dev`, or pass the reachable server's base URL with `--url`. Run `npx mastra api experiment run --schema` before constructing different input, and get user approval before starting an experiment because it can make model calls. Install Mastra's skill with `npx skills add mastra-ai/skills --skill mastra` for complete API CLI discovery, targeting, schema, authentication, and error-handling guidance.
@@ -142,6 +142,28 @@ for (const item of summary.results) {
 ```
 
 Visit the [Scorers overview](/docs/evals/overview) for details on available and custom scorers.
+
+## Control persistence per run
+
+Use `persistence` to prevent experiment records, score records, or both from being written to storage for a specific run:
+
+```typescript title="src/mastra/experiments/no-persistence.ts"
+const summary = await dataset.startExperiment({
+  targetType: 'agent',
+  targetId: 'translation-agent',
+  scorers: ['accuracy'],
+  persistence: {
+    experiments: 'none',
+    scores: 'none',
+  },
+})
+```
+
+The target and scorers still run, and `startExperiment()` still returns the item results and scores in `summary`. The settings are independent. For example, set only `scores: 'none'` to persist the experiment and its item results without creating score records.
+
+Omitted settings default to `'default'`, which preserves the standard storage behavior. This policy only controls experiment and score records created by the run. It doesn't disable storage used by the target, such as agent memory, vectors, observability, or custom tool storage.
+
+When `startExperimentAsync()` runs with `experiments: 'none'`, the returned experiment ID isn't stored and can't be used to poll the experiment with `getExperiment()`.
 
 ## Tool mocks
 

--- a/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
+++ b/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Running experiments | Datasets"
-description: "Run experiments against agents or workflows, with scoring and result tracking."
+title: 'Running experiments | Datasets'
+description: 'Run experiments against agents or workflows, with scoring and result tracking.'
 packages:
-  - "@mastra/core"
+  - '@mastra/core'
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Running experiments
 
@@ -163,7 +163,7 @@ The target and scorers still run, and `startExperiment()` still returns the item
 
 Omitted settings default to `'default'`, which preserves the standard storage behavior. This policy only controls experiment and score records created by the run. It doesn't disable storage used by the target, such as agent memory, vectors, observability, or custom tool storage.
 
-When `startExperimentAsync()` runs with `experiments: 'none'`, it doesn't create a pollable experiment record. Without an experiment event observer, the run is fire-and-forget. The experiment API can't report whether the run completed or failed. It also can't retrieve item results or scores.
+When `startExperimentAsync()` runs with `experiments: 'none'`, it doesn't persist an experiment record, progress updates, or item results. Score persistence remains controlled separately by `persistence.scores`. Without an experiment event observer, the run is fire-and-forget, and the experiment API can't report whether it completed or failed.
 
 Use synchronous `startExperiment()` when the caller needs the returned summary. An experiment event observer can receive lifecycle events and the terminal summary.
 

--- a/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
+++ b/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
@@ -163,7 +163,9 @@ The target and scorers still run, and `startExperiment()` still returns the item
 
 Omitted settings default to `'default'`, which preserves the standard storage behavior. This policy only controls experiment and score records created by the run. It doesn't disable storage used by the target, such as agent memory, vectors, observability, or custom tool storage.
 
-When `startExperimentAsync()` runs with `experiments: 'none'`, the returned experiment ID isn't stored and can't be used to poll the experiment with `getExperiment()`.
+When `startExperimentAsync()` runs with `experiments: 'none'`, it doesn't create a pollable experiment record. Without an experiment event observer, the run is fire-and-forget. The experiment API can't report whether the run completed or failed. It also can't retrieve item results or scores.
+
+Use synchronous `startExperiment()` when the caller needs the returned summary. An experiment event observer can receive lifecycle events and the terminal summary.
 
 ## Tool mocks
 

--- a/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
+++ b/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
@@ -145,7 +145,7 @@ Visit the [Scorers overview](/docs/evals/overview) for details on available and 
 
 ## Control persistence per run
 
-Use `persistence` to prevent experiment records, score records, or both from being written to storage for a specific run:
+Use `persistence` to skip storage writes for a specific run. Experiment records and score records can be disabled independently:
 
 ```typescript title="src/mastra/experiments/no-persistence.ts"
 const summary = await dataset.startExperiment({

--- a/docs/src/content/en/reference/datasets/startExperiment.mdx
+++ b/docs/src/content/en/reference/datasets/startExperiment.mdx
@@ -137,6 +137,35 @@ console.log(`Status: ${summary2.status}`)
     description:
       'Controls undeclared agent tool calls. `allow` executes them live. `deny` fails the item with `TOOL_MOCK_NOT_DECLARED` before execution. An item-level value overrides this experiment default.',
   },
+  {
+    name: 'persistence',
+    type: 'ExperimentPersistencePolicy',
+    isOptional: true,
+    description:
+      'Controls whether this run writes experiment records and score records. Targets and scorers still execute, and results remain available in the returned summary.',
+    properties: [
+      {
+        type: 'ExperimentPersistencePolicy',
+        parameters: [
+          {
+            name: 'experiments',
+            type: "'default' | 'none'",
+            isOptional: true,
+            defaultValue: "'default'",
+            description:
+              'Set to `none` to skip experiment creation, item results, progress, and terminal status writes.',
+          },
+          {
+            name: 'scores',
+            type: "'default' | 'none'",
+            isOptional: true,
+            defaultValue: "'default'",
+            description: 'Set to `none` to skip score writes while still running scorers.',
+          },
+        ],
+      },
+    ],
+  },
 ]}
 />
 

--- a/docs/src/content/en/reference/datasets/startExperimentAsync.mdx
+++ b/docs/src/content/en/reference/datasets/startExperimentAsync.mdx
@@ -38,6 +38,8 @@ console.log(`Current status: ${experiment.status}`)
 
 Takes the same `StartExperimentConfig` as [`dataset.startExperiment()`](/reference/datasets/startExperiment).
 
+When `persistence.experiments` is set to `'none'`, the run isn't stored. The returned `experimentId` identifies the background execution but can't be used with `dataset.getExperiment()`.
+
 ## Returns
 
 <PropertiesTable

--- a/docs/src/content/en/reference/datasets/startExperimentAsync.mdx
+++ b/docs/src/content/en/reference/datasets/startExperimentAsync.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Reference: dataset.startExperimentAsync() | Datasets"
-description: "Documentation for the `dataset.startExperimentAsync()` method, which starts an experiment asynchronously."
+title: 'Reference: dataset.startExperimentAsync() | Datasets'
+description: 'Documentation for the `dataset.startExperimentAsync()` method, which starts an experiment asynchronously.'
 packages:
-  - "@mastra/core"
+  - '@mastra/core'
 ---
 
 # dataset.startExperimentAsync()
@@ -38,7 +38,7 @@ console.log(`Current status: ${experiment.status}`)
 
 Takes the same `StartExperimentConfig` as [`dataset.startExperiment()`](/reference/datasets/startExperiment).
 
-When `persistence.experiments` is set to `'none'`, `startExperimentAsync()` doesn't create a pollable experiment record. Without an experiment event observer, the run is fire-and-forget. The experiment API can't report whether the run completed or failed. It also can't retrieve item results or scores.
+When `persistence.experiments` is set to `'none'`, `startExperimentAsync()` doesn't persist an experiment record, progress updates, or item results. Score persistence remains controlled separately by `persistence.scores`. Without an experiment event observer, the run is fire-and-forget, and the experiment API can't report whether it completed or failed.
 
 Use synchronous [`startExperiment()`](/reference/datasets/startExperiment) when the caller needs the returned summary. An experiment event observer can receive lifecycle events and the terminal summary.
 

--- a/docs/src/content/en/reference/datasets/startExperimentAsync.mdx
+++ b/docs/src/content/en/reference/datasets/startExperimentAsync.mdx
@@ -38,7 +38,9 @@ console.log(`Current status: ${experiment.status}`)
 
 Takes the same `StartExperimentConfig` as [`dataset.startExperiment()`](/reference/datasets/startExperiment).
 
-When `persistence.experiments` is set to `'none'`, the run isn't stored. The returned `experimentId` identifies the background execution but can't be used with `dataset.getExperiment()`.
+When `persistence.experiments` is set to `'none'`, `startExperimentAsync()` doesn't create a pollable experiment record. Without an experiment event observer, the run is fire-and-forget. The experiment API can't report whether the run completed or failed. It also can't retrieve item results or scores.
+
+Use synchronous [`startExperiment()`](/reference/datasets/startExperiment) when the caller needs the returned summary. An experiment event observer can receive lifecycle events and the terminal summary.
 
 ## Returns
 

--- a/packages/core/src/datasets/__tests__/dataset.test.ts
+++ b/packages/core/src/datasets/__tests__/dataset.test.ts
@@ -344,6 +344,26 @@ describe('Dataset', () => {
     await new Promise(r => setTimeout(r, 500));
   });
 
+  it('startExperimentAsync skips experiment storage when experiment persistence is disabled', async () => {
+    await ds.addItem({ input: { prompt: 'Hello' } });
+    const task = vi.fn().mockResolvedValue('ok');
+
+    const { experimentId, status, totalItems } = await ds.startExperimentAsync({
+      task,
+      scorers: [],
+      persistence: { experiments: 'none' },
+    });
+
+    expect(status).toBe('pending');
+    expect(experimentId).toBeTruthy();
+    expect(totalItems).toBe(1);
+    expect(mockStorage.getStore).not.toHaveBeenCalledWith('experiments');
+
+    await vi.waitFor(() => expect(task).toHaveBeenCalledOnce());
+    expect(db.experiments.size).toBe(0);
+    expect(db.experimentResults.size).toBe(0);
+  });
+
   it('startExperimentAsync throws EXPERIMENT_NO_ITEMS on empty dataset', async () => {
     await expect(
       ds.startExperimentAsync({

--- a/packages/core/src/datasets/dataset.ts
+++ b/packages/core/src/datasets/dataset.ts
@@ -365,7 +365,8 @@ export class Dataset {
   async startExperimentAsync<I = unknown, O = unknown, E = unknown>(
     config: StartExperimentConfig<I, O, E>,
   ): Promise<{ experimentId: string; status: 'pending'; totalItems: number }> {
-    const experimentsStore = await this.#getExperimentsStore();
+    const persistExperiments = config.persistence?.experiments !== 'none';
+    const experimentsStore = persistExperiments ? await this.#getExperimentsStore() : undefined;
     const datasetsStore = await this.#getDatasetsStore();
 
     const dataset = await datasetsStore.getDatasetById({ id: this.id, filters: this.#scope });
@@ -393,21 +394,24 @@ export class Dataset {
       });
     }
 
-    const run = await experimentsStore.createExperiment({
-      datasetId: this.id,
-      datasetVersion: targetVersion,
-      targetType: config.targetType ?? 'agent',
-      targetId: config.targetId ?? 'inline',
-      totalItems: items.length,
-      name: config.name,
-      description: config.description,
-      metadata: config.metadata,
-      agentVersion: config.agentVersion,
-      organizationId: dataset.organizationId ?? null,
-      projectId: dataset.projectId ?? null,
-    });
+    const experimentId = crypto.randomUUID();
 
-    const experimentId = run.id;
+    if (experimentsStore) {
+      await experimentsStore.createExperiment({
+        id: experimentId,
+        datasetId: this.id,
+        datasetVersion: targetVersion,
+        targetType: config.targetType ?? 'agent',
+        targetId: config.targetId ?? 'inline',
+        totalItems: items.length,
+        name: config.name,
+        description: config.description,
+        metadata: config.metadata,
+        agentVersion: config.agentVersion,
+        organizationId: dataset.organizationId ?? null,
+        projectId: dataset.projectId ?? null,
+      });
+    }
 
     // Fire-and-forget — runExperiment resolves the applicable run, item, or dataset scorer source
     void runExperiment(this.#mastra, {
@@ -417,13 +421,15 @@ export class Dataset {
       version: targetVersion,
       filters: this.#scope,
     } as ExperimentConfig).catch(async err => {
-      await experimentsStore
-        .updateExperiment({
-          id: experimentId,
-          status: 'failed',
-          completedAt: new Date(),
-        })
-        .catch(() => {});
+      if (experimentsStore) {
+        await experimentsStore
+          .updateExperiment({
+            id: experimentId,
+            status: 'failed',
+            completedAt: new Date(),
+          })
+          .catch(() => {});
+      }
       this.#mastra.getLogger()?.error(`Experiment ${experimentId} failed: ${err?.message ?? err}`);
     });
 

--- a/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
@@ -8,6 +8,7 @@ import type { MastraCompositeStore, StorageDomains } from '../../../storage/base
 import { DatasetsInMemory } from '../../../storage/domains/datasets/inmemory';
 import { ExperimentsInMemory } from '../../../storage/domains/experiments/inmemory';
 import { InMemoryDB } from '../../../storage/domains/inmemory-db';
+import { ScoresInMemory } from '../../../storage/domains/scores/inmemory';
 import { createStep, createWorkflow } from '../../../workflows';
 import { EXPERIMENT_ITEM_SCORER_NOT_FOUND, runExperiment } from '../index';
 
@@ -40,6 +41,7 @@ describe('runExperiment', () => {
   let db: InMemoryDB;
   let datasetsStorage: DatasetsInMemory;
   let experimentsStorage: ExperimentsInMemory;
+  let scoresStorage: ScoresInMemory;
   let mockStorage: MastraCompositeStore;
   let mastra: Mastra;
   let datasetId: string;
@@ -49,6 +51,7 @@ describe('runExperiment', () => {
     db = new InMemoryDB();
     datasetsStorage = new DatasetsInMemory({ db });
     experimentsStorage = new ExperimentsInMemory({ db });
+    scoresStorage = new ScoresInMemory({ db });
 
     // Create test dataset with items
     const dataset = await datasetsStorage.createDataset({
@@ -74,10 +77,12 @@ describe('runExperiment', () => {
       stores: {
         datasets: datasetsStorage,
         experiments: experimentsStorage,
+        scores: scoresStorage,
       } as unknown as StorageDomains,
       getStore: vi.fn().mockImplementation(async (name: keyof StorageDomains) => {
         if (name === 'datasets') return datasetsStorage;
         if (name === 'experiments') return experimentsStorage;
+        if (name === 'scores') return scoresStorage;
         return undefined;
       }),
     } as unknown as MastraCompositeStore;
@@ -677,6 +682,84 @@ describe('runExperiment', () => {
 
       await expect(runExperiment(localMastra, { datasetId: dataset.id, task })).rejects.toThrow('Scorer not found');
       expect(task).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('persistence policy', () => {
+    it('preserves experiment and score persistence by default', async () => {
+      const scorer = createMockScorer('default-scorer', 'Default Scorer');
+
+      const result = await runExperiment(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        scorers: [scorer],
+      });
+
+      expect(result.results).toHaveLength(2);
+      expect(result.results.every(item => item.scores[0]?.score === 1)).toBe(true);
+      expect(db.experiments.size).toBe(1);
+      expect(db.experimentResults.size).toBe(2);
+      expect(db.scores.size).toBe(2);
+    });
+
+    it('suppresses experiment writes independently while still persisting scores', async () => {
+      const scorer = createMockScorer('score-only', 'Score Only');
+
+      const result = await runExperiment(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        scorers: [scorer],
+        persistence: { experiments: 'none' },
+      });
+
+      expect(result.status).toBe('completed');
+      expect(result.persistenceFailures).toBe(0);
+      expect(result.results.every(item => item.scores[0]?.score === 1)).toBe(true);
+      expect(db.experiments.size).toBe(0);
+      expect(db.experimentResults.size).toBe(0);
+      expect(db.scores.size).toBe(2);
+      expect(mockStorage.getStore).not.toHaveBeenCalledWith('experiments');
+    });
+
+    it('suppresses score writes independently while still returning scores and persisting experiment results', async () => {
+      const scorer = createMockScorer('in-memory-only', 'In-memory Only');
+
+      const result = await runExperiment(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        scorers: [scorer],
+        persistence: { scores: 'none' },
+      });
+
+      expect(scorer.run).toHaveBeenCalledTimes(2);
+      expect(result.results.every(item => item.scores[0]?.score === 1)).toBe(true);
+      expect(db.experiments.size).toBe(1);
+      expect(db.experimentResults.size).toBe(2);
+      expect(db.scores.size).toBe(0);
+      expect(mockStorage.getStore).not.toHaveBeenCalledWith('scores');
+    });
+
+    it('performs no selected-domain writes when a run is cancelled', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await runExperiment(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        scorers: [createMockScorer('cancelled', 'Cancelled')],
+        signal: controller.signal,
+        persistence: { experiments: 'none', scores: 'none' },
+      });
+
+      expect(result.status).toBe('failed');
+      expect(result.results).toHaveLength(0);
+      expect(db.experiments.size).toBe(0);
+      expect(db.experimentResults.size).toBe(0);
+      expect(db.scores.size).toBe(0);
     });
   });
 

--- a/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { z } from 'zod';
-import { ScorerRunError } from '../../../evals/base';
+import { createScorer, ScorerRunError } from '../../../evals/base';
 import type { MastraScorer } from '../../../evals/base';
 import type { Mastra } from '../../../mastra';
 import { RequestContext } from '../../../request-context';
@@ -8,6 +8,7 @@ import type { MastraCompositeStore, StorageDomains } from '../../../storage/base
 import { DatasetsInMemory } from '../../../storage/domains/datasets/inmemory';
 import { ExperimentsInMemory } from '../../../storage/domains/experiments/inmemory';
 import { InMemoryDB } from '../../../storage/domains/inmemory-db';
+import { ObservabilityInMemory } from '../../../storage/domains/observability/inmemory';
 import { ScoresInMemory } from '../../../storage/domains/scores/inmemory';
 import { createStep, createWorkflow } from '../../../workflows';
 import { EXPERIMENT_ITEM_SCORER_NOT_FOUND, runExperiment } from '../index';
@@ -740,6 +741,69 @@ describe('runExperiment', () => {
       expect(db.experimentResults.size).toBe(2);
       expect(db.scores.size).toBe(0);
       expect(mockStorage.getStore).not.toHaveBeenCalledWith('scores');
+    });
+
+    it('suppresses observability score records from real scorers while retaining in-memory results', async () => {
+      const scorer = createScorer({
+        id: 'real-persistence-scorer',
+        description: 'Exercises real scorer persistence',
+      }).generateScore(() => 0.75);
+      const observabilityStorage = new ObservabilityInMemory({ db });
+      const addScore = vi.fn(async ({ traceId, spanId, score }) => {
+        await observabilityStorage.createScore({
+          score: {
+            ...score,
+            scoreId: crypto.randomUUID(),
+            traceId: traceId ?? null,
+            spanId: spanId ?? null,
+            timestamp: new Date(),
+          },
+        });
+      });
+      const localMastra = {
+        ...mastra,
+        observability: {
+          addScore,
+          getSelectedInstance: vi.fn().mockReturnValue(undefined),
+        },
+        getLogger: vi.fn().mockReturnValue({
+          debug: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          trackException: vi.fn(),
+        }),
+      } as unknown as Mastra;
+      scorer.__registerMastra(localMastra);
+
+      const defaultResult = await runExperiment(localMastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        scorers: [scorer],
+      });
+
+      expect(defaultResult.results.map(item => item.scores)).toEqual([
+        [expect.objectContaining({ score: 0.75 })],
+        [expect.objectContaining({ score: 0.75 })],
+      ]);
+      expect((await observabilityStorage.listScores({})).scores).toHaveLength(2);
+
+      db.scoreRecords.length = 0;
+      db.scores.clear();
+      addScore.mockClear();
+
+      const suppressedResult = await runExperiment(localMastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        scorers: [scorer],
+        persistence: { scores: 'none' },
+      });
+
+      expect(suppressedResult.results.every(item => item.scores[0]?.score === 0.75)).toBe(true);
+      expect(addScore).not.toHaveBeenCalled();
+      expect((await observabilityStorage.listScores({})).scores).toHaveLength(0);
+      expect(db.scores.size).toBe(0);
     });
 
     it('performs no selected-domain writes when a run is cancelled', async () => {

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -40,6 +40,7 @@ type ExperimentItem = {
 export type {
   DataItem,
   ExperimentConfig,
+  ExperimentPersistencePolicy,
   ExperimentSummary,
   ItemWithScores,
   ItemResult,
@@ -70,6 +71,12 @@ export * from './analytics';
  * Executes all items in the dataset concurrently (up to maxConcurrency) against
  * the specified target (agent or workflow). Optionally applies scorers to each
  * result and persists both results and scores to storage.
+ *
+ * Persistence is controlled per run and per domain via `config.persistence`. Selecting
+ * `none` for a domain skips its writes entirely while execution, scoring, and the
+ * returned summary stay identical. This governs experiment bookkeeping only — it does
+ * not disable other storage the target itself touches (agent memory, vectors,
+ * observability traces) and is not a sandbox.
  *
  * @param mastra - Mastra instance for storage and target resolution
  * @param config - Experiment configuration
@@ -105,16 +112,27 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
     requestContext: globalRequestContext,
     agentVersion,
     versions,
+    persistence,
   } = config;
 
   const startedAt = new Date();
   // Use provided experimentId (async trigger) or generate new one
   const experimentId = providedExperimentId ?? crypto.randomUUID();
 
+  // Per-run persistence policy. Each domain is independent and defaults to
+  // `default`, so an omitted (or partially specified) policy preserves the
+  // pre-policy behavior exactly.
+  const persistExperiments = persistence?.experiments !== 'none';
+  const persistScores = persistence?.scores !== 'none';
+
   // 1. Get storage and resolve components
   const storage = mastra.getStorage();
   const datasetsStore = await storage?.getStore('datasets');
-  const experimentsStore = await storage?.getStore('experiments');
+  // Under `experiments: 'none'` the store is never resolved, so every write site
+  // below — creation, progress, per-item results, and both terminal updates — is
+  // suppressed by the same guard that already handles "no storage configured".
+  // Dataset reads and scorer trajectory reads are unaffected: they use `storage`.
+  const experimentsStore = persistExperiments ? await storage?.getStore('experiments') : undefined;
 
   // Helper: if the experiment record was pre-created (async path) and we fail
   // during setup (Phase A/B), mark the experiment as failed so it doesn't stay stuck in 'pending'.
@@ -483,6 +501,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
             execResult.scorerOutput,
             execResult.traceId ?? undefined,
             workflowData,
+            persistScores,
           );
 
           const stepScores = await runStepScorersForItem(
@@ -495,6 +514,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
             targetId ?? 'inline',
             item.id,
             execResult.traceId ?? undefined,
+            persistScores,
           );
 
           itemScores = [...flatScores, ...stepScores];

--- a/packages/core/src/datasets/experiment/scorer.ts
+++ b/packages/core/src/datasets/experiment/scorer.ts
@@ -200,6 +200,7 @@ export async function runScorersForItem(
         targetCorrelationContext,
         scorer.type === 'trajectory' ? trajectoryOutput : undefined,
         workflowData,
+        persistScores,
       );
 
       // Persist only scores from successful scorer runs.
@@ -313,6 +314,7 @@ async function runScorerSafe(
   targetCorrelationContext?: CorrelationContext,
   trajectoryOutput?: Trajectory,
   workflowData?: WorkflowScorerData,
+  persistScores: boolean = true,
 ): Promise<{ result: ScorerResult; promptMetadata: ScorerPromptMetadata }> {
   try {
     const effectiveOutput = trajectoryOutput ?? scorerOutput ?? output;
@@ -341,6 +343,7 @@ async function runScorerSafe(
       ...(workflowData?.spanId ? { targetSpanId: workflowData.spanId } : {}),
       ...(targetCorrelationContext ? { targetCorrelationContext } : {}),
       ...(targetMetadata ? { targetMetadata } : {}),
+      _internal: { emitObservabilityScore: persistScores },
     });
 
     // Extract fields with typeof guards — scorer run result types use complex
@@ -496,6 +499,7 @@ export async function runStepScorersForItem(
             targetEntityType: EntityType.WORKFLOW_STEP,
             targetTraceId: traceId,
             ...(targetCorrelationContext ? { targetCorrelationContext } : {}),
+            _internal: { emitObservabilityScore: persistScores },
           });
 
           if (typeof scoreResult !== 'object' || scoreResult === null) {

--- a/packages/core/src/datasets/experiment/scorer.ts
+++ b/packages/core/src/datasets/experiment/scorer.ts
@@ -145,6 +145,11 @@ export interface WorkflowScorerData {
  * Errors are isolated per scorer - one failing scorer doesn't affect others.
  * Trajectory scorers (scorer.type === 'trajectory') receive a pre-extracted
  * Trajectory as their output, mirroring the dispatch runEvals performs.
+ *
+ * `persistScores: false` suppresses score writes while leaving `storage` usable
+ * for reads. The two are deliberately separate parameters: `storage` is also the
+ * source for trajectory extraction, so nulling it to stop writes would silently
+ * downgrade trajectory scorers to the raw-message fallback.
  */
 export async function runScorersForItem(
   scorers: MastraScorer<any, any, any, any>[],
@@ -159,6 +164,7 @@ export async function runScorersForItem(
   scorerOutput?: ScorerRunOutputForAgent,
   traceId?: string,
   workflowData?: WorkflowScorerData,
+  persistScores: boolean = true,
 ): Promise<ScorerResult[]> {
   if (scorers.length === 0) return [];
 
@@ -197,7 +203,7 @@ export async function runScorersForItem(
       );
 
       // Persist only scores from successful scorer runs.
-      if (storage && result.error === null && result.score !== null) {
+      if (persistScores && storage && result.error === null && result.score !== null) {
         try {
           // Legacy score-store emission. This path is being deprecated.
           await validateAndSaveScore(storage, {
@@ -437,6 +443,7 @@ export async function runStepScorersForItem(
   targetId: string,
   itemId: string,
   traceId?: string,
+  persistScores: boolean = true,
 ): Promise<ScorerResult[]> {
   const stepIds = Object.keys(stepScorers);
   if (stepIds.length === 0) return [];
@@ -507,7 +514,7 @@ export async function runStepScorersForItem(
           const reason = typeof fields.reason === 'string' ? fields.reason : null;
 
           // Persist score (best-effort, mirrors runScorersForItem)
-          if (storage && score !== null) {
+          if (persistScores && storage && score !== null) {
             try {
               await validateAndSaveScore(storage, {
                 scorerId: scorer.id,

--- a/packages/core/src/datasets/experiment/types.ts
+++ b/packages/core/src/datasets/experiment/types.ts
@@ -59,6 +59,29 @@ export interface DataItem<I = unknown, E = unknown> {
 }
 
 /**
+ * Per-domain persistence selection for a single experiment run.
+ *
+ * - `default` — write through the `Mastra` instance's configured storage (current behavior).
+ * - `none` — perform no writes for that domain for this run. Execution, scoring, and the
+ *   returned {@link ExperimentSummary} are unaffected; only the storage writes are skipped.
+ *
+ * The two domains are independent: selecting `none` for one does not change the other.
+ *
+ * This policy governs *experiment bookkeeping* only. It does not disable unrelated
+ * application storage the target itself may use — agent memory, vectors, working memory,
+ * observability traces, or arbitrary code the target runs. It is not a sandbox.
+ */
+export interface ExperimentPersistencePolicy {
+  /**
+   * Experiment records, progress updates, and per-item results
+   * (`mastra_experiments` / `mastra_experiment_results`). Default: `default`.
+   */
+  experiments?: 'default' | 'none';
+  /** Scores emitted by experiment scorers. Default: `default`. */
+  scores?: 'default' | 'none';
+}
+
+/**
  * Internal configuration for running a dataset experiment.
  * Not publicly exported — users interact via Dataset.startExperiment().
  * All new fields are optional — existing internal callers are unaffected.
@@ -103,6 +126,25 @@ export interface ExperimentConfig<I = unknown, O = unknown, E = unknown> {
   itemTimeout?: number;
   /** Maximum retries per item on failure (default: 0 = no retries). Abort errors are never retried. */
   maxRetries?: number;
+  /**
+   * Per-run, per-domain persistence policy. Omitted or partially specified fields
+   * default to `default`, so omitting this preserves existing behavior exactly.
+   *
+   * Selecting `none` lets a caller own persistence itself — for example a run
+   * executing inside a sandbox whose results are recorded by the host rather than
+   * through the bundled `Mastra` instance's storage.
+   *
+   * @example
+   * ```ts
+   * await runExperiment(mastra, {
+   *   data: items,
+   *   targetType: 'agent',
+   *   targetId: 'my-agent',
+   *   persistence: { experiments: 'none', scores: 'none' },
+   * });
+   * ```
+   */
+  persistence?: ExperimentPersistencePolicy;
   /** Default handling for agent tool calls not declared in an item's `toolMocks` (default: `allow`). */
   unmockedToolPolicy?: UnmockedToolPolicy;
   /** Pre-created experiment ID (for async trigger — skips experiment creation). */

--- a/packages/core/src/evals/base.test.ts
+++ b/packages/core/src/evals/base.test.ts
@@ -1447,6 +1447,27 @@ describe('createScorer', () => {
       });
     });
 
+    it('should suppress addScore without leaking internal controls into the result', async () => {
+      const mockMastra = createMockMastra();
+      const scorer = createScorer({
+        id: 'non-persisted-scorer',
+        description: 'Non-persisted scorer',
+      }).generateScore(() => 0.8);
+
+      scorer.__registerMastra(mockMastra as any);
+
+      const result = await scorer.run({
+        ...testData.scoringInput,
+        scoreSource: 'experiment',
+        targetTraceId: 'trace-123',
+        _internal: { emitObservabilityScore: false },
+      });
+
+      expect(result.score).toBe(0.8);
+      expect(result).not.toHaveProperty('_internal');
+      expect(mockMastra.observability.addScore).not.toHaveBeenCalled();
+    });
+
     it('should emit addScore without a target trace id when unanchored scoring is allowed', async () => {
       const mockMastra = createMockMastra();
 

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -212,6 +212,11 @@ interface ScorerRun<TInput = any, TOutput = any> {
 
   /** Live target metadata to merge into emitted score metadata when available. */
   targetMetadata?: Record<string, unknown>;
+
+  /** @internal Framework controls that must not affect scorer execution or returned results. */
+  _internal?: {
+    emitObservabilityScore?: boolean;
+  };
 }
 
 // Prompt object definition with conditional typing
@@ -902,6 +907,8 @@ class MastraScorer<
   }
 
   async run(input: ScorerRun<TInput, TRunOutput>): Promise<ScorerRunResult<TAccumulatedResults, TInput, TRunOutput>> {
+    const { _internal, ...scorerInput } = input;
+
     // Runtime check: execute only allowed after generateScore
     if (!this.hasGenerateScore) {
       throw new MastraError({
@@ -918,7 +925,7 @@ class MastraScorer<
 
     // Apply prepareRun transformation before span creation to reduce data
     // flowing into both the observability span and the scorer pipeline.
-    const prepared = this.config.prepareRun ? await this.config.prepareRun(input) : input;
+    const prepared = this.config.prepareRun ? await this.config.prepareRun(scorerInput) : scorerInput;
 
     let runId = prepared.runId;
     if (!runId) {
@@ -1062,7 +1069,11 @@ class MastraScorer<
       },
     });
 
-    if (this.#mastra?.observability.addScore && typeof scorerResult.score === 'number') {
+    if (
+      _internal?.emitObservabilityScore !== false &&
+      this.#mastra?.observability.addScore &&
+      typeof scorerResult.score === 'number'
+    ) {
       try {
         const targetTraceId = input.targetTraceId ?? input.targetCorrelationContext?.traceId;
         const targetSpanId = input.targetSpanId ?? input.targetCorrelationContext?.spanId;


### PR DESCRIPTION
Adds a typed per-run persistence policy for dataset experiments, tracked by MASTRA-4507.

Callers can independently skip experiment bookkeeping and score writes while targets and scorers still execute and return their results in memory:

```typescript
const summary = await dataset.startExperiment({
  targetType: 'agent',
  targetId: 'my-agent',
  scorers: ['accuracy'],
  persistence: {
    experiments: 'none',
    scores: 'none',
  },
})
```

The default behavior remains unchanged. Async experiments also avoid pre-creating experiment records when experiment persistence is disabled. The docs and API reference cover the policy and the async polling limitation.

Test plan: `pnpm build:core`; `pnpm --filter ./packages/core check`; focused dataset and experiment tests (117 passing); docs formatting, Remark, and sidebar/frontmatter validation. The full core suite passed 12,832 tests with one unrelated existing tool-approval E2E recording failure.

Linear: MASTRA-4507


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

You can choose which experiment details to save for each run. The experiment still runs and returns results when selected details are not saved.

## Summary

- Added typed `ExperimentPersistencePolicy` controls to `dataset.startExperiment()` and experiment configuration.
- Added independent controls for experiment records and score records.
- Preserved existing behavior when no policy is provided.
- Kept target and scorer execution, reads, tracing, and in-memory results available when persistence is disabled.
- Suppressed both legacy score writes and observability score records when score persistence is disabled.
- Updated asynchronous experiments to avoid creating experiment records when experiment persistence is disabled.
- Documented the policy and asynchronous polling limitation.
- Added tests for synchronous and asynchronous runs, partial persistence, scorer observability suppression, workflow and trajectory paths, and pre-cancelled runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->