### PR TITLE
fix(request-context): share the serialization probe budget across nested contexts

### DIFF
--- a/.changeset/tame-eagles-share.md
+++ b/.changeset/tame-eagles-share.md
@@ -1,0 +1,6 @@
+---
+'@internal/core': patch
+'@mastra/core': patch
+---
+
+Fixed `RequestContext.toJSON()` so nested contexts reached through shared-reference graphs no longer block the event loop. The serialization safety budget is now shared across nested probes within one serialization, so such values are handled in bounded time — and filtered when they exceed the budget — instead of blocking for seconds.

--- a/packages/_internal-core/src/request-context/index.ts
+++ b/packages/_internal-core/src/request-context/index.ts
@@ -137,14 +137,12 @@ let _toJSONDepth = 0;
  * to persist. 1M visits keeps the worst-case probe in the tens of
  * milliseconds while remaining far above any reasonable context value.
  *
- * Two caveats to that bound. The budget is per `JSON.stringify` call, and a
- * nested value's `toJSON()` runs before the replacer sees it — so a stored
- * graph that reaches a nested `RequestContext` through N shared paths
- * re-runs that context's probes with a fresh budget on every visit
- * (tracked in #20446). And `Buffer.prototype.toJSON` materializes a
- * `{ type, data }` object before the replacer, so Buffers charge one budget
- * unit per byte rather than the arithmetic typed-array fast path — a Buffer
- * past the budget is filtered.
+ * The budget is shared across nested `RequestContext` probes within one
+ * outermost probe (see `_probeBudgetRemaining`), so a shared-reference graph of
+ * nested contexts is bounded too. One caveat remains: `Buffer.prototype.toJSON`
+ * materializes a `{ type, data }` object before the replacer, so Buffers charge
+ * one budget unit per byte rather than the arithmetic typed-array fast path — a
+ * Buffer past the budget is filtered.
  */
 const SERIALIZATION_PROBE_BUDGET = 1_000_000;
 
@@ -176,6 +174,21 @@ function isPlainObjectOrArray(value: unknown): boolean {
     return false;
   }
 }
