### PR TITLE
fix(factory): start Slack sessions on the factory's default model

### DIFF
--- a/.changeset/olive-jars-shiver.md
+++ b/.changeset/olive-jars-shiver.md
@@ -1,0 +1,20 @@
+---
+'@mastra/core': patch
+---
+
+Added an `onSessionStart` hook to `AgentControllerChannels` config, called once per session after it is bound to its mapped chat thread and before the first message dispatches. Messages arriving while the hook is still running wait for it instead of dispatching on an unconfigured session.
+
+```typescript
+const controller = new AgentController({
+  id: 'support-controller',
+  agent,
+  channels: {
+    adapters: { slack: createSlackAdapter() },
+    onSessionStart: async ({ session, thread }) => {
+      await session.model.switch({ modelId: 'anthropic/claude-sonnet-4-6' });
+    },
+  },
+});
+```
+
+A host can already name a channel session through `resolveResourceId`, but it never receives the `Session` object, which is created inside the channel machinery. Without a seam there, a host could only configure sessions it created itself, and channel-created sessions silently ran on the built-in default models. Hook errors are logged and swallowed so a session that cannot be configured still answers the message.

--- a/.changeset/tidy-hounds-attend.md
+++ b/.changeset/tidy-hounds-attend.md
@@ -1,0 +1,9 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Slack sessions ignoring the factory's configured default model and memory settings.
+
+Sessions started from Slack ran on the built-in default model rather than the model configured on the factory project, so a factory set up for a provider other than the built-in default failed every Slack message with a missing-credentials error. Repo-backed Slack threads now start on the project's configured model and observational-memory settings, matching runs started from the web.
+
+A thread keeps a model chosen inside it. Once a model is set on the thread, restarting the server no longer resets it to the project default.

--- a/docs/src/content/en/docs/harness/agent-controller.mdx
+++ b/docs/src/content/en/docs/harness/agent-controller.mdx
@@ -331,6 +331,10 @@ const controller = new AgentController({
       if (thread.isDM) return message.author.userId
       return defaultResourceId
     },
+    onSessionStart: async ({ session, thread }) => {
+      const plan = await billing.planFor(thread.resourceId)
+      await session.model.switch({ modelId: plan.modelId })
+    },
   },
 })
 
