### PR TITLE
fix(core): key the response cache on URL and binary prompt parts

### DIFF
--- a/.changeset/clever-hats-wink.md
+++ b/.changeset/clever-hats-wink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the response cache serving one image's answer for a different image. `ResponseCache` derives its key from the resolved prompt, but URL-valued image and file parts were serialized as `{}`, so two requests that differed only in which image they pointed at collided on the same cache entry. URLs now contribute their full href, and inline binary data contributes a digest of its bytes instead of being expanded one property per byte (which turned a 1 MiB image into ~11 MiB of intermediate JSON, hashed synchronously before every model call).

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -554,6 +554,8 @@ This means the cache key is derived from the resolved `LanguageModelV2Prompt` Ma
 
 When you don't supply `key`, the processor derives one deterministically from the inputs that change the LLM's response at this step: `agentId`, `stepNumber` (so each step in a tool loop has its own cache entry), `scope`, model identity (`provider`, `modelId`, spec version), and the resolved `prompt` (post-memory + post-processors). Any change to these inputs automatically invalidates the cache.
 
+Multimodal prompts are included too. Image and file parts reach the key by value: a URL contributes its full href, and inline binary data (`Uint8Array`, `ArrayBuffer`) contributes a digest of its bytes. Two requests that differ only in which image they reference therefore get different cache entries.
+
 #### Customize the cache key
 
 Pass `key` as a function on the constructor or per-call to derive your own cache key from any subset of those inputs. The function receives the same inputs the deterministic hash would have consumed and returns a string (or a `Promise<string>`):

