### PR TITLE
fix(factory): start Linear issue investigations

### DIFF
--- a/.changeset/khaki-rockets-appear.md
+++ b/.changeset/khaki-rockets-appear.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed Linear issue investigations failing to start because automatic Factory session preparation only supported GitHub metadata.
+Fixed Linear issue investigations failing to start from unsupported metadata or resolving a stale work item binding after the same session was rebound.

--- a/.changeset/khaki-rockets-appear.md
+++ b/.changeset/khaki-rockets-appear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Linear issue investigations failing to start because automatic Factory session preparation only supported GitHub metadata.

--- a/.changeset/khaki-rockets-appear.md
+++ b/.changeset/khaki-rockets-appear.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed Linear issue investigations failing to start from unsupported metadata or resolving a stale work item binding after the same session was rebound.
+Fixed Linear issue investigations using inconsistent metadata, failing to start, or resolving a stale work item binding after the same session was rebound.

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
@@ -51,7 +51,7 @@ const linearWorkItem = {
     url: 'https://linear.app/acme/issue/ENG-42/fix-intake-sync',
   },
   title: 'ENG-42: Fix intake sync',
-  metadata: { linearIssueIdentifier: 'ENG-42' },
+  metadata: { identifier: 'ENG-42' },
 };
 
 /**

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
@@ -41,11 +41,24 @@ const issueWorkItem = {
   updatedAt: '2026-07-18T00:00:00.000Z',
 };
 
+const linearWorkItem = {
+  ...issueWorkItem,
+  id: 'linear-item-1',
+  externalSource: {
+    integrationId: 'linear',
+    type: 'issue',
+    externalId: 'linear:linear-issue-1',
+    url: 'https://linear.app/acme/issue/ENG-42/fix-intake-sync',
+  },
+  title: 'ENG-42: Fix intake sync',
+  metadata: { linearIssueIdentifier: 'ENG-42' },
+};
+
 /**
  * Stubs the board's data endpoints and captures run-start requests. The run
  * start never resolves, keeping the test on the board (no thread navigation).
  */
-function stubBoardEndpoints({ issues = [] as object[] } = {}) {
+function stubBoardEndpoints({ issues = [] as object[], workItems = [issueWorkItem] as object[] } = {}) {
   const startRequests: Array<Record<string, unknown>> = [];
 
   server.use(
@@ -73,9 +86,7 @@ function stubBoardEndpoints({ issues = [] as object[] } = {}) {
         ],
       }),
     ),
-    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
-      HttpResponse.json({ workItems: [issueWorkItem] }),
-    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () => HttpResponse.json({ workItems })),
     http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions`, () =>
       HttpResponse.json({ decisions: [] }),
     ),
@@ -130,6 +141,28 @@ describe('Board card click starts the default run', () => {
     expect(startRequests[0]).toMatchObject({
       invocation: { type: 'skill', skillName: 'factory-triage' },
       workItem: { id: 'item-1', role: 'plan' },
+    });
+  });
+
+  it('starts a persisted Linear Triage item with the Linear kickoff invocation', async () => {
+    const { startRequests } = stubBoardEndpoints({ workItems: [linearWorkItem] });
+    const user = userEvent.setup();
+    renderWorkBoard();
+
+    await user.click(await screen.findByRole('button', { name: 'Investigate ENG-42: Fix intake sync' }));
+
+    await waitFor(() => expect(startRequests).toHaveLength(1));
+    expect(startRequests[0]).toMatchObject({
+      destinationStage: 'planning',
+      invocation: {
+        type: 'skill',
+        skillName: 'factory-triage',
+        arguments: expect.stringContaining(
+          `Linear issue ENG-42 (https://linear.app/acme/issue/ENG-42/fix-intake-sync)\n\n` +
+            `Start by fetching the issue's full details (description and comments) with the linear_get_issue tool.`,
+        ),
+      },
+      workItem: { id: 'linear-item-1', role: 'plan' },
     });
   });
 

