### PR TITLE
fix(playground-ui): only pin the traces list to the full endpoint after a real signal

### DIFF
--- a/.changeset/trace-list-light-transient-500.md
+++ b/.changeset/trace-list-light-transient-500.md
@@ -1,0 +1,17 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed the Observability traces list permanently falling back to the heavier trace endpoint after a single server error.
+
+The list asks the server for lightweight trace rows and falls back to the full ones when a server is too old to serve them. A `500` was treated as that signal, so one transient fault — a database hiccup, a request timeout — pinned the tab to the heavier endpoint for the rest of the session, silently undoing the bandwidth savings until a reload. A `500` now falls back for that request only; the session switches for good after a second consecutive one. A `404` still switches immediately, since a server without the route will never grow one mid-session.
+
+Also removed two dead fallbacks from the traces list: the entity column no longer reads `attributes.agentId`/`attributes.workflowId`, and the status column no longer reads `attributes.status`. Trace rows carry `entityName`/`entityId` and a computed `status` directly, and lightweight rows never carry `attributes` at all. The `attributes` field and the exported `TraceAttributes` type are gone from `TracesListViewTrace`:
+
+```tsx
+// Before — attributes were accepted and read as a fallback
+<TracesListView traces={[{ traceId, name, createdAt, attributes: { status: 'completed' } }]} />
+
+// After — rows carry status and entity naming directly
+<TracesListView traces={[{ traceId, name, createdAt, status: 'success', entityName: 'weatherAgent' }]} />
+```

--- a/.changeset/trace-list-light-transient-500.md
+++ b/.changeset/trace-list-light-transient-500.md
@@ -2,16 +2,6 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed the Observability traces list permanently falling back to the heavier trace endpoint after a single server error.
+Fixed the Observability traces list permanently falling back to the heavier trace endpoint after a passing server error.
 
 The list asks the server for lightweight trace rows and falls back to the full ones when a server is too old to serve them. A `500` was treated as that signal, so one transient fault — a database hiccup, a request timeout — pinned the tab to the heavier endpoint for the rest of the session, silently undoing the bandwidth savings until a reload. A `500` now falls back for that request only; the session switches for good once the errors have lasted more than ten seconds, which no longer looks like a hiccup. A `404` still switches immediately, since a server without the route will never grow one mid-session.
-
-Also removed two dead fallbacks from the traces list: the entity column no longer reads `attributes.agentId`/`attributes.workflowId`, and the status column no longer reads `attributes.status`. Trace rows carry `entityName`/`entityId` and a computed `status` directly, and lightweight rows never carry `attributes` at all. The `attributes` field and the exported `TraceAttributes` type are gone from `TracesListViewTrace`:
-
-```tsx
-// Before — attributes were accepted and read as a fallback
-<TracesListView traces={[{ traceId, name, createdAt, attributes: { status: 'completed' } }]} />
-
-// After — rows carry status and entity naming directly
-<TracesListView traces={[{ traceId, name, createdAt, status: 'success', entityName: 'weatherAgent' }]} />
-```

--- a/.changeset/trace-list-light-transient-500.md
+++ b/.changeset/trace-list-light-transient-500.md
@@ -4,7 +4,7 @@
 
 Fixed the Observability traces list permanently falling back to the heavier trace endpoint after a single server error.
 
-The list asks the server for lightweight trace rows and falls back to the full ones when a server is too old to serve them. A `500` was treated as that signal, so one transient fault — a database hiccup, a request timeout — pinned the tab to the heavier endpoint for the rest of the session, silently undoing the bandwidth savings until a reload. A `500` now falls back for that request only; the session switches for good after a second consecutive one. A `404` still switches immediately, since a server without the route will never grow one mid-session.
+The list asks the server for lightweight trace rows and falls back to the full ones when a server is too old to serve them. A `500` was treated as that signal, so one transient fault — a database hiccup, a request timeout — pinned the tab to the heavier endpoint for the rest of the session, silently undoing the bandwidth savings until a reload. A `500` now falls back for that request only; the session switches for good once the errors have lasted more than ten seconds, which no longer looks like a hiccup. A `404` still switches immediately, since a server without the route will never grow one mid-session.
 
 Also removed two dead fallbacks from the traces list: the entity column no longer reads `attributes.agentId`/`attributes.workflowId`, and the status column no longer reads `attributes.status`. Trace rows carry `entityName`/`entityId` and a computed `status` directly, and lightweight rows never carry `attributes` at all. The `attributes` field and the exported `TraceAttributes` type are gone from `TracesListViewTrace`:
 

