### PR TITLE
fix(core): stabilize Gemini 3 e2e recordings against provider sentinel drift

### DIFF
--- a/packages/core/src/agent/agent-gemini.e2e.test.ts
+++ b/packages/core/src/agent/agent-gemini.e2e.test.ts
@@ -66,6 +66,13 @@ beforeEach(async c => {
       // Normalize client-generated tool call ids echoed back in Gemini
       // functionCall/functionResponse parts — the AI SDK generates a fresh
       // random id per run, so they can never match the recorded request.
+      // Also drop the provider-injected `skip_thought_signature_validator`
+      // sentinel: @ai-sdk/google decides when to inject it for Gemini 3
+      // parallel function calls without a real thoughtSignature, and that
+      // decision changed across provider versions (4.0.18 injected it on
+      // every unsigned call; 4.0.25 skips calls that follow a signed call
+      // in the same model response). Real signatures are replay-stable and
+      // remain part of the hash.
       const normalizeFunctionCallIds = (value: unknown): void => {
         if (Array.isArray(value)) {
           for (const item of value) normalizeFunctionCallIds(item);
@@ -73,6 +80,9 @@ beforeEach(async c => {
         }
         if (value && typeof value === 'object') {
           const obj = value as Record<string, unknown>;
+          if (obj.thoughtSignature === 'skip_thought_signature_validator') {
+            delete obj.thoughtSignature;
+          }
           for (const [key, child] of Object.entries(obj)) {
             if (
               (key === 'functionCall' || key === 'functionResponse') &&


### PR DESCRIPTION
## Summary

The `agent-gemini.e2e.test.ts` test "should handle multi-step tool calls with gemini 3 pro" is failing repo-wide in CI (seen on many unrelated branches) with an llm-recorder exact-hash mismatch (`5c537af3106b6eb7` vs recorded `ac61e8f95548754b`) followed by a 401 on the live fallback (CI has no Google API key).

**Root cause:** #20149 bumped `@ai-sdk/google-v7` from 4.0.18 to 4.0.25. The new provider version changed when it injects the documented `skip_thought_signature_validator` sentinel for Gemini 3 parallel function calls: it no longer injects it on unsigned function calls that follow a signed call in the same model response (they legitimately have no signature). The recorded request still carries the sentinel on the second parallel `functionCall`, so the request hash no longer matches.

**Fix:** strip the provider-injected sentinel from request bodies during the recorder's `transformRequest` normalization (alongside the existing functionCall id normalization). This makes recordings stable across provider versions in both directions — real thought signatures are replay-deterministic and remain part of the hash, so signature round-trip coverage is unchanged.

Test-only change; no changeset needed.

## Test plan

- [x] Reproduced the CI failure locally in replay mode (no API key) — identical hash mismatch, diff shows the sentinel on the second `functionCall` as the only drift
- [x] After fix: `vitest run src/agent/agent-gemini.e2e.test.ts` in replay mode — 23 passed, 1 skipped, no hash-mismatch warnings for the failing test
- [x] Verified `packages/core/__recordings__` is the only recording set containing the sentinel pattern (no other test files affected)

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Gemini can add a temporary marker that changes recorded request hashes. This change removes only that marker during test recording, so recordings stay stable while real thought signatures remain intact.

## Changes

- Updated `agent-gemini.e2e.test.ts` to recursively remove `thoughtSignature` values equal to `skip_thought_signature_validator`.
- Preserved real thought signatures.
- Kept function-call ID normalization unchanged.
- Limited the change to tests. No production behavior or public API changes.
- No changeset required.

## Validation

- Replay mode passed with 23 tests and 1 skipped.
- No hash-mismatch warnings occurred for the affected test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->