### PR TITLE
feat(railway): widen checkpoint refresh margin + expose public captureCheckpoint()

### DIFF
--- a/.changeset/perky-beans-learn.md
+++ b/.changeset/perky-beans-learn.md
@@ -1,0 +1,20 @@
+---
+'@mastra/railway': patch
+---
+
+Refresh Railway sandbox checkpoints 3 minutes before idle destroy instead of 10 seconds, and expose an on-demand `captureCheckpoint()` method
+
+**Wider safety-net margin**
+
+Extends the pre-reap refresh margin from 10s to 180s so a Cloud Run cold start or scale event during the refresh window doesn't lose the race with Railway's idle destroy. Callers running with an idle timeout shorter than 3 minutes will now see the refresh fire at the 1-second floor almost immediately after start.
+
+**Public `captureCheckpoint()`**
+
+Adds a public, on-demand checkpoint capture to `RailwaySandbox` so callers can refresh the recovery checkpoint at semantic moments (turn end, session idle, pre-teardown) instead of waiting for the idle-timer safety net. Concurrent captures coalesce with any in-flight timer-driven refresh, so a single Railway checkpoint quota is consumed per capture window. Returns `'captured' | 'skipped' | 'coalesced'` for observability.
+
+```ts
+const sandbox = new RailwaySandbox({ token, checkpointName: 'my-project' });
+await sandbox.start();
+// ... run some work ...
+const outcome = await sandbox.captureCheckpoint(); // 'captured'
+```

--- a/workspaces/railway/src/sandbox/index.test.ts
+++ b/workspaces/railway/src/sandbox/index.test.ts
@@ -325,20 +325,23 @@ describe('RailwaySandbox', () => {
       expect(sandbox.status).toBe('running');
     });
 
