### PR TITLE
chore: update Enterprise Edition license

### DIFF
--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -21,10 +21,8 @@ License Keys. Deployment of the Software (including Agent Builder) in a
 self-hosted environment or to the Mastra platform requires an Enterprise Edition
 license key provisioned by Kepler. Kepler may issue a license key that is
 limited to specific features of the Software, including a key that enables only
-the features required for Agent Builder. License key checks are enforced only
-during the build and deployment phase and are not required at runtime, so that a
-deployed instance of the Software has no runtime dependency on Kepler’s license
-key server.
+the features required for Agent Builder. Use of features requiring an Enterprise
+Edition license key is subject to license validation by Kepler.
 
 Your rights under this License terminate automatically, without notice, if you fail
 to comply with any of its terms. If the violation is curable, your rights will be

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -4,28 +4,16 @@ Copyright (c) 2026 Kepler Software, Inc.
 
 With regard to the Mastra Software:
 
-This software and associated documentation files (the "Software") may only be
-used in production if you (and any entity that you represent) have entered into,
-and remain in compliance with, a written agreement with Kepler Software, Inc.
-("Kepler") explicitly permitting the use of the Software in production, including
-any additional restrictions set forth therein with respect to such use.
-Subject to the foregoing sentence, you are free to modify this Software for your
-own internal development and testing purposes, and submit patches to Kepler for
-inclusion in the upstream Mastra Software. You agree that Kepler and/or its
-licensors (as applicable) retain all right, title, and interest in and to all such
-modifications. You are not granted any other rights beyond what is expressly
-stated herein. Subject to the foregoing, it is forbidden to copy, merge, publish,
-distribute, sublicense, and/or sell the Software.
-Your rights under this License terminate automatically, without notice, if you fail
-to comply with any of its terms. If the violation is curable, your rights will be
-reinstated upon cure of the violation within thirty (30) days after you become
-aware (or should reasonably have become aware) of the violation. Upon
-termination, you must immediately cease all production use of the Software.
+This software and associated documentation files (the "Software") may only be used in production if you (and any entity that you represent) have entered into, and remain in compliance with, a written agreement with Kepler Software, Inc. ("Kepler") explicitly permitting the use of the Software in production, including any additional restrictions set forth therein with respect to such use. Subject to the foregoing sentence, you are free to modify this Software for your own internal development and testing purposes, and submit patches to Kepler for
+inclusion in the upstream Mastra Software. You agree that Kepler and/or its licensors (as applicable) retain all right, title, and interest in and to all such modifications. You are not granted any other rights beyond what is expressly stated herein. Subject to the foregoing, it is forbidden to copy, merge, publish, distribute, sublicense, and/or sell the Software.
+
+License Keys. Deployment of the Software (including Agent Builder) in a self-hosted environment or to the Mastra platform requires an Enterprise Edition license key provisioned by Kepler. Kepler may issue a license key that is limited to specific features of the Software, including a key that enables only the features required for Agent Builder. License key checks are enforced only during the build and deployment phase and are not required at runtime, so that a deployed instance of the Software has no runtime dependency on Kepler’s license key server.
+
+Your rights under this License terminate automatically, without notice, if you fail to comply with any of its terms. If the violation is curable, your rights will be reinstated upon cure of the violation within thirty (30) days after you become aware (or should reasonably have become aware) of the violation. Upon termination, you must immediately cease all production use of the Software.
 
 For purposes of the foregoing, "production" means any use of the Software
 beyond development and testing on your own systems. "Development and
-testing" includes running the Software locally or in a staging environment for the
-purpose of evaluating, developing, or testing modifications to the Software.
+testing" includes running the Software locally or in a staging environment for the purpose of evaluating, developing, or testing modifications to the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND “WITH ALL FAULTS” WITHOUT
 WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
@@ -37,7 +25,4 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
 OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-For all third-party components incorporated into the Software, those components
-are licensed under the original license provided by the owner of the applicable
-component and nothing set forth herein is intended to supersede such third-party
-license.
+For all third-party components incorporated into the Software, those components are licensed under the original license provided by the owner of the applicable component and nothing set forth herein is intended to supersede such third-party license.

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -4,16 +4,38 @@ Copyright (c) 2026 Kepler Software, Inc.
 
 With regard to the Mastra Software:
 
