### PR TITLE
fix(memory): hide recall's search mode when semantic search is not configured

### DIFF
--- a/.changeset/recall-search-mode-gating.md
+++ b/.changeset/recall-search-mode-gating.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Hide the recall tool's `mode: "search"` when semantic search is not configured. Previously the tool always advertised search in its schema and description, but calling it without a vector store and embedder threw `searchMessages requires a vector store...` — the "Search is not configured" guidance in `searchMessagesForResource` was unreachable because the standard `Memory` class always has a `searchMessages` method. `listTools` now passes `hasRetrievalSearch()` into `recallTool`, which drops `"search"` from the mode enum, the `query` parameter, and the tool description when search can't work, so the model is never invited to call it. If a model passes `mode: "search"` anyway, input validation rejects it with a self-correcting message, and an execute-level guard returns the not-configured guidance as a final fallback.

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -2345,7 +2345,10 @@ Notes:
     if (omConfig?.retrieval) {
       const retrievalScope =
         typeof omConfig.retrieval === 'object' ? (omConfig.retrieval.scope ?? 'resource') : 'resource';
-      tools.recall = recallTool(mergedConfig, { retrievalScope });
+      tools.recall = recallTool(mergedConfig, {
+        retrievalScope,
+        searchEnabled: this.hasRetrievalSearch(omConfig.retrieval),
+      });
     }
 
     return tools;

--- a/packages/memory/src/tools/om-tools.test.ts
+++ b/packages/memory/src/tools/om-tools.test.ts
@@ -1,4 +1,5 @@
 import type { MastraDBMessage } from '@mastra/core/agent';
+import { standardSchemaToJSONSchema } from '@mastra/core/schema';
 import { InMemoryStore } from '@mastra/core/storage';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -894,6 +895,44 @@ describe('om-tools', () => {
       await expect(tool.execute?.({ cursor: 'msg-2' }, { agent: { threadId, resourceId } } as any)).rejects.toThrow(
         'Memory instance is required for recall',
       );
+    });
+
+    // ── search gating ───────────────────────────────────────────────
+
+    it('should advertise mode="search" by default', () => {
+      const tool = recallTool(undefined, { retrievalScope: 'resource' });
+      const schema = standardSchemaToJSONSchema(tool.inputSchema!) as any;
+
+      expect(schema.properties.mode.enum).toContain('search');
+      expect(schema.properties.query).toBeDefined();
+      expect(tool.description).toContain('mode="search"');
+    });
+
+    it('should hide mode="search" from the schema and description when search is not enabled', () => {
+      for (const retrievalScope of ['thread', 'resource'] as const) {
+        const tool = recallTool(undefined, { retrievalScope, searchEnabled: false });
+        const schema = standardSchemaToJSONSchema(tool.inputSchema!) as any;
+
+        expect(schema.properties.mode.enum).toEqual(['messages', 'threads']);
+        expect(schema.properties.query).toBeUndefined();
+        expect(tool.description).not.toContain('mode="search"');
+      }
+    });
+
+    it('should reject mode="search" with actionable feedback instead of throwing when search is not enabled', async () => {
+      const tool = recallTool(undefined, { retrievalScope: 'resource', searchEnabled: false });
+
+      // Input validation catches the out-of-enum mode before execution and
+      // returns a self-correcting message rather than throwing the
+      // "searchMessages requires a vector store" error.
+      const result = (await tool.execute?.({ mode: 'search', query: 'architecture diagram' }, {
+        memory,
+        agent: { threadId, resourceId },
+      } as any)) as { error?: boolean; message?: string };
+
+      expect(result.error).toBe(true);
+      expect(result.message).toContain('allowed values');
+      expect(result.message).not.toContain('requires a vector store');
     });
   });
 

