### PR TITLE
fix(mastracode): notify at event receipt when the agent requests user input

### DIFF
--- a/.changeset/notify-input-request-20398.md
+++ b/.changeset/notify-input-request-20398.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed notifications for assistant questions, plan approvals, sandbox access requests, and tool approvals so the bell, system notification, and Notification hooks fire the moment Mastra Code starts waiting for input — even while an earlier prompt is still pending. Fixes #20398.

--- a/mastracode/tui/e2e/fixtures/notify-input-request-hook.json
+++ b/mastracode/tui/e2e/fixtures/notify-input-request-hook.json
@@ -1,0 +1,34 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
+        "userMessage": "Run the notify input request hook e2e.",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_notify_input_request",
+            "name": "ask_user",
+            "arguments": {
+              "question": "Which notification channel should the notify hook e2e verify?"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
+        "toolCallId": "call_notify_input_request",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Notify hook e2e complete for Bell."
+      }
+    }
+  ]
+}

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -69,6 +69,7 @@ import { notificationInboxCrudFlowScenario } from './notification-inbox-crud-flo
 import { notificationInboxReloadScenario } from './notification-inbox-reload.js';
 import { notificationInboxToolFlowScenario } from './notification-inbox-tool-flow.js';
 import { notificationSignalRenderingScenario } from './notification-signal-rendering.js';
+import { notifyInputRequestHookScenario } from './notify-input-request-hook.js';
 import { omAttachmentObservationScenario } from './om-attachment-observation.js';
 import { omGlobalSettingsPersistenceScenario } from './om-global-settings-persistence.js';
 import { omModelOverrideReloadScenario } from './om-model-override-reload.js';
@@ -236,6 +237,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'notification-inbox-reload': notificationInboxReloadScenario,
   'notification-inbox-tool-flow': notificationInboxToolFlowScenario,
   'notification-signal-rendering': notificationSignalRenderingScenario,
+  'notify-input-request-hook': notifyInputRequestHookScenario,
   'om-attachment-observation': omAttachmentObservationScenario,
   'om-global-settings-persistence': omGlobalSettingsPersistenceScenario,
   'om-model-override-reload': omModelOverrideReloadScenario,

