### PR TITLE
fix(factory-ui): tool rows spin forever when an SSE gap swallows tool_end

### DIFF
--- a/mastracode/factory-ui/src/api/keys.ts
+++ b/mastracode/factory-ui/src/api/keys.ts
@@ -118,6 +118,10 @@ export const queryKeys = {
     resourceId: string | undefined,
     projectPath: string | undefined,
   ) => [...queryKeys.agentControllerSession(agentControllerId, resourceId, projectPath), 'threads'] as const,
+  // Prefix over every thread's messages for a resource — invalidation target
+  // when an SSE gap may have dropped events for any thread of the session.
+  agentControllerResourceThreadMessages: (agentControllerId: string | undefined, resourceId: string | undefined) =>
+    ['agent-controller', agentControllerId ?? null, 'sessions', resourceId ?? null, 'threads'] as const,
   // Thread ids are unique across the resource, so messages are keyed by threadId
   // alone (no projectPath) — caches survive worktree switches and seeding does
   // not need to know the thread's scope.
@@ -133,11 +137,7 @@ export const queryKeys = {
     limit?: number,
   ) =>
     [
-      'agent-controller',
-      agentControllerId ?? null,
-      'sessions',
-      resourceId ?? null,
-      'threads',
+      ...queryKeys.agentControllerResourceThreadMessages(agentControllerId, resourceId),
       threadId ?? null,
       'messages',
       ...(limit === undefined ? [] : [limit]),

--- a/mastracode/factory-ui/src/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
@@ -468,4 +468,54 @@ describe('useAgentControllerConnection', () => {
 
     expect(result.current.state?.threadId).toBe('state-thread-2');
   });
+
+  it('given the stream drops and recovers, then the resource message windows are invalidated to close the event gap', async () => {
+    const onStream = vi.fn();
+    const onEvent = vi.fn();
+
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, () =>
+        HttpResponse.json({ controllerId, resourceId, threadId: 'created-thread' }),
+      ),
+      http.get(sessionUrl, () =>
+        HttpResponse.json({
+          controllerId,
+          resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: 'state-thread',
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        }),
+      ),
+      http.get(`${sessionUrl}/stream`, () => {
+        onStream();
+        if (onStream.mock.calls.length === 1) {
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                setTimeout(() => controller.error(new Error('stream dropped')), 0);
+              },
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          );
+        }
+        return new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }),
+    );
+
+    const { client, result } = renderHookWithProviders(() => useAgentControllerConnection({ ...hookArgs, onEvent }));
+
+    const messagesKey = queryKeys.agentControllerThreadMessages(controllerId, resourceId, 'thread-x', 100);
+    const otherResourceKey = queryKeys.agentControllerThreadMessages(controllerId, 'other-resource', 'thread-y', 100);
+    client.setQueryData(messagesKey, []);
+    client.setQueryData(otherResourceKey, []);
+
+    await waitFor(() => expect(onStream).toHaveBeenCalledTimes(2), { timeout: 2500 });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await waitFor(() => expect(client.getQueryState(messagesKey)?.isInvalidated).toBe(true));
+    expect(client.getQueryState(otherResourceKey)?.isInvalidated).toBe(false);
+  });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../../../hooks/useAgentControllerRunMutations';
 import { stripSerializedAnsi } from '../services/ansi';
 import { AGENT_CONTROLLER_ID } from '../services/constants';
+import { isTerminalInvocationState } from '../services/transcript';
 import { isTranscriptToolVisible, ToolFactory } from './ToolFactory';
 import { Markdown } from '../../../ui/Markdown';
 