--- a/mastracode/factory-ui/src/ui/domains/factory/services/workItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/workItems.ts
@@ -119,13 +119,19 @@ function toWireCreateInput(input: CreateWorkItemInput): WireCreateWorkItemInput 
 
 function fromWireWorkItem(item: WireWorkItem): WorkItem {
   const { factoryProjectId, externalSource, metadata, ...rest } = item;
+  const rawMetadata = metadata ?? {};
+  const linearIssueIdentifier = rawMetadata.linearIssueIdentifier;
+  const normalizedMetadata =
+    rawMetadata.identifier === undefined && typeof linearIssueIdentifier === 'string'
+      ? { ...rawMetadata, identifier: linearIssueIdentifier }
+      : rawMetadata;
   return {
     ...rest,
     githubProjectId: factoryProjectId,
     source: sourceFromExternalSource(externalSource),
     sourceKey: externalSource?.externalId ?? null,
     url: externalSource?.url ?? null,
-    metadata: metadata ?? {},
+    metadata: normalizedMetadata,
   };
 }
 

--- a/mastracode/factory-ui/src/ui/domains/factory/services/workItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/workItems.ts
@@ -119,19 +119,13 @@ function toWireCreateInput(input: CreateWorkItemInput): WireCreateWorkItemInput 
 
 function fromWireWorkItem(item: WireWorkItem): WorkItem {
   const { factoryProjectId, externalSource, metadata, ...rest } = item;
-  const rawMetadata = metadata ?? {};
-  const linearIssueIdentifier = rawMetadata.linearIssueIdentifier;
-  const normalizedMetadata =
-    rawMetadata.identifier === undefined && typeof linearIssueIdentifier === 'string'
-      ? { ...rawMetadata, identifier: linearIssueIdentifier }
-      : rawMetadata;
   return {
     ...rest,
     githubProjectId: factoryProjectId,
     source: sourceFromExternalSource(externalSource),
     sourceKey: externalSource?.externalId ?? null,
     url: externalSource?.url ?? null,
-    metadata: normalizedMetadata,
+    metadata: metadata ?? {},
   };
 }
 

--- a/mastracode/factory/src/routes/surface.test.ts
+++ b/mastracode/factory/src/routes/surface.test.ts
@@ -20,15 +20,13 @@ describe('factoryRuleBranch', () => {
     updatedAt: new Date(),
   };
 
-  it('supports canonical and legacy Linear issue metadata', () => {
-    const linearItem = {
-      ...item,
-      externalSource: { integrationId: 'linear', type: 'issue', externalId: 'issue-1' },
-    };
-
-    expect(factoryRuleBranch({ ...linearItem, metadata: { identifier: 'ENG-42' } })).toBe('factory/linear-eng-42');
-    expect(factoryRuleBranch({ ...linearItem, metadata: { linearIssueIdentifier: 'ENG-43' } })).toBe(
-      'factory/linear-eng-43',
-    );
+  it('supports Linear issue metadata', () => {
+    expect(
+      factoryRuleBranch({
+        ...item,
+        externalSource: { integrationId: 'linear', type: 'issue', externalId: 'issue-1' },
+        metadata: { identifier: 'ENG-42' },
+      }),
+    ).toBe('factory/linear-eng-42');
   });
 });

--- a/mastracode/factory/src/routes/surface.test.ts
+++ b/mastracode/factory/src/routes/surface.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { factoryRuleBranch } from './surface.js';
+
+describe('factoryRuleBranch', () => {
+  const item = {
+    id: 'item-1',
+    orgId: 'org-1',
+    factoryProjectId: 'project-1',
+    externalSource: { integrationId: 'github', type: 'issue', externalId: '42' },
+    parentWorkItemId: null,
+    title: 'Issue 42',
+    stages: ['triage'],
+    sessions: {},
+    stageHistory: [],
+    metadata: {},
+    revision: 1,
+    createdBy: 'user-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it('supports Linear issue metadata', () => {
+    expect(
+      factoryRuleBranch({
+        ...item,
+        externalSource: { integrationId: 'linear', type: 'issue', externalId: 'issue-1' },
+        metadata: { linearIssueIdentifier: 'ENG-42' },
+      }),
+    ).toBe('factory/linear-eng-42');
+  });
+});

