### PR TITLE
fix(pg/dsql): serialize TransactionClient queries on one PoolClient

### DIFF
--- a/.changeset/tx-client-drain-before-commit.md
+++ b/.changeset/tx-client-drain-before-commit.md
@@ -3,4 +3,4 @@
 '@mastra/dsql': patch
 ---
 
-Drain TransactionClient query queue before COMMIT/ROLLBACK so batch failure and fire-and-forget paths cannot race the control statements on one PoolClient.
+Fixed transaction completion when applications start several database operations at the same time. Pending operations now finish before the transaction completes or is cancelled, preventing query conflicts after batch failures and operations that application code does not await.

--- a/.changeset/tx-client-drain-before-commit.md
+++ b/.changeset/tx-client-drain-before-commit.md
@@ -1,0 +1,6 @@
+---
+'@mastra/pg': patch
+'@mastra/dsql': patch
+---
+
+Drain TransactionClient query queue before COMMIT/ROLLBACK so batch failure and fire-and-forget paths cannot race the control statements on one PoolClient.

--- a/stores/dsql/src/storage/client.ts
+++ b/stores/dsql/src/storage/client.ts
@@ -173,8 +173,9 @@ export class PoolAdapter implements DbClient {
         return result;
       } catch (error) {
         // Drain before ROLLBACK: Promise.all in batch() rejects on the first
-        // failure while later enqueued queries may still be running.
-        await txClient.drain();
+        // failure while later enqueued queries may still be running. Preserve
+        // the callback/drain error that caused this catch.
+        await txClient.drain().catch(() => undefined);
         try {
           await client.query('ROLLBACK');
         } catch (rollbackError) {
@@ -205,23 +206,34 @@ class TransactionClient implements TxClient {
    * Serialization tail. Without this gate, concurrent t.none()/t.query()
    * from Promise.all / batch land on the same PoolClient at once.
    */
-  #tail: Promise<unknown> = Promise.resolve();
+  #tail: Promise<void> = Promise.resolve();
+  #error: { value: unknown } | undefined;
 
   constructor(private readonly client: PoolClient) {}
 
   #enqueue<T>(fn: () => Promise<T>): Promise<T> {
-    const next = this.#tail.then(fn, fn);
-    this.#tail = next.catch(() => undefined);
+    const next = this.#tail.then(fn);
+    this.#tail = next.then(
+      () => undefined,
+      error => {
+        this.#error ??= { value: error };
+      },
+    );
     return next;
   }
 
   /**
-   * Wait until every enqueued query has settled.
+   * Wait until every enqueued query has settled and surface the first failure.
    * PoolAdapter calls this before COMMIT/ROLLBACK so those control
    * statements never overlap in-flight work on the same client.
    */
   async drain(): Promise<void> {
     await this.#tail;
+    if (this.#error) {
+      const { value } = this.#error;
+      this.#error = undefined;
+      throw value;
+    }
   }
 
   none(query: string, values?: QueryValues): Promise<null> {

--- a/stores/dsql/src/storage/client.ts
+++ b/stores/dsql/src/storage/client.ts
@@ -165,17 +165,24 @@ export class PoolAdapter implements DbClient {
     try {
       await client.query('BEGIN');
       const txClient = new TransactionClient(client);
-      const result = await callback(txClient);
-      await client.query('COMMIT');
-      return result;
-    } catch (error) {
       try {
-        await client.query('ROLLBACK');
-      } catch (rollbackError) {
-        // Log rollback failure but throw original error
-        console.error('Transaction rollback failed:', rollbackError);
+        const result = await callback(txClient);
+        // Drain before COMMIT so fire-and-forget / batch tails can't race it.
+        await txClient.drain();
+        await client.query('COMMIT');
+        return result;
+      } catch (error) {
+        // Drain before ROLLBACK: Promise.all in batch() rejects on the first
+        // failure while later enqueued queries may still be running.
+        await txClient.drain();
+        try {
+          await client.query('ROLLBACK');
+        } catch (rollbackError) {
+          // Log rollback failure but throw original error
+          console.error('Transaction rollback failed:', rollbackError);
+        }
+        throw error;
       }
-      throw error;
     } finally {
       client.release();
     }
@@ -206,6 +213,15 @@ class TransactionClient implements TxClient {
     const next = this.#tail.then(fn, fn);
     this.#tail = next.catch(() => undefined);
     return next;
+  }
+
+  /**
+   * Wait until every enqueued query has settled.
+   * PoolAdapter calls this before COMMIT/ROLLBACK so those control
+   * statements never overlap in-flight work on the same client.
+   */
+  async drain(): Promise<void> {
+    await this.#tail;
   }
 
   none(query: string, values?: QueryValues): Promise<null> {

--- a/stores/dsql/src/storage/client.ts
+++ b/stores/dsql/src/storage/client.ts
@@ -83,7 +83,11 @@ export interface TxClient {
   manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]>;
   many<T = any>(query: string, values?: QueryValues): Promise<T[]>;
   query(query: string, values?: QueryValues): Promise<QueryResult>;
-  /** Execute multiple promises in parallel */
+  /**
+   * Await multiple query promises. Prefer collecting results from
+   * TransactionClient methods (which serialize onto one PoolClient);
+   * do not start raw `client.query` calls concurrently.
+   */
   batch<T>(promises: Promise<T>[]): Promise<T[]>;
 }
 
@@ -180,59 +184,91 @@ export class PoolAdapter implements DbClient {
 
 /**
  * Transaction client that wraps a PoolClient for executing queries within a transaction.
+ *
+ * Query methods are serialized through a tail promise (same pattern as
+ * PinnedClientAdapter). Callers such as memory.updateMessages historically
+ * did `queries.push(t.none(...))` then `await t.batch(queries)` — each
+ * `t.none()` is async and starts `client.query` immediately, so by the time
+ * batch runs, N queries are already in flight on one PoolClient. pg@8 queues
+ * those internally and emits a DeprecationWarning; pg@9 will throw.
+ * (#20820)
  */
 class TransactionClient implements TxClient {
+  /**
+   * Serialization tail. Without this gate, concurrent t.none()/t.query()
+   * from Promise.all / batch land on the same PoolClient at once.
+   */
+  #tail: Promise<unknown> = Promise.resolve();
+
   constructor(private readonly client: PoolClient) {}
 
-  async none(query: string, values?: QueryValues): Promise<null> {
-    await this.client.query(query, values);
-    return null;
+  #enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.#tail.then(fn, fn);
+    this.#tail = next.catch(() => undefined);
+    return next;
   }
 
-  async one<T = any>(query: string, values?: QueryValues): Promise<T> {
-    const result = await this.client.query(query, values);
-    if (result.rows.length === 0) {
-      throw new Error(`No data returned from query: ${truncateQuery(query)}`);
-    }
-    if (result.rows.length > 1) {
-      throw new Error(`Multiple rows returned when one was expected: ${truncateQuery(query)}`);
-    }
-    return result.rows[0] as T;
-  }
-
-  async oneOrNone<T = any>(query: string, values?: QueryValues): Promise<T | null> {
-    const result = await this.client.query(query, values);
-    if (result.rows.length === 0) {
+  none(query: string, values?: QueryValues): Promise<null> {
+    return this.#enqueue(async () => {
+      await this.client.query(query, values);
       return null;
-    }
-    if (result.rows.length > 1) {
-      throw new Error(`Multiple rows returned when one or none was expected: ${truncateQuery(query)}`);
-    }
-    return result.rows[0] as T;
+    });
   }
 
-  async any<T = any>(query: string, values?: QueryValues): Promise<T[]> {
-    const result = await this.client.query(query, values);
-    return result.rows as T[];
+  one<T = any>(query: string, values?: QueryValues): Promise<T> {
+    return this.#enqueue(async () => {
+      const result = await this.client.query(query, values);
+      if (result.rows.length === 0) {
+        throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+      }
+      if (result.rows.length > 1) {
+        throw new Error(`Multiple rows returned when one was expected: ${truncateQuery(query)}`);
+      }
+      return result.rows[0] as T;
+    });
   }
 
-  async manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+  oneOrNone<T = any>(query: string, values?: QueryValues): Promise<T | null> {
+    return this.#enqueue(async () => {
+      const result = await this.client.query(query, values);
+      if (result.rows.length === 0) {
+        return null;
+      }
+      if (result.rows.length > 1) {
+        throw new Error(`Multiple rows returned when one or none was expected: ${truncateQuery(query)}`);
+      }
+      return result.rows[0] as T;
+    });
+  }
+
+  any<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+    return this.#enqueue(async () => {
+      const result = await this.client.query(query, values);
+      return result.rows as T[];
+    });
+  }
+
+  manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]> {
     return this.any<T>(query, values);
   }
 
