### PR TITLE
feat(platform-workspace): route execs over private network when workspace-proxy discloses instanceUrl

### DIFF
--- a/.changeset/itchy-snakes-sell.md
+++ b/.changeset/itchy-snakes-sell.md
@@ -1,0 +1,33 @@
+---
+'@mastra/platform-workspace': minor
+---
+
+`PlatformSandbox.executeCommand` can now dial the sandbox directly over Railway's private network instead of going through the platform's public exec proxy. On paths where the direct route is available, per-exec latency drops from ~400 ms p50 to ~16 ms p50, and the exec stops touching the platform control plane. This flows through to every filesystem call (`SandboxFilesystem.readFile`, `writeFile`, `readdir`, `mkdir`, `stat`, `exists`, `copyFile`, `moveFile`, `deleteFile`), which is where most agent tool time was going.
+
+Direct-path availability is a runtime property, not a configuration knob. When it's not available — no address registry wired up, the workspace-proxy hasn't discovered the sandbox address yet, or a direct dial fails — `executeCommand` transparently falls back to the existing exec-lease path with no behavior change. Timed-out execs are never retried on the fallback path (they're returned to the caller as-is), so this is safe for non-idempotent commands.
+
+### Enabling the direct path
+
+Wire a `SandboxAddressRegistry` into `PlatformSandbox`:
+
+```ts
+import { PlatformSandbox, InProcessSandboxAddressRegistry } from '@mastra/platform-workspace';
+
+const registry = new InProcessSandboxAddressRegistry();
+
+const sandbox = new PlatformSandbox({
+  accessToken: process.env.MASTRA_PLATFORM_ACCESS_TOKEN,
+  projectId: process.env.MASTRA_PLATFORM_PROJECT_ID,
+  environmentId: process.env.MASTRA_PLATFORM_ENVIRONMENT_ID,
+  addressRegistry: registry,
+});
+```
+
+`PlatformSandbox.start()` populates the registry from the workspace-proxy's response; `executeCommand` reads it, tries the direct path first, evicts on transport failure. `destroy()` also evicts. `clone()` shares the same registry — each child sandbox looks up its own id.
+
+### New public exports
+
+- `SandboxAddressRegistry` — the `{ get, set, delete }` interface `PlatformSandbox` sees. Callers can implement their own (e.g. shared across a worker pool) or use the default.
+- `InProcessSandboxAddressRegistry` — the default `Map`-backed implementation.
+- `PlatformSandboxOptions.addressRegistry?` — DI seam. Optional; omitted keeps pre-existing behavior.
+- `execViaPrivateNetwork`, `PrivateNetExecHttpError`, `PrivateNetExecOptions`, `PrivateNetExecResult`, `PrivateNetFetch` — standalone transport for callers that want to talk to a sandbox directly without going through `PlatformSandbox`.

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -23,7 +23,7 @@ import { Mastra } from '@mastra/core/mastra';
 import { LocalSandbox } from '@mastra/core/workspace';
 import { LibSQLFactoryStorage } from '@mastra/libsql';
 import { PgVector, PgFactoryStorage } from '@mastra/pg';
-import { PlatformSandbox } from '@mastra/platform-workspace';
+import { InProcessSandboxAddressRegistry, PlatformSandbox } from '@mastra/platform-workspace';
 import { RedisStreamsPubSub } from '@mastra/redis-streams';
 import { getDatabasePath } from '@mastra/code-sdk/utils/project';
 import { DEFAULT_RETENTION } from '@mastra/code-sdk/utils/storage-maintenance';
@@ -154,10 +154,20 @@ function localSandboxEnv(): Record<string, string> {
 const PLATFORM_SANDBOX_ENV_KEYS = ['MASTRA_ENVIRONMENT_ID', 'MASTRA_PROJECT_ID', 'MASTRA_PLATFORM_SECRET_KEY'] as const;
 const hasPlatformSandboxEnv = PLATFORM_SANDBOX_ENV_KEYS.every(key => Boolean(process.env[key]?.trim()));
 
+// Private-network exec: the workspace-proxy discovers each sandbox's private
+// IPv6 during `POST /v1/projects/:pid/sandbox` and returns it as an
+// `instanceUrl` field. `PlatformSandbox.start()` copies that field into this
+// in-process registry; `PlatformSandbox.executeCommand()` reads it on every
+// exec to dial the sidecar's `POST /exec` directly over Railway's private
+// network, falling back to the lease path when no address is registered or
+// a dial fails. Only constructed when `PlatformSandbox` is in play; a
+// `LocalSandbox` dev run has no sidecar and no need for the registry.
+const sandboxAddressRegistry = hasPlatformSandboxEnv ? new InProcessSandboxAddressRegistry() : undefined;
+
 // Use PlatformSandbox only when its complete identity is configured. Otherwise
 // fall back to LocalSandbox for single-user development.
 const sandbox = hasPlatformSandboxEnv
-  ? new PlatformSandbox()
+  ? new PlatformSandbox({ addressRegistry: sandboxAddressRegistry })
   : new LocalSandbox({
       workingDirectory:
         process.env.MASTRACODE_LOCAL_SANDBOX_ROOT?.trim() || join(homedir(), '.mastracode', 'web', 'sandboxes'),

--- a/workspaces/platform-workspace/src/address-registry.test.ts
+++ b/workspaces/platform-workspace/src/address-registry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { InProcessSandboxAddressRegistry } from './address-registry.js';
+
+describe('InProcessSandboxAddressRegistry', () => {
+  it('returns undefined for an unknown sandbox id', () => {
+    const registry = new InProcessSandboxAddressRegistry();
+    expect(registry.get('sbx_missing')).toBeUndefined();
+  });
+
+  it('round-trips a set → get', () => {
+    const registry = new InProcessSandboxAddressRegistry();
+    registry.set('sbx_1', 'http://[fd12::1]:47000');
+    expect(registry.get('sbx_1')).toBe('http://[fd12::1]:47000');
+  });
+
+  it('overwrites on repeat set', () => {
+    const registry = new InProcessSandboxAddressRegistry();
+    registry.set('sbx_1', 'http://[fd12::1]:47000');
+    registry.set('sbx_1', 'http://[fd12::2]:47000');
+    expect(registry.get('sbx_1')).toBe('http://[fd12::2]:47000');
+  });
+
+  it('delete removes the entry and is a no-op on unknown ids', () => {
+    const registry = new InProcessSandboxAddressRegistry();
+    registry.set('sbx_1', 'http://[fd12::1]:47000');
+    registry.delete('sbx_1');
+    expect(registry.get('sbx_1')).toBeUndefined();
+    // No throw on unknown id.
+    registry.delete('sbx_missing');
+  });
+
+  it('tracks isolated entries for independent sandbox ids', () => {
+    const registry = new InProcessSandboxAddressRegistry();
+    registry.set('sbx_a', 'http://[fd12::a]:47000');
+    registry.set('sbx_b', 'http://[fd12::b]:47000');
+    expect(registry.get('sbx_a')).toBe('http://[fd12::a]:47000');
+    expect(registry.get('sbx_b')).toBe('http://[fd12::b]:47000');
+    expect(registry.size).toBe(2);
+  });
+});

--- a/workspaces/platform-workspace/src/address-registry.ts
+++ b/workspaces/platform-workspace/src/address-registry.ts
@@ -1,0 +1,60 @@
+/**
+ * In-process `sandboxId → instanceUrl` registry populated by
+ * {@link PlatformSandbox.start} from the `instanceUrl` field workspace-proxy
+ * includes on create + get responses, and consumed by
+ * {@link PlatformSandbox.executeCommand} on the private-network fast path.
+ *
+ * The registry lives in the same Node process as the `PlatformSandbox`
+ * consumer — for shipyard, that is the Mastra runtime deployed from
+ * `mastracode/web`. There is no receiver route and no cross-service dance;
+ * the address is just a field copied from a response the runtime already
+ * receives.
+ *
+ * State intentionally does not persist:
+ *
+ *  - The IPv6 rotates on every sandbox recreate.
+ *  - The URL has no meaning after the sandbox is destroyed.
+ *  - The live sandbox binding, session context, and lease all die with the
+ *    runtime process; the address dying with them is correct.
+ *  - The proxy's `environment_sandboxes.instance_url` column is the durable
+ *    source of truth — a runtime restart re-populates the registry on the
+ *    next `start()` / reattach from the proxy's response.
+ */
+
+import type { SandboxAddressRegistry } from './sandbox.js';
+
+/**
+ * Concrete in-process {@link SandboxAddressRegistry}. Backed by a `Map`; no
+ * eviction policy, no TTL — entries live until an observed transport failure
+ * calls `delete`, until the sandbox is explicitly destroyed, or until the
+ * process exits.
+ */
+export class InProcessSandboxAddressRegistry implements SandboxAddressRegistry {
+  readonly #map = new Map<string, string>();
+
+  get(sandboxId: string): string | undefined {
+    return this.#map.get(sandboxId);
+  }
+
+  /**
+   * Populate or overwrite the address for a sandbox. Called by
+   * {@link PlatformSandbox.start} on every fresh provision and every reattach;
+   * overwriting is intentional so a re-provision with a fresh IPv6 heals the
+   * map without a branch.
+   */
+  set(sandboxId: string, instanceUrl: string): void {
+    this.#map.set(sandboxId, instanceUrl);
+  }
+
+  delete(sandboxId: string): void {
+    this.#map.delete(sandboxId);
+  }
+
+  /**
+   * Test-only introspection. Not part of {@link SandboxAddressRegistry} —
+   * production callers must not read the registry as a whole.
+   */
+  get size(): number {
+    return this.#map.size;
+  }
+}

--- a/workspaces/platform-workspace/src/index.ts
+++ b/workspaces/platform-workspace/src/index.ts
@@ -6,5 +6,14 @@ export {
   SandboxDestroyedError,
   type PlatformSandboxOptions,
   type PlatformSandboxNetworkIsolation,
+  type SandboxAddressRegistry,
 } from './sandbox.js';
 export { platformFilesystemProvider, platformSandboxProvider } from './provider.js';
+export {
+  execViaPrivateNetwork,
+  PrivateNetExecHttpError,
+  type PrivateNetExecOptions,
+  type PrivateNetExecResult,
+  type PrivateNetFetch,
+} from './private-net-exec.js';
+export { InProcessSandboxAddressRegistry } from './address-registry.js';

--- a/workspaces/platform-workspace/src/private-net-exec.test.ts
+++ b/workspaces/platform-workspace/src/private-net-exec.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from 'vitest';
+import { execViaPrivateNetwork, PrivateNetExecHttpError, type PrivateNetFetch } from './private-net-exec.js';
+
+/**
+ * Build a fake fetch that returns a streaming Response driven by the frames
+ * pushed onto the returned `push`/`end` handles. Lets tests drive the NDJSON
+ * frame protocol chunk-by-chunk without a real HTTP server.
+ */
+function streamingFetch(): {
+  fetch: PrivateNetFetch;
+  push: (chunk: string) => void;
+  end: () => void;
+  fail: (err: Error) => void;
+  calls: Array<{ url: string; init: RequestInit | undefined }>;
+} {
+  const encoder = new TextEncoder();
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  let controllerRef: ReadableStreamDefaultController<Uint8Array> | undefined;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controllerRef = controller;
+    },
+  });
+
+  const fetch: PrivateNetFetch = async (input, init) => {
+    calls.push({ url: String(input), init });
+    // Honor upstream aborts by erroring the stream — matches how a real
+    // fetch surfaces `AbortController.abort()` to a mid-stream reader.
+    init?.signal?.addEventListener('abort', () => {
+      try {
+        controllerRef?.error(new Error('aborted'));
+      } catch {
+        /* already closed */
+      }
+    });
+    return new Response(stream, { status: 200, headers: { 'content-type': 'text/plain' } });
+  };
+
+  return {
+    fetch,
+    push: chunk => controllerRef!.enqueue(encoder.encode(chunk)),
+    end: () => controllerRef!.close(),
+    fail: err => controllerRef!.error(err),
+    calls,
+  };
+}
+
+describe('execViaPrivateNetwork', () => {
+  it('posts to `<instanceUrl>/exec` with a JSON envelope and parses NDJSON frames end-to-end', async () => {
+    const { fetch, push, end, calls } = streamingFetch();
+
+    const promise = execViaPrivateNetwork('http://[fd00::1]:47000', {
+      command: 'echo hi',
+      cwd: '/workspace',
+      env: { A: '1' },
+      fetch,
+    });
+
+    // Drive the response stream.
+    push('{"type":"stdout","data":"hi\\n"}\n');
+    push('{"type":"exit","code":0}\n');
+    end();
+
+    const result = await promise;
+    expect(result).toEqual({
+      exitCode: 0,
+      stdout: 'hi\n',
+      stderr: '',
+      timedOut: false,
+      opened: true,
+      status: 200,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('http://[fd00::1]:47000/exec');
+    const body = JSON.parse(calls[0]!.init!.body as string);
+    expect(body).toEqual({ command: 'echo hi', cwd: '/workspace', env: { A: '1' } });
+    // No auth header when bearerToken is not supplied — private-network is
+    // the auth boundary.
+    const headers = new Headers(calls[0]!.init!.headers);
+    expect(headers.get('authorization')).toBeNull();
+    expect(headers.get('content-type')).toBe('application/json');
+  });
+
+  it('forwards a bearer token when supplied', async () => {
+    const { fetch, push, end, calls } = streamingFetch();
+    const promise = execViaPrivateNetwork('http://[fd00::1]:47000', {
+      command: 'true',
+      bearerToken: 'secret-xyz',
+      fetch,
+    });
+    push('{"type":"exit","code":0}\n');
+    end();
+    await promise;
+    const headers = new Headers(calls[0]!.init!.headers);
+    expect(headers.get('authorization')).toBe('Bearer secret-xyz');
+  });
+
+  it('handles frames that arrive split across chunks (partial NDJSON lines)', async () => {
+    const { fetch, push, end } = streamingFetch();
+    const chunks: string[] = [];
+    const promise = execViaPrivateNetwork('http://[fd00::1]:47000', {
+      command: 'echo split',
+      onStdout: c => chunks.push(c),
+      fetch,
+    });
+
+    push('{"type":"stdout","data":"hel');
+    push('lo\\n"}\n{"type":"std');
+    push('out","data":"world\\n"}\n');
+    push('{"type":"exit","code":0}\n');
+    end();
+
+    const result = await promise;
+    expect(result.stdout).toBe('hello\nworld\n');
+    expect(chunks).toEqual(['hello\n', 'world\n']);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('accumulates stderr frames separately from stdout', async () => {
+    const { fetch, push, end } = streamingFetch();
+    const promise = execViaPrivateNetwork('http://[fd00::1]:47000', {
+      command: 'runit',
+      fetch,
+    });
+    push('{"type":"stdout","data":"out"}\n');
+    push('{"type":"stderr","data":"err"}\n');
+    push('{"type":"exit","code":2}\n');
+    end();
+
+    const result = await promise;
+    expect(result).toMatchObject({ stdout: 'out', stderr: 'err', exitCode: 2, timedOut: false });
+  });
+
+  it('returns opened=false and transportErrorMessage when the connection is refused', async () => {
+    const fetch: PrivateNetFetch = async () => {
+      throw new Error('connect ECONNREFUSED');
+    };
+    const result = await execViaPrivateNetwork('http://[fd00::1]:47000', { command: 'x', fetch });
+    expect(result).toMatchObject({
+      opened: false,
+      exitCode: null,
+      timedOut: false,
+      transportErrorMessage: expect.stringContaining('ECONNREFUSED'),
+    });
+  });
+
+  it('throws PrivateNetExecHttpError on a non-2xx response from the sidecar', async () => {
+    const fetch: PrivateNetFetch = async () =>
+      new Response('boom', { status: 500, headers: { 'content-type': 'text/plain' } });
+    await expect(execViaPrivateNetwork('http://[fd00::1]:47000', { command: 'x', fetch })).rejects.toBeInstanceOf(
+      PrivateNetExecHttpError,
+    );
+  });
+
+  it('returns exitCode=null with opened=true when the stream closes without an exit frame', async () => {
+    const { fetch, push, end } = streamingFetch();
+    const promise = execViaPrivateNetwork('http://[fd00::1]:47000', { command: 'x', fetch });
+    push('{"type":"stdout","data":"partial\\n"}\n');
+    end();
+    const result = await promise;
+    expect(result).toMatchObject({
+      exitCode: null,
+      stdout: 'partial\n',
+      opened: true,
+      timedOut: false,
+    });
+  });
+
+  it('returns timedOut=true with exitCode=124 when timeoutMs elapses before the exit frame', async () => {
+    vi.useFakeTimers();
+    try {
+      const { fetch, push } = streamingFetch();
+      const promise = execViaPrivateNetwork('http://[fd00::1]:47000', {
+        command: 'sleep',
+        timeoutMs: 50,
+        fetch,
+      });
+      // Push some stdout but never an exit frame.
+      push('{"type":"stdout","data":"..."}\n');
+      await vi.advanceTimersByTimeAsync(100);
+      const result = await promise;
+      expect(result.timedOut).toBe(true);
+      expect(result.exitCode).toBe(124);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores unknown frame types (forward-compat)', async () => {
+    const { fetch, push, end } = streamingFetch();
+    const promise = execViaPrivateNetwork('http://[fd00::1]:47000', { command: 'x', fetch });
+    push('{"type":"progress","pct":50}\n');
+    push('{"type":"stdout","data":"ok\\n"}\n');
+    push('{"type":"exit","code":0}\n');
+    end();
+    const result = await promise;
+    expect(result).toMatchObject({ stdout: 'ok\n', exitCode: 0 });
+  });
+
+  it('tolerates malformed JSON lines without crashing the parser', async () => {
+    const { fetch, push, end } = streamingFetch();
+    const promise = execViaPrivateNetwork('http://[fd00::1]:47000', { command: 'x', fetch });
+    push('not-json\n');
+    push('{"type":"stdout","data":"ok\\n"}\n');
+    push('{"type":"exit","code":0}\n');
+    end();
+    const result = await promise;
+    expect(result).toMatchObject({ stdout: 'ok\n', exitCode: 0 });
+  });
+
+  it('strips a trailing slash from the base URL before appending /exec', async () => {
+    const { fetch, push, end, calls } = streamingFetch();
+    const promise = execViaPrivateNetwork('http://[fd00::1]:47000/', { command: 'x', fetch });
+    push('{"type":"exit","code":0}\n');
+    end();
+    await promise;
+    expect(calls[0]!.url).toBe('http://[fd00::1]:47000/exec');
+  });
+
+  it('processes a final line that arrives without a trailing newline (EOF flush)', async () => {
+    const { fetch, push, end } = streamingFetch();
+    const promise = execViaPrivateNetwork('http://[fd00::1]:47000', { command: 'x', fetch });
+    push('{"type":"stdout","data":"ok\\n"}\n');
+    // Last frame with no trailing newline — depends on the EOF flush path.
+    push('{"type":"exit","code":7}');
+    end();
+    const result = await promise;
+    expect(result.exitCode).toBe(7);
+    expect(result.stdout).toBe('ok\n');
+  });
+});

--- a/workspaces/platform-workspace/src/private-net-exec.ts
+++ b/workspaces/platform-workspace/src/private-net-exec.ts
@@ -1,0 +1,303 @@
+/**
+ * Private-network exec client — dials the in-sandbox sidecar HTTP server
+ * directly over Railway's private IPv6 network, bypassing the workspace-proxy
+ * exec lease and the public tcp-proxy WebSocket entirely.
+ *
+ * Wire spec (matches the sidecar's `POST /exec` route, see
+ * `.scratch/factory-deploy/issue-sandbox-sidecar-agent-in-base-image.md` in
+ * the Platform repo):
+ *
+ * - Request:  `POST ${instanceUrl}/exec` with JSON body
+ *   `{command, cwd?, env?, timeoutMs?}`.
+ * - Response: `text/plain` NDJSON, one JSON object per line, terminated by an
+ *   `exit` frame:
+ *     `{"type":"stdout","data":"…"}`
+ *     `{"type":"stderr","data":"…"}`
+ *     `{"type":"exit","code":<number>}`
+ *
+ * Auth is *network position* — the private ULA IPv6 space is only reachable
+ * from workloads inside this Railway environment, and every workload there is
+ * our own code. A bearer secret adds no boundary today so we do not send one;
+ * `bearerToken` is accepted here as a defense-in-depth hook for when
+ * untrusted-tenant sandboxes eventually share a private network.
+ *
+ * Return shape mirrors {@link ../direct-exec.ts}'s `DirectExecResult` so the
+ * caller in `sandbox.ts` can hand results back with no translation regardless
+ * of which transport served the exec.
+ */
+
+/**
+ * Minimal fetch surface this module depends on. Matches the global `fetch`
+ * exposed by Node 22+ (undici) and the browser. Extracted so tests can inject
+ * a fake without spinning up a real HTTP server.
+ */
+export type PrivateNetFetch = typeof fetch;
+
+/** Inputs to a private-network exec invocation. Mirrors {@link DirectExecOptions}. */
+export interface PrivateNetExecOptions {
+  command: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  /**
+   * Wall-clock cap for the exec. When elapsed, we abort the request and
+   * return `{timedOut: true, exitCode: 124}` matching the semantics of
+   * `direct-exec.ts` (and the proxy's `/exec` route before it).
+   */
+  timeoutMs?: number;
+  onStdout?: (chunk: string) => void;
+  onStderr?: (chunk: string) => void;
+  /** Injected for tests. Defaults to `globalThis.fetch`. */
+  fetch?: PrivateNetFetch;
+  /**
+   * Optional bearer secret forwarded as `Authorization: Bearer <token>`.
+   * Not required today (network position is the boundary). Present so we can
+   * flip on per-sandbox secrets in a follow-up without a client-side reshape.
+   */
+  bearerToken?: string;
+}
+
+/**
+ * Result of a private-network exec. Same shape as `DirectExecResult` — the
+ * caller does not care which transport produced it.
+ *
+ * `exitCode` is `null` when the response body ended without an `exit` frame
+ * AND the exec did not time out. That is a transport-level failure (the
+ * sidecar died mid-stream or the socket was cut) and callers should treat it
+ * as such (invalidate the cached `instanceUrl`, fall back to the lease path).
+ */
+export interface PrivateNetExecResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  /**
+   * True when we got a full HTTP response (status + at least the response
+   * headers), even if the stream later dropped. False when we could not
+   * establish the connection or the sidecar refused the request outright.
+   * Used by the caller to distinguish "sidecar unreachable" (invalidate
+   * cache) from "sidecar answered but the stream broke" (still invalidate,
+   * but log differently).
+   */
+  opened: boolean;
+  /** HTTP status when we got a response. Undefined on connection failure. */
+  status?: number;
+  /** Populated when we could not even open the request (DNS/connect/TLS). */
+  transportErrorMessage?: string;
+}
+
+/**
+ * Thrown by {@link execViaPrivateNetwork} when the sidecar returns a non-2xx
+ * HTTP response. This is an *application* error, not a transport error — the
+ * sidecar is reachable and answered, it just refused the exec. Callers should
+ * fall back to the lease path for this one call but MUST NOT invalidate the
+ * cached `instanceUrl` (the address is still good).
+ */
+export class PrivateNetExecHttpError extends Error {
+  readonly status: number;
+  readonly body: string;
+
+  constructor(status: number, body: string) {
+    super(`Sidecar /exec returned ${status}${body ? `: ${body.slice(0, 200)}` : ''}`);
+    this.name = 'PrivateNetExecHttpError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+const DEFAULT_FETCH: PrivateNetFetch = (input, init) => {
+  const f = (globalThis as { fetch?: typeof fetch }).fetch;
+  if (!f) {
+    throw new Error(
+      'Private-network exec requires a fetch implementation. Node 22+ provides one globally; on older runtimes, pass fetch explicitly.',
+    );
+  }
+  return f(input, init);
+};
+
+/**
+ * Wire frame shapes accepted from the sidecar. Anything else on the stream
+ * is ignored so a future sidecar can add new frame types without breaking
+ * older clients.
+ */
+type SidecarFrame =
+  | { type: 'stdout'; data: string }
+  | { type: 'stderr'; data: string }
+  | { type: 'exit'; code: number };
+
+/**
+ * Dial `${instanceUrl}/exec` and stream the response, resolving with the
+ * accumulated stdout/stderr + exit code.
+ *
+ * Errors:
+ * - Connection failure (DNS, refused, reset) → resolves with
+ *   `{opened:false, exitCode:null, transportErrorMessage}`. Never throws for
+ *   transport failures — the shape matches the lease-path result so the
+ *   caller can treat both transports uniformly.
+ * - Non-2xx HTTP response from the sidecar → throws {@link PrivateNetExecHttpError}.
+ *   Application-level; caller decides whether to fall back.
+ * - Stream ends without an `exit` frame → resolves with
+ *   `{opened:true, exitCode:null}`, matching the lease-path semantics for a
+ *   mid-stream drop.
+ * - `timeoutMs` elapsed → aborts the request, resolves with
+ *   `{timedOut:true, exitCode:124}`.
+ */
+export async function execViaPrivateNetwork(
+  instanceUrl: string,
+  options: PrivateNetExecOptions,
+): Promise<PrivateNetExecResult> {
+  const fetchImpl = options.fetch ?? DEFAULT_FETCH;
+  const url = `${instanceUrl.replace(/\/$/, '')}/exec`;
+
+  const controller = new AbortController();
+  let timedOut = false;
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+  if (options.timeoutMs !== undefined && options.timeoutMs > 0) {
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, options.timeoutMs);
+  }
+
+  const body: Record<string, unknown> = { command: options.command };
+  if (options.cwd) body.cwd = options.cwd;
+  if (options.env && Object.keys(options.env).length > 0) body.env = options.env;
+  if (options.timeoutMs !== undefined && options.timeoutMs > 0) body.timeoutMs = options.timeoutMs;
+
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (options.bearerToken) headers.authorization = `Bearer ${options.bearerToken}`;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+    // AbortError from our own timeout → treat as timeout, not transport error.
+    if (timedOut) {
+      return {
+        exitCode: 124,
+        stdout: '',
+        stderr: '',
+        timedOut: true,
+        opened: false,
+      };
+    }
+    return {
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      opened: false,
+      transportErrorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  if (!response.ok) {
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+    const text = await response.text().catch(() => '');
+    throw new PrivateNetExecHttpError(response.status, text);
+  }
+
+  if (!response.body) {
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+    // A 200 without a body is a broken sidecar. Treat as mid-stream drop
+    // (opened=true, no exit frame) so the caller invalidates cache.
+    return {
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      opened: true,
+      status: response.status,
+    };
+  }
+
+  let stdout = '';
+  let stderr = '';
+  let exitCode: number | null = null;
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const handleLine = (line: string): void => {
+    if (!line) return;
+    let frame: SidecarFrame | undefined;
+    try {
+      frame = JSON.parse(line) as SidecarFrame;
+    } catch {
+      // Unknown / malformed frame — ignore. A well-behaved sidecar only emits
+      // JSON objects, but tolerating garbage protects against a partial write.
+      return;
+    }
+    if (!frame || typeof frame !== 'object') return;
+    if (frame.type === 'stdout' && typeof frame.data === 'string') {
+      stdout += frame.data;
+      options.onStdout?.(frame.data);
+    } else if (frame.type === 'stderr' && typeof frame.data === 'string') {
+      stderr += frame.data;
+      options.onStderr?.(frame.data);
+    } else if (frame.type === 'exit' && typeof frame.code === 'number') {
+      exitCode = frame.code;
+    }
+    // Any other frame type is intentionally ignored (see SidecarFrame jsdoc).
+  };
+
+  try {
+    const reader = response.body.getReader();
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      // NDJSON: split on newline; last piece stays in buffer for the next chunk.
+      let newlineIdx = buffer.indexOf('\n');
+      while (newlineIdx !== -1) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+        handleLine(line);
+        newlineIdx = buffer.indexOf('\n');
+      }
+    }
+    // Flush the decoder + any trailing (no-newline) line at EOF.
+    buffer += decoder.decode();
+    const trailing = buffer.trim();
+    if (trailing) handleLine(trailing);
+  } catch (error) {
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+    if (timedOut) {
+      return {
+        exitCode: 124,
+        stdout,
+        stderr,
+        timedOut: true,
+        opened: true,
+        status: response.status,
+      };
+    }
+    // Mid-stream failure. Return whatever we accumulated with exitCode=null
+    // so the caller sees this as a transport failure and can invalidate.
+    return {
+      exitCode,
+      stdout,
+      stderr,
+      timedOut: false,
+      opened: true,
+      status: response.status,
+      transportErrorMessage: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+  }
+
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    timedOut: false,
+    opened: true,
+    status: response.status,
+  };
+}

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { DirectExecWebSocket, DirectExecWebSocketFactory } from './direct-exec.js';
-import { PlatformSandbox } from './sandbox.js';
+import { PlatformSandbox, type SandboxAddressRegistry } from './sandbox.js';
 
 function json(body: unknown, init?: ResponseInit) {
   return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' }, ...init });
@@ -969,6 +969,562 @@ describe('PlatformSandbox', () => {
       expect(String(fetchMock.mock.calls[1]![0])).toBe(
         'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
       );
+    });
+  });
+
+  describe('private-network exec', () => {
+    /**
+     * Build a fake `privateNetFetch` that streams NDJSON frames driven by the
+     * caller. Mirrors the streamingFetch helper in private-net-exec.test.ts
+     * but scoped to this suite so the two files don't couple test helpers.
+     */
+    function streamingPrivateNetFetch() {
+      const encoder = new TextEncoder();
+      const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+      let controllerRef: ReadableStreamDefaultController<Uint8Array> | undefined;
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controllerRef = controller;
+        },
+      });
+      const fetch: typeof globalThis.fetch = async (input, init) => {
+        calls.push({ url: String(input), init });
+        return new Response(stream, { status: 200, headers: { 'content-type': 'text/plain' } });
+      };
+      return {
+        fetch,
+        calls,
+        push: (chunk: string) => controllerRef!.enqueue(encoder.encode(chunk)),
+        end: () => controllerRef!.close(),
+      };
+    }
+
+    /**
+     * Trivial in-memory implementation of the {@link SandboxAddressRegistry}
+     * three-method interface. On shipyard the same shape is populated by
+     * {@link PlatformSandbox.start} from the `instanceUrl` field on the
+     * workspace-proxy create/get response; here the test pre-seeds entries
+     * where convenient and observes `set`/`delete` calls to prove the
+     * lifecycle contract.
+     */
+    function fakeAddressRegistry(seed: Record<string, string> = {}) {
+      const entries = new Map<string, string>(Object.entries(seed));
+      const sets: Array<{ sandboxId: string; instanceUrl: string }> = [];
+      const deletes: string[] = [];
+      return {
+        registry: {
+          get: (id: string) => entries.get(id),
+          set: (id: string, url: string) => {
+            sets.push({ sandboxId: id, instanceUrl: url });
+            entries.set(id, url);
+          },
+          delete: (id: string) => {
+            deletes.push(id);
+            entries.delete(id);
+          },
+        } as SandboxAddressRegistry,
+        entries,
+        sets,
+        deletes,
+      };
+    }
+
+    it('routes execs to the sidecar over the private network when the registry has an address for the sandbox', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const { factory: wsFactory, sockets } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
+      const priv = streamingPrivateNetFetch();
+      const { registry } = fakeAddressRegistry({
+        sbx_1: 'http://[fd12:752d:16f5:1:d000:41:e7de:188c]:47000',
+      });
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: wsFactory,
+        privateNetFetch: priv.fetch,
+        addressRegistry: registry,
+      });
+
+      await sandbox._start();
+      const execPromise = sandbox.executeCommand('echo', ['ok'], { cwd: '/workspace', env: { A: '1' } });
+      priv.push('{"type":"stdout","data":"ok"}\n');
+      priv.push('{"type":"exit","code":0}\n');
+      priv.end();
+      const result = await execPromise;
+
+      expect(result).toMatchObject({ success: true, exitCode: 0, stdout: 'ok', command: 'echo ok' });
+      // Only the provision call to the proxy — no lease mint, no /exec-lease.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      // The lease-path WebSocket was never opened.
+      expect(sockets).toHaveLength(0);
+      // The private-net fetch was called against the sidecar URL from the registry.
+      expect(priv.calls).toHaveLength(1);
+      expect(priv.calls[0]!.url).toBe('http://[fd12:752d:16f5:1:d000:41:e7de:188c]:47000/exec');
+      const body = JSON.parse(priv.calls[0]!.init!.body as string);
+      expect(body).toEqual({ command: 'echo ok', cwd: '/workspace', env: { A: '1' } });
+    });
+
+    it('falls straight through to the lease path when the registry has no address for the sandbox', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      // Registry is empty — the proxy response had no `instanceUrl` (older
+      // proxy, or discovery on the proxy side hasn't produced one yet).
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse());
+      const { factory: wsFactory, sockets } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
+      const priv = streamingPrivateNetFetch();
+      const { registry } = fakeAddressRegistry();
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: wsFactory,
+        privateNetFetch: priv.fetch,
+        addressRegistry: registry,
+      });
+
+      await sandbox._start();
+      const result = await sandbox.executeCommand('echo', ['ok']);
+
+      expect(result).toMatchObject({ success: true, exitCode: 0, stdout: 'ok' });
+      // Private-net fetch never called — no address to dial.
+      expect(priv.calls).toHaveLength(0);
+      // Lease was minted and the WS opened.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(sockets).toHaveLength(1);
+    });
+
+    it('falls straight through to the lease path when no addressRegistry is configured at all', async () => {
+      // Callers that don't opt into the registry (existing code, non-factory
+      // deployments) must keep the pre-existing lease-only behavior — no
+      // private-net dial, no crash on the optional-chain lookup.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse());
+      const { factory: wsFactory, sockets } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
+      const priv = streamingPrivateNetFetch();
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: wsFactory,
+        privateNetFetch: priv.fetch,
+        // no addressRegistry
+      });
+
+      await sandbox._start();
+      const result = await sandbox.executeCommand('echo', ['ok']);
+
+      expect(result).toMatchObject({ success: true, exitCode: 0, stdout: 'ok' });
+      expect(priv.calls).toHaveLength(0);
+      expect(sockets).toHaveLength(1);
+    });
+
+    it('evicts the registry entry and falls back to the lease when the sidecar refuses the connection', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse());
+      const { factory: wsFactory, sockets } = fakeExecSocket({ exitCode: 0, stdout: 'fallback-ok' });
+      const privFetch: typeof globalThis.fetch = async () => {
+        throw new Error('connect ECONNREFUSED');
+      };
+      const { registry, deletes, entries } = fakeAddressRegistry({ sbx_1: 'http://[fd00::1]:47000' });
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: wsFactory,
+        privateNetFetch: privFetch,
+        addressRegistry: registry,
+      });
+
+      await sandbox._start();
+      const result = await sandbox.executeCommand('pwd');
+
+      // Fallback served the exec cleanly — no error surfaced to the caller.
+      expect(result).toMatchObject({ success: true, exitCode: 0, stdout: 'fallback-ok' });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(sockets).toHaveLength(1);
+      // The registry saw the exact delete for this sandboxId — the next
+      // start() has to re-read `instanceUrl` from the workspace-proxy
+      // response before subsequent execs will trust the private-net path
+      // again.
+      expect(deletes).toEqual(['sbx_1']);
+      expect(entries.has('sbx_1')).toBe(false);
+    });
+
+    it('does not re-dial the sidecar after a transport-level eviction until the registry is re-populated', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse())
+        .mockResolvedValueOnce(leaseResponse());
+      const { factory: wsFactory } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
+      let privCalls = 0;
+      const privFetch: typeof globalThis.fetch = async () => {
+        privCalls++;
+        throw new Error('connect ECONNREFUSED');
+      };
+      const { registry } = fakeAddressRegistry({ sbx_1: 'http://[fd00::1]:47000' });
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: wsFactory,
+        privateNetFetch: privFetch,
+        addressRegistry: registry,
+      });
+
+      await sandbox._start();
+      await sandbox.executeCommand('one');
+      await sandbox.executeCommand('two');
+
+      // Sidecar dialed exactly once — the first attempt evicted the registry
+      // entry so `two` skipped straight to the lease path without wasting a
+      // second connection.
+      expect(privCalls).toBe(1);
+    });
+
+    it('falls back for a single call without evicting the registry entry when the sidecar returns 500', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse());
+      const { factory: wsFactory } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
+
+      // First private-net call returns 500; second streams a valid exec.
+      let privCallCount = 0;
+      const encoder = new TextEncoder();
+      const privFetch: typeof globalThis.fetch = async () => {
+        privCallCount++;
+        if (privCallCount === 1) {
+          return new Response('sidecar bug', { status: 500 });
+        }
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode('{"type":"stdout","data":"second-ok"}\n'));
+            controller.enqueue(encoder.encode('{"type":"exit","code":0}\n'));
+            controller.close();
+          },
+        });
+        return new Response(stream, { status: 200 });
+      };
+      const { registry, deletes } = fakeAddressRegistry({ sbx_1: 'http://[fd00::1]:47000' });
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: wsFactory,
+        privateNetFetch: privFetch,
+        addressRegistry: registry,
+      });
+
+      await sandbox._start();
+      // First exec: 500 → fall back to lease. Registry entry preserved.
+      const first = await sandbox.executeCommand('one');
+      expect(first.stdout).toBe('ok');
+      // Second exec: sidecar back to normal → private-net path used again.
+      const second = await sandbox.executeCommand('two');
+      expect(second.stdout).toBe('second-ok');
+
+      // Both private-net attempts happened; the 500 did not evict the entry.
+      expect(privCallCount).toBe(2);
+      expect(deletes).toEqual([]);
+    });
+
+    it('clone looks up its own sandboxId in the shared registry, not the parent address', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_parent', createdAt: '2026-06-26T00:00:00.000Z' }))
+        // Child provisions its own sandbox.
+        .mockResolvedValueOnce(json({ id: 'sbx_child', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse());
+      const { factory: wsFactory, sockets } = fakeExecSocket({ exitCode: 0, stdout: 'child-ok' });
+      const priv = streamingPrivateNetFetch();
+      // Only the parent has a registered address. The child's sandbox id is
+      // absent from the registry (its sidecar hasn't posted ready yet).
+      const { registry } = fakeAddressRegistry({ sbx_parent: 'http://[fd00::parent]:47000' });
+
+      const parent = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: wsFactory,
+        privateNetFetch: priv.fetch,
+        addressRegistry: registry,
+      });
+      await parent._start();
+
+      const child = parent.clone();
+      await child._start();
+      const result = await child.executeCommand('pwd');
+
+      // Child went straight to the lease path — the shared registry has no
+      // entry for `sbx_child`, and the parent's `sbx_parent` address is not
+      // reachable via a child-scoped lookup.
+      expect(result.stdout).toBe('child-ok');
+      expect(priv.calls).toHaveLength(0);
+      expect(sockets).toHaveLength(1);
+    });
+
+    it('does not send an Authorization header on private-net execs — the private IPv6 network is the auth boundary', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const priv = streamingPrivateNetFetch();
+      const { registry } = fakeAddressRegistry({ sbx_1: 'http://[fd00::1]:47000' });
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        privateNetFetch: priv.fetch,
+        addressRegistry: registry,
+      });
+      await sandbox._start();
+      const execPromise = sandbox.executeCommand('x');
+      priv.push('{"type":"exit","code":0}\n');
+      priv.end();
+      await execPromise;
+
+      const headers = new Headers(priv.calls[0]!.init!.headers);
+      expect(headers.get('authorization')).toBeNull();
+    });
+
+    it('destroy() explicitly evicts the registry entry for the destroyed sandbox', async () => {
+      // The transport-failure path also self-heals, but a clean destroy must
+      // not leave a stale entry that will produce a dial-to-nowhere on the
+      // next exec against a reused instance.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(new Response(null, { status: 204 }));
+      const { registry, deletes, entries } = fakeAddressRegistry({ sbx_1: 'http://[fd00::1]:47000' });
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        addressRegistry: registry,
+      });
+
+      await sandbox._start();
+      await sandbox.destroy();
+
+      expect(deletes).toEqual(['sbx_1']);
+      expect(entries.has('sbx_1')).toBe(false);
+    });
+
+    it('returns a timed-out private-net result to the caller instead of re-running the command via lease', async () => {
+      // Regression: a pre-headers timeout used to classify as a transport
+      // failure because `opened=false`, so the caller would evict the
+      // address AND re-execute the same command through the lease path
+      // with a fresh timeout window. For non-idempotent work (rm, git
+      // push, DB migrations) that's a silent double-run and the caller
+      // never sees `timedOut: true`. `timedOut` must short-circuit the
+      // lease fallback.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const { factory: wsFactory, sockets } = fakeExecSocket({ exitCode: 0, stdout: 'lease-ran-it' });
+      const { registry, deletes, entries } = fakeAddressRegistry({ sbx_1: 'http://[fd12::1]:47000' });
+
+      // A private-net fetch that respects the AbortSignal — never resolves
+      // on its own, only rejects when the transport's own timer fires.
+      const privateNetCalls: Array<{ url: string; init: RequestInit | undefined }> = [];
+      const hangingFetch: typeof globalThis.fetch = (input, init) =>
+        new Promise((_resolve, reject) => {
+          privateNetCalls.push({ url: String(input), init });
+          init?.signal?.addEventListener('abort', () => {
+            const err = new Error('The operation was aborted.');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        });
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        timeout: 10,
+        fetch: fetchMock,
+        webSocketFactory: wsFactory,
+        privateNetFetch: hangingFetch,
+        addressRegistry: registry,
+      });
+      await sandbox._start();
+
+      const result = await sandbox.executeCommand('rm -rf /nope');
+
+      // The timed-out private-net attempt IS the answer — no lease mint,
+      // no WebSocket, no second execution.
+      expect(result.timedOut).toBe(true);
+      expect(result.exitCode).toBe(124);
+      expect(privateNetCalls).toHaveLength(1);
+      expect(sockets).toHaveLength(0);
+      // Only the initial create fetch happened; no /exec-lease follow-up.
+      expect(fetchMock.mock.calls).toHaveLength(1);
+      // Address is still evicted so the next exec doesn't dial into the
+      // same hang — but the timed-out RESULT went back to the caller.
+      expect(deletes).toEqual(['sbx_1']);
+      expect(entries.has('sbx_1')).toBe(false);
+    });
+
+    it('populates the registry from the create response instanceUrl field on a fresh provision', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(
+        json({
+          id: 'sbx_fresh',
+          createdAt: '2026-06-26T00:00:00.000Z',
+          instanceUrl: 'http://[fd12:752d:16f5:1:d000:41:e7de:188c]:47000',
+        }),
+      );
+      const { registry, sets, entries } = fakeAddressRegistry();
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        addressRegistry: registry,
+      });
+      await sandbox._start();
+
+      // The one `set` came from the create response — no discovery exec,
+      // no side channel. Field copy, that's it.
+      expect(sets).toEqual([
+        { sandboxId: 'sbx_fresh', instanceUrl: 'http://[fd12:752d:16f5:1:d000:41:e7de:188c]:47000' },
+      ]);
+      expect(entries.get('sbx_fresh')).toBe('http://[fd12:752d:16f5:1:d000:41:e7de:188c]:47000');
+    });
+
+    it('populates the registry from the reattach GET response instanceUrl on session recovery', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      // Reattach path: GET /sandbox/:id succeeds with the proxy-cached
+      // instanceUrl for a live sandbox. No POST /sandbox is issued.
+      const fetchMock = vi.fn().mockResolvedValueOnce(
+        json({
+          id: 'sbx_existing',
+          createdAt: '2026-06-26T00:00:00.000Z',
+          instanceUrl: 'http://[fd12::abcd]:47000',
+        }),
+      );
+      const { registry, sets } = fakeAddressRegistry();
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        sandboxId: 'sbx_existing',
+        fetch: fetchMock,
+        addressRegistry: registry,
+      });
+      await sandbox._start();
+
+      // Only the reattach GET fired — proxy's cached instanceUrl went
+      // straight into the registry with no extra round-trip.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing');
+      expect(sets).toEqual([{ sandboxId: 'sbx_existing', instanceUrl: 'http://[fd12::abcd]:47000' }]);
+    });
+
+    it('leaves the registry untouched when the create response omits instanceUrl', async () => {
+      // Older proxies that predate the discovery field, or a fresh provision
+      // where the proxy's discovery exec failed and it stored NULL.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse());
+      const { factory } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
+      const { registry, sets, entries } = fakeAddressRegistry();
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+        addressRegistry: registry,
+      });
+      await sandbox._start();
+      const result = await sandbox.executeCommand('echo ok');
+
+      // No `set` fired, registry stays empty, exec falls straight through
+      // to the lease path (proven by the /exec-lease mint on the second fetch).
+      expect(sets).toEqual([]);
+      expect(entries.size).toBe(0);
+      expect(result.success).toBe(true);
+      expect(String(fetchMock.mock.calls[1]![0])).toBe(
+        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/exec-lease',
+      );
+    });
+
+    it('leaves the registry untouched when the create response has instanceUrl: null', async () => {
+      // The proxy explicitly returns `null` when its discovery exec failed
+      // during Sandbox.create(); this must be treated the same as an absent
+      // field — leave the registry alone, exec via lease.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z', instanceUrl: null }));
+      const { registry, sets } = fakeAddressRegistry();
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        addressRegistry: registry,
+      });
+      await sandbox._start();
+
+      expect(sets).toEqual([]);
+    });
+
+    it('start() does not touch the registry when no addressRegistry is injected', async () => {
+      // Baseline: pre-existing callers that don't opt into the registry must
+      // continue to work unchanged even when the proxy starts returning
+      // instanceUrl on the response.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z', instanceUrl: 'http://[fd12::1]:47000' }),
+        );
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        // no addressRegistry
+      });
+
+      await expect(sandbox._start()).resolves.toBeUndefined();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -15,8 +15,34 @@ import type { PlatformClientOptions } from './client.js';
 import { PlatformApiError, PlatformClient } from './client.js';
 import type { DirectExecWebSocketFactory, ExecLease } from './direct-exec.js';
 import { execViaLease } from './direct-exec.js';
