### PR TITLE
fix(core): set the caller context on every subscription entry point

### DIFF
--- a/packages/core/src/agent-controller/__tests__/trailing-guard-new-run.test.ts
+++ b/packages/core/src/agent-controller/__tests__/trailing-guard-new-run.test.ts
@@ -121,4 +121,70 @@ describe('Trailing guard does not swallow new-run null-runId chunks', () => {
       organizationId: 'org-1',
     });
   });
+
+  // Resuming is a caller-authenticated entry point that starts the subscription
+  // itself, so an approval arriving after it must not fall back to whatever
+  // identity a previous send happened to leave behind — or to none at all.
+  it('uses the resuming caller context for an approval that follows a resume', async () => {
+    const controller = createController();
+    await controller.init();
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    session.suspensions.register({ toolCallId: 'suspended-1', runId: 'run-a', toolName: 'ask_user' });
+
+    const requestContext = new RequestContext();
+    requestContext.set('user', { id: 'resuming-user', organizationId: 'org-1' });
+    vi.spyOn(session, 'resolveToolApproval').mockReturnValue('allow');
+    const approveToolCall = vi.spyOn(session, 'approveToolCall').mockResolvedValue();
+
+    await session
+      .resumeToolCall({ resumeData: 'answer', toolCallId: 'suspended-1', requestContext })
+      .catch(() => undefined);
+
+    await processSubscribedChunks(session, [
+      { type: 'start', runId: 'run-b' },
+      {
+        type: 'tool-call-approval',
+        runId: 'run-b',
+        payload: { toolCallId: 'tool-call-1', toolName: 'factory_transition_work_item', args: {} },
+      },
+      { type: 'finish', runId: 'run-b', payload: { stepResult: { reason: 'stop' } } },
+    ]);
+
+    expect(approveToolCall).toHaveBeenCalledOnce();
+    expect(approveToolCall.mock.calls[0]?.[0].requestContext?.get('user')).toEqual({
+      id: 'resuming-user',
+      organizationId: 'org-1',
+    });
+  });
+
+  it('uses the notifying caller context for an approval that follows a notification signal', async () => {
+    const controller = createController();
+    await controller.init();
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+
+    const requestContext = new RequestContext();
+    requestContext.set('user', { id: 'notifying-user', organizationId: 'org-1' });
+    vi.spyOn(session, 'resolveToolApproval').mockReturnValue('allow');
+    const approveToolCall = vi.spyOn(session, 'approveToolCall').mockResolvedValue();
+
+    await session
+      .sendNotificationSignal({ tagName: 'system', contents: 'ping' } as any, { requestContext })
+      .catch(() => undefined);
+
+    await processSubscribedChunks(session, [
+      { type: 'start', runId: 'run-b' },
+      {
+        type: 'tool-call-approval',
+        runId: 'run-b',
+        payload: { toolCallId: 'tool-call-1', toolName: 'factory_transition_work_item', args: {} },
+      },
+      { type: 'finish', runId: 'run-b', payload: { stepResult: { reason: 'stop' } } },
+    ]);
+
+    expect(approveToolCall).toHaveBeenCalledOnce();
+    expect(approveToolCall.mock.calls[0]?.[0].requestContext?.get('user')).toEqual({
+      id: 'notifying-user',
+      organizationId: 'org-1',
+    });
+  });
 });

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3174,6 +3174,7 @@ export class Session<TState = unknown> {
     const threadId = this.thread.getId()!;
 
     const agent = this.machinery.getAgent();
+    this.runEngine.setRequestContext(requestContextInput);
     await this.thread.ensureSubscription(threadId);
 
     if (this.run.getRunId() && this.stream.activeRunId()) {
@@ -3562,6 +3563,7 @@ export class Session<TState = unknown> {
       throw new Error('Cannot resume a suspended tool without a current thread');
     }
 
+    this.runEngine.setRequestContext(requestContextInput);
     await this.thread.ensureSubscription(threadId);
     const resumedSubscriptionBoundary = this.createSubscribedResumeBoundaryWaiter(
       suspension.toolName === 'submit_plan' ? toolCallId : undefined,


### PR DESCRIPTION
Targets #20741, not `main` — merge it into that branch and the PR ships complete.

Your fix routes the caller's request context into the subscribed stream, but only from the send path. Two other entry points start the subscription themselves and already hold a caller context they never pass on: `resumeToolCall` and `sendNotificationSignal`. So the loop keeps whatever a previous send happened to leave behind, and after a restart it has nothing at all — an approval following a resume still resolves with no caller identity, which is the case the guard exists to catch. It is also what CodeRabbit flagged on `session.ts:3085`.

Both now set the context before `ensureSubscription`, two lines each.

The two regression tests drive the real entry points rather than calling the setter, so they cover the wiring your existing test can't see: resume with a caller context, then an approval on the subscribed stream, and the same for a notification signal. Without the change both fail with the identity coming back `undefined`. The full agent-controller suite is green.

Left alone deliberately: `setRequestContext` still ignores `undefined`, so a context set once outlives the request that set it. Scoping the context to the run — the chunks already carry a `runId` — would remove both the staleness and the question of who set it last, but that's a refactor rather than a fix and it belongs in its own PR.