--- a/packages/core/src/agent/__tests__/response-cache-url-part.test.ts
+++ b/packages/core/src/agent/__tests__/response-cache-url-part.test.ts
@@ -1,0 +1,264 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { MastraServerCache } from '../../cache';
+import { buildResponseCacheKey, ResponseCache } from '../../processors/processors/response-cache';
+import { Agent } from '../agent';
+
+class RecordingServerCache extends MastraServerCache {
+  readonly store = new Map<string, unknown>();
+  sets = 0;
+
+  constructor() {
+    super({ name: 'RecordingServerCache' });
+  }
+
+  async get(key: string): Promise<unknown> {
+    return this.store.get(key);
+  }
+
+  async set(key: string, value: unknown): Promise<void> {
+    this.sets++;
+    this.store.set(key, value);
+  }
+
+  async listLength(): Promise<number> {
+    return 0;
+  }
+
+  async listPush(): Promise<void> {}
+
+  async listFromTo(): Promise<unknown[]> {
+    return [];
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  async clear(): Promise<void> {
+    this.store.clear();
+  }
+
+  async increment(): Promise<number> {
+    return 0;
+  }
+}
+
+async function waitForSets(cache: RecordingServerCache, expected: number) {
+  const deadline = Date.now() + 1_000;
+  while (cache.sets < expected) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${expected} cache writes (saw ${cache.sets})`);
+    }
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+}
+
+/**
+ * Declares every https URL as natively supported so the prompt keeps
+ * `data: URL` file parts instead of downloading them into `Uint8Array`.
+ * That is the shape real providers with URL support (e.g. Anthropic PDFs,
+ * OpenAI image URLs) receive.
+ */
+function createUrlCapableModel(responseText: string) {
+  return new MockLanguageModelV2({
+    modelId: 'url-capable-model',
+    supportedUrls: { '*': [/^https?:\/\/.*$/] },
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'url-capable-model', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: responseText },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+        },
+      ]),
+    }),
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      finishReason: 'stop',
+      usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+      content: [{ type: 'text', text: responseText }],
+    }),
+  });
+}
+
+function urlPrompt(url: string) {
+  return [
+    {
+      role: 'user' as const,
+      content: [
+        { type: 'text' as const, text: 'Describe this image' },
+        { type: 'file' as const, mediaType: 'image/png', filename: undefined, data: new URL(url) },
+      ],
+    },
+  ];
+}
+
+describe('buildResponseCacheKey with non-plain prompt values', () => {
+  const base = {
+    agentId: 'url-agent',
+    model: { provider: 'test', modelId: 'url-capable-model', specVersion: 'v2' },
+    stepNumber: 0,
+  };
+
+  it('distinguishes prompts whose only difference is a URL file part', () => {
+    const cat = buildResponseCacheKey({ ...base, prompt: urlPrompt('https://example.com/cat.png') as never });
+    const dog = buildResponseCacheKey({ ...base, prompt: urlPrompt('https://example.com/dog.png') as never });
+
+    expect(cat).not.toBe(dog);
+  });
+
+  it('distinguishes prompts whose only difference is binary file data', () => {
+    const bytesPrompt = (bytes: number[]) => [
+      {
+        role: 'user' as const,
+        content: [
+          { type: 'text' as const, text: 'Describe this image' },
+          { type: 'file' as const, mediaType: 'image/png', filename: undefined, data: new Uint8Array(bytes) },
+        ],
+      },
+    ];
+
+    const a = buildResponseCacheKey({ ...base, prompt: bytesPrompt([1, 2, 3]) as never });
+    const b = buildResponseCacheKey({ ...base, prompt: bytesPrompt([4, 5, 6]) as never });
+
+    expect(a).not.toBe(b);
+  });
+
+  it('stays deterministic for the same URL file part', () => {
+    const first = buildResponseCacheKey({ ...base, prompt: urlPrompt('https://example.com/cat.png') as never });
+    const second = buildResponseCacheKey({ ...base, prompt: urlPrompt('https://example.com/cat.png') as never });
+
+    expect(first).toBe(second);
+  });
+
+  it('treats an equal Uint8Array copy as the same key', () => {
+    const bytesPrompt = (bytes: Uint8Array) => [
+      {
+        role: 'user' as const,
+        content: [{ type: 'file' as const, mediaType: 'image/png', filename: undefined, data: bytes }],
+      },
+    ];
+
+    const first = buildResponseCacheKey({ ...base, prompt: bytesPrompt(new Uint8Array([1, 2, 3])) as never });
+    const second = buildResponseCacheKey({ ...base, prompt: bytesPrompt(new Uint8Array([1, 2, 3])) as never });
+
+    expect(first).toBe(second);
+  });
+
+  it('does not expand binary file data byte-by-byte', () => {
+    // A 1 MiB image expanded into one JSON property per byte took ~680 ms and
+    // ~11 MiB of intermediate JSON, synchronously, before the model was called.
+    const prompt = [
+      {
+        role: 'user' as const,
+        content: [
+          { type: 'text' as const, text: 'Describe this image' },
+          {
+            type: 'file' as const,
+            mediaType: 'image/png',
+            filename: undefined,
+            data: new Uint8Array(1024 * 1024).fill(7),
+          },
+        ],
+      },
+    ];
+
+    const start = performance.now();
+    buildResponseCacheKey({ ...base, prompt: prompt as never });
+    const elapsed = performance.now() - start;
+
+    // Generous bound: the byte-walk is ~2 orders of magnitude slower, so this
+    // catches a regression without being flaky on a loaded CI worker.
+    expect(elapsed).toBeLessThan(150);
+  });
+
+  it('keeps Date values distinguishable', () => {
+    const datePrompt = (iso: string) => [
+      {
+        role: 'user' as const,
+        content: [{ type: 'text' as const, text: 'hi' }],
+        providerOptions: { custom: { at: new Date(iso) } },
+      },
+    ];
+
+    const a = buildResponseCacheKey({ ...base, prompt: datePrompt('2020-01-01T00:00:00.000Z') as never });
+    const b = buildResponseCacheKey({ ...base, prompt: datePrompt('2021-01-01T00:00:00.000Z') as never });
+
+    expect(a).not.toBe(b);
+  });
+
+  it('still strips providerOptions.mastra from nested plain objects', () => {
+    const withMastraMeta = [
+      {
+        role: 'user' as const,
+        content: [
+          {
+            type: 'text' as const,
+            text: 'hi',
+            providerOptions: { mastra: { createdAt: '2020-01-01T00:00:00.000Z' }, openai: { cacheControl: 'x' } },
+          },
+        ],
+      },
+    ];
+    const withoutMastraMeta = [
+      {
+        role: 'user' as const,
+        content: [{ type: 'text' as const, text: 'hi', providerOptions: { openai: { cacheControl: 'x' } } }],
+      },
+    ];
+
+    expect(buildResponseCacheKey({ ...base, prompt: withMastraMeta as never })).toBe(
+      buildResponseCacheKey({ ...base, prompt: withoutMastraMeta as never }),
+    );
+  });
+});
+
+describe('ResponseCache with URL file parts (integration via Agent)', () => {
+  it('does not serve one image URL response for a different image URL', async () => {
+    const cache = new RecordingServerCache();
+    const model = createUrlCapableModel('A cat on a mat');
+    const agent = new Agent({
+      id: 'url-agent',
+      name: 'URL Agent',
+      instructions: 'You describe images',
+      model,
+      inputProcessors: [new ResponseCache({ cache, agentId: 'url-agent' })],
+    });
+
+    await agent.generate([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this image' },
+          { type: 'image', image: new URL('https://example.com/cat.png'), mimeType: 'image/png' },
+        ],
+      },
+    ]);
+    await waitForSets(cache, 1);
+    expect(model.doGenerateCalls).toHaveLength(1);
+
+    // Same text, different image URL: this must reach the model, not replay
+    // the cat answer.
+    await agent.generate([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this image' },
+          { type: 'image', image: new URL('https://example.com/dog.png'), mimeType: 'image/png' },
+        ],
+      },
+    ]);
+
+    expect(model.doGenerateCalls).toHaveLength(2);
+    expect(cache.store.size).toBe(2);
+  });
+});

--- a/packages/core/src/processors/processors/response-cache.ts
+++ b/packages/core/src/processors/processors/response-cache.ts
@@ -528,9 +528,12 @@ function isPlainObject(value: object): boolean {
 }
 
 /**
+ * Takes `unknown` rather than `object`: both checks are runtime-safe on any
+ * value, so callers don't need to prove it's an object first.
+ *
  * @internal
  */
-function isBinary(value: object): value is ArrayBufferView | ArrayBuffer {
+function isBinary(value: unknown): value is ArrayBufferView | ArrayBuffer {
   return ArrayBuffer.isView(value) || value instanceof ArrayBuffer;
 }
 

--- a/packages/core/src/processors/processors/response-cache.ts
+++ b/packages/core/src/processors/processors/response-cache.ts
@@ -454,6 +454,11 @@ function extractModelInfo(model: unknown): {
 function stripMastraInternalMetadata(value: unknown): unknown {
   if (!value || typeof value !== 'object') return value;
   if (Array.isArray(value)) return value.map(stripMastraInternalMetadata);
+  // Class instances (URL, Uint8Array, Date, ...) carry no `providerOptions`,
+  // and rebuilding them from their own enumerable keys would destroy them —
+  // a URL has none, so it would collapse to `{}`. Hand them to
+  // normalizeForHash unchanged.
+  if (!isPlainObject(value)) return value;
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
     if (k === 'providerOptions' && v && typeof v === 'object' && !Array.isArray(v)) {
@@ -484,9 +489,22 @@ function normalizeForHash(value: unknown): unknown {
   if (value === null) return null;
   if (typeof value === 'function') return '[function]';
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  if (typeof value === 'bigint') return `bigint:${value.toString()}`;
   if (value instanceof Date) return value.toISOString();
+  // `LanguageModelV2DataContent` is `string | Uint8Array | URL`, so file and
+  // image parts routinely carry both of the shapes below.
+  if (value instanceof URL) return `url:${value.href}`;
+  if (isBinary(value)) return `binary:${hashBinary(value)}`;
   if (Array.isArray(value)) return value.map(normalizeForHash);
   if (typeof value === 'object') {
+    // A class instance with no enumerable own keys would otherwise serialize
+    // as `{}`, silently erasing whatever it identified. `LanguageModelV2Prompt`
+    // doesn't permit instances beyond the ones handled above, so this is a
+    // last-resort tag: it keeps such a value from colliding with an empty
+    // object, but two distinct instances of the same class still collide.
+    if (!isPlainObject(value) && Object.keys(value).length === 0) {
+      return `${value.constructor?.name ?? 'object'}:${String(value)}`;
+    }
     const out: Record<string, unknown> = {};
     for (const k of Object.keys(value as Record<string, unknown>)) {
       const v = (value as Record<string, unknown>)[k];
@@ -496,6 +514,41 @@ function normalizeForHash(value: unknown): unknown {
     return out;
   }
   return String(value);
+}
+
+/**
+ * True for objects whose prototype is `Object.prototype` or `null` — i.e. the
+ * ones we can safely rebuild key-by-key.
+ *
+ * @internal
+ */
+function isPlainObject(value: object): boolean {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * @internal
+ */
+function isBinary(value: object): value is ArrayBufferView | ArrayBuffer {
+  return ArrayBuffer.isView(value) || value instanceof ArrayBuffer;
+}
+
+/**
+ * Digest binary payloads instead of walking them.
+ *
+ * `Object.keys(new Uint8Array(n))` is `['0', ..., 'n-1']`, so the generic
+ * object walk turns every byte into its own property. A 1 MiB image serializes
+ * to ~11 MiB of JSON that way, and the whole walk + stringify + hash runs
+ * synchronously on the request path before the model is called.
+ *
+ * @internal
+ */
+function hashBinary(value: ArrayBufferView | ArrayBuffer): string {
+  const bytes = ArrayBuffer.isView(value)
+    ? new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+    : new Uint8Array(value);
+  return `${bytes.byteLength}:${createHash('sha256').update(bytes).digest('hex')}`;
 }
 
 /**


### PR DESCRIPTION
## Description

`ResponseCache` derives its cache key from the resolved `LanguageModelV2Prompt`, but `stripMastraInternalMetadata` and `normalizeForHash` rebuild every object from its own enumerable keys. A `URL` has none, so a URL-valued image or file part serialized to `{}` — and two prompts that differed **only** in which image they referenced hashed to the same key. The second request was served the first one's answer.

Measured on `facabe07` via the exported `buildResponseCacheKey`:

```
cat key: mastra:agent-response:demo:5ec8197e2042e5b3d8f5fca2fbaed4cd
dog key: mastra:agent-response:demo:5ec8197e2042e5b3d8f5fca2fbaed4cd
collide: true
```

The hashed prompt shows the erasure directly:

```json
[{"content":[{"text":"Describe this image","type":"text"},
             {"data":{},"mediaType":"image/png","type":"file"}],"role":"user"}]
```

This shape is reachable through the normal API: `convertImageFilePart` (`prompt/convert-file.ts:26-35`) deliberately keeps `data` as a `URL` when the model declares the URL supported via `supportedUrls`, which is the documented path for providers with native URL support.

**Same root cause, second symptom.** `Object.keys(new Uint8Array(n))` is `['0', …, 'n-1']`, so the same walk expanded inline binary one JSON property per byte. Measured on the helpers directly (Node 24.13.0, i7-14650HX), one inline image part:

| image size | intermediate JSON | walk + stringify + sha256 | after this PR |
| ---------- | ----------------- | ------------------------- | ------------- |
| 64 KiB     | 0.61 MiB          | 45 ms                     | 0.7 ms        |
| 256 KiB    | 2.64 MiB          | 165 ms                    | 0.2 ms        |
| 1 MiB      | 10.94 MiB         | 681 ms                    | 0.8 ms        |

That ran synchronously on the request path before every model call, hit or miss.

### The fix

- `stripMastraInternalMetadata` returns non-plain objects untouched. A class instance never carries `providerOptions`, and rebuilding it from its own keys is what destroyed it.
- `normalizeForHash` gains explicit branches beside its existing `Date` branch: `URL` → its full href; `Uint8Array`/`ArrayBuffer`/any `ArrayBufferView` → a length-prefixed sha256 of the bytes. `bigint` is handled too, since `JSON.stringify` throws on it.
- Plain objects keep their key-by-key treatment, so keys for text-only prompts and `providerOptions.mastra` stripping are unchanged (asserted by a test).

The last-resort branch for an unrecognized zero-key class instance tags it by constructor name rather than letting it collapse to `{}`. Its docblock says plainly that two distinct instances of the same class still collide — `LanguageModelV2Prompt` doesn't permit such values, so this is a guard against silent erasure, not a general solution.

## Related issue(s)

Closes #20655

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement
- [x] Documentation update
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Verification

New file `packages/core/src/agent/__tests__/response-cache-url-part.test.ts`, 8 tests. Confirmed red on the unmodified tree before keeping any of them:

```
# base facabe07, fix reverted
Tests  4 failed | 4 passed (8)
  × distinguishes prompts whose only difference is a URL file part
  × does not expand binary file data byte-by-byte
  × keeps Date values distinguishable
  × does not serve one image URL response for a different image URL

# with the fix
Tests  8 passed (8)
```

The `Date` test failing pre-fix is worth calling out: `normalizeForHash` already had a `Date` branch, but `stripMastraInternalMetadata` ran **first** and had already flattened the `Date` to `{}`, so the branch never saw one. Two different timestamps in `providerOptions` produced the same key.

The end-to-end test drives a real `Agent` through `ResponseCache` with a `MockLanguageModelV2` declaring `supportedUrls: { '*': [/^https?:\/\/.*$/] }`, so the prompt keeps `data: URL` instead of downloading it into a `Uint8Array`. Pre-fix, the second `generate()` with a different image URL made no model call (`doGenerateCalls` = 1, `cache.store.size` = 1).

The binary-cost test asserts `< 150 ms` for a 1 MiB part — ~2 orders of magnitude of headroom over the measured 681 ms, so it catches a regression without being flaky on a loaded worker.

Also run:

- `agent-response-cache.test.ts` (18) and `durable-agent-cached-response.test.ts` — all pass, unchanged.
- `vitest run src/processors` — `16 failed | 1034 passed | 1 skipped`. Identical numbers with the fix reverted, so those 16 (in `tool-result-reminder.test.ts` and one other) are pre-existing on `facabe07` and untouched by this change.
- `tsc --noEmit -p tsconfig.build.json`, `oxlint`, `eslint`, `oxfmt --check` — all clean on the changed files.

Changeset: `.changeset/clever-hats-wink.md`, patch on `@mastra/core`.

The docs change is one additive paragraph in `docs/agents/processors.mdx` under "What's in the cache key", stating that image and file parts contribute by value. I hand-edited it rather than running a formatter, to keep the diff free of unrelated reflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The response cache now treats different image and file inputs as different requests. It also stores binary data as a compact fingerprint instead of processing every byte individually.

## Changes

- Generate cache keys from the full `href` of `URL` values.
- Hash binary values with length-prefixed SHA-256 digests.
- Support `bigint` values.
- Preserve non-plain objects during metadata stripping.
- Tag empty class instances with their constructor name.
- Preserve existing plain-object handling and `providerOptions.mastra` stripping.
- Document multimodal prompt data in automatic response-cache keys.
- Add regression and integration tests for URL parts, binary data, cache separation, deterministic keys, `Date` values, and metadata removal.
- Add a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->