### PR TITLE
feat(factory): re-review a PR when review is re-requested from the Factory bot

### DIFF
--- a/.changeset/wicked-dolls-glow.md
+++ b/.changeset/wicked-dolls-glow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+The Factory now re-reviews a pull request when review is re-requested from its GitHub bot. After any Factory verdict (approve or request changes), clicking GitHub's re-request review button on the Factory reviewer moves the Review card back into Reviewing and starts a fresh review pass. Only trusted collaborators (write or admin) can trigger it, and re-requests aimed at human reviewers or on closed, merged, or already-in-review pull requests are ignored.

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -521,6 +521,240 @@ describe('GithubRules', () => {
     );
   });
 
+  it('commits a re-review transition when review is re-requested from the Factory bot', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    const reviewed = await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'pull-request',
+          externalId: 'github-pr:17',
+          url: 'https://github.com/acme/repo/pull/17',
+        },
+        title: 'PR 17',
+        stages: ['done'],
+        sessions: {},
+        metadata: {},
+      },
+    });
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    const reviewRequested = (deliveryId: string, reviewer: string) => ({
+      event: 'pull_request',
+      deliveryId,
+      payload: {
+        action: 'review_requested',
+        installation: { id: 7 },
+        repository: { id: 10, full_name: 'acme/repo' },
+        sender: { login: 'maintainer' },
+        requested_reviewer: { login: reviewer },
+        pull_request: {
+          number: 17,
+          title: 'PR 17',
+          html_url: 'https://github.com/acme/repo/pull/17',
+          created_at: '2030-01-01T00:00:00Z',
+          state: 'open',
+          merged: false,
+          head: { ref: 'feature' },
+          base: { ref: 'main' },
+        },
+      },
+    });
+
+    // A human reviewer re-request is not Factory's signal: no decision.
+    expect(await service.ingest(reviewRequested('delivery-rr-human', 'ada'))).toEqual({ status: 'committed' });
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual([]);
+
+    // Re-requesting from Factory's own bot restarts the review pass.
+    expect(await service.ingest(reviewRequested('delivery-rr-factory', 'factory-app[bot]'))).toEqual({
+      status: 'committed',
+    });
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual([
+      expect.objectContaining({
+        workItemId: reviewed.item.id,
+        decision: expect.objectContaining({ type: 'transition', board: 'review', stage: 'review' }),
+      }),
+    ]);
+  });
+
+  it('re-reviews a Factory-authored PR: provenance binds neither the card nor the human requester', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    // The Work item Factory implemented the PR from, bound by provenance.
+    const work = await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue',
+          externalId: 'github-issue:42',
+          url: 'https://github.com/acme/repo/issues/42',
+        },
+        title: 'Issue 42',
+        stages: ['execute'],
+        sessions: {},
+        metadata: {},
+      },
+    });
+    await integrationStorage.subscriptions.create({
+      orgId: 'org-1',
+      targetKey: 'factory-pr-provenance:10:17',
+      threadId: 'thread-1',
+      status: 'active',
+      data: { kind: 'factory-pr-provenance', workItemId: work.item.id },
+    });
+    // The PR's own Review card, already reviewed once.
+    const card = await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'pull-request',
+          externalId: 'github-pr:17',
+          url: 'https://github.com/acme/repo/pull/17',
+        },
+        title: 'PR 17',
+        stages: ['done'],
+        sessions: {},
+        metadata: {},
+      },
+    });
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await expect(
+      service.ingest({
+        event: 'pull_request',
+        deliveryId: 'delivery-rr-provenance',
+        payload: {
+          action: 'review_requested',
+          installation: { id: 7 },
+          repository: { id: 10, full_name: 'acme/repo' },
+          sender: { login: 'maintainer' },
+          requested_reviewer: { login: 'factory-app[bot]' },
+          pull_request: {
+            number: 17,
+            title: 'PR 17',
+            html_url: 'https://github.com/acme/repo/pull/17',
+            created_at: '2030-01-01T00:00:00Z',
+            state: 'open',
+            merged: false,
+            head: { ref: 'feature' },
+            base: { ref: 'main' },
+          },
+        },
+      }),
+    ).resolves.toEqual({ status: 'committed' });
+
+    // The re-review lands on the PR's Review card, not the provenance-bound Work item.
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual([
+      expect.objectContaining({
+        workItemId: card.item.id,
+        decision: expect.objectContaining({ type: 'transition', board: 'review', stage: 'review' }),
+      }),
+    ]);
+  });
+
+  it('dispatches a re-review transition back into Reviewing and queues a fresh factory-review pass', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    const card = await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'pull-request',
+          externalId: 'github-pr:17',
+          url: 'https://github.com/acme/repo/pull/17',
+        },
+        title: 'PR 17',
+        stages: ['done'],
+        sessions: {},
+        metadata: {},
+      },
+    });
+    const rules = builtInFactoryRules();
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules,
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: { getSessionByResource: vi.fn(async () => undefined) } as never,
+      transitionService: new FactoryTransitionService({ storage: workItems, rules }),
+      storage: workItems,
+      ownerId: 'worker-1',
+    });
+
+    const reviewRequested = (deliveryId: string) => ({
+      event: 'pull_request',
+      deliveryId,
+      payload: {
+        action: 'review_requested',
+        installation: { id: 7 },
+        repository: { id: 10, full_name: 'acme/repo' },
+        sender: { login: 'maintainer' },
+        requested_reviewer: { login: 'factory-app[bot]' },
+        pull_request: {
+          number: 17,
+          title: 'PR 17',
+          html_url: 'https://github.com/acme/repo/pull/17',
+          created_at: '2030-01-01T00:00:00Z',
+          state: 'open',
+          merged: false,
+          head: { ref: 'feature' },
+          base: { ref: 'main' },
+        },
+      },
+    });
+
+    await expect(service.ingest(reviewRequested('delivery-rr-dispatch'))).resolves.toEqual({ status: 'committed' });
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+
+    // The card is back in Reviewing and the review onEnter rule queued a fresh pass.
+    const [item] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
+    expect(item).toMatchObject({ id: card.item.id, stages: ['review'] });
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workItemId: card.item.id,
+          decision: expect.objectContaining({ type: 'invokeSkill', skillName: 'factory-review', role: 'review' }),
+        }),
+      ]),
+    );
+
+    // Replaying the same delivery does not stack another pass.
+    await expect(service.ingest(reviewRequested('delivery-rr-dispatch'))).resolves.toEqual({ status: 'replayed' });
+    // A second re-request while the card is already Reviewing is a guarded no-op.
+    await expect(service.ingest(reviewRequested('delivery-rr-again'))).resolves.toEqual({ status: 'committed' });
+    const decisions = await workItems.listDeferredDecisions('org-1', project.id);
+    expect(decisions.filter(entry => entry.decision.type === 'transition')).toHaveLength(1);
+    expect(decisions.filter(entry => entry.decision.type === 'invokeSkill')).toHaveLength(1);
+  });
+
   it.each(['maintain', 'triage', 'read', undefined])('fails closed for GitHub permission %s', async permission => {
     const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup(permission);
     const seen = vi.fn(() => undefined);

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -202,6 +202,12 @@ export class GithubRules {
           ).find(subscription => subscription.orgId === project.orgId)?.data,
         )
       : null;
+    // A review re-request targets the PR's own Review card, not the Work item
+    // that provenance would bind the event to — and the sender is whoever
+    // clicked re-request, so a Factory-authored PR must not brand a human
+    // requester as factory-authored.
+    const reviewRequested = event === 'pullRequestReviewRequested';
+    const requestedReviewer = string(object(parsed.payload.requested_reviewer)?.login);
     const relatedItem = await this.#relatedItem(
       project.orgId,
       project.factoryProjectId,
@@ -209,13 +215,13 @@ export class GithubRules {
       issueNumber,
       pullRequestNumber,
       string(object(pullRequest?.head)?.ref),
-      provenance,
+      reviewRequested ? null : provenance,
     );
     const actor = await githubActor(this.options.github, {
       installationId,
       repository: repositoryName,
       login,
-      factoryAuthored: provenance !== null || login === `${this.options.github.slug}[bot]`,
+      factoryAuthored: (!reviewRequested && provenance !== null) || login === `${this.options.github.slug}[bot]`,
     });
     if (
       actor.type === 'github' &&
@@ -289,6 +295,14 @@ export class GithubRules {
               merged: boolean(pullRequest?.merged) ?? false,
               headBranch: string(object(pullRequest?.head)?.ref) ?? '',
               baseBranch: string(object(pullRequest?.base)?.ref) ?? '',
+            },
+          }
+        : {}),
+      ...(reviewRequested && requestedReviewer
+        ? {
+            reviewRequest: {
+              reviewer: requestedReviewer,
+              factoryReviewer: requestedReviewer === `${this.options.github.slug}[bot]`,
             },
           }
         : {}),

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -138,6 +138,7 @@ describe('defaultFactoryRules', () => {
     expect(rules.github.issueCommentEdited?.onEvent).toBeTypeOf('function');
     expect(rules.github.issueCommentDeleted?.onEvent).toBeTypeOf('function');
     expect(rules.github.pullRequestOpened?.onEvent).toBeTypeOf('function');
+    expect(rules.github.pullRequestReviewRequested?.onEvent).toBeTypeOf('function');
     expect(rules.github.pullRequestMerged?.onEvent).toBeTypeOf('function');
     expect(rules.linear.issueObserved?.onEvent).toBeTypeOf('function');
     expect(rules.work.triage?.linearIssue?.onEnter).toBeTypeOf('function');
@@ -337,6 +338,67 @@ describe('defaultFactoryRules', () => {
     ]) {
       expect(await rule?.(context)).toBeUndefined();
     }
+  });
+
+  describe('pullRequestReviewRequested', () => {
+    const prItem = {
+      ...item,
+      source: 'github-pr' as const,
+      sourceKey: 'github-pr:17',
+      title: 'PR 17',
+      url: 'https://github.test/acme/repo/pull/17',
+      stages: ['done'],
+    };
+
+    function reReviewContext(overrides: Partial<FactoryGithubRuleContext> = {}): FactoryGithubRuleContext {
+      return {
+        ...githubContext('pullRequestReviewRequested'),
+        item: prItem,
+        board: 'review',
+        itemRevision: 5,
+        reviewRequest: { reviewer: 'factory-app[bot]', factoryReviewer: true },
+        ...overrides,
+      };
+    }
+
+    it('re-enters Review when review is re-requested from Factory on a finished card', async () => {
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewRequested?.onEvent;
+      expect(await rule?.(reReviewContext())).toMatchObject({
+        type: 'transition',
+        idempotencyKey: 'delivery-1:re-review-requested',
+        board: 'review',
+        stage: 'review',
+      });
+    });
+
+    it('ignores re-requests that do not target Factory or come from untrusted senders', async () => {
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewRequested?.onEvent;
+      for (const context of [
+        // Review requested from a human reviewer, not Factory's bot.
+        reReviewContext({ reviewRequest: { reviewer: 'ada', factoryReviewer: false } }),
+        reReviewContext({ reviewRequest: undefined }),
+        // Untrusted sender.
+        reReviewContext({ actor: { type: 'github', login: 'reader', trusted: false, factoryAuthored: false } }),
+        // Factory-authored ingress must not restart its own review.
+        reReviewContext({ actor: { type: 'github', login: 'factory-app[bot]', trusted: true, factoryAuthored: true } }),
+        // No linked Review card.
+        reReviewContext({ item: undefined, board: undefined, itemRevision: undefined }),
+        // Card already in Reviewing: a pass is pending or running.
+        reReviewContext({ item: { ...prItem, stages: ['review'] } }),
+      ]) {
+        expect(await rule?.(context)).toBeUndefined();
+      }
+    });
+
+    it('ignores re-requests on closed or merged pull requests', async () => {
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewRequested?.onEvent;
+      const closed = reReviewContext();
+      closed.pullRequest = { ...closed.pullRequest!, state: 'closed' };
+      const merged = reReviewContext();
+      merged.pullRequest = { ...merged.pullRequest!, merged: true };
+      expect(await rule?.(closed)).toBeUndefined();
+      expect(await rule?.(merged)).toBeUndefined();
+    });
   });
 
   it.each(['issueOpened', 'pullRequestOpened'] as const)(

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -228,6 +228,26 @@ function pullRequestClosed(context: FactoryGithubRuleContext) {
   } as const;
 }
 
