### PR TITLE
feat(client-js): export isKnownAgentControllerEvent to narrow stream events

### DIFF
--- a/.changeset/salty-toes-watch.md
+++ b/.changeset/salty-toes-watch.md
@@ -1,0 +1,30 @@
+---
+'@mastra/client-js': minor
+---
+
+Added `isKnownAgentControllerEvent` to narrow agent controller stream events. `AgentControllerEvent` includes a forward-compatibility arm whose `type` is `string`, so comparing `event.type` to a literal never narrows the union and payload fields stay `unknown` — consumers had to cast.
+
+**Before**
+
+```ts
+session.subscribe({
+  onEvent: event => {
+    const known = event as KnownAgentControllerEvent;
+    if (known.type === 'message_end') save(known.message);
+  },
+});
+```
+
+**After**
+
+```ts
+import { isKnownAgentControllerEvent } from '@mastra/client-js';
+
+session.subscribe({
+  onEvent: event => {
+    if (isKnownAgentControllerEvent(event) && event.type === 'message_end') save(event.message);
+  },
+});
+```
+
+The guard is kept in sync with the event union at compile time, so a new event type cannot be added without it.

--- a/client-sdks/client-js/src/index.ts
+++ b/client-sdks/client-js/src/index.ts
@@ -16,7 +16,7 @@ export type {
   GetAgentCardOptions,
   VerifyAgentCardSignatureOptions,
 } from './resources/a2a';
