### PR TITLE
feat(core): derive request context for subagent delegation

### DIFF
--- a/.changeset/shaggy-lemons-shop.md
+++ b/.changeset/shaggy-lemons-shop.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': minor
+---
+
+Added a delegated request context to `onDelegationStart`. Each subagent run receives a context map derived from its parent, so hooks can add values before dynamic agent configuration resolves without changing the parent context.
+
+```typescript
+await supervisor.stream('Research AI trends', {
+  delegation: {
+    onDelegationStart: context => {
+      context.requestContext.set('specialty', context.primitiveId);
+    },
+  },
+});
+```
+
+Subagent request contexts inherit caller entries but exclude parent memory, thread, and resource identity. Setting or deleting entries during a subagent run no longer changes the parent context map or another concurrent delegation's map.

--- a/docs/src/content/en/docs/capabilities/subagents.mdx
+++ b/docs/src/content/en/docs/capabilities/subagents.mdx
@@ -123,6 +123,24 @@ The `context` object includes:
 | `primitiveId` | The ID of the subagent being delegated to |
 | `prompt` | The prompt the parent agent is sending |
 | `iteration` | Current iteration number |
+| `requestContext` | The request context the subagent run will receive |
+
+### Request context at the delegation boundary
+
+Each delegation receives a request context whose entries are shallowly copied from the parent run, excluding run-scoped identity keys. Setting or deleting entries during the subagent run does not affect the parent's context. Set entries on `context.requestContext` in `onDelegationStart` to pass values to the delegated run:
+
+```typescript title="src/mastra/agents/parent-agent.ts"
+const stream = await parentAgent.stream('Research AI trends', {
+  maxSteps: 10,
+  delegation: {
+    onDelegationStart: async context => {
+      context.requestContext.set('audience', 'technical')
+    },
+  },
+})
+```
+
+The subagent reads these entries in its tools and dynamic configuration, such as `instructions: ({ requestContext }) => ...`. See [Request Context](/docs/server/request-context) for details. Values must be JSON-serializable to work with durable agents.
 
 ### `onDelegationComplete`
 

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -223,7 +223,7 @@ const result = await agent.generate('message for agent')
                     type: '(context: DelegationStartContext) => DelegationStartResult | void | Promise<DelegationStartResult | void>',
                     isOptional: true,
                     description:
-                      'Called before delegating to a subagent. Use this to modify the delegation parameters or reject the delegation entirely.',
+                      "Called before delegating to a subagent. Use this to modify the delegation parameters, reject the delegation entirely, or mutate `context.requestContext` to add entries to the subagent run's request context.",
                   },
                 ],
               },

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -281,7 +281,7 @@ const stream = await agent.stream('message for agent')
                     type: '(context: DelegationStartContext) => DelegationStartResult | void | Promise<DelegationStartResult | void>',
                     isOptional: true,
                     description:
-                      'Called before delegating to a subagent. Use this to modify the delegation parameters or reject the delegation entirely.',
+                      "Called before delegating to a subagent. Use this to modify the delegation parameters, reject the delegation entirely, or mutate `context.requestContext` to add entries to the subagent run's request context.",
                   },
                 ],
               },

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -4563,3 +4563,143 @@ describe('Delegation maxSteps cap', () => {
     expect(generateSpy.mock.calls[0]?.[1]?.maxSteps).toBe(12);
   });
 });
