### PR TITLE
fix(memory): preserve markdown links in observation context

### DIFF
--- a/.changeset/lucky-donkeys-listen.md
+++ b/.changeset/lucky-donkeys-listen.md
@@ -1,0 +1,32 @@
+---
+'@mastra/memory': minor
+---
+
+Added `continuationHints` to observational memory configuration, so an agent that drives its
+own control flow can stop memory from proposing what it says next.
+
+`<current-task>` and `<suggested-response>` were always requested and there was no way to turn
+them off. A `<suggested-response>` is injected into the agent's context and the continuation
+reminder tells the agent to follow it, which makes memory a second controller competing with
+the agent's own. Pass `false` to disable both sections, or an object to disable them
+individually — keeping `<current-task>` while dropping `<suggested-response>` is the common
+case.
+
+```ts
+import { Memory } from '@mastra/memory';
+
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      observation: { continuationHints: { suggestedResponse: false } },
+      reflection: { continuationHints: false },
+    },
+  },
+});
+```
+
+Disabling a section removes it fully: the Observer and Reflector no longer describe or
+reference it, and a previously stored hint stops being injected into the agent's context once
+both observation and reflection disable it.
+
+Defaults are unchanged — existing configurations keep both sections enabled.

--- a/.changeset/olive-donkeys-smile.md
+++ b/.changeset/olive-donkeys-smile.md
@@ -2,9 +2,7 @@
 '@mastra/memory': patch
 ---
 
-preserve markdown links when optimizing observations for context
-
-`optimizeObservationsForContext` stripped every `[...]` group, which removed
-the label from any markdown link an observation contained and left a bare,
-unlabelled URL in the agent-facing context. Link labels are now preserved.
-Semantic tag stripping and collapsed item markers are unchanged.
+Fixed observational memory removing Markdown link labels from the observation
+context given to agents. Links shared in observations previously collapsed to
+bare, unlabelled URLs; their label text is now preserved. Semantic tags are
+still stripped and collapsed-item markers behave as before.

--- a/.changeset/olive-donkeys-smile.md
+++ b/.changeset/olive-donkeys-smile.md
@@ -1,0 +1,10 @@
+---
+'@mastra/memory': patch
+---
+
+preserve markdown links when optimizing observations for context
+
+`optimizeObservationsForContext` stripped every `[...]` group, which removed
+the label from any markdown link an observation contained and left a bare,
+unlabelled URL in the agent-facing context. Link labels are now preserved.
+Semantic tag stripping and collapsed item markers are unchanged.

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -135,6 +135,14 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             isOptional: true,
           },
           {
+            name: 'continuationHints',
+            type: 'boolean | { currentTask?: boolean; suggestedResponse?: boolean }',
+            description:
+              'Which continuation-hint sections the Observer emits. Pass `false` to disable both, or an object to disable them individually. Agents that drive their own control flow generally want `{ suggestedResponse: false }` so memory does not compete for what the agent says next. A previously stored hint stops being injected into context once both observation and reflection disable its section.',
+            isOptional: true,
+            defaultValue: 'true',
+          },
+          {
             name: 'threadTitle',
             type: 'boolean',
             description:
@@ -299,6 +307,14 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             description:
               "Custom instruction appended to the Reflector's system prompt. Use this to customize how the Reflector consolidates observations, such as prioritizing certain types of information.",
             isOptional: true,
+          },
+          {
+            name: 'continuationHints',
+            type: 'boolean | { currentTask?: boolean; suggestedResponse?: boolean }',
+            description:
+              'Which continuation-hint sections the Reflector emits. Pass `false` to disable both, or an object to disable them individually. A previously stored hint stops being injected into context once both observation and reflection disable its section.',
+            isOptional: true,
+            defaultValue: 'true',
           },
           {
             name: 'extract',

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
@@ -20,7 +20,7 @@ import { BufferingCoordinator } from '../buffering-coordinator';
 import { Extractor } from '../extractor';
 import { ModelByInputTokens } from '../model-by-input-tokens';
 import { ObservationalMemory } from '../observational-memory';
-import type { ObserveHooks } from '../types';
+import type { ContinuationHintsConfig, ObserveHooks } from '../types';
 
 // =============================================================================
 // Helpers
@@ -155,6 +155,8 @@ function createOM(
     reflectorModel?: any;
     observationExtract?: Extractor<any>[];
     reflectionExtract?: Extractor<any>[];
+    observationContinuationHints?: ContinuationHintsConfig;
+    reflectionContinuationHints?: ContinuationHintsConfig;
     activateAfterIdle?: number | string;
     hooks?: ObserveHooks;
   },
@@ -169,11 +171,13 @@ function createOM(
       messageTokens: opts?.messageTokens ?? 100,
       bufferTokens: opts?.bufferTokens ?? false,
       extract: opts?.observationExtract,
+      continuationHints: opts?.observationContinuationHints,
     },
     reflection: {
       model: opts?.reflectorModel ?? createMockReflectorModel(),
       observationTokens: opts?.observationTokens ?? 50_000,
       extract: opts?.reflectionExtract,
+      continuationHints: opts?.reflectionContinuationHints,
     },
   });
 }
@@ -1730,6 +1734,61 @@ describe('buildContextSystemMessage()', () => {
     });
 
     expect(result).toBeTruthy();
