### PR TITLE
feat(core): make the workspace write-lock timeout configurable

### DIFF
--- a/.changeset/tidy-hounds-argue.md
+++ b/.changeset/tidy-hounds-argue.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': minor
+---
+
+Made the workspace write-lock timeout configurable via `tools.writeLockTimeoutMs`.
+
+`InMemoryFileWriteLock` already accepted a `timeoutMs` option, but `createWorkspaceTools` constructed it with no arguments, so the 30-second default was unreachable from user code. That default suits a local filesystem, where a write is a sub-second operation. It does not suit a remote or cold-starting sandbox filesystem, where the first write can legitimately take minutes — the lock rejected those writes with `write-lock timeout` before they ever landed, and there was no supported way to widen it.
+
+```typescript
+const workspace = new Workspace({
+  filesystem: mySandboxFilesystem,
+  tools: {
+    // allow a cold-starting sandbox time to accept its first write
+    writeLockTimeoutMs: 210_000,
+  },
+});
+```
+
+The default is unchanged at 30 000 ms, so existing workspaces behave exactly as before.

--- a/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
@@ -480,4 +480,43 @@ describe('createWorkspaceTools', () => {
       expect(writeTool.needsApprovalFn).toBeUndefined();
     });
   });
+  describe('writeLockTimeoutMs', () => {
+    /** A filesystem whose writes never settle, so the lock timeout is what ends the call. */
+    function hangingWriteFilesystem(basePath: string) {
+      const filesystem = new LocalFilesystem({ basePath });
+      filesystem.writeFile = () => new Promise<never>(() => {});
+      return filesystem;
+    }
+
+    it('bounds a hung write by the configured timeout', async () => {
+      const workspace = new Workspace({
+        filesystem: hangingWriteFilesystem(tempDir),
+        tools: { writeLockTimeoutMs: 50 },
+      });
+      const tools = await createWorkspaceTools(workspace);
+
+      await expect(
+        tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE].execute({ path: 'hangs.txt', content: 'x' }, { workspace }),
+      ).rejects.toThrow('write-lock timeout on "hangs.txt" after 50ms');
+    });
+
+    it('falls back to the 30s default when unset', async () => {
+      const workspace = new Workspace({
+        filesystem: hangingWriteFilesystem(tempDir),
+      });
+      const tools = await createWorkspaceTools(workspace);
+
+      const write = tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE].execute(
+        { path: 'hangs.txt', content: 'x' },
+        { workspace },
+      );
+      // Still pending well past the configured-timeout case above: the default
+      // is what is in force, not a value inherited from another test.
+      const settled = await Promise.race([
+        write.then(() => 'settled').catch(() => 'settled'),
+        new Promise<string>(resolve => setTimeout(() => resolve('pending'), 200)),
+      ]);
+      expect(settled).toBe('pending');
+    });
+  });
 });

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -387,8 +387,11 @@ export async function createWorkspaceTools(
   const toolsConfig = workspace.getToolsConfig();
   const isReadOnly = workspace.filesystem?.readOnly ?? false;
 
-  // Shared write lock — serializes concurrent writes to the same file path
-  const writeLock: FileWriteLock = new InMemoryFileWriteLock();
+  // Shared write lock — serializes concurrent writes to the same file path.
+  // `timeoutMs: undefined` falls back to the lock's own default (30s).
+  const writeLock: FileWriteLock = new InMemoryFileWriteLock({
+    timeoutMs: toolsConfig?.writeLockTimeoutMs,
+  });
 
   // Shared read tracker — always active so optimistic concurrency (mtime
   // checking) works on every write, regardless of the requireReadBeforeWrite

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -301,6 +301,17 @@ export type WorkspaceToolsConfig = {
    * If the owning agent also defines hooks, workspace hooks run inside the agent hook wrapper.
    */
   hooks?: WorkspaceToolHooks;
+
+  /**
+   * Maximum time (ms) a single write-tool call may hold the per-file write lock
+   * before it is rejected with a `write-lock timeout` error. Default: 30 000.
+   *
+   * The default suits a local filesystem, where a write is a sub-second
+   * operation. Raise it when writes go somewhere slower — a remote or
+   * cold-starting sandbox filesystem can legitimately take minutes to accept
+   * its first write, and the default rejects those before they ever land.
+   */
+  writeLockTimeoutMs?: number;
 } & {
   [K in typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]?: ExecuteCommandToolConfig;
 } & {


### PR DESCRIPTION
## Description

Expose the workspace write-lock timeout as `tools.writeLockTimeoutMs`.

`InMemoryFileWriteLock` already accepts a `timeoutMs` option — it is part of the exported `FileWriteLockOptions` type and `file-write-lock.test.ts` covers it — but `createWorkspaceTools` constructs the lock with no arguments:

```ts
const writeLock: FileWriteLock = new InMemoryFileWriteLock();
```

so the 30-second default is unreachable from user code.

That default is right for a local filesystem, where a write is a sub-second operation. It is wrong for a remote or cold-starting sandbox filesystem: the first write after a container comes up can legitimately take minutes, and the lock rejects it with `write-lock timeout on "<path>" after 30000ms` before it ever lands. The write tool fails for a reason that has nothing to do with the write.

**Change:**

- add `WorkspaceToolsConfig.writeLockTimeoutMs?: number`
- pass it through at the construction site

```ts
const workspace = new Workspace({
  filesystem: mySandboxFilesystem,
  tools: {
    // allow a cold-starting sandbox time to accept its first write
    writeLockTimeoutMs: 210_000,
  },
});
```

Passing `undefined` through preserves the lock's own `?? 30_000` fallback, so **the default is unchanged and existing workspaces are unaffected**. There is no behaviour change unless the option is set.

**Tests** — two cases added to `tool-creation.test.ts`, driving the real `write_file` tool over a filesystem whose write never settles:

- with `writeLockTimeoutMs: 50`, the call rejects with `write-lock timeout on "hangs.txt" after 50ms`
- with the option unset, the call is still pending at 200ms — proving the default is what is in force, not a value leaked from the other case

I checked the first test is discriminating: with the `tools.ts` change reverted it runs the full 30s and reports `after 30000ms`. `tool-creation.test.ts` (30) and `file-write-lock.test.ts` (9) pass, no type errors.

## Related issue(s)

Fixes #20807

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable) — the new option carries a TSDoc block explaining when to raise it; a changeset is included
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Workspace writes can now wait for a custom amount of time before they fail. If no custom value is set, writes keep the existing 30-second timeout.

## Changes

- Added optional `WorkspaceToolsConfig.writeLockTimeoutMs`.
- Passed the setting to `InMemoryFileWriteLock`.
- Added tests for a 50 ms timeout.
- Added tests that confirm the 30-second default remains unchanged.
- Added a `@mastra/core` changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->