### PR TITLE
fix(mongodb): bump @mastra/core peer dependency floor to 1.53.0 (#20586)

### DIFF
--- a/.changeset/mongodb-core-peer-range.md
+++ b/.changeset/mongodb-core-peer-range.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mongodb': patch
+---
+
+Bump the `@mastra/core` peer dependency floor to `>=1.53.0-0`. `@mastra/mongodb` imports `storageMessageMatchesMetadataFilter` from `@mastra/core/storage`, which core only exports from 1.53.0, but the peer range previously allowed `>=1.51.0-0`. Projects resolving core to 1.51.x/1.52.x installed cleanly and then failed at import time. Fixes https://github.com/mastra-ai/mastra/issues/20586

--- a/stores/mongodb/package.json
+++ b/stores/mongodb/package.json
@@ -51,7 +51,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.51.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
`@mastra/mongodb` imports `storageMessageMatchesMetadataFilter` from `@mastra/core/storage`, which core only exports starting in 1.53.0. But the peer range allowed `@mastra/core >=1.51.0-0`, so projects that resolved core to 1.51.x or 1.52.x installed cleanly and then crashed at import with `does not provide an export named 'storageMessageMatchesMetadataFilter'`.

This bumps the peer floor to `>=1.53.0-0` so the incompatible core versions are caught at install time. Added a changeset.

Fixes #20586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The MongoDB package now requires a compatible version of `@mastra/core`. This prevents installation with older core versions that would fail when the package starts.

## Changes

- Raised the `@mastra/core` peer dependency minimum for `@mastra/mongodb` from `>=1.51.0-0` to `>=1.53.0-0`.
- Kept the upper bound at `<2.0.0-0`.
- Added a patch changeset for `@mastra/mongodb`.
- Aligned the requirement with the `storageMessageMatchesMetadataFilter` export introduced in core 1.53.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->