--- a/mastracode/factory/src/routes/surface.test.ts
+++ b/mastracode/factory/src/routes/surface.test.ts
@@ -20,13 +20,15 @@ describe('factoryRuleBranch', () => {
     updatedAt: new Date(),
   };
 
-  it('supports Linear issue metadata', () => {
-    expect(
-      factoryRuleBranch({
-        ...item,
-        externalSource: { integrationId: 'linear', type: 'issue', externalId: 'issue-1' },
-        metadata: { linearIssueIdentifier: 'ENG-42' },
-      }),
-    ).toBe('factory/linear-eng-42');
+  it('supports canonical and legacy Linear issue metadata', () => {
+    const linearItem = {
+      ...item,
+      externalSource: { integrationId: 'linear', type: 'issue', externalId: 'issue-1' },
+    };
+
+    expect(factoryRuleBranch({ ...linearItem, metadata: { identifier: 'ENG-42' } })).toBe('factory/linear-eng-42');
+    expect(factoryRuleBranch({ ...linearItem, metadata: { linearIssueIdentifier: 'ENG-43' } })).toBe(
+      'factory/linear-eng-43',
+    );
   });
 });

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -148,9 +148,8 @@ export function factoryRuleBranch(item: FactoryBindingPreparationInput['item']):
   ) {
     return `factory/pr-${pullRequestNumber}`;
   }
-  const linearIdentifier = metadata.identifier ?? metadata.linearIssueIdentifier;
-  if (item.externalSource?.integrationId === 'linear' && typeof linearIdentifier === 'string') {
-    return `factory/linear-${linearIdentifier.toLowerCase()}`;
+  if (item.externalSource?.integrationId === 'linear' && typeof metadata.identifier === 'string') {
+    return `factory/linear-${metadata.identifier.toLowerCase()}`;
   }
   throw new Error('Factory skill invocation requires a supported issue or pull request identifier.');
 }

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -148,7 +148,11 @@ export function factoryRuleBranch(item: FactoryBindingPreparationInput['item']):
   ) {
     return `factory/pr-${pullRequestNumber}`;
   }
-  throw new Error('Factory skill invocation requires a GitHub issue or pull request number.');
+  const linearIdentifier = metadata.linearIssueIdentifier ?? metadata.identifier;
+  if (item.externalSource?.integrationId === 'linear' && typeof linearIdentifier === 'string') {
+    return `factory/linear-${linearIdentifier.toLowerCase()}`;
+  }
+  throw new Error('Factory skill invocation requires a supported issue or pull request identifier.');
 }
 
 async function prepareFactoryRuleBinding(

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -148,7 +148,7 @@ export function factoryRuleBranch(item: FactoryBindingPreparationInput['item']):
   ) {
     return `factory/pr-${pullRequestNumber}`;
   }
-  const linearIdentifier = metadata.linearIssueIdentifier ?? metadata.identifier;
+  const linearIdentifier = metadata.identifier ?? metadata.linearIssueIdentifier;
   if (item.externalSource?.integrationId === 'linear' && typeof linearIdentifier === 'string') {
     return `factory/linear-${linearIdentifier.toLowerCase()}`;
   }

--- a/mastracode/factory/src/rules/bindings.test.ts
+++ b/mastracode/factory/src/rules/bindings.test.ts
@@ -5,7 +5,8 @@ import { createFactoryStorageForTests } from '../storage/test-utils.js';
 
 const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
 
-async function prepareBinding(storage: WorkItemsStorage) {
+async function prepareBinding(storage: WorkItemsStorage, options: { issue?: number; kickoffKey?: string } = {}) {
+  const issue = options.issue ?? 1;
   return storage.prepareRunStart({
     orgId: 'org-1',
     userId: 'user-1',
@@ -15,18 +16,18 @@ async function prepareBinding(storage: WorkItemsStorage) {
         externalSource: {
           integrationId: 'github',
           type: 'issue',
-          externalId: 'github-issue:1',
+          externalId: `github-issue:${issue}`,
         },
-        title: 'Issue',
+        title: `Issue ${issue}`,
         stages: ['intake'],
         sessions: {},
         metadata: {},
       },
     },
     role: 'work',
-    session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-1' },
+    session: { sessionId: 'session-1', branch: `factory/issue-${issue}`, threadId: 'thread-1' },
     resourceId: 'resource-1',
-    kickoffKey: 'kickoff-1',
+    kickoffKey: options.kickoffKey ?? 'kickoff-1',
     kickoffMessage: null,
   });
 }
