### PR TITLE
docs: move supervisor agents to subagents

### DIFF
--- a/docs/src/content/en/docs/agents/a2a.mdx
+++ b/docs/src/content/en/docs/agents/a2a.mdx
@@ -75,7 +75,7 @@ Use `A2AAgent` when another Mastra agent should delegate work to a remote agent.
 
 ## Consume A2A agents as subagents
 
-Use `A2AAgent` to wrap a remote A2A agent, then add it to a parent agent with the [supervisor agents](/docs/agents/supervisor-agents) pattern. Pass an explicit agent card URL when the remote server hosts multiple agents or uses a custom well-known path.
+Use `A2AAgent` to wrap a remote A2A agent, then add it to a parent agent with the [supervisor agents](/docs/capabilities/subagents) pattern. Pass an explicit agent card URL when the remote server hosts multiple agents or uses a custom well-known path.
 
 ```typescript title="src/mastra/agents/support-agent.ts"
 import { Agent } from '@mastra/core/agent'

--- a/docs/src/content/en/docs/agents/acp.mdx
+++ b/docs/src/content/en/docs/agents/acp.mdx
@@ -137,6 +137,6 @@ See the [AcpAgent workspace integration](/reference/acp/acp-agent#workspace-inte
 - [AcpAgent reference](/reference/acp/acp-agent)
 - [createACPTool() reference](/reference/acp/create-acp-tool)
 - [Agent reference](/reference/agents/agent)
-- [Subagents](/docs/agents/supervisor-agents)
+- [Subagents](/docs/capabilities/subagents)
 - [Agent Client Protocol introduction](https://agentclientprotocol.com/overview/introduction)
 - [Agent Client Protocol schema](https://agentclientprotocol.com/protocol/schema)

--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -523,7 +523,7 @@ Suspended runs only survive restarts when your Mastra instance is configured wit
 
 ## Tool approval: Supervisor agents
 
-A [supervisor agent](/docs/agents/supervisor-agents) coordinates multiple subagents using `.stream()` or `.generate()`. When a subagent calls a tool that requires approval, the request propagates up through the delegation chain and surfaces at the supervisor level:
+A [supervisor agent](/docs/capabilities/subagents) coordinates multiple subagents using `.stream()` or `.generate()`. When a subagent calls a tool that requires approval, the request propagates up through the delegation chain and surfaces at the supervisor level:
 
 1. The supervisor delegates a task to a subagent.
 1. The subagent calls a tool that has `requireApproval: true` or uses `suspend()`.

--- a/docs/src/content/en/docs/agents/networks.mdx
+++ b/docs/src/content/en/docs/agents/networks.mdx
@@ -11,7 +11,7 @@ packages:
 
 :::warning[Deprecated]
 
-Agent networks are deprecated and will be removed in a future major release. [Supervisor agents](./supervisor-agents) using `agent.stream()` or `agent.generate()` are now the recommended approach. It provides the same multi-agent coordination with better control, a simpler API, and easier debugging.
+Agent networks are deprecated and will be removed in a future major release. [Supervisor agents](../capabilities/subagents) using `agent.stream()` or `agent.generate()` are now the recommended approach. It provides the same multi-agent coordination with better control, a simpler API, and easier debugging.
 
 See the [migration guide](/guides/migrations/network-to-supervisor) to upgrade.
 
@@ -199,5 +199,5 @@ Requirements for automatic resumption:
 
 ## Related
 
-- [Supervisor agents](./supervisor-agents)
+- [Supervisor agents](../capabilities/subagents)
 - [Migration: `.network()` to supervisor agents](/guides/migrations/network-to-supervisor)

--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -112,11 +112,11 @@ Once your agent is running, use this table to find the right page for what you w
 | Keep context and preferences across conversations | [Memory](/docs/memory/overview) |
 | Get typed objects back instead of plain text | [Structured output](/docs/agents/structured-output) |
 | Human-in-the-loop: Pause execution and wait for human approval | [Approval](/docs/agents/agent-approval) |
-| Build a multi-agent network | [Supervisor agents](/docs/agents/supervisor-agents) |
+| Build a multi-agent network | [Supervisor agents](/docs/capabilities/subagents) |
 | Register subagents | [Tools](/docs/agents/using-tools#agents-as-tools) |
 | Intercept or transform messages before and after generation | [Processors](/docs/agents/processors) |
 | Keep your agent safe | [Guardrails](/docs/agents/guardrails) |
-| Build agents that correct their work | [Rubric scorer](/docs/agents/supervisor-agents#rubric-scorer) |
+| Build agents that correct their work | [Rubric scorer](/docs/capabilities/subagents#rubric-scorer) |
 | Swap instructions or models based on request context | [Dynamic configuration](/docs/server/request-context) |
 | Add speech-to-text or text-to-speech | [Voice](/guides/voice/overview) |
 | Connect to Slack, Discord, or Telegram | [Channels](/docs/capabilities/channels/overview) |

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -178,7 +178,7 @@ export const weatherAgent = new Agent({
 
 ## Agents as tools
 
-Add subagents through the `agents` configuration to create a [supervisor](/docs/agents/supervisor-agents). Mastra converts each subagent to an `agent-<key>` tool. Include a `description` on each subagent so the supervisor knows when to delegate.
+Add subagents through the `agents` configuration to create a [supervisor](/docs/capabilities/subagents). Mastra converts each subagent to an `agent-<key>` tool. Include a `description` on each subagent so the supervisor knows when to delegate.
 
 ```typescript title="src/mastra/agents/supervisor.ts"
 import { Agent } from '@mastra/core/agent'

