### PR TITLE
feat(core): make the workspace write-lock timeout configurable

### DIFF
--- a/.changeset/tidy-hounds-argue.md
+++ b/.changeset/tidy-hounds-argue.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': minor
+---
+
+Made the workspace write-lock timeout configurable via `tools.writeLockTimeoutMs`.
+
+`InMemoryFileWriteLock` already accepted a `timeoutMs` option, but `createWorkspaceTools` constructed it with no arguments, so the 30-second default was unreachable from user code. That default suits a local filesystem, where a write is a sub-second operation. It does not suit a remote or cold-starting sandbox filesystem, where the first write can legitimately take minutes — the lock rejected those writes with `write-lock timeout` before they ever landed, and there was no supported way to widen it.
+
+```typescript
+const workspace = new Workspace({
+  filesystem: mySandboxFilesystem,
+  tools: {
+    // allow a cold-starting sandbox time to accept its first write
+    writeLockTimeoutMs: 210_000,
+  },
+});
+```
+
+The default is unchanged at 30 000 ms, so existing workspaces behave exactly as before.

--- a/.changeset/tidy-hounds-argue.md
+++ b/.changeset/tidy-hounds-argue.md
@@ -2,9 +2,7 @@
 '@mastra/core': minor
 ---
 
-Made the workspace write-lock timeout configurable via `tools.writeLockTimeoutMs`.
-
-`InMemoryFileWriteLock` already accepted a `timeoutMs` option, but `createWorkspaceTools` constructed it with no arguments, so the 30-second default was unreachable from user code. That default suits a local filesystem, where a write is a sub-second operation. It does not suit a remote or cold-starting sandbox filesystem, where the first write can legitimately take minutes — the lock rejected those writes with `write-lock timeout` before they ever landed, and there was no supported way to widen it.
+Set `tools.writeLockTimeoutMs` when a remote or cold-starting filesystem needs more than 30 seconds to accept a write. The write tool waits for the configured timeout before returning a `write-lock timeout` error.
 
 ```typescript
 const workspace = new Workspace({
@@ -16,4 +14,4 @@ const workspace = new Workspace({
 });
 ```
 
-The default is unchanged at 30 000 ms, so existing workspaces behave exactly as before.
+The default is unchanged at 30 000 ms.

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -177,6 +177,14 @@ const workspace = new Workspace({
             defaultValue: '2000',
           },
           {
+            name: 'writeLockTimeoutMs',
+            type: 'number',
+            description:
+              'Maximum time in milliseconds a write tool waits to acquire the per-file write lock before failing. Raise this for slow or cold-starting filesystems (e.g. remote sandboxes).',
+            isOptional: true,
+            defaultValue: '30000',
+          },
+          {
             name: 'hooks',
             type: 'WorkspaceToolHooks',
             description: 'Hooks that run before and after every enabled workspace tool call. See Tool hooks below.',

--- a/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
@@ -480,4 +480,43 @@ describe('createWorkspaceTools', () => {
       expect(writeTool.needsApprovalFn).toBeUndefined();
     });
   });
+  describe('writeLockTimeoutMs', () => {
+    /** A filesystem whose writes never settle, so the lock timeout is what ends the call. */
+    function hangingWriteFilesystem(basePath: string) {
+      const filesystem = new LocalFilesystem({ basePath });
+      filesystem.writeFile = () => new Promise<never>(() => {});
+      return filesystem;
+    }
+
+    it('bounds a hung write by the configured timeout', async () => {
+      const workspace = new Workspace({
+        filesystem: hangingWriteFilesystem(tempDir),
+        tools: { writeLockTimeoutMs: 50 },
+      });
+      const tools = await createWorkspaceTools(workspace);
+
+      await expect(
+        tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE].execute({ path: 'hangs.txt', content: 'x' }, { workspace }),
+      ).rejects.toThrow('write-lock timeout on "hangs.txt" after 50ms');
+    });
+
+    it('falls back to the 30s default when unset', async () => {
+      const workspace = new Workspace({
+        filesystem: hangingWriteFilesystem(tempDir),
+      });
+      const tools = await createWorkspaceTools(workspace);
+
+      const write = tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE].execute(
+        { path: 'hangs.txt', content: 'x' },
+        { workspace },
+      );
+      // Still pending well past the configured-timeout case above: the default
+      // is what is in force, not a value inherited from another test.
+      const settled = await Promise.race([
+        write.then(() => 'settled').catch(() => 'settled'),
+        new Promise<string>(resolve => setTimeout(() => resolve('pending'), 200)),
+      ]);
+      expect(settled).toBe('pending');
+    });
+  });
 });

--- a/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { WORKSPACE_TOOLS } from '../../constants';
 import { LocalFilesystem } from '../../filesystem';
@@ -506,17 +506,21 @@ describe('createWorkspaceTools', () => {
       });
       const tools = await createWorkspaceTools(workspace);
 
