### PR TITLE
docs: add iMessage channel page

### DIFF
--- a/docs/src/content/en/docs/capabilities/channels/imessage.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/imessage.mdx
@@ -95,7 +95,26 @@ https://your-app.example.com/api/agents/imessage-agent/channels/imessage/webhook
 
 Register this URL in the [Photon dashboard](https://app.photon.codes), then set the signing secret it returns as `IMESSAGE_WEBHOOK_SECRET`. The secret is shown once at registration. The adapter verifies the signature on every delivery and rejects requests that don't match. Webhooks are available in hosted mode only.
 
-Deliveries are retried with backoff and can arrive more than once, so treat repeated messages as expected.
+Photon retries failed deliveries with backoff and delivers at least once, so the same message can arrive twice. Chat SDK drops the repeat using the channel state adapter, and Mastra's default keeps those dedup keys in memory. That covers a single long-running server.
+
+A repeat can still reach the agent after a restart, or on serverless where the retry is routed to a different instance. Pass a shared state adapter on `channels.state` so dedup keys are visible everywhere. `createRedisState()` reads the `REDIS_URL` environment variable:
+
+```typescript title="src/mastra/agents/imessage-agent.ts"
+import { createRedisState } from '@chat-adapter/state-redis'
+
+channels: {
+  adapters: {
+    imessage: {
+      adapter: createiMessageAdapter(),
+      toolDisplay: 'text',
+    },
+  },
+  threadContext: { maxMessages: 0 },
+  state: createRedisState(),
+},
+```
+
+This matters most for tools with side effects, where handling the same message twice is visible to the user.
 
 :::note
 

--- a/docs/src/content/en/docs/capabilities/channels/imessage.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/imessage.mdx
@@ -97,7 +97,13 @@ Register this URL in the [Photon dashboard](https://app.photon.codes), then set 
 
 Photon retries failed deliveries with backoff and delivers at least once, so the same message can arrive twice. Chat SDK drops the repeat using the channel state adapter, and Mastra's default keeps those dedup keys in memory. That covers a single long-running server.
 
-A repeat can still reach the agent after a restart, or on serverless where the retry is routed to a different instance. Pass a shared state adapter on `channels.state` so dedup keys are visible everywhere. `createRedisState()` reads the `REDIS_URL` environment variable:
+A repeat can still reach the agent after a restart, or on serverless where the retry is routed to a different instance. Pass a shared state adapter on `channels.state` so dedup keys are visible everywhere. Install one alongside the adapter:
+
+```bash npm2yarn
+npm install @chat-adapter/state-redis
+```
+
+`createRedisState()` reads the `REDIS_URL` environment variable:
 
 ```typescript title="src/mastra/agents/imessage-agent.ts"
 import { createRedisState } from '@chat-adapter/state-redis'

--- a/docs/src/content/en/docs/capabilities/channels/imessage.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/imessage.mdx
@@ -1,0 +1,125 @@
+---
+title: "iMessage | Channels"
+description: "Configure a Mastra agent to receive iMessage messages through a channel adapter."
+packages:
+  - "@mastra/core"
+---
+
+# iMessage
+
+iMessage channels let a Mastra agent receive direct messages and group messages from iMessage. Mastra handles the agent wiring, the webhook route, and the gateway listener; the Photon iMessage adapter docs cover number provisioning, credentials, and webhook registration.
+
+## Install the adapter
+
+Install the Photon iMessage adapter:
+
+```bash npm2yarn
+npm install @photon-ai/chat-adapter-imessage
+```
+
+## Agent configuration
+
+Add `createiMessageAdapter()` to the agent's `channels.adapters` object:
+
+```typescript title="src/mastra/agents/imessage-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { createiMessageAdapter } from '@photon-ai/chat-adapter-imessage'
+
+export const imessageAgent = new Agent({
+  id: 'imessage-agent',
+  name: 'iMessage Agent',
+  instructions: 'Answer questions and help with tasks over iMessage.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  channels: {
+    adapters: {
+      imessage: {
+        adapter: createiMessageAdapter(),
+        toolDisplay: 'text',
+      },
+    },
+    threadContext: { maxMessages: 0 },
+  },
+})
+```
+
+Register the agent on the Mastra instance:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { imessageAgent } from './agents/imessage-agent'
+
+export const mastra = new Mastra({
+  agents: { imessageAgent },
+})
+```
+
+Use `imessage` as the adapter key. Mastra derives the webhook path and the `platform` value on `requestContext` from this key.
+
+`toolDisplay: 'text'` describes tool calls in the message, since iMessage has no interactive cards for Approve and Deny actions. `threadContext: { maxMessages: 0 }` skips the platform history lookup Mastra runs when an agent is first mentioned in a group chat, which the adapter can't perform. Both override defaults that assume platform features iMessage lacks.
+
+## Adapter setup
+
+Follow the [Photon iMessage adapter docs](https://github.com/photon-hq/vercel-chat-adapter-imessage) for iMessage-specific setup, including number provisioning, hosted and self-hosted modes, and webhook registration. The adapter picks its mode from the environment variables you set.
+
+For the hosted service, create a project at [app.photon.codes](https://app.photon.codes) and use the project credentials:
+
+```bash title=".env"
+IMESSAGE_PROJECT_ID=your-project-id
+IMESSAGE_PROJECT_SECRET=your-project-secret
+IMESSAGE_WEBHOOK_SECRET=your-webhook-signing-secret
+```
+
+For a self-hosted server, point the adapter at its gRPC address, written as `host:port`. The adapter strips any URL scheme and appends `:443` to a bare host:
+
+```bash title=".env"
+IMESSAGE_SERVER_URL=imessage.example.com:443
+IMESSAGE_API_KEY=your-server-token
+IMESSAGE_PHONE=+15551234567
+```
+
+`IMESSAGE_PHONE` is optional and routes messages when a self-hosted server has several numbers. You can also pass these values to `createiMessageAdapter()` directly, including a `credentials` function that resolves the project ID and secret at first use from a secret store.
+
+## Webhook URL
+
+Mastra generates the iMessage webhook route from the agent ID and adapter key:
+
+```text
+/api/agents/imessage-agent/channels/imessage/webhook
+```
+
+Use your public Mastra server URL as the base URL:
+
+```text
+https://your-app.example.com/api/agents/imessage-agent/channels/imessage/webhook
+```
+
+Register this URL in the [Photon dashboard](https://app.photon.codes), then set the signing secret it returns as `IMESSAGE_WEBHOOK_SECRET`. The secret is shown once at registration. The adapter verifies the signature on every delivery and rejects requests that don't match. Webhooks are available in hosted mode only.
+
+Deliveries are retried with backoff and can arrive more than once, so treat repeated messages as expected.
+
+:::note
+
+Photon delivers to public HTTPS endpoints only. It won't deliver to `http://`, to private addresses like `localhost`, or through a redirect. For local development, use a tunnel as described in the [Channels overview](/docs/capabilities/channels/overview#webhook-routes).
+
+:::
+
+## Gateway listener
+
+The adapter can hold an open connection and stream messages in real time instead of receiving webhooks. This works in both hosted and self-hosted modes.
+
+Mastra starts this listener during initialization and reconnects it if it drops, so no cron job or extra route is needed on a long-running server. Set `gateway: false` on the adapter config to turn it off when you use webhooks:
+
+```typescript title="src/mastra/agents/imessage-agent.ts"
+imessage: {
+  adapter: createiMessageAdapter(),
+  toolDisplay: 'text',
+  gateway: false,
+},
+```
+
+On serverless platforms, prefer webhooks. A gateway listener needs a process that stays alive. See [Serverless deployment](/docs/capabilities/channels/overview#serverless-deployment).
+
+## Related
+
+- [Channels overview](/docs/capabilities/channels/overview)
+- [More](/docs/capabilities/channels/other-adapters)

--- a/docs/src/content/en/docs/capabilities/channels/overview.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/overview.mdx
@@ -18,6 +18,7 @@ Start with the page for your platform:
 - [Discord](/docs/capabilities/channels/discord)
 - [Telegram](/docs/capabilities/channels/telegram)
 - [WhatsApp](/docs/capabilities/channels/whatsapp)
+- [iMessage](/docs/capabilities/channels/imessage)
 
 [More](/docs/capabilities/channels/other-adapters) lists additional platforms. Mastra channels work with compatible [Chat SDK adapters](https://chat-sdk.dev/adapters) beyond the platforms listed here, and the same Mastra configuration pattern applies across adapters.
 

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -392,6 +392,11 @@ const sidebars = {
             },
             {
               type: 'doc',
+              id: 'capabilities/channels/imessage',
+              label: 'iMessage',
+            },
+            {
+              type: 'doc',
               id: 'capabilities/channels/other-adapters',
               label: 'More',
             },


### PR DESCRIPTION
## Description

Adds an iMessage page to the Channels section, documenting the Photon adapter (`@photon-ai/chat-adapter-imessage`) as an official channel alongside Slack, Teams, Discord, Telegram, and WhatsApp.

iMessage was previously only a name in the Chat SDK adapter catalog on the "More" page, with no setup instructions. The page follows the same structure as the existing platform pages, with two additions specific to iMessage:

- **Two non-default settings, with the reason for each.** `toolDisplay: 'text'` is required because `resolveToolDisplay` defaults to `'cards'` with no platform capability check, and iMessage has no interactive card for Approve and Deny actions. `threadContext: { maxMessages: 0 }` is required because the adapter has no `fetchMessages`, so the default 10-message history lookup on first mention in a group chat cannot succeed.
- **A Gateway listener section.** Photon supports webhooks and a persistent gateway connection. Mastra starts the gateway automatically and reconnects it, so the cron route Photon's own docs describe isn't needed on a long-running server. The section also covers `gateway: false` and the serverless tradeoff.

No code changes. Mastra already generates the webhook route and starts the gateway listener for any adapter exposing `startGatewayListener`, so no provider package is needed. Unlike Slack, Photon has no OAuth or token rotation to wrap.

## Related issue(s)

<!-- TODO: link the tracking issue before merge -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Testing

- `pnpm build` — passed, no broken links
- `pnpm validate` — passed
- `pnpm lint:prose` (Vale + remark) — passed
- `pnpm format:mdx:check` — passed

Not verified against a live Photon project. Content is derived from Photon's published adapter docs and `packages/core/src/channels`. The least-verified claim is that Mastra's gateway loop matches Photon's `startGatewayListener(options, durationMs)` signature — the shapes agree, but no message has round-tripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds instructions for connecting Mastra to iMessage. It explains setup steps and important limits so messages work correctly.

## Changes

- Added an iMessage channel guide.
- Documented Photon adapter installation and configuration.
- Documented agent and instance registration.
- Documented hosted and self-hosted credentials.
- Documented webhook setup and verification.
- Documented duplicate-event prevention with shared Redis state.
- Documented required `toolDisplay: 'text'` configuration.
- Documented required `threadContext: { maxMessages: 0 }` configuration.
- Documented Photon Gateway listener startup and reconnection.
- Documented the `gateway: false` option and serverless tradeoffs.
- Added iMessage to the channel overview and documentation sidebar.

## Validation

- Documentation validation passed.
- Build checks passed.
- Prose linting passed.
- MDX formatting checks passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->