@@ -347,6 +351,8 @@ Point each platform webhook at the controller-specific route:
 ```
 
 Each external chat thread maps to one controller Session and Mastra thread. By default, new sessions use a resource ID derived from the adapter's chat-thread ID, prefixed with `channel:`. Use `resolveResourceId` to map direct messages to an existing application user or choose another memory owner. The callback only affects new threads; an existing thread keeps its stored resource ID.
+
+Channel sessions are created by the controller rather than by your code, so `onSessionStart` is where you configure them. It runs once per session, after the session is bound to its mapped thread and before the first message is handled. Use it to apply a model, memory settings, or session state that a channel session would otherwise miss. Later messages in the same thread reuse the session and don't call it again. Errors are logged and swallowed so a session that can't be configured still answers the message.
 
 Controller channel sessions and auto-approval state are held in memory, so use a long-lived server. Pending approvals and live Session state don't survive process restarts. Adapters that can't render approval controls automatically run tools without an approval prompt so the run doesn't remain suspended.
 

--- a/mastracode/factory/src/integrations/base.ts
+++ b/mastracode/factory/src/integrations/base.ts
@@ -35,6 +35,7 @@ import type { AuditEmitter } from '../storage/domains/audit/domain.js';
 import type { ChannelIdentityStorage } from '../storage/domains/channel-identity/base.js';
 import type { IntakeStorage } from '../storage/domains/intake/base.js';
 import type { IntegrationStorageHandle } from '../storage/domains/integrations/base.js';
+import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
@@ -100,6 +101,11 @@ export interface IntegrationContext {
     sourceControlOwner?: SourceControlStorageHandle;
     /** Factory projects domain — e.g. resolving a project's default model. */
     projects: FactoryProjectsStorage;
+    /**
+     * Observational-memory settings domain, so a session an integration starts
+     * adopts the same memory configuration the web kickoff applies.
+     */
+    memorySettings: MemorySettingsStorage;
     /** Cross-integration intake selection (which sources are synced). */
     intake: IntakeStorage;
     /**

--- a/mastracode/factory/src/integrations/slack/integration.test.ts
+++ b/mastracode/factory/src/integrations/slack/integration.test.ts
@@ -5,27 +5,14 @@ vi.mock('@mastra/slack', () => ({
   createSlackAdapter: vi.fn(() => ({ __adapter: true })),
 }));
 
-const { adaptSourceControlOwner } = vi.hoisted(() => ({
-  adaptSourceControlOwner: vi.fn(() => ({ __sourceControl: true })),
-}));
-
-vi.mock('./slack.js', async importOriginal => ({
-  ...(await importOriginal<typeof import('./slack.js')>()),
-  adaptSourceControlOwner,
-}));
-
 import { SlackIntegration } from './integration.js';
 
 function ctxWith(overrides: Record<string, unknown> = {}) {
   return {
-    storage: { channelIdentity: {}, projects: {}, ...overrides },
+    storage: { channelIdentity: {}, projects: {}, memorySettings: {}, ...overrides },
     rules: { workItems: {} },
   } as any;
 }
-
-beforeEach(() => {
-  adaptSourceControlOwner.mockClear();
-});
 
 describe('SlackIntegration.channels', () => {
   it('returns a channels config (not a built instance) with the slack adapter entry in config form', () => {
@@ -42,22 +29,22 @@ describe('SlackIntegration.channels', () => {
     expect(config.resolveThreadId).toBeTypeOf('function');
   });
 
-  it('wires a source-control adapter from the context source-control owner when present', () => {
+  it('reports repo-backed sessions when the context carries a source-control owner', () => {
     const integration = new SlackIntegration({ signingSecret: 'secret' });
-    const sourceControlOwner = { integrationId: 'github' };
 
-    integration.channels(ctxWith({ sourceControlOwner }));
+    const config = integration.channels(ctxWith({ sourceControlOwner: { integrationId: 'github' } }));
 
-    expect(adaptSourceControlOwner).toHaveBeenCalledWith(sourceControlOwner);
     expect(integration.diagnostics()).toMatchObject({ repoBackedSessions: true });
+    // Sessions the channel machinery creates are configured through this hook;
+    // without it they would run on the SDK's built-in model defaults.
+    expect(config.onSessionStart).toBeTypeOf('function');
   });
 
-  it('wires no source-control adapter when the context has no source-control owner', () => {
+  it('reports no repo-backed sessions when the context has no source-control owner', () => {
     const integration = new SlackIntegration({ signingSecret: 'secret' });
 
     integration.channels(ctxWith());
 
-    expect(adaptSourceControlOwner).not.toHaveBeenCalled();
     expect(integration.diagnostics()).toMatchObject({ repoBackedSessions: false });
   });
 });

--- a/mastracode/factory/src/integrations/slack/integration.ts
+++ b/mastracode/factory/src/integrations/slack/integration.ts
@@ -23,7 +23,7 @@ import type { ApiRoute } from '@mastra/core/server';
 import type { FactoryChannelsConfig, FactoryIntegration, IntegrationContext } from '../base.js';
 
 import { createSlackConnectRoutes } from './connect-route.js';
-import { createSlackChannelsConfig, adaptSourceControlOwner } from './slack.js';
+import { createSlackChannelsConfig } from './slack.js';
 
 /**
  * Slack app credentials, read from env ONCE by the deploy entry. `signingSecret`
@@ -92,7 +92,8 @@ export class SlackIntegration implements FactoryIntegration {
       },
       accountLinks: ctx.storage.channelIdentity,
       projects: ctx.storage.projects,
-      sourceControl: sourceControlOwner ? adaptSourceControlOwner(sourceControlOwner) : undefined,
+      sourceControl: sourceControlOwner,
+      memorySettings: ctx.storage.memorySettings,
       workItems: ctx.rules?.workItems,
     });
   }

--- a/mastracode/factory/src/integrations/slack/slack.test.ts
+++ b/mastracode/factory/src/integrations/slack/slack.test.ts
@@ -3,8 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createChannelResourceIdResolver,
+  createChannelSessionStartHook,
   resolveChannelThreadId,
-  adaptSourceControlOwner,
   createHandlers,
   resolveLinkedSender,
   resolveFactoryForLink,
@@ -381,17 +381,23 @@ describe('handler dispatch gating', () => {
 });
 
 describe('repo-backed thread sessions (resolveResourceId)', () => {
-  function makeSourceControl({
-    existingSession = null as { sessionId: string } | null,
-    repo = { projectRepositoryId: 'pr-1', baseBranch: 'main' } as {
-      projectRepositoryId: string;
-      baseBranch: string;
-    } | null,
-  } = {}) {
+  // Shaped like the real `SourceControlStorageHandle` the Slack wiring now
+  // consumes directly: repo resolution is the shared factory-session helper,
+  // so the stub has to answer the same row lookups it makes.
+  function makeSourceControl({ existingSession = null as { sessionId: string } | null, hasRepo = true } = {}) {
     return {
-      resolveProjectRepository: vi.fn().mockResolvedValue(repo),
-      getSessionForBranch: vi.fn().mockResolvedValue(existingSession),
-      createSession: vi.fn().mockResolvedValue({ sessionId: 'us-new' }),
+      integrationId: 'github',
+      connections: {
+        list: vi.fn().mockResolvedValue([{ id: 'conn-gh', integrationId: 'github', createdByUserId: 'owner-1' }]),
+      },
+      projectRepositories: {
+        list: vi.fn().mockResolvedValue(hasRepo ? [{ id: 'pr-1', repositoryId: 'repo-1', branch: null }] : []),
+      },
+      repositories: { get: vi.fn().mockResolvedValue({ defaultBranch: 'main', slug: 'acme/app' }) },
+      sessions: {
+        getForBranch: vi.fn().mockResolvedValue(existingSession),
+        create: vi.fn().mockResolvedValue({ sessionId: 'us-new' }),
+      },
     };
   }
 
@@ -424,11 +430,13 @@ describe('repo-backed thread sessions (resolveResourceId)', () => {
 
     await expect(resolve(resolveArgs())).resolves.toBe('us-new');
 
-    expect(deps.sourceControl.resolveProjectRepository).toHaveBeenCalledWith({
+    expect(deps.sourceControl.connections.list).toHaveBeenCalledWith({
       orgId: 'org-1',
       factoryProjectId: 'fp-1',
     });
-    expect(deps.sourceControl.createSession).toHaveBeenCalledWith({
+    // Attributed to the Slack sender, not to whoever connected the repository.
+    expect(deps.sourceControl.sessions.create).toHaveBeenCalledWith({
+      sessionId: expect.any(String),
       projectRepositoryId: 'pr-1',
       orgId: 'org-1',
       userId: 'user-1',
@@ -444,12 +452,12 @@ describe('repo-backed thread sessions (resolveResourceId)', () => {
 
     await expect(resolve(resolveArgs())).resolves.toBe('us-existing');
 
-    expect(sourceControl.getSessionForBranch).toHaveBeenCalledWith({
+    expect(sourceControl.sessions.getForBranch).toHaveBeenCalledWith({
       projectRepositoryId: 'pr-1',
       userId: 'user-1',
       branch: 'slack/1700-42',
     });
-    expect(sourceControl.createSession).not.toHaveBeenCalled();
+    expect(sourceControl.sessions.create).not.toHaveBeenCalled();
   });
 
   it('no sourceControl → chat-only channel resourceId', async () => {
@@ -460,12 +468,12 @@ describe('repo-backed thread sessions (resolveResourceId)', () => {
   });
 
   it('a factory without a repository falls back to a chat-only session', async () => {
-    const sourceControl = makeSourceControl({ repo: null });
+    const sourceControl = makeSourceControl({ hasRepo: false });
     const deps = makeResolverDeps({ sourceControl });
     const resolve = createChannelResourceIdResolver(deps as any);
 
     await expect(resolve(resolveArgs())).resolves.toBe('channel:slack:C-1:1700.42');
-    expect(sourceControl.createSession).not.toHaveBeenCalled();
+    expect(sourceControl.sessions.create).not.toHaveBeenCalled();
   });
 
   it('an unlinked sender stays chat-only and creates no session row', async () => {
@@ -474,14 +482,14 @@ describe('repo-backed thread sessions (resolveResourceId)', () => {
     const resolve = createChannelResourceIdResolver(deps as any);
 
     await expect(resolve(resolveArgs())).resolves.toBe('channel:slack:C-1:1700.42');
-    expect(sourceControl.resolveProjectRepository).not.toHaveBeenCalled();
-    expect(sourceControl.createSession).not.toHaveBeenCalled();
+    expect(sourceControl.connections.list).not.toHaveBeenCalled();
+    expect(sourceControl.sessions.create).not.toHaveBeenCalled();
   });
 
   it('a source-control failure falls back to chat-only instead of dropping the message', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const sourceControl = makeSourceControl();
-    sourceControl.createSession.mockRejectedValue(new Error('db down'));
+    sourceControl.sessions.create.mockRejectedValue(new Error('db down'));
     const deps = makeResolverDeps({ sourceControl });
     const resolve = createChannelResourceIdResolver(deps as any);
 
@@ -752,102 +760,113 @@ describe('Slack thread work-item creation', () => {
 });
 
 /**
- * The adapter between the factory's source-control storage handle and the
- * narrow surface the Slack handlers consume. Most of it delegates, but repo
- * resolution encodes real policy — which connection counts, which repo, and
- * what the base branch is — so it gets tested against a stubbed owner rather
- * than through the handlers, which stub the adapted surface instead.
+ * Sessions created by the channel machinery are configured here or nowhere.
+ * Without this hook a Slack session runs on the SDK's built-in mode default
+ * (`openai/gpt-5.5`), so a factory pointed at any other provider fails every
+ * message with a missing-credentials error.
  */
-describe('adaptSourceControlOwner', () => {
-  function makeOwner({
-    connections = [{ id: 'conn-gh', integrationId: 'github' }],
-    projectRepositories = [{ id: 'pr-1', repositoryId: 'repo-1', branch: null }] as Array<{
-      id: string;
-      repositoryId: string;
-      branch?: string | null;
-    }>,
-    repository = { defaultBranch: 'main' } as { defaultBranch: string } | null,
-  } = {}) {
+describe('session start (onSessionStart)', () => {
+  function makeSession({ persistedModeModel = null as string | null, mode = 'build' } = {}) {
+    const settings = new Map<string, unknown>();
+    if (persistedModeModel) settings.set(`modeModelId_${mode}`, persistedModeModel);
     return {
-      integrationId: 'github',
-      connections: { list: vi.fn().mockResolvedValue(connections) },
-      projectRepositories: { list: vi.fn().mockResolvedValue(projectRepositories) },
-      repositories: { get: vi.fn().mockResolvedValue(repository) },
-      sessions: {
-        getForBranch: vi.fn().mockResolvedValue({ sessionId: 'us-existing' }),
-        create: vi.fn(input => Promise.resolve({ sessionId: input.sessionId })),
+      mode: { get: () => mode },
+      thread: {
+        getSetting: vi.fn(async ({ key }: { key: string }) => settings.get(key) ?? null),
       },
+      model: { switch: vi.fn(async () => {}) },
+      om: {
+        observer: { switchModel: vi.fn(async () => {}) },
+        reflector: { switchModel: vi.fn(async () => {}) },
+      },
+      state: { set: vi.fn(async () => {}) },
     };
   }
 
-  const resolveArgs = { orgId: 'org-1', factoryProjectId: 'fp-1' };
-
-  it('resolves the first repository linked to the owner-owned connection, defaulting the base branch to the repo default', async () => {
-    const owner = makeOwner();
-
-    const result = await adaptSourceControlOwner(owner as any).resolveProjectRepository(resolveArgs);
-
-    expect(result).toEqual({ projectRepositoryId: 'pr-1', baseBranch: 'main' });
-    expect(owner.projectRepositories.list).toHaveBeenCalledWith({ orgId: 'org-1', connectionId: 'conn-gh' });
-    expect(owner.repositories.get).toHaveBeenCalledWith({ orgId: 'org-1', id: 'repo-1' });
-  });
-
-  it('prefers the branch pinned on the project repository over the repository default', async () => {
-    const owner = makeOwner({ projectRepositories: [{ id: 'pr-1', repositoryId: 'repo-1', branch: 'develop' }] });
-
-    const result = await adaptSourceControlOwner(owner as any).resolveProjectRepository(resolveArgs);
-
-    expect(result).toEqual({ projectRepositoryId: 'pr-1', baseBranch: 'develop' });
-  });
-
-  // A project can carry connections for several integrations; only the one
-  // belonging to this owner can back a session.
-  it('ignores connections belonging to other integrations', async () => {
-    const owner = makeOwner({ connections: [{ id: 'conn-linear', integrationId: 'linear' }] });
-
-    expect(await adaptSourceControlOwner(owner as any).resolveProjectRepository(resolveArgs)).toBeNull();
-    expect(owner.projectRepositories.list).not.toHaveBeenCalled();
-  });
-
-  it('resolves nothing when the connection has no linked repository', async () => {
-    const owner = makeOwner({ projectRepositories: [] });
-
-    expect(await adaptSourceControlOwner(owner as any).resolveProjectRepository(resolveArgs)).toBeNull();
-    expect(owner.repositories.get).not.toHaveBeenCalled();
-  });
-
-  it('resolves nothing when the linked repository row is missing', async () => {
-    const owner = makeOwner({ repository: null });
-
-    expect(await adaptSourceControlOwner(owner as any).resolveProjectRepository(resolveArgs)).toBeNull();
-  });
-
-  it('delegates branch lookup to the owner unchanged', async () => {
-    const owner = makeOwner();
-    const args = { projectRepositoryId: 'pr-1', userId: 'user-1', branch: 'slack/thread-1' };
-
-    const session = await adaptSourceControlOwner(owner as any).getSessionForBranch(args);
-
-    expect(session).toEqual({ sessionId: 'us-existing' });
-    expect(owner.sessions.getForBranch).toHaveBeenCalledWith(args);
-  });
-
-  // The storage handle requires a session id the caller shouldn't invent, so
-  // the adapter mints one.
-  it('mints a session id when creating a session', async () => {
-    const owner = makeOwner();
-    const args = {
-      projectRepositoryId: 'pr-1',
-      orgId: 'org-1',
-      userId: 'user-1',
-      branch: 'slack/thread-1',
-      baseBranch: 'main',
+  function makeStartDeps({
+    defaultModelId = 'anthropic/claude-opus-5' as string | null,
+    session = { orgId: 'org-1', userId: 'user-1', projectRepositoryId: 'pr-1' } as Record<string, string> | null,
+    memoryRecord = null as Record<string, unknown> | null,
+  } = {}) {
+    return {
+      projects: { getById: vi.fn(async () => ({ id: 'fp-1', defaultModelId })) } as any,
+      sourceControl: {
+        sessions: { getBySessionId: vi.fn(async () => session) },
+        projectRepositories: { get: vi.fn(async () => ({ id: 'pr-1', connectionId: 'conn-gh' })) },
+        connections: { get: vi.fn(async () => ({ id: 'conn-gh', factoryProjectId: 'fp-1' })) },
+      } as any,
+      memorySettings: { get: vi.fn(async () => memoryRecord) } as any,
     };
+  }
 
-    const session = await adaptSourceControlOwner(owner as any).createSession(args);
+  const startArgs = (session: unknown, resourceId = 'us-1') => ({
+    session: session as any,
+    thread: { id: resourceId, resourceId },
+  });
 
-    expect(owner.sessions.create).toHaveBeenCalledWith(expect.objectContaining(args));
-    expect(session.sessionId).toEqual(expect.any(String));
-    expect(session.sessionId).not.toHaveLength(0);
+  it('a repo-backed session adopts the factory default model instead of the SDK default', async () => {
+    const deps = makeStartDeps();
+    const { model, ...rest } = makeSession();
+    const session = { model, ...rest };
+
+    await createChannelSessionStartHook(deps as any)(startArgs(session) as any);
+
+    expect(session.model.switch).toHaveBeenCalledWith({ modelId: 'anthropic/claude-opus-5' });
+    // Resolved from the session row, not from anything held in memory, so it
+    // works on a thread created before this process started.
+    expect(deps.sourceControl.sessions.getBySessionId).toHaveBeenCalledWith('us-1');
+    expect(deps.projects.getById).toHaveBeenCalledWith({ id: 'fp-1' });
+  });
+
+  it('applies the owner observational-memory settings, matching the web kickoff', async () => {
+    const deps = makeStartDeps({ memoryRecord: { observerModelId: 'openai/gpt-5.4-mini', observationThreshold: 111 } });
+    const session = makeSession();
+
+    await createChannelSessionStartHook(deps as any)(startArgs(session) as any);
+
+    expect(deps.memorySettings.get).toHaveBeenCalledWith({ orgId: 'org-1', userId: 'user-1' });
+    expect(session.om.observer.switchModel).toHaveBeenCalledWith({ modelId: 'openai/gpt-5.4-mini' });
+    expect(session.state.set).toHaveBeenCalledWith(expect.objectContaining({ observationThreshold: 111 }));
+  });
+
+  // The durable record of a deliberate choice: either an earlier start or the
+  // user's own switch. Re-applying the factory default over it would undo the
+  // user's selection every time the process restarts.
+  it('leaves a session alone when its mode already has a model persisted on the thread', async () => {
+    const deps = makeStartDeps();
+    const session = makeSession({ persistedModeModel: 'anthropic/claude-fable-5' });
+
+    await createChannelSessionStartHook(deps as any)(startArgs(session) as any);
+
+    expect(session.model.switch).not.toHaveBeenCalled();
+    expect(deps.sourceControl.sessions.getBySessionId).not.toHaveBeenCalled();
+  });
+
+  it('skips chat-only threads, whose resourceId names no project', async () => {
+    const deps = makeStartDeps();
+    const session = makeSession();
+
+    await createChannelSessionStartHook(deps as any)(startArgs(session, 'channel:slack:C-1:1700.42') as any);
+
+    expect(session.model.switch).not.toHaveBeenCalled();
+    expect(deps.sourceControl.sessions.getBySessionId).not.toHaveBeenCalled();
+  });
+
+  it('configures nothing when the session row is gone', async () => {
+    const deps = makeStartDeps({ session: null });
+    const session = makeSession();
+
+    await createChannelSessionStartHook(deps as any)(startArgs(session) as any);
+
+    expect(session.model.switch).not.toHaveBeenCalled();
+  });
+
+  it('leaves the session on its default when the factory has no default model', async () => {
+    const deps = makeStartDeps({ defaultModelId: null });
+    const session = makeSession();
+
+    await createChannelSessionStartHook(deps as any)(startArgs(session) as any);
+
+    expect(session.model.switch).not.toHaveBeenCalled();
   });
 });

--- a/mastracode/factory/src/integrations/slack/slack.ts
+++ b/mastracode/factory/src/integrations/slack/slack.ts
@@ -4,6 +4,7 @@ import type {
   ChannelHandler,
   ChannelHandlerContext,
   ChannelHandlers,
+  ChannelSessionStart,
   ResolveResourceId,
   ResolveThreadId,
 } from '@mastra/core/channels';
@@ -11,12 +12,20 @@ import type { Mastra } from '@mastra/core/mastra';
 import { createSlackAdapter } from '@mastra/slack';
 import { Card, CardText, Actions, LinkButton } from 'chat';
 
+import {
+  hydrateFactorySession,
+  resolveFactoryDefaultModelId,
+  resolveFactoryProjectForSession,
+  resolveFactorySourceRepository,
+} from '../../session/factory-session.js';
 import type {
   ChannelAccountLink,
   ChannelAccountLinkKey,
   ChannelIdentityStorage,
 } from '../../storage/domains/channel-identity/base.js';
+import type { MemorySettingsStorage } from '../../storage/domains/memory-settings/base.js';
 import type { FactoryProjectsStorage } from '../../storage/domains/projects/base.js';
+import type { SourceControlStorageHandle } from '../../storage/domains/source-control/base.js';
 import type { WorkItemsStorage } from '../../storage/domains/work-items/base.js';
 import type { FactoryChannelsConfig } from '../base.js';
 
@@ -48,14 +57,22 @@ interface SlackChannelDeps {
    */
   projects?: FactoryProjectsStorage;
   /**
-   * Narrow source-control surface used to make new Slack threads repo-backed:
-   * when the sender is linked and their factory has a repository, the thread's
-   * resourceId becomes a Factory user-session id (repo cloned on a
-   * `slack/{threadTs}` branch) instead of the chat-only `channel:...` id.
-   * Absent (no source-control integration registered) → chat-only sessions as
-   * before.
+   * Storage handle of the integration that owns source control
+   * (`IntegrationContext.storage.sourceControlOwner`). Used to make new Slack
+   * threads repo-backed: when the sender is linked and their factory has a
+   * repository, the thread's resourceId becomes a Factory user-session id (repo
+   * cloned on a `slack/{threadTs}` branch) instead of the chat-only
+   * `channel:...` id. It also lets a started session read back the project it
+   * belongs to. Nothing here is provider-specific — the connection is matched
+   * by the handle's own `integrationId`. Absent (no source-control integration
+   * registered) → chat-only sessions as before.
    */
-  sourceControl?: SlackSourceControl;
+  sourceControl?: SourceControlStorageHandle;
+  /**
+   * Observational-memory settings domain. When provided, a repo-backed session
+   * adopts its owner's memory settings on start, matching the web kickoff.
+   */
+  memorySettings?: MemorySettingsStorage;
   /**
    * Factory work-items domain. When provided, a dispatched new-session thread
    * (DM or mention) upserts a Work-board card in Building (`execute`) carrying
@@ -63,101 +80,6 @@ interface SlackChannelDeps {
    * session. Best-effort — a failure never blocks the run. Unset → no card.
    */
   workItems?: WorkItemsStorage;
-}
-
-/**
- * The slice of the source-control owner's storage the Slack wiring needs.
- * Structural (not the storage types themselves) so slack.ts stays decoupled
- * from the owning integration's module graph and tests can stub it.
- */
-export interface SlackSourceControl {
-  /**
-   * Resolve the factory's linked repository — first repo on the factory's
-   * source-control connection, the same single-repo assumption the web kickoff
-   * makes.
-   */
-  resolveProjectRepository(args: {
-    orgId: string;
-    factoryProjectId: string;
-  }): Promise<{ projectRepositoryId: string; baseBranch: string } | null>;
-  /** Look up an existing user session for a repo branch (idempotent reuse). */
-  getSessionForBranch(args: {
-    projectRepositoryId: string;
-    userId: string;
-    branch: string;
-  }): Promise<{ sessionId: string } | null>;
-  /** Create the durable user-session row the workspace factory materializes. */
-  createSession(args: {
-    projectRepositoryId: string;
-    orgId: string;
-    userId: string;
-    branch: string;
-    baseBranch: string;
-  }): Promise<{ sessionId: string }>;
-}
-
-/**
- * Structural slice of the source-control owner's storage handle
- * (`IntegrationContext.storage.sourceControlOwner`, a `SourceControlStorageHandle`)
- * the adapter reads. Structural so slack.ts stays decoupled from the storage
- * module graph and tests can stub it. The handle is bound during
- * `factory.prepare()`; all access here is lazy (request time).
- */
-interface SourceControlOwnerSlice {
-  integrationId: string;
-  connections: {
-    list(args: { orgId: string; factoryProjectId: string }): Promise<Array<{ id: string; integrationId: string }>>;
-  };
-  projectRepositories: {
-    list(args: {
-      orgId: string;
-      connectionId: string;
-    }): Promise<Array<{ id: string; repositoryId: string; branch?: string | null }>>;
-  };
-  repositories: {
-    get(args: { orgId: string; id: string }): Promise<{ defaultBranch: string } | null>;
-  };
-  sessions: {
-    getForBranch(args: {
-      projectRepositoryId: string;
-      userId: string;
-      branch: string;
-    }): Promise<{ sessionId: string } | null>;
-    create(input: {
-      sessionId: string;
-      projectRepositoryId: string;
-      orgId: string;
-      userId: string;
-      branch: string;
-      baseBranch: string;
-    }): Promise<{ sessionId: string }>;
-  };
-}
-
-/**
- * Adapt the source-control owner's storage handle into the
- * {@link SlackSourceControl} surface. Nothing here is GitHub-specific — the
- * owner is whichever integration owns source control, matched by its own
- * `integrationId`. Repo resolution mirrors the factory's own
- * `ensureFactorySourceSession`: the owner's connection on the factory → its
- * first linked repository → pinned branch or repo default as the base.
- */
-export function adaptSourceControlOwner(owner: SourceControlOwnerSlice): SlackSourceControl {
-  return {
-    async resolveProjectRepository({ orgId, factoryProjectId }) {
-      const connections = await owner.connections.list({ orgId, factoryProjectId });
-      const connection = connections.find(candidate => candidate.integrationId === owner.integrationId);
-      if (!connection) return null;
-      const projectRepositories = await owner.projectRepositories.list({ orgId, connectionId: connection.id });
-      const first = projectRepositories[0];
-      if (!first) return null;
-      const repository = await owner.repositories.get({ orgId, id: first.repositoryId });
-      if (!repository) return null;
-      return { projectRepositoryId: first.id, baseBranch: first.branch ?? repository.defaultBranch };
-    },
-    getSessionForBranch: args => owner.sessions.getForBranch(args),
-    createSession: args => owner.sessions.create({ sessionId: randomUUID(), ...args }),
-  };
 }
 
 /**
@@ -401,17 +323,20 @@ export function createChannelResourceIdResolver(deps: SlackChannelDeps): Resolve
       }
       if (!factoryProjectId) return chatOnlyResourceId;
 
-      const repo = await sourceControl.resolveProjectRepository({ orgId, factoryProjectId });
-      if (!repo) return chatOnlyResourceId;
+      const repo = await resolveFactorySourceRepository({ sourceControl, orgId, factoryProjectId });
+      if (!repo.found) return chatOnlyResourceId;
 
       const branch = threadBranch(thread.id);
-      const existing = await sourceControl.getSessionForBranch({
+      // Attributed to the Slack sender, not to whoever connected the repository:
+      // unlike an autonomous rule run, a Slack thread has a real interactive user.
+      const existing = await sourceControl.sessions.getForBranch({
         projectRepositoryId: repo.projectRepositoryId,
         userId: link.userId,
         branch,
       });
       if (existing) return existing.sessionId;
-      const session = await sourceControl.createSession({
+      const session = await sourceControl.sessions.create({
+        sessionId: randomUUID(),
         projectRepositoryId: repo.projectRepositoryId,
         orgId,
         userId: link.userId,
@@ -438,6 +363,46 @@ export function createChannelResourceIdResolver(deps: SlackChannelDeps): Resolve
  */
 export const resolveChannelThreadId: ResolveThreadId = ({ resourceId, defaultThreadId }) =>
   resourceId.startsWith('channel:') ? defaultThreadId : resourceId;
+
+/**
+ * Apply the factory's configuration to a Slack-created session the first time
+ * its thread reaches the controller.
+ *
+ * Without this a Slack session runs on the SDK's built-in mode default
+ * (`openai/gpt-5.5`), so a factory configured for any other provider fails every
+ * message with a missing-credentials error. The web kickoff has always applied
+ * the factory default; this brings Slack to the same footing.
+ *
+ * Only repo-backed threads are configured. Their resourceId IS the Factory
+ * session id, which the source-control rows turn back into a project — a
+ * chat-only `channel:...` id names no project, so there is nothing to read.
+ *
+ * Skips a session whose mode already has a model persisted on the thread. That
+ * is the durable record of a deliberate choice — either an earlier start or a
+ * user's own switch — and re-applying the factory default over it would undo
+ * the user's selection every time the process restarts.
+ */
+export function createChannelSessionStartHook(deps: SlackChannelDeps): ChannelSessionStart {
+  const { projects, sourceControl, memorySettings } = deps;
+  return async ({ session, thread }) => {
+    if (!projects || !sourceControl) return;
+    if (thread.resourceId.startsWith('channel:')) return;
+
+    const modeModelKey = `modeModelId_${session.mode.get()}`;
+    if (await session.thread.getSetting({ key: modeModelKey })) return;
+
+    const owner = await resolveFactoryProjectForSession({ sourceControl, sessionId: thread.resourceId });
+    if (!owner) return;
+
+    const defaultModelId = await resolveFactoryDefaultModelId(projects, owner.factoryProjectId);
+    await hydrateFactorySession(session, {
+      orgId: owner.orgId,
+      userId: owner.userId,
+      defaultModelId,
+      memorySettings,
+    });
+  };
+}
 
 /**
  * The internal Mastra thread the framework created for a channel conversation.
@@ -709,5 +674,8 @@ export function createSlackChannelsConfig(deps: SlackChannelDeps & { slack: Slac
     // resourceId, which is what makes the controller session repo-backed.
     resolveResourceId: createChannelResourceIdResolver(deps),
     resolveThreadId: resolveChannelThreadId,
+    // Those sessions are created by the channel machinery, not the web kickoff,
+    // so this is where they pick up the factory's configuration.
+    onSessionStart: createChannelSessionStartHook(deps),
   };
 }

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -219,7 +219,10 @@ export function buildIntegrationContext(
     emitAudit?: AuditEmitter['emit'];
     rules: FactoryRules;
     factoryReady: boolean;
-    domains: Pick<FactoryApiRoutesDeps['domains'], 'projects' | 'intake' | 'workItems' | 'channelIdentity'>;
+    domains: Pick<
+      FactoryApiRoutesDeps['domains'],
+      'projects' | 'intake' | 'workItems' | 'channelIdentity' | 'memorySettings'
+    >;
     /**
      * Stable id of the registered source-control-owning integration (today:
      * `'github'` when registered). Every call site must derive and pass it so
@@ -245,6 +248,7 @@ export function buildIntegrationContext(
       projects: deps.domains.projects,
       intake: deps.domains.intake,
       channelIdentity: deps.domains.channelIdentity,
+      memorySettings: deps.domains.memorySettings,
     },
     ...(deps.factoryReady ? { rules: { config: deps.rules, workItems: deps.domains.workItems } } : {}),
     ...(deps.emitAudit ? { hooks: { emitAudit: deps.emitAudit } } : {}),

--- a/mastracode/factory/src/session/factory-session.test.ts
+++ b/mastracode/factory/src/session/factory-session.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
-import { ensureFactorySourceSession, hydrateFactorySession, resolveFactoryDefaultModelId } from './factory-session.js';
+import {
+  ensureFactorySourceSession,
+  hydrateFactorySession,
+  resolveFactoryDefaultModelId,
+  resolveFactoryProjectForSession,
+  resolveFactorySourceRepository,
+} from './factory-session.js';
 
-type StarterSession = Parameters<typeof hydrateFactorySession>[0];
+type FactorySessionHandle = Parameters<typeof hydrateFactorySession>[0];
 
 async function seedLinkedRepository(options?: { pinnedBranch?: string }) {
   const seeded = await createFactoryStorageForTests();
@@ -46,7 +52,7 @@ function createSessionDouble() {
     state: { set: vi.fn(async () => void calls.push('state')) },
     model: { switch: vi.fn(async () => void calls.push('model')) },
   };
-  return { session: session as unknown as StarterSession, double: session, calls };
+  return { session: session as unknown as FactorySessionHandle, double: session, calls };
 }
 
 describe('ensureFactorySourceSession', () => {
@@ -227,5 +233,114 @@ describe('resolveFactoryDefaultModelId', () => {
     await expect(resolveFactoryDefaultModelId(undefined, 'project-1')).resolves.toBeUndefined();
     await expect(resolveFactoryDefaultModelId(seeded.projects, undefined)).resolves.toBeUndefined();
     await expect(resolveFactoryDefaultModelId(seeded.projects, 'missing-project')).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * Repo resolution encodes real policy — which connection counts, which
+ * repository, and what the base branch is. It backs both the autonomous
+ * entry points and the Slack wiring, so it is tested directly against seeded
+ * storage rather than through either caller.
+ */
+describe('resolveFactorySourceRepository', () => {
+  it('resolves the repository linked to the owner-owned connection, defaulting the base branch to the repo default', async () => {
+    const { sourceControl, project, projectRepository } = await seedLinkedRepository();
+
+    const result = await resolveFactorySourceRepository({
+      sourceControl,
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+    });
+
+    expect(result).toEqual({
+      found: true,
+      projectRepositoryId: projectRepository.id,
+      baseBranch: 'main',
+      connectedByUserId: 'user-1',
+    });
+  });
+
+  it('prefers the branch pinned on the project repository over the repository default', async () => {
+    const { sourceControl, project } = await seedLinkedRepository({ pinnedBranch: 'develop' });
+
+    const result = await resolveFactorySourceRepository({
+      sourceControl,
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+    });
+
+    expect(result).toMatchObject({ found: true, baseBranch: 'develop' });
+  });
+
+  // A project can carry connections for several integrations; only the one
+  // belonging to this owner can back a session.
+  it('ignores connections belonging to other integrations', async () => {
+    const { seeded, project } = await seedLinkedRepository();
+
+    const result = await resolveFactorySourceRepository({
+      sourceControl: seeded.sourceControl.forIntegration('linear'),
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+    });
+
+    expect(result).toEqual({ found: false, reason: 'connection' });
+  });
+
+  it('reports a missing repository apart from a missing connection', async () => {
+    const { seeded, sourceControl, project } = await seedLinkedRepository();
+    const bareProject = await seeded.projects.create({
+      orgId: 'org-1',
+      userId: 'user-1',
+      input: { name: 'No repos' },
+    });
+    const installation = await sourceControl.installations.upsert({
+      orgId: 'org-1',
+      connectedByUserId: 'user-1',
+      externalId: '123',
+    });
+    await sourceControl.connections.create({
+      orgId: 'org-1',
+      factoryProjectId: bareProject.id,
+      installationId: installation.id,
+      createdByUserId: 'user-1',
+    });
+
+    await expect(
+      resolveFactorySourceRepository({ sourceControl, orgId: 'org-1', factoryProjectId: bareProject.id }),
+    ).resolves.toEqual({ found: false, reason: 'repository' });
+    // The seeded project still resolves, so the miss is about this project.
+    await expect(
+      resolveFactorySourceRepository({ sourceControl, orgId: 'org-1', factoryProjectId: project.id }),
+    ).resolves.toMatchObject({ found: true });
+  });
+});
+
+/**
+ * A repo-backed channel thread is keyed by its Factory session id, and that id
+ * is the only handle a session-start hook receives. This is the walk back to
+ * the project whose configuration the session should adopt.
+ */
+describe('resolveFactoryProjectForSession', () => {
+  it('walks a session id back to its project, org, and owner', async () => {
+    const { sourceControl, project, repository } = await seedLinkedRepository();
+    const created = await ensureFactorySourceSession({
+      sourceControl,
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      repositorySlug: repository.slug,
+      branch: 'slack/1700-42',
+    });
+
+    await expect(resolveFactoryProjectForSession({ sourceControl, sessionId: created.sessionId })).resolves.toEqual({
+      factoryProjectId: project.id,
+      orgId: 'org-1',
+      userId: 'user-1',
+    });
+  });
+
+  it('resolves nothing for a session id that does not exist', async () => {
+    const { sourceControl } = await seedLinkedRepository();
+
+    await expect(resolveFactoryProjectForSession({ sourceControl, sessionId: 'not-a-session' })).resolves.toBeNull();
   });
 });

--- a/mastracode/factory/src/session/factory-session.ts
+++ b/mastracode/factory/src/session/factory-session.ts
@@ -49,6 +49,92 @@ export interface EnsuredFactorySourceSession {
   baseBranch: string;
 }
 
+export interface ResolvedFactorySourceRepository {
+  projectRepositoryId: string;
+  /** The repository's pinned branch, else its default branch. */
+  baseBranch: string;
+  /** Who connected the repository. The attribution for runs with no interactive user. */
+  connectedByUserId: string;
+}
+
+/**
+ * Outcome of {@link resolveFactorySourceRepository}. A miss carries which step
+ * failed: callers differ on whether that is an error (an autonomous run cannot
+ * proceed) or a routine fallback (a chat integration drops to a chat-only
+ * session), and the two steps fail for different reasons worth reporting apart.
+ */
+export type FactorySourceRepositoryResult =
+  | ({ found: true } & ResolvedFactorySourceRepository)
+  | { found: false; reason: 'connection' | 'repository' };
+
+/**
+ * Resolve which repository a factory project's source-control runs act on: the
+ * owner's connection on the project, then one of its linked repositories.
+ *
+ * The owner is whichever integration owns source control, matched by the
+ * handle's own `integrationId` — nothing here is provider-specific.
+ */
+export async function resolveFactorySourceRepository(args: {
+  sourceControl: SourceControlStorageHandle;
+  orgId: string;
+  factoryProjectId: string;
+  /** Pick a specific linked repository by slug. Defaults to the first linked repository. */
+  repositorySlug?: string;
+}): Promise<FactorySourceRepositoryResult> {
+  const { sourceControl, orgId, factoryProjectId, repositorySlug } = args;
+
+  const connections = await sourceControl.connections.list({ orgId, factoryProjectId });
+  const connection = connections.find(candidate => candidate.integrationId === sourceControl.integrationId);
+  if (!connection) return { found: false, reason: 'connection' };
+
+  const projectRepositories = await sourceControl.projectRepositories.list({ orgId, connectionId: connection.id });
+  const resolvedRepositories = await Promise.all(
+    projectRepositories.map(async projectRepository => ({
+      projectRepository,
+      repository: await sourceControl.repositories.get({ orgId, id: projectRepository.repositoryId }),
+    })),
+  );
+  const resolved = resolvedRepositories.find(
+    candidate => candidate.repository && (!repositorySlug || candidate.repository.slug === repositorySlug),
+  );
+  if (!resolved?.repository) return { found: false, reason: 'repository' };
+
+  return {
+    found: true,
+    projectRepositoryId: resolved.projectRepository.id,
+    baseBranch: resolved.projectRepository.branch ?? resolved.repository.defaultBranch,
+    connectedByUserId: connection.createdByUserId,
+  };
+}
+
+/**
+ * Walk a Factory user-session id back to the project it belongs to.
+ *
+ * Repo-backed channel threads are keyed by their Factory session id, which is
+ * the only handle a session-start hook gets. This turns that id back into the
+ * project whose configuration the session should adopt. Durable by
+ * construction — it reads the same rows the session was created from, so it
+ * survives restarts without any in-memory mapping.
+ */
+export async function resolveFactoryProjectForSession(args: {
+  sourceControl: SourceControlStorageHandle;
+  sessionId: string;
+}): Promise<{ factoryProjectId: string; orgId: string; userId: string } | null> {
+  const { sourceControl, sessionId } = args;
+
+  const session = await sourceControl.sessions.getBySessionId(sessionId);
+  if (!session) return null;
+  const projectRepository = await sourceControl.projectRepositories.get({
+    orgId: session.orgId,
+    id: session.projectRepositoryId,
+  });
+  if (!projectRepository) return null;
+  const connection = await sourceControl.connections.get({ orgId: session.orgId, id: projectRepository.connectionId });
+  if (!connection) return null;
+
+  return { factoryProjectId: connection.factoryProjectId, orgId: session.orgId, userId: session.userId };
+}
+
 /**
  * Create the source-control session a repo-backed factory run needs.
  *
@@ -68,38 +154,30 @@ export async function ensureFactorySourceSession(
 ): Promise<EnsuredFactorySourceSession> {
   const { sourceControl, orgId, factoryProjectId, branch, repositorySlug } = args;
 
-  const connections = await sourceControl.connections.list({ orgId, factoryProjectId });
-  const connection = connections.find(candidate => candidate.integrationId === sourceControl.integrationId);
-  if (!connection) throw new Error('Factory source-control connection not found.');
+  const resolved = await resolveFactorySourceRepository({ sourceControl, orgId, factoryProjectId, repositorySlug });
+  if (!resolved.found) {
+    throw new Error(
+      resolved.reason === 'connection'
+        ? 'Factory source-control connection not found.'
+        : 'Factory source-control repository not found.',
+    );
+  }
 
-  const projectRepositories = await sourceControl.projectRepositories.list({ orgId, connectionId: connection.id });
-  const resolvedRepositories = await Promise.all(
-    projectRepositories.map(async projectRepository => ({
-      projectRepository,
-      repository: await sourceControl.repositories.get({ orgId, id: projectRepository.repositoryId }),
-    })),
-  );
-  const resolved = resolvedRepositories.find(
-    candidate => candidate.repository && (!repositorySlug || candidate.repository.slug === repositorySlug),
-  );
-  if (!resolved?.repository) throw new Error('Factory source-control repository not found.');
-
-  const userId = connection.createdByUserId;
-  const baseBranch = resolved.projectRepository.branch ?? resolved.repository.defaultBranch;
+  const userId = resolved.connectedByUserId;
   const session = await sourceControl.sessions.create({
     sessionId: randomUUID(),
-    projectRepositoryId: resolved.projectRepository.id,
+    projectRepositoryId: resolved.projectRepositoryId,
     orgId,
     userId,
     branch,
-    baseBranch,
+    baseBranch: resolved.baseBranch,
   });
   return {
     sessionId: session.sessionId,
     userId,
-    projectRepositoryId: resolved.projectRepository.id,
+    projectRepositoryId: resolved.projectRepositoryId,
     branch: session.branch,
-    baseBranch,
+    baseBranch: resolved.baseBranch,
   };
 }
 

--- a/packages/core/src/channels/__tests__/agent-controller-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-controller-channels.test.ts
@@ -126,6 +126,7 @@ async function createSetup({
   toolDisplay,
   stateSchema,
   agentMemory,
+  onSessionStart,
 }: {
   responseText?: string;
   model?: MockLanguageModelV2;
@@ -134,6 +135,7 @@ async function createSetup({
   stateSchema?: z.ZodTypeAny;
   /** Memory for the mode agent — required for signal persistence assertions. */
   agentMemory?: MockMemory;
+  onSessionStart?: (ctx: any) => void | Promise<void>;
 } = {}) {
   const adapter = createMockAdapter('discord');
   const agent = new Agent({
@@ -153,6 +155,7 @@ async function createSetup({
     defaultModeId: 'build',
     channels: {
       adapters: { discord: toolDisplay ? { adapter, toolDisplay } : adapter },
+      ...(onSessionStart ? { onSessionStart } : {}),
     },
     ...(stateSchema ? { stateSchema } : {}),
   });
@@ -292,6 +295,97 @@ describe('AgentControllerChannels', () => {
     const threads = await getChannelThreads(mastra, 'chan-1:t-1');
     expect(threads).toHaveLength(1);
   }, 30_000);
+
+  /**
+   * A host can name a session (`resolveResourceId`) but never receives the
+   * `Session` object — it is created in here. This hook is the only seam where
+   * a channel-created session can be configured before it answers anything.
+   */
+  describe('session start hook', () => {
+    it('fires once per session, with the session already bound to its mapped thread', async () => {
+      const starts: Array<{ resourceId: string; boundThreadId: string }> = [];
+      const { adapter, mastra, channels } = await createSetup({
+        onSessionStart: ({ session, thread }) =>
+          void starts.push({ resourceId: thread.resourceId, boundThreadId: session.thread.getId() }),
+      });
+      const chatThread = createChatThread(adapter, 'chan-1:t-1');
+
+      await (channels as any).processChatMessage(
+        chatThread,
+        createMessage('m-1', 'first'),
+        mastra,
+        new RequestContext(),
+      );
+      await waitFor(() => chatThread.post.mock.calls.length >= 1, { what: 'first reply' });
+
+      const threads = await getChannelThreads(mastra, 'chan-1:t-1');
+      expect(starts).toEqual([{ resourceId: 'channel:chan-1:t-1', boundThreadId: threads[0]!.id }]);
+
+      // A second message reuses the session, so it must not be reconfigured —
+      // that would overwrite anything set on the thread since.
+      await (channels as any).processChatMessage(
+        chatThread,
+        createMessage('m-2', 'second'),
+        mastra,
+        new RequestContext(),
+      );
+      await waitFor(() => chatThread.post.mock.calls.length >= 2, { what: 'second reply' });
+      expect(starts).toHaveLength(1);
+    }, 30_000);
+
+    it('makes concurrent first messages wait for the hook instead of dispatching unconfigured', async () => {
+      // Hold the hook open: any message that dispatches while it is pending
+      // would run on an unconfigured session, which is exactly the race a
+      // skip-style once-guard allows.
+      let releaseHook!: () => void;
+      const hookGate = new Promise<void>(resolve => (releaseHook = resolve));
+      let hookCalls = 0;
+      const { adapter, mastra, channels } = await createSetup({
+        onSessionStart: async () => {
+          hookCalls += 1;
+          await hookGate;
+        },
+      });
+      const chatThread = createChatThread(adapter, 'chan-1:t-1');
+
+      const dispatches = Promise.all([
+        (channels as any).processChatMessage(chatThread, createMessage('m-1', 'first'), mastra, new RequestContext()),
+        (channels as any).processChatMessage(chatThread, createMessage('m-2', 'second'), mastra, new RequestContext()),
+      ]);
+
+      // Give a leaked dispatch every chance to happen before asserting.
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(chatThread.post).not.toHaveBeenCalled();
+
+      releaseHook();
+      await dispatches;
+      // Concurrent messages on one session may supersede each other, so only
+      // require that replies exist at all - the claim under test is that none
+      // happened before the hook finished, asserted above.
+      await waitFor(() => chatThread.post.mock.calls.length >= 1, { what: 'a reply after the hook' });
+      expect(hookCalls).toBe(1);
+    }, 30_000);
+
+    it('still answers the message when the hook throws', async () => {
+      const { adapter, mastra, channels } = await createSetup({
+        onSessionStart: () => {
+          throw new Error('configuration backend down');
+        },
+      });
+      const chatThread = createChatThread(adapter, 'chan-1:t-1');
+
+      await (channels as any).processChatMessage(
+        chatThread,
+        createMessage('m-1', 'hello'),
+        mastra,
+        new RequestContext(),
+      );
+
+      await waitFor(() => postedText(chatThread).includes('Hello from the controller!'), {
+        what: 'reply posted despite the failing hook',
+      });
+    }, 30_000);
+  });
 
   it('produces distinct sessions for distinct chat threads', async () => {
     const { adapter, controller, mastra, channels } = await createSetup();

--- a/packages/core/src/channels/agent-controller-channels.ts
+++ b/packages/core/src/channels/agent-controller-channels.ts
@@ -12,8 +12,45 @@ import type { RequestContext } from '../request-context';
 import { AgentChannels } from './agent-channels';
 import type { ChannelConfig } from './types';
 
-/** Configuration for {@link AgentControllerChannels}. Same shape as agent channels. */
-export type AgentControllerChannelsConfig = ChannelConfig;
+/** Context passed to {@link AgentControllerChannelsConfig.onSessionStart}. */
+export interface ChannelSessionStartContext {
+  /**
+   * The controller session, already bound to `thread`. Bound before the hook
+   * runs on purpose: session settings persist to the bound thread's metadata,
+   * so a hook that writes settings must not race the thread switch.
+   */
+  session: Session<any>;
+  /** The mapped Mastra thread the session is bound to. */
+  thread: Pick<StorageThreadType, 'id' | 'resourceId'>;
+  /** Request context of the message that started the session, when there is one. */
+  requestContext?: RequestContext;
+}
+
+/**
+ * Configure a session the first time a channel thread reaches it, before the
+ * inbound message is dispatched.
+ *
+ * The seam exists because a host can name a session (`resolveResourceId`) but
+ * never receives the `Session` object — it is created here, inside the channel
+ * machinery. Without this hook a host that resolves its own resourceIds can
+ * only ever configure sessions the web UI created, and channel-created sessions
+ * silently run on the SDK's built-in defaults.
+ *
+ * Errors are logged and swallowed: configuration is best-effort and must not
+ * drop the message that triggered it.
+ */
+export type ChannelSessionStart = (ctx: ChannelSessionStartContext) => void | Promise<void>;
+
+/** Configuration for {@link AgentControllerChannels}. */
+export interface AgentControllerChannelsConfig extends ChannelConfig {
+  /**
+   * Called once per session per process, after the session is bound to its
+   * thread and before the first message dispatches. Concurrent messages on a
+   * new session wait for the hook to settle rather than dispatching on an
+   * unconfigured session. See {@link ChannelSessionStart}.
+   */
+  onSessionStart?: ChannelSessionStart;
+}
 
 /**
  * Runs an AgentController inside chat channels (Slack, Discord, ...).
@@ -42,6 +79,24 @@ export class AgentControllerChannels extends AgentChannels {
    * server scope.
    */
   private autoApproveResourceIds = new Set<string>();
+
+  /** See {@link AgentControllerChannelsConfig.onSessionStart}. */
+  private readonly onSessionStart: ChannelSessionStart | undefined;
+
+  /**
+   * One start-hook invocation per session resourceId. A map of promises rather
+   * than a set of ids: concurrent messages on a new thread must all WAIT for
+   * the hook, not just skip it, or the losers dispatch on an unconfigured
+   * session. In-memory, matching the v1 scope where sessions themselves don't
+   * survive a restart: a session rebuilt after a restart is a new session and
+   * gets configured again.
+   */
+  private sessionStartRuns = new Map<string, Promise<void>>();
+
+  constructor(config: AgentControllerChannelsConfig) {
+    super(config);
+    this.onSessionStart = config.onSessionStart;
+  }
 
   /** @internal Called by AgentController's constructor to bind itself. */
   __setController(controller: AgentController<any>): void {
@@ -236,7 +291,41 @@ export class AgentControllerChannels extends AgentChannels {
     if (session.thread.getId() !== thread.id) {
       await session.thread.switch({ threadId: thread.id });
     }
+    await this.runSessionStartHook(session, thread, requestContext);
     return session;
+  }
+
+  /**
+   * Run the configured session-start hook at most once per session. Fires after
+   * the thread binding above, so a hook that persists session settings writes
+   * them to the thread the session actually ends up on.
+   */
+  private async runSessionStartHook(
+    session: Session<any>,
+    thread: Pick<StorageThreadType, 'id' | 'resourceId'>,
+    requestContext?: RequestContext,
+  ): Promise<void> {
+    const onSessionStart = this.onSessionStart;
+    if (!onSessionStart) return;
+    // Memoize before the first await: two messages arriving together on a new
+    // thread both reach this point. The first starts the hook; every later
+    // caller awaits the same run, so no message dispatches before the session
+    // is configured.
+    let run = this.sessionStartRuns.get(thread.resourceId);
+    if (!run) {
+      run = (async () => {
+        try {
+          await onSessionStart({ session, thread, requestContext });
+        } catch (error) {
+          // Best-effort by contract: a session that couldn't be configured
+          // still answers the message, on whatever defaults it was created
+          // with.
+          this.log('error', `Channel session-start hook failed for resourceId=${thread.resourceId}: ${error}`);
+        }
+      })();
+      this.sessionStartRuns.set(thread.resourceId, run);
+    }
+    await run;
   }
 
   private requireController(): AgentController<any> {

--- a/packages/core/src/channels/index.ts
+++ b/packages/core/src/channels/index.ts
@@ -1,6 +1,10 @@
 export { AgentChannels } from './agent-channels';
 export { AgentControllerChannels } from './agent-controller-channels';
-export type { AgentControllerChannelsConfig } from './agent-controller-channels';
+export type {
+  AgentControllerChannelsConfig,
+  ChannelSessionStart,
+  ChannelSessionStartContext,
+} from './agent-controller-channels';
 export { ChatChannelProcessor } from './processor';
 export { MastraStateAdapter } from './state-adapter';
 export { defaultTypingStatus } from './typing-status';


### PR DESCRIPTION
Slack sessions run on whatever model the SDK hardcodes, not the one the factory is configured with. On a factory pointed at any non-OpenAI provider, that means every Slack message fails with a missing `OPENAI_API_KEY`.

> [!NOTE]
> Stacked on #20827. Review that one first; this PR targets its branch, and the diff here is only the second commit.

## Why it happens

Sessions created from Slack are built by the channel machinery, not by the web kickoff. The web path has always applied the factory's default model. The Slack path had nowhere to do it.

That gap is structural rather than an oversight. A host can *name* a channel session through `resolveResourceId`, but the `Session` object is created inside `AgentControllerChannels` and never handed back, so there was no seam where a host could configure a session the channel machinery created. Every mode in the SDK hardcodes an OpenAI default (`build`/`plan` → `openai/gpt-5.5`, `explore` → `openai/gpt-5.4-mini`), so a session nobody configures lands on OpenAI regardless of the factory's settings.

## What changed

**Core** gains an `onSessionStart` hook on `AgentControllerChannelsConfig`, fired once per session from `getSessionForThread`. Two details are load-bearing:

- It fires **after** the thread binding, because session settings persist to the bound thread's metadata. Firing earlier would race the switch and write settings to the wrong thread.
- Hook errors are logged and swallowed. A session that could not be configured should still answer the message.

**Slack** implements the hook, applying the project's default model and observational-memory settings, so it reaches the same footing as the web kickoff.

Two decisions worth reviewing:

- **The project is read back from storage, not from memory.** The resourceId of a repo-backed thread *is* the Factory session id, so the source-control rows walk it back to its project. That works on threads created before the process started, with no cache to go stale.
- **A session whose mode already has a model persisted on its thread is skipped.** `model.switch` persists `modeModelId_<mode>` to thread metadata and the session reads it back on resume, so that key is the durable record of a deliberate choice — an earlier start, or the user's own switch. Without this gate, every process restart would overwrite a model a user picked mid-thread.

Consuming the source-control handle directly also retires the narrow adapter Slack used to reach it (`SlackSourceControl`, `SourceControlOwnerSlice`, `adaptSourceControlOwner`). Its repo-resolution policy was a second copy of the traversal the session starter already owned; both now share `resolveFactorySourceRepository`. The moved tests landed on seeded storage instead of hand-built stubs.

## What this does not fix

**Chat-only Slack threads are unchanged.** Their `channel:...` resourceId names no project, so there is nothing to read a default from. They still run on the SDK default. That needs its own fix.

**A mid-thread mode switch still falls back to the SDK default.** Hydration sets the model for the mode that is active when the session starts; switching plan→build lands on a mode whose only default is `openai/gpt-5.5`. This is not a regression — the board path behaves the same way — and it is the reason model packs exist, since `applyPackToSession` stamps every mode. The real gap is that a factory project can only express a single `defaultModelId` and has no pointer to a pack, so one model is all a factory can currently apply. Giving projects a default pack is the follow-up.

## Test plan

Every behavioral claim was red-verified — the implementation was temporarily reverted to confirm each test fails for its stated reason rather than passing on a lenient harness:

- removing the hydration call → the 2 Slack behavior tests fail, guards stay green
- removing the persisted-model gate → only the "leaves a session alone" test fails
- removing core's once-only guard → the hook fires twice (`expected [...] to have a length of 1 but got 2`)

```bash
pnpm --filter ./packages/core exec vitest run src/channels --reporter=dot          # 12 files, 271 tests
pnpm --filter ./mastracode/factory exec vitest run --reporter=dot                  # 74 files, 1283 tests
pnpm --filter ./packages/core check && pnpm --filter ./mastracode/factory check
pnpm --filter ./packages/core lint && pnpm --filter ./mastracode/factory lint
```

The 2 failures in the full factory suite are the known pre-existing work-items distributed-locking timeouts in `src/storage/domains/work-items/base.test.ts`, confirmed identical on the untouched tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Slack sessions now use the model and memory settings configured for the project. Existing sessions keep their saved model settings, and session setup errors do not stop message handling.

## Changes

- Added the `onSessionStart` hook to `AgentControllerChannels`.
  - Runs once after thread binding and before the first message.
  - Shares initialization with concurrent messages.
  - Logs and ignores hook errors.
- Configured Slack to apply factory default model and observational-memory settings.
- Preserved persisted mode-specific models across restarts.
- Kept chat-only threads and mid-thread mode switches unchanged.
- Added shared helpers to resolve Factory projects and source repositories.
- Replaced the Slack-specific source-control adapter with shared storage APIs.
- Added `memorySettings` to the factory integration context.
- Added documentation and changesets.

## Testing

- Added core coverage for hook timing, reuse, concurrency, and error handling.
- Added factory coverage for repository resolution, project lookup, Slack session initialization, persisted models, memory settings, and failure cases.
- Checks and lint pass.
- Two pre-existing factory test timeouts remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->