### PR TITLE
fix(core): make workspace write-lock timeout configurable

### DIFF
--- a/.changeset/configurable-write-lock-timeout.md
+++ b/.changeset/configurable-write-lock-timeout.md
@@ -2,4 +2,11 @@
 '@mastra/core': patch
 ---
 
-Expose `writeLockTimeoutMs` on `WorkspaceToolsConfig` so the per-file write-lock timeout is configurable. `createWorkspaceTools` constructed the shared `InMemoryFileWriteLock` with no options, leaving its 30s default unreachable from user code. That default is right for a local filesystem but wrong for a remote or cold-starting sandbox filesystem, where the first write after a container comes up can legitimately take minutes — the lock rejected it with `write-lock timeout` for a reason unrelated to the write. Leaving the option unset preserves the 30s default, so existing workspaces are unaffected.
+Configure the workspace write-lock timeout for remote or cold-starting filesystems, where the first write can legitimately take longer than the 30-second default. Set `tools.writeLockTimeoutMs` to raise it; existing workspaces keep the 30-second default when the option is omitted.
+
+```ts
+new Workspace({
+  filesystem,
+  tools: { writeLockTimeoutMs: 120_000 },
+});
+```

--- a/.changeset/configurable-write-lock-timeout.md
+++ b/.changeset/configurable-write-lock-timeout.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Expose `writeLockTimeoutMs` on `WorkspaceToolsConfig` so the per-file write-lock timeout is configurable. `createWorkspaceTools` constructed the shared `InMemoryFileWriteLock` with no options, leaving its 30s default unreachable from user code. That default is right for a local filesystem but wrong for a remote or cold-starting sandbox filesystem, where the first write after a container comes up can legitimately take minutes — the lock rejected it with `write-lock timeout` for a reason unrelated to the write. Leaving the option unset preserves the 30s default, so existing workspaces are unaffected.

