### PR TITLE
docs(core): clarify signal webhook routing

### DIFF
--- a/.changeset/four-walls-smile.md
+++ b/.changeset/four-walls-smile.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed SignalProvider webhook documentation to explain how applications should expose verified HTTP endpoints.

--- a/docs/src/content/en/reference/signals/signal-provider.mdx
+++ b/docs/src/content/en/reference/signals/signal-provider.mdx
@@ -333,6 +333,8 @@ provider.stopPolling()
 
 Handle an incoming webhook request. Override to parse the payload and match it to subscriptions. Then emit notification signals. See [`WebhookSignalProvider`](/reference/signals/webhook-signal-provider) for a ready-to-use implementation.
 
+Call this method from an application-defined HTTP endpoint after verifying the webhook request.
+
 ```typescript prettier:false
 async handleWebhook(request) {
   const payload = request.body as { repo: string, event: string }

--- a/packages/core/src/signals/signal-provider.ts
+++ b/packages/core/src/signals/signal-provider.ts
@@ -419,7 +419,8 @@ export abstract class SignalProvider<TId extends string = string> {
    * Override to parse the payload, match it to subscriptions,
    * and emit notification signals.
    *
-   * The framework routes `POST /api/signals/:providerId` to this method.
+   * Call this method from an application-defined HTTP endpoint after
+   * performing provider-specific webhook verification.
    */
   handleWebhook?(request: SignalProviderWebhookRequest): Promise<{ status?: number; body?: unknown }>;
 


### PR DESCRIPTION
SignalProvider documentation previously claimed that Mastra automatically mounted `POST /api/signals/:providerId`, but that route does not exist. This updates the core JSDoc and API reference to explain the actual application-managed webhook flow.

Before: Mastra routes the provider webhook automatically.

After: Call `handleWebhook()` from an application-defined HTTP endpoint after verifying the webhook request.

Formatting and Remark checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra does not create the signal webhook URL for you. Your application must create the endpoint, verify the request, and then call `handleWebhook()`.

## Changes

- Updated `SignalProvider` JSDoc and API documentation.
- Removed the incorrect claim that Mastra automatically mounts `POST /api/signals/:providerId`.
- Added guidance for application-defined, verified webhook endpoints.
- Added a patch changeset.
- Formatting and Remark checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->