+
+/**
+ * Shared state for the serialization probe budget.
+ *
+ * The budget is drawn down by every `isSerializable` probe running within one
+ * outermost probe — including the probes a nested `RequestContext.toJSON()`
+ * runs, which `JSON.stringify` invokes *before* the outer replacer sees the
+ * result. Sharing one budget across them keeps the probe's time bound holding
+ * regardless of nesting; a fresh per-call budget (the earlier approach) let a
+ * shared-reference graph of nested contexts re-run full-budget probes on every
+ * visit and block for seconds. `_probeBudgetActive` marks that an outermost
+ * probe owns the budget so nested probes draw down rather than reset it.
+ */
+let _probeBudgetActive = false;
+let _probeBudgetRemaining = 0;
 
 export class RequestContext<Values extends Record<string, any> | unknown = unknown> {
   private registry = new Map<string, unknown>();
@@ -327,7 +340,10 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
    * serialization would visit an unbounded number of nodes — an acyclic
    * graph with layered shared references expands as 2^depth — is treated as
    * non-serializable and filtered instead of blocking the event loop for
-   * the full expansion.
+   * the full expansion. The budget is shared across nested `RequestContext`
+   * probes within one outermost probe (a nested `toJSON()` runs before the
+   * replacer sees its result), so the bound holds even when the graph reaches
+   * nested contexts through many shared paths.
    *
    * Re-throws `CyclicRequestContextToJSONError` when called from a nested
    * `toJSON()` (`_toJSONDepth > 1`), so the marker propagates up to the
@@ -341,10 +357,18 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
     if (typeof value === 'symbol') return false;
     if (typeof value !== 'object') return true;
 
+    // The outermost probe owns the budget; nested probes (a nested
+    // `RequestContext.toJSON()` invoked while this JSON.stringify runs) draw
+    // down the same remaining budget instead of starting fresh, so total probe
+    // time is bounded regardless of how many nested contexts the graph reaches.
+    const outermostProbe = !_probeBudgetActive;
+    if (outermostProbe) {
+      _probeBudgetActive = true;
+      _probeBudgetRemaining = SERIALIZATION_PROBE_BUDGET;
+    }
     try {
-      let budget = SERIALIZATION_PROBE_BUDGET;
       JSON.stringify(value, (_key, probed) => {
-        if (--budget < 0) {
+        if (--_probeBudgetRemaining < 0) {
           throw new RangeError('RequestContext.isSerializable: value expands past the serialization probe budget');
         }
         // Typed arrays serialize one element per index; charge them against
@@ -376,8 +400,8 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
           }
           // Charge the intrinsic element count — an own `length` data
           // property can shadow the prototype getter and lie.
-          budget -= elementCount;
-          if (budget < 0) {
+          _probeBudgetRemaining -= elementCount;
+          if (_probeBudgetRemaining < 0) {
             throw new RangeError('RequestContext.isSerializable: value expands past the serialization probe budget');
           }
           // Preserve probe semantics for non-index own enumerable properties
@@ -405,6 +429,10 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
         throw e;
       }
       return false;
+    } finally {
+      if (outermostProbe) {
+        _probeBudgetActive = false;
+      }
     }
   }
 

--- a/packages/core/src/request-context/index.test.ts
+++ b/packages/core/src/request-context/index.test.ts
@@ -282,6 +282,46 @@ describe('RequestContext', () => {
       expect(json).toHaveProperty('smallDag');
     });
 
+    it('should bound nested RequestContext probes by sharing one budget across them (#20446)', () => {
+      // A shared-reference graph that reaches a nested RequestContext through
+      // 2^8 paths. With a per-call budget each of the 256 visits re-ran the
+      // inner probe with a fresh full budget (~9-10s). Sharing one budget across
+      // nested probes bounds the total work and filters the over-budget key.
+      const inner = new RequestContext();
+      let big: unknown = { leaf: true };
+      for (let i = 0; i < 25; i++) big = { a: big, b: big }; // over budget on its own
+      inner.set('big', big);
+
+      let outer: unknown = inner;
+      for (let i = 0; i < 8; i++) outer = { a: outer, b: outer }; // 2^8 shared paths to inner
+
+      const ctx = new RequestContext();
+      ctx.set('outer', outer);
+      ctx.set('serializable', 'value');
+
+      const start = Date.now();
+      const json = ctx.toJSON();
+      const elapsed = Date.now() - start;
+
+      // Loose threshold: assert "bounded", not "fast" (was ~9-10s unbounded).
+      expect(elapsed).toBeLessThan(2000);
+      expect(json).toEqual({ serializable: 'value' });
+      expect(json).not.toHaveProperty('outer');
+    });
+
+    it('should keep nested RequestContext values whose total probe stays within budget', () => {
+      const inner = new RequestContext();
+      inner.set('userId', 'user-123');
+      inner.set('data', { nested: { value: 1 } });
+
+      const ctx = new RequestContext();
+      ctx.set('inner', { ctx: inner });
+
+      const json = ctx.toJSON();
+
+      expect(json).toHaveProperty('inner');
+    });
+
     it('should skip oversized typed arrays without materializing their elements, and keep small ones', () => {
       const ctx = new RequestContext();
       ctx.set('bigTyped', new Float64Array(8 * 1024 * 1024));


### PR DESCRIPTION
## Description

#20375 bounded the `isSerializable` probe, but the budget was **per `JSON.stringify` call**. A nested `RequestContext`'s `toJSON()` runs *before* the replacer sees it (per spec: `toJSON` first, then replacer), so a shared-reference graph that reaches a nested context through 2^d paths re-ran that context's probe with a **fresh full budget on every visit** — ~9–10s at outer depth 8, growing as 2^depth (a depth-20 run was killed at 180s). The value was *kept*; the cost was amplified probing.

**Fix:** move the probe budget to module-level state that the **outermost probe owns and nested probes draw down**, reset per top-level value. Total probe time is now bounded regardless of nesting.

- `_probeBudgetActive` marks that an outermost probe owns the budget; nested probes (a nested `RequestContext.toJSON()` invoked while the outer `JSON.stringify` runs) decrement the same remaining budget instead of resetting it.
- A `finally` resets ownership when the outermost probe exits, so the budget is fresh for each top-level value and never leaks across calls.
- The cyclic-reentry contract from #16685/#16686 (`_toJSONDepth`/`CyclicRequestContextToJSONError`) is untouched — the outermost probe is always at `_toJSONDepth === 1`, so it still swallows the marker and filters the key.

**Behavior note:** a nested-context graph whose *total* probe work exceeds the shared budget is now **filtered** in bounded time, consistent with how flat over-budget values are already handled (#20375). Nested contexts whose total stays within budget are unaffected.

Validation: `pnpm --filter @mastra/core test:unit src/request-context/index.test.ts` (35 passing, incl. the #20446 repro — 2^8 shared paths to a nested context — now completing in bounded time and a legit-nested-context-kept case), `@internal/core` build/typecheck, prettier.

## Related issue(s)

Fixes #20446. Follow-up to #20366 / #20375 (the residual scoped out there).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable; internal serialization path)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015rmrtWcDSwFW3bxFLrv5w7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Nested `RequestContext` objects now share one serialization budget. This prevents deeply linked data from taking too long to serialize while preserving small valid contexts.

## Changes

- Moved the serialization probe budget to module-level state owned by the outermost probe.
- Made nested probes consume the shared remaining budget.
- Preserved existing cyclic re-entry handling.
- Filtered nested-context graphs that exceed the shared budget.
- Added regression tests for shared-reference graphs and valid nested contexts.
- Added a changeset for patch releases of `@internal/core` and `@mastra/core`.

## Validation

- Unit tests completed.
- Build and typecheck completed.
- Formatting validation completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->