+function reReviewRequestedPullRequest(context: FactoryGithubRuleContext) {
+  // Only a review re-requested *from Factory's own bot* restarts the review —
+  // requesting a human reviewer is not Factory's signal.
+  if (!context.item || context.board !== 'review' || !context.reviewRequest?.factoryReviewer) return;
+  if (!context.pullRequest || context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
+  // Trusted (write/admin) requesters only: re-entering review checks out and
+  // executes PR code, the same bar pullRequestOpened applies to auto-review.
+  if (!trustedGithubActor(context)) return;
+  if (context.actor.type === 'github' && context.actor.factoryAuthored) return;
+  // Already in Reviewing: a review pass is pending or running; re-entering
+  // would be a same-stage no-op anyway (stage rules only fire on change).
+  if (context.item.stages.length === 1 && context.item.stages[0] === 'review') return;
+  return {
+    type: 'transition',
+    idempotencyKey: `${context.ingress.id}:re-review-requested`,
+    board: 'review',
+    stage: 'review',
+  } as const;
+}
+
 function linearIssueObserved(context: FactoryLinearRuleContext) {
   if (context.item) return;
   return {
@@ -272,6 +292,7 @@ const BUILT_IN_DEFAULTS: FactoryRulesOverrides = {
     issueCommentEdited: { onEvent: retriageGithubIssue },
     issueCommentDeleted: { onEvent: retriageGithubIssue },
     pullRequestOpened: { onEvent: pullRequestOpened },
+    pullRequestReviewRequested: { onEvent: reReviewRequestedPullRequest },
     pullRequestMerged: { onEvent: pullRequestMerged },
     pullRequestClosed: { onEvent: pullRequestClosed },
   },

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -122,6 +122,8 @@ export interface FactoryGithubRuleContext extends FactoryRuleContextBase {
     headBranch: string;
     baseBranch: string;
   };
+  /** Present on `pullRequestReviewRequested`: who review was (re-)requested from. */
+  reviewRequest?: { reviewer: string; factoryReviewer: boolean };
 }
 
 export interface FactoryLinearRuleContext extends FactoryRuleContextBase {


### PR DESCRIPTION
## Summary

The Factory reviews pull requests, but its verdict was final: once a review pass finished there was no way to make it look again after the author addressed feedback. This PR wires GitHub's **re-request review** button into the Factory's rule engine — re-requesting review from the Factory's bot moves the PR's Review card back into Reviewing and starts a fresh `factory-review` pass.

## How it works

1. A human re-requests review from the Factory reviewer on GitHub (available after any Factory verdict — approve or request changes).
2. The `pull_request` / `review_requested` webhook is ingested as a new `pullRequestReviewRequested` rule event, with the requested reviewer matched against the Factory's bot login.
3. A new default rule (`reReviewRequestedPullRequest`) transitions the Review card back to Reviewing.
4. The existing `review` onEnter rule queues a fresh `factory-review` skill run.

Deliberately **not** triggered by pushes — only by an explicit re-request aimed at the Factory's bot.

## Guards

- Requested reviewer must be the Factory's bot; re-requests aimed at human reviewers are ignored.
- Sender must be a trusted (write/admin) collaborator — same bar as auto-review on PR open, since re-entering review checks out and executes PR code. Permission lookup failures fail closed.
- Ignored on closed or merged PRs, PRs with no linked Review card, cards already in Reviewing (prevents stacking passes), and Factory-authored ingress (the bot can't restart its own review).

## Factory-authored PRs

`review_requested` events bind to the PR's own Review card instead of the provenance-bound Work item, and PR provenance no longer marks a *human* re-requester as factory-authored — so PRs the Factory itself opened can be re-reviewed through the same button.

## Test plan

- [x] Rule unit tests: fires on a finished card; ignores human-reviewer targets, untrusted senders, factory-authored ingress, missing cards, already-Reviewing cards, closed/merged PRs (`defaults.test.ts`)
- [x] Ingestion end-to-end: human re-request is a no-op; Factory-bot re-request commits a Review transition (`rules.test.ts`)
- [x] Factory-authored PR: transition lands on the Review card, not the provenance Work item (`rules.test.ts`)
- [x] Full dispatch chain: ingest → dispatcher → card Done → Reviewing → `factory-review` queued; delivery replay and an already-Reviewing re-request don't stack passes (`rules.test.ts`)
- [x] `tsc --noEmit`, oxlint, eslint clean
- [x] `@mastra/factory` suite: 1271/1273 passing (2 failures are pre-existing `work-items/base.test.ts` locking timeouts on the base branch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Factory can review a pull request again when a trusted collaborator asks the Factory bot to review it again. It only restarts reviews for eligible pull requests.

## Changes

- Added `pullRequestReviewRequested` event handling for Factory bot review requests.
- Added `reReviewRequestedPullRequest` behavior to move linked Review cards back to `Reviewing`.
- Triggered a new `factory-review` skill run after a valid re-review request.
- Ignored untrusted requests, human reviewers, closed or merged pull requests, Factory-authored ingress, missing cards, and cards already in `Reviewing`.
- Added reviewer details to `FactoryGithubRuleContext`.
- Added tests for rule behavior, webhook ingestion, dispatch, replay, Factory-authored pull requests, and duplicate prevention.
- Added a minor changeset for `@mastra/factory`.
- TypeScript, oxlint, and eslint checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->