+
+describe('Delegation request context derivation', () => {
+  it('exposes a delegated-run context on onDelegationStart with inherited entries and without reserved keys', async () => {
+    const subAgent = makeSubAgent('ctx-agent', 'done');
+    let hookContext: RequestContext | undefined;
+    let hookHadMastraMemory: boolean | undefined;
+    let hookHadThreadId: boolean | undefined;
+    let hookHadResourceId: boolean | undefined;
+
+    const supervisor = new Agent({
+      id: 'ctx-supervisor',
+      name: 'ctx-supervisor',
+      instructions: 'You orchestrate sub-agents.',
+      model: makeSupervisorModel('ctxAgent', 'do work'),
+      agents: { ctxAgent: subAgent },
+      memory: new MockMemory(),
+    });
+
+    const parentContext = new RequestContext();
+    parentContext.set('tenantId', 'acme');
+    parentContext.set(MASTRA_THREAD_ID_KEY, 'parent-thread');
+    parentContext.set(MASTRA_RESOURCE_ID_KEY, 'parent-resource');
+
+    await supervisor.generate('go', {
+      maxSteps: 3,
+      requestContext: parentContext,
+      memory: { resource: 'parent-resource', thread: 'parent-thread' },
+      delegation: {
+        onDelegationStart: context => {
+          hookContext = context.requestContext;
+          hookHadMastraMemory = hookContext.has('MastraMemory');
+          hookHadThreadId = hookContext.has(MASTRA_THREAD_ID_KEY);
+          hookHadResourceId = hookContext.has(MASTRA_RESOURCE_ID_KEY);
+          return { proceed: true };
+        },
+      },
+    });
+
+    expect(hookContext).toBeDefined();
+    expect(hookContext!.get('tenantId')).toBe('acme');
+    expect(hookHadMastraMemory).toBe(false);
+    expect(hookHadThreadId).toBe(false);
+    expect(hookHadResourceId).toBe(false);
+    expect(hookContext).not.toBe(parentContext);
+  });
+
+  it('applies hook context mutations to the delegated run (dynamic instructions and tool execute)', async () => {
+    let instructionsSawSpecialty: unknown;
+    let toolSawSpecialty: unknown;
+
+    const contextTool = createTool({
+      id: 'context-tool',
+      description: 'Reads the specialty from request context',
+      inputSchema: z.object({}),
+      execute: async (_input, context) => {
+        toolSawSpecialty = context?.requestContext?.get('specialty');
+        return { ok: true };
+      },
+    });
+
+    const specialistAgent = new Agent({
+      id: 'specialist-agent',
+      name: 'specialist-agent',
+      description: 'Adapts to the configured specialty',
+      instructions: ({ requestContext }) => {
+        instructionsSawSpecialty = requestContext.get('specialty');
+        return 'You are a helpful sub-agent.';
+      },
+      tools: { contextTool },
+      model: makeSubAgentModelWithTool('contextTool', {}),
+    });
+
+    const supervisor = new Agent({
+      id: 'hook-mutation-supervisor',
+      name: 'hook-mutation-supervisor',
+      instructions: 'You orchestrate sub-agents.',
+      model: makeSupervisorModel('specialistAgent', 'do specialized work'),
+      agents: { specialistAgent },
+      memory: new MockMemory(),
+    });
+
+    const parentContext = new RequestContext();
+    parentContext.set('tenantId', 'acme');
+
+    await supervisor.generate('go', {
+      maxSteps: 5,
+      requestContext: parentContext,
+      delegation: {
+        onDelegationStart: context => {
+          context.requestContext.set('specialty', context.primitiveId);
+        },
+      },
+    });
+
+    expect(instructionsSawSpecialty).toBe('specialist-agent');
+    expect(toolSawSpecialty).toBe('specialist-agent');
+    expect(parentContext.has('specialty')).toBe(false);
+  });
+
+  it('does not leak sub-agent context mutations into the parent context', async () => {
+    const writerTool = createTool({
+      id: 'writer-tool',
+      description: 'Writes a value into the request context',
+      inputSchema: z.object({}),
+      execute: async (_input, context) => {
+        context?.requestContext?.set('subAgentWrote', true);
+        return { ok: true };
+      },
+    });
+
+    const subAgent = new Agent({
+      id: 'writer-agent',
+      name: 'writer-agent',
+      description: 'Writes into request context',
+      instructions: 'Call the writer tool.',
+      tools: { writerTool },
+      model: makeSubAgentModelWithTool('writerTool', {}),
+    });
+
+    const supervisor = new Agent({
+      id: 'leak-supervisor',
+      name: 'leak-supervisor',
+      instructions: 'You orchestrate sub-agents.',
+      model: makeSupervisorModel('writerAgent', 'write something'),
+      agents: { writerAgent: subAgent },
+      memory: new MockMemory(),
+    });
+
+    const parentContext = new RequestContext();
+    parentContext.set('tenantId', 'acme');
+
+    await supervisor.generate('go', {
+      maxSteps: 3,
+      requestContext: parentContext,
+    });
+
+    expect(parentContext.has('subAgentWrote')).toBe(false);
+    expect(parentContext.get('tenantId')).toBe('acme');
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -132,6 +132,7 @@ import type {
   NetworkOptions,
   DelegationConfig,
   DelegationStartContext,
+  DelegationStartResult,
   DelegationCompleteContext,
 } from './agent.types';
 // Value import of durable constants is safe: constants.ts is a leaf module
@@ -4716,6 +4717,16 @@ export class Agent<
             // Each iteration typically produces an assistant message
             const derivedIteration = Math.max(1, sanitizedMessages.filter(m => m.role === 'assistant').length);
 
+            // The sub-agent run gets its own RequestContext map derived from the
+            // parent's entries, excluding run-scoped identity keys. This isolates
+            // set/delete operations across the delegation boundary and matches the
+            // durable engine's snapshot/rehydrate behavior.
+            const subAgentRequestContext: RequestContext = new RequestContext<unknown>(
+              [...requestContext.entries()].filter(
+                ([key]) => key !== 'MastraMemory' && key !== MASTRA_THREAD_ID_KEY && key !== MASTRA_RESOURCE_ID_KEY,
+              ) as Iterable<readonly [string, unknown]>,
+            );
+
             // Build delegation start context
             const delegationStartContext: DelegationStartContext = {
               primitiveId: agent.id,
@@ -4735,6 +4746,7 @@ export class Agent<
               parentAgentName: this.name,
               toolCallId,
               messages: sanitizedMessages,
+              requestContext: subAgentRequestContext,
             };
 
             // Generate sub-agent thread and resource IDs early (before any rejection)
@@ -4757,31 +4769,25 @@ export class Agent<
                   entityId: agentName,
                 }) || `${slugify.default(this.id)}-${agentName}`;
 
-            // Save the parent agent's MastraMemory before the sub-agent runs.
-            // The sub-agent's prepare-memory-step will overwrite this key with
-            // its own thread/resource identity. We restore it after the sub-agent
-            // returns so the parent's processors (OM, working memory, etc.) still
-            // see the correct context on subsequent steps.
-            const savedMastraMemory = requestContext.get('MastraMemory');
-
-            // Save and clear reserved thread/resource keys so they don't override the
-            // sub-agent's isolated memory config. These keys take precedence over the
-            // memory option in generate/stream, so leaving them would cause the
-            // sub-agent to write to the parent's thread instead of its own.
-            const savedThreadIdKey = requestContext.get(MASTRA_THREAD_ID_KEY) as string | undefined;
-            const savedResourceIdKey = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
-            if (savedThreadIdKey !== undefined) {
-              requestContext.delete(MASTRA_THREAD_ID_KEY);
-            }
-            if (savedResourceIdKey !== undefined) {
-              requestContext.delete(MASTRA_RESOURCE_ID_KEY);
+            // Call onDelegationStart before resolving the sub-agent's runtime
+            // config so mutations of the delegated run's context in the hook
+            // are visible to version, model, and default-options resolution
+            // below. Rejection handling happens after resolution because the
+            // rejection path needs the resolved model version and memory config.
+            let startResult: DelegationStartResult | void | undefined;
+            if (delegation?.onDelegationStart) {
+              try {
+                startResult = await delegation.onDelegationStart(delegationStartContext);
+              } catch (hookError) {
+                this.logger.error('onDelegationStart hook error', { agent: this.name, error: hookError });
+                // Continue with original values on hook error
+              }
             }
 
-            // Resolve versioned sub-agent if a version override exists on requestContext.
-            // This must happen before onDelegationStart so the rejection branch can
-            // use the correct model version and memory config from the resolved agent.
+            // Resolve versioned sub-agent if a version override exists on the
+            // delegated run's requestContext (inherited from the parent).
             let resolvedAgent = agent;
-            const versionOverrides = requestContext.get(MASTRA_VERSIONS_KEY) as VersionOverrides | undefined;
+            const versionOverrides = subAgentRequestContext.get(MASTRA_VERSIONS_KEY) as VersionOverrides | undefined;
             const agentVersionSelector =
               versionOverrides?.agents?.[agent.id] ??
               (versionOverrides?.defaultStatus ? { status: versionOverrides.defaultStatus } : undefined);
@@ -4801,15 +4807,16 @@ export class Agent<
 
             // Recompute derived values from the resolved agent (may differ from
             // code-defined agent if a stored version changed the model or defaults)
-            const resolvedModelVersion = (await resolvedAgent.getModel({ requestContext })).specificationVersion;
+            const resolvedModelVersion = (await resolvedAgent.getModel({ requestContext: subAgentRequestContext }))
+              .specificationVersion;
             const resolvedDefaultOptions =
               'getDefaultOptions' in resolvedAgent
-                ? await (resolvedAgent as Agent).getDefaultOptions({ requestContext })
+                ? await (resolvedAgent as Agent).getDefaultOptions({ requestContext: subAgentRequestContext })
                 : {};
             const resolvedHasOwnMemoryConfig = resolvedDefaultOptions?.memory !== undefined;
 
             // Propagate parent memory to the resolved agent if it doesn't have its own.
-            // This must happen before onDelegationStart so the rejection path can
+            // This must happen before rejection handling so the rejection path can
             // save messages via resolvedAgent.getMemory().
             if (
               (methodType === 'generate' ||
@@ -4823,7 +4830,6 @@ export class Agent<
               }
             }
 
-            // Call onDelegationStart hook if provided
             let effectivePrompt = inputData.prompt;
             let effectiveInstructions = inputData.instructions;
             let effectiveMaxSteps = inputData.maxSteps;
@@ -4845,120 +4851,106 @@ export class Agent<
               });
               effectiveMaxSteps = subAgentMaxStepsCap;
             }
