### PR TITLE
fix(core): ensure streamLegacy always releases writer lock

### DIFF
--- a/.changeset/fix-stream-legacy-cleanup-error.md
+++ b/.changeset/fix-stream-legacy-cleanup-error.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix resource leak in `streamLegacy` cleanup by using `Promise.allSettled` for observer handlers and ensuring stream writer locks are always released.

--- a/.changeset/fix-stream-legacy-cleanup-error.md
+++ b/.changeset/fix-stream-legacy-cleanup-error.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix resource leak in `streamLegacy` cleanup by using `Promise.allSettled` for observer handlers and ensuring stream writer locks are always released.
+Fixed an issue where observer cleanup failures no longer prevent legacy workflow streams from completing cleanly.

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1218,6 +1218,46 @@ describe('Workflow (Default Engine Specifics)', () => {
       expect(nestedWorkflowStoreResult?.status).toBe('success');
     });
   });
+
+  describe('streamLegacy cleanup error safety', () => {
+    it('releases writer lock and completes cleanup even if observer handler rejects', async () => {
+      const step = createStep({
+        id: 'test-step',
+        inputSchema: z.object({ value: z.string() }),
+        outputSchema: z.object({ value: z.string() }),
+        execute: async ({ inputData }) => inputData,
+      });
+
+      const workflow = createWorkflow({
+        id: 'stream-legacy-cleanup-error-wf',
+        inputSchema: z.object({ value: z.string() }),
+        outputSchema: z.object({ value: z.string() }),
+        steps: [step],
+      })
+        .then(step)
+        .commit();
+
+      const run = await workflow.createRun();
+      const { stream, getWorkflowState } = run.streamLegacy({ inputData: { value: 'test' } });
+
+      // Register an observer stream which pushes a throwing handler to #observerHandlers
+      run.observeStreamLegacy();
+
+      // Spy on console/logger error to verify error is caught cleanly
+      const loggerErrorSpy = vi.spyOn(workflow.logger, 'error');
+
+      // Consume stream chunks
+      for await (const _event of stream) {
+        // Discard events
+      }
+
+      const result = await getWorkflowState();
+      expect(result.status).toBe('success');
+
+      // Verify closeStreamAction completes without throwing unhandled rejection
+      await expect((run as any).closeStreamAction()).resolves.not.toThrow();
+    });
+  });
 });
 
 describe('createRun storage existence read (issue #19015)', () => {

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1240,11 +1240,13 @@ describe('Workflow (Default Engine Specifics)', () => {
       const run = await workflow.createRun();
       const { stream, getWorkflowState } = run.streamLegacy({ inputData: { value: 'test' } });
 
-      // Register an observer stream which pushes a throwing handler to #observerHandlers
-      run.observeStreamLegacy();
-
-      // Spy on console/logger error to verify error is caught cleanly
+      // Spy on logger error to verify logger behavior
       const loggerErrorSpy = vi.spyOn(workflow.logger, 'error');
+
+      // Create an observer stream whose underlying reader cancel method rejects
+      const observer = run.observeStreamLegacy();
+      const reader = observer.stream.getReader();
+      vi.spyOn(reader, 'cancel').mockRejectedValue(new Error('Observer cleanup failed'));
 
       // Consume stream chunks
       for await (const _event of stream) {
@@ -1254,8 +1256,8 @@ describe('Workflow (Default Engine Specifics)', () => {
       const result = await getWorkflowState();
       expect(result.status).toBe('success');
 
-      // Verify closeStreamAction completes without throwing unhandled rejection
-      await expect((run as any).closeStreamAction()).resolves.not.toThrow();
+      // Verify closeStreamAction resolves smoothly to undefined
+      await expect((run as any).closeStreamAction()).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -3545,10 +3545,10 @@ export class Run<
         data: { type: 'workflow-finish', payload: { runId: this.runId } },
       });
       unwatch();
-      await Promise.all(this.#observerHandlers.map(handler => handler()));
-      this.#observerHandlers = [];
 
       try {
+        await Promise.allSettled(this.#observerHandlers.map(handler => handler()));
+        this.#observerHandlers = [];
         await writer.close();
       } catch (err) {
         this.mastra?.getLogger()?.error('Error closing stream:', err);


### PR DESCRIPTION
## Description

Fixes #20651

`streamLegacy()` executes observer cleanup before closing and releasing the stream writer.

Previously, observer cleanup used `Promise.all()` outside the `try/finally` block responsible for stream cleanup. If an observer cleanup handler rejected, execution could exit before reaching the writer cleanup logic.

This change:

- Moves observer cleanup inside the cleanup block.
- Replaces `Promise.all()` with `Promise.allSettled()` so failures in individual observer cleanup handlers do not interrupt the remaining cleanup.
- Ensures `writer.close()` is still attempted.
- Guarantees `writer.releaseLock()` always executes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] I have added a regression test covering the cleanup path.
- [ ] I have addressed all CodeRabbit comments on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If an observer cleanup task fails, `streamLegacy()` still attempts to close the stream and always releases the writer lock. A regression test confirms that the workflow completes successfully.

## Changes

- Move observer cleanup into the stream cleanup block.
- Use `Promise.allSettled()` so all observer cleanup handlers run independently.
- Attempt `writer.close()` after observer cleanup failures.
- Always execute `writer.releaseLock()`.
- Add a regression test for a rejected observer `cancel()` handler.
- Add a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->