### PR TITLE
fix(mastracode): pass windowsVerbatimArguments when spawning hook commands on Windows

### DIFF
--- a/mastracode/sdk/src/hooks/executor.test.ts
+++ b/mastracode/sdk/src/hooks/executor.test.ts
@@ -1,0 +1,74 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HookDefinition, HookStdinSession } from './types.js';
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+const { executeHook } = await import('./executor.js');
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  stdin = { write: vi.fn(), end: vi.fn() };
+  kill = vi.fn();
+}
+
+function makeHook(command: string): HookDefinition {
+  return { type: 'command', command };
+}
+
+function makeStdin(): HookStdinSession {
+  return { session_id: 'session-1', cwd: '/tmp/project', hook_event_name: 'SessionStart' };
+}
+
+describe('executeHook Windows argument handling', () => {
+  let originalPlatform: NodeJS.Platform;
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    originalPlatform = process.platform;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+
+  it('passes windowsVerbatimArguments: true when spawning cmd on win32', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    const fakeChild = new FakeChildProcess();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => fakeChild.emit('close', 0));
+      return fakeChild;
+    });
+
+    await executeHook(makeHook('node "C:/tools/my-hook.mjs"'), makeStdin());
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'cmd',
+      ['/c', 'node "C:/tools/my-hook.mjs"'],
+      expect.objectContaining({ windowsVerbatimArguments: true }),
+    );
+  });
+
+  it('does not pass windowsVerbatimArguments on non-Windows platforms', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+
+    const fakeChild = new FakeChildProcess();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => fakeChild.emit('close', 0));
+      return fakeChild;
+    });
+
+    await executeHook(makeHook('node "/tools/my-hook.mjs"'), makeStdin());
+
+    const callOptions = spawnMock.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(callOptions).not.toHaveProperty('windowsVerbatimArguments');
+  });
+});

--- a/mastracode/sdk/src/hooks/executor.ts
+++ b/mastracode/sdk/src/hooks/executor.ts
@@ -21,6 +21,12 @@ export async function executeHook(hook: HookDefinition, stdinPayload: HookStdin)
     const child = spawn(shell, shellArgs, {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: stdinPayload.cwd,
+      // Without this, Node's default Windows argument escaping re-quotes
+      // hook.command before cmd.exe ever sees it, so a quoted path (or any
+      // path containing spaces) reaches the child process with literal "
+      // characters embedded in it. mastracode/tui's shell-runner.ts already
+      // sets this for its own cmd invocations; this call site just missed it.
+      ...(isWindows ? { windowsVerbatimArguments: true } : {}),
       env: {
         ...process.env,
         MASTRA_HOOK_EVENT: stdinPayload.hook_event_name,


### PR DESCRIPTION
## Description

`executeHook` spawns `cmd` on Windows without `windowsVerbatimArguments`, so Node's default Windows argument escaping re-quotes `hook.command` before `cmd.exe` ever sees it. A quoted path in a `hooks.json` command (or any unquoted path containing spaces) reaches the child process with literal `"` characters embedded in it, so the hook fails to run — with no way to express a spaced path at all, since quoting breaks it and not quoting breaks it too.

This isn't a new pattern for the codebase — `mastracode/tui`'s `shell-runner.ts` already sets `windowsVerbatimArguments: true` for its own `cmd` invocations via `execa`; this call site in `mastracode/sdk` just missed it. Same class of bug as #17646 (Windows shell-quote escaping in `create-mastra`), different package.

### Verification
- Confirmed the reported code matches current `main` exactly.
- The reporter's own repro script already validated this exact fix empirically on a real Windows machine (their `'quoted + windowsVerbatimArguments (proposed fix)'` case passes; the others fail) — I don't have a Windows environment to re-run it myself, but the fix is unchanged from what they tested.
- Added `executor.test.ts` (no prior direct test coverage existed for this file — `manager.test.ts` mocks it away entirely) covering both that `windowsVerbatimArguments: true` is passed on `win32` and that it's genuinely absent (not just falsy) on other platforms, following the `process.platform` mocking convention already used in `mastracode/tui`'s test suite.
- This doesn't change behavior for the unquoted-no-spaces case, and correctly doesn't attempt to fix unquoted-with-spaces (unfixable by this flag alone — quoting a spaced path is required, matching how `/bin/sh -c` already behaves on macOS/Linux).
- All 21 tests in `mastracode/sdk/src/hooks` pass; `oxlint` and `tsc --noEmit` clean on both changed files.

## Related issue(s)

Fixes #20681

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Windows now runs Mastra Code hook commands correctly when paths contain spaces or quote marks. Regression tests confirm the fix works only on Windows.

## Summary

- Pass `windowsVerbatimArguments: true` when spawning `cmd.exe` on Windows.
- Prevent Node.js from changing command arguments before they reach `cmd.exe`.
- Add tests for Windows and non-Windows behavior.

## Tests

- Hook tests
- Linting
- TypeScript checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->