### PR TITLE
docs: document the injected platform access token

### DIFF
--- a/docs/src/content/en/docs/mastra-platform/workspaces.mdx
+++ b/docs/src/content/en/docs/mastra-platform/workspaces.mdx
@@ -108,11 +108,11 @@ One variable is **not** injected and must be set on your project yourself:
 
 | Variable | Contents |
 | - | - |
-| `MASTRA_PLATFORM_SECRET_KEY` | Secret key the workspace providers use to authenticate. Create one on your project's settings page under **API Tokens** and store it as an environment variable on your project. `MASTRA_PLATFORM_ACCESS_TOKEN` is accepted as a deprecated alias. |
+| `MASTRA_PLATFORM_SECRET_KEY` | Secret key the workspace providers use to authenticate. Create one on your organization's settings page under **API Tokens** and store it as an environment variable on your project. |
 
 ## Local development
 
-Reuse the same providers locally by putting the four variables in your `.env` file. Get the project, environment, and bucket values from your project's Workspaces tab, and the secret key from the settings page under **API Tokens**:
+Reuse the same providers locally by putting the four variables in your `.env` file. Get the project, environment, and bucket values from your project's Workspaces tab, and create the secret key on your organization's settings page under **API Tokens**:
 
 ```bash title=".env"
 MASTRA_PLATFORM_SECRET_KEY=your-secret-key

--- a/docs/src/content/en/docs/mastra-platform/workspaces.mdx
+++ b/docs/src/content/en/docs/mastra-platform/workspaces.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Workspaces | Mastra platform"
-description: Give each Mastra platform environment a workspace with a shared bucket for filesystem storage and on-demand sandboxes for command execution. The platform provisions the resources and injects the credentials your deploy needs.
+description: Give each Mastra platform environment a workspace with a shared bucket for filesystem storage and on-demand sandboxes for command execution. The platform provisions the resources your deploy needs.
 ---
 
 # Workspaces
@@ -12,7 +12,7 @@ Every workspace exposes two capabilities:
 - One **bucket** for filesystem storage, wrapped by [`PlatformFilesystem`](/reference/workspace/platform-filesystem). The bucket is a durable, environment-scoped store agents read from and write to across runs.
 - A pool of **on-demand sandboxes** for command execution, wrapped by [`PlatformSandbox`](/reference/workspace/platform-sandbox). Each `PlatformSandbox` instance provisions its own remote sandbox on `start()` and destroys it on `destroy()`. Agents typically spin up many sandboxes per session, use them for a task, and let them go.
 
-Workspaces are scoped to a single [environment](/docs/mastra-platform/environments), so `production` and `staging` don't share buckets or sandbox pools. The platform manages provisioning, credentials, and idle cleanup. Your deploy only constructs the providers.
+Workspaces are scoped to a single [environment](/docs/mastra-platform/environments), so `production` and `staging` don't share buckets or sandbox pools. The platform manages provisioning and idle cleanup. Your deploy constructs the providers and supplies a secret key (see [Environment variables](#environment-variables)).
 
 ## When workspaces are provisioned
 
@@ -51,7 +51,7 @@ export const mastra = new Mastra({
 })
 ```
 
-`PlatformFilesystem` and `PlatformSandbox` read their credentials from environment variables the platform injects at deploy time, so you don't pass any options on the platform.
+`PlatformFilesystem` and `PlatformSandbox` read their configuration from environment variables, so you don't pass any options on the platform. The platform injects most of them at deploy time, but you must set `MASTRA_PLATFORM_SECRET_KEY` yourself. See [Environment variables](#environment-variables).
 
 ## One bucket, many sandboxes
 
@@ -92,18 +92,23 @@ await perProjectSandbox.start()
 
 See [`PlatformSandbox` reference](/reference/workspace/platform-sandbox) for the full lifecycle, checkpoint recovery, reattachment, and clone options.
 
-## Injected environment variables
+## Environment variables
 
-Every deploy that runs on a platform environment with a workspace receives these variables:
+Every deploy that runs on a platform environment with a workspace receives these variables automatically:
 
 | Variable | Contents |
 | - | - |
