### PR TITLE
docs(changeset): correct captureCheckpoint result-shape note

### DIFF
--- a/.changeset/checkpoint-capture-result-shape.md
+++ b/.changeset/checkpoint-capture-result-shape.md
@@ -25,6 +25,6 @@ switch (result.status) {
 }
 ```
 
-Both `captured` and `coalesced` now carry `checkpointName` — they both represent a successful capture the caller can persist against. `skipped` carries a machine-readable `reason` so the set stays extensible without another breaking return-shape change.
+Both `captured` and `coalesced` now carry `checkpointName` — they both represent a successful capture the caller can persist against. `skipped` carries a machine-readable `reason` so the set stays extensible without another return-shape change.
 
-This is a breaking change to the `captureCheckpoint()` return type introduced in the previous release. The method has no other callers in the OSS packages.
+The prior return shape landed one release ago and has no consumers yet, so this is a straight fix rather than a semver-breaking change.


### PR DESCRIPTION
Tiny changeset-wording fix for the `captureCheckpoint()` result-shape change (PR #20877).

The changeset already bumps `@mastra/railway` as `patch` (correct — the previous release's return shape had zero consumers, so this was never a semver break), but the description text still said "breaking change". Corrected before the pending "Version Packages" PR consumes it so the release notes read accurately.

No code change.
