### PR TITLE
fix(factory): recover when session branch already exists

### DIFF
--- a/.changeset/two-gifts-relate.md
+++ b/.changeset/two-gifts-relate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed a materialize storm where a session would loop retrying `git checkout -b` when the target branch already existed locally (surfacing as `fatal: a branch named 'factory/pr-XXXX' already exists`). The initial `show-ref` probe can miss branches that live only in `packed-refs` or that a prior partially-completed checkout left behind; when that happens, checkout now falls back to switching to the existing branch instead of throwing, so other sessions sharing the workspace are no longer starved.

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -621,6 +621,46 @@ describe('checkoutSessionBranch', () => {
     expect(err).toBeInstanceOf(MaterializeError);
     expect(err.code).toBe('clone-failed');
   });
+
+  it('recovers by switching to the branch when checkout -b reports it already exists', async () => {
+    // Reproduces the "materialize loop" storm: `show-ref` says the branch is
+    // absent but `checkout -b` then reports it exists (e.g. the ref only lives
+    // in packed-refs, or a prior partially-completed checkout left the branch
+    // pointer behind). The old behavior threw MaterializeError on every retry,
+    // starving other sessions on the workspace. The recovery path must switch
+    // to the existing branch rather than fail hard.
+    let checkoutBAttempts = 0;
+    const sandbox = new FakeSandbox(script => {
+      if (script.includes('branch --show-current')) {
+        return { exitCode: 0, stdout: 'main\n', stderr: '' };
+      }
+      if (script.includes('show-ref')) return { exitCode: 1, stdout: '', stderr: '' };
+      if (script.includes('checkout -b')) {
+        checkoutBAttempts += 1;
+        return {
+          exitCode: 128,
+          stdout: '',
+          stderr:
+            'From https://github.com/octocat/hello\n * branch                main       -> FETCH_HEAD\n' +
+            "fatal: a branch named 'factory/pr-1' already exists\n",
+        };
+      }
+      return OK;
+    });
+
+    await expect(checkoutSessionBranch(sandbox, '/workspace/repo', opts)).resolves.toBeUndefined();
+
+    // Verify the recovery actually switched to the existing branch.
+    const joined = sandbox.calls.join('\n');
+    expect(joined).toMatch(/git -C .* checkout 'factory\/pr-1'/);
+    // And we did not force-delete or reset the branch behind the user's back.
+    expect(joined).not.toMatch(/branch -D|reset --hard|checkout -B/);
+    // Token still scrubbed back to the clean URL in the finally.
+    const scrub = sandbox.calls.filter(c => c.includes('remote set-url origin')).at(-1);
+    expect(scrub).toContain('https://github.com/octocat/hello.git');
+    expect(scrub).not.toContain('tok-secret');
+    expect(checkoutBAttempts).toBe(1);
+  });
 });
 
 describe('recycleClaimedWorkdir', () => {

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -412,11 +412,35 @@ export async function checkoutSessionBranch(
       // Same rule as above: uncommitted work in the tree blocks the switch
       // to the new branch. Leave the checkout on its current branch.
       if (isBlockedByLocalWork(fetch)) return;
+      // The `show-ref` probe above can miss branches that only live in
+      // `packed-refs`, or a previous partially-completed checkout can leave
+      // the branch pointer behind. In either case `checkout -b` refuses with
+      // "already exists" — but the branch *does* exist locally and is a
+      // valid target. Fall back to a plain `checkout` so materialization can
+      // proceed instead of looping forever on retry.
+      if (isBranchAlreadyExists(fetch)) {
+        const checkout = await sh(sandbox, `git -C ${shellQuote(workdir)} checkout ${shellQuote(branch)}`);
+        if (checkout.exitCode === 0) return;
+        if (isBlockedByLocalWork(checkout)) return;
+        throw classifyGitFailure(checkout, 'clone-failed');
+      }
       throw classifyGitFailure(fetch, 'clone-failed');
     }
   } finally {
     await sh(sandbox, `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(cleanUrl(repoFullName))}`);
   }
+}
+
+/**
+ * True when `git checkout -b` refused because the branch already exists.
+ * Happens when `show-ref` missed the ref (e.g. it lives only in `packed-refs`)
+ * or a prior partially-completed checkout left the branch pointer behind. The
+ * caller recovers by switching to the existing branch — hard-failing here is
+ * what produced the shipyard materialize storm.
+ */
+function isBranchAlreadyExists(result: SandboxCommandResult): boolean {
+  const output = `${result.stderr || ''}\n${result.stdout || ''}`;
+  return /a branch named .* already exists/i.test(output);
 }
 
 /**


### PR DESCRIPTION
## Summary

When a factory session materializes into a sandbox, `checkoutSessionBranch` probes for the target branch with `git show-ref --verify --quiet refs/heads/<branch>` and, if the probe reports the branch is missing, runs `git checkout -b <branch> FETCH_HEAD`.

That probe can miss real local branches — for example refs that only live in `packed-refs`, or a branch pointer left behind by a prior partially-completed checkout. When that happens, `checkout -b` refuses with:

```
fatal: a branch named 'factory/pr-XXXX' already exists
```

`classifyGitFailure` had no case for that stderr, so the failure was thrown as a `MaterializeError`. The session then retried materialization on every wake and never made progress — starving neighbouring sessions on the shared sandbox and generating a storm of identical errors.

## Fix

Detect the "already exists" stderr from the fetch + `checkout -b` step and fall back to a plain `git checkout <branch>`. The branch does exist and is the correct target; the probe was just wrong about whether it existed. Uncommitted work still blocks the switch, matching the existing `isBlockedByLocalWork` convention in this file.

Deliberately **not** doing a force `checkout -B` or `branch -D`: the surrounding code (`isBenignNonFastForward`, `isBlockedByLocalWork`) establishes a firm convention that in-progress work in the sandbox always wins over branch mechanics. Recreating the branch behind the user would violate that.

## Test plan

- New unit test reproduces the exact production stderr and asserts the recovery path switches to the existing branch and still scrubs the auth token from the remote.
- Confirmed the test is red without the fix and green with it.
- `pnpm --filter @mastra/factory test` — 79 passed
- `pnpm --filter @mastra/factory check` — clean
- `pnpm --filter @mastra/factory lint` — clean
- `prettier --check` on modified files — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a factory session branch already exists, materialization now switches to it instead of retrying and failing. This prevents repeated retries and session starvation while preserving safety checks for uncommitted work.

## Changes

- Added a fallback from `git checkout -b <branch> FETCH_HEAD` to `git checkout <branch>` when Git reports that the branch already exists.
- Preserved remote authentication-token scrubbing.
- Preserved blocking behavior for uncommitted work.
- Added a regression test for the missed `git show-ref` scenario.
- Added a patch changeset for `@mastra/factory`.
- Factory tests, checks, linting, and formatting pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->