### PR TITLE
fix(core): stop re-publishing prior step results on workflow watch events

### DIFF
--- a/.changeset/eleven-plants-check.md
+++ b/.changeset/eleven-plants-check.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workflow watch events re-publishing stale step state, which could grow to megabytes per event. `workflow-step-start` events spread the step's previous result into their payload, so on loops (including durable agent runs) every start event shipped the previous iteration's `output` next to a byte-identical input `payload`. On Cloudflare Workers this made the request streaming a durable agent run exceed the 128 MB isolate memory limit and fail, even though the run itself kept executing. Watch events now only carry the fields describing the current transition: the input (`payload` or `resumePayload`), timestamps, and `status` on start events, plus the fresh result on `workflow-step-result` and `workflow-step-suspended` events. A step's prior `output`, `error`, and suspend state are no longer re-published on later events. Persisted run snapshots are unchanged.

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -50,7 +50,7 @@ import type {
 } from './types';
 // Used by the per-type execute methods (executeAgent/executeTool/executeMapping)
 // to build a runnable step from a declarative entry.
-import { getSingleStepEntryId } from './utils';
+import { getSingleStepEntryId, omitPriorCompletionFields } from './utils';
 
 // Re-export ExecutionContext for backwards compatibility
 export type { ExecutionContext } from './types';
@@ -242,7 +242,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
             payload: {
               id: params.step.id,
               stepCallId: params.stepCallId,
-              ...params.stepInfo,
+              ...omitPriorCompletionFields(params.stepInfo),
             },
           },
         });

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -24,6 +24,7 @@ import {
   getSingleStepEntryId,
   getStepIds,
   isSingleStepEntry,
+  omitPriorCompletionFields,
   validateStepResumeData,
 } from '../../utils';
 import { resolveCurrentState } from '../helpers';
@@ -2539,9 +2540,13 @@ export class WorkflowEventProcessor extends EventProcessor {
           type: 'workflow-step-suspended',
           payload: {
             id: stepId,
-            ...prevResult,
+            // Strip completion fields of the step's *previous* run (a stale
+            // `output` would otherwise re-publish state blobs), then re-add
+            // the fields describing the current suspension.
+            ...omitPriorCompletionFields(prevResult),
             suspendedAt: Date.now(),
             suspendPayload: prevResult.suspendPayload,
+            ...(prevResult.suspendOutput !== undefined ? { suspendOutput: prevResult.suspendOutput } : {}),
           },
         },
       });
@@ -2648,7 +2653,11 @@ export class WorkflowEventProcessor extends EventProcessor {
           type: 'workflow-step-result',
           payload: {
             id: stepId,
-            ...prevResult,
+            // Strip completion fields of the step's *previous* run (stale
+            // suspend state, errors), then re-add this run's own result.
+            ...omitPriorCompletionFields(prevResult),
+            ...('output' in prevResult ? { output: prevResult.output } : {}),
+            ...('endedAt' in prevResult && prevResult.endedAt !== undefined ? { endedAt: prevResult.endedAt } : {}),
           },
         },
       });

--- a/packages/core/src/workflows/handlers/control-flow.ts
+++ b/packages/core/src/workflows/handlers/control-flow.ts
@@ -34,6 +34,7 @@ import {
   runCountDeprecationMessage,
   getResumeLabelsByStepId,
   getSingleStepEntryId,
+  omitPriorCompletionFields,
   resolveForeachConcurrency,
 } from '../utils';
 import type { ExecuteStepParams } from './step';