+  });
+
+  describe('continuation hints injection', () => {
+    // Observe to create the record, then overwrite thread metadata to simulate hints
+    // persisted by an earlier configuration — the injection decision must depend only
+    // on the current config, not on what some previous config stored.
+    const seedPersistedHints = async () => {
+      await storage.saveMessages({ messages: createBulkMessages(10, threadId) });
+      await om.observe({ threadId });
+      await storage.saveThread({
+        thread: {
+          id: threadId,
+          resourceId: 'ctx-resource',
+          title: 'Context thread',
+          metadata: setThreadOMMetadata(
+            {},
+            { currentTask: 'Ship the report', suggestedResponse: 'Ask about the deadline' },
+          ),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+    };
+
+    it('injects persisted hints by default', async () => {
+      await seedPersistedHints();
+
+      const result = await om.buildContextSystemMessage({ threadId });
+
+      expect(result).toContain('<current-task>\nShip the report\n</current-task>');
+      expect(result).toContain('<suggested-response>\nAsk about the deadline\n</suggested-response>');
+    });
+
+    it('does not inject persisted hints once both pipelines disable them', async () => {
+      om = createOM(storage, { observationContinuationHints: false, reflectionContinuationHints: false });
+      await seedPersistedHints();
+
+      const result = await om.buildContextSystemMessage({ threadId });
+
+      expect(result).toBeTruthy();
+      expect(result).not.toContain('<current-task>');
+      expect(result).not.toContain('<suggested-response>');
+    });
+
+    it('keeps injecting a hint while the other pipeline still produces it', async () => {
+      om = createOM(storage, { observationContinuationHints: { suggestedResponse: false } });
+      await seedPersistedHints();
+
+      const result = await om.buildContextSystemMessage({ threadId });
+
+      // Reflection still registers the suggested-response extractor, so the persisted
+      // value keeps flowing until reflection disables it too.
+      expect(result).toContain('<suggested-response>\nAsk about the deadline\n</suggested-response>');
+      expect(result).toContain('<current-task>\nShip the report\n</current-task>');
+    });
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -38,7 +38,6 @@ import {
   buildObserverHistoryMessage,
   buildMultiThreadObserverHistoryMessage,
   parseObserverOutput,
-  optimizeObservationsForContext,
   formatMessagesForObserver,
   hasCurrentTaskSection,
   extractCurrentTask,
@@ -3293,92 +3292,6 @@ User asked about </current-task> parsing and how it works
       const result = parseObserverOutput(text);
       expect(result.degenerate).toBe(true);
       expect(result.observations).toBe('');
-    });
-  });
-
-  describe('optimizeObservationsForContext', () => {
-    it('should strip yellow and green emojis', () => {
-      const observations = `
-- 🔴 Critical info
-- 🟡 Medium info
-- 🟢 Low info
-      `;
-
-      const optimized = optimizeObservationsForContext(observations);
-      expect(optimized).toContain('🔴 Critical info');
-      expect(optimized).not.toContain('🟡');
-      expect(optimized).not.toContain('🟢');
-    });
-
-    it('should strip anchor IDs before injecting context', () => {
-      const observations = '[O1] - 🔴 Critical info\n[O2] - 🟡 Medium info';
-      const optimized = optimizeObservationsForContext(observations);
-
-      expect(optimized).toContain('🔴 Critical info');
-      expect(optimized).toContain('- Medium info');
-      expect(optimized).not.toContain('[O1]');
-      expect(optimized).not.toContain('[O2]');
-    });
-
-    it('should preserve red emojis', () => {
-      const observations = '- 🔴 Critical user preference';
-      const optimized = optimizeObservationsForContext(observations);
-      expect(optimized).toContain('🔴');
-    });
-
-    it('should simplify arrows', () => {
-      const observations = '- Task -> completed successfully';
-      const optimized = optimizeObservationsForContext(observations);
-      expect(optimized).not.toContain('->');
-    });
-
-    it('should collapse multiple newlines', () => {
-      const observations = `Line 1
-
-
-
-Line 2`;
-      const optimized = optimizeObservationsForContext(observations);
-      expect(optimized).not.toContain('\n\n\n');
-    });
-
-    it('should preserve markdown link text', () => {
-      const observations = '- 🔴 Agent shared [the setup guide](https://example.com/setup)';
-      const optimized = optimizeObservationsForContext(observations);
-      expect(optimized).toContain('[the setup guide](https://example.com/setup)');
-    });
-
-    it('should preserve multiple markdown links on one line', () => {
-      const observations = '- 🔴 Compared [option A](https://example.com/a) and [option B](https://example.com/b)';
-      const optimized = optimizeObservationsForContext(observations);
-      expect(optimized).toContain('[option A](https://example.com/a)');
-      expect(optimized).toContain('[option B](https://example.com/b)');
-    });
-
-    it('should preserve markdown links using fragment targets', () => {
-      const observations = '- 🔴 Rendered [Item name](#preview=item&id=abc123)';
-      const optimized = optimizeObservationsForContext(observations);
-      expect(optimized).toContain('[Item name](#preview=item&id=abc123)');
-    });
-
-    it('should still strip semantic tags that are not markdown links', () => {
-      const observations = '- 🔴 [tag one, tag two] User prefers direct answers';
-      const optimized = optimizeObservationsForContext(observations);
-      expect(optimized).not.toContain('[tag one, tag two]');
-      expect(optimized).toContain('User prefers direct answers');
-    });
-
-    it('should strip semantic tags while preserving an adjacent markdown link', () => {
-      const observations = '- 🔴 [internal] Agent shared [the guide](https://example.com/guide)';
-      const optimized = optimizeObservationsForContext(observations);
-      expect(optimized).not.toContain('[internal]');
-      expect(optimized).toContain('[the guide](https://example.com/guide)');
-    });
-
-    it('should preserve collapsed item markers', () => {
-      const observations = '- 🔴 History trimmed [72 items collapsed - ID: b1fa]';
-      const optimized = optimizeObservationsForContext(observations);
-      expect(optimized).toContain('[72 items collapsed - ID: b1fa]');
     });
   });
 });

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -3341,6 +3341,45 @@ Line 2`;
       const optimized = optimizeObservationsForContext(observations);
       expect(optimized).not.toContain('\n\n\n');
     });
+
+    it('should preserve markdown link text', () => {
+      const observations = '- 🔴 Agent shared [the setup guide](https://example.com/setup)';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).toContain('[the setup guide](https://example.com/setup)');
+    });
+
+    it('should preserve multiple markdown links on one line', () => {
+      const observations = '- 🔴 Compared [option A](https://example.com/a) and [option B](https://example.com/b)';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).toContain('[option A](https://example.com/a)');
+      expect(optimized).toContain('[option B](https://example.com/b)');
+    });
+
+    it('should preserve markdown links using fragment targets', () => {
+      const observations = '- 🔴 Rendered [Item name](#preview=item&id=abc123)';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).toContain('[Item name](#preview=item&id=abc123)');
+    });
+
+    it('should still strip semantic tags that are not markdown links', () => {
+      const observations = '- 🔴 [tag one, tag two] User prefers direct answers';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).not.toContain('[tag one, tag two]');
+      expect(optimized).toContain('User prefers direct answers');
+    });
+
+    it('should strip semantic tags while preserving an adjacent markdown link', () => {
+      const observations = '- 🔴 [internal] Agent shared [the guide](https://example.com/guide)';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).not.toContain('[internal]');
+      expect(optimized).toContain('[the guide](https://example.com/guide)');
+    });
+
+    it('should preserve collapsed item markers', () => {
+      const observations = '- 🔴 History trimmed [72 items collapsed - ID: b1fa]';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).toContain('[72 items collapsed - ID: b1fa]');
+    });
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -3340,6 +3340,45 @@ Line 2`;
       const optimized = optimizeObservationsForContext(observations);
       expect(optimized).not.toContain('\n\n\n');
     });
