### PR TITLE
fix(pg): write memory timestamps as UTC

### DIFF
--- a/.changeset/wise-lights-pay.md
+++ b/.changeset/wise-lights-pay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed PostgreSQL memory timestamps to stay aligned across server timezones.

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -136,6 +136,14 @@ function inPlaceholders(count: number, startIndex = 1): string {
   return Array.from({ length: count }, (_, i) => `$${i + startIndex}`).join(', ');
 }
 
+/**
+ * Bind dates as UTC strings because node-postgres serializes Date parameters
+ * for TIMESTAMP columns using the process's local timezone.
+ */
+function toUtcISOString(date: Date): string {
+  return date.toISOString();
+}
+
 function dedupeMessagesForSave(messages: MastraDBMessage[]): MastraDBMessage[] {
   const deduped = new Map<string, MastraDBMessage>();
   for (const message of messages) {
@@ -647,6 +655,8 @@ export class MemoryPG extends MemoryStorage {
   async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
     try {
       const tableName = getTableName({ indexName: TABLE_THREADS, schemaName: getSchemaName(this.#schema) });
+      const createdAt = toUtcISOString(thread.createdAt);
+      const updatedAt = toUtcISOString(thread.updatedAt);
       await this.#db.client.none(
         `INSERT INTO ${tableName} (
           id,
@@ -671,10 +681,10 @@ export class MemoryPG extends MemoryStorage {
           thread.resourceId,
           thread.title,
           thread.metadata ? JSON.stringify(thread.metadata) : null,
-          thread.createdAt,
-          thread.createdAt,
-          thread.updatedAt,
-          thread.updatedAt,
+          createdAt,
+          createdAt,
+          updatedAt,
+          updatedAt,
         ],
       );
 
@@ -725,6 +735,7 @@ export class MemoryPG extends MemoryStorage {
 
     try {
       const now = new Date();
+      const nowStr = toUtcISOString(now);
       const thread = await this.#db.client.one<StorageThreadType & { createdAtZ: Date; updatedAtZ: Date }>(
         `UPDATE ${threadTableName}
                     SET
@@ -735,7 +746,7 @@ export class MemoryPG extends MemoryStorage {
                     WHERE id = $5
                     RETURNING *
                 `,
-        [title, mergedMetadata, now, now, id],
+        [title, mergedMetadata, nowStr, nowStr, id],
       );
 
       return {
@@ -1404,7 +1415,7 @@ export class MemoryPG extends MemoryStorage {
           const values: unknown[] = [];
           const valuePlaceholders = batch
             .map((message, messageIndex) => {
-              const createdAt = message.createdAt || new Date();
+              const createdAt = toUtcISOString(message.createdAt || new Date());
               values.push(
                 message.id,
                 message.threadId,
@@ -1438,7 +1449,7 @@ export class MemoryPG extends MemoryStorage {
         }
 
         const threadTableName = getTableName({ indexName: TABLE_THREADS, schemaName: getSchemaName(this.#schema) });
-        const now = new Date();
+        const now = toUtcISOString(new Date());
         for (const threadIdToUpdate of threadIds) {
           await t.none(
             `UPDATE ${threadTableName}
@@ -1812,6 +1823,7 @@ export class MemoryPG extends MemoryStorage {
         const sourceMessages = await t.manyOrNone<MessageRowFromDB>(messageQuery, messageParams);
 
         const now = new Date();
+        const nowStr = toUtcISOString(now);
 
         // Determine the last message ID for clone metadata
         const lastMessageId = sourceMessages.length > 0 ? sourceMessages[sourceMessages.length - 1]!.id : undefined;
@@ -1853,10 +1865,10 @@ export class MemoryPG extends MemoryStorage {
             newThread.resourceId,
             newThread.title,
             newThread.metadata ? JSON.stringify(newThread.metadata) : null,
-            now,
-            now,
-            now,
-            now,
+            nowStr,
+            nowStr,
+            nowStr,
+            nowStr,
           ],
         );
 
@@ -1875,6 +1887,7 @@ export class MemoryPG extends MemoryStorage {
           } catch {
             // use content as is
           }
+          const createdAt = toUtcISOString(new Date(normalizedMsg.createdAt));
 
           await t.none(
             `INSERT INTO ${messageTableName} (id, thread_id, content, "createdAt", "createdAtZ", role, type, "resourceId")
@@ -1883,8 +1896,8 @@ export class MemoryPG extends MemoryStorage {
               newMessageId,
               newThreadId,
               typeof normalizedMsg.content === 'string' ? normalizedMsg.content : JSON.stringify(normalizedMsg.content),
-              normalizedMsg.createdAt,
-              normalizedMsg.createdAt,
+              createdAt,
+              createdAt,
               normalizedMsg.role,
               normalizedMsg.type || 'v2',
               targetResourceId,

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -1679,11 +1679,15 @@ export class MemoryPG extends MemoryStorage {
   }
 
   async saveResource({ resource }: { resource: StorageResourceType }): Promise<StorageResourceType> {
+    const createdAt = toUtcISOString(resource.createdAt);
+    const updatedAt = toUtcISOString(resource.updatedAt);
     await this.#db.insert({
       tableName: TABLE_RESOURCES,
       record: {
         ...resource,
         metadata: JSON.stringify(resource.metadata),
+        createdAt,
+        updatedAt,
       },
     });
 

--- a/stores/pg/src/storage/domains/memory/save-messages.test.ts
+++ b/stores/pg/src/storage/domains/memory/save-messages.test.ts
@@ -11,6 +11,7 @@ type RecordedQuery = {
 
 class RecordingTxClient implements TxClient {
   queries: RecordedQuery[] = [];
+  sourceMessages: Record<string, any>[] = [];
 
   async none(query: string, values?: QueryValues): Promise<null> {
     this.queries.push({ query, values });
@@ -30,7 +31,7 @@ class RecordingTxClient implements TxClient {
   }
 
   async manyOrNone<T = any>(): Promise<T[]> {
-    throw new Error('not implemented');
+    return this.sourceMessages as T[];
   }
 
   async many<T = any>(): Promise<T[]> {
@@ -356,5 +357,33 @@ describe('MemoryPG.saveResource', () => {
     expect(client.queries[0]!.values![4]).toBe(updatedAt.toISOString());
     expect(client.queries[0]!.values![5]).toBe(createdAt.toISOString());
     expect(client.queries[0]!.values![6]).toBe(updatedAt.toISOString());
+  });
+});
+
+describe('MemoryPG.cloneThread', () => {
+  it('prefers createdAtZ and binds the UTC string to both timestamp columns', async () => {
+    const client = new RecordingDbClient();
+    const memory = new MemoryPG({ client });
+    const legacyCreatedAt = new Date('2025-07-01T07:34:56.789Z');
+    const createdAtZ = new Date('2025-07-01T12:34:56.789Z');
+    client.txClient.sourceMessages.push({
+      id: 'message-1',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      role: 'user',
+      type: 'v2',
+      content: JSON.stringify({ format: 2, parts: [{ type: 'text', text: 'hello' }] }),
+      createdAt: legacyCreatedAt,
+      createdAtZ,
+    });
+
+    const result = await memory.cloneThread({ sourceThreadId: 'thread-1', newThreadId: 'thread-2' });
+
+    const messageInsert = client.txClient.queries[1]!;
+    expect(messageInsert.query).toContain('mastra_messages');
+    expect(messageInsert.values![3]).toBe(createdAtZ.toISOString());
+    expect(messageInsert.values![4]).toBe(createdAtZ.toISOString());
+    expect(messageInsert.values![3]).not.toBe(legacyCreatedAt.toISOString());
+    expect(result.clonedMessages[0]!.createdAt).toEqual(createdAtZ);
   });
 });

--- a/stores/pg/src/storage/domains/memory/save-messages.test.ts
+++ b/stores/pg/src/storage/domains/memory/save-messages.test.ts
@@ -50,6 +50,7 @@ class RecordingDbClient implements DbClient {
   readonly $pool = {} as DbClient['$pool'];
   readonly txClient = new RecordingTxClient();
   readonly threads = new Map<string, Record<string, unknown>>();
+  readonly queries: RecordedQuery[] = [];
 
   constructor({
     thread,
@@ -73,8 +74,9 @@ class RecordingDbClient implements DbClient {
     throw new Error('not implemented');
   }
 
-  async none(): Promise<null> {
-    throw new Error('not implemented');
+  async none(query: string, values?: QueryValues): Promise<null> {
+    this.queries.push({ query, values });
+    return null;
   }
 
   async one<T = any>(): Promise<T> {
@@ -122,6 +124,20 @@ function createMessage(overrides: Partial<MastraDBMessage> = {}): MastraDBMessag
 }
 
 describe('MemoryPG.saveMessages', () => {
+  it('binds UTC strings for both timestamp column variants', async () => {
+    const client = new RecordingDbClient();
+    const memory = new MemoryPG({ client });
+    const createdAt = new Date('2025-07-01T12:34:56.789Z');
+
+    await memory.saveMessages({ messages: [createMessage({ id: 'message-1', createdAt })] });
+
+    const [insertQuery, threadUpdateQuery] = client.txClient.queries;
+    expect(insertQuery!.values![3]).toBe(createdAt.toISOString());
+    expect(insertQuery!.values![4]).toBe(createdAt.toISOString());
+    expect(threadUpdateQuery!.values![0]).toMatch(/Z$/);
+    expect(threadUpdateQuery!.values![1]).toBe(threadUpdateQuery!.values![0]);
+  });
+
   it('inserts multiple messages with one multi-row upsert statement', async () => {
     const client = new RecordingDbClient();
     const memory = new MemoryPG({ client });
@@ -161,8 +177,8 @@ describe('MemoryPG.saveMessages', () => {
     expect(insertQuery!.query).not.toContain('$9');
     expect(insertQuery!.values).toHaveLength(8);
     expect(insertQuery!.values![2]).toBe(JSON.stringify({ content: 'second' }));
-    expect(insertQuery!.values![3]).toBe(firstCreatedAt);
-    expect(insertQuery!.values![4]).toBe(firstCreatedAt);
+    expect(insertQuery!.values![3]).toBe(firstCreatedAt.toISOString());
+    expect(insertQuery!.values![4]).toBe(firstCreatedAt.toISOString());
   });
 
   it('chunks message inserts under the Postgres bind parameter limit and updates the thread once', async () => {
@@ -282,5 +298,37 @@ describe('MemoryPG.saveMessages', () => {
       'Thread thread-1 not found',
     );
     expect(client.txClient.queries).toHaveLength(0);
+  });
+});
+
+describe('MemoryPG.saveThread', () => {
+  it('binds UTC strings for both timestamp column variants', async () => {
+    const client = new RecordingDbClient();
+    const memory = new MemoryPG({ client });
+    const createdAt = new Date('2025-07-01T12:34:56.789Z');
+    const updatedAt = new Date('2025-07-02T01:02:03.456Z');
+
+    await memory.saveThread({
+      thread: {
+        id: 'thread-1',
+        resourceId: 'resource-1',
+        title: 'Test thread',
+        metadata: {},
+        createdAt,
+        updatedAt,
+      },
+    });
+
+    expect(client.queries).toHaveLength(1);
+    expect(client.queries[0]!.values).toEqual([
+      'thread-1',
+      'resource-1',
+      'Test thread',
+      '{}',
+      createdAt.toISOString(),
+      createdAt.toISOString(),
+      updatedAt.toISOString(),
+      updatedAt.toISOString(),
+    ]);
   });
 });

--- a/stores/pg/src/storage/domains/memory/save-messages.test.ts
+++ b/stores/pg/src/storage/domains/memory/save-messages.test.ts
@@ -92,7 +92,8 @@ class RecordingDbClient implements DbClient {
     throw new Error('not implemented');
   }
 
-  async manyOrNone<T = any>(): Promise<T[]> {
+  async manyOrNone<T = any>(query?: string): Promise<T[]> {
+    if (query?.includes('information_schema.columns')) return [];
     throw new Error('not implemented');
   }
 
@@ -330,5 +331,30 @@ describe('MemoryPG.saveThread', () => {
       updatedAt.toISOString(),
       updatedAt.toISOString(),
     ]);
+  });
+});
+
+describe('MemoryPG.saveResource', () => {
+  it('binds UTC strings for both timestamp column variants', async () => {
+    const client = new RecordingDbClient();
+    const memory = new MemoryPG({ client });
+    const createdAt = new Date('2025-07-01T12:34:56.789Z');
+    const updatedAt = new Date('2025-07-02T01:02:03.456Z');
+
+    await memory.saveResource({
+      resource: {
+        id: 'resource-1',
+        workingMemory: 'Test memory',
+        metadata: {},
+        createdAt,
+        updatedAt,
+      },
+    });
+
+    expect(client.queries).toHaveLength(1);
+    expect(client.queries[0]!.values![3]).toBe(createdAt.toISOString());
+    expect(client.queries[0]!.values![4]).toBe(updatedAt.toISOString());
+    expect(client.queries[0]!.values![5]).toBe(createdAt.toISOString());
+    expect(client.queries[0]!.values![6]).toBe(updatedAt.toISOString());
   });
 });


### PR DESCRIPTION
## Description

`@mastra/pg` wrote one JavaScript `Date` value to two PostgreSQL column types. One column uses `TIMESTAMP`. The other column uses `TIMESTAMPTZ`.

node-postgres formats a `Date` with the local time-zone offset. A `TIMESTAMP` column removes this offset. A `TIMESTAMPTZ` column uses this offset. The two columns can then contain different times.

This change converts memory timestamps to UTC ISO strings before each database write. It applies to threads, messages, resources, and thread clones. It keeps the standard timestamp columns and the time-zone-aware columns aligned.

The tests check the database values for messages, threads, and resources. This change prevents new mismatched rows. It does not change existing rows.

I used these checks:

- `TZ=America/Los_Angeles pnpm --filter @mastra/pg exec vitest run src/storage/domains/memory/save-messages.test.ts`
- `pnpm --filter @mastra/pg build:lib`
- `pnpm --filter @mastra/pg lint`
- Prettier
- `git diff --check`

## Related issue(s)

This change is a follow-up to #14120 and #11496.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all CodeRabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR saves memory timestamps in one standard UTC format. This keeps timestamps correct when servers use different time zones.

## Summary

- Convert JavaScript `Date` values to UTC ISO strings before PostgreSQL writes.
- Apply the conversion to thread, message, resource, and thread-clone persistence paths.
- Ensure cloned messages prefer `createdAtZ`.
- Bind the same UTC ISO string to both timestamp columns.
- Add regression tests for message, thread, resource, duplicate-message, and cloned-message timestamps.
- Preserve existing database rows.
- Add a patch changeset for `@mastra/pg`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