@@ -957,7 +958,7 @@ export async function executeForeach(
       type: 'workflow-step-start',
       payload: {
         id: stepId,
-        ...stepInfo,
+        ...omitPriorCompletionFields(stepInfo),
         status: 'running',
       },
     },

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -32,6 +32,7 @@ import type {
 import {
   validateStepInput,
   createDeprecationProxy,
+  omitPriorCompletionFields,
   runCountDeprecationMessage,
   validateStepResumeData,
   validateStepSuspendData,
@@ -516,7 +517,10 @@ export async function executeStep(
       await emitStepResultEvents({
         stepId: step.id,
         stepCallId,
-        execResults: { ...stepInfo, ...execResults } as StepResult<any, any, any, any>,
+        // The persisted step result keeps the full prior-result spread (see
+        // `stepResult` below); the emitted event must not re-publish the
+        // previous completion's state blobs alongside the fresh execResults.
+        execResults: { ...omitPriorCompletionFields(stepInfo), ...execResults } as StepResult<any, any, any, any>,
         pubsub,
         runId,
       });

--- a/packages/core/src/workflows/utils.ts
+++ b/packages/core/src/workflows/utils.ts
@@ -614,6 +614,38 @@ export function cleanStepResult(stepResult: unknown): unknown {
 }
 
 /**
+ * Strips fields that describe a step's *previous* completion from a step-info
+ * object before it is published on a watch event.
+ *
+ * Step-info objects spread the step's prior result (`...stepResults[step.id]`)
+ * so persisted snapshots keep resume context (original `payload`, timestamps).
+ * Watch events must not re-publish those completion blobs: on a loop, the
+ * previous iteration's `output` is byte-identical to the next iteration's
+ * `payload`, so every `workflow-step-start` would ship the state twice
+ * (megabytes per event for durable agent runs). Result/suspended events get
+ * their fresh completion fields from the current execution result instead.
+ */
+export function omitPriorCompletionFields<T extends Record<string, unknown>>(
+  stepInfo: T,
+): Omit<
+  T,
+  'output' | 'error' | 'endedAt' | 'suspendedAt' | 'suspendPayload' | 'suspendOutput' | 'tripwire' | 'nonRetryable'
+> {
+  const {
+    output: _output,
+    error: _error,
+    endedAt: _endedAt,
+    suspendedAt: _suspendedAt,
+    suspendPayload: _suspendPayload,
+    suspendOutput: _suspendOutput,
+    tripwire: _tripwire,
+    nonRetryable: _nonRetryable,
+    ...rest
+  } = stepInfo;
+  return rest;
+}
+
+/**
  * Resolves the effective concurrency for a foreach entry at execution time.
  *
  * Supports both a static number and a {@link ForeachConcurrencyResolver}

--- a/packages/core/src/workflows/watch-event-payload.test.ts
+++ b/packages/core/src/workflows/watch-event-payload.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage/mock';
+import { createWorkflow } from './create';
+import { createStep } from './workflow';
+
+/**
+ * Regression tests for watch-event payload amplification.
+ *
+ * Step lifecycle events on `workflow.events.v2.<runId>` used to spread the
+ * step's *previous* result (`...stepResults[step.id]`) into the emitted
+ * payload. On a loop (e.g. a durable agent's dountil), the previous
+ * iteration's `output` is the next iteration's input, so every
+ * `workflow-step-start` shipped the cumulative state twice — `output` and
+ * `payload` were byte-identical, megabytes per event in production.
+ *
+ * Watch events must only carry fields describing the current transition:
+ * a start event has the input (`payload` / `resumePayload`), a result event
+ * has the fresh result. Prior-completion state stays in the run snapshot.
+ */
+describe('watch events: no prior-result amplification', () => {
+  const collect = async (streamResult: { fullStream: AsyncIterable<any>; result: Promise<any> }) => {
+    const events: any[] = [];
+    for await (const event of streamResult.fullStream) {
+      events.push(JSON.parse(JSON.stringify(event)));
+    }
+    const result = await streamResult.result;
+    return { events, result };
+  };
+
+  const startEventsFor = (events: any[], id: string) =>
+    events.filter(e => e.type === 'workflow-step-start' && e.payload?.id === id);
+  const resultEventsFor = (events: any[], id: string) =>
+    events.filter(e => e.type === 'workflow-step-result' && e.payload?.id === id);
+
+  it('emits a start event with input but no completion fields for a normal step', async () => {
+    const echo = createStep({
+      id: 'echo',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      execute: async ({ inputData }) => ({ value: inputData.value }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'normal-step-workflow',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+    })
+      .then(echo)
+      .commit();
+
+    const run = await workflow.createRun();
+    const { events, result } = await collect(run.stream({ inputData: { value: 'hello' } }));
+    expect(result.status).toBe('success');
+
+    const [start] = startEventsFor(events, 'echo');
+    expect(start.payload.payload).toEqual({ value: 'hello' });
+    expect(start.payload.status).toBe('running');
+    expect(start.payload.startedAt).toBeDefined();
+    expect(start.payload).not.toHaveProperty('output');
+    expect(start.payload).not.toHaveProperty('error');
+    expect(start.payload).not.toHaveProperty('endedAt');
+    expect(start.payload).not.toHaveProperty('suspendPayload');
+    expect(start.payload).not.toHaveProperty('suspendOutput');
+
+    const [stepResult] = resultEventsFor(events, 'echo');
+    expect(stepResult.payload.status).toBe('success');
+    expect(stepResult.payload.output).toEqual({ value: 'hello' });
+  });
+
+  it('does not re-publish the previous iteration output on loop start events', async () => {
+    const counter = createStep({
+      id: 'counter',
+      inputSchema: z.object({ n: z.number() }),
+      outputSchema: z.object({ n: z.number() }),
+      execute: async ({ inputData }) => ({ n: inputData.n + 1 }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'loop-workflow',
+      inputSchema: z.object({ n: z.number() }),
+      outputSchema: z.object({ n: z.number() }),
+    })
+      .dountil(counter, async ({ inputData }) => inputData.n >= 3)
+      .commit();
+
+    const run = await workflow.createRun();
+    const { events, result } = await collect(run.stream({ inputData: { n: 0 } }));
+    expect(result.status).toBe('success');
+
+    const starts = startEventsFor(events, 'counter');
+    expect(starts.length).toBe(3);
+
+    // Iterations 2+ previously spread the prior iteration's success result into
+    // the start event, so `output` (previous state) duplicated `payload` (next
+    // input). The start event must only carry the input once.
+    for (const [i, start] of starts.entries()) {
+      expect(start.payload.payload).toEqual({ n: i });
+      expect(start.payload).not.toHaveProperty('output');
+      expect(start.payload).not.toHaveProperty('endedAt');
+    }
+
+    const results = resultEventsFor(events, 'counter');
+    expect(results.length).toBe(3);
+    for (const [i, stepResult] of results.entries()) {
+      expect(stepResult.payload.output).toEqual({ n: i + 1 });
+    }
+  });
+
+  it('does not re-publish the previous iteration output for a nested workflow step in a loop', async () => {
+    const inner = createStep({
+      id: 'inner-step',
+      inputSchema: z.object({ n: z.number() }),
+      outputSchema: z.object({ n: z.number() }),
+      execute: async ({ inputData }) => ({ n: inputData.n + 1 }),
+    });
+
+    const nested = createWorkflow({
+      id: 'nested-workflow',
+      inputSchema: z.object({ n: z.number() }),
+      outputSchema: z.object({ n: z.number() }),
+    })
+      .then(inner)
+      .commit();
+
+    const workflow = createWorkflow({
+      id: 'nested-loop-workflow',
+      inputSchema: z.object({ n: z.number() }),
+      outputSchema: z.object({ n: z.number() }),
+    })
+      .dountil(nested, async ({ inputData }) => inputData.n >= 2)
+      .commit();
+
+    const run = await workflow.createRun();
+    const { events, result } = await collect(run.stream({ inputData: { n: 0 } }));
+    expect(result.status).toBe('success');
+
+    const starts = startEventsFor(events, 'nested-workflow');
+    expect(starts.length).toBe(2);
+    for (const start of starts) {
+      expect(start.payload).not.toHaveProperty('output');
+      expect(start.payload).not.toHaveProperty('endedAt');
+    }
+  });
+
+  it('keeps suspendPayload on the suspended event but off resumed start and final result events', async () => {
+    const gate = createStep({
+      id: 'gate',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ approved: z.boolean() }),
+      suspendSchema: z.object({ question: z.string() }),
+      resumeSchema: z.object({ approved: z.boolean() }),
+      execute: async ({ resumeData, suspend }) => {
+        if (!resumeData) {
+          await suspend({ question: 'proceed?' });
+          return { approved: false };
+        }
+        return { approved: resumeData.approved };
+      },
+    });
+
+    const workflow = createWorkflow({
+      id: 'suspend-workflow',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ approved: z.boolean() }),
+    })
+      .then(gate)
+      .commit();
+
+    const storage = new MockStore();
+    new Mastra({ logger: false, storage, workflows: { 'suspend-workflow': workflow } });
+
+    const run = await workflow.createRun();
+    const { events: startEvents, result: startResult } = await collect(run.stream({ inputData: { value: 'go' } }));
+    expect(startResult.status).toBe('suspended');
+
+    const suspendedEvent = startEvents.find(e => e.type === 'workflow-step-suspended' && e.payload?.id === 'gate');
+    expect(suspendedEvent.payload.suspendPayload).toMatchObject({ question: 'proceed?' });
+    // The suspension is fresh, but there is no completed output to re-publish.
+    expect(suspendedEvent.payload).not.toHaveProperty('output');
+
+    const resumeRun = await workflow.createRun({ runId: run.runId });
+    const { events: resumeEvents, result: resumeResult } = await collect(
+      resumeRun.resumeStream({ step: 'gate', resumeData: { approved: true } }),
+    );
+    expect(resumeResult.status).toBe('success');
+
+    const [resumedStart] = startEventsFor(resumeEvents, 'gate');
+    expect(resumedStart.payload.resumePayload).toEqual({ approved: true });
+    expect(resumedStart.payload.resumedAt).toBeDefined();
+    // Original input survives the resume (it comes from the persisted result).
+    expect(resumedStart.payload.payload).toEqual({ value: 'go' });
+    // The prior suspension's state must not be re-published on the new start.
+    expect(resumedStart.payload).not.toHaveProperty('suspendPayload');
+    expect(resumedStart.payload).not.toHaveProperty('suspendOutput');
+    expect(resumedStart.payload).not.toHaveProperty('output');
+
+    const [finalResult] = resultEventsFor(resumeEvents, 'gate');
+    expect(finalResult.payload.status).toBe('success');
+    expect(finalResult.payload.output).toEqual({ approved: true });
+    expect(finalResult.payload).not.toHaveProperty('suspendPayload');
+  });
+
+  it('does not attach a stale prior output to a failed result event', async () => {
+    const flaky = createStep({
+      id: 'flaky',
+      inputSchema: z.object({ n: z.number() }),
+      outputSchema: z.object({ n: z.number() }),
+      execute: async ({ inputData }) => {
+        if (inputData.n >= 1) {
+          throw new Error('boom');
+        }
+        return { n: inputData.n + 1 };
+      },
+    });
+
+    const workflow = createWorkflow({
+      id: 'failing-loop-workflow',
+      inputSchema: z.object({ n: z.number() }),
+      outputSchema: z.object({ n: z.number() }),
+    })
+      .dountil(flaky, async ({ inputData }) => inputData.n >= 3)
+      .commit();
+
+    const run = await workflow.createRun();
+    const { events, result } = await collect(run.stream({ inputData: { n: 0 } }));
+    expect(result.status).toBe('failed');
+
+    const results = resultEventsFor(events, 'flaky');
+    const failed = results.find(e => e.payload.status === 'failed');
+    expect(failed.payload.error).toBeDefined();
+    // Iteration 1 succeeded with output {n:1}; the iteration-2 failure event
+    // must not re-publish it.
+    expect(failed.payload).not.toHaveProperty('output');
+
+    // The iteration-2 start event must not carry iteration 1's output either.
+    const starts = startEventsFor(events, 'flaky');
+    expect(starts.length).toBe(2);
+    expect(starts[1].payload.payload).toEqual({ n: 1 });
+    expect(starts[1].payload).not.toHaveProperty('output');
+  });
+
+  it('emits a clean foreach start event on resume (no accumulated iteration state)', async () => {
+    const approval = createStep({
+      id: 'approval',
+      inputSchema: z.object({ name: z.string() }),
+      outputSchema: z.object({ name: z.string(), approved: z.boolean() }),
+      suspendSchema: z.object({ waitingFor: z.string() }),
+      resumeSchema: z.object({ approved: z.boolean() }),
+      execute: async ({ inputData, resumeData, suspend }) => {
+        if (inputData.name === 'beta' && !resumeData) {
+          await suspend({ waitingFor: inputData.name });
+          return { name: inputData.name, approved: false };
+        }
+        return { name: inputData.name, approved: resumeData?.approved ?? true };
+      },
+    });
+
+    const workflow = createWorkflow({
+      id: 'foreach-workflow',
+      inputSchema: z.array(z.object({ name: z.string() })),
+      outputSchema: z.array(z.object({ name: z.string(), approved: z.boolean() })),
+    })
+      .foreach(approval)
+      .commit();
+
+    const storage = new MockStore();
+    new Mastra({ logger: false, storage, workflows: { 'foreach-workflow': workflow } });
+
+    const run = await workflow.createRun();
+    const { result: startResult } = await collect(run.stream({ inputData: [{ name: 'alpha' }, { name: 'beta' }] }));
+    expect(startResult.status).toBe('suspended');
+
+    const resumeRun = await workflow.createRun({ runId: run.runId });
+    const { events: resumeEvents, result: resumeResult } = await collect(
+      resumeRun.resumeStream({ step: 'approval', resumeData: { approved: true } }),
+    );
+    expect(resumeResult.status).toBe('success');
+
+    // The foreach re-emits a start event on resume. It used to spread the
+    // suspended step result, dragging in the prior suspendPayload (which holds
+    // every completed iteration's output under __workflow_meta.foreachOutput).
+    const [start] = startEventsFor(resumeEvents, 'approval');
+    expect(start.payload).not.toHaveProperty('output');
+    expect(start.payload).not.toHaveProperty('suspendPayload');
+    expect(start.payload).not.toHaveProperty('suspendOutput');
+  });
+});


### PR DESCRIPTION
## Description

Streaming a durable agent run (`createInngestAgent`) on Cloudflare Workers kills the observing request with `Worker exceeded memory limit` (128 MB isolate heap) at ~32-38s, 100% of the time - the run keeps executing, but the user watching it gets a generic error. The cause is watch-event payload amplification in core's workflow engine.

Step lifecycle events on `workflow.events.v2.<runId>` build their payload from `stepInfo`, which spreads the step's *previous* result (`...stepResults[step.id]`). On a loop the previous iteration's `output` is byte-identical to the next iteration's input `payload`, so every `workflow-step-start` shipped the cumulative agent state twice. Measured in production: a single start event of **1.83 MB** (`output` = `payload` = 900,982 chars, byte-identical), **13-15 MB of raw JSON per run**.

The fix: emitted watch events no longer carry fields describing the step's previous completion (`output`, `error`, `endedAt`, `suspendedAt`, `suspendPayload`, `suspendOutput`, `tripwire`, `nonRetryable`). A start event keeps its input (`payload`/`resumePayload`), timestamps, `status`, and `metadata`; result/suspended events keep their own fresh result fields. Applied to the default engine's start/result/suspended emit paths, the foreach start event, and the evented engine's result/suspended emits (its start event was already clean). Persisted run snapshots and returned step results are unchanged - only what goes on the wire.

Before changing anything I audited every consumer of these events (server, client-js, react accumulator, ai-sdk transformer, playground reducers, docs). Three reducers build live run state from the events; they read `payload.id`, `status`, the input `payload` (from start events), and `output` (from result events) - all preserved. No consumer reads `output` on a start event; it existed only via the stale spread. All fields removed here were optional in `WorkflowStreamEvent`, so the public type shape is unchanged and this is not a breaking change. The input `payload` on result events is also deliberately kept (the AI SDK/Studio reducers treat result events as self-contained records).

Benchmark (production-shaped dountil loop over a nested agent-like workflow, 10 iterations, state growing to ~900 KB, run with #19217 applied to the tree):

| metric | before | after |
| --- | --- | --- |
| largest `workflow-step-start` event | 867 KB (`output` === `payload`, byte-identical) | 433 KB (input once) |
| `workflow-step-start` bytes per run | 6.73 MB | 4.49 MB (-33%) |
| total bytes per run on the topic | 16.62 MB | 14.38 MB |

Mapped to the production numbers, the measured 1.83 MB start events halve to ~0.92 MB. Note on #19217: it compacts the nested invoke *envelope* (`steps` map + `input`) against Inngest's body-size limit, but keeps `result` - and the watch event's `output` is `result.result` (the cumulative agent state itself), so #19217 does not shrink these events; the two fixes are complementary and there is no double-counting. The remaining per-event bytes are the load-bearing state that consumers render; shrinking those further would mean dropping fields Studio and the AI SDK actually read, which the consumer audit rules out.

Tests: new `watch-event-payload.test.ts` covers normal step, loop, nested-workflow-in-loop, suspend/resume, failure-after-success, and foreach resume, asserting prior-result blobs are absent (5 of 6 fail against the old code). Full core workflow + stream suites pass (57 files, 1358 tests), and the Inngest durable-agent suites pass against the built core with #19217 applied.

## Related issue(s)

Fixes #20660

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Workflow events no longer repeat old step data each time a workflow runs. This reduces event size and prevents memory problems while keeping current results and saved workflow data unchanged.

## Changes

- Added `omitPriorCompletionFields` to remove stale completion and suspension fields from watch-event payloads.
- Updated default, evented, step, and foreach workflow engines to use the filtered payloads.
- Preserved step inputs, statuses, timestamps, metadata, current results, persisted snapshots, and returned step results.
- Added regression tests for steps, loops, nested workflows, failures, suspend/resume, and foreach resume.
- Added a patch changeset for `@mastra/core`.
- Reduced workflow watch-event and topic payload sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->