-      const write = tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE].execute(
-        { path: 'hangs.txt', content: 'x' },
-        { workspace },
-      );
-      // Still pending well past the configured-timeout case above: the default
-      // is what is in force, not a value inherited from another test.
-      const settled = await Promise.race([
-        write.then(() => 'settled').catch(() => 'settled'),
-        new Promise<string>(resolve => setTimeout(() => resolve('pending'), 200)),
-      ]);
-      expect(settled).toBe('pending');
+      // Fake timers so the 30s default can be asserted exactly without waiting
+      // it out, and so the test leaves no pending lock timer behind.
+      vi.useFakeTimers();
+      try {
+        const write = tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE].execute(
+          { path: 'hangs.txt', content: 'x' },
+          { workspace },
+        );
+        const rejected = expect(write).rejects.toThrow('write-lock timeout on "hangs.txt" after 30000ms');
+
+        await vi.advanceTimersByTimeAsync(30_000);
+        await rejected;
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -387,8 +387,11 @@ export async function createWorkspaceTools(
   const toolsConfig = workspace.getToolsConfig();
   const isReadOnly = workspace.filesystem?.readOnly ?? false;
 
-  // Shared write lock — serializes concurrent writes to the same file path
-  const writeLock: FileWriteLock = new InMemoryFileWriteLock();
+  // Shared write lock — serializes concurrent writes to the same file path.
+  // `timeoutMs: undefined` falls back to the lock's own default (30s).
+  const writeLock: FileWriteLock = new InMemoryFileWriteLock({
+    timeoutMs: toolsConfig?.writeLockTimeoutMs,
+  });
 
   // Shared read tracker — always active so optimistic concurrency (mtime
   // checking) works on every write, regardless of the requireReadBeforeWrite

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -301,6 +301,17 @@ export type WorkspaceToolsConfig = {
    * If the owning agent also defines hooks, workspace hooks run inside the agent hook wrapper.
    */
   hooks?: WorkspaceToolHooks;
+
+  /**
+   * Maximum time (ms) a single write-tool call may hold the per-file write lock
+   * before it is rejected with a `write-lock timeout` error. Default: 30 000.
+   *
+   * The default suits a local filesystem, where a write is a sub-second
+   * operation. Raise it when writes go somewhere slower — a remote or
+   * cold-starting sandbox filesystem can legitimately take minutes to accept
+   * its first write, and the default rejects those before they ever land.
+   */
+  writeLockTimeoutMs?: number;
 } & {
   [K in typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]?: ExecuteCommandToolConfig;
 } & {


### PR DESCRIPTION
## Description

Expose the workspace write-lock timeout as `tools.writeLockTimeoutMs`.

`InMemoryFileWriteLock` already accepts a `timeoutMs` option: it is declared on `FileWriteLockOptions`, and covered by [existing tests](https://github.com/mastra-ai/mastra/blob/a1c43592bf468a7ac1ba1a9d959de13208a4fa1d/packages/core/src/workspace/filesystem/file-write-lock.test.ts#L120-L131).

https://github.com/mastra-ai/mastra/blob/a1c43592bf468a7ac1ba1a9d959de13208a4fa1d/packages/core/src/workspace/filesystem/file-write-lock.ts#L12-L15

But `createWorkspaceTools` constructs the lock with no arguments:

https://github.com/mastra-ai/mastra/blob/a1c43592bf468a7ac1ba1a9d959de13208a4fa1d/packages/core/src/workspace/tools/tools.ts#L390-L391

so the 30-second default is unreachable from user code.

That default is right for a local filesystem, where a write is a sub-second operation. It is wrong for a remote or cold-starting sandbox filesystem, where the first write after a container comes up can legitimately take minutes. The lock [rejects the caller](https://github.com/mastra-ai/mastra/blob/a1c43592bf468a7ac1ba1a9d959de13208a4fa1d/packages/core/src/workspace/filesystem/file-write-lock.ts#L66-L72) with `write-lock timeout on "<path>" after 30000ms`, so the write tool reports failure for a reason that has nothing to do with the write. The underlying write is not cancelled, which makes it worse rather than better: the caller sees an error while the write may still land afterwards.

**Change:**

- add `WorkspaceToolsConfig.writeLockTimeoutMs?: number`
- pass it through at the construction site

```ts
const workspace = new Workspace({
  filesystem: mySandboxFilesystem,
  tools: {
    // allow a cold-starting sandbox time to accept its first write
    writeLockTimeoutMs: 210_000,
  },
});
```

Passing `undefined` through preserves the lock's own `?? 30_000` fallback, so **the default is unchanged and existing workspaces are unaffected**. There is no behaviour change unless the option is set.

**Tests.** Two cases added to `tool-creation.test.ts`, driving the real `write_file` tool over a filesystem whose write never settles:

- with `writeLockTimeoutMs: 50`, the call rejects with `write-lock timeout on "hangs.txt" after 50ms`
- with the option unset, the call is still pending at 200ms, proving the default is what is in force rather than a value leaked from the other case

I checked the first test is discriminating: with the `tools.ts` change reverted it runs the full 30s and reports `after 30000ms`. `tool-creation.test.ts` (30) and `file-write-lock.test.ts` (9) pass, no type errors.

## Related issue(s)

Fixes #20807

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable). The new option carries a TSDoc block explaining when to raise it, and a changeset is included.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets workspace file writes wait longer on slow or remote filesystems. The default remains 30 seconds when no timeout is configured.

## Changes

- Added optional `WorkspaceToolsConfig.writeLockTimeoutMs`.
- Passed the configured timeout to `InMemoryFileWriteLock`.
- Added tests for configured timeouts and the 30-second default.
- Documented the option and added a `@mastra/core` changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
