### PR TITLE
fix(core): preserve parallel delegation approval targets

### DIFF
--- a/.changeset/ready-cats-remain.md
+++ b/.changeset/ready-cats-remain.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed parallel sub-agent approvals and suspensions so every persisted target remains resumable after refresh.

--- a/packages/core/src/agent/__tests__/parallel-delegation-approval.test.ts
+++ b/packages/core/src/agent/__tests__/parallel-delegation-approval.test.ts
@@ -11,24 +11,16 @@ import { Agent } from '../agent';
  * Deterministic reproduction of the parallel sub-agent delegation
  * suspend/resume collision.
  *
- * Root cause: the agentic loop tracks suspended/pending tool state in a map
- * keyed by toolName (metadata.pendingToolApprovals[toolName]), NOT by
- * toolCallId — see tool-call-step.ts. When a supervisor emits TWO parallel
- * delegations to the SAME sub-agent in one assistant step, both suspend their
- * own inner sub-agent run, but they share ONE outer supervisor run. The second
- * suspension overwrites the first's entry in the toolName-keyed map, so only
- * one inner runId survives.
- *
- * On resume, approveToolCall() reconstructs the inner run by looking the entry
- * up by toolName, so both approvals resolve to the same surviving entry.
- * Approving the first advances/clears the shared state; the second
- * approveToolCall() then finds no snapshot and fails with
- * AGENT_RESUME_NO_SNAPSHOT_FOUND — so only one of the two delegated actions
- * executes.
+ * Root cause: both delegated calls share one assistant response. The first
+ * suspension flushes that response, removing it from the unsaved response view.
+ * The second suspension previously found no response message and silently skipped
+ * its pendingToolApprovals write. Both approval chunks and workflow snapshots
+ * existed, but only one approval target survived in persisted message metadata,
+ * so a cold reload could not reconstruct and resume both calls.
  *
  * Two parallel delegations to the same sub-agent are required to reproduce
- * faithfully: the two distinct approval chunks emit correctly (proving emission
- * is fine), and the bug is isolated to the resume path.
+ * faithfully: each call has its own toolCallId and inner suspended run, while
+ * both metadata writes target the same outer assistant message.
  *
  * Originally observed live with real OpenRouter models in a support-copilot
  * demo (two parallel refunds → only one refund landed).
