### PR TITLE
fix(core): give each dataset experiment item its own memory thread when the context only carries a resource id

### DIFF
--- a/.changeset/experiment-memory-thread-20663.md
+++ b/.changeset/experiment-memory-thread-20663.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed dataset experiment runs failing with a missing-thread memory error when the target agent has memory configured and the request context provides only a resource id (for example from auth middleware or Studio). Each dataset item now runs in its own fresh memory thread; explicitly supplied thread ids are still respected. Fixes #20663

--- a/docs/src/content/en/docs/datasets/running-experiments.mdx
+++ b/docs/src/content/en/docs/datasets/running-experiments.mdx
@@ -68,6 +68,24 @@ const summary = await dataset.startExperiment({
 
 Each item's `input` is passed directly to `agent.generate()`, so it must be a `string`, `string[]`, or `CoreMessage[]`.
 
+#### Memory-enabled agents
+
+When the target agent has its own memory and the request context carries a resource id (`MASTRA_RESOURCE_ID_KEY`, set by auth middleware, the experiment or item `requestContext`, or the Studio **Run Experiment** form), the experiment runner injects a fresh memory thread for each item. A resource id in the request context means "run as this resource": each item's conversation persists as a thread under that resource, and retried items get a new thread per attempt so earlier failed attempts can't leak into the retry's context.
+
+Injected threads are tagged so you can map them back to the run: thread metadata carries the `experimentId` and the dataset item's id as `experimentItemId`. No thread title is generated for them.
+
+Because the threads belong to the caller's resource, resource-scoped memory features both read and write that resource's state during the run:
+
+- Resource-scoped working memory updates persist to the resource, and later items in the run see updates made by earlier items.
+- Resource-scoped semantic recall can surface the resource's prior conversations to the experiment, and experiment transcripts become recallable in that resource's later conversations.
+
+This is useful when you want to evaluate an agent against a real user's accumulated context. If you don't want experiment runs touching real user state, run the experiment with a dedicated evaluation resource id instead.
+
+Thread injection is skipped in the following cases:
+
+- If the request context also sets `MASTRA_THREAD_ID_KEY`, the runner uses that thread as-is, so every item (and retry) shares the same conversation.
+- If the agent has no memory, or the request context has no resource id, the run is memoryless and nothing is persisted.
+
 ### Registered workflow
 
 Point to a workflow registered on your Mastra instance:

--- a/packages/core/src/datasets/__tests__/experiment-memory.test.ts
+++ b/packages/core/src/datasets/__tests__/experiment-memory.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Regression tests for #20663 — startExperiment against a memory-enabled agent
+ * with a requestContext carrying only MASTRA_RESOURCE_ID_KEY (as set by auth
+ * middleware or the Studio "Run Experiment" field) used to throw
+ * AGENT_MEMORY_MISSING_RESOURCE_ID for every item, because the experiment
+ * executor forwarded the resourceId without any thread.
+ *
+ * The executor now injects a distinct per-item thread (mirroring the
+ * multi-turn evals runner precedent) whenever a resourceId is present, no
+ * threadId is supplied, and the agent has its own memory. These tests use a
+ * real Agent + MockMemory + real Dataset.startExperiment — the pre-existing
+ * experiment tests mock the agent, which is why the bug went unnoticed.
+ */
+import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect, vi } from 'vitest';
+import { Agent } from '../../agent/agent';
+import type { Mastra } from '../../mastra';
+import { MockMemory } from '../../memory/mock';
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../../request-context';
+import { InMemoryStore } from '../../storage';
+import type { MastraCompositeStore, StorageDomains } from '../../storage/base';
+import { DatasetsInMemory } from '../../storage/domains/datasets/inmemory';
+import { ExperimentsInMemory } from '../../storage/domains/experiments/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { ScoresInMemory } from '../../storage/domains/scores/inmemory';
+import { Dataset } from '../dataset';
+
+const ITEM_INPUTS = ['Hello there', 'Second item', 'Third item'];
+
+function createV2Model() {
+  return new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [{ type: 'text' as const, text: 'Dummy response' }],
+      warnings: [],
+    }),
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      stream: convertArrayToReadableStream([
+        { type: 'text-delta' as const, id: 'text-1', delta: 'Dummy response' },
+        {
+          type: 'finish' as const,
+          id: '2',
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        },
+      ]),
+      warnings: [],
+    }),
+  });
+}
+
+function createV1Model() {
+  return new MockLanguageModelV1({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { promptTokens: 10, completionTokens: 20 },
+      text: 'Dummy response',
+    }),
+  });
+}
+
+function createMemoryAgent(model: MockLanguageModelV1 | MockLanguageModelV2) {
+  const memory = new MockMemory({ storage: new InMemoryStore() });
+  const agent = new Agent({
+    id: 'memory-agent',
+    name: 'Memory Agent',
+    instructions: 'test agent',
+    model,
+    memory,
+  });
+  return { agent, memory };
+}
+
+async function setupDataset(agent: Agent) {
+  const db = new InMemoryDB();
+  const datasetsStorage = new DatasetsInMemory({ db });
+  const experimentsStorage = new ExperimentsInMemory({ db });
+  const scoresStorage = new ScoresInMemory({ db });
+
+  const mockStorage = {
+    id: 'test-storage',
+    stores: {
+      datasets: datasetsStorage,
+      experiments: experimentsStorage,
+      scores: scoresStorage,
+    } as unknown as StorageDomains,
+    getStore: vi.fn().mockImplementation(async (name: keyof StorageDomains) => {
+      if (name === 'datasets') return datasetsStorage;
+      if (name === 'experiments') return experimentsStorage;
+      if (name === 'scores') return scoresStorage;
+      return undefined;
+    }),
+  } as unknown as MastraCompositeStore;
+
+  const mastra = {
+    getStorage: vi.fn().mockReturnValue(mockStorage),
+    getAgent: vi.fn().mockReturnValue(agent),
+    getAgentById: vi.fn().mockReturnValue(agent),
+    getScorerById: vi.fn(),
+    getWorkflowById: vi.fn(),
+    getWorkflow: vi.fn(),
+    getLogger: vi.fn().mockReturnValue({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+  } as unknown as Mastra;
+
+  const record = await datasetsStorage.createDataset({ name: 'Experiment Memory DS' });
+  for (const input of ITEM_INPUTS) {
+    await datasetsStorage.addItem({ datasetId: record.id, input });
+  }
+
+  return new Dataset(record.id, mastra);
+}
+
+async function listThreadsForResource(memory: MockMemory, resourceId: string) {
+  const { threads } = await memory.listThreads({ filter: { resourceId } });
+  return threads;
+}
+
+describe('experiment executor memory-thread injection (#20663)', () => {
+  it('SC1: memory-enabled agent + lone resourceId succeeds with a distinct thread per item', async () => {
+    const { agent, memory } = createMemoryAgent(createV2Model());
+    const ds = await setupDataset(agent);
+
+    const summary = await ds.startExperiment({
+      targetType: 'agent',
+      targetId: 'memory-agent',
+      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'user-1' },
+    });
+
+    expect(summary.failedCount).toBe(0);
+    expect(summary.succeededCount).toBe(ITEM_INPUTS.length);
+
+    const threads = await listThreadsForResource(memory, 'user-1');
+    expect(threads).toHaveLength(ITEM_INPUTS.length);
+    expect(new Set(threads.map(t => t.id)).size).toBe(ITEM_INPUTS.length);
+    for (const thread of threads) {
+      expect(thread.resourceId).toBe('user-1');
+    }
+  });
+
+  it('SC1 (legacy): memory-enabled v1-model agent + lone resourceId succeeds with a distinct thread per item', async () => {
+    const { agent, memory } = createMemoryAgent(createV1Model());
+    const ds = await setupDataset(agent);
+
+    const summary = await ds.startExperiment({
+      targetType: 'agent',
+      targetId: 'memory-agent',
+      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'user-legacy' },
+    });
+
+    expect(summary.failedCount).toBe(0);
+    expect(summary.succeededCount).toBe(ITEM_INPUTS.length);
+
+    const threads = await listThreadsForResource(memory, 'user-legacy');
+    expect(threads).toHaveLength(ITEM_INPUTS.length);
+    expect(new Set(threads.map(t => t.id)).size).toBe(ITEM_INPUTS.length);
+  });
+
+  it('SC2a: no resourceId in context — run succeeds memory-less, no threads created', async () => {
+    const { agent, memory } = createMemoryAgent(createV2Model());
+    const ds = await setupDataset(agent);
+
+    const summary = await ds.startExperiment({
+      targetType: 'agent',
+      targetId: 'memory-agent',
+    });
+
+    expect(summary.failedCount).toBe(0);
+    expect(summary.succeededCount).toBe(ITEM_INPUTS.length);
+
+    const { threads } = await memory.listThreads({ filter: {} });
+    expect(threads).toHaveLength(0);
+  });
+
+  it('SC2b: memory-less agent + resourceId — no injection, run succeeds unchanged', async () => {
+    const agent = new Agent({
+      id: 'memory-agent',
+      name: 'No Memory Agent',
+      instructions: 'test agent',
+      model: createV2Model(),
+    });
+    const ds = await setupDataset(agent);
+
+    const summary = await ds.startExperiment({
+      targetType: 'agent',
+      targetId: 'memory-agent',
+      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'user-2' },
+    });
+
+    expect(summary.failedCount).toBe(0);
+    expect(summary.succeededCount).toBe(ITEM_INPUTS.length);
+  });
+
+  it('SC3: explicit threadId in context wins — no per-item injection, all items share the supplied thread', async () => {
+    const { agent, memory } = createMemoryAgent(createV2Model());
+    const ds = await setupDataset(agent);
+
+    const summary = await ds.startExperiment({
+      targetType: 'agent',
+      targetId: 'memory-agent',
+      requestContext: {
+        [MASTRA_RESOURCE_ID_KEY]: 'user-3',
+        [MASTRA_THREAD_ID_KEY]: 'caller-supplied-thread',
+      },
+    });
+
+    expect(summary.failedCount).toBe(0);
+    expect(summary.succeededCount).toBe(ITEM_INPUTS.length);
+
+    const threads = await listThreadsForResource(memory, 'user-3');
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.id).toBe('caller-supplied-thread');
+  });
+});

