### PR TITLE
fix(factory): use the injected platform access token

### DIFF
--- a/.changeset/crisp-ears-speak.md
+++ b/.changeset/crisp-ears-speak.md
@@ -1,0 +1,13 @@
+---
+'@mastra/factory': major
+---
+
+Removed support for `MASTRA_PLATFORM_SECRET_KEY` in the platform-managed GitHub and Linear integrations. Factories deployed on Mastra Platform now use the injected `MASTRA_PLATFORM_ACCESS_TOKEN`.
+
+**Before:** Set `MASTRA_PLATFORM_SECRET_KEY` to enable platform-managed integrations.
+
+**After:** Mastra Platform injects `MASTRA_PLATFORM_ACCESS_TOKEN`. For local development, set it to an organization API token.
+
+```env
+MASTRA_PLATFORM_ACCESS_TOKEN=sk_your-api-token
+```

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -202,8 +202,8 @@ export interface MastraFactorySandboxConfig {
 
 const CONTROLLER_ID = 'code';
 
-function hasPlatformSecretKey(): boolean {
-  return Boolean(process.env.MASTRA_PLATFORM_SECRET_KEY?.trim());
+function hasPlatformAccessToken(): boolean {
+  return Boolean(process.env.MASTRA_PLATFORM_ACCESS_TOKEN?.trim());
 }
 
 /**
@@ -336,7 +336,7 @@ export class MastraFactory {
     // Explicit integrations win. Platform credentials fill only missing GitHub
     // and Linear slots so callers can override either provider independently.
     const integrations = [...(this.#config.integrations ?? [])];
-    if (hasPlatformSecretKey()) {
+    if (hasPlatformAccessToken()) {
       if (!integrations.some(integration => integration.id === 'github')) {
         integrations.push(
           new PlatformGithubIntegration({

--- a/mastracode/factory/src/integrations/platform/api-client.test.ts
+++ b/mastracode/factory/src/integrations/platform/api-client.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { PlatformApiClient, PlatformApiError, platformApiClientConfigFromEnv } from './api-client.js';
 
-const accessToken = 'platform-secret-token';
+const accessToken = 'platform-access-token';
 
 function client(fetchImpl: typeof fetch) {
   return new PlatformApiClient({ baseUrl: 'https://platform.example.com/', accessToken, fetchImpl });
@@ -17,7 +17,7 @@ afterEach(() => {
 describe('PlatformApiClient', () => {
   it('resolves config from MASTRA_SHARED_API_URL and normalizes the /v1 root', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', 'https://platform.example.com/v1/');
-    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', accessToken);
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', accessToken);
 
     expect(platformApiClientConfigFromEnv()).toEqual({
       baseUrl: 'https://platform.example.com',
@@ -25,20 +25,19 @@ describe('PlatformApiClient', () => {
     });
   });
 
-  it('defaults shared API config to platform.mastra.ai and requires a secret key', () => {
+  it('defaults shared API config to platform.mastra.ai and requires an access token', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', '');
-    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', accessToken);
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', accessToken);
     expect(platformApiClientConfigFromEnv()).toMatchObject({ baseUrl: 'https://platform.mastra.ai' });
 
-    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
     vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
-    expect(() => platformApiClientConfigFromEnv()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
+    expect(() => platformApiClientConfigFromEnv()).toThrow(/MASTRA_PLATFORM_ACCESS_TOKEN/);
   });
 
-  it('requires MASTRA_PLATFORM_SECRET_KEY even when the deprecated access token is set', () => {
-    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'legacy-token');
-    expect(() => platformApiClientConfigFromEnv()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
+  it('does not use MASTRA_PLATFORM_SECRET_KEY', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'secret-key');
+    expect(() => platformApiClientConfigFromEnv()).toThrow(/MASTRA_PLATFORM_ACCESS_TOKEN/);
   });
 
   it('uses bearer authentication without ambient cookie credentials', async () => {

--- a/mastracode/factory/src/integrations/platform/api-client.ts
+++ b/mastracode/factory/src/integrations/platform/api-client.ts
@@ -6,9 +6,9 @@ export interface PlatformApiClientConfig {
 
 export function platformApiClientConfigFromEnv(): PlatformApiClientConfig {
   const sharedApiUrl = process.env.MASTRA_SHARED_API_URL?.trim() || 'https://platform.mastra.ai/v1';
-  const accessToken = process.env.MASTRA_PLATFORM_SECRET_KEY?.trim();
+  const accessToken = process.env.MASTRA_PLATFORM_ACCESS_TOKEN?.trim();
   if (!accessToken) {
-    throw new Error('Platform integration: missing required environment variable MASTRA_PLATFORM_SECRET_KEY.');
+    throw new Error('Platform integration: missing required environment variable MASTRA_PLATFORM_ACCESS_TOKEN.');
   }
   return { baseUrl: normalizeSharedApiUrl(sharedApiUrl), accessToken };
 }

--- a/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
@@ -69,7 +69,7 @@ function json(data: unknown): Response {
 beforeEach(() => {
   vi.useFakeTimers();
   vi.stubEnv('MASTRA_SHARED_API_URL', 'https://platform.example.com/v1');
-  vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'platform-token');
+  vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
   vi.stubEnv('MASTRA_PLATFORM_GITHUB_POLLING_INTERVAL_MS', '60000');
   harness.reset();
 });

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -62,7 +62,7 @@ function json(data: unknown, status = 200): Response {
 
 beforeEach(() => {
   vi.stubEnv('MASTRA_SHARED_API_URL', config.baseUrl);
-  vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', config.accessToken);
+  vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', config.accessToken);
 });
 
 afterEach(() => {
@@ -1021,13 +1021,13 @@ describe('PlatformGithubIntegration', () => {
     });
   });
 
-  it('defaults the Platform base URL and requires MASTRA_PLATFORM_SECRET_KEY', () => {
+  it('defaults the Platform base URL and requires MASTRA_PLATFORM_ACCESS_TOKEN', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', '');
     expect(new PlatformGithubIntegration().diagnostics()).toMatchObject({ endpointHost: 'platform.mastra.ai' });
 
-    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'legacy-token');
-    expect(() => new PlatformGithubIntegration()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'secret-key');
+    expect(() => new PlatformGithubIntegration()).toThrow(/MASTRA_PLATFORM_ACCESS_TOKEN/);
   });
 
   it('exposes an explicitly configured GitHub App slug to webhook rules', () => {

--- a/mastracode/factory/src/integrations/platform/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.test.ts
@@ -70,7 +70,7 @@ function json(data: unknown, status = 200): Response {
 
 beforeEach(() => {
   vi.stubEnv('MASTRA_SHARED_API_URL', config.baseUrl);
-  vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', config.accessToken);
+  vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', config.accessToken);
 });
 
 afterEach(() => {
@@ -84,7 +84,7 @@ function createIntegration(fetchImpl?: typeof fetch): PlatformLinearIntegration 
 }
 
 describe('PlatformLinearIntegration', () => {
-  it('does not expose the Platform secret through synthetic Linear connections', async () => {
+  it('does not expose the Platform access token through synthetic Linear connections', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(json({ workspaces: [workspace] }));
     const integration = createIntegration(fetchImpl);
 
@@ -549,15 +549,15 @@ describe('PlatformLinearIntegration', () => {
     );
   });
 
-  it('defaults the Platform base URL and requires MASTRA_PLATFORM_SECRET_KEY', () => {
+  it('defaults the Platform base URL and requires MASTRA_PLATFORM_ACCESS_TOKEN', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', '');
     expect(new PlatformLinearIntegration().diagnostics()).toEqual({
       mode: 'platform',
       endpointHost: 'platform.mastra.ai',
     });
 
-    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'legacy-token');
-    expect(() => new PlatformLinearIntegration()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'secret-key');
+    expect(() => new PlatformLinearIntegration()).toThrow(/MASTRA_PLATFORM_ACCESS_TOKEN/);
   });
 });


### PR DESCRIPTION
## Summary

- authenticate Factory's managed GitHub and Linear integrations with the platform-injected `MASTRA_PLATFORM_ACCESS_TOKEN`
- auto-register those integrations when the access token is present instead of requiring `MASTRA_PLATFORM_SECRET_KEY`
- update regression tests and add breaking-change migration guidance

## Test plan

- focused Factory platform integration tests: 4 files, 61 tests
- `pnpm --filter @mastra/factory check`
- `pnpm --filter @mastra/factory lint`
- `pnpm --filter @mastra/factory build:lib`
- changed-file formatting and diff checks

## Deployment order

Deploy the Platform integrations JWT-auth change, with its `JWT_SECRET` infrastructure binding applied, before releasing this Factory change.
