### PR TITLE
fix(core): record tool errors as output-error in message history

### DIFF
--- a/.changeset/new-words-shake.md
+++ b/.changeset/new-words-shake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed how tool errors are stored in message history. When a tool throws (or a background task fails), the tool call is now recorded with an error state and its message in an `errorText` field, instead of being stored as a successful result. This keeps failed tool calls distinguishable from real results when messages are recalled or replayed to the model.

--- a/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
@@ -229,11 +229,15 @@ export function createDurableLLMMappingStep() {
           const updated = messageList.updateToolInvocation({
             type: 'tool-invocation' as const,
             toolInvocation: {
-              state: 'result' as const,
+              // A tool error must be recorded as `output-error` with the message in
+              // `errorText` so the transcript/adapters read it as a failure rather than
+              // a normal result. Successful results keep `state: 'result'` + `result`.
+              ...(toolResult.error
+                ? { state: 'output-error' as const, errorText: toolResult.error.message }
+                : { state: 'result' as const, result }),
               toolCallId: toolResult.toolCallId,
               toolName: toolResult.toolName,
               args: toolResult.args,
-              result,
               // Preserve the approval decision for an approved approval-gated tool so it
               // round-trips on recall as `approval: { approved: true }`.
               ...(toolResult.approval ? { approval: toolResult.approval } : {}),

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -1021,11 +1021,14 @@ export function createDurableToolCallStep() {
                     {
                       type: 'tool-invocation',
                       toolInvocation: {
-                        state: 'result',
+                        // A failed background task is recorded as `output-error` with the
+                        // message in `errorText`; a successful one keeps `state: 'result'`.
+                        ...(params.status === 'failed'
+                          ? { state: 'output-error' as const, errorText: result }
+                          : { state: 'result' as const, result }),
                         toolCallId: params.toolCallId,
                         toolName: params.toolName,
                         args: cleanedArgs,
-                        result,
                         // Preserve the approval decision for an approved approval-gated tool that
                         // ran in the background so it round-trips on recall, matching the sync path.
                         ...(approvalGrant ?? {}),

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -244,6 +244,19 @@ describe('createLLMMappingStep HITL behavior', () => {
     // Should NOT bail — the agentic loop should continue so the model can see the error and retry
     expect(bail).not.toHaveBeenCalled();
     expect(result.stepResult.isContinued).toBe(true);
+    // Should record the failure as `output-error` with the message in `errorText`,
+    // not as a successful `result`, so it stays distinguishable on recall/replay.
+    expect(messageList.updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-invocation',
+        toolInvocation: expect.objectContaining({
+          state: 'output-error',
+          toolCallId: 'call-1',
+          toolName: 'brokenTool',
+          errorText: 'Tool execution failed',
+        }),
+      }),
+    );
   });
 
   it('should continue the agentic loop (not bail) when all errors are tool-not-found', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -333,7 +333,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
             rest.messageList.updateToolInvocation({
               type: 'tool-invocation' as const,
               toolInvocation: {
-                state: 'result' as const,
+                state: 'output-error' as const,
                 toolCallId: toolCall.toolCallId,
                 toolName: sanitizeToolName(toolCall.toolName),
                 args: toolCall.args,
@@ -341,7 +341,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
                 // plain {name,message,stack} shape after the pubsub JSON round-trip).
                 // Without reification the `instanceof Error` check below falls through to
                 // `safeStringify`, dumping the whole stringified payload into the history.
-                result: reifiedError.message || 'Tool execution failed',
+                errorText: reifiedError.message || 'Tool execution failed',
               },
               ...(withToolPayloadTransformProviderMetadata(
                 toolCall.providerMetadata as ProviderMetadata,

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -1148,11 +1148,14 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                     {
                       type: 'tool-invocation',
                       toolInvocation: {
-                        state: 'result',
+                        // A failed background task is recorded as `output-error` with the
+                        // message in `errorText`; a successful one keeps `state: 'result'`.
+                        ...(params.status === 'failed'
+                          ? { state: 'output-error' as const, errorText: result as string }
+                          : { state: 'result' as const, result }),
                         toolCallId: params.toolCallId,
                         toolName: params.toolName,
                         args,
-                        result,
                         // Preserve the approval decision for an approved approval-gated tool that
                         // ran in the background so it round-trips on recall, matching the sync path
                         // and the "started" placeholder above.


### PR DESCRIPTION
## Description

Fix #20701

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a tool fails, the system now records it as an error instead of a successful result. This keeps message history accurate and includes the error message for diagnosis.

## Changes

- Record failed tool calls and background tasks with `state: 'output-error'`.
- Store failure details in `errorText`.
- Keep successful tool executions as `state: 'result'` with their result data.
- Add tests for failed tool calls and their recorded error messages.
- Add a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->