-| `MASTRA_PLATFORM_SECRET_KEY` | Secret key scoped to the deploy. Used by the workspace providers to authenticate. `MASTRA_PLATFORM_ACCESS_TOKEN` is also injected as a deprecated alias. |
 | `MASTRA_PROJECT_ID` | Project the deploy belongs to. |
 | `MASTRA_ENVIRONMENT_ID` | Environment the deploy belongs to. Selects which sandbox pool the platform uses. |
 | `MASTRA_PLATFORM_BUCKET_NAME` | Bucket name attached to the environment. Selects which bucket `PlatformFilesystem` reads and writes. |
 
 These names are reserved. If your project sets any of them explicitly, the platform-managed values take precedence.
+
+One variable is **not** injected and must be set on your project yourself:
+
+| Variable | Contents |
+| - | - |
+| `MASTRA_PLATFORM_SECRET_KEY` | Secret key the workspace providers use to authenticate. Get it from your project's Workspaces tab and store it as an environment variable on your project. `MASTRA_PLATFORM_ACCESS_TOKEN` is accepted as a deprecated alias. |
 
 ## Local development
 

--- a/docs/src/content/en/docs/mastra-platform/workspaces.mdx
+++ b/docs/src/content/en/docs/mastra-platform/workspaces.mdx
@@ -108,11 +108,11 @@ One variable is **not** injected and must be set on your project yourself:
 
 | Variable | Contents |
 | - | - |
-| `MASTRA_PLATFORM_SECRET_KEY` | Secret key the workspace providers use to authenticate. Get it from your project's Workspaces tab and store it as an environment variable on your project. `MASTRA_PLATFORM_ACCESS_TOKEN` is accepted as a deprecated alias. |
+| `MASTRA_PLATFORM_SECRET_KEY` | Secret key the workspace providers use to authenticate. Create one on your project's settings page under **API Tokens** and store it as an environment variable on your project. `MASTRA_PLATFORM_ACCESS_TOKEN` is accepted as a deprecated alias. |
 
 ## Local development
 
-Reuse the same providers locally by putting the four variables in your `.env` file. Get the values from your project's Workspaces tab:
+Reuse the same providers locally by putting the four variables in your `.env` file. Get the project, environment, and bucket values from your project's Workspaces tab, and the secret key from the settings page under **API Tokens**:
 
 ```bash title=".env"
 MASTRA_PLATFORM_SECRET_KEY=your-secret-key

--- a/docs/src/content/en/docs/mastra-platform/workspaces.mdx
+++ b/docs/src/content/en/docs/mastra-platform/workspaces.mdx
@@ -55,7 +55,7 @@ export const mastra = new Mastra({
 
 ## One bucket, many sandboxes
 
-The two providers have different lifecycles, and the difference matters when you design agents.
+`PlatformFilesystem` and `PlatformSandbox` have different lifecycles, which matters when you design agents.
 
 **`PlatformFilesystem` is a long-lived handle to the environment's bucket.** All requests, all agents, and all sandboxes in the environment read and write the same object storage. Anything an agent writes is visible on the next request unless you explicitly delete it.
 
@@ -104,7 +104,7 @@ Every deploy that runs on a platform environment with a workspace receives these
 
 These names are reserved. If your project sets any of them explicitly, the platform-managed values take precedence.
 
-One variable is **not** injected and must be set on your project yourself:
+`MASTRA_PLATFORM_SECRET_KEY` isn't injected. Set it on your project:
 
 | Variable | Contents |
 | - | - |

--- a/docs/src/content/en/docs/mastra-platform/workspaces.mdx
+++ b/docs/src/content/en/docs/mastra-platform/workspaces.mdx
@@ -12,7 +12,7 @@ Every workspace exposes two capabilities:
 - One **bucket** for filesystem storage, wrapped by [`PlatformFilesystem`](/reference/workspace/platform-filesystem). The bucket is a durable, environment-scoped store agents read from and write to across runs.
 - A pool of **on-demand sandboxes** for command execution, wrapped by [`PlatformSandbox`](/reference/workspace/platform-sandbox). Each `PlatformSandbox` instance provisions its own remote sandbox on `start()` and destroys it on `destroy()`. Agents typically spin up many sandboxes per session, use them for a task, and let them go.
 
-Workspaces are scoped to a single [environment](/docs/mastra-platform/environments), so `production` and `staging` don't share buckets or sandbox pools. The platform manages provisioning and idle cleanup. Your deploy constructs the providers and supplies a secret key (see [Environment variables](#environment-variables)).
+Workspaces are scoped to a single [environment](/docs/mastra-platform/environments), so `production` and `staging` don't share buckets or sandbox pools. The platform manages provisioning, authentication, and idle cleanup.
 
 ## When workspaces are provisioned
 
@@ -51,7 +51,7 @@ export const mastra = new Mastra({
 })
 ```
 