-  async many<T = any>(query: string, values?: QueryValues): Promise<T[]> {
-    const result = await this.client.query(query, values);
-    if (result.rows.length === 0) {
-      throw new Error(`No data returned from query: ${truncateQuery(query)}`);
-    }
-    return result.rows as T[];
+  many<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+    return this.#enqueue(async () => {
+      const result = await this.client.query(query, values);
+      if (result.rows.length === 0) {
+        throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+      }
+      return result.rows as T[];
+    });
   }
 
-  async query(query: string, values?: QueryValues): Promise<QueryResult> {
-    return this.client.query(query, values);
+  query(query: string, values?: QueryValues): Promise<QueryResult> {
+    return this.#enqueue(() => this.client.query(query, values));
   }
 
   async batch<T>(promises: Promise<T>[]): Promise<T[]> {
+    // Promises are already enqueued (and thus serialized) by the query
+    // methods above; awaiting them together is fine.
     return Promise.all(promises);
   }
 }

--- a/stores/dsql/src/storage/client.tx-serialize.test.ts
+++ b/stores/dsql/src/storage/client.tx-serialize.test.ts
@@ -95,4 +95,21 @@ describe('TransactionClient COMMIT/ROLLBACK drain (dsql)', () => {
 
     expect(statements).toEqual(['BEGIN', 'SLOW2', 'COMMIT']);
   });
