### PR TITLE
refactor(playground): clean up suggested prompts

### DIFF
--- a/packages/playground/src/domains/agents/components/agent-chat.tsx
+++ b/packages/playground/src/domains/agents/components/agent-chat.tsx
@@ -7,6 +7,22 @@ import { Thread } from '@/lib/ai-ui/thread';
 
 import type { ChatProps } from '@/types';
 
+interface AvailableSuggestedPromptsOptions {
+  suggestedPrompts?: string[];
+  isNewThread?: boolean;
+  isMessagesLoading: boolean;
+}
+
+const getAvailableSuggestedPrompts = ({
+  suggestedPrompts,
+  isNewThread,
+  isMessagesLoading,
+}: AvailableSuggestedPromptsOptions) => {
+  if (isNewThread) return suggestedPrompts;
+  if (isMessagesLoading) return undefined;
+  return suggestedPrompts;
+};
+
 export const AgentChat = ({
   agentId,
   agentName,
@@ -65,6 +81,11 @@ export const AgentChat = ({
   }
 
   const messages = data?.messages ?? emptyMessagesRef.current.messages;
+  const availableSuggestedPrompts = getAvailableSuggestedPrompts({
+    suggestedPrompts,
+    isNewThread,
+    isMessagesLoading,
+  });
 
   return (
     <ChatProvider
@@ -83,7 +104,7 @@ export const AgentChat = ({
         agentName={agentName ?? ''}
         agentId={agentId}
         threadId={threadId}
-        suggestedPrompts={isNewThread || !isMessagesLoading ? suggestedPrompts : undefined}
+        suggestedPrompts={availableSuggestedPrompts}
         hasModelList={Boolean(modelList)}
         hideModelSwitcher={hideModelSwitcher}
         refreshThreadList={refreshThreadList}

--- a/packages/playground/src/domains/agents/components/agent-chat.tsx
+++ b/packages/playground/src/domains/agents/components/agent-chat.tsx
@@ -13,6 +13,10 @@ interface AvailableSuggestedPromptsOptions {
   isMessagesLoading: boolean;
 }
 
+/**
+ * Keeps existing-thread prompts hidden until message history has loaded, so
+ * they do not briefly appear before the conversation replaces the welcome UI.
+ */
 const getAvailableSuggestedPrompts = ({
   suggestedPrompts,
   isNewThread,

--- a/packages/playground/src/domains/agents/utils/__tests__/agent-suggested-prompts.test.ts
+++ b/packages/playground/src/domains/agents/utils/__tests__/agent-suggested-prompts.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getAgentSuggestedPrompts } from '../agent-suggested-prompts';
+
+describe('getAgentSuggestedPrompts', () => {
+  describe('when suggested prompts are missing or malformed', () => {
+    it('returns no prompts', () => {
+      expect(getAgentSuggestedPrompts(undefined)).toEqual([]);
+      expect(getAgentSuggestedPrompts({ suggestedPrompts: 'Check the weather' })).toEqual([]);
+    });
+  });
+
+  describe('when suggested prompts contain invalid and duplicate values', () => {
+    it('returns the first three unique non-empty strings', () => {
+      const metadata = {
+        suggestedPrompts: [
+          '  Check the weather  ',
+          '',
+          42,
+          'Check the weather',
+          'Check a stock',
+          null,
+          'Build a page',
+          'Ignored after the limit',
+        ],
+      };
+
+      expect(getAgentSuggestedPrompts(metadata)).toEqual(['Check the weather', 'Check a stock', 'Build a page']);
+    });
+  });
+});

--- a/packages/playground/src/domains/agents/utils/agent-suggested-prompts.ts
+++ b/packages/playground/src/domains/agents/utils/agent-suggested-prompts.ts
@@ -1,0 +1,28 @@
+const MAX_SUGGESTED_PROMPTS = 3;
+
+/**
+ * Reads the suggested-prompt convention from free-form agent metadata.
+ * Invalid, blank, and duplicate entries are ignored so the chat always receives
+ * a small list that is safe to render with the prompt text as its React key.
+ */
+export function getAgentSuggestedPrompts(metadata: Record<string, unknown> | undefined): string[] {
+  const configuredPrompts = metadata?.suggestedPrompts;
+  if (!Array.isArray(configuredPrompts)) return [];
+
+  const prompts: string[] = [];
+  const seenPrompts = new Set<string>();
+
+  for (const configuredPrompt of configuredPrompts) {
+    if (typeof configuredPrompt !== 'string') continue;
+
+    const prompt = configuredPrompt.trim();
+    if (!prompt || seenPrompts.has(prompt)) continue;
+
+    prompts.push(prompt);
+    seenPrompts.add(prompt);
+
+    if (prompts.length === MAX_SUGGESTED_PROMPTS) break;
+  }
+
+  return prompts;
+}

--- a/packages/playground/src/lib/ai-ui/__tests__/thread.test.tsx
+++ b/packages/playground/src/lib/ai-ui/__tests__/thread.test.tsx
@@ -101,10 +101,13 @@ const Wrapper = ({ children, threadId = 'thread-1' }: { children: ReactNode; thr
   );
 };
 
-const renderThreadTree = (
-  initialMessages: MastraDBMessage[],
-  options: { hasModelList?: boolean; threadId?: string; suggestedPrompts?: string[] } = {},
-) => {
+interface RenderThreadOptions {
+  hasModelList?: boolean;
+  threadId?: string;
+  suggestedPrompts?: string[];
+}
+
+const renderThreadTree = (initialMessages: MastraDBMessage[], options: RenderThreadOptions = {}) => {
   const { hasModelList = true, threadId = 'thread-1', suggestedPrompts } = options;
 
   return (
@@ -131,10 +134,8 @@ const renderThreadTree = (
   );
 };
 
-const renderThread = (
-  initialMessages: MastraDBMessage[],
-  options: { hasModelList?: boolean; threadId?: string; suggestedPrompts?: string[] } = { hasModelList: true },
-) => render(renderThreadTree(initialMessages, options));
+const renderThread = (initialMessages: MastraDBMessage[], options?: RenderThreadOptions) =>
+  render(renderThreadTree(initialMessages, options));
 
 const userMessage = (text: string): MastraDBMessage => ({
   id: `m-${text}`,
@@ -230,12 +231,12 @@ describe('Thread', () => {
         renderThread([], { suggestedPrompts: ['Check the weather'] });
       });
 
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'Check the weather' }));
-        await new Promise(resolve => setTimeout(resolve, 80));
+      fireEvent.click(screen.getByRole('button', { name: 'Check the weather' }));
+
+      await waitFor(() => {
+        expect(captured).toHaveLength(1);
       });
 
-      expect(captured).toHaveLength(1);
       expect(JSON.stringify(captured[0].body.messages ?? [])).toContain('Check the weather');
     });
   });

--- a/packages/playground/src/lib/ai-ui/suggested-prompt-list.tsx
+++ b/packages/playground/src/lib/ai-ui/suggested-prompt-list.tsx
@@ -7,6 +7,7 @@ interface SuggestedPromptListProps {
   prompts: string[];
 }
 
+/** Renders agent-configured prompts as chat actions that respect send permissions. */
 export const SuggestedPromptList = ({ prompts }: SuggestedPromptListProps) => {
   const send = useChatSend();
   const { isRunning, canSendWhileStreaming } = useChatRunning();

--- a/packages/playground/src/lib/ai-ui/suggested-prompt-list.tsx
+++ b/packages/playground/src/lib/ai-ui/suggested-prompt-list.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+
+import { useChatRunning, useChatSend } from './chat/chat-context';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+
+interface SuggestedPromptListProps {
+  prompts: string[];
+}
+
+export const SuggestedPromptList = ({ prompts }: SuggestedPromptListProps) => {
+  const send = useChatSend();
+  const { isRunning, canSendWhileStreaming } = useChatRunning();
+  const { canExecute } = usePermissions();
+
+  if (prompts.length === 0) return null;
+
+  const sendBlocked = isRunning && !canSendWhileStreaming;
+  const isDisabled = sendBlocked || !canExecute('agents');
+
+  return (
+    <div className="mt-6 flex max-w-full flex-row gap-2 overflow-x-auto px-4">
+      {prompts.map(prompt => (
+        <Button
+          key={prompt}
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={isDisabled}
+          onClick={() => send({ message: prompt })}
+        >
+          {prompt}
+        </Button>
+      ))}
+    </div>
+  );
+};

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -36,6 +36,7 @@ import { BracketOverlay } from './components/bracket-overlay';
 import './thread.css';
 import { SaveFullConversationAction } from './messages/dataset-save-action';
 import { MessageRow } from './messages/message-row';
+import { SuggestedPromptList } from './suggested-prompt-list';
 import { TaskPanel } from './task-panel';
 import { BrowserThumbnail, useBrowserSession } from '@/domains/agents';
 import { ComposerModelSettings } from '@/domains/agents/components/composer-model-settings';
@@ -47,6 +48,7 @@ import type { VoiceCallControls } from '@/domains/voice';
 import { usePlaygroundStore } from '@/store/playground-store';
 
 const SKELETON_DELAY_MS = 300;
+const EMPTY_SUGGESTED_PROMPTS: string[] = [];
 
 /**
  * Returns true only after `flag` has stayed true for `delayMs` continuously, so
@@ -232,33 +234,12 @@ export interface ThreadWelcomeProps {
   suggestedPrompts?: string[];
 }
 
-const ThreadWelcome = ({ agentName, suggestedPrompts = [] }: ThreadWelcomeProps) => {
-  const send = useChatSend();
-  const { isRunning, canSendWhileStreaming } = useChatRunning();
-  const { canExecute } = usePermissions();
-  const canExecuteAgent = canExecute('agents');
-  const sendBlocked = isRunning && !canSendWhileStreaming;
-
+const ThreadWelcome = ({ agentName, suggestedPrompts = EMPTY_SUGGESTED_PROMPTS }: ThreadWelcomeProps) => {
   return (
     <div className="flex w-full grow flex-col items-center pt-[15vh]">
       <Avatar name={agentName || 'Agent'} size="lg" />
       <p className="mt-4 font-medium">How can I help you today?</p>
-      {suggestedPrompts.length > 0 && (
-        <div className="mt-6 flex max-w-full flex-row gap-2 overflow-x-auto px-4">
-          {suggestedPrompts.map(prompt => (
-            <Button
-              key={prompt}
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={sendBlocked || !canExecuteAgent}
-              onClick={() => send({ message: prompt })}
-            >
-              {prompt}
-            </Button>
-          ))}
-        </div>
-      )}
+      <SuggestedPromptList prompts={suggestedPrompts} />
     </div>
   );
 };

--- a/packages/playground/src/pages/agents/agent/__tests__/suggested-prompts.msw.test.tsx
+++ b/packages/playground/src/pages/agents/agent/__tests__/suggested-prompts.msw.test.tsx
@@ -3,9 +3,8 @@ import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
-import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import AgentPage from '../index';
 import { StudioConfigContext } from '@/domains/configuration';
@@ -16,13 +15,6 @@ const BASE_URL = 'http://localhost:4111';
 const AGENT_ID = 'agent-1';
 const THREAD_ID = 'thread-1';
 const SUGGESTED_PROMPT = 'Check the weather';
-
-vi.mock('@/domains/agents/agent-sidebar', () => ({
-  AgentSidebar: () => <div data-testid="stub-sidebar" />,
-}));
-vi.mock('@/domains/agents/components/browser-view', () => ({
-  BrowserViewPanel: () => null,
-}));
 
 const createGate = () => {
   let release = () => {};

--- a/packages/playground/src/pages/agents/agent/__tests__/suggested-prompts.msw.test.tsx
+++ b/packages/playground/src/pages/agents/agent/__tests__/suggested-prompts.msw.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import AgentPage from '../index';
+import { StudioConfigContext } from '@/domains/configuration';
+import { memoryEnabled, v2Agent } from '@/lib/ai-ui/__tests__/fixtures/agent';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+const AGENT_ID = 'agent-1';
+const THREAD_ID = 'thread-1';
+const SUGGESTED_PROMPT = 'Check the weather';
+
+vi.mock('@/domains/agents/agent-sidebar', () => ({
+  AgentSidebar: () => <div data-testid="stub-sidebar" />,
+}));
+vi.mock('@/domains/agents/components/browser-view', () => ({
+  BrowserViewPanel: () => null,
+}));
+
+const createGate = () => {
+  let release = () => {};
+  const promise = new Promise<void>(resolve => {
+    release = resolve;
+  });
+
+  return { promise, release };
+};
+
+const renderPage = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <StudioConfigContext.Provider
+      value={{ baseUrl: BASE_URL, headers: {}, apiPrefix: undefined, isLoading: false, setConfig: () => {} }}
+    >
+      <MastraReactProvider baseUrl={BASE_URL}>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={[`/agents/${AGENT_ID}/chat/${THREAD_ID}`]}>
+            <Routes>
+              <Route path="/agents/:agentId/chat/:threadId" element={<AgentPage />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </MastraReactProvider>
+    </StudioConfigContext.Provider>,
+  );
+};
+
+afterEach(() => cleanup());
+
+describe('agent suggested prompts', () => {
+  describe('when an existing thread is still loading its messages', () => {
+    it('withholds the prompts until the message query resolves', async () => {
+      const messagesGate = createGate();
+
+      server.use(
+        http.get(`${BASE_URL}/api/agents/${AGENT_ID}`, () =>
+          HttpResponse.json({
+            ...v2Agent,
+            metadata: { suggestedPrompts: [SUGGESTED_PROMPT] },
+          }),
+        ),
+        http.get(`${BASE_URL}/api/auth/me`, () => HttpResponse.json({ id: 'user-1' })),
+        http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json({ enabled: false, login: null })),
+        http.get(`${BASE_URL}/api/memory/status`, () => HttpResponse.json(memoryEnabled)),
+        http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: {} })),
+        http.get(`${BASE_URL}/api/memory/threads`, () => HttpResponse.json({ threads: [] })),
+        http.get(`${BASE_URL}/api/memory/threads/${THREAD_ID}/working-memory`, () =>
+          HttpResponse.json({
+            workingMemory: null,
+            source: 'thread',
+            workingMemoryTemplate: null,
+            threadExists: true,
+          }),
+        ),
+        http.get(`${BASE_URL}/api/memory/threads/${THREAD_ID}/messages`, async () => {
+          await messagesGate.promise;
+          return HttpResponse.json({ messages: [] });
+        }),
+        http.get(`${BASE_URL}/api/memory/observational-memory`, () => HttpResponse.json({ record: null })),
+        http.get(`${BASE_URL}/api/agents/providers`, () => HttpResponse.json({ providers: [] })),
+        http.get(`${BASE_URL}/api/agents/${AGENT_ID}/voice/speakers`, () => HttpResponse.json([])),
+        http.get(`${BASE_URL}/api/editor/builder/settings`, () =>
+          HttpResponse.json({ enabled: false, modelPolicy: { active: false } }),
+        ),
+        http.get(`${BASE_URL}/api/editor/builder/models/available`, () => HttpResponse.json({ providers: [] })),
+        http.post(`${BASE_URL}/api/agents/${AGENT_ID}/threads/subscribe`, () => HttpResponse.json({ ok: true })),
+      );
+
+      renderPage();
+
+      expect(await screen.findByText('How can I help you today?')).not.toBeNull();
+      expect(screen.queryByRole('button', { name: SUGGESTED_PROMPT })).toBeNull();
+
+      messagesGate.release();
+
+      expect(await screen.findByRole('button', { name: SUGGESTED_PROMPT })).not.toBeNull();
+    });
+  });
+});

--- a/packages/playground/src/pages/agents/agent/index.tsx
+++ b/packages/playground/src/pages/agents/agent/index.tsx
@@ -24,6 +24,7 @@ import { BrowserToolCallsProvider } from '@/domains/agents/context/browser-tool-
 import { MemoryTimelineProvider } from '@/domains/agents/context/memory-timeline-context';
 import { useAgent } from '@/domains/agents/hooks/use-agent';
 import { buildAgentDefaultSettings } from '@/domains/agents/utils/agent-default-settings';
+import { getAgentSuggestedPrompts } from '@/domains/agents/utils/agent-suggested-prompts';
 import { ThreadInputProvider } from '@/domains/conversation/context/ThreadInputContext';
 import { useMemory, useThreads } from '@/domains/memory/hooks/use-memory';
 import { SchemaRequestContextProvider } from '@/domains/request-context/context/schema-request-context';
@@ -73,9 +74,7 @@ function Agent({ view = 'chat' }: { view?: 'chat' | 'settings' }) {
   }, [isSettingsView, threadId, agentId, navigate]);
 
   const messageId = searchParams.get('messageId') ?? undefined;
-  const suggestedPrompts = Array.isArray(agent?.metadata?.suggestedPrompts)
-    ? agent.metadata.suggestedPrompts.filter(prompt => typeof prompt === 'string').slice(0, 3)
-    : [];
+  const suggestedPrompts = getAgentSuggestedPrompts(agent?.metadata);
 
   const defaultSettings = useMemo(() => buildAgentDefaultSettings(agent), [agent]);
 


### PR DESCRIPTION
Follow-up to #20794. Moves free-form metadata parsing and prompt actions into focused units, ignores blank and duplicate prompts, and keeps the existing-thread loading rule out of JSX. It also adds the missing delayed-message MSW regression and replaces the fixed-timeout send assertion.

Validated with 26 focused Vitest tests, Playground typecheck and production build, ESLint, Oxlint, diff checks, and React Doctor with no changed-file findings.

No screenshot because the visible prompt UI is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The Playground now shows suggested prompts more reliably. It ignores unusable or repeated prompts and waits for existing thread messages to load before showing them.

## Changes

- Added `getAgentSuggestedPrompts` for metadata parsing.
- Filters non-string, blank, duplicate, and excess prompts.
- Added `SuggestedPromptList` for rendering and submission.
- Moved existing-thread loading logic out of JSX.
- Added an MSW regression test for delayed message loading.
- Replaced the fixed-timeout assertion with `waitFor`.
- Added unit tests for prompt parsing and filtering.
- Ensured prompt actions respect chat permissions.

## Validation

- 26 focused Vitest tests passed.
- Playground typecheck and production build passed.
- ESLint, Oxlint, and diff checks passed.
- React Doctor found no issues in changed files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->