-`PlatformFilesystem` and `PlatformSandbox` read their configuration from environment variables, so you don't pass any options on the platform. The platform injects most of them at deploy time, but you must set `MASTRA_PLATFORM_SECRET_KEY` yourself. See [Environment variables](#environment-variables).
+`PlatformFilesystem` and `PlatformSandbox` read their configuration from environment variables, so you don't pass any options on the platform. The platform injects them at deploy time. See [Environment variables](#environment-variables).
 
 ## One bucket, many sandboxes
 
@@ -98,24 +98,19 @@ Every deploy that runs on a platform environment with a workspace receives these
 
 | Variable | Contents |
 | - | - |
+| `MASTRA_PLATFORM_ACCESS_TOKEN` | Platform-issued JSON Web Token (JWT) the workspace providers use to authenticate. The token is scoped to the deploy's organization and project. |
 | `MASTRA_PROJECT_ID` | Project the deploy belongs to. |
 | `MASTRA_ENVIRONMENT_ID` | Environment the deploy belongs to. Selects which sandbox pool the platform uses. |
 | `MASTRA_PLATFORM_BUCKET_NAME` | Bucket name attached to the environment. Selects which bucket `PlatformFilesystem` reads and writes. |
 
 These names are reserved. If your project sets any of them explicitly, the platform-managed values take precedence.
 
-`MASTRA_PLATFORM_SECRET_KEY` isn't injected. Set it on your project:
-
-| Variable | Contents |
-| - | - |
-| `MASTRA_PLATFORM_SECRET_KEY` | Secret key the workspace providers use to authenticate. Create one on your organization's settings page under **API Tokens** and store it as an environment variable on your project. |
-
 ## Local development
 
-Reuse the same providers locally by putting the four variables in your `.env` file. Get the project, environment, and bucket values from your project's Workspaces tab, and create the secret key on your organization's settings page under **API Tokens**:
+Reuse the same providers locally by putting the four variables in your `.env` file. Get the project, environment, and bucket values from your project's **Workspaces** tab. For `MASTRA_PLATFORM_ACCESS_TOKEN`, create an `sk_` API token on your organization's settings page under **API Tokens**. Platform deploys use an injected JWT instead.
 
 ```bash title=".env"
-MASTRA_PLATFORM_SECRET_KEY=your-secret-key
+MASTRA_PLATFORM_ACCESS_TOKEN=sk_your-api-token
 MASTRA_PROJECT_ID=your-project-id
 MASTRA_ENVIRONMENT_ID=your-environment-id
 MASTRA_PLATFORM_BUCKET_NAME=your-bucket-name

--- a/docs/src/content/en/reference/workspace/platform-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/platform-filesystem.mdx
@@ -48,7 +48,7 @@ Configure the platform credentials. The access token, project ID, and bucket nam
   </TabItem>
 </Tabs>
 
-On a Mastra Platform deployment these variables are injected automatically, so the constructor can be called with no options.
+On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_PLATFORM_BUCKET_NAME` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; the value is available in your project's Workspaces tab. With all three set, the constructor can be called with no options.
 
 ## Usage
 

--- a/docs/src/content/en/reference/workspace/platform-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/platform-filesystem.mdx
@@ -31,7 +31,7 @@ Configure the platform credentials. The access token, project ID, and bucket nam
 <Tabs>
   <TabItem value="env-file" label=".env file">
     ```bash
-    MASTRA_PLATFORM_SECRET_KEY=your-platform-secret-key
+    MASTRA_PLATFORM_ACCESS_TOKEN=your-platform-access-token
     MASTRA_PROJECT_ID=your-project-id
     MASTRA_PLATFORM_BUCKET_NAME=your-bucket-name
     ```
@@ -48,7 +48,7 @@ Configure the platform credentials. The access token, project ID, and bucket nam
   </TabItem>
 </Tabs>
 
