### PR TITLE
fix(core): preserve media in V4 tool results

### DIFF
--- a/.changeset/wide-clouds-hang.md
+++ b/.changeset/wide-clouds-hang.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed multimodal tool results losing media when routed to AI SDK v7 providers.

--- a/packages/core/src/llm/model/aisdk/v7/model.test.ts
+++ b/packages/core/src/llm/model/aisdk/v7/model.test.ts
@@ -136,6 +136,103 @@ describe('AISDKV7LanguageModel', () => {
       });
     });
 
+    it('normalizes media from a V2 tool result before calling a V4 provider', async () => {
+      const model = createMockV4Model();
+      const wrapped = new AISDKV7LanguageModel(model);
+
+      await wrapped.doGenerate({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call_1',
+                toolName: 'read_image',
+                input: {},
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_1',
+                toolName: 'read_image',
+                output: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'image result' },
+                    { type: 'media', data: 'iVBORw0KGgo=', mediaType: 'image/png' },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      } as unknown as LanguageModelV4CallOptions);
+
+      const passed = (model.doGenerate as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      const toolMessage = passed.prompt[1];
+      const toolResult = toolMessage.content[0];
+
+      expect(toolMessage.role).toBe('tool');
+      expect(toolResult).toMatchObject({
+        type: 'tool-result',
+        output: {
+          type: 'content',
+          value: [
+            { type: 'text', text: 'image result' },
+            {
+              type: 'file',
+              data: { type: 'data', data: 'iVBORw0KGgo=' },
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      });
+    });
+
+    it('normalizes media from a V2 tool result nested in an assistant message', async () => {
+      const model = createMockV4Model();
+      const wrapped = new AISDKV7LanguageModel(model);
+
+      await wrapped.doGenerate({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_1',
+                toolName: 'read_image',
+                output: {
+                  type: 'content',
+                  value: [{ type: 'media', data: 'iVBORw0KGgo=', mediaType: 'image/png' }],
+                },
+              },
+            ],
+          },
+        ],
+      } as unknown as LanguageModelV4CallOptions);
+
+      const passed = (model.doGenerate as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(passed.prompt[0].content[0]).toMatchObject({
+        type: 'tool-result',
+        output: {
+          type: 'content',
+          value: [
+            {
+              type: 'file',
+              data: { type: 'data', data: 'iVBORw0KGgo=' },
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      });
+    });
+
     it('normalizes all legacy file data forms for doGenerate and preserves tagged data', async () => {
       const model = createMockV4Model();
       const wrapped = new AISDKV7LanguageModel(model);

--- a/packages/core/src/llm/model/aisdk/v7/model.ts
+++ b/packages/core/src/llm/model/aisdk/v7/model.ts
@@ -70,15 +70,88 @@ function normalizeFileDataForV4(data: FileData): {
   };
 }
 
+function isLegacyToolResultMediaPart(
+  value: unknown,
+): value is Record<string, unknown> & { type: 'media'; data: string; mediaType: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    value.type === 'media' &&
+    'data' in value &&
+    typeof value.data === 'string' &&
+    'mediaType' in value &&
+    typeof value.mediaType === 'string'
+  );
+}
+
+function remapToolResultMediaPartsToV4(part: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (part.type !== 'tool-result' || typeof part.output !== 'object' || part.output === null) {
+    return undefined;
+  }
+
+  const output = part.output as Record<string, unknown>;
+  if (output.type !== 'content' || !Array.isArray(output.value)) {
+    return undefined;
+  }
+
+  let valueModified = false;
+  const value = output.value.map(contentPart => {
+    if (!isLegacyToolResultMediaPart(contentPart)) {
+      return contentPart;
+    }
+
+    const { data, mediaType } = normalizeFileDataForV4(contentPart.data);
+    valueModified = true;
+
+    return {
+      ...contentPart,
+      type: 'file' as const,
+      data,
+      mediaType: mediaType ?? contentPart.mediaType,
+    };
+  });
+
+  return valueModified ? { ...part, output: { ...output, value } } : undefined;
+}
+
 function remapFilePartsToV4(options: LanguageModelV4CallOptions): LanguageModelV4CallOptions {
   let promptModified = false;
   const prompt = options.prompt.map(message => {
+    if (message.role === 'tool') {
+      let contentModified = false;
+      const content = message.content.map(part => {
+        const remappedPart = remapToolResultMediaPartsToV4(part as unknown as Record<string, unknown>);
+        if (remappedPart === undefined) {
+          return part;
+        }
+
+        contentModified = true;
+        return remappedPart;
+      });
+
+      if (!contentModified) {
+        return message;
+      }
+
+      promptModified = true;
+      return { ...message, content };
+    }
+
     if (message.role !== 'user' && message.role !== 'assistant') {
       return message;
     }
 
     let contentModified = false;
     const content = message.content.map(part => {
+      if (message.role === 'assistant' && part.type === 'tool-result') {
+        const remappedPart = remapToolResultMediaPartsToV4(part as unknown as Record<string, unknown>);
+        if (remappedPart !== undefined) {
+          contentModified = true;
+          return remappedPart;
+        }
+      }
+
       if (part.type !== 'file') {
         return part;
       }

--- a/packages/core/src/llm/model/router-v4-tool-result-media.test.ts
+++ b/packages/core/src/llm/model/router-v4-tool-result-media.test.ts
@@ -1,0 +1,103 @@
+import type { LanguageModelV4 } from '@ai-sdk/provider-v7';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MastraModelGateway } from './gateways/base';
+import type { GatewayLanguageModel, ProviderConfig } from './gateways/base';
+import { ModelRouterLanguageModel } from './router';
+
+function createMockV4Model(): LanguageModelV4 {
+  return {
+    specificationVersion: 'v4',
+    provider: 'openai',
+    modelId: 'gpt-5',
+    supportedUrls: {},
+    doGenerate: vi.fn(async () => ({
+      content: [],
+      finishReason: 'stop',
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      warnings: [],
+    })),
+    doStream: vi.fn(async () => ({ stream: new ReadableStream() })),
+  } as unknown as LanguageModelV4;
+}
+
+class V4Gateway extends MastraModelGateway {
+  readonly id = 'v4-gateway';
+  readonly name = 'V4 Gateway';
+
+  constructor(private readonly model: LanguageModelV4) {
+    super();
+  }
+
+  async fetchProviders(): Promise<Record<string, ProviderConfig>> {
+    return {
+      openai: {
+        name: 'OpenAI',
+        models: ['gpt-5'],
+        apiKeyEnvVar: 'OPENAI_API_KEY',
+        gateway: this.id,
+      },
+    };
+  }
+
+  buildUrl(): string {
+    return 'https://api.openai.com';
+  }
+
+  async getApiKey(): Promise<string> {
+    return 'test-api-key';
+  }
+
+  resolveLanguageModel(): GatewayLanguageModel {
+    return this.model;
+  }
+}
+
+describe('ModelRouterLanguageModel with V4 tool-result media (#20378)', () => {
+  beforeEach(() => {
+    (ModelRouterLanguageModel as unknown as { _clearCachesForTests: () => void })._clearCachesForTests();
+  });
+
+  it('normalizes V2 media content before delegating to a V4 provider', async () => {
+    const model = createMockV4Model();
+    const router = new ModelRouterLanguageModel('v4-gateway/openai/gpt-5', [new V4Gateway(model)]);
+
+    await router.doStream({
+      inputFormat: 'messages',
+      prompt: [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_1',
+              toolName: 'read_image',
+              output: {
+                type: 'content',
+                value: [
+                  { type: 'text', text: 'image result' },
+                  { type: 'media', data: 'iVBORw0KGgo=', mediaType: 'image/png' },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    const passed = (model.doStream as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(passed.prompt[0].content[0]).toMatchObject({
+      type: 'tool-result',
+      output: {
+        type: 'content',
+        value: [
+          { type: 'text', text: 'image result' },
+          {
+            type: 'file',
+            data: { type: 'data', data: 'iVBORw0KGgo=' },
+            mediaType: 'image/png',
+          },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Description

When ModelRouter sent a V2-shaped tool result to an AI SDK v7 provider, nested media parts were left as `type: "media"`. V4 providers expect a `file` part with tagged data, so the text from a tool result survived while its image could disappear during request serialization.

This change converts only those legacy media parts before calling the V4 model. It preserves neighboring text content and already-valid V4 data, and covers tool results in both tool and assistant messages.

I also added a router-level regression test so this is checked through the same path that exposed the bug, not only at the adapter boundary.

## Related issue(s)

Fixes #20378

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Validation

- `pnpm turbo build --filter ./packages/core --concurrency=1`
- 16 focused adapter and router tests
- Type checking through Vitest
- Oxfmt, Oxlint, ESLint, and `git diff --check`

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR