### PR TITLE
ci: publish factory UI assets to R2

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -136,6 +136,30 @@ jobs:
             --endpoint-url "${STUDIO_ENDPOINT_URL}" \
             --delete
 
+      - name: Upload factory assets to R2 (staging)
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.STUDIO_R2_ACCESS_KEY_ID_STAGING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STUDIO_R2_ACCESS_SECRET_STAGING }}
+          STUDIO_BUCKET_NAME: ${{ vars.STUDIO_R2_BUCKET_STAGING }}
+          STUDIO_ENDPOINT_URL: ${{ vars.STUDIO_R2_ENDPOINT_URL_STAGING }}
+        run: |
+          aws s3 sync packages/cli/dist/factory "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/factory/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete
+
+      - name: Upload factory assets to R2 (production)
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.STUDIO_R2_ACCESS_KEY_ID_PROD }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STUDIO_R2_ACCESS_SECRET_PROD }}
+          STUDIO_BUCKET_NAME: ${{ vars.STUDIO_R2_BUCKET_PROD }}
+          STUDIO_ENDPOINT_URL: ${{ vars.STUDIO_R2_ENDPOINT_URL_PROD }}
+        run: |
+          aws s3 sync packages/cli/dist/factory "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/factory/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete
+
       - name: Notify linked issues (alpha available)
         if: ${{ !inputs.dry_run }}
         continue-on-error: true
@@ -275,6 +299,33 @@ jobs:
           STUDIO_ENDPOINT_URL: ${{ vars.STUDIO_R2_ENDPOINT_URL_PROD }}
         run: |
           aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete
+
+      - name: Upload factory assets to R2 (staging)
+        if: ${{ !inputs.dry_run }}
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.STUDIO_R2_ACCESS_KEY_ID_STAGING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STUDIO_R2_ACCESS_SECRET_STAGING }}
+          STUDIO_BUCKET_NAME: ${{ vars.STUDIO_R2_BUCKET_STAGING }}
+          STUDIO_ENDPOINT_URL: ${{ vars.STUDIO_R2_ENDPOINT_URL_STAGING }}
+        run: |
+          aws s3 sync packages/cli/dist/factory "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/factory/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete
+
+      # TODO: Remove continue-on-error once production CF R2 credentials are configured.
+      - name: Upload factory assets to R2 (production)
+        if: ${{ !inputs.dry_run }}
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.STUDIO_R2_ACCESS_KEY_ID_PROD }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STUDIO_R2_ACCESS_SECRET_PROD }}
+          STUDIO_BUCKET_NAME: ${{ vars.STUDIO_R2_BUCKET_PROD }}
+          STUDIO_ENDPOINT_URL: ${{ vars.STUDIO_R2_ENDPOINT_URL_PROD }}
+        run: |
+          aws s3 sync packages/cli/dist/factory "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/factory/" \
             --endpoint-url "${STUDIO_ENDPOINT_URL}" \
             --delete
 
@@ -554,5 +605,29 @@ jobs:
           STUDIO_ENDPOINT_URL: ${{ vars.STUDIO_R2_ENDPOINT_URL_PROD }}
         run: |
           aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete
+
+      - name: Upload factory assets to R2 (staging)
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.STUDIO_R2_ACCESS_KEY_ID_STAGING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STUDIO_R2_ACCESS_SECRET_STAGING }}
+          STUDIO_BUCKET_NAME: ${{ vars.STUDIO_R2_BUCKET_STAGING }}
+          STUDIO_ENDPOINT_URL: ${{ vars.STUDIO_R2_ENDPOINT_URL_STAGING }}
+        run: |
+          aws s3 sync packages/cli/dist/factory "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/factory/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete
+
+      - name: Upload factory assets to R2 (production)
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.STUDIO_R2_ACCESS_KEY_ID_PROD }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STUDIO_R2_ACCESS_SECRET_PROD }}
+          STUDIO_BUCKET_NAME: ${{ vars.STUDIO_R2_BUCKET_PROD }}
+          STUDIO_ENDPOINT_URL: ${{ vars.STUDIO_R2_ENDPOINT_URL_PROD }}
+        run: |
+          aws s3 sync packages/cli/dist/factory "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/factory/" \
             --endpoint-url "${STUDIO_ENDPOINT_URL}" \
             --delete


### PR DESCRIPTION
## Summary

The factory UI is currently only served from the Railway container origin. CLI-based deploys happen to bake a snapshot of the SPA into the artifact zip, so the UI renders. GitHub-source deploys have no such step, so requests fall through to the sandbox's welcome page and the factory renders as broken.

This mirrors the pattern that already fixes studio: publish the built SPA to a versioned R2 key on every release so the edge-router can serve it from CDN, keyed by `mastraVersion`. Both CLI and GitHub-source deploys then serve identical bytes from R2 instead of the origin.

This PR is the publisher half of that fix. The edge-router R2-first serve change lives in the platform repo and will land after this ships at least one release.

## Changes

`.github/workflows/npm-publish.yml` — after each of the three existing studio upload pairs (in `prerelease`, `stable`, and `snapshot` jobs), added a mirrored factory upload pair. Each new step:

- Reuses the existing `Get CLI version` step's output (`steps.cli-version.outputs.version`).
- Reuses the same `STUDIO_R2_*` secrets/vars — same bucket, no infra changes required.
- Writes to key prefix `<version>/factory/`, sitting alongside the existing `<version>/studio/`.
- Mirrors surrounding guards: the `stable` job's factory steps carry `if: ${{ !inputs.dry_run }}` to match the studio steps in that job.

`packages/cli/dist/factory/` is produced by the same `pnpm turbo build --filter="mastra"` command the workflow already runs. It is copied from `mastracode/factory-ui/dist/` in `packages/cli/tsdown.config.ts`'s `onSuccess` hook, and `@internal/factory-ui` is a workspace dep of the CLI so turbo builds it first.

## Test plan

- YAML parses cleanly.
- Locally verified `packages/cli/dist/factory/` is produced by `pnpm build:cli`: removed the directory, ran the build, and the directory reappeared with a complete SPA (`index.html`, hashed JS/CSS, fonts, icons, manifest).
- After merge, next release of any type will populate `s3://<bucket>/<mastraVersion>/factory/` and can be inspected in the R2 dashboard the same way `<version>/studio/` is today.

## Follow-ups (not in this PR)

- Edge-router change in the platform repo to serve `product === 'factory'` from R2, keyed by `mastraVersion`.
- `.github/workflows/upload-studio-r2.yml` has a latent bug: it references `steps.cli-version.outputs.version` without a corresponding step, so any manual dispatch uploads to `<bucket>//studio/` (empty version segment) instead of `<bucket>/<version>/studio/`. Not touched here; the automated `npm-publish.yml` path is unaffected because it has the step.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

After a release, the workflow uploads the factory web app files to cloud storage. This allows the factory app to load from the CDN for released versions.

## Changes

- Added factory asset uploads to the `prerelease`, `stable`, and `snapshot` jobs.
- Uploads `packages/cli/dist/factory/` to the versioned `<version>/factory/` path.
- Reuses the existing studio R2 bucket, credentials, and CLI version output.
- Preserves the stable job's dry-run guard.
- Allows upload errors without failing the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->