@@ -320,16 +312,15 @@ describe('parallel sub-agent delegation (suspend/resume)', () => {
   it('resuming from a cold reload (no live workflow run) still processes BOTH orders', async () => {
     // Page-refresh scenario: the run that emitted the approvals is gone. Resume happens on a
     // *fresh* agent/Mastra instance backed by the same storage, so the suspended run ids must be
-    // recovered purely from the persisted assistant message. If pendingToolApprovals were keyed
-    // by toolName, the two delegations to the same sub-agent would collapse to one persisted
-    // entry and the second resume would fail (AGENT_RESUME_NO_SNAPSHOT_FOUND) — exactly the
-    // collision the live-resume snapshot path cannot help with after a reload.
+    // recovered purely from the persisted assistant message. If the second suspension loses its
+    // metadata write after the first suspension flushes their shared response, the second resume
+    // fails because its exact persisted target is unavailable after the reload.
     processedOrders.length = 0;
     const storage = new InMemoryStore();
 
     // First instance: emit the two approvals, then discard the instance entirely.
-    let runId: string;
     let approvals: ApprovalSeen[];
+    const persistedTargets = new Map<string, { runId: string; delegatedRunId?: string }>();
     {
       const supervisor = buildSupervisorAgent(storage);
       const stream = await supervisor.stream('Process both orders in parallel.', {
@@ -337,16 +328,48 @@ describe('parallel sub-agent delegation (suspend/resume)', () => {
         memory: { resource: 'rep_approval', thread: 'thread-reload' },
       });
       approvals = await collectApprovals(stream);
-      runId = stream.runId;
       expect(approvals.length).toBe(2);
+
+      const memory = await supervisor.getMemory();
+      const recalled = await memory?.recall({
+        threadId: 'thread-reload',
+        resourceId: 'rep_approval',
+        perPage: false,
+      });
+      for (const message of recalled?.messages ?? []) {
+        const metadata = message.content?.metadata as Record<string, unknown> | undefined;
+        const pending = (metadata?.pendingToolApprovals ?? {}) as Record<string, unknown>;
+        for (const entry of Object.values(pending) as Array<{
+          toolCallId?: string;
+          runId?: string;
+          delegatedRunId?: string;
+        }>) {
+          if (entry.toolCallId && entry.runId) {
+            persistedTargets.set(entry.toolCallId, {
+              runId: entry.runId,
+              delegatedRunId: entry.delegatedRunId,
+            });
+          }
+        }
+      }
+
+      expect([...persistedTargets.keys()].sort()).toEqual(approvals.map(approval => approval.toolCallId).sort());
+      expect([...persistedTargets.values()].every(target => target.runId === stream.runId)).toBe(true);
+      const delegatedRunIds = [...persistedTargets.values()].map(target => target.delegatedRunId);
+      expect(delegatedRunIds.every(Boolean)).toBe(true);
+      expect(new Set(delegatedRunIds).size).toBe(2);
     }
 
     // Second instance: brand-new agent + Mastra over the SAME storage. No in-memory run state
-    // survives, so resume relies solely on the persisted pendingToolApprovals entries.
+    // survives, so resume uses only the exact targets reconstructed from pendingToolApprovals.
     const reloadedSupervisor = buildSupervisorAgent(storage);
     const resumeErrors: string[] = [];
-    for (const a of approvals) {
-      const resumed = await reloadedSupervisor.approveToolCall({ runId, toolCallId: a.toolCallId });
+    for (const approval of [...approvals].reverse()) {
+      const target = persistedTargets.get(approval.toolCallId)!;
+      const resumed = await reloadedSupervisor.approveToolCall({
+        runId: target.runId,
+        toolCallId: approval.toolCallId,
+      });
       for await (const chunk of resumed.fullStream) {
         if (chunk.type === 'tool-error') resumeErrors.push(JSON.stringify((chunk as any).payload ?? chunk));
       }

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -2,7 +2,7 @@ import type { ToolSet } from '@internal/ai-sdk-v5';
 import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 import type { Mock } from 'vitest';
 import { z } from 'zod/v4';
-import type { MessageList } from '../../../agent/message-list';
+import { MessageList } from '../../../agent/message-list';
 import { RequestContext } from '../../../request-context';
 import { ChunkFrom } from '../../../stream/types';
 import { createTool } from '../../../tools';
@@ -667,12 +667,95 @@ describe('createToolCallStep tool approval workflow', () => {
   });
 });
 
-describe('createToolCallStep delegated agent tool approvals', () => {
+describe('createToolCallStep delegated agent tool metadata', () => {
   let controller: { enqueue: Mock };
   let suspend: Mock;
   let streamState: { serialize: Mock };
-  let messageList: MessageList;
   let neverResolve: Promise<never>;
+
+  const createAssistantMessage = (
+    id: string,
+    toolCallId: string,
+    toolName: string,
+    args: Record<string, unknown> = {},
+  ) => ({
+    id,
+    role: 'assistant' as const,
+    createdAt: new Date(0),
+    content: {
+      format: 2 as const,
+      metadata: {} as Record<string, unknown>,
+      parts: [
+        {
+          type: 'tool-invocation' as const,
+          toolInvocation: {
+            state: 'call' as const,
+            toolCallId,
+            toolName,
+            args,
+          },
+        },
+      ],
+    },
+  });
+
+  const startDelegatedTool = ({
+    messageList,
+    requireApproval,
+    suspendPayload = {},
+    logger,
+    toolCallId = 'parent-tool-call-id',
+    delegatedRunId = 'sub-agent-run-id',
+  }: {
+    messageList: MessageList;
+    requireApproval: boolean;
+    suspendPayload?: unknown;
+    logger?: { warn: Mock; debug?: Mock };
+    toolCallId?: string;
+    delegatedRunId?: string;
+  }) => {
+    const tools = {
+      'agent-subAgent': {
+        execute: vi.fn(async (_args: unknown, opts: MastraToolInvocationOptions) => {
+          await opts.suspend?.(suspendPayload, {
+            ...(requireApproval ? { requireToolApproval: true } : {}),
+            runId: delegatedRunId,
+          });
+          return { text: 'done' };
+        }),
+      },
+    } as ToolSet;
+    const inputData = {
+      toolCallId,
+      toolName: 'agent-subAgent',
+      args: { prompt: 'do thing' },
+    };
+    const toolCallStep = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      runId: 'parent-run-id',
+      streamState,
+      logger: logger as any,
+    });
+
+    return toolCallStep.execute({
+      ...makeBaseExecuteParams(suspend),
+      writer: new ToolStream({
+        prefix: 'tool',
+        callId: inputData.toolCallId,
+        name: inputData.toolName,
+        runId: 'parent-run-id',
+      }),
+      inputData,
+    });
+  };
+
+  const settleToolSuspension = async () => {
+    for (let i = 0; i < 5; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+  };
 
   beforeEach(() => {
     controller = { enqueue: vi.fn() };
@@ -687,11 +770,10 @@ describe('createToolCallStep delegated agent tool approvals', () => {
   });
 
   it('stores the outer resumable runId with delegatedRunId when a nested agent run requests tool approval', async () => {
-    const assistantMessage = {
-      role: 'assistant',
-      content: { metadata: {} as Record<string, unknown> },
-    };
-    messageList = {
+    const assistantMessage = createAssistantMessage('assistant-target', 'parent-tool-call-id', 'agent-subAgent', {
+      prompt: 'do thing',
+    });
+    const messageList = {
       get: {
         input: { aiV5: { model: () => [] } },
         response: { db: () => [assistantMessage] },
@@ -699,45 +781,8 @@ describe('createToolCallStep delegated agent tool approvals', () => {
       },
     } as unknown as MessageList;
 
-    const tools = {
-      'agent-subAgent': {
-        execute: vi.fn(async (_args: unknown, opts: MastraToolInvocationOptions) => {
-          await opts.suspend?.({}, { requireToolApproval: true, runId: 'sub-agent-run-id' });
-          return { text: 'done' };
-        }),
-      },
-    } as ToolSet;
-
-    const toolCallStep = createToolCallStep({
-      tools,
-      messageList,
-      controller,
-      runId: 'parent-run-id',
-      streamState,
-    });
-
-    const inputData = {
-      toolCallId: 'parent-tool-call-id',
-      toolName: 'agent-subAgent',
-      args: { prompt: 'do thing' },
-    };
-
-    const executePromise = toolCallStep.execute({
-      ...makeBaseExecuteParams(suspend),
-      writer: new ToolStream({
-        prefix: 'tool',
-        callId: inputData.toolCallId,
-        name: inputData.toolName,
-        runId: 'parent-run-id',
-      }),
-      inputData,
-    });
-
-    // Allow the microtask / setImmediate chain through tool execution → inner
-    // suspend → addToolMetadata to settle before inspecting the metadata.
-    for (let i = 0; i < 5; i++) {
-      await new Promise(resolve => setImmediate(resolve));
-    }
+    const executePromise = startDelegatedTool({ messageList, requireApproval: true });
+    await settleToolSuspension();
 
     const pending = (assistantMessage.content.metadata as Record<string, any>).pendingToolApprovals?.[
       'parent-tool-call-id'
@@ -751,6 +796,134 @@ describe('createToolCallStep delegated agent tool approvals', () => {
       delegatedRunId: 'sub-agent-run-id',
     });
     expect(pending.parentRunId).toBeUndefined();
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('recovers a drained response message when persisting a delegated tool suspension', async () => {
+    const targetMessage = createAssistantMessage('assistant-target', 'parent-tool-call-id', 'agent-subAgent', {
+      prompt: 'do thing',
+    });
+    const unrelatedMessage = createAssistantMessage('assistant-unrelated', 'unrelated-tool-call-id', 'unrelatedTool');
+    const messageList = new MessageList();
+    messageList.add(targetMessage, 'response');
+    messageList.drainUnsavedMessages();
+    messageList.add({ role: 'user', content: 'next turn' }, 'input');
+    messageList.add(unrelatedMessage, 'response');
+    const updateMessageMetadataByToolCallId = vi.spyOn(messageList, 'updateMessageMetadataByToolCallId');
+
+    const executePromise = startDelegatedTool({
+      messageList,
+      requireApproval: false,
+      suspendPayload: { reason: 'review' },
+    });
+    await settleToolSuspension();
+
+    expect(updateMessageMetadataByToolCallId).toHaveBeenCalledWith(
+      'parent-tool-call-id',
+      expect.objectContaining({
+        suspendedTools: expect.objectContaining({
+          'parent-tool-call-id': expect.objectContaining({
+            runId: 'parent-run-id',
+            delegatedRunId: 'sub-agent-run-id',
+            suspendPayload: { reason: 'review' },
+          }),
+        }),
+      }),
+    );
+    expect(unrelatedMessage.content.metadata).toEqual({});
+    expect((targetMessage.content.metadata as Record<string, any>).suspendedTools).toHaveProperty(
+      'parent-tool-call-id',
+    );
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('persists BOTH siblings when the shared response is drained before each metadata write', async () => {
+    // Two parallel delegations to the same sub-agent share one assistant message. Flush the
+    // response before EACH sibling's metadata write so both take the drained-message fallback;
+    // the second fallback merge must preserve the first sibling's already-persisted entry.
+    const targetMessage = createAssistantMessage('assistant-target', 'tool-call-A', 'agent-subAgent', {
+      prompt: 'do thing',
+    });
+    targetMessage.content.parts.push({
+      type: 'tool-invocation' as const,
+      toolInvocation: {
+        state: 'call' as const,
+        toolCallId: 'tool-call-B',
+        toolName: 'agent-subAgent',
+        args: { prompt: 'do other thing' },
+      },
+    });
+    const messageList = new MessageList();
+    messageList.add(targetMessage, 'response');
+    messageList.drainUnsavedMessages();
+
+    const executeA = startDelegatedTool({
+      messageList,
+      requireApproval: false,
+      suspendPayload: { reason: 'review-A' },
+      toolCallId: 'tool-call-A',
+      delegatedRunId: 'sub-agent-run-A',
+    });
+    await settleToolSuspension();
+    // A's fallback re-queued the message; flush again so B also finds a drained response view.
+    messageList.drainUnsavedMessages();
+
+    const executeB = startDelegatedTool({
+      messageList,
+      requireApproval: false,
+      suspendPayload: { reason: 'review-B' },
+      toolCallId: 'tool-call-B',
+      delegatedRunId: 'sub-agent-run-B',
+    });
+    await settleToolSuspension();
+
+    const suspendedTools = (targetMessage.content.metadata as Record<string, any>).suspendedTools ?? {};
+    expect(Object.keys(suspendedTools).sort()).toEqual(['tool-call-A', 'tool-call-B']);
+    expect(suspendedTools['tool-call-A']).toMatchObject({
+      runId: 'parent-run-id',
+      delegatedRunId: 'sub-agent-run-A',
+      suspendPayload: { reason: 'review-A' },
+    });
+    expect(suspendedTools['tool-call-B']).toMatchObject({
+      runId: 'parent-run-id',
+      delegatedRunId: 'sub-agent-run-B',
+      suspendPayload: { reason: 'review-B' },
+    });
+    // The recovered message must be queued for persistence again.
+    expect(messageList.get.response.db()).toContain(targetMessage);
+
+    await expect(Promise.race([executeA, Promise.resolve('completed')])).resolves.toBe('completed');
+    await expect(Promise.race([executeB, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('logs at debug when a drained response message cannot be marked unsaved', async () => {
+    const targetMessage = createAssistantMessage('assistant-target', 'parent-tool-call-id', 'agent-subAgent', {
+      prompt: 'do thing',
+    });
+    const unrelatedMessage = createAssistantMessage('assistant-unrelated', 'unrelated-tool-call-id', 'unrelatedTool');
+    const logger = { warn: vi.fn(), debug: vi.fn() };
+    const messageList = {
+      get: {
+        input: { aiV5: { model: () => [] } },
+        response: { db: () => [unrelatedMessage] },
+        all: { db: () => [targetMessage, unrelatedMessage], aiV5: { model: () => [] } },
+      },
+      updateMessageMetadataByToolCallId: vi.fn().mockReturnValue(false),
+    } as unknown as MessageList;
+
+    const executePromise = startDelegatedTool({
+      messageList,
+      requireApproval: false,
+      suspendPayload: { reason: 'review' },
+      logger,
+    });
+    await settleToolSuspension();
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('could not update the assistant message for tool call parent-tool-call-id'),
+    );
 
     await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
   });

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -706,6 +706,7 @@ describe('createToolCallStep delegated agent tool metadata', () => {
     logger,
     toolCallId = 'parent-tool-call-id',
     delegatedRunId = 'sub-agent-run-id',
+    toolPayloadTransform,
   }: {
     messageList: MessageList;
     requireApproval: boolean;
@@ -713,6 +714,7 @@ describe('createToolCallStep delegated agent tool metadata', () => {
     logger?: { warn: Mock; debug?: Mock };
     toolCallId?: string;
     delegatedRunId?: string;
+    toolPayloadTransform?: unknown;
   }) => {
     const tools = {
       'agent-subAgent': {
@@ -737,6 +739,7 @@ describe('createToolCallStep delegated agent tool metadata', () => {
       runId: 'parent-run-id',
       streamState,
       logger: logger as any,
+      _internal: toolPayloadTransform ? ({ toolPayloadTransform } as any) : undefined,
     });
 
     return toolCallStep.execute({
@@ -798,6 +801,60 @@ describe('createToolCallStep delegated agent tool metadata', () => {
     expect(pending.parentRunId).toBeUndefined();
 
     await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('preserves explicitly transformed null payloads in approval and suspension metadata', async () => {
+    const toolPayloadTransform = {
+      targets: ['transcript'],
+      transformToolPayload: vi.fn(() => null),
+    };
+    const approvalMessage = createAssistantMessage('assistant-approval', 'parent-tool-call-id', 'agent-subAgent', {
+      secret: 'approval-secret',
+    });
+    const approvalMessageList = {
+      get: {
+        input: { aiV5: { model: () => [] } },
+        response: { db: () => [approvalMessage] },
+        all: { db: () => [approvalMessage], aiV5: { model: () => [] } },
+      },
+    } as unknown as MessageList;
+
+    const approvalExecution = startDelegatedTool({
+      messageList: approvalMessageList,
+      requireApproval: true,
+      toolPayloadTransform,
+    });
+    await settleToolSuspension();
+    expect(
+      (approvalMessage.content.metadata as Record<string, any>).pendingToolApprovals['parent-tool-call-id'].args,
+    ).toBeNull();
+
+    const suspensionMessage = createAssistantMessage('assistant-suspension', 'parent-tool-call-id', 'agent-subAgent', {
+      secret: 'suspension-secret',
+    });
+    const suspensionMessageList = {
+      get: {
+        input: { aiV5: { model: () => [] } },
+        response: { db: () => [suspensionMessage] },
+        all: { db: () => [suspensionMessage], aiV5: { model: () => [] } },
+      },
+    } as unknown as MessageList;
+
+    const suspensionExecution = startDelegatedTool({
+      messageList: suspensionMessageList,
+      requireApproval: false,
+      suspendPayload: { secret: 'suspend-payload-secret' },
+      toolPayloadTransform,
+    });
+    await settleToolSuspension();
+    const suspendedEntry = (suspensionMessage.content.metadata as Record<string, any>).suspendedTools[
+      'parent-tool-call-id'
+    ];
+    expect(suspendedEntry.args).toBeNull();
+    expect(suspendedEntry.suspendPayload).toBeNull();
+
+    await expect(Promise.race([approvalExecution, Promise.resolve('completed')])).resolves.toBe('completed');
+    await expect(Promise.race([suspensionExecution, Promise.resolve('completed')])).resolves.toBe('completed');
   });
 
   it('recovers a drained response message when persisting a delegated tool suspension', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -161,26 +161,27 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         metadata: toolStateTransformMetadata,
       }: AddToolMetadataOptions) => {
         const metadataKey = type === 'suspension' ? 'suspendedTools' : 'pendingToolApprovals';
-        const inputTransform = getTransformedToolPayload(
-          toolStateTransformMetadata,
-          'transcript',
-          'input-available',
-        )?.transformed;
-        const approvalTransform = getTransformedToolPayload(
-          toolStateTransformMetadata,
-          'transcript',
-          'approval',
-        )?.transformed;
-        const suspendTransform = getTransformedToolPayload(
-          toolStateTransformMetadata,
-          'transcript',
-          'suspend',
-        )?.transformed;
+        const inputTransform = getTransformedToolPayload(toolStateTransformMetadata, 'transcript', 'input-available');
+        const approvalTransform = getTransformedToolPayload(toolStateTransformMetadata, 'transcript', 'approval');
+        const suspendTransform = getTransformedToolPayload(toolStateTransformMetadata, 'transcript', 'suspend');
         const transformedArgs =
           type === 'approval'
-            ? (approvalTransform ?? inputTransform ?? args)
-            : (inputTransform ?? suspendTransform ?? args);
-        const transformedSuspendPayload = type === 'suspension' ? (suspendTransform ?? suspendPayload) : undefined;
+            ? hasTransformedToolPayload(approvalTransform)
+              ? approvalTransform.transformed
+              : hasTransformedToolPayload(inputTransform)
+                ? inputTransform.transformed
+                : args
+            : hasTransformedToolPayload(inputTransform)
+              ? inputTransform.transformed
+              : hasTransformedToolPayload(suspendTransform)
+                ? suspendTransform.transformed
+                : args;
+        const transformedSuspendPayload =
+          type === 'suspension'
+            ? hasTransformedToolPayload(suspendTransform)
+              ? suspendTransform.transformed
+              : suspendPayload
+            : undefined;
         const entry = {
           toolCallId,
           toolName,

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -161,75 +161,87 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         metadata: toolStateTransformMetadata,
       }: AddToolMetadataOptions) => {
         const metadataKey = type === 'suspension' ? 'suspendedTools' : 'pendingToolApprovals';
-        // Find the last assistant message in the response (which should contain this tool call)
-        const responseMessages = messageList.get.response.db();
-        const lastAssistantMessage = [...responseMessages].reverse().find(msg => msg.role === 'assistant');
+        const inputTransform = getTransformedToolPayload(
+          toolStateTransformMetadata,
+          'transcript',
+          'input-available',
+        )?.transformed;
+        const approvalTransform = getTransformedToolPayload(
+          toolStateTransformMetadata,
+          'transcript',
+          'approval',
+        )?.transformed;
+        const suspendTransform = getTransformedToolPayload(
+          toolStateTransformMetadata,
+          'transcript',
+          'suspend',
+        )?.transformed;
+        const transformedArgs =
+          type === 'approval'
+            ? (approvalTransform ?? inputTransform ?? args)
+            : (inputTransform ?? suspendTransform ?? args);
+        const transformedSuspendPayload = type === 'suspension' ? (suspendTransform ?? suspendPayload) : undefined;
+        const entry = {
+          toolCallId,
+          toolName,
+          args: transformedArgs,
+          type,
+          // Store the OUTER (resumable) runId so clients can resume after page refresh or
+          // server restart via `resumeStream({ runId, toolCallId })`. For delegated sub-agent /
+          // workflow tools the inner suspended run is preserved separately as `delegatedRunId`
+          // — it is required to resume the delegate's own suspended stream, but it is not a
+          // valid public resume target (resuming with it fails closed). No `parentRunId` is
+          // written: readers that resume `parentRunId ?? runId` (channels) get the outer run
+          // from `runId` directly; legacy entries with `parentRunId` keep working.
+          runId,
+          ...(suspendedToolRunId && suspendedToolRunId !== runId ? { delegatedRunId: suspendedToolRunId } : {}),
+          ...(type === 'suspension' ? { suspendPayload: transformedSuspendPayload } : {}),
+          resumeSchema,
+          ...(toolStateTransformMetadata ? { metadata: toolStateTransformMetadata } : {}),
+        };
+        const carriesToolCall = (message: MastraDBMessage) =>
+          message.role === 'assistant' &&
+          (message.content?.parts ?? []).some(
+            part => part.type === 'tool-invocation' && part.toolInvocation.toolCallId === toolCallId,
+          );
 
-        if (lastAssistantMessage) {
-          const content = lastAssistantMessage.content;
-          if (!content) return;
-          // Add metadata to indicate this tool call is pending approval.
-          // Reuse the live metadata object on the message and bind it back immediately. Two
-          // parallel suspensions for the same step (e.g. two delegations to one sub-agent) run
-          // concurrently; if each seeded a fresh {} and only reassigned at the end, the last
-          // writer would clobber the first's entry (lost write). Mutating one shared object in
-          // place keeps both entries.
-          let metadata: Record<string, any>;
-          if (
-            typeof lastAssistantMessage.content.metadata === 'object' &&
-            lastAssistantMessage.content.metadata !== null
-          ) {
-            metadata = lastAssistantMessage.content.metadata as Record<string, any>;
-          } else {
-            metadata = {};
-            lastAssistantMessage.content.metadata = metadata;
-          }
+        const responseMessages = messageList.get.response.db();
+        const responseMessage = [...responseMessages].reverse().find(carriesToolCall);
+        if (responseMessage?.content) {
+          const metadata =
+            typeof responseMessage.content.metadata === 'object' && responseMessage.content.metadata !== null
+              ? (responseMessage.content.metadata as Record<string, any>)
+              : {};
+          responseMessage.content.metadata = metadata;
           metadata[metadataKey] = metadata[metadataKey] || {};
-          // Key by toolCallId (not toolName) so multiple parallel calls to the SAME tool — e.g.
-          // two parallel delegations to one sub-agent — each persist their own suspension entry.
-          // Keying by toolName collapsed them in storage, dropping all but the last suspended
-          // runId; on resume (including page-refresh, which reconstructs purely from the persisted
-          // message) the others could not be recovered (AGENT_RESUME_NO_SNAPSHOT_FOUND). Read and
-          // remove paths match by the entry's toolCallId value, with a legacy toolName-key
-          // fallback so pre-upgrade persisted metadata still resolves.
-          const inputTransform = getTransformedToolPayload(
-            toolStateTransformMetadata,
-            'transcript',
-            'input-available',
-          )?.transformed;
-          const approvalTransform = getTransformedToolPayload(
-            toolStateTransformMetadata,
-            'transcript',
-            'approval',
-          )?.transformed;
-          const suspendTransform = getTransformedToolPayload(
-            toolStateTransformMetadata,
-            'transcript',
-            'suspend',
-          )?.transformed;
-          const transformedArgs =
-            type === 'approval'
-              ? (approvalTransform ?? inputTransform ?? args)
-              : (inputTransform ?? suspendTransform ?? args);
-          const transformedSuspendPayload = type === 'suspension' ? (suspendTransform ?? suspendPayload) : undefined;
-          metadata[metadataKey][toolCallId] = {
-            toolCallId,
-            toolName,
-            args: transformedArgs,
-            type,
-            // Store the OUTER (resumable) runId so clients can resume after page refresh or
-            // server restart via `resumeStream({ runId, toolCallId })`. For delegated sub-agent /
-            // workflow tools the inner suspended run is preserved separately as `delegatedRunId`
-            // — it is required to resume the delegate's own suspended stream, but it is not a
-            // valid public resume target (resuming with it fails closed). No `parentRunId` is
-            // written: readers that resume `parentRunId ?? runId` (channels) get the outer run
-            // from `runId` directly; legacy entries with `parentRunId` keep working.
-            runId,
-            ...(suspendedToolRunId && suspendedToolRunId !== runId ? { delegatedRunId: suspendedToolRunId } : {}),
-            ...(type === 'suspension' ? { suspendPayload: transformedSuspendPayload } : {}),
-            resumeSchema,
-            ...(toolStateTransformMetadata ? { metadata: toolStateTransformMetadata } : {}),
-          };
+          metadata[metadataKey][toolCallId] = entry;
+          return;
+        }
+
+        // A sibling suspension may have already flushed the shared assistant response, leaving
+        // this iteration's tool call absent from the response view. Update the drained message
+        // and mark it unsaved again so this sibling's metadata reaches the next flush.
+        const target = [...messageList.get.all.db()].reverse().find(carriesToolCall);
+        if (!target?.content) {
+          logger?.warn?.(
+            `addToolMetadata could not find an assistant message for tool call ${toolCallId} (${toolName}); ${metadataKey} entry was not persisted.`,
+          );
+          return;
+        }
+        const existingMetadata =
+          typeof target.content.metadata === 'object' && target.content.metadata !== null
+            ? (target.content.metadata as Record<string, any>)
+            : {};
+        const existingEntries = (existingMetadata[metadataKey] ?? {}) as Record<string, any>;
+        const updated = messageList.updateMessageMetadataByToolCallId(toolCallId, {
+          [metadataKey]: { ...existingEntries, [toolCallId]: entry },
+        });
+        if (!updated) {
+          // updateMessageMetadataByToolCallId already logged a warning; add the metadata context
+          // at debug level instead of duplicating the warn.
+          logger?.debug?.(
+            `addToolMetadata could not update the assistant message for tool call ${toolCallId} (${toolName}); ${metadataKey} entry was not persisted.`,
+          );
         }
       };
 
@@ -744,13 +756,10 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                   },
                   __streamState: streamState.serialize(),
                   __agentId: agentId,
-                  // Persist the inner suspended run id in the workflow snapshot, partitioned
-                  // per tool call (resumeLabel = toolCallId). The shared per-message
-                  // pendingToolApprovals metadata is keyed by toolName and flushed/rehydrated
-                  // concurrently across parallel branches of the same assistant step, so for two
-                  // delegations to the same sub-agent the second branch's entry is overwritten,
-                  // leaving its run id unrecoverable on resume (AGENT_RESUME_NO_SNAPSHOT_FOUND).
-                  // The foreach snapshot is collision-free, so it is the reliable source here.
+                  // Persist the inner suspended run id in the workflow snapshot, partitioned per
+                  // tool call (resumeLabel = toolCallId). Persisted message metadata exposes the
+                  // same id as delegatedRunId for cold reloads, while the snapshot remains the
+                  // runtime source for routing this targeted resume.
                   suspendedToolRunId: options.runId,
                 },
                 {


### PR DESCRIPTION
Parallel sub-agent delegations share one assistant response. When the first sibling suspended, it could flush that response before another sibling saved its approval or suspension metadata. The later sibling then had no response message to update, so its persisted resume target disappeared even though its workflow snapshot still existed.

This finds the assistant message containing the exact tool call. If a sibling already flushed it, the message is recovered from the full message list, its metadata is merged, and it is queued for persistence again. This keeps every `(runId, toolCallId)` target available after a refresh without changing provider-executed tools.

Before, a cold reload could reconstruct only one of two parallel approval targets. After, both targets are persisted and can be resumed in either order.

Verified with focused tool-call and parallel-delegation tests, the core typecheck, and core lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When several delegated tasks pause at the same time, the system now saves every approval and suspension target. After a refresh, each task can resume in either order.

## Changes

- Recover and requeue the exact assistant message that contains a delegated tool call.
- Persist transformed tool arguments and suspension payloads.
- Preserve separate metadata for concurrent approvals and suspensions.
- Preserve explicit `null` and `undefined` transformed payloads.
- Add warnings when the matching assistant message cannot be found.
- Expand regression tests for cold reloads, delegated run IDs, metadata recovery, and persistence failures.
- Add a patch changeset for `@mastra/core`.

## Validation

- Focused tests pass.
- Core typecheck passes.
- Core lint passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->