### PR TITLE
fix(ci): restore baseline validation and Gemini E2E stability

### DIFF
--- a/client-sdks/client-js/src/client.test.ts
+++ b/client-sdks/client-js/src/client.test.ts
@@ -1132,7 +1132,16 @@ describe('MastraClient', () => {
       (global.fetch as any).mockResolvedValueOnce({
         ok: true,
         headers: { get: () => 'application/json' },
-        json: async () => ({ experimentId: 'exp-1', status: 'pending', totalItems: 1, succeededCount: 0, failedCount: 0, startedAt: new Date().toISOString(), completedAt: null, results: [] }),
+        json: async () => ({
+          experimentId: 'exp-1',
+          status: 'pending',
+          totalItems: 1,
+          succeededCount: 0,
+          failedCount: 0,
+          startedAt: new Date().toISOString(),
+          completedAt: null,
+          results: [],
+        }),
       });
 
       await client.triggerDatasetExperiment({
@@ -1147,7 +1156,13 @@ describe('MastraClient', () => {
       const [url, init] = (global.fetch as any).mock.calls[0];
       expect(url).toBe('http://localhost:4111/api/datasets/ds-1/experiments');
       expect(init.method).toBe('POST');
-      expect(JSON.parse(init.body)).toMatchObject({ targetType: 'agent', targetId: 'agent-1', name, description, metadata });
+      expect(JSON.parse(init.body)).toMatchObject({
+        targetType: 'agent',
+        targetId: 'agent-1',
+        name,
+        description,
+        metadata,
+      });
     });
 
     it('batchInsertDatasetItems preserves an explicit empty scorerIds override', async () => {

--- a/observability/mastra/src/recorded.test.ts
+++ b/observability/mastra/src/recorded.test.ts
@@ -653,7 +653,10 @@ describe('RecordedTrace', () => {
       };
     }
 
-    function createMastraWithStorageExporter(storage: MockStore, scoringMirror: ReturnType<typeof createScoringMirror>) {
+    function createMastraWithStorageExporter(
+      storage: MockStore,
+      scoringMirror: ReturnType<typeof createScoringMirror>,
+    ) {
       const observability = new Observability({
         configs: {
           default: {

--- a/observability/otel-bridge/src/bridge.test.ts
+++ b/observability/otel-bridge/src/bridge.test.ts
@@ -36,7 +36,7 @@ describe('OtelBridge', () => {
 
     logExporter = new InMemoryLogRecordExporter();
     loggerProvider = new LoggerProvider({
-      processors: [new SimpleLogRecordProcessor(logExporter)],
+      processors: [new SimpleLogRecordProcessor({ exporter: logExporter })],
     });
     otelLogs.setGlobalLoggerProvider(loggerProvider);
   });
@@ -507,7 +507,7 @@ describe('OtelBridge', () => {
       try {
         const customLogExporter = new InMemoryLogRecordExporter();
         const customLoggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(customLogExporter)],
+          processors: [new SimpleLogRecordProcessor({ exporter: customLogExporter })],
         });
         const bridge = new OtelBridge({ loggerProvider: customLoggerProvider });
 
@@ -560,7 +560,7 @@ describe('OtelBridge', () => {
         const customTracerProvider = new tracing.BasicTracerProvider();
         const customLogExporter = new InMemoryLogRecordExporter();
         const customLoggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(customLogExporter)],
+          processors: [new SimpleLogRecordProcessor({ exporter: customLogExporter })],
         });
 
         const bridge = new OtelBridge({ tracerProvider: customTracerProvider, loggerProvider: customLoggerProvider });

--- a/packages/core/src/agent/agent-gemini.e2e.test.ts
+++ b/packages/core/src/agent/agent-gemini.e2e.test.ts
@@ -83,6 +83,13 @@ beforeEach(async c => {
           if (obj.thoughtSignature === 'skip_thought_signature_validator') {
             delete obj.thoughtSignature;
           }
+          // Provider upgrades can represent this permissive schema differently.
+          // Its shape does not affect the suspension behavior under test.
+          if (obj.description === 'The resumeData object created from the resumeSchema of suspended tool') {
+            for (const key of Object.keys(obj)) {
+              if (key !== 'description') delete obj[key];
+            }
+          }
           for (const [key, child] of Object.entries(obj)) {
             if (
               (key === 'functionCall' || key === 'functionResponse') &&

--- a/packages/memory/src/processors/observational-memory/extraction-runner.ts
+++ b/packages/memory/src/processors/observational-memory/extraction-runner.ts
@@ -25,8 +25,7 @@ function shouldRetryEmptyStructuredObject(
   extractors: readonly Extractor<any>[],
 ): boolean {
   return (
-    Object.keys(object).length === 0 &&
-    extractors.some(extractor => extractor.retryStructuredExtractionOnEmptyObject)
+    Object.keys(object).length === 0 && extractors.some(extractor => extractor.retryStructuredExtractionOnEmptyObject)
   );
 }
 

--- a/packages/schema-compat/src/provider-compats/google.ts
+++ b/packages/schema-compat/src/provider-compats/google.ts
@@ -385,7 +385,10 @@ export class GoogleSchemaCompatLayer extends SchemaCompatLayer {
     ) {
       s['anyOf'] = [
         ...['string', 'number', 'integer', 'boolean', 'object'].map(t => ({ type: t })),
-        { type: 'array', items: { anyOf: ['string', 'number', 'integer', 'boolean', 'object'].map(t => ({ type: t })) } },
+        {
+          type: 'array',
+          items: { anyOf: ['string', 'number', 'integer', 'boolean', 'object'].map(t => ({ type: t })) },
+        },
       ];
       s['nullable'] = true;
     }

--- a/patches/read-yaml-file@1.1.0.patch
+++ b/patches/read-yaml-file@1.1.0.patch
@@ -1,0 +1,14 @@
+diff --git a/index.js b/index.js
+index bcb70193b4bf60c5a1d021a6756adf5f81d67ac6..25bac0990d014acc358e65731458050c4b657d0e 100644
+--- a/index.js
++++ b/index.js
+@@ -5,7 +5,8 @@ const pify = require('pify')
+ const stripBom = require('strip-bom')
+ const yaml = require('js-yaml')
+ 
+-const parse = data => yaml.safeLoad(stripBom(data))
++// js-yaml >= 4 removed safeLoad; load is safe by default there.
++const parse = data => (yaml.safeLoad || yaml.load).call(yaml, stripBom(data))
+ 
+ const readYamlFile = fp => pify(fs.readFile)(fp, 'utf8').then(data => parse(data))
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,7 @@ patchedDependencies:
   '@changesets/get-dependents-graph@2.1.4': eb65c5cbf43c61ce6dcb0c77fa30d9aebcdffa3a70dee1faefc4cde4125f28fa
   '@earendil-works/pi-tui@0.80.6': 88572df39a8452647fa073db5bc0907de3f1cb04c52c4559c8cc6e662973818b
   gray-matter@4.0.3: 058d8be9f17b95a6f86e58debce82671ee3f258e44883a9da932cf16a717ebb8
+  read-yaml-file@1.1.0: 834a9a43c1785ff0b4911ae833daf9fc54055df0834080003b572e6cf4131eb9
 
 importers:
 
@@ -39651,7 +39652,7 @@ snapshots:
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
-      read-yaml-file: 1.1.0
+      read-yaml-file: 1.1.0(patch_hash=834a9a43c1785ff0b4911ae833daf9fc54055df0834080003b572e6cf4131eb9)
 
   '@manypkg/get-packages@3.1.0':
     dependencies:
@@ -55530,7 +55531,7 @@ snapshots:
       json-parse-even-better-errors: 6.0.0
       npm-normalize-package-bin: 6.0.0
 
-  read-yaml-file@1.1.0:
+  read-yaml-file@1.1.0(patch_hash=834a9a43c1785ff0b4911ae833daf9fc54055df0834080003b572e6cf4131eb9):
     dependencies:
       graceful-fs: 4.2.11
       js-yaml: 5.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,6 +52,7 @@ patchedDependencies:
   '@changesets/get-dependents-graph@2.1.4': patches/@changesets__get-dependents-graph@2.1.4.patch
   '@earendil-works/pi-tui@0.80.6': patches/@earendil-works__pi-tui@0.80.6.patch
   gray-matter@4.0.3: patches/gray-matter@4.0.3.patch
+  read-yaml-file@1.1.0: patches/read-yaml-file@1.1.0.patch
 
 packageExtensions:
   '@ai-sdk/provider-utils@3.0.25':


### PR DESCRIPTION
## Summary

Open PRs were failing baseline CI checks unrelated to their changes. This fixes the failures at the source so PR CI is trustworthy again.

**1. Validate peer dependencies — `yaml.safeLoad is not a function`**

The js-yaml@5.2.2 security override (#19265) forces js-yaml 5 onto `read-yaml-file@1.1.0`, a transitive dependency of `@changesets/cli` (via `@manypkg/get-packages`). That package still calls `yaml.safeLoad`, which was removed after js-yaml 3, so the job's `npx changeset pre exit && npx changeset version` step crashes on every PR.

Fix: a pnpm patch that falls back to `yaml.load` when `safeLoad` is absent — the same treatment gray-matter got in #20865 for the same override.

**2. Lint — root `lint:format` task**

Four files on main fail `oxfmt --check` because they merged with stale formatting. Reformatted with oxfmt — whitespace/line-wrapping only, no code changes:

- `client-sdks/client-js/src/client.test.ts`
- `observability/mastra/src/recorded.test.ts`
- `packages/memory/src/processors/observational-memory/extraction-runner.ts`
- `packages/schema-compat/src/provider-compats/google.ts`

**3. Package E2E — Gemini suspension recording replay**

Provider upgrades changed the JSON Schema representation of the permissive `resumeData` value, causing the four Gemini tool/workflow suspension tests to miss their recordings. The recording transform now removes provider-specific schema details that do not affect the behavior under test.

No changeset: CI tooling, formatting, and test stabilization only; no published package behavior changes.

## Test plan

- `npx changeset pre exit && npx changeset version` exits 0 with the patch; reproduced the `yaml.safeLoad is not a function` crash without it
- `npx changeset status`
- `pnpm lint:format` passes on all 10,802 files
- `pnpm --filter ./packages/core exec vitest run src/agent/agent-gemini.e2e.test.ts --project e2e:packages/core --reporter=dot --bail=1` — 23 passed, 1 skipped
- `pnpm --filter ./packages/core check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes CI failures caused by a dependency update, formatting issues, and provider-specific Gemini test data. It also updates test setup to match the current OpenTelemetry API.

## Changes

- Patched `read-yaml-file@1.1.0` to use `yaml.load` when `yaml.safeLoad` is unavailable.
- Registered the patch in `pnpm-workspace.yaml`.
- Reformatted four files without changing behavior.
- Normalized Gemini `resumeData` schemas for stable request comparisons.
- Updated client test fixture formatting without changing expectations.
- Updated `SimpleLogRecordProcessor` test setup to use the OpenTelemetry options-object API.

## Validation

- Changesets status and versioning commands passed.
- `pnpm lint:format` passed across 10,802 files.
- Gemini E2E tests passed: 23 passed and 1 skipped.
- Core package checks passed.

No changeset is included because this PR changes CI tooling, tests, and formatting only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->