--- a/packages/memory/src/tools/om-tools.ts
+++ b/packages/memory/src/tools/om-tools.ts
@@ -1146,14 +1146,18 @@ export async function recallThreadFromStart({
 
 export const recallTool = (
   _memoryConfig?: MemoryConfigInternal,
-  options?: { retrievalScope?: 'thread' | 'resource' },
+  options?: { retrievalScope?: 'thread' | 'resource'; searchEnabled?: boolean },
 ) => {
   const retrievalScope = options?.retrievalScope ?? 'thread';
   const isResourceScope = retrievalScope === 'resource';
+  // Semantic search requires a vector store and embedder. When they aren't
+  // configured, hide mode="search" from the schema and description so the
+  // model is never invited to call a mode that can't work.
+  const searchEnabled = options?.searchEnabled ?? true;
 
   const description = isResourceScope
-    ? 'Browse conversation history. Use mode="threads" to list all threads for the current user. Use mode="messages" (default) to browse messages in the current thread or pass threadId to browse another thread in the active resource. When mode="messages" has no cursor or threadId, it defaults to the current thread and says so at the top of the result. If you pass only a cursor, it must belong to the current thread. Use mode="search" to find messages by content across all threads.'
-    : 'Browse conversation history in the current thread. Use mode="messages" (default) to page through messages near a cursor. Use mode="search" to find messages by content in this thread. Use mode="threads" to get the current thread\'s ID and title.';
+    ? `Browse conversation history. Use mode="threads" to list all threads for the current user. Use mode="messages" (default) to browse messages in the current thread or pass threadId to browse another thread in the active resource. When mode="messages" has no cursor or threadId, it defaults to the current thread and says so at the top of the result. If you pass only a cursor, it must belong to the current thread.${searchEnabled ? ' Use mode="search" to find messages by content across all threads.' : ''}`
+    : `Browse conversation history in the current thread. Use mode="messages" (default) to page through messages near a cursor.${searchEnabled ? ' Use mode="search" to find messages by content in this thread.' : ''} Use mode="threads" to get the current thread's ID and title.`;
 
   return createTool({
     id: 'recall',
@@ -1166,9 +1170,8 @@ export const recallTool = (
           ? {
               mode: {
                 type: 'string',
-                enum: ['messages', 'threads', 'search'],
-                description:
-                  'What to retrieve. "messages" (default) pages through message history. "threads" lists all threads for the current user. "search" finds messages by semantic similarity across all threads.',
+                enum: searchEnabled ? ['messages', 'threads', 'search'] : ['messages', 'threads'],
+                description: `What to retrieve. "messages" (default) pages through message history. "threads" lists all threads for the current user.${searchEnabled ? ' "search" finds messages by semantic similarity across all threads.' : ''}`,
               },
               threadId: {
                 type: 'string',
@@ -1190,16 +1193,19 @@ export const recallTool = (
           : {
               mode: {
                 type: 'string',
-                enum: ['messages', 'threads', 'search'],
-                description:
-                  'What to retrieve. "messages" (default) pages through message history. "threads" returns info about the current thread. "search" finds messages by semantic similarity in this thread.',
+                enum: searchEnabled ? ['messages', 'threads', 'search'] : ['messages', 'threads'],
+                description: `What to retrieve. "messages" (default) pages through message history. "threads" returns info about the current thread.${searchEnabled ? ' "search" finds messages by semantic similarity in this thread.' : ''}`,
               },
             }),
-        query: {
-          type: 'string',
-          minLength: 1,
-          description: 'Search query for mode="search". Finds messages semantically similar to this text.',
-        },
+        ...(searchEnabled
+          ? {
+              query: {
+                type: 'string',
+                minLength: 1,
+                description: 'Search query for mode="search". Finds messages semantically similar to this text.',
+              },
+            }
+          : {}),
         cursor: {
           type: 'string',
           minLength: 1,
@@ -1295,6 +1301,13 @@ export const recallTool = (
 
       // Search mode
       if (mode === 'search') {
+        if (!searchEnabled) {
+          return {
+            results:
+              'Search is not configured. Enable it with `retrieval: { vector: true }` and configure a vector store and embedder on your Memory instance.',
+            count: 0,
+          };
+        }
         if (!query) {
           throw new Error('query is required for mode="search"');
         }


### PR DESCRIPTION
## Description

When observational memory retrieval is enabled without a vector store and embedder, the `recall` tool still advertises `mode: "search"` in its schema and description. Models naturally try it, and the call throws:

```
searchMessages requires a vector store. Configure vector and embedder on your Memory instance.
```

The graceful "Search is not configured" branch in `searchMessagesForResource` is unreachable in practice, because the standard `Memory` class always has a `searchMessages` method — it only throws once called.

This PR gates the search mode on actual availability:

- `Memory.listTools` now passes `hasRetrievalSearch()` (which already existed for the retrieval instructions) into `recallTool` as `searchEnabled`.
- When search is unavailable, `recallTool` drops `"search"` from the `mode` enum, removes the `query` parameter, and omits the search sentences from the tool description — the model is never invited to call a mode that can't work.
- If a model passes `mode: "search"` anyway, input validation rejects it with a self-correcting message listing the allowed values, and an execute-level guard returns the existing "Search is not configured" guidance as a final fallback instead of throwing.

`searchEnabled` defaults to `true`, so direct callers of `recallTool` keep the previous behavior.

## Related issue(s)

Fixes #20775

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The `recall` tool now shows search options only when semantic search is configured. Without search configuration, users can still browse memory, and search attempts return guidance instead of an error.

## Changes

- Pass `hasRetrievalSearch()` to `recallTool` as `searchEnabled`.
- Hide the `search` mode, `query` parameter, and search guidance when search is disabled.
- Reject forced `mode: "search"` requests with the allowed modes.
- Return `"Search is not configured"` guidance instead of throwing during execution.
- Keep `searchEnabled` enabled by default for direct `recallTool` callers.
- Add tests for schema generation, descriptions, validation, and execution behavior.
- Add a patch changeset for `@mastra/memory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->