--- a/mastracode/tui/e2e/tui/notify-input-request-hook.ts
+++ b/mastracode/tui/e2e/tui/notify-input-request-hook.ts
@@ -1,0 +1,141 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect } from './expect.js';
+import type { McE2eScenario } from './types.js';
+
+/**
+ * E2E scenario for receipt-time input-request notifications (#20398).
+ *
+ * Configures a Notification hook that logs every notification's stdin payload
+ * to a JSONL file, then triggers an ask_user prompt through the real TUI. The
+ * scenario asserts the hook received an `ask_question` notification while the
+ * prompt is still unanswered — proving the notification fired when the input
+ * request arrived, through the production subscription wiring, not when the
+ * prompt handler eventually resolved.
+ *
+ * This guards the pre-queue notification tap's production call site: if the
+ * TUI's controller subscription stops routing events through the tap, no
+ * notification fires at all (the old in-handler notify calls were removed)
+ * and this scenario fails.
+ */
+
+let notificationLogPath = '';
+
+export const notifyInputRequestHookScenario: McE2eScenario = {
+  name: 'notify-input-request-hook',
+  description:
+    'Configure a Notification hook, trigger an ask_user prompt, and verify the hook fires while the prompt is still pending.',
+  testName: 'fires the Notification hook at input-request receipt while the prompt is unanswered',
+  projectFixture: 'long-branch',
+  useOpenAIModel: true,
+  aimockFixture: 'notify-input-request-hook.json',
+  env() {
+    return { MASTRACODE_DISABLE_HOOKS: '0' };
+  },
+  prepare({ projectDir }) {
+    const hooksDir = join(projectDir, '.mastracode');
+    mkdirSync(hooksDir, { recursive: true });
+    notificationLogPath = join(hooksDir, 'notification-events.jsonl');
+
+    // Hook script: log each Notification payload (reason + message) to a
+    // JSONL file, then exit 0 (notification hooks are non-blocking).
+    writeFileSync(
+      join(hooksDir, 'notify-hook.cjs'),
+      `const fs = require('node:fs');
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  const payload = JSON.parse(input || '{}');
+  fs.appendFileSync('.mastracode/notification-events.jsonl', JSON.stringify({
+    event: payload.hook_event_name,
+    reason: payload.reason || null,
+    message: payload.message ?? null,
+  }) + '\\n');
+  process.exit(0);
+});
+`,
+    );
+
+    writeFileSync(
+      join(hooksDir, 'hooks.json'),
+      JSON.stringify(
+        {
+          Notification: [
+            {
+              type: 'command',
+              command: 'node .mastracode/notify-hook.cjs',
+              timeout: 5000,
+              description: 'log notification events',
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    runtime.printScreen('spawned', terminal);
+
+    await (
+      expect(terminal.getByText(/Mastra Code|Build|Plan|Fast|Type|Press|>/gi, { full: true, strict: false })) as any
+    ).toBeVisible();
+    runtime.printScreen('after startup', terminal);
+
+    terminal.submit('Run the notify input request hook e2e.');
+    await runtime.waitForScreenText(
+      /Which notification channel should the notify hook e2e verify\?/i,
+      terminal,
+      15_000,
+    );
+    runtime.printScreen('ask_user prompt visible', terminal);
+
+    // The prompt is on screen and unanswered. The Notification hook must have
+    // fired at event receipt — poll the hook log for the ask_question record.
+    // The hook runs as a fire-and-forget child process, so allow it a moment
+    // to append its line.
+    const deadline = Date.now() + 10_000;
+    let askQuestionRecord: { event: string; reason: string | null; message: string | null } | undefined;
+    while (Date.now() < deadline && !askQuestionRecord) {
+      if (existsSync(notificationLogPath)) {
+        const lines = readFileSync(notificationLogPath, 'utf8')
+          .trim()
+          .split(/\n+/)
+          .filter(Boolean)
+          .map(line => JSON.parse(line));
+        askQuestionRecord = lines.find(entry => entry.event === 'Notification' && entry.reason === 'ask_question');
+      }
+      if (!askQuestionRecord) {
+        await runtime.sleep(100);
+      }
+    }
+
+    if (!askQuestionRecord) {
+      throw new Error('Notification hook never received an ask_question record while the prompt was pending');
+    }
+    if (askQuestionRecord.message !== 'Which notification channel should the notify hook e2e verify?') {
+      throw new Error(`Notification hook received the wrong message: ${JSON.stringify(askQuestionRecord.message)}`);
+    }
+    runtime.printScreen('notification hook verified while prompt pending', terminal);
+
+    // Answer the prompt and let the run finish normally.
+    terminal.write('Bell');
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Notify hook e2e complete for Bell\./i, terminal, 15_000);
+    runtime.printScreen('after prompt answered', terminal);
+
+    terminal.keyCtrlC();
+    runtime.printScreen('after Ctrl-C', terminal);
+  },
+  verifyAimockRequests(requests) {
+    const serialized = JSON.stringify(requests);
+    if (!serialized.includes('call_notify_input_request')) {
+      throw new Error('Expected AIMock requests to include the ask_user tool call id');
+    }
+    if (requests.length < 2) {
+      throw new Error(`Expected at least 2 AIMock requests for suspend + resume, received ${requests.length}`);
+    }
+  },
+};

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -101,6 +101,7 @@ export type ScenarioName =
   | 'notification-inbox-reload'
   | 'notification-inbox-tool-flow'
   | 'notification-signal-rendering'
+  | 'notify-input-request-hook'
   | 'om-settings'
   | 'om-attachment-observation'
   | 'om-global-settings-persistence'

--- a/mastracode/tui/src/tui/__tests__/notify-input-request.test.ts
+++ b/mastracode/tui/src/tui/__tests__/notify-input-request.test.ts
@@ -246,6 +246,7 @@ describe('input-request notifications fire at event receipt (#20398)', () => {
       handled.push(event.type);
     });
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    let stderrOutput: string[] = [];
 
     try {
       subscribeToAgentController(poisonedState, handleEvent);
@@ -257,10 +258,12 @@ describe('input-request notifications fire at event receipt (#20398)', () => {
       });
       await delivery;
     } finally {
+      stderrOutput = stderrSpy.mock.calls.map(args => String(args[0]));
       stderrSpy.mockRestore();
     }
 
     expect(handled).toEqual(['tool_suspended']);
     expect(mocks.sendNotification).not.toHaveBeenCalled();
+    expect(stderrOutput.join('')).toContain('[notify error] poisoned state');
   });
 });