-This software and associated documentation files (the "Software") may only be used in production if you (and any entity that you represent) have entered into, and remain in compliance with, a written agreement with Kepler Software, Inc. ("Kepler") explicitly permitting the use of the Software in production, including any additional restrictions set forth therein with respect to such use. Subject to the foregoing sentence, you are free to modify this Software for your own internal development and testing purposes, and submit patches to Kepler for
-inclusion in the upstream Mastra Software. You agree that Kepler and/or its licensors (as applicable) retain all right, title, and interest in and to all such modifications. You are not granted any other rights beyond what is expressly stated herein. Subject to the foregoing, it is forbidden to copy, merge, publish, distribute, sublicense, and/or sell the Software.
+This software and associated documentation files (the "Software") may only be
+used in production if you (and any entity that you represent) have entered into,
+and remain in compliance with, a written agreement with Kepler Software, Inc.
+("Kepler") explicitly permitting the use of the Software in production, including
+any additional restrictions set forth therein with respect to such use.
+Subject to the foregoing sentence, you are free to modify this Software for your
+own internal development and testing purposes, and submit patches to Kepler for
+inclusion in the upstream Mastra Software. You agree that Kepler and/or its
+licensors (as applicable) retain all right, title, and interest in and to all such
+modifications. You are not granted any other rights beyond what is expressly
+stated herein. Subject to the foregoing, it is forbidden to copy, merge, publish,
+distribute, sublicense, and/or sell the Software.
 
-License Keys. Deployment of the Software (including Agent Builder) in a self-hosted environment or to the Mastra platform requires an Enterprise Edition license key provisioned by Kepler. Kepler may issue a license key that is limited to specific features of the Software, including a key that enables only the features required for Agent Builder. License key checks are enforced only during the build and deployment phase and are not required at runtime, so that a deployed instance of the Software has no runtime dependency on Kepler’s license key server.
+License Keys. Deployment of the Software (including Agent Builder) in a
+self-hosted environment or to the Mastra platform requires an Enterprise Edition
+license key provisioned by Kepler. Kepler may issue a license key that is
+limited to specific features of the Software, including a key that enables only
+the features required for Agent Builder. License key checks are enforced only
+during the build and deployment phase and are not required at runtime, so that a
+deployed instance of the Software has no runtime dependency on Kepler’s license
+key server.
 
-Your rights under this License terminate automatically, without notice, if you fail to comply with any of its terms. If the violation is curable, your rights will be reinstated upon cure of the violation within thirty (30) days after you become aware (or should reasonably have become aware) of the violation. Upon termination, you must immediately cease all production use of the Software.
+Your rights under this License terminate automatically, without notice, if you fail
+to comply with any of its terms. If the violation is curable, your rights will be
+reinstated upon cure of the violation within thirty (30) days after you become
+aware (or should reasonably have become aware) of the violation. Upon
+termination, you must immediately cease all production use of the Software.
 
 For purposes of the foregoing, "production" means any use of the Software
 beyond development and testing on your own systems. "Development and
-testing" includes running the Software locally or in a staging environment for the purpose of evaluating, developing, or testing modifications to the Software.
+testing" includes running the Software locally or in a staging environment for the
+purpose of evaluating, developing, or testing modifications to the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND “WITH ALL FAULTS” WITHOUT
 WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
@@ -25,4 +47,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
 OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-For all third-party components incorporated into the Software, those components are licensed under the original license provided by the owner of the applicable component and nothing set forth herein is intended to supersede such third-party license.
+For all third-party components incorporated into the Software, those components
+are licensed under the original license provided by the owner of the applicable
+component and nothing set forth herein is intended to supersede such third-party
+license.


### PR DESCRIPTION
Updates the Enterprise Edition license with the legal team's terms for license keys used in self-hosted and Mastra platform deployments. The new language covers feature-limited keys, build and deployment enforcement, and the absence of a runtime dependency on Kepler's license key server.\n\nVerified with `git diff --check`; no code tests are needed for this license-only change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mastra-ai/mastra/pull/20654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR explains how Enterprise Edition license keys control access to licensed features. It covers self-hosted and Mastra platform deployments without requiring a live connection to Kepler’s license server during runtime.

## Changes

- Added terms for Enterprise Edition license keys.
- Defined feature-limited keys, including Agent Builder-only keys.
- Clarified build and deployment enforcement.
- Clarified that deployments do not require runtime access to Kepler’s license key server.

## Validation

- `git diff --check` passed.
- No code tests are required for this license-only change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->