### PR TITLE
test(core): repair durable tool-call step tests broken by flush-gated rebuild

### DIFF
--- a/packages/core/src/agent/durable/workflows/steps/tool-approval-recall.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-approval-recall.test.ts
@@ -24,6 +24,7 @@ import { createDurableToolCallStep } from './tool-call';
 vi.mock('../../utils/resolve-runtime', () => ({
   resolveTool: vi.fn(),
   toolRequiresApproval: vi.fn().mockResolvedValue(true),
+  rebuildRunToolsFromMastra: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../stream-adapter', () => ({

--- a/packages/core/src/agent/durable/workflows/steps/tool-call-bg.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call-bg.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../../../background-tasks/resolve-config', () => ({
 vi.mock('../../utils/resolve-runtime', () => ({
   resolveTool: vi.fn(),
   toolRequiresApproval: vi.fn().mockResolvedValue(false),
+  rebuildRunToolsFromMastra: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../stream-adapter', () => ({

--- a/packages/core/src/agent/durable/workflows/steps/tool-call-xproc-workspace.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call-xproc-workspace.test.ts
@@ -112,6 +112,10 @@ describe('durable tool-call cross-process workspace tool resolution', () => {
     globalRunRegistry.set(RUN_ID, {
       tools: { skill: { id: 'skill', execute: executeMock } as any },
       model: {} as any,
+      // A registry entry produced by a real `stream()` call carries a SaveQueueManager;
+      // without one the flush-gating rebuild (needsSaveQueueForFlush) would fire and
+      // defeat what this test asserts — that a registry hit avoids the Mastra rebuild.
+      saveQueueManager: {} as any,
     } as any);
 
     const step = createDurableToolCallStep();


### PR DESCRIPTION
## Summary

#18856 added a `needsSaveQueueForFlush` path to the durable tool-call step (`packages/core/src/agent/durable/workflows/steps/tool-call.ts`) that calls `rebuildRunToolsFromMastra` whenever the run-registry entry lacks a `SaveQueueManager` and the run has a `threadId`. Three older test files were not updated for it, so `main` currently fails 4 tests in the Affected UNIT Test job:

- `tool-approval-recall.test.ts` and `tool-call-bg.test.ts` mock `../../utils/resolve-runtime` without the `rebuildRunToolsFromMastra` export, throwing `[vitest] No "rebuildRunToolsFromMastra" export is defined` as soon as the new path runs.
- `tool-call-xproc-workspace.test.ts`'s registry-hit test asserts the rebuild is never called, which no longer holds for a registry entry without a `SaveQueueManager`.

## Fix

- Add `rebuildRunToolsFromMastra: vi.fn().mockResolvedValue(undefined)` to the two incomplete mocks (the step guards on a falsy result, matching how `tool-call-actor.test.ts` and `tool-call-fga.test.ts` already mock it).
- Give the registry-hit test's entry a `SaveQueueManager` stub — mirroring what a real `stream()` call registers — so the test keeps asserting its original intent: a usable registry hit avoids the Mastra rebuild.

Test-only change; no changeset needed.

## Test plan

- `npx vitest run` on the three files in `packages/core`: 3 files, 17 tests pass (previously 4 failed).

Example red run on a branch merged with current main: https://github.com/mastra-ai/mastra/actions/runs/31105283952/job/92630665560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

These test updates help the tests handle a new rebuild step correctly. They ensure registry tools still work without triggering an unnecessary rebuild.

## Changes

- Mocked `rebuildRunToolsFromMastra` in two durable tool-call test files.
- Added a `SaveQueueManager` stub to the registry-hit test fixture.
- Preserved coverage that usable registry entries avoid Mastra rebuilds.

## Validation

- 17 tests pass.
- No changeset is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->