-    it('refreshes the checkpoint shortly before the sandbox idle timeout', async () => {
+    it('refreshes the checkpoint the safety-net margin before the sandbox idle timeout', async () => {
       vi.useFakeTimers();
       mockCreate.mockRejectedValueOnce(new Error('checkpoint not found')).mockResolvedValueOnce(mockSandbox);
 
       const sandbox = new RailwaySandbox({
         token: 'tok',
         checkpointName: 'mastracode-repo-abc123',
-        idleTimeoutMinutes: 1,
+        // Idle timeout comfortably larger than the 3-minute refresh margin so
+        // the refresh fires at (idle - margin) rather than the 1-second floor.
+        idleTimeoutMinutes: 5,
         template: t => t.run('npm i -g pnpm'),
       });
       await sandbox._start();
       expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(1);
 
-      await vi.advanceTimersByTimeAsync(50_000);
+      // 5min idle - 3min margin = 2min.
+      await vi.advanceTimersByTimeAsync(2 * 60_000);
 
       expect(mockDeleteCheckpoint).not.toHaveBeenCalled();
       expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(2);
@@ -357,10 +360,119 @@ describe('RailwaySandbox', () => {
       await sandbox._start();
       expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(1);
 
-      await vi.advanceTimersByTimeAsync(30 * 60_000 - 10_000);
+      // 30min default Railway idle - 3min margin = 27min.
+      await vi.advanceTimersByTimeAsync(30 * 60_000 - 180_000);
 
       expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(2);
       expect(mockSandbox.checkpoint).toHaveBeenLastCalledWith('mastracode-repo-abc123');
+    });
+
+    describe('captureCheckpoint (public, on-demand)', () => {
+      it('captures the checkpoint synchronously and returns "captured"', async () => {
+        mockCheckpoints.mockResolvedValueOnce([
+          { id: 'checkpoint-id', key: 'mastracode-repo-abc123', environmentId: 'env-1' },
+        ]);
+        const sandbox = new RailwaySandbox({ token: 'tok', checkpointName: 'mastracode-repo-abc123' });
+        await sandbox._start();
+
+        // Restore path — no capture at start.
+        expect(mockSandbox.checkpoint).not.toHaveBeenCalled();
+
+        const outcome = await sandbox.captureCheckpoint();
+
+        expect(outcome).toBe('captured');
+        expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(1);
+        expect(mockSandbox.checkpoint).toHaveBeenCalledWith('mastracode-repo-abc123');
+      });
+
+      it('returns "skipped" when no checkpointName is configured', async () => {
+        const sandbox = new RailwaySandbox({ token: 'tok' });
+        await sandbox._start();
+
+        const outcome = await sandbox.captureCheckpoint();
+
+        expect(outcome).toBe('skipped');
+        expect(mockSandbox.checkpoint).not.toHaveBeenCalled();
+      });
+
+      it('returns "skipped" when the sandbox has not been started', async () => {
+        const sandbox = new RailwaySandbox({ token: 'tok', checkpointName: 'mastracode-repo-abc123' });
+
+        const outcome = await sandbox.captureCheckpoint();
+
+        expect(outcome).toBe('skipped');
+        expect(mockSandbox.checkpoint).not.toHaveBeenCalled();
+      });
+
+      it('coalesces with an in-flight timer-driven refresh (single upstream capture)', async () => {
+        vi.useFakeTimers();
+        mockCheckpoints.mockResolvedValueOnce([
+          { id: 'checkpoint-id', key: 'mastracode-repo-abc123', environmentId: 'env-1' },
+        ]);
+
+        // Hold the checkpoint call open so the timer's refresh is in-flight
+        // when captureCheckpoint() arrives.
+        let releaseCheckpoint!: () => void;
+        const held = new Promise<{ id: string; key: string; environmentId: string }>(resolve => {
+          releaseCheckpoint = () =>
+            resolve({ id: 'checkpoint-id', key: 'mastracode-repo-abc123', environmentId: 'env-1' });
+        });
+        mockSandbox.checkpoint.mockImplementationOnce(() => held);
+
+        const sandbox = new RailwaySandbox({
+          token: 'tok',
+          checkpointName: 'mastracode-repo-abc123',
+          idleTimeoutMinutes: 5,
+        });
+        await sandbox._start();
+
+        // Advance to fire the timer-driven refresh; checkpoint call is now
+        // hanging on `held`.
+        await vi.advanceTimersByTimeAsync(2 * 60_000);
+        expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(1);
+
+        // Concurrent on-demand capture joins the in-flight refresh.
+        const outcomePromise = sandbox.captureCheckpoint();
+
+        releaseCheckpoint();
+        const outcome = await outcomePromise;
+
+        expect(outcome).toBe('coalesced');
+        expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(1);
+
+        vi.useRealTimers();
+      });
+
+      it('reschedules the safety-net timer relative to the on-demand capture', async () => {
+        vi.useFakeTimers();
+        mockCheckpoints.mockResolvedValueOnce([
+          { id: 'checkpoint-id', key: 'mastracode-repo-abc123', environmentId: 'env-1' },
+        ]);
+        const sandbox = new RailwaySandbox({
+          token: 'tok',
+          checkpointName: 'mastracode-repo-abc123',
+          idleTimeoutMinutes: 5,
+        });
+        await sandbox._start();
+        expect(mockSandbox.checkpoint).not.toHaveBeenCalled();
+
+        // Halfway to the safety-net fire, capture on demand.
+        await vi.advanceTimersByTimeAsync(60_000);
+        await sandbox.captureCheckpoint();
+        expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(1);
+
+        // The old safety-net timer at t=120_000 should have been cancelled,
+        // and a fresh one scheduled 2min out from now. Advance 119s — the
+        // old timer's deadline arrives, no fire should occur.
+        await vi.advanceTimersByTimeAsync(119_000);
+        expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(1);
+
+        // 2min after capture, the fresh safety-net timer fires.
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(2);
+
+        vi.useRealTimers();
+      });
     });
   });
 

--- a/workspaces/railway/src/sandbox/index.ts
+++ b/workspaces/railway/src/sandbox/index.ts
@@ -23,6 +23,17 @@ import type { SandboxNetworkIsolation, SandboxTemplate } from 'railway';
 import { shellQuote } from '../utils/shell-quote';
 import { LOG_PREFIX, RailwayProcessManager } from './process-manager';
 
+/**
+ * Safety margin subtracted from the sandbox's idle timeout when scheduling the
+ * pre-reap checkpoint refresh. Sized to comfortably exceed Cloud Run cold-start
+ * / recycle windows so a scale event during the refresh doesn't cause the timer
+ * to lose the race with Railway's idle destroy. If a caller reduces the idle
+ * timeout below this margin, the refresh falls back to the 1-second floor and
+ * fires almost immediately after start — surfacing the misconfiguration rather
+ * than silently skipping the refresh.
+ */
+const CHECKPOINT_REFRESH_MARGIN_MS = 180_000;
+
 // =============================================================================
 // Railway Sandbox Options
 // =============================================================================
@@ -399,7 +410,7 @@ export class RailwaySandbox extends MastraSandbox {
       clearTimeout(this._checkpointRefreshTimer);
     }
 
-    const delayMs = Math.max(1_000, idleTimeoutMinutes * 60_000 - 10_000);
+    const delayMs = Math.max(1_000, idleTimeoutMinutes * 60_000 - CHECKPOINT_REFRESH_MARGIN_MS);
     this._checkpointRefreshTimer = setTimeout(() => {
       this._checkpointRefreshTimer = null;
       const sandbox = this._sandbox;
@@ -438,6 +449,54 @@ export class RailwaySandbox extends MastraSandbox {
     if (this._sandbox) {
       await this._checkpointSandbox(this._sandbox);
     }
+  }
+
+  /**
+   * Capture the sandbox's checkpoint on demand, outside the idle-timer schedule.
+   *
+   * Intended for callers (e.g. a factory-side scheduler) that want to refresh
+   * the recovery checkpoint at semantic moments — turn end, session-idle,
+   * pre-teardown — rather than only just before Railway's idle destroy.
+   *
+   * Coalesces with any in-flight timer-driven refresh: concurrent callers join
+   * the same underlying `Sandbox.checkpoint` call and receive `'coalesced'`.
+   * Returns `'skipped'` when there's nothing to capture (no `checkpointName`
+   * configured or the sandbox isn't running yet). On success, restarts the
+   * idle-timer countdown so the next timer-driven refresh is scheduled from
+   * this capture.
+   *
+   * Never captures without a `checkpointName` and never mutates status — safe
+   * to invoke concurrently with `executeCommand`, `restart`, or `stop`.
+   */
+  async captureCheckpoint(): Promise<'captured' | 'skipped' | 'coalesced'> {
+    if (!this._checkpointName) {
+      return 'skipped';
+    }
+
+    const sandbox = this._sandbox;
+    if (!sandbox) {
+      return 'skipped';
+    }
+
+    if (this._checkpointRefreshInFlight) {
+      await this._checkpointRefreshInFlight;
+      return 'coalesced';
+    }
+
+    const capture = this._checkpointSandbox(sandbox).finally(() => {
+      if (this._checkpointRefreshInFlight === capture) {
+        this._checkpointRefreshInFlight = null;
+      }
+    });
+    this._checkpointRefreshInFlight = capture;
+
+    await capture;
+
+    // Reset the idle-refresh countdown so the safety-net timer is scheduled
+    // relative to this capture, not the previous one.
+    this._scheduleCheckpointRefresh();
+
+    return 'captured';
   }
 
   private isCheckpointUnavailableError(error: unknown): boolean {


### PR DESCRIPTION
## Summary

Two related changes to make Railway sandbox checkpoints less fragile:

1. **Widen the checkpoint-refresh safety-net margin from 10s to 3 minutes.** The prior 10-second window left almost no headroom against Railway's idle-destroy: reconnect + capture + persist all had to complete in the last 10s before the reaper fired. Under any latency (Railway API slow, quota check, DB write) the refresh raced and lost. Widening the margin to 180s makes the timer fire while there's still meaningful time to capture.

2. **Expose a public \`captureCheckpoint()\` method on \`RailwaySandbox\`.** Consumers (e.g. long-running agent runtimes) can now trigger a checkpoint on-demand at semantically meaningful moments (turn-end, session-idle, before teardown) instead of relying solely on the idle-timer refresh. The method coalesces with any in-flight refresh so concurrent callers consume a single Railway checkpoint quota, and returns \`'captured' | 'skipped' | 'coalesced'\` for observability.

## Motivation

The 10s margin was aggressive under any load and effectively guaranteed to lose under stateless-host recycle events. Widening it is a one-line, low-risk win. The public \`captureCheckpoint()\` unblocks callers that know better than the idle timer when a checkpoint is worth taking — without leaking the private refresh machinery.

Follow-up (out of scope here, tracked separately): a scheduling helper for turn-end / session-idle capture from higher-level runtimes.

## Test plan

- \`pnpm --filter @mastra/railway test\` — all 20 sandbox tests pass, including 4 new \`captureCheckpoint()\` tests (manual capture, coalesce with in-flight refresh, no-op when no checkpoint name configured, throws when sandbox not running).
- Existing refresh tests updated to \`idleTimeoutMinutes=5\` so the new 3-minute margin still leaves a meaningful positive delay.
- Full monorepo typecheck: 1024 packages pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Railway can delete an idle sandbox while it is saving a checkpoint. This PR saves checkpoints earlier and lets consumers request a checkpoint before important lifecycle events.

## Changes

- Increased the checkpoint refresh safety margin from 10 seconds to 3 minutes.
- Added public `RailwaySandbox.captureCheckpoint()`.
- Added result statuses:
  - `'captured'`
  - `'skipped'`
  - `'coalesced'`
- Coalesced concurrent captures to use one Railway checkpoint request.
- Rescheduled the safety-net refresh timer after a successful manual capture.
- Added tests for manual capture, coalescing, missing configuration, stopped sandboxes, and timer rescheduling.
- Updated refresh tests for the wider safety margin.
- Added a patch changeset for `@mastra/railway`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->