### PR TITLE
fix(mastracode): strip stray mastracode/ prefix on custom provider model ids

### DIFF
--- a/.changeset/pretty-crabs-cough.md
+++ b/.changeset/pretty-crabs-cough.md
@@ -1,0 +1,6 @@
+---
+'@mastra/code-sdk': patch
+'mastracode': patch
+---
+
+Fixed custom provider models saved with a stray `mastracode/` prefix in settings, which broke selecting and using them after choosing them from `/models` (#20799)

--- a/mastracode/sdk/src/agents/__tests__/model.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/model.test.ts
@@ -169,16 +169,20 @@ const mockLoadSettings = vi.hoisted(() =>
   })),
 );
 
-vi.mock('../../onboarding/settings.js', () => ({
-  loadSettings: mockLoadSettings,
-  getCustomProviderId: (name: string) =>
-    name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-|-$/g, ''),
-  MASTRA_GATEWAY_PROVIDER: 'mastra-gateway',
-  MASTRA_GATEWAY_DEFAULT_URL: 'https://gateway-api.mastra.ai',
-}));
+vi.mock('../../onboarding/settings.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../onboarding/settings.js')>();
+  return {
+    ...actual,
+    loadSettings: mockLoadSettings,
+    getCustomProviderId: (name: string) =>
+      name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, ''),
+    MASTRA_GATEWAY_PROVIDER: 'mastra-gateway',
+    MASTRA_GATEWAY_DEFAULT_URL: 'https://gateway-api.mastra.ai',
+  };
+});
 
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createAnthropic } from '@ai-sdk/anthropic';
@@ -620,6 +624,40 @@ describe('resolveModel', () => {
         'x-thread-id': 'thread-123',
         'x-resource-id': 'resource-456',
       });
