### PR TITLE
fix(factory): stop holding the delete request open while a sandbox is reclaimed

### DIFF
--- a/.changeset/plenty-pugs-shake.md
+++ b/.changeset/plenty-pugs-shake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Return from deleting a workspace as soon as its session is gone instead of holding the request open while the sandbox is reclaimed. Waking the VM and scrubbing its checkout took minutes on a large repository, so the UI appeared to hang long after the workspace had been removed. The scrub and pool release now run in the background; because a sandbox only becomes claimable once it is published to the reuse pool, the next session still gets a clean checkout.

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -1817,17 +1817,52 @@ describe('Factory session routes', () => {
     expect(tables.sessions).toHaveLength(0);
     // The VM stays alive for the next session, but the released session's
     // work is scrubbed off it before it enters the pool.
-    expect(reattachSandbox).toHaveBeenCalledWith('sb-live');
-    expect(recycleClaimedWorkdir).toHaveBeenCalledWith(expect.anything(), '/workspace/hello', 'main');
-    expect(sourceControlStorage.sandboxPoolRows).toEqual([
-      expect.objectContaining({
-        orgId: 'org1',
-        projectRepositoryId: 'p1',
-        userId: 'u1',
+    await vi.waitFor(() => {
+      expect(reattachSandbox).toHaveBeenCalledWith('sb-live');
+      expect(recycleClaimedWorkdir).toHaveBeenCalledWith(expect.anything(), '/workspace/hello', 'main');
+      expect(sourceControlStorage.sandboxPoolRows).toEqual([
+        expect.objectContaining({
+          orgId: 'org1',
+          projectRepositoryId: 'p1',
+          userId: 'u1',
+          sandboxId: 'sb-live',
+          sandboxWorkdir: '/workspace/hello',
+        }),
+      ]);
+    });
+  });
+
+  it('deletes the session without waiting for the sandbox scrub to finish', async () => {
+    seedMaterializedProject();
+    const app = buildApp({ workosId: 'u1' });
+    const created = await postJson(app, '/web/github/projects/p1/sessions', { branch: 'feat/x' });
+    const sessionId = (await created.json()).session.sessionId;
+    Object.assign(
+      tables.sessions.find(row => row.sessionId === sessionId)!,
+      {
         sandboxId: 'sb-live',
         sandboxWorkdir: '/workspace/hello',
-      }),
-    ]);
+      },
+    );
+    // Scrubbing a large checkout takes minutes on a real VM.
+    let finishScrub!: () => void;
+    const scrubbing = new Promise<void>(resolve => {
+      finishScrub = resolve;
+    });
+    recycleClaimedWorkdir.mockImplementationOnce(async () => {
+      await scrubbing;
+    });
+
+    const deleted = await app.request(`/web/user-sessions/${sessionId}`, { method: 'DELETE' });
+
+    // The workspace is gone from the user's list while the VM is still busy.
+    expect(deleted.status).toBe(200);
+    expect(tables.sessions).toHaveLength(0);
+    // Nothing can claim the sandbox until the scrub completes.
+    expect(sourceControlStorage.sandboxPoolRows).toEqual([]);
+
+    finishScrub();
+    await vi.waitFor(() => expect(sourceControlStorage.sandboxPoolRows).toHaveLength(1));
   });
 
   it('does not expose another user or organization session', async () => {

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -36,7 +36,7 @@ import type { GithubIntegration } from './integration.js';
 import { clearGithubPat, getGithubPat, getGithubPatStatus, setGithubPat } from './pat.js';
 import type { GithubPatKind } from './pat.js';
 
-import { cleanReleasedSandbox } from './sandbox-release.js';
+import { reclaimDeletedSessionSandbox } from './sandbox-release.js';
 import {
   commitAll,
   computeWorktreePath,
@@ -1354,50 +1354,22 @@ function buildProjectGitRoutes({
         if (!session || session.orgId !== resolved.tenant.orgId || session.userId !== resolved.tenant.userId) {
           return c.json({ error: 'Session not found' }, 404);
         }
-        if (session.sandboxId && fleet.provider !== 'local' && session.sandboxWorkdir) {
-          // Keep the remote VM alive: return it to the reuse pool so the next
-          // session for this repository link and user claims it (repo already
-          // cloned) instead of provisioning a fresh sandbox. Scrub the
-          // session's work off the VM first so it doesn't idle with stale
-          // branches or dirty state.
-          await cleanReleasedSandbox({
-            fleet,
-            sourceControl: github.sourceControlStorage,
-            orgId: session.orgId,
-            projectRepositoryId: session.projectRepositoryId,
-            sandboxId: session.sandboxId,
-            sandboxWorkdir: session.sandboxWorkdir,
-          });
-          await github.sourceControlStorage.sandboxPool.release({
-            orgId: session.orgId,
-            projectRepositoryId: session.projectRepositoryId,
-            userId: session.userId,
-            sandboxId: session.sandboxId,
-            sandboxWorkdir: session.sandboxWorkdir,
-          });
-        } else if (session.sandboxId) {
-          let sandbox: MaterializationSandbox | undefined;
-          try {
-            sandbox = await fleet.reattachSandbox(session.sandboxId);
-          } catch {
-            // The provider may already have reclaimed the sandbox.
-          }
-          await fleet.teardownSandbox(
-            {
-              sandboxId: session.sandboxId,
-              setSandboxId: async () => {},
-              clear: async () => {
-                await github.sourceControlStorage.sessions.setSandbox({
-                  id: session.id,
-                  sandboxId: null,
-                  sandboxWorkdir: session.sandboxWorkdir ?? '',
-                });
-              },
-            },
-            sandbox,
-          );
-        }
+        // Answer as soon as the workspace is actually gone. Reclaiming its
+        // sandbox wakes the VM and scrubs the checkout, which takes minutes on
+        // a large repository — the caller must not sit through that for a
+        // workspace that has already been removed.
         await github.sourceControlStorage.sessions.delete(session.id);
+        void reclaimDeletedSessionSandbox({
+          fleet,
+          sourceControl: github.sourceControlStorage,
+          session,
+        }).catch((error: unknown) => {
+          console.error('[GitHub Sessions] Failed to reclaim sandbox for deleted session', {
+            sessionId: session.sessionId,
+            sandboxId: session.sandboxId,
+            error,
+          });
+        });
         return c.json({ removed: true });
       },
     }),

--- a/mastracode/factory/src/integrations/github/sandbox-release.ts
+++ b/mastracode/factory/src/integrations/github/sandbox-release.ts
@@ -1,5 +1,5 @@
-import type { SandboxFleet } from '../../sandbox/fleet.js';
-import type { SourceControlStorageHandle } from '../../storage/domains/source-control/base.js';
+import type { MaterializationSandbox, SandboxFleet } from '../../sandbox/fleet.js';
+import type { SourceControlSession, SourceControlStorageHandle } from '../../storage/domains/source-control/base.js';
 import type { WorkItemsStorage } from '../../storage/domains/work-items/base.js';
 import { recycleClaimedWorkdir } from './sandbox.js';
 
@@ -37,6 +37,59 @@ export async function cleanReleasedSandbox(options: {
     // Reaped, unreachable, or wedged — the claim-side recycle is the
     // correctness guarantee; this scrub is hygiene for idle VMs.
   }
+}
+
+/**
+ * Reclaim the sandbox a just-deleted user session was holding: return a remote
+ * VM to the reuse pool (scrubbed first), or tear a local/unpooled one down.
+ *
+ * Runs after the session row is already gone. Waking the VM and scrubbing a
+ * large checkout takes minutes, and none of it is something the caller can act
+ * on — the workspace has disappeared from their list either way. Nothing can
+ * claim the sandbox until `release` publishes it to the pool, so deferring the
+ * whole sequence preserves the scrub-before-reuse guarantee.
+ */
+export async function reclaimDeletedSessionSandbox(options: {
+  fleet: Pick<SandboxFleet, 'provider' | 'reattachSandbox' | 'teardownSandbox'>;
+  sourceControl: Pick<SourceControlStorageHandle, 'sandboxPool' | 'projectRepositories' | 'repositories'>;
+  session: Pick<SourceControlSession, 'orgId' | 'userId' | 'projectRepositoryId' | 'sandboxId' | 'sandboxWorkdir'>;
+}): Promise<void> {
+  const { fleet, sourceControl, session } = options;
+  if (!session.sandboxId) return;
+  if (fleet.provider !== 'local' && session.sandboxWorkdir) {
+    // Keep the remote VM alive: return it to the reuse pool so the next
+    // session for this repository link and user claims it (repo already
+    // cloned) instead of provisioning a fresh sandbox. Scrub the session's
+    // work off the VM first so it doesn't idle with stale branches or dirty
+    // state, and so nothing claims it mid-scrub.
+    await cleanReleasedSandbox({
+      fleet,
+      sourceControl,
+      orgId: session.orgId,
+      projectRepositoryId: session.projectRepositoryId,
+      sandboxId: session.sandboxId,
+      sandboxWorkdir: session.sandboxWorkdir,
+    });
+    await sourceControl.sandboxPool.release({
+      orgId: session.orgId,
+      projectRepositoryId: session.projectRepositoryId,
+      userId: session.userId,
+      sandboxId: session.sandboxId,
+      sandboxWorkdir: session.sandboxWorkdir,
+    });
+    return;
+  }
+  let sandbox: MaterializationSandbox | undefined;
+  try {
+    sandbox = await fleet.reattachSandbox(session.sandboxId);
+  } catch {
+    // The provider may already have reclaimed the sandbox.
+  }
+  // The session row is deleted, so there is no binding left to clear.
+  await fleet.teardownSandbox(
+    { sandboxId: session.sandboxId, setSandboxId: async () => {}, clear: async () => {} },
+    sandbox,
+  );
 }
 
 /**


### PR DESCRIPTION
Deleting a Factory workspace used to hang. The request waited on waking the sandbox VM and scrubbing its checkout before responding, which takes minutes on a large repository, so the UI appeared frozen long after the workspace itself was gone.

This returns as soon as the session row is deleted and runs the scrub and pool release in the background.

## This is an extraction, not new work

The commit is an **unmodified cherry-pick of `cb7b51a9f6`, authored by @abhiaiyer91**, lifted out of #20474.

That PR is 45 files and currently conflicting, and it mixes two sandbox-lifecycle fixes in with unrelated feature work — re-review on new commits, a run-start toast, thread retention on delete, an active-working indicator — plus several reliability patches. The sandbox fixes are ready and the rest is not, so waiting on the whole branch means shipping nothing.

The pick is byte-identical to the original on purpose:

```
$ git diff-tree -p cb7b51a9f6 | git patch-id --stable
e01e169ef43e999426b2f816dbbbb6047fa5bbb9
$ git diff-tree -p HEAD | git patch-id --stable
e01e169ef43e999426b2f816dbbbb6047fa5bbb9

$ git range-diff cb7b51a9f6~1..cb7b51a9f6 HEAD~1..HEAD
1:  cb7b51a9f6 = 1:  038cf201ec
```

Git matches commits by patch-id, so when @abhiaiyer91 next rebases `further-optimizations` this commit drops out on its own. Nothing to untangle, and his authorship is preserved on the commit. Editing the patch — even reformatting it — would break that property, which is why it is untouched.

The companion extraction is #20784 (the factory-ui side). The two are independent: different packages, no shared files, neither stacked on the other. They can merge in either order.

## What changed

- `routes.ts` — the delete handler deletes the session row and returns; the reclaim is detached.
- `sandbox-release.ts` — the scrub and pool release move into `reclaimDeletedSessionSandbox`.
- `routes.test.ts` — assertions that the handler returns before the scrub resolves.

## Why the next session still gets a clean checkout

A sandbox becomes claimable only once it is published to the reuse pool, and that still happens after the scrub — so nothing can claim it mid-scrub.

One clarification on the changeset's wording, since it matters for reviewing this: pool ordering guarantees *not claimable mid-scrub*, but it is not by itself what guarantees *clean*. `cleanReleasedSandbox` returns early if the project-repository or repository row is missing, and swallows a failed scrub, while the pool release runs unconditionally afterwards. The actual clean-checkout guarantee is the **claim side** — `workspace.ts:315` recycles the workdir when a pooled sandbox is claimed. `sandbox-release.ts`'s own comment says as much ("the claim-side recycle is the correctness guarantee; this scrub is hygiene for idle VMs"). The conclusion holds either way; the mechanism is worth naming accurately.

## A trade-off worth knowing about before you approve

Two independent adversarial reviews flagged the same thing, and it is not in the commit message, so stating it here.

**On `main`, the delete handler reclaims first and deletes the session row last. That ordering is retry-safe.** If `sandboxPool.release` throws, or the process restarts mid-scrub, `sessions.delete` never runs — the row survives, the workspace stays in the user's list, and a retry re-enters the same path. The session row is the handle on the sandbox.

**This change deletes the row first, so that property is gone.** If the detached reclaim fails, the VM is live with no session row and no pool row. A retry `DELETE` returns 404. `cleanReleasedSandbox` swallows all errors by design, so only a `sandboxPool.release` failure can reject, and that is caught and logged.

Bounding it:

- The leak is capped by the fleet idle timeout, default **30 minutes** (`sandbox/fleet.ts:276`) — though providers without idle GC ignore it.
- There is no reconciliation sweep. `sandboxPool` has exactly two writers and one reader; nothing scans for sandboxes without a session row.

This looks inherent to the fix rather than an oversight: you cannot both return before the reclaim and keep the row as a retry handle, since keeping the row is exactly what leaves a deleted workspace sitting in the user's list. The trade may well be right. It is a reviewer's call, not one to make silently, and the alternative — editing the patch — costs the clean-drop property described above.

## How this was verified, and where the proof stops

**The latency claim is argued from tests, not measured against a live sandbox.** Measuring it means provisioning a real workspace, letting it clone, then deleting it and timing the response. That was offered and deliberately not done, so I am not going to imply otherwise.

The substitute is the commit's own test, `routes.test.ts:1835`, which holds the scrub open on a hand-resolved promise and asserts *while it is still blocked* that the request returned 200, the session row is gone, and the pool is still empty — then, after releasing it, that the pool row appears.

To check that test can actually fail, I restored `main`'s source under it. It does not fail an assertion — it **times out at 5000ms**, because on `main` the DELETE never returns while the scrub is blocked. The hang reproduces in the test runner.

Precisely what that establishes: the **latency** claim only. The run dies at the request line, so the safety assertion six lines later never executes on base. The safety assertion rests on its construction — it reads the pool at a moment when the scrub is provably suspended — rather than on a red baseline.

## Test plan

```sh
pnpm --filter ./mastracode/factory exec vitest run src/integrations/github --reporter=dot
pnpm --filter ./mastracode/factory check
pnpm --filter ./mastracode/factory lint
```

Results: 17 files / 317 tests passed (316 at baseline — the one case this commit adds), typecheck exit 0, lint 0 warnings and 0 errors.

The suite is directory-scoped rather than pointed at `routes.test.ts` on purpose: `sandbox-release.ts` has a second consumer, `releaseWorkItemSandboxes` (imported by `factory.ts`), covered by `sandbox-release.test.ts` — a file this commit does not touch and could otherwise regress silently.

## Related

Server-side lazy sandbox provisioning is in flight separately, and is complementary rather than overlapping: it changes what the server does when asked to provision, while this changes when a sandbox goes back in the pool after a delete. Opened as a draft so it can be reconciled with that work if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Workspace deletion now finishes faster. The system removes the session first and cleans the sandbox in the background. The sandbox stays unavailable until cleanup completes.

## Changes

- Delete the session record before sandbox reclamation.
- Run sandbox scrubbing and pool release asynchronously.
- Reattach and tear down local or unpooled sandboxes after deletion.
- Log reclamation failures without delaying the deletion response.
- Keep sandboxes unavailable until scrubbing finishes and pool publication completes.
- Add tests for immediate deletion responses and delayed pool reuse.
- Add a patch changeset for `@mastra/factory`.

## Trade-off

If background reclamation fails, the sandbox can remain live until provider idle cleanup. No reconciliation sweep is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->