### PR TITLE
feat(railway)!: return checkpoint name inline from captureCheckpoint

### DIFF
--- a/.changeset/checkpoint-capture-result-shape.md
+++ b/.changeset/checkpoint-capture-result-shape.md
@@ -1,0 +1,30 @@
+---
+'@mastra/railway': patch
+---
+
+Widen `RailwaySandbox.captureCheckpoint()` return type to a discriminated object so callers get the checkpoint name inline instead of having to reach back into the sandbox for it.
+
+Before:
+
+```ts
+const outcome = await sandbox.captureCheckpoint(); // 'captured' | 'skipped' | 'coalesced'
+```
+
+After:
+
+```ts
+const result = await sandbox.captureCheckpoint();
+switch (result.status) {
+  case 'captured':
+  case 'coalesced':
+    await persistBinding({ sessionId, checkpointName: result.checkpointName });
+    break;
+  case 'skipped':
+    // result.reason: 'no-checkpoint-name-configured' | 'sandbox-not-running'
+    break;
+}
+```
+
+Both `captured` and `coalesced` now carry `checkpointName` — they both represent a successful capture the caller can persist against. `skipped` carries a machine-readable `reason` so the set stays extensible without another breaking return-shape change.
+
+This is a breaking change to the `captureCheckpoint()` return type introduced in the previous release. The method has no other callers in the OSS packages.

