### PR TITLE
test(ai-sdk): fix 5 broken test files in the ai-sdk suite

### DIFF
--- a/client-sdks/ai-sdk/src/__tests__/abort-signal.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/abort-signal.test.ts
@@ -2,9 +2,9 @@
  * Tests for issue #13038: chatRoute should pass abort signal to enable request cancellation.
  */
 import type { UIMessage } from '@internal/ai-sdk-v5';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { Agent } from '@mastra/core/agent';
 import { Mastra } from '@mastra/core/mastra';
-import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai/test';
 import { describe, expect, it, vi } from 'vitest';
 
 import { chatRoute, handleChatStream } from '../chat-route';
@@ -112,6 +112,7 @@ describe('abort signal propagation (issue #13038)', () => {
             if (name === 'agentId') return 'test-agent';
             return undefined;
           },
+          query: () => undefined,
         },
         get: (key: string) => contextStore.get(key),
       };

--- a/client-sdks/ai-sdk/src/__tests__/add-tool-result-message-id.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/add-tool-result-message-id.test.ts
@@ -18,10 +18,10 @@
  * instead of appending to the existing one.
  */
 import type { UIMessage } from '@internal/ai-sdk-v5';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { Agent } from '@mastra/core/agent';
 import { Mastra } from '@mastra/core/mastra';
 import { createTool } from '@mastra/core/tools';
-import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai/test';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 

--- a/client-sdks/ai-sdk/src/__tests__/browser-bundle.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/browser-bundle.test.ts
@@ -71,6 +71,8 @@ it('loads toAISdkMessages in a browser bundle', async () => {
 
   // Supply only the web globals touched during module initialization. Node-only
   // globals such as require, process, and Buffer remain unavailable.
+  // `fetch` is a browser global too — @ai-sdk/provider-utils inspects it
+  // (Function.prototype.toString) at module init, so it must be a function.
   const sandbox: {
     self?: unknown;
     convertedMessages?: unknown;
@@ -78,7 +80,14 @@ it('loads toAISdkMessages in a browser bundle', async () => {
     TextDecoder: typeof TextDecoder;
     TextEncoder: typeof TextEncoder;
     URL: typeof URL;
-  } = { TransformStream, TextDecoder, TextEncoder, URL };
+    fetch: typeof fetch;
+  } = {
+    TransformStream,
+    TextDecoder,
+    TextEncoder,
+    URL,
+    fetch: () => Promise.reject(new Error('fetch not available in sandbox')),
+  };
   sandbox.self = sandbox;
   runInNewContext(await readFile(path.join(outputPath, 'bundle.js'), 'utf8'), sandbox);
 

--- a/client-sdks/ai-sdk/src/__tests__/regenerate.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/regenerate.test.ts
@@ -8,9 +8,9 @@
  * step-start chunks without text content.
  */
 import type { UIMessage } from '@internal/ai-sdk-v5';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { Agent } from '@mastra/core/agent';
 import { Mastra } from '@mastra/core/mastra';
-import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai/test';
 import { describe, expect, it } from 'vitest';
 
 import { handleChatStream } from '../chat-route';

--- a/client-sdks/ai-sdk/src/middleware.test.ts
+++ b/client-sdks/ai-sdk/src/middleware.test.ts
@@ -19,7 +19,7 @@ import type {
 } from '@mastra/core/processors';
 import type { MemoryStorage } from '@mastra/core/storage';
 import { LibSQLStore } from '@mastra/libsql';
-import { ObservationalMemory } from '@mastra/memory/processors';
+import { Memory } from '@mastra/memory';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createProcessorMiddleware, withMastra } from './middleware';
@@ -820,10 +820,17 @@ describe('withMastra middleware', () => {
     });
 
     it('should save messages via observational memory after streaming completes', async () => {
-      const observationalMemory = new ObservationalMemory({
-        storage: memoryStore,
-        observation: { messageTokens: 100000, model: 'test-model', bufferTokens: false },
-        reflection: { observationTokens: 200000, model: 'test-model' },
+      // The OM engine is not a Processor itself — Memory wraps it in an
+      // ObservationalMemoryProcessor via getInputProcessors/getOutputProcessors.
+      const memory = new Memory({
+        storage,
+        options: {
+          lastMessages: false,
+          observationalMemory: {
+            observation: { messageTokens: 100000, model: 'test-model', bufferTokens: false },
+            reflection: { observationTokens: 200000, model: 'test-model' },
+          },
+        },
       });
 
       const model = withMastra(createMockModel(), {
@@ -833,8 +840,8 @@ describe('withMastra middleware', () => {
           resourceId,
           lastMessages: false,
         },
-        inputProcessors: [observationalMemory],
-        outputProcessors: [observationalMemory],
+        inputProcessors: await memory.getInputProcessors(),
+        outputProcessors: await memory.getOutputProcessors(),
       });
 
       const { messages: initialMessages } = await memoryStore.listMessages({ threadId });


### PR DESCRIPTION
## Summary

Fixes 5 test files in `client-sdks/ai-sdk` that fail on a clean checkout of `main`. All fixes are test-only — no production code is touched.

- **`abort-signal.test.ts`, `add-tool-result-message-id.test.ts`, `regenerate.test.ts`** — imported test utilities from `'ai/test'`, but `ai` is not a devDependency of `@mastra/ai-sdk`, so resolution depends on incidental hoisting. Switched to the vendored `@internal/ai-sdk-v5/test`, which exports the same `MockLanguageModelV2` / `convertArrayToReadableStream`. `abort-signal` also needed a `c.req.query` mock for the current handler signature.
- **`browser-bundle.test.ts`** — `@ai-sdk/provider-utils` calls `Function.prototype.toString.call(fetch)` at module init, which crashes in the test sandbox because it has no `fetch` global. Added a stub `fetch` to the sandbox globals — `fetch` is a legitimate browser global, so this doesn't weaken the test's "no Node globals" premise.
- **`middleware.test.ts`** — the observational-memory test passed the `ObservationalMemory` engine directly as input/output processors, but the `Processor` interface moved to `ObservationalMemoryProcessor`, so every hook was a silent no-op and the `storedMessages.length >= 2` assertion failed. Rewired it through `Memory`'s `getInputProcessors()` / `getOutputProcessors()`, matching real usage and exercising the actual processor adapter.

## Test plan

- `npx vitest run` in `client-sdks/ai-sdk`: 27/27 files, 184/184 tests pass (previously 5 files failed)
- `tsc --noEmit` in `client-sdks/ai-sdk`: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR repairs five test files so they work with the project’s bundled tools and test setup. It changes test code only and confirms that all tests and TypeScript checks pass.

## Changes

- Replaced `ai/test` imports with `@internal/ai-sdk-v5/test`.
- Added the required `c.req.query` mock in `abort-signal.test.ts`.
- Added a rejecting `fetch` stub to the browser bundle test sandbox.
- Updated the observational-memory middleware test to use processors from `Memory`.
- Verified `27/27` test files and `184/184` tests pass.
- Confirmed `tsc --noEmit` completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->