### PR TITLE
fix(factory): sessions stop responding after a server restart

### DIFF
--- a/.changeset/chatty-toys-grin.md
+++ b/.changeset/chatty-toys-grin.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed Factory sessions stalling after a GitHub webhook woke them. When the process had restarted, rebuilding the session failed with `Factory session … is not available to the current user` because a webhook has no signed-in user to run as, so the update was silently dropped: the thread kept its spinner, showed no "working…" indicator and never finished. Webhook deliveries now rebuild the session as its owner.
+Fixed Factory sessions that stopped responding after a server restart. A GitHub event on the pull request now revives the session instead of failing with `Factory session … is not available to the current user`, so the thread picks up where it left off instead of sitting on a spinner.

--- a/.changeset/chatty-toys-grin.md
+++ b/.changeset/chatty-toys-grin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory sessions stalling after a GitHub webhook woke them. When the process had restarted, rebuilding the session failed with `Factory session … is not available to the current user` because a webhook has no signed-in user to run as, so the update was silently dropped: the thread kept its spinner, showed no "working…" indicator and never finished. Webhook deliveries now rebuild the session as its owner.

--- a/.changeset/chatty-toys-grin.md
+++ b/.changeset/chatty-toys-grin.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed Factory sessions that stopped responding after a server restart. A GitHub event on the pull request now revives the session instead of failing with `Factory session … is not available to the current user`, so the thread picks up where it left off instead of sitting on a spinner.
+Fixed Factory sessions that stopped responding after a server restart. GitHub webhook deliveries now restore the saved session owner when they rebuild a session, so the delivery goes through and the session picks up where it left off.

--- a/mastracode/factory/src/integrations/github/webhook.test.ts
+++ b/mastracode/factory/src/integrations/github/webhook.test.ts
@@ -1,6 +1,5 @@
 import { RequestContext } from '@mastra/core/request-context';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { GithubIntegration } from './integration.js';
 import type { GithubSignalSubscriptionRow } from './subscriptions.js';
 
 const getRepositoryCollaboratorPermission = vi.fn<
@@ -11,17 +10,23 @@ const getRepositoryCollaboratorPermission = vi.fn<
     signal?: AbortSignal,
   ) => Promise<'admin' | 'maintain' | 'write' | 'triage' | 'read' | 'none' | undefined>
 >(async () => 'write');
-// Stub integration: dispatch consumes the injected instance for permission checks.
-const githubStub = { getRepositoryCollaboratorPermission } as unknown as GithubIntegration;
 
-function githubWithSessionRow(row: { userId: string; orgId: string } | null) {
+function githubWithSessionRow(row: FactorySessionOwner | null): GithubWebhookDispatchIntegration {
   return {
+    // Every dispatch test overrides listSubscriptions/retireSubscription.
+    integrationStorage: {} as never,
     getRepositoryCollaboratorPermission,
     sourceControlStorage: { sessions: { getBySessionId: async () => row } },
-  } as unknown as GithubIntegration;
+  };
 }
+
+const githubStub = githubWithSessionRow(null);
 import { classifyGithubWebhook, dispatchGithubWebhook } from './webhook.js';
