### PR TITLE
docs: document Stagehand pnpm build approvals

### DIFF
--- a/docs/src/content/en/docs/browser/stagehand.mdx
+++ b/docs/src/content/en/docs/browser/stagehand.mdx
@@ -26,6 +26,22 @@ Install the package:
 npm install @mastra/stagehand
 ```
 
+If you use pnpm, approve the dependency build scripts that Stagehand requires in `pnpm-workspace.yaml`:
+
+```yaml title="pnpm-workspace.yaml"
+allowBuilds:
+  '@google/genai': true
+  bufferutil: true
+  protobufjs: true
+
+onlyBuiltDependencies:
+  - '@google/genai'
+  - bufferutil
+  - protobufjs
+```
+
+Run `pnpm install` again after saving the file. pnpm blocks dependency build scripts unless the project explicitly approves them.
+
 Create a browser instance and assign it to an agent:
 
 ```typescript title="src/mastra/agents/stagehand-agent.ts"

--- a/templates/template-browsing-agent/pnpm-workspace.yaml
+++ b/templates/template-browsing-agent/pnpm-workspace.yaml
@@ -1,0 +1,14 @@
+packages:
+  - .
+
+allowBuilds:
+  '@google/genai': true
+  bufferutil: true
+  esbuild: true
+  protobufjs: true
+
+onlyBuiltDependencies:
+  - '@google/genai'
+  - bufferutil
+  - esbuild
+  - protobufjs


### PR DESCRIPTION
pnpm blocks dependency build scripts unless they are explicitly approved. Stagehand depends on build scripts from `@google/genai`, `bufferutil`, and `protobufjs`, so an otherwise successful install can leave those dependencies incomplete.

This documents the required `allowBuilds` and `onlyBuiltDependencies` configuration and adds the same policy to the browsing-agent template, including its existing `esbuild` requirement.

Validated with a clean pnpm 11.13.1 template install, targeted MDX formatting and Remark lint, the docs validation suite, and `git diff --check`.