@@ -40,6 +41,28 @@ describe('Factory run binding authority', () => {
     expect([first.replayed, second.replayed].sort()).toEqual([false, true]);
     expect(second.binding.id).toBe(first.binding.id);
     expect(second.pendingStart.id).toBe(first.pendingStart.id);
+  });
+
+  it('keeps only the newest active binding for an exact session address', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const first = await prepareBinding(storage);
+    const second = await prepareBinding(storage, { issue: 2, kickoffKey: 'kickoff-2' });
+    const address = {
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      sessionId: 'session-1',
+    };
+
+    await expect(storage.findActiveRunBinding(address)).resolves.toMatchObject({
+      id: second.binding.id,
+      workItemId: second.item.id,
+    });
+    await expect(storage.listRunBindings('org-1', PROJECT_ID)).resolves.toEqual([
+      expect.objectContaining({ id: first.binding.id, status: 'revoked' }),
+      expect.objectContaining({ id: second.binding.id, status: 'active' }),
+    ]);
   });
 
   it('requires the complete tenant, project, thread, resource, and session tuple', async () => {

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -152,7 +152,7 @@ describe('defaultFactoryRules', () => {
       sourceKey: 'linear:ENG-42',
       title: 'ENG-42: Fix intake sync',
       stage: 'triage',
-      metadata: { linearIssueId: 'issue-1', linearIssueIdentifier: 'ENG-42' },
+      metadata: { linearIssueId: 'issue-1', identifier: 'ENG-42' },
     });
   });
 

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -241,7 +241,7 @@ function linearIssueObserved(context: FactoryLinearRuleContext) {
     stage: 'triage',
     metadata: {
       linearIssueId: context.issue.id,
-      linearIssueIdentifier: context.issue.identifier,
+      identifier: context.issue.identifier,
       linearState: context.issue.state,
       linearStateType: context.issue.stateType,
       linearPriority: context.issue.priorityLabel,

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -1493,6 +1493,18 @@ export class WorkItemsStorage extends FactoryStorageDomain {
           {
             org_id: input.orgId,
             factory_project_id: input.factoryProjectId,
+            thread_id: input.session.threadId,
+            resource_id: input.resourceId,
+            session_id: input.session.sessionId,
+            status: 'active',
+          },
+          { status: 'revoked', revoked_at: now },
+        );
+        await ops.updateMany(
+          'factory_run_bindings',
+          {
+            org_id: input.orgId,
+            factory_project_id: input.factoryProjectId,
             work_item_id: item.id,
             role: input.role,
             status: 'active',


### PR DESCRIPTION
Linear issue investigations could fail during automatic session preparation because Factory only knew how to derive GitHub branches. Persisted Linear work items also expose `linearIssueIdentifier`, while the UI run-spec path expected `identifier`, causing board-started runs to lose the Linear-specific kickoff context.

This adds source-aware Linear branch preparation and normalizes the persisted Linear identifier at the UI boundary. Automatic triage effects and sessionless board cards now both start `factory-triage` with the Linear issue reference and instructions to fetch its full details. The source-aware branch coverage lives with the route helper rather than under the GitHub integration, and the UI behavior is covered through the real client, React Query, and MSW path.

Verified with the Factory route tests and package check, the full Factory UI MSW suite (81 files / 419 tests), Factory UI typecheck, Oxlint, Prettier, and production builds for Factory and Factory UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Factory can now start investigations for Linear issues correctly. It uses the issue reference to prepare sessions, fetch issue details, and avoid conflicts with older session links.

## Changes

- Added Linear-aware branch preparation with `factory/linear-*` branch names.
- Updated automatic triage and sessionless board cards to start `factory-triage` with the Linear issue reference and fetch instructions.
- Standardized persisted Linear issue metadata on the shared `identifier` key.
- Revoked stale bindings when Factory rebinds a session address.
- Updated unsupported-input errors so they do not refer only to GitHub issue numbers.

## Tests and validation

- Added route coverage for Linear branch preparation.
- Added UI coverage for starting a persisted Linear item through the real client, React Query, and MSW.
- Updated binding and default-rule tests.
- Verified Factory UI MSW tests, typechecks, linting, formatting, and production builds for Factory and Factory UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->