--- a/docs/src/content/en/docs/capabilities/subagents.mdx
+++ b/docs/src/content/en/docs/capabilities/subagents.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Supervisor agents | Agents"
+title: "Subagents | Capabilities"
 description: Learn how to coordinate multiple agents with delegation hooks, iteration monitoring, message filtering, and task completion scoring.
 packages:
   - "@mastra/core"
   - "@mastra/memory"
 ---
 
-# Supervisor agents
+# Subagents
 
 **Added in:** `@mastra/core@1.8.0`
 

--- a/docs/src/content/en/docs/capabilities/subagents.mdx
+++ b/docs/src/content/en/docs/capabilities/subagents.mdx
@@ -10,11 +10,11 @@ packages:
 
 **Added in:** `@mastra/core@1.8.0`
 
-A supervisor agent coordinates multiple subagents using [`Agent.stream()`](/reference/streaming/agents/stream) or [`Agent.generate()`](/reference/agents/generate). You configure subagents on the supervisor's `agents` property, and the supervisor uses its instructions and each subagent's `description` to decide when and how to delegate tasks.
+Subagents are specialized agents that another agent can delegate tasks to. Add them to the parent agent's `agents` property, then call [`Agent.stream()`](/reference/streaming/agents/stream) or [`Agent.generate()`](/reference/agents/generate). The parent agent uses its instructions and each subagent's `description` to decide when and how to delegate tasks.
 
-## When to use supervisor agents
+## When to use subagents
 
-Use supervisor agents when a task requires multiple agents with different specializations to work together. The supervisor handles delegation decisions and context passing, plus result synthesis.
+Use subagents when a task requires agents with different specializations to work together. The parent agent decides when to delegate and passes context to each subagent. It then synthesizes their results.
 
 Common use cases:
 
@@ -24,15 +24,15 @@ Common use cases:
 
 :::note
 
-Supervisor agents are one approach to building multi-agent systems in Mastra. For other patterns, read the [conceptual overview](/guides/concepts/multi-agent-systems).
+A parent agent that coordinates subagents is often called a supervisor. The supervisor pattern is one approach to building multi-agent systems in Mastra. For other patterns, read the [conceptual overview](/guides/concepts/multi-agent-systems).
 
 :::
 
 ## Quickstart
 
-Define subagents with clear descriptions, then create a supervisor agent that references them:
+Define subagents with clear descriptions, then add them to a parent agent:
 
-```typescript title="src/mastra/agents/supervisor.ts"
+```typescript title="src/mastra/agents/parent-agent.ts"
 import { Agent } from '@mastra/core/agent'
 import { Memory } from '@mastra/memory'
 import { LibSQLStore } from '@mastra/libsql'
@@ -52,8 +52,8 @@ const writingAgent = new Agent({
 })
 
 // highlight-start