--- a/packages/core/src/workspace/tools/__tests__/write-lock-timeout.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/write-lock-timeout.test.ts
@@ -1,0 +1,65 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { RequestContext } from '../../../request-context';
+import { WORKSPACE_TOOLS } from '../../constants';
+import { LocalFilesystem } from '../../filesystem';
+import { Workspace } from '../../workspace';
+import { createWorkspaceTools } from '../tools';
+
+// Regression coverage for the `writeLockTimeoutMs` workspace-tools option:
+// `createWorkspaceTools` must forward it to the shared write lock, and leaving
+// it unset must preserve the lock's own 30s default. See issue #20807.
+describe('workspace write-lock timeout config', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-write-lock-timeout-'));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('honors tools.writeLockTimeoutMs — a hung write is rejected after the configured window, not the 30s default', async () => {
+    // Make the underlying write hang forever so the only thing that can end the
+    // call is the write lock's timeout.
+    vi.spyOn(LocalFilesystem.prototype, 'writeFile').mockImplementation(
+      () => new Promise<void>(() => {}),
+    );
+
+    const workspace = new Workspace({
+      filesystem: () => new LocalFilesystem({ basePath: tempDir }),
+      tools: { writeLockTimeoutMs: 50 },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const ctx = { requestContext: new RequestContext() };
+    const write = tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE].execute(
+      { path: 'hang.txt', content: 'never lands' },
+      ctx,
+    );
+
+    // The configured 50ms timeout — proving the option reached the lock. If it
+    // did not, the message would read `after 30000ms` (and the test would hang).
+    await expect(write).rejects.toThrow(/write-lock timeout on "hang\.txt" after 50ms/);
+  });
+
+  it('leaves the default untouched when writeLockTimeoutMs is unset — writes still succeed', async () => {
+    const workspace = new Workspace({
+      filesystem: () => new LocalFilesystem({ basePath: tempDir }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const ctx = { requestContext: new RequestContext() };
+    await tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE].execute(
+      { path: 'ok.txt', content: 'hello' },
+      ctx,
+    );
+
+    expect(await fs.readFile(path.join(tempDir, 'ok.txt'), 'utf-8')).toBe('hello');
+  });
+});

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -387,8 +387,12 @@ export async function createWorkspaceTools(
   const toolsConfig = workspace.getToolsConfig();
   const isReadOnly = workspace.filesystem?.readOnly ?? false;
 
-  // Shared write lock — serializes concurrent writes to the same file path
-  const writeLock: FileWriteLock = new InMemoryFileWriteLock();
+  // Shared write lock — serializes concurrent writes to the same file path.
+  // `writeLockTimeoutMs` is optional; passing `undefined` preserves the lock's
+  // own 30s default (see FileWriteLockOptions), so the default is unchanged.
+  const writeLock: FileWriteLock = new InMemoryFileWriteLock({
+    timeoutMs: toolsConfig?.writeLockTimeoutMs,
+  });
 
   // Shared read tracker — always active so optimistic concurrency (mtime
   // checking) works on every write, regardless of the requireReadBeforeWrite

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -301,6 +301,19 @@ export type WorkspaceToolsConfig = {
    * If the owning agent also defines hooks, workspace hooks run inside the agent hook wrapper.
    */
   hooks?: WorkspaceToolHooks;
+
+  /**
+   * Timeout, in milliseconds, for the per-file write lock that serializes the
+   * write tools (`write_file`, `edit_file`, `delete`, `ast_edit`). A write that
+   * does not complete within this window is rejected with a `write-lock timeout`
+   * error.
+   *
+   * Defaults to 30_000 (30s), which suits a local filesystem. Raise it for a
+   * remote or cold-starting sandbox filesystem, where the first write after the
+   * container comes up can legitimately take much longer. Leaving it `undefined`
+   * preserves the 30s default, so existing workspaces are unaffected.
+   */
+  writeLockTimeoutMs?: number;
 } & {
   [K in typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]?: ExecuteCommandToolConfig;
 } & {


### PR DESCRIPTION
## What

`createWorkspaceTools` constructs the shared `InMemoryFileWriteLock` with no options, so its 30s default timeout is unreachable from user code. `InMemoryFileWriteLock` already accepts `timeoutMs` (with a `?? 30_000` fallback) and that path is covered by existing tests — there was just no workspace-facing config wired to it.

This exposes `writeLockTimeoutMs` on `WorkspaceToolsConfig` and passes it through at the construction site, as proposed in the issue:

```ts
const workspace = new Workspace({
  filesystem: mySandboxFilesystem,
  tools: {
    // allow a cold-starting sandbox time to accept its first write
    writeLockTimeoutMs: 210_000,
  },
});
```

## Why

The 30s default is right for a local filesystem but wrong for a remote or cold-starting sandbox, where the first write after a container comes up can legitimately take minutes. Today that write fails with `write-lock timeout on "<path>" after 30000ms` for a reason that has nothing to do with the write, and there is no supported knob to change it.

## Behavior change

None unless the option is set. Passing `undefined` preserves the lock's own `?? 30_000` fallback, so the default is unchanged and existing workspaces are unaffected.

## Test

Added `packages/core/src/workspace/tools/__tests__/write-lock-timeout.test.ts`:

- with `tools: { writeLockTimeoutMs: 50 }` and a hung `writeFile`, the write rejects with `write-lock timeout ... after 50ms` — proving the option reaches the lock rather than the 30s default;
- with the option unset, a normal write still succeeds (no regression).

Closes #20807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Workspace writes can wait longer when filesystems are slow to start or respond. If no timeout is set, the existing 30-second default remains unchanged.

## Changes

- Added optional `tools.writeLockTimeoutMs` to `WorkspaceToolsConfig`.
- Passed the configured timeout to `InMemoryFileWriteLock`.
- Added tests for configured and default timeout behavior.
- Added a changeset with a `Workspace` usage example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->