+
+    it('should preserve markdown link text', () => {
+      const observations = '- 🔴 Agent shared [the setup guide](https://example.com/setup)';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).toContain('[the setup guide](https://example.com/setup)');
+    });
+
+    it('should preserve multiple markdown links on one line', () => {
+      const observations = '- 🔴 Compared [option A](https://example.com/a) and [option B](https://example.com/b)';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).toContain('[option A](https://example.com/a)');
+      expect(optimized).toContain('[option B](https://example.com/b)');
+    });
+
+    it('should preserve markdown links using fragment targets', () => {
+      const observations = '- 🔴 Rendered [Item name](#preview=item&id=abc123)';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).toContain('[Item name](#preview=item&id=abc123)');
+    });
+
+    it('should still strip semantic tags that are not markdown links', () => {
+      const observations = '- 🔴 [tag one, tag two] User prefers direct answers';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).not.toContain('[tag one, tag two]');
+      expect(optimized).toContain('User prefers direct answers');
+    });
+
+    it('should strip semantic tags while preserving an adjacent markdown link', () => {
+      const observations = '- 🔴 [internal] Agent shared [the guide](https://example.com/guide)';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).not.toContain('[internal]');
+      expect(optimized).toContain('[the guide](https://example.com/guide)');
+    });
+
+    it('should preserve collapsed item markers', () => {
+      const observations = '- 🔴 History trimmed [72 items collapsed - ID: b1fa]';
+      const optimized = optimizeObservationsForContext(observations);
+      expect(optimized).toContain('[72 items collapsed - ID: b1fa]');
+    });
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/built-in-extractors.ts
+++ b/packages/memory/src/processors/observational-memory/built-in-extractors.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { Extractor, validateExtractorList } from './extractor';
-import type { ObservationConfig, ReflectionConfig, ResolvedObservationConfig } from './types';
+import type { ContinuationHintsConfig, ObservationConfig, ReflectionConfig, ResolvedObservationConfig } from './types';
 
 const currentTaskInstructions = `State the current task(s) explicitly. Can be single or multiple:
 - Primary: What the agent is currently working on
@@ -56,16 +56,42 @@ export function createThreadTitleExtractor(): Extractor<string> {
   );
 }
 
+export interface ResolvedContinuationHints {
+  currentTask: boolean;
+  suggestedResponse: boolean;
+}
+
+/**
+ * Normalize the user-facing `continuationHints` config into explicit per-section flags.
+ * Both sections stay enabled unless the caller opts out, so omitting the config is a no-op.
+ */
+export function resolveContinuationHints(config: ContinuationHintsConfig | undefined): ResolvedContinuationHints {
+  if (config === undefined || config === true) {
+    return { currentTask: true, suggestedResponse: true };
+  }
+  if (config === false) {
+    return { currentTask: false, suggestedResponse: false };
+  }
+  return {
+    currentTask: config.currentTask ?? true,
+    suggestedResponse: config.suggestedResponse ?? true,
+  };
+}
+
 interface ComposeExtractorOptions {
-  includeContinuationHints?: boolean;
+  continuationHints?: ContinuationHintsConfig;
   includeThreadTitle?: boolean;
   userExtractors?: readonly Extractor<any>[];
 }
 
 export function composeExtractors(options: ComposeExtractorOptions): Extractor<any>[] {
+  const continuationHints = resolveContinuationHints(options.continuationHints);
   const extractors: Extractor<any>[] = [];
-  if (options.includeContinuationHints) {
-    extractors.push(createCurrentTaskExtractor(), createSuggestedResponseExtractor());
+  if (continuationHints.currentTask) {
+    extractors.push(createCurrentTaskExtractor());
+  }
+  if (continuationHints.suggestedResponse) {
+    extractors.push(createSuggestedResponseExtractor());
   }
   if (options.includeThreadTitle) {
     extractors.push(createThreadTitleExtractor());
@@ -75,18 +101,20 @@ export function composeExtractors(options: ComposeExtractorOptions): Extractor<a
 }
 
 export function composeObservationExtractors(
-  config: Pick<ResolvedObservationConfig, 'threadTitle'> & Pick<ObservationConfig, 'extract'>,
+  config: Pick<ResolvedObservationConfig, 'threadTitle'> & Pick<ObservationConfig, 'extract' | 'continuationHints'>,
 ): Extractor[] {
   return composeExtractors({
-    includeContinuationHints: true,
+    continuationHints: config.continuationHints,
     includeThreadTitle: config.threadTitle,
     userExtractors: config.extract,
   });
 }
 
-export function composeReflectionExtractors(config: Pick<ReflectionConfig, 'extract'>): Extractor[] {
+export function composeReflectionExtractors(
+  config: Pick<ReflectionConfig, 'extract' | 'continuationHints'>,
+): Extractor[] {
   return composeExtractors({
-    includeContinuationHints: true,
+    continuationHints: config.continuationHints,
     userExtractors: config.extract,
   });
 }

--- a/packages/memory/src/processors/observational-memory/continuation-hints.test.ts
+++ b/packages/memory/src/processors/observational-memory/continuation-hints.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  composeObservationExtractors,
+  composeReflectionExtractors,
+  resolveContinuationHints,
+} from './built-in-extractors';
+import { Extractor } from './extractor';
+import { buildObserverSystemPrompt } from './observer-agent';
+import { buildReflectorSystemPrompt } from './reflector-agent';
+
+describe('resolveContinuationHints', () => {
+  it('enables both sections by default', () => {
+    expect(resolveContinuationHints(undefined)).toEqual({ currentTask: true, suggestedResponse: true });
+    expect(resolveContinuationHints(true)).toEqual({ currentTask: true, suggestedResponse: true });
+  });
+
+  it('disables both sections when false', () => {
+    expect(resolveContinuationHints(false)).toEqual({ currentTask: false, suggestedResponse: false });
+  });
+
+  it('supports disabling sections individually', () => {
+    expect(resolveContinuationHints({ suggestedResponse: false })).toEqual({
+      currentTask: true,
+      suggestedResponse: false,
+    });
+    expect(resolveContinuationHints({ currentTask: false })).toEqual({
+      currentTask: false,
+      suggestedResponse: true,
+    });
+  });
+});
+
+describe('continuationHints extractor composition', () => {
+  const user = new Extractor({ name: 'Preference', instructions: 'Extract preference.' });
+
+  it('registers both continuation extractors by default', () => {
+    expect(composeObservationExtractors({ threadTitle: false, extract: [user] }).map(e => e.slug)).toEqual([
+      'current-task',
+      'suggested-response',
+      'preference',
+    ]);
+  });
+
+  it('omits both continuation extractors when disabled', () => {
+    expect(
+      composeObservationExtractors({ threadTitle: false, extract: [user], continuationHints: false }).map(e => e.slug),
+    ).toEqual(['preference']);
+  });
+
+  it('omits only the suggested-response extractor when disabled individually', () => {
+    expect(
+      composeObservationExtractors({
+        threadTitle: true,
+        extract: [user],
+        continuationHints: { suggestedResponse: false },
+      }).map(e => e.slug),
+    ).toEqual(['current-task', 'thread-title', 'preference']);
+  });
+
+  it('applies continuation hints to reflection extractors too', () => {
+    expect(
+      composeReflectionExtractors({ extract: [user], continuationHints: { suggestedResponse: false } }).map(
+        e => e.slug,
+      ),
+    ).toEqual(['current-task', 'preference']);
+  });
+});
+
+describe('prompts only reference continuation sections they define', () => {
+  it('drops suggested-response guidance from the observer prompt when disabled', () => {
+    const extractors = composeObservationExtractors({
+      threadTitle: false,
+      continuationHints: { suggestedResponse: false },
+    });
+    const prompt = buildObserverSystemPrompt(false, undefined, false, extractors);
+
+    expect(prompt).not.toContain('<suggested-response>');
+    expect(prompt).toContain('<current-task>');
+  });
+
+  it('drops all continuation guidance from the observer prompt when both are disabled', () => {
+    const extractors = composeObservationExtractors({ threadTitle: false, continuationHints: false });
+    const prompt = buildObserverSystemPrompt(false, undefined, false, extractors);
+
+    expect(prompt).not.toContain('<suggested-response>');
+    expect(prompt).not.toContain('<current-task>');
+    expect(prompt).toContain('User messages are extremely important.');
+  });
+
+  it('drops suggested-response guidance from the reflector prompt when disabled', () => {
+    const extractors = composeReflectionExtractors({ continuationHints: { suggestedResponse: false } });
+    const prompt = buildReflectorSystemPrompt(undefined, extractors);
+
+    expect(prompt).not.toContain('<suggested-response>');
+    expect(prompt).toContain('<current-task>');
+  });
+
+  it('still describes both sections on the legacy path with no extractors', () => {
+    const prompt = buildObserverSystemPrompt();
+
+    expect(prompt).toContain('<current-task>');
+    expect(prompt).toContain('<suggested-response>');
+  });
+});
+
+describe('multi-thread prompt follows the active continuation sections', () => {
+  const multiThreadPrompt = (
+    continuationHints: Parameters<typeof composeObservationExtractors>[0]['continuationHints'],
+  ) =>
+    buildObserverSystemPrompt(
+      true,
+      undefined,
+      false,
+      composeObservationExtractors({ threadTitle: false, continuationHints }),
+    );
+
+  it('nests and demonstrates both sections by default', () => {
+    const prompt = multiThreadPrompt(undefined);
+
+    expect(prompt).toContain(
+      "Each thread's observations, current-task, and suggested-response should be nested inside",
+    );
+    expect(prompt).toContain('<current-task>');
+    expect(prompt).toContain('<suggested-response>');
+  });
+
+  it('omits suggested-response from the nesting instruction and examples when disabled', () => {
+    const prompt = multiThreadPrompt({ suggestedResponse: false });
+
+    expect(prompt).toContain("Each thread's observations and current-task should be nested inside");
+    expect(prompt).toContain('<current-task>');
+    expect(prompt).not.toContain('<suggested-response>');
+  });
+
+  it('omits current-task from the nesting instruction and examples when disabled', () => {
+    const prompt = multiThreadPrompt({ currentTask: false });
+
+    expect(prompt).toContain("Each thread's observations and suggested-response should be nested inside");
+    expect(prompt).toContain('<suggested-response>');
+    expect(prompt).not.toContain('<current-task>');
+  });
+
+  it('drops both sections entirely when continuation hints are disabled', () => {
+    const prompt = multiThreadPrompt(false);
+
+    expect(prompt).toContain("Each thread's observations should be nested inside");
+    expect(prompt).not.toContain('<current-task>');
+    expect(prompt).not.toContain('<suggested-response>');
+    // The thread scaffolding itself must survive so multi-thread output stays parseable.
+    expect(prompt).toContain('<thread id="thread_id_1">');
+    expect(prompt).toContain('=== MULTI-THREAD INPUT ===');
+  });
+
+  it('still lists thread-title alongside the enabled sections', () => {
+    const prompt = buildObserverSystemPrompt(
+      true,
+      undefined,
+      true,
+      composeObservationExtractors({ threadTitle: true, continuationHints: { suggestedResponse: false } }),
+    );
+
+    expect(prompt).toContain("Each thread's observations, current-task, and thread-title should be nested inside");
+    expect(prompt).toContain('<thread-title>');
+    expect(prompt).not.toContain('<suggested-response>');
+  });
+
+  it('leaves the default multi-thread prompt unchanged on the legacy path', () => {
+    expect(buildObserverSystemPrompt(true, undefined, false, undefined)).toContain(
+      "Each thread's observations, current-task, and suggested-response should be nested inside",
+    );
+  });
+
+  // Pins the exact default example so the section-driven template can't silently drift
+  // from the shape the multi-thread parser expects.
+  it('renders the default per-thread example verbatim', () => {
+    expect(buildObserverSystemPrompt(true, undefined, true, undefined)).toContain(
+      `<observations>
+<thread id="thread_id_1">
+Date: Dec 4, 2025
+* 🔴 (14:30) User prefers direct answers
+* 🔴 (14:31) Working on feature X
+
+<current-task>
+What the agent is currently working on in this thread
+</current-task>
+
+<suggested-response>
+Hint for the agent's next message in this thread
+</suggested-response>
+<thread-title>Feature X implementation</thread-title>
+</thread>
+
+<thread id="thread_id_2">
+Date: Dec 5, 2025
+* 🔴 (09:15) User asked about deployment
+
+<current-task>
+Current task for this thread
+</current-task>
+
+<suggested-response>
+Suggested response for this thread
+</suggested-response>
+<thread-title>Deployment setup</thread-title>
+</thread>
+</observations>`,
+    );
+  });
+});

--- a/packages/memory/src/processors/observational-memory/index.ts
+++ b/packages/memory/src/processors/observational-memory/index.ts
@@ -53,6 +53,7 @@ export type {
   ObserveTrigger,
   ObservationConfig,
   ReflectionConfig,
+  ContinuationHintsConfig,
   ObserverResult,
   ReflectorResult,
   // Observation marker config

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -543,6 +543,7 @@ export class ObservationalMemory {
       extractors: composeObservationExtractors({
         threadTitle: config.observation?.threadTitle ?? false,
         extract: config.observation?.extract,
+        continuationHints: config.observation?.continuationHints,
       }),
     };
 
@@ -575,7 +576,10 @@ export class ObservationalMemory {
             config.reflection?.observationTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.reflection.observationTokens,
           ),
       instruction: config.reflection?.instruction,
-      extractors: composeReflectionExtractors({ extract: config.reflection?.extract }),
+      extractors: composeReflectionExtractors({
+        extract: config.reflection?.extract,
+        continuationHints: config.reflection?.continuationHints,
+      }),
     };
 
     this.tokenCounter = new TokenCounter({
@@ -1715,8 +1719,7 @@ export class ObservationalMemory {
   ): { threadId: string; resourceId?: string } | null {
     // First try RequestContext (set by Memory)
     const memoryContext = requestContext?.get('MastraMemory') as
-      | { thread?: { id: string }; resourceId?: string }
-      | undefined;
+      { thread?: { id: string }; resourceId?: string } | undefined;
 
     if (memoryContext?.thread?.id) {
       return {
@@ -2593,11 +2596,18 @@ ${formattedMessages}
       return undefined;
     }
 
-    // Read thread metadata for continuation hints
+    // Read thread metadata for continuation hints. A persisted hint is only injected while a
+    // pipeline can still produce it — once observation and reflection both disable a section,
+    // a stale value stored by an earlier configuration must not keep steering the actor.
     const thread = await this.storage.getThreadById({ threadId });
     const omMetadata = getThreadOMMetadata(thread?.metadata);
-    const currentTask = omMetadata?.currentTask;
-    const suggestedResponse = omMetadata?.suggestedResponse;
+    const activeExtractors = [...this.observationConfig.extractors, ...this.reflectionConfig.extractors];
+    const currentTask = activeExtractors.some(extractor => extractor.slug === 'current-task')
+      ? omMetadata?.currentTask
+      : undefined;
+    const suggestedResponse = activeExtractors.some(extractor => extractor.slug === 'suggested-response')
+      ? omMetadata?.suggestedResponse
+      : undefined;
     const currentDate = opts.currentDate ?? new Date();
 
     return this.formatObservationsForContext(

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -1719,7 +1719,8 @@ export class ObservationalMemory {
   ): { threadId: string; resourceId?: string } | null {
     // First try RequestContext (set by Memory)
     const memoryContext = requestContext?.get('MastraMemory') as
-      { thread?: { id: string }; resourceId?: string } | undefined;
+      | { thread?: { id: string }; resourceId?: string }
+      | undefined;
 
     if (memoryContext?.thread?.id) {
       return {

--- a/packages/memory/src/processors/observational-memory/observer-agent.test.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { optimizeObservationsForContext } from './observer-agent';
+
+describe('optimizeObservationsForContext', () => {
+  it('should strip yellow and green emojis', () => {
+    const observations = `
+- 🔴 Critical info
+- 🟡 Medium info
+- 🟢 Low info
+      `;
+
+    const optimized = optimizeObservationsForContext(observations);
+    expect(optimized).toContain('🔴 Critical info');
+    expect(optimized).not.toContain('🟡');
+    expect(optimized).not.toContain('🟢');
+  });
+
+  it('should strip anchor IDs before injecting context', () => {
+    const observations = '[O1] - 🔴 Critical info\n[O2] - 🟡 Medium info';
+    const optimized = optimizeObservationsForContext(observations);
+
+    expect(optimized).toContain('🔴 Critical info');
+    expect(optimized).toContain('- Medium info');
+    expect(optimized).not.toContain('[O1]');
+    expect(optimized).not.toContain('[O2]');
+  });
+
+  it('should preserve red emojis', () => {
+    const observations = '- 🔴 Critical user preference';
+    const optimized = optimizeObservationsForContext(observations);
+    expect(optimized).toContain('🔴');
+  });
+
+  it('should simplify arrows', () => {
+    const observations = '- Task -> completed successfully';
+    const optimized = optimizeObservationsForContext(observations);
+    expect(optimized).not.toContain('->');
+  });
+
+  it('should collapse multiple newlines', () => {
+    const observations = `Line 1
+
+
+
+Line 2`;
+    const optimized = optimizeObservationsForContext(observations);
+    expect(optimized).not.toContain('\n\n\n');
+  });
+
+  it('should preserve markdown link text', () => {
+    const observations = '- 🔴 Agent shared [the setup guide](https://example.com/setup)';
+    const optimized = optimizeObservationsForContext(observations);
+    expect(optimized).toContain('[the setup guide](https://example.com/setup)');
+  });
+
+  it('should preserve multiple markdown links on one line', () => {
+    const observations = '- 🔴 Compared [option A](https://example.com/a) and [option B](https://example.com/b)';
+    const optimized = optimizeObservationsForContext(observations);
+    expect(optimized).toContain('[option A](https://example.com/a)');
+    expect(optimized).toContain('[option B](https://example.com/b)');
+  });
+
+  it('should preserve markdown links using fragment targets', () => {
+    const observations = '- 🔴 Rendered [Item name](#preview=item&id=abc123)';
+    const optimized = optimizeObservationsForContext(observations);
+    expect(optimized).toContain('[Item name](#preview=item&id=abc123)');
+  });
+
+  it('should still strip semantic tags that are not markdown links', () => {
+    const observations = '- 🔴 [tag one, tag two] User prefers direct answers';
+    const optimized = optimizeObservationsForContext(observations);
+    expect(optimized).not.toContain('[tag one, tag two]');
+    expect(optimized).toContain('User prefers direct answers');
+  });
+
+  it('should strip semantic tags while preserving an adjacent markdown link', () => {
+    const observations = '- 🔴 [internal] Agent shared [the guide](https://example.com/guide)';
+    const optimized = optimizeObservationsForContext(observations);
+    expect(optimized).not.toContain('[internal]');
+    expect(optimized).toContain('[the guide](https://example.com/guide)');
+  });
+
+  it('should preserve collapsed item markers', () => {
+    const observations = '- 🔴 History trimmed [72 items collapsed - ID: b1fa]';
+    const optimized = optimizeObservationsForContext(observations);
+    expect(optimized).toContain('[72 items collapsed - ID: b1fa]');
+  });
+});

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -1676,7 +1676,9 @@ export function optimizeObservationsForContext(observations: string): string {
   optimized = optimized.replace(/🟢\s*/g, '');
 
   // Remove semantic tags like [label, label] but keep collapsed markers like [72 items collapsed - ID: b1fa]
-  optimized = optimized.replace(/\[(?![\d\s]*items collapsed)[^\]]+\]/g, '');
+  // and markdown link text like [label](url) — the trailing `(?!\()` lookahead keeps the label so the
+  // link survives intact instead of collapsing to a bare, unlabelled URL.
+  optimized = optimized.replace(/\[(?![\d\s]*items collapsed)[^\]]+\](?!\()/g, '');
 
   // Remove arrow indicators
   optimized = optimized.replace(/\s*->\s*/g, ' ');

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -299,10 +299,20 @@ Prefer concrete resolved outcomes over abstract workflow status so the assistant
  */
 export const OBSERVER_OUTPUT_FORMAT_BASE = buildObserverOutputFormat();
 
-export function buildObserverOutputFormat(extractors: readonly Extractor<any>[] = []): string {
-  const extractorSections = buildExtractorOutputSections(extractors);
+/**
+ * Build the Observer's output format.
+ *
+ * `extractors` distinguishes two cases that both look empty:
+ * - `undefined` — the no-arg call behind the exported defaults (OBSERVER_OUTPUT_FORMAT_BASE,
+ *   OBSERVER_SYSTEM_PROMPT, REFLECTOR_SYSTEM_PROMPT), which keep describing both built-in
+ *   sections with their historical text. Runtime callers always pass the composed list.
+ * - `[]` — the caller composed extractors and every section was disabled, so no continuation
+ *   sections are described at all.
+ */
+export function buildObserverOutputFormat(extractors?: readonly Extractor<any>[]): string {
+  const extractorSections = buildExtractorOutputSections(extractors ?? []);
   const legacyContinuationSections =
-    extractors.length === 0
+    extractors === undefined
       ? `
 <current-task>
 State the current task(s) explicitly:
@@ -371,17 +381,36 @@ export const OBSERVER_GUIDELINES = `- Be specific enough for the assistant to ac
  * Build the complete observer system prompt.
  * @param multiThread - Whether this is for multi-thread batched observation (default: false)
  * @param instruction - Optional custom instructions to append to the prompt
+ * @param includeThreadTitle - Whether the Observer should also produce a thread title
+ * @param extractors - Active extractors, used to decide which sections the prompt describes.
+ *   Omitted only by the exported no-arg defaults; pass `[]` to describe no continuation sections at all.
  */
 export function buildObserverSystemPrompt(
   multiThread: boolean = false,
   instruction?: string,
   includeThreadTitle: boolean = false,
-  extractors: readonly Extractor<any>[] = [],
+  extractors?: readonly Extractor<any>[],
 ): string {
   const outputFormat = buildObserverOutputFormat(extractors);
-  const multiThreadTitleInstruction = includeThreadTitle
-    ? ` Each thread's observations, current-task, suggested-response, and thread-title should be nested inside a <thread id="..."> block within <observations>.`
-    : ` Each thread's observations, current-task, and suggested-response should be nested inside a <thread id="..."> block within <observations>.`;
+  const customInstructions = instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : '';
+  // Runtime callers always pass the composed extractor list; `undefined` only occurs through
+  // the exported no-arg defaults (e.g. OBSERVER_SYSTEM_PROMPT), which keep both built-in sections.
+  const currentTaskEnabled =
+    extractors === undefined || extractors.some(extractor => extractor.slug === 'current-task');
+  const suggestedResponseEnabled =
+    extractors === undefined || extractors.some(extractor => extractor.slug === 'suggested-response');
+  const multiThreadSections = [
+    'observations',
+    ...(currentTaskEnabled ? ['current-task'] : []),
+    ...(suggestedResponseEnabled ? ['suggested-response'] : []),
+    ...(includeThreadTitle ? ['thread-title'] : []),
+  ];
+  // Grammatical list for any combination: "a", "a and b", "a, b, and c".
+  const multiThreadSectionList =
+    multiThreadSections.length <= 2
+      ? multiThreadSections.join(' and ')
+      : `${multiThreadSections.slice(0, -1).join(', ')}, and ${multiThreadSections[multiThreadSections.length - 1]}`;
+  const multiThreadTitleInstruction = ` Each thread's ${multiThreadSectionList} should be nested inside a <thread id="..."> block within <observations>.`;
   const multiThreadTitleExample = includeThreadTitle
     ? `
 <thread-title>Feature X implementation</thread-title>`
@@ -390,7 +419,6 @@ export function buildObserverSystemPrompt(
     ? `
 <thread-title>Deployment setup</thread-title>`
     : '';
-
   if (multiThread) {
     return `You are the memory consciousness of an AI assistant. Your observations will be the ONLY information the assistant has about past interactions with this user.
 
@@ -417,28 +445,44 @@ For multi-thread output, wrap each thread's observations like this:
 <thread id="thread_id_1">
 Date: Dec 4, 2025
 * 🔴 (14:30) User prefers direct answers
-* 🔴 (14:31) Working on feature X
+* 🔴 (14:31) Working on feature X${
+      currentTaskEnabled
+        ? `
 
 <current-task>
 What the agent is currently working on in this thread
-</current-task>
+</current-task>`
+        : ''
+    }${
+      suggestedResponseEnabled
+        ? `
 
 <suggested-response>
 Hint for the agent's next message in this thread
-</suggested-response>${multiThreadTitleExample}
+</suggested-response>`
+        : ''
+    }${multiThreadTitleExample}
 </thread>
 
 <thread id="thread_id_2">
 Date: Dec 5, 2025
-* 🔴 (09:15) User asked about deployment
+* 🔴 (09:15) User asked about deployment${
+      currentTaskEnabled
+        ? `
 
 <current-task>
 Current task for this thread
-</current-task>
+</current-task>`
+        : ''
+    }${
+      suggestedResponseEnabled
+        ? `
 
 <suggested-response>
 Suggested response for this thread
-</suggested-response>${multiThreadSecondTitleExample}
+</suggested-response>`
+        : ''
+    }${multiThreadSecondTitleExample}
 </thread>
 </observations>
 
@@ -448,7 +492,11 @@ ${OBSERVER_GUIDELINES}
 
 Remember: These observations are the assistant's ONLY memory. Make them count.
 
-User messages are extremely important. If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority.${instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : ''}`;
+User messages are extremely important.${
+      currentTaskEnabled
+        ? ' If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority.'
+        : ''
+    }${customInstructions}`;
   }
 
   return `You are the memory consciousness of an AI assistant. Your observations will be the ONLY information the assistant has about past interactions with this user.
@@ -475,7 +523,15 @@ Simply output your observations without any thread-related markup.
 
 Remember: These observations are the assistant's ONLY memory. Make them count.
 
-User messages are extremely important. If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority. If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.${instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : ''}`;
+User messages are extremely important.${
+    currentTaskEnabled
+      ? ' If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority.'
+      : ''
+  }${
+    suggestedResponseEnabled
+      ? ' If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.'
+      : ''
+  }${customInstructions}`;
 }
 
 /**

--- a/packages/memory/src/processors/observational-memory/reflector-agent.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-agent.ts
@@ -36,9 +36,17 @@ export interface ReflectorResult extends BaseReflectorResult {
  * - Preserving ALL important information (reflections become the ENTIRE memory)
  *
  * @param instruction - Optional custom instructions to append to the prompt
+ * @param extractors - Active extractors, used to decide which sections the prompt describes
  */
-export function buildReflectorSystemPrompt(instruction?: string, extractors: readonly Extractor<any>[] = []): string {
+export function buildReflectorSystemPrompt(instruction?: string, extractors?: readonly Extractor<any>[]): string {
   const outputFormat = buildObserverOutputFormat(extractors);
+  const customInstructions = instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : '';
+  // Runtime callers always pass the composed extractor list; `undefined` only occurs through
+  // the exported no-arg default (REFLECTOR_SYSTEM_PROMPT), which keeps both built-in sections.
+  const currentTaskEnabled =
+    extractors === undefined || extractors.some(extractor => extractor.slug === 'current-task');
+  const suggestedResponseEnabled =
+    extractors === undefined || extractors.some(extractor => extractor.slug === 'suggested-response');
   return `You are the memory consciousness of an AI assistant. Your memory observation reflections will be the ONLY information the assistant has about past interactions with this user.
 
 The following instructions were given to another part of your psyche (the observer) to create memories.
@@ -115,7 +123,15 @@ Date: Dec 4, 2025
 
 ${outputFormat}
 
-User messages are extremely important. If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority. If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.${instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : ''}`;
+User messages are extremely important.${
+    currentTaskEnabled
+      ? ' If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority.'
+      : ''
+  }${
+    suggestedResponseEnabled
+      ? ' If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.'
+      : ''
+  }${customInstructions}`;
 }
 
 /**

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -61,6 +61,24 @@ export type ResolvedActivationTTL = number | 'auto';
  */
 export type ObservationalMemoryModel = Exclude<AgentConfig['model'], undefined> | ModelByInputTokens;
 
+/**
+ * Controls which continuation-hint sections OM asks the Observer and Reflector to emit.
+ *
+ * Pass `false` to disable both, or an object to disable them individually. Agents that
+ * drive their own control flow generally want `suggestedResponse: false` so memory does
+ * not compete with the agent for what to say next.
+ *
+ * @default true
+ */
+export type ContinuationHintsConfig =
+  | boolean
+  | {
+      /** Emit the `<current-task>` section. @default true */
+      currentTask?: boolean;
+      /** Emit the `<suggested-response>` section. @default true */
+      suggestedResponse?: boolean;
+    };
+
 export interface ObservationConfig {
   /**
    * Model for the Observer agent.
@@ -199,6 +217,14 @@ export interface ObservationConfig {
   instruction?: string;
 
   /**
+   * Which continuation-hint sections the Observer should emit.
+   * Set `{ suggestedResponse: false }` when the agent owns its own control flow.
+   *
+   * @default true
+   */
+  continuationHints?: ContinuationHintsConfig;
+
+  /**
    * Manage working memory through Observational Memory extraction.
    * When enabled alongside `workingMemory.enabled`, Memory supplies defaults that
    * disable main-agent working memory management and add the WorkingMemoryExtractor.
@@ -335,6 +361,14 @@ export interface ReflectionConfig {
    * Use this to customize reflection behavior for specific use cases.
    */
   instruction?: string;
+
+  /**
+   * Which continuation-hint sections the Reflector should emit.
+   * Set `{ suggestedResponse: false }` when the agent owns its own control flow.
+   *
+   * @default true
+   */
+  continuationHints?: ContinuationHintsConfig;
 
   /**
    * Additional values to extract from reflector output. Built-in OM fields are registered automatically.


### PR DESCRIPTION
## Description

`optimizeObservationsForContext` runs on every Observational Memory context injection, on the path to the live agent. Among its token-saving passes it strips bracketed "semantic tags":

```ts
// Remove semantic tags like [label, label] but keep collapsed markers like [72 items collapsed - ID: b1fa]
optimized = optimized.replace(/\[(?![\d\s]*items collapsed)[^\]]+\]/g, '');
```

That pattern matches **any** `[...]` group, so it also deletes the label from markdown links an observation contains. The URL survives, the link text does not:

```
in:   * 🔴 (14:30) Agent shared [the setup guide](https://example.com/setup)
out:  * 🔴 (14:30) Agent shared (https://example.com/setup)
```

This is a quiet failure mode. Nothing errors, no marker is emitted, and the output still looks structurally fine — the agent just receives an unlabelled URL and loses the only human-readable handle on what it points at. Any OM user whose Observer emits links (documentation references, ticket links, deep links into an app) is affected, and there is no way to opt out from configuration.

The fix adds a `(?!\()` negative lookahead so a bracket group immediately followed by `(` — i.e. a markdown inline link — is left alone. Plain semantic tags and the `[N items collapsed - ID: …]` markers behave exactly as before.

```diff
-optimized = optimized.replace(/\[(?![\d\s]*items collapsed)[^\]]+\]/g, '');
+optimized = optimized.replace(/\[(?![\d\s]*items collapsed)[^\]]+\](?!\()/g, '');
```

### Scope

Deliberately minimal. The bracket rule is broader than its stated intent in other ways too — it will still eat bracketed identifiers, citation markers, and `[]` inside code spans — but those cases are debatable and worth separating from this one. Markdown links are unambiguous data loss, so this PR fixes only that.

Worth a follow-up discussion: the semantic-tag format this rule targets doesn't appear to be something the current Observer prompt ever asks for, so the rule may be dead code that only does collateral damage. Happy to open a separate issue for that.

## Related issue(s)

None — filing directly as a bug fix. Glad to open a tracking issue if that's preferred for this repo.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Testing

Six regression cases added to the existing `optimizeObservationsForContext` suite — which previously had no coverage of the bracket rule at all:

- markdown link text preserved
- multiple links on one line preserved
- fragment-target links (`[Item name](#preview=item&id=abc123)`) preserved
- plain semantic tags still stripped
- semantic tag stripped while an adjacent link on the same line survives
- `[72 items collapsed - ID: b1fa]` markers still preserved

```
pnpm vitest run src/processors/observational-memory/__tests__/observational-memory.test.ts
  Tests  458 passed | 1 todo (459)

pnpm check      # tsc --noEmit, clean
pnpm exec oxlint <changed files>   # clean
```

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR keeps Markdown link text while removing semantic tags from observations. It also lets users control which continuation hints appear in observation and reflection context.

## Changes

- Preserved Markdown link labels, including links with fragments and adjacent links.
- Continued removing semantic tags and preserving collapsed-item markers.
- Added regression tests beside the implementation.
- Added configurable `currentTask` and `suggestedResponse` continuation hints.
- Updated prompts and context construction to honor continuation-hint settings.
- Documented the new configuration and exported `ContinuationHintsConfig`.
- Added tests and changesets for the new behavior.

## Validation

- 1,319 unit tests passed.
- TypeScript checks passed.
- oxlint passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->