### PR TITLE
fix(observability): preserve model attribution for blank responses

### DIFF
--- a/.changeset/breezy-pets-mix.md
+++ b/.changeset/breezy-pets-mix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed token metrics losing model labels and cost data when providers return blank response model IDs.

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -39,6 +39,7 @@ import { LoggerContextImpl } from '../context/logger';
 import { MetricsContextImpl } from '../context/metrics';
 import { emitAutoExtractedMetrics, emitTokenMetricsForUsage } from '../metrics/auto-extract';
 import { CardinalityFilter } from '../metrics/cardinality';
+import { resolveModelId } from '../model-id';
 import { NoOpSpan } from '../spans';
 import { addUsageStats } from '../usage';
 
@@ -247,7 +248,7 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     // original creation options so captureExcludedModelUsage can use them.
     if (rest.type === SpanType.MODEL_GENERATION && this.config.excludeSpanTypes?.includes(SpanType.MODEL_GENERATION)) {
       const attrs = rest.attributes as ModelGenerationAttributes | undefined;
-      const model = attrs?.responseModel ?? attrs?.model;
+      const model = resolveModelId(attrs?.responseModel, attrs?.model);
       if (attrs?.provider || model) {
         this.#excludedModelMeta.set(span, { provider: attrs?.provider, model });
       }
@@ -852,7 +853,7 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     if (!ancestor) return undefined;
 
     const provider = endAttrs?.provider ?? liveAttrs?.provider;
-    const model = endAttrs?.responseModel ?? endAttrs?.model ?? liveAttrs?.responseModel ?? liveAttrs?.model;
+    const model = resolveModelId(endAttrs?.responseModel, endAttrs?.model, liveAttrs?.responseModel, liveAttrs?.model);
 
     return { ancestor, usage, provider, model };
   }
@@ -881,8 +882,13 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     // (provider, model). Fall back to the stash populated at creation time.
     const stashed = this.#excludedModelMeta.get(span);
     const provider = endAttrs?.provider ?? liveAttrs?.provider ?? stashed?.provider;
-    const model =
-      endAttrs?.responseModel ?? endAttrs?.model ?? liveAttrs?.responseModel ?? liveAttrs?.model ?? stashed?.model;
+    const model = resolveModelId(
+      endAttrs?.responseModel,
+      endAttrs?.model,
+      liveAttrs?.responseModel,
+      liveAttrs?.model,
+      stashed?.model,
+    );
 
     return { usage, provider, model };
   }

--- a/observability/mastra/src/metrics/auto-extract.test.ts
+++ b/observability/mastra/src/metrics/auto-extract.test.ts
@@ -154,13 +154,14 @@ describe('AutoExtractedMetrics', () => {
     expect(emittedMetrics[0]!.metric.labels.status).toBe('error');
   });
 
-  it('should extract token usage metrics for model generation', () => {
+  it('should use the configured model when the response model is blank', () => {
     setup();
     const span = createMockSpan({
       type: SpanType.MODEL_GENERATION,
       endTime: new Date('2026-01-01T00:00:02Z'),
       attributes: {
         model: 'gpt-4',
+        responseModel: '   ',
         provider: 'openai',
         usage: {
           inputTokens: 100,

--- a/observability/mastra/src/metrics/auto-extract.ts
+++ b/observability/mastra/src/metrics/auto-extract.ts
@@ -10,6 +10,7 @@ import type {
   ModelGenerationAttributes,
   UsageStats,
 } from '@mastra/core/observability';
+import { resolveModelId } from '../model-id';
 import { estimateCosts } from './estimator';
 import { TokenMetrics } from './types';
 import { getTokenMetricSamples } from './usage-metrics';
@@ -78,7 +79,7 @@ function emitUsageMetrics(
   } else {
     try {
       const provider = attrs.provider;
-      const model = attrs.responseModel ?? attrs.model;
+      const model = resolveModelId(attrs.responseModel, attrs.model);
 
       if (provider && model) {
         metricCosts = estimateCosts({
@@ -137,7 +138,7 @@ function getProvidedCostContext(
 
   const carrierMetric = usage.inputTokens !== undefined ? TokenMetrics.TOTAL_INPUT : TokenMetrics.TOTAL_OUTPUT;
   const provider = costContext.provider ?? attrs.provider;
-  const model = costContext.model ?? attrs.responseModel ?? attrs.model;
+  const model = resolveModelId(costContext.model, attrs.responseModel, attrs.model);
   const contexts = new Map<TokenMetrics, CostContext>();
 
   for (const sample of getTokenMetricSamples(usage)) {

--- a/observability/mastra/src/model-id.ts
+++ b/observability/mastra/src/model-id.ts
@@ -1,0 +1,4 @@
+/** Return the first model id that contains non-whitespace characters. */
+export function resolveModelId(...candidates: Array<string | undefined>): string | undefined {
+  return candidates.find(candidate => candidate?.trim());
+}

--- a/observability/mastra/src/span-filtering.test.ts
+++ b/observability/mastra/src/span-filtering.test.ts
@@ -666,12 +666,13 @@ describe('Span Filtering', () => {
           attributes: {
             provider: 'mock-provider',
             model: 'mock-model-id',
+            responseModel: '   ',
           },
         });
         // end() only passes responseModel + usage (not provider/model)
         modelSpan.end({
           attributes: {
-            responseModel: 'mock-model-id',
+            responseModel: '',
             usage: { inputTokens: 20, outputTokens: 15 },
           },
         });
@@ -751,6 +752,7 @@ describe('Span Filtering', () => {
         attributes: {
           provider: 'mock-provider',
           model: 'mock-model-id',
+          responseModel: '   ',
           usage: { inputTokens: 50, outputTokens: 10 },
         },
       });


### PR DESCRIPTION
## Description

Some providers return an empty or whitespace-only `responseModel`. Observability resolved models with nullish coalescing, so that blank value took precedence over the configured `model` and token metrics lost their provider, model, and estimated cost context.

This change treats blank model IDs as absent at every observability model-resolution point. Metrics and filtered or internal span usage rollups now fall back to the configured model while preserving valid response model IDs.

For example, `{ model: 'gemini-3.5-flash-lite', responseModel: '' }` now resolves to `gemini-3.5-flash-lite`.

Validated with 44 focused tests, the `@mastra/observability` package build and lint, and `git diff --check`.

## Related issue(s)

No linked GitHub issue; this was reported directly with production trace evidence.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some providers return an empty model name. This PR uses the configured model name instead, so metrics, costs, and span data remain correct.

## Changes

- Added `resolveModelId` to ignore empty and whitespace-only model IDs.
- Applied fallback handling to:
  - Token cost estimation.
  - Excluded model-generation spans.
  - Usage rollups.
  - Filtered and internal span metrics.
- Preserved valid provider response model IDs.
- Added focused tests for blank `responseModel` values.
- Added a patch changeset for `@mastra/observability`.

## Validation

- Built `@mastra/observability`.
- Ran lint.
- Ran `git diff --check`.
- Added 44 focused tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->