### PR TITLE
fix(factory-ui): stop provisioning a sandbox just because someone opened a factory page

### DIFF
--- a/mastracode/factory-ui/src/ui/__tests__/SandboxEnsureGating.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/SandboxEnsureGating.msw.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * The chat shell is the router layout for every factory route, so the sandbox
+ * `/ensure` call it owns used to fire on the board, metrics and settings pages —
+ * provisioning a VM and cloning the repo before the user did anything. Ensure
+ * must only run when the caller actually enters a session.
+ */
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../e2e/ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import { createAppRoutes } from '../router';
+
+const FACTORY_ID = 'fp-1';
+const REPO_ID = 'repo-1';
+const SESSION_ID = 'sess-1';
+const AC = `${TEST_BASE_URL}/api/agent-controller/code`;
+
+const userSession = {
+  id: 'row-1',
+  sessionId: SESSION_ID,
+  projectRepositoryId: REPO_ID,
+  orgId: 'org-1',
+  userId: 'user-1',
+  branch: 'factory/pr-1',
+  baseBranch: 'main',
+  sandboxId: 'sb-1',
+  sandboxWorkdir: '/repo',
+  materializedAt: null,
+  createdAt: '2026-07-30T00:00:00.000Z',
+  updatedAt: '2026-07-30T00:00:00.000Z',
+};
+
+/** Stubs every factory route's network surface and records `/ensure` calls. */
+function stubFactoryRoutes() {
+  const ensureCalls: string[] = [];
+
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'conn-1',
+            installationId: 'inst-1',
+            repositories: [
+              {
+                id: REPO_ID,
+                branch: 'main',
+                sandboxWorkdir: '/repo',
+                repository: { slug: 'acme/app', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+      HttpResponse.json({ workItems: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions`, () =>
+      HttpResponse.json({ decisions: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/intake/config`, () =>
+      HttpResponse.json({
+        config: { github: { enabled: true, sourceIds: ['acme/app'] }, linear: { enabled: false, sourceIds: null } },
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/linear/status`, () =>
+      HttpResponse.json({ enabled: false, connected: false, workspace: null }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/issues`, () =>
+      HttpResponse.json({ issues: [], nextPage: null }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+      HttpResponse.json({ sessions: [userSession] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/subscriptions`, () => HttpResponse.json({ subscriptions: [] })),
+    http.get(`${TEST_BASE_URL}/web/user-sessions/${SESSION_ID}`, () => HttpResponse.json({ session: userSession })),
+    http.post(`${TEST_BASE_URL}/web/github/projects/:projectRepositoryId/ensure`, ({ params }) => {
+      ensureCalls.push(String(params.projectRepositoryId));
+      return HttpResponse.json({
+        resourceId: FACTORY_ID,
+        factoryProjectId: FACTORY_ID,
+        projectRepositoryId: REPO_ID,
+        sandboxId: 'sb-1',
+        sandboxWorkdir: '/repo',
+      });
+    }),
+    http.post(`${AC}/sessions`, async ({ request }) => {
+      const { resourceId } = (await request.json()) as { resourceId: string };
+      return HttpResponse.json({ controllerId: 'code', resourceId, threadId: SESSION_ID });
+    }),
+    http.get(`${AC}/sessions/:resourceId`, ({ params }) =>
+      HttpResponse.json({
+        controllerId: 'code',
+        resourceId: params.resourceId,
+        modeId: 'build',
+        modelId: 'openai/gpt-4o-mini',
+        threadId: SESSION_ID,
+        settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+      }),
+    ),
+    http.get(`${AC}/sessions/:resourceId/permissions`, () =>
+      HttpResponse.json({
+        categories: { read: 'ask', edit: 'ask', execute: 'ask', mcp: 'ask', other: 'ask' },
+        tools: {},
+      }),
+    ),
+    http.get(`${AC}/sessions/:resourceId/threads`, () => HttpResponse.json({ threads: [] })),
+    http.get(`${AC}/sessions/:resourceId/threads/:threadId/messages`, () => HttpResponse.json({ messages: [] })),
+    http.post(`${AC}/sessions/:resourceId/thread`, () => HttpResponse.json({ ok: true })),
+    http.put(`${AC}/sessions/:resourceId/state`, () => HttpResponse.json({ ok: true })),
+    http.get(`${AC}/modes`, () => HttpResponse.json({ modes: [] })),
+    http.get(
+      `${AC}/sessions/:resourceId/stream`,
+      () =>
+        new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    ),
+  );
+
+  return ensureCalls;
+}
+
+function renderRoute(path: string) {
+  const router = createMemoryRouter(createAppRoutes(), { initialEntries: [path] });
+  return renderWithProviders(<RouterProvider router={router} />);
+}
+
+describe('sandbox ensure gating', () => {
+  it('does not materialize a sandbox for the work board', async () => {
+    const ensureCalls = stubFactoryRoutes();
+    renderRoute(`/factories/${FACTORY_ID}/work`);
+
+    await screen.findByTestId('board-column-planning');
+    await waitFor(() => expect(screen.getByTestId('board-column-planning')).toHaveAccessibleName('Planning, empty'));
+    expect(ensureCalls).toEqual([]);
+  });
+
+  it('keeps factory-level settings working without materializing a sandbox', async () => {
+    const ensureCalls = stubFactoryRoutes();
+    renderRoute(`/factories/${FACTORY_ID}/settings/behavior`);
+
+    // The behavior toggles only render enabled once the factory-level session
+    // settings load, which proves the resource address resolved without /ensure.
+    const yolo = await screen.findByRole('switch', { name: 'Auto-approve tools' });
+    await waitFor(() => expect(yolo).toBeEnabled());
+    expect(ensureCalls).toEqual([]);
+  });
+
+  it('materializes the sandbox when entering a workspace thread', async () => {
+    const ensureCalls = stubFactoryRoutes();
+    renderRoute(`/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${SESSION_ID}`);
+
+    await waitFor(() => expect(ensureCalls).toEqual([REPO_ID]));
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -48,17 +48,23 @@ export function ChatSessionConfigProvider({
         (repo: LinkedRepositoryPayload) => repo.projectRepositoryId === storedSession.projectRepositoryId,
       )
     : factory?.repositories[0];
-  const ensureQuery = useEnsureMaterializedSandbox(repository?.projectRepositoryId);
-  const resolvingSession = Boolean(userScoped ? threadId : sessionId) && sessionQuery.isPending;
+  // Materializing a sandbox provisions a VM and clones the repo, so it may only
+  // happen when the caller actually enters a session. Every factory route mounts
+  // this provider (the chat shell is the router layout), so an ungated /ensure
+  // here provisioned a sandbox just for visiting the board, metrics or settings.
+  const inSession = Boolean(userScoped ? threadId : sessionId);
+  const ensureQuery = useEnsureMaterializedSandbox(inSession ? repository?.projectRepositoryId : undefined);
+  const resolvingSession = inSession && sessionQuery.isPending;
   // Sessions and their threads are provisioned with the session's own id as the
   // memory resourceId and no scope (see FactoryStartCoordinator.prepare and
   // UserSessionsSection), so the chat surface must address the same
   // (resourceId, no scope) session to read threads and share the live run.
   // On user routes the :threadId param IS the sessionId. Factory routes with
   // no workspace session (e.g. /settings/*) fall back to the factory-level
-  // session address returned by the /ensure route so resource-scoped surfaces
-  // (behavior settings, tool permissions) stay functional.
-  const resourceId = userScoped ? threadId : (storedSession?.sessionId ?? sessionId ?? ensureQuery.data?.resourceId);
+  // session address — which is the factory project id, the same value /ensure
+  // returns — so resource-scoped surfaces (behavior settings, tool permissions)
+  // stay functional without provisioning a sandbox.
+  const resourceId = userScoped ? threadId : (storedSession?.sessionId ?? sessionId ?? factory?.id);
   const projectPath = undefined;
   // A `?resourceId=` query param overrides the resolved factory resource so the
   // whole chat session (transcript, messages, connection, thread switch) binds
@@ -79,10 +85,15 @@ export function ChatSessionConfigProvider({
       ? Boolean(resourceOverride)
       : ensureQuery.isSuccess && Boolean(storedSession) && !resolvingSession;
   const sessionError = userScoped ? undefined : (ensureQuery.error ?? undefined);
+  // Outside a session the factory resource is addressable straight away (its id
+  // is the factory project id); inside one we keep the original ordering and
+  // wait for the workspace so resource reads follow materialization.
+  const resourceEnabled =
+    userScoped || !inSession ? Boolean(resourceId) : Boolean(resourceOverride) || ensureQuery.isSuccess;
   const value = {
     resourceId: resourceOverride ?? resourceId ?? '',
     sessionEnabled,
-    resourceEnabled: userScoped ? Boolean(resourceId) : resourceOverride ? true : ensureQuery.isSuccess,
+    resourceEnabled,
     sessionError,
     retrySession: sessionError ? () => void ensureQuery.refetch() : undefined,
     projectPath,

--- a/mastracode/factory-ui/src/ui/domains/factory/components/QueueHealthPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/QueueHealthPanel.tsx
@@ -7,7 +7,6 @@ import { useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 
 import { useApiConfig } from '../../../../api/config';
-import { useEnsureMaterializedSandbox } from '../../../../hooks/useEnsureMaterializedSandbox';
 import { useFactoryQuery } from '../../../../hooks/useFactories';
 import { useQueueHealthThresholds } from '../../../../hooks/useQueueHealthThresholds';
 import { useWorkItemsQuery } from '../../../../hooks/useWorkItems';
@@ -102,17 +101,18 @@ function useActivePaths(): ReadonlySet<string> {
   const { factoryId } = useParams<{ factoryId: string }>();
   const factoryQuery = useFactoryQuery(factoryId);
   const repository = factoryQuery.data?.repositories[0];
-  const materializeQuery = useEnsureMaterializedSandbox(repository?.projectRepositoryId);
   const workspaces = useWorkspacesQuery(repository?.projectRepositoryId);
   const workspaceSessions = workspaces.data?.workspaces ?? [];
-  const resourceId = materializeQuery.data?.resourceId;
+  // The factory-level session address is the factory project id, so read
+  // activity without materializing a sandbox for a page that only renders counts.
+  const resourceId = factoryQuery.data?.id;
   const runningByPath = useWorkspaceActivity({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId: resourceId ?? '',
     scope: repository?.projectRepositoryId,
     worktreePaths: workspaceSessions.map(workspace => workspace.sessionId),
     baseUrl,
-    enabled: materializeQuery.isSuccess && Boolean(resourceId && repository?.projectRepositoryId),
+    enabled: Boolean(resourceId && repository?.projectRepositoryId),
   });
   return useMemo(() => new Set(Object.keys(runningByPath).filter(path => runningByPath[path])), [runningByPath]);
 }

--- a/mastracode/factory-ui/src/ui/pages/MetricsPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/MetricsPage.tsx
@@ -12,7 +12,6 @@ import { flushSync } from 'react-dom';
 import { useParams } from 'react-router';
 
 import { useApiConfig } from '../../api/config';
-import { useEnsureMaterializedSandbox } from '../../hooks/useEnsureMaterializedSandbox';
 import { useFactoryQuery } from '../../hooks/useFactories';
 import { useFactoryMetrics } from '../../hooks/useFactoryMetrics';
 import { useWorkspaceActivity } from '../../hooks/useWorkspaceActivity';
@@ -207,17 +206,18 @@ function useAgentsRunningCount(): number {
   const { factoryId } = useParams<{ factoryId: string }>();
   const factoryQuery = useFactoryQuery(factoryId);
   const repository = factoryQuery.data?.repositories[0];
-  const materializeQuery = useEnsureMaterializedSandbox(repository?.projectRepositoryId);
   const workspaces = useWorkspacesQuery(repository?.projectRepositoryId);
   const workspaceSessions = workspaces.data?.workspaces ?? [];
-  const resourceId = materializeQuery.data?.resourceId;
+  // The factory-level session address is the factory project id, so read
+  // activity without materializing a sandbox for a page that only renders counts.
+  const resourceId = factoryQuery.data?.id;
   const runningByPath = useWorkspaceActivity({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId: resourceId ?? '',
     scope: repository?.projectRepositoryId,
     worktreePaths: workspaceSessions.map(workspace => workspace.sessionId),
     baseUrl,
-    enabled: materializeQuery.isSuccess && Boolean(resourceId && repository?.projectRepositoryId),
+    enabled: Boolean(resourceId && repository?.projectRepositoryId),
   });
   return Object.values(runningByPath).filter(Boolean).length;
 }


### PR DESCRIPTION
Opening a factory page provisioned a sandbox. Landing on `/factories/:id/work` — the board, or metrics, rules, audit, settings — was enough to start a VM and clone the repository, before the user asked for anything.

`ChatSessionProvider` is the router layout for *every* factory route, and it owned an unconditional `POST /web/github/projects/:projectRepositoryId/ensure` call. Any route under a factory mounted it, so any route materialized the factory's first linked repository. The metrics page asked a second time on its own.

This gates that call on actually being in a session, and gives the pages that only need a factory-level address (settings, permissions, workspace-activity polling) the factory id instead — the same value the ensure route returns (`mastracode/factory/src/integrations/github/routes.ts:1195`) — so they keep working without materializing anything.

## This is someone else's commit

This is an **unmodified cherry-pick of `bea54e10c6`**, authored by @abhiaiyer91, lifted out of #20474.

That PR is 45 files across sandbox-lifecycle fixes, feature work, and reliability patches, and it is currently conflicting. This one commit is independent of the rest of it and applies cleanly to `main` today, so it does not need to wait.

The patch is byte-identical to the original — same patch-id, `git range-diff` reports `=`, original authorship and commit message preserved:

```
$ git diff-tree -p bea54e10c6 | git patch-id --stable   cf7d0294781dfb7a39223ac258af5b574fe8c1f3
$ git diff-tree -p HEAD       | git patch-id --stable   cf7d0294781dfb7a39223ac258af5b574fe8c1f3
$ git range-diff bea54e10c6~1..bea54e10c6 HEAD~1..HEAD
1:  bea54e10c6 = 1:  bf0b4bf5a1 fix(factory-ui): only materialize a sandbox when entering a session
```

That matters for @abhiaiyer91: git matches commits by patch-id, so his next rebase of `further-optimizations` drops this one automatically. Merging here costs him nothing and removes nothing from his PR.

Opened as a draft because there is complementary server-side work in flight (lazy sandbox provisioning — a sandbox starting when someone speaks rather than when a session is created) that could touch `ChatSessionProvider.tsx`. This change is the client-side half: it stops the UI *asking* on mount. Worth a look from whoever lands that.

Note for anyone tempted to push this deeper into the server: the same author already tried that inside the branch (`309f17b08e`, *return from review-session start before the sandbox materializes*) and reverted it wholesale. The client-side gating is the version that survived.

## No changeset

`@internal/factory-ui` is `private: true` and is consumed only by `packages/cli`, so it is not independently versioned. The four most recent factory-ui-only commits on `main` carry no changeset either.

## Proven in a browser, not just in tests

A real Chromium was driven against the factory SPA proxied to a real factory server — real hosted database, real platform sandbox provider — counting `POST …/ensure` requests on three routes, once on the base commit and once on this one.

| Route | Base (`990611ba76`) | This branch (`bf0b4bf5a1`) |
| --- | --- | --- |
| `/factories/:id/work` — the board | **1 ensure call**, repo `14aefd25…` | **0** |
| `/factories/:id/metrics` | **1 ensure call**, repo `14aefd25…` | **0** |
| `/factories/:id/workspaces/:sid/threads/:sid` — a session | 1 ensure call | **1** |

Each route also asserts a locator that only it renders, and only once its data resolves — the board's settled planning column, the metrics "Agents running" readout, the chat composer. All three mounted in both runs. That closes the gap where a zero count on a page that silently failed to render would look exactly like the fix working.

**The substituted `resourceId` is measured, not argued.** The demo also records which `resourceId` the workspace-activity poll addresses (`GET /agent-controller/:id/sessions/:resourceId/threads`, issued by `useWorkspaceActivity`). It is the factory's own id — `7edb8b9e…` — on base *and* on this branch. That is the point: the pick swaps `ensureQuery.data.resourceId` for `factoryQuery.data.id`, and the ensure route returns `project.factoryProjectId`, so the address should be unchanged. Now it is observed to be unchanged rather than reasoned to be.

Because the metrics readout settles, `BreakdownSection` and therefore `QueueHealthPanel` mounted too (`MetricsPage.tsx:96,167`) — so all three changed source files are exercised, not just the provider.

One caveat on reading the base numbers: the layout and the metrics page share the React Query key `ensureSandbox(projectRepositoryId)` with `staleTime: Infinity`, so on base two callers collapse into one request — hence 1 rather than 2. The branch-side zero is what carries the claim; with the layout gated, any remaining call could only be the metrics page's.

The session row is the control: it proves the counter still sees requests, and that the change does not over-gate. Entering a session still materializes, which is the behavior you want.

Console errors were counted per route too: 4 / 5 / 10 on base against 4 / 5 / 11 here, with the metrics figure varying by one between runs of the same commit — the rig's pre-existing noise, unchanged.

The commit's own test was measured against `main` rather than assumed meaningful: with the three source files restored from `origin/main` and the new test kept, both gating cases fail (`expected [ 'repo-1' ] to deeply equal []`) while the session case passes.

## Reviewer note

The activity poll in `MetricsPage`/`QueueHealthPanel` no longer waits for materialization before firing — same `resourceId` as before, but earlier and unconditional. That is inside the picked patch, so it was deliberately left alone rather than adjusted here; flagging it for review rather than burying it.

## Test plan

```sh
# the commit's own test, new in this pick
pnpm --filter ./mastracode/factory-ui exec vitest run --project msw:factory-ui \
  src/ui/__tests__/SandboxEnsureGating.msw.test.tsx --reporter=dot
#  Test Files  1 passed (1) / Tests  3 passed (3)

# the whole MSW project — 82/421 here against 81/418 on main, i.e. exactly this pick's new tests
pnpm --filter ./mastracode/factory-ui exec vitest run --project msw:factory-ui --reporter=dot
#  Test Files  82 passed (82) / Tests  421 passed (421)

pnpm --filter ./mastracode/factory-ui typecheck
#  exit 0

git status --porcelain
#  (empty)
```

The live demo is deliberately not in that list as a casual step: **every run provisions a real sandbox and clones a real repository**, on purpose — that is what the session half asserts. Rerun it when you want to see it yourself, not as a routine check.

Docs: nothing to update. `docs/src` has no factory section and no reference to the factory UI; the workspace/sandbox docs describe the sandbox primitive and never mention the factory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory pages no longer create a sandbox until a user opens a session. This reduces unnecessary requests while keeping session behavior unchanged.

## Changes

- Gate sandbox `/ensure` requests on an active session.
- Use the factory ID for settings, permissions, queue health, and workspace activity on factory-level pages.
- Keep workspace-based resource resolution for active sessions.
- Add MSW tests for board, metrics, settings, and session routes.

## Validation

- 82 MSW test files passed.
- 421 tests passed.
- Type checking passed.
- Browser verification confirmed zero `/ensure` requests on non-session routes and one request on session routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->