### PR TITLE
fix(platform-workspace): skip proxy hit in PlatformSandbox.getInfo() when private-net registry is populated

### DIFF
--- a/.changeset/ready-files-see.md
+++ b/.changeset/ready-files-see.md
@@ -1,0 +1,5 @@
+---
+'@mastra/platform-workspace': patch
+---
+
+Skip the workspace-proxy round-trip in `PlatformSandbox.getInfo()` when the sandbox address registry has an entry for the sandbox. Serving `getInfo()` from local state removes a per-poll `GET /sandbox/:id` hit that otherwise triggered a Railway GraphQL call plus a `sandboxExec` inside the sandbox on every workspace status poll. When no registry entry exists (or after an exec transport failure evicts it) `getInfo()` falls through to the proxy exactly as before.

--- a/.changeset/ready-files-see.md
+++ b/.changeset/ready-files-see.md
@@ -2,4 +2,4 @@
 '@mastra/platform-workspace': patch
 ---
 
-Skip the workspace-proxy round-trip in `PlatformSandbox.getInfo()` when the sandbox address registry has an entry for the sandbox. Serving `getInfo()` from local state removes a per-poll `GET /sandbox/:id` hit that otherwise triggered a Railway GraphQL call plus a `sandboxExec` inside the sandbox on every workspace status poll. When no registry entry exists (or after an exec transport failure evicts it) `getInfo()` falls through to the proxy exactly as before.
+Improved `PlatformSandbox.getInfo()` to return cached sandbox information when the sandbox is known to be directly reachable, removing a redundant network round-trip on every workspace status poll. When no cached address is available, `getInfo()` behaves exactly as before.

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1526,6 +1526,134 @@ describe('PlatformSandbox', () => {
       await expect(sandbox._start()).resolves.toBeUndefined();
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
+
+    it('getInfo() skips the proxy round-trip when the registry has an address for the sandbox', async () => {
+      // The issue this fix targets: workspace-proxy was seeing dozens of
+      // `GET /sandbox/:id` hits per session because `Workspace.getInfo()`
+      // polls unconditionally. When the address registry is populated the
+      // sandbox is provably reachable via the private-net path, so we can
+      // serve `getInfo()` from cached local state and skip the proxy hit
+      // (and the Railway GraphQL + `sandboxExec` awk it triggers on the
+      // proxy side).
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(
+        json({
+          id: 'sbx_1',
+          createdAt: '2026-06-26T00:00:00.000Z',
+          instanceUrl: 'http://[fd12::1]:47000',
+        }),
+      );
+      const { registry } = fakeAddressRegistry();
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        addressRegistry: registry,
+      });
+      await sandbox._start();
+
+      const info = await sandbox.getInfo();
+
+      // Only the create call fired; no `GET /sandbox/:id`.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      // Info still carries the platform-assigned sandboxId so callers that
+      // persist a reattach id continue to work.
+      expect(info.metadata?.sandboxId).toBe('sbx_1');
+      expect(info.id).toBe('sbx_1');
+    });
+
+    it('getInfo() falls through to the proxy when the registry has no entry for the sandbox', async () => {
+      // No registry entry means we don't know the sandbox is reachable via
+      // private-net, so the proxy remains the source of truth. Preserves the
+      // pre-existing behavior for older proxies / failed discovery.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        // create response has no instanceUrl → registry stays empty
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        // getInfo() falls through to `GET /sandbox/:id`
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z', status: 'ready' }));
+      const { registry } = fakeAddressRegistry();
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        addressRegistry: registry,
+      });
+      await sandbox._start();
+      await sandbox.getInfo();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1');
+    });
+
+    it('getInfo() falls through to the proxy when no addressRegistry is configured at all', async () => {
+      // Callers that don't opt into the registry (existing code, non-factory
+      // deployments) must keep the pre-existing proxy behavior for getInfo().
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          json({
+            id: 'sbx_1',
+            createdAt: '2026-06-26T00:00:00.000Z',
+            instanceUrl: 'http://[fd12::1]:47000',
+          }),
+        )
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z', status: 'ready' }));
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        // no addressRegistry
+      });
+      await sandbox._start();
+      await sandbox.getInfo();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1');
+    });
+
+    it('getInfo() falls through to the proxy after the registry entry has been evicted', async () => {
+      // Executes that fail transport evict the registry entry — the next
+      // getInfo() must return to proxy-truth because we no longer have
+      // liveness evidence for this sandbox.
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          json({
+            id: 'sbx_1',
+            createdAt: '2026-06-26T00:00:00.000Z',
+            instanceUrl: 'http://[fd12::1]:47000',
+          }),
+        )
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z', status: 'ready' }));
+      const { registry } = fakeAddressRegistry();
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        addressRegistry: registry,
+      });
+      await sandbox._start();
+
+      // Simulate an eviction (as _tryExecViaPrivateNetwork would do on
+      // transport failure). The next getInfo() must go to the proxy.
+      registry.delete('sbx_1');
+
+      await sandbox.getInfo();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1');
+    });
   });
 
   describe('clone', () => {

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -838,6 +838,31 @@ export class PlatformSandbox extends MastraSandbox {
         createdAt: this._createdAt ?? new Date(),
       };
     }
+    // Skip the workspace-proxy round-trip when the address registry has an
+    // entry for this sandbox — a live entry is proof that start() saw an
+    // `instanceUrl` on the create/reattach response and that no exec since
+    // has evicted it via a transport failure. Serving `getInfo()` from
+    // local state here removes the per-poll `GET /sandbox/:id` hit that
+    // otherwise triggers a Railway GraphQL call + `sandboxExec` awk on
+    // `/proc/net/if_inet6` inside the proxy. See
+    // `.scratch/factory-deploy/issue-workspace-getinfo-hits-proxy-when-registry-populated.md`.
+    //
+    // Note: this does NOT probe the sidecar. If the sandbox has been
+    // destroyed out-of-band the next exec will fail transport, evict the
+    // registry entry, and a subsequent getInfo() will fall through to the
+    // proxy below and observe the true status.
+    if (this._addressRegistry?.get(this._sandboxId)) {
+      return {
+        id: this._sandboxId,
+        name: this.name,
+        provider: this.provider,
+        status: this.status,
+        createdAt: this._createdAt ?? new Date(),
+        metadata: {
+          sandboxId: this._sandboxId,
+        },
+      };
+    }
     const response = await this._client.request(`/sandbox/${encodeURIComponent(this._sandboxId)}`);
     const json = (await response.json()) as CreateSandboxResponse;
     return {

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -844,8 +844,7 @@ export class PlatformSandbox extends MastraSandbox {
     // has evicted it via a transport failure. Serving `getInfo()` from
     // local state here removes the per-poll `GET /sandbox/:id` hit that
     // otherwise triggers a Railway GraphQL call + `sandboxExec` awk on
-    // `/proc/net/if_inet6` inside the proxy. See
-    // `.scratch/factory-deploy/issue-workspace-getinfo-hits-proxy-when-registry-populated.md`.
+    // `/proc/net/if_inet6` inside the proxy.
     //
     // Note: this does NOT probe the sidecar. If the sandbox has been
     // destroyed out-of-band the next exec will fail transport, evict the


### PR DESCRIPTION
## Summary

\`PlatformSandbox.getInfo()\` unconditionally hit workspace-proxy on every call, even when the private-network address registry already proved the sandbox was reachable directly. Because \`@mastra/core\`'s \`Workspace.getInfo()\` polls this on every workspace info request (status panels, activity polling hooks, factory UI), a single 40-minute factory session was generating **65+ \`GET /sandbox/:id\` hits per sandbox** — every one triggering a Railway GraphQL call plus a \`sandboxExec\` inside the sandbox to re-derive the IPv6 the proxy could have cached.

That contradicts the whole point of the private-net + \`InProcessSandboxAddressRegistry\` design: once we have \`instanceUrl\`, workspace-proxy is supposed to be off the runtime hot path.

## What changed

- \`PlatformSandbox.getInfo()\` now returns from local state (id, name, provider, status, \`createdAt\`, and the platform-assigned \`sandboxId\` in metadata) when \`_addressRegistry?.get(sandboxId)\` returns a URL.
- When the registry has no entry (older proxy, discovery failed, or an exec transport failure evicted it), \`getInfo()\` falls through to the existing \`GET /sandbox/:id\` call unchanged.
- No new sidecar contract is defined — the registry's presence IS the liveness signal, and any subsequent transport failure evicts the entry, causing the next \`getInfo()\` to naturally return to proxy truth.

## Test plan

Four new tests in \`sandbox.test.ts\` under the \`private-network exec\` suite:

- \`getInfo()\` skips the proxy round-trip when the registry has an address for the sandbox (asserts fetch was called exactly once — for create — with no follow-up \`GET /sandbox/:id\`).
- \`getInfo()\` falls through to the proxy when the registry has no entry for the sandbox.
- \`getInfo()\` falls through to the proxy when no \`addressRegistry\` is configured at all (baseline behavior for non-factory callers).
- \`getInfo()\` falls through to the proxy after the registry entry has been evicted (simulating post-transport-failure eviction).

\`\`\`
✓ src/sandbox.test.ts (52 tests) 161ms
Tests  97 passed (97)
\`\`\`

Typecheck + lint + build all clean in \`workspaces/platform-workspace\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the platform already knows a sandbox’s address, `getInfo()` uses that local information instead of asking another service. If the address is unavailable, it keeps using the existing service request.

## Changes

- Updated `PlatformSandbox.getInfo()` to return local sandbox details when the address registry contains the sandbox.
- Preserved fallback to `GET /sandbox/:id` when no registry entry exists, no registry is configured, or transport failure evicts the entry.
- Added four tests for cached information and fallback behavior.
- Added a patch changeset for `@mastra/platform-workspace`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->