+    });
+
+    it('normalizes legacy mastracode/-prefixed custom provider ids at resolution time (#20799)', () => {
+      mockLoadSettings.mockReturnValue({
+        customProviders: [
+          {
+            name: 'Acme',
+            url: 'https://llm.acme.dev/v1',
+            apiKey: 'acme-secret',
+          },
+        ],
+        memoryGateway: {},
+      });
+
+      // Previously-saved settings may carry the gateway-qualified catalog id.
+      const result = resolveModel('mastracode/acme/reasoner-v1') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('custom-openai-compatible');
+      expect(result.modelId).toBe('reasoner-v1');
+      expect(result.url).toBe('https://llm.acme.dev/v1');
+      expect(result.apiKey).toBe('acme-secret');
+    });
+
+    it('leaves mastracode/-prefixed ids alone when the segment is not a configured custom provider', () => {
+      mockLoadSettings.mockReturnValue({
+        customProviders: [],
+        memoryGateway: {},
+      });
+
+      const result = resolveModel('mastracode/acme/reasoner-v1') as Record<string, unknown>;
+
+      // No matching custom provider: id passes through to the model router unchanged.
+      expect(result.__provider).toBe('model-router');
+      expect(result.modelId).toBe('mastracode/acme/reasoner-v1');
     });
 
     it('passes controller headers to custom providers', () => {

--- a/mastracode/sdk/src/agents/model.ts
+++ b/mastracode/sdk/src/agents/model.ts
@@ -1,7 +1,7 @@
 import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
 import type { GatewayLanguageModel, MastraModelGatewayInterface } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';
-import { loadSettings } from '../onboarding/settings.js';
+import { loadSettings, stripMastraCodeCustomProviderPrefix } from '../onboarding/settings.js';
 import { AMAZON_BEDROCK_GATEWAY_ID, createAmazonBedrockGateway } from '../providers/amazon-bedrock-gateway.js';
 import type { ThinkingLevel } from '../providers/openai-codex.js';
 import { resolveCredentialStore } from './credential-resolver.js';
@@ -90,9 +90,20 @@ export function resolveModel(
   // standalone `amazon-bedrock/<model>` form so they resolve through the
   // dedicated Bedrock gateway.
   const bedrockLegacyPrefix = `${MASTRACODE_GATEWAY_ID}/amazon-bedrock/`;
-  const normalizedInput = modelId.startsWith(bedrockLegacyPrefix)
+  const bedrockNormalizedInput = modelId.startsWith(bedrockLegacyPrefix)
     ? modelId.slice(MASTRACODE_GATEWAY_ID.length + 1)
     : modelId;
+  // Deployed web registers a custom providers source (DB-backed, tenant
+  // scoped); when registered it is authoritative and settings.json custom
+  // providers are ignored. Undefined = local settings-based behavior.
+  const customProviders = resolveCustomProviders(options?.requestContext) ?? settings.customProviders;
+  // Ids selected from the shared /models catalog were previously persisted in
+  // the gateway-qualified `mastracode/<customProviderId>/<model>` form, which
+  // parses the provider as `mastracode` and breaks provider config lookup.
+  // Normalize at resolution time (in addition to stripping at selection time)
+  // so already-saved ids and any surface that persists the raw catalog id
+  // still resolve to the custom provider.
+  const normalizedInput = stripMastraCodeCustomProviderPrefix(bedrockNormalizedInput, customProviders);
   const isMastraGatewayModel = normalizedInput.startsWith(MASTRA_GATEWAY_PREFIX);
   const normalizedModelId = stripMastraGatewayPrefix(normalizedInput);
   const [providerId, ...modelParts] = normalizedModelId.split('/');
@@ -127,10 +138,6 @@ export function resolveModel(
   // request carries an authenticated tenant, resolve credentials through the
   // caller's own store (user > org > env). Undefined = global AuthStorage.
   const credentialStore = resolveCredentialStore(options?.requestContext);
-  // Deployed web registers a custom providers source (DB-backed, tenant
-  // scoped); when registered it is authoritative and settings.json custom
-  // providers are ignored. Undefined = local settings-based behavior.
-  const customProviders = resolveCustomProviders(options?.requestContext) ?? settings.customProviders;
   const gateway = createMastraCodeGateway({
     mastraGatewayBaseUrl: rawGatewayBase.replace(/\/+$/, '').replace(/\/v1$/, ''),
     mastraGatewayApiKey: mgApiKey,

--- a/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
+++ b/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
@@ -14,8 +14,9 @@ import {
   resolveOmRoleModel,
   resolveThreadActiveModelPackId,
   saveSettings,
+  stripMastraCodeCustomProviderPrefix,
 } from '../settings.js';
-import type { BrowserSettings, GlobalSettings, StorageSettings } from '../settings.js';
+import type { BrowserSettings, CustomProviderSetting, GlobalSettings, StorageSettings } from '../settings.js';
 
 function createSettings(overrides?: Partial<GlobalSettings>): GlobalSettings {
   const storage: StorageSettings = { backend: 'libsql', libsql: {}, pg: {} };
@@ -538,6 +539,42 @@ describe('customProviders parsing/persistence', () => {
   it('creates custom provider ids without custom- prefix', () => {
     expect(getCustomProviderId('Acme Provider')).toBe('acme-provider');
     expect(getCustomProviderId('  !!!  ')).toBe('provider');
+  });
+
+  describe('stripMastraCodeCustomProviderPrefix', () => {
+    const customProviders: CustomProviderSetting[] = [
+      { name: 'Custom Provider', url: 'https://example.com/v1', models: ['gemma-4-31b'] },
+    ];
+
+    it('strips the mastracode/ gateway prefix for a configured custom provider', () => {
+      expect(stripMastraCodeCustomProviderPrefix('mastracode/custom-provider/gemma-4-31b', customProviders)).toBe(
+        'custom-provider/gemma-4-31b',
+      );
+    });
+
+    it('preserves nested model name segments after stripping', () => {
+      expect(stripMastraCodeCustomProviderPrefix('mastracode/custom-provider/nested/model-name', customProviders)).toBe(
+        'custom-provider/nested/model-name',
+      );
+    });
+
+    it('leaves legitimate mastracode gateway-routed ids unchanged', () => {
+      expect(
+        stripMastraCodeCustomProviderPrefix('mastracode/anthropic/claude-sonnet-4-20250514', customProviders),
+      ).toBe('mastracode/anthropic/claude-sonnet-4-20250514');
+    });
+
+    it('leaves ids for unrecognized providers unchanged', () => {
+      expect(stripMastraCodeCustomProviderPrefix('mastracode/unknown-provider/model', customProviders)).toBe(
+        'mastracode/unknown-provider/model',
+      );
+    });
+
+    it('leaves ids without the mastracode/ prefix unchanged', () => {
+      expect(stripMastraCodeCustomProviderPrefix('custom-provider/gemma-4-31b', customProviders)).toBe(
+        'custom-provider/gemma-4-31b',
+      );
+    });
   });
 
   it('round-trips optional api keys without forcing apiKey field', () => {

--- a/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
+++ b/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
@@ -575,6 +575,12 @@ describe('customProviders parsing/persistence', () => {
         'custom-provider/gemma-4-31b',
       );
     });
+
+    it('leaves ids with an empty model portion unchanged', () => {
+      expect(stripMastraCodeCustomProviderPrefix('mastracode/custom-provider/', customProviders)).toBe(
+        'mastracode/custom-provider/',
+      );
+    });
   });
 
   it('round-trips optional api keys without forcing apiKey field', () => {

--- a/mastracode/sdk/src/onboarding/settings.ts
+++ b/mastracode/sdk/src/onboarding/settings.ts
@@ -448,7 +448,10 @@ export function toCustomProviderModelId(providerName: string, modelName: string)
  * middle segment matches one of the user's configured custom providers, so
  * legitimate `mastracode/...` gateway-routed ids are left untouched.
  */
-export function stripMastraCodeCustomProviderPrefix(modelId: string, customProviders: CustomProviderSetting[]): string {
+export function stripMastraCodeCustomProviderPrefix(
+  modelId: string,
+  customProviders: Array<Pick<CustomProviderSetting, 'name'>>,
+): string {
   const gatewayPrefix = 'mastracode/';
   if (!modelId.startsWith(gatewayPrefix)) return modelId;
 

--- a/mastracode/sdk/src/onboarding/settings.ts
+++ b/mastracode/sdk/src/onboarding/settings.ts
@@ -438,6 +438,28 @@ export function toCustomProviderModelId(providerName: string, modelName: string)
   return `${providerId}/${trimmedModelName}`;
 }
 
+/**
+ * The shared gateway catalog namespaces provider keys under their owning
+ * gateway id, so a custom provider's models surface in the `/models` catalog
+ * as `mastracode/<providerId>/<model>` instead of the canonical
+ * `<providerId>/<model>` that model resolution expects. Persisting the
+ * gateway-qualified id verbatim breaks lookup later (the provider is parsed
+ * as `mastracode`). Strip the prefix before saving — but only when the
+ * middle segment matches one of the user's configured custom providers, so
+ * legitimate `mastracode/...` gateway-routed ids are left untouched.
+ */
+export function stripMastraCodeCustomProviderPrefix(modelId: string, customProviders: CustomProviderSetting[]): string {
+  const gatewayPrefix = 'mastracode/';
+  if (!modelId.startsWith(gatewayPrefix)) return modelId;
+
+  const rest = modelId.slice(gatewayPrefix.length);
+  const [providerId, ...modelParts] = rest.split('/');
+  if (!providerId || modelParts.length === 0) return modelId;
+
+  const isCustomProvider = customProviders.some(provider => getCustomProviderId(provider.name) === providerId);
+  return isCustomProvider ? rest : modelId;
+}
+
 export function parseCustomProviders(rawProviders: unknown): CustomProviderSetting[] {
   if (!Array.isArray(rawProviders)) return [];
 

--- a/mastracode/sdk/src/onboarding/settings.ts
+++ b/mastracode/sdk/src/onboarding/settings.ts
@@ -454,7 +454,7 @@ export function stripMastraCodeCustomProviderPrefix(modelId: string, customProvi
 
   const rest = modelId.slice(gatewayPrefix.length);
   const [providerId, ...modelParts] = rest.split('/');
-  if (!providerId || modelParts.length === 0) return modelId;
+  if (!providerId || modelParts.length === 0 || modelParts.some(part => part.length === 0)) return modelId;
 
   const isCustomProvider = customProviders.some(provider => getCustomProviderId(provider.name) === providerId);
   return isCustomProvider ? rest : modelId;

--- a/mastracode/tui/src/tui/commands/models-pack.ts
+++ b/mastracode/tui/src/tui/commands/models-pack.ts
@@ -9,6 +9,7 @@ import {
   loadSettings,
   resolveThreadActiveModelPackId,
   saveSettings,
+  stripMastraCodeCustomProviderPrefix,
   THREAD_ACTIVE_MODEL_PACK_ID_KEY,
 } from '@mastra/code-sdk/onboarding/settings';
 import type { GlobalSettings } from '@mastra/code-sdk/onboarding/settings';
@@ -93,7 +94,8 @@ async function selectModel(
       onSelect: async (model: ModelItem) => {
         ctx.state.ui.hideOverlay();
         await promptForApiKeyIfNeeded(ctx.state.ui, model, ctx.authStorage);
-        resolve(model.id);
+        const { customProviders } = loadSettings();
+        resolve(stripMastraCodeCustomProviderPrefix(model.id, customProviders));
       },
       onCancel: () => {
         ctx.state.ui.hideOverlay();


### PR DESCRIPTION
Fixes #20799

When you pick a custom-provider model from `/models`, the catalog shows it as `mastracode/<provider>/<model>` (namespaced under the gateway), and that full string gets saved into `settings.json`. Model resolution only understands `<provider>/<model>`, so it parses the provider as `mastracode` and blows up:

```
Could not find config for provider mastracode with model id mastracode/customprovider/gemma-4-31b
```

This strips the `mastracode/` prefix before saving, but only when the next segment actually matches one of your configured custom providers — so real `mastracode/anthropic/...` gateway-routed ids are left alone.

Before:
```json
{ "modeDefaults": { "build": "mastracode/customprovider/gemma-4-31b" } }
```

After:
```json
{ "modeDefaults": { "build": "customprovider/gemma-4-31b" } }
```

This only fixes new selections going forward. Anyone already hit by this can still use the manual workaround from the issue (edit `settings.json` to drop the prefix) until existing saved ids are also normalized on the resolve side, which I've left as a follow-up.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a user selects a custom-provider model, the app now removes the incorrect `mastracode/` prefix. Existing saved model IDs also resolve correctly without manual edits. Valid gateway IDs remain unchanged.

## Changes

- Added `stripMastraCodeCustomProviderPrefix` to normalize IDs only for configured custom providers.
- Applied normalization when saving model selections and resolving existing saved IDs.
- Preserved built-in, unknown-provider, malformed, unprefixed, and gateway-routed IDs.
- Added tests for selection and model-resolution behavior.
- Added patch changesets for `@mastra/code-sdk` and `mastracode`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->