+
+  it('rolls back when a fire-and-forget query fails', async () => {
+    const { client, statements } = createStrictClient();
+    const pool = {
+      connect: vi.fn(async () => client),
+    } as unknown as Pool;
+    const adapter = new PoolAdapter(pool);
+
+    await expect(
+      adapter.tx(async t => {
+        void t.none('FAIL1');
+        return 'ok';
+      }),
+    ).rejects.toThrow('FAIL1');
+
+    expect(statements).toEqual(['BEGIN', 'FAIL1', 'ROLLBACK']);
+  });
 });

--- a/stores/dsql/src/storage/client.tx-serialize.test.ts
+++ b/stores/dsql/src/storage/client.tx-serialize.test.ts
@@ -1,11 +1,13 @@
 import type { Pool, PoolClient, QueryResult } from 'pg';
 import { describe, expect, it, vi } from 'vitest';
 
-import { PinnedClientAdapter, PoolAdapter } from './client';
+import { PoolAdapter } from './client';
 
 /**
  * Fake PoolClient that rejects overlapping queries (pg@9 semantics).
- * Used to prove COMMIT/ROLLBACK never races in-flight transaction work.
+ * Mirrors stores/pg/src/storage/client.tx-serialize.test.ts — the dsql
+ * TransactionClient is a separate copy of the pg one, so it needs its own
+ * guard against drift.
  */
 function createStrictClient() {
   let inFlight = 0;
@@ -38,7 +40,7 @@ function createStrictClient() {
   return { client, statements, query };
 }
 
-describe('TransactionClient COMMIT/ROLLBACK drain', () => {
+describe('TransactionClient COMMIT/ROLLBACK drain (dsql)', () => {
   it('serializes concurrent t.none() calls onto one client', async () => {
     const { client, statements } = createStrictClient();
     const pool = {
@@ -92,21 +94,5 @@ describe('TransactionClient COMMIT/ROLLBACK drain', () => {
     });
 
     expect(statements).toEqual(['BEGIN', 'SLOW2', 'COMMIT']);
-  });
-
-  it('PinnedClientAdapter also drains before ROLLBACK', async () => {
-    const { client, statements } = createStrictClient();
-    const pool = {} as Pool;
-    const adapter = new PinnedClientAdapter(pool, client);
-
-    await expect(
-      adapter.tx(async t => {
-        const q1 = t.none('FAIL1');
-        const q2 = t.none('SLOW2');
-        await t.batch([q1, q2]);
-      }),
-    ).rejects.toThrow('FAIL1');
-
-    expect(statements).toEqual(['BEGIN', 'FAIL1', 'SLOW2', 'ROLLBACK']);
   });
 });

--- a/stores/pg/src/storage/client.ts
+++ b/stores/pg/src/storage/client.ts
@@ -174,8 +174,9 @@ export class PoolAdapter implements DbClient {
         return result;
       } catch (error) {
         // Drain before ROLLBACK: Promise.all in batch() rejects on the first
-        // failure while later enqueued queries may still be running.
-        await txClient.drain();
+        // failure while later enqueued queries may still be running. Preserve
+        // the callback/drain error that caused this catch.
+        await txClient.drain().catch(() => undefined);
         try {
           await client.query('ROLLBACK');
         } catch (rollbackError) {
@@ -206,23 +207,34 @@ class TransactionClient implements TxClient {
    * Serialization tail. Without this gate, concurrent t.none()/t.query()
    * from Promise.all / batch land on the same PoolClient at once.
    */
-  #tail: Promise<unknown> = Promise.resolve();
+  #tail: Promise<void> = Promise.resolve();
+  #error: { value: unknown } | undefined;
 
   constructor(private readonly client: PoolClient) {}
 
   #enqueue<T>(fn: () => Promise<T>): Promise<T> {
-    const next = this.#tail.then(fn, fn);
-    this.#tail = next.catch(() => undefined);
+    const next = this.#tail.then(fn);
+    this.#tail = next.then(
+      () => undefined,
+      error => {
+        this.#error ??= { value: error };
+      },
+    );
     return next;
   }
 
   /**
-   * Wait until every enqueued query has settled.
+   * Wait until every enqueued query has settled and surface the first failure.
    * PoolAdapter / PinnedClientAdapter call this before COMMIT/ROLLBACK so
    * those control statements never overlap in-flight work on the same client.
    */
   async drain(): Promise<void> {
     await this.#tail;
+    if (this.#error) {
+      const { value } = this.#error;
+      this.#error = undefined;
+      throw value;
+    }
   }
 
   none(query: string, values?: QueryValues): Promise<null> {
@@ -289,7 +301,6 @@ class TransactionClient implements TxClient {
     return Promise.all(promises);
   }
 }
-
 
 /**
  * DbClient adapter that pins all queries to a single PoolClient.
@@ -416,7 +427,7 @@ export class PinnedClientAdapter implements DbClient {
         await this.pinnedClient.query('COMMIT');
         return result;
       } catch (error) {
-        await txClient.drain();
+        await txClient.drain().catch(() => undefined);
         try {
           await this.pinnedClient.query('ROLLBACK');
         } catch (rollbackError) {

--- a/stores/pg/src/storage/client.ts
+++ b/stores/pg/src/storage/client.ts
@@ -84,7 +84,11 @@ export interface TxClient {
   manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]>;
   many<T = any>(query: string, values?: QueryValues): Promise<T[]>;
   query(query: string, values?: QueryValues): Promise<QueryResult>;
-  /** Execute multiple promises in parallel */
+  /**
+   * Await multiple query promises. Prefer collecting results from
+   * TransactionClient methods (which serialize onto one PoolClient);
+   * do not start raw `client.query` calls concurrently.
+   */
   batch<T>(promises: Promise<T>[]): Promise<T[]>;
 }
 
@@ -181,62 +185,95 @@ export class PoolAdapter implements DbClient {
 
 /**
  * Transaction client that wraps a PoolClient for executing queries within a transaction.
+ *
+ * Query methods are serialized through a tail promise (same pattern as
+ * PinnedClientAdapter). Callers such as memory.updateMessages historically
+ * did `queries.push(t.none(...))` then `await t.batch(queries)` — each
+ * `t.none()` is async and starts `client.query` immediately, so by the time
+ * batch runs, N queries are already in flight on one PoolClient. pg@8 queues
+ * those internally and emits a DeprecationWarning; pg@9 will throw.
+ * (#20820)
  */
 class TransactionClient implements TxClient {
+  /**
+   * Serialization tail. Without this gate, concurrent t.none()/t.query()
+   * from Promise.all / batch land on the same PoolClient at once.
+   */
+  #tail: Promise<unknown> = Promise.resolve();
+
   constructor(private readonly client: PoolClient) {}
 
-  async none(query: string, values?: QueryValues): Promise<null> {
-    await this.client.query(query, values);
-    return null;
+  #enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.#tail.then(fn, fn);
+    this.#tail = next.catch(() => undefined);
+    return next;
   }
 
-  async one<T = any>(query: string, values?: QueryValues): Promise<T> {
-    const result = await this.client.query(query, values);
-    if (result.rows.length === 0) {
-      throw new Error(`No data returned from query: ${truncateQuery(query)}`);
-    }
-    if (result.rows.length > 1) {
-      throw new Error(`Multiple rows returned when one was expected: ${truncateQuery(query)}`);
-    }
-    return result.rows[0] as T;
-  }
-
-  async oneOrNone<T = any>(query: string, values?: QueryValues): Promise<T | null> {
-    const result = await this.client.query(query, values);
-    if (result.rows.length === 0) {
+  none(query: string, values?: QueryValues): Promise<null> {
+    return this.#enqueue(async () => {
+      await this.client.query(query, values);
       return null;
-    }
-    if (result.rows.length > 1) {
-      throw new Error(`Multiple rows returned when one or none was expected: ${truncateQuery(query)}`);
-    }
-    return result.rows[0] as T;
+    });
   }
 
-  async any<T = any>(query: string, values?: QueryValues): Promise<T[]> {
-    const result = await this.client.query(query, values);
-    return result.rows as T[];
+  one<T = any>(query: string, values?: QueryValues): Promise<T> {
+    return this.#enqueue(async () => {
+      const result = await this.client.query(query, values);
+      if (result.rows.length === 0) {
+        throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+      }
+      if (result.rows.length > 1) {
+        throw new Error(`Multiple rows returned when one was expected: ${truncateQuery(query)}`);
+      }
+      return result.rows[0] as T;
+    });
   }
 
-  async manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+  oneOrNone<T = any>(query: string, values?: QueryValues): Promise<T | null> {
+    return this.#enqueue(async () => {
+      const result = await this.client.query(query, values);
+      if (result.rows.length === 0) {
+        return null;
+      }
+      if (result.rows.length > 1) {
+        throw new Error(`Multiple rows returned when one or none was expected: ${truncateQuery(query)}`);
+      }
+      return result.rows[0] as T;
+    });
+  }
+
+  any<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+    return this.#enqueue(async () => {
+      const result = await this.client.query(query, values);
+      return result.rows as T[];
+    });
+  }
+
+  manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]> {
     return this.any<T>(query, values);
   }
 
