### PR TITLE
fix: patch gray-matter so core imports survive the js-yaml 5 security override

### DIFF
--- a/patches/gray-matter@4.0.3.patch
+++ b/patches/gray-matter@4.0.3.patch
@@ -1,0 +1,19 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index eebdf42eb721b756d4f554b09b943774faa659b0..0000000000000000000000000000000000000000
+diff --git a/lib/engines.js b/lib/engines.js
+index 38f993db06cf364191ac635a6590c2d29303297d..bc95719c5cc4f417d35380b855858086fd56e80c 100644
+--- a/lib/engines.js
++++ b/lib/engines.js
+@@ -13,8 +13,9 @@ const engines = exports = module.exports;
+  */
+ 
+ engines.yaml = {
+-  parse: yaml.safeLoad.bind(yaml),
+-  stringify: yaml.safeDump.bind(yaml)
++  // js-yaml >= 4 removed safeLoad/safeDump; load/dump are safe by default there.
++  parse: (yaml.safeLoad || yaml.load).bind(yaml),
++  stringify: (yaml.safeDump || yaml.dump).bind(yaml)
+ };
+ 
+ /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,7 @@ packageExtensionsChecksum: sha256-xGYNP5bHLPlbBT+RiHXWlNCiUtPhW6W9ntBiVM/duy4=
 patchedDependencies:
   '@changesets/get-dependents-graph@2.1.4': eb65c5cbf43c61ce6dcb0c77fa30d9aebcdffa3a70dee1faefc4cde4125f28fa
   '@earendil-works/pi-tui@0.80.6': 88572df39a8452647fa073db5bc0907de3f1cb04c52c4559c8cc6e662973818b
+  gray-matter@4.0.3: 058d8be9f17b95a6f86e58debce82671ee3f258e44883a9da932cf16a717ebb8
 
 importers:
 
@@ -4369,7 +4370,7 @@ importers:
         version: 1.20.1
       gray-matter:
         specifier: ^4.0.3
-        version: 4.0.3
+        version: 4.0.3(patch_hash=058d8be9f17b95a6f86e58debce82671ee3f258e44883a9da932cf16a717ebb8)
       ignore:
         specifier: ^7.0.5
         version: 7.0.5
@@ -4710,7 +4711,7 @@ importers:
         version: 11.3.5
       gray-matter:
         specifier: ^4.0.3
-        version: 4.0.3
+        version: 4.0.3(patch_hash=058d8be9f17b95a6f86e58debce82671ee3f258e44883a9da932cf16a717ebb8)
       hono:
         specifier: ^4.12.8
         version: 4.12.30
@@ -37481,7 +37482,7 @@ snapshots:
       fs-extra: 11.3.5
       github-slugger: 1.5.0
       globby: 11.1.0
-      gray-matter: 4.0.3
+      gray-matter: 4.0.3(patch_hash=058d8be9f17b95a6f86e58debce82671ee3f258e44883a9da932cf16a717ebb8)
       jiti: 1.21.7
       js-yaml: 5.2.3
       lodash: 4.18.1
@@ -37522,7 +37523,7 @@ snapshots:
       fs-extra: 11.3.5
       github-slugger: 1.5.0
       globby: 11.1.0
-      gray-matter: 4.0.3
+      gray-matter: 4.0.3(patch_hash=058d8be9f17b95a6f86e58debce82671ee3f258e44883a9da932cf16a717ebb8)
       jiti: 1.21.7
       js-yaml: 5.2.3
       lodash: 4.18.1
@@ -50636,7 +50637,7 @@ snapshots:
 
   graphql@16.14.0: {}
 
-  gray-matter@4.0.3:
+  gray-matter@4.0.3(patch_hash=058d8be9f17b95a6f86e58debce82671ee3f258e44883a9da932cf16a717ebb8):
     dependencies:
       js-yaml: 5.2.3
       kind-of: 6.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,6 +51,7 @@ catalog:
 patchedDependencies:
   '@changesets/get-dependents-graph@2.1.4': patches/@changesets__get-dependents-graph@2.1.4.patch
   '@earendil-works/pi-tui@0.80.6': patches/@earendil-works__pi-tui@0.80.6.patch
+  gray-matter@4.0.3: patches/gray-matter@4.0.3.patch
 
 packageExtensions:
   '@ai-sdk/provider-utils@3.0.25':


### PR DESCRIPTION
## What changed

The security update in #19265 overrides `js-yaml` to `^5.2.2` workspace-wide (CVE-2026-59869). `gray-matter@4.0.3` — a dependency of `@mastra/core` (skills frontmatter parsing) and `@mastra/deployer` — still calls `yaml.safeLoad` / `yaml.safeDump` at require time, APIs that were removed in js-yaml 4. Since that merge, any workspace import of `gray-matter` throws:

```
TypeError: Cannot read properties of undefined (reading 'bind')
    at node_modules/gray-matter/lib/engines.js:16:24
```

which fails every `packages/core` test file that transitively imports skills support (e.g. all the aimock loop scenario suites) before a single test runs.

This adds a `pnpm patch` for `gray-matter@4.0.3` (same mechanism as the existing `fetch-to-node` / `tsup` patches) that falls back to `load` / `dump`, which are safe-by-default in js-yaml >= 4:

```js
parse: (yaml.safeLoad || yaml.load).bind(yaml),
stringify: (yaml.safeDump || yaml.dump).bind(yaml)
```

This keeps the security override intact rather than scoping gray-matter back to vulnerable js-yaml 3.x.

No changeset: the patch only affects the workspace install. Published consumers of `@mastra/core` resolve gray-matter's own `js-yaml ^3` dependency and never hit this.

## Test plan

- Before: `packages/core` `src/loop/test-utils/aimock/scenarios/agents-as-tools.scenario.test.ts` fails at import with the `bind` TypeError (0 tests run).
- After: same file passes (3 tests), and `src/workspace/skills` suites pass (251 tests, 4 files) — these exercise gray-matter's yaml engine directly through SKILL.md frontmatter parsing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR helps `gray-matter` work with the newer `js-yaml` version used by the workspace. It prevents imports from failing while keeping the security fix in place.

## Summary

- Patched `gray-matter@4.0.3` to use `yaml.load` and `yaml.dump` when `safeLoad` and `safeDump` are unavailable.
- Preserved bound parser and serializer methods.
- Added the patch through `pnpm-workspace.yaml`.
- Kept the workspace-wide `js-yaml@^5.2.2` security override for CVE-2026-59869.
- Deleted the patched package's `CHANGELOG.md`.
- Applied the change only to the workspace installation.
- Added no changeset because published `@mastra/core` consumers use `gray-matter`'s own `js-yaml ^3` dependency.
- Verified the affected core and workspace skills test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->