### PR TITLE
feat(mcp): opt-in allowedHosts URL policy and inheritDefaultEnv stdio isolation for MCP client

### DIFF
--- a/.changeset/mcp-client-security-hardening.md
+++ b/.changeset/mcp-client-security-hardening.md
@@ -2,4 +2,7 @@
 '@mastra/mcp': minor
 ---
 
-Add opt-in security hardening options to the MCP client: `allowedHosts` on HTTP server configs restricts which hosts the client's HTTP requests (including redirect hops, the SSE fallback, and OAuth discovery) may target, and `inheritDefaultEnv: false` on stdio server configs stops the subprocess from inheriting the SDK's default environment variables. Both options are opt-in; default behavior is unchanged.
+Add opt-in security hardening options to the MCP client. Both options are opt-in; default behavior is unchanged.
+
+- `allowedHosts` on HTTP server configs restricts which hosts the client's HTTP requests may target, covering the initial connection, the SSE fallback, and OAuth discovery. On the default fetch path redirect hops are blocked before they are sent; with a custom `fetch`, the final response URL is validated after the request runs, so custom fetch implementations must enforce redirect policy themselves when preventing outbound contact is required.
+- `inheritDefaultEnv: false` on stdio server configs stops the subprocess from inheriting the SDK's default environment variables; only the entries you list in `env` are passed.

--- a/.changeset/mcp-client-security-hardening.md
+++ b/.changeset/mcp-client-security-hardening.md
@@ -6,3 +6,20 @@ Add opt-in security hardening options to the MCP client. Both options are opt-in
 
 - `allowedHosts` on HTTP server configs restricts which hosts the client's HTTP requests may target, covering the initial connection, the SSE fallback, and OAuth discovery. On the default fetch path redirect hops are blocked before they are sent; with a custom `fetch`, the final response URL is validated after the request runs, so custom fetch implementations must enforce redirect policy themselves when preventing outbound contact is required.
 - `inheritDefaultEnv: false` on stdio server configs stops the subprocess from inheriting the SDK's default environment variables; only the entries you list in `env` are passed.
+
+```typescript
+const mcp = new MCPClient({
+  servers: {
+    weather: {
+      url: new URL('https://weather.example/mcp'),
+      allowedHosts: ['weather.example'],
+    },
+    local: {
+      command: 'npx',
+      args: ['tsx', 'stdio-server.ts'],
+      inheritDefaultEnv: false,
+      env: { WEATHER_API_KEY: process.env.WEATHER_API_KEY! },
+    },
+  },
+});
+```

--- a/.changeset/mcp-client-security-hardening.md
+++ b/.changeset/mcp-client-security-hardening.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': minor
+---
+
+Add opt-in security hardening options to the MCP client: `allowedHosts` on HTTP server configs restricts which hosts the client's HTTP requests (including redirect hops, the SSE fallback, and OAuth discovery) may target, and `inheritDefaultEnv: false` on stdio server configs stops the subprocess from inheriting the SDK's default environment variables. Both options are opt-in; default behavior is unchanged.

--- a/docs/src/content/en/docs/mcp/overview.mdx
+++ b/docs/src/content/en/docs/mcp/overview.mdx
@@ -131,6 +131,16 @@ requireToolApproval: ({ toolName }) => toolName.startsWith('delete_')
 
 Treat tool annotations from servers you don't control as untrusted hints. Visit [tool approval](/reference/tools/mcp-client#tool-approval) for the callback context and security guidance.
 