+import type { PrivateNetExecOptions, PrivateNetExecResult, PrivateNetFetch } from './private-net-exec.js';
+import { execViaPrivateNetwork, PrivateNetExecHttpError } from './private-net-exec.js';
 
 export type PlatformSandboxNetworkIsolation = 'ISOLATED' | 'PRIVATE';
+
+/**
+ * In-process `sandboxId → instanceUrl` map that lets
+ * {@link PlatformSandbox.executeCommand} dial the in-sandbox sidecar over
+ * Railway's private network instead of paying for a lease + WebSocket
+ * round-trip through Railway's public control plane.
+ *
+ * The workspace proxy discovers each sandbox's IPv6 during
+ * `POST /v1/projects/:pid/sandbox` and returns it as `instanceUrl` on the
+ * create + get responses (see the platform inline-discovery issue). The
+ * `PlatformSandbox` client copies that field into this registry from both
+ * {@link PlatformSandbox.start} branches (fresh provision + reattach), evicts
+ * on {@link PlatformSandbox.destroy}, and evicts again on any observed
+ * transport failure so the next exec falls back to the lease path cleanly.
+ *
+ * See:
+ *   - `.scratch/factory-deploy/issue-runtime-sandbox-address-discovery.md`
+ *   - `.scratch/factory-deploy/issue-platform-sandbox-exec-via-private-network.md`
+ */
+export interface SandboxAddressRegistry {
+  set(sandboxId: string, instanceUrl: string): void;
+  get(sandboxId: string): string | undefined;
+  delete(sandboxId: string): void;
+}
 
 export interface PlatformSandboxOptions extends Omit<MastraSandboxOptions, 'processes'>, PlatformClientOptions {
   id?: string;
@@ -34,6 +60,27 @@ export interface PlatformSandboxOptions extends Omit<MastraSandboxOptions, 'proc
    * without a real network socket.
    */
   webSocketFactory?: DirectExecWebSocketFactory;
+  /**
+   * Injected fetch implementation used by the private-network exec code path
+   * to dial the in-sandbox sidecar. Defaults to `globalThis.fetch` and only
+   * exists so tests can drive that transport without a real HTTP server.
+   * Note: this is separate from the `fetch` on {@link PlatformClientOptions},
+   * which is used for calls to the workspace proxy.
+   */
+  privateNetFetch?: PrivateNetFetch;
+  /**
+   * Registry that maps `sandboxId → instanceUrl` for the private-network
+   * exec path. When set, {@link PlatformSandbox.start} populates it from the
+   * `instanceUrl` field workspace-proxy returns on create + get responses,
+   * and {@link PlatformSandbox.executeCommand} looks it up before every exec
+   * and tries the private-network transport first, falling back to the lease
+   * path on any transport failure (and invalidating the registry entry so
+   * the next call goes to the lease path cleanly). When absent, all execs
+   * go straight to the lease path — this is the pre-existing behavior and
+   * the expected mode outside the shipyard runtime. See
+   * {@link SandboxAddressRegistry}.
+   */
+  addressRegistry?: SandboxAddressRegistry;
 }
 
 interface ExecLeaseResponse {
@@ -59,6 +106,17 @@ interface CreateSandboxResponse {
   status?: string;
   createdAt?: string;
   destroyedAt?: string | null;
+  /**
+   * Full sidecar URL (`http://[<ipv6>]:<port>`) the runtime can dial over
+   * Railway's private network to reach the in-sandbox exec sidecar. The
+   * workspace proxy discovers the sandbox's IPv6 during `Sandbox.create()`
+   * via one `sandbox.exec("awk … /proc/net/if_inet6")` and stores it in
+   * `environment_sandboxes.instance_url`; the same field is echoed on
+   * `GET /sandbox/:id`. `null` when discovery failed (returned by the proxy
+   * so the runtime knows to skip private-net dial for this sandbox rather
+   * than fall back on a missing-field ambiguity).
+   */
+  instanceUrl?: string | null;
 }
 
 /** Max attempts for `POST /sandbox` when the proxy returns transient 5xx errors. */
@@ -239,6 +297,19 @@ export class PlatformSandbox extends MastraSandbox {
   private readonly _instructionsOverride?: InstructionsOption;
   private _createdAt: Date | null = null;
   private readonly _webSocketFactory?: DirectExecWebSocketFactory;
+  private readonly _privateNetFetch?: PrivateNetFetch;
+  /**
+   * Registry that maps `sandboxId → instanceUrl` for the private-network
+   * exec path. Injected by the composition site via
+   * {@link PlatformSandboxOptions.addressRegistry} and populated by this
+   * class itself in `start()` when the workspace-proxy's create/reattach
+   * response includes an `instanceUrl` field. The registry IS the cache —
+   * there is no per-instance mirror on `PlatformSandbox`, so every exec is
+   * a `Map.get()` (in the default in-process impl) against the live view.
+   * When absent, executes go straight to the lease path with no extra
+   * round-trip.
+   */
+  private readonly _addressRegistry?: SandboxAddressRegistry;
   /**
    * Cached exec lease for this sandbox. `null` before the first exec and
    * after {@link destroy}. Refreshed when `expiresAt - LEASE_REFRESH_MARGIN_MS < now`
@@ -267,6 +338,8 @@ export class PlatformSandbox extends MastraSandbox {
     this._timeout = options.timeout;
     this._instructionsOverride = options.instructions;
     this._webSocketFactory = options.webSocketFactory;
+    this._privateNetFetch = options.privateNetFetch;
+    this._addressRegistry = options.addressRegistry;
   }
 
   private generateId(): string {
@@ -306,6 +379,12 @@ export class PlatformSandbox extends MastraSandbox {
       ...(this._timeout !== undefined && { timeout: this._timeout }),
       ...(this._instructionsOverride !== undefined && { instructions: this._instructionsOverride }),
       ...(this._webSocketFactory !== undefined && { webSocketFactory: this._webSocketFactory }),
+      ...(this._privateNetFetch !== undefined && { privateNetFetch: this._privateNetFetch }),
+      // Propagate the registry — the clone is a different sandbox with a
+      // different id, so it will `get()` its OWN address (or nothing) out
+      // of the shared registry, not the parent's. See
+      // `.scratch/factory-deploy/issue-platform-sandbox-exec-via-private-network.md`.
+      ...(this._addressRegistry !== undefined && { addressRegistry: this._addressRegistry }),
     });
   }
 
@@ -319,6 +398,7 @@ export class PlatformSandbox extends MastraSandbox {
         // provision instead of pointing exec at a dead resource.
         if (!json.destroyedAt) {
           this._createdAt = json.createdAt ? new Date(json.createdAt) : new Date();
+          this._populateAddressFromResponse(json);
           return;
         }
         this._sandboxId = undefined;
@@ -364,6 +444,29 @@ export class PlatformSandbox extends MastraSandbox {
     const json = (await response.json()) as CreateSandboxResponse;
     this._sandboxId = json.id;
     this._createdAt = json.createdAt ? new Date(json.createdAt) : new Date();
+    this._populateAddressFromResponse(json);
+  }
+
+  /**
+   * Copy `response.instanceUrl` into the injected {@link SandboxAddressRegistry}
+   * when both are present. Called from both {@link start} branches (fresh
+   * provision + reattach) with the workspace-proxy response for this sandbox.
+   *
+   * The proxy discovers the IPv6 during `Sandbox.create()` and stores it in
+   * `environment_sandboxes.instance_url`; both the create response and
+   * `GET /sandbox/:id` echo the same field. The runtime does not do any
+   * discovery of its own — it only mirrors the field into an in-process map
+   * so {@link executeCommand} can `Map.get()` before every exec without an
+   * HTTP round-trip.
+   *
+   * `null`/absent `instanceUrl` (proxy discovery failed, or an older proxy
+   * that predates the field) leaves the registry untouched — executes fall
+   * through to the lease path with no branch here.
+   */
+  private _populateAddressFromResponse(json: CreateSandboxResponse): void {
+    if (!this._addressRegistry) return;
+    if (!json.instanceUrl) return;
+    this._addressRegistry.set(json.id, json.instanceUrl);
   }
 
   async stop(): Promise<void> {
@@ -372,7 +475,8 @@ export class PlatformSandbox extends MastraSandbox {
 
   async destroy(): Promise<void> {
     if (!this._sandboxId) return;
-    await this._client.request(`/sandbox/${encodeURIComponent(this._sandboxId)}`, { method: 'DELETE' });
+    const destroyedSandboxId = this._sandboxId;
+    await this._client.request(`/sandbox/${encodeURIComponent(destroyedSandboxId)}`, { method: 'DELETE' });
     // Clear local state so a subsequent start() creates a fresh remote sandbox
     // instead of taking the reattach branch and pointing exec at a deleted resource.
     this._sandboxId = undefined;
@@ -380,6 +484,13 @@ export class PlatformSandbox extends MastraSandbox {
     // Drop the exec lease with the sandbox — the JWT is tied to the provider
     // instance id and would be rejected against a fresh one.
     this._lease = null;
+    // Evict the sidecar address from the registry explicitly. Destroy
+    // deallocates the IPv6, so any stale entry would be a dial-to-nowhere;
+    // clearing here prevents a transport-failure round-trip on the next
+    // exec against a reused instance. A subsequent start() (fresh provision
+    // or reattach) will re-populate the entry from the workspace-proxy's
+    // response.
+    this._addressRegistry?.delete(destroyedSandboxId);
   }
 
   /**
@@ -410,14 +521,43 @@ export class PlatformSandbox extends MastraSandbox {
     // the value is 0, which disables the client-side timer entirely.
     const effectiveTimeout = options?.timeout ?? this._timeout;
 
-    // Direct-exec (WebSocket straight to Railway's tcp-proxy) is the only
-    // data plane. `_runDirectExec` handles single-shot transport retry and
-    // throws typed errors on unrecoverable failure: `SandboxDestroyedError`
-    // when `/exec-lease` returns 410 (fleet must reprovision),
-    // `SandboxExecTransportError` when the WebSocket transport fails twice
-    // against a live sandbox, `PlatformApiError` for other `/exec-lease`
-    // errors (404/500/501). See ./direct-exec.ts and
-    // `docs/factory/direct-sandbox-connection.md` in the Platform repo.
+    // Preferred path: dial the in-sandbox sidecar over Railway's private
+    // network (~16 ms p50). No GraphQL, no lease mint, no public tcp-proxy.
+    // Available only when the in-process address registry has an entry for
+    // this sandboxId — populated by start() from the workspace-proxy's
+    // create/reattach response when the proxy discloses `instanceUrl`. On
+    // any transport failure (connection refused, mid-stream drop, no exit
+    // frame) we invalidate the registry entry and fall through to the lease
+    // path — application-level failures (sidecar returns 5xx) still fall
+    // back for this call but do NOT invalidate the entry. See
+    // `.scratch/factory-deploy/issue-platform-sandbox-exec-via-private-network.md`.
+    const instanceUrl = this._addressRegistry?.get(this._sandboxId);
+    if (instanceUrl) {
+      const privateNet = await this._tryExecViaPrivateNetwork(instanceUrl, fullCommand, effectiveTimeout, options);
+      if (privateNet) {
+        const privateExit = privateNet.exitCode ?? 124;
+        return {
+          success: privateExit === 0,
+          exitCode: privateExit,
+          stdout: privateNet.stdout,
+          stderr: privateNet.stderr,
+          timedOut: privateNet.timedOut,
+          command: fullCommand,
+          executionTimeMs: Date.now() - started,
+        };
+      }
+      // Fall through — `_tryExecViaPrivateNetwork` already evicted the
+      // registry entry if this was a transport failure.
+    }
+
+    // Fallback: WebSocket direct-exec via `/exec-lease`. `_runDirectExec`
+    // handles single-shot transport retry and throws typed errors on
+    // unrecoverable failure: `SandboxDestroyedError` when `/exec-lease`
+    // returns 410 (fleet must reprovision), `SandboxExecTransportError`
+    // when the WebSocket transport fails twice against a live sandbox,
+    // `PlatformApiError` for other `/exec-lease` errors (404/500/501).
+    // See ./direct-exec.ts and `docs/factory/direct-sandbox-connection.md`
+    // in the Platform repo.
     const result = await this._runDirectExec(fullCommand, effectiveTimeout, options);
     // `_runDirectExec` throws on transport failure (see its jsdoc), so a
     // `null` exitCode here can only mean `timedOut: true` — the sandbox
@@ -550,6 +690,93 @@ export class PlatformSandbox extends MastraSandbox {
         wsEndpoint: lease.wsEndpoint,
       },
     );
+  }
+
+  /**
+   * Try to run the exec against the in-sandbox sidecar over Railway's private
+   * network. Returns the result on success (including non-zero exit codes and
+   * timeouts — those are real command results, not failures). Returns
+   * `undefined` when the caller should fall back to the lease path:
+   *
+   * - Transport failure (connection refused, mid-stream drop, no `exit`
+   *   frame). The registry entry is evicted so subsequent execs skip the
+   *   private-net dial until the sidecar re-registers.
+   * - Sidecar answered with a non-2xx HTTP status. Registry is left intact —
+   *   the address is still valid; something else is wrong (bad request,
+   *   sidecar bug). Only this specific exec falls back.
+   */
+  private async _tryExecViaPrivateNetwork(
+    instanceUrl: string,
+    fullCommand: string,
+    effectiveTimeout: number | undefined,
+    options: ExecuteCommandOptions | undefined,
+  ): Promise<PrivateNetExecResult | undefined> {
+    // Match the env-filter dance in `_runDirectExec`: ExecuteCommandOptions.env
+    // is NodeJS.ProcessEnv (string | undefined) but the wire body wants a
+    // Record<string, string>.
+    const filteredEnv = options?.env
+      ? Object.fromEntries(
+          Object.entries(options.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+        )
+      : undefined;
+
+    const execOptions: PrivateNetExecOptions = {
+      command: fullCommand,
+      ...(options?.cwd !== undefined && { cwd: options.cwd }),
+      ...(filteredEnv !== undefined && { env: filteredEnv }),
+      ...(effectiveTimeout != null && effectiveTimeout > 0 && { timeoutMs: effectiveTimeout }),
+      ...(this._privateNetFetch && { fetch: this._privateNetFetch }),
+    };
+
+    let result: PrivateNetExecResult;
+    try {
+      result = await execViaPrivateNetwork(instanceUrl, execOptions);
+    } catch (error) {
+      if (error instanceof PrivateNetExecHttpError) {
+        // Application-level failure from a reachable sidecar. Fall back for
+        // this call, but do NOT evict the registry entry — future calls
+        // should still prefer the private-network path.
+        return undefined;
+      }
+      // Anything else escaping is unexpected (e.g. options validation). Treat
+      // it like a transport failure so we don't wedge the caller.
+      this._invalidateAddress();
+      return undefined;
+    }
+
+    // A timeout is always the caller's answer, never a lease-fallback trigger:
+    // the sidecar may already be running the command, so re-executing on the
+    // lease path would double-run non-idempotent work (rm, git push, DB
+    // migrations) and return the second result instead of `timedOut: true`.
+    // If we never opened the response (pre-headers abort), the address is
+    // still evicted so subsequent execs skip a dial we already know is slow —
+    // but the timed-out result itself flows back to the caller unchanged.
+    if (result.timedOut) {
+      if (!result.opened) this._invalidateAddress();
+      return result;
+    }
+
+    // A completed exec (real exit code) is a valid result — hand it back even
+    // if exitCode is non-zero. Only evict when the transport itself failed:
+    // never opened, or opened without an exit frame. `opened=false` here
+    // means connection refused (no timeout to disambiguate).
+    const transportFailed = !result.opened || result.exitCode === null;
+    if (transportFailed) {
+      this._invalidateAddress();
+      return undefined;
+    }
+
+    return result;
+  }
+
+  /**
+   * Evict this sandbox's entry from the address registry after an observed
+   * transport failure. The entry stays gone until the next start() re-reads
+   * `instanceUrl` from a workspace-proxy response — until then, execs skip
+   * the private-net dial and go straight to the lease path.
+   */
+  private _invalidateAddress(): void {
+    if (this._sandboxId) this._addressRegistry?.delete(this._sandboxId);
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a private-network exec transport to `PlatformSandbox`. When the workspace-proxy discloses a sandbox's `instanceUrl` on its create or reattach response, `PlatformSandbox.start()` copies that field into an in-process `Map`, and every subsequent `executeCommand` dials the in-sandbox sidecar directly over Railway's private IPv6 network instead of minting a lease and opening a WebSocket to Railway's public tcp-proxy. Callers that don't wire the registry — or sandboxes whose proxy response has no `instanceUrl` — transparently take the existing lease path with no wire-shape change.

## Why

`PlatformSandbox.executeCommand` today pays 160–750 ms per exec: a GraphQL round-trip to `backboard.railway.com` (lease mint) plus a WebSocket handshake to `ssh.railway.com:2226`. It's also subject to Railway control-plane rate limits.

Every agent tool call is an exec under the hood — `SandboxFilesystem.readFile`, `writeFile`, `readdir`, `mkdir`, `stat`, `exists`, `copyFile`, `moveFile`, `deleteFile` all shell out through `sandbox.executeCommand(...)`. So this is the whole tool-surface latency win, not a slice of it.

Measured against sibling sandboxes over the private network: p50 drops from ~400 ms to ~16 ms per exec. GraphQL leaves the hot path; Node's HTTP agent can keep-alive the connection to the sidecar across execs.

## Design (see `.scratch/factory-deploy/design-private-network-exec-lifecycle.md`)

**Discovery lives entirely on the workspace-proxy.** The proxy runs one `sandbox.exec("awk … /proc/net/if_inet6")` inside `RailwaySandboxProvisioner.provision()`, persists the IPv6 to `environment_sandboxes.instance_url`, and echoes it as a nullable `instanceUrl` field on both `POST /sandbox` and `GET /sandbox/:id`.

**The mastra runtime does zero discovery of its own.** No `sandbox.exec` from the client side, no `POST /internal/sandbox-ready` callback route, no shared secret injected into the sandbox. `PlatformSandbox.start()` just copies `response.instanceUrl` into an in-process `Map<sandboxId, instanceUrl>`. Only writer is `PlatformSandbox` itself, only in response to a workspace-proxy call the runtime just made.

**Trust boundary is where it should be.** Runtime trusts workspace-proxy (already does — that's the whole client). Runtime does not trust anything the sandbox says. Registry has no inbound surface anyone else can poison.

**Previous drafts** shipped a `POST /internal/sandbox-ready` receiver route so the sidecar could phone home its IPv6. Killed — that put an inbound writeable HTTP surface on the runtime and required a shared secret in every sandbox.

## What's in this PR

### 1. Transport (`workspaces/platform-workspace/src/private-net-exec.ts`)

Standalone `execViaPrivateNetwork(instanceUrl, options)`:

- `POST ${instanceUrl}/exec` with `{command, cwd?, env?, timeoutMs?}`.
- Streams NDJSON frames: `{"type":"stdout","data":"…"}`, `stderr`, `{"type":"exit","code":N}`.
- Timeout via `AbortController`. No auth header — private-network position IS the auth.
- Distinguishes **transport failures** (dial refused, mid-stream drop, no exit frame) from **application errors** (non-2xx from the sidecar).

### 2. In-process registry (`address-registry.ts`)

```ts
export interface SandboxAddressRegistry {
  set(sandboxId: string, instanceUrl: string): void;
  get(sandboxId: string): string | undefined;
  delete(sandboxId: string): void;
}

export class InProcessSandboxAddressRegistry implements SandboxAddressRegistry { /* Map-backed */ }
```

`set` is called exclusively by `PlatformSandbox.start()` when the proxy response includes `instanceUrl`. No TTL, no eviction; entries live until an observed transport failure, an explicit `destroy()`, or process exit.

### 3. Client integration (`sandbox.ts`)

- New `CreateSandboxResponse.instanceUrl?: string | null` field, populated by workspace-proxy (companion platform PR).
- New `PlatformSandbox._populateAddressFromResponse(json)` called from both `start()` branches (fresh provision + reattach). Field copy, no branching if either the registry or the field is absent.
- `executeCommand` reads `registry.get(sandboxId)` before every exec, tries the private-net transport first, falls back to `execViaLease` on transport failure and evicts the registry entry so the next call goes to the lease path cleanly.
- `destroy()` explicitly evicts the entry so a reused instance doesn't dial a stale IPv6 Railway already reclaimed.
- `clone()` propagates the shared registry reference; the child looks up its own sandbox id (populated by its own `start()`).

### 4. Composition (`mastracode/web/src/mastra/index.ts`)

Constructs one `InProcessSandboxAddressRegistry` when the platform-sandbox env is complete and hands it to `new PlatformSandbox({ addressRegistry })`. Local dev keeps `LocalSandbox` and no registry.

## API surface (all additive)

- `SandboxAddressRegistry` — `{ get, set, delete }` interface.
- `InProcessSandboxAddressRegistry` — concrete `Map`-backed implementation.
- `PlatformSandboxOptions.addressRegistry?` — DI seam. Optional; omitted keeps pre-existing lease-only behavior.
- `PlatformSandboxOptions.privateNetFetch?` — injectable fetch (tests only).
- `execViaPrivateNetwork`, `PrivateNetExecHttpError`, `PrivateNetExecOptions`, `PrivateNetExecResult`, `PrivateNetFetch` — standalone transport module.

## Test plan

- `pnpm --filter @mastra/platform-workspace test`: **93 tests pass**.
  - `address-registry.test.ts` — 5 tests: get missing, set/get, overwrite, delete + no-op-delete, isolated ids.
  - `private-net-exec.test.ts` — 12 tests: NDJSON parse, split-chunk framing, stderr/stdout separation, connection failure, HTTP error taxonomy, mid-stream drop, timeout, unknown/malformed frame tolerance, base-URL normalization, EOF flush.
  - `sandbox.test.ts` — 47 tests including 13 private-net routing tests:
    - private-net when registry has entry
    - lease path when registry has no entry
    - lease path when no registry configured
    - transport error → evict + fall through
    - sidecar 5xx → preserve entry, fall back this call
    - `clone()` looks up its own id in the shared registry, not the parent's
    - no `Authorization` header on private-net execs
    - `destroy()` explicitly evicts
    - **populates from create response `instanceUrl`** (new)
    - **populates from reattach GET response `instanceUrl`** (new)
    - **leaves registry untouched when create response omits `instanceUrl`** (new)
    - **leaves registry untouched when create response has `instanceUrl: null`** (new)
    - **`start()` no-op on registry when no `addressRegistry` is injected** (new)
- `pnpm --filter @mastra/platform-workspace lint` clean.
- `tsc --noEmit` clean.
- `prettier --check` clean on all touched files.
- `mastracode/web`: `pnpm check` (tsc --noEmit) clean.

E2E "proxy discovers, sandbox execs private-net" is out of scope here (needs the sibling platform PRs + real Railway IPv6) — verified in the shipyard smoke test.

## Prerequisites

Full end-to-end private-network exec requires the companion platform PRs:

1. **Sidecar in the sandbox recipe** (`issue-sandbox-sidecar-agent-in-base-image.md`) — HTTP server binding `[::]:47000`, `POST /exec`, `GET /health`, no phone-home, no env-var injection. Amends Platform PR #1856.
2. **Workspace-proxy inline discovery** (`issue-workspace-proxy-inline-sandbox-address-discovery.md`) — `sandbox.exec("awk … /proc/net/if_inet6")` inside `RailwaySandboxProvisioner.provision()`, nullable `instance_url` column on `environment_sandboxes`, `instanceUrl` field on the create + get response bodies.

This PR is safe to merge before those land — `PlatformSandbox` gracefully skips the private-net path when the response has no `instanceUrl`.

## Follow-ups (not in this PR)

- Instrument `platform_sandbox.exec.fallback_reason` (`no_address`, `dial_failed`, `sidecar_5xx`, etc.) to watch the fallback rate. Distinguish never-populated fallback from steady-state fallback (address existed and dial failed).
- Once fallback rate is stably ~0% on shipyard for 7 days, delete `execViaLease` the same way `execViaProxy` was deleted in #20482.
- If Railway ships `<sandbox-id>.railway.internal` DNS registration, drop the `instance_url` column + response field entirely and dial by name.