--- a/mastracode/tui/src/tui/__tests__/notify-input-request.test.ts
+++ b/mastracode/tui/src/tui/__tests__/notify-input-request.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Regression tests for #20398: input-request notifications must fire the moment
+ * the event is received by the controller subscription listener, BEFORE the
+ * event enters the TUI's serialized dispatch queue. A pending prompt blocks
+ * that queue until the user answers, so a notification queued behind it would
+ * be starved exactly when the user has walked away.
+ *
+ * These tests exercise the REAL subscription listener (subscribeToAgentController)
+ * and the REAL display.notify / notifyForInputRequest mapping. Observation
+ * happens one layer down, at the notify.js module boundary (sendNotification),
+ * which display.ts calls through a cross-module import — the reliable
+ * interception point. Events are delivered through the captured listener, never
+ * via direct handleEvent calls, so the queue semantics are genuinely exercised.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  sendNotification: vi.fn(),
+}));
+
+vi.mock('../notify.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../notify.js')>()),
+  sendNotification: mocks.sendNotification,
+}));
+
+import { subscribeToAgentController } from '../setup.js';
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(r => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function createHarness() {
+  let listener: ((event: any) => Promise<void>) | undefined;
+  const state = {
+    session: {
+      state: { get: vi.fn(() => ({ notifications: 'off' })) },
+      subscribe: vi.fn((handler: any) => {
+        listener = handler;
+        return vi.fn();
+      }),
+    },
+    hookManager: undefined,
+  } as any;
+
+  const releaseBlocker = createDeferred<void>();
+  const handled: string[] = [];
+  const handleEvent = vi.fn(async (event: { type: string }) => {
+    handled.push(`start:${event.type}`);
+    if (event.type === 'blocking_prompt') {
+      await releaseBlocker.promise;
+    }
+    handled.push(`end:${event.type}`);
+  });
+
+  subscribeToAgentController(state, handleEvent);
+  if (!listener) throw new Error('subscribe did not capture a listener');
+
+  return {
+    state,
+    listener: listener as (event: any) => Promise<void>,
+    releaseBlocker,
+    handled,
+    handleEvent,
+  };
+}
+
+beforeEach(() => {
+  mocks.sendNotification.mockClear();
+});
+
+describe('input-request notifications fire at event receipt (#20398)', () => {
+  it('notifies for ask_user while the queue is blocked by a pending prompt', async () => {
+    const { listener, releaseBlocker, handled } = createHarness();
+
+    const blocked = listener({ type: 'blocking_prompt' });
+    await Promise.resolve();
+    expect(handled).toEqual(['start:blocking_prompt']);
+
+    const second = listener({
+      type: 'tool_suspended',
+      toolCallId: 't-ask',
+      toolName: 'ask_user',
+      suspendPayload: { question: 'Which option do you prefer?' },
+    });
+
+    // The queue is still blocked — the notification must already have fired.
+    expect(handled).toEqual(['start:blocking_prompt']);
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.sendNotification).toHaveBeenCalledWith(
+      'ask_question',
+      expect.objectContaining({ message: 'Which option do you prefer?', mode: 'off' }),
+    );
+
+    // Releasing the queue preserves strict delivery order.
+    releaseBlocker.resolve();
+    await blocked;
+    await second;
+    expect(handled).toEqual([
+      'start:blocking_prompt',
+      'end:blocking_prompt',
+      'start:tool_suspended',
+      'end:tool_suspended',
+    ]);
+  });
+
+  it('notifies for submit_plan while the queue is blocked', async () => {
+    const { listener, releaseBlocker, handled } = createHarness();
+
+    void listener({ type: 'blocking_prompt' });
+    await Promise.resolve();
+
+    void listener({
+      type: 'tool_suspended',
+      toolCallId: 't-plan',
+      toolName: 'submit_plan',
+      suspendPayload: { path: 'plans/my-plan.md' },
+    });
+
+    expect(handled).toEqual(['start:blocking_prompt']);
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.sendNotification).toHaveBeenCalledWith(
+      'plan_approval',
+      expect.objectContaining({ message: 'Plan requires your approval' }),
+    );
+    releaseBlocker.resolve();
+  });
+
+  it('notifies for request_access by toolName while the queue is blocked', async () => {
+    const { listener, releaseBlocker, handled } = createHarness();
+
+    void listener({ type: 'blocking_prompt' });
+    await Promise.resolve();
+
+    void listener({
+      type: 'tool_suspended',
+      toolCallId: 't-sandbox',
+      toolName: 'request_access',
+      suspendPayload: { path: '/srv/data', reason: 'read datasets' },
+    });
+
+    expect(handled).toEqual(['start:blocking_prompt']);
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.sendNotification).toHaveBeenCalledWith(
+      'sandbox_access',
+      expect.objectContaining({ message: 'Sandbox access requested: /srv/data' }),
+    );
+    releaseBlocker.resolve();
+  });
+
+  it('notifies for a sandbox_access_request payload kind regardless of toolName', async () => {
+    const { listener, releaseBlocker } = createHarness();
+
+    void listener({ type: 'blocking_prompt' });
+    await Promise.resolve();
+
+    void listener({
+      type: 'tool_suspended',
+      toolCallId: 't-sandbox-kind',
+      toolName: 'some_workspace_tool',
+      suspendPayload: { kind: 'sandbox_access_request', path: '/opt/shared' },
+    });
+
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.sendNotification).toHaveBeenCalledWith(
+      'sandbox_access',
+      expect.objectContaining({ message: 'Sandbox access requested: /opt/shared' }),
+    );
+    releaseBlocker.resolve();
+  });
+
+  it('notifies for tool_approval_required while the queue is blocked', async () => {
+    const { listener, releaseBlocker, handled } = createHarness();
+
+    void listener({ type: 'blocking_prompt' });
+    await Promise.resolve();
+
+    void listener({
+      type: 'tool_approval_required',
+      toolCallId: 't-approve',
+      toolName: 'execute_command',
+      args: { command: 'ls' },
+    });
+
+    expect(handled).toEqual(['start:blocking_prompt']);
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.sendNotification).toHaveBeenCalledWith(
+      'tool_approval',
+      expect.objectContaining({ message: 'Approve execute_command?' }),
+    );
+    releaseBlocker.resolve();
+  });
+
+  it('coerces a missing suspendPayload to an empty message instead of undefined', async () => {
+    const { listener, releaseBlocker } = createHarness();
+
+    void listener({ type: 'blocking_prompt' });
+    await Promise.resolve();
+
+    void listener({ type: 'tool_suspended', toolCallId: 't-bare', toolName: 'ask_user' });
+
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.sendNotification).toHaveBeenCalledWith('ask_question', expect.objectContaining({ message: '' }));
+    releaseBlocker.resolve();
+  });
+
+  it('does not notify for a tool_suspended event of an unrelated tool', async () => {
+    const { listener, releaseBlocker } = createHarness();
+
+    void listener({ type: 'blocking_prompt' });
+    await Promise.resolve();
+
+    void listener({
+      type: 'tool_suspended',
+      toolCallId: 't-other',
+      toolName: 'some_other_tool',
+      suspendPayload: { anything: true },
+    });
+    void listener({ type: 'message_update' });
+
+    expect(mocks.sendNotification).not.toHaveBeenCalled();
+    releaseBlocker.resolve();
+  });
+
+  it('keeps delivering events when notification state access throws', async () => {
+    let listener: ((event: any) => Promise<void>) | undefined;
+    const poisonedState = {
+      session: {
+        state: {
+          get: vi.fn(() => {
+            throw new Error('poisoned state');
+          }),
+        },
+        subscribe: vi.fn((handler: any) => {
+          listener = handler;
+          return vi.fn();
+        }),
+      },
+      hookManager: undefined,
+    } as any;
+    const handled: string[] = [];
+    const handleEvent = vi.fn(async (event: { type: string }) => {
+      handled.push(event.type);
+    });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      subscribeToAgentController(poisonedState, handleEvent);
+      const delivery = listener!({
+        type: 'tool_suspended',
+        toolCallId: 't-poison',
+        toolName: 'ask_user',
+        suspendPayload: { question: 'still delivered?' },
+      });
+      await delivery;
+    } finally {
+      stderrSpy.mockRestore();
+    }
+
+    expect(handled).toEqual(['tool_suspended']);
+    expect(mocks.sendNotification).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/tui/src/tui/__tests__/notify-input-request.test.ts
+++ b/mastracode/tui/src/tui/__tests__/notify-input-request.test.ts
@@ -124,6 +124,27 @@ describe('input-request notifications fire at event receipt (#20398)', () => {
     expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
     expect(mocks.sendNotification).toHaveBeenCalledWith(
       'plan_approval',
+      expect.objectContaining({ message: 'Plan "plans/my-plan.md" requires approval' }),
+    );
+    releaseBlocker.resolve();
+  });
+
+  it('falls back to a generic plan approval message when the payload has no path', async () => {
+    const { listener, releaseBlocker } = createHarness();
+
+    void listener({ type: 'blocking_prompt' });
+    await Promise.resolve();
+
+    void listener({
+      type: 'tool_suspended',
+      toolCallId: 't-plan-nopath',
+      toolName: 'submit_plan',
+      suspendPayload: {},
+    });
+
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.sendNotification).toHaveBeenCalledWith(
+      'plan_approval',
       expect.objectContaining({ message: 'Plan requires your approval' }),
     );
     releaseBlocker.resolve();

--- a/mastracode/tui/src/tui/display.ts
+++ b/mastracode/tui/src/tui/display.ts
@@ -118,3 +118,36 @@ export function notify(state: TUIState, reason: NotificationReason, message?: st
     hookManager: state.hookManager,
   });
 }
