### PR TITLE
fix(core): preserve caller context for stream approvals

### DIFF
--- a/.changeset/famous-kiwis-smash.md
+++ b/.changeset/famous-kiwis-smash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent controller approvals losing the current caller identity while processing subscribed thread streams.

--- a/packages/core/src/agent-controller/__tests__/trailing-guard-new-run.test.ts
+++ b/packages/core/src/agent-controller/__tests__/trailing-guard-new-run.test.ts
@@ -121,4 +121,70 @@ describe('Trailing guard does not swallow new-run null-runId chunks', () => {
       organizationId: 'org-1',
     });
   });
+
+  // Resuming is a caller-authenticated entry point that starts the subscription
+  // itself, so an approval arriving after it must not fall back to whatever
+  // identity a previous send happened to leave behind — or to none at all.
+  it('uses the resuming caller context for an approval that follows a resume', async () => {
+    const controller = createController();
+    await controller.init();
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    session.suspensions.register({ toolCallId: 'suspended-1', runId: 'run-a', toolName: 'ask_user' });
+
+    const requestContext = new RequestContext();
+    requestContext.set('user', { id: 'resuming-user', organizationId: 'org-1' });
+    vi.spyOn(session, 'resolveToolApproval').mockReturnValue('allow');
+    const approveToolCall = vi.spyOn(session, 'approveToolCall').mockResolvedValue();
+
+    await session
+      .resumeToolCall({ resumeData: 'answer', toolCallId: 'suspended-1', requestContext })
+      .catch(() => undefined);
+
+    await processSubscribedChunks(session, [
+      { type: 'start', runId: 'run-b' },
+      {
+        type: 'tool-call-approval',
+        runId: 'run-b',
+        payload: { toolCallId: 'tool-call-1', toolName: 'factory_transition_work_item', args: {} },
+      },
+      { type: 'finish', runId: 'run-b', payload: { stepResult: { reason: 'stop' } } },
+    ]);
+
+    expect(approveToolCall).toHaveBeenCalledOnce();
+    expect(approveToolCall.mock.calls[0]?.[0].requestContext?.get('user')).toEqual({
+      id: 'resuming-user',
+      organizationId: 'org-1',
+    });
+  });
+
+  it('uses the notifying caller context for an approval that follows a notification signal', async () => {
+    const controller = createController();
+    await controller.init();
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+
+    const requestContext = new RequestContext();
+    requestContext.set('user', { id: 'notifying-user', organizationId: 'org-1' });
+    vi.spyOn(session, 'resolveToolApproval').mockReturnValue('allow');
+    const approveToolCall = vi.spyOn(session, 'approveToolCall').mockResolvedValue();
+
+    await session
+      .sendNotificationSignal({ tagName: 'system', contents: 'ping' } as any, { requestContext })
+      .catch(() => undefined);
+
+    await processSubscribedChunks(session, [
+      { type: 'start', runId: 'run-b' },
+      {
+        type: 'tool-call-approval',
+        runId: 'run-b',
+        payload: { toolCallId: 'tool-call-1', toolName: 'factory_transition_work_item', args: {} },
+      },
+      { type: 'finish', runId: 'run-b', payload: { stepResult: { reason: 'stop' } } },
+    ]);
+
+    expect(approveToolCall).toHaveBeenCalledOnce();
+    expect(approveToolCall.mock.calls[0]?.[0].requestContext?.get('user')).toEqual({
+      id: 'notifying-user',
+      organizationId: 'org-1',
+    });
+  });
 });

--- a/packages/core/src/agent-controller/__tests__/trailing-guard-new-run.test.ts
+++ b/packages/core/src/agent-controller/__tests__/trailing-guard-new-run.test.ts
@@ -12,8 +12,9 @@
  *
  * Fix: clear lastFinishedRunId when creating a new run (`!currentRun` branch).
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Agent } from '../../agent';
+import { RequestContext } from '../../request-context';
 import { InMemoryStore } from '../../storage/mock';
 import { AgentController } from '../agent-controller';
 import type { Session } from '../session';