--- a/.changeset/traces-list-view-drop-attributes.md
+++ b/.changeset/traces-list-view-drop-attributes.md
@@ -1,0 +1,19 @@
+---
+'@mastra/playground-ui': major
+---
+
+Removed the `attributes` field and the `TraceAttributes` type from `TracesListViewTrace`.
+
+The traces list used to fall back to `attributes.agentId`/`attributes.workflowId` for the entity column and to `attributes.status` for the status column. Rows now carry `entityName`/`entityId` and a computed `status` directly, and the lightweight rows the list fetches never carried `attributes` at all, so both fallbacks were dead code reading a field nothing produced.
+
+Rows that relied on those fallbacks must set `status` and the entity fields directly:
+
+```tsx
+// Before
+<TracesListView traces={[{ traceId, name, createdAt, attributes: { status: 'completed' } }]} />
+
+// After
+<TracesListView traces={[{ traceId, name, createdAt, status: 'success', entityName: 'weatherAgent' }]} />
+```
+
+`TraceAttributes` was reachable as `import type { TraceAttributes } from '@mastra/playground-ui/domains/traces/components/traces-list-view'` and no longer exists. There is no replacement — read `status`, `entityType`, `entityName` and `entityId` off the row instead.

--- a/.changeset/traces-list-view-drop-attributes.md
+++ b/.changeset/traces-list-view-drop-attributes.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/playground-ui': major
+'@mastra/playground-ui': minor
 ---
 
 Removed the `attributes` field and the `TraceAttributes` type from `TracesListViewTrace`.

--- a/packages/playground-ui/src/domains/traces/components/__tests__/traces-list-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/traces-list-view.test.tsx
@@ -115,20 +115,27 @@ describe('TracesListView — status column', () => {
     expect(statuses).toEqual(['ERR', 'OK', 'RUN']);
   });
 
-  it('prefers the computed status over attributes.status', () => {
+  it('renders a dash when a row carries no status', () => {
+    render(<TracesListView traces={[makeTrace({ traceId: 'trace-unknown' })]} onTraceClick={vi.fn()} />);
+
+    const statuses = screen.getAllByRole('button').map(row => row.lastElementChild?.textContent);
+    expect(statuses).toEqual(['-']);
+  });
+});
+
+describe('TracesListView — entity column', () => {
+  it('names the entity from entityName, falling back to entityId', () => {
     render(
       <TracesListView
         traces={[
-          makeTrace({
-            traceId: 'trace-workflow',
-            status: 'error',
-            attributes: { status: 'completed' },
-          }),
+          makeTrace({ traceId: 'trace-named', entityType: 'agent', entityName: 'weatherAgent' }),
+          makeTrace({ traceId: 'trace-unnamed', entityType: 'agent', entityId: 'agent-42' }),
         ]}
         onTraceClick={vi.fn()}
       />,
     );
 
-    expect(screen.getByText('ERR')).not.toBeNull();
+    expect(screen.getByText('weatherAgent')).not.toBeNull();
+    expect(screen.getByText('agent-42')).not.toBeNull();
   });
 });

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -12,15 +12,6 @@ import { formatCompact, formatCost } from '@/domains/metrics/components/metrics-
 import { DataList, DataListSkeleton, TracesDataList } from '@/ds/components/DataList';
 import { cn } from '@/lib/utils';
 
