### PR TITLE
fix(core): make thread scope a single source of truth

### DIFF
--- a/.changeset/bright-grapes-behave.md
+++ b/.changeset/bright-grapes-behave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed sessions creating a new empty thread instead of resuming their conversation. Thread selection filtered threads by the controller-wide `projectPath` while thread creation stamped the session's own, so on hosts where a dynamic workspace gives each session its own working directory the two never matched and every session start left an orphaned thread behind. Selection now reads the scope from the session itself, and a thread carrying no scope stays resumable instead of being skipped.

--- a/.changeset/bright-grapes-behave.md
+++ b/.changeset/bright-grapes-behave.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed sessions creating a new empty thread instead of resuming their conversation. Thread selection filtered threads by the controller-wide `projectPath` while thread creation stamped the session's own, so on hosts where a dynamic workspace gives each session its own working directory the two never matched and every session start left an orphaned thread behind. Selection now reads the scope from the session itself, and a thread carrying no scope stays resumable instead of being skipped.
+Fixed sessions opening a new empty thread on every start instead of resuming their conversation. This affected setups that give each session its own working directory: the conversation stayed in storage but the session never reopened it, leaving an unused thread behind each time.

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -557,30 +557,20 @@ export class AgentController<TState = {}> {
         await session.thread.create({ id: overrides.threadId });
       }
     } else {
-      // Bring the session online with a current thread. Selection is tag-aware so
-      // worktrees sharing a resourceId each resume their own thread without
-      // claiming threads owned by another scope. A thread is a candidate only when
-      // its metadata matches every provided tag; with no tags every thread
-      // qualifies. Tags default to the controller-global state when omitted.
-      const selectionTags: Record<string, string> = {};
-      if (tags && Object.keys(tags).length > 0) {
-        Object.assign(selectionTags, tags);
-      } else {
-        const projectPath = (this.config.initialState as any)?.projectPath as string | undefined;
-        if (projectPath) selectionTags.projectPath = projectPath;
-      }
-      const tagEntries = Object.entries(selectionTags);
+      // Same scope `thread.create()` stamps. An inferred scope is a guess, so a
+      // thread carrying no value for the key is claimed by nobody and stays
+      // resumable; caller tags are a claim, so they filter strictly.
+      const { tags: scopeTags, explicit } = session.getThreadScope();
+      const scopeEntries = Object.entries(scopeTags);
 
       const threads = await session.thread.list();
-      const candidates =
-        tagEntries.length > 0
-          ? threads.filter(t => {
-              const metadata = (t.metadata as Record<string, unknown> | undefined) ?? {};
-              return tagEntries.every(([key, value]) => metadata[key] === value);
-            })
-          : threads;
+      const candidates = threads.filter(t => {
+        const metadata = (t.metadata as Record<string, unknown> | undefined) ?? {};
+        return scopeEntries.every(
+          ([key, value]) => metadata[key] === value || (!explicit && metadata[key] === undefined),
+        );
+      });
 
-      // Resume the most recent same-resource candidate, or create a new thread.
       if (candidates.length === 0) {
         await session.thread.create();
       } else {

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -557,18 +557,15 @@ export class AgentController<TState = {}> {
         await session.thread.create({ id: overrides.threadId });
       }
     } else {
-      // Same scope `thread.create()` stamps. An inferred scope is a guess, so a
-      // thread carrying no value for the key is claimed by nobody and stays
-      // resumable; caller tags are a claim, so they filter strictly.
-      const { tags: scopeTags, explicit } = session.getThreadScope();
-      const scopeEntries = Object.entries(scopeTags);
+      // Same scope `thread.create()` stamps, matched strictly: a thread outside
+      // this session's scope — including one carrying no scope at all — belongs
+      // to nobody here and must not be auto-resumed.
+      const scopeEntries = Object.entries(session.getThreadScope());
 
       const threads = await session.thread.list();
       const candidates = threads.filter(t => {
         const metadata = (t.metadata as Record<string, unknown> | undefined) ?? {};
-        return scopeEntries.every(
-          ([key, value]) => metadata[key] === value || (!explicit && metadata[key] === undefined),
-        );
+        return scopeEntries.every(([key, value]) => metadata[key] === value);
       });
 
       if (candidates.length === 0) {

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -541,21 +541,9 @@ export class SessionThread {
       metadata[`modeModelId_${session.mode.get()}`] = modelId;
     }
 
-    // Stamp the session's scoping tags onto the thread so listings can be
-    // filtered back to this session's scope (e.g. a `projectPath` per git
-    // worktree). Fall back to a `projectPath` read from state for unscoped
-    // sessions that still carry one in their initial state.
-    const tags = session.getTags();
-    if (Object.keys(tags).length > 0) {
-      for (const [key, value] of Object.entries(tags)) {
-        if (!isReservedThreadMetadataKey(key)) metadata[key] = value;
-      }
-    } else {
-      const projectPath = (session.state.get() as any).projectPath;
-      if (projectPath) {
-        metadata.projectPath = projectPath;
-      }
-    }
+    // Stamp the session's scope so thread selection can filter listings back to
+    // it (e.g. a `projectPath` per git worktree).
+    Object.assign(metadata, session.getThreadScope().tags);
 
     // Acquire lock on new thread before releasing old one.
     // If acquire fails, attempt to re-acquire the old lock before rethrowing.
@@ -2692,6 +2680,20 @@ export class Session<TState = unknown> {
    */
   getTags(): Record<string, string> {
     return { ...this.#tags };
+  }
+
+  /**
+   * The scope this session's threads carry: what `thread.create()` stamps and
+   * what thread selection filters on. Both must read it here — computing it on
+   * each side is what let selection drift off the controller-global state while
+   * creation stamped the session's own. `explicit` distinguishes caller-provided
+   * tags, which filter strictly, from a scope inferred from state, which does not.
+   */
+  getThreadScope(): { tags: Record<string, string>; explicit: boolean } {
+    const tags = Object.fromEntries(Object.entries(this.#tags).filter(([key]) => !isReservedThreadMetadataKey(key)));
+    if (Object.keys(tags).length > 0) return { tags, explicit: true };
+    const { projectPath } = this.state.get() as { projectPath?: string };
+    return { tags: projectPath ? { projectPath } : {}, explicit: false };
   }
 
   /**

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -543,7 +543,7 @@ export class SessionThread {
 
     // Stamp the session's scope so thread selection can filter listings back to
     // it (e.g. a `projectPath` per git worktree).
-    Object.assign(metadata, session.getThreadScope().tags);
+    Object.assign(metadata, session.getThreadScope());
 
     // Acquire lock on new thread before releasing old one.
     // If acquire fails, attempt to re-acquire the old lock before rethrowing.
@@ -2686,14 +2686,13 @@ export class Session<TState = unknown> {
    * The scope this session's threads carry: what `thread.create()` stamps and
    * what thread selection filters on. Both must read it here — computing it on
    * each side is what let selection drift off the controller-global state while
-   * creation stamped the session's own. `explicit` distinguishes caller-provided
-   * tags, which filter strictly, from a scope inferred from state, which does not.
+   * creation stamped the session's own.
    */
-  getThreadScope(): { tags: Record<string, string>; explicit: boolean } {
+  getThreadScope(): Record<string, string> {
     const tags = Object.fromEntries(Object.entries(this.#tags).filter(([key]) => !isReservedThreadMetadataKey(key)));
-    if (Object.keys(tags).length > 0) return { tags, explicit: true };
+    if (Object.keys(tags).length > 0) return tags;
     const { projectPath } = this.state.get() as { projectPath?: string };
-    return { tags: projectPath ? { projectPath } : {}, explicit: false };
+    return projectPath ? { projectPath } : {};
   }
 
   /**

--- a/packages/core/src/agent-controller/thread-selection-scope.test.ts
+++ b/packages/core/src/agent-controller/thread-selection-scope.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryStore } from '../storage/mock';
+import { AgentController } from './agent-controller';
+import { createMockWorkspace, createTestAgent } from './test-utils';
+import type { AgentControllerRequestContext } from './types';
+
+const SERVER_ROOT = '/srv/mastra-code';
+const SESSION_WORKDIR = '/srv/sandboxes/session-1';
+
+/**
+ * Mirrors the Factory's workspace factory: it pins the session's `projectPath`
+ * to that session's sandbox workdir before the session is built, so the
+ * controller-global `projectPath` is never the session's own scope.
+ */
+function createSessionScopedWorkspaceFactory(workdir: string) {
+  return async ({ requestContext }: { requestContext: any }) => {
+    const ctx = requestContext.get('controller') as AgentControllerRequestContext<{ projectPath?: string }> | undefined;
+    if (ctx && ctx.getState()?.projectPath !== workdir) {
+      await ctx.setState({ projectPath: workdir });
+    }
+    return createMockWorkspace();
+  };
+}
+
+function createController(
+  storage: InMemoryStore,
+  options: { workspace?: unknown; initialState?: Record<string, unknown> } = {},
+) {
+  return new AgentController({
+    id: 'test-controller',
+    storage,
+    workspace: (options.workspace ?? createMockWorkspace()) as any,
+    initialState: options.initialState ?? { projectPath: SERVER_ROOT },
+    modes: [{ id: 'default', name: 'Default', default: true, agent: createTestAgent() }],
+  });
+}
+
+describe('AgentController thread selection — session scope', () => {
+  it('resumes the thread of a session whose workspace rewrote its projectPath', async () => {
+    const storage = new InMemoryStore();
+    const workspace = createSessionScopedWorkspaceFactory(SESSION_WORKDIR);
+
+    const first = createController(storage, { workspace });
+    await first.init();
+    const firstSession = await first.createSession({ id: 'session-1', ownerId: 'owner', resourceId: 'session-1' });
+    const threadId = firstSession.thread.requireId();
+
+    const restarted = createController(storage, { workspace });
+    await restarted.init();
+    const resumed = await restarted.createSession({ id: 'session-1', ownerId: 'owner', resourceId: 'session-1' });
+
+    expect(resumed.thread.requireId()).toBe(threadId);
+    expect(await resumed.thread.list()).toHaveLength(1);
+  });
+
+  it('resumes a tagged thread from a caller that passes no tags', async () => {
+    const storage = new InMemoryStore();
+    const workspace = createSessionScopedWorkspaceFactory(SESSION_WORKDIR);
+
+    const first = createController(storage, { workspace });
+    await first.init();
+    const created = await first.createSession({
+      id: 'session-1',
+      ownerId: 'owner',
+      resourceId: 'session-1',
+      threadId: 'session-1',
+      tags: { factoryProjectId: 'project-1', projectRepositoryId: 'repo-1' },
+    });
+    expect(created.thread.requireId()).toBe('session-1');
+
+    const restarted = createController(storage, { workspace });
+    await restarted.init();
+    const resumed = await restarted.createSession({ id: 'session-1', ownerId: 'owner', resourceId: 'session-1' });
+
+    expect(resumed.thread.requireId()).toBe('session-1');
+    expect(await resumed.thread.list()).toHaveLength(1);
+  });
+
+  it('keeps worktrees on their own thread when the caller tags the scope', async () => {
+    const storage = new InMemoryStore();
+    const controller = createController(storage, { initialState: {} });
+    await controller.init();
+
+    const a = await controller.createSession({
+      id: 'a',
+      ownerId: 'owner',
+      resourceId: 'shared',
+      scope: '/wt/a',
+      tags: { projectPath: '/wt/a' },
+    });
+    const b = await controller.createSession({
+      id: 'b',
+      ownerId: 'owner',
+      resourceId: 'shared',
+      scope: '/wt/b',
+      tags: { projectPath: '/wt/b' },
+    });
+
+    expect(b.thread.requireId()).not.toBe(a.thread.requireId());
+  });
+
+  it('does not let an inferred scope claim a thread another scope tagged', async () => {
+    const storage = new InMemoryStore();
+    const controller = createController(storage, { initialState: {} });
+    await controller.init();
+
+    const tagged = await controller.createSession({
+      id: 'a',
+      ownerId: 'owner',
+      resourceId: 'shared',
+      scope: '/wt/a',
+      tags: { projectPath: '/wt/a' },
+    });
+
+    const inferred = createController(storage, { initialState: { projectPath: '/wt/b' } });
+    await inferred.init();
+    const other = await inferred.createSession({ id: 'b', ownerId: 'owner', resourceId: 'shared' });
+
+    expect(other.thread.requireId()).not.toBe(tagged.thread.requireId());
+  });
+});

--- a/packages/core/src/agent-controller/thread-selection-scope.test.ts
+++ b/packages/core/src/agent-controller/thread-selection-scope.test.ts
@@ -53,27 +53,20 @@ describe('AgentController thread selection — session scope', () => {
     expect(await resumed.thread.list()).toHaveLength(1);
   });
 
-  it('resumes a tagged thread from a caller that passes no tags', async () => {
+  // Worktrees of one repo share a resourceId, so a thread carrying no scope is
+  // exactly the one a worktree session must leave alone.
+  it('does not resume an unscoped thread from a scoped session', async () => {
     const storage = new InMemoryStore();
-    const workspace = createSessionScopedWorkspaceFactory(SESSION_WORKDIR);
 
-    const first = createController(storage, { workspace });
-    await first.init();
-    const created = await first.createSession({
-      id: 'session-1',
-      ownerId: 'owner',
-      resourceId: 'session-1',
-      threadId: 'session-1',
-      tags: { factoryProjectId: 'project-1', projectRepositoryId: 'repo-1' },
-    });
-    expect(created.thread.requireId()).toBe('session-1');
+    const unscoped = createController(storage, { initialState: {} });
+    await unscoped.init();
+    const untagged = await unscoped.createSession({ id: 'a', ownerId: 'owner', resourceId: 'shared' });
 
-    const restarted = createController(storage, { workspace });
-    await restarted.init();
-    const resumed = await restarted.createSession({ id: 'session-1', ownerId: 'owner', resourceId: 'session-1' });
+    const worktree = createController(storage, { initialState: { projectPath: '/wt/current' } });
+    await worktree.init();
+    const scoped = await worktree.createSession({ id: 'b', ownerId: 'owner', resourceId: 'shared' });
 
-    expect(resumed.thread.requireId()).toBe('session-1');
-    expect(await resumed.thread.list()).toHaveLength(1);
+    expect(scoped.thread.requireId()).not.toBe(untagged.thread.requireId());
   });
 
   it('keeps worktrees on their own thread when the caller tags the scope', async () => {


### PR DESCRIPTION
Every session start on a host that gives each session its own working directory creates a new empty thread instead of resuming the one that session already has. The conversation stays in storage, the session just never looks at it. On my local factory instance 141 of 258 threads are empty, one per start.

Selection and creation each computed the session's scope themselves, and the two had drifted. Creation stamped the `projectPath` read off the *session*, which a dynamic workspace factory pins to a per-session workdir. Selection, when the caller passed no tags, inferred it from `initialState.projectPath` on the *controller* — the server's own checkout. The two are never equal, so the filter matched nothing, and nothing matched means create a new thread.

I removed the second copy rather than realign it. `Session.getThreadScope()` now answers "what scope do this session's threads carry" in one place; `thread.create()` stamps what it returns and selection filters on what it returns. Matching stays strict as before — an unscoped thread is not claimable by a scoped session, which is what keeps two worktrees sharing a resourceId off each other's threads. One behaviour does change: tags made only of reserved metadata keys used to suppress the `projectPath` fallback when writing while still being filtered on when reading, so reserved keys are now dropped from the scope on both sides.

Four tests, the first of which fails on `main`. Agent-controller, memory and storage suites are green, as is the TUI `worktree-thread-scoping` scenario. Locally, reopening a factory workspace no longer adds a thread and the session binds to the real conversation.

What this doesn't do: the empty threads already in the database stay, and a session whose orphan is newer than its real thread's last activity still resumes the orphan, since selection orders by `updatedAt` — 44 of 136 resources on my instance are in that shape. I've also only measured this against my local instance, not the hosted factory.