-On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_PLATFORM_BUCKET_NAME` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; create the token on your organization's settings page under **API Tokens**. With all three set, the constructor can be called with no options.
+On a Mastra Platform deployment, `MASTRA_PLATFORM_ACCESS_TOKEN`, `MASTRA_PROJECT_ID`, and `MASTRA_PLATFORM_BUCKET_NAME` are injected automatically, so the constructor can be called with no options. For local development, `MASTRA_PLATFORM_ACCESS_TOKEN` can contain an `sk_` API token from your organization's settings page under **API Tokens**.
 
 ## Usage
 
@@ -115,7 +115,7 @@ await fs.writeFile('/analyses/repo.md', 'x') // throws WorkspaceReadOnlyError
   {
     name: 'accessToken',
     type: 'string',
-    description: 'Platform secret key. Falls back to the MASTRA_PLATFORM_SECRET_KEY environment variable.',
+    description: 'Platform access token. Falls back to the MASTRA_PLATFORM_ACCESS_TOKEN environment variable.',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/workspace/platform-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/platform-filesystem.mdx
@@ -48,7 +48,7 @@ Configure the platform credentials. The access token, project ID, and bucket nam
   </TabItem>
 </Tabs>
 
-On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_PLATFORM_BUCKET_NAME` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; the value is available in your project's Workspaces tab. With all three set, the constructor can be called with no options.
+On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_PLATFORM_BUCKET_NAME` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; create the token on your project's settings page under **API Tokens**. With all three set, the constructor can be called with no options.
 
 ## Usage
 

--- a/docs/src/content/en/reference/workspace/platform-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/platform-filesystem.mdx
@@ -48,7 +48,7 @@ Configure the platform credentials. The access token, project ID, and bucket nam
   </TabItem>
 </Tabs>
 
-On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_PLATFORM_BUCKET_NAME` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; create the token on your project's settings page under **API Tokens**. With all three set, the constructor can be called with no options.
+On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_PLATFORM_BUCKET_NAME` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; create the token on your organization's settings page under **API Tokens**. With all three set, the constructor can be called with no options.
 
 ## Usage
 
@@ -115,8 +115,7 @@ await fs.writeFile('/analyses/repo.md', 'x') // throws WorkspaceReadOnlyError
   {
     name: 'accessToken',
     type: 'string',
-    description:
-      'Platform secret key. Falls back to the MASTRA_PLATFORM_SECRET_KEY environment variable (MASTRA_PLATFORM_ACCESS_TOKEN is a deprecated fallback).',
+    description: 'Platform secret key. Falls back to the MASTRA_PLATFORM_SECRET_KEY environment variable.',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/workspace/platform-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/platform-sandbox.mdx
@@ -50,7 +50,7 @@ Configure the platform credentials. The access token, project ID, and environmen
   </TabItem>
 </Tabs>
 
-On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_ENVIRONMENT_ID` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; create the token on your project's settings page under **API Tokens**. With all three set, the constructor can be called with no options.
+On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_ENVIRONMENT_ID` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; create the token on your organization's settings page under **API Tokens**. With all three set, the constructor can be called with no options.
 
 ## Usage
 
@@ -176,8 +176,7 @@ The `command` argument is a shell string and is concatenated verbatim into the r
   {
     name: 'accessToken',
     type: 'string',
-    description:
-      'Platform secret key. Falls back to the MASTRA_PLATFORM_SECRET_KEY environment variable (MASTRA_PLATFORM_ACCESS_TOKEN is a deprecated fallback).',
+    description: 'Platform secret key. Falls back to the MASTRA_PLATFORM_SECRET_KEY environment variable.',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/workspace/platform-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/platform-sandbox.mdx
@@ -33,7 +33,7 @@ Configure the platform credentials. The access token, project ID, and environmen
 <Tabs>
   <TabItem value="env-file" label=".env file">
     ```bash
-    MASTRA_PLATFORM_SECRET_KEY=your-platform-secret-key
+    MASTRA_PLATFORM_ACCESS_TOKEN=your-platform-access-token
     MASTRA_PROJECT_ID=your-project-id
     MASTRA_ENVIRONMENT_ID=your-environment-id
     ```
@@ -50,7 +50,7 @@ Configure the platform credentials. The access token, project ID, and environmen
   </TabItem>
 </Tabs>
 
-On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_ENVIRONMENT_ID` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; create the token on your organization's settings page under **API Tokens**. With all three set, the constructor can be called with no options.
+On a Mastra Platform deployment, `MASTRA_PLATFORM_ACCESS_TOKEN`, `MASTRA_PROJECT_ID`, and `MASTRA_ENVIRONMENT_ID` are injected automatically, so the constructor can be called with no options. For local development, `MASTRA_PLATFORM_ACCESS_TOKEN` can contain an `sk_` API token from your organization's settings page under **API Tokens**.
 
 ## Usage
 
