### PR TITLE
fix(core): preserve request context for subscribed runs

### DIFF
--- a/.changeset/great-parks-stay.md
+++ b/.changeset/great-parks-stay.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed request context propagation for subscribed agent-controller runs.
+Fixed subscribed agent-controller runs so dynamic workspaces use the identity from the request that started the run.

--- a/.changeset/great-parks-stay.md
+++ b/.changeset/great-parks-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed request context propagation for subscribed agent-controller runs.

--- a/mastracode/tui/src/tui/__tests__/mastra-tui-hooks.test.ts
+++ b/mastracode/tui/src/tui/__tests__/mastra-tui-hooks.test.ts
@@ -127,7 +127,8 @@ describe('MastraTUI hook wiring', () => {
     const runStop = vi.fn().mockResolvedValue(createHookResult());
     const runAgentStart = vi.fn().mockResolvedValue(createHookResult());
     const setRunId = vi.fn();
-    const tui = createBareTui({ runStop, runAgentStart, setRunId });
+    const getRunId = vi.fn(() => undefined);
+    const tui = createBareTui({ runStop, runAgentStart, setRunId, getRunId });
 
     await tui.handleEvent({ type: 'agent_start' });
 
@@ -250,8 +251,9 @@ describe('MastraTUI hook wiring', () => {
 
   it('generates a run_id and sets it before firing AgentStart on agent_start', async () => {
     const setRunId = vi.fn();
+    const getRunId = vi.fn(() => undefined);
     const runAgentStart = vi.fn().mockResolvedValue(createHookResult());
-    const tui = createBareTui({ setRunId, runAgentStart });
+    const tui = createBareTui({ setRunId, getRunId, runAgentStart });
 
     await tui.handleEvent({ type: 'agent_start' });
 

--- a/mastracode/tui/src/tui/__tests__/permission-hooks-receipt.test.ts
+++ b/mastracode/tui/src/tui/__tests__/permission-hooks-receipt.test.ts
@@ -316,11 +316,16 @@ describe('runId edge with a real HookManager (#20861, Risk R1)', () => {
     rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it('silently no-ops when a permission event arrives before setRunId', async () => {
+  it('silently no-ops when a permission event arrives with no preceding agent_start', async () => {
     // The runId bail lives in the real HookManager.runPermissionRequest — a
     // fake manager would never execute it. HookManager reads hook config from
     // the filesystem at construction, so config is injected via controlled
     // temp dirs (project + home) to keep the test hermetic.
+    //
+    // The receipt-time tap sets runId when agent_start arrives (see
+    // runPermissionHooksForEvent in display.ts). This test deliberately sends
+    // NO agent_start, so the runId remains unset and the hook bails — proving
+    // the guard still works when no run has been started.
     const marker = join(tmpProject, 'permission-hook-ran.marker');
     mkdirSync(join(tmpProject, '.mastracode'), { recursive: true });
     writeFileSync(
@@ -365,6 +370,61 @@ describe('runId edge with a real HookManager (#20861, Risk R1)', () => {
     const result = await spy.mock.results[0]!.value;
     expect(result.results).toEqual([]);
     expect(existsSync(marker)).toBe(false);
+
+    releaseBlocker.resolve();
+    await blocked;
+  });
+
+  it('sets runId at receipt time so a permission event after agent_start fires the hook', async () => {
+    // The receipt-time tap (runPermissionHooksForEvent in display.ts) sets the
+    // runId when agent_start arrives, BEFORE the queued handler processes it.
+    // This closes the race where a tool_suspended arriving in the same
+    // synchronous batch as agent_start would find runId unset and bail.
+    const marker = join(tmpProject, 'permission-hook-ran.marker');
+    mkdirSync(join(tmpProject, '.mastracode'), { recursive: true });
+    writeFileSync(
+      join(tmpProject, '.mastracode', 'hooks.json'),
+      JSON.stringify({
+        PermissionRequest: [
+          {
+            type: 'command',
+            command: `node -e "require('node:fs').appendFileSync('${marker}', 'x')"`,
+            timeout: 5000,
+          },
+        ],
+      }),
+    );
+
+    const manager = new HookManager(tmpProject, 'session-runid-test', '.mastracode', tmpHome);
+    expect(manager.getConfig().PermissionRequest).toHaveLength(1);
+    expect(manager.getRunId()).toBeUndefined();
+
+    const spy = vi.spyOn(manager, 'runPermissionRequest');
+    const { listener, releaseBlocker } = createHarness(manager);
+    const blocked = listener({ type: 'blocking_prompt' });
+    await Promise.resolve();
+
+    // agent_start arrives at receipt time — the tap should set the runId.
+    void listener({ type: 'agent_start' });
+    expect(manager.getRunId()).toBeDefined();
+
+    // tool_suspended for request_access arrives in the same batch — the hook
+    // must fire now that runId is set.
+    void listener({
+      type: 'tool_suspended',
+      toolCallId: 'call-access',
+      toolName: 'request_access',
+      suspendPayload: { kind: 'sandbox_access_request', path: '/tmp/test' },
+    });
+    expect(spy).toHaveBeenCalledWith('sandbox_access', 'call-access', 'request_access', {
+      kind: 'sandbox_access_request',
+      path: '/tmp/test',
+    });
+
+    // The hook process should have run and written the marker.
+    const result = await spy.mock.results[0]!.value;
+    expect(result.results).toHaveLength(1);
+    expect(existsSync(marker)).toBe(true);
 
     releaseBlocker.resolve();
     await blocked;

--- a/mastracode/tui/src/tui/display.ts
+++ b/mastracode/tui/src/tui/display.ts
@@ -1,6 +1,8 @@
 /**
  * Display helpers for the TUI: error messages, info messages, notifications.
  */
+import { randomUUID } from 'node:crypto';
+
 import { Container, Text } from '@earendil-works/pi-tui';
 
 import { parseError } from '@mastra/code-sdk/utils/errors';
@@ -186,15 +188,14 @@ export function notifyForInputRequest(state: TUIState, event: AgentControllerEve
  * synchronously in the controller subscription listener instead — the sibling
  * of notifyForInputRequest for hook dispatch rather than user pings.
  *
- * runId semantics (accepted, not handled): HookManager.runPermissionRequest
- * silently bails when no run id is set, and setRunId/clearRunId both run
- * inside the QUEUED agent_start/agent_end handling. Two cross-run microtask
- * edges therefore exist at receipt time: a permission event arriving before
- * its run's queued agent_start has been processed (hook silently skipped),
- * and a stale run id left over from the previous run (no constructible
- * trigger found — a new run cannot start while a prompt blocks the queue).
- * In the real starvation scenario the blocking run's id IS set, because its
- * agent_end cannot have been processed while its prompt blocks the queue.
+ * runId semantics: HookManager.runPermissionRequest silently bails when no run
+ * id is set, and setRunId/clearRunId both run inside the QUEUED agent_start/
+ * agent_end handling. To close the receipt-time gap — a permission event
+ * arriving before its run's queued agent_start has been processed — agent_start
+ * is handled here by setting the run id immediately (before the queued handler
+ * runs). beginLifecycleRun() in the queued handler reuses an existing run id
+ * instead of overwriting it, so the receipt-time id propagates to AgentStart
+ * hooks and beyond.
  *
  * Never throws: a hook failure must not break event delivery.
  */
@@ -202,6 +203,15 @@ export function runPermissionHooksForEvent(state: TUIState, event: AgentControll
   try {
     const hookMgr = state.hookManager;
     if (!hookMgr) return;
+    if (event.type === 'agent_start') {
+      // Set the run id at receipt time so subsequent permission events (e.g.
+      // a tool_suspended for request_access arriving in the same synchronous
+      // batch) have it available. beginLifecycleRun() reuses this id.
+      if (!hookMgr.getRunId()) {
+        hookMgr.setRunId(randomUUID());
+      }
+      return;
+    }
     if (event.type === 'tool_approval_required') {
       hookMgr.runPermissionRequest('tool_approval', event.toolCallId, event.toolName, event.args).catch(() => {});
       return;

--- a/mastracode/tui/src/tui/mastra-tui.ts
+++ b/mastracode/tui/src/tui/mastra-tui.ts
@@ -1026,8 +1026,12 @@ export class MastraTUI {
   private beginLifecycleRun(): void {
     const hookMgr = this.state.hookManager;
     if (!hookMgr) return;
-    const runId = randomUUID();
-    hookMgr.setRunId(runId);
+    // Reuse a run id set at receipt time (runPermissionHooksForEvent) so the
+    // PermissionRequest hook fired before the queued agent_start carries the
+    // same id as subsequent hooks in this run.
+    if (!hookMgr.getRunId()) {
+      hookMgr.setRunId(randomUUID());
+    }
     hookMgr.runAgentStart().catch(() => {});
   }
 

--- a/packages/core/src/agent-controller/__tests__/trailing-guard-new-run.test.ts
+++ b/packages/core/src/agent-controller/__tests__/trailing-guard-new-run.test.ts
@@ -37,12 +37,22 @@ function createController() {
   });
 }
 
-async function processSubscribedChunks(session: Session<any>, chunks: any[], activeRunId = 'run-b') {
+async function processSubscribedChunks(
+  session: Session<any>,
+  chunks: any[],
+  activeRunId = 'run-b',
+  requestContexts = new Map<string, RequestContext>(),
+) {
+  let currentRequestContext: RequestContext | undefined;
   const subscription = {
     stream: (async function* () {
-      for (const chunk of chunks) yield chunk;
+      for (const chunk of chunks) {
+        if (chunk.runId) currentRequestContext = requestContexts.get(chunk.runId);
+        yield chunk;
+      }
     })(),
     activeRunId: () => activeRunId,
+    __getCurrentRunRequestContext: () => currentRequestContext,
     abort: () => {},
     unsubscribe: () => {},
   };
@@ -95,96 +105,46 @@ describe('Trailing guard does not swallow new-run null-runId chunks', () => {
     expect(processedChunkTypes).toContain('data-om-status');
   });
 
-  it('uses the latest caller context when an approval arrives on the subscribed stream', async () => {
+  it('uses the request context owned by each subscribed run', async () => {
     const controller = createController();
     await controller.init();
     const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
-    const requestContext = new RequestContext();
-    requestContext.set('user', { id: 'user-1', organizationId: 'org-1' });
-    session.runEngine.setRequestContext(requestContext);
+    const firstContext = new RequestContext();
+    firstContext.set('user', { id: 'first-user' });
+    const secondContext = new RequestContext();
+    secondContext.set('user', { id: 'second-user' });
+    const contexts = new Map([
+      ['run-a', firstContext],
+      ['run-b', secondContext],
+    ]);
+
     vi.spyOn(session, 'resolveToolApproval').mockReturnValue('allow');
     const approveToolCall = vi.spyOn(session, 'approveToolCall').mockResolvedValue();
 
-    await processSubscribedChunks(session, [
-      { type: 'start', runId: 'run-a' },
-      {
-        type: 'tool-call-approval',
-        runId: 'run-a',
-        payload: { toolCallId: 'tool-call-1', toolName: 'factory_transition_work_item', args: {} },
-      },
-      { type: 'finish', runId: 'run-a', payload: { stepResult: { reason: 'stop' } } },
-    ]);
+    await processSubscribedChunks(
+      session,
+      [
+        { type: 'start', runId: 'run-a' },
+        {
+          type: 'tool-call-approval',
+          runId: 'run-a',
+          payload: { toolCallId: 'tool-call-1', toolName: 'factory_transition_work_item', args: {} },
+        },
+        { type: 'finish', runId: 'run-a', payload: { stepResult: { reason: 'stop' } } },
+        { type: 'start', runId: 'run-b' },
+        {
+          type: 'tool-call-approval',
+          runId: 'run-b',
+          payload: { toolCallId: 'tool-call-2', toolName: 'factory_transition_work_item', args: {} },
+        },
+        { type: 'finish', runId: 'run-b', payload: { stepResult: { reason: 'stop' } } },
+      ],
+      'run-b',
+      contexts,
+    );
 
-    expect(approveToolCall).toHaveBeenCalledOnce();
-    expect(approveToolCall.mock.calls[0]?.[0].requestContext?.get('user')).toEqual({
-      id: 'user-1',
-      organizationId: 'org-1',
-    });
-  });
-
-  // Resuming is a caller-authenticated entry point that starts the subscription
-  // itself, so an approval arriving after it must not fall back to whatever
-  // identity a previous send happened to leave behind — or to none at all.
-  it('uses the resuming caller context for an approval that follows a resume', async () => {
-    const controller = createController();
-    await controller.init();
-    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
-    session.suspensions.register({ toolCallId: 'suspended-1', runId: 'run-a', toolName: 'ask_user' });
-
-    const requestContext = new RequestContext();
-    requestContext.set('user', { id: 'resuming-user', organizationId: 'org-1' });
-    vi.spyOn(session, 'resolveToolApproval').mockReturnValue('allow');
-    const approveToolCall = vi.spyOn(session, 'approveToolCall').mockResolvedValue();
-
-    await session
-      .resumeToolCall({ resumeData: 'answer', toolCallId: 'suspended-1', requestContext })
-      .catch(() => undefined);
-
-    await processSubscribedChunks(session, [
-      { type: 'start', runId: 'run-b' },
-      {
-        type: 'tool-call-approval',
-        runId: 'run-b',
-        payload: { toolCallId: 'tool-call-1', toolName: 'factory_transition_work_item', args: {} },
-      },
-      { type: 'finish', runId: 'run-b', payload: { stepResult: { reason: 'stop' } } },
-    ]);
-
-    expect(approveToolCall).toHaveBeenCalledOnce();
-    expect(approveToolCall.mock.calls[0]?.[0].requestContext?.get('user')).toEqual({
-      id: 'resuming-user',
-      organizationId: 'org-1',
-    });
-  });
-
-  it('uses the notifying caller context for an approval that follows a notification signal', async () => {
-    const controller = createController();
-    await controller.init();
-    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
-
-    const requestContext = new RequestContext();
-    requestContext.set('user', { id: 'notifying-user', organizationId: 'org-1' });
-    vi.spyOn(session, 'resolveToolApproval').mockReturnValue('allow');
-    const approveToolCall = vi.spyOn(session, 'approveToolCall').mockResolvedValue();
-
-    await session
-      .sendNotificationSignal({ tagName: 'system', contents: 'ping' } as any, { requestContext })
-      .catch(() => undefined);
-
-    await processSubscribedChunks(session, [
-      { type: 'start', runId: 'run-b' },
-      {
-        type: 'tool-call-approval',
-        runId: 'run-b',
-        payload: { toolCallId: 'tool-call-1', toolName: 'factory_transition_work_item', args: {} },
-      },
-      { type: 'finish', runId: 'run-b', payload: { stepResult: { reason: 'stop' } } },
-    ]);
-
-    expect(approveToolCall).toHaveBeenCalledOnce();
-    expect(approveToolCall.mock.calls[0]?.[0].requestContext?.get('user')).toEqual({
-      id: 'notifying-user',
-      organizationId: 'org-1',
-    });
+    expect(approveToolCall).toHaveBeenCalledTimes(2);
+    expect(approveToolCall.mock.calls[0]?.[0].requestContext?.get('user')).toEqual({ id: 'first-user' });
+    expect(approveToolCall.mock.calls[1]?.[0].requestContext?.get('user')).toEqual({ id: 'second-user' });
   });
 });

--- a/packages/core/src/agent-controller/__tests__/trailing-guard-new-run.test.ts
+++ b/packages/core/src/agent-controller/__tests__/trailing-guard-new-run.test.ts
@@ -14,6 +14,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { Agent } from '../../agent';
+import { RequestContext } from '../../request-context';
 import { InMemoryStore } from '../../storage/mock';
 import { AgentController } from '../agent-controller';
 import type { Session } from '../session';
@@ -92,5 +93,37 @@ describe('Trailing guard does not swallow new-run null-runId chunks', () => {
     // The null-runId chunks from run B must have been processed, not skipped.
     expect(processedChunkTypes).toContain('data-user-message');
     expect(processedChunkTypes).toContain('data-om-status');
+  });
+
+  it('uses the context staged for each subscribed run and clears it after completion', async () => {
+    const controller = createController();
+    await controller.init();
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    const firstContext = new RequestContext();
+    firstContext.set('user', { id: 'first-user' });
+    const deliveredContext = new RequestContext();
+    deliveredContext.set('user', { id: 'delivered-user' });
+    expect(session.run.stageRequestContext(firstContext)).toBe(true);
+    expect(session.run.stageRequestContext(deliveredContext)).toBe(false);
+
+    const users: unknown[] = [];
+    const origProcessStreamChunk = session.runEngine.processStreamChunk.bind(session.runEngine);
+    session.runEngine.processStreamChunk = async (state: any, chunk: any, requestContext: any) => {
+      users.push(requestContext.get('user'));
+      return origProcessStreamChunk(state, chunk, requestContext);
+    };
+
+    await processSubscribedChunks(session, [
+      { type: 'start', runId: 'run-a' },
+      { type: 'data-user-message', data: { content: 'First run' } },
+      { type: 'finish', runId: 'run-a', payload: { stepResult: { reason: 'stop' } } },
+      { type: 'start', runId: 'run-b' },
+      { type: 'data-user-message', data: { content: 'Second run' } },
+      { type: 'finish', runId: 'run-b', payload: { stepResult: { reason: 'stop' } } },
+    ]);
+
+    expect(users).toContainEqual({ id: 'first-user' });
+    expect(users.at(-1)).toBeUndefined();
+    expect(session.run.getRequestContext()).toBeUndefined();
   });
 });

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -1244,7 +1244,7 @@ export class SessionRunEngine {
           this.#session.run.ensureAbortController();
           this.#session.run.setRunId({ runId });
           this.#session.run.setTraceId({ traceId: null });
-          requestContext = await this.#machinery.buildRequestContext(subscription.__getCurrentRunRequestContext());
+          requestContext = await this.#machinery.buildRequestContext(subscription.__getCurrentRunRequestContext?.());
           this.#session.emit({ type: 'agent_start' });
         }
 

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -1238,7 +1238,7 @@ export class SessionRunEngine {
         }
 
         if (!currentRun) {
-          const runId = 'runId' in chunk ? chunk.runId : subscription.activeRunId();
+          const runId = ('runId' in chunk ? chunk.runId : undefined) ?? subscription.activeRunId();
           currentRun = this.createStreamState();
           this.#session.run.nextOperation();
           this.#session.run.ensureAbortController();

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -252,15 +252,10 @@ type StreamState = {
 export class SessionRunEngine {
   readonly #session: Session;
   readonly #machinery: SessionMachinery;
-  #requestContext?: RequestContext;
 
   constructor(session: Session, machinery: SessionMachinery) {
     this.#session = session;
     this.#machinery = machinery;
-  }
-
-  setRequestContext(requestContext?: RequestContext): void {
-    if (requestContext) this.#requestContext = requestContext;
   }
 
   private createEmptyAssistantMessage(): MastraDBMessage {
@@ -1231,6 +1226,7 @@ export class SessionRunEngine {
 
   async processSubscribedThreadStream(subscription: AgentThreadSubscription<StreamChunk>): Promise<void> {
     let currentRun: StreamState | undefined;
+    let requestContext!: RequestContext;
     let bailed = false;
 
     const consume = async (): Promise<void> => {
@@ -1242,11 +1238,13 @@ export class SessionRunEngine {
         }
 
         if (!currentRun) {
+          const runId = 'runId' in chunk ? chunk.runId : subscription.activeRunId();
           currentRun = this.createStreamState();
           this.#session.run.nextOperation();
           this.#session.run.ensureAbortController();
-          this.#session.run.setRunId({ runId: subscription.activeRunId() ?? ('runId' in chunk ? chunk.runId : null) });
+          this.#session.run.setRunId({ runId });
           this.#session.run.setTraceId({ traceId: null });
+          requestContext = await this.#machinery.buildRequestContext(subscription.__getCurrentRunRequestContext());
           this.#session.emit({ type: 'agent_start' });
         }
 
@@ -1255,7 +1253,6 @@ export class SessionRunEngine {
         }
 
         try {
-          const requestContext = await this.#machinery.buildRequestContext(this.#requestContext);
           const streamResult = await this.processStreamChunk(currentRun, chunk, requestContext);
           if (
             streamResult ||

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -1034,7 +1034,7 @@ export class SessionRunEngine {
   }
 
   async processSubscribedThreadStream(subscription: AgentThreadSubscription<StreamChunk>): Promise<void> {
-    const requestContext = await this.#machinery.buildRequestContext();
+    let requestContext!: RequestContext;
     let currentRun: StreamState | undefined;
 
     try {
@@ -1050,6 +1050,7 @@ export class SessionRunEngine {
           this.#session.run.ensureAbortController();
           this.#session.run.setRunId({ runId: subscription.activeRunId() ?? ('runId' in chunk ? chunk.runId : null) });
           this.#session.run.setTraceId({ traceId: null });
+          requestContext = await this.#machinery.buildRequestContext(this.#session.run.getRequestContext());
           this.#session.emit({ type: 'agent_start' });
         }
 

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3343,7 +3343,6 @@ export class Session<TState = unknown> {
       const threadId = this.thread.getId()!;
 
       const agent = this.machinery.getAgent();
-      this.runEngine.setRequestContext(requestContextInput);
       await this.thread.ensureSubscription(threadId);
 
       // A deferred abort (parked approval gate) leaves the AbortController
@@ -3439,7 +3438,6 @@ export class Session<TState = unknown> {
     const threadId = this.thread.getId()!;
 
     const agent = this.machinery.getAgent();
-    this.runEngine.setRequestContext(requestContextInput);
     await this.thread.ensureSubscription(threadId);
 
     if (this.run.getRunId() && this.stream.activeRunId()) {
@@ -3828,7 +3826,6 @@ export class Session<TState = unknown> {
       throw new Error('Cannot resume a suspended tool without a current thread');
     }
 
-    this.runEngine.setRequestContext(requestContextInput);
     await this.thread.ensureSubscription(threadId);
     const resumedSubscriptionBoundary = this.createSubscribedResumeBoundaryWaiter(
       suspension.toolName === 'submit_plan' ? toolCallId : undefined,

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -1283,6 +1283,8 @@ export class SessionRun {
   #abortController: AbortController | null = null;
   /** Whether an abort has been requested for the current run. */
   #abortRequested = false;
+  /** Request-scoped state staged by the signal that started this run. */
+  #requestContext: RequestContext | undefined;
   readonly #teardownWaiters = new Set<() => void>();
 
   #notifyTeardown(): void {
@@ -1327,6 +1329,25 @@ export class SessionRun {
     this.#traceId = traceId;
   }
 
+  /** Stage request-scoped state for the next run started from this idle session. */
+  stageRequestContext(requestContext: RequestContext | undefined): boolean {
+    if (!requestContext || this.#requestContext) return false;
+    this.#requestContext = requestContext;
+    return true;
+  }
+
+  /** Return the request-scoped state associated with the active run. */
+  getRequestContext(): RequestContext | undefined {
+    return this.#requestContext;
+  }
+
+  /** Clear staged request-scoped state only when it belongs to `requestContext`. */
+  clearRequestContext(requestContext?: RequestContext): void {
+    if (!requestContext || this.#requestContext === requestContext) {
+      this.#requestContext = undefined;
+    }
+  }
+
   /**
    * Clear all run state (run id, trace id, abort controller + requested flag)
    * when a run ends or is reset. Does not touch the operation counter.
@@ -1336,6 +1357,7 @@ export class SessionRun {
     this.#traceId = null;
     this.#abortController = null;
     this.#abortRequested = false;
+    this.#requestContext = undefined;
     this.#notifyTeardown();
   }
 
@@ -3127,16 +3149,33 @@ export class Session<TState = unknown> {
         tracingOptions,
       });
 
+      // The thread subscription outlives individual runs, so stage the
+      // originating request context before the wake can publish its first chunk.
+      // Keep an earlier signal's staged context if this signal is delivered to it.
+      const stagedRequestContext = this.run.stageRequestContext(requestContextInput);
+      const clearStagedRequestContext = () => {
+        if (stagedRequestContext) this.run.clearRequestContext(requestContextInput);
+      };
       const result = agent.sendSignal(signal, {
         resourceId: this.identity.getResourceId(),
         threadId,
         ifActive,
         ifIdle: { ...ifIdle, streamOptions: streamOptions as any },
       });
+      const settleRequestContext = <T>(settled: SendAgentSignalAccepted<T>) => {
+        if (settled.action !== 'wake') clearStagedRequestContext();
+        return settled;
+      };
       if (requireDelivery) {
         // Delivery-guaranteed path: surface the real acceptance decision and
         // propagate routing/stream-setup failures to the caller.
-        const settled = await result.accepted;
+        let settled: SendAgentSignalAccepted<undefined>;
+        try {
+          settled = settleRequestContext(await result.accepted);
+        } catch (error) {
+          clearStagedRequestContext();
+          throw error;
+        }
         return {
           accepted: true as const,
           runId: 'runId' in settled ? settled.runId : undefined,
@@ -3145,13 +3184,14 @@ export class Session<TState = unknown> {
       }
       try {
         await Promise.race([
-          result.accepted.then(() => undefined),
+          result.accepted.then(settleRequestContext).then(() => undefined),
           new Promise<void>(resolve => setTimeout(resolve, 0)),
         ]);
       } catch (error) {
+        clearStagedRequestContext();
         throw error;
       }
-      void result.accepted.catch(() => {});
+      void result.accepted.then(settleRequestContext).catch(clearStagedRequestContext);
       return { accepted: true as const, runId: undefined };
     });
 
@@ -3190,12 +3230,31 @@ export class Session<TState = unknown> {
       tracingOptions,
     });
 
-    return agent.sendNotificationSignal(input, {
-      resourceId: this.identity.getResourceId(),
-      threadId,
-      ifActive,
-      ifIdle: { ...ifIdle, streamOptions: streamOptions as any },
-    });
+    const stagedRequestContext = this.run.stageRequestContext(requestContextInput);
+    const clearStagedRequestContext = () => {
+      if (stagedRequestContext) this.run.clearRequestContext(requestContextInput);
+    };
+    try {
+      const result = await agent.sendNotificationSignal<unknown>(input, {
+        resourceId: this.identity.getResourceId(),
+        threadId,
+        ifActive,
+        ifIdle: { ...ifIdle, streamOptions: streamOptions as any },
+      });
+      if (result.accepted) {
+        void result.accepted
+          .then(accepted => {
+            if (accepted.action !== 'wake') clearStagedRequestContext();
+          })
+          .catch(clearStagedRequestContext);
+      } else {
+        clearStagedRequestContext();
+      }
+      return result;
+    } catch (error) {
+      clearStagedRequestContext();
+      throw error;
+    }
   }
 
   /**

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -16,6 +16,7 @@ import { MAX_NOTIFICATION_DELIVERY_ATTEMPTS } from '../../notifications/delivery
 import { dispatchDueNotifications } from '../../notifications/dispatcher';
 import { InMemoryNotificationsStorage } from '../../notifications/storage';
 import { createNotificationInboxTool } from '../../notifications/tool';
+import { RequestContext } from '../../request-context';
 import { MastraCompositeStore } from '../../storage/base';
 import { Agent } from '../agent';
 import {
@@ -975,6 +976,70 @@ describe('Agent signals', () => {
     } finally {
       firstSubscription.unsubscribe();
       secondSubscription.unsubscribe();
+    }
+  });
+
+  it('keeps request context associated with the exact queued stream record', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const agent = { id: 'request-context-stream-agent' } as Agent<any, any, any, any>;
+    const threadId = 'request-context-stream-thread';
+    const resourceId = 'request-context-stream-user';
+    const runId = 'shared-run-id';
+    const firstContext = new RequestContext();
+    firstContext.set('name', 'first-context');
+    const secondContext = new RequestContext();
+    secondContext.set('name', 'second-context');
+
+    const subscription = await runtime.subscribeToThread(agent, { threadId, resourceId });
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+
+    const registerCompletedRun = async (requestContext: RequestContext) => {
+      let finish!: () => void;
+      const finished = new Promise<void>(resolve => {
+        finish = resolve;
+      });
+      const parts = [
+        { type: 'start', runId },
+        { type: 'finish', runId, payload: { finishReason: 'stop' } },
+      ];
+      const output = {
+        runId,
+        status: 'running',
+        fullStream: new ReadableStream({
+          pull(controller) {
+            const part = parts.shift();
+            if (part) {
+              controller.enqueue(part);
+            } else {
+              controller.close();
+              finish();
+            }
+          },
+        }),
+        _waitUntilFinished: () => finished,
+      } as any;
+      await runtime.registerRun(agent, output, {
+        memory: { thread: threadId, resource: resourceId },
+        requestContext,
+      } as any);
+      await nextTick();
+    };
+
+    try {
+      await registerCompletedRun(firstContext);
+      await registerCompletedRun(secondContext);
+
+      const firstStart = await withTimeout(iterator.next(), 'Timed out waiting for first queued stream');
+      expect(firstStart.value).toMatchObject({ type: 'start', runId });
+      expect(subscription.__getCurrentRunRequestContext()).toBe(firstContext);
+      await withTimeout(iterator.next(), 'Timed out waiting for first queued stream finish');
+
+      const secondStart = await withTimeout(iterator.next(), 'Timed out waiting for second queued stream');
+      expect(secondStart.value).toMatchObject({ type: 'start', runId });
+      expect(subscription.__getCurrentRunRequestContext()).toBe(secondContext);
+      await withTimeout(iterator.next(), 'Timed out waiting for second queued stream finish');
+    } finally {
+      subscription.unsubscribe();
     }
   });
 

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -1727,6 +1727,7 @@ export class AgentThreadStreamRuntime {
     const replayedStreamIds = new Set<string>();
     let currentReader: ReadableStreamDefaultReader<any> | null = null;
     let activeReaderRunId: string | null = null;
+    let currentRunRequestContext: RequestContext | undefined;
     let cancelledByAbort = false;
 
     const markActiveIfLive = async (runId: string, streamId: string, local: boolean) => {
@@ -1909,6 +1910,7 @@ export class AgentThreadStreamRuntime {
 
     return {
       activeRunId,
+      __getCurrentRunRequestContext: () => currentRunRequestContext,
       abort: () => this.abortThread(options, resolvedPubSub),
       unsubscribe,
       stream: (async function* () {
@@ -1926,6 +1928,7 @@ export class AgentThreadStreamRuntime {
             const reader = subscriberStream.getReader();
             currentReader = reader as ReadableStreamDefaultReader<any>;
             activeReaderRunId = run.runId;
+            currentRunRequestContext = run.streamOptions.requestContext;
             let readerReleased = false;
             try {
               while (true) {
@@ -1972,6 +1975,7 @@ export class AgentThreadStreamRuntime {
             } finally {
               currentReader = null;
               activeReaderRunId = null;
+              currentRunRequestContext = undefined;
               if (!readerReleased) {
                 reader.releaseLock();
               }

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -352,6 +352,8 @@ export interface AgentSubscribeToThreadOptions {
 export interface AgentThreadSubscription<OUTPUT = unknown> {
   stream: AsyncIterable<AgentChunkType<OUTPUT>>;
   activeRunId: () => string | null;
+  /** @internal */
+  __getCurrentRunRequestContext: () => RequestContext | undefined;
   abort: () => boolean;
   unsubscribe: () => void;
 }

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -353,7 +353,7 @@ export interface AgentThreadSubscription<OUTPUT = unknown> {
   stream: AsyncIterable<AgentChunkType<OUTPUT>>;
   activeRunId: () => string | null;
   /** @internal */
-  __getCurrentRunRequestContext: () => RequestContext | undefined;
+  __getCurrentRunRequestContext?: () => RequestContext | undefined;
   abort: () => boolean;
   unsubscribe: () => void;
 }


### PR DESCRIPTION
## Summary

Preserves the request context for subscribed agent-controller runs so dynamic workspaces and approval callbacks resolve under the identity that started the winning run.

The previous session-level context slot was not associated with a run, so competing callers could overwrite or donate identity across runs. The subscription now exposes the context attached to the exact queued stream record being consumed. Remote-owned runs intentionally receive no local caller context.

## Changes

- Resolve subscribed-run context from the current thread stream record instead of shared session state.
- Keep context tied to each stream incarnation, including buffered streams and resumed streams that share a run ID.
- Remove session entry-point writes to the unkeyed request-context slot.
- Add regression coverage for per-stream context ownership and approval callbacks across consecutive runs.
- Add a patch changeset for `@mastra/core`.

## Test plan

- `pnpm --filter ./packages/core exec vitest run src/agent-controller/__tests__/trailing-guard-new-run.test.ts --reporter=dot --bail=1`
- `pnpm --filter ./packages/core exec vitest run src/agent/__tests__/agent-signals.test.ts --reporter=dot --bail=1`
- `pnpm build:core`

`pnpm --filter ./packages/core check` currently reaches an unrelated error already present on `main`: `RunEvalsResult` is declared but not exported in `src/evals/run/index.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Each delayed run now keeps the identity and settings of the caller that created it. This prevents another caller from supplying the wrong context, especially when runs share an ID or resume later.

## Changes

- Resolve request context from the exact queued stream record consumed by the subscription.
- Preserve context for buffered streams and repeated `runId` incarnations.
- Exclude local context from remote-owned runs.
- Track the active run context through `__getCurrentRunRequestContext`.
- Remove session-level context storage and `setRequestContext`.
- Preserve request context during approval callbacks across consecutive runs.
- Add regression tests for queued stream ownership and approval callbacks.
- Add a patch changeset for `@mastra/core`.

## Validation

- Focused tests passed.
- `pnpm build:core` passed.
- `pnpm --filter ./packages/core check` encounters the existing `RunEvalsResult` export error on `main`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->