### PR TITLE
fix(platform-workspace): use the injected platform access token

### DIFF
--- a/.changeset/wet-experts-travel.md
+++ b/.changeset/wet-experts-travel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/platform-workspace': major
+---
+
+Removed support for using MASTRA_PLATFORM_ACCESS_TOKEN to authenticate workspace providers. Set MASTRA_PLATFORM_SECRET_KEY or pass accessToken explicitly instead.

--- a/.changeset/wet-experts-travel.md
+++ b/.changeset/wet-experts-travel.md
@@ -2,4 +2,18 @@
 '@mastra/platform-workspace': major
 ---
 
-Removed support for using MASTRA_PLATFORM_SECRET_KEY to authenticate workspace providers. Use the platform-injected MASTRA_PLATFORM_ACCESS_TOKEN or pass accessToken explicitly instead.
+Removed support for using `MASTRA_PLATFORM_SECRET_KEY` to authenticate workspace providers. Use the platform-injected `MASTRA_PLATFORM_ACCESS_TOKEN` or pass `accessToken` explicitly instead.
+
+**Before:** Set `MASTRA_PLATFORM_SECRET_KEY`.
+
+**After:** Use the platform-injected `MASTRA_PLATFORM_ACCESS_TOKEN`. For local development, set `MASTRA_PLATFORM_ACCESS_TOKEN` to an organization API token, or pass it explicitly:
+
+```typescript
+import { PlatformSandbox } from '@mastra/platform-workspace';
+
+const sandbox = new PlatformSandbox({
+  accessToken: 'sk_your-api-token',
+  projectId: 'project_abc',
+  environmentId: 'environment_abc',
+});
+```

--- a/.changeset/wet-experts-travel.md
+++ b/.changeset/wet-experts-travel.md
@@ -2,4 +2,4 @@
 '@mastra/platform-workspace': major
 ---
 
-Removed support for using MASTRA_PLATFORM_ACCESS_TOKEN to authenticate workspace providers. Set MASTRA_PLATFORM_SECRET_KEY or pass accessToken explicitly instead.
+Removed support for using MASTRA_PLATFORM_SECRET_KEY to authenticate workspace providers. Use the platform-injected MASTRA_PLATFORM_ACCESS_TOKEN or pass accessToken explicitly instead.

--- a/workspaces/platform-workspace/README.md
+++ b/workspaces/platform-workspace/README.md
@@ -12,12 +12,12 @@ npm install @mastra/platform-workspace
 
 All options can be passed to the constructor or read from environment variables:
 
-| Option          | Env var                       | Required         |
-| --------------- | ----------------------------- | ---------------- |
-| `accessToken`   | `MASTRA_PLATFORM_SECRET_KEY`  | Yes              |
-| `projectId`     | `MASTRA_PROJECT_ID`           | Yes              |
-| `environmentId` | `MASTRA_ENVIRONMENT_ID`       | Yes (sandbox)    |
-| `bucketName`    | `MASTRA_PLATFORM_BUCKET_NAME` | Yes (filesystem) |
+| Option          | Env var                        | Required         |
+| --------------- | ------------------------------ | ---------------- |
+| `accessToken`   | `MASTRA_PLATFORM_ACCESS_TOKEN` | Yes              |
+| `projectId`     | `MASTRA_PROJECT_ID`            | Yes              |
+| `environmentId` | `MASTRA_ENVIRONMENT_ID`        | Yes (sandbox)    |
+| `bucketName`    | `MASTRA_PLATFORM_BUCKET_NAME`  | Yes (filesystem) |
 
 The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` env var (useful for staging).
 

--- a/workspaces/platform-workspace/README.md
+++ b/workspaces/platform-workspace/README.md
@@ -19,8 +19,6 @@ All options can be passed to the constructor or read from environment variables:
 | `environmentId` | `MASTRA_ENVIRONMENT_ID`       | Yes (sandbox)    |
 | `bucketName`    | `MASTRA_PLATFORM_BUCKET_NAME` | Yes (filesystem) |
 
-`MASTRA_PLATFORM_ACCESS_TOKEN` is still read as a deprecated fallback for `accessToken`.
-
 The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` env var (useful for staging).
 
 Requests to the proxy are authenticated with `Authorization: Bearer <accessToken>`.

--- a/workspaces/platform-workspace/src/client.test.ts
+++ b/workspaces/platform-workspace/src/client.test.ts
@@ -29,15 +29,15 @@ describe('PlatformClient', () => {
     expect(init.method).toBe('POST');
   });
 
-  it('reads the access token from MASTRA_PLATFORM_SECRET_KEY', () => {
-    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'sk_secret');
+  it('reads the access token from MASTRA_PLATFORM_ACCESS_TOKEN', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform_access_token');
     vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');
 
-    expect(resolvePlatformOptions({}).accessToken).toBe('sk_secret');
+    expect(resolvePlatformOptions({}).accessToken).toBe('platform_access_token');
   });
 
