### PR TITLE
fix(github-signals): suppress noisy activity notifications

### DIFF
--- a/.changeset/quiet-signals-rest.md
+++ b/.changeset/quiet-signals-rest.md
@@ -1,0 +1,5 @@
+---
+'@mastra/github-signals': patch
+---
+
+Fixed duplicate GitHub signal notifications caused by transient mergeability checks and edits to already-observed bot comments.

--- a/signals/github/src/index.test.ts
+++ b/signals/github/src/index.test.ts
@@ -2460,6 +2460,170 @@ describe('GithubSignals', () => {
     expect(botNoise).not.toHaveBeenCalled();
   });
 
+  it('ignores transient unknown mergeability recomputes', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-mergeability-noise',
+      resourceId: 'resource-mergeability-noise',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 42,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-mergeability-noise',
+                lastObservedGithubUpdatedAt: '2026-01-01T00:00:00.000Z',
+                lastObservedContentHash: 'blocked-hash',
+                lastObservedThreadContentHash: 'thread-hash',
+                lastObservedHeadSha: 'head-sha',
+                lastObservedState: 'open',
+                lastObservedMergeableState: 'blocked',
+                lastObservedCiState: 'success',
+                lastObservedReviewStateHash: 'reviews-0',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const mergeableStates = ['unknown', 'blocked'];
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => ({
+        title: 'Test PR',
+        state: 'open',
+        githubUpdatedAt: '2026-01-01T00:00:00.000Z',
+        contentHash: `${mergeableStates[0]}-hash`,
+        threadContentHash: 'thread-hash',
+        headSha: 'head-sha',
+        mergeableState: mergeableStates.shift(),
+        ciState: 'success' as const,
+        reviewStateHash: 'reviews-0',
+      })),
+    };
+    const threadStore = createThreadStore(thread);
+    const sendNotificationSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true }) }));
+    const processor = new GithubSignals({ threadStore, syncClient, agentId: 'code-agent' });
+    processor.__registerMastra({
+      getAgentById: vi.fn(() => ({ sendSignal: vi.fn(), sendNotificationSignal })),
+    } as any);
+
+    await processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId });
+    await processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId });
+
+    expect(sendNotificationSignal).not.toHaveBeenCalled();
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls.at(-1)![0].thread;
+    const [subscription] = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    expect(subscription.lastObservedMergeableState).toBe('blocked');
+  });
+
+  it('ignores observed bot comment edits without suppressing other thread activity', async () => {
+    const firstCommentUrl = 'https://github.com/mastra-ai/mastra/pull/42#issuecomment-1';
+    const secondCommentUrl = 'https://github.com/mastra-ai/mastra/pull/42#issuecomment-2';
+    const thread: StorageThreadType = {
+      id: 'thread-bot-edit',
+      resourceId: 'resource-bot-edit',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 42,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-bot-edit',
+                lastObservedGithubUpdatedAt: '2026-01-01T00:01:00.000Z',
+                lastObservedContentHash: 'content-hash',
+                lastObservedThreadContentHash: 'thread-hash',
+                lastObservedHeadSha: 'head-sha',
+                lastObservedState: 'open',
+                lastObservedMergeableState: 'blocked',
+                lastObservedCiState: 'success',
+                lastObservedReviewStateHash: 'reviews-0',
+                lastObservedCommentUrl: firstCommentUrl,
+                lastObservedCommentAuthor: 'coderabbitai[bot]',
+                lastObservedCommentIsBot: true,
+              },
+            ],
+          },
+        },
+      },
+    };
+    const comments = [
+      {
+        url: firstCommentUrl,
+        body: 'Updated walkthrough for the same comment',
+        updatedAt: '2026-01-01T00:02:00.000Z',
+        threadContentHash: 'edited-bot-comment-hash',
+      },
+      {
+        url: firstCommentUrl,
+        body: 'Updated walkthrough for the same comment',
+        githubUpdatedAt: '2026-01-01T00:03:00.000Z',
+        updatedAt: '2026-01-01T00:02:00.000Z',
+        threadContentHash: 'updated-pr-body-hash',
+      },
+      {
+        url: secondCommentUrl,
+        body: 'A new review comment',
+        githubUpdatedAt: '2026-01-01T00:04:00.000Z',
+        updatedAt: '2026-01-01T00:04:00.000Z',
+        threadContentHash: 'new-bot-comment-hash',
+      },
+    ];
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => {
+        const comment = comments.shift()!;
+        return {
+          title: 'Test PR',
+          state: 'open',
+          githubUpdatedAt: comment.githubUpdatedAt ?? comment.updatedAt,
+          contentHash: `${comment.threadContentHash}-aggregate`,
+          threadContentHash: comment.threadContentHash,
+          headSha: 'head-sha',
+          mergeableState: 'blocked',
+          ciState: 'success' as const,
+          reviewStateHash: 'reviews-0',
+          latestCommentAuthor: 'coderabbitai[bot]',
+          latestCommentAuthorType: 'Bot',
+          latestCommentIsBot: true,
+          latestCommentBody: comment.body,
+          latestCommentUrl: comment.url,
+          latestCommentUpdatedAt: comment.updatedAt,
+        };
+      }),
+    };
+    const threadStore = createThreadStore(thread);
+    const sendNotificationSignal = vi.fn(() => ({ accepted: Promise.resolve({ accepted: true }) }));
+    const processor = new GithubSignals({ threadStore, syncClient, agentId: 'code-agent' });
+    processor.__registerMastra({
+      getAgentById: vi.fn(() => ({ sendSignal: vi.fn(), sendNotificationSignal })),
+    } as any);
+
+    await processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId });
+    expect(sendNotificationSignal).not.toHaveBeenCalled();
+
+    await processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId });
+    expect(sendNotificationSignal).toHaveBeenCalledTimes(1);
+
+    await processor.pollThreadNow({ threadId: thread.id, resourceId: thread.resourceId });
+    expect(sendNotificationSignal).toHaveBeenCalledTimes(2);
+    expect(sendNotificationSignal).toHaveBeenCalledWith(
+      [expect.objectContaining({ kind: 'pull-request-activity', priority: 'high' })],
+      expect.anything(),
+    );
+  });
+
   it('suppresses activity notifications from unauthorized commenters', async () => {
     const baseThread: StorageThreadType = {
       id: 'thread-perm',

--- a/signals/github/src/index.test.ts
+++ b/signals/github/src/index.test.ts
@@ -703,6 +703,9 @@ describe('GithubSignals', () => {
                 lastObservedContentHash: 'aggregate-hash',
                 lastObservedThreadContentHash: 'thread-hash',
                 lastObservedHeadSha: 'head-sha',
+                lastObservedCommentUrl: 'https://github.com/mastra-ai/mastra/pull/123#issuecomment-1',
+                lastObservedCommentAuthor: 'coderabbitai[bot]',
+                lastObservedCommentIsBot: true,
               },
             ],
           },
@@ -730,6 +733,9 @@ describe('GithubSignals', () => {
       lastObservedContentHash: 'aggregate-hash',
       lastObservedThreadContentHash: 'thread-hash',
       lastObservedHeadSha: 'head-sha',
+      lastObservedCommentUrl: 'https://github.com/mastra-ai/mastra/pull/123#issuecomment-1',
+      lastObservedCommentAuthor: 'coderabbitai[bot]',
+      lastObservedCommentIsBot: true,
       lastSyncStatus: 'skipped',
     });
   });