+
+/**
+ * Fire the notification for an input-request event the moment it is received,
+ * before the event enters the TUI's serialized dispatch queue. A pending prompt
+ * blocks that queue until the user answers, so any notify call living inside a
+ * queued handler is starved exactly when the user has walked away. This helper
+ * runs synchronously in the controller subscription listener instead.
+ *
+ * Non-input-request events are a no-op. Never throws: a notification failure
+ * must not break event delivery.
+ */
+export function notifyForInputRequest(state: TUIState, event: any): void {
+  try {
+    if (event?.type === 'tool_approval_required') {
+      notify(state, 'tool_approval', `Approve ${event.toolName}?`);
+      return;
+    }
+    if (event?.type === 'tool_suspended') {
+      const payload = (event.suspendPayload ?? {}) as Record<string, unknown>;
+      // Sandbox check first, mirroring the dispatch routing order.
+      if (event.toolName === 'request_access' || payload.kind === 'sandbox_access_request') {
+        notify(state, 'sandbox_access', `Sandbox access requested: ${String(payload.path ?? '')}`);
+      } else if (event.toolName === 'ask_user') {
+        notify(state, 'ask_question', String(payload.question ?? ''));
+      } else if (event.toolName === 'submit_plan') {
+        notify(state, 'plan_approval', 'Plan requires your approval');
+      }
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[notify error] ${msg}\n`);
+  }
+}

--- a/mastracode/tui/src/tui/display.ts
+++ b/mastracode/tui/src/tui/display.ts
@@ -4,6 +4,7 @@
 import { Container, Text } from '@earendil-works/pi-tui';
 
 import { parseError } from '@mastra/code-sdk/utils/errors';
+import type { AgentControllerEvent } from '@mastra/core/agent-controller';
 import { insertChatComponentWithBoundarySpacing } from './chat-boundary-reconciliation.js';
 import type { ChatSpacingKind } from './components/chat-spacing.js';
 import type { NotificationMode, NotificationReason } from './notify.js';
@@ -129,13 +130,13 @@ export function notify(state: TUIState, reason: NotificationReason, message?: st
  * Non-input-request events are a no-op. Never throws: a notification failure
  * must not break event delivery.
  */
-export function notifyForInputRequest(state: TUIState, event: any): void {
+export function notifyForInputRequest(state: TUIState, event: AgentControllerEvent): void {
   try {
-    if (event?.type === 'tool_approval_required') {
+    if (event.type === 'tool_approval_required') {
       notify(state, 'tool_approval', `Approve ${event.toolName}?`);
       return;
     }
-    if (event?.type === 'tool_suspended') {
+    if (event.type === 'tool_suspended') {
       const payload = (event.suspendPayload ?? {}) as Record<string, unknown>;
       // Sandbox check first, mirroring the dispatch routing order.
       if (event.toolName === 'request_access' || payload.kind === 'sandbox_access_request') {

--- a/mastracode/tui/src/tui/display.ts
+++ b/mastracode/tui/src/tui/display.ts
@@ -144,7 +144,12 @@ export function notifyForInputRequest(state: TUIState, event: AgentControllerEve
       } else if (event.toolName === 'ask_user') {
         notify(state, 'ask_question', String(payload.question ?? ''));
       } else if (event.toolName === 'submit_plan') {
-        notify(state, 'plan_approval', 'Plan requires your approval');
+        const planPath = String(payload.path ?? '');
+        notify(
+          state,
+          'plan_approval',
+          planPath ? `Plan "${planPath}" requires approval` : 'Plan requires your approval',
+        );
       }
     }
   } catch (err) {

--- a/mastracode/tui/src/tui/handlers/__tests__/prompts.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/prompts.test.ts
@@ -82,6 +82,9 @@ describe('handleSandboxAccessRequest', () => {
       path: '/tmp/project',
       reason: 'Read workspace files',
     });
+    // #20398: the notification now fires at event receipt in the subscription
+    // listener, not inside the queued handler.
+    expect(ctx.notify).not.toHaveBeenCalled();
   });
 });
 
@@ -100,6 +103,10 @@ describe('handleAskQuestion goal mode', () => {
 
     state.activeInlineQuestion!.handleInput('\r');
     await promise;
+
+    // #20398: the notification now fires at event receipt in the subscription
+    // listener, not inside the queued handler.
+    expect(ctx.notify).not.toHaveBeenCalled();
   });
 
   it('resolves a multi_select prompt with an array of every toggled option label', async () => {
@@ -250,6 +257,9 @@ describe('handlePlanApproval regular approval', () => {
     expect(state.activeInlinePlanApproval).toBe(streamedComponent);
     expect(state.ui.setFocus).toHaveBeenCalledWith(streamedComponent);
     expect(streamedComponent.render(80).join('\n')).toContain('Use as /goal');
+    // #20398: the notification now fires at event receipt in the subscription
+    // listener, not inside the queued handler.
+    expect(ctx.notify).not.toHaveBeenCalled();
   });
 
   it('approves the plan without sending a handoff signal', async () => {

--- a/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
@@ -5,6 +5,7 @@ import {
   clearPendingShellOutputs,
   clearToolInputParsers,
   handleShellOutput,
+  handleToolApprovalRequired,
   handleToolEnd,
   handleToolInputDelta,
   handleToolInputEnd,
@@ -260,5 +261,26 @@ describe('tool event handlers', () => {
     expect(rendered).toContain('search_content');
     expect(rendered).not.toContain('Streaming answer text');
     expect(rendered).toContain('Updated answer text');
+  });
+});
+
+describe('handleToolApprovalRequired', () => {
+  it('does not notify from the queued handler (#20398 — notification fires at event receipt)', () => {
+    const ctx = {
+      state: {
+        ui: {
+          showOverlay: vi.fn(() => ({ close: vi.fn() })),
+          requestRender: vi.fn(),
+          terminal: { columns: 120, rows: 40 },
+        },
+        hookManager: undefined,
+      },
+      notify: vi.fn(),
+    } as any;
+
+    handleToolApprovalRequired(ctx, 'call-approve', 'execute_command', { command: 'ls' });
+
+    expect(ctx.state.ui.showOverlay).toHaveBeenCalledTimes(1);
+    expect(ctx.notify).not.toHaveBeenCalled();
   });
 });

--- a/mastracode/tui/src/tui/handlers/prompts.ts
+++ b/mastracode/tui/src/tui/handlers/prompts.ts
@@ -212,8 +212,6 @@ export async function handleAskQuestion(
       showModalOverlay(state.ui, dialog, { widthPercent: 0.7 });
       dialog.focused = true;
     }
-
-    ctx.notify('ask_question', question);
   });
 }
 
@@ -284,8 +282,6 @@ export async function handleSandboxAccessRequest(
     } else {
       activate();
     }
-
-    ctx.notify('sandbox_access', `Sandbox access requested: ${requestedPath}`);
   });
 }
 
@@ -482,7 +478,5 @@ export async function handlePlanApproval(
     state.ui.requestRender();
     state.chatContainer.invalidate();
     state.ui.setFocus(approvalComponent);
-
-    ctx.notify('plan_approval', `Plan "${resolvedTitle}" requires approval`);
   });
 }

--- a/mastracode/tui/src/tui/handlers/tool.ts
+++ b/mastracode/tui/src/tui/handlers/tool.ts
@@ -350,9 +350,6 @@ export function handleToolApprovalRequired(
   const category = getToolCategory(toolName);
   const categoryLabel = category ? TOOL_CATEGORIES[category]?.label : undefined;
 
-  // Send notification to alert the user
-  ctx.notify('tool_approval', `Approve ${toolName}?`);
-
   const firePermissionResult = (decision: 'approved' | 'declined' | 'dismissed' | 'auto_approved') => {
     state.hookManager?.runPermissionResult('tool_approval', toolCallId, toolName, decision, args).catch(() => {});
   };

--- a/mastracode/tui/src/tui/setup.ts
+++ b/mastracode/tui/src/tui/setup.ts
@@ -14,7 +14,7 @@ import { renderBanner } from './components/banner.js';
 import { IdleCounterComponent } from './components/idle-counter.js';
 import { SimpleProgressComponent } from './components/simple-progress.js';
 import { TaskProgressComponent } from './components/task-progress.js';
-import { showError, showInfo } from './display.js';
+import { notifyForInputRequest, showError, showInfo } from './display.js';
 import { isGoalJudgeInputLocked, showGoalJudgeInputLockInfo } from './goal-input-lock.js';
 import { askModalQuestion } from './modal-question.js';
 import { showModalOverlay } from './overlay.js';
@@ -573,6 +573,10 @@ export function setupKeyHandlers(
 export function subscribeToAgentController(state: TUIState, handleEvent: (event: any) => Promise<void>): void {
   let eventQueue = Promise.resolve();
   const listener: AgentControllerEventListener = event => {
+    // Notify at receipt, before queueing: a pending prompt blocks the serial
+    // queue until answered, which would starve any notification queued behind
+    // it — exactly when the user has walked away and needs the ping.
+    notifyForInputRequest(state, event);
     eventQueue = eventQueue.then(async () => {
       try {
         await handleEvent(event);


### PR DESCRIPTION
## Summary

Closes #20398

When Mastra Code asks the user a question, requests plan approval, asks for sandbox access, or waits on a tool approval, the configured notification path (terminal bell, system notification, Notification hooks) is supposed to ping the user. It often did not fire until much later, and in the worst case not until the user came back on their own. The user who walked away, the one the notification exists for, was exactly the one who never got pinged.

This PR moves the notification to the moment the input request arrives, before it enters the TUI's serialized event queue. The prompt itself still renders and resolves exactly as before, but the ping now happens when the agent starts waiting, even while an earlier prompt is still pending and blocking the queue.

## Root cause

The TUI processes agent controller events on a serial promise queue: `subscribeToAgentController` in `mastracode/tui/src/tui/setup.ts` chains every event onto `eventQueue = eventQueue.then(...)`. Prompt handlers like `handleAskQuestion` return a promise that only resolves when the user answers, so a pending prompt blocks every later event's handling until the answer arrives.

Every notification call lived inside those queued handlers. If a prompt was already pending, the next input request's notification sat in the queue behind it, waiting for a user who was not there. The starvation covered assistant questions, plan approvals, sandbox access requests, and tool approvals alike.

## Lineage

iulspop reported the bug and opened #20399 with a fix and a regression test, which he later closed himself. His diagnosis was right and the regression test instinct was exactly the correct one. The fix layer was the problem: it moved the notify calls into `handleEvent`, but `handleEvent` is the queued task, so the relocated calls still starved behind a pending prompt. The test called `handleEvent` directly, bypassing the queue, which is why it passed against a fix that could not work live. The regression tests in this PR deliver events through the real subscription listener with the queue deliberately blocked, so they fail on main and cannot green a fix that sits inside the queue.

## What changed

- **A pre-queue notification tap.** New `notifyForInputRequest(state, event)` in `display.ts`, invoked synchronously at the top of the subscription listener before the event is chained onto the queue. It maps the four input request shapes to their notification reason and message: `tool_approval_required` to a tool approval ping, and `tool_suspended` to sandbox access (checked first, mirroring dispatch routing), assistant question, or plan approval based on the tool. Anything else is a no-op.
- **The four in-handler notify calls are removed.** Ask question, sandbox access, plan approval, and tool approval no longer notify from inside their handlers, so each input request produces exactly one notification.
- **Plan approval notifications carry the plan path.** This is a user-visible message change, not a pure relocation: the old notification said `Plan "<resolvedTitle>" requires approval`, while the new one names the plan by its file path, because the resolved title is not available at receipt time without reading the plan file and the path identifies the waiting plan just as precisely. The old generic message is kept as a fallback for a payload without a path.
- **The tap is typed and defensive.** It takes an `AgentControllerEvent` so SDK event shape changes surface as type errors rather than silently silencing notifications, payload fields are coerced with `String(... ?? '')` to preserve the hook stdin contract, and the body is wrapped so a notification failure can never break event delivery.
- **The event queue is untouched.** Serialization semantics, prompt display, answering, stacking, and cancellation all behave exactly as before, and the existing serialization and prompt suites pass unmodified.

## Design notes

- Notification hooks fire even when the built-in notification mode is off, so the tap serves hook users unconditionally, matching the existing `sendNotification` behavior.
- A suspended prompt can later be retracted when its run fails (#19444). The receipt-time notification is still truthful, input was requested at that moment, and the error surfaces through the normal error path, so the tap does not attempt retraction handling.
- Two neighbors suffer the same starvation and are deliberately out of scope here: the `agent_done` notification still fires from inside the queued lifecycle handler (#20860), and `runPermissionRequest` permission hooks still fire inside the queued task (#20861). Both are the same disease and are now tracked as their own follow-ups rather than a silently grown diff.

## Test plan

- New regression suite `notify-input-request.test.ts` (9 tests) exercises the real subscription listener with the queue genuinely blocked by a never-resolving handler: each of the four input request shapes notifies at receipt while the blocking event is still being handled, delivery order is preserved after release, a missing suspend payload coerces to an empty message rather than dropping the hook's message key, an unrelated suspension does not notify, and a poisoned state read logs to stderr without breaking event delivery.
- Recorded red run: the suite copied onto the base commit fails 6 of 8 (every receipt-time assertion, notify never called while the queue was blocked), proving it goes through the queue rather than around it.
- Handler suites gained negative assertions pinning that the removed in-handler notify calls stay removed, alongside the untouched serialization, parallel prompt, and cancellation suites.
- New checked-in E2E scenario `notify-input-request-hook` drives the real TUI with a real Notification hook script and asserts the hook receives the ask question record while the prompt is still unanswered on screen. Mutation checked: commenting out the single tap invocation in the listener makes the scenario fail, so it guards the production wiring that unit tests mock away.
- A standalone red/green demo wires the real subscription, the real notify pipeline, and a real `HookManager` Notification hook writing to a log file: on base the log stays empty behind a pending prompt, on this branch all four notifications land in the log within milliseconds while the queue is blocked.
- Focused TUI suites green (39 and 64 tests), `tsc --noEmit` clean, `oxlint` and `eslint` clean, patch changeset for `mastracode` included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra Code now sends notifications as soon as it needs input from the user. A waiting prompt no longer delays the notification.

## Changes

- Added synchronous notifications for:
  - Assistant questions
  - Plan approvals
  - Sandbox access requests
  - Tool approvals
- Added plan path details when available, with a generic fallback.
- Moved notifications before the serialized TUI event queue.
- Removed duplicate notifications from prompt and tool handlers.
- Added defensive event typing and error handling.
- Preserved existing prompt rendering, response handling, stacking, cancellation, and serialization behavior.
- Added regression, handler, and end-to-end tests.
- Added a `mastracode` changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
