### PR TITLE
fix(factory): normalize the authenticated user read off the request context

### DIFF
--- a/.changeset/factory-better-auth-user-shape.md
+++ b/.changeset/factory-better-auth-user-shape.md
@@ -1,0 +1,6 @@
+---
+'@mastra/factory': patch
+'@mastra/code-sdk': patch
+---
+
+Fixed signed-in users being treated as somebody else when the app uses a session-based auth provider such as better-auth. Opening a Factory session failed with "Factory session ... is not available to the current user", the GitHub session tools quietly went missing, and per-tenant credentials resolved to nothing. The authenticated user is now read through a normalizer that understands both the flat user shape and the session-wrapped one. See https://github.com/mastra-ai/mastra/issues/20688

--- a/mastracode/factory/src/auth.ts
+++ b/mastracode/factory/src/auth.ts
@@ -112,6 +112,25 @@ export function getFactoryAuthUser(c: Context): FactoryAuthUser | undefined {
   return c.get(FACTORY_AUTH_USER_KEY) as FactoryAuthUser | undefined;
 }
 
+/**
+ * Read the authenticated user off a request context, normalizing whatever the
+ * active auth provider put there.
+ *
+ * The server's auth layer writes the provider's `authenticateToken` result into
+ * the request context's `user` slot verbatim, so the value's shape follows the
+ * provider: WorkOS writes a flat user, better-auth writes a `{ session, user }`
+ * wrapper whose org lives on the session. Reading that slot as a
+ * {@link FactoryAuthUser} therefore yields `undefined` for both the id and the
+ * org under better-auth, which reads as "this session belongs to somebody else"
+ * at every ownership check. Normalize on the way in instead.
+ */
+export function getFactoryAuthUserFromContext(
+  requestContext: { get: (key: string) => unknown } | undefined,
+): FactoryAuthUser | undefined {
+  if (!requestContext || typeof requestContext.get !== 'function') return undefined;
+  return toFactoryAuthUser(requestContext.get('user')) ?? undefined;
+}
+
 /** Resolve the stable user id from an authenticated user shape. */
 export function getFactoryAuthUserId(user: FactoryAuthUser | undefined): string | undefined {
   return user?.workosId ?? user?.id;
@@ -170,7 +189,10 @@ function toFactoryAuthUser(result: unknown): FactoryAuthUser | null {
   if (!result || typeof result !== 'object') return null;
   const record = result as Record<string, unknown>;
 
-  // Session-shaped results: { session, user }.
+  // Session-shaped results: { session, user }. A result carrying both halves and
+  // top-level identity fields is read as session-shaped: the session half is the
+  // authenticated one, and preferring it keeps the org and the id from coming
+  // from two different places.
   if (record.user && typeof record.user === 'object' && record.session && typeof record.session === 'object') {
     const user = record.user as { id?: unknown; email?: unknown; name?: unknown };
     const session = record.session as { activeOrganizationId?: unknown };

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -29,12 +29,12 @@ import type { FactoryStorage } from '@mastra/core/storage';
 import type { MastraVector } from '@mastra/core/vector';
 import { LocalSandbox } from '@mastra/core/workspace';
 import type { WorkspaceSandbox } from '@mastra/core/workspace';
-import type { FactoryAuthUser } from './auth.js';
 import {
   buildAuthRoutes,
   createFactoryAuthGate,
   createFactoryRouteAuth,
   getFactoryAuthOrgId,
+  getFactoryAuthUserFromContext,
   getFactoryAuthUserId,
 } from './auth.js';
 import type { FactoryIntegration, IntegrationPostToolContext, IntegrationTools } from './integrations/base.js';
@@ -407,7 +407,7 @@ export class MastraFactory {
       projects: factoryProjectsStorage,
       sinks: integrations,
       agentTenant: requestContext => {
-        const user = requestContext.get('user') as FactoryAuthUser | undefined;
+        const user = getFactoryAuthUserFromContext(requestContext);
         return { orgId: getFactoryAuthOrgId(user), userId: getFactoryAuthUserId(user) };
       },
     });

--- a/mastracode/factory/src/integrations/github/session-subscriptions.test.ts
+++ b/mastracode/factory/src/integrations/github/session-subscriptions.test.ts
@@ -135,6 +135,14 @@ describe('GitHub subscription entry points', () => {
     expect(createGithubSubscriptionTools(requestContext, githubStub)).toEqual({});
   });
 
+  it('does not expose tools without an active thread', () => {
+    const requestContext = new RequestContext();
+    requestContext.set('user', { workosId: 'user-1', organizationId: 'org-1' });
+    requestContext.set('controller', { getState: () => ({ projectRepositoryId: 'project-repository-1' }) });
+
+    expect(createGithubSubscriptionTools(requestContext, githubStub)).toEqual({});
+  });
+
   it('mints repository access and injects the fresh token into the active sandbox', async () => {
     const requestContext = authenticatedRequestContext();
     const inject = vi.fn();

--- a/mastracode/factory/src/integrations/github/session-subscriptions.ts
+++ b/mastracode/factory/src/integrations/github/session-subscriptions.ts
@@ -175,9 +175,7 @@ export async function refreshGithubToken(requestContext: RequestContext, github:
 }
 
 export function createGithubSubscriptionTools(requestContext: RequestContext, github: GithubIntegration) {
-  const context = requestContext.get('controller') as AgentControllerRequestContext<RepositorySessionState> | undefined;
-  if (!context?.getState().projectRepositoryId || !sessionOrgId(requestContext) || !sessionUserId(requestContext))
-    return {};
+  if (!isGithubProjectSession(requestContext)) return {};
 
   return {
     github_refresh_token: createTool({

--- a/mastracode/factory/src/integrations/github/session-subscriptions.ts
+++ b/mastracode/factory/src/integrations/github/session-subscriptions.ts
@@ -2,6 +2,7 @@ import type { AgentControllerRequestContext } from '@mastra/core/agent-controlle
 import type { RequestContext } from '@mastra/core/request-context';
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
+import { getFactoryAuthOrgId, getFactoryAuthUserFromContext, getFactoryAuthUserId } from '../../auth.js';
 import type {
   ProjectRepository,
   ProjectSourceControlConnection,
@@ -16,23 +17,18 @@ import { getRegisteredGithubPatKind, injectGithubToken } from './token-refresh.j
 type RepositorySessionState = { factoryProjectId?: string; projectRepositoryId?: string };
 
 /**
- * Minimal shape of the host-authenticated user placed on the request context
- * under the `user` key. Mirrors the host's auth user without importing it:
- * `workosId` (stable external id) wins over the row `id`, and `organizationId`
- * scopes org tenancy.
+ * The host-authenticated user placed on the request context under the `user`
+ * key, read through the host's own normalizer. A local mirror of that shape
+ * used to live here; it silently missed the provider shapes the normalizer
+ * knows about, which turned every subscription tool into a no-op for those
+ * users instead of an error anybody could see.
  */
-interface SessionAuthUser {
-  workosId?: string;
-  id?: string;
-  organizationId?: string;
+function sessionUserId(requestContext: RequestContext): string | undefined {
+  return getFactoryAuthUserId(getFactoryAuthUserFromContext(requestContext));
 }
 
-function sessionUserId(user: SessionAuthUser | undefined): string | undefined {
-  return user?.workosId ?? user?.id;
-}
-
-function sessionOrgId(user: SessionAuthUser | undefined): string | undefined {
-  return user?.organizationId;
+function sessionOrgId(requestContext: RequestContext): string | undefined {
+  return getFactoryAuthOrgId(getFactoryAuthUserFromContext(requestContext));
 }
 
 const pullRequestInputSchema = z.object({
@@ -67,17 +63,18 @@ function parsePullRequest(value: number | string, expectedRepo: string): number 
  */
 function isGithubProjectSession(requestContext: RequestContext): boolean {
   const context = requestContext.get('controller') as AgentControllerRequestContext<RepositorySessionState> | undefined;
-  const user = requestContext.get('user') as SessionAuthUser | undefined;
   return Boolean(
-    context?.threadId && context.getState().projectRepositoryId && sessionOrgId(user) && sessionUserId(user),
+    context?.threadId &&
+    context.getState().projectRepositoryId &&
+    sessionOrgId(requestContext) &&
+    sessionUserId(requestContext),
   );
 }
 
 async function resolveSessionTarget(requestContext: RequestContext, github: GithubIntegration): Promise<SessionTarget> {
   const context = requestContext.get('controller') as AgentControllerRequestContext<RepositorySessionState> | undefined;
-  const user = requestContext.get('user') as SessionAuthUser | undefined;
-  const orgId = sessionOrgId(user);
-  const userId = sessionUserId(user);
+  const orgId = sessionOrgId(requestContext);
+  const userId = sessionUserId(requestContext);
   const projectRepositoryId = context?.getState().projectRepositoryId;
   if (!context || !context.threadId || !projectRepositoryId || !orgId || !userId) {
     throw new Error('GitHub subscriptions require an authenticated repository session with an active thread.');
@@ -179,8 +176,8 @@ export async function refreshGithubToken(requestContext: RequestContext, github:
 
 export function createGithubSubscriptionTools(requestContext: RequestContext, github: GithubIntegration) {
   const context = requestContext.get('controller') as AgentControllerRequestContext<RepositorySessionState> | undefined;
-  const user = requestContext.get('user') as SessionAuthUser | undefined;
-  if (!context?.getState().projectRepositoryId || !sessionOrgId(user) || !sessionUserId(user)) return {};
+  if (!context?.getState().projectRepositoryId || !sessionOrgId(requestContext) || !sessionUserId(requestContext))
+    return {};
 
   return {
     github_refresh_token: createTool({

--- a/mastracode/factory/src/rules/binding-context.ts
+++ b/mastracode/factory/src/rules/binding-context.ts
@@ -1,8 +1,7 @@
 import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
 import type { RequestContext } from '@mastra/core/request-context';
 
-import type { FactoryAuthUser } from '../auth.js';
-import { getFactoryAuthOrgId } from '../auth.js';
+import { getFactoryAuthOrgId, getFactoryAuthUserFromContext } from '../auth.js';
 import type { FactoryRunBindingAddress, FactoryRunBindingSessionAddress } from '../storage/domains/work-items/base.js';
 
 interface FactorySessionState {
@@ -27,7 +26,7 @@ export function getFactorySessionCoordinates(
 export function getFactorySessionAddress(requestContext: RequestContext | undefined): FactoryRunBindingAddress | null {
   const coordinates = getFactorySessionCoordinates(requestContext);
   if (!coordinates || !requestContext || typeof requestContext.get !== 'function') return null;
-  const user = requestContext.get('user') as FactoryAuthUser | undefined;
+  const user = getFactoryAuthUserFromContext(requestContext);
   const orgId = getFactoryAuthOrgId(user);
   if (!orgId) return null;
   return { orgId, ...coordinates };

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -523,6 +523,63 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.sessions.find(session => session.id === 'session-b')?.sandboxWorkdir).toBe(workdirB);
   });
 
+  it('opens the session for a session-shaped auth user, whose org lives on the session half', async () => {
+    const { root, workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    // better-auth's `authenticateToken` answers with a wrapper rather than a
+    // flat user, and the server writes that answer onto the request context
+    // verbatim. Read as a flat user it has neither an id nor an org, so the
+    // owner of the session gets refused their own session.
+    const requestContext = createGithubRequestContext('project-1', 'session-a', {
+      session: { activeOrganizationId: 'org-1' },
+      user: { id: 'user-1', email: 'owner@example.com' },
+    });
+
+    const opened = await workspace({ requestContext });
+
+    expect(opened.id).toContain('project-1-session-a');
+    expect(mocks.materializeRepo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        row: expect.objectContaining({
+          id: 'session-a',
+          sandboxWorkdir: path.join(root, 'github-sessions', 'octocat', 'hello', 'session-a'),
+        }),
+      }),
+    );
+  });
+
+  it('still refuses a session-shaped auth user from another organization', async () => {
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    const requestContext = createGithubRequestContext('project-1', 'session-a', {
+      session: { activeOrganizationId: 'org-2' },
+      user: { id: 'user-1' },
+    });
+
+    await expect(workspace({ requestContext })).rejects.toThrow(
+      'Factory session session-a is not available to the current user',
+    );
+  });
+
+  it('refuses a session-shaped auth user whose session carries no active organization', async () => {
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    // No active org on the session half means no org at all: the wrapper's inner
+    // user is never consulted for one. Refusing is the only safe answer, and it
+    // is the answer a signed-in user gets before they pick an organization.
+    const requestContext = createGithubRequestContext('project-1', 'session-a', {
+      session: {},
+      user: { id: 'user-1', organizationId: 'org-1' },
+    });
+
+    await expect(workspace({ requestContext })).rejects.toThrow(
+      'Factory session session-a is not available to the current user',
+    );
+  });
+
   it('pins the session workdir into controller state so the agent prompt never points at the host checkout', async () => {
     const { root, workspace } = await createLocalFactory();
     addProject();

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -10,8 +10,7 @@ import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
 import { LocalSandbox, LocalSkillSource, Workspace } from '@mastra/core/workspace';
 import type { SkillSource, SkillSourceEntry, SkillSourceStat } from '@mastra/core/workspace';
-import { getFactoryAuthUserId } from './auth.js';
-import type { FactoryAuthUser } from './auth.js';
+import { getFactoryAuthUserFromContext, getFactoryAuthUserId } from './auth.js';
 import type { MastraFactorySandboxConfig } from './factory.js';
 import type { GithubIntegration } from './integrations/github/integration.js';
 import { getGithubPat } from './integrations/github/pat.js';
@@ -152,7 +151,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       return getDynamicWorkspace({ requestContext, mastra, skillExtension: effectiveSkillExtension });
     }
 
-    const user = requestContext.get('user') as FactoryAuthUser | undefined;
+    const user = getFactoryAuthUserFromContext(requestContext);
     const userId = getFactoryAuthUserId(user);
     if (!user?.organizationId || !userId || user.organizationId !== session.orgId || userId !== session.userId) {
       throw new Error(`Factory session ${session.sessionId} is not available to the current user`);

--- a/mastracode/sdk/src/agents/credential-resolver.test.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.test.ts
@@ -97,6 +97,18 @@ describe('credential store provider registry', () => {
     ctx.set('user', 'not-a-user');
     expect(resolveTenantFromRequestContext(ctx)).toBeUndefined();
   });
+
+  it('refuses a tenant whose resolved user id is not a string', () => {
+    const ctx = new RequestContext();
+    ctx.set('user', { session: { activeOrganizationId: 'org_1' }, user: { id: 7 } });
+    expect(resolveTenantFromRequestContext(ctx)).toBeUndefined();
+  });
+
+  it('refuses a tenant whose resolved org id is not a string', () => {
+    const ctx = new RequestContext();
+    ctx.set('user', { session: { activeOrganizationId: 7 }, user: { id: 'prov_5' } });
+    expect(resolveTenantFromRequestContext(ctx)).toBeUndefined();
+  });
 });
 
 describe('gateway credentialStore injection', () => {

--- a/mastracode/sdk/src/agents/credential-resolver.test.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.test.ts
@@ -77,6 +77,21 @@ describe('credential store provider registry', () => {
     expect(resolveTenantFromRequestContext(ctx)).toEqual({ orgId: undefined, userId: 'prov_2' });
   });
 
+  it('reads a session-shaped user, whose org lives on the session half', () => {
+    const ctx = new RequestContext();
+    ctx.set('user', { session: { activeOrganizationId: 'org_1' }, user: { id: 'prov_3' } });
+    expect(resolveTenantFromRequestContext(ctx)).toEqual({ orgId: 'org_1', userId: 'prov_3' });
+  });
+
+  it('takes a session-shaped user org from the session half only, never the inner user', () => {
+    const ctx = new RequestContext();
+    ctx.set('user', { session: {}, user: { id: 'prov_4', organizationId: 'org_9' } });
+    // `toFactoryAuthUser` in `@mastra/factory` reads the session half and nothing
+    // else. Falling back to the inner user here would resolve a tenant the
+    // Factory refuses, and the two would disagree about who the caller is.
+    expect(resolveTenantFromRequestContext(ctx)).toEqual({ orgId: undefined, userId: 'prov_4' });
+  });
+
   it('ignores malformed user values', () => {
     const ctx = new RequestContext();
     ctx.set('user', 'not-a-user');

--- a/mastracode/sdk/src/agents/credential-resolver.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.ts
@@ -69,16 +69,38 @@ interface RequestContextUser {
 }
 
 /**
+ * Session-shaped `authenticateToken` results (better-auth) arrive as a wrapper
+ * whose active org lives on the session half rather than on the user.
+ */
+interface RequestContextSession {
+  user?: RequestContextUser;
+  session?: { activeOrganizationId?: string };
+}
+
+/**
  * Derive the calling tenant from a request context, if an authenticated web
  * user was stashed on it. Mirrors the web layer's stable-id resolution
  * (`workosId` falling back to the provider `id`).
+ *
+ * The value under `user` is whatever the active auth provider's
+ * `authenticateToken` returned, so its shape follows the provider: a flat user
+ * (WorkOS) or a `{ session, user }` wrapper (better-auth). Reading only the
+ * flat shape resolves no tenant at all for the wrapper, which in deployed mode
+ * fails closed to an empty credential store.
  */
 export function resolveTenantFromRequestContext(requestContext?: RequestContext): CredentialTenant | undefined {
-  const user = requestContext?.get('user') as RequestContextUser | undefined;
-  if (!user || typeof user !== 'object') return undefined;
+  const raw = requestContext?.get('user') as (RequestContextUser & RequestContextSession) | undefined;
+  if (!raw || typeof raw !== 'object') return undefined;
+
+  // Precedence matches `toFactoryAuthUser` in `@mastra/factory`: a wrapper's org
+  // comes from the session half only, never from the inner user. The two parsers
+  // cannot share code across the package boundary, so they must agree by rule.
+  const wrapped = Boolean(raw.user && typeof raw.user === 'object' && raw.session && typeof raw.session === 'object');
+  const user = wrapped ? (raw.user as RequestContextUser) : raw;
+  const orgId = wrapped ? raw.session?.activeOrganizationId : user.organizationId;
   const userId = user.workosId ?? user.id;
   if (!userId) return undefined;
-  return { orgId: user.organizationId, userId };
+  return { orgId, userId };
 }
 
 /**

--- a/mastracode/sdk/src/agents/credential-resolver.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.ts
@@ -99,7 +99,11 @@ export function resolveTenantFromRequestContext(requestContext?: RequestContext)
   const user = wrapped ? (raw.user as RequestContextUser) : raw;
   const orgId = wrapped ? raw.session?.activeOrganizationId : user.organizationId;
   const userId = user.workosId ?? user.id;
-  if (!userId) return undefined;
+  // The slot holds whatever the provider returned, so the declared string
+  // types are hopes, not guarantees. A non-string id must refuse the tenant
+  // (fail closed), not flow onward as a mistyped key.
+  if (typeof userId !== 'string' || !userId) return undefined;
+  if (orgId !== undefined && typeof orgId !== 'string') return undefined;
   return { orgId, userId };
 }
 


### PR DESCRIPTION
Fixes #20688

## The bug

`@mastra/server` writes the auth provider's `authenticateToken()` result into the request context's `user` slot verbatim (`packages/server/src/server/auth/helpers.ts:444-450`), so the value's shape follows the provider. WorkOS answers with a flat user. better-auth answers with a `{ session, user }` wrapper whose active org lives on `session.activeOrganizationId`.

Several sites read that slot cast as a flat `FactoryAuthUser`. Under better-auth they resolved neither a user id nor an org, which falsified every ownership comparison built on them:

* `mastracode/factory/src/workspace.ts:157` threw `Factory session <id> is not available to the current user` at the session's actual owner.
* The GitHub session subscription tools returned an empty toolset instead of erroring, so the tools just appeared to be missing.
* `resolveTenantFromRequestContext` in the SDK produced no tenant, which in deployed mode fails closed to an empty credential store.

The first one hides until a restart. The ownership check only runs when a workspace must be *created*, and a live session never re-enters that path. Everything looks healthy until the process restarts, at which point every session belonging to that user dies at once and cannot be re-minted either. Found on a live deployment; three sessions were unrecoverable through the UI.

## The fix

The converter for exactly this case already ships in the same package and simply was not called at those read sites. `toFactoryAuthUser` handles both result families and normalizes them onto the neutral SPA user shape.

* Export `getFactoryAuthUserFromContext(requestContext)` from `mastracode/factory/src/auth.ts` and read the slot through it at `workspace.ts:155`, `factory.ts:410` (audit tenant), `rules/binding-context.ts:30`, and `integrations/github/session-subscriptions.ts`. The last one had grown its own private mirror of the flat shape; that duplicate is deleted in favour of the shared reader.
* Teach `mastracode/sdk/src/agents/credential-resolver.ts` the same two shapes. It cannot import from `@mastra/factory`, so the rule is duplicated deliberately and each copy now has a test pinning it, including the precedence rule: a wrapper's org comes from the session half only and never from the inner user, so the two parsers cannot drift into disagreeing about who the caller is.

Nothing here widens who passes an ownership check. A missing org, a missing id, or a malformed value is still a refusal, and a session-shaped user whose session carries no active organization is refused with a test to say so.

## Tests

Three regression tests, each verified to fail against the unfixed code:

* `mastracode/factory/src/workspace.test.ts` — a session-shaped user opens their own session; a session-shaped user from another org is still refused; a session-shaped user with no active organization is refused.
* `mastracode/sdk/src/agents/credential-resolver.test.ts` — a session-shaped user resolves a tenant; its org comes from the session half only.

`pnpm --filter ./mastracode/factory exec vitest run` passes 1182 of 1184. The two failures are in `src/storage/domains/work-items/base.test.ts` and reproduce on a clean checkout of `main` with this branch stashed, so they are pre-existing and unrelated. `src/agents` in the SDK passes 222. `tsc --noEmit` is clean for both packages and the factory package lints clean.

## Not fixed here, but the same misread

Two other readers of that slot assume the flat shape. Both degrade quietly rather than erroring, which is probably why nobody has reported them:

* `packages/server/src/server/handlers/authorship.ts:29` — `getCallerAuthorId` checks `'id' in user`, so a wrapper resolves no author and falls through to `null`.
* `packages/editor/src/providers/composio.ts:521` — the same read, falling back to the default internal user id.

They live in other packages and want their own decision about whether the normalization belongs at the write site instead, so this PR leaves them alone rather than growing its blast radius. Happy to follow up on either if a maintainer would rather have them in one change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Different authentication systems return user information in different formats. This PR supports both formats so Factory and SDK authentication work correctly with WorkOS and better-auth.

## Overview

This PR normalizes authenticated users from request contexts across Factory and SDK code.

WorkOS returns a flat user object. Better-auth returns a `{ session, user }` wrapper, with the active organization ID in `session.activeOrganizationId`. Consumers that expected the flat format could fail ownership checks, GitHub session tools, and SDK tenant resolution.

## Changes

- Added and exported `getFactoryAuthUserFromContext()`.
- Updated Factory workspace, audit tenant, binding context, and GitHub subscription code to use shared normalization.
- Removed duplicate GitHub user-shape parsing.
- Updated SDK tenant resolution for flat and session-wrapped users.
- Rejected missing, malformed, or non-string user and organization IDs.
- Required an active organization for wrapped better-auth users.
- Required an active thread before exposing GitHub subscription tools.
- Added a changeset for patch releases of `@mastra/factory` and `@mastra/code-sdk`.

## Testing

- Added Factory workspace tests for ownership, organization mismatch, and missing active organization.
- Added SDK credential resolver tests for organization precedence and invalid identity values.
- Added a GitHub subscription test for requests without an active thread.
- Factory tests pass 1182 of 1184. The two failures are unrelated and pre-existing.
- SDK agent tests and TypeScript checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->