--- a/signals/github/src/index.ts
+++ b/signals/github/src/index.ts
@@ -1448,8 +1448,7 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
     resourceId?: string;
   } {
     const memoryContext = args.requestContext?.get('MastraMemory') as
-      | { thread?: { id?: string }; resourceId?: string }
-      | undefined;
+      { thread?: { id?: string }; resourceId?: string } | undefined;
     return { threadId: memoryContext?.thread?.id, resourceId: memoryContext?.resourceId };
   }
 
@@ -2053,6 +2052,11 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
       ...(existing?.lastObservedCiState ? { lastObservedCiState: existing.lastObservedCiState } : {}),
       ...(existing?.lastObservedReviewStateHash
         ? { lastObservedReviewStateHash: existing.lastObservedReviewStateHash }
+        : {}),
+      ...(existing?.lastObservedCommentUrl ? { lastObservedCommentUrl: existing.lastObservedCommentUrl } : {}),
+      ...(existing?.lastObservedCommentAuthor ? { lastObservedCommentAuthor: existing.lastObservedCommentAuthor } : {}),
+      ...(typeof existing?.lastObservedCommentIsBot === 'boolean'
+        ? { lastObservedCommentIsBot: existing.lastObservedCommentIsBot }
         : {}),
     };
 

--- a/signals/github/src/index.ts
+++ b/signals/github/src/index.ts
@@ -67,6 +67,9 @@ export type GithubPRSubscription = {
   lastObservedMergeableState?: string;
   lastObservedCiState?: string;
   lastObservedReviewStateHash?: string;
+  lastObservedCommentUrl?: string;
+  lastObservedCommentAuthor?: string;
+  lastObservedCommentIsBot?: boolean;
   lastNotificationAt?: string;
   lastNotificationKind?: string;
   lastNotificationPriority?: 'medium' | 'high';
@@ -412,6 +415,15 @@ function getGithubMetadata(threadMetadata: Record<string, unknown> | undefined):
       ...(readString(rawSubscription.lastObservedReviewStateHash)
         ? { lastObservedReviewStateHash: readString(rawSubscription.lastObservedReviewStateHash)! }
         : {}),
+      ...(readString(rawSubscription.lastObservedCommentUrl)
+        ? { lastObservedCommentUrl: readString(rawSubscription.lastObservedCommentUrl)! }
+        : {}),
+      ...(readString(rawSubscription.lastObservedCommentAuthor)
+        ? { lastObservedCommentAuthor: readString(rawSubscription.lastObservedCommentAuthor)! }
+        : {}),
+      ...(typeof rawSubscription.lastObservedCommentIsBot === 'boolean'
+        ? { lastObservedCommentIsBot: rawSubscription.lastObservedCommentIsBot }
+        : {}),
       ...(readString(rawSubscription.lastNotificationAt)
         ? { lastNotificationAt: readString(rawSubscription.lastNotificationAt)! }
         : {}),
@@ -680,6 +692,26 @@ function isBotOnlyActivity(snapshot: GithubPullRequestSnapshot): boolean {
   return snapshot.latestCommentIsBot === true && (!snapshot.ciState || snapshot.ciState === 'unknown');
 }
 
+function isKnownMergeableState(state: string | undefined): state is string {
+  return !!state && state.toLowerCase() !== 'unknown';
+}
+
+function hasMeaningfulMergeableStateChange(previous: string | undefined, current: string | undefined): boolean {
+  if (!isKnownMergeableState(current) || current === previous) return false;
+  return current === 'dirty' || previous === 'dirty' || isKnownMergeableState(previous);
+}
+
+function isExistingBotCommentEdit(subscription: GithubPRSubscription, snapshot: GithubPullRequestSnapshot): boolean {
+  return (
+    snapshot.latestCommentIsBot === true &&
+    subscription.lastObservedCommentIsBot === true &&
+    !!snapshot.latestCommentUrl &&
+    snapshot.latestCommentUrl === subscription.lastObservedCommentUrl &&
+    !!snapshot.latestCommentAuthor &&
+    snapshot.latestCommentAuthor === subscription.lastObservedCommentAuthor
+  );
+}
+
 function stringifyEvidence(value: unknown): string {
   if (typeof value === 'string') return value;
   try {
@@ -753,7 +785,7 @@ function classifyGithubActivityNotification(input: {
     };
   }
   if (
-    input.snapshot.mergeableState &&
+    isKnownMergeableState(input.snapshot.mergeableState) &&
     input.subscription.lastObservedMergeableState === 'dirty' &&
     input.snapshot.mergeableState !== 'dirty'
   ) {
@@ -842,9 +874,12 @@ function applySnapshotCursor(subscription: GithubPRSubscription, snapshot: Githu
   if (snapshot.threadContentHash) subscription.lastObservedThreadContentHash = snapshot.threadContentHash;
   if (snapshot.headSha) subscription.lastObservedHeadSha = snapshot.headSha;
   if (snapshot.state) subscription.lastObservedState = snapshot.state;
-  if (snapshot.mergeableState) subscription.lastObservedMergeableState = snapshot.mergeableState;
+  if (isKnownMergeableState(snapshot.mergeableState)) subscription.lastObservedMergeableState = snapshot.mergeableState;
   if (snapshot.ciState) subscription.lastObservedCiState = snapshot.ciState;
   if (snapshot.reviewStateHash) subscription.lastObservedReviewStateHash = snapshot.reviewStateHash;
+  if (snapshot.latestCommentUrl) subscription.lastObservedCommentUrl = snapshot.latestCommentUrl;
+  if (snapshot.latestCommentAuthor) subscription.lastObservedCommentAuthor = snapshot.latestCommentAuthor;
+  if (snapshot.latestCommentIsBot !== undefined) subscription.lastObservedCommentIsBot = snapshot.latestCommentIsBot;
 }
 
 function parseGitHubRemoteUrl(remoteUrl: string): GithubRepository | undefined {
@@ -1602,10 +1637,13 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
         const previousContentHash = subscription.lastObservedContentHash;
         const previousThreadContentHash = subscription.lastObservedThreadContentHash;
         const previousHeadSha = subscription.lastObservedHeadSha;
-        const latestCommentChanged =
+        const latestCommentTimestampChanged =
           !!previousGithubUpdatedAt &&
           !!snapshot?.latestCommentUpdatedAt &&
           Date.parse(snapshot.latestCommentUpdatedAt) > Date.parse(previousGithubUpdatedAt);
+        const existingBotCommentEdited =
+          latestCommentTimestampChanged && !!snapshot && isExistingBotCommentEdit(subscription, snapshot);
+        const latestCommentChanged = latestCommentTimestampChanged && !existingBotCommentEdited;
         if (snapshot) applySnapshotCursor(nextSubscription, snapshot);
 
         // First observation (no previous cursor) always counts as changed so we
@@ -1626,12 +1664,11 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
               latestCommentChanged ||
               (previousThreadContentHash &&
                 snapshot.threadContentHash &&
-                previousThreadContentHash !== snapshot.threadContentHash) ||
+                previousThreadContentHash !== snapshot.threadContentHash &&
+                !existingBotCommentEdited) ||
               (previousHeadSha && snapshot.headSha && previousHeadSha !== snapshot.headSha) ||
               (subscription.lastObservedState && snapshot.state && subscription.lastObservedState !== snapshot.state) ||
-              (subscription.lastObservedMergeableState &&
-                snapshot.mergeableState &&
-                subscription.lastObservedMergeableState !== snapshot.mergeableState) ||
+              hasMeaningfulMergeableStateChange(subscription.lastObservedMergeableState, snapshot.mergeableState) ||
               (subscription.lastObservedCiState &&
                 snapshot.ciState &&
                 subscription.lastObservedCiState !== snapshot.ciState) ||


### PR DESCRIPTION
## Description

- ignore transient `unknown` mergeability results and keep the last stable mergeability cursor
- track the latest comment identity so edits to an already-observed bot comment do not wake subscribed agents
- preserve notifications for new bot comments and unrelated PR thread changes
- add regression coverage for mergeability recomputes, bot edits, new comments, and concurrent thread activity

## Related issue(s)

Fixes #20560

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Verification

- `pnpm --filter @mastra/github-signals test` (62 passed)
- `pnpm --filter @mastra/github-signals lint`
- `pnpm --filter @mastra/github-signals build`
- `pnpm exec oxfmt --check signals/github/src/index.ts signals/github/src/index.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR stops `github-signals` from sending alerts for temporary GitHub status changes and edits to comments it already saw. It still sends alerts for new comments and real pull-request changes.

## Changes

- Ignore transient `unknown` and empty mergeability states.
- Preserve the last stable mergeability cursor during recomputation.
- Track the latest observed bot comment by URL, author, and bot status.
- Suppress notifications for edits to an already observed bot comment.
- Preserve notifications for new bot comments and unrelated pull-request thread changes.
- Preserve comment cursor fields during resubscription.
- Add regression tests for mergeability recomputes, bot comment edits, new comments, concurrent thread activity, and resubscription.
- Add a patch changeset for `@mastra/github-signals`.

## Verification

- 62 tests pass.
- Lint, build, formatting, and TypeScript declaration checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->