-export { agentControllerMessageText } from './resources/agent-controller';
+export { agentControllerMessageText, isKnownAgentControllerEvent } from './resources/agent-controller';
 export type {
   AgentControllerInfo,
   MastraDBMessage,

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -2,7 +2,7 @@ import { RequestContext } from '@mastra/core/request-context';
 import { describe, expect, beforeEach, it, vi } from 'vitest';
 
 import { MastraClient } from '../client';
-import { agentControllerMessageText } from './agent-controller';
+import { agentControllerMessageText, isKnownAgentControllerEvent } from './agent-controller';
 import type { AgentControllerEvent, KnownAgentControllerEvent } from './agent-controller';
 
 global.fetch = vi.fn();
@@ -297,7 +297,9 @@ describe('AgentController Resource', () => {
       .getAgentController('code')
       .session('user-1')
       .subscribe({
-        onEvent: e => received.push(e as KnownAgentControllerEvent),
+        onEvent: e => {
+          if (isKnownAgentControllerEvent(e)) received.push(e);
+        },
       });
 
     // Allow the async pump to drain the (already-closed) stream.

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -155,10 +155,70 @@ export interface OtherAgentControllerEvent {
 }
 
 /**
- * An agent controller event. Narrow on `type` to access known payloads; unknown
- * event types fall through to {@link OtherAgentControllerEvent}.
+ * An agent controller event. Comparing `event.type` to a literal does NOT
+ * narrow this union — {@link OtherAgentControllerEvent} types `type` as
+ * `string`, which matches every literal. Narrow with
+ * {@link isKnownAgentControllerEvent} first, then switch on `type`.
  */
 export type AgentControllerEvent = KnownAgentControllerEvent | OtherAgentControllerEvent;
+
+// Runtime mirror of the union — Record keyed by its `type` makes tsc reject a
+// missing or extra entry.
+const KNOWN_AGENT_CONTROLLER_EVENT_TYPES = new Set<string>(
+  Object.keys({
+    agent_start: true,
+    agent_end: true,
+    message_start: true,
+    message_update: true,
+    message_end: true,
+    tool_input_start: true,
+    tool_input_delta: true,
+    tool_input_end: true,
+    tool_start: true,
+    tool_update: true,
+    shell_output: true,
+    tool_end: true,
+    tool_approval_required: true,
+    tool_suspended: true,
+    mode_changed: true,
+    model_changed: true,
+    thread_changed: true,
+    thread_created: true,
+    thread_deleted: true,
+    subagent_start: true,
+    subagent_end: true,
+    task_updated: true,
+    notification: true,
+    notification_summary: true,
+    usage_update: true,
+    display_state_changed: true,
+    goal_evaluation: true,
+    follow_up_queued: true,
+    om_observation_start: true,
+    om_observation_end: true,
+    om_observation_failed: true,
+    om_reflection_start: true,
+    om_reflection_end: true,
+    om_reflection_failed: true,
+    om_buffering_start: true,
+    om_buffering_end: true,
+    om_buffering_failed: true,
+    om_model_changed: true,
+    om_activation: true,
+    om_status: true,
+    om_thread_title_updated: true,
+    workspace_ready: true,
+    workspace_error: true,
+    workspace_status_changed: true,
+    info: true,
+    error: true,
+  } satisfies Record<KnownAgentControllerEvent['type'], true>),
+);
+
+/** Narrows to the explicitly typed events; see {@link AgentControllerEvent}. */
+export function isKnownAgentControllerEvent(event: AgentControllerEvent): event is KnownAgentControllerEvent {
+  return KNOWN_AGENT_CONTROLLER_EVENT_TYPES.has(event.type);
+}
 
 type SerializedMastraDBMessage = Omit<MastraDBMessage, 'createdAt'> & { createdAt: Date | string };
 

--- a/mastracode/factory-ui/src/ui/domains/chat/services/runtime.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/runtime.ts
@@ -1,4 +1,5 @@
-import type { AgentControllerEvent, AgentControllerOMProgress, KnownAgentControllerEvent } from '@mastra/client-js';
+import type { AgentControllerEvent, AgentControllerOMProgress } from '@mastra/client-js';
+import { isKnownAgentControllerEvent } from '@mastra/client-js';
 
 export interface UsageSnapshot {
   promptTokens?: number;
@@ -37,19 +38,19 @@ export const initialChatRuntime: ChatRuntimeState = {
 };
 
 export function runtimeReducer(state: ChatRuntimeState, event: AgentControllerEvent): ChatRuntimeState {
-  const knownEvent = event as KnownAgentControllerEvent;
+  if (!isKnownAgentControllerEvent(event)) return state;
 
-  switch (knownEvent.type) {
+  switch (event.type) {
     case 'agent_start':
       return { ...state, tokensPerSec: 0, _decodeStartedAt: 0 };
     case 'agent_end':
       return { ...state, _decodeStartedAt: 0 };
     case 'message_start':
     case 'message_update':
-      if (!hasAssistantText(knownEvent.message) || state._decodeStartedAt > 0) return state;
+      if (!hasAssistantText(event.message) || state._decodeStartedAt > 0) return state;
       return { ...state, _decodeStartedAt: Date.now() };
     case 'usage_update': {
-      const usage = knownEvent.usage as UsageSnapshot;
+      const usage = event.usage as UsageSnapshot;
       const stepTokens = (usage.completionTokens ?? 0) + (usage.reasoningTokens ?? 0);
       let tokensPerSec = state.tokensPerSec;
       if (state._decodeStartedAt > 0 && stepTokens > 0) {
@@ -65,23 +66,23 @@ export function runtimeReducer(state: ChatRuntimeState, event: AgentControllerEv
     case 'display_state_changed':
       return {
         ...state,
-        omProgress: knownEvent.displayState.omProgress ?? state.omProgress,
-        usage: (knownEvent.displayState.tokenUsage as UsageSnapshot | undefined) ?? state.usage,
+        omProgress: event.displayState.omProgress ?? state.omProgress,
+        usage: (event.displayState.tokenUsage as UsageSnapshot | undefined) ?? state.usage,
       };
     case 'goal_evaluation':
       return {
         ...state,
         goal: {
-          objective: knownEvent.payload.objective,
-          status: knownEvent.payload.status,
-          iteration: knownEvent.payload.iteration,
-          maxRuns: knownEvent.payload.maxRuns,
-          passed: knownEvent.payload.passed,
-          reason: knownEvent.payload.reason,
+          objective: event.payload.objective,
+          status: event.payload.status,
+          iteration: event.payload.iteration,
+          maxRuns: event.payload.maxRuns,
+          passed: event.payload.passed,
+          reason: event.payload.reason,
         },
       };
     case 'follow_up_queued':
-      return { ...state, followUpCount: knownEvent.count };
+      return { ...state, followUpCount: event.count };
     case 'om_observation_start':
       return { ...state, omPhase: 'observing' };
     case 'om_observation_end':
@@ -96,7 +97,7 @@ export function runtimeReducer(state: ChatRuntimeState, event: AgentControllerEv
     case 'om_buffering_start':
       return { ...state, omPhase: 'buffering' };
     case 'om_activation':
-      return knownEvent.enabled ? state : { ...state, omPhase: 'idle' };
+      return event.enabled ? state : { ...state, omPhase: 'idle' };
     default:
       return state;
   }

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -1,9 +1,5 @@
-import type {
-  AgentControllerEvent,
-  KnownAgentControllerEvent,
-  AgentControllerTaskSnapshot,
-  AgentControllerOMProgress,
-} from '@mastra/client-js';
+import type { AgentControllerEvent, AgentControllerTaskSnapshot, AgentControllerOMProgress } from '@mastra/client-js';
+import { isKnownAgentControllerEvent } from '@mastra/client-js';
 import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent-controller';
 
 import { stripAnsi } from './ansi';
@@ -272,8 +268,8 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
   }
 }
 
-function applyEvent(state: TranscriptState, raw: AgentControllerEvent): TranscriptState {
-  const event = raw as KnownAgentControllerEvent;
+function applyEvent(state: TranscriptState, event: AgentControllerEvent): TranscriptState {
+  if (!isKnownAgentControllerEvent(event)) return state;
   switch (event.type) {
     case 'agent_start':
       // Reset the rate at the start of a new turn (not at the end) so the last

--- a/mastracode/web/e2e/web/driver.ts
+++ b/mastracode/web/e2e/web/driver.ts
@@ -1,5 +1,5 @@
-import { MastraClient } from '@mastra/client-js';
-import type { KnownAgentControllerEvent, PlanResume, SendNotificationInput } from '@mastra/client-js';
+import { MastraClient, isKnownAgentControllerEvent } from '@mastra/client-js';
+import type { PlanResume, SendNotificationInput } from '@mastra/client-js';
 
 import {
   createInitialTranscript,
@@ -118,15 +118,16 @@ export async function createDriver(opts: {
     onEvent: event => {
       // Mirror the app: mode/model changes update the session-state layer
       // (query invalidation → refetch in React), not the transcript.
-      const known = event as KnownAgentControllerEvent;
-      if (known.type === 'mode_changed') {
-        sessionState = { ...sessionState, modeId: known.modeId };
-      } else if (known.type === 'model_changed') {
-        sessionState = { ...sessionState, modelId: known.modelId };
-      } else if (known.type === 'agent_start') {
-        running = true;
-      } else if (known.type === 'agent_end') {
-        running = false;
+      if (isKnownAgentControllerEvent(event)) {
+        if (event.type === 'mode_changed') {
+          sessionState = { ...sessionState, modeId: event.modeId };
+        } else if (event.type === 'model_changed') {
+          sessionState = { ...sessionState, modelId: event.modelId };
+        } else if (event.type === 'agent_start') {
+          running = true;
+        } else if (event.type === 'agent_end') {
+          running = false;
+        }
       }
       apply(transcriptReducer(state, { type: 'event', event }));
     },


### PR DESCRIPTION
`AgentControllerEvent` unions the typed events with a forward-compatibility arm, `OtherAgentControllerEvent`, whose `type` is `string`. Since `string` matches every literal, comparing `event.type === 'message_end'` never drops that arm — the compiler keeps the payload as `unknown` no matter what you test. The doc comment on the union claimed the opposite ("Narrow on `type` to access known payloads"), and every consumer that needed a known payload had quietly worked around it with an `as KnownAgentControllerEvent` cast: both factory-ui reducers, the web e2e driver, and client-js's own test.

This fixes it once at the source. `isKnownAgentControllerEvent` is a runtime guard whose set of known types is derived from a `Record` keyed by `KnownAgentControllerEvent['type']`, so tsc rejects both a missing and an extra entry — a new event type cannot be added to the union without the guard learning it in the same edit. I updated the four cast sites to use it and fixed the union's doc comment.

Behavior is unchanged at every site: both reducers already fell through to `default: return state` for unknown event types, and the driver ignored them — the guard's early return is the same path, stated honestly instead of cast around.

Verified: client-js unit tests (33 files / 597 tests), factory-ui suite (96 files / 522 tests — one unrelated flake on the first run, green on rerun in line with the known parallel flakiness), `tsc --noEmit` clean on factory-ui and mastracode/web. Not verified in a browser; nothing here changes runtime behavior, only what the compiler knows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The client now checks whether an event is recognized before processing it. This prevents unsafe type casts while keeping support for future event types.

## What changed

- Added and exported `isKnownAgentControllerEvent` from `@mastra/client-js`.
- Derived known event types from `KnownAgentControllerEvent['type']`.
- Added compile-time checks for missing or extra event mappings.
- Updated factory-ui reducers, the web e2e driver, and a client-js test to use the guard.
- Updated `AgentControllerEvent` documentation to describe forward-compatible event narrowing.
- Added a minor changeset for `@mastra/client-js`.

## Testing

- Tests and TypeScript checks completed.
- One unrelated factory-ui flake passed on rerun.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->