### PR TITLE
fix(cli): authenticate `mastra api --url` to Mastra Cloud studio/factory instances

### DIFF
--- a/.changeset/mastra-api-platform-auth.md
+++ b/.changeset/mastra-api-platform-auth.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed `mastra api --url` returning 401 when pointed at a Mastra Cloud Studio or Factory instance. The CLI now uses your logged-in credentials to authenticate requests to `*.studio.mastra.cloud` and `*.factory.mastra.cloud` (and the corresponding staging domains). User-hosted `*.server.mastra.cloud` URLs and custom URLs are unchanged, and an explicit `--header Authorization: ...` always wins.

--- a/packages/cli/src/commands/api/target.test.ts
+++ b/packages/cli/src/commands/api/target.test.ts
@@ -404,6 +404,7 @@ describe('resolveTarget', () => {
       ['https://shipyard.server.mastra.cloud', 'production user-provided server'],
       ['https://shipyard.server.staging.mastra.cloud', 'staging user-provided server'],
       ['https://runtime.example.com', 'arbitrary custom URL'],
+      ['http://shipyard.factory.mastra.cloud', 'non-HTTPS platform host'],
     ])('does not attach Bearer for %s (%s)', async url => {
       await expect(resolveTarget(options({ url }))).resolves.toEqual({
         baseUrl: url,

--- a/packages/cli/src/commands/api/target.test.ts
+++ b/packages/cli/src/commands/api/target.test.ts
@@ -384,6 +384,81 @@ describe('resolveTarget', () => {
     });
   });
 
+  describe('platform-hosted --url', () => {
+    it.each([
+      ['https://shipyard.factory.mastra.cloud', 'production factory'],
+      ['https://shipyard.studio.mastra.cloud', 'production studio'],
+      ['https://shipyard.factory.staging.mastra.cloud', 'staging factory'],
+      ['https://shipyard.studio.staging.mastra.cloud', 'staging studio'],
+    ])('attaches Bearer from stored credentials for %s (%s)', async url => {
+      await expect(resolveTarget(options({ url }))).resolves.toEqual({
+        baseUrl: url,
+        headers: { Authorization: 'Bearer platform-token' },
+        timeoutMs: 30_000,
+      });
+
+      expect(mocks.getToken).toHaveBeenCalledOnce();
+    });
+
+    it.each([
+      ['https://shipyard.server.mastra.cloud', 'production user-provided server'],
+      ['https://shipyard.server.staging.mastra.cloud', 'staging user-provided server'],
+      ['https://runtime.example.com', 'arbitrary custom URL'],
+    ])('does not attach Bearer for %s (%s)', async url => {
+      await expect(resolveTarget(options({ url }))).resolves.toEqual({
+        baseUrl: url,
+        headers: {},
+        timeoutMs: 30_000,
+      });
+
+      expect(mocks.getToken).not.toHaveBeenCalled();
+    });
+
+    it('respects an explicit Authorization header for platform-hosted URLs', async () => {
+      await expect(
+        resolveTarget(
+          options({
+            url: 'https://shipyard.factory.mastra.cloud',
+            header: ['Authorization: Bearer override'],
+          }),
+        ),
+      ).resolves.toEqual({
+        baseUrl: 'https://shipyard.factory.mastra.cloud',
+        headers: { Authorization: 'Bearer override' },
+        timeoutMs: 30_000,
+      });
+
+      expect(mocks.getToken).not.toHaveBeenCalled();
+    });
+
+    it('matches an explicit Authorization header case-insensitively', async () => {
+      await expect(
+        resolveTarget(
+          options({
+            url: 'https://shipyard.factory.mastra.cloud',
+            header: ['authorization: Bearer override'],
+          }),
+        ),
+      ).resolves.toEqual({
+        baseUrl: 'https://shipyard.factory.mastra.cloud',
+        headers: { authorization: 'Bearer override' },
+        timeoutMs: 30_000,
+      });
+
+      expect(mocks.getToken).not.toHaveBeenCalled();
+    });
+
+    it('omits Authorization when no stored credentials are available', async () => {
+      mocks.getToken.mockRejectedValueOnce(new Error('not logged in'));
+
+      await expect(resolveTarget(options({ url: 'https://shipyard.factory.mastra.cloud' }))).resolves.toEqual({
+        baseUrl: 'https://shipyard.factory.mastra.cloud',
+        headers: {},
+        timeoutMs: 30_000,
+      });
+    });
+  });
+
   it('throws malformed header errors before probing targets', async () => {
     await expect(resolveTarget(options({ header: ['invalid'] }))).rejects.toMatchObject({
       code: 'MALFORMED_HEADER',

--- a/packages/cli/src/commands/api/target.ts
+++ b/packages/cli/src/commands/api/target.ts
@@ -42,7 +42,14 @@ export async function resolveTarget(
   const apiPrefix = resolveApiPrefix(options);
 
   if (options.url) {
-    return { baseUrl: options.url, headers: customHeaders, timeoutMs, apiPrefix };
+    const headers = { ...customHeaders };
+    if (isPlatformHostedInstance(options.url) && !getHeader(customHeaders, AUTHORIZATION_HEADER)) {
+      const token = await getOptionalToken();
+      if (token) {
+        headers[AUTHORIZATION_HEADER] = `Bearer ${token}`;
+      }
+    }
+    return { baseUrl: options.url, headers, timeoutMs, apiPrefix };
   }
 
   if (isObservabilityPath(path)) {
@@ -143,6 +150,27 @@ async function resolvePlatformServiceTarget(
     timeoutMs,
     fallbackHeaders,
   };
+}
+
+/**
+ * True when a URL points at a platform-hosted Mastra Studio or Factory instance
+ * (production or staging). Excludes `*.server.mastra.cloud` — those are
+ * user-provided instances that authenticate with their own credentials, not the
+ * stored CLI user token.
+ */
+export function isPlatformHostedInstance(url: string): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return (
+    hostname.endsWith('.studio.mastra.cloud') ||
+    hostname.endsWith('.factory.mastra.cloud') ||
+    hostname.endsWith('.studio.staging.mastra.cloud') ||
+    hostname.endsWith('.factory.staging.mastra.cloud')
+  );
 }
 
 function isObservabilityPath(path?: string): boolean {

--- a/packages/cli/src/commands/api/target.ts
+++ b/packages/cli/src/commands/api/target.ts
@@ -161,7 +161,11 @@ async function resolvePlatformServiceTarget(
 export function isPlatformHostedInstance(url: string): boolean {
   let hostname: string;
   try {
-    hostname = new URL(url).hostname.toLowerCase();
+    const parsed = new URL(url);
+    // Only attach the stored bearer token over HTTPS to avoid leaking
+    // credentials on unencrypted connections.
+    if (parsed.protocol !== 'https:') return false;
+    hostname = parsed.hostname.toLowerCase();
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

Fixes `mastra api --url https://<slug>.studio.mastra.cloud` and `--url https://<slug>.factory.mastra.cloud` returning 401 from the Mastra Cloud edge router. The `--url` branch of `resolveTarget` dropped the CLI-stored user token, so every call to a platform-hosted Studio or Factory instance went out unauthenticated.

The CLI now attaches `Authorization: Bearer <token>` from `~/.mastra/credentials.json` (loaded through `getToken()` so it auto-refreshes) whenever `--url` points at:

- `*.studio.mastra.cloud`
- `*.factory.mastra.cloud`
- `*.studio.staging.mastra.cloud`
- `*.factory.staging.mastra.cloud`

...and no explicit `Authorization` header was passed.

User-hosted `*.server.mastra.cloud` URLs and arbitrary custom URLs are left alone — they authenticate with their own credentials and were never expected to accept the platform user token. An explicit `--header Authorization: ...` always wins.

## Test plan

- Unit tests in `packages/cli/src/commands/api/target.test.ts` cover: production + staging factory/studio hosts (token attached), `*.server.mastra.cloud` and arbitrary hosts (no token), explicit header override (case-insensitive), and the no-credentials case (silent skip). 31/31 pass.
- Verified end-to-end against real infrastructure with the built binary:
  - `mastra api --url https://shipyard.factory.mastra.cloud agent list` → 200 with agent list (was 401 before)
  - `mastra api --url https://shipyard.studio.mastra.cloud agent list` → 200 with agent list (was 401 before)
  - `mastra api --url https://nonexistent.server.mastra.cloud agent list` → passes through without injecting stored token
  - `mastra api --url https://shipyard.factory.mastra.cloud --header "Authorization: Bearer garbage" agent list` → 401 from edge, confirming override wins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The CLI now logs in automatically when it connects to Mastra Cloud Studio or Factory over HTTPS. It keeps server and custom URL behavior unchanged and respects manually provided authorization headers.

## Changes

- Added automatic Bearer token authentication for production and staging `*.studio.mastra.cloud` and `*.factory.mastra.cloud` URLs.
- Loaded credentials through `getToken()` for automatic token refresh.
- Limited stored credentials to HTTPS platform URLs.
- Preserved existing behavior for `*.server.mastra.cloud` and custom URLs.
- Kept explicit `Authorization` headers as the highest-priority option.
- Added `isPlatformHostedInstance` to identify supported platform URLs.
- Added tests for supported hosts, excluded hosts, HTTP URLs, header overrides, and missing credentials.
- Added a patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->