-  it('does not use MASTRA_PLATFORM_ACCESS_TOKEN as an access token fallback', () => {
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform_observability_token');
+  it('does not use MASTRA_PLATFORM_SECRET_KEY as an access token fallback', () => {
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'sk_secret');
     vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');
 
     expect(() => resolvePlatformOptions({})).toThrow('accessToken is required');

--- a/workspaces/platform-workspace/src/client.test.ts
+++ b/workspaces/platform-workspace/src/client.test.ts
@@ -36,19 +36,11 @@ describe('PlatformClient', () => {
     expect(resolvePlatformOptions({}).accessToken).toBe('sk_secret');
   });
 
-  it('prefers MASTRA_PLATFORM_SECRET_KEY over the deprecated MASTRA_PLATFORM_ACCESS_TOKEN', () => {
-    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'sk_secret');
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'sk_legacy');
+  it('does not use MASTRA_PLATFORM_ACCESS_TOKEN as an access token fallback', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform_observability_token');
     vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');
 
-    expect(resolvePlatformOptions({}).accessToken).toBe('sk_secret');
-  });
-
-  it('falls back to the deprecated MASTRA_PLATFORM_ACCESS_TOKEN', () => {
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'sk_legacy');
-    vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');
-
-    expect(resolvePlatformOptions({}).accessToken).toBe('sk_legacy');
+    expect(() => resolvePlatformOptions({})).toThrow('accessToken is required');
   });
 
   it('throws PlatformApiError for non-2xx responses', async () => {

--- a/workspaces/platform-workspace/src/client.ts
+++ b/workspaces/platform-workspace/src/client.ts
@@ -24,7 +24,7 @@ export function requireOption(value: string | undefined, name: string): string {
 
 export function resolvePlatformOptions(options: PlatformClientOptions) {
   return {
-    accessToken: requireOption(options.accessToken ?? process.env.MASTRA_PLATFORM_SECRET_KEY, 'accessToken'),
+    accessToken: requireOption(options.accessToken ?? process.env.MASTRA_PLATFORM_ACCESS_TOKEN, 'accessToken'),
     projectId: requireOption(options.projectId ?? process.env.MASTRA_PROJECT_ID, 'projectId'),
     proxyUrl: (process.env.MASTRA_WORKSPACE_PROXY_URL ?? DEFAULT_PROXY_URL).replace(/\/$/, ''),
     fetch: options.fetch ?? fetch,

--- a/workspaces/platform-workspace/src/client.ts
+++ b/workspaces/platform-workspace/src/client.ts
@@ -24,13 +24,7 @@ export function requireOption(value: string | undefined, name: string): string {
 
 export function resolvePlatformOptions(options: PlatformClientOptions) {
   return {
-    accessToken: requireOption(
-      options.accessToken ??
-        process.env.MASTRA_PLATFORM_SECRET_KEY ??
-        // Deprecated alias — prefer MASTRA_PLATFORM_SECRET_KEY.
-        process.env.MASTRA_PLATFORM_ACCESS_TOKEN,
-      'accessToken',
-    ),
+    accessToken: requireOption(options.accessToken ?? process.env.MASTRA_PLATFORM_SECRET_KEY, 'accessToken'),
     projectId: requireOption(options.projectId ?? process.env.MASTRA_PROJECT_ID, 'projectId'),
     proxyUrl: (process.env.MASTRA_WORKSPACE_PROXY_URL ?? DEFAULT_PROXY_URL).replace(/\/$/, ''),
     fetch: options.fetch ?? fetch,

--- a/workspaces/platform-workspace/src/provider.ts
+++ b/workspaces/platform-workspace/src/provider.ts
@@ -13,7 +13,7 @@ export const platformSandboxProvider: SandboxProvider<PlatformSandboxOptions> = 
     properties: {
       accessToken: {
         type: 'string',
-        description: 'Mastra Platform secret key (falls back to MASTRA_PLATFORM_SECRET_KEY)',
+        description: 'Mastra Platform access token (falls back to MASTRA_PLATFORM_ACCESS_TOKEN)',
       },
       projectId: { type: 'string', description: 'Platform project ID (falls back to MASTRA_PROJECT_ID)' },
       environmentId: { type: 'string', description: 'Platform environment ID (falls back to MASTRA_ENVIRONMENT_ID)' },
@@ -41,7 +41,7 @@ export const platformFilesystemProvider: FilesystemProvider<PlatformFilesystemOp
     properties: {
       accessToken: {
         type: 'string',
-        description: 'Mastra Platform secret key (falls back to MASTRA_PLATFORM_SECRET_KEY)',
+        description: 'Mastra Platform access token (falls back to MASTRA_PLATFORM_ACCESS_TOKEN)',
       },
       projectId: { type: 'string', description: 'Platform project ID (falls back to MASTRA_PROJECT_ID)' },
       bucketName: {


### PR DESCRIPTION
Mastra Platform injects `MASTRA_PLATFORM_ACCESS_TOKEN` into deployed projects. The token may be a platform-issued JWT or a WorkOS `sk_` organization key, and the workspace proxy accepts both forms.

This aligns `PlatformSandbox` and `PlatformFilesystem` with that managed credential by reading `MASTRA_PLATFORM_ACCESS_TOKEN` exclusively. `MASTRA_PLATFORM_SECRET_KEY` is no longer used; callers may still pass `accessToken` explicitly.

The provider schema descriptions, package README, regression tests, and breaking changeset now reflect the managed access-token flow.

Test plan:
- `pnpm --filter @mastra/platform-workspace test:unit`
- `pnpm --filter @mastra/platform-workspace lint`
- `pnpm --filter @mastra/platform-workspace build`
- `pnpm exec tsc --noEmit -p workspaces/platform-workspace/tsconfig.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Workspace providers now use the platform access token for authentication. They no longer use `MASTRA_PLATFORM_SECRET_KEY`, while callers can still provide `accessToken` directly.

## Changes

- Removed the `MASTRA_PLATFORM_SECRET_KEY` fallback from `resolvePlatformOptions`.
- Updated `PlatformSandbox` and `PlatformFilesystem` schemas to document `MASTRA_PLATFORM_ACCESS_TOKEN`.
- Updated the README and authentication tests.
- Added regression coverage to confirm that `MASTRA_PLATFORM_SECRET_KEY` is not used.
- Added breaking-change migration guidance and a `PlatformSandbox` example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