-const supervisor = new Agent({
-  id: 'supervisor',
+const parentAgent = new Agent({
+  id: 'parent-agent',
   instructions: `You coordinate research and writing using specialized agents.
     Delegate to research-agent for facts, then writing-agent for content.`,
   model: '__GATEWAY_OPENAI_MODEL__',
@@ -64,7 +64,7 @@ const supervisor = new Agent({
 })
 // highlight-end
 
-const stream = await supervisor.stream('Research AI in education and write an article', {
+const stream = await parentAgent.stream('Research AI in education and write an article', {
   maxSteps: 10,
 })
 
@@ -79,15 +79,15 @@ Delegation hooks let you intercept, modify, or reject delegations as they happen
 
 ### `onDelegationStart`
 
-Called before the supervisor delegates to a subagent. Return an object to control the delegation:
+Called before the parent agent delegates to a subagent. Return an object to control the delegation:
 
 - `proceed: true`: Allow the delegation (default behavior)
 - `proceed: false`: Reject the delegation with a `rejectionReason`
 - `modifiedPrompt`: Rewrite the prompt sent to the subagent
 - `modifiedMaxSteps`: Limit the subagent's iteration count
 
-```typescript title="src/mastra/agents/supervisor.ts"
-const stream = await supervisor.stream('Research AI trends', {
+```typescript title="src/mastra/agents/parent-agent.ts"
+const stream = await parentAgent.stream('Research AI trends', {
   maxSteps: 10,
   delegation: {
     onDelegationStart: async context => {
@@ -121,18 +121,18 @@ The `context` object includes:
 | Property | Description |
 | - | - |
 | `primitiveId` | The ID of the subagent being delegated to |
-| `prompt` | The prompt the supervisor is sending |
+| `prompt` | The prompt the parent agent is sending |
 | `iteration` | Current iteration number |
 
 ### `onDelegationComplete`
 
 Called after a delegation finishes. Use it to inspect results or provide feedback, or alternatively stop execution:
 
-- `context.bail()`: Stop the supervisor loop immediately
-- Return `{ feedback: '...' }`: Add feedback that gets saved to the supervisor's memory and is visible to subsequent iterations
+- `context.bail()`: Stop the parent agent's loop immediately
+- Return `{ feedback: '...' }`: Add feedback that gets saved to the parent agent's memory and is visible to subsequent iterations
 
-```typescript title="src/mastra/agents/supervisor.ts"
-const stream = await supervisor.stream('Research AI trends', {
+```typescript title="src/mastra/agents/parent-agent.ts"
+const stream = await parentAgent.stream('Research AI trends', {
   maxSteps: 10,
   delegation: {
     onDelegationComplete: async context => {
@@ -157,14 +157,14 @@ The `context` object includes:
 | `primitiveId` | The ID of the subagent that ran |
 | `result` | The subagent's response |
 | `error` | Error if the delegation failed |
-| `bail()` | Function to stop the supervisor loop |
+| `bail()` | Function to stop the parent agent's loop |
 
 ## Message filtering
 
-By default, subagents receive the full conversation context from the supervisor. Use `messageFilter` to control what messages are shared, for example, to remove sensitive data or limit context size.
+By default, subagents receive the full conversation context from the parent agent. Use `messageFilter` to control what messages are shared, for example, to remove sensitive data or limit context size.
 
-```typescript title="src/mastra/agents/supervisor.ts"
-const stream = await supervisor.stream('Research AI trends', {
+```typescript title="src/mastra/agents/parent-agent.ts"
+const stream = await parentAgent.stream('Research AI trends', {
   maxSteps: 10,
   delegation: {
     messageFilter: ({ messages, primitiveId, prompt }) => {
@@ -185,16 +185,16 @@ The callback receives `messages` (the full conversation history), `primitiveId` 
 
 ## Subagent result context
 
-When a subagent completes, the supervisor model receives the subagent's text response in later iterations. Nested tool calls and subagent metadata, such as thread and resource IDs, aren't added to the supervisor model context.
+When a subagent completes, the parent agent's model receives the subagent's text response in later iterations. Nested tool calls and subagent metadata, such as thread and resource IDs, aren't added to the parent agent's model context.
 
 Application code and UI integrations can still inspect `subAgentToolResults` and the rest of the raw delegation result in the tool result payload.
 
-This keeps debugging and display data available without sending nested tool arguments or outputs back into the supervisor's next model call.
+This keeps debugging and display data available without sending nested tool arguments or outputs back into the parent agent's next model call.
 
-Set `includeSubAgentToolResultsInModelContext` to include the full subagent result, including nested tool results and subagent metadata, in the supervisor model context.
+Set `includeSubAgentToolResultsInModelContext` to include the full subagent result, including nested tool results and subagent metadata, in the parent agent's model context.
 
-```typescript title="src/mastra/agents/supervisor.ts"
-await supervisor.generate('Research AI trends', {
+```typescript title="src/mastra/agents/parent-agent.ts"
+await parentAgent.generate('Research AI trends', {
   delegation: {
     includeSubAgentToolResultsInModelContext: true,
   },
@@ -203,10 +203,10 @@ await supervisor.generate('Research AI trends', {
 
 ## Iteration monitoring
 
-`onIterationComplete` is called after each iteration of the supervisor loop. Use it to log progress or inject feedback, or alternatively stop execution early.
+`onIterationComplete` is called after each iteration of the parent agent's loop. Use it to monitor execution or guide the next iteration. You can also stop execution early.
 
-```typescript title="src/mastra/agents/supervisor.ts"
-const stream = await supervisor.stream('Research AI trends', {
+```typescript title="src/mastra/agents/parent-agent.ts"
+const stream = await parentAgent.stream('Research AI trends', {
   maxSteps: 10,
   onIterationComplete: async context => {
     console.log(`Iteration ${context.iteration}/${context.maxIterations}`)
@@ -234,19 +234,19 @@ Return `{ continue: true }` to keep iterating, or `{ continue: false }` to stop.
 
 ## Memory isolation
 
-Supervisor agents implement memory isolation. Subagents receive the full conversation context for better decision-making, but only their specific delegation prompt and response are saved to their memory.
+Mastra isolates subagent memory during delegation. Subagents receive the full conversation context for better decision-making, but only their specific delegation prompt and response are saved to their memory.
 
 How it works:
 
-1. **Full context forwarded**: When the supervisor delegates, the subagent receives all messages from the supervisor's conversation
+1. **Full context forwarded**: When the parent agent delegates, the subagent receives all messages from the parent agent's conversation
 1. **Scoped memory saves**: Only the delegation prompt and the subagent's response are saved to the subagent's memory
 1. **Fresh thread per invocation**: Each delegation uses a unique thread ID, ensuring clean separation
 
-As a result, subagents have the context they need without cluttering their memory with the entire supervisor conversation. Visit [memory in multi-agent systems](/docs/memory/overview#memory-in-multi-agent-systems) for more details.
+As a result, subagents have the context they need without cluttering their memory with the parent agent's entire conversation. Visit [memory in multi-agent systems](/docs/memory/overview#memory-in-multi-agent-systems) for more details.
 
 ## Tool approval propagation
 
-Tool approvals propagate through the delegation chain. When a subagent uses a tool with `requireApproval: true` or calls `suspend()`, the approval request surfaces to the supervisor level.
+Tool approvals propagate through the delegation chain. When a subagent uses a tool with `requireApproval: true` or calls `suspend()`, the approval request surfaces in the parent agent's stream.
 
 ```typescript
 const sensitiveDataTool = createTool({
@@ -262,13 +262,13 @@ const dataAgent = new Agent({
   tools: { sensitiveDataTool },
 })
 
-const supervisor = new Agent({
-  id: 'supervisor',
+const parentAgent = new Agent({
+  id: 'parent-agent',
   agents: { dataAgent },
   memory: new Memory(),
 })
 
-const stream = await supervisor.stream('Get data for user 123')
+const stream = await parentAgent.stream('Get data for user 123')
 
 for await (const chunk of stream.fullStream) {
   if (chunk.type === 'tool-call-approval') {
@@ -279,22 +279,22 @@ for await (const chunk of stream.fullStream) {
 
 ## Cancellation
 
-When you pass an `abortSignal` to the supervisor's [`stream()`](/reference/streaming/agents/stream) or [`generate()`](/reference/agents/generate) call, Mastra forwards that same signal to delegated subagents. Calling `AbortController.abort()` cancels in-flight subagent runs at their next step instead of letting them run to completion.
+When you pass an `abortSignal` to the parent agent's [`stream()`](/reference/streaming/agents/stream) or [`generate()`](/reference/agents/generate) call, Mastra forwards that same signal to delegated subagents. Calling `AbortController.abort()` cancels in-flight subagent runs at their next step instead of letting them run to completion.
 
 ```typescript
 const controller = new AbortController()
 
-const stream = await supervisor.stream('Research AI trends', {
+const stream = await parentAgent.stream('Research AI trends', {
   abortSignal: controller.signal,
 })
 
-// Cancel the supervisor and any in-flight subagents
+// Cancel the parent agent and any in-flight subagents
 controller.abort()
 ```
 
 ## Task completion scoring
 
-Agents don't always produce a complete, correct output on the first try. Task completion scorers can help with that by validating whether the task is complete after each iteration. If validation fails, the supervisor continues iterating. Feedback from failed scorers is included in the conversation context so subagents can see what was missing.
+Agents don't always produce a complete, correct output on the first try. Task completion scorers can help by validating whether the task is complete after each iteration. If validation fails, the parent agent continues iterating. Feedback from failed scorers is included in the conversation context so subagents can see what was missing.
 
 ```typescript
 import { createScorer } from '@mastra/core/evals'
@@ -309,7 +309,7 @@ const taskCompleteScorer = createScorer({
   return hasAnalysis && hasRecommendations ? 1 : 0
 })
 
-const stream = await supervisor.stream('Research AI in education', {
+const stream = await parentAgent.stream('Research AI in education', {
   maxSteps: 10,
   isTaskComplete: {
     scorers: [taskCompleteScorer],
@@ -333,8 +333,8 @@ This is most effective for tasks with clear, verifiable success criteria. You ca
 import { Agent } from '@mastra/core/agent'
 import { createRubricScorer } from '@mastra/evals/scorers/prebuilt'
 
-const supervisor = new Agent({
-  id: 'supervisor',
+const parentAgent = new Agent({
+  id: 'parent-agent',
   instructions: 'You coordinate research and writing using specialized agents.',
   model: '__GATEWAY_OPENAI_MODEL__',
   agents: { researchAgent, writingAgent },
@@ -348,7 +348,7 @@ const rubricScorer = createRubricScorer({
   ],
 })
 
-const stream = await supervisor.stream('Research AI in education', {
+const stream = await parentAgent.stream('Research AI in education', {
   maxSteps: 10,
   isTaskComplete: {
     scorers: [rubricScorer],
@@ -363,15 +363,15 @@ For full API details, see the [rubric scorer reference](/reference/evals/rubric)
 
 Clear instructions are essential for effective delegation.
 
-Your supervisor's `instructions` should specify the available resources and when to use each one. They should also define coordination behavior and success criteria.
+The parent agent's `instructions` should specify the available resources and when to use each one. They should also define coordination behavior and success criteria.
 
-Each subagent should have a clear `description` that explains its purpose and return format, including when the supervisor should use it.
+Each subagent should have a clear `description` that explains its purpose and return format, including when the parent agent should use it.
 
-The supervisor uses these descriptions to make delegation decisions.
+The parent agent uses these descriptions to make delegation decisions.
 
 ```typescript
-const supervisor = new Agent({
-  id: 'supervisor',
+const parentAgent = new Agent({
+  id: 'parent-agent',
   instructions: `You coordinate research and writing tasks.
 
 Available resources:
@@ -392,13 +392,13 @@ Success criteria:
 
 ## Running subagents in the background
 
-Subagent invocations are dispatched as tool calls, so they can run as [background tasks](/docs/long-running-agents/background-tasks). This is useful when one or more delegations are long-running and you don't want them to block the supervisor's response.
+Subagent invocations are dispatched as tool calls, so they can run as [background tasks](/docs/long-running-agents/background-tasks). This is useful when one or more delegations are long-running and you don't want them to block the parent agent's response.
 
-Enable the [backgroundTasks manager](/reference/configuration#backgroundtasks) on the Mastra instance, then opt subagents in on the supervisor:
+Enable the [backgroundTasks manager](/reference/configuration#backgroundtasks) on the Mastra instance, then opt subagents in on the parent agent:
 
-```typescript title="src/mastra/agents/supervisor.ts"
-const supervisor = new Agent({
-  id: 'supervisor',
+```typescript title="src/mastra/agents/parent-agent.ts"
+const parentAgent = new Agent({
+  id: 'parent-agent',
   instructions: 'Coordinate research and writing using the available agents.',
   model: '__GATEWAY_OPENAI_MODEL__',
   agents: { researchAgent, writingAgent },
@@ -412,21 +412,21 @@ const supervisor = new Agent({
   // highlight-end
 })
 
-const stream = await supervisor.streamUntilIdle('Research AI in education and write an article', {
+const stream = await parentAgent.streamUntilIdle('Research AI in education and write an article', {
   memory: { thread: 't1', resource: 'u1' },
 })
 ```
 
-Use [`streamUntilIdle()`](/reference/streaming/agents/streamUntilIdle) instead of `stream()` so the stream stays open until the subagents complete and the supervisor has had a chance to respond to their results.
+Use [`streamUntilIdle()`](/reference/streaming/agents/streamUntilIdle) instead of `stream()` so the stream stays open until the subagents complete and the parent agent has had a chance to respond to their results.
 
-If a subagent isn't listed on the supervisor but has its own background-eligible tools, the supervisor still dispatches the subagent as a background task and inherits its config. See [Inheriting from the subagent](/docs/long-running-agents/background-tasks#inheriting-from-the-subagent) for details.
+If a subagent isn't listed under the parent agent's `backgroundTasks.tools` but has its own background-eligible tools, the parent agent still dispatches the subagent as a background task and inherits its config. See [Inheriting from the subagent](/docs/long-running-agents/background-tasks#inheriting-from-the-subagent) for details.
 
 ## Subagent versioning
 
-When using the [editor](/docs/editor/overview), you can control which stored version of each subagent the supervisor uses at runtime. Set version overrides on the Mastra instance or per invocation:
+When using the [editor](/docs/editor/overview), you can control which stored version of each subagent the parent agent uses at runtime. Set version overrides on the Mastra instance or per invocation:
 
 ```typescript
-const result = await supervisor.generate('Research and write about AI safety', {
+const result = await parentAgent.generate('Research and write about AI safety', {
   versions: {
     agents: {
       'research-agent': { status: 'published' },

--- a/docs/src/content/en/docs/capabilities/subagents.mdx
+++ b/docs/src/content/en/docs/capabilities/subagents.mdx
@@ -446,7 +446,7 @@ Version overrides propagate automatically through delegation. See [Subagent vers
 - [Agent.stream() reference](/reference/streaming/agents/stream)
 - [Agent.streamUntilIdle() reference](/reference/streaming/agents/streamUntilIdle)
 - [Agent.generate() reference](/reference/agents/generate)
-- [Agent approval](./agent-approval)
+- [Agent approval](/docs/agents/agent-approval)
 - [Memory in multi-agent systems](/docs/memory/overview#memory-in-multi-agent-systems)
 - [Concept: Multi-agent systems](/guides/concepts/multi-agent-systems)
 - 📹 [Mastra supervisor agents workshop](https://www.youtube.com/watch?v=FNb2fL9WhQg\&t=1872s)

--- a/docs/src/content/en/docs/long-running-agents/background-tasks.mdx
+++ b/docs/src/content/en/docs/long-running-agents/background-tasks.mdx
@@ -395,6 +395,6 @@ These read from storage rather than the pubsub stream, so they're suitable for p
 - [`Agent.stream()` reference](/reference/streaming/agents/stream)
 - [backgroundTasks configuration reference](/reference/configuration#backgroundtasks)
 - [Durable agents](./durable-agents)
-- [Supervisor agents](/docs/agents/supervisor-agents)
+- [Supervisor agents](/docs/capabilities/subagents)
 - [Stream chunk types](/reference/streaming/ChunkType)
 - [Storage](/docs/storage/overview)

--- a/docs/src/content/en/docs/long-running-agents/goals.mdx
+++ b/docs/src/content/en/docs/long-running-agents/goals.mdx
@@ -20,7 +20,7 @@ A goal is a durable, thread-scoped objective: a standing instruction the agent k
 
 The objective is persisted in thread state, so it survives reloads and is evaluated in-loop, even when a new message arrives in the middle of an already-running turn.
 
-Goals build on the same machinery as [`isTaskComplete`](/docs/agents/supervisor-agents): an LLM-as-judge scores the agent's output each iteration and gates the loop. The difference is that a goal is **durable** (stored in thread state, not passed per call) and is set and updated through `Agent` methods rather than per-`stream()` options.
+Goals build on the same machinery as [`isTaskComplete`](/docs/capabilities/subagents): an LLM-as-judge scores the agent's output each iteration and gates the loop. The difference is that a goal is **durable** (stored in thread state, not passed per call) and is set and updated through `Agent` methods rather than per-`stream()` options.
 
 ## When to use goals
 
@@ -30,7 +30,7 @@ Use a goal when you want an agent to keep working toward a single objective acro
 - Work that should continue across mid-run messages (a message delivered into a live run is still judged against the goal).
 - An objective that must persist across thread reloads or process restarts.
 
-For a one-off completion check within a single `stream()` call, use [`isTaskComplete`](/docs/agents/supervisor-agents) instead.
+For a one-off completion check within a single `stream()` call, use [`isTaskComplete`](/docs/capabilities/subagents) instead.
 
 ## Quickstart
 
@@ -123,6 +123,6 @@ Per-objective values written by `setObjective` / `updateObjectiveOptions` take p
 
 ## Related
 
-- [Supervisor agents](/docs/agents/supervisor-agents): `isTaskComplete` and the rubric scorer
+- [Supervisor agents](/docs/capabilities/subagents): `isTaskComplete` and the rubric scorer
 - [Signal providers](/docs/long-running-agents/signal-providers): how the objective is projected into context
 - [Memory storage](/docs/storage/overview): the storage backend goals require

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -184,7 +184,7 @@ Conversation messages are ordered by timestamp and deduplicated by message ID, s
 
 ## Memory in multi-agent systems
 
-When a [supervisor agent](/docs/agents/supervisor-agents) delegates to a subagent, Mastra isolates subagent memory automatically. No flag enables this as it happens on every delegation. Understanding how this scoping works lets you decide what stays private and what to share intentionally.
+When a [supervisor agent](/docs/capabilities/subagents) delegates to a subagent, Mastra isolates subagent memory automatically. No flag enables this as it happens on every delegation. Understanding how this scoping works lets you decide what stays private and what to share intentionally.
 
 ### How delegation scopes memory
 
@@ -200,7 +200,7 @@ Title generation (`generateTitle`) is a top-level thread concern and **isn't** a
 
 :::
 
-The supervisor forwards its conversation context to the subagent so it has enough background to complete the task. Only the delegation prompt and the subagent's response are saved, the full parent conversation isn't stored. You can control which messages reach the subagent with the [`messageFilter`](/docs/agents/supervisor-agents#message-filtering) callback.
+The supervisor forwards its conversation context to the subagent so it has enough background to complete the task. Only the delegation prompt and the subagent's response are saved, the full parent conversation isn't stored. You can control which messages reach the subagent with the [`messageFilter`](/docs/capabilities/subagents#message-filtering) callback.
 
 :::note
 

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -70,11 +70,6 @@ const sidebars = {
             },
             {
               type: 'doc',
-              id: 'agents/supervisor-agents',
-              label: 'Supervisor Agents',
-            },
-            {
-              type: 'doc',
               id: 'agents/guardrails',
               label: 'Guardrails',
             },
@@ -260,6 +255,11 @@ const sidebars = {
         displayAsGroup: true,
       },
       items: [
+        {
+          type: 'doc',
+          id: 'capabilities/subagents',
+          label: 'Subagents',
+        },
         {
           type: 'doc',
           id: 'agents/skills',

--- a/docs/src/content/en/guides/concepts/multi-agent-systems.mdx
+++ b/docs/src/content/en/guides/concepts/multi-agent-systems.mdx
@@ -50,7 +50,7 @@ A supervisor pattern keeps one lead agent in control for the full task. The supe
 Use this pattern when the task is open-ended and the full sequence isn't known in advance. For example, a research task may require different lines of inquiry based on what earlier steps uncover. A supervisor can adapt as the task unfolds.
 The tradeoff is that the supervisor becomes the main coordination point. That makes the pattern flexible, but it also means the result depends heavily on good delegation behavior and clear subagent boundaries.
 
-In Mastra, this pattern maps directly to [supervisor agents](/docs/agents/supervisor-agents). A supervisor agent defines subagents on the `agents` property and uses `stream()` or `generate()` to coordinate them. Mastra also provides delegation hooks, message filtering, and memory isolation to help control this pattern.
+In Mastra, this pattern maps directly to [supervisor agents](/docs/capabilities/subagents). A supervisor agent defines subagents on the `agents` property and uses `stream()` or `generate()` to coordinate them. Mastra also provides delegation hooks, message filtering, and memory isolation to help control this pattern.
 
 :::tip
 
@@ -74,7 +74,7 @@ These patterns differ mainly in how they distribute control:
 | - | - | - | - | - |
 | Handoffs | Current specialist | Ownership should move between specialists | Context transfer becomes more important | Agents with workflows and memory |
 | Workflows | Execution graph | The path is known in advance | Less adaptive when the task changes | [Workflows](/docs/workflows/overview) |
-| Supervisor agents | One lead agent | Delegation must adapt during execution | Results depend on good coordination and clear boundaries | [Supervisor agents](/docs/agents/supervisor-agents) |
+| Supervisor agents | One lead agent | Delegation must adapt during execution | Results depend on good coordination and clear boundaries | [Supervisor agents](/docs/capabilities/subagents) |
 | Council | Final synthesis step | The task needs multiple independent perspectives | Higher cost and latency | Agents with workflow parallelism |
 
 In practice, these patterns are often combined:

--- a/docs/src/content/en/guides/guide/research-coordinator.mdx
+++ b/docs/src/content/en/guides/guide/research-coordinator.mdx
@@ -405,5 +405,5 @@ You can extend this research coordinator to:
 
 Learn more:
 
-- [Supervisor Agents](/docs/agents/supervisor-agents)
+- [Supervisor Agents](/docs/capabilities/subagents)
 - [Agent.stream() Reference](/reference/streaming/agents/stream)

--- a/docs/src/content/en/guides/migrations/network-to-supervisor.mdx
+++ b/docs/src/content/en/guides/migrations/network-to-supervisor.mdx
@@ -262,7 +262,7 @@ const stream = await supervisorAgent.stream('Research AI in education', {
 
 ## See also
 
-- [Supervisor Agents](/docs/agents/supervisor-agents)
+- [Supervisor Agents](/docs/capabilities/subagents)
 - [Agent Networks](/docs/agents/networks)
 - [Agent.stream() Reference](/reference/streaming/agents/stream)
 - [Agent.generate() Reference](/reference/agents/generate)

--- a/docs/src/content/en/reference/acp/acp-agent.mdx
+++ b/docs/src/content/en/reference/acp/acp-agent.mdx
@@ -322,6 +322,6 @@ Use this callback to enforce local policy or inspect the permission title. It ca
 - [Agent Client Protocol docs](/docs/agents/acp)
 - [createACPTool() reference](/reference/acp/create-acp-tool)
 - [Agent reference](/reference/agents/agent)
-- [Subagents](/docs/agents/supervisor-agents)
+- [Subagents](/docs/capabilities/subagents)
 - [Agent Client Protocol introduction](https://agentclientprotocol.com/overview/introduction)
 - [Agent Client Protocol schema](https://agentclientprotocol.com/protocol/schema)

--- a/docs/src/content/en/reference/agents/network.mdx
+++ b/docs/src/content/en/reference/agents/network.mdx
@@ -13,7 +13,7 @@ The `.network()` method enables multi-agent collaboration and routing. This meth
 
 :::warning[Deprecated]
 
-The `.network()` primitive has been deprecated and will be removed in a future major release. Use [supervisor agents](/docs/agents/supervisor-agents) with `agent.stream()` or `agent.generate()` instead. See the [migration guide](/guides/migrations/network-to-supervisor) to upgrade.
+The `.network()` primitive has been deprecated and will be removed in a future major release. Use [supervisor agents](/docs/capabilities/subagents) with `agent.stream()` or `agent.generate()` instead. See the [migration guide](/guides/migrations/network-to-supervisor) to upgrade.
 
 :::
 

--- a/docs/src/content/en/reference/ai-sdk/handle-network-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-network-stream.mdx
@@ -11,7 +11,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 :::warning[Deprecated]
 
-Agent networks are deprecated and will be removed in a future release. Use [supervisor agents](/docs/agents/supervisor-agents) with `agent.stream()` or `agent.generate()` instead. See the [migration guide](/guides/migrations/network-to-supervisor) to upgrade.
+Agent networks are deprecated and will be removed in a future release. Use [supervisor agents](/docs/capabilities/subagents) with `agent.stream()` or `agent.generate()` instead. See the [migration guide](/guides/migrations/network-to-supervisor) to upgrade.
 
 :::
 

--- a/docs/src/content/en/reference/ai-sdk/network-route.mdx
+++ b/docs/src/content/en/reference/ai-sdk/network-route.mdx
@@ -12,7 +12,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 :::warning[Deprecated]
 
-Agent networks are deprecated and will be removed in a future release. Use [supervisor agents](/docs/agents/supervisor-agents) with `agent.stream()` or `agent.generate()` instead. See the [migration guide](/guides/migrations/network-to-supervisor) to upgrade.
+Agent networks are deprecated and will be removed in a future release. Use [supervisor agents](/docs/capabilities/subagents) with `agent.stream()` or `agent.generate()` instead. See the [migration guide](/guides/migrations/network-to-supervisor) to upgrade.
 
 :::
 

--- a/docs/src/content/en/reference/editor/versioning.mdx
+++ b/docs/src/content/en/reference/editor/versioning.mdx
@@ -61,7 +61,7 @@ See the [Client SDK agents reference](/reference/client-js/agents#version-manage
 
 ## Sub-agent versioning
 
-Version overrides propagate through [supervisor-agent delegation](/docs/agents/supervisor-agents) in request context. Define selectors at three levels:
+Version overrides propagate through [supervisor-agent delegation](/docs/capabilities/subagents) in request context. Define selectors at three levels:
 
 1. `Mastra` instance `versions`: Defaults for every invocation
 1. Server request-body `versions`: Per-request values added to request context

--- a/docs/src/content/en/reference/evals/rubric.mdx
+++ b/docs/src/content/en/reference/evals/rubric.mdx
@@ -184,5 +184,5 @@ The `reason` summarizes the result and lists each criterion with its verdict, so
 ## Related
 
 - [isTaskComplete on stream()](/reference/streaming/agents/stream)
-- [Supervisor agents](/docs/agents/supervisor-agents)
+- [Supervisor agents](/docs/capabilities/subagents)
 - [createScorer](/reference/evals/create-scorer)

--- a/docs/src/content/en/reference/file-based-agents/subagents.mdx
+++ b/docs/src/content/en/reference/file-based-agents/subagents.mdx
@@ -9,7 +9,7 @@ packages:
 
 A file-based agent can declare **subagents**, specialist child agents it delegates to. The parent model sees each subagent as a delegation tool named after the subagent directory and calls that tool to hand off a task. The subagent's result returns to the parent conversation.
 
-Use this page for the file-based convention. For broader delegation patterns, hooks, memory isolation, tool approval propagation, and scoring, see [Supervisor agents](/docs/agents/supervisor-agents).
+Use this page for the file-based convention. For broader delegation patterns, hooks, memory isolation, tool approval propagation, and scoring, see [Supervisor agents](/docs/capabilities/subagents).
 
 ## Quickstart
 

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1196,6 +1196,11 @@
       "permanent": true
     },
     {
+      "source": "/docs/agents/supervisor-agents",
+      "destination": "/docs/capabilities/subagents",
+      "permanent": true
+    },
+    {
       "source": "/docs/editor/prompts/llms.txt",
       "destination": "/docs/editor/overview/llms.txt",
       "permanent": true
@@ -2033,6 +2038,11 @@
     {
       "source": "/docs/agent-controller/channels/llms.txt",
       "destination": "/docs/harness/agent-controller/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/agents/supervisor-agents/llms.txt",
+      "destination": "/docs/capabilities/subagents/llms.txt",
       "permanent": true
     }
   ]

--- a/docs/vercel.redirects.json
+++ b/docs/vercel.redirects.json
@@ -1179,6 +1179,11 @@
       "source": "/docs/agent-controller/channels",
       "destination": "/docs/harness/agent-controller",
       "permanent": true
+    },
+    {
+      "source": "/docs/agents/supervisor-agents",
+      "destination": "/docs/capabilities/subagents",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- move the Supervisor agents page to `/docs/capabilities/subagents`
- list it as Subagents under the Extend sidebar section
- update inbound links and add redirects for the previous route

## Testing

- `pnpm run validate`
- `pnpm run build`
- `pnpm test scripts/__tests__/generate-vercel-redirects.test.ts`
- verified `/docs/capabilities/subagents` locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR moves the “Supervisor agents” docs to a new home called “Subagents”. It also updates links so people do not hit old pages, and it adds redirects so old URLs still work.

## Summary
- Moved the docs page to `/docs/capabilities/subagents`.
- Renamed the sidebar entry to **Subagents** under **Extend**.
- Updated inbound links across docs to point to the new route.
- Added redirects for the old `/docs/agents/supervisor-agents` path, including the `llms.txt` variant.
- Adjusted the page content to use “Subagents” and `parentAgent` language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->