-import type { ParsedGithubWebhook } from './webhook.js';
+import type {
+  FactorySessionOwner,
+  GithubWebhookDispatchIntegration,
+  ParsedGithubWebhook,
+} from './webhook.js';
 
 function parsed(event: string, action: string, extra: Record<string, unknown> = {}): ParsedGithubWebhook {
   return {

--- a/mastracode/factory/src/integrations/github/webhook.test.ts
+++ b/mastracode/factory/src/integrations/github/webhook.test.ts
@@ -229,13 +229,19 @@ describe('dispatchGithubWebhook', () => {
     expect(sendA.mock.calls[0]).toHaveLength(1);
   });
 
-  it('recreates a session under its owner identity', async () => {
-    // No identity — workspace factory rejects the session, delivery dropped.
+  it('recreates a session as the owner recorded on its Factory session row', async () => {
+    // Not the subscription's `ownerId`: that can be a non-user id (the SDK's
+    // default owner), and the workspace guard compares against the row.
     const send = vi.fn(async () => ({ record: { id: 'n-a' }, decision: { action: 'deliver' } }));
     const createSession = vi.fn(async (_input: { requestContext: RequestContext }) => ({
       thread: { getId: () => 'thread-a', switch: vi.fn() },
       sendNotificationSignal: send,
     }));
+    const github = {
+      sourceControlStorage: {
+        sessions: { getBySessionId: async () => ({ userId: 'user-real', orgId: 'org-real' }) },
+      },
+    } as unknown as GithubIntegration;
 
     const result = await dispatchGithubWebhook(
       parsed('issue_comment', 'created', {
@@ -245,6 +251,7 @@ describe('dispatchGithubWebhook', () => {
       }),
       {
         controller: { getSessionByResource: async () => undefined, createSession } as never,
+        github,
         listSubscriptions: async () => [subscription('a', '/worktrees/a')],
         isAuthorizedSender: async () => true,
       },
@@ -252,8 +259,8 @@ describe('dispatchGithubWebhook', () => {
 
     expect(result).toEqual({ delivered: 1, failed: 0, ignored: false });
     expect(createSession.mock.calls[0]![0].requestContext.get('user')).toEqual({
-      workosId: 'owner-1',
-      organizationId: 'org-1',
+      workosId: 'user-real',
+      organizationId: 'org-real',
     });
   });
 

--- a/mastracode/factory/src/integrations/github/webhook.test.ts
+++ b/mastracode/factory/src/integrations/github/webhook.test.ts
@@ -1,3 +1,4 @@
+import { RequestContext } from '@mastra/core/request-context';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GithubIntegration } from './integration.js';
 import type { GithubSignalSubscriptionRow } from './subscriptions.js';
@@ -212,6 +213,7 @@ describe('dispatchGithubWebhook', () => {
         projectRepositoryId: 'project-repository-1',
         worktreePath: '/worktrees/b',
       },
+      requestContext: expect.any(RequestContext),
     });
     expect(switchB).not.toHaveBeenCalled();
     expect(sendA).toHaveBeenCalledWith(
@@ -225,6 +227,34 @@ describe('dispatchGithubWebhook', () => {
       }),
     );
     expect(sendA.mock.calls[0]).toHaveLength(1);
+  });
+
+  it('recreates a session under its owner identity', async () => {
+    // No identity — workspace factory rejects the session, delivery dropped.
+    const send = vi.fn(async () => ({ record: { id: 'n-a' }, decision: { action: 'deliver' } }));
+    const createSession = vi.fn(async (_input: { requestContext: RequestContext }) => ({
+      thread: { getId: () => 'thread-a', switch: vi.fn() },
+      sendNotificationSignal: send,
+    }));
+
+    const result = await dispatchGithubWebhook(
+      parsed('issue_comment', 'created', {
+        issue: { number: 34, pull_request: { url: 'https://api.github.test/pr/34' } },
+        comment: { html_url: 'https://github.com/octo/hello/pull/34#issuecomment-123' },
+        pull_request: undefined,
+      }),
+      {
+        controller: { getSessionByResource: async () => undefined, createSession } as never,
+        listSubscriptions: async () => [subscription('a', '/worktrees/a')],
+        isAuthorizedSender: async () => true,
+      },
+    );
+
+    expect(result).toEqual({ delivered: 1, failed: 0, ignored: false });
+    expect(createSession.mock.calls[0]![0].requestContext.get('user')).toEqual({
+      workosId: 'owner-1',
+      organizationId: 'org-1',
+    });
   });
 
   it('switches an exact live scoped session to its subscribed thread', async () => {

--- a/mastracode/factory/src/integrations/github/webhook.test.ts
+++ b/mastracode/factory/src/integrations/github/webhook.test.ts
@@ -13,6 +13,13 @@ const getRepositoryCollaboratorPermission = vi.fn<
 >(async () => 'write');
 // Stub integration: dispatch consumes the injected instance for permission checks.
 const githubStub = { getRepositoryCollaboratorPermission } as unknown as GithubIntegration;
+
+function githubWithSessionRow(row: { userId: string; orgId: string } | null) {
+  return {
+    getRepositoryCollaboratorPermission,
+    sourceControlStorage: { sessions: { getBySessionId: async () => row } },
+  } as unknown as GithubIntegration;
+}
 import { classifyGithubWebhook, dispatchGithubWebhook } from './webhook.js';
 import type { ParsedGithubWebhook } from './webhook.js';
 
@@ -185,7 +192,7 @@ describe('dispatchGithubWebhook', () => {
     const getSessionByResource = vi.fn(async (_resourceId: string, scope?: string) =>
       scope === '/worktrees/a' ? liveA : undefined,
     );
-    const createSession = vi.fn(async () => resumedB);
+    const createSession = vi.fn(async (_input: { requestContext: RequestContext }) => resumedB);
     const rows = [subscription('a', '/worktrees/a'), subscription('b', '/worktrees/b')];
 
     const result = await dispatchGithubWebhook(
@@ -196,6 +203,7 @@ describe('dispatchGithubWebhook', () => {
       }),
       {
         controller: { getSessionByResource, createSession } as never,
+        github: githubWithSessionRow({ userId: 'user-1', orgId: 'org-1' }),
         listSubscriptions: async () => rows,
         isAuthorizedSender: async () => true,
       },
@@ -203,9 +211,11 @@ describe('dispatchGithubWebhook', () => {
 
     expect(result).toEqual({ delivered: 2, failed: 0, ignored: false });
     expect(getSessionByResource).toHaveBeenCalledWith('resource-1', '/worktrees/a');
+    // Owner and identity both come from the Factory session row, not from the
+    // subscription's `ownerId` ('owner-1'), which matches no user.
     expect(createSession).toHaveBeenCalledWith({
       id: 'session-b',
-      ownerId: 'owner-1',
+      ownerId: 'user-1',
       resourceId: 'resource-1',
       scope: '/worktrees/b',
       tags: {
@@ -214,6 +224,10 @@ describe('dispatchGithubWebhook', () => {
         worktreePath: '/worktrees/b',
       },
       requestContext: expect.any(RequestContext),
+    });
+    expect(createSession.mock.calls[0]![0]!.requestContext.get('user')).toEqual({
+      workosId: 'user-1',
+      organizationId: 'org-1',
     });
     expect(switchB).not.toHaveBeenCalled();
     expect(sendA).toHaveBeenCalledWith(
@@ -229,39 +243,23 @@ describe('dispatchGithubWebhook', () => {
     expect(sendA.mock.calls[0]).toHaveLength(1);
   });
 
-  it('recreates a session as the owner recorded on its Factory session row', async () => {
-    // Not the subscription's `ownerId`: that can be a non-user id (the SDK's
-    // default owner), and the workspace guard compares against the row.
-    const send = vi.fn(async () => ({ record: { id: 'n-a' }, decision: { action: 'deliver' } }));
-    const createSession = vi.fn(async (_input: { requestContext: RequestContext }) => ({
-      thread: { getId: () => 'thread-a', switch: vi.fn() },
-      sendNotificationSignal: send,
-    }));
-    const github = {
-      sourceControlStorage: {
-        sessions: { getBySessionId: async () => ({ userId: 'user-real', orgId: 'org-real' }) },
-      },
-    } as unknown as GithubIntegration;
-
+  it('fails the delivery instead of reviving a session it cannot attribute to a user', async () => {
+    const createSession = vi.fn();
     const result = await dispatchGithubWebhook(
       parsed('issue_comment', 'created', {
         issue: { number: 34, pull_request: { url: 'https://api.github.test/pr/34' } },
-        comment: { html_url: 'https://github.com/octo/hello/pull/34#issuecomment-123' },
         pull_request: undefined,
       }),
       {
         controller: { getSessionByResource: async () => undefined, createSession } as never,
-        github,
+        github: githubWithSessionRow(null),
         listSubscriptions: async () => [subscription('a', '/worktrees/a')],
         isAuthorizedSender: async () => true,
       },
     );
 
-    expect(result).toEqual({ delivered: 1, failed: 0, ignored: false });
-    expect(createSession.mock.calls[0]![0].requestContext.get('user')).toEqual({
-      workosId: 'user-real',
-      organizationId: 'org-real',
-    });
+    expect(result).toEqual({ delivered: 0, failed: 1, ignored: false });
+    expect(createSession).not.toHaveBeenCalled();
   });
 
   it('switches an exact live scoped session to its subscribed thread', async () => {

--- a/mastracode/factory/src/integrations/github/webhook.ts
+++ b/mastracode/factory/src/integrations/github/webhook.ts
@@ -60,6 +60,9 @@ export interface GithubWebhookNotification {
   payload: Record<string, unknown>;
 }
 
+/** The Factory session row fields a woken session has to run as. */
+export type FactorySessionOwner = { userId: string; orgId: string };
+
 export interface GithubWebhookDispatchDependencies {
   controller: MountedMastraCode['controller'];
   /**
@@ -74,6 +77,9 @@ export interface GithubWebhookDispatchDependencies {
   ) => Promise<GithubSignalSubscriptionRow[]>;
   retireSubscription?: (id: string, status: 'open' | 'closed' | 'merged') => Promise<void>;
   isAuthorizedSender?: (notification: GithubWebhookNotification) => Promise<boolean>;
+  /** Owner lookup for sessions this dispatch has to recreate. Defaults to
+   * `github`, which the platform event worker does not supply. */
+  getFactorySession?: (sessionId: string) => Promise<FactorySessionOwner | null>;
   onTargetError?: (subscription: GithubSignalSubscriptionRow, error: unknown) => void;
 }
 
@@ -287,7 +293,7 @@ export function classifyGithubWebhook(parsed: ParsedGithubWebhook): GithubWebhoo
 async function resolveSubscriptionSession(
   controller: MountedMastraCode['controller'],
   subscription: GithubSignalSubscriptionRow,
-  github?: GithubIntegration,
+  getFactorySession: (sessionId: string) => Promise<FactorySessionOwner | null>,
 ) {
   const { sessionId, resourceId, threadId } = subscription;
   if (!sessionId || !resourceId || !threadId) {
@@ -303,7 +309,7 @@ async function resolveSubscriptionSession(
     };
     // Creating the session resolves its workspace, which authorizes the caller
     // against the Factory session row — no signed-in user, so run as its owner.
-    const sessionRow = await github?.sourceControlStorage.sessions.getBySessionId(resourceId);
+    const sessionRow = await getFactorySession(resourceId);
     if (!sessionRow) {
       throw new Error(`GitHub subscription ${subscription.id} has no Factory session ${resourceId} to run as.`);
     }
@@ -411,13 +417,19 @@ export async function dispatchGithubWebhook(
       if (!dependencies.github) throw new Error('GitHub integration is required to retire webhook subscriptions.');
       return retirePullRequestSubscription(id, status, dependencies.github.integrationStorage);
     });
+  const getFactorySession =
+    dependencies.getFactorySession ??
+    ((sessionId: string) => {
+      if (!dependencies.github) throw new Error('GitHub integration is required to resolve a Factory session owner.');
+      return dependencies.github.sourceControlStorage.sessions.getBySessionId(sessionId);
+    });
   const subscriptions = await listSubscriptions(target, { includeTerminal: notification.action === 'reopened' });
   let delivered = 0;
   let failed = 0;
 
   for (const subscription of subscriptions) {
     try {
-      const session = await resolveSubscriptionSession(dependencies.controller, subscription, dependencies.github);
+      const session = await resolveSubscriptionSession(dependencies.controller, subscription, getFactorySession);
       const result = await session.sendNotificationSignal({
         source: 'github',
         kind: notification.kind,

--- a/mastracode/factory/src/integrations/github/webhook.ts
+++ b/mastracode/factory/src/integrations/github/webhook.ts
@@ -287,6 +287,7 @@ export function classifyGithubWebhook(parsed: ParsedGithubWebhook): GithubWebhoo
 async function resolveSubscriptionSession(
   controller: MountedMastraCode['controller'],
   subscription: GithubSignalSubscriptionRow,
+  github?: GithubIntegration,
 ) {
   const { sessionId, resourceId, threadId } = subscription;
   if (!sessionId || !resourceId || !threadId) {
@@ -302,9 +303,13 @@ async function resolveSubscriptionSession(
     };
     // Recreating the session resolves its workspace, which authorizes the
     // caller against the Factory session row. A webhook has no signed-in user,
-    // so it stands in as the session's owner.
+    // so it stands in as the session's owner — read from that row, since a
+    // subscription's `ownerId` may be a non-user id (the SDK's default owner).
+    const sessionRow = await github?.sourceControlStorage.sessions.getBySessionId(resourceId);
     const requestContext = new RequestContext();
-    requestContext.set('user', { workosId: subscription.data.ownerId, organizationId: subscription.orgId });
+    if (sessionRow) {
+      requestContext.set('user', { workosId: sessionRow.userId, organizationId: sessionRow.orgId });
+    }
     session = await controller.createSession({
       id: sessionId,
       ownerId: subscription.data.ownerId,
@@ -413,7 +418,7 @@ export async function dispatchGithubWebhook(
 
   for (const subscription of subscriptions) {
     try {
-      const session = await resolveSubscriptionSession(dependencies.controller, subscription);
+      const session = await resolveSubscriptionSession(dependencies.controller, subscription, dependencies.github);
       const result = await session.sendNotificationSignal({
         source: 'github',
         kind: notification.kind,

--- a/mastracode/factory/src/integrations/github/webhook.ts
+++ b/mastracode/factory/src/integrations/github/webhook.ts
@@ -301,18 +301,17 @@ async function resolveSubscriptionSession(
       projectRepositoryId: subscription.data.projectRepositoryId,
       ...(scope ? { worktreePath: scope } : {}),
     };
-    // Recreating the session resolves its workspace, which authorizes the
-    // caller against the Factory session row. A webhook has no signed-in user,
-    // so it stands in as the session's owner — read from that row, since a
-    // subscription's `ownerId` may be a non-user id (the SDK's default owner).
+    // Creating the session resolves its workspace, which authorizes the caller
+    // against the Factory session row — no signed-in user, so run as its owner.
     const sessionRow = await github?.sourceControlStorage.sessions.getBySessionId(resourceId);
-    const requestContext = new RequestContext();
-    if (sessionRow) {
-      requestContext.set('user', { workosId: sessionRow.userId, organizationId: sessionRow.orgId });
+    if (!sessionRow) {
+      throw new Error(`GitHub subscription ${subscription.id} has no Factory session ${resourceId} to run as.`);
     }
+    const requestContext = new RequestContext();
+    requestContext.set('user', { workosId: sessionRow.userId, organizationId: sessionRow.orgId });
     session = await controller.createSession({
       id: sessionId,
-      ownerId: subscription.data.ownerId,
+      ownerId: sessionRow.userId,
       resourceId,
       scope,
       tags,

--- a/mastracode/factory/src/integrations/github/webhook.ts
+++ b/mastracode/factory/src/integrations/github/webhook.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { MountedMastraCode } from '@mastra/code-sdk';
 import type { NotificationPriority } from '@mastra/core/notifications';
+import { RequestContext } from '@mastra/core/request-context';
 import type { Context } from 'hono';
 import type { GithubIntegration } from './integration.js';
 import type { GithubIssueTriageInput, GithubIssueTriageResult } from './issue-triage.js';
@@ -299,12 +300,18 @@ async function resolveSubscriptionSession(
       projectRepositoryId: subscription.data.projectRepositoryId,
       ...(scope ? { worktreePath: scope } : {}),
     };
+    // Recreating the session resolves its workspace, which authorizes the
+    // caller against the Factory session row. A webhook has no signed-in user,
+    // so it stands in as the session's owner.
+    const requestContext = new RequestContext();
+    requestContext.set('user', { workosId: subscription.data.ownerId, organizationId: subscription.orgId });
     session = await controller.createSession({
       id: sessionId,
       ownerId: subscription.data.ownerId,
       resourceId,
       scope,
       tags,
+      requestContext,
     });
   }
   if (session.thread.getId() !== threadId) {

--- a/mastracode/factory/src/integrations/github/webhook.ts
+++ b/mastracode/factory/src/integrations/github/webhook.ts
@@ -3,10 +3,14 @@ import type { MountedMastraCode } from '@mastra/code-sdk';
 import type { NotificationPriority } from '@mastra/core/notifications';
 import { RequestContext } from '@mastra/core/request-context';
 import type { Context } from 'hono';
-import type { GithubIntegration } from './integration.js';
+import type { GithubIntegration, GithubRepositoryPermission } from './integration.js';
 import type { GithubIssueTriageInput, GithubIssueTriageResult } from './issue-triage.js';
 import { listPullRequestSubscriptionsForWebhook, retirePullRequestSubscription } from './subscriptions.js';
-import type { GithubSignalSubscriptionRow, GithubWebhookPullRequestTarget } from './subscriptions.js';
+import type {
+  GithubSignalSubscriptionRow,
+  GithubSubscriptionStorage,
+  GithubWebhookPullRequestTarget,
+} from './subscriptions.js';
 
 export type GithubIssueTriageRunInput = GithubIssueTriageInput;
 export type GithubIssueTriageRunResult = GithubIssueTriageResult;
@@ -63,23 +67,39 @@ export interface GithubWebhookNotification {
 /** The Factory session row fields a woken session has to run as. */
 export type FactorySessionOwner = { userId: string; orgId: string };
 
+/**
+ * The integration surface this dispatch uses. Narrow on purpose: the GitHub App
+ * integration and the platform-backed one are unrelated classes, and only this
+ * much is common to both.
+ */
+export interface GithubWebhookDispatchIntegration {
+  readonly integrationStorage: GithubSubscriptionStorage;
+  readonly sourceControlStorage: {
+    sessions: { getBySessionId(sessionId: string): Promise<FactorySessionOwner | null> };
+  };
+  getRepositoryCollaboratorPermission(
+    installationId: number,
+    repoFullName: string,
+    username: string,
+    signal?: AbortSignal,
+  ): Promise<GithubRepositoryPermission | undefined>;
+}
+
 export interface GithubWebhookDispatchDependencies {
   controller: MountedMastraCode['controller'];
   /**
    * Integration used by the default sender-authorization check (collaborator
-   * permission lookup). Author-gated notifications fail closed when neither
-   * this nor an `isAuthorizedSender` override is supplied.
+   * permission lookup) and to resolve the owner of a session being recreated.
+   * Author-gated notifications fail closed when neither this nor an
+   * `isAuthorizedSender` override is supplied.
    */
-  github?: GithubIntegration;
+  github?: GithubWebhookDispatchIntegration;
   listSubscriptions?: (
     target: GithubWebhookPullRequestTarget,
     options?: { includeTerminal?: boolean },
   ) => Promise<GithubSignalSubscriptionRow[]>;
   retireSubscription?: (id: string, status: 'open' | 'closed' | 'merged') => Promise<void>;
   isAuthorizedSender?: (notification: GithubWebhookNotification) => Promise<boolean>;
-  /** Owner lookup for sessions this dispatch has to recreate. Defaults to
-   * `github`, which the platform event worker does not supply. */
-  getFactorySession?: (sessionId: string) => Promise<FactorySessionOwner | null>;
   onTargetError?: (subscription: GithubSignalSubscriptionRow, error: unknown) => void;
 }
 
@@ -293,7 +313,7 @@ export function classifyGithubWebhook(parsed: ParsedGithubWebhook): GithubWebhoo
 async function resolveSubscriptionSession(
   controller: MountedMastraCode['controller'],
   subscription: GithubSignalSubscriptionRow,
-  getFactorySession: (sessionId: string) => Promise<FactorySessionOwner | null>,
+  github?: GithubWebhookDispatchIntegration,
 ) {
   const { sessionId, resourceId, threadId } = subscription;
   if (!sessionId || !resourceId || !threadId) {
@@ -309,7 +329,7 @@ async function resolveSubscriptionSession(
     };
     // Creating the session resolves its workspace, which authorizes the caller
     // against the Factory session row — no signed-in user, so run as its owner.
-    const sessionRow = await getFactorySession(resourceId);
+    const sessionRow = await github?.sourceControlStorage.sessions.getBySessionId(resourceId);
     if (!sessionRow) {
       throw new Error(`GitHub subscription ${subscription.id} has no Factory session ${resourceId} to run as.`);
     }
@@ -347,7 +367,7 @@ const AUTHOR_GATED_KINDS = new Set([
 
 async function isAuthorizedGithubSender(
   notification: GithubWebhookNotification,
-  github: GithubIntegration | undefined,
+  github: Pick<GithubWebhookDispatchIntegration, 'getRepositoryCollaboratorPermission'> | undefined,
 ): Promise<boolean> {
   if (!AUTHOR_GATED_KINDS.has(notification.kind)) return true;
   const sender = notification.metadata.sender;
@@ -417,19 +437,13 @@ export async function dispatchGithubWebhook(
       if (!dependencies.github) throw new Error('GitHub integration is required to retire webhook subscriptions.');
       return retirePullRequestSubscription(id, status, dependencies.github.integrationStorage);
     });
-  const getFactorySession =
-    dependencies.getFactorySession ??
-    ((sessionId: string) => {
-      if (!dependencies.github) throw new Error('GitHub integration is required to resolve a Factory session owner.');
-      return dependencies.github.sourceControlStorage.sessions.getBySessionId(sessionId);
-    });
   const subscriptions = await listSubscriptions(target, { includeTerminal: notification.action === 'reopened' });
   let delivered = 0;
   let failed = 0;
 
   for (const subscription of subscriptions) {
     try {
-      const session = await resolveSubscriptionSession(dependencies.controller, subscription, getFactorySession);
+      const session = await resolveSubscriptionSession(dependencies.controller, subscription, dependencies.github);
       const result = await session.sendNotificationSignal({
         source: 'github',
         kind: notification.kind,

--- a/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
@@ -38,6 +38,9 @@ function createSettingsStorage(initial: unknown = null) {
 function createGithub(): PlatformGithubEventDispatchIntegration {
   return {
     integrationStorage: {} as never,
+    sourceControlStorage: {
+      sessions: { getBySessionId: async () => ({ userId: 'user-1', orgId: 'org-1' }) },
+    },
     getRepositoryCollaboratorPermission: vi.fn<
       PlatformGithubEventDispatchIntegration['getRepositoryCollaboratorPermission']
     >(async () => 'write'),
@@ -241,6 +244,40 @@ describe('PlatformGithubEventWorker', () => {
       version: 1,
       repositories: { '101': { afterEventId: '1001-0' } },
     });
+    await worker.stop();
+  });
+
+  it('gives the dispatch a session-owner lookup, since it never passes the integration itself', async () => {
+    const settings = createSettingsStorage();
+    const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
+      delivered: 1,
+      failed: 0,
+      ignored: false,
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/installations')) {
+        return json({ installations: [{ installationId: 7, usable: true, suspendedAt: null }] });
+      }
+      if (url.pathname.endsWith('/installations/7/repositories')) return json({ repositories: [{ id: 101 }] });
+      if (url.pathname.endsWith('/repositories/101/events')) {
+        if (url.searchParams.has('afterEventId')) return json({ events: [], nextCursor: null });
+        return json({
+          events: [{ id: '1001-0', deliveryId: 'delivery-1', event: 'pull_request', payload: { action: 'closed' } }],
+          nextCursor: '1001-0',
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const worker = createWorker({ fetchImpl, storage: settings.storage, intervalMs: 1_000, dispatch });
+
+    await worker.init(createDeps());
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const { getFactorySession } = dispatch.mock.calls[0]![1];
+    await expect(getFactorySession?.('session-1')).resolves.toEqual({ userId: 'user-1', orgId: 'org-1' });
     await worker.stop();
   });
 

--- a/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
@@ -247,7 +247,7 @@ describe('PlatformGithubEventWorker', () => {
     await worker.stop();
   });
 
-  it('gives the dispatch a session-owner lookup, since it never passes the integration itself', async () => {
+  it('hands the dispatch its integration, so a woken session can be attributed to its owner', async () => {
     const settings = createSettingsStorage();
     const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
       delivered: 1,
@@ -276,8 +276,11 @@ describe('PlatformGithubEventWorker', () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(dispatch).toHaveBeenCalledTimes(1);
-    const { getFactorySession } = dispatch.mock.calls[0]![1];
-    await expect(getFactorySession?.('session-1')).resolves.toEqual({ userId: 'user-1', orgId: 'org-1' });
+    const { github } = dispatch.mock.calls[0]![1];
+    await expect(github?.sourceControlStorage.sessions.getBySessionId('session-1')).resolves.toEqual({
+      userId: 'user-1',
+      orgId: 'org-1',
+    });
     await worker.stop();
   });
 

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -12,7 +12,11 @@ import type { GithubPullRequestReconciler, ReconcileRepository } from '../../git
 import { listPullRequestSubscriptionsForWebhook, retirePullRequestSubscription } from '../../github/subscriptions.js';
 import type { GithubSubscriptionStorage } from '../../github/subscriptions.js';
 import { dispatchGithubWebhook } from '../../github/webhook.js';
-import type { FactorySessionOwner, GithubWebhookNotification, ParsedGithubWebhook } from '../../github/webhook.js';
+import type {
+  GithubWebhookDispatchIntegration,
+  GithubWebhookNotification,
+  ParsedGithubWebhook,
+} from '../../github/webhook.js';
 import type { PlatformApiClient } from '../api-client.js';
 import { PlatformApiError } from '../api-client.js';
 
@@ -61,18 +65,7 @@ type EventLogEntry = {
 
 type Repository = { id: number; fullName?: string; installationId: number };
 
-export interface PlatformGithubEventDispatchIntegration {
-  readonly integrationStorage: GithubSubscriptionStorage;
-  readonly sourceControlStorage: {
-    sessions: { getBySessionId(sessionId: string): Promise<FactorySessionOwner | null> };
-  };
-  getRepositoryCollaboratorPermission(
-    installationId: number,
-    repoFullName: string,
-    username: string,
-    signal?: AbortSignal,
-  ): Promise<GithubRepositoryPermission | undefined>;
-}
+export type PlatformGithubEventDispatchIntegration = GithubWebhookDispatchIntegration;
 
 export interface PlatformGithubEventWorkerConfig {
   client: PlatformApiClient;
@@ -385,8 +378,8 @@ export class PlatformGithubEventWorker extends MastraWorker {
             listPullRequestSubscriptionsForWebhook(target, options, this.#github.integrationStorage),
           retireSubscription: (id, status) =>
             retirePullRequestSubscription(id, status, this.#github.integrationStorage),
+          github: this.#github,
           isAuthorizedSender: notification => this.#isAuthorizedSender(notification),
-          getFactorySession: sessionId => this.#github.sourceControlStorage.sessions.getBySessionId(sessionId),
           onTargetError: (subscription, error) => {
             this.deps?.logger.error('Platform GitHub event delivery failed for a subscription', {
               subscriptionId: subscription.id,

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -12,7 +12,7 @@ import type { GithubPullRequestReconciler, ReconcileRepository } from '../../git
 import { listPullRequestSubscriptionsForWebhook, retirePullRequestSubscription } from '../../github/subscriptions.js';
 import type { GithubSubscriptionStorage } from '../../github/subscriptions.js';
 import { dispatchGithubWebhook } from '../../github/webhook.js';
-import type { GithubWebhookNotification, ParsedGithubWebhook } from '../../github/webhook.js';
+import type { FactorySessionOwner, GithubWebhookNotification, ParsedGithubWebhook } from '../../github/webhook.js';
 import type { PlatformApiClient } from '../api-client.js';
 import { PlatformApiError } from '../api-client.js';
 
@@ -63,6 +63,9 @@ type Repository = { id: number; fullName?: string; installationId: number };
 
 export interface PlatformGithubEventDispatchIntegration {
   readonly integrationStorage: GithubSubscriptionStorage;
+  readonly sourceControlStorage: {
+    sessions: { getBySessionId(sessionId: string): Promise<FactorySessionOwner | null> };
+  };
   getRepositoryCollaboratorPermission(
     installationId: number,
     repoFullName: string,
@@ -383,6 +386,7 @@ export class PlatformGithubEventWorker extends MastraWorker {
           retireSubscription: (id, status) =>
             retirePullRequestSubscription(id, status, this.#github.integrationStorage),
           isAuthorizedSender: notification => this.#isAuthorizedSender(notification),
+          getFactorySession: sessionId => this.#github.sourceControlStorage.sessions.getBySessionId(sessionId),
           onTargetError: (subscription, error) => {
             this.deps?.logger.error('Platform GitHub event delivery failed for a subscription', {
               subscriptionId: subscription.id,

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -154,7 +154,12 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
 
     const user = requestContext.get('user') as FactoryAuthUser | undefined;
     const userId = getFactoryAuthUserId(user);
-    if (!user?.organizationId || !userId || user.organizationId !== session.orgId || userId !== session.userId) {
+    // No identity at all is a server-side caller that forgot to seed one
+    // (webhook, cron), not someone reaching for another user's session.
+    if (!user?.organizationId || !userId) {
+      throw new Error(`Factory session ${session.sessionId} was resolved without a caller identity`);
+    }
+    if (user.organizationId !== session.orgId || userId !== session.userId) {
       throw new Error(`Factory session ${session.sessionId} is not available to the current user`);
     }
     if (!sandboxConfig || !github || !fleet) {


### PR DESCRIPTION
A session bound to a pull request stops responding after the server restarts. The thread sits there with a spinner on the last message, no "working…" indicator ever appears, and sending a message changes nothing. The banner says `Factory session <id> is not available to the current user`, which is misleading — it is your session.

The controller keeps sessions in memory only, so a restart empties them. The next GitHub event on that PR recreates the session, and creating one resolves its workspace, which authorizes the caller against the Factory session row. A GitHub event has no signed-in user and we passed no request context at all, so the guard found no identity and threw. The dispatch catches that per subscription, counts a failure and moves on — which is why it only ever looked like a thread that stopped moving.

The session now gets rebuilt under an identity, read from the Factory session row. That row is the right source because it is the one the guard compares against — `workspace.ts` does the same lookup a few lines later, so the identity we seed and the identity that gets checked cannot diverge. Not the subscription's `ownerId`: that field can hold `mastra-code`, the SDK's default owner for sessions created outside the authenticated routes, and I found such a row in my local database. The session's `ownerId` comes from the same place, so the revived session matches the one it replaces.

There are two ways a GitHub event reaches that dispatch, and my first pass only fixed one of them. A self-hosted install with its own GitHub App comes through the webhook route, which passes the integration. The Mastra-hosted factory comes through the platform event worker, which passed none at all. The dispatch typed its `github` dependency as the whole `GithubIntegration` class while using three members of it, and the platform integration is an unrelated class, so the worker could not pass what it had. Reading the session row off `github` therefore did nothing on the hosted path, the one that actually serves production events.

The dependency now declares the three members it uses, and the worker passes its integration directly. `PlatformGithubEventDispatchIntegration` had already converged on exactly those three members, so it becomes an alias rather than a second definition of the same contract, and the test stubs satisfy the type structurally instead of being cast. A test asserts the worker hands its integration over — nothing else would have caught that wiring, which is how the gap opened in the first place.

Two smaller things came out of it. The guard threw the same "not available to the current user" whether the caller was the wrong user or no user at all, and that conflation is most of why this took a while to find — those are two messages now. And a subscription with no session row used to fail three layers down reporting a missing identity; it now fails where the reason is known.

Note that `requestContext.get('user')` appears exactly once in `workspace.ts`, in the guard. Everything after it is scoped to the session or the org, so nothing else in workspace resolution can fail *because* the caller is a webhook.

On testing: 839 tests pass across `integrations`, `rules`, `routes` and `workspace`. The existing dispatch test asserted `expect.any(RequestContext)` — a type, not a behaviour — so it passed with an empty context and was green-lighting the bug. It now asserts the seeded identity, and deleting the seeding line makes it fail.

What I have not done is reproduce this end to end. The local instance has never ingested a GitHub event — no `source = 'github'` notifications, no cursor for the platform event worker, no GitHub connection — so there is nothing local to wake. The diagnosis rests on the code path and the banner. Since the two error messages were indistinguishable before this change, I also cannot prove the specific session I saw failed for the missing-identity reason rather than a genuine ownership mismatch; from now on the message says which.

Two follow-ups I left out. Subscriptions created through `explicit-tool` and `auto-gh-pr-create` store the factory project id as their `resourceId`, so the lookup finds nothing and they fail permanently while the event worker retries — broken before this branch, still broken, but now saying so. And six places in the factory hand-roll `new RequestContext()` followed by `set('user', …)`, which is what let the identity be forgotten here; a helper would remove the whole class of bug, but it touches the dispatcher and the start coordinator, which this branch doesn't test.

Two failures in the full `@mastra/factory` run are unrelated and predate this branch: the distributed-locking tests in `storage/domains/work-items/base.test.ts` time out at 5s, and `integrations/workos/integration.test.ts` fails to start its vitest worker. Both reproduce in isolation with none of this code loaded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the server restarts, Factory can rebuild GitHub sessions with the correct owner. This prevents those sessions from becoming unresponsive.

## Changes

- Read the session owner from the Factory session row during GitHub event dispatch.
- Seed `RequestContext` with the stored user and organization IDs.
- Use the stored user as the recreated session owner.
- Share the `GithubWebhookDispatchIntegration` contract between webhook routes and the platform event worker.
- Pass the GitHub integration through the platform event worker path.
- Distinguish missing caller identity from unauthorized access.
- Fail earlier when the Factory session row does not exist.
- Add tests for context seeding, session ownership, missing sessions, and platform worker wiring.
- Add a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->