@@ -92,5 +93,32 @@ describe('Trailing guard does not swallow new-run null-runId chunks', () => {
     // The null-runId chunks from run B must have been processed, not skipped.
     expect(processedChunkTypes).toContain('data-user-message');
     expect(processedChunkTypes).toContain('data-om-status');
+  });
+
+  it('uses the latest caller context when an approval arrives on the subscribed stream', async () => {
+    const controller = createController();
+    await controller.init();
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    const requestContext = new RequestContext();
+    requestContext.set('user', { id: 'user-1', organizationId: 'org-1' });
+    session.runEngine.setRequestContext(requestContext);
+    vi.spyOn(session, 'resolveToolApproval').mockReturnValue('allow');
+    const approveToolCall = vi.spyOn(session, 'approveToolCall').mockResolvedValue();
+
+    await processSubscribedChunks(session, [
+      { type: 'start', runId: 'run-a' },
+      {
+        type: 'tool-call-approval',
+        runId: 'run-a',
+        payload: { toolCallId: 'tool-call-1', toolName: 'factory_transition_work_item', args: {} },
+      },
+      { type: 'finish', runId: 'run-a', payload: { stepResult: { reason: 'stop' } } },
+    ]);
+
+    expect(approveToolCall).toHaveBeenCalledOnce();
+    expect(approveToolCall.mock.calls[0]?.[0].requestContext?.get('user')).toEqual({
+      id: 'user-1',
+      organizationId: 'org-1',
+    });
   });
 });

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -212,10 +212,15 @@ type StreamState = {
 export class SessionRunEngine {
   readonly #session: Session;
   readonly #machinery: SessionMachinery;
+  #requestContext?: RequestContext;
 
   constructor(session: Session, machinery: SessionMachinery) {
     this.#session = session;
     this.#machinery = machinery;
+  }
+
+  setRequestContext(requestContext?: RequestContext): void {
+    if (requestContext) this.#requestContext = requestContext;
   }
 
   private createEmptyAssistantMessage(): MastraDBMessage {
@@ -1034,7 +1039,6 @@ export class SessionRunEngine {
   }
 
   async processSubscribedThreadStream(subscription: AgentThreadSubscription<StreamChunk>): Promise<void> {
-    const requestContext = await this.#machinery.buildRequestContext();
     let currentRun: StreamState | undefined;
 
     try {
@@ -1058,6 +1062,7 @@ export class SessionRunEngine {
         }
 
         try {
+          const requestContext = await this.#machinery.buildRequestContext(this.#requestContext);
           const streamResult = await this.processStreamChunk(currentRun, chunk, requestContext);
           if (
             streamResult ||

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3082,6 +3082,7 @@ export class Session<TState = unknown> {
       const threadId = this.thread.getId()!;
 
       const agent = this.machinery.getAgent();
+      this.runEngine.setRequestContext(requestContextInput);
       await this.thread.ensureSubscription(threadId);
 
       if (submittedRunId && submittedActiveRunId && submittedIsRunning) {

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3174,6 +3174,7 @@ export class Session<TState = unknown> {
     const threadId = this.thread.getId()!;
 
     const agent = this.machinery.getAgent();
+    this.runEngine.setRequestContext(requestContextInput);
     await this.thread.ensureSubscription(threadId);
 
     if (this.run.getRunId() && this.stream.activeRunId()) {
@@ -3562,6 +3563,7 @@ export class Session<TState = unknown> {
       throw new Error('Cannot resume a suspended tool without a current thread');
     }
 
+    this.runEngine.setRequestContext(requestContextInput);
     await this.thread.ensureSubscription(threadId);
     const resumedSubscriptionBoundary = this.createSubscribedResumeBoundaryWaiter(
       suspension.toolName === 'submit_plan' ? toolCallId : undefined,


### PR DESCRIPTION
Agent Controller sessions could lose the authenticated caller identity when a subscribed thread emitted an approval chunk. The subscription processor created a new controller-only request context, so an approved Factory tool resumed without the user identity required to resolve its workspace.

This keeps the latest request context supplied with the session message and applies it while processing subscribed stream chunks. The Factory ownership guard remains unchanged. Regression coverage verifies an approval arriving through the subscription receives the current caller identity.

Verified with the focused Agent Controller test, Core typecheck and build, formatting, and the previously failing Factory session after an API restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an approval arrives later, the system now remembers who started the request. This lets approved tools access the correct user workspace.

## Changes

- Preserve the latest `RequestContext` for each session.
- Apply the stored context while processing approval chunks from subscribed threads.
- Add `SessionRunEngine.setRequestContext`.
- Set the request context before subscriptions started by user signals, notification signals, and suspended-tool resumes.
- Keep the Factory ownership guard unchanged.
- Add regression coverage for subscription, resume, and notification approval flows.
- Add a patch changeset for `@mastra/core`.

## Validation

- Focused Agent Controller test.
- Core typecheck and build.
- Formatting checks.
- Previously failing Factory session after an API restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->