### PR TITLE
docs: move datasets out of evals

### DIFF
--- a/docs/src/content/en/docs/datasets/overview.mdx
+++ b/docs/src/content/en/docs/datasets/overview.mdx
@@ -59,7 +59,7 @@ Visit the [`DatasetsManager` reference](/reference/datasets/datasets-manager) fo
 
 You can also manage datasets in [Studio](/docs/studio/overview). After opening Studio, select **Datasets** from the sidebar to see all your available datasets or create a new one.
 
-To get started, select **Create Dataset** and set a name, description, and optional schemas. After confirming, you'll see the dataset details page with two tabs: **Items** and [**Experiments**](/docs/evals/datasets/running-experiments#studio).
+To get started, select **Create Dataset** and set a name, description, and optional schemas. After confirming, you'll see the dataset details page with two tabs: **Items** and [**Experiments**](/docs/datasets/running-experiments#studio).
 
 In the **Items** view you can add, update, and delete items, and view version history. Select **Add Item** to insert a new item with JSON editors for input and ground truth. From this view you can also import items in bulk from a CSV or JSON file. When importing, map each column to the corresponding dataset field.
 
@@ -208,11 +208,11 @@ Fetch the exact items that existed at a past version:
 const items = await dataset.listItems({ version: 2 })
 ```
 
-You can also pin experiments to a version, see [running experiments](/docs/evals/datasets/running-experiments). Visit the [`Dataset` reference](/reference/datasets/dataset) for the full list of methods and parameters.
+You can also pin experiments to a version, see [running experiments](/docs/datasets/running-experiments). Visit the [`Dataset` reference](/reference/datasets/dataset) for the full list of methods and parameters.
 
 ## Related
 
-- [Running experiments](/docs/evals/datasets/running-experiments)
+- [Running experiments](/docs/datasets/running-experiments)
 - [Scorers overview](/docs/evals/overview)
 - [DatasetsManager reference](/reference/datasets/datasets-manager)
 - [Dataset reference](/reference/datasets/dataset)

--- a/docs/src/content/en/docs/datasets/running-experiments.mdx
+++ b/docs/src/content/en/docs/datasets/running-experiments.mdx
@@ -414,7 +414,7 @@ Visit the [`startExperiment` reference](/reference/datasets/startExperiment) for
 
 ## Related
 
-- [Datasets overview](/docs/evals/datasets/overview)
+- [Datasets overview](/docs/datasets/overview)
 - [Scorers overview](/docs/evals/overview)
 - [`startExperiment` reference](/reference/datasets/startExperiment)
 - [`listExperimentResults` reference](/reference/datasets/listExperimentResults)

--- a/docs/src/content/en/docs/editor/overview.mdx
+++ b/docs/src/content/en/docs/editor/overview.mdx
@@ -304,7 +304,7 @@ See the [Editor versioning reference](/reference/editor/versioning) for version 
 
 ## Programmatic access
 
-Everything available in Studio is also available programmatically through [`mastra.getEditor()`](/reference/core/getEditor), the REST API, or the Client SDK. Use it to script bulk updates or seed stored configurations from code. It can also power automation that tunes agents based on [evaluation results](/docs/evals/datasets/running-experiments).
+Everything available in Studio is also available programmatically through [`mastra.getEditor()`](/reference/core/getEditor), the REST API, or the Client SDK. Use it to script bulk updates or seed stored configurations from code. It can also power automation that tunes agents based on [evaluation results](/docs/datasets/running-experiments).
 
 Call `mastra.getEditor()` when application code has access to the Mastra instance:
 

--- a/docs/src/content/en/docs/evals/evals-with-memory.mdx
+++ b/docs/src/content/en/docs/evals/evals-with-memory.mdx
@@ -149,6 +149,6 @@ The inline `task` receives the item's `metadata`, so each row can drive its own 
 ## Related
 
 - [Running scorers in CI](/docs/evals/running-in-ci)
-- [Running experiments](/docs/evals/datasets/running-experiments)
+- [Running experiments](/docs/datasets/running-experiments)
 - [Observational memory](/docs/memory/observational-memory)
 - [runEvals API reference](/reference/evals/run-evals)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -846,22 +846,6 @@ const sidebars = {
               id: 'evals/evals-with-memory',
               label: 'Evals with Memory',
             },
-            {
-              type: 'category',
-              label: 'Datasets',
-              items: [
-                {
-                  type: 'doc',
-                  id: 'evals/datasets/overview',
-                  label: 'Overview',
-                },
-                {
-                  type: 'doc',
-                  id: 'evals/datasets/running-experiments',
-                  label: 'Running Experiments',
-                },
-              ],
-            },
           ],
         },
         {
@@ -910,6 +894,22 @@ const sidebars = {
               customProps: {
                 tags: ['beta'],
               },
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Datasets',
+          items: [
+            {
+              type: 'doc',
+              id: 'datasets/overview',
+              label: 'Overview',
+            },
+            {
+              type: 'doc',
+              id: 'datasets/running-experiments',
+              label: 'Running Experiments',
             },
           ],
         },

--- a/docs/src/content/en/docs/studio/overview.mdx
+++ b/docs/src/content/en/docs/studio/overview.mdx
@@ -92,13 +92,13 @@ The Scorers tab displays the results of your agent's scorers as they run. When m
 
 Create and manage collections of test cases to evaluate your agents and workflows. Import items from CSV or JSON and define input and ground-truth schemas, plus pin to specific versions so you can reproduce experiments exactly. Run experiments with [scorers](/docs/evals/overview) to compare quality across prompts, models, or code changes.
 
-See [datasets overview](/docs/evals/datasets/overview) for the full API and versioning details.
+See [datasets overview](/docs/datasets/overview) for the full API and versioning details.
 
 ### Experiments
 
 Run all items in a dataset against an agent, workflow, or scorer and collect the results in one place. Select a target, optionally attach scorers, and trigger the experiment. The results view shows each item's input, output, status, and individual score breakdowns. Compare two experiments side by side to measure the impact of prompt, model, or code changes.
 
-See [datasets overview](/docs/evals/datasets/overview) for setup details.
+See [datasets overview](/docs/datasets/overview) for setup details.
 
 ## Observability
 

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1146,6 +1146,11 @@
       "permanent": true
     },
     {
+      "source": "/docs/evals/datasets/:path*",
+      "destination": "/docs/datasets/:path*",
+      "permanent": true
+    },
+    {
       "source": "/docs/editor/prompts/llms.txt",
       "destination": "/docs/editor/overview/llms.txt",
       "permanent": true
@@ -1933,6 +1938,11 @@
     {
       "source": "/docs/voice/:path*/llms.txt",
       "destination": "/guides/voice/:path*/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/evals/datasets/:path*/llms.txt",
+      "destination": "/docs/datasets/:path*/llms.txt",
       "permanent": true
     }
   ]

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -787,12 +787,12 @@
     },
     {
       "source": "/docs/observability/datasets/overview",
-      "destination": "/docs/evals/datasets/overview",
+      "destination": "/docs/datasets/overview",
       "permanent": true
     },
     {
       "source": "/docs/observability/datasets/running-experiments",
-      "destination": "/docs/evals/datasets/running-experiments",
+      "destination": "/docs/datasets/running-experiments",
       "permanent": true
     },
     {
@@ -1662,12 +1662,12 @@
     },
     {
       "source": "/docs/observability/datasets/overview/llms.txt",
-      "destination": "/docs/evals/datasets/overview/llms.txt",
+      "destination": "/docs/datasets/overview/llms.txt",
       "permanent": true
     },
     {
       "source": "/docs/observability/datasets/running-experiments/llms.txt",
-      "destination": "/docs/evals/datasets/running-experiments/llms.txt",
+      "destination": "/docs/datasets/running-experiments/llms.txt",
       "permanent": true
     },
     {

--- a/docs/vercel.redirects.json
+++ b/docs/vercel.redirects.json
@@ -1129,6 +1129,11 @@
       "source": "/docs/voice/:path*",
       "destination": "/guides/voice/:path*",
       "permanent": true
+    },
+    {
+      "source": "/docs/evals/datasets/:path*",
+      "destination": "/docs/datasets/:path*",
+      "permanent": true
     }
   ]
 }

--- a/docs/vercel.redirects.json
+++ b/docs/vercel.redirects.json
@@ -772,12 +772,12 @@
     },
     {
       "source": "/docs/observability/datasets/overview",
-      "destination": "/docs/evals/datasets/overview",
+      "destination": "/docs/datasets/overview",
       "permanent": true
     },
     {
       "source": "/docs/observability/datasets/running-experiments",
-      "destination": "/docs/evals/datasets/running-experiments",
+      "destination": "/docs/datasets/running-experiments",
       "permanent": true
     },
     {

--- a/packages/playground/src/domains/datasets/components/datasets-list/no-datasets-info.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/no-datasets-info.tsx
@@ -28,7 +28,7 @@ export const NoDatasetsInfo = ({ onCreateClick }: NoDatasetsInfoProps = {}) => (
           <Button
             variant="ghost"
             as="a"
-            href="https://mastra.ai/en/docs/evals/datasets/overview"
+            href="https://mastra.ai/en/docs/datasets/overview"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/packages/playground/src/domains/datasets/components/empty-datasets-table.tsx
+++ b/packages/playground/src/domains/datasets/components/empty-datasets-table.tsx
@@ -28,7 +28,7 @@ export function EmptyDatasetsTable({ onCreateClick }: EmptyDatasetsTableProps) {
               size="lg"
               variant="outline"
               as="a"
-              href="https://mastra.ai/docs/evals/datasets/overview"
+              href="https://mastra.ai/docs/datasets/overview"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/packages/playground/src/domains/experiments/components/no-experiments-info.tsx
+++ b/packages/playground/src/domains/experiments/components/no-experiments-info.tsx
@@ -18,7 +18,7 @@ export const NoExperimentsInfo = () => (
           <Button
             variant="ghost"
             as="a"
-            href="https://mastra.ai/en/docs/evals/datasets/running-experiments"
+            href="https://mastra.ai/en/docs/datasets/running-experiments"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/packages/playground/src/lib/nav/nav-items.tsx
+++ b/packages/playground/src/lib/nav/nav-items.tsx
@@ -144,7 +144,7 @@ export const mainNav: NavSection[] = [
         name: 'Datasets',
         url: '/datasets',
         Icon: DatasetsIcon,
-        docs: { href: 'https://mastra.ai/en/docs/evals/datasets/overview', label: 'Datasets documentation' },
+        docs: { href: 'https://mastra.ai/en/docs/datasets/overview', label: 'Datasets documentation' },
         isOnMastraPlatform: true,
       },
       {
@@ -152,7 +152,7 @@ export const mainNav: NavSection[] = [
         url: '/experiments',
         Icon: ExperimentsIcon,
         docs: {
-          href: 'https://mastra.ai/en/docs/evals/datasets/running-experiments',
+          href: 'https://mastra.ai/en/docs/datasets/running-experiments',
           label: 'Experiments documentation',
         },
         isOnMastraPlatform: true,


### PR DESCRIPTION
## Summary

- move dataset and experiment docs from `/docs/evals/datasets/*` to `/docs/datasets/*`
- place Datasets last in the Production sidebar group and update docs and Studio links
- add direct redirects for old dataset routes and regenerate `vercel.json` without dataset redirect chains

## Validation

- `pnpm build`
- scoped Remark and Vale lint for changed docs
- `pnpm --filter ./packages/playground lint` (passes with existing warnings)
- dataset redirect-chain check across all six dataset-related entries in generated `vercel.json`

Full `pnpm lint:prose` also reports four existing Vale errors in untouched docs pages. A strict global wildcard expansion finds pre-existing chains through broad version redirects such as `/docs/v1/:path* -> /docs/:path*`; this PR does not add any dataset redirect chains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR moves dataset documentation to a clearer location. It updates links and redirects so old pages still work.

## Changes

- Moved dataset documentation from `/docs/evals/datasets/*` to `/docs/datasets/*`.
- Added Datasets as a top-level Production sidebar section.
- Updated documentation and Studio links to use the new paths.
- Updated Playground dataset and experiment links.
- Added direct redirects for legacy dataset routes and `/llms.txt` routes.
- Regenerated `vercel.json` without redirect chains.

## Validation

- Documentation build passed.
- Scoped Remark and Vale linting passed.
- Playground linting passed.
- Redirect-chain checks passed.
- Full prose linting reports four existing Vale errors in unchanged pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->