### PR TITLE
fix(otel-exporter): adapt BatchLogRecordProcessor to sdk-logs 0.221 API

### DIFF
--- a/.changeset/otel-batch-log-processor-args.md
+++ b/.changeset/otel-batch-log-processor-args.md
@@ -1,0 +1,5 @@
+---
+'@mastra/otel-exporter': patch
+---
+
+Fix build break from the @opentelemetry/sdk-logs 0.221 upgrade: BatchLogRecordProcessor now takes a single options object with the exporter inside it, instead of (exporter, options).

--- a/observability/otel-exporter/src/tracing.ts
+++ b/observability/otel-exporter/src/tracing.ts
@@ -377,7 +377,8 @@ export class OtelExporter extends BaseExporter {
       this.loggerProvider = new LoggerProvider({
         resource,
         processors: [
-          new BatchLogRecordProcessor(exporterForProcessor, {
+          new BatchLogRecordProcessor({
+            exporter: exporterForProcessor,
             maxExportBatchSize: this.config.batchSize || 512,
             maxQueueSize: 2048,
             scheduledDelayMillis: 5000,


### PR DESCRIPTION
## Summary
The OpenTelemetry dependency bump in #19784 upgraded `@opentelemetry/sdk-logs` to 0.221.0, where `BatchLogRecordProcessor` now takes a single options object (with the exporter as an `exporter` field) instead of `(exporter, options)`. `tracing.ts` still used the old two-argument call, so `pnpm build` fails on main with TS2554 in `@mastra/otel-exporter`.

This updates the call site to the new constructor shape. All batching options (`maxExportBatchSize`, `maxQueueSize`, `scheduledDelayMillis`, `exportTimeoutMillis`) are preserved.

## Test plan
- `pnpm build` — 170/170 successful (was failing on `@mastra/otel-exporter#build`)
- `pnpm --filter ./observability/otel-exporter test` — 5 files, 98/98 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The OpenTelemetry library changed how its batch logger is configured. This update uses the new format while keeping the existing batching settings, so the exporter builds and works correctly.

## Changes

- Updated `BatchLogRecordProcessor` configuration in `@mastra/otel-exporter`.
- Preserved all batching options.
- Added a patch changeset for OpenTelemetry SDK Logs 0.221 compatibility.

## Validation

- `pnpm build`: 170/170 successful
- OTEL exporter tests: 98/98 passed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->