### PR TITLE
fix(memory): count output-error and approval-responded tool states in observational memory

### DIFF
--- a/.changeset/wise-memory-token-states.md
+++ b/.changeset/wise-memory-token-states.md
@@ -2,6 +2,4 @@
 '@mastra/memory': patch
 ---
 
-Fixed observational memory crashing when counting tokens for conversations that contain a failed tool call or an answered approval.
-
-Persisted tool invocations can carry the `output-error` state (a tool that threw) or the `approval-responded` state (a resolved human-in-the-loop approval). The observational-memory token counter did not handle these states and threw `Unhandled tool-invocation state`, so recall on those conversations failed. Both states are now counted like the other tool states — `output-error` by its error text, `approval-responded` as control metadata with no tokens.
+Fixed observational memory crashes when counting conversations with failed tool calls or completed approvals. Failed tool calls use their error text, or `Tool execution failed` when no error text is stored. Completed approvals no longer cause token counting errors.

--- a/.changeset/wise-memory-token-states.md
+++ b/.changeset/wise-memory-token-states.md
@@ -1,0 +1,7 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory crashing when counting tokens for conversations that contain a failed tool call or an answered approval.
+
+Persisted tool invocations can carry the `output-error` state (a tool that threw) or the `approval-responded` state (a resolved human-in-the-loop approval). The observational-memory token counter did not handle these states and threw `Unhandled tool-invocation state`, so recall on those conversations failed. Both states are now counted like the other tool states — `output-error` by its error text, `approval-responded` as control metadata with no tokens.

--- a/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
@@ -1279,6 +1279,86 @@ describe('TokenCounter', () => {
     });
   });
 
