### PR TITLE
fix(clickhouse): cast DateTime64 cursor column in delta table TTL

### DIFF
--- a/.changeset/sour-crabs-yawn.md
+++ b/.changeset/sour-crabs-yawn.md
@@ -6,7 +6,7 @@ Fixed ClickHouse observability storage failing to start against ClickHouse serve
 
 The delta polling tables declared their retention TTL directly on a `DateTime64` column. Servers before 25.6 reject that with `BAD_TTL_EXPRESSION (code 450)`, so `init()` threw and the store could not be adopted at all:
 
-```
+```text
 Failed to initialize ClickHouse v-next observability tables: TTL expression result column should have DateTime or Date type, but has DateTime64(9, 'UTC')
 ```
 

--- a/.changeset/sour-crabs-yawn.md
+++ b/.changeset/sour-crabs-yawn.md
@@ -1,0 +1,13 @@
+---
+'@mastra/clickhouse': patch
+---
+
+Fixed ClickHouse observability storage failing to start against ClickHouse servers older than 25.6.
+
+The delta polling tables declared their retention TTL directly on a `DateTime64` column. Servers before 25.6 reject that with `BAD_TTL_EXPRESSION (code 450)`, so `init()` threw and the store could not be adopted at all:
+
+```
+Failed to initialize ClickHouse v-next observability tables: TTL expression result column should have DateTime or Date type, but has DateTime64(9, 'UTC')
+```
+
+The TTL expression now casts the column to `DateTime` before applying the interval. Stored column precision is unchanged, and tables already created on newer servers are unaffected.

--- a/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
@@ -363,6 +363,10 @@ WHERE spanType IN (${BRANCH_SPAN_TYPE_VALUES.map(v => `'${v}'`).join(', ')})
 `;
 
 const DELTA_INGESTED_AT_TYPE = `DateTime64(9, 'UTC')`;
+// ClickHouse before 25.6 rejects TTL expressions that evaluate to DateTime64
+// (BAD_TTL_EXPRESSION), so the cursor timestamp is cast down to second
+// precision here. The stored column keeps its full nanosecond precision.
+const DELTA_TTL_CLAUSE = `TTL toDateTime(ingestedAt) + toIntervalDay(2)`;
 const DELTA_CURSOR_EPOCH_MS = 1777852800000;
 const DELTA_CURSOR_SUFFIX_BITS = 26;
 const DELTA_CURSOR_SUFFIX_MASK = 67108863;
@@ -407,7 +411,7 @@ CREATE TABLE IF NOT EXISTS ${TABLE_TRACE_ROOTS_DELTA} (
 ENGINE = MergeTree
 PARTITION BY toDate(ingestedAt)
 ORDER BY (cursorId)
-TTL ingestedAt + toIntervalDay(2)
+${DELTA_TTL_CLAUSE}
 `;
 }
 
@@ -453,7 +457,7 @@ CREATE TABLE IF NOT EXISTS ${TABLE_TRACE_BRANCHES_DELTA} (
 ENGINE = MergeTree
 PARTITION BY toDate(ingestedAt)
 ORDER BY (cursorId)
-TTL ingestedAt + toIntervalDay(2)
+${DELTA_TTL_CLAUSE}
 `;
 }
 
@@ -630,7 +634,7 @@ CREATE TABLE IF NOT EXISTS ${TABLE_LOG_EVENTS_DELTA} (
 ENGINE = MergeTree
 PARTITION BY toDate(ingestedAt)
 ORDER BY (cursorId)
-TTL ingestedAt + toIntervalDay(2)
+${DELTA_TTL_CLAUSE}
 `;
 }
 
@@ -734,7 +738,7 @@ CREATE TABLE IF NOT EXISTS ${TABLE_SCORE_EVENTS_DELTA} (
 ENGINE = MergeTree
 PARTITION BY toDate(ingestedAt)
 ORDER BY (cursorId)
-TTL ingestedAt + toIntervalDay(2)
+${DELTA_TTL_CLAUSE}
 SETTINGS allow_nullable_key = 1
 `;
 }
@@ -844,7 +848,7 @@ CREATE TABLE IF NOT EXISTS ${TABLE_FEEDBACK_EVENTS_DELTA} (
 ENGINE = MergeTree
 PARTITION BY toDate(ingestedAt)
 ORDER BY (cursorId)
-TTL ingestedAt + toIntervalDay(2)
+${DELTA_TTL_CLAUSE}
 SETTINGS allow_nullable_key = 1
 `;
 }
@@ -889,7 +893,7 @@ CREATE TABLE IF NOT EXISTS ${TABLE_METRIC_EVENTS_DELTA} (
 ENGINE = MergeTree
 PARTITION BY toDate(ingestedAt)
 ORDER BY (cursorId)
-TTL ingestedAt + toIntervalDay(2)
+${DELTA_TTL_CLAUSE}
 `;
 }
 

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
@@ -3773,6 +3773,16 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       expect(buildRetentionDDL({})).toEqual([]);
     });
 
