### PR TITLE
Add isolated producer-side regression test for nullish toModelOutput

### DIFF
--- a/packages/core/src/agent/durable/__tests__/durable-agent-to-model-output.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-to-model-output.test.ts
@@ -16,6 +16,7 @@ import { InMemoryStore } from '../../../storage';
 import { createTool } from '../../../tools';
 import { Agent } from '../../agent';
 import { createDurableAgent } from '../create-durable-agent';
+import { globalRunRegistry } from '../run-registry';
 
 function createToolCallingModel(
   toolName: string,
@@ -228,5 +229,64 @@ describe('DurableAgent toModelOutput parity', () => {
     expect(toolResultPart).toBeDefined();
     expect(toolResultPart.output).toBeDefined();
     expect(JSON.stringify(toolResultPart.output)).toContain('the answer is 42');
+  });
+
+  it('does not write a modelOutput key into the message list when toModelOutput returns nullish (producer guard)', async () => {
+    // Isolates the producer-side guard in llm-mapping.ts. A nullish toModelOutput
+    // must NOT be persisted as `mastra: { modelOutput: undefined }` on the
+    // tool-invocation part. JSON storage round-trips drop `undefined`, so the bad
+    // key is only observable on the in-memory MessageList (via the run registry);
+    // asserting there is what makes this test go red when the guard is reverted.
+    const toModelOutputSpy = vi.fn(() => undefined);
+
+    const testTool = createTool({
+      id: 'text-tool',
+      description: 'A tool that only maps media results',
+      inputSchema: z.object({ path: z.string() }),
+      outputSchema: z.object({ contents: z.string() }),
+      execute: async () => ({ contents: 'the answer is 42' }),
+      toModelOutput: toModelOutputSpy,
+    });
+
+    const model = createToolCallingModel('text-tool', { path: 'data.txt' });
+
+    const storage = new InMemoryStore();
+    const baseAgent = new Agent({
+      name: 'text-agent',
+      instructions: 'You are a test agent.',
+      model,
+      tools: { 'text-tool': testTool },
+    });
+
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub, cleanupTimeoutMs: 0 });
+
+    new Mastra({
+      agents: { 'text-agent': durableAgent as any },
+      storage,
+    });
+
+    const threadId = 'thread-producer-guard';
+    const resourceId = 'resource-producer-guard';
+    const result = await durableAgent.stream('Read data.txt', {
+      memory: { thread: threadId, resource: resourceId },
+    });
+
+    for await (const _ of result.fullStream) {
+      // drain
+    }
+
+    const entry = globalRunRegistry.get(result.runId);
+    const messageList = entry?.messageList;
+    expect(messageList).toBeDefined();
+    const messages = messageList!.get.all.db();
+    const invocation = messages
+      .filter((m: any) => m.role === 'assistant' && m.content?.format === 2)
+      .flatMap((m: any) => m.content.parts)
+      .find((p: any) => p.type === 'tool-invocation' && p.toolInvocation?.state === 'result');
+
+    expect(invocation).toBeDefined();
+    // Producer guard: a nullish modelOutput must not be written as a key at all.
+    const mastraMeta = (invocation as any)?.providerMetadata?.mastra ?? {};
+    expect(Object.hasOwn(mastraMeta, 'modelOutput')).toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up to #20405 (merged). That PR fixed the durable `llm-mapping.ts` guard and the consumer-side `message-list.ts` fallback, but the producer-side guard has no test that pins it on its own — the durable test there only goes red when BOTH fixes are reverted, because the consumer fallback rescues the run.

This adds a test that fails on its own when the `llm-mapping.ts` guard is reverted:

- When a tool's `toModelOutput` returns nullish, the tool-invocation part on the in-memory MessageList must NOT carry a `modelOutput` key. We assert against the run registry's messageList because JSON storage round-trips silently drop `undefined` — the bad key is only observable in-memory.

Verification matrix (run locally):

- Guard present: 4 passed (this test + #20404's three)
- Revert `llm-mapping.ts` only: this test goes red; the other 3 still pass
- Revert `message-list.ts` only: 4 passed (proves this test doesn't depend on the consumer-side fix)

Single file change, rebased on latest `main`.

Fixes #20402

Refs #20404 — producer-side guard shipped there; this test pins it independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a test for a bug where a missing tool result could be stored as if it had a value. The test checks the in-memory message data to ensure the incorrect field is not present.

## Changes

- Added a durable-agent regression test for nullish `toModelOutput` results.
- Used `globalRunRegistry` to inspect the in-memory `MessageList`.
- Verified that completed tool invocations do not contain a `modelOutput` key when the result is nullish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->