### PR TITLE
fix(cli): Use git defaults during init

### DIFF
--- a/.changeset/ten-parts-go.md
+++ b/.changeset/ten-parts-go.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+During the create step correctly initialize git with user's default global config instead of an empty one.

--- a/.changeset/ten-parts-go.md
+++ b/.changeset/ten-parts-go.md
@@ -2,4 +2,4 @@
 'mastra': patch
 ---
 
-During the create step correctly initialize git with user's default global config instead of an empty one.
+Fixed Git initialization during project creation. Git now uses the user's global Git configuration.

--- a/packages/cli/src/commands/utils.test.ts
+++ b/packages/cli/src/commands/utils.test.ts
@@ -1,8 +1,3 @@
-import fs from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-
-import type * as ExecaModule from 'execa';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 vi.mock('execa', () => ({
@@ -142,99 +137,27 @@ describe('getVersionTag', () => {
 });
 
 describe('gitInit', () => {
-  test('creates a protected initial commit without inheriting global identity, signing, or hooks', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'mastra-git-init-'));
-    const project = path.join(root, 'project');
-    const home = path.join(root, 'home');
-    const globalHooks = path.join(root, 'global-hooks');
-    const globalExcludes = path.join(root, 'global-excludes');
-    const hookMarker = path.join(root, 'hook-ran');
-    const globalConfig = path.join(root, 'global.gitconfig');
-    await Promise.all([fs.mkdir(project), fs.mkdir(home), fs.mkdir(globalHooks)]);
-    await fs.writeFile(path.join(project, 'index.ts'), 'export const value = true;\n');
-    await fs.writeFile(path.join(project, '.env'), 'SECRET=private\n');
-    await fs.writeFile(path.join(project, '.env.local'), 'LOCAL_SECRET=private\n');
-    await fs.writeFile(path.join(project, '.env.example'), 'SECRET=\n');
-    await fs.writeFile(path.join(project, '.env.test.example'), 'TEST_SECRET=\n');
-    await fs.writeFile(path.join(globalHooks, 'post-commit'), `#!/bin/sh\ntouch ${JSON.stringify(hookMarker)}\n`);
-    await fs.chmod(path.join(globalHooks, 'post-commit'), 0o755);
-    await fs.writeFile(globalExcludes, 'index.ts\n');
-    await fs.writeFile(
-      globalConfig,
-      `[commit]\n\tgpgSign = true\n[core]\n\thooksPath = ${globalHooks}\n\texcludesFile = ${globalExcludes}\n`,
+  test('initializes the repository, stages files, and creates the initial commit', async () => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    const { execa } = await import('execa');
+    vi.mocked(execa).mockResolvedValue({} as any);
+    const { gitInit } = await import('./utils');
+
+    await gitInit({ cwd: '/project' });
+
+    expect(execa).toHaveBeenNthCalledWith(1, 'git', ['init'], { cwd: '/project', stdio: 'ignore' });
+    expect(execa).toHaveBeenNthCalledWith(2, 'git', ['add', '-A'], { cwd: '/project', stdio: 'ignore' });
+    expect(execa).toHaveBeenNthCalledWith(
+      3,
+      'git',
+      [
+        'commit',
+        '-m',
+        'Initial commit from Mastra',
+        '--author="dane-ai-mastra[bot] <dane-ai-mastra[bot]@users.noreply.github.com>"',
+      ],
+      { cwd: '/project', stdio: 'ignore' },
     );
-
-    const originalEnv = {
-      HOME: process.env.HOME,
-      XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
-      GIT_CONFIG_GLOBAL: process.env.GIT_CONFIG_GLOBAL,
-    };
-    process.env.HOME = home;
-    process.env.XDG_CONFIG_HOME = path.join(home, '.config');
-    process.env.GIT_CONFIG_GLOBAL = globalConfig;
-
-    try {
-      const actualExecaModule = await vi.importActual<typeof ExecaModule>('execa');
-      const mockedExecaModule = await import('execa');
-      vi.mocked(mockedExecaModule.execa).mockImplementation(actualExecaModule.execa as typeof mockedExecaModule.execa);
-      const { gitInit } = await import('./utils');
-
-      await gitInit({ cwd: project });
-
-      const gitCalls = vi.mocked(mockedExecaModule.execa).mock.calls as unknown as Array<
-        [command: string, args: string[], options?: unknown]
-      >;
-      const commitCall = gitCalls.find(([, args]) => args.includes('commit'));
-      expect(commitCall).toBeDefined();
-      expect(commitCall?.[1]).not.toEqual(expect.arrayContaining([expect.stringContaining('"')]));
-      for (const [command, args, options] of gitCalls) {
-        if (command !== 'git' || !args.some(argument => ['init', 'add', 'commit'].includes(argument))) continue;
-        expect(options).toEqual(
-          expect.objectContaining({
-            env: expect.objectContaining({
-              GIT_CONFIG_NOSYSTEM: '1',
-              GIT_CONFIG_COUNT: '0',
-              GIT_CONFIG_GLOBAL: expect.stringContaining('mastra-git-config-'),
-            }),
-          }),
-        );
-      }
-      const hooksArgument = commitCall?.[1].find(argument => argument.startsWith('core.hooksPath='));
-      expect(hooksArgument).toBeDefined();
-      expect(await fs.stat(hooksArgument!.slice('core.hooksPath='.length)).catch(() => undefined)).toBeUndefined();
-
-      const { stdout: commitCount } = await actualExecaModule.execa('git', ['rev-list', '--count', 'HEAD'], {
-        cwd: project,
-      });
-      expect(commitCount).toBe('1');
-      const { stdout: author } = await actualExecaModule.execa('git', ['log', '-1', '--format=%an <%ae>'], {
-        cwd: project,
-      });
-      expect(author).toBe('Mastra <noreply@mastra.ai>');
-      const { stdout: files } = await actualExecaModule.execa('git', ['ls-files'], { cwd: project });
-      expect(files.split('\n')).toEqual(['.env.example', '.env.test.example', 'index.ts']);
-      expect(await fs.readFile(path.join(project, '.git', 'info', 'exclude'), 'utf8')).toContain(
-        '.env\n.env.*\n!.env.example\n!.env.*.example',
-      );
-      await expect(fs.stat(path.join(project, '.gitignore'))).rejects.toThrow();
-      await expect(fs.stat(hookMarker)).rejects.toThrow();
-
-      for (const key of ['user.name', 'user.email', 'commit.gpgSign', 'core.hooksPath']) {
-        const result = await actualExecaModule.execa('git', ['config', '--local', '--get', key], {
-          cwd: project,
-          reject: false,
-        });
-        expect(result.exitCode).toBe(1);
-        expect(result.stdout).toBe('');
-      }
-    } finally {
-      if (originalEnv.HOME === undefined) delete process.env.HOME;
-      else process.env.HOME = originalEnv.HOME;
-      if (originalEnv.XDG_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
-      else process.env.XDG_CONFIG_HOME = originalEnv.XDG_CONFIG_HOME;
-      if (originalEnv.GIT_CONFIG_GLOBAL === undefined) delete process.env.GIT_CONFIG_GLOBAL;
-      else process.env.GIT_CONFIG_GLOBAL = originalEnv.GIT_CONFIG_GLOBAL;
-      await fs.rm(root, { recursive: true, force: true });
-    }
   });
 });

--- a/packages/cli/src/commands/utils.ts
+++ b/packages/cli/src/commands/utils.ts
@@ -142,40 +142,16 @@ export async function isGitInitialized({ cwd }: { cwd: string }): Promise<boolea
  * Initialize a git repository in the specified directory.
  */
 export async function gitInit({ cwd }: { cwd: string }) {
-  const isolatedConfigDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'mastra-git-config-'));
-  const emptyHooksDirectory = path.join(isolatedConfigDirectory, 'hooks');
-  const emptyGlobalConfig = path.join(isolatedConfigDirectory, 'global.gitconfig');
-  await fs.mkdir(emptyHooksDirectory);
-  await fs.writeFile(emptyGlobalConfig, '');
-  const env = {
-    GIT_CONFIG_NOSYSTEM: '1',
-    GIT_CONFIG_GLOBAL: emptyGlobalConfig,
-    GIT_CONFIG_COUNT: '0',
-  };
-
-  try {
-    await execa('git', ['init'], { cwd, stdio: 'ignore', env });
-    await fs.appendFile(path.join(cwd, '.git', 'info', 'exclude'), '\n.env\n.env.*\n!.env.example\n!.env.*.example\n');
-    await execa('git', ['add', '-A'], { cwd, stdio: 'ignore', env });
-    await execa(
-      'git',
-      [
-        '-c',
-        'user.name=Mastra',
-        '-c',
-        'user.email=noreply@mastra.ai',
-        '-c',
-        'commit.gpgSign=false',
-        '-c',
-        `core.hooksPath=${emptyHooksDirectory}`,
-        'commit',
-        '--no-verify',
-        '-m',
-        'Initial commit from Mastra',
-      ],
-      { cwd, stdio: 'ignore', env },
-    );
-  } finally {
-    await fs.rm(isolatedConfigDirectory, { recursive: true, force: true });
-  }
+  await execa('git', ['init'], { cwd, stdio: 'ignore' });
+  await execa('git', ['add', '-A'], { cwd, stdio: 'ignore' });
+  await execa(
+    'git',
+    [
+      'commit',
+      '-m',
+      '"Initial commit from Mastra"',
+      '--author="dane-ai-mastra[bot] <dane-ai-mastra[bot]@users.noreply.github.com>"',
+    ],
+    { cwd, stdio: 'ignore' },
+  );
 }

--- a/packages/cli/src/commands/utils.ts
+++ b/packages/cli/src/commands/utils.ts
@@ -149,7 +149,7 @@ export async function gitInit({ cwd }: { cwd: string }) {
     [
       'commit',
       '-m',
-      '"Initial commit from Mastra"',
+      'Initial commit from Mastra',
       '--author="dane-ai-mastra[bot] <dane-ai-mastra[bot]@users.noreply.github.com>"',
     ],
     { cwd, stdio: 'ignore' },


### PR DESCRIPTION
## Description

In the refactor of https://github.com/mastra-ai/mastra/pull/19825 the git functionality was unintentionally changed. This PR reverts the specific changes made there so that the user's global git config is used again.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The CLI now lets Git use the user’s normal global settings again. This restores the expected Git setup when the CLI creates a project.

## Changes

- Updated `gitInit` to:
  - Initialize the repository.
  - Stage all files.
  - Create the initial commit with a fixed bot author.
- Removed temporary Git configuration and related cleanup.
- Removed special handling that excluded environment files and disabled hooks or signing.
- Replaced the integration-style test with a focused unit test for the expected Git commands.
- Added a changeset for a patch release of `mastra`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->