+  describe('tool error (output-error)', () => {
+    // Regression: a failed tool call persists as state 'output-error' with the failure
+    // surfaced in `errorText`. The counter did not handle this state and threw
+    // ("Unhandled tool-invocation state ..."), so observational memory crashed on any
+    // conversation containing a tool call that errored. It now counts the error text
+    // like a small tool result.
+    const DEFAULT_ERROR_TEXT = 'Tool execution failed';
+
+    const createErroredMessage = (errorText?: string) =>
+      createMessage({
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'output-error',
+              toolCallId: 'tool-1',
+              toolName: 'findUserTool',
+              args: { name: 'Dero Israel' },
+              ...(errorText ? { errorText } : {}),
+            },
+          },
+        ],
+      });
+
+    it('counts a failed tool call by its error text instead of throwing', () => {
+      const counter = new TokenCounter();
+      const errorText = 'Network request timed out after 30s';
+      const message = createErroredMessage(errorText);
+
+      const tokens = counter.countMessage(message);
+      const estimate = message.content.parts[0].providerMetadata?.mastra?.tokenEstimate;
+
+      expect(tokens).toBeGreaterThan(0);
+      expect(estimate?.key).toContain('tool-result-error');
+      expect(estimate?.tokens).toBe(counter.countString(errorText));
+    });
+
+    it('falls back to a default error text when errorText is absent', () => {
+      const counter = new TokenCounter();
+      const message = createErroredMessage();
+
+      const tokens = counter.countMessage(message);
+      const estimate = message.content.parts[0].providerMetadata?.mastra?.tokenEstimate;
+
+      expect(tokens).toBeGreaterThan(0);
+      expect(estimate?.key).toContain('tool-result-error');
+      expect(estimate?.tokens).toBe(counter.countString(DEFAULT_ERROR_TEXT));
+    });
+  });
+
+  describe('tool approval (approval-responded)', () => {
+    // Regression: an answered approval persists as state 'approval-responded', a
+    // tool-invocation state the counter did not handle and threw on. Like
+    // 'approval-requested' it is control metadata with no model-visible output of its
+    // own — the resulting tool output arrives separately — so it contributes no tokens.
+    it('counts an answered approval as zero tokens instead of throwing', () => {
+      const counter = new TokenCounter();
+      const message = createMessage({
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'approval-responded',
+              toolCallId: 'tool-1',
+              toolName: 'deleteFile',
+              args: { path: 'fixture.txt' },
+              approval: { id: 'approval-1', approved: true },
+            },
+          },
+        ],
+      });
+      const emptyMessage = createMessage({ format: 2, parts: [] });
+
+      expect(() => counter.countMessage(message)).not.toThrow();
+      expect(counter.countMessage(message)).toBe(counter.countMessage(emptyMessage));
+    });
+  });
+
   describe('countObservations', () => {
     it('delegates to countString', () => {
       const counter = new TokenCounter();

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -1770,6 +1770,23 @@ export class TokenCounter {
         return { tokens, overheadDelta, toolResultDelta };
       }
 
+      if (invocation.state === 'output-error') {
+        // A failed tool call surfaces its error text to the model in place of a result,
+        // so count it like a small tool result to keep token accounting consistent
+        // (and not throw on the state).
+        toolResultDelta++;
+        const errorText = (invocation as { errorText?: string }).errorText ?? 'Tool execution failed';
+        tokens += this.readOrPersistPartEstimate(part, 'tool-result-error', errorText);
+        return { tokens, overheadDelta, toolResultDelta };
+      }
+
+      if (invocation.state === 'approval-responded') {
+        // An answered approval is control metadata with no model-visible output of its
+        // own; the resulting tool output arrives separately as a 'result' or
+        // 'output-error' part. Mirror 'approval-requested' and count nothing.
+        return { tokens, overheadDelta, toolResultDelta };
+      }
+
       throw new Error(
         `Unhandled tool-invocation state '${(part as any).toolInvocation?.state}' in token counting for part type '${part.type}'`,
       );


### PR DESCRIPTION
## What

Observational Memory's `TokenCounter` handled the `call`, `partial-call`, `result`, and `output-denied` tool-invocation states, then threw `Unhandled tool-invocation state` on anything else:

```
Unhandled tool-invocation state 'output-error' in token counting for part type 'tool-invocation'
```

But `MastraToolInvocation.state` (`packages/core/src/agent/message-list/state/types.ts:45`) declares two more valid states that weren't handled — **`output-error`** (a tool call that threw) and **`approval-responded`** (a resolved approval) — both produced across the message-list adapters (AIV5/AIV6), `MessageMerger`, and `output-converter`. So counting tokens for any persisted conversation that contained a failed tool call crashed observational memory.

Same class as #20607 (which #20608 fixes for `approval-requested`); these are the two remaining unhandled states.

Fixes #20674

## Change

In `countNonAttachmentPart`, add handling before the throw, mirroring the existing `output-denied` block:

- **`output-error`** — surfaces its error text to the model in place of a result, so count `errorText` like a small tool result (`toolResultDelta++`).
- **`approval-responded`** — control metadata with no model-visible output of its own (the resulting output arrives separately as `result`/`output-error`), so count nothing, matching `approval-requested`.

## Tests

Added regression tests alongside the existing `output-denied` suite in `token-counter.test.ts`. I confirmed both new tests **throw against `main`** (reproducing the bug), then pass with the fix. Full file: **53 passed**.

- `output-error`: counts by `errorText`, falls back to a default when absent.
- `approval-responded`: counts as zero tokens (equal to an empty message), doesn't throw.

Patch changeset included.

Note: local `tsc --noEmit` for `@mastra/memory` only surfaces pre-existing `Cannot find module '@mastra/core/*'` errors from unbuilt workspace deps (unrelated files); no type errors in the changed files. `oxlint` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Token counting now works when saved conversations contain failed tool calls or completed approval steps. This prevents observational memory from failing and counts only the text that users can see.

## Changes

- Count `output-error` tool invocations from their `errorText`.
- Use fallback text when `errorText` is absent.
- Count `approval-responded` invocations as zero tokens.
- Add regression tests for both invocation states.
- Add a patch changeset for `@mastra/memory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->