--- a/workspaces/railway/src/sandbox/index.test.ts
+++ b/workspaces/railway/src/sandbox/index.test.ts
@@ -368,7 +368,7 @@ describe('RailwaySandbox', () => {
     });
 
     describe('captureCheckpoint (public, on-demand)', () => {
-      it('captures the checkpoint synchronously and returns "captured"', async () => {
+      it('captures the checkpoint synchronously and returns the captured name', async () => {
         mockCheckpoints.mockResolvedValueOnce([
           { id: 'checkpoint-id', key: 'mastracode-repo-abc123', environmentId: 'env-1' },
         ]);
@@ -380,27 +380,27 @@ describe('RailwaySandbox', () => {
 
         const outcome = await sandbox.captureCheckpoint();
 
-        expect(outcome).toBe('captured');
+        expect(outcome).toEqual({ status: 'captured', checkpointName: 'mastracode-repo-abc123' });
         expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(1);
         expect(mockSandbox.checkpoint).toHaveBeenCalledWith('mastracode-repo-abc123');
       });
 
-      it('returns "skipped" when no checkpointName is configured', async () => {
+      it('returns skipped with a reason when no checkpointName is configured', async () => {
         const sandbox = new RailwaySandbox({ token: 'tok' });
         await sandbox._start();
 
         const outcome = await sandbox.captureCheckpoint();
 
-        expect(outcome).toBe('skipped');
+        expect(outcome).toEqual({ status: 'skipped', reason: 'no-checkpoint-name-configured' });
         expect(mockSandbox.checkpoint).not.toHaveBeenCalled();
       });
 
-      it('returns "skipped" when the sandbox has not been started', async () => {
+      it('returns skipped with a reason when the sandbox has not been started', async () => {
         const sandbox = new RailwaySandbox({ token: 'tok', checkpointName: 'mastracode-repo-abc123' });
 
         const outcome = await sandbox.captureCheckpoint();
 
-        expect(outcome).toBe('skipped');
+        expect(outcome).toEqual({ status: 'skipped', reason: 'sandbox-not-running' });
         expect(mockSandbox.checkpoint).not.toHaveBeenCalled();
       });
 
@@ -437,7 +437,7 @@ describe('RailwaySandbox', () => {
         releaseCheckpoint();
         const outcome = await outcomePromise;
 
-        expect(outcome).toBe('coalesced');
+        expect(outcome).toEqual({ status: 'coalesced', checkpointName: 'mastracode-repo-abc123' });
         expect(mockSandbox.checkpoint).toHaveBeenCalledTimes(1);
 
         vi.useRealTimers();

--- a/workspaces/railway/src/sandbox/index.ts
+++ b/workspaces/railway/src/sandbox/index.ts
@@ -35,6 +35,24 @@ import { LOG_PREFIX, RailwayProcessManager } from './process-manager';
 const CHECKPOINT_REFRESH_MARGIN_MS = 180_000;
 
 // =============================================================================
+// Public capture result
+// =============================================================================
+
+/**
+ * Outcome of a {@link RailwaySandbox.captureCheckpoint} call.
+ *
+ * `captured` and `coalesced` both represent a successful capture the caller can
+ * persist against — they carry the checkpoint name inline so callers don't have
+ * to reach back into the sandbox instance to learn what they just wrote.
+ * `skipped` carries a machine-readable reason so the set stays extensible
+ * without another breaking change.
+ */
+export type CaptureCheckpointResult =
+  | { status: 'captured'; checkpointName: string }
+  | { status: 'coalesced'; checkpointName: string }
+  | { status: 'skipped'; reason: 'no-checkpoint-name-configured' | 'sandbox-not-running' };
+
+// =============================================================================
 // Railway Sandbox Options
 // =============================================================================
 
@@ -459,28 +477,33 @@ export class RailwaySandbox extends MastraSandbox {
    * pre-teardown — rather than only just before Railway's idle destroy.
    *
    * Coalesces with any in-flight timer-driven refresh: concurrent callers join
-   * the same underlying `Sandbox.checkpoint` call and receive `'coalesced'`.
-   * Returns `'skipped'` when there's nothing to capture (no `checkpointName`
-   * configured or the sandbox isn't running yet). On success, restarts the
-   * idle-timer countdown so the next timer-driven refresh is scheduled from
-   * this capture.
+   * the same underlying `Sandbox.checkpoint` call and receive
+   * `{ status: 'coalesced', checkpointName }`. Both `captured` and `coalesced`
+   * carry the checkpoint name inline so callers can persist a session→
+   * checkpoint binding without a second, non-atomic read against the sandbox.
+   * Returns `{ status: 'skipped', reason }` when there's nothing to capture
+   * (no `checkpointName` configured, or the sandbox isn't running yet).
+   *
+   * On successful capture, restarts the idle-timer countdown so the next
+   * timer-driven refresh is scheduled from this capture.
    *
    * Never captures without a `checkpointName` and never mutates status — safe
    * to invoke concurrently with `executeCommand`, `restart`, or `stop`.
    */
-  async captureCheckpoint(): Promise<'captured' | 'skipped' | 'coalesced'> {
-    if (!this._checkpointName) {
-      return 'skipped';
+  async captureCheckpoint(): Promise<CaptureCheckpointResult> {
+    const checkpointName = this._checkpointName;
+    if (!checkpointName) {
+      return { status: 'skipped', reason: 'no-checkpoint-name-configured' };
     }
 
     const sandbox = this._sandbox;
     if (!sandbox) {
-      return 'skipped';
+      return { status: 'skipped', reason: 'sandbox-not-running' };
     }
 
     if (this._checkpointRefreshInFlight) {
       await this._checkpointRefreshInFlight;
-      return 'coalesced';
+      return { status: 'coalesced', checkpointName };
     }
 
     const capture = this._checkpointSandbox(sandbox).finally(() => {
@@ -496,7 +519,7 @@ export class RailwaySandbox extends MastraSandbox {
     // relative to this capture, not the previous one.
     this._scheduleCheckpointRefresh();
 
-    return 'captured';
+    return { status: 'captured', checkpointName };
   }
 
   private isCheckpointUnavailableError(error: unknown): boolean {


### PR DESCRIPTION
Follow-up to #20875 addressing review feedback from @rphansen91.

## Summary

Widen `RailwaySandbox.captureCheckpoint()` return from a bare status string to a discriminated result object that carries the checkpoint name inline for successful captures.

```ts
export type CaptureCheckpointResult =
  | { status: 'captured'; checkpointName: string }
  | { status: 'coalesced'; checkpointName: string }
  | { status: 'skipped'; reason: 'no-checkpoint-name-configured' | 'sandbox-not-running' };
```

## Motivation

The bare-string shape forced callers into a second, unrelated read to learn what they just wrote — either against a private `_checkpointName` (not publicly exposed) or against a future public getter that wouldn't be atomic with the awaited capture. Concrete usage that motivated the change:

```ts
const result = await sandbox.captureCheckpoint();
if (result.status === 'captured' || result.status === 'coalesced') {
  await persistBinding({ sessionId, checkpointName: result.checkpointName });
}
```

Both `captured` and `coalesced` represent a successful capture the caller can persist against, so both carry the name. `skipped` carries a machine-readable `reason` so future skip conditions can be added without another breaking return-shape change.

## Breaking change scope

Breaking change to `captureCheckpoint()` return type introduced in the previous release (#20875). No other OSS callers exist. Marked with `!` and a patch changeset (initial API landed one release ago, no consumers yet).

## Test plan

- `pnpm vitest run ./src/sandbox/index.test.ts` in `workspaces/railway` — all 48 tests pass, including the 4 `captureCheckpoint()` cases updated to assert the new object shape (captured / skipped-no-name / skipped-not-running / coalesced).
- `tsc --noEmit` clean in the railway package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

`captureCheckpoint()` now returns clear details about what happened. Callers can get the saved checkpoint name directly or see why the operation was skipped.

## Changes

- Added the `CaptureCheckpointResult` discriminated union.
- Successful results include `checkpointName`.
- Skipped results include one of these reasons:
  - `no-checkpoint-name-configured`
  - `sandbox-not-running`
- Updated Railway checkpoint capture tests.
- Added a changeset for the breaking return-type change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->