@@ -998,8 +999,8 @@ function FileAttachment({ part }: { part: FilePart }) {
 
 /** Terminal status carried by the persisted part, if it reached one. */
 function terminalInvocationStatus(invocation: ToolInvocationPart['toolInvocation']): 'done' | 'error' | undefined {
-  if (invocation.state === 'output-error' || invocation.state === 'output-denied') return 'error';
-  if (invocation.state !== 'result') return undefined;
+  if (!isTerminalInvocationState(invocation.state)) return undefined;
+  if (invocation.state !== 'result') return 'error';
   return 'isError' in invocation && invocation.isError === true ? 'error' : 'done';
 }
 

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -996,17 +996,30 @@ function FileAttachment({ part }: { part: FilePart }) {
   return <pre className={resultBlock}>{stringify(part)}</pre>;
 }
 
+/** Terminal status carried by the persisted part, if it reached one. */
+function terminalInvocationStatus(invocation: ToolInvocationPart['toolInvocation']): 'done' | 'error' | undefined {
+  if (invocation.state === 'output-error' || invocation.state === 'output-denied') return 'error';
+  if (invocation.state !== 'result') return undefined;
+  return 'isError' in invocation && invocation.isError === true ? 'error' : 'done';
+}
+
 function toolFromInvocationPart(part: ToolInvocationPart, runtime?: ToolCall): ToolCall {
   const invocation = part.toolInvocation;
-  const failed = invocation.state === 'output-error' || invocation.state === 'output-denied';
   const persistedResult = 'result' in invocation ? invocation.result : undefined;
+  // Persisted terminal state beats the live overlay: `tool_end` can be lost in
+  // an SSE gap (no server replay), and a terminal part never regresses — the
+  // overlay's 'running' would otherwise spin forever.
+  const terminalStatus = terminalInvocationStatus(invocation);
+  const result = terminalStatus
+    ? (persistedResult ?? invocation.errorText ?? runtime?.result)
+    : (runtime?.result ?? persistedResult ?? invocation.errorText);
   return {
     toolCallId: invocation.toolCallId,
     toolName: invocation.toolName,
     argsText: runtime?.argsText ?? '',
     args: runtime?.args ?? ('args' in invocation ? invocation.args : undefined),
-    status: runtime?.status ?? (failed ? 'error' : invocation.state === 'result' ? 'done' : 'running'),
-    result: runtime?.result ?? persistedResult ?? invocation.errorText,
+    status: terminalStatus ?? runtime?.status ?? 'running',
+    result,
     output: runtime?.output ?? '',
   };
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
@@ -114,6 +114,30 @@ describe('TranscriptEntries tool rows', () => {
     expect(within(row).queryByLabelText('Running')).not.toBeInTheDocument();
   });
 
+  it.each(['output-error', 'output-denied'] as const)(
+    'renders a persisted %s part as failed even under a stale running overlay',
+    state => {
+      renderEntries([
+        assistantMessage(
+          'msg-1',
+          [
+            {
+              type: 'tool-invocation',
+              toolInvocation: { state, toolCallId: 'call-1', toolName: 'write_file', args: {}, errorText: 'nope' },
+            },
+          ],
+          {
+            'call-1': { toolCallId: 'call-1', toolName: 'write_file', argsText: '', status: 'running', output: '' },
+          },
+        ),
+      ]);
+
+      const row = screen.getByRole('group', { name: 'Tool: write_file' });
+      expect(within(row).getByRole('img', { name: 'Failed' })).toBeInTheDocument();
+      expect(within(row).queryByLabelText('Running')).not.toBeInTheDocument();
+    },
+  );
+
   it('gives prose entries their own vertical margins so rows stay on a uniform rhythm', () => {
     renderEntries([
       userMessage('msg-user', 'Please run the tests'),

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
@@ -1,18 +1,23 @@
-import type { MastraDBMessage } from '@mastra/core/agent-controller';
+import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent-controller';
 import { screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { renderWithProviders } from '../../../../../../e2e/ui/render';
-import type { TimelineEntry } from '../../services/transcript';
+import type { TimelineEntry, ToolCall } from '../../services/transcript';
 import { TranscriptEntries } from '../Transcript';
 
 const CREATED_AT = new Date('2026-07-15T10:00:00.000Z');
 
-function assistantMessage(id: string, parts: MastraDBMessage['content']['parts']): TimelineEntry {
+function assistantMessage(
+  id: string,
+  parts: MastraDBMessage['content']['parts'],
+  runtimeTools?: Record<string, ToolCall>,
+): TimelineEntry {
   return {
     kind: 'message',
     id,
     message: { id, role: 'assistant', createdAt: CREATED_AT, content: { format: 2, parts } },
+    runtimeTools,
   };
 }
 
@@ -23,6 +28,12 @@ function userMessage(id: string, text: string): TimelineEntry {
     message: { id, role: 'user', createdAt: CREATED_AT, content: { format: 2, parts: [{ type: 'text', text }] } },
   };
 }
+
+// Core writes `isError` onto persisted result invocations (session-run-engine)
+// without it being part of the declared invocation type.
+type ToolInvocationFixture = Extract<MastraMessagePart, { type: 'tool-invocation' }>['toolInvocation'] & {
+  isError?: boolean;
+};
 
 function doneTool(toolCallId: string, toolName: string): MastraDBMessage['content']['parts'][number] {
   return {
@@ -69,6 +80,38 @@ describe('TranscriptEntries tool rows', () => {
     // Failure keeps its red cross.
     const failedRow = screen.getByRole('group', { name: 'Tool: write_file' });
     expect(within(failedRow).getByRole('img', { name: 'Failed' })).toBeInTheDocument();
+  });
+
+  it('trusts the persisted result over a stale running overlay — a lost tool_end must not spin forever', () => {
+    renderEntries([
+      assistantMessage('msg-1', [doneTool('call-1', 'view')], {
+        'call-1': { toolCallId: 'call-1', toolName: 'view', argsText: '', status: 'running', output: '' },
+      }),
+    ]);
+
+    expect(screen.queryByLabelText('Running')).not.toBeInTheDocument();
+    const row = screen.getByRole('group', { name: 'Tool: view' });
+    expect(within(row).queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('renders a persisted errored result as failed even under a stale running overlay', () => {
+    const toolInvocation: ToolInvocationFixture = {
+      state: 'result',
+      toolCallId: 'call-1',
+      toolName: 'write_file',
+      args: {},
+      result: 'boom',
+      isError: true,
+    };
+    renderEntries([
+      assistantMessage('msg-1', [{ type: 'tool-invocation', toolInvocation }], {
+        'call-1': { toolCallId: 'call-1', toolName: 'write_file', argsText: '', status: 'running', output: '' },
+      }),
+    ]);
+
+    const row = screen.getByRole('group', { name: 'Tool: write_file' });
+    expect(within(row).getByRole('img', { name: 'Failed' })).toBeInTheDocument();
+    expect(within(row).queryByLabelText('Running')).not.toBeInTheDocument();
   });
 
   it('gives prose entries their own vertical margins so rows stay on a uniform rhythm', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
@@ -5,14 +5,11 @@ import { http, HttpResponse } from 'msw';
 import { useEffect } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { server } from '../../../e2e/ui/msw-server';
-import { queryKeys } from '../../api/keys';
-import { renderHookWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
-import {
-  deriveConnectionStatus,
-  useAgentControllerConnection,
-} from '../../ui/domains/chat/hooks/useAgentControllerConnection';
-import { reconnectRefetchInterval } from '../useAgentControllerSessionSync';
+import { server } from '../../../../../../e2e/ui/msw-server';
+import { queryKeys } from '../../../../../api/keys';
+import { renderHookWithProviders, TEST_BASE_URL } from '../../../../../../e2e/ui/render';
+import { deriveConnectionStatus, useAgentControllerConnection } from '../useAgentControllerConnection';
+import { reconnectRefetchInterval } from '../../../../../hooks/useAgentControllerSessionSync';
 
 const controllerId = 'code';
 const resourceId = 'resource-test';

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
@@ -1,6 +1,6 @@
 import type { AgentControllerEvent, AgentControllerSessionState } from '@mastra/client-js';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useEffectEvent, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { queryKeys } from '../../../../api/keys';
 import type { FactorySessionState } from '../context/ChatSessionContext';
 import { createAgentControllerClient } from '../services/agentControllerClient';
@@ -10,6 +10,11 @@ import { useAgentControllerSessionSync } from '../../../../hooks/useAgentControl
 
 export type ConnectionStatus = 'connecting' | 'ready' | 'reconnecting' | 'error';
 type SseConnectionState = 'never' | 'connected' | 'dropped';
+
+function nextSseConnectionState(previous: SseConnectionState, connected: boolean): SseConnectionState {
+  if (connected) return 'connected';
+  return previous === 'connected' ? 'dropped' : previous;
+}
 
 interface UseAgentControllerConnectionArgs {
   agentControllerId: string;
@@ -35,6 +40,7 @@ export function useAgentControllerConnection({
 }: UseAgentControllerConnectionArgs) {
   const queryClient = useQueryClient();
   const [sseConnectionState, setSseConnectionState] = useState<SseConnectionState>('never');
+  const sseStateRef = useRef<SseConnectionState>('never');
   const sseConnected = sseConnectionState === 'connected';
   const hasEverConnected = sseConnectionState !== 'never';
   const { session } = createAgentControllerClient({
@@ -62,27 +68,22 @@ export function useAgentControllerConnection({
     sseConnected,
   });
   const handleConnectedChange = (connected: boolean) => {
-    setSseConnectionState(current => {
-      if (connected) return 'connected';
-      if (current === 'connected') return 'dropped';
-      return current;
-    });
+    // Ref mirrors the state so back-to-back events see the true previous value
+    // even when React batches the renders in between.
+    const previous = sseStateRef.current;
+    const next = nextSseConnectionState(previous, connected);
+    if (next === previous) return;
+    sseStateRef.current = next;
+    setSseConnectionState(next);
+    // Events sent while the stream was down are gone for good (the server does
+    // not replay them), so a reconnect refetches the mounted message windows —
+    // mergeWindow folds whatever the gap dropped back into the transcript.
+    if (previous === 'dropped' && next === 'connected') {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.agentControllerResourceThreadMessages(agentControllerId, resourceId),
+      });
+    }
   };
-
-  // Events sent while the stream was down are gone for good (the server does
-  // not replay them), so a reconnect refetches the mounted message windows —
-  // mergeWindow folds whatever the gap dropped back into the transcript.
-  const invalidateResourceMessages = useEffectEvent(() => {
-    void queryClient.invalidateQueries({
-      queryKey: queryKeys.agentControllerResourceThreadMessages(agentControllerId, resourceId),
-    });
-  });
-  const previousSseStateRef = useRef<SseConnectionState>('never');
-  useEffect(() => {
-    const previous = previousSseStateRef.current;
-    previousSseStateRef.current = sseConnectionState;
-    if (previous === 'dropped' && sseConnectionState === 'connected') invalidateResourceMessages();
-  }, [sseConnectionState]);
 
   const handleEvent = (event: AgentControllerEvent) => {
     const displayStateRunning =

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
@@ -1,6 +1,6 @@
 import type { AgentControllerEvent, AgentControllerSessionState } from '@mastra/client-js';
 import { useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useEffectEvent, useRef, useState } from 'react';
 import { queryKeys } from '../../../../api/keys';
 import type { FactorySessionState } from '../context/ChatSessionContext';
 import { createAgentControllerClient } from '../services/agentControllerClient';
@@ -68,6 +68,21 @@ export function useAgentControllerConnection({
       return current;
     });
   };
+
+  // Events sent while the stream was down are gone for good (the server does
+  // not replay them), so a reconnect refetches the mounted message windows —
+  // mergeWindow folds whatever the gap dropped back into the transcript.
+  const invalidateResourceMessages = useEffectEvent(() => {
+    void queryClient.invalidateQueries({
+      queryKey: queryKeys.agentControllerResourceThreadMessages(agentControllerId, resourceId),
+    });
+  });
+  const previousSseStateRef = useRef<SseConnectionState>('never');
+  useEffect(() => {
+    const previous = previousSseStateRef.current;
+    previousSseStateRef.current = sseConnectionState;
+    if (previous === 'dropped' && sseConnectionState === 'connected') invalidateResourceMessages();
+  }, [sseConnectionState]);
 
   const handleEvent = (event: AgentControllerEvent) => {
     const displayStateRunning =

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -706,6 +706,67 @@ describe('transcript reducer mergeWindow', () => {
     },
   );
 
+  it('adopts trailing parts the gap swallowed when the run ended before reconnect', () => {
+    // The stream died mid-turn: the live entry holds a cut-off text and a tool
+    // stuck at call. The run finished during the gap, so the refetched window
+    // is the only carrier of the extended text, the result and the final text.
+    let state = createInitialTranscript({ messages: [] });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('live-1', 'assistant', [
+          { type: 'text', text: 'working' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'call', toolCallId: 'tool-1', toolName: 'view', args: {} },
+          },
+        ]),
+      },
+    });
+
+    const next = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [
+        dbMessage('persisted-1', 'assistant', [
+          { type: 'text', text: 'working on it' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'result', toolCallId: 'tool-1', toolName: 'view', args: {}, result: 'ok' },
+          },
+          { type: 'text', text: 'final answer' },
+        ]),
+      ],
+    });
+
+    expect(next.entries).toHaveLength(1);
+    expect(messageParts(next.entries[0])).toEqual([
+      { type: 'text', text: 'working on it' },
+      expect.objectContaining({ toolInvocation: expect.objectContaining({ state: 'result', result: 'ok' }) }),
+      { type: 'text', text: 'final answer' },
+    ]);
+  });
+
+  it('returns the same state when the window matches the on-screen turn exactly', () => {
+    // Routine revalidation must stay a referential no-op or every refetch
+    // rerenders the whole transcript.
+    const parts: MastraMessagePart[] = [
+      { type: 'text', text: 'done' },
+      {
+        type: 'tool-invocation',
+        toolInvocation: { state: 'result', toolCallId: 'tool-1', toolName: 'view', args: {}, result: 'ok' },
+      },
+    ];
+    const onScreen = createInitialTranscript({ messages: [dbMessage('assistant-1', 'assistant', parts)] });
+
+    const next = transcriptReducer(onScreen, {
+      type: 'mergeWindow',
+      messages: [dbMessage('assistant-1', 'assistant', parts)],
+    });
+
+    expect(next).toBe(onScreen);
+  });
+
   it('does not duplicate a turn the window carries under its persisted id', () => {
     // A streamed turn keeps its display id; the persisted copy arrives under a
     // different id but shares the toolCallId. Merge must heal in place, not

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -549,6 +549,105 @@ describe('transcript reducer mergeWindow', () => {
     expect(next.entries[0]).toMatchObject({ kind: 'message', id: 'assistant-1', streaming: true });
     expect(messageParts(next.entries[0])).toEqual([{ type: 'text', text: 'partial' }]);
   });
+
+  it('replaces a tool part stuck at call with the terminal copy from the window', () => {
+    // A dropped stream can swallow tool_end; the refetched window carries the
+    // persisted result and must heal the stuck part.
+    const onScreen = createInitialTranscript({
+      messages: [
+        dbMessage('assistant-1', 'assistant', [
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'call', toolCallId: 'tool-1', toolName: 'execute_command', args: {} },
+          },
+        ]),
+      ],
+    });
+
+    const next = transcriptReducer(onScreen, {
+      type: 'mergeWindow',
+      messages: [
+        dbMessage('assistant-1', 'assistant', [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'execute_command',
+              args: {},
+              result: 'ok',
+            },
+          },
+        ]),
+      ],
+    });
+
+    expect(messageParts(next.entries[0])).toMatchObject([{ toolInvocation: { state: 'result', result: 'ok' } }]);
+  });
+
+  it('heals a stuck tool part without touching live-streamed text', () => {
+    let state = createInitialTranscript({ messages: [] });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('assistant-1', 'assistant', [
+          { type: 'text', text: 'streamed text' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'call', toolCallId: 'tool-1', toolName: 'view', args: {} },
+          },
+        ]),
+      },
+    });
+
+    const next = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [
+        dbMessage('assistant-1', 'assistant', [
+          { type: 'text', text: 'persisted prefix' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'result', toolCallId: 'tool-1', toolName: 'view', args: {}, result: 'done' },
+          },
+        ]),
+      ],
+    });
+
+    expect(messageParts(next.entries[0])).toEqual([
+      { type: 'text', text: 'streamed text' },
+      expect.objectContaining({
+        toolInvocation: expect.objectContaining({ state: 'result', result: 'done' }),
+      }),
+    ]);
+  });
+
+  it('never regresses a terminal tool part to an older call state from the window', () => {
+    const onScreen = createInitialTranscript({
+      messages: [
+        dbMessage('assistant-1', 'assistant', [
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'result', toolCallId: 'tool-1', toolName: 'view', args: {}, result: 'ok' },
+          },
+        ]),
+      ],
+    });
+
+    const next = transcriptReducer(onScreen, {
+      type: 'mergeWindow',
+      messages: [
+        dbMessage('assistant-1', 'assistant', [
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'call', toolCallId: 'tool-1', toolName: 'view', args: {} },
+          },
+        ]),
+      ],
+    });
+
+    expect(next).toBe(onScreen);
+  });
 });
 
 describe('transcript reducer error notices', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -411,6 +411,33 @@ describe('transcript reducer message entries', () => {
       },
     ]);
   });
