### PR TITLE
fix(factory-ui): start work items from global search

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardRuns.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardRuns.ts
@@ -26,7 +26,7 @@ export function useBoardRuns({
   refetchItems,
 }: {
   factoryProjectId: string;
-  projectRepositoryId: string;
+  projectRepositoryId: string | undefined;
   workItems: readonly WorkItem[];
   refetchItems: ReturnType<typeof useWorkItemsQuery>['refetch'];
 }) {
@@ -95,7 +95,7 @@ export function useBoardRuns({
         return;
       }
       const spec = itemSessionSpec(refreshed.item);
-      start.mutate({
+      await start.mutateAsync({
         branch: spec.branch,
         threadTitle: spec.threadTitle,
         workItem: {
@@ -132,7 +132,7 @@ export function useBoardRuns({
     const spec = itemRunSpec(refreshed.item);
     const action = spec?.actions.find(candidate => candidate.role === role);
     if (!spec || !action) return;
-    start.mutate({
+    await start.mutateAsync({
       branch: spec.branch,
       threadTitle: spec.threadTitle,
       threadTags: action.threadTags,
@@ -149,24 +149,30 @@ export function useBoardRuns({
     });
   };
 
-  const startCandidateRun = (candidate: BoardCandidate, action: RunAction, prompt?: string) => {
-    start.mutate({
-      branch: candidate.branch,
-      threadTitle: candidate.threadTitle,
-      threadTags: action.threadTags,
-      invocation: prompt === undefined ? action.invocation : { type: 'prompt', prompt: candidate.customPrompt(prompt) },
-      workItem: {
-        role: action.role,
-        stages: [action.stage],
-        source: candidate.source,
-        sourceKey: candidate.sourceKey,
-        parentWorkItemId:
-          candidate.source === 'github-pr' ? inferredParentWorkItemId(candidate.metadata, workItems) : undefined,
-        title: candidate.title,
-        url: candidate.url,
-        metadata: candidate.metadata,
-      },
-    });
+  const startCandidateRun = async (candidate: BoardCandidate, action: RunAction, prompt?: string) => {
+    if (!beginPreparingItem(candidate.sourceKey, 'Starting run…')) return;
+    try {
+      await start.mutateAsync({
+        branch: candidate.branch,
+        threadTitle: candidate.threadTitle,
+        threadTags: action.threadTags,
+        invocation:
+          prompt === undefined ? action.invocation : { type: 'prompt', prompt: candidate.customPrompt(prompt) },
+        workItem: {
+          role: action.role,
+          stages: [action.stage],
+          source: candidate.source,
+          sourceKey: candidate.sourceKey,
+          parentWorkItemId:
+            candidate.source === 'github-pr' ? inferredParentWorkItemId(candidate.metadata, workItems) : undefined,
+          title: candidate.title,
+          url: candidate.url,
+          metadata: candidate.metadata,
+        },
+      });
+    } finally {
+      clearPreparingItem(candidate.sourceKey);
+    }
   };
 
   const pendingByItem = new Map<string, Map<string, FactoryRunPhase | undefined>>();
@@ -188,6 +194,7 @@ export function useBoardRuns({
     pendingRolesFor: (itemId: string): PendingRoles => pendingByItem.get(itemId) ?? EMPTY_PENDING_ROLES,
     preparingFor: (itemId: string): string | undefined => preparingItems[itemId],
     pendingRolesForSource: (sourceKey: string): PendingRoles => pendingBySource.get(sourceKey) ?? EMPTY_PENDING_ROLES,
+    preparingForSource: (sourceKey: string): string | undefined => preparingItems[sourceKey],
     openOrCreateSession,
     openOrStartRun,
     startCandidateRun,

--- a/mastracode/factory-ui/src/ui/domains/search/__tests__/GlobalSearch.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/search/__tests__/GlobalSearch.msw.test.tsx
@@ -35,6 +35,7 @@ const AGENT_CONTROLLER_API = `${TEST_BASE_URL}/api/agent-controller/code`;
 interface SearchRequestState {
   abortRequests: number;
   createSessionRequests: number;
+  runStarts: Record<string, unknown>[];
   intakeRequests: number;
   sessionRequests: Record<string, number>;
   workItemRequests: number;
@@ -45,6 +46,7 @@ interface StubSearchOptions {
   failRepositories?: string[];
   failIntake?: boolean;
   failWorkItems?: boolean;
+  runStartGate?: Promise<void>;
   secondRepositoryGate?: Promise<void>;
   onSecondRepositoryAbort?: () => void;
   running?: boolean;
@@ -60,6 +62,7 @@ function stubSearchApi(options: StubSearchOptions = {}): SearchRequestState {
   const state: SearchRequestState = {
     abortRequests: 0,
     createSessionRequests: 0,
+    runStarts: [],
     intakeRequests: 0,
     sessionRequests: {},
     workItemRequests: 0,
@@ -137,9 +140,15 @@ function stubSearchApi(options: StubSearchOptions = {}): SearchRequestState {
       }
       return HttpResponse.json({ sessions: sessionsByRepository[repositoryId] ?? [] });
     }),
-    http.post(`${TEST_BASE_URL}/web/github/projects/:projectRepositoryId/sessions`, () => {
+    http.post(`${TEST_BASE_URL}/web/github/projects/:projectRepositoryId/sessions`, async ({ request }) => {
       state.createSessionRequests += 1;
-      return HttpResponse.json({ error: 'Search must not create sessions' }, { status: 500 });
+      const body = (await request.json()) as { branch?: string };
+      return HttpResponse.json({
+        session: {
+          sessionId: 'session-search',
+          branch: body.branch ?? 'factory/search',
+        },
+      });
     }),
     http.get(`${TEST_BASE_URL}/web/user-sessions/:sessionId`, ({ params }) => {
       const sessionId = String(params.sessionId);
@@ -157,6 +166,18 @@ function stubSearchApi(options: StubSearchOptions = {}): SearchRequestState {
         sandboxWorkdir: `/workspaces/${String(params.projectRepositoryId)}`,
       }),
     ),
+    http.post(`${TEST_BASE_URL}/web/factory/projects/${ACTIVE_FACTORY_ID}/runs/start`, async ({ request }) => {
+      state.runStarts.push((await request.json()) as Record<string, unknown>);
+      if (options.runStartGate) await options.runStartGate;
+      return HttpResponse.json({
+        prepared: {
+          workItemId: 'started-work-item',
+          threadId: 'thread-search',
+          sessionId: 'session-search',
+          kickoffStatus: 'sent',
+        },
+      });
+    }),
     http.post(`${AGENT_CONTROLLER_API}/sessions`, async ({ request }) => {
       const resourceId = resourceIdFromRequestBody(await request.json());
       return HttpResponse.json({ controllerId: 'code', resourceId, threadId: 'thread-search' });
@@ -478,10 +499,14 @@ describe('Global search', () => {
     expect(screen.queryByText('feature/offline-index')).not.toBeInTheDocument();
   });
 
-  it('finds a board card with no session by identifier and opens its board', async () => {
-    const requests = stubSearchApi();
+  it('finds a board card with no session by identifier and starts its default run', async () => {
+    let releaseRunStart = () => {};
+    const runStartGate = new Promise<void>(resolve => {
+      releaseRunStart = resolve;
+    });
+    const requests = stubSearchApi({ runStartGate });
     const user = userEvent.setup();
-    const { router } = renderSearchRoute();
+    renderSearchRoute();
     const dialog = await openFromSidebar();
     await screen.findByText('Review command palette PR');
 
@@ -496,9 +521,18 @@ describe('Global search', () => {
 
     await user.click(card);
 
-    await waitFor(() => expect(router.state.location.pathname).toBe(`/factories/${ACTIVE_FACTORY_ID}/review`));
-    expect(screen.queryByRole('dialog', { name: 'Global search' })).not.toBeInTheDocument();
-    expect(requests.createSessionRequests).toBe(0);
+    await waitFor(() => expect(requests.runStarts).toHaveLength(1));
+    const loadingOption = card.closest('[role="option"]');
+    expect(loadingOption).toHaveAttribute('data-disabled', 'true');
+    expect(within(loadingOption as HTMLElement).getByRole('status', { name: 'Loading' })).toBeInTheDocument();
+    expect(within(loadingOption as HTMLElement).getByText('Preparing run…')).toBeInTheDocument();
+    await user.click(card);
+    expect(requests.runStarts).toHaveLength(1);
+    expect(requests.createSessionRequests).toBe(1);
+
+    releaseRunStart();
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Global search' })).not.toBeInTheDocument());
+    expect(requests.runStarts[0]).toMatchObject({ workItem: { id: 'work-item-unstarted-review', role: 'review' } });
   });
 
   it('scopes results to board cards with no session', async () => {
@@ -519,10 +553,10 @@ describe('Global search', () => {
     expect(screen.queryByText('research-notes')).not.toBeInTheDocument();
   });
 
-  it('finds a pull request that has no card yet and opens the review board', async () => {
+  it('finds a pull request that has no card yet and starts its default run', async () => {
     const requests = stubSearchApi();
     const user = userEvent.setup();
-    const { router } = renderSearchRoute();
+    renderSearchRoute();
     const dialog = await openFromSidebar();
     await screen.findByText('Review command palette PR');
 
@@ -532,8 +566,15 @@ describe('Global search', () => {
 
     await user.click(candidate);
 
-    await waitFor(() => expect(router.state.location.pathname).toBe(`/factories/${ACTIVE_FACTORY_ID}/review`));
-    expect(requests.createSessionRequests).toBe(0);
+    await waitFor(() => expect(requests.runStarts).toHaveLength(1));
+    expect(requests.runStarts[0]).toMatchObject({
+      workItem: {
+        role: 'review',
+        input: { title: 'Harden the review board drop target' },
+      },
+    });
+    expect(screen.queryByRole('dialog', { name: 'Global search' })).not.toBeInTheDocument();
+    expect(requests.createSessionRequests).toBe(1);
   });
 
   it('lists a pull request already filed as a card only once', async () => {

--- a/mastracode/factory-ui/src/ui/domains/search/components/FactoryGlobalSearchContent.tsx
+++ b/mastracode/factory-ui/src/ui/domains/search/components/FactoryGlobalSearchContent.tsx
@@ -9,6 +9,8 @@ import { Kbd } from '@mastra/playground-ui/components/Kbd';
 import { useState } from 'react';
 
 import { useFactoriesQuery } from '../../../../hooks/useFactories';
+import { RUN_PHASE_LABELS, itemRunSpec } from '../../factory/boardRunSpecs';
+import { useBoardRuns } from '../../factory/hooks/useBoardRuns';
 import { useGlobalSearchIntake } from '../hooks/useGlobalSearchIntake';
 import { useGlobalSearchNavigation } from '../hooks/useGlobalSearchNavigation';
 import { useGlobalSearchSessions } from '../hooks/useGlobalSearchSessions';
@@ -36,7 +38,14 @@ export function FactoryGlobalSearchContent({ factoryId, closeSearch }: { factory
   const sessions = useGlobalSearchSessions(repositoryIds);
   const workItems = useGlobalSearchWorkItems(repositoryIds.length > 0 ? factoryId : undefined);
   // Both boards read `repositories[0]`, so that is the repository whose intake feeds are searchable.
-  const intake = useGlobalSearchIntake(activeFactory?.repositories[0]?.projectRepositoryId);
+  const projectRepositoryId = activeFactory?.repositories[0]?.projectRepositoryId;
+  const intake = useGlobalSearchIntake(projectRepositoryId);
+  const runs = useBoardRuns({
+    factoryProjectId: factoryId,
+    projectRepositoryId,
+    workItems: workItems.items,
+    refetchItems: workItems.refetch,
+  });
   const { selectPath } = useGlobalSearchNavigation(closeSearch);
   const [activeScope, setActiveScope] = useState<GlobalSearchScope>('all');
 
@@ -83,7 +92,35 @@ export function FactoryGlobalSearchContent({ factoryId, closeSearch }: { factory
             <GlobalSearchSessionResults title="Review Sessions" results={sessionGroups.review} onSelect={selectPath} />
           )}
           {scopeIncludes(activeScope, 'items') && (
-            <GlobalSearchWorkItemResults results={unstartedItems} onSelect={selectPath} />
+            <GlobalSearchWorkItemResults
+              results={unstartedItems}
+              loadingFor={result => {
+                const target = result.target;
+                const preparing =
+                  target.kind === 'candidate'
+                    ? runs.preparingForSource(target.candidate.sourceKey)
+                    : runs.preparingFor(target.item.id);
+                if (preparing) return preparing;
+                const pendingRoles =
+                  target.kind === 'candidate'
+                    ? runs.pendingRolesForSource(target.candidate.sourceKey)
+                    : runs.pendingRolesFor(target.item.id);
+                const phase = pendingRoles.values().next().value;
+                return phase ? RUN_PHASE_LABELS[phase] : pendingRoles.size > 0 ? 'Starting run…' : undefined;
+              }}
+              onSelect={async result => {
+                if (result.target.kind === 'candidate') {
+                  const [defaultAction] = result.target.candidate.runActions;
+                  await runs.startCandidateRun(result.target.candidate, defaultAction);
+                } else {
+                  const spec = itemRunSpec(result.target.item);
+                  const defaultAction = spec?.actions[0];
+                  if (defaultAction) await runs.openOrStartRun(result.target.item, defaultAction.role);
+                  else await runs.openOrCreateSession(result.target.item, result.target.item.stages[0] ?? 'intake');
+                }
+                closeSearch();
+              }}
+            />
           )}
           {scopeIncludes(activeScope, 'user') && (
             <GlobalSearchSessionResults title="User Sessions" results={sessionGroups.user} onSelect={selectPath} />

--- a/mastracode/factory-ui/src/ui/domains/search/components/GlobalSearchWorkItemResults.tsx
+++ b/mastracode/factory-ui/src/ui/domains/search/components/GlobalSearchWorkItemResults.tsx
@@ -1,32 +1,38 @@
 import { CommandGroup } from '@mastra/playground-ui/components/Command';
 import { CommandPaletteItem } from '@mastra/playground-ui/components/CommandPalette';
+import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Ticket } from 'lucide-react';
 
-import type { GlobalSearchSelectHandler } from '../services/searchNavigation';
 import type { WorkItemSearchResult } from '../services/searchResults';
 
 export function GlobalSearchWorkItemResults({
   results,
+  loadingFor,
   onSelect,
 }: {
   results: WorkItemSearchResult[];
-  onSelect: GlobalSearchSelectHandler;
+  loadingFor: (result: WorkItemSearchResult) => string | undefined;
+  onSelect: (result: WorkItemSearchResult) => void;
 }) {
   if (results.length === 0) return null;
 
   return (
     <CommandGroup heading="Work Items">
-      {results.map(result => (
-        <CommandPaletteItem
-          key={result.id}
-          icon={<Ticket />}
-          title={result.title}
-          subtitle={result.context}
-          badge={result.identifier}
-          value={result.value}
-          onSelect={() => onSelect(result.path, false)}
-        />
-      ))}
+      {results.map(result => {
+        const loading = loadingFor(result);
+        return (
+          <CommandPaletteItem
+            key={result.id}
+            icon={loading ? <Spinner size="sm" /> : <Ticket />}
+            title={result.title}
+            subtitle={loading ?? result.context}
+            badge={result.identifier}
+            value={result.value}
+            disabled={loading !== undefined}
+            onSelect={() => onSelect(result)}
+          />
+        );
+      })}
     </CommandGroup>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/search/hooks/useGlobalSearchWorkItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/search/hooks/useGlobalSearchWorkItems.ts
@@ -6,6 +6,7 @@ export function useGlobalSearchWorkItems(factoryId: string | undefined) {
 
   return {
     items: query.data ?? [],
+    refetch: query.refetch,
     pending: query.isLoading,
     failed: query.isError,
     retry: () => {

--- a/mastracode/factory-ui/src/ui/domains/search/services/searchResults.ts
+++ b/mastracode/factory-ui/src/ui/domains/search/services/searchResults.ts
@@ -26,7 +26,7 @@ export interface SessionSearchResult {
   updatedAt: string;
 }
 
-/** A board entry nobody has started yet: no session to jump to, only its board column. */
+/** A board entry nobody has started yet. */
 export interface WorkItemSearchResult {
   id: string;
   title: string;
@@ -35,6 +35,7 @@ export interface WorkItemSearchResult {
   value: string;
   path: string;
   updatedAt: string;
+  target: { kind: 'work-item'; item: WorkItem } | { kind: 'candidate'; candidate: BoardCandidate };
 }
 
 interface SessionWorkItem {
@@ -167,6 +168,7 @@ function createWorkItemResult(factoryId: string, item: WorkItem): WorkItemSearch
     value: joinValue([item.title, 'work item', sourceLabel, stage, identifier, item.sourceKey]),
     path: relationshipPath(item, factoryId),
     updatedAt: item.updatedAt,
+    target: { kind: 'work-item', item },
   };
 }
 
@@ -183,6 +185,7 @@ function createCandidateResult(factoryId: string, candidate: BoardCandidate, upd
     value: joinValue([candidate.title, 'work item', sourceLabel, stage, identifier, candidate.sourceKey]),
     path: relationshipPath(candidate, factoryId),
     updatedAt,
+    target: { kind: 'candidate', candidate },
   };
 }
 


### PR DESCRIPTION
Global Search Work Item results now behave like their matching board cards instead of only navigating to a board column. Selecting an unstarted item or intake candidate creates or opens the appropriate session and run, then navigates to its thread.

The selected result stays visible with preparation/start progress and is disabled while loading to prevent duplicate starts. Existing sessions still navigate directly.

Verified with the focused Global Search MSW suite (27 tests), Factory UI typecheck, Oxlint, Prettier, production build, and a local end-to-end run from Global Search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Global Search now handles work items like board cards. When you select an item, Factory UI starts or opens the correct session and run, then takes you to its thread. Loading items are disabled to prevent duplicate starts.

## Changes

- Added asynchronous session and run startup for work items and intake candidates.
- Opened existing sessions directly.
- Added preparation and pending-state indicators to search results.
- Disabled selected results while they load.
- Added duplicate-start protection.
- Added search-result targets for work items and candidates.
- Exposed `refetch` from `useGlobalSearchWorkItems`.
- Updated MSW tests for run starts, session creation, loading states, and duplicate-click prevention.

## Verification

- Focused Global Search MSW suite
- Factory UI typecheck
- Oxlint
- Prettier
- Production build
- Local end-to-end run

<!-- end of auto-generated comment: release notes by coderabbit.ai -->