### PR TITLE
fix(server): catch rejected workflow /start Run.start()

### DIFF
--- a/packages/server/src/server/handlers/workflows.test.ts
+++ b/packages/server/src/server/handlers/workflows.test.ts
@@ -624,6 +624,44 @@ describe('vNext Workflow Handlers', () => {
       expect(result).toEqual({ message: 'Workflow run started' });
     });
 
+    it('should not leave an unhandled rejection when run.start() rejects', async () => {
+      const run = await mockWorkflow.createRun({
+        runId: 'test-run-reject',
+      });
+      await run.start({ inputData: {} });
+
+      const createRunSpy = vi.spyOn(mockWorkflow, 'createRun').mockResolvedValue({
+        start: vi.fn().mockRejectedValue(new Error('invalid workflow input')),
+      } as any);
+
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => {
+        unhandled.push(reason);
+      };
+      process.on('unhandledRejection', onUnhandled);
+
+      try {
+        const result = await START_WORKFLOW_RUN_ROUTE.handler({
+          mastra: mockMastra,
+          workflowId: 'test-workflow',
+          runId: 'test-run-reject',
+          inputData: { bad: true },
+          tracingOptions,
+        } as any);
+
+        expect(result).toEqual({ message: 'Workflow run started' });
+
+        // Let the rejected promise settle; .catch on the route must swallow it.
+        await new Promise(resolve => setImmediate(resolve));
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+        createRunSpy.mockRestore();
+      }
+    });
+
     it('should preserve resourceId when starting workflow run after server restart', async () => {
       const resourceId = 'user-start-test';
 

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -581,10 +581,16 @@ export const START_WORKFLOW_RUN_ROUTE = createRoute({
       await validateRunOwnership(run, effectiveResourceId);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
-      void _run.start({
-        ...params,
-        requestContext,
-      });
+      // Fire-and-forget: attach .catch so a rejected start (e.g. invalid input
+      // schema) cannot become an unhandledRejection and tear down the process.
+      void _run
+        .start({
+          ...params,
+          requestContext,
+        })
+        .catch(error => {
+          mastra.getLogger().error('Failed to start workflow run', { error, workflowId, runId });
+        });
 
       return { message: 'Workflow run started' };
     } catch (e) {


### PR DESCRIPTION
## Summary
- `START_WORKFLOW_RUN_ROUTE` fire-and-forgets `Run.start()` with `void` and no rejection handler.
- Schema/input failures still return `{ message: "Workflow run started" }` (200) and then raise `unhandledRejection`, which can terminate Node.
- Attach `.catch()` that logs via `mastra.getLogger()` (same pattern as `restartAllActiveWorkflowRuns`).

## Test plan
- [x] Vitest: rejected `start()` must not emit `unhandledRejection`
- [x] Source A/B: stashing the `.catch` fails the regression check; pop restores it

Fixes #20829

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The workflow start endpoint now handles errors from background workflow starts. This prevents server crashes caused by failed starts that were not reported.

## Changes

- Added a rejection handler to the fire-and-forget `Run.start()` call.
- Logs failed starts with workflow and run identifiers through `mastra.getLogger()`.
- Added a test that verifies rejected starts do not emit `unhandledRejection`.
- Added coverage to confirm the rejection handler remains in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->