+
+  it('stamps isError on the mirrored part when tool_end reports a failure', () => {
+    // Without the flag the terminal-state render precedence would read the
+    // failed tool as a bare successful `result`.
+    const started = transcriptReducer(initialTranscript, {
+      type: 'event',
+      event: { type: 'tool_start', toolCallId: 'tool-1', toolName: 'view', args: {} },
+    });
+    const ended = transcriptReducer(started, {
+      type: 'event',
+      event: { type: 'tool_end', toolCallId: 'tool-1', result: 'exploded', isError: true },
+    });
+
+    expect(messageParts(ended.entries[0])).toEqual([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'tool-1',
+          toolName: 'view',
+          args: {},
+          result: 'exploded',
+          isError: true,
+        },
+      },
+    ]);
+  });
 });
 
 describe('transcript reducer mergeWindow', () => {
@@ -647,6 +674,75 @@ describe('transcript reducer mergeWindow', () => {
     });
 
     expect(next).toBe(onScreen);
+  });
+
+  it.each(['output-error', 'output-denied'] as const)(
+    'replaces a tool part stuck at call with a terminal %s copy from the window',
+    state => {
+      const onScreen = createInitialTranscript({
+        messages: [
+          dbMessage('assistant-1', 'assistant', [
+            {
+              type: 'tool-invocation',
+              toolInvocation: { state: 'call', toolCallId: 'tool-1', toolName: 'view', args: {} },
+            },
+          ]),
+        ],
+      });
+
+      const next = transcriptReducer(onScreen, {
+        type: 'mergeWindow',
+        messages: [
+          dbMessage('assistant-1', 'assistant', [
+            {
+              type: 'tool-invocation',
+              toolInvocation: { state, toolCallId: 'tool-1', toolName: 'view', args: {}, errorText: 'nope' },
+            },
+          ]),
+        ],
+      });
+
+      expect(messageParts(next.entries[0])).toMatchObject([{ toolInvocation: { state, errorText: 'nope' } }]);
+    },
+  );
+
+  it('does not duplicate a turn the window carries under its persisted id', () => {
+    // A streamed turn keeps its display id; the persisted copy arrives under a
+    // different id but shares the toolCallId. Merge must heal in place, not
+    // append a second copy of the turn.
+    let state = createInitialTranscript({ messages: [] });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('live-1', 'assistant', [
+          { type: 'text', text: 'working on it' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'call', toolCallId: 'tool-1', toolName: 'view', args: {} },
+          },
+        ]),
+      },
+    });
+
+    const next = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [
+        dbMessage('persisted-1', 'assistant', [
+          { type: 'text', text: 'working on it' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'result', toolCallId: 'tool-1', toolName: 'view', args: {}, result: 'ok' },
+          },
+        ]),
+      ],
+    });
+
+    expect(next.entries).toHaveLength(1);
+    expect(messageParts(next.entries[0])).toMatchObject([
+      { type: 'text' },
+      { toolInvocation: { state: 'result', result: 'ok' } },
+    ]);
   });
 });
 

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -113,7 +113,12 @@ export interface SubagentEntry {
 
 export type PromptEntry = ApprovalPrompt | SuspensionPrompt;
 export type TimelineEntry =
-  MessageEntry | NoticeEntry | PromptEntry | NotificationEntry | NotificationSummaryEntry | SubagentEntry;
+  | MessageEntry
+  | NoticeEntry
+  | PromptEntry
+  | NotificationEntry
+  | NotificationSummaryEntry
+  | SubagentEntry;
 
 /** Token usage snapshot from usage_update events. */
 export interface UsageSnapshot {
@@ -639,8 +644,10 @@ function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]):
   return { ...reconciled, entries };
 }
 
