### PR TITLE
fix(core): finalize failed controller tool calls

### DIFF
--- a/.changeset/olive-carpets-smoke.md
+++ b/.changeset/olive-carpets-smoke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed AgentController tool errors remaining in a running display state after the agent recovered.

--- a/examples/agent/src/mastra/agents/failed-tool-loop-agent.ts
+++ b/examples/agent/src/mastra/agents/failed-tool-loop-agent.ts
@@ -1,0 +1,47 @@
+import { Agent } from '@mastra/core/agent';
+import { AgentController } from '@mastra/core/agent-controller';
+import { createTool } from '@mastra/core/tools';
+import { LocalFilesystem, Workspace } from '@mastra/core/workspace';
+import { z } from 'zod';
+
+const throwingTool = createTool({
+  id: 'throwing-tool',
+  description: 'Always throws an intentional error.',
+  inputSchema: z.object({ reason: z.string() }),
+  execute: async () => {
+    throw new Error('intentional example-agent tool failure');
+  },
+});
+
+export const failedToolLoopAgent = new Agent({
+  id: 'failed-tool-loop-repro',
+  name: 'Failed Tool Loop Reproduction',
+  description: 'Reproduces an agent loop after a tool throws an error.',
+  model: 'openai/gpt-5.4-mini',
+  instructions:
+    'Call throwingTool exactly once. After it fails, do not retry it. Briefly explain that the tool failed and finish.',
+  tools: { throwingTool },
+  defaultOptions: {
+    maxSteps: 4,
+    prepareStep: ({ stepNumber }) => ({
+      toolChoice: stepNumber === 0 ? { type: 'tool', toolName: 'throwingTool' } : 'none',
+    }),
+  },
+});
+
+export const failedToolLoopController = new AgentController({
+  id: 'failed-tool-loop-controller',
+  workspace: new Workspace({
+    name: 'Failed tool loop reproduction',
+    filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  }),
+  modes: [
+    {
+      id: 'default',
+      name: 'Default',
+      default: true,
+      agent: failedToolLoopAgent,
+    },
+  ],
+  initialState: { yolo: true },
+});

--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -107,6 +107,7 @@ import { askUserAgent } from './agents/ask-user-agent';
 import { codeModeAgent } from './agents/code-mode-agent';
 import { clinicDirectAgent, clinicSpecialistAgent, clinicSupervisorAgent } from './agents/clinic-context-agents';
 import { approvalDemoAgent } from './agents/approval-demo-agent';
+import { failedToolLoopAgent, failedToolLoopController } from './agents/failed-tool-loop-agent';
 import {
   standupNoteNormalizerAgent,
   standupDigestAgent,
@@ -137,10 +138,14 @@ const storage = new MastraCompositeStore({
 });
 
 export const mastra = new Mastra({
+  agentControllers: {
+    failedToolLoop: failedToolLoopController,
+  },
   agents: {
     gatewayAgent,
     askUserAgent,
     approvalDemoAgent,
+    failedToolLoopAgent,
     chefAgent,
     chefAgentResponses,
     codeOverrideEditableAgent,

--- a/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
@@ -141,6 +141,44 @@ describe('SessionRunEngine — MastraDBMessage contract', () => {
     expect((toolPart.toolInvocation as { isError?: boolean }).isError).toBe(true);
   });
 
+  it('Given a tool call that throws, When the tool-error arrives, Then it emits an errored tool result', async () => {
+    const { engine, events } = createHarness();
+    const state = engine.createStreamState();
+    const ctx = requestContext();
+
+    await engine.processStreamChunk(
+      state,
+      chunk({ type: 'tool-call', payload: { toolCallId: 'tc1', toolName: 'throwingTool', args: { reason: 'repro' } } }),
+      ctx,
+    );
+    await engine.processStreamChunk(
+      state,
+      chunk({
+        type: 'tool-error',
+        payload: { toolCallId: 'tc1', toolName: 'throwingTool', error: 'intentional failure' },
+      }),
+      ctx,
+    );
+
+    const message = lastMessageEvent(events);
+    const toolPart = message.content.parts.find(part => part.type === 'tool-invocation');
+    if (!toolPart || toolPart.type !== 'tool-invocation') throw new Error('no tool invocation part emitted');
+    expect(toolPart.toolInvocation).toMatchObject({
+      state: 'result',
+      toolCallId: 'tc1',
+      toolName: 'throwingTool',
+      args: { reason: 'repro' },
+      result: 'intentional failure',
+      isError: true,
+    });
+    expect(events).toContainEqual({
+      type: 'tool_end',
+      toolCallId: 'tc1',
+      result: 'intentional failure',
+      isError: true,
+    });
+  });
+
   it('Given a signal data chunk, When it arrives, Then it emits a DB-native signal message', async () => {
     const { engine, events } = createHarness();
     const state = engine.createStreamState();

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -542,12 +542,38 @@ export class SessionRunEngine {
       case 'tool-error': {
         const toolError = getPayload(chunk);
         const toolCallId = getString(toolError.toolCallId) ?? '';
+        const toolName = getString(toolError.toolName) ?? '';
+        const result = getDisplayTransform(chunk.metadata, 'error', toolError.error);
+        const toolIndex = state.toolPartById.get(toolCallId);
+        const existing = toolIndex !== undefined ? state.currentMessage.content.parts[toolIndex] : undefined;
+        if (existing && existing.type === 'tool-invocation') {
+          existing.toolInvocation = Object.assign(existing.toolInvocation, {
+            state: 'result' as const,
+            result,
+            isError: true,
+          });
+        } else {
+          state.currentMessage.content.parts.push({
+            type: 'tool-invocation',
+            toolInvocation: Object.assign(
+              {
+                state: 'result' as const,
+                toolCallId,
+                toolName,
+                args: {},
+                result,
+              },
+              { isError: true },
+            ),
+          });
+        }
         this.#session.emit({
           type: 'tool_end',
           toolCallId,
-          result: getDisplayTransform(chunk.metadata, 'error', toolError.error),
+          result,
           isError: true,
         });
+        this.#session.emit({ type: 'message_update', message: this.cloneMessage(state.currentMessage) });
         break;
       }
 


### PR DESCRIPTION
AgentController emitted `tool_end` for thrown tools but left the DB-native tool invocation in its original `call` state. The run itself completed, while clients continued rendering the tool as active.

Before:
```ts
{ state: "call", toolCallId }
```

After:
```ts
{ state: "result", toolCallId, result: error, isError: true }
```

This updates the message snapshot when `tool-error` arrives and adds focused regression coverage plus an example controller that reproduces the failure.