@@ -176,7 +176,7 @@ The `command` argument is a shell string and is concatenated verbatim into the r
   {
     name: 'accessToken',
     type: 'string',
-    description: 'Platform secret key. Falls back to the MASTRA_PLATFORM_SECRET_KEY environment variable.',
+    description: 'Platform access token. Falls back to the MASTRA_PLATFORM_ACCESS_TOKEN environment variable.',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/workspace/platform-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/platform-sandbox.mdx
@@ -50,7 +50,7 @@ Configure the platform credentials. The access token, project ID, and environmen
   </TabItem>
 </Tabs>
 
-On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_ENVIRONMENT_ID` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; the value is available in your project's Workspaces tab. With all three set, the constructor can be called with no options.
+On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_ENVIRONMENT_ID` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; create the token on your project's settings page under **API Tokens**. With all three set, the constructor can be called with no options.
 
 ## Usage
 

--- a/docs/src/content/en/reference/workspace/platform-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/platform-sandbox.mdx
@@ -10,7 +10,7 @@ import TabItem from "@theme/TabItem";
 
 # PlatformSandbox
 
-Client for provisioning sandboxes in a Mastra Platform environment. Each `PlatformSandbox` instance owns one remote sandbox: `start()` provisions it, `executeCommand()` runs against it, and `destroy()` tears it down. Construct additional instances to own additional remote sandboxes; use `clone()` to derive them from a configured template (see [Cloning](#cloning-for-a-fleet-of-sandboxes)).
+Client for provisioning sandboxes in a Mastra Platform environment. Each `PlatformSandbox` instance owns one remote sandbox: `start()` provisions it, `executeCommand()` runs against it, and `destroy()` tears it down. Construct additional instances to own additional remote sandboxes. Use `clone()` to derive them from a configured template (see [Cloning](#cloning-for-a-fleet-of-sandboxes)).
 
 Sandboxes boot from a pre-built recipe checkpoint with Python 3, Node 22, TypeScript, tsx, and common build tooling already installed. Pass a stable `id` to opt into [checkpoint recovery](#checkpoint-recovery) so a new sandbox boots from the previous one's filesystem.
 
@@ -117,7 +117,7 @@ When `sandboxId` is set, `environmentId` isn't required because the sandbox alre
 The constructor `id` (explicit or auto-generated) is sent to the platform on `POST /sandbox` as an advisory recovery key:
 
 - If the platform recognises the `id` from a previous session, the new sandbox boots from the most recent checkpoint of that earlier sandbox's filesystem instead of the base recipe.
-- If the `id` isn't recognised, the platform falls through to a fresh sandbox from the base recipe. Auto-generated ids never match, so omitting `id` disables checkpoint recovery.
+- If the `id` isn't recognised, the platform starts a fresh sandbox from the base recipe. Auto-generated ids never match, so omitting `id` disables checkpoint recovery.
 
 Pass a stable `id` to preserve a sandbox's filesystem across sessions or across a `destroy()`/`start()` cycle:
 

--- a/docs/src/content/en/reference/workspace/platform-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/platform-sandbox.mdx
@@ -50,7 +50,7 @@ Configure the platform credentials. The access token, project ID, and environmen
   </TabItem>
 </Tabs>
 
-On a Mastra Platform deployment these variables are injected automatically, so the constructor can be called with no options.
+On a Mastra Platform deployment, `MASTRA_PROJECT_ID` and `MASTRA_ENVIRONMENT_ID` are injected automatically. Set `MASTRA_PLATFORM_SECRET_KEY` as an environment variable on your project yourself; the value is available in your project's Workspaces tab. With all three set, the constructor can be called with no options.
 
 ## Usage
 


### PR DESCRIPTION
Mastra Platform injects `MASTRA_PLATFORM_ACCESS_TOKEN` into workspace-enabled deploys alongside the project, environment, and bucket variables. The token is a platform-issued JWT scoped to the deploy's organization and project.

This updates the workspaces guide and the `PlatformFilesystem` and `PlatformSandbox` reference pages to document the zero-config deployment flow. It also explains that local development can use an `sk_` API token created from the organization's **API Tokens** settings.

Validation:
- `pnpm run format:check`
- `pnpm run lint:remark`
- `pnpm run validate`
- Vale on the three changed MDX files