--- a/packages/core/src/datasets/__tests__/experiment-memory.test.ts
+++ b/packages/core/src/datasets/__tests__/experiment-memory.test.ts
@@ -123,6 +123,7 @@ async function listThreadsForResource(memory: MockMemory, resourceId: string) {
 describe('experiment executor memory-thread injection (#20663)', () => {
   it('SC1: memory-enabled agent + lone resourceId succeeds with a distinct thread per item', async () => {
     const { agent, memory } = createMemoryAgent(createV2Model());
+    const generateSpy = vi.spyOn(agent, 'generate');
     const ds = await setupDataset(agent);
 
     const summary = await ds.startExperiment({
@@ -139,6 +140,16 @@ describe('experiment executor memory-thread injection (#20663)', () => {
     expect(new Set(threads.map(t => t.id)).size).toBe(ITEM_INPUTS.length);
     for (const thread of threads) {
       expect(thread.resourceId).toBe('user-1');
+      // Injected threads are tagged with the experiment id for traceability.
+      expect(thread.metadata).toMatchObject({ experimentId: expect.any(String) });
+    }
+
+    // Contract check the mock cannot surface: injected threads are ephemeral
+    // bookkeeping, so title generation and history recall must be suppressed
+    // (MockMemory never titles threads, so only the passed option proves this).
+    for (const call of generateSpy.mock.calls) {
+      const options = (call as unknown[])[1] as { memory?: { options?: Record<string, unknown> } };
+      expect(options?.memory?.options).toMatchObject({ generateTitle: false, lastMessages: false });
     }
   });
 
@@ -176,13 +187,14 @@ describe('experiment executor memory-thread injection (#20663)', () => {
     expect(threads).toHaveLength(0);
   });
 
-  it('SC2b: memory-less agent + resourceId — no injection, run succeeds unchanged', async () => {
+  it('SC2b: memory-less agent + resourceId — no memory option is injected, run succeeds unchanged', async () => {
     const agent = new Agent({
       id: 'memory-agent',
       name: 'No Memory Agent',
       instructions: 'test agent',
       model: createV2Model(),
     });
+    const generateSpy = vi.spyOn(agent, 'generate');
     const ds = await setupDataset(agent);
 
     const summary = await ds.startExperiment({
@@ -193,6 +205,41 @@ describe('experiment executor memory-thread injection (#20663)', () => {
 
     expect(summary.failedCount).toBe(0);
     expect(summary.succeededCount).toBe(ITEM_INPUTS.length);
+
+    // The contract, not just the outcome: the executor must not pass a memory
+    // option for a memory-less agent (deleting the hasOwnMemory() gate would
+    // still produce failedCount === 0 with MockMemory-less agents otherwise).
+    expect(generateSpy).toHaveBeenCalledTimes(ITEM_INPUTS.length);
+    for (const call of generateSpy.mock.calls) {
+      const options = (call as unknown[])[1];
+      expect(options).not.toHaveProperty('memory');
+    }
+  });
+
+  it('SC2c: empty-string resourceId — no injection, run stays memory-less as before the fix', async () => {
+    const { agent, memory } = createMemoryAgent(createV2Model());
+    const generateSpy = vi.spyOn(agent, 'generate');
+    const ds = await setupDataset(agent);
+
+    const summary = await ds.startExperiment({
+      targetType: 'agent',
+      targetId: 'memory-agent',
+      requestContext: { [MASTRA_RESOURCE_ID_KEY]: '' },
+    });
+
+    // An empty-string resourceId is falsy downstream (prepare-memory-step skips
+    // memory entirely), so injecting a thread here would turn a previously
+    // succeeding memory-less run into a per-item failure.
+    expect(summary.failedCount).toBe(0);
+    expect(summary.succeededCount).toBe(ITEM_INPUTS.length);
+
+    for (const call of generateSpy.mock.calls) {
+      const options = (call as unknown[])[1];
+      expect(options).not.toHaveProperty('memory');
+    }
+
+    const { threads } = await memory.listThreads({ filter: {} });
+    expect(threads).toHaveLength(0);
   });
 
   it('SC3: explicit threadId in context wins — no per-item injection, all items share the supplied thread', async () => {

--- a/packages/core/src/datasets/__tests__/experiment-memory.test.ts
+++ b/packages/core/src/datasets/__tests__/experiment-memory.test.ts
@@ -76,7 +76,7 @@ function createMemoryAgent(model: MockLanguageModelV1 | MockLanguageModelV2) {
   return { agent, memory };
 }
 
-async function setupDataset(agent: Agent) {
+async function setupDataset(agent: Agent, inputs: string[] = ITEM_INPUTS) {
   const db = new InMemoryDB();
   const datasetsStorage = new DatasetsInMemory({ db });
   const experimentsStorage = new ExperimentsInMemory({ db });
@@ -108,11 +108,13 @@ async function setupDataset(agent: Agent) {
   } as unknown as Mastra;
 
   const record = await datasetsStorage.createDataset({ name: 'Experiment Memory DS' });
-  for (const input of ITEM_INPUTS) {
-    await datasetsStorage.addItem({ datasetId: record.id, input });
+  const itemIds: string[] = [];
+  for (const input of inputs) {
+    const item = await datasetsStorage.addItem({ datasetId: record.id, input });
+    itemIds.push(item.id);
   }
 
-  return new Dataset(record.id, mastra);
+  return { ds: new Dataset(record.id, mastra), itemIds };
 }
 
 async function listThreadsForResource(memory: MockMemory, resourceId: string) {
@@ -124,7 +126,7 @@ describe('experiment executor memory-thread injection (#20663)', () => {
   it('SC1: memory-enabled agent + lone resourceId succeeds with a distinct thread per item', async () => {
     const { agent, memory } = createMemoryAgent(createV2Model());
     const generateSpy = vi.spyOn(agent, 'generate');
-    const ds = await setupDataset(agent);
+    const { ds, itemIds } = await setupDataset(agent);
 
     const summary = await ds.startExperiment({
       targetType: 'agent',
@@ -140,14 +142,22 @@ describe('experiment executor memory-thread injection (#20663)', () => {
     expect(new Set(threads.map(t => t.id)).size).toBe(ITEM_INPUTS.length);
     for (const thread of threads) {
       expect(thread.resourceId).toBe('user-1');
-      // Injected threads are tagged with the experiment id for traceability.
-      expect(thread.metadata).toMatchObject({ experimentId: expect.any(String) });
+      // Injected threads are tagged with the experiment id and item id so a large
+      // run's threads map back to their items without matching transcripts.
+      expect(thread.metadata).toMatchObject({
+        experimentId: expect.any(String),
+        experimentItemId: expect.any(String),
+      });
       // The transcript must actually be persisted — an injected memory option that
       // disables lastMessages would suppress the MessageHistory output processor
       // and leave every one of these threads empty.
       const recalled = await memory.recall({ threadId: thread.id, resourceId: 'user-1' });
       expect(recalled.messages.length).toBeGreaterThan(0);
     }
+
+    // The tagged item ids must be exactly the dataset's item ids — one thread per item.
+    const taggedItemIds = threads.map(t => (t.metadata as Record<string, unknown>).experimentItemId);
+    expect(new Set(taggedItemIds)).toEqual(new Set(itemIds));
 
     // Contract check the mock cannot surface: title generation must be suppressed
     // (MockMemory never titles threads, so only the passed option proves this),
@@ -162,7 +172,7 @@ describe('experiment executor memory-thread injection (#20663)', () => {
 
   it('SC1 (legacy): memory-enabled v1-model agent + lone resourceId succeeds with a distinct thread per item', async () => {
     const { agent, memory } = createMemoryAgent(createV1Model());
-    const ds = await setupDataset(agent);
+    const { ds } = await setupDataset(agent);
 
     const summary = await ds.startExperiment({
       targetType: 'agent',
@@ -178,13 +188,16 @@ describe('experiment executor memory-thread injection (#20663)', () => {
     expect(new Set(threads.map(t => t.id)).size).toBe(ITEM_INPUTS.length);
     for (const thread of threads) {
       expect(thread.resourceId).toBe('user-legacy');
-      expect(thread.metadata).toMatchObject({ experimentId: expect.any(String) });
+      expect(thread.metadata).toMatchObject({
+        experimentId: expect.any(String),
+        experimentItemId: expect.any(String),
+      });
     }
   });
 
   it('SC2a: no resourceId in context — run succeeds memory-less, no threads created', async () => {
     const { agent, memory } = createMemoryAgent(createV2Model());
-    const ds = await setupDataset(agent);
+    const { ds } = await setupDataset(agent);
 
     const summary = await ds.startExperiment({
       targetType: 'agent',
@@ -206,7 +219,7 @@ describe('experiment executor memory-thread injection (#20663)', () => {
       model: createV2Model(),
     });
     const generateSpy = vi.spyOn(agent, 'generate');
-    const ds = await setupDataset(agent);
+    const { ds } = await setupDataset(agent);
 
     const summary = await ds.startExperiment({
       targetType: 'agent',
@@ -230,7 +243,7 @@ describe('experiment executor memory-thread injection (#20663)', () => {
   it('SC2c: empty-string resourceId — no injection, run stays memory-less as before the fix', async () => {
     const { agent, memory } = createMemoryAgent(createV2Model());
     const generateSpy = vi.spyOn(agent, 'generate');
-    const ds = await setupDataset(agent);
+    const { ds } = await setupDataset(agent);
 
     const summary = await ds.startExperiment({
       targetType: 'agent',
@@ -255,7 +268,7 @@ describe('experiment executor memory-thread injection (#20663)', () => {
 
   it('SC3: explicit threadId in context wins — no per-item injection, all items share the supplied thread', async () => {
     const { agent, memory } = createMemoryAgent(createV2Model());
-    const ds = await setupDataset(agent);
+    const { ds } = await setupDataset(agent);
 
     const summary = await ds.startExperiment({
       targetType: 'agent',
@@ -272,5 +285,54 @@ describe('experiment executor memory-thread injection (#20663)', () => {
     const threads = await listThreadsForResource(memory, 'user-3');
     expect(threads).toHaveLength(1);
     expect(threads[0]?.id).toBe('caller-supplied-thread');
+  });
+
+  it('SC4: each retry attempt gets a fresh injected thread (same item id, distinct thread ids)', async () => {
+    // Fail the first generate call, succeed on the retry — retries re-enter
+    // executeAgent, so each attempt must mint its own thread rather than
+    // appending the retry transcript to the failed attempt's thread.
+    let calls = 0;
+    const model = new MockLanguageModelV2({
+      doGenerate: async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('transient model failure');
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text' as const, text: 'Dummy response' }],
+          warnings: [],
+        };
+      },
+    });
+    const { agent } = createMemoryAgent(model);
+    const generateSpy = vi.spyOn(agent, 'generate');
+    const { ds, itemIds } = await setupDataset(agent, ['Only item']);
+
+    const summary = await ds.startExperiment({
+      targetType: 'agent',
+      targetId: 'memory-agent',
+      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'user-retry' },
+      maxRetries: 1,
+    });
+
+    expect(summary.failedCount).toBe(0);
+    expect(summary.succeededCount).toBe(1);
+    expect(generateSpy).toHaveBeenCalledTimes(2);
+
+    // Contract check on the passed options (thread persistence timing for the
+    // failed attempt is an implementation detail of the memory pipeline).
+    const passedThreads = generateSpy.mock.calls.map(call => {
+      const options = (call as unknown[])[1] as {
+        memory?: { thread?: { id?: string; metadata?: Record<string, unknown> } };
+      };
+      return options?.memory?.thread;
+    });
+    expect(passedThreads[0]?.id).toBeDefined();
+    expect(passedThreads[1]?.id).toBeDefined();
+    expect(passedThreads[0]?.id).not.toBe(passedThreads[1]?.id);
+    // Both attempts stay traceable to the same item.
+    expect(passedThreads[0]?.metadata?.experimentItemId).toBe(itemIds[0]);
+    expect(passedThreads[1]?.metadata?.experimentItemId).toBe(itemIds[0]);
   });
 });

--- a/packages/core/src/datasets/__tests__/experiment-memory.test.ts
+++ b/packages/core/src/datasets/__tests__/experiment-memory.test.ts
@@ -142,14 +142,21 @@ describe('experiment executor memory-thread injection (#20663)', () => {
       expect(thread.resourceId).toBe('user-1');
       // Injected threads are tagged with the experiment id for traceability.
       expect(thread.metadata).toMatchObject({ experimentId: expect.any(String) });
+      // The transcript must actually be persisted — an injected memory option that
+      // disables lastMessages would suppress the MessageHistory output processor
+      // and leave every one of these threads empty.
+      const recalled = await memory.recall({ threadId: thread.id, resourceId: 'user-1' });
+      expect(recalled.messages.length).toBeGreaterThan(0);
     }
 
-    // Contract check the mock cannot surface: injected threads are ephemeral
-    // bookkeeping, so title generation and history recall must be suppressed
-    // (MockMemory never titles threads, so only the passed option proves this).
+    // Contract check the mock cannot surface: title generation must be suppressed
+    // (MockMemory never titles threads, so only the passed option proves this),
+    // while lastMessages must stay enabled — it gates the MessageHistory output
+    // processor, and disabling it would persist every injected thread empty.
     for (const call of generateSpy.mock.calls) {
       const options = (call as unknown[])[1] as { memory?: { options?: Record<string, unknown> } };
-      expect(options?.memory?.options).toMatchObject({ generateTitle: false, lastMessages: false });
+      expect(options?.memory?.options).toMatchObject({ generateTitle: false });
+      expect(options?.memory?.options).not.toHaveProperty('lastMessages');
     }
   });
 
@@ -169,6 +176,10 @@ describe('experiment executor memory-thread injection (#20663)', () => {
     const threads = await listThreadsForResource(memory, 'user-legacy');
     expect(threads).toHaveLength(ITEM_INPUTS.length);
     expect(new Set(threads.map(t => t.id)).size).toBe(ITEM_INPUTS.length);
+    for (const thread of threads) {
+      expect(thread.resourceId).toBe('user-legacy');
+      expect(thread.metadata).toMatchObject({ experimentId: expect.any(String) });
+    }
   });
 
   it('SC2a: no resourceId in context — run succeeds memory-less, no threads created', async () => {

--- a/packages/core/src/datasets/experiment/executor.ts
+++ b/packages/core/src/datasets/experiment/executor.ts
@@ -243,13 +243,32 @@ async function executeAgent(
   // auth middleware or the Studio "Run Experiment" field) but no threadId would throw
   // AGENT_MEMORY_MISSING_RESOURCE_ID downstream — the runner owns no conversation, so
   // it injects a fresh thread per item, mirroring the multi-turn evals precedent
-  // (runAgentTurns). An explicit MASTRA_THREAD_ID_KEY wins via requestContext
-  // precedence, so no injection happens then; memory-less agents are left untouched.
+  // (runAgentTurns). When an explicit MASTRA_THREAD_ID_KEY is present we decline to
+  // inject and let the context key resolve downstream; memory-less agents are left
+  // untouched. Truthiness (not null-ness) checks match the downstream `||` resolution
+  // in prepare-memory-step: an empty-string resourceId skipped memory before this fix
+  // and must keep doing so.
   const contextResourceId = requestContext?.[MASTRA_RESOURCE_ID_KEY];
   const shouldInjectThread =
-    contextResourceId != null && requestContext?.[MASTRA_THREAD_ID_KEY] == null && agent.hasOwnMemory();
+    Boolean(contextResourceId) &&
+    !requestContext?.[MASTRA_THREAD_ID_KEY] &&
+    typeof agent.hasOwnMemory === 'function' &&
+    agent.hasOwnMemory();
   const memoryOption = shouldInjectThread
-    ? { memory: { thread: randomUUID(), resource: String(contextResourceId) } }
+    ? {
+        memory: {
+          thread: {
+            id: randomUUID(),
+            ...(experimentId ? { metadata: { experimentId } } : {}),
+          },
+          resource: String(contextResourceId),
+          // The runner's threads are ephemeral bookkeeping, not user conversations:
+          // suppress title generation to avoid an extra LLM call per item (and per
+          // retry), and skip history recall — each thread is brand new anyway.
+          // Mirrors the ephemeral subagent-delegation precedent (issue #18738).
+          options: { lastMessages: false as const, generateTitle: false },
+        },
+      }
     : undefined;
 
   // Build a fresh matcher per item run so ordered consumption is deterministic and
@@ -277,7 +296,7 @@ async function executeAgent(
           scorers: {},
           returnScorerData: true,
           abortSignal: generateSignal,
-          ...(memoryOption ?? {}),
+          ...memoryOption,
           ...(reqCtx ? { requestContext: reqCtx } : {}),
           ...(tracingOptions ? { tracingOptions } : {}),
           ...(versions ? { versions } : {}),
@@ -288,7 +307,7 @@ async function executeAgent(
           scorers: {},
           returnScorerData: true,
           abortSignal: generateSignal,
-          ...(memoryOption ?? {}),
+          ...memoryOption,
           ...(reqCtx ? { requestContext: reqCtx } : {}),
           ...(tracingOptions ? { tracingOptions } : {}),
           ...(mockHooks ? { hooks: mockHooks } : {}),

--- a/packages/core/src/datasets/experiment/executor.ts
+++ b/packages/core/src/datasets/experiment/executor.ts
@@ -114,6 +114,7 @@ export async function executeTarget(
   target: Target,
   targetType: TargetType,
   item: {
+    id?: string;
     input: unknown;
     groundTruth?: unknown;
     metadata?: Record<string, unknown>;
@@ -218,7 +219,7 @@ function raceWithSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T>
  */
 async function executeAgent(
   agent: Agent,
-  item: { input: unknown; groundTruth?: unknown },
+  item: { id?: string; input: unknown; groundTruth?: unknown },
   signal?: AbortSignal,
   requestContext?: Record<string, unknown>,
   experimentId?: string,
@@ -259,7 +260,16 @@ async function executeAgent(
         memory: {
           thread: {
             id: randomUUID(),
-            ...(experimentId ? { metadata: { experimentId } } : {}),
+            // Tag experimentId (and the item id when known) so a large run's threads
+            // map back to their items without matching transcripts.
+            ...(experimentId || item.id
+              ? {
+                  metadata: {
+                    ...(experimentId ? { experimentId } : {}),
+                    ...(item.id ? { experimentItemId: item.id } : {}),
+                  },
+                }
+              : {}),
           },
           resource: String(contextResourceId),
           // Suppress title generation: these threads are runner bookkeeping, so an

--- a/packages/core/src/datasets/experiment/executor.ts
+++ b/packages/core/src/datasets/experiment/executor.ts
@@ -262,11 +262,12 @@ async function executeAgent(
             ...(experimentId ? { metadata: { experimentId } } : {}),
           },
           resource: String(contextResourceId),
-          // The runner's threads are ephemeral bookkeeping, not user conversations:
-          // suppress title generation to avoid an extra LLM call per item (and per
-          // retry), and skip history recall — each thread is brand new anyway.
-          // Mirrors the ephemeral subagent-delegation precedent (issue #18738).
-          options: { lastMessages: false as const, generateTitle: false },
+          // Suppress title generation: these threads are runner bookkeeping, so an
+          // extra title LLM call per item (and per retry) is pure waste (precedent:
+          // ephemeral subagent-delegation threads, issue #18738). lastMessages is
+          // deliberately NOT disabled — it also gates the MessageHistory output
+          // processor, and disabling it would persist every injected thread empty.
+          options: { generateTitle: false },
         },
       }
     : undefined;

--- a/packages/core/src/datasets/experiment/executor.ts
+++ b/packages/core/src/datasets/experiment/executor.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { Agent } from '../../agent';
 import { isSupportedLanguageModel } from '../../agent';
 import type { MessageListInput } from '../../agent/message-list';
@@ -6,7 +7,7 @@ import type { ScorerRunInputForAgent, ScorerRunOutputForAgent } from '../../eval
 import type { ScoringData } from '../../llm/model/base.types';
 import type { VersionOverrides } from '../../mastra/types';
 import { resolveObservabilityContext } from '../../observability';
-import { RequestContext } from '../../request-context';
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY, RequestContext } from '../../request-context';
 import type { TargetType } from '../../storage/types';
 import type { ToolHooks } from '../../tools/types';
 import type { StepResult, Workflow } from '../../workflows';
@@ -238,6 +239,19 @@ async function executeAgent(
   // Pass experimentId as tracing metadata so it appears on the AGENT_RUN span
   const tracingOptions = experimentId ? { metadata: { experimentId } } : undefined;
 
+  // A memory-enabled agent given a resourceId (e.g. via MASTRA_RESOURCE_ID_KEY set by
+  // auth middleware or the Studio "Run Experiment" field) but no threadId would throw
+  // AGENT_MEMORY_MISSING_RESOURCE_ID downstream — the runner owns no conversation, so
+  // it injects a fresh thread per item, mirroring the multi-turn evals precedent
+  // (runAgentTurns). An explicit MASTRA_THREAD_ID_KEY wins via requestContext
+  // precedence, so no injection happens then; memory-less agents are left untouched.
+  const contextResourceId = requestContext?.[MASTRA_RESOURCE_ID_KEY];
+  const shouldInjectThread =
+    contextResourceId != null && requestContext?.[MASTRA_THREAD_ID_KEY] == null && agent.hasOwnMemory();
+  const memoryOption = shouldInjectThread
+    ? { memory: { thread: randomUUID(), resource: String(contextResourceId) } }
+    : undefined;
+
   // Build a fresh matcher per item run so ordered consumption is deterministic and
   // not leaked across retries. Compose with the agent's configured hooks.
   const matcher = new ToolMockMatcher(toolMocks, unmockedToolPolicy);
@@ -263,6 +277,7 @@ async function executeAgent(
           scorers: {},
           returnScorerData: true,
           abortSignal: generateSignal,
+          ...(memoryOption ?? {}),
           ...(reqCtx ? { requestContext: reqCtx } : {}),
           ...(tracingOptions ? { tracingOptions } : {}),
           ...(versions ? { versions } : {}),
@@ -273,6 +288,7 @@ async function executeAgent(
           scorers: {},
           returnScorerData: true,
           abortSignal: generateSignal,
+          ...(memoryOption ?? {}),
           ...(reqCtx ? { requestContext: reqCtx } : {}),
           ...(tracingOptions ? { tracingOptions } : {}),
           ...(mockHooks ? { hooks: mockHooks } : {}),


### PR DESCRIPTION
## Summary

Closes #20663

Running a dataset experiment against an agent that has memory configured fails on every item when the request context carries a resource id but no thread id. That combination is the normal case, not the edge case: auth middleware and Studio both stamp the resource id onto the request context, and nothing on the experiment path ever supplies a thread. Each item then dies in the agent's memory preparation step with the "A resourceId and a threadId must be provided when using Memory" error from the issue.

This PR makes the experiment executor mint a fresh memory thread per item when it detects that situation, so memory-enabled agents can be exercised by experiments without the caller having to know about thread plumbing. Explicitly supplied thread ids are respected untouched.

## Root cause

`executeAgent` in `packages/core/src/datasets/experiment/executor.ts` forwards the merged request context to `agent.generate` but never forwards a `memory` option. The agent's prepare-memory step only skips memory when both the thread id and the resource id are absent, so a lone `mastra__resourceId` gets past that gate and then fails validation because there is no thread. The reporter hit this from Studio, whose server handler forwards the live request context with reserved keys included.

The evals runner solved the same problem by generating a thread id per item in `runAgentTurns`. The experiment path never got the equivalent.

## What changed

- **The executor injects `memory: { thread: randomUUID(), resource }`** when the merged request context carries a truthy resource id, no truthy thread id, and the target agent reports its own memory via `hasOwnMemory()`. Both the `generate` and `generateLegacy` branches receive the option.
- **Each item gets its own thread.** No cross-item conversation bleed, and results cannot depend on item ordering through shared message history.
- **Injected threads are tagged and quiet.** The thread carries `metadata: { experimentId }` for findability, and `generateTitle: false` avoids paying a title generation model call per item. Message history stays enabled so the transcript persists on the thread.
- **Falsy reserved keys are treated as absent.** An empty string resource id keeps the previous memory-less behavior instead of newly throwing, and values like `0` are not coerced into memory identities.
- **Nothing else changes.** Memory-less agents, contexts with no resource id, and contexts with an explicit thread id all behave exactly as before, and the reserved context keys keep their precedence.

## Design notes

- The evals runner's no-thread stance for scorer-only paths (per #18395) reads as deliberate maintainer intent and is untouched here.
- Retries mint a fresh thread per attempt, matching `runAgentTurns`. A retried item starts clean rather than replaying the failed attempt's history.
- Per-item threads isolate thread-scoped memory only. Resource-scoped working memory and semantic recall still key off the caller's resource id, so an experiment run against a real user's resource can read and write that user's resource-scoped state. Previously this path threw before touching anything. That exposure is worth a maintainer opinion and possibly a follow-up issue.
- Injected threads persist to the configured memory store, so a run adds one thread per item. The experiment id metadata makes them identifiable.

## Test plan

- New regression suite `experiment-memory.test.ts` built on a real `Agent`, `MockMemory`, and a real `Dataset.startExperiment` (the existing experiment tests use a mocked agent, which is why this was never caught). It covers: a distinct thread per item with the transcript persisted, the same behavior through the legacy generate branch, no injection without a resource id, no injection for memory-less agents (asserted with a spy on the generate call), an empty string resource id staying memory-less, and an explicit thread id winning over injection.
- Recorded red run: with the executor change stashed, the per-item thread tests fail on base with the exact error from the issue.
- Every new assertion was mutation checked by reverting the specific code it pins and confirming exactly that test fails.
- Full datasets suite (114 tests) and evals suite (95 tests) green, `tsc --noEmit` clean.
- A standalone red/green demo against built artifacts fails on base `233a6ca01a` with the reported error and passes on this branch with two distinct per-item threads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an experiment has a resource ID but no thread ID, each item now gets its own memory thread. This prevents failures and keeps item conversations separate.

## Changes

- Create a fresh memory thread when the agent has memory, the request has a truthy resource ID, and no truthy thread ID exists.
- Add `experimentId` and `experimentItemId` to injected thread metadata.
- Disable automatic title generation for injected threads.
- Preserve message history and persisted transcripts.
- Create a fresh thread for each retry attempt.
- Apply the behavior to both `generate` and `generateLegacy`.
- Keep explicit thread IDs unchanged.
- Preserve previous behavior for memory-less agents and missing or falsy resource IDs.
- Document resource-scoped working memory and semantic recall behavior.
- Add a patch changeset for `@mastra/core`.

## Tests

- Added regression tests for per-item thread isolation.
- Covered both generation paths and v1/v2 language models.
- Verified transcript persistence, metadata, title suppression, and `lastMessages`.
- Verified retry isolation and stable `experimentItemId` metadata.
- Verified explicit thread precedence and unsupported memory conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->