### PR TITLE
fix(core): preserve provider-executed tool errors in message history

### DIFF
--- a/.changeset/quiet-pugs-repeat.md
+++ b/.changeset/quiet-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed provider-executed tool errors being dropped when stream chunks are converted into assistant message history. `buildMessagesFromChunks` handled `tool-call` and `tool-result` but not the declared `tool-error` chunk, so a failed provider tool stayed in the pending `call` state with no error text. The matching invocation now becomes `output-error` with the normalized failure message. Fixes https://github.com/mastra-ai/mastra/issues/20715

--- a/.changeset/quiet-pugs-repeat.md
+++ b/.changeset/quiet-pugs-repeat.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed provider-executed tool errors being dropped when stream chunks are converted into assistant message history. `buildMessagesFromChunks` handled `tool-call` and `tool-result` but not the declared `tool-error` chunk, so a failed provider tool stayed in the pending `call` state with no error text. The matching invocation now becomes `output-error` with the normalized failure message. Fixes https://github.com/mastra-ai/mastra/issues/20715
+Fixed assistant message history so provider-executed tool failures are preserved instead of remaining as pending calls. Matching tool invocations now use `state: "output-error"`, and the normalized provider message is stored in `errorText` with a fallback when no usable message is available. Fixes https://github.com/mastra-ai/mastra/issues/20715

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -290,6 +290,150 @@ describe('buildMessagesFromChunks', () => {
     });
   });
 
+  it('should preserve string tool-error messages', () => {
+    const result = parts([
+      {
+        type: 'tool-call',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          providerExecuted: true,
+        },
+      },
+      {
+        type: 'tool-error',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          error: 'boom',
+          providerExecuted: true,
+        },
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'output-error',
+        toolCallId: 'tc1',
+        toolName: 'myTool',
+        args: { q: 'test' },
+        errorText: 'boom',
+      },
+      providerExecuted: true,
+    });
+  });
+
+  it('should preserve plain-object tool-error messages', () => {
+    const result = parts([
+      {
+        type: 'tool-call',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          providerExecuted: true,
+        },
+      },
+      {
+        type: 'tool-error',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          error: { message: 'Provider object failure' },
+          providerExecuted: true,
+        },
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'output-error',
+        toolCallId: 'tc1',
+        toolName: 'myTool',
+        args: { q: 'test' },
+        errorText: 'Provider object failure',
+      },
+      providerExecuted: true,
+    });
+  });
+
+  it('should fall back for falsy tool errors', () => {
+    const result = parts([
+      {
+        type: 'tool-call',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          providerExecuted: true,
+        },
+      },
+      {
+        type: 'tool-error',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          error: null,
+          providerExecuted: true,
+        },
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'output-error',
+        toolCallId: 'tc1',
+        toolName: 'myTool',
+        args: { q: 'test' },
+        errorText: 'Tool execution failed',
+      },
+      providerExecuted: true,
+    });
+  });
+
+  it('should fall back for Error instances without usable messages', () => {
+    const result = parts([
+      {
+        type: 'tool-call',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          providerExecuted: true,
+        },
+      },
+      {
+        type: 'tool-error',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          error: new Error(''),
+          providerExecuted: true,
+        },
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'output-error',
+        toolCallId: 'tc1',
+        toolName: 'myTool',
+        args: { q: 'test' },
+        errorText: 'Tool execution failed',
+      },
+      providerExecuted: true,
+    });
+  });
+
   // ── Source and file parts ───────────────────────────────────
 
   it('should produce a source part', () => {

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -254,6 +254,42 @@ describe('buildMessagesFromChunks', () => {
     });
   });
 