-function isTerminalInvocationState(invocationState: string): boolean {
-  return invocationState === 'result' || invocationState === 'output-error' || invocationState === 'output-denied';
+type ToolInvocationMessagePart = Extract<MastraMessagePart, { type: 'tool-invocation' }>;
+
+export function isTerminalInvocationState(state: ToolInvocationMessagePart['toolInvocation']['state']): boolean {
+  return state === 'result' || state === 'output-error' || state === 'output-denied';
 }
 
 /**
@@ -651,7 +658,7 @@ function isTerminalInvocationState(invocationState: string): boolean {
  * everything else (streamed text, live overlay) is left alone.
  */
 function reconcileToolResults(state: TranscriptState, messages: MastraDBMessage[]): TranscriptState {
-  const serverTerminalParts = new Map<string, MastraMessagePart>();
+  const serverTerminalParts = new Map<string, ToolInvocationMessagePart>();
   for (const message of messages) {
     for (const part of message.content.parts) {
       if (part.type !== 'tool-invocation') continue;
@@ -695,7 +702,8 @@ function reconcileToolResults(state: TranscriptState, messages: MastraDBMessage[
 function isChannelOriginSignal(message: MastraDBMessage): boolean {
   const signal = message.content.metadata?.signal as { providerOptions?: unknown } | undefined;
   const dataPart = (message.content.parts ?? []).find(part => part.type === 'data-user-message') as
-    { data?: { providerOptions?: unknown } } | undefined;
+    | { data?: { providerOptions?: unknown } }
+    | undefined;
 
   for (const candidate of [signal?.providerOptions, dataPart?.data?.providerOptions]) {
     if (!candidate || typeof candidate !== 'object') continue;

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -617,23 +617,45 @@ function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]):
 
   const reconciled = reconcileToolResults(state, messages);
 
-  const onScreen = new Set(reconciled.entries.flatMap(entry => (entry.kind === 'message' ? [entry.id] : [])));
-  if (messages.every(message => onScreen.has(message.id))) return reconciled;
+  // A streamed turn and its persisted copy carry different message ids (the
+  // engine mints display ids independently of what MessageList persists), so
+  // identity falls back to shared toolCallIds — inserting such a window message
+  // would duplicate a turn that reconcileToolResults already heals in place.
+  const entryToolCallIds = reconciled.entries.map(entry =>
+    entry.kind === 'message' && entry.message.role === 'assistant'
+      ? new Set(toolCallIdsOf(entry.message.content.parts))
+      : undefined,
+  );
+  const matchesEntry = (entryIndex: number, message: MastraDBMessage): boolean => {
+    const entry = reconciled.entries[entryIndex];
+    if (entry.kind !== 'message') return false;
+    if (entry.id === message.id) return true;
+    if (message.role !== 'assistant') return false;
+    const toolCallIds = entryToolCallIds[entryIndex];
+    if (!toolCallIds || toolCallIds.size === 0) return false;
+    return toolCallIdsOf(message.content.parts).some(toolCallId => toolCallIds.has(toolCallId));
+  };
+  const onScreenIndexFor = (message: MastraDBMessage, from: number): number => {
+    for (let entryIndex = from; entryIndex < reconciled.entries.length; entryIndex++) {
+      if (matchesEntry(entryIndex, message)) return entryIndex;
+    }
+    return -1;
+  };
+
+  if (messages.every(message => onScreenIndexFor(message, 0) !== -1)) return reconciled;
 
   const entries: TimelineEntry[] = [];
   let cursor = 0;
   let missing: MastraDBMessage[] = [];
 
   for (const message of messages) {
-    if (!onScreen.has(message.id)) {
+    if (onScreenIndexFor(message, 0) === -1) {
       missing.push(message);
       continue;
     }
-    const anchorIndex = reconciled.entries.findIndex(
-      (entry, index) => index >= cursor && entry.kind === 'message' && entry.id === message.id,
-    );
     // Out-of-order anchor (the window disagrees with the timeline): leave it
     // where the timeline put it rather than moving rendered content around.
+    const anchorIndex = onScreenIndexFor(message, cursor);
     if (anchorIndex === -1) continue;
     entries.push(...reconciled.entries.slice(cursor, anchorIndex), ...messagesToEntries(missing));
     missing = [];
@@ -642,6 +664,13 @@ function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]):
   entries.push(...reconciled.entries.slice(cursor), ...messagesToEntries(missing));
 
   return { ...reconciled, entries };
+}
+
+function toolCallIdsOf(parts: MastraMessagePart[]): string[] {
+  return parts.flatMap(part => {
+    const toolCallId = toolCallIdForPart(part);
+    return toolCallId === undefined ? [] : [toolCallId];
+  });
 }
 
 type ToolInvocationMessagePart = Extract<MastraMessagePart, { type: 'tool-invocation' }>;
@@ -961,16 +990,18 @@ function toolPart(tool: ToolCall): MastraMessagePart {
     };
   }
 
-  return {
-    type: 'tool-invocation',
-    toolInvocation: {
-      state: 'result',
-      toolCallId: tool.toolCallId,
-      toolName: tool.toolName,
-      args: tool.args,
-      result: tool.result,
-    },
+  // isError mirrors what core stamps on persisted result invocations
+  // (session-run-engine) — without it the terminal-state render precedence
+  // would read a failed live tool as a bare successful `result`.
+  const toolInvocation: ToolInvocationMessagePart['toolInvocation'] & { isError?: boolean } = {
+    state: 'result',
+    toolCallId: tool.toolCallId,
+    toolName: tool.toolName,
+    args: tool.args,
+    result: tool.result,
+    ...(tool.status === 'error' ? { isError: true } : {}),
   };
+  return { type: 'tool-invocation', toolInvocation };
 }
 
 function pushPrompt(state: TranscriptState, prompt: PromptEntry): TranscriptState {

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -113,7 +113,12 @@ export interface SubagentEntry {
 
 export type PromptEntry = ApprovalPrompt | SuspensionPrompt;
 export type TimelineEntry =
-  MessageEntry | NoticeEntry | PromptEntry | NotificationEntry | NotificationSummaryEntry | SubagentEntry;
+  | MessageEntry
+  | NoticeEntry
+  | PromptEntry
+  | NotificationEntry
+  | NotificationSummaryEntry
+  | SubagentEntry;
 
 /** Token usage snapshot from usage_update events. */
 export interface UsageSnapshot {
@@ -782,7 +787,8 @@ function reconcileToolResults(state: TranscriptState, messages: MastraDBMessage[
 function isChannelOriginSignal(message: MastraDBMessage): boolean {
   const signal = message.content.metadata?.signal as { providerOptions?: unknown } | undefined;
   const dataPart = (message.content.parts ?? []).find(part => part.type === 'data-user-message') as
-    { data?: { providerOptions?: unknown } } | undefined;
+    | { data?: { providerOptions?: unknown } }
+    | undefined;
 
   for (const candidate of [signal?.providerOptions, dataPart?.data?.providerOptions]) {
     if (!candidate || typeof candidate !== 'object') continue;

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -113,12 +113,7 @@ export interface SubagentEntry {
 
 export type PromptEntry = ApprovalPrompt | SuspensionPrompt;
 export type TimelineEntry =
-  | MessageEntry
-  | NoticeEntry
-  | PromptEntry
-  | NotificationEntry
-  | NotificationSummaryEntry
-  | SubagentEntry;
+  MessageEntry | NoticeEntry | PromptEntry | NotificationEntry | NotificationSummaryEntry | SubagentEntry;
 
 /** Token usage snapshot from usage_update events. */
 export interface UsageSnapshot {
@@ -615,8 +610,10 @@ function persistedSuspensionPrompts(message: MastraDBMessage): SuspensionPrompt[
 function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]): TranscriptState {
   if (messages.length === 0) return state;
 
-  const onScreen = new Set(state.entries.flatMap(entry => (entry.kind === 'message' ? [entry.id] : [])));
-  if (messages.every(message => onScreen.has(message.id))) return state;
+  const reconciled = reconcileToolResults(state, messages);
+
+  const onScreen = new Set(reconciled.entries.flatMap(entry => (entry.kind === 'message' ? [entry.id] : [])));
+  if (messages.every(message => onScreen.has(message.id))) return reconciled;
 
   const entries: TimelineEntry[] = [];
   let cursor = 0;
@@ -627,19 +624,60 @@ function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]):
       missing.push(message);
       continue;
     }
-    const anchorIndex = state.entries.findIndex(
+    const anchorIndex = reconciled.entries.findIndex(
       (entry, index) => index >= cursor && entry.kind === 'message' && entry.id === message.id,
     );
     // Out-of-order anchor (the window disagrees with the timeline): leave it
     // where the timeline put it rather than moving rendered content around.
     if (anchorIndex === -1) continue;
-    entries.push(...state.entries.slice(cursor, anchorIndex), ...messagesToEntries(missing));
+    entries.push(...reconciled.entries.slice(cursor, anchorIndex), ...messagesToEntries(missing));
     missing = [];
     cursor = anchorIndex;
   }
-  entries.push(...state.entries.slice(cursor), ...messagesToEntries(missing));
+  entries.push(...reconciled.entries.slice(cursor), ...messagesToEntries(missing));
 
-  return { ...state, entries };
+  return { ...reconciled, entries };
+}
+
+function isTerminalInvocationState(invocationState: string): boolean {
+  return invocationState === 'result' || invocationState === 'output-error' || invocationState === 'output-denied';
+}
+
+/**
+ * Fold terminal tool results from the refetched window into entries already on
+ * screen. The stream can lose a `tool_end` (SSE drop — the server does not
+ * replay missed events), leaving an on-screen part stuck at `call` and its row
+ * spinning forever. Terminal states never regress, so the server copy wins;
+ * everything else (streamed text, live overlay) is left alone.
+ */
+function reconcileToolResults(state: TranscriptState, messages: MastraDBMessage[]): TranscriptState {
+  const serverTerminalParts = new Map<string, MastraMessagePart>();
+  for (const message of messages) {
+    for (const part of message.content.parts) {
+      if (part.type !== 'tool-invocation') continue;
+      if (!isTerminalInvocationState(part.toolInvocation.state)) continue;
+      serverTerminalParts.set(part.toolInvocation.toolCallId, part);
+    }
+  }
+  if (serverTerminalParts.size === 0) return state;
+
+  let changed = false;
+  const entries = state.entries.map(entry => {
+    if (entry.kind !== 'message' || entry.message.role !== 'assistant') return entry;
+    let entryChanged = false;
+    const parts = entry.message.content.parts.map(part => {
+      if (part.type !== 'tool-invocation' || isTerminalInvocationState(part.toolInvocation.state)) return part;
+      const serverPart = serverTerminalParts.get(part.toolInvocation.toolCallId);
+      if (!serverPart) return part;
+      entryChanged = true;
+      return serverPart;
+    });
+    if (!entryChanged) return entry;
+    changed = true;
+    return { ...entry, message: { ...entry.message, content: { ...entry.message.content, parts } } };
+  });
+
+  return changed ? { ...state, entries } : state;
 }
 
 /**
@@ -657,8 +695,7 @@ function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]):
 function isChannelOriginSignal(message: MastraDBMessage): boolean {
   const signal = message.content.metadata?.signal as { providerOptions?: unknown } | undefined;
   const dataPart = (message.content.parts ?? []).find(part => part.type === 'data-user-message') as
-    | { data?: { providerOptions?: unknown } }
-    | undefined;
+    { data?: { providerOptions?: unknown } } | undefined;
 
   for (const candidate of [signal?.providerOptions, dataPart?.data?.providerOptions]) {
     if (!candidate || typeof candidate !== 'object') continue;

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -113,12 +113,7 @@ export interface SubagentEntry {
 
 export type PromptEntry = ApprovalPrompt | SuspensionPrompt;
 export type TimelineEntry =
-  | MessageEntry
-  | NoticeEntry
-  | PromptEntry
-  | NotificationEntry
-  | NotificationSummaryEntry
-  | SubagentEntry;
+  MessageEntry | NoticeEntry | PromptEntry | NotificationEntry | NotificationSummaryEntry | SubagentEntry;
 
 /** Token usage snapshot from usage_update events. */
 export interface UsageSnapshot {
@@ -615,7 +610,7 @@ function persistedSuspensionPrompts(message: MastraDBMessage): SuspensionPrompt[
 function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]): TranscriptState {
   if (messages.length === 0) return state;
 
-  const reconciled = reconcileToolResults(state, messages);
+  const reconciled = reconcileToolResults(adoptCoveringWindowCopies(state, messages), messages);
 
   // A streamed turn and its persisted copy carry different message ids (the
   // engine mints display ids independently of what MessageList persists), so
@@ -680,6 +675,62 @@ export function isTerminalInvocationState(state: ToolInvocationMessagePart['tool
 }
 
 /**
+ * Adopt the persisted copy of a streamed turn when it strictly extends what is
+ * on screen. When the run ends inside an SSE gap the refetched window is the
+ * only carrier of the turn's trailing parts (text after the last tool result) —
+ * reconcileToolResults alone would heal the tool but drop that text. Adoption
+ * only fires when nothing on screen would be lost; a live turn ahead of the
+ * snapshot fails the prefix check and keeps its streamed parts.
+ */
+function adoptCoveringWindowCopies(state: TranscriptState, messages: MastraDBMessage[]): TranscriptState {
+  let changed = false;
+  const entries = state.entries.map(entry => {
+    if (entry.kind !== 'message' || entry.message.role !== 'assistant') return entry;
+    const onScreenParts = entry.message.content.parts;
+    const toolCallIds = new Set(toolCallIdsOf(onScreenParts));
+    const copy = messages.find(
+      message =>
+        message.role === 'assistant' &&
+        (message.id === entry.id ||
+          (toolCallIds.size > 0 && toolCallIdsOf(message.content.parts).some(id => toolCallIds.has(id)))),
+    );
+    if (!copy) return entry;
+    const covers = windowCopyCovers(onScreenParts, copy.content.parts);
+    const identical = covers && windowCopyCovers(copy.content.parts, onScreenParts);
+    if (!covers || identical) return entry;
+    changed = true;
+    return {
+      ...entry,
+      message: { ...entry.message, content: { ...entry.message.content, parts: copy.content.parts } },
+    };
+  });
+
+  return changed ? { ...state, entries } : state;
+}
+
+/**
+ * True when adopting `persisted` loses nothing from `onScreen`: parts match
+ * positionally, text may only extend, tool parts keep their toolCallId and
+ * never regress from a terminal state. Snapshot streams mirror the same
+ * MessageList that persists, so positional comparison is sound.
+ */
+function windowCopyCovers(onScreen: MastraMessagePart[], persisted: MastraMessagePart[]): boolean {
+  if (persisted.length < onScreen.length) return false;
+  return onScreen.every((part, index) => {
+    const counterpart = persisted[index];
+    if (part.type === 'text' && counterpart.type === 'text') return counterpart.text.startsWith(part.text);
+    if (part.type === 'tool-invocation' && counterpart.type === 'tool-invocation') {
+      if (part.toolInvocation.toolCallId !== counterpart.toolInvocation.toolCallId) return false;
+      return (
+        !isTerminalInvocationState(part.toolInvocation.state) ||
+        isTerminalInvocationState(counterpart.toolInvocation.state)
+      );
+    }
+    return JSON.stringify(counterpart) === JSON.stringify(part);
+  });
+}
+
+/**
  * Fold terminal tool results from the refetched window into entries already on
  * screen. The stream can lose a `tool_end` (SSE drop — the server does not
  * replay missed events), leaving an on-screen part stuck at `call` and its row
@@ -731,8 +782,7 @@ function reconcileToolResults(state: TranscriptState, messages: MastraDBMessage[
 function isChannelOriginSignal(message: MastraDBMessage): boolean {
   const signal = message.content.metadata?.signal as { providerOptions?: unknown } | undefined;
   const dataPart = (message.content.parts ?? []).find(part => part.type === 'data-user-message') as
-    | { data?: { providerOptions?: unknown } }
-    | undefined;
+    { data?: { providerOptions?: unknown } } | undefined;
 
   for (const candidate of [signal?.providerOptions, dataPart?.data?.providerOptions]) {
     if (!candidate || typeof candidate !== 'object') continue;


### PR DESCRIPTION
A tool row in the Factory UI could spin forever even though the tool had long finished — the persisted result was there, the agent's final summary rendered right below the spinner.

The trigger needs no connection drop at all. Thread messages are cached with `staleTime: 0` + `refetchOnMount: 'always'`, so a remount first serves the cached window synchronously. If that window was fetched while the tool was mid-flight, it contains the invocation at `state: 'call'` and there is no runtime overlay to save it, so the row renders as running. The background refetch then returns the terminal result plus everything the run produced meanwhile — but `mergeServerWindow` was insert-only: it appended the new messages and never touched an entry already on screen. Spinner stuck, summary below it. A lossy SSE stream produces the same picture through a second door: the server does not replay events missed while disconnected (documented in client-js `subscribe()`), so a dropped `tool_end` leaves the overlay stuck at `running`, and render precedence let that overlay beat the persisted terminal part forever.

The fix makes the persisted snapshot the source of truth and treats stream deltas as the latency optimization they are:

- `toolFromInvocationPart` now lets a persisted terminal state (`result` / `output-error` / `output-denied`, honoring the `isError` flag core stamps) win over a stale `running` overlay. The overlay still drives everything while the part is genuinely non-terminal.
- `mergeServerWindow` folds terminal tool results from a refetched window into entries already on screen (`reconcileToolResults`). Streamed text is left alone and a terminal part never regresses to an older `call` from the window.
- An SSE reconnect invalidates the resource's thread-message queries (new `agentControllerResourceThreadMessages` key prefix, which the per-thread key now builds on), since events missed during the gap are gone for good. Detection lives in the `onConnectedChange` handler itself — the reconnect is an event, not something to mirror into state and watch with an effect.

Verifying the diagnosis surfaced two gaps in my own fix, both corrected here. `toolPart()` mirrored an errored overlay as a bare `{state: 'result'}` part, so the new render precedence would have read a failed live tool as successful on the `tool-error` chunk path (which emits no corrective `message_update`); the mirror now stamps `isError` the way core does. And a streamed turn and its persisted copy carry different message ids (the engine mints display ids independently of what `MessageList` persists), so a revalidation while live entries are on screen would have re-inserted the same turn under its persisted id — `mergeServerWindow` now falls back to shared toolCallIds as turn identity and heals in place instead of duplicating.

The investigation also found server-side issues this PR deliberately does not touch: a declined/auto-denied tool call is persisted as `output-denied` but never emits any terminal event (by design since #17218), and the engine keeps re-sending the part as `state: 'call'` for the rest of the run; the `tool-error` chunk path emits `tool_end` but never upgrades the in-flight message part nor emits `message_update`; and `display_state_changed.activeTools` is a `Map`, which serializes to `{}` on the wire, so the server's own end-of-run healing never reaches clients. Those need core changes and I'll file them separately — the frontend resilience here is wanted regardless, since it is currently the only recovery channel that exists.

Tested with the transcript reducer unit suite (heal, no-regress, no-duplicate, `isError` mirroring, `output-error`/`output-denied` variants) and MSW component/hook tests (stale-overlay rows render done/failed correctly, reconnect invalidates exactly the resource's message windows). The full factory-ui MSW suite passes. What I did not verify: an end-to-end browser repro of a real mid-run disconnect, and the id-divergence duplication was established by reading the id minting paths, not observed live. User-message echoes (`local-…` ids) can still duplicate on a reconnect refetch — pre-existing exposure, much rarer, and worth its own look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the connection briefly breaks, the UI can keep showing a tool as “loading” even after the tool finished. This change refreshes saved results and displays completed, failed, and denied tools correctly.

## Changes

- Prioritize persisted terminal tool states over stale `running` overlays.
- Preserve live non-terminal tool behavior.
- Merge refetched terminal results and strictly extended persisted text without replacing newer streamed content.
- Prevent terminal tools from reverting to call states.
- Deduplicate streamed and persisted turns by `toolCallId`.
- Preserve `isError` for failed live tools.
- Invalidate thread-message queries for the affected resource after SSE reconnection.
- Add reducer and MSW coverage for healing, terminal states, stale overlays, deduplication, error mirroring, and resource-specific invalidation.

The full Factory UI MSW suite passes. Real browser disconnect behavior was not verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->