### PR TITLE
fix(playground-ui): ellipsize truncated Crumb labels and stop clipping descenders

### DIFF
--- a/.changeset/breadcrumb-crumb-truncation.md
+++ b/.changeset/breadcrumb-crumb-truncation.md
@@ -1,0 +1,10 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fix Crumb truncating labels without an ellipsis and clipping their descenders
+
+`truncate` sat on Crumb's flex root, where `text-overflow` cannot apply — a
+clamped label was hard-cut mid-glyph instead of ellipsized, and the accompanying
+`overflow-hidden` sheared the descenders off the line box. Text children now get
+their own truncating box while icons stay flex siblings.

--- a/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
@@ -31,7 +31,23 @@ export interface CrumbProps {
   'data-testid'?: string;
 }
 
-export const Crumb = ({ className, as, isCurrent, action, ...props }: CrumbProps) => {
+// `text-overflow` only ellipsizes inline content in a block container, so
+// `truncate` on this flex Root hard-cut the label mid-glyph instead of showing
+// one, and its `overflow-hidden` sheared the descenders off the line box. Text
+// children get their own truncating box (as in DataList) and icons stay flex
+// siblings, which keeps `gap-2` and the icon on the same line as the label.
+const crumbTextTruncateStyles = 'min-w-0 flex-1 truncate';
+
+const truncateTextChildren = (children: React.ReactNode) =>
+  React.Children.map(children, child =>
+    typeof child === 'string' || typeof child === 'number' ? (
+      <span className={crumbTextTruncateStyles}>{child}</span>
+    ) : (
+      child
+    ),
+  );
+
+export const Crumb = ({ className, as, isCurrent, action, children, ...props }: CrumbProps) => {
   const Root = as || 'span';
 
   return (
@@ -40,7 +56,7 @@ export const Crumb = ({ className, as, isCurrent, action, ...props }: CrumbProps
         <Root
           aria-current={isCurrent ? 'page' : undefined}
           className={cn(
-            'flex min-w-0 items-center gap-2 truncate rounded-md px-1 text-ui-md leading-ui-md',
+            'flex min-w-0 items-center gap-2 overflow-hidden rounded-md px-1 py-0.5 text-ui-md leading-ui-md',
             transitions.colors,
             isCurrent
               ? 'font-medium text-neutral6'
@@ -48,7 +64,9 @@ export const Crumb = ({ className, as, isCurrent, action, ...props }: CrumbProps
             className,
           )}
           {...props}
-        />
+        >
+          {truncateTextChildren(children)}
+        </Root>
         {action}
       </li>
       {!isCurrent && (

--- a/packages/playground-ui/src/ds/components/Breadcrumb/breadcrumb.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/breadcrumb.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ChevronDown } from 'lucide-react';
+import { Icon } from '../../icons/Icon';
+import { WorkspacesIcon } from '../../icons/WorkspacesIcon';
 import { Breadcrumb, Crumb } from './Breadcrumb';
 
 const meta: Meta<typeof Breadcrumb> = {
@@ -91,6 +93,27 @@ export const SingleItem: Story = {
     <Breadcrumb label="Navigation">
       <Crumb as="span" to="/dashboard" isCurrent>
         Dashboard
+      </Crumb>
+    </Breadcrumb>
+  ),
+};
+
+/**
+ * A label clamped by `className` must ellipsize rather than cut mid-glyph, and
+ * must keep its descenders (g, p, y). The icon stays a flex sibling of the
+ * label so it is never truncated and keeps its gap.
+ */
+export const TruncatedLabel: Story = {
+  render: () => (
+    <Breadcrumb label="Navigation">
+      <Crumb as="a" to="/workspaces" className="max-w-40">
+        <Icon>
+          <WorkspacesIcon />
+        </Icon>
+        Staging deployment registry
+      </Crumb>
+      <Crumb as="span" to="/workspaces/playground" isCurrent className="max-w-40">
+        Agent playground copy
       </Crumb>
     </Breadcrumb>
   ),

--- a/packages/playground/src/lib/route-header/route-header.tsx
+++ b/packages/playground/src/lib/route-header/route-header.tsx
@@ -3,20 +3,26 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { Header } from '@mastra/playground-ui/components/Header';
 import { DocsIcon } from '@mastra/playground-ui/icons/DocsIcon';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
+import type { ReactNode } from 'react';
 import { Link } from 'react-router';
 import { RouteHeaderActionsSlot } from './route-header-actions';
 import { useRouteHeaderCrumbsOverride } from './route-header-crumbs-context';
 import type { CrumbDef } from './types';
 import { useRouteHeader } from './use-route-header';
 
-function RouteHeaderCrumbContent({ def }: { def: CrumbDef }) {
+/**
+ * Returns the crumb content rather than rendering it as a component, so a plain
+ * label reaches Crumb as a string child and gets Crumb's truncating box. Wrapped
+ * in a component it arrives as an element and falls through untruncated.
+ */
+function routeHeaderCrumbContent(def: CrumbDef): ReactNode {
   if ('Component' in def && def.Component) {
     const Component = def.Component;
     return <Component />;
   }
 
-  if ('node' in def) return <>{def.node}</>;
-  return <>{def.label}</>;
+  if ('node' in def) return def.node;
+  return def.label;
 }
 
 export function RouteHeader() {
@@ -46,7 +52,7 @@ export function RouteHeader() {
                     <IconComponent />
                   </Icon>
                 )}
-                <RouteHeaderCrumbContent def={def} />
+                {routeHeaderCrumbContent(def)}
               </Crumb>
             );
           })}


### PR DESCRIPTION
Fixes #20815

A clamped breadcrumb label was cut mid-glyph instead of ellipsized, and its descenders were sheared off. Both come from one class.

`truncate` sat on `Crumb`'s **flex** root. `text-overflow` only ellipsizes inline content in a *block* container — a flex container's text becomes an anonymous flex item that never ellipsizes. So the `text-overflow: ellipsis` half did nothing, and the `overflow: hidden` half clipped the label to the line box, taking the descenders with it (143% leading leaves under 1.5px below the baseline at 14px).

Text children now get their own `min-w-0 flex-1 truncate` box, matching the helper `DataList` already uses (`dataListInlineTextTruncateStyles`, `data-list-cells.tsx:45`). Element children — icons, comboboxes — stay flex siblings, so they keep `gap-2` and are never truncated.

## Why the icon can't go inside the truncating span

I rendered all three arrangements before picking one:

| Structure | Result |
| --- | --- |
| Icon inside the truncating span | Icon claims its own line |
| Icon inside, forced `inline-block` | Renders, but `gap-2` collapses |
| **Icon as a flex sibling** | Correct |

`Icon` renders `display: block`. A block-level child inside a `white-space: nowrap` block container still generates its own line box — `nowrap` stops *text* from wrapping, it does not stop a block child from claiming a line. Wrapping only string/number children gives this for free: `<Icon>` is an element and passes through untouched.

## Why `route-header.tsx` is in this PR

`RouteHeaderCrumbContent` was a component, so a plain label reached `Crumb` as a React *element* and fell through unwrapped. As a plain function it returns the string, which `Children.map` can see. The `Component` branch still returns an element, so custom crumb components keep their own render (and hooks).

Without this second file the fix does not reach Studio's own breadcrumbs at all.

## Verified in Studio, not just Storybook

Driven against a real Chromium on the `kitchen-sink` e2e fixture (`mastra dev` on :4111, Vite on :5173), same route `/workflows`, same width constraint, with only the `@mastra/playground-ui` build swapped between runs:

| | rendered | crumb children |
| --- | --- | --- |
| base | `Workfl` — hard cut, no ellipsis | `[Icon]` only; label is an unstyleable anonymous flex item |
| this branch | `Wor…` | `[Icon, span.min-w-0.flex-1.truncate]` |

The DOM column is the measured part. The label having its own element on this branch is what makes `text-overflow` apply at all; on base there was nothing to apply it to.

New `TruncatedLabel` story reproduces it without the server:

```sh
pnpm --filter ./packages/playground-ui storybook
# Navigation/Breadcrumb → TruncatedLabel
```

## Also live on projects.mastra.ai

The Cloud bundle (`/assets/index-D5DYsM-C.js`) inlines this same component with the same defect:

```js
className: ve("text-ui-md leading-ui-md flex min-w-0 items-center gap-2 truncate", ...)
```

Same props, same `<li className="flex h-full min-w-0 items-center gap-1">`, same `role="separator"` sibling. Identity confirmed by matching the `SlashIcon` path data byte-for-byte against `ds/icons/SlashIcon.tsx`. It predates `e0f39159` (no `rounded-md px-1`), so Cloud is pinned to an older `@mastra/playground-ui` — this reaches it on the next bump, not on merge.

## What this does not fix

Detail-page crumbs whose child is a control, not text. The workflow detail crumb renders `<div><button role="combobox">`, so it passes through unwrapped and still clips against the container's `overflow-hidden` without an ellipsis. Ellipsizing those means each control owning its own truncation — a separate change, flagging it rather than burying it.

Also: the descender clip is severe on long labels but close to sub-pixel on Studio's short ones, where the visible delta is the crumb box going 28px → 32px from `py-0.5`. The truncation half is the one that reproduces hard.

## Test plan

```sh
pnpm --filter ./packages/playground-ui exec tsc --noEmit
#  96 errors on this branch AND on main — identical, all pre-existing
#  "Cannot find module '@mastra/core/...'" from unbuilt workspace deps

pnpm --filter ./packages/playground-ui exec vitest run --reporter=dot
#  Test Files  14 failed | 96 passed (110)
#  Tests       17 failed | 657 passed (674)
#  byte-identical to main; no Breadcrumb or route-header failures

pnpm --filter ./packages/playground-ui exec eslint src/ds/components/Breadcrumb/
#  7 warnings on this branch AND on main (pre-existing classnames-order in WithAction)

pnpm --filter ./packages/playground exec eslint src/lib/route-header/route-header.tsx
#  clean
```

Every count above was taken twice, once on `main` and once here, so the claim is "no delta" rather than "passes". The suite is not green on `main` and this branch does not change that.

Changeset: `patch` for `@mastra/playground-ui` (published package). `packages/playground` is versioned with it and needs no separate entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Long breadcrumb names now show an ellipsis instead of being cut off. Icons and other breadcrumb elements remain visible.

## Changes

- Wrapped text labels in a dedicated `min-w-0 flex-1 truncate` element.
- Preserved icons, comboboxes, and other element children as separate flex siblings.
- Updated `RouteHeaderCrumbContent` so string labels receive truncation.
- Added the `TruncatedLabel` Storybook story.
- Added a patch changeset for `@mastra/playground-ui`.

## Validation

- No new test, TypeScript, or lint regressions were found.
- Existing failures and warnings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->