### PR TITLE
fix(mastracode): show the whole thread after leaving and re-entering its route

### DIFF
--- a/mastracode/factory-ui/src/hooks/useAgentControllerThreadMessages.ts
+++ b/mastracode/factory-ui/src/hooks/useAgentControllerThreadMessages.ts
@@ -73,10 +73,8 @@ export function useAgentControllerThreadMessages({
     queryFn: () => session!.listMessages(threadId!, limit),
     enabled: enabled && Boolean(session) && Boolean(threadId),
     refetchOnWindowFocus: false,
-    // A thread the agent is still writing to is stale the moment it is read, and
-    // the live stream only reaches a mounted transcript — leaving the route and
-    // coming back must re-read the window rather than serve whatever was cached
-    // when the thread was first opened.
+    // Live stream only reaches a mounted transcript — re-entering the route must
+    // re-read the window, not serve the snapshot from when it was first opened.
     staleTime: 0,
     refetchOnMount: 'always',
     // Growing the limit changes the query key, which would otherwise flip the

--- a/mastracode/factory-ui/src/hooks/useAgentControllerThreadMessages.ts
+++ b/mastracode/factory-ui/src/hooks/useAgentControllerThreadMessages.ts
@@ -73,6 +73,12 @@ export function useAgentControllerThreadMessages({
     queryFn: () => session!.listMessages(threadId!, limit),
     enabled: enabled && Boolean(session) && Boolean(threadId),
     refetchOnWindowFocus: false,
+    // A thread the agent is still writing to is stale the moment it is read, and
+    // the live stream only reaches a mounted transcript — leaving the route and
+    // coming back must re-read the window rather than serve whatever was cached
+    // when the thread was first opened.
+    staleTime: 0,
+    refetchOnMount: 'always',
     // Growing the limit changes the query key, which would otherwise flip the
     // query back to `pending` and blank the transcript to a skeleton on every
     // load-more. That blank also collapses the scroll container to the top,

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptSkillRows.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptSkillRows.msw.test.tsx
@@ -59,7 +59,7 @@ function notificationSignalDBMessage(id: string, text: string): MastraDBMessage 
 /** Feed a DB message through the reducer to get a coerced TimelineEntry. */
 function entryViaReducer(message: MastraDBMessage): TimelineEntry {
   const state = transcriptReducer(initialTranscript, {
-    type: 'prependOlder',
+    type: 'mergeWindow',
     messages: [message],
   });
   return state.entries[0]!;

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -138,10 +138,8 @@ export function ChatSessionBoundary({
 
   return (
     <ChatTranscriptProvider
-      // Identity is the session address alone. The transcript used to remount on
-      // the pending -> ready flip to re-seed its reducer from the first result;
-      // results now merge in, so remounting would only drop the live SSE
-      // listener and any streamed content that arrived before the fetch landed.
+      // No `isPending` segment: remounting on the pending -> ready flip would drop
+      // the live SSE listener. Results merge into the reducer instead.
       key={`${resourceId}:${threadId ?? 'draft'}`}
       threadId={threadId}
       initialMessages={messagesQuery.data}

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -138,7 +138,11 @@ export function ChatSessionBoundary({
 
   return (
     <ChatTranscriptProvider
-      key={`${resourceId}:${threadId ?? 'draft'}:${messagesQuery.isPending ? 'loading' : 'ready'}`}
+      // Identity is the session address alone. The transcript used to remount on
+      // the pending -> ready flip to re-seed its reducer from the first result;
+      // results now merge in, so remounting would only drop the live SSE
+      // listener and any streamed content that arrived before the fetch landed.
+      key={`${resourceId}:${threadId ?? 'draft'}`}
       threadId={threadId}
       initialMessages={messagesQuery.data}
       hasMoreHistory={messagesQuery.hasMore}

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
@@ -1,6 +1,6 @@
 import type { MastraDBMessage } from '@mastra/core/agent-controller';
 import type { ReactNode } from 'react';
-import { useEffect, useReducer, useRef } from 'react';
+import { useEffect, useReducer } from 'react';
 
 import { useAgentControllerTranscript } from '../hooks/useAgentControllerTranscript';
 import { initialChatRuntime, runtimeReducer } from '../services/runtime';
@@ -34,20 +34,14 @@ export function ChatTranscriptProvider({
     dispatchRuntime(event);
   };
 
-  // The history query seeds the transcript once at mount (via `initialMessages`).
-  // When the user loads more, the query grows its limit and refetches a larger
-  // newest-N window; feed each larger result to `prependOlder`, which keeps only
-  // the messages older than what is already on screen and prepends them. The
-  // first (mount) result is skipped because it already seeded the transcript.
-  const { prependOlder } = transcriptApi;
-  const seededRef = useRef(false);
+  // Every result of the history query — the mount seed, a grown window from
+  // load-more, a revalidation after the route was re-entered — is folded in by
+  // id. The merge is idempotent, so replaying the seed costs nothing and a
+  // window carrying messages the transcript missed lands in the right place.
+  const { mergeWindow } = transcriptApi;
   useEffect(() => {
-    if (!seededRef.current) {
-      seededRef.current = true;
-      return;
-    }
     if (initialMessages && initialMessages.length > 0) {
-      prependOlder(initialMessages);
+      mergeWindow(initialMessages);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialMessages]);

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
@@ -1,6 +1,6 @@
 import type { MastraDBMessage } from '@mastra/core/agent-controller';
 import type { ReactNode } from 'react';
-import { useEffect, useReducer } from 'react';
+import { useEffect, useEffectEvent, useReducer } from 'react';
 
 import { useAgentControllerTranscript } from '../hooks/useAgentControllerTranscript';
 import { initialChatRuntime, runtimeReducer } from '../services/runtime';
@@ -34,16 +34,13 @@ export function ChatTranscriptProvider({
     dispatchRuntime(event);
   };
 
-  // Every result of the history query — the mount seed, a grown window from
-  // load-more, a revalidation after the route was re-entered — is folded in by
-  // id. The merge is idempotent, so replaying the seed costs nothing and a
-  // window carrying messages the transcript missed lands in the right place.
-  const { mergeWindow } = transcriptApi;
+  // Merge is by id and idempotent — mount seed, grown load-more window and
+  // post-navigation revalidation all fold in through the same path.
+  const mergeWindow = useEffectEvent((messages: MastraDBMessage[]) => transcriptApi.mergeWindow(messages));
   useEffect(() => {
     if (initialMessages && initialMessages.length > 0) {
       mergeWindow(initialMessages);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialMessages]);
 
   const loadMore: LoadMoreHistory = {

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerTranscript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerTranscript.ts
@@ -58,8 +58,8 @@ export function useAgentControllerTranscript({
     dispatch({ type: 'localNotice', text, level });
   };
 
-  const prependOlder = (messages: MastraDBMessage[]) => {
-    dispatch({ type: 'prependOlder', messages });
+  const mergeWindow = (messages: MastraDBMessage[]) => {
+    dispatch({ type: 'mergeWindow', messages });
   };
 
   return {
@@ -71,6 +71,6 @@ export function useAgentControllerTranscript({
     resolvePrompt,
     clearPending,
     pushNotice,
-    prependOlder,
+    mergeWindow,
   };
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -497,9 +497,6 @@ describe('transcript reducer mergeWindow', () => {
   });
 
   it('appends messages the run produced while the transcript was unmounted', () => {
-    // Leaving the thread route drops the live stream, so a transcript rebuilt
-    // from the cached window only holds the kickoff. Revalidating returns
-    // everything the agent wrote meanwhile — all of it newer than the anchor.
     const onScreen = createInitialTranscript({
       messages: [dbMessage('kickoff', 'user', [{ type: 'text', text: 'review this PR' }])],
     });

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -413,7 +413,7 @@ describe('transcript reducer message entries', () => {
   });
 });
 
-describe('transcript reducer prependOlder', () => {
+describe('transcript reducer mergeWindow', () => {
   it('prepends only messages older than the oldest entry already on screen', () => {
     // On screen: newest window (msg-3, msg-4). Grown fetch returns an older
     // window that overlaps at msg-3 (the anchor).
@@ -431,7 +431,7 @@ describe('transcript reducer prependOlder', () => {
       dbMessage('msg-4', 'assistant', [{ type: 'text', text: 'fourth' }]),
     ];
 
-    const next = transcriptReducer(onScreen, { type: 'prependOlder', messages: grown });
+    const next = transcriptReducer(onScreen, { type: 'mergeWindow', messages: grown });
 
     expect(next.entries.map(e => (e.kind === 'message' ? e.id : e.kind))).toEqual(['msg-1', 'msg-2', 'msg-3', 'msg-4']);
   });
@@ -446,7 +446,7 @@ describe('transcript reducer prependOlder', () => {
       dbMessage('msg-2', 'assistant', [{ type: 'text', text: 'second' }]),
     ];
 
-    const next = transcriptReducer(onScreen, { type: 'prependOlder', messages: grown });
+    const next = transcriptReducer(onScreen, { type: 'mergeWindow', messages: grown });
     const ids = next.entries.filter(e => e.kind === 'message').map(e => (e.kind === 'message' ? e.id : ''));
 
     expect(ids).toEqual(['msg-1', 'msg-2']);
@@ -471,7 +471,7 @@ describe('transcript reducer prependOlder', () => {
       dbMessage('history-2', 'assistant', [{ type: 'text', text: 'older reply' }]),
     ];
 
-    const next = transcriptReducer(state, { type: 'prependOlder', messages: grown });
+    const next = transcriptReducer(state, { type: 'mergeWindow', messages: grown });
     const ids = next.entries.filter(e => e.kind === 'message').map(e => (e.kind === 'message' ? e.id : ''));
 
     // Older history joins the front; the live message stays at the tail.
@@ -482,8 +482,75 @@ describe('transcript reducer prependOlder', () => {
     const onScreen = createInitialTranscript({
       messages: [dbMessage('msg-1', 'user', [{ type: 'text', text: 'only' }])],
     });
-    const next = transcriptReducer(onScreen, { type: 'prependOlder', messages: [] });
+    const next = transcriptReducer(onScreen, { type: 'mergeWindow', messages: [] });
     expect(next).toBe(onScreen);
+  });
+
+  it('is a no-op when the window is already fully on screen', () => {
+    const messages = [
+      dbMessage('msg-1', 'user', [{ type: 'text', text: 'first' }]),
+      dbMessage('msg-2', 'assistant', [{ type: 'text', text: 'second' }]),
+    ];
+    const onScreen = createInitialTranscript({ messages });
+    const next = transcriptReducer(onScreen, { type: 'mergeWindow', messages });
+    expect(next).toBe(onScreen);
+  });
+
+  it('appends messages the run produced while the transcript was unmounted', () => {
+    // Leaving the thread route drops the live stream, so a transcript rebuilt
+    // from the cached window only holds the kickoff. Revalidating returns
+    // everything the agent wrote meanwhile — all of it newer than the anchor.
+    const onScreen = createInitialTranscript({
+      messages: [dbMessage('kickoff', 'user', [{ type: 'text', text: 'review this PR' }])],
+    });
+
+    const refreshed = [
+      dbMessage('kickoff', 'user', [{ type: 'text', text: 'review this PR' }]),
+      dbMessage('reply-1', 'assistant', [{ type: 'text', text: 'reading the diff' }]),
+      dbMessage('reply-2', 'assistant', [{ type: 'text', text: 'here is the review' }]),
+    ];
+
+    const next = transcriptReducer(onScreen, { type: 'mergeWindow', messages: refreshed });
+
+    expect(next.entries.map(e => (e.kind === 'message' ? e.id : e.kind))).toEqual(['kickoff', 'reply-1', 'reply-2']);
+  });
+
+  it('fills a gap between two on-screen messages', () => {
+    const onScreen = createInitialTranscript({
+      messages: [
+        dbMessage('msg-1', 'user', [{ type: 'text', text: 'first' }]),
+        dbMessage('msg-3', 'assistant', [{ type: 'text', text: 'third' }]),
+      ],
+    });
+
+    const refreshed = [
+      dbMessage('msg-1', 'user', [{ type: 'text', text: 'first' }]),
+      dbMessage('msg-2', 'assistant', [{ type: 'text', text: 'second' }]),
+      dbMessage('msg-3', 'assistant', [{ type: 'text', text: 'third' }]),
+    ];
+
+    const next = transcriptReducer(onScreen, { type: 'mergeWindow', messages: refreshed });
+
+    expect(next.entries.map(e => (e.kind === 'message' ? e.id : e.kind))).toEqual(['msg-1', 'msg-2', 'msg-3']);
+  });
+
+  it('keeps the streaming entry for a message the window also carries', () => {
+    let state = createInitialTranscript({ messages: [] });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('assistant-1', 'assistant', [{ type: 'text', text: 'partial' }]),
+      },
+    });
+
+    const next = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [dbMessage('assistant-1', 'assistant', [{ type: 'text', text: 'persisted prefix' }])],
+    });
+
+    expect(next.entries[0]).toMatchObject({ kind: 'message', id: 'assistant-1', streaming: true });
+    expect(messageParts(next.entries[0])).toEqual([{ type: 'text', text: 'partial' }]);
   });
 });
 

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -607,18 +607,10 @@ function persistedSuspensionPrompts(message: MastraDBMessage): SuspensionPrompt[
 
 /**
  * Reconcile the persisted newest-N window (oldest-first) with the timeline.
- *
- * Messages already on screen are anchors: they keep their position, their live
- * tool state, and their streaming flag, so a window landing mid-run never
- * clobbers what is being rendered. Messages the window has and the timeline does
- * not are inserted at the position the window gives them — before the next
- * anchor, or at the tail when they are newer than every anchor.
- *
- * Both directions matter. Growing the window (scroll-to-top) delivers older
- * history that belongs at the front; refetching the same window after the
- * transcript was rebuilt from a stale cache delivers everything the run produced
- * meanwhile, which belongs at the back. Only prepending would silently drop the
- * latter.
+ * On-screen messages are anchors — they keep their position, live tool state and
+ * streaming flag; the rest are inserted where the window puts them. Insertion
+ * runs both ways: load-more delivers older history, revalidation after a route
+ * revisit delivers everything the run produced meanwhile.
  */
 function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]): TranscriptState {
   if (messages.length === 0) return state;

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -203,7 +203,7 @@ type Action =
   | { type: 'clearPending' }
   | { type: 'localNotice'; text: string; level: 'info' | 'error' }
   | { type: 'resolvePrompt'; id: string }
-  | { type: 'prependOlder'; messages: MastraDBMessage[] }
+  | { type: 'mergeWindow'; messages: MastraDBMessage[] }
   | {
       type: 'reset';
       threadId?: string;
@@ -257,8 +257,8 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
           ),
         ],
       };
-    case 'prependOlder':
-      return prependOlderMessages(state, action.messages);
+    case 'mergeWindow':
+      return mergeServerWindow(state, action.messages);
     case 'clearPending':
       return { ...state, pending: false };
     case 'localNotice':
@@ -606,28 +606,48 @@ function persistedSuspensionPrompts(message: MastraDBMessage): SuspensionPrompt[
 }
 
 /**
- * Prepend older history messages to the front of the timeline. `messages` is the
- * newest-N window from a grown history fetch (oldest-first). We keep only the
- * portion strictly older than the oldest message already on screen — anchored on
- * the first existing message entry's id — and prepend those. The overlapping tail
- * of the fetch (messages we already have, including any that streamed in live and
- * later persisted) is discarded, so nothing double-renders. If no anchor is found
- * (e.g. the transcript has no message entries yet) the full window is seeded.
+ * Reconcile the persisted newest-N window (oldest-first) with the timeline.
+ *
+ * Messages already on screen are anchors: they keep their position, their live
+ * tool state, and their streaming flag, so a window landing mid-run never
+ * clobbers what is being rendered. Messages the window has and the timeline does
+ * not are inserted at the position the window gives them — before the next
+ * anchor, or at the tail when they are newer than every anchor.
+ *
+ * Both directions matter. Growing the window (scroll-to-top) delivers older
+ * history that belongs at the front; refetching the same window after the
+ * transcript was rebuilt from a stale cache delivers everything the run produced
+ * meanwhile, which belongs at the back. Only prepending would silently drop the
+ * latter.
  */
-function prependOlderMessages(state: TranscriptState, messages: MastraDBMessage[]): TranscriptState {
+function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]): TranscriptState {
   if (messages.length === 0) return state;
 
-  const firstMessageEntry = state.entries.find(e => e.kind === 'message');
-  const anchorId = firstMessageEntry?.kind === 'message' ? firstMessageEntry.id : undefined;
+  const onScreen = new Set(state.entries.flatMap(entry => (entry.kind === 'message' ? [entry.id] : [])));
+  if (messages.every(message => onScreen.has(message.id))) return state;
 
-  const anchorIndex = anchorId != null ? messages.findIndex(m => m.id === anchorId) : -1;
-  // Older messages are everything before the anchor; if the anchor isn't in this
-  // window (transcript had no message entries, or the window didn't reach it),
-  // treat the whole window as older history to seed.
-  const olderMessages = anchorIndex === -1 ? messages : messages.slice(0, anchorIndex);
-  if (olderMessages.length === 0) return state;
+  const entries: TimelineEntry[] = [];
+  let cursor = 0;
+  let missing: MastraDBMessage[] = [];
 
-  return { ...state, entries: [...messagesToEntries(olderMessages), ...state.entries] };
+  for (const message of messages) {
+    if (!onScreen.has(message.id)) {
+      missing.push(message);
+      continue;
+    }
+    const anchorIndex = state.entries.findIndex(
+      (entry, index) => index >= cursor && entry.kind === 'message' && entry.id === message.id,
+    );
+    // Out-of-order anchor (the window disagrees with the timeline): leave it
+    // where the timeline put it rather than moving rendered content around.
+    if (anchorIndex === -1) continue;
+    entries.push(...state.entries.slice(cursor, anchorIndex), ...messagesToEntries(missing));
+    missing = [];
+    cursor = anchorIndex;
+  }
+  entries.push(...state.entries.slice(cursor), ...messagesToEntries(missing));
+
+  return { ...state, entries };
 }
 
 /**

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageRevisit.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageRevisit.msw.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Regression coverage for re-entering a thread route.
+ *
+ * The transcript is React state under the thread route, and the live stream is
+ * subscribed from the same subtree — leaving for the board tears both down, so
+ * everything the run produced meanwhile exists only on the server. Coming back
+ * must revalidate the message window and show the full conversation, not the
+ * snapshot that was cached when the thread was first opened.
+ */
+import type { MastraDBMessage } from '@mastra/core/agent-controller';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../e2e/ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../e2e/ui/render';
+import { createAppRoutes } from '../../router';
+
+const FACTORY_ID = 'fp-1';
+const REPO_ID = 'ghp-1';
+const SESSION_ID = 'sess-1';
+const AC = `${TEST_BASE_URL}/api/agent-controller/code`;
+
+const userSession = {
+  id: 'row-1',
+  sessionId: SESSION_ID,
+  projectRepositoryId: REPO_ID,
+  orgId: 'org-1',
+  userId: 'user-1',
+  branch: 'factory/pr-1',
+  baseBranch: 'main',
+  sandboxId: null,
+  sandboxWorkdir: null,
+  materializedAt: null,
+  createdAt: '2026-07-23T00:00:00.000Z',
+  updatedAt: '2026-07-23T00:00:00.000Z',
+};
+
+function dbMessage(id: string, role: MastraDBMessage['role'], text: string): MastraDBMessage {
+  return {
+    id,
+    role,
+    createdAt: new Date('2026-07-23T00:00:00.000Z'),
+    content: { format: 2, parts: [{ type: 'text', text }] },
+  };
+}
+
+/** Thread transcript as the server holds it; the test grows it mid-run. */
+function stubThreadRoute(initialMessages: MastraDBMessage[]) {
+  let messages = initialMessages;
+
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'conn-1',
+            installationId: 'inst-1',
+            repositories: [
+              {
+                id: REPO_ID,
+                branch: 'main',
+                sandboxWorkdir: '/repo',
+                repository: { slug: 'acme/app', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+      HttpResponse.json({ workItems: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+      HttpResponse.json({ sessions: [userSession] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/subscriptions`, () => HttpResponse.json({ subscriptions: [] })),
+    http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () => HttpResponse.json({ ok: true })),
+    http.get(`${TEST_BASE_URL}/web/user-sessions/${SESSION_ID}`, () => HttpResponse.json({ session: userSession })),
+    http.post(`${AC}/sessions`, () =>
+      HttpResponse.json({ controllerId: 'code', resourceId: SESSION_ID, threadId: SESSION_ID }),
+    ),
+    http.get(`${AC}/sessions/:resourceId`, () =>
+      HttpResponse.json({
+        controllerId: 'code',
+        resourceId: SESSION_ID,
+        modeId: 'build',
+        modelId: 'openai/gpt-4o-mini',
+        threadId: SESSION_ID,
+        settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+      }),
+    ),
+    http.post(`${AC}/sessions/:resourceId/thread`, () => HttpResponse.json({ ok: true })),
+    http.put(`${AC}/sessions/:resourceId/state`, () => HttpResponse.json({ ok: true })),
+    http.get(
+      `${AC}/sessions/:resourceId/stream`,
+      () =>
+        new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    ),
+    http.get(`${AC}/sessions/:resourceId/permissions`, () => HttpResponse.json({})),
+    http.get(`${AC}/sessions/:resourceId/threads`, () => HttpResponse.json({ threads: [{ id: SESSION_ID }] })),
+    http.get(`${AC}/sessions/:resourceId/threads/:threadId/messages`, ({ request }) => {
+      const limit = Number(new URL(request.url).searchParams.get('limit'));
+      return HttpResponse.json({ messages: messages.slice(Math.max(0, messages.length - limit)) });
+    }),
+    http.get(`${AC}/modes`, () => HttpResponse.json({ modes: [] })),
+    http.get(`${TEST_BASE_URL}/web/workspace/rendered/list`, () =>
+      HttpResponse.json({ workspacePath: `/ws/${SESSION_ID}`, root: '.artifacts', rootPath: '', entries: [] }),
+    ),
+  );
+
+  return { runProduces: (next: MastraDBMessage[]) => (messages = [...messages, ...next]) };
+}
+
+const THREAD_PATH = `/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${SESSION_ID}`;
+
+describe('ThreadPage revisit', () => {
+  it('shows messages the run produced while the route was elsewhere', async () => {
+    const { runProduces } = stubThreadRoute([dbMessage('kickoff', 'user', 'review this PR')]);
+    const router = createMemoryRouter(createAppRoutes(), { initialEntries: [THREAD_PATH] });
+    renderWithProviders(<RouterProvider router={router} />);
+
+    expect(await screen.findByText('review this PR')).toBeInTheDocument();
+
+    await router.navigate(`/factories/${FACTORY_ID}/work`);
+    await waitFor(() => expect(screen.queryByText('review this PR')).not.toBeInTheDocument());
+
+    // The agent keeps working with nobody subscribed to the stream.
+    runProduces([
+      dbMessage('reply-1', 'assistant', 'reading the diff'),
+      dbMessage('reply-2', 'assistant', 'here is the review'),
+    ]);
+
+    await router.navigate(THREAD_PATH);
+
+    expect(await screen.findByText('here is the review')).toBeInTheDocument();
+    expect(screen.getByText('reading the diff')).toBeInTheDocument();
+    expect(screen.getByText('review this PR')).toBeInTheDocument();
+  });
+});

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageRevisit.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageRevisit.msw.test.tsx
@@ -5,7 +5,7 @@ import { createMemoryRouter, RouterProvider } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../../e2e/ui/msw-server';
-import { renderWithProviders, TEST_BASE_URL } from '../../../../e2e/ui/render';
+import { renderWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../../e2e/ui/render';
 import { createAppRoutes } from '../../router';
 
 const FACTORY_ID = 'fp-1';
@@ -118,9 +118,10 @@ describe('ThreadPage revisit', () => {
   it('shows messages the run produced while the route was elsewhere', async () => {
     const { runProduces } = stubThreadRoute([dbMessage('kickoff', 'user', 'review this PR')]);
     const router = createMemoryRouter(createAppRoutes(), { initialEntries: [THREAD_PATH] });
-    renderWithProviders(<RouterProvider router={router} />);
+    const { client } = renderWithProviders(<RouterProvider router={router} />);
 
     expect(await screen.findByText('review this PR')).toBeInTheDocument();
+    await waitForMutationsIdle(client);
 
     await router.navigate(`/factories/${FACTORY_ID}/work`);
     await waitFor(() => expect(screen.queryByText('review this PR')).not.toBeInTheDocument());
@@ -132,6 +133,7 @@ describe('ThreadPage revisit', () => {
     ]);
 
     await router.navigate(THREAD_PATH);
+    await waitForMutationsIdle(client);
 
     expect(await screen.findByText('here is the review')).toBeInTheDocument();
     expect(screen.getByText('reading the diff')).toBeInTheDocument();

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageRevisit.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageRevisit.msw.test.tsx
@@ -1,12 +1,3 @@
-/**
- * Regression coverage for re-entering a thread route.
- *
- * The transcript is React state under the thread route, and the live stream is
- * subscribed from the same subtree — leaving for the board tears both down, so
- * everything the run produced meanwhile exists only on the server. Coming back
- * must revalidate the message window and show the full conversation, not the
- * snapshot that was cached when the thread was first opened.
- */
 import type { MastraDBMessage } from '@mastra/core/agent-controller';
 import { screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';


### PR DESCRIPTION
Open a Factory review thread, go to the work board, come back: the transcript shows only the kickoff message. Everything the agent wrote in between is missing, and it stays missing until a new message arrives on the stream.

The transcript is a `useReducer` under the thread route, and the SSE subscription lives in the same subtree, so leaving for the board tears both down. The conversation only ever existed in that reducer — nothing writes streamed messages back into the query cache and nothing invalidates it when a run produces messages, so the cached window is still the snapshot taken when the thread was first opened (for a review started from the board, that is the kickoff and nothing else).

Coming back seeds the reducer from that snapshot. A revalidation does return the real transcript, but the only consumer of a later query result was `prependOlder`, which keeps `messages.slice(0, anchorIndex)` where the anchor is the oldest message on screen. For a window that starts at the thread's first message the anchor sits at index 0, the slice is empty, and the refetch is discarded. `prependOlder` was written for scroll-to-top, where the delta is at the front; here it is at the back. When the cached snapshot happened to be empty the anchor was missing entirely and the whole window got seeded, which is why the bug looked intermittent.

I replaced it with `mergeWindow`. Messages already on screen stay anchors: they keep their position, their live tool state, and their streaming flag, so a window landing mid-run never clobbers what is being rendered. Messages only the window carries are inserted where the window puts them — before the next anchor, or at the tail when they are newer than every anchor. It is a superset of the old behaviour and the four existing reducer tests pass unchanged.

The message query also drops to `staleTime: 0` with `refetchOnMount: 'always'`. It inherited the client-wide 30s default, so returning to a thread within that window did not even attempt a read. A thread the agent is still writing to is stale the moment it is read, and the live stream only reaches a mounted transcript.

Last, the transcript provider no longer remounts on the `pending -> ready` flip. That segment of the key existed only to force a fresh `useReducer` seed from the first result; now that results merge in, the remount buys nothing and costs the live listener plus anything streamed before the fetch landed.

I also renamed the reducer action `prependOlder` -> `mergeWindow` since the old name no longer describes it, which touches one line of `TranscriptSkillRows.msw.test.tsx`.

Tested: `ThreadPageRevisit.msw.test.tsx` drives the real router, `@mastra/client-js` and React Query through MSW — renders the thread, navigates to `/work`, grows the server-side transcript, navigates back, asserts all three messages render. I confirmed it fails on `main` (`Unable to find an element with the text: here is the review`) and passes here. Full package suite: 96 files, 520 tests, plus typecheck and oxfmt.

Not covered here: nothing yet keeps the cache current *while* a thread is mounted, so this fix pays a refetch on every mount — a follow-up writes streamed messages back into the cache. Also untouched: the sidebar session rows have no loading affordance, and their running dot comes from a poll that is disabled off workspace routes. Neither is a regression from this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you leave a Factory thread and return, the app now reloads and shows all messages, including new messages added while you were away.

## Changes

- Replaced `prependOlder` with `mergeWindow`.
- Merged fetched message windows without losing existing or streaming messages.
- Configured message queries to always refetch on mount.
- Prevented transcript remounts when message loading changes state.
- Updated related test action references.
- Added a regression test for revisiting a thread after new messages arrive.
- Updated route tests to wait for `waitForMutationsIdle`.

## Validation

- Full package suite: 96 files and 520 tests.
- Typecheck passed.
- Formatting checks passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->