+### Security
+
+MCP servers run code and return content on your agent's behalf, so configure them with the same care as any other external dependency:
+
+- **Stdio subprocess environment**: subprocesses inherit only the MCP SDK's curated environment whitelist (for example `PATH` and `HOME` on POSIX), not the full parent environment. Set `inheritDefaultEnv: false` on a server to pass only the variables you list in `env`.
+- **Outbound host restriction**: when HTTP server URLs come from untrusted configuration, set `allowedHosts` to restrict which hosts the client will contact and block server-side request forgery through redirects.
+- **Tool response trust**: tool results are untrusted model input. Use [input and output processors](/docs/agents/processors) to inspect or sanitize content before it reaches the model, and `requireToolApproval` to gate sensitive tools.
+
+Visit the [MCPClient security reference](/reference/tools/mcp-client#security) for enforcement details of each option.
+
 ### MCP registries
 
 Registries provide hosted or packaged MCP servers. The client configuration above works with registry endpoints and commands.

--- a/docs/src/content/en/docs/mcp/overview.mdx
+++ b/docs/src/content/en/docs/mcp/overview.mdx
@@ -136,7 +136,7 @@ Treat tool annotations from servers you don't control as untrusted hints. Visit 
 MCP servers run code and return content on your agent's behalf, so configure them with the same care as any other external dependency:
 
 - **Stdio subprocess environment**: subprocesses inherit only the MCP SDK's curated environment whitelist (for example `PATH` and `HOME` on POSIX), not the full parent environment. Set `inheritDefaultEnv: false` on a server to pass only the variables you list in `env`.
-- **Outbound host restriction**: when HTTP server URLs come from untrusted configuration, set `allowedHosts` to restrict which hosts the client will contact and block server-side request forgery through redirects.
+- **Outbound host restriction**: when HTTP server URLs come from untrusted configuration, set `allowedHosts` to restrict which hosts the client will contact. On the default fetch path this also blocks redirect hops before they're sent; a custom `fetch` gets its final response URL validated after the request runs, so it must enforce redirect policy itself when preventing outbound contact is required.
 - **Tool response trust**: tool results are untrusted model input. Use [input and output processors](/docs/agents/processors) to inspect or sanitize content before it reaches the model, and `requireToolApproval` to gate sensitive tools.
 
 Visit the [MCPClient security reference](/reference/tools/mcp-client#security) for enforcement details of each option.

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -280,7 +280,7 @@ When `forwardInstructions` is omitted (the default), instructions are still cach
 
 ### Subprocess environment for Stdio servers
 
-Stdio subprocesses do not inherit the full parent process environment. By default the subprocess environment starts from the MCP SDK's curated whitelist (POSIX: `HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`; Windows: `APPDATA`, `HOMEDRIVE`, `HOMEPATH`, `LOCALAPPDATA`, `PATH`, `PROCESSOR_ARCHITECTURE`, `SYSTEMDRIVE`, `SYSTEMROOT`, `TEMP`, `USERNAME`, `USERPROFILE`), merged with any variables you set in `env`. Sensitive variables such as API keys are not inherited unless you pass them explicitly.
+Stdio subprocesses don't inherit the full parent process environment. By default the subprocess environment starts from the MCP SDK's curated whitelist (POSIX: `HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`; Windows: `APPDATA`, `HOMEDRIVE`, `HOMEPATH`, `LOCALAPPDATA`, `PATH`, `PROCESSOR_ARCHITECTURE`, `SYSTEMDRIVE`, `SYSTEMROOT`, `TEMP`, `USERNAME`, `USERPROFILE`), merged with any variables you set in `env`. Sensitive variables such as API keys aren't inherited unless you pass them explicitly.
 
 For stricter isolation, set `inheritDefaultEnv: false` so only your configured `env` entries reach the subprocess:
 
@@ -296,7 +296,7 @@ const mcp = new MCPClient({
 })
 ```
 
-Variables you place in `env` are forwarded verbatim — treat server configurations that come from untrusted sources (for example, user-supplied config files) as untrusted input.
+Variables you place in `env` are forwarded verbatim, so treat server configurations that come from untrusted sources (for example, user-supplied config files) as untrusted input.
 
 ### Restricting outbound hosts with `allowedHosts`
 
@@ -315,16 +315,16 @@ const mcp = new MCPClient({
 
 Enforcement details:
 
-- On the default fetch path, requests to disallowed hosts — including every redirect hop — are blocked **before** they are sent. Redirects are followed manually (up to 5 hops) so each hop is validated, and the `Authorization` header is not carried across hops to a different host.
-- When you supply a custom `fetch` (or a custom `eventSourceInit.fetch`), the initial URL is still checked before the request, but redirect hops are validated **after the fact** using `response.url`: the outbound hop may occur, and the response is discarded if it landed on a disallowed host. A hand-built `Response` with an empty `response.url` skips this post-hoc check.
+- On the default fetch path, requests to disallowed hosts, including every redirect hop, are blocked **before** they're sent. Redirects are followed manually (up to 5 hops) so each hop is validated, and the `Authorization` header isn't carried across hops to a different origin (any scheme, host, or port change drops it, matching standard fetch behavior).
+- When you supply a custom `fetch` (or a custom `eventSourceInit.fetch`), the initial URL is still checked before the request, but redirect hops are validated **after the fact** using `response.url`: the outbound hop may occur, and the response is discarded when its final URL points at a disallowed host. A hand-built `Response` with an empty `response.url` skips this post-hoc check.
 - OAuth requests made through `authProvider` (authorization server metadata discovery, token exchange, refresh) are also validated. If your authorization server runs on a different host than the MCP server, add that host to `allowedHosts` too.
 - A blocked host fails the connection with a clear error and is never retried by the reconnect logic.
 
-`allowedHosts` is intentionally simple: exact host matching, no wildcards, scheme not checked. If you need richer policy (scheme checks, IP-range rules), supply a custom `fetch` implementation — it is invoked for every request the client makes.
+`allowedHosts` is intentionally minimal: it matches exact hosts and doesn't support wildcards or scheme checks. If you need richer policy (scheme checks, IP-range rules), supply a custom `fetch` implementation, which is invoked for every request the client makes.
 
 ### Treat tool responses as untrusted input
 
-Tool results returned by MCP servers flow into your agent's context as model input. A malicious or compromised server can use tool output for prompt injection. The transport client does not sanitize tool responses — sanitization policy belongs at the agent layer, where Mastra's [input and output processors](/docs/agents/processors) let you inspect, transform, or block content before and after it reaches the model. Combine this with `requireToolApproval` and the `forwardInstructions` security note above when working with third-party servers.
+Tool results returned by MCP servers flow into your agent's context as model input. A malicious or compromised server can use tool output for prompt injection. The transport client doesn't sanitize tool responses: sanitization policy belongs at the agent layer, where Mastra's [input and output processors](/docs/agents/processors) let you inspect, transform, or block content before and after it reaches the model. Combine this with `requireToolApproval` and the `forwardInstructions` security note above when working with third-party servers.
 
 ## Methods
 

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -81,6 +81,14 @@ Each server in the `servers` map is configured using the `MastraMCPServerDefinit
     description: 'For Stdio servers: Environment variables to set for the command.',
   },
   {
+    name: 'inheritDefaultEnv',
+    type: 'boolean',
+    isOptional: true,
+    defaultValue: 'true',
+    description:
+      "For Stdio servers: Whether the subprocess environment starts from the MCP SDK's default inherited environment. The default is a curated whitelist, not the full process environment: on POSIX it inherits HOME, LOGNAME, PATH, SHELL, TERM, and USER; on Windows it inherits APPDATA, HOMEDRIVE, HOMEPATH, LOCALAPPDATA, PATH, PROCESSOR_ARCHITECTURE, SYSTEMDRIVE, SYSTEMROOT, TEMP, USERNAME, and USERPROFILE. When set to `false`, only the variables explicitly listed in `env` are passed to the subprocess. Note that a subprocess without PATH may fail to spawn commands that are not absolute paths.",
+  },
+  {
     name: 'url',
     type: 'URL',
     isOptional: true,
@@ -105,6 +113,13 @@ Each server in the `servers` map is configured using the `MastraMCPServerDefinit
     isOptional: true,
     description:
       'For HTTP servers: Custom fetch implementation used for all network requests. Receives an optional third `requestContext` parameter containing request-scoped data (e.g., authentication cookies, bearer tokens) from the incoming request. When provided, this function will be used for all HTTP requests, allowing you to add dynamic authentication headers, forward request-scoped credentials to the MCP server, customize request behavior per-request, or intercept and modify requests/responses. When `fetch` is provided, `requestInit`, `eventSourceInit`, and `authProvider` become optional, as you can handle these concerns within your custom fetch function.',
+  },
+  {
+    name: 'allowedHosts',
+    type: 'string[]',
+    isOptional: true,
+    description:
+      'For HTTP servers: Opt-in allowlist of hosts the client may contact on behalf of this server. Each entry is matched against the URL host (hostname plus port when the URL carries a non-default port), for example `"api.example.com"` or `"localhost:8080"`. Matching is exact and case-insensitive on the hostname; wildcards are not supported and the URL scheme is not checked. An empty array denies all requests. When unset, no restriction is applied. See the Security section below for enforcement details.',
   },
   {
     name: 'logger',
@@ -260,6 +275,56 @@ const agent = new Agent({
 When `forwardInstructions` is omitted (the default), instructions are still cached and can be inspected via [`getServerInstructions()`](#getserverinstructions), but aren't added to any agent's system prompt.
 
 > **Security note:** server instructions are forwarded verbatim (subject only to length truncation) into the agent's system prompt. A malicious or compromised MCP server can use them to inject instructions the agent will treat as trusted system guidance. Only enable `forwardInstructions` for servers you trust, and prefer reviewing instructions with `getServerInstructions()` before forwarding instructions from third-party servers.
+
+## Security
+
+### Subprocess environment for Stdio servers
+
+Stdio subprocesses do not inherit the full parent process environment. By default the subprocess environment starts from the MCP SDK's curated whitelist (POSIX: `HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`; Windows: `APPDATA`, `HOMEDRIVE`, `HOMEPATH`, `LOCALAPPDATA`, `PATH`, `PROCESSOR_ARCHITECTURE`, `SYSTEMDRIVE`, `SYSTEMROOT`, `TEMP`, `USERNAME`, `USERPROFILE`), merged with any variables you set in `env`. Sensitive variables such as API keys are not inherited unless you pass them explicitly.
+
+For stricter isolation, set `inheritDefaultEnv: false` so only your configured `env` entries reach the subprocess:
+
+```typescript
+const mcp = new MCPClient({
+  servers: {
+    myTool: {
+      command: '/usr/local/bin/my-mcp-server',
+      inheritDefaultEnv: false,
+      env: { MY_TOOL_API_KEY: process.env.MY_TOOL_API_KEY! },
+    },
+  },
+})
+```
+
+Variables you place in `env` are forwarded verbatim — treat server configurations that come from untrusted sources (for example, user-supplied config files) as untrusted input.
+
+### Restricting outbound hosts with `allowedHosts`
+
+When HTTP server URLs come from untrusted configuration, an attacker-controlled URL can point the client at internal services (server-side request forgery). Set `allowedHosts` on such servers to restrict which hosts the client will contact:
+
+```typescript
+const mcp = new MCPClient({
+  servers: {
+    remote: {
+      url: new URL(untrustedConfig.serverUrl),
+      allowedHosts: ['api.example.com'],
+    },
+  },
+})
+```
+
+Enforcement details:
+
+- On the default fetch path, requests to disallowed hosts — including every redirect hop — are blocked **before** they are sent. Redirects are followed manually (up to 5 hops) so each hop is validated, and the `Authorization` header is not carried across hops to a different host.
+- When you supply a custom `fetch` (or a custom `eventSourceInit.fetch`), the initial URL is still checked before the request, but redirect hops are validated **after the fact** using `response.url`: the outbound hop may occur, and the response is discarded if it landed on a disallowed host. A hand-built `Response` with an empty `response.url` skips this post-hoc check.
+- OAuth requests made through `authProvider` (authorization server metadata discovery, token exchange, refresh) are also validated. If your authorization server runs on a different host than the MCP server, add that host to `allowedHosts` too.
+- A blocked host fails the connection with a clear error and is never retried by the reconnect logic.
+
+`allowedHosts` is intentionally simple: exact host matching, no wildcards, scheme not checked. If you need richer policy (scheme checks, IP-range rules), supply a custom `fetch` implementation — it is invoked for every request the client makes.
+
+### Treat tool responses as untrusted input
+
+Tool results returned by MCP servers flow into your agent's context as model input. A malicious or compromised server can use tool output for prompt injection. The transport client does not sanitize tool responses — sanitization policy belongs at the agent layer, where Mastra's [input and output processors](/docs/agents/processors) let you inspect, transform, or block content before and after it reaches the model. Combine this with `requireToolApproval` and the `forwardInstructions` security note above when working with third-party servers.
 
 ## Methods
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,7 +26,7 @@
     "build:lib": "tsdown --silent --config tsdown.config.ts",
     "prepack": "tsx ../../scripts/generate-package-docs.ts",
     "build:watch": "pnpm build:lib --watch",
-    "test:client": "vitest run ./src/client/client.test.ts ./src/client/configuration.test.ts ./src/client/oauth.test.ts ./src/client/oauth-callback-server.test.ts ./src/client/oauth-flow.test.ts",
+    "test:client": "vitest run ./src/client/client.test.ts ./src/client/configuration.test.ts ./src/client/oauth.test.ts ./src/client/oauth-callback-server.test.ts ./src/client/oauth-flow.test.ts ./src/client/url-policy.test.ts",
     "test:server": "vitest run ./src/server",
     "test:integration": "cd integration-tests && pnpm test:mcp",
     "test": "pnpm test:server && pnpm test:client && pnpm test:integration",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,7 +26,7 @@
     "build:lib": "tsdown --silent --config tsdown.config.ts",
     "prepack": "tsx ../../scripts/generate-package-docs.ts",
     "build:watch": "pnpm build:lib --watch",
-    "test:client": "vitest run ./src/client/client.test.ts ./src/client/configuration.test.ts ./src/client/oauth.test.ts ./src/client/oauth-callback-server.test.ts ./src/client/oauth-flow.test.ts ./src/client/url-policy.test.ts",
+    "test:client": "vitest run ./src/client/client.test.ts ./src/client/configuration.test.ts ./src/client/oauth.test.ts ./src/client/oauth-callback-server.test.ts ./src/client/oauth-flow.test.ts ./src/client/url-policy.test.ts ./src/client/stdio-env.test.ts",
     "test:server": "vitest run ./src/server",
     "test:integration": "cd integration-tests && pnpm test:mcp",
     "test": "pnpm test:server && pnpm test:client && pnpm test:integration",

--- a/packages/mcp/src/__fixtures__/env-reporter.ts
+++ b/packages/mcp/src/__fixtures__/env-reporter.ts
@@ -1,0 +1,22 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+const server = new Server({ name: 'Env Reporter', version: '1.0.0' }, { capabilities: { tools: {} } });
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'getEnvKeys',
+      description: 'Returns Object.keys(process.env)',
+      inputSchema: { type: 'object', properties: {} },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async () => ({
+  content: [{ type: 'text', text: JSON.stringify(Object.keys(process.env)) }],
+}));
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -420,13 +420,30 @@ export class InternalMastraMCPClient extends MastraBase {
     await this.client.notification({ method: 'notifications/roots/list_changed' });
   }
 
+  private buildStdioEnv(): Record<string, string> {
+    const configured = this.serverConfig.env || {};
+    if (this.serverConfig.inheritDefaultEnv === false) {
+      // The SDK's StdioClientTransport unconditionally spreads getDefaultEnvironment()
+      // under the env we pass it, so an empty base alone cannot suppress the curated
+      // defaults. Explicitly override each curated key with undefined — Node's spawn
+      // drops env entries whose value is undefined — so only configured entries reach
+      // the subprocess.
+      const suppressed: Record<string, string | undefined> = {};
+      for (const key of Object.keys(getDefaultEnvironment())) {
+        suppressed[key] = undefined;
+      }
+      return { ...suppressed, ...configured } as Record<string, string>;
+    }
+    return { ...getDefaultEnvironment(), ...configured };
+  }
+
   private async connectStdio(command: string) {
     this.log('debug', `Using Stdio transport for command: ${command}`);
     try {
       this.transport = new StdioClientTransport({
         command,
         args: this.serverConfig.args,
-        env: { ...getDefaultEnvironment(), ...(this.serverConfig.env || {}) },
+        env: this.buildStdioEnv(),
         stderr: this.serverConfig.stderr,
         cwd: this.serverConfig.cwd,
       });

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -62,8 +62,8 @@ import type {
 } from './types';
 import {
   assertHostAllowed,
-  assertResponseHostAllowed,
   fetchFollowingAllowedRedirects,
+  isUrlPolicyError,
   wrapFetchWithHostPolicy,
 } from './url-policy';
 
@@ -469,19 +469,16 @@ export class InternalMastraMCPClient extends MastraBase {
     // When allowedHosts is set, the same wrapper enforces the host policy: on the default
     // path via manual redirect following (hops blocked before being sent), and on the
     // custom-fetch path via a pre-request check plus post-hoc response validation.
+    const policyUserFetch =
+      userFetch && allowedHosts !== undefined ? wrapFetchWithHostPolicy(userFetch, allowedHosts) : undefined;
     const fetch: FetchLike = (requestUrl: string | URL, init?: RequestInit) => {
       const requestContext = this.operationContextStore.getStore() ?? null;
       const executeFetch = (): Promise<Response> => {
         if (allowedHosts === undefined) {
           return userFetch ? userFetch(requestUrl, init, requestContext) : globalThis.fetch(requestUrl, init);
         }
-        if (userFetch) {
-          const guardedUserFetch = async () => {
-            assertHostAllowed(requestUrl, allowedHosts);
-            const response = await userFetch(requestUrl, init, requestContext);
-            return assertResponseHostAllowed(response, allowedHosts);
-          };
-          return guardedUserFetch();
+        if (policyUserFetch) {
+          return policyUserFetch(requestUrl, init, requestContext);
         }
         return fetchFollowingAllowedRedirects(
           (u: string | URL, i?: RequestInit) => globalThis.fetch(u, i),
@@ -524,6 +521,13 @@ export class InternalMastraMCPClient extends MastraBase {
         // Guarded on authProvider so servers without one never carry an auth state.
         if (authProvider && error instanceof UnauthorizedError) {
           this.markNeedsAuth(streamableTransport);
+          throw error;
+        }
+
+        // A policy violation is final: retrying the blocked host over SSE cannot
+        // succeed, and falling through would bury the policy error under a generic
+        // "could not connect" message.
+        if (isUrlPolicyError(error)) {
           throw error;
         }
 
@@ -572,6 +576,10 @@ export class InternalMastraMCPClient extends MastraBase {
       } catch (sseError) {
         if (authProvider && sseError instanceof UnauthorizedError) {
           this.markNeedsAuth(sseTransport);
+          throw sseError;
+        }
+        // Surface policy violations directly instead of the generic connect error.
+        if (isUrlPolicyError(sseError)) {
           throw sseError;
         }
         this.log(

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -60,6 +60,12 @@ import type {
   Root,
   RequireToolApproval,
 } from './types';
+import {
+  assertHostAllowed,
+  assertResponseHostAllowed,
+  fetchFollowingAllowedRedirects,
+  wrapFetchWithHostPolicy,
+} from './url-policy';
 
 // Re-export types for convenience
 export type {
@@ -433,14 +439,40 @@ export class InternalMastraMCPClient extends MastraBase {
   }
 
   private async connectHttp(url: URL) {
-    const { requestInit, eventSourceInit, authProvider, connectTimeout, fetch: userFetch } = this.serverConfig;
+    const { requestInit, eventSourceInit, authProvider, connectTimeout, fetch: userFetch, allowedHosts } =
+      this.serverConfig;
+
+    // Fail fast with a clear error before any transport is constructed.
+    if (allowedHosts !== undefined) {
+      assertHostAllowed(url, allowedHosts);
+    }
 
     // Wrap fetch so request-scoped metadata still flows through normal MCP POSTs, while
     // the long-lived Streamable HTTP event stream does not inherit the active Datadog span.
+    // When allowedHosts is set, the same wrapper enforces the host policy: on the default
+    // path via manual redirect following (hops blocked before being sent), and on the
+    // custom-fetch path via a pre-request check plus post-hoc response validation.
     const fetch: FetchLike = (requestUrl: string | URL, init?: RequestInit) => {
       const requestContext = this.operationContextStore.getStore() ?? null;
-      const executeFetch = () =>
-        userFetch ? userFetch(requestUrl, init, requestContext) : globalThis.fetch(requestUrl, init);
+      const executeFetch = (): Promise<Response> => {
+        if (allowedHosts === undefined) {
+          return userFetch ? userFetch(requestUrl, init, requestContext) : globalThis.fetch(requestUrl, init);
+        }
+        if (userFetch) {
+          const guardedUserFetch = async () => {
+            assertHostAllowed(requestUrl, allowedHosts);
+            const response = await userFetch(requestUrl, init, requestContext);
+            return assertResponseHostAllowed(response, allowedHosts);
+          };
+          return guardedUserFetch();
+        }
+        return fetchFollowingAllowedRedirects(
+          (u: string | URL, i?: RequestInit) => globalThis.fetch(u, i),
+          requestUrl,
+          init,
+          allowedHosts,
+        );
+      };
 
       return shouldDetachPersistentTransportRequest(init) ? runOutsideDatadogTraceScope(executeFetch) : executeFetch();
     };
@@ -498,8 +530,17 @@ export class InternalMastraMCPClient extends MastraBase {
       // Fallback to SSE transport
       // The top-level fetch is used for POST requests, but eventSourceInit.fetch is needed for the SSE stream.
       // Only supply our span-detaching fetch when the caller hasn't provided one, so an explicit
-      // eventSourceInit.fetch is preserved rather than overwritten.
-      const sseEventSourceInit = { ...eventSourceInit, fetch: eventSourceInit?.fetch ?? fetch };
+      // eventSourceInit.fetch is preserved rather than overwritten. When allowedHosts is set, a
+      // caller-supplied eventSourceInit.fetch is wrapped with the same policy check + post-hoc
+      // redirect validation as the custom-fetch path — otherwise it would bypass the policy.
+      const callerSseFetch = eventSourceInit?.fetch;
+      const sseEventSourceInit = {
+        ...eventSourceInit,
+        fetch:
+          callerSseFetch && allowedHosts !== undefined
+            ? wrapFetchWithHostPolicy(callerSseFetch, allowedHosts)
+            : (callerSseFetch ?? fetch),
+      };
 
       const sseTransport = new SSEClientTransport(url, {
         requestInit,

--- a/packages/mcp/src/client/stdio-env.test.ts
+++ b/packages/mcp/src/client/stdio-env.test.ts
@@ -1,0 +1,63 @@
+import path from 'node:path';
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { InternalMastraMCPClient } from './client.js';
+
+// Real subprocess, no module mocks: `connectStdio` really spawns, and the
+// client checks `this.transport instanceof StdioClientTransport`, which a
+// module mock would break. The committed env-reporter fixture echoes
+// `Object.keys(process.env)` back through a tool call.
+describe('MastraMCPClient - Stdio inheritDefaultEnv', () => {
+  // Resolve the tsx CLI binary from the workspace instead of using npx -y,
+  // which can be flaky in CI when tsx needs to be downloaded on-the-fly.
+  const tsxCli = path.join(path.dirname(require.resolve('tsx/package.json')), 'dist', 'cli.mjs');
+  const fixturePath = path.join(__dirname, '..', '__fixtures__/env-reporter.ts');
+
+  let client: InternalMastraMCPClient | undefined;
+
+  afterEach(async () => {
+    await client?.disconnect().catch(() => {});
+    client = undefined;
+  });
+
+  async function getChildEnvKeys(serverOptions: { env?: Record<string, string>; inheritDefaultEnv?: boolean }) {
+    client = new InternalMastraMCPClient({
+      name: 'env-reporter',
+      server: {
+        command: process.execPath,
+        args: [tsxCli, fixturePath],
+        ...serverOptions,
+      },
+    });
+    await client.connect();
+    const tools = await client.tools();
+    const result = (await tools['getEnvKeys']!.execute({})) as { content: Array<{ type: string; text: string }> };
+    return JSON.parse(result.content[0]!.text) as string[];
+  }
+
+  it('inherits the SDK default environment plus configured entries by default', async () => {
+    const keys = await getChildEnvKeys({ env: { MARKER: 'configured' } });
+    // PATH is on the SDK's curated inherit list on every platform.
+    expect(keys).toContain('PATH');
+    expect(keys).toContain('MARKER');
+  }, 30000);
+
+  it('passes only configured entries when inheritDefaultEnv is false', async () => {
+    const keys = await getChildEnvKeys({ inheritDefaultEnv: false, env: { MARKER: 'configured' } });
+    expect(keys).toContain('MARKER');
+    // Curated defaults must NOT be inherited. Assert absence of specific
+    // curated keys rather than exact set equality — the runtime may inject
+    // its own variables into the child.
+    expect(keys).not.toContain('HOME');
+    expect(keys).not.toContain('LOGNAME');
+    expect(keys).not.toContain('USER');
+    expect(keys).not.toContain('APPDATA');
+    expect(keys).not.toContain('USERPROFILE');
+  }, 30000);
+
+  it('behaves identically to unset when inheritDefaultEnv is explicitly true', async () => {
+    const keys = await getChildEnvKeys({ inheritDefaultEnv: true, env: { MARKER: 'configured' } });
+    expect(keys).toContain('PATH');
+    expect(keys).toContain('MARKER');
+  }, 30000);
+});

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -417,7 +417,9 @@ export type HttpServerDefinition = BaseServerOptions & {
    *   `'localhost:8080'`.
    * - Matching is exact and case-insensitive on the hostname. No wildcards.
    * - The URL scheme is NOT checked — matching is host-only, so `http://` and
-   *   `https://` URLs to an allowed host both pass.
+   *   `https://` URLs to an allowed host both pass. The `Authorization` header
+   *   is still dropped on any cross-origin redirect hop (scheme, host, or port
+   *   change), so a same-host scheme downgrade never re-sends credentials.
    * - An empty array (`allowedHosts: []`) denies all hosts.
    *
    * Enforcement strength varies by path:

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -305,6 +305,23 @@ export type StdioServerDefinition = BaseServerOptions & {
   /** Optional environment variables for the subprocess */
   env?: Record<string, string>;
   /**
+   * Whether the subprocess environment starts from the MCP SDK's default
+   * inherited environment. Defaults to `true`.
+   *
+   * The default is NOT the full `process.env`: the SDK's
+   * `getDefaultEnvironment()` inherits only a curated platform whitelist —
+   * on POSIX: `HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`; on Windows:
+   * `APPDATA`, `HOMEDRIVE`, `HOMEPATH`, `LOCALAPPDATA`, `PATH`,
+   * `PROCESSOR_ARCHITECTURE`, `SYSTEMDRIVE`, `SYSTEMROOT`, `TEMP`, `USERNAME`,
+   * `USERPROFILE` — and skips functions and variables starting with `()`.
+   *
+   * When `false`, the subprocess environment base is empty (`{}`) and only the
+   * variables explicitly listed in `env` are passed to the subprocess. Note
+   * that a subprocess without `PATH` may fail to spawn commands that are not
+   * absolute paths.
+   */
+  inheritDefaultEnv?: boolean;
+  /**
    * How to handle stderr of the child process. Matches the semantics of Node's `child_process.spawn`.
    *
    * - `"inherit"` (default): stderr is printed to the parent process's stderr
@@ -346,6 +363,7 @@ export type HttpServerDefinition = BaseServerOptions & {
   command?: never;
   args?: never;
   env?: never;
+  inheritDefaultEnv?: never;
   stderr?: never;
   cwd?: never;
 

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -327,6 +327,7 @@ export type StdioServerDefinition = BaseServerOptions & {
   sessionId?: never;
   connectTimeout?: never;
   fetch?: never;
+  allowedHosts?: never;
 };
 
 /**
@@ -381,6 +382,43 @@ export type HttpServerDefinition = BaseServerOptions & {
    * ```
    */
   fetch?: MastraFetchLike;
+  /**
+   * Optional allowlist of hosts this server's HTTP requests may target.
+   *
+   * When set, every outgoing request made on behalf of this server (initial
+   * connect, Streamable HTTP POSTs, the SSE fallback and its event stream,
+   * OAuth discovery/token requests routed through the transport fetch, and
+   * every redirect hop) is checked against this list. When unset, no
+   * restriction applies (current behavior).
+   *
+   * Matching semantics:
+   * - Entries are host values matched against `URL.host` — the hostname plus
+   *   the port when the URL carries a non-default port. WHATWG URL elides
+   *   default ports, so `https://x.com:443` has host `x.com` and matches the
+   *   entry `'x.com'`, not `'x.com:443'`. Examples: `'api.example.com'`,
+   *   `'localhost:8080'`.
+   * - Matching is exact and case-insensitive on the hostname. No wildcards.
+   * - The URL scheme is NOT checked — matching is host-only, so `http://` and
+   *   `https://` URLs to an allowed host both pass.
+   * - An empty array (`allowedHosts: []`) denies all hosts.
+   *
+   * Enforcement strength varies by path:
+   * - On the default path (no custom `fetch`), requests to disallowed hosts —
+   *   including redirect hops, via manual redirect following — are blocked
+   *   BEFORE being sent.
+   * - When a custom `fetch` (or a caller-supplied `eventSourceInit.fetch`) is
+   *   in play, the initial URL is checked before the request, but redirect
+   *   hops are validated post-hoc via `response.url`: the outbound hop may
+   *   occur, but the response never reaches the caller or the model. A
+   *   hand-built `Response` with an empty `response.url` skips the post-hoc
+   *   check (documented limitation — custom fetches legitimately construct
+   *   such responses).
+   *
+   * OAuth note: the SDK routes OAuth discovery and token requests through the
+   * transport's fetch, so when using an `authProvider` whose authorization
+   * server lives on a different host, that host must also be allowlisted.
+   */
+  allowedHosts?: string[];
   /** Optional request configuration for HTTP requests (optional when `fetch` is provided) */
   requestInit?: StreamableHTTPClientTransportOptions['requestInit'];
   /** Optional configuration for SSE fallback (required when using custom headers with SSE, optional when `fetch` is provided) */

--- a/packages/mcp/src/client/url-policy.test.ts
+++ b/packages/mcp/src/client/url-policy.test.ts
@@ -1,0 +1,761 @@
+import { randomUUID } from 'node:crypto';
+import { createServer } from 'node:http';
+import type { IncomingMessage, Server as HttpServer, ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { z } from 'zod/v3';
+
+import { InternalMastraMCPClient } from './client.js';
+import { isReconnectableMCPError } from './error-utils.js';
+import { MCPOAuthClientProvider, InMemoryOAuthStorage } from './oauth-provider.js';
+import {
+  assertHostAllowed,
+  assertResponseHostAllowed,
+  fetchFollowingAllowedRedirects,
+  wrapFetchWithHostPolicy,
+} from './url-policy.js';
+
+// =============================================================================
+// Unit tests: assertHostAllowed
+// =============================================================================
+
+describe('assertHostAllowed', () => {
+  it('passes an exactly matching host', () => {
+    expect(() => assertHostAllowed('https://api.example.com/mcp', ['api.example.com'])).not.toThrow();
+  });
+
+  it('matches case-insensitively on the hostname', () => {
+    expect(() => assertHostAllowed('https://API.Example.COM/mcp', ['api.example.com'])).not.toThrow();
+    expect(() => assertHostAllowed('https://api.example.com/mcp', ['API.EXAMPLE.COM'])).not.toThrow();
+  });
+
+  it('elides default ports per WHATWG URL: https://x.com:443 has host x.com', () => {
+    expect(() => assertHostAllowed('https://x.com:443/a', ['x.com'])).not.toThrow();
+    expect(() => assertHostAllowed('http://x.com:80/a', ['x.com'])).not.toThrow();
+  });
+
+  it('requires the port in the entry when the URL carries a non-default port', () => {
+    expect(() => assertHostAllowed('https://x.com:8443/a', ['x.com'])).toThrow(/allowedHosts/);
+    expect(() => assertHostAllowed('https://x.com:8443/a', ['x.com:8443'])).not.toThrow();
+  });
+
+  it('matches IPv6 hosts with brackets, as rendered by URL.host', () => {
+    expect(() => assertHostAllowed('http://[::1]:8080/', ['[::1]:8080'])).not.toThrow();
+    expect(() => assertHostAllowed('http://[::1]:8080/', ['::1:8080'])).toThrow(/allowedHosts/);
+  });
+
+  it('denies every host when the allowlist is empty', () => {
+    expect(() => assertHostAllowed('https://anything.example/', [])).toThrow(/allowedHosts/);
+    expect(() => assertHostAllowed('http://localhost:3000/', [])).toThrow(/allowedHosts/);
+  });
+
+  it('throws an error that is not treated as reconnectable', () => {
+    let thrown: unknown;
+    try {
+      assertHostAllowed('https://blocked.example/', ['allowed.example']);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain('blocked.example');
+    expect((thrown as Error).message).toContain('allowedHosts');
+    // A policy violation must never feed the reconnect machinery.
+    expect(isReconnectableMCPError(thrown)).toBe(false);
+  });
+});
+
+// =============================================================================
+// Unit tests: assertResponseHostAllowed (post-hoc validation)
+// =============================================================================
+
+describe('assertResponseHostAllowed', () => {
+  it('returns the response when the final URL host is allowed', () => {
+    const response = { url: 'https://api.example.com/mcp' };
+    expect(assertResponseHostAllowed(response, ['api.example.com'])).toBe(response);
+  });
+
+  it('throws when the final URL landed on a disallowed host', () => {
+    const response = { url: 'https://internal.attacker.example/steal' };
+    expect(() => assertResponseHostAllowed(response, ['api.example.com'])).toThrow(/allowedHosts/);
+  });
+
+  it('fails open for a hand-built Response with an empty url (documented limitation)', () => {
+    const handBuilt = new Response('{}', { status: 200 });
+    expect(handBuilt.url).toBe('');
+    expect(assertResponseHostAllowed(handBuilt, ['api.example.com'])).toBe(handBuilt);
+  });
+});
+
+// =============================================================================
+// Unit tests: wrapFetchWithHostPolicy (custom fetch / eventSourceInit.fetch path)
+// =============================================================================
+
+describe('wrapFetchWithHostPolicy', () => {
+  it('checks the request URL before the wrapped fetch runs', async () => {
+    const inner = vi.fn(async () => ({ url: '' }));
+    const wrapped = wrapFetchWithHostPolicy(inner, ['api.example.com']);
+    await expect(wrapped('https://blocked.example/')).rejects.toThrow(/allowedHosts/);
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it('validates the response post-hoc when the wrapped fetch auto-followed to a disallowed host', async () => {
+    const inner = vi.fn(async () => ({ url: 'https://internal.example/secret' }));
+    const wrapped = wrapFetchWithHostPolicy(inner, ['api.example.com']);
+    await expect(wrapped('https://api.example.com/mcp')).rejects.toThrow(/allowedHosts/);
+    expect(inner).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes an allowed response through unchanged', async () => {
+    const response = { url: 'https://api.example.com/mcp' };
+    const inner = vi.fn(async () => response);
+    const wrapped = wrapFetchWithHostPolicy(inner, ['api.example.com']);
+    await expect(wrapped('https://api.example.com/mcp')).resolves.toBe(response);
+  });
+});
+
+// =============================================================================
+// Unit tests: fetchFollowingAllowedRedirects (manual redirect loop)
+// =============================================================================
+
+function redirectResponse(status: number, location?: string): Response {
+  return new Response(null, { status, headers: location ? { location } : {} });
+}
+
+describe('fetchFollowingAllowedRedirects', () => {
+  const allowed = ['a.example', 'b.example'];
+
+  it('dispatches with redirect: manual and returns a non-redirect response', async () => {
+    const impl = vi.fn(async () => new Response('ok', { status: 200 }));
+    const res = await fetchFollowingAllowedRedirects(impl, 'https://a.example/x', undefined, allowed);
+    expect(res.status).toBe(200);
+    expect(impl).toHaveBeenCalledTimes(1);
+    expect(impl.mock.calls[0]![1]).toMatchObject({ redirect: 'manual' });
+  });
+
+  it('follows an absolute-Location redirect to an allowed host', async () => {
+    const impl = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse(302, 'https://b.example/next'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    const res = await fetchFollowingAllowedRedirects(impl, 'https://a.example/x', undefined, allowed);
+    expect(res.status).toBe(200);
+    expect(impl).toHaveBeenCalledTimes(2);
+    expect(String(impl.mock.calls[1]![0])).toBe('https://b.example/next');
+  });
+
+  it('resolves a relative Location against the current hop URL', async () => {
+    const impl = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse(302, '/moved/here'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    await fetchFollowingAllowedRedirects(impl, 'https://a.example/base/path', undefined, allowed);
+    expect(String(impl.mock.calls[1]![0])).toBe('https://a.example/moved/here');
+  });
+
+  it('blocks a redirect hop to a disallowed host before it is sent', async () => {
+    const impl = vi.fn().mockResolvedValueOnce(redirectResponse(302, 'https://evil.example/steal'));
+    await expect(fetchFollowingAllowedRedirects(impl, 'https://a.example/x', undefined, allowed)).rejects.toThrow(
+      /allowedHosts/,
+    );
+    // The disallowed hop was never dispatched.
+    expect(impl).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws after more than 5 redirect hops', async () => {
+    const impl = vi.fn(async () => redirectResponse(302, 'https://a.example/again'));
+    await expect(fetchFollowingAllowedRedirects(impl, 'https://a.example/x', undefined, allowed)).rejects.toThrow(
+      /redirect hops/i,
+    );
+    // Initial request + 5 followed hops = 6 dispatches; the 6th redirect overflows.
+    expect(impl).toHaveBeenCalledTimes(6);
+  });
+
+  it('switches POST to GET and drops the body on 303', async () => {
+    const impl = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse(303, 'https://b.example/next'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    await fetchFollowingAllowedRedirects(
+      impl,
+      'https://a.example/x',
+      { method: 'POST', body: '{"x":1}', headers: { 'content-type': 'application/json' } },
+      allowed,
+    );
+    const secondInit = impl.mock.calls[1]![1]!;
+    expect(secondInit.method).toBe('GET');
+    expect(secondInit.body).toBeUndefined();
+    expect((secondInit.headers as Headers).get('content-type')).toBeNull();
+  });
+
+  it('preserves method and string body on 307', async () => {
+    const impl = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse(307, 'https://b.example/next'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    await fetchFollowingAllowedRedirects(impl, 'https://a.example/x', { method: 'POST', body: '{"x":1}' }, allowed);
+    const secondInit = impl.mock.calls[1]![1]!;
+    expect(secondInit.method).toBe('POST');
+    expect(secondInit.body).toBe('{"x":1}');
+  });
+
+  it('throws on 307 when the body is not replayable instead of silently re-sending an empty body', async () => {
+    const impl = vi.fn().mockResolvedValueOnce(redirectResponse(307, 'https://b.example/next'));
+    const streamBody = new ReadableStream();
+    await expect(
+      fetchFollowingAllowedRedirects(
+        impl,
+        'https://a.example/x',
+        { method: 'POST', body: streamBody, duplex: 'half' } as RequestInit,
+        allowed,
+      ),
+    ).rejects.toThrow(/not replayable/);
+  });
+
+  it('strips the Authorization header on a hop to a different host but keeps it same-host', async () => {
+    const crossHost = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse(302, 'https://b.example/next'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    await fetchFollowingAllowedRedirects(
+      crossHost,
+      'https://a.example/x',
+      { headers: { authorization: 'Bearer secret' } },
+      allowed,
+    );
+    expect((crossHost.mock.calls[1]![1]!.headers as Headers).get('authorization')).toBeNull();
+
+    const sameHost = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse(302, 'https://a.example/next'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    await fetchFollowingAllowedRedirects(
+      sameHost,
+      'https://a.example/x',
+      { headers: { authorization: 'Bearer secret' } },
+      allowed,
+    );
+    expect((sameHost.mock.calls[1]![1]!.headers as Headers).get('authorization')).toBe('Bearer secret');
+  });
+
+  it('throws on a redirect status with no Location header', async () => {
+    const impl = vi.fn().mockResolvedValueOnce(redirectResponse(301));
+    await expect(fetchFollowingAllowedRedirects(impl, 'https://a.example/x', undefined, allowed)).rejects.toThrow(
+      /Location/,
+    );
+  });
+});
+
+// =============================================================================
+// Integration helpers: real MCP servers over node:http
+// =============================================================================
+
+type TestMcpServer = {
+  httpServer: HttpServer;
+  baseUrl: URL;
+  host: string;
+  /** All requests received, in order. */
+  requests: { method: string; url: string }[];
+  close: () => Promise<void>;
+};
+
+function buildMcpServer(): McpServer {
+  const mcpServer = new McpServer({ name: 'url-policy-test-server', version: '1.0.0' }, { capabilities: { tools: {} } });
+  mcpServer.tool(
+    'greet',
+    'A simple greeting tool',
+    { name: z.string().describe('Name to greet').default('World') },
+    async ({ name }): Promise<CallToolResult> => ({ content: [{ type: 'text', text: `Hello, ${name}!` }] }),
+  );
+  return mcpServer;
+}
+
+function listen(httpServer: HttpServer, pathname: string): Promise<URL> {
+  return new Promise<URL>(resolve => {
+    httpServer.listen(0, '127.0.0.1', () => {
+      const addr = httpServer.address() as AddressInfo;
+      resolve(new URL(`http://127.0.0.1:${addr.port}${pathname}`));
+    });
+  });
+}
+
+function closeServer(httpServer: HttpServer): Promise<void> {
+  return new Promise<void>(resolve => {
+    httpServer.closeAllConnections?.();
+    httpServer.close(() => resolve());
+  });
+}
+
+/**
+ * Stateless Streamable HTTP MCP server (SDK 1.27+ requires a fresh transport per
+ * request). `intercept` runs first for every request; returning true means the
+ * interceptor handled the response.
+ */
+async function startStreamableServer(
+  intercept?: (req: IncomingMessage, res: ServerResponse) => boolean,
+): Promise<TestMcpServer> {
+  const mcpServer = buildMcpServer();
+  const requests: { method: string; url: string }[] = [];
+
+  const httpServer = createServer();
+  httpServer.on('request', async (req, res) => {
+    requests.push({ method: req.method ?? '', url: req.url ?? '' });
+    if (intercept?.(req, res)) {
+      return;
+    }
+    await mcpServer.close().catch(() => {});
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    await mcpServer.connect(transport);
+    await transport.handleRequest(req, res);
+  });
+
+  const baseUrl = await listen(httpServer, '/mcp');
+  return {
+    httpServer,
+    baseUrl,
+    host: baseUrl.host,
+    requests,
+    close: async () => {
+      await mcpServer.close().catch(() => {});
+      await closeServer(httpServer);
+    },
+  };
+}
+
+/** Stateful Streamable HTTP MCP server — needed for the persistent GET event stream. */
+async function startStatefulStreamableServer(): Promise<TestMcpServer> {
+  const mcpServer = buildMcpServer();
+  const requests: { method: string; url: string }[] = [];
+  const serverTransport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
+  await mcpServer.connect(serverTransport);
+
+  const httpServer = createServer();
+  httpServer.on('request', async (req, res) => {
+    requests.push({ method: req.method ?? '', url: req.url ?? '' });
+    await serverTransport.handleRequest(req, res);
+  });
+
+  const baseUrl = await listen(httpServer, '/mcp');
+  return {
+    httpServer,
+    baseUrl,
+    host: baseUrl.host,
+    requests,
+    close: async () => {
+      await mcpServer.close().catch(() => {});
+      await serverTransport.close().catch(() => {});
+      await closeServer(httpServer);
+    },
+  };
+}
+
+/** Legacy HTTP+SSE MCP server, for exercising the eventSourceInit.fetch path. */
+async function startSseServer(): Promise<TestMcpServer> {
+  const mcpServer = buildMcpServer();
+  const requests: { method: string; url: string }[] = [];
+  const transports = new Map<string, SSEServerTransport>();
+
+  const httpServer = createServer();
+  httpServer.on('request', async (req, res) => {
+    requests.push({ method: req.method ?? '', url: req.url ?? '' });
+    const requestUrl = new URL(req.url ?? '', 'http://127.0.0.1');
+    if (req.method === 'GET' && requestUrl.pathname === '/sse') {
+      const transport = new SSEServerTransport('/messages', res);
+      transports.set(transport.sessionId, transport);
+      await mcpServer.connect(transport);
+      return;
+    }
+    if (req.method === 'POST' && requestUrl.pathname === '/messages') {
+      const sessionId = requestUrl.searchParams.get('sessionId') ?? '';
+      const transport = transports.get(sessionId);
+      if (!transport) {
+        res.writeHead(404).end();
+        return;
+      }
+      await transport.handlePostMessage(req, res);
+      return;
+    }
+    res.writeHead(404).end();
+  });
+
+  const baseUrl = await listen(httpServer, '/sse');
+  return {
+    httpServer,
+    baseUrl,
+    host: baseUrl.host,
+    requests,
+    close: async () => {
+      await mcpServer.close().catch(() => {});
+      await closeServer(httpServer);
+    },
+  };
+}
+
+/** A plain HTTP server standing in for a disallowed internal service. Counts requests. */
+async function startDecoyServer(): Promise<TestMcpServer> {
+  const requests: { method: string; url: string }[] = [];
+  const httpServer = createServer((req, res) => {
+    requests.push({ method: req.method ?? '', url: req.url ?? '' });
+    res.writeHead(200, { 'content-type': 'text/plain' }).end('decoy');
+  });
+  const baseUrl = await listen(httpServer, '/mcp');
+  return { httpServer, baseUrl, host: baseUrl.host, requests, close: () => closeServer(httpServer) };
+}
+
+// =============================================================================
+// Integration tests: InternalMastraMCPClient with allowedHosts
+// =============================================================================
+
+describe('MastraMCPClient allowedHosts policy', () => {
+  const datadogTracerTestSymbol = Symbol.for('mastra.mcp.dd-trace-test-tracer');
+  let client: InternalMastraMCPClient | undefined;
+  const cleanups: Array<() => Promise<void>> = [];
+
+  const track = <T extends TestMcpServer>(server: T): T => {
+    cleanups.push(server.close);
+    return server;
+  };
+
+  afterEach(async () => {
+    await client?.disconnect().catch(() => {});
+    client = undefined;
+    while (cleanups.length) {
+      await cleanups.pop()!().catch(() => {});
+    }
+    delete (globalThis as Record<PropertyKey, unknown>)[datadogTracerTestSymbol];
+    vi.restoreAllMocks();
+  });
+
+  it('connects and calls tools when the host (with its explicit port) is allowlisted', async () => {
+    const server = track(await startStreamableServer());
+    client = new InternalMastraMCPClient({
+      name: 'allowed-host-test',
+      server: { url: server.baseUrl, allowedHosts: [server.host] },
+    });
+    await client.connect();
+    const tools = await client.tools();
+    const result = await tools['greet']!.execute({ name: 'Policy' });
+    expect(JSON.stringify(result)).toContain('Hello, Policy!');
+  }, 15000);
+
+  it('rejects a disallowed host at connect time without dispatching any request', async () => {
+    const decoy = track(await startDecoyServer());
+    const fetchSpy = vi.fn((url: string | URL, init?: RequestInit) => fetch(url, init));
+    client = new InternalMastraMCPClient({
+      name: 'disallowed-host-test',
+      server: { url: decoy.baseUrl, allowedHosts: ['allowed.example'], fetch: fetchSpy },
+    });
+    await expect(client.connect()).rejects.toThrow(/allowedHosts/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(decoy.requests).toHaveLength(0);
+  }, 15000);
+
+  it('denies everything with an empty allowlist', async () => {
+    const server = track(await startStreamableServer());
+    client = new InternalMastraMCPClient({
+      name: 'empty-allowlist-test',
+      server: { url: server.baseUrl, allowedHosts: [] },
+    });
+    await expect(client.connect()).rejects.toThrow(/allowedHosts/);
+    expect(server.requests).toHaveLength(0);
+  }, 15000);
+
+  it('leaves the default path untouched when allowedHosts is unset', async () => {
+    const server = track(await startStreamableServer());
+    const fetchSpy = vi.fn((url: string | URL, init?: RequestInit) => fetch(url, init));
+    client = new InternalMastraMCPClient({
+      name: 'default-path-test',
+      server: { url: server.baseUrl, fetch: fetchSpy },
+    });
+    await client.connect();
+    await client.tools();
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(0);
+    // No forced redirect mode leaks into the default path.
+    for (const [, init] of fetchSpy.mock.calls) {
+      expect(init?.redirect).toBeUndefined();
+    }
+  }, 15000);
+
+  it('blocks a mid-connection redirect to a disallowed host before it is sent and does not reconnect-retry', async () => {
+    const decoy = track(await startDecoyServer());
+    let redirectServed = 0;
+    let redirecting = false;
+    const server = track(
+      await startStreamableServer((req, res) => {
+        if (redirecting && req.method === 'POST') {
+          redirectServed += 1;
+          res.writeHead(302, { location: `http://${decoy.host}/mcp` }).end();
+          return true;
+        }
+        return false;
+      }),
+    );
+
+    client = new InternalMastraMCPClient({
+      name: 'mid-stream-redirect-test',
+      server: { url: server.baseUrl, allowedHosts: [server.host] },
+    });
+    await client.connect();
+    const tools = await client.tools();
+
+    redirecting = true;
+    await expect(tools['greet']!.execute({ name: 'X' })).rejects.toThrow(/allowedHosts/);
+
+    // The blocked host never saw a request, and the policy error was not fed
+    // into the reconnect machinery (a retry would have served a second redirect).
+    expect(decoy.requests).toHaveLength(0);
+    expect(redirectServed).toBe(1);
+  }, 15000);
+
+  it('keeps the Datadog span-detach behavior for persistent GET streams with the policy on', async () => {
+    const server = track(await startStatefulStreamableServer());
+    const globalFetchSpy = vi.spyOn(globalThis, 'fetch');
+    const activateSpy = vi.fn((_span: unknown, callback: () => unknown) => callback());
+    (globalThis as Record<PropertyKey, unknown>)[datadogTracerTestSymbol] = {
+      scope: () => ({ activate: activateSpy }),
+    };
+
+    client = new InternalMastraMCPClient({
+      name: 'datadog-policy-test',
+      server: { url: server.baseUrl, allowedHosts: [server.host] },
+    });
+    await client.connect();
+
+    const getCalls = globalFetchSpy.mock.calls.filter(
+      ([, init]) => ((init?.method as string | undefined) ?? 'GET').toUpperCase() === 'GET',
+    );
+    expect(getCalls.length).toBeGreaterThan(0);
+    expect(activateSpy).toHaveBeenCalledTimes(getCalls.length);
+    expect(activateSpy).toHaveBeenNthCalledWith(1, null, expect.any(Function));
+    // The policy path dispatches with manual redirect handling.
+    expect(globalFetchSpy.mock.calls.every(([, init]) => init?.redirect === 'manual')).toBe(true);
+
+    activateSpy.mockClear();
+    globalFetchSpy.mockClear();
+    await client.tools();
+    const postCalls = globalFetchSpy.mock.calls.filter(
+      ([, init]) => ((init?.method as string | undefined) ?? 'GET').toUpperCase() === 'POST',
+    );
+    expect(postCalls.length).toBeGreaterThan(0);
+    expect(activateSpy).not.toHaveBeenCalled();
+  }, 15000);
+
+  it('validates a custom fetch post-hoc when it auto-follows a redirect to a disallowed host', async () => {
+    const decoy = track(await startDecoyServer());
+    const server = track(
+      await startStreamableServer((req, res) => {
+        if (req.method === 'POST') {
+          res.writeHead(302, { location: `http://${decoy.host}/mcp` }).end();
+        } else {
+          // Fail the SSE fallback's GET stream fast instead of leaving it open.
+          res.writeHead(404).end();
+        }
+        return true;
+      }),
+    );
+
+    // A pass-through custom fetch auto-follows redirects (platform default).
+    const userFetch = vi.fn((url: string | URL, init?: RequestInit) => fetch(url, init));
+    client = new InternalMastraMCPClient({
+      name: 'posthoc-test',
+      server: { url: server.baseUrl, allowedHosts: [server.host], fetch: userFetch },
+    });
+
+    await expect(client.connect()).rejects.toThrow();
+    expect(userFetch.mock.calls.length).toBeGreaterThan(0);
+    // Post-hoc semantics: the outbound hop DID reach the disallowed host
+    // (documented limitation of the custom-fetch path) …
+    expect(decoy.requests.length).toBeGreaterThan(0);
+  }, 15000);
+
+  it('wraps a caller-supplied eventSourceInit.fetch (SSE stream) with the policy', async () => {
+    const sse = track(await startSseServer());
+    const sseFetchSpy = vi.fn((url: string | URL, init?: RequestInit) => fetch(url, init));
+    client = new InternalMastraMCPClient({
+      name: 'sse-wrap-positive-test',
+      server: {
+        url: sse.baseUrl,
+        allowedHosts: [sse.host],
+        eventSourceInit: { fetch: sseFetchSpy as any },
+      },
+    });
+    await client.connect();
+    // The caller's fetch was used for the SSE stream (wrapping preserves it).
+    expect(sseFetchSpy.mock.calls.length).toBeGreaterThan(0);
+    const tools = await client.tools();
+    expect(tools['greet']).toBeDefined();
+  }, 15000);
+
+  it('blocks the SSE stream post-hoc when eventSourceInit.fetch lands on a disallowed host', async () => {
+    const decoy = track(await startDecoyServer());
+    const sse = track(await startSseServer());
+    // A caller fetch that (like a redirect-following or rewriting proxy) ends up
+    // on a different host than requested.
+    const sseFetchSpy = vi.fn((_url: string | URL, init?: RequestInit) => fetch(decoy.baseUrl, init));
+    client = new InternalMastraMCPClient({
+      name: 'sse-wrap-negative-test',
+      server: {
+        url: sse.baseUrl,
+        allowedHosts: [sse.host],
+        eventSourceInit: { fetch: sseFetchSpy as any },
+      },
+    });
+    await expect(client.connect()).rejects.toThrow();
+    // Pre-request check passed (requested URL was allowed), the fetch ran …
+    expect(sseFetchSpy.mock.calls.length).toBeGreaterThan(0);
+    expect(decoy.requests.length).toBeGreaterThan(0);
+  }, 15000);
+});
+
+// =============================================================================
+// OAuth discovery + allowedHosts
+//
+// Observed branch (SDK 1.29.0): the transports route auth() through
+// _fetchWithInit, built from the transport's `fetch` option — OAuth discovery
+// goes THROUGH the policy-wrapped fetch. These tests pin that observation:
+// a change in SDK routing flips them visibly.
+// =============================================================================
+
+describe('allowedHosts and OAuth discovery', () => {
+  let client: InternalMastraMCPClient | undefined;
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await client?.disconnect().catch(() => {});
+    client = undefined;
+    while (cleanups.length) {
+      await cleanups.pop()!().catch(() => {});
+    }
+  });
+
+  /** Minimal fake authorization server: metadata + dynamic registration. */
+  async function startAuthServer() {
+    const requests: string[] = [];
+    const httpServer = createServer((req, res) => {
+      requests.push(req.url ?? '');
+      const requestUrl = new URL(req.url ?? '', 'http://127.0.0.1');
+      const base = `http://127.0.0.1:${(httpServer.address() as AddressInfo).port}`;
+      if (requestUrl.pathname === '/.well-known/oauth-authorization-server') {
+        res.writeHead(200, { 'content-type': 'application/json' }).end(
+          JSON.stringify({
+            issuer: base,
+            authorization_endpoint: `${base}/authorize`,
+            token_endpoint: `${base}/token`,
+            registration_endpoint: `${base}/register`,
+            response_types_supported: ['code'],
+            grant_types_supported: ['authorization_code'],
+            code_challenge_methods_supported: ['S256'],
+            token_endpoint_auth_methods_supported: ['none'],
+          }),
+        );
+        return;
+      }
+      if (requestUrl.pathname === '/register' && req.method === 'POST') {
+        let body = '';
+        req.on('data', chunk => (body += chunk));
+        req.on('end', () => {
+          const metadata = JSON.parse(body);
+          res.writeHead(201, { 'content-type': 'application/json' }).end(
+            JSON.stringify({ ...metadata, client_id: `client-${randomUUID()}`, token_endpoint_auth_method: 'none' }),
+          );
+        });
+        return;
+      }
+      res.writeHead(404).end();
+    });
+    const baseUrl = await listen(httpServer, '/');
+    const close = () => closeServer(httpServer);
+    cleanups.push(close);
+    return { host: baseUrl.host, url: `http://${baseUrl.host}`, requests };
+  }
+
+  /** Protected MCP server: 401s everything, advertises the auth server via RFC 9728 metadata. */
+  async function startProtectedServer(authServerUrl: string) {
+    const requests: string[] = [];
+    const httpServer = createServer((req, res) => {
+      requests.push(req.url ?? '');
+      const requestUrl = new URL(req.url ?? '', 'http://127.0.0.1');
+      const base = `http://127.0.0.1:${(httpServer.address() as AddressInfo).port}`;
+      if (requestUrl.pathname === '/.well-known/oauth-protected-resource') {
+        res.writeHead(200, { 'content-type': 'application/json' }).end(
+          JSON.stringify({
+            resource: `${base}/mcp`,
+            authorization_servers: [authServerUrl],
+            bearer_methods_supported: ['header'],
+          }),
+        );
+        return;
+      }
+      res
+        .writeHead(401, {
+          'www-authenticate': `Bearer resource_metadata="${base}/.well-known/oauth-protected-resource"`,
+        })
+        .end();
+    });
+    const baseUrl = await listen(httpServer, '/mcp');
+    const close = () => closeServer(httpServer);
+    cleanups.push(close);
+    return { host: baseUrl.host, baseUrl, requests };
+  }
+
+  function createProvider(authorizationUrls: URL[]) {
+    return new MCPOAuthClientProvider({
+      redirectUrl: 'http://127.0.0.1:39999/oauth/callback',
+      clientMetadata: {
+        redirect_uris: ['http://127.0.0.1:39999/oauth/callback'],
+        client_name: 'URL Policy Test Client',
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+      },
+      storage: new InMemoryOAuthStorage(),
+      onRedirectToAuthorization: url => void authorizationUrls.push(url),
+    });
+  }
+
+  it('blocks OAuth discovery when the authorization server host is not allowlisted', async () => {
+    const authServer = await startAuthServer();
+    const mcpServer = await startProtectedServer(authServer.url);
+    const authorizationUrls: URL[] = [];
+
+    client = new InternalMastraMCPClient({
+      name: 'oauth-blocked-test',
+      server: {
+        url: mcpServer.baseUrl,
+        authProvider: createProvider(authorizationUrls),
+        allowedHosts: [mcpServer.host], // auth server host deliberately absent
+      },
+    });
+
+    await expect(client.connect()).rejects.toThrow();
+    // Discovery went through the policy-wrapped fetch: the MCP host was reached,
+    // the auth server was never contacted, and no authorization redirect happened.
+    expect(mcpServer.requests.length).toBeGreaterThan(0);
+    expect(authServer.requests).toHaveLength(0);
+    expect(authorizationUrls).toHaveLength(0);
+  }, 15000);
+
+  it('lets the OAuth flow proceed when the authorization server host is allowlisted', async () => {
+    const authServer = await startAuthServer();
+    const mcpServer = await startProtectedServer(authServer.url);
+    const authorizationUrls: URL[] = [];
+
+    client = new InternalMastraMCPClient({
+      name: 'oauth-allowed-test',
+      server: {
+        url: mcpServer.baseUrl,
+        authProvider: createProvider(authorizationUrls),
+        allowedHosts: [mcpServer.host, authServer.host],
+      },
+    });
+
+    // Connect still rejects (interactive authorization is required), but the
+    // flow reached the authorization redirect through the allowlisted hosts.
+    await expect(client.connect()).rejects.toThrow();
+    expect(authServer.requests.length).toBeGreaterThan(0);
+    expect(authorizationUrls).toHaveLength(1);
+  }, 15000);
+});

--- a/packages/mcp/src/client/url-policy.test.ts
+++ b/packages/mcp/src/client/url-policy.test.ts
@@ -215,6 +215,22 @@ describe('fetchFollowingAllowedRedirects', () => {
     ).rejects.toThrow(/not replayable/);
   });
 
+  it('throws on a 302 that preserves a non-replayable body (non-POST method) instead of re-sending it', async () => {
+    // A 302 only switches to GET for POST; a PUT keeps its method and body, so
+    // a consumed one-shot body must fail loudly rather than be re-sent empty.
+    const impl = vi.fn().mockResolvedValueOnce(redirectResponse(302, 'https://b.example/next'));
+    const streamBody = new ReadableStream();
+    await expect(
+      fetchFollowingAllowedRedirects(
+        impl,
+        'https://a.example/x',
+        { method: 'PUT', body: streamBody, duplex: 'half' } as RequestInit,
+        allowed,
+      ),
+    ).rejects.toThrow(/not replayable/);
+    expect(impl).toHaveBeenCalledTimes(1);
+  });
+
   it('strips the Authorization header on a hop to a different host but keeps it same-host', async () => {
     const crossHost = vi
       .fn()

--- a/packages/mcp/src/client/url-policy.test.ts
+++ b/packages/mcp/src/client/url-policy.test.ts
@@ -241,6 +241,66 @@ describe('fetchFollowingAllowedRedirects', () => {
     expect((sameHost.mock.calls[1]![1]!.headers as Headers).get('authorization')).toBe('Bearer secret');
   });
 
+  it('strips the Authorization header on a same-host scheme downgrade (origin change)', async () => {
+    // WHATWG Fetch strips credentials when the ORIGIN changes, not just the host:
+    // https://a.example -> http://a.example must not re-send the bearer token in cleartext.
+    const downgrade = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse(302, 'http://a.example/next'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    await fetchFollowingAllowedRedirects(
+      downgrade,
+      'https://a.example/x',
+      { headers: { authorization: 'Bearer secret' } },
+      allowed,
+    );
+    expect((downgrade.mock.calls[1]![1]!.headers as Headers).get('authorization')).toBeNull();
+  });
+
+  it('throws only non-reconnectable errors from the redirect loop', async () => {
+    // Every terminal redirect-loop error must dodge isReconnectableMCPError, or a
+    // final failure gets misclassified as transient and fed to the reconnect
+    // machinery. The hop-overflow case is the sharpest: the request URL contains
+    // "sessionId" (as legacy SSE POST endpoints do), which would match the
+    // reconnectable "session" substring if the message interpolated the full URL.
+    const alwaysRedirect = vi.fn().mockResolvedValue(redirectResponse(302, 'https://a.example/loop'));
+    const overflow = await fetchFollowingAllowedRedirects(
+      alwaysRedirect,
+      'https://a.example/messages?sessionId=abc123',
+      undefined,
+      allowed,
+    ).then(
+      () => undefined,
+      e => e,
+    );
+    expect(overflow).toBeInstanceOf(Error);
+    expect(isReconnectableMCPError(overflow)).toBe(false);
+
+    const noLocation = await fetchFollowingAllowedRedirects(
+      vi.fn().mockResolvedValueOnce(redirectResponse(301)),
+      'https://a.example/messages?sessionId=abc123',
+      undefined,
+      allowed,
+    ).then(
+      () => undefined,
+      e => e,
+    );
+    expect(noLocation).toBeInstanceOf(Error);
+    expect(isReconnectableMCPError(noLocation)).toBe(false);
+
+    const notReplayable = await fetchFollowingAllowedRedirects(
+      vi.fn().mockResolvedValueOnce(redirectResponse(307, 'https://a.example/next')),
+      'https://a.example/messages?sessionId=abc123',
+      { method: 'POST', body: new Uint8Array([1]) },
+      allowed,
+    ).then(
+      () => undefined,
+      e => e,
+    );
+    expect(notReplayable).toBeInstanceOf(Error);
+    expect(isReconnectableMCPError(notReplayable)).toBe(false);
+  });
+
   it('throws on a redirect status with no Location header', async () => {
     const impl = vi.fn().mockResolvedValueOnce(redirectResponse(301));
     await expect(fetchFollowingAllowedRedirects(impl, 'https://a.example/x', undefined, allowed)).rejects.toThrow(
@@ -564,11 +624,14 @@ describe('MastraMCPClient allowedHosts policy', () => {
       server: { url: server.baseUrl, allowedHosts: [server.host], fetch: userFetch },
     });
 
-    await expect(client.connect()).rejects.toThrow();
+    // The policy error surfaces directly (no SSE-fallback burial into a
+    // generic "could not connect" message) …
+    await expect(client.connect()).rejects.toThrow(/allowedHosts/);
     expect(userFetch.mock.calls.length).toBeGreaterThan(0);
-    // Post-hoc semantics: the outbound hop DID reach the disallowed host
-    // (documented limitation of the custom-fetch path) …
-    expect(decoy.requests.length).toBeGreaterThan(0);
+    // … and post-hoc semantics: the outbound hop DID reach the disallowed host
+    // (documented limitation of the custom-fetch path) — exactly once, because
+    // a policy violation must not trigger a second connect attempt over SSE.
+    expect(decoy.requests.length).toBe(1);
   }, 15000);
 
   it('wraps a caller-supplied eventSourceInit.fetch (SSE stream) with the policy', async () => {
@@ -603,10 +666,21 @@ describe('MastraMCPClient allowedHosts policy', () => {
         eventSourceInit: { fetch: sseFetchSpy as any },
       },
     });
-    await expect(client.connect()).rejects.toThrow();
+    // The policy error surfaces directly instead of the generic connect error.
+    const thrown = await client.connect().then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/allowedHosts/);
+    // The error that crossed the eventsource boundary (flattened to a message
+    // string and re-wrapped as SseError) must STILL be non-reconnectable, or
+    // the reconnect machinery would retry the blocked host.
+    expect(isReconnectableMCPError(thrown)).toBe(false);
     // Pre-request check passed (requested URL was allowed), the fetch ran …
     expect(sseFetchSpy.mock.calls.length).toBeGreaterThan(0);
-    expect(decoy.requests.length).toBeGreaterThan(0);
+    // … exactly one outbound hop reached the decoy: no retry, no reconnect.
+    expect(decoy.requests.length).toBe(1);
   }, 15000);
 });
 

--- a/packages/mcp/src/client/url-policy.ts
+++ b/packages/mcp/src/client/url-policy.ts
@@ -228,12 +228,17 @@ export async function fetchFollowingAllowedRedirects(
     assertHostAllowed(nextUrl, allowedHosts, `A redirect from "${currentUrl.host}" pointed at it; the hop was not followed.`);
 
     const methodUpper = method.toUpperCase();
-    if (response.status === 303 || ((response.status === 301 || response.status === 302) && methodUpper === 'POST')) {
+    const dropsBody =
+      response.status === 303 || ((response.status === 301 || response.status === 302) && methodUpper === 'POST');
+    if (dropsBody) {
       method = 'GET';
       body = undefined;
       headers.delete('content-type');
       headers.delete('content-length');
-    } else if ((response.status === 307 || response.status === 308) && body != null && typeof body !== 'string') {
+    } else if (body != null && typeof body !== 'string') {
+      // Any hop that preserves the body (307/308 always; 301/302 for non-POST
+      // methods) would re-send an already consumed one-shot body, so guard on
+      // "the body is preserved", not on specific status codes.
       throw new MastraError({
         id: 'MCP_CLIENT_REDIRECT_BODY_NOT_REPLAYABLE',
         domain: ErrorDomain.MCP,

--- a/packages/mcp/src/client/url-policy.ts
+++ b/packages/mcp/src/client/url-policy.ts
@@ -18,12 +18,35 @@ function normalizeHost(host: string): string {
  * and the eventsource package's `FetchLikeResponse` (used for a caller-supplied
  * `eventSourceInit.fetch`) satisfy it.
  */
-type ResponseLike = { readonly url: string };
+type ResponseLike = { readonly url: string; readonly body?: unknown };
+
+/** Best-effort release of a discarded response body so its socket is not left undrained. */
+function cancelResponseBody(response: ResponseLike): void {
+  const body = response.body as { cancel?: () => Promise<unknown> } | null | undefined;
+  if (typeof body?.cancel !== 'function') {
+    return;
+  }
+  try {
+    void Promise.resolve(body.cancel()).catch(() => {});
+  } catch {
+    // some Response implementations throw synchronously on cancel
+  }
+}
 
 function isHostAllowed(host: string, allowedHosts: readonly string[]): boolean {
   const normalized = normalizeHost(host);
   return allowedHosts.some(allowed => normalizeHost(allowed) === normalized);
 }
+
+/**
+ * Marker phrase embedded in every policy error's message. The `eventsource`
+ * package flattens errors thrown from the SSE stream's fetch into a plain
+ * message string (its internal `flattenError`), and the SDK re-wraps that
+ * string as `SseError` — the `MastraError` identity does not survive that
+ * boundary, but the message text does. {@link isUrlPolicyError} falls back to
+ * matching this marker.
+ */
+const URL_POLICY_ERROR_MARKER = 'allowedHosts policy';
 
 /**
  * Build the policy-violation error. The message deliberately avoids every
@@ -84,6 +107,7 @@ export function assertResponseHostAllowed<R extends ResponseLike>(response: R, a
   }
   const parsed = new URL(response.url);
   if (!isHostAllowed(parsed.host, allowedHosts)) {
+    cancelResponseBody(response);
     throw hostNotAllowedError(
       parsed.host,
       allowedHosts,
@@ -94,9 +118,40 @@ export function assertResponseHostAllowed<R extends ResponseLike>(response: R, a
 }
 
 /**
+ * True when the error is one of the allowedHosts policy errors. Policy
+ * violations are final: they must never trigger the SSE fallback or the
+ * reconnect machinery, because retrying a blocked host cannot succeed.
+ *
+ * Matches by `MastraError` id when the identity is intact, and by the
+ * {@link URL_POLICY_ERROR_MARKER} message marker for errors that crossed the
+ * eventsource boundary (which flattens thrown errors to message strings) or
+ * were re-wrapped by another layer.
+ */
+const URL_POLICY_ERROR_IDS = new Set([
+  'MCP_CLIENT_HOST_NOT_ALLOWED',
+  'MCP_CLIENT_TOO_MANY_REDIRECTS',
+  'MCP_CLIENT_REDIRECT_MISSING_LOCATION',
+  'MCP_CLIENT_REDIRECT_BODY_NOT_REPLAYABLE',
+]);
+
+export function isUrlPolicyError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if (error instanceof MastraError && URL_POLICY_ERROR_IDS.has(error.id)) {
+    return true;
+  }
+  return error.message.includes(URL_POLICY_ERROR_MARKER);
+}
+
+/**
  * Wrap a caller-supplied fetch with the allowedHosts policy: the request URL is
  * validated before the wrapped fetch runs, and the response is validated
  * post-hoc via {@link assertResponseHostAllowed}.
+ *
+ * Variadic over the trailing arguments deliberately: the same wrapper serves
+ * the 3-arg `MastraFetchLike` (url, init, requestContext) and the 2-arg
+ * eventsource stream fetch (url, init).
  */
 export function wrapFetchWithHostPolicy<Args extends [url: string | URL, ...rest: any[]], R extends ResponseLike>(
   fetchImpl: (...args: Args) => Promise<R>,
@@ -119,7 +174,12 @@ export function wrapFetchWithHostPolicy<Args extends [url: string | URL, ...rest
  * - 303 switches the method to GET and drops the body; 301/302 on POST do the same.
  * - 307/308 preserve method and body; a non-replayable body (anything other
  *   than a string) throws rather than silently re-sending an empty body.
- * - The `Authorization` header is not carried across hops to a different host.
+ * - 301/302 on non-POST methods preserve the method and body, matching
+ *   platform behavior.
+ * - The `Authorization` header is not carried across hops to a different
+ *   origin (scheme, host, or port change), matching the WHATWG Fetch
+ *   credential-stripping rule — same host over a downgraded scheme still
+ *   drops the header.
  * - A redirect status with no `Location` header throws.
  * - More than {@link MAX_REDIRECT_HOPS} hops throws.
  */
@@ -146,7 +206,7 @@ export async function fetchFollowingAllowedRedirects(
         id: 'MCP_CLIENT_REDIRECT_MISSING_LOCATION',
         domain: ErrorDomain.MCP,
         category: ErrorCategory.THIRD_PARTY,
-        text: `Received a ${response.status} redirect with no Location header from "${currentUrl.host}".`,
+        text: `Received a ${response.status} redirect with no Location header from "${currentUrl.host}" while following redirects under the allowedHosts policy.`,
       });
     }
     if (redirectsFollowed >= MAX_REDIRECT_HOPS) {
@@ -154,12 +214,15 @@ export async function fetchFollowingAllowedRedirects(
         id: 'MCP_CLIENT_TOO_MANY_REDIRECTS',
         domain: ErrorDomain.MCP,
         category: ErrorCategory.THIRD_PARTY,
-        text: `Exceeded the maximum of ${MAX_REDIRECT_HOPS} redirect hops while requesting "${String(url)}".`,
+        // Interpolate only the host, not the full URL: a URL's path/query could
+        // contain substrings (e.g. "sessionId") that isReconnectableMCPError
+        // matches, which would misclassify this terminal failure as transient.
+        text: `Exceeded the maximum of ${MAX_REDIRECT_HOPS} redirect hops while requesting host "${currentUrl.host}" under the allowedHosts policy.`,
       });
     }
 
     // Release the redirect response's body so its socket can be reused.
-    void response.body?.cancel().catch(() => {});
+    cancelResponseBody(response);
 
     const nextUrl = new URL(location, currentUrl);
     assertHostAllowed(nextUrl, allowedHosts, `A redirect from "${currentUrl.host}" pointed at it; the hop was not followed.`);
@@ -175,11 +238,14 @@ export async function fetchFollowingAllowedRedirects(
         id: 'MCP_CLIENT_REDIRECT_BODY_NOT_REPLAYABLE',
         domain: ErrorDomain.MCP,
         category: ErrorCategory.USER,
-        text: `Cannot follow a ${response.status} redirect: the request body is not replayable (only string bodies can be re-sent).`,
+        text: `Cannot follow a ${response.status} redirect under the allowedHosts policy: the request body is not replayable (only string bodies can be re-sent).`,
       });
     }
 
-    if (normalizeHost(nextUrl.host) !== normalizeHost(currentUrl.host)) {
+    // WHATWG Fetch strips Authorization when the ORIGIN (scheme + host + port)
+    // changes — host alone is not enough: a same-host https→http downgrade must
+    // also drop the header or the bearer token is re-sent in cleartext.
+    if (nextUrl.origin !== currentUrl.origin) {
       headers.delete('authorization');
     }
 

--- a/packages/mcp/src/client/url-policy.ts
+++ b/packages/mcp/src/client/url-policy.ts
@@ -1,0 +1,188 @@
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+
+/**
+ * Redirect status codes the manual redirect loop follows. Other 3xx statuses
+ * (e.g. 304) are not redirects and are returned to the caller as-is.
+ */
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+
+/** Maximum number of redirect hops followed before failing. */
+const MAX_REDIRECT_HOPS = 5;
+
+function normalizeHost(host: string): string {
+  return host.toLowerCase();
+}
+
+/**
+ * Minimal structural view of a fetch response. Both the platform `Response`
+ * and the eventsource package's `FetchLikeResponse` (used for a caller-supplied
+ * `eventSourceInit.fetch`) satisfy it.
+ */
+type ResponseLike = { readonly url: string };
+
+function isHostAllowed(host: string, allowedHosts: readonly string[]): boolean {
+  const normalized = normalizeHost(host);
+  return allowedHosts.some(allowed => normalizeHost(allowed) === normalized);
+}
+
+/**
+ * Build the policy-violation error. The message deliberately avoids every
+ * substring matched by `isReconnectableMCPError` (see ./error-utils.ts) so a
+ * policy violation is never treated as a transient transport failure and fed
+ * into the reconnect machinery — a blocked host must not be retried.
+ */
+function hostNotAllowedError(host: string, allowedHosts: readonly string[], detail: string): MastraError {
+  const allowedList =
+    allowedHosts.length > 0 ? allowedHosts.map(h => `"${h}"`).join(', ') : '(empty list — all hosts are denied)';
+  return new MastraError({
+    id: 'MCP_CLIENT_HOST_NOT_ALLOWED',
+    domain: ErrorDomain.MCP,
+    category: ErrorCategory.USER,
+    text: `Host "${host}" is blocked by the allowedHosts policy. Allowed hosts: ${allowedList}. ${detail}`,
+    details: { host, allowedHosts: allowedHosts.join(',') },
+  });
+}
+
+/**
+ * Assert that the URL's host is in the allowlist.
+ *
+ * Matching is exact and case-insensitive against `URL.host` (hostname plus
+ * port when the URL carries a non-default port — WHATWG URL elides default
+ * ports, so `https://x.com:443` has host `x.com`). No wildcards. An empty
+ * allowlist denies every host. The URL scheme is not checked.
+ *
+ * @returns the parsed URL, for callers that need it.
+ * @throws {MastraError} `MCP_CLIENT_HOST_NOT_ALLOWED` when the host is not allowed.
+ */
+export function assertHostAllowed(
+  url: string | URL,
+  allowedHosts: readonly string[],
+  detail = 'The request was not sent.',
+): URL {
+  const parsed = typeof url === 'string' ? new URL(url) : url;
+  if (!isHostAllowed(parsed.host, allowedHosts)) {
+    throw hostNotAllowedError(parsed.host, allowedHosts, detail);
+  }
+  return parsed;
+}
+
+/**
+ * Post-hoc validation for responses produced by a caller-supplied fetch.
+ *
+ * A custom fetch may auto-follow redirects, so the final URL can differ from
+ * the (already validated) request URL. When `response.url` lands on a
+ * disallowed host the response is discarded by throwing — the outbound hop
+ * already happened, but the data never reaches the caller or the model.
+ *
+ * Limitation (fail-open by design): a hand-built or proxied `Response` with an
+ * empty `response.url` skips this check, because custom fetch implementations
+ * legitimately construct such responses.
+ */
+export function assertResponseHostAllowed<R extends ResponseLike>(response: R, allowedHosts: readonly string[]): R {
+  if (!response.url) {
+    return response;
+  }
+  const parsed = new URL(response.url);
+  if (!isHostAllowed(parsed.host, allowedHosts)) {
+    throw hostNotAllowedError(
+      parsed.host,
+      allowedHosts,
+      'A custom fetch implementation followed a redirect to this host; the response was discarded.',
+    );
+  }
+  return response;
+}
+
+/**
+ * Wrap a caller-supplied fetch with the allowedHosts policy: the request URL is
+ * validated before the wrapped fetch runs, and the response is validated
+ * post-hoc via {@link assertResponseHostAllowed}.
+ */
+export function wrapFetchWithHostPolicy<Args extends [url: string | URL, ...rest: any[]], R extends ResponseLike>(
+  fetchImpl: (...args: Args) => Promise<R>,
+  allowedHosts: readonly string[],
+): (...args: Args) => Promise<R> {
+  return async (...args: Args) => {
+    assertHostAllowed(args[0], allowedHosts);
+    const response = await fetchImpl(...args);
+    return assertResponseHostAllowed(response, allowedHosts);
+  };
+}
+
+/**
+ * Fetch with manual redirect handling so every redirect hop is validated
+ * against the allowlist BEFORE the hop request is sent. Platform fetch follows
+ * redirects transparently, which would bypass a per-call host check.
+ *
+ * Semantics follow platform conventions:
+ * - `Location` is resolved against the current hop's URL (relative Locations are legal).
+ * - 303 switches the method to GET and drops the body; 301/302 on POST do the same.
+ * - 307/308 preserve method and body; a non-replayable body (anything other
+ *   than a string) throws rather than silently re-sending an empty body.
+ * - The `Authorization` header is not carried across hops to a different host.
+ * - A redirect status with no `Location` header throws.
+ * - More than {@link MAX_REDIRECT_HOPS} hops throws.
+ */
+export async function fetchFollowingAllowedRedirects(
+  fetchImpl: (url: string | URL, init?: RequestInit) => Promise<Response>,
+  url: string | URL,
+  init: RequestInit | undefined,
+  allowedHosts: readonly string[],
+): Promise<Response> {
+  let currentUrl = assertHostAllowed(url, allowedHosts);
+  let method = init?.method ?? 'GET';
+  let body = init?.body;
+  const headers = new Headers(init?.headers);
+
+  for (let redirectsFollowed = 0; ; redirectsFollowed++) {
+    const response = await fetchImpl(currentUrl, { ...init, method, body, headers, redirect: 'manual' });
+    if (!REDIRECT_STATUS_CODES.has(response.status)) {
+      return response;
+    }
+
+    const location = response.headers.get('location');
+    if (!location) {
+      throw new MastraError({
+        id: 'MCP_CLIENT_REDIRECT_MISSING_LOCATION',
+        domain: ErrorDomain.MCP,
+        category: ErrorCategory.THIRD_PARTY,
+        text: `Received a ${response.status} redirect with no Location header from "${currentUrl.host}".`,
+      });
+    }
+    if (redirectsFollowed >= MAX_REDIRECT_HOPS) {
+      throw new MastraError({
+        id: 'MCP_CLIENT_TOO_MANY_REDIRECTS',
+        domain: ErrorDomain.MCP,
+        category: ErrorCategory.THIRD_PARTY,
+        text: `Exceeded the maximum of ${MAX_REDIRECT_HOPS} redirect hops while requesting "${String(url)}".`,
+      });
+    }
+
+    // Release the redirect response's body so its socket can be reused.
+    void response.body?.cancel().catch(() => {});
+
+    const nextUrl = new URL(location, currentUrl);
+    assertHostAllowed(nextUrl, allowedHosts, `A redirect from "${currentUrl.host}" pointed at it; the hop was not followed.`);
+
+    const methodUpper = method.toUpperCase();
+    if (response.status === 303 || ((response.status === 301 || response.status === 302) && methodUpper === 'POST')) {
+      method = 'GET';
+      body = undefined;
+      headers.delete('content-type');
+      headers.delete('content-length');
+    } else if ((response.status === 307 || response.status === 308) && body != null && typeof body !== 'string') {
+      throw new MastraError({
+        id: 'MCP_CLIENT_REDIRECT_BODY_NOT_REPLAYABLE',
+        domain: ErrorDomain.MCP,
+        category: ErrorCategory.USER,
+        text: `Cannot follow a ${response.status} redirect: the request body is not replayable (only string bodies can be re-sent).`,
+      });
+    }
+
+    if (normalizeHost(nextUrl.host) !== normalizeHost(currentUrl.host)) {
+      headers.delete('authorization');
+    }
+
+    currentUrl = nextUrl;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #19636

The issue reports three security concerns in the MCP client: environment variable leakage into stdio subprocesses, SSRF through the HTTP transport, and unsanitized tool responses. Each claim was verified against the actual code paths before writing anything. The env claim is overstated: the SDK inherits a small curated whitelist (HOME, PATH, SHELL, and so on), not the full process env. The SSRF claim is mechanically true, but blocking localhost or private ranges by default would break the most common legitimate setup (local MCP servers), so restriction has to be opt-in. Response sanitization belongs in Mastra's input/output processor layer, not the transport client.

This PR ships the two defensible hardening legs as strictly opt-in options, plus docs covering all three claims. When neither option is set, behavior is byte for byte unchanged.

```ts
const client = new MCPClient({
  servers: {
    remote: {
      url: new URL('https://mcp.example.com/mcp'),
      allowedHosts: ['mcp.example.com'], // any other host is refused
    },
    local: {
      command: 'npx',
      args: ['my-mcp-server'],
      inheritDefaultEnv: false, // subprocess sees only the env you configure
      env: { API_KEY: '...' },
    },
  },
});
```

## What changed

- **`allowedHosts: string[]` on HTTP server configs.** An exact-match host allowlist (matched against `URL.host`, case-insensitive, no wildcards, empty array means deny all) enforced on every request the client makes for that server: the initial connect, Streamable HTTP requests, the SSE fallback stream, redirect hops, and OAuth discovery and token requests (the SDK routes those through the transport's fetch, so they are covered). On the default path the client follows redirects manually (bounded at 5 hops) and validates every hop before sending it. Policy violations are deliberately non-reconnectable: a blocked host is never retried by the reconnect machinery.
- **`inheritDefaultEnv: boolean` on stdio server configs** (default `true`, current behavior). When `false`, the spawned server process receives only the entries you configure in `env`, none of the SDK's default inherited variables.
- **Docs.** New Security section in the MCPClient reference covering the exact env inherit list, when to set `allowedHosts`, and guidance to treat tool responses as untrusted model input with processors as the sanitization seam.

## Design notes

- **Enforcement strength varies by path, and the docs say so.** With the built-in fetch, disallowed requests (including redirect hops) are blocked before they are sent. When you supply your own `fetch` or `eventSourceInit.fetch`, the initial URL is checked pre-request, but redirect hops are validated post-hoc via `response.url` (the outbound hop may occur; the response is discarded and the socket released). A hand-built Response with an empty `url` skips the post-hoc check, documented as a limitation, because overrides legitimately construct Responses.
- **The `Authorization` header is dropped when a redirect crosses origins** (any scheme, host, or port change), matching standard fetch behavior. 303 responses (and 301/302 on POST) switch to GET and drop the body; 307/308 preserve method and body, and throw rather than silently re-send if the body is not replayable.
- **The eventsource library flattens fetch rejections into bare message strings**, so a policy error loses its class identity crossing the SSE seam. The policy error message carries a marker phrase that survives flattening, and classification checks the error id or the marker, so SSE-path violations still surface as policy errors instead of a generic connect failure, and are still classified non-reconnectable.
- **The SDK's `StdioClientTransport.start()` unconditionally merges `getDefaultEnvironment()` under whatever env the client passes**, so passing a smaller env object is not enough to isolate the subprocess. `buildStdioEnv()` explicitly overrides each curated key with `undefined` (Node's spawn drops undefined entries), then applies the configured `env`. The obvious mechanism does not work; this one does, proven by a red-to-green subprocess test.
- **No response sanitization code.** That layer decision is documented instead: MCP tool outputs are untrusted model input and Mastra's processor system is the right seam.

## Notes for reviewers

- The riskiest change is the manual redirect loop in `url-policy.ts`; it only runs when `allowedHosts` is set and no custom fetch is in play at that call site. The default path does not touch `redirect` or `init` at all, and a regression test asserts that.
- Root `pnpm lint:format` currently fails on two files this branch never touches (`packages/memory/src/processors/observational-memory/extraction-runner.ts` and `packages/schema-compat/src/provider-compats/google.ts`); pre-existing on main.

## Test plan

- 36 new tests in `url-policy.test.ts` (real `node:http` servers, fetch spies): host matching semantics (case, default-port elision, IPv6 brackets, empty array), pre-send blocking, redirect hops including relative Location, hop overflow, Authorization stripping across origins, custom fetch composition and post-hoc validation, the `eventSourceInit.fetch` bypass path, mid-stream violation with zero requests reaching the blocked host and no reconnect retry, Datadog span-detach unchanged with policy on, and OAuth discovery blocked or allowed depending on whether the auth server host is allowlisted.
- 3 new tests in `stdio-env.test.ts` spawning a real subprocess fixture that echoes its env keys: default inherits the curated set, strict mode passes only configured entries (this test failed before the fix and passes after), explicit `true` matches unset.
- Full client suite: 7 files, 221 tests passing. `tsc --noEmit` clean, lint clean, docs validate/remark/format/Vale clean on the changed files.
- Standalone demos against the built package: without `allowedHosts` a client connects to an internal service and exposes its tools to the model; with `allowedHosts` the connect is refused with a clear policy error. Env demo shows default mode inheriting the curated keys and strict mode passing only the configured marker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds optional controls that limit where MCP clients can connect and which environment variables stdio subprocesses receive. It also documents that MCP tool responses are untrusted and should be sanitized by processors.

## Changes

- Added `allowedHosts` for HTTP MCP servers.
  - Enforces exact, case-insensitive host matching.
  - Covers initial requests, redirects, SSE fallback, Streamable HTTP, custom fetches, and OAuth discovery.
  - Handles redirect limits, method and body rules, response cleanup, and cross-origin `Authorization` removal.
  - Prevents transport fallback for host-policy errors.

- Added `inheritDefaultEnv` for stdio MCP servers.
  - When `false`, subprocesses do not inherit the SDK’s curated default environment.
  - Explicitly configured environment variables remain available.
  - Existing behavior remains unchanged when unset or set to `true`.

- Added type restrictions so HTTP-only and stdio-only options cannot be used on the wrong server definition.

- Added documentation for host restrictions, environment isolation, redirect and OAuth enforcement, and processor-based tool-response sanitization.

- Added 39 tests covering environment inheritance, host policies, redirects, transports, custom fetches, OAuth, and error handling.

- Updated `test:client` to run the URL-policy and stdio-environment test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->