+    it('delta tables cast the DateTime64 cursor column in their TTL expression', () => {
+      const deltaDdl = buildAllTableDDL().filter(ddl => ddl.includes('_delta ('));
+      expect(deltaDdl).toHaveLength(6);
+
+      for (const ddl of deltaDdl) {
+        expect(ddl).toContain('TTL toDateTime(ingestedAt) + toIntervalDay(2)');
+        expect(ddl).not.toMatch(/TTL\s+ingestedAt/);
+      }
+    });
+
     it('buildRetentionDDL generates tracing TTL for span_events, trace_roots, and trace_branches', () => {
       const stmts = buildRetentionDDL({ tracing: 30 });
       expect(stmts).toHaveLength(3);


### PR DESCRIPTION
## Description

`ObservabilityStorageClickhouseVNext.init()` could not run against ClickHouse servers older than 25.6. The six delta polling tables declared their retention TTL directly on an `ingestedAt DateTime64(9, 'UTC')` column, which those servers reject, so the store failed to initialize and could not be adopted at all.

- Cast the cursor timestamp in the TTL expression: `TTL ingestedAt + toIntervalDay(2)` becomes `TTL toDateTime(ingestedAt) + toIntervalDay(2)`
- Extracted the clause into a single `DELTA_TTL_CLAUSE` constant next to the existing `DELTA_INGESTED_AT_TYPE`, so the six delta tables can't drift apart
- The stored column keeps its full nanosecond precision; only the TTL expression is cast, and a 2 day TTL is unaffected by second granularity
- Tables already created on 25.6+ are untouched — `CREATE TABLE IF NOT EXISTS` does not rewrite them, and both forms have identical retention behaviour

Before, on ClickHouse 25.3.14.14:

```
Failed to initialize ClickHouse v-next observability tables: TTL expression result
column should have DateTime or Date type, but has DateTime64(9, 'UTC')
```

After, on the same server: `init()` succeeds and all six delta tables plus their materialized views are created.

Verified by running the exact output of `buildAllDDL()` against real servers. All 25 statements now succeed on every version tested — 24.3, 24.8, 25.3, 25.4, 25.5, 25.6, 25.8, 25.10, 26.3 and 26.6 — where previously the six delta tables failed on everything below 25.6. CI pins 26.6, which is why this was never caught.

## Related Issue(s)

Fixes #20684

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes ClickHouse initialization that fails on older database servers. The database was trying to apply expiration rules to a special high-precision time column, which older versions do not allow. The fix converts the timestamp to a simpler format just for the expiration rule, while keeping the stored data at full precision. This works on both old and new database versions.

## Problem

The `ObservabilityStorageClickhouseVNext.init()` method fails when ClickHouse servers are older than version 25.6. Six delta polling tables declare TTL (time-to-live) retention directly on a `DateTime64(9, 'UTC')` column. Servers older than 25.6 reject this configuration with error code 450, because TTL expressions must resolve to `Date` or `DateTime` types, not `DateTime64`.

The affected tables include trace roots, trace branches, metric events, log events, score events, and feedback events. The error is thrown immediately during initialization, which makes ClickHouse observability completely unusable on older servers.

## Solution

The fix extracts the TTL clause into a new `DELTA_TTL_CLAUSE` constant that wraps the TTL expression with a `toDateTime()` cast. The expression changed from `TTL ingestedAt + toIntervalDay(2)` to `TTL toDateTime(ingestedAt) + toIntervalDay(2)`.

This approach:
- Maintains the stored column's full nanosecond precision
- Applies the cast only in the TTL expression, not to stored data
- Preserves identical retention behavior (2-day TTL is unaffected by second-level granularity)
- Prevents the six delta tables from diverging by centralizing the TTL clause

## Backward Compatibility

The fix maintains backward compatibility with tables already created on version 25.6 and later. The `CREATE TABLE IF NOT EXISTS` statement does not rewrite existing tables, and both TTL forms have identical retention behavior.

## Verification

The fix was verified against ClickHouse versions 24.3, 24.8, 25.3, 25.4, 25.5, 25.6, 25.8, 25.10, 26.3, and 26.6. All 25 DDL statements now succeed on every tested version, whereas previously the six delta tables failed on versions below 25.6.

## Changes

- Added `DELTA_TTL_CLAUSE` constant to wrap TTL expressions with the required `toDateTime()` cast
- Updated five delta table builder functions and one delta materialized view function to reference the constant
- Added a retention test that verifies all six delta tables use `toDateTime(ingestedAt)` conversion in their two-day TTL expression
- Created a changeset entry documenting the patch version bump for the `@mastra/clickhouse` package
<!-- end of auto-generated comment: release notes by coderabbit.ai -->