-/** Span attributes fields the list view reads directly. Extra unknown keys are allowed so callers
- *  can pass the full attributes record from @mastra/core/storage without mapping. */
-export type TraceAttributes = {
-  status?: string | null;
-  agentId?: string | null;
-  workflowId?: string | null;
-  [key: string]: unknown;
-};
-
 export type TracesListViewTrace = {
   traceId: string;
   /** Required for branch rows; absent on plain trace rows (which are root-rooted). */
@@ -32,7 +23,6 @@ export type TracesListViewTrace = {
   entityId?: string | null;
   entityName?: string | null;
   status?: string | null;
-  attributes?: TraceAttributes | null;
   /** Server-rendered preview of `input`. Present on lightweight rows, which omit `input` itself. */
   inputPreview?: string | null;
   input?: unknown;
@@ -175,8 +165,7 @@ export function TracesListView({
             const rowKey = `${trace.traceId}:${trace.spanId ?? ''}`;
             const isRecentlyAdded = recentlyAddedKeys?.has(rowKey) ?? false;
             const displayDate = trace.startedAt ?? trace.createdAt;
-            const entityName =
-              trace.entityName || trace.entityId || trace.attributes?.agentId || trace.attributes?.workflowId;
+            const entityName = trace.entityName || trace.entityId;
             const usage = usageByTraceId?.get(trace.traceId);
 
             return (
@@ -201,7 +190,7 @@ export function TracesListView({
                 {hasTraceColumn(columnPreferences, 'entity') && (
                   <TracesDataList.EntityCell entityType={trace.entityType} entityName={entityName} />
                 )}
-                <TracesDataList.StatusCell status={trace.status ?? trace.attributes?.status} />
+                <TracesDataList.StatusCell status={trace.status} />
                 {hasTraceColumn(columnPreferences, 'duration') && (
                   <DataList.NumberCell>{formatSpanDuration(trace.startedAt, trace.endedAt)}</DataList.NumberCell>
                 )}

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-traces-light-list.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-traces-light-list.test.tsx
@@ -24,8 +24,11 @@ const FULL_URL = `${BASE_URL}/api/observability/traces`;
 
 const server = setupServer();
 
+const queryClients: QueryClient[] = [];
+
 function makeWrapper() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  queryClients.push(queryClient);
   return ({ children }: { children: ReactNode }) => (
     <MastraReactProvider baseUrl={BASE_URL}>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -34,6 +37,13 @@ function makeWrapper() {
 }
 
 const renderTraces = () => renderHook(() => useTraces({}), { wrapper: makeWrapper() });
+
+/** Page-0 response with no `deltaCursor`, so the delta query never enables. A test that isn't
+ *  asserting polling must not leave a poller running into the next test, where it lands on that
+ *  test's handlers and inflates its request counts. */
+function pageOnly(response: { deltaCursor?: string }) {
+  return { ...response, deltaCursor: undefined };
+}
 
 /** Serves both page-mode and delta-mode requests for one endpoint, recording each query string. */
 function listHandler(url: string, pageResponse: unknown, deltaResponse: unknown, searches: string[]) {
@@ -48,6 +58,9 @@ function listHandler(url: string, pageResponse: unknown, deltaResponse: unknown,
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {
   cleanup();
+  // Unmounting stops the observers but leaves the cached queries armed. A leaked poller
+  // lands on the next test's handlers and inflates its request counts.
+  queryClients.splice(0).forEach(queryClient => queryClient.clear());
   server.resetHandlers();
 });
 afterAll(() => server.close());
@@ -84,7 +97,7 @@ describe('useTraces light-list fetching', () => {
     const fullSearches: string[] = [];
     server.use(
       http.get(LIGHT_URL, () => new HttpResponse(null, { status: 500 })),
-      listHandler(FULL_URL, fullTracesPage0, fullDeltaBatch, fullSearches),
+      listHandler(FULL_URL, pageOnly(fullTracesPage0), fullDeltaBatch, fullSearches),
     );
 
     const { result, unmount } = renderTraces();
@@ -186,6 +199,31 @@ describe('useTraces light-list fetching', () => {
     expect(result.current.error?.message).toContain('status: 403');
     expect(result.current.data).toBeUndefined();
     expect(fullRequests).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  // A 500 also comes from a DB hiccup or a request timeout, not only from an old core's
+  // store throwing. Serving that one request from the full endpoint is right; degrading
+  // the list for the rest of the session is not.
+  it('recovers to the light endpoint after a single 500', async () => {
+    let lightFailures = 0;
+    server.use(
+      http.get(LIGHT_URL, () => {
+        if (lightFailures === 0) {
+          lightFailures += 1;
+          return new HttpResponse(null, { status: 500 });
+        }
+        return HttpResponse.json(lightPage0);
+      }),
+      http.get(FULL_URL, () => HttpResponse.json(pageOnly(fullTracesPage0))),
+    );
+
+    const { result, unmount } = renderTraces();
+
+    // Light rows once the fault clears — a pinned client would be stuck on `trace-full`.
+    await waitFor(() => expect(result.current.data?.spans.map(s => s.traceId)).toEqual(['trace-alpha']));
+    expect(result.current.data?.spans[0]?.inputPreview).toBe('What is the weather in Paris?');
+    expect(result.current.isError).toBe(false);
     unmount();
   });
 

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-traces.test.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-traces.test.ts
@@ -418,22 +418,32 @@ describe('shouldResetAfterIdle', () => {
 });
 
 describe('shouldPinLightList', () => {
+  const START = 1_700_000_000_000;
+
   it('pins on 404, which means the server has no light route at all', () => {
-    expect(shouldPinLightList(404, 0)).toBe(true);
+    expect(shouldPinLightList(404, undefined, START)).toBe(true);
   });
 
-  it('does not pin on a first 500, which is as likely a transient fault as an old store', () => {
-    expect(shouldPinLightList(500, 0)).toBe(false);
+  it('does not pin on the 500 that opens a run, which is as likely a fault as an old store', () => {
+    expect(shouldPinLightList(500, undefined, START)).toBe(false);
   });
 
-  it('pins once a second consecutive 500 rules out a transient fault', () => {
-    expect(shouldPinLightList(500, 1)).toBe(true);
-    expect(shouldPinLightList(500, 5)).toBe(true);
+  // Three queries can fail in the same instant, and chase mode re-polls every 100ms
+  // through an outage, so a burst of 500s must not add up to a pin.
+  it('does not pin while the 500s are still within the blip window', () => {
+    expect(shouldPinLightList(500, START, START)).toBe(false);
+    expect(shouldPinLightList(500, START, START + 200)).toBe(false);
+    expect(shouldPinLightList(500, START, START + 9_999)).toBe(false);
+  });
+
+  it('pins once the 500s have outlasted the blip window', () => {
+    expect(shouldPinLightList(500, START, START + 10_000)).toBe(true);
+    expect(shouldPinLightList(500, START, START + 60_000)).toBe(true);
   });
 
   it('never pins on statuses the full endpoint would hit too', () => {
     for (const status of [401, 403, 429, 501, 502, 503, undefined]) {
-      expect(shouldPinLightList(status, 1)).toBe(false);
+      expect(shouldPinLightList(status, START, START + 60_000)).toBe(false);
     }
   });
 });

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-traces.test.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-traces.test.ts
@@ -6,6 +6,7 @@ import {
   mergeDeltaIntoPage0,
   refreshPage0Rows,
   selectUniqueTraces,
+  shouldPinLightList,
   shouldResetAfterIdle,
 } from '../use-traces';
 
@@ -413,5 +414,26 @@ describe('shouldResetAfterIdle', () => {
   it('returns true when past the threshold', () => {
     const now = 1_000_000_000;
     expect(shouldResetAfterIdle(now - threshold - 1, now, threshold)).toBe(true);
+  });
+});
+
+describe('shouldPinLightList', () => {
+  it('pins on 404, which means the server has no light route at all', () => {
+    expect(shouldPinLightList(404, 0)).toBe(true);
+  });
+
+  it('does not pin on a first 500, which is as likely a transient fault as an old store', () => {
+    expect(shouldPinLightList(500, 0)).toBe(false);
+  });
+
+  it('pins once a second consecutive 500 rules out a transient fault', () => {
+    expect(shouldPinLightList(500, 1)).toBe(true);
+    expect(shouldPinLightList(500, 5)).toBe(true);
+  });
+
+  it('never pins on statuses the full endpoint would hit too', () => {
+    for (const status of [401, 403, 429, 501, 502, 503, undefined]) {
+      expect(shouldPinLightList(status, 1)).toBe(false);
+    }
   });
 });

--- a/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
@@ -30,13 +30,16 @@ const deltaSupportByClient = new WeakMap<ReturnType<typeof useMastraClient>, Del
 type LightListSupport = 'unknown' | 'unsupported';
 const lightListSupportByClient = new WeakMap<ReturnType<typeof useMastraClient>, LightListSupport>();
 
-/** Consecutive 500s from the light endpoint, per client. Reset by any light success. */
-const lightListServerErrorsByClient = new WeakMap<ReturnType<typeof useMastraClient>, number>();
+/** When the current run of light-endpoint 500s started, per client. Cleared by any light success. */
+const lightListFirstServerErrorAtByClient = new WeakMap<ReturnType<typeof useMastraClient>, number>();
 
-/** A 500 is ambiguous — an old core's store throwing, or a transient server fault. Serve the
- *  request from the full endpoint either way, but only pin the session once a second consecutive
- *  one rules out a blip; a DB hiccup would otherwise degrade the list for the rest of the session. */
-const LIGHT_LIST_SERVER_ERRORS_BEFORE_PINNING = 2;
+/** A 500 is ambiguous — an old core's store throwing, or a transient fault (DB hiccup, timeout).
+ *  Serve the request from the full endpoint either way, but only pin the session once the 500s
+ *  have outlasted a blip; a hiccup would otherwise degrade the list until the tab is reloaded.
+ *  Elapsed time, not a request count: the page refetch, the delta poll and the status refresh can
+ *  fail in the same instant, and a fallback response still looks like a success to the delta query,
+ *  so chase mode keeps re-polling every `deltaChaseIntervalMs` throughout the outage. */
+const LIGHT_LIST_SERVER_ERROR_PIN_AFTER_MS = 10_000;
 
 /** Tunables for live-tail polling. All fields optional — defaults below.
  *  Platform consumers override individual fields to throttle traffic or
@@ -103,11 +106,17 @@ function lightListFallbackStatus(error: unknown): 404 | 500 | undefined {
 }
 
 /** Whether a failed light-list request should pin the session to the full endpoint.
- *  Exported for testing — pure function of the status and the prior failure count. */
-export function shouldPinLightList(status: number | undefined, priorConsecutiveServerErrors: number): boolean {
+ *  `firstServerErrorAt` is undefined when this 500 opens a new run of them, so a single
+ *  fault never pins. Exported for testing — pure function of the status and timestamps. */
+export function shouldPinLightList(
+  status: number | undefined,
+  firstServerErrorAt: number | undefined,
+  now: number,
+): boolean {
   if (status === 404) return true;
   if (status !== 500) return false;
-  return priorConsecutiveServerErrors + 1 >= LIGHT_LIST_SERVER_ERRORS_BEFORE_PINNING;
+  if (firstServerErrorAt === undefined) return false;
+  return now - firstServerErrorAt >= LIGHT_LIST_SERVER_ERROR_PIN_AFTER_MS;
 }
 
 type FetchTracesFnArgs = TracesFilters & {
@@ -147,15 +156,18 @@ const fetchTracesFn = async (args: FetchTracesFnArgs) => {
         return client.listTraces(params as ListTracesArgs);
       }
     }
-    lightListServerErrorsByClient.delete(client);
+    lightListFirstServerErrorAtByClient.delete(client);
     return response;
   } catch (error) {
     const status = lightListFallbackStatus(error);
     if (status === undefined) throw error;
 
-    const priorServerErrors = lightListServerErrorsByClient.get(client) ?? 0;
-    if (status === 500) lightListServerErrorsByClient.set(client, priorServerErrors + 1);
-    if (shouldPinLightList(status, priorServerErrors)) {
+    const now = Date.now();
+    const firstServerErrorAt = lightListFirstServerErrorAtByClient.get(client);
+    if (status === 500 && firstServerErrorAt === undefined) {
+      lightListFirstServerErrorAtByClient.set(client, now);
+    }
+    if (shouldPinLightList(status, firstServerErrorAt, now)) {
       lightListSupportByClient.set(client, 'unsupported');
     }
     return client.listTraces(params as ListTracesArgs);

--- a/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
@@ -22,15 +22,21 @@ type DeltaSupport = 'unknown' | 'unsupported';
 const deltaSupportByClient = new WeakMap<ReturnType<typeof useMastraClient>, DeltaSupport>();
 
 /**
- * Per-MastraClient light-list support cache. Sticks once the light endpoint
- * fails with one of the two legacy-server signals (404 from servers without
- * the route, 500 from servers whose store throws instead of serving the
- * projection), so every subsequent page fetch, delta poll and periodic refresh
- * uses the full list endpoint instead. Other failures (auth, rate limits,
+ * Per-MastraClient light-list support cache. Sticks once the light endpoint is
+ * shown not to be served, so every subsequent page fetch, delta poll and periodic
+ * refresh uses the full list endpoint instead. Other failures (auth, rate limits,
  * outages) propagate without pinning — they'd hit the full endpoint too.
  */
 type LightListSupport = 'unknown' | 'unsupported';
 const lightListSupportByClient = new WeakMap<ReturnType<typeof useMastraClient>, LightListSupport>();
+
+/** Consecutive 500s from the light endpoint, per client. Reset by any light success. */
+const lightListServerErrorsByClient = new WeakMap<ReturnType<typeof useMastraClient>, number>();
+
+/** A 500 is ambiguous — an old core's store throwing, or a transient server fault. Serve the
+ *  request from the full endpoint either way, but only pin the session once a second consecutive
+ *  one rules out a blip; a DB hiccup would otherwise degrade the list for the rest of the session. */
+const LIGHT_LIST_SERVER_ERRORS_BEFORE_PINNING = 2;
 
 /** Tunables for live-tail polling. All fields optional — defaults below.
  *  Platform consumers override individual fields to throttle traffic or
@@ -86,15 +92,22 @@ function isHttp501(error: unknown): boolean {
   return (error as { status?: number } | null)?.status === 501;
 }
 
-/** Only the two legacy-server signals mean the light endpoint isn't served: 404
- *  from servers without the route, 500 from cores whose store throws instead of
- *  serving the projection. Anything else (401, 403, 429, 5xx outages, the 501
- *  disabled-domain signal) is a condition the full endpoint would hit too, so it
- *  propagates instead of pinning the session to full rows — mirroring how the
- *  delta-support cache matches exactly 501. */
-function isLightListUnsupportedError(error: unknown): boolean {
+/** Only 404 and 500 can mean the light endpoint isn't served: 404 from servers without
+ *  the route, 500 from cores whose store throws instead of serving the projection.
+ *  Anything else (401, 403, 429, other 5xx, the 501 disabled-domain signal) is a
+ *  condition the full endpoint would hit too, so it propagates instead of falling
+ *  back — mirroring how the delta-support cache matches exactly 501. */
+function lightListFallbackStatus(error: unknown): 404 | 500 | undefined {
   const status = (error as { status?: number } | null)?.status;
-  return status === 404 || status === 500;
+  return status === 404 || status === 500 ? status : undefined;
+}
+
+/** Whether a failed light-list request should pin the session to the full endpoint.
+ *  Exported for testing — pure function of the status and the prior failure count. */
+export function shouldPinLightList(status: number | undefined, priorConsecutiveServerErrors: number): boolean {
+  if (status === 404) return true;
+  if (status !== 500) return false;
+  return priorConsecutiveServerErrors + 1 >= LIGHT_LIST_SERVER_ERRORS_BEFORE_PINNING;
 }
 
 type FetchTracesFnArgs = TracesFilters & {
@@ -134,10 +147,17 @@ const fetchTracesFn = async (args: FetchTracesFnArgs) => {
         return client.listTraces(params as ListTracesArgs);
       }
     }
+    lightListServerErrorsByClient.delete(client);
     return response;
   } catch (error) {
-    if (!isLightListUnsupportedError(error)) throw error;
-    lightListSupportByClient.set(client, 'unsupported');
+    const status = lightListFallbackStatus(error);
+    if (status === undefined) throw error;
+
+    const priorServerErrors = lightListServerErrorsByClient.get(client) ?? 0;
+    if (status === 500) lightListServerErrorsByClient.set(client, priorServerErrors + 1);
+    if (shouldPinLightList(status, priorServerErrors)) {
+      lightListSupportByClient.set(client, 'unsupported');
+    }
     return client.listTraces(params as ListTracesArgs);
   }
 };


### PR DESCRIPTION
Stacked on #20677 — base is `t3code/optimize-trace-list-polling`, so the diff here is only my commit. Merge that one first, then this one retargets to `main`.

#20677 makes the Observability traces list ask for lightweight rows and fall back to the full `listTraces` endpoint when a server cannot serve them. The fallback keys off two statuses, and both pin the client for the rest of the session: 404, meaning the server has no `/observability/traces/light` route, and 500, meaning an older core whose store throws instead of serving the projection.

404 is a safe signal — a server without the route will not grow one mid-session. 500 is not. A database hiccup, a request timeout or any transient server fault returns 500 too, and one of those silently undid the whole point of #20677 until the user reloaded the tab. I kept the fallback for the failing request, because the list has to keep rendering either way, but moved the pinning behind how long the 500s have lasted: the first one starts a clock, and the session only switches for good once they are still coming ten seconds later. Any light success clears the clock.

My first pass counted consecutive 500s instead and required two, which does not survive contact with the polling shape. Three queries hit the light endpoint — the infinite page query, the delta poll and the 60s status refresh — so a single instant of downtime produces up to three failures at once. Worse, `fetchTracesFn` catches the 500 and returns full rows, so the delta query sees a *success*; if that response carries `delta.hasMore` the chase interval keeps re-polling every 100ms for the whole outage. A count of two fills in about 200ms, which is not a blip filter at all. Elapsed time is the only measure that separates a hiccup from a store that always throws.

The decision lives in a pure `shouldPinLightList(status, firstServerErrorAt, now)`. That is partly for testing, and partly because the existing MSW tests turned out to be a bad place to assert this — see below.

While in there I removed two fallbacks that #20677 made unreachable. The entity column read `attributes.agentId` / `attributes.workflowId` when both `entityName` and `entityId` were empty, and the status column read `attributes.status` when `status` was missing. Lightweight rows never carry `attributes`, so in traces mode both were silently dead. In branches mode they were already dead: branch rows come from `traceSpanSchema`, which requires `status`, and I could not find any producer for `attributes.agentId` in `packages/core/src/observability` at all — it looks like a leftover from the schema that predates `entityId`/`entityName`. With both reads gone, `attributes` and the exported `TraceAttributes` type had no remaining use in `TracesListViewTrace`, so I dropped them. The one external consumer I could check, `ObserveTracesPage.tsx` in the platform repo, passes `traces={traces}` from a variable rather than an object literal, so the removed field does not trip an excess-property check there. I left the two `attributes?.agentId` reads in `packages/playground/src/pages/traces/` alone — those are on the detail panel, which still receives full spans, so they are dead-but-harmless and out of scope.

That removal is a public API change, not a bugfix, so it gets its own changeset rather than being buried in the 500 fix. `vite.config.ts` builds one library entry per file under `src/domains`, so `traces-list-view.tsx` is a published entry point and `TraceAttributes` was importable from `@mastra/playground-ui/domains/traces/components/traces-list-view`. Dropping it, and the optional `attributes` field on the props type, is technically breaking for anyone who set or read them, dead fallback or not. I wrote it as a major first; `check-major-bump` gates those behind an org member commenting `!allow-major`, which is not worth spending on a field nothing produces, so it ships as a minor with the migration note intact. Say so if you want the major instead.

## Two things I found and did not fix

`useTraces` fires the page-0 query four times on a single mount in the test harness, with identical `?page=0&perPage=25` query strings. That is pre-existing and was invisible before, because #20677 pins on the first 500, so fetches two through four went to the full endpoint. It is worth a look on its own.

Relatedly, `use-traces-light-list.test.tsx` leaks between tests: with real timers and a 100ms delta chase interval, pollers and in-flight page fetches from one test land on the next test's MSW handlers and inflate its request counts. The suite only passed before because pinning on the first 500 accidentally kept those leaked requests off the light endpoint. My change removed that accident and the pre-existing "keeps delta polling on the full endpoint after falling back" test started failing with three light calls instead of one. I fixed that one by stripping `deltaCursor` from the 500 test's page response so it never starts polling, which is why there is a small `pageOnly` helper in the diff. I did not try to make the whole file leak-proof — that is a bigger change than this PR should carry.

That leakage is also why the pinning threshold is verified through the pure function rather than through MSW. Count-based assertions in that file are not trustworthy.

## Testing

`shouldPinLightList` gets unit tests for 404, the 500 that opens a run, a burst still inside the window (0ms, 200ms, 9999ms), 500s that outlast it, and the statuses that must never pin (401, 403, 429, 501, 502, 503, undefined). One MSW test covers the end-to-end recovery: a single 500 falls back, and the next fetch returns light rows with `inputPreview` rather than staying on full rows. In `traces-list-view.test.tsx` I replaced the now-meaningless `attributes.status` precedence test with a no-status case, and added one covering entity naming from `entityName` with an `entityId` fallback.

Full `@mastra/playground-ui` suite passes (770 tests, 111 files), `tsc --noEmit` clean, eslint clean at `--max-warnings 0` on the touched files. I have not run the Playwright e2e suite.