-  async many<T = any>(query: string, values?: QueryValues): Promise<T[]> {
-    const result = await this.client.query(query, values);
-    if (result.rows.length === 0) {
-      throw new Error(`No data returned from query: ${truncateQuery(query)}`);
-    }
-    return result.rows as T[];
+  many<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+    return this.#enqueue(async () => {
+      const result = await this.client.query(query, values);
+      if (result.rows.length === 0) {
+        throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+      }
+      return result.rows as T[];
+    });
   }
 
-  async query(query: string, values?: QueryValues): Promise<QueryResult> {
-    return this.client.query(query, values);
+  query(query: string, values?: QueryValues): Promise<QueryResult> {
+    return this.#enqueue(() => this.client.query(query, values));
   }
 
   async batch<T>(promises: Promise<T>[]): Promise<T[]> {
+    // Promises are already enqueued (and thus serialized) by the query
+    // methods above; awaiting them together is fine.
     return Promise.all(promises);
   }
 }
+
 
 /**
  * DbClient adapter that pins all queries to a single PoolClient.

--- a/stores/pg/src/storage/client.ts
+++ b/stores/pg/src/storage/client.ts
@@ -166,17 +166,24 @@ export class PoolAdapter implements DbClient {
     try {
       await client.query('BEGIN');
       const txClient = new TransactionClient(client);
-      const result = await callback(txClient);
-      await client.query('COMMIT');
-      return result;
-    } catch (error) {
       try {
-        await client.query('ROLLBACK');
-      } catch (rollbackError) {
-        // Log rollback failure but throw original error
-        console.error('Transaction rollback failed:', rollbackError);
+        const result = await callback(txClient);
+        // Drain before COMMIT so fire-and-forget / batch tails can't race it.
+        await txClient.drain();
+        await client.query('COMMIT');
+        return result;
+      } catch (error) {
+        // Drain before ROLLBACK: Promise.all in batch() rejects on the first
+        // failure while later enqueued queries may still be running.
+        await txClient.drain();
+        try {
+          await client.query('ROLLBACK');
+        } catch (rollbackError) {
+          // Log rollback failure but throw original error
+          console.error('Transaction rollback failed:', rollbackError);
+        }
+        throw error;
       }
-      throw error;
     } finally {
       client.release();
     }
@@ -207,6 +214,15 @@ class TransactionClient implements TxClient {
     const next = this.#tail.then(fn, fn);
     this.#tail = next.catch(() => undefined);
     return next;
+  }
+
+  /**
+   * Wait until every enqueued query has settled.
+   * PoolAdapter / PinnedClientAdapter call this before COMMIT/ROLLBACK so
+   * those control statements never overlap in-flight work on the same client.
+   */
+  async drain(): Promise<void> {
+    await this.#tail;
   }
 
   none(query: string, values?: QueryValues): Promise<null> {
@@ -393,11 +409,14 @@ export class PinnedClientAdapter implements DbClient {
     // can't interleave statements inside someone else's transaction.
     return this.#enqueue(async () => {
       await this.pinnedClient.query('BEGIN');
+      const txClient = new TransactionClient(this.pinnedClient);
       try {
-        const result = await callback(new TransactionClient(this.pinnedClient));
+        const result = await callback(txClient);
+        await txClient.drain();
         await this.pinnedClient.query('COMMIT');
         return result;
       } catch (error) {
+        await txClient.drain();
         try {
           await this.pinnedClient.query('ROLLBACK');
         } catch (rollbackError) {

--- a/stores/pg/src/storage/client.tx-serialize.test.ts
+++ b/stores/pg/src/storage/client.tx-serialize.test.ts
@@ -94,6 +94,23 @@ describe('TransactionClient COMMIT/ROLLBACK drain', () => {
     expect(statements).toEqual(['BEGIN', 'SLOW2', 'COMMIT']);
   });
 
+  it('rolls back when a fire-and-forget query fails', async () => {
+    const { client, statements } = createStrictClient();
+    const pool = {
+      connect: vi.fn(async () => client),
+    } as unknown as Pool;
+    const adapter = new PoolAdapter(pool);
+
+    await expect(
+      adapter.tx(async t => {
+        void t.none('FAIL1');
+        return 'ok';
+      }),
+    ).rejects.toThrow('FAIL1');
+
+    expect(statements).toEqual(['BEGIN', 'FAIL1', 'ROLLBACK']);
+  });
+
   it('PinnedClientAdapter also drains before ROLLBACK', async () => {
     const { client, statements } = createStrictClient();
     const pool = {} as Pool;
@@ -108,5 +125,20 @@ describe('TransactionClient COMMIT/ROLLBACK drain', () => {
     ).rejects.toThrow('FAIL1');
 
     expect(statements).toEqual(['BEGIN', 'FAIL1', 'SLOW2', 'ROLLBACK']);
+  });
+
+  it('PinnedClientAdapter rolls back when a fire-and-forget query fails', async () => {
+    const { client, statements } = createStrictClient();
+    const pool = {} as Pool;
+    const adapter = new PinnedClientAdapter(pool, client);
+
+    await expect(
+      adapter.tx(async t => {
+        void t.none('FAIL1');
+        return 'ok';
+      }),
+    ).rejects.toThrow('FAIL1');
+
+    expect(statements).toEqual(['BEGIN', 'FAIL1', 'ROLLBACK']);
   });
 });

--- a/stores/pg/src/storage/client.tx-serialize.test.ts
+++ b/stores/pg/src/storage/client.tx-serialize.test.ts
@@ -1,0 +1,93 @@
+import type { Pool, PoolClient, QueryResult } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PinnedClientAdapter, PoolAdapter } from './client';
+
+/**
+ * Fake PoolClient that rejects overlapping queries (pg@9 semantics).
+ * Used to prove COMMIT/ROLLBACK never races in-flight transaction work.
+ */
+function createStrictClient() {
+  let inFlight = 0;
+  const statements: string[] = [];
+
+  const query = vi.fn(async (sql: string): Promise<QueryResult> => {
+    if (inFlight > 0) {
+      throw new Error(`Overlapping query while in-flight: ${sql}`);
+    }
+    inFlight += 1;
+    statements.push(sql);
+    try {
+      if (sql === 'FAIL1') {
+        throw new Error('FAIL1');
+      }
+      if (sql.startsWith('SLOW')) {
+        await new Promise(resolve => setTimeout(resolve, 30));
+      }
+      return { rows: [], rowCount: 0, command: 'QUERY', oid: 0, fields: [] } as QueryResult;
+    } finally {
+      inFlight -= 1;
+    }
+  });
+
+  const client = {
+    query,
+    release: vi.fn(),
+  } as unknown as PoolClient;
+
+  return { client, statements, query };
+}
+
+describe('TransactionClient COMMIT/ROLLBACK drain', () => {
+  it('drains queued queries before ROLLBACK when batch fails', async () => {
+    const { client, statements } = createStrictClient();
+    const pool = {
+      connect: vi.fn(async () => client),
+    } as unknown as Pool;
+    const adapter = new PoolAdapter(pool);
+
+    await expect(
+      adapter.tx(async t => {
+        const q1 = t.none('FAIL1');
+        const q2 = t.none('SLOW2');
+        const q3 = t.none('SLOW3');
+        await t.batch([q1, q2, q3]);
+      }),
+    ).rejects.toThrow('FAIL1');
+
+    expect(statements).toEqual(['BEGIN', 'FAIL1', 'SLOW2', 'SLOW3', 'ROLLBACK']);
+    // No overlapping-query errors — ROLLBACK waited for the drain.
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('drains fire-and-forget queries before COMMIT', async () => {
+    const { client, statements } = createStrictClient();
+    const pool = {
+      connect: vi.fn(async () => client),
+    } as unknown as Pool;
+    const adapter = new PoolAdapter(pool);
+
+    await adapter.tx(async t => {
+      void t.none('SLOW2');
+      return 'ok';
+    });
+
+    expect(statements).toEqual(['BEGIN', 'SLOW2', 'COMMIT']);
+  });
+
+  it('PinnedClientAdapter also drains before ROLLBACK', async () => {
+    const { client, statements } = createStrictClient();
+    const pool = {} as Pool;
+    const adapter = new PinnedClientAdapter(pool, client);
+
+    await expect(
+      adapter.tx(async t => {
+        const q1 = t.none('FAIL1');
+        const q2 = t.none('SLOW2');
+        await t.batch([q1, q2]);
+      }),
+    ).rejects.toThrow('FAIL1');
+
+    expect(statements).toEqual(['BEGIN', 'FAIL1', 'SLOW2', 'ROLLBACK']);
+  });
+});


### PR DESCRIPTION
## Summary
- `memory.updateMessages` does `queries.push(t.none(...))` then `await t.batch(queries)`. Because `t.none()` is async, each call starts `client.query` immediately — so N queries race on one transaction `PoolClient`.
- pg@8 queues those and emits `DeprecationWarning`; pg@9 will throw.
- Serialize `TransactionClient` methods through a tail promise (same pattern as `PinnedClientAdapter`) in both `@mastra/pg` and `@mastra/dsql`.
- **Also drain the queue before COMMIT/ROLLBACK** so `batch()` failure (and fire-and-forget queries) cannot race the control statements on the same client.

## Test plan
- [x] Unit tests with a strict single-flight fake `PoolClient` (pg@9 semantics):
  - batch failure → `ROLLBACK` only after queued work settles
  - fire-and-forget → `COMMIT` only after queued work settles
  - same drain path on `PinnedClientAdapter.tx()`
- [x] Changeset for `@mastra/pg` + `@mastra/dsql`

Fixes #20820

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This change makes database work in a transaction run one query at a time. It ensures queued work finishes before the transaction commits or rolls back, preventing warnings and failures from overlapping queries.

## Changes

- Serialized `TransactionClient` query methods in `@mastra/pg` and `@mastra/dsql`.
- Drained pending queries before `COMMIT` and `ROLLBACK`, including after batch failures.
- Preserved query failures and callback errors during transaction completion.
- Applied the same behavior to `PoolAdapter` and `PinnedClientAdapter`.
- Added regression tests for concurrent queries, fire-and-forget queries, batch failures, commits, rollbacks, and client release.
- Added a changeset for `@mastra/pg` and `@mastra/dsql`.
- Documented serialized execution in `TxClient.batch`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->