-            if (delegation?.onDelegationStart) {
-              try {
-                const startResult = await delegation.onDelegationStart(delegationStartContext);
-                if (startResult) {
-                  // Check if delegation should be rejected
-                  if (startResult.proceed === false) {
-                    const rejectionMessage =
-                      startResult.rejectionReason || 'Delegation rejected by onDelegationStart hook';
-                    this.logger.debug('Delegation rejected', {
-                      agent: this.name,
-                      targetAgent: agentName,
-                      reason: rejectionMessage,
+            // Process the onDelegationStart result captured above (rejection
+            // handling needs the resolved model version and memory config)
+            if (startResult) {
+              // Check if delegation should be rejected
+              if (startResult.proceed === false) {
+                const rejectionMessage = startResult.rejectionReason || 'Delegation rejected by onDelegationStart hook';
+                this.logger.debug('Delegation rejected', {
+                  agent: this.name,
+                  targetAgent: agentName,
+                  reason: rejectionMessage,
+                });
+
+                if (
+                  (methodType === 'stream' || methodType === 'streamLegacy') &&
+                  supportedLanguageModelSpecifications.includes(resolvedModelVersion)
+                ) {
+                  await context.writer?.write({
+                    type: 'text-delta',
+                    payload: {
+                      id: randomUUID(),
+                      text: `[Delegation Rejected] ${rejectionMessage}`,
+                    },
+                    runId,
+                    from: ChunkFrom.AGENT,
+                  });
+                }
+
+                // Save rejection messages to sub-agent's memory so the UI can display them
+                const memory = await resolvedAgent.getMemory({ requestContext: subAgentRequestContext });
+                if (memory) {
+                  try {
+                    // Create user message with the original prompt
+                    const userMessage: MastraDBMessage = {
+                      id: this.#mastra?.generateId() || randomUUID(),
+                      role: 'user',
+                      type: 'text',
+                      createdAt: new Date(),
+                      threadId: subAgentThreadId,
+                      resourceId: subAgentResourceId,
+                      content: {
+                        format: 2,
+                        parts: [
+                          {
+                            type: 'text',
+                            text: effectivePrompt,
+                          },
+                        ],
+                      },
+                    };
+
+                    // Create assistant message with the rejection
+                    const assistantMessage: MastraDBMessage = {
+                      id: this.#mastra?.generateId() || randomUUID(),
+                      role: 'assistant',
+                      type: 'text',
+                      createdAt: new Date(new Date().getTime() + 1),
+                      threadId: subAgentThreadId,
+                      resourceId: subAgentResourceId,
+                      content: {
+                        format: 2,
+                        parts: [
+                          {
+                            type: 'text',
+                            text: `[Delegation Rejected] ${rejectionMessage}`,
+                          },
+                        ],
+                      },
+                    };
+
+                    await memory.createThread({
+                      resourceId: subAgentResourceId,
+                      threadId: subAgentThreadId,
                     });
 
-                    if (
-                      (methodType === 'stream' || methodType === 'streamLegacy') &&
-                      supportedLanguageModelSpecifications.includes(resolvedModelVersion)
-                    ) {
-                      await context.writer?.write({
-                        type: 'text-delta',
-                        payload: {
-                          id: randomUUID(),
-                          text: `[Delegation Rejected] ${rejectionMessage}`,
-                        },
-                        runId,
-                        from: ChunkFrom.AGENT,
-                      });
-                    }
-
-                    // Save rejection messages to sub-agent's memory so the UI can display them
-                    const memory = await resolvedAgent.getMemory({ requestContext });
-                    if (memory) {
-                      try {
-                        // Create user message with the original prompt
-                        const userMessage: MastraDBMessage = {
-                          id: this.#mastra?.generateId() || randomUUID(),
-                          role: 'user',
-                          type: 'text',
-                          createdAt: new Date(),
-                          threadId: subAgentThreadId,
-                          resourceId: subAgentResourceId,
-                          content: {
-                            format: 2,
-                            parts: [
-                              {
-                                type: 'text',
-                                text: effectivePrompt,
-                              },
-                            ],
-                          },
-                        };
-
-                        // Create assistant message with the rejection
-                        const assistantMessage: MastraDBMessage = {
-                          id: this.#mastra?.generateId() || randomUUID(),
-                          role: 'assistant',
-                          type: 'text',
-                          createdAt: new Date(new Date().getTime() + 1),
-                          threadId: subAgentThreadId,
-                          resourceId: subAgentResourceId,
-                          content: {
-                            format: 2,
-                            parts: [
-                              {
-                                type: 'text',
-                                text: `[Delegation Rejected] ${rejectionMessage}`,
-                              },
-                            ],
-                          },
-                        };
-
-                        await memory.createThread({
-                          resourceId: subAgentResourceId,
-                          threadId: subAgentThreadId,
-                        });
-
-                        await memory.saveMessages({
-                          messages: [userMessage, assistantMessage],
-                        });
-                      } catch (memoryError) {
-                        this.logger.error('Failed to save rejection to sub-agent memory', {
-                          agent: this.name,
-                          error: memoryError,
-                        });
-                      }
-                    }
-
-                    if (savedThreadIdKey !== undefined) {
-                      requestContext.set(MASTRA_THREAD_ID_KEY, savedThreadIdKey);
-                    }
-                    if (savedResourceIdKey !== undefined) {
-                      requestContext.set(MASTRA_RESOURCE_ID_KEY, savedResourceIdKey);
-                    }
-
-                    return {
-                      text: `[Delegation Rejected] ${rejectionMessage}`,
-                      subAgentThreadId,
-                      subAgentResourceId,
-                    };
-                  }
-                  // Apply modifications
-                  if (startResult.modifiedPrompt !== undefined) {
-                    effectivePrompt = startResult.modifiedPrompt;
-                  }
-                  if (startResult.modifiedInstructions !== undefined) {
-                    effectiveInstructions = startResult.modifiedInstructions;
-                  }
-                  if (startResult.modifiedMaxSteps !== undefined) {
-                    effectiveMaxSteps = startResult.modifiedMaxSteps;
+                    await memory.saveMessages({
+                      messages: [userMessage, assistantMessage],
+                    });
+                  } catch (memoryError) {
+                    this.logger.error('Failed to save rejection to sub-agent memory', {
+                      agent: this.name,
+                      error: memoryError,
+                    });
                   }
                 }
-              } catch (hookError) {
-                this.logger.error('onDelegationStart hook error', { agent: this.name, error: hookError });
-                // Continue with original values on hook error
+
+                return {
+                  text: `[Delegation Rejected] ${rejectionMessage}`,
+                  subAgentThreadId,
+                  subAgentResourceId,
+                };
+              }
+              // Apply modifications
+              if (startResult.modifiedPrompt !== undefined) {
+                effectivePrompt = startResult.modifiedPrompt;
+              }
+              if (startResult.modifiedInstructions !== undefined) {
+                effectiveInstructions = startResult.modifiedInstructions;
+              }
+              if (startResult.modifiedMaxSteps !== undefined) {
+                effectiveMaxSteps = startResult.modifiedMaxSteps;
               }
             }
 
@@ -4972,7 +4964,9 @@ export class Agent<
 
             // Append LLM-provided instructions to the sub-agent's own instructions
             if (effectiveInstructions) {
-              const agentOwnInstructions = await resolvedAgent.getInstructions({ requestContext });
+              const agentOwnInstructions = await resolvedAgent.getInstructions({
+                requestContext: subAgentRequestContext,
+              });
               if (agentOwnInstructions) {
                 const ownStr = this.#convertInstructionsToString(agentOwnInstructions);
                 if (ownStr) {
@@ -5088,7 +5082,7 @@ export class Agent<
                 const generateResult = resumeData
                   ? await resolvedAgent.resumeGenerate(resumeData, {
                       runId: suspendedToolRunId,
-                      requestContext,
+                      requestContext: subAgentRequestContext,
                       actor: invocationActor,
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
@@ -5099,7 +5093,7 @@ export class Agent<
                       disableBackgroundTasks: true,
                     })
                   : await resolvedAgent.generate(messagesForSubAgent, {
-                      requestContext,
+                      requestContext: subAgentRequestContext,
                       actor: invocationActor,
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
@@ -5121,7 +5115,7 @@ export class Agent<
                 fullSubAgentMessages = [subAgentUserMessage, ...agentResponseMessages];
 
                 // Save response messages to sub-agent's memory so the UI can display them
-                const memory = await resolvedAgent.getMemory({ requestContext });
+                const memory = await resolvedAgent.getMemory({ requestContext: subAgentRequestContext });
                 if (memory) {
                   try {
                     await memory.createThread({
@@ -5141,12 +5135,6 @@ export class Agent<
                 }
 
                 if (generateResult.finishReason === 'suspended') {
-                  if (savedThreadIdKey !== undefined) {
-                    requestContext.set(MASTRA_THREAD_ID_KEY, savedThreadIdKey);
-                  }
-                  if (savedResourceIdKey !== undefined) {
-                    requestContext.set(MASTRA_RESOURCE_ID_KEY, savedResourceIdKey);
-                  }
                   return suspend?.(generateResult.suspendPayload, {
                     resumeSchema: generateResult.resumeSchema,
                     runId: generateResult.runId,
@@ -5169,7 +5157,7 @@ export class Agent<
                   throw new Error(`Sub-agent ${agent.id} returned a v1 model but does not implement generateLegacy`);
                 }
                 const generateResult = await resolvedAgent.generateLegacy(messagesForSubAgent, {
-                  requestContext,
+                  requestContext: subAgentRequestContext,
                   actor: invocationActor,
                   ...resolveObservabilityContext(context ?? {}),
                   context: filteredContextMessages as unknown as CoreMessage[],
@@ -5186,7 +5174,7 @@ export class Agent<
                 const streamResult = resumeData
                   ? await resolvedAgent.resumeStream(resumeData, {
                       runId: suspendedToolRunId,
-                      requestContext,
+                      requestContext: subAgentRequestContext,
                       actor: invocationActor,
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
@@ -5197,7 +5185,7 @@ export class Agent<
                       disableBackgroundTasks: true,
                     })
                   : await resolvedAgent.stream(messagesForSubAgent, {
-                      requestContext,
+                      requestContext: subAgentRequestContext,
                       actor: invocationActor,
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
@@ -5252,7 +5240,7 @@ export class Agent<
                 fullSubAgentMessages = [subAgentUserMessage, ...agentResponseMessages];
 
                 // Save response messages to sub-agent's memory so the UI can display them
-                const streamMemory = await resolvedAgent.getMemory({ requestContext });
+                const streamMemory = await resolvedAgent.getMemory({ requestContext: subAgentRequestContext });
                 if (streamMemory) {
                   try {
                     await streamMemory.createThread({
@@ -5272,12 +5260,6 @@ export class Agent<
                 }
 
                 if (requireToolApproval || suspendedPayload || resumeSchema) {
-                  if (savedThreadIdKey !== undefined) {
-                    requestContext.set(MASTRA_THREAD_ID_KEY, savedThreadIdKey);
-                  }
-                  if (savedResourceIdKey !== undefined) {
-                    requestContext.set(MASTRA_RESOURCE_ID_KEY, savedResourceIdKey);
-                  }
                   return suspend?.(suspendedPayload, {
                     resumeSchema,
                     requireToolApproval,
@@ -5302,7 +5284,7 @@ export class Agent<
                   throw new Error(`Sub-agent ${agent.id} returned a v1 model but does not implement streamLegacy`);
                 }
                 const streamResult = await resolvedAgent.streamLegacy(effectivePrompt, {
-                  requestContext,
+                  requestContext: subAgentRequestContext,
                   actor: invocationActor,
                   ...resolveObservabilityContext(context ?? {}),
                   ...subAgentAbortOptions,
@@ -5399,17 +5381,6 @@ export class Agent<
                   this.logger.error('onDelegationComplete hook error', { agent: this.name, error: hookError });
                 }
               }
-              // Restore the parent agent's MastraMemory after sub-agent execution
-              if (savedMastraMemory !== undefined) {
-                requestContext.set('MastraMemory', savedMastraMemory);
-              }
-              if (savedThreadIdKey !== undefined) {
-                requestContext.set(MASTRA_THREAD_ID_KEY, savedThreadIdKey);
-              }
-              if (savedResourceIdKey !== undefined) {
-                requestContext.set(MASTRA_RESOURCE_ID_KEY, savedResourceIdKey);
-              }
-
               return result;
             } catch (err) {
               let bailed = false;
@@ -5480,18 +5451,6 @@ export class Agent<
                     error: hookError,
                   });
                 }
-              }
-
-              // Restore even on error so the parent's retry/fallback logic
-              // sees the correct memory context
-              if (savedMastraMemory !== undefined) {
-                requestContext.set('MastraMemory', savedMastraMemory);
-              }
-              if (savedThreadIdKey !== undefined) {
-                requestContext.set(MASTRA_THREAD_ID_KEY, savedThreadIdKey);
-              }
-              if (savedResourceIdKey !== undefined) {
-                requestContext.set(MASTRA_RESOURCE_ID_KEY, savedResourceIdKey);
               }
 
               const mastraError = new MastraError(

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -105,6 +105,14 @@ export interface DelegationStartContext {
   toolCallId: string;
   /** Messages accumulated so far */
   messages: MastraDBMessage[];
+  /**
+   * The request context the delegated run will receive. Entries are shallowly
+   * copied from the parent run's context, excluding `MastraMemory` and the
+   * reserved thread/resource keys. Mutate it with `requestContext.set()` to add
+   * entries without modifying the parent's context map. Values must be
+   * JSON-serializable to work with durable agents.
+   */
+  requestContext: RequestContext;
 }
 
 /**

--- a/packages/core/src/agent/durable/__tests__/durable-agent-delegation.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-delegation.test.ts
@@ -190,4 +190,46 @@ describe('DurableAgent delegation hooks', () => {
 
     cleanup();
   });
+
+  it('applies onDelegationStart context mutations to the delegated run', async () => {
+    let subAgentSawSpecialty: unknown;
+
+    const subAgent = new Agent({
+      id: 'specialistAgent',
+      name: 'specialistAgent',
+      description: 'Runtime-configured sub-agent',
+      instructions: ({ requestContext }) => {
+        subAgentSawSpecialty = requestContext.get('specialty');
+        return 'You are a helpful sub-agent.';
+      },
+      model: makeSubAgentModel('Task done.') as LanguageModelV2,
+    });
+
+    const supervisor = new Agent({
+      id: 'supervisor-delegation-context',
+      name: 'supervisor-delegation-context',
+      instructions: 'You orchestrate sub-agents.',
+      model: makeSupervisorModel('specialistAgent', 'do specialized work') as LanguageModelV2,
+      agents: { specialistAgent: subAgent },
+    });
+
+    const durableAgent = createDurableAgent({ agent: supervisor, pubsub });
+
+    const { fullStream, cleanup } = await durableAgent.stream('Do the work', {
+      maxSteps: 3,
+      delegation: {
+        onDelegationStart: context => {
+          context.requestContext.set('specialty', context.primitiveId);
+        },
+      },
+    });
+
+    for await (const _chunk of fullStream) {
+      // no-op
+    }
+
+    expect(subAgentSawSpecialty).toBe('specialistAgent');
+
+    cleanup();
+  });
 });


### PR DESCRIPTION
This gives each delegated subagent its own request context map and exposes it to `onDelegationStart` before dynamic agent configuration resolves.

```typescript
await supervisor.stream('Research AI trends', {
  delegation: {
    onDelegationStart: context => {
      context.requestContext.set('specialty', context.primitiveId);
    },
  },
});
```

The delegated context inherits caller entries but not the parent's memory, thread, or resource identity. Setting entries for a subagent therefore doesn't change the parent context or another concurrent delegation. This also preserves the existing Observational Memory and reserved-key isolation behavior without mutating and restoring the parent context around each delegation.

I added in-process and durable coverage for hook mutations and context isolation, and updated the subagent documentation and API references. The focused core delegation suites, core build and typecheck, Observational Memory regression suite, and docs validation pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Each delegated subagent now gets its own request context. It can use the caller’s settings without changing the caller’s memory, thread, or resource information.

## Changes

- Added isolated request-context handling for delegated subagents.
- Exposed `context.requestContext` to `onDelegationStart` before model and configuration resolution.
- Preserved ordinary caller entries while excluding memory, thread, and resource identity keys.
- Prevented context changes from leaking between the parent and concurrent delegations.
- Applied the isolated context to generate, resume, stream, legacy, rejection, and persistence flows.
- Added in-process and durable delegation tests.
- Updated subagent documentation and API references.
- Added a `@mastra/core` changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->