### PR TITLE
feat(ai-sdk): add optional chat route heartbeats

### DIFF
--- a/.changeset/common-teams-share.md
+++ b/.changeset/common-teams-share.md
@@ -1,0 +1,12 @@
+---
+'@mastra/ai-sdk': minor
+---
+
+Added optional SSE heartbeats to `chatRoute()` so streams can remain active through infrastructure with idle timeouts.
+
+```typescript
+chatRoute({
+  path: '/chat/:agentId',
+  heartbeatMs: 15_000,
+});
+```

--- a/.changeset/quick-teams-sniff.md
+++ b/.changeset/quick-teams-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/express': patch
+---
+
+Added integration coverage for AI SDK chat route heartbeats through the Express adapter.

--- a/.changeset/quick-teams-sniff.md
+++ b/.changeset/quick-teams-sniff.md
@@ -1,5 +1,0 @@
----
-'@mastra/express': patch
----
-
-Added integration coverage for AI SDK chat route heartbeats through the Express adapter.

--- a/client-sdks/ai-sdk/src/__tests__/chat-route-heartbeat.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/chat-route-heartbeat.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { chatRoute } from '../chat-route';
+import { withSseHeartbeat } from '../sse-heartbeat';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function createControlledResponse(init?: ResponseInit) {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const cancel = vi.fn();
+  const stream = new ReadableStream<Uint8Array>({
+    start(streamController) {
+      controller = streamController;
+    },
+    cancel,
+  });
+
+  return {
+    cancel,
+    controller,
+    response: new Response(stream, init),
+  };
+}
+
+function createRouteContext(fullStream: ReadableStream) {
+  const agent = {
+    stream: vi.fn().mockResolvedValue({ fullStream }),
+  };
+  const mastra = {
+    getAgentById: vi.fn().mockReturnValue(agent),
+  };
+  const body = {
+    messages: [{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+  };
+  const request = new Request('http://localhost/chat/test-agent', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  return {
+    mastra,
+    context: {
+      req: {
+        raw: request,
+        json: () => Promise.resolve(body),
+        param: (name: string) => (name === 'agentId' ? 'test-agent' : undefined),
+        query: () => undefined,
+      },
+      get: (key: string) => (key === 'mastra' ? mastra : undefined),
+    },
+  };
+}
+
+async function invokeRoute(
+  route: ReturnType<typeof chatRoute>,
+  context: ReturnType<typeof createRouteContext>['context'],
+): Promise<Response> {
+  if (!('handler' in route)) throw new Error('Expected chatRoute to return a route handler');
+  // The route only reads the context members supplied by createRouteContext.
+  const response = await route.handler(context as never, async () => {});
+  if (!(response instanceof Response)) throw new Error('Expected chatRoute handler to return a Response');
+  return response;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('withSseHeartbeat', () => {
+  it.each([undefined, 0, -1, Number.NEGATIVE_INFINITY])(
+    'returns the original response when heartbeatMs is %s',
+    heartbeatMs => {
+      const response = new Response('data: value\n\n');
+      expect(withSseHeartbeat(response, heartbeatMs)).toBe(response);
+    },
+  );
+
+  it('returns the original response when it has no body', () => {
+    const response = new Response(null);
+    expect(withSseHeartbeat(response, 1_000)).toBe(response);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648])(
+    'rejects unsupported heartbeatMs value %s',
+    heartbeatMs => {
+      const response = new Response('data: value\n\n');
+      expect(() => withSseHeartbeat(response, heartbeatMs)).toThrow(RangeError);
+    },
+  );
+
+  it('preserves response metadata and source bytes around periodic heartbeats', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { controller, response } = createControlledResponse({
+      status: 202,
+      statusText: 'Accepted',
+      headers: { 'x-test': 'preserved' },
+    });
+    const wrapped = withSseHeartbeat(response, 1_000);
+    const reader = wrapped.body!.getReader();
+
+    expect(wrapped.status).toBe(202);
+    expect(wrapped.statusText).toBe('Accepted');
+    expect(wrapped.headers.get('x-test')).toBe('preserved');
+
+    controller.enqueue(encoder.encode('data: one\n\n'));
+    expect(decoder.decode((await reader.read()).value)).toBe('data: one\n\n');
+
+    const heartbeat = reader.read();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(decoder.decode((await heartbeat).value)).toBe(': heartbeat\n\n');
+
+    controller.enqueue(encoder.encode('data: two\n\n'));
+    expect(decoder.decode((await reader.read()).value)).toBe('data: two\n\n');
+
+    await reader.cancel();
+  });
+
+  it('does not reset the heartbeat deadline when source data arrives', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { controller, response } = createControlledResponse();
+    const reader = withSseHeartbeat(response, 1_000).body!.getReader();
+
+    await vi.advanceTimersByTimeAsync(500);
+    controller.enqueue(encoder.encode('data: active\n\n'));
+    expect(decoder.decode((await reader.read()).value)).toBe('data: active\n\n');
+
+    const heartbeat = reader.read();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(decoder.decode((await heartbeat).value)).toBe(': heartbeat\n\n');
+
+    await reader.cancel();
+  });
+
+  it('retains a pending source read across multiple heartbeats', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { controller, response } = createControlledResponse();
+    const reader = withSseHeartbeat(response, 1_000).body!.getReader();
+
+    const firstHeartbeat = reader.read();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(decoder.decode((await firstHeartbeat).value)).toBe(': heartbeat\n\n');
+
+    const secondHeartbeat = reader.read();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(decoder.decode((await secondHeartbeat).value)).toBe(': heartbeat\n\n');
+
+    controller.enqueue(encoder.encode('data: retained\n\n'));
+    expect(decoder.decode((await reader.read()).value)).toBe('data: retained\n\n');
+
+    await reader.cancel();
+  });
+
+  it('waits for an SSE frame boundary before inserting an overdue heartbeat', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { controller, response } = createControlledResponse();
+    const reader = withSseHeartbeat(response, 1_000).body!.getReader();
+
+    controller.enqueue(encoder.encode('data: {"partial"'));
+    expect(decoder.decode((await reader.read()).value)).toBe('data: {"partial"');
+
+    let settled = false;
+    const frameEnd = reader.read().then(result => {
+      settled = true;
+      return result;
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(settled).toBe(false);
+
+    controller.enqueue(encoder.encode(':true}\n\n'));
+    expect(decoder.decode((await frameEnd).value)).toBe(':true}\n\n');
+
+    const overdueHeartbeat = reader.read();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(decoder.decode((await overdueHeartbeat).value)).toBe(': heartbeat\n\n');
+
+    await reader.cancel();
+  });
+
+  it('recognizes a frame boundary completed by a one-byte newline chunk', async () => {
+    vi.useFakeTimers();
+    const { controller, response } = createControlledResponse();
+    const reader = withSseHeartbeat(response, 1_000).body!.getReader();
+
+    controller.enqueue(encoder.encode('data: complete\n'));
+    expect(decoder.decode((await reader.read()).value)).toBe('data: complete\n');
+
+    const boundary = reader.read();
+    await vi.advanceTimersByTimeAsync(1_000);
+    controller.enqueue(encoder.encode('\n'));
+    expect(decoder.decode((await boundary).value)).toBe('\n');
+
+    const heartbeat = reader.read();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(decoder.decode((await heartbeat).value)).toBe(': heartbeat\n\n');
+
+    await reader.cancel();
+  });
+
+  it('clears its timer after normal completion', async () => {
+    vi.useFakeTimers();
+    const { controller, response } = createControlledResponse();
+    const wrapped = withSseHeartbeat(response, 1_000);
+
+    controller.close();
+    await expect(wrapped.text()).resolves.toBe('');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('prioritizes source data buffered at the heartbeat deadline', async () => {
+    vi.useFakeTimers();
+    const { controller, response } = createControlledResponse();
+    const sendSource = setTimeout(() => controller.enqueue(encoder.encode('data: ready\n\n')), 1_000);
+    const reader = withSseHeartbeat(response, 1_000).body!.getReader();
+    const read = reader.read();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(decoder.decode((await read).value)).toBe('data: ready\n\n');
+    clearTimeout(sendSource);
+    await reader.cancel();
+  });
+
+  it('prioritizes source completion at the heartbeat deadline', async () => {
+    vi.useFakeTimers();
+    const { controller, response } = createControlledResponse();
+    const wrapped = withSseHeartbeat(response, 1_000);
+    const closeSource = setTimeout(() => controller.close(), 1_000);
+    const read = wrapped.body!.getReader().read();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(read).resolves.toEqual({ done: true, value: undefined });
+    expect(vi.getTimerCount()).toBe(0);
+    clearTimeout(closeSource);
+  });
+
+  it('clears its timer and propagates source errors', async () => {
+    vi.useFakeTimers();
+    const { controller, response } = createControlledResponse();
+    const reader = withSseHeartbeat(response, 1_000).body!.getReader();
+    const error = new Error('source failed');
+
+    const read = reader.read();
+    controller.error(error);
+
+    await expect(read).rejects.toBe(error);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('prioritizes source errors at the heartbeat deadline', async () => {
+    vi.useFakeTimers();
+    const { controller, response } = createControlledResponse();
+    const error = new Error('source failed');
+    const failSource = setTimeout(() => controller.error(error), 1_000);
+    const read = withSseHeartbeat(response, 1_000).body!.getReader().read();
+    const rejection = expect(read).rejects.toBe(error);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await rejection;
+    expect(vi.getTimerCount()).toBe(0);
+    clearTimeout(failSource);
+  });
+
+  it('cancels the source and clears its timer when the consumer disconnects', async () => {
+    vi.useFakeTimers();
+    const { cancel, response } = createControlledResponse();
+    const reader = withSseHeartbeat(response, 1_000).body!.getReader();
+
+    const pendingRead = reader.read();
+    await reader.cancel('consumer disconnected');
+
+    await expect(pendingRead).resolves.toEqual({ done: true, value: undefined });
+    expect(cancel).toHaveBeenCalledWith('consumer disconnected');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe('chatRoute heartbeat', () => {
+  it('accepts the maximum supported heartbeatMs value', () => {
+    expect(() => chatRoute({ path: '/chat/:agentId', heartbeatMs: 2_147_483_647 })).not.toThrow();
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648])(
+    'throws a RangeError at route creation for unsupported heartbeatMs value %s',
+    heartbeatMs => {
+      expect(() => chatRoute({ path: '/chat/:agentId', heartbeatMs })).toThrow(RangeError);
+    },
+  );
+
+  it.each(['v5', 'v6'] as const)('interleaves heartbeat comments with AI SDK %s events', async version => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let streamController!: ReadableStreamDefaultController;
+    const fullStream = new ReadableStream({
+      start(controller) {
+        streamController = controller;
+      },
+    });
+    const { context } = createRouteContext(fullStream);
+    const route = chatRoute({
+      path: '/chat/:agentId',
+      version,
+      heartbeatMs: 1_000,
+    });
+
+    const response = await invokeRoute(route, context);
+    const reader = response.body!.getReader();
+
+    streamController.enqueue({
+      type: 'start',
+      runId: 'run-1',
+      from: 'AGENT',
+      payload: { messageId: 'assistant-1' },
+    });
+    streamController.enqueue({
+      type: 'text-start',
+      runId: 'run-1',
+      from: 'AGENT',
+      payload: { id: 'text-1' },
+    });
+    const startEvent = decoder.decode((await reader.read()).value);
+    const textStartEvent = decoder.decode((await reader.read()).value);
+    expect(JSON.parse(startEvent.slice('data: '.length))).toMatchObject({ type: 'start' });
+    expect(JSON.parse(textStartEvent.slice('data: '.length))).toEqual({ type: 'text-start', id: 'text-1' });
+
+    const heartbeat = reader.read();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(decoder.decode((await heartbeat).value)).toBe(': heartbeat\n\n');
+
+    await reader.cancel();
+    streamController.close();
+  });
+
+  it.each(['v5', 'v6'] as const)(
+    'does not emit heartbeats for AI SDK %s when heartbeatMs is omitted',
+    async version => {
+      vi.useFakeTimers();
+      let streamController!: ReadableStreamDefaultController;
+      const fullStream = new ReadableStream({
+        start(controller) {
+          streamController = controller;
+        },
+      });
+      const { context } = createRouteContext(fullStream);
+      const route = chatRoute({ path: '/chat/:agentId', version });
+
+      const response = await invokeRoute(route, context);
+      const reader = response.body!.getReader();
+      let settled = false;
+      const pendingRead = reader.read().then((result: { done: boolean; value?: Uint8Array }) => {
+        settled = true;
+        return result;
+      });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(settled).toBe(false);
+
+      await reader.cancel();
+      await expect(pendingRead).resolves.toEqual({ done: true, value: undefined });
+      streamController.close();
+    },
+  );
+});

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -23,6 +23,7 @@ import type {
   V6UIMessageStream,
 } from './public-types';
 import type { MastraStreamTransformOptions } from './smooth-stream';
+import { assertValidHeartbeatMs, withSseHeartbeat } from './sse-heartbeat';
 
 export interface V6NativeApprovalResponse {
   resumeData: Record<string, unknown>;
@@ -436,6 +437,8 @@ export type chatRouteOptions<OUTPUT = undefined> = {
     sendFinish?: boolean;
     sendReasoning?: boolean;
     sendSources?: boolean;
+    /** Target interval for periodic SSE comment heartbeats. Values up to 0 disable heartbeats. `NaN`, positive infinity, and values above 2,147,483,647 throw a `RangeError`. */
+    heartbeatMs?: number;
     onError?: (error: unknown) => string;
   };
 
@@ -452,11 +455,13 @@ export type chatRouteOptions<OUTPUT = undefined> = {
  * @param {boolean} [options.sendFinish=true] - Whether to send finish events in the stream
  * @param {boolean} [options.sendReasoning=false] - Whether to include reasoning steps in the stream
  * @param {boolean} [options.sendSources=false] - Whether to include source citations in the stream
+ * @param {number} [options.heartbeatMs] - Target interval for periodic SSE comment heartbeats. Already-buffered source events and stream lifecycle signals take priority. Values up to 0 disable heartbeats. `NaN`, positive infinity, and values above 2,147,483,647 throw a `RangeError`.
  * @param {(error: unknown) => string} [options.onError] - Custom error serializer streamed to the client. When omitted, errors are passed through a default serializer that strips sensitive fields (e.g. `APICallError.requestBodyValues`, which holds the system prompt) before they reach the client.
  *
  * @returns {ReturnType<typeof registerApiRoute>} A registered API route handler
  *
  * @throws {Error} When path doesn't include `:agentId` and no fixed agent is specified
+ * @throws {RangeError} When `heartbeatMs` is `NaN`, positive infinity, or greater than 2,147,483,647
  * @throws {Error} When agent ID is missing at runtime
  * @throws {Error} When specified agent is not found in Mastra instance
  *
@@ -479,7 +484,7 @@ export type chatRouteOptions<OUTPUT = undefined> = {
  * @remarks
  * - The route handler expects a JSON body with a `messages` array
  * - Messages should follow the format: `{ role: 'user' | 'assistant' | 'system', content: string }`
- * - The response is a Server-Sent Events (SSE) stream compatible with AI SDK v5
+ * - The response is a Server-Sent Events (SSE) stream compatible with the selected AI SDK version
  * - If both `agent` and `:agentId` are present, a warning is logged and the fixed `agent` takes precedence
  * - Request context from the incoming request overrides `defaultOptions.requestContext` if both are present
  */
@@ -494,11 +499,13 @@ export function chatRoute<OUTPUT = undefined>({
   sendFinish = true,
   sendReasoning = false,
   sendSources = false,
+  heartbeatMs,
   onError,
 }: chatRouteOptions<OUTPUT>): ReturnType<typeof registerApiRoute> {
   if (!agent && !path.includes('/:agentId')) {
     throw new Error('Path must include :agentId to route to the correct agent or pass the agent explicitly');
   }
+  assertValidHeartbeatMs(heartbeatMs);
 
   return registerApiRoute(path, {
     method: 'POST',
@@ -694,17 +701,19 @@ export function chatRoute<OUTPUT = undefined>({
         onError,
       };
 
+      let response: Response;
       if (version === 'v6') {
         const uiMessageStream = await handleChatStream({
           ...handlerOptions,
           version: 'v6',
         });
-
-        return createUIMessageStreamResponseV6({ stream: uiMessageStream });
+        response = createUIMessageStreamResponseV6({ stream: uiMessageStream });
+      } else {
+        const uiMessageStream = await handleChatStream(handlerOptions);
+        response = createUIMessageStreamResponseV5({ stream: uiMessageStream });
       }
 
-      const uiMessageStream = await handleChatStream(handlerOptions);
-      return createUIMessageStreamResponseV5({ stream: uiMessageStream });
+      return withSseHeartbeat(response, heartbeatMs);
     },
   });
 }

--- a/client-sdks/ai-sdk/src/sse-heartbeat.ts
+++ b/client-sdks/ai-sdk/src/sse-heartbeat.ts
@@ -1,0 +1,159 @@
+const SSE_HEARTBEAT_BYTES = new TextEncoder().encode(': heartbeat\n\n');
+const LF_BYTE = 10;
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+type StreamReadResult<T> = { done: false; value: T } | { done: true; value?: undefined };
+type WakeReason = 'read' | 'heartbeat';
+
+/** Throws when an enabled heartbeat interval cannot be scheduled with a timer. */
+export function assertValidHeartbeatMs(heartbeatMs?: number): void {
+  if (
+    heartbeatMs !== undefined &&
+    !(heartbeatMs <= 0) &&
+    (!Number.isFinite(heartbeatMs) || heartbeatMs > MAX_TIMEOUT_MS)
+  ) {
+    throw new RangeError(`heartbeatMs must be a finite number no greater than ${MAX_TIMEOUT_MS}`);
+  }
+}
+
+/**
+ * Adds periodic SSE comment heartbeats to an AI SDK response body.
+ * AI SDK serialization uses LF-delimited frames, which this private wrapper preserves and relies on.
+ */
+export function withSseHeartbeat(response: Response, heartbeatMs?: number): Response {
+  assertValidHeartbeatMs(heartbeatMs);
+  if (heartbeatMs === undefined || heartbeatMs <= 0 || !response.body) {
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  let heartbeatTimeout: ReturnType<typeof setTimeout> | undefined;
+  let wakePull: ((reason: WakeReason) => void) | undefined;
+  let readResult: StreamReadResult<Uint8Array> | undefined;
+  let readError: unknown;
+  let hasReadError = false;
+  let reading = false;
+  let finished = false;
+  let readerReleased = false;
+  let atFrameBoundary = true;
+  let lastByte: number | undefined;
+  let nextHeartbeatAt = performance.now() + heartbeatMs;
+
+  const clearHeartbeat = () => {
+    if (heartbeatTimeout !== undefined) {
+      clearTimeout(heartbeatTimeout);
+      heartbeatTimeout = undefined;
+    }
+  };
+
+  const releaseReader = () => {
+    if (readerReleased) return;
+    readerReleased = true;
+    reader.releaseLock();
+  };
+
+  const updateFrameBoundary = (chunk: Uint8Array) => {
+    if (chunk.byteLength === 0) return;
+
+    atFrameBoundary =
+      chunk.byteLength === 1
+        ? lastByte === LF_BYTE && chunk[0] === LF_BYTE
+        : chunk[chunk.byteLength - 2] === LF_BYTE && chunk[chunk.byteLength - 1] === LF_BYTE;
+    lastByte = chunk[chunk.byteLength - 1];
+  };
+
+  const startRead = () => {
+    if (reading || readResult || hasReadError || finished) return;
+    reading = true;
+    void reader.read().then(
+      result => {
+        reading = false;
+        readResult = result;
+        wakePull?.('read');
+      },
+      error => {
+        reading = false;
+        readError = error;
+        hasReadError = true;
+        wakePull?.('read');
+      },
+    );
+  };
+
+  const forwardRead = (controller: ReadableStreamDefaultController<Uint8Array>) => {
+    if (hasReadError) {
+      finished = true;
+      releaseReader();
+      controller.error(readError);
+      return;
+    }
+    if (!readResult) return;
+
+    const result = readResult;
+    readResult = undefined;
+    if (result.done) {
+      finished = true;
+      releaseReader();
+      controller.close();
+      return;
+    }
+
+    updateFrameBoundary(result.value);
+    controller.enqueue(result.value);
+  };
+
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (finished) return;
+      startRead();
+
+      // Buffered source results always win over an overdue heartbeat, so completion, errors,
+      // and data are never delayed behind a comment.
+      if (readResult || hasReadError) {
+        forwardRead(controller);
+        return;
+      }
+
+      const next = await new Promise<WakeReason>(resolve => {
+        wakePull = resolve;
+        // Heartbeats can only be inserted between complete SSE frames. AI SDK serialization emits
+        // complete `data:` frames, so a split frame only pauses heartbeats until its remaining bytes arrive.
+        // A ready source read settles in a microtask and outruns an overdue (0 ms) heartbeat timer.
+        if (atFrameBoundary) {
+          heartbeatTimeout = setTimeout(() => resolve('heartbeat'), Math.max(0, nextHeartbeatAt - performance.now()));
+        }
+      });
+
+      wakePull = undefined;
+      clearHeartbeat();
+      if (finished) return;
+
+      // Prefer source completion, errors, and data if they became available at the heartbeat deadline.
+      if (readResult || hasReadError) {
+        forwardRead(controller);
+        return;
+      }
+
+      if (next === 'heartbeat') {
+        controller.enqueue(SSE_HEARTBEAT_BYTES.slice());
+        nextHeartbeatAt = performance.now() + heartbeatMs;
+      }
+    },
+    async cancel(reason) {
+      if (finished) return;
+      finished = true;
+      clearHeartbeat();
+      try {
+        await reader.cancel(reason);
+      } finally {
+        releaseReader();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}

--- a/docs/src/content/en/reference/ai-sdk/chat-route.mdx
+++ b/docs/src/content/en/reference/ai-sdk/chat-route.mdx
@@ -128,6 +128,13 @@ export const mastra = new Mastra({
     isOptional: true,
     defaultValue: 'false',
   },
+  {
+    name: 'heartbeatMs',
+    type: 'number',
+    description:
+      'Interval in milliseconds for SSE heartbeats that keep connections active through infrastructure with idle timeouts.',
+    isOptional: true,
+  },
 ]}
 />
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6230,6 +6230,9 @@ importers:
       '@internal/types-builder':
         specifier: workspace:*
         version: link:../../packages/_types-builder
+      '@mastra/ai-sdk':
+        specifier: workspace:*
+        version: link:../../client-sdks/ai-sdk
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core

--- a/server-adapters/express/package.json
+++ b/server-adapters/express/package.json
@@ -36,6 +36,7 @@
     "@internal/server-adapter-test-utils": "workspace:*",
     "@internal/storage-test-utils": "workspace:*",
     "@internal/types-builder": "workspace:*",
+    "@mastra/ai-sdk": "workspace:*",
     "@mastra/core": "workspace:*",
     "@mastra/evals": "workspace:*",
     "@mastra/libsql": "workspace:*",

--- a/server-adapters/express/src/__tests__/chat-route-heartbeat.test.ts
+++ b/server-adapters/express/src/__tests__/chat-route-heartbeat.test.ts
@@ -1,0 +1,131 @@
+import type { Server } from 'node:http';
+import { chatRoute } from '@mastra/ai-sdk';
+import { Mastra } from '@mastra/core';
+import express from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MastraServer } from '../index';
+
+const decoder = new TextDecoder();
+
+function createSseFrameReader(reader: ReadableStreamDefaultReader<Uint8Array>) {
+  let buffer = '';
+
+  return async () => {
+    while (true) {
+      const frameEnd = buffer.indexOf('\n\n');
+      if (frameEnd !== -1) {
+        const frame = buffer.slice(0, frameEnd + 2);
+        buffer = buffer.slice(frameEnd + 2);
+        return frame;
+      }
+
+      const result = await reader.read();
+      if (result.done) throw new Error('Stream ended before receiving a complete SSE frame');
+      buffer += decoder.decode(result.value, { stream: true });
+    }
+  };
+}
+
+async function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), 5_000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+describe('chatRoute heartbeat through Express', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (!server) return;
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => server!.close(error => (error ? reject(error) : resolve())));
+    server = undefined;
+  });
+
+  it('streams idle heartbeats and AI SDK events, then aborts the agent on disconnect', async () => {
+    let streamController!: ReadableStreamDefaultController;
+    const fullStream = new ReadableStream({
+      start(controller) {
+        streamController = controller;
+      },
+    });
+    const agent = {
+      stream: vi.fn().mockResolvedValue({ fullStream }),
+    };
+    const mastra = new Mastra({});
+    // chatRoute only calls stream(), so a full Agent would add unrelated model setup to this transport test.
+    vi.spyOn(mastra, 'getAgentById').mockReturnValue(agent as never);
+
+    const app = express();
+    app.use(express.json());
+    const adapter = new MastraServer({
+      app,
+      mastra,
+      customApiRoutes: [chatRoute({ path: '/chat/:agentId', heartbeatMs: 25 })],
+    });
+    await adapter.init();
+
+    const listeningServer: Server = await new Promise(resolve => {
+      const startedServer = app.listen(0, '127.0.0.1', () => resolve(startedServer));
+    });
+    server = listeningServer;
+    const address = listeningServer.address();
+    if (!address || typeof address === 'string') throw new Error('Failed to get server address');
+
+    const clientAbort = new AbortController();
+    const response = await withTimeout(
+      fetch(`http://127.0.0.1:${address.port}/chat/test-agent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+        }),
+        signal: clientAbort.signal,
+      }),
+      'HTTP response headers',
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+
+    const reader = response.body!.getReader();
+    const readFrame = createSseFrameReader(reader);
+    expect(await withTimeout(readFrame(), 'heartbeat frame')).toBe(': heartbeat\n\n');
+
+    streamController.enqueue({
+      type: 'start',
+      runId: 'run-1',
+      from: 'AGENT',
+      payload: { messageId: 'assistant-1' },
+    });
+    streamController.enqueue({
+      type: 'text-start',
+      runId: 'run-1',
+      from: 'AGENT',
+      payload: { id: 'text-1' },
+    });
+
+    let eventFrame = await withTimeout(readFrame(), 'AI SDK event frame');
+    while (eventFrame.startsWith(':')) {
+      expect(eventFrame).toBe(': heartbeat\n\n');
+      eventFrame = await withTimeout(readFrame(), 'AI SDK event frame');
+    }
+    expect(eventFrame.startsWith('data: ')).toBe(true);
+    expect(JSON.parse(eventFrame.slice('data: '.length))).toMatchObject({ type: 'start' });
+
+    expect(agent.stream).toHaveBeenCalledOnce();
+    const agentOptions = agent.stream.mock.calls[0]![1] as { abortSignal: AbortSignal };
+    expect(agentOptions.abortSignal.aborted).toBe(false);
+
+    clientAbort.abort();
+    await vi.waitFor(() => expect(agentOptions.abortSignal.aborted).toBe(true), { timeout: 5_000 });
+  }, 10_000);
+});


### PR DESCRIPTION
Adds an optional `heartbeatMs` setting to `chatRoute()` for SSE streams that need to remain active through infrastructure with idle timeouts. Heartbeats are emitted as SSE comments, so AI SDK consumers continue to receive the same data events.

The wrapper preserves response metadata, stream framing, backpressure, completion, errors, and cancellation. Coverage includes AI SDK v5 and v6 behavior plus an Express HTTP integration test.

```typescript
chatRoute({
  path: "/chat/:agentId",
  heartbeatMs: 15_000,
});
```

Closes #20691.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

SSE connections can close when they stay quiet for too long. This change lets `chatRoute()` send small periodic signals to keep idle connections active.

## Changes

- Added optional `heartbeatMs` configuration to `chatRoute()`.
- Added validation for finite heartbeat intervals within timer limits.
- Added SSE comment heartbeats between complete SSE frames.
- Preserved event ordering, response metadata, backpressure, completion, errors, and cancellation.
- Preserved behavior when `heartbeatMs` is omitted.
- Added AI SDK v5 and v6 unit tests.
- Added Express HTTP integration coverage for heartbeat delivery and client disconnect handling.
- Documented the new option and added release changesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->