+  it('should merge tool-call + tool-error into a single output-error part', () => {
+    const result = parts([
+      {
+        type: 'tool-call',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          providerExecuted: true,
+        },
+      },
+      {
+        type: 'tool-error',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          error: new Error('Provider tool failed'),
+          providerExecuted: true,
+        },
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'output-error',
+        toolCallId: 'tc1',
+        toolName: 'myTool',
+        args: { q: 'test' },
+        errorText: 'Provider tool failed',
+      },
+      providerExecuted: true,
+    });
+  });
+
   // ── Source and file parts ───────────────────────────────────
 
   it('should produce a source part', () => {

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -1,6 +1,7 @@
 import type { ToolSet } from '@internal/ai-sdk-v5';
 
 import type { MastraDBMessage, MastraMessagePart } from '../../../agent/message-list';
+import { getErrorFromUnknown } from '../../../error';
 import type {
   FilePayload,
   ReasoningDeltaPayload,
@@ -9,6 +10,7 @@ import type {
   TextDeltaPayload,
   TextStartPayload,
   ToolCallPayload,
+  ToolErrorPayload,
   ToolResultPayload,
 } from '../../../stream/types';
 import { withToolPayloadTransformProviderMetadata } from '../../../tools/payload-transform';
@@ -270,6 +272,22 @@ export function buildMessagesFromChunks({
             providerMetadata,
             providerExecuted,
           } as MastraMessagePart);
+        }
+        break;
+      }
+
+      case 'tool-error': {
+        const p = chunk.payload as ToolErrorPayload;
+        const invocationPart = parts.find(
+          part => part.type === 'tool-invocation' && part.toolInvocation.toolCallId === p.toolCallId,
+        );
+
+        if (invocationPart?.type === 'tool-invocation') {
+          invocationPart.toolInvocation = {
+            ...invocationPart.toolInvocation,
+            state: 'output-error',
+            errorText: getErrorFromUnknown(p.error, { fallbackMessage: 'Tool execution failed' }).message,
+          };
         }
         break;
       }

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -283,10 +283,11 @@ export function buildMessagesFromChunks({
         );
 
         if (invocationPart?.type === 'tool-invocation') {
+          const errorMessage = getErrorFromUnknown(p.error, { fallbackMessage: 'Tool execution failed' }).message;
           invocationPart.toolInvocation = {
             ...invocationPart.toolInvocation,
             state: 'output-error',
-            errorText: getErrorFromUnknown(p.error, { fallbackMessage: 'Tool execution failed' }).message,
+            errorText: errorMessage.trim() ? errorMessage : 'Tool execution failed',
           };
         }
         break;

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -318,7 +318,7 @@ export interface StepFinishPayload<Tools extends ToolSet = ToolSet, OUTPUT = und
   [key: string]: unknown;
 }
 
-interface ToolErrorPayload {
+export interface ToolErrorPayload {
   id?: string;
   providerMetadata?: ProviderMetadata;
   toolCallId: string;


### PR DESCRIPTION
## Description

Provider-executed `tool-error` chunks were ignored when stream chunks were converted into assistant message history, so failed invocations remained in the pending `call` state without error text. This changes the matching invocation to `output-error` and records the normalized error message, while leaving tool-call/tool-result merging and the other message parts unchanged. I added a focused regression for the `tool-call`/`tool-error` pair; it and the existing agentic-execution suites pass. Core typechecking and focused lint and format checks also pass.

## Related issue(s)

Fixes #20715

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test update

## Checklist

- [x] I have linked the related issue in the description above
- [ ] I have made corresponding documentation changes (not applicable)
- [x] I have added a test that proves the fix is effective
- [ ] I have addressed all CodeRabbit comments (review has not run)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a provider reports that a tool failed, assistant history now records the failure instead of leaving the tool marked as running. It preserves the provider’s error message and the tool’s existing details.

## Changes

- Handle `tool-error` chunks in assistant message history.
- Mark the matching tool invocation as `state: "output-error"`.
- Store the normalized provider error in `errorText`.
- Use fallback text for missing or empty errors.
- Export `ToolErrorPayload`.
- Add regression tests for tool-error merging and error normalization.
- Preserve existing tool-call, tool-result, and other message-part behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->