### PR TITLE
fix(memory): handle failed tool states in token counting

### DIFF
--- a/.changeset/tame-stars-repeat.md
+++ b/.changeset/tame-stars-repeat.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Fixed observational memory stalling agent loops after a tool fails.

--- a/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
@@ -1279,6 +1279,34 @@ describe('TokenCounter', () => {
     });
   });
 
+  describe('failed tools (output-error)', () => {
+    it('counts the tool error instead of rejecting async message counting', async () => {
+      const counter = new TokenCounter();
+      const errorText = 'File not found: __intentional_missing_file_for_tool_error_test__';
+      const message = createMessage({
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'output-error',
+              toolCallId: 'tool-1',
+              toolName: 'view',
+              args: { path: '__intentional_missing_file_for_tool_error_test__' },
+              errorText,
+            },
+          },
+        ],
+      });
+
+      await expect(counter.countMessagesAsync([message])).resolves.toBeGreaterThan(0);
+      expect(counter.countMessage(message)).toBeGreaterThan(0);
+      const estimate = message.content.parts[0].providerMetadata?.mastra?.tokenEstimate;
+      expect(estimate?.key).toContain('tool-result-error');
+      expect(estimate?.tokens).toBe(counter.countString(errorText));
+    });
+  });
+
   describe('countObservations', () => {
     it('delegates to countString', () => {
       const counter = new TokenCounter();

--- a/packages/memory/src/processors/observational-memory/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.test.ts
@@ -1,7 +1,7 @@
 import probeImageSize from 'probe-image-size';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { TokenCounter } from '../token-counter';
+import { TokenCounter } from './token-counter';
 
 vi.mock('probe-image-size', () => ({
   default: vi.fn(),

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -1770,6 +1770,14 @@ export class TokenCounter {
         return { tokens, overheadDelta, toolResultDelta };
       }
 
+      if (invocation.state === 'output-error') {
+        toolResultDelta++;
+        const errorText = (invocation as { errorText?: unknown }).errorText;
+        const errorMessage = typeof errorText === 'string' ? errorText : 'Tool execution failed';
+        tokens += this.readOrPersistPartEstimate(part, 'tool-result-error', errorMessage);
+        return { tokens, overheadDelta, toolResultDelta };
+      }
+
       throw new Error(
         `Unhandled tool-invocation state '${(part as any).toolInvocation?.state}' in token counting for part type '${part.type}'`,
       );


### PR DESCRIPTION
This fixes agents with observational memory stalling after a tool throws.

The regression was introduced by #20705, merged August 5, 2026 at 9:21 AM PT. That change correctly began recording failed tool calls as `output-error`, but observational memory’s `TokenCounter` did not recognize that state. It threw during the next input-processing iteration, so the agent never returned to the model.

Before:
```ts
state: 'output-error' // TokenCounter throws
```

After:
```ts
state: 'output-error' // TokenCounter counts errorText and continues
```

This adds `output-error` token handling and regression coverage for both asynchronous and synchronous message counting. I verified the focused memory tests, the memory package typecheck, core and memory builds, and the real `mc` failure flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a tool fails, memory agents no longer get stuck. The token counter now records the tool error and continues processing.

## Changes

- Handle `output-error` tool invocations in `TokenCounter`.
- Count `errorText`, or use a default failure message when it is missing or invalid.
- Record the error as a `tool-result-error` estimate.
- Add synchronous and asynchronous regression tests.
- Add patch changesets for `@mastra/memory` and `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->