### PR TITLE
fix(observability): reparent spans past excludeSpanTypes ancestors

### DIFF
--- a/.changeset/calm-pans-reparent.md
+++ b/.changeset/calm-pans-reparent.md
@@ -2,4 +2,4 @@
 "@mastra/observability": patch
 ---
 
-fix(observability): reparent spans past excludeSpanTypes ancestors so exporters no longer orphan tool-call descendants
+Fixed span exports when `excludeSpanTypes` removes a parent span. Descendant spans now use the nearest exported parent, so exporters retain tool calls.

--- a/.changeset/calm-pans-reparent.md
+++ b/.changeset/calm-pans-reparent.md
@@ -1,0 +1,5 @@
+---
+"@mastra/observability": patch
+---
+
+fix(observability): reparent spans past excludeSpanTypes ancestors so exporters no longer orphan tool-call descendants

--- a/observability/mastra/src/span-filtering.test.ts
+++ b/observability/mastra/src/span-filtering.test.ts
@@ -125,6 +125,9 @@ describe('Span Filtering', () => {
       expect(stepSpan.isExcluded).toBe(true);
       expect(toolSpan.getParentSpanId()).toBe(modelSpan.id);
       expect(toolSpan.exportSpan().parentSpanId).toBe(modelSpan.id);
+      // includeInternalSpans must still skip excludeSpanTypes ancestors
+      expect(toolSpan.getParentSpanId(true)).toBe(modelSpan.id);
+      expect(toolSpan.exportSpan(true).parentSpanId).toBe(modelSpan.id);
 
       toolSpan.end();
       stepSpan.end();

--- a/observability/mastra/src/span-filtering.test.ts
+++ b/observability/mastra/src/span-filtering.test.ts
@@ -91,6 +91,59 @@ describe('Span Filtering', () => {
       expect(spanTypes).toContain(SpanType.MODEL_GENERATION);
     });
 
+    it('should reparent descendants of excluded spans so exporters see no orphans', () => {
+      // Documented config: drop MODEL_STEP / MODEL_CHUNK. Tool calls are
+      // children of MODEL_STEP — without reparenting they export parentSpanId
+      // pointing at a span exporters never received (#20818).
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [testExporter],
+        excludeSpanTypes: [SpanType.MODEL_CHUNK, SpanType.MODEL_STEP],
+      });
+
+      const agentSpan = tracing.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'test-agent',
+      });
+      const modelSpan = agentSpan.createChildSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-model',
+        attributes: { model: 'gpt-4', provider: 'openai' },
+      });
+      const stepSpan = modelSpan.createChildSpan({
+        type: SpanType.MODEL_STEP,
+        name: 'test-step',
+      });
+      const toolSpan = stepSpan.createChildSpan({
+        type: SpanType.TOOL_CALL,
+        name: "tool: 'my_tool'",
+        attributes: { toolId: 'my_tool', toolType: 'function' },
+      });
+
+      expect(stepSpan.isExcluded).toBe(true);
+      expect(toolSpan.getParentSpanId()).toBe(modelSpan.id);
+      expect(toolSpan.exportSpan().parentSpanId).toBe(modelSpan.id);
+
+      toolSpan.end();
+      stepSpan.end();
+      modelSpan.end();
+      agentSpan.end();
+
+      const exported = testExporter.events
+        .filter(e => e.type === 'span_ended' || e.type === 'span_started')
+        .map(e => e.exportedSpan);
+      const byId = new Map(exported.map(s => [s.id, s]));
+      const toolExported = exported.find(s => s.type === SpanType.TOOL_CALL);
+      expect(toolExported).toBeDefined();
+      expect(toolExported!.parentSpanId).toBe(modelSpan.id);
+      expect(byId.has(toolExported!.parentSpanId!)).toBe(true);
+
+      const orphans = exported.filter(s => s.parentSpanId && !byId.has(s.parentSpanId));
+      expect(orphans).toEqual([]);
+    });
+
     it('should export all spans when excludeSpanTypes is empty', () => {
       const tracing = new DefaultObservabilityInstance({
         serviceName: 'test',

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -24,7 +24,11 @@ import { deepClean, mergeSerializationOptions } from './serialization';
 import type { DeepCleanOptions } from './serialization';
 
 /** Extended span type that includes getParentSpan method available on BaseSpan instances */
-type AnyBaseSpan = AnySpan & { getParentSpan(includeInternalSpans?: boolean): AnySpan | undefined };
+type AnyBaseSpan = AnySpan & {
+  getParentSpan(includeInternalSpans?: boolean): AnySpan | undefined;
+  /** True when the span is dropped before export (excludeSpanTypes / internal / alwaysExcluded) */
+  readonly isExcluded?: boolean;
+};
 
 /**
  * Determines if a span type should be considered internal based on flags.
@@ -73,12 +77,12 @@ function isSpanInternal(spanType: SpanType, flags?: InternalSpans): boolean {
 /**
  * Get the external parent span ID from CreateSpanOptions.
  *
- * If the parent is internal, walks up the parent chain to find
- * the closest external ancestor. If the parent is already external,
- * returns its ID directly.
+ * If the parent is internal or excluded from export (`excludeSpanTypes`),
+ * walks up the parent chain to find the closest exported ancestor.
+ * If the parent is already exportable, returns its ID directly.
  *
  * This is useful when exporting spans to external observability systems
- * that shouldn't include internal framework spans.
+ * that shouldn't include internal framework spans or excluded types.
  *
  * @param options - Span creation options
  * @returns The external parent span ID, or undefined if no external parent exists
@@ -102,13 +106,12 @@ export function getExternalParentId(options: CreateSpanOptions<any>): string | u
     return undefined;
   }
 
-  if (options.parent.isInternal) {
-    // Parent is internal, find its external ancestor
-    return options.parent.getParentSpanId(false);
-  } else {
-    // Parent is already external, use it directly
-    return options.parent.id;
+  const parent = options.parent as AnyBaseSpan;
+  if (parent.isInternal || parent.isExcluded) {
+    // Parent won't reach exporters — walk to the closest exported ancestor
+    return parent.getParentSpanId(false);
   }
+  return parent.id;
 }
 
 export abstract class BaseSpan<TType extends SpanType = any> implements Span<TType> {
@@ -159,11 +162,15 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
    * when the span is internal and includeInternalSpans is false, or when
    * the subclass is always excluded (e.g., NoOpSpan).
    *
+   * Public so parent-chain walks (`getParentSpan`) can skip ancestors that
+   * exporters will never receive — otherwise descendants export a
+   * `parentSpanId` pointing at a dropped span and become orphans.
+   *
    * Note: metadata is still attached and deepCleaned because it is read in
    * process by getCorrelationContext() and by getLoggerContext() /
    * getMetricsContext() (which structuredClone it).
    */
-  protected isExcluded: boolean;
+  public isExcluded: boolean;
   /** Cached canonical correlation context for this live span */
   protected correlationContext?: CorrelationContext;
 
@@ -278,17 +285,25 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
   /** Returns `TRUE` if the span is a valid span (not a NO-OP Span) */
   abstract get isValid(): boolean;
 
-  /** Get the closest parent span, optionally skipping internal spans */
+  /**
+   * Get the closest parent span, optionally skipping internal spans.
+   * When `includeInternalSpans` is false/undefined, also skips ancestors
+   * dropped by `excludeSpanTypes` so exported `parentSpanId` values point
+   * at spans that exporters actually receive.
+   */
   public getParentSpan(includeInternalSpans?: boolean): AnySpan | undefined {
     if (!this.parent) {
       return undefined;
     }
     if (includeInternalSpans) return this.parent;
-    if (this.parent.isInternal) return (this.parent as AnyBaseSpan).getParentSpan(includeInternalSpans);
+    const parent = this.parent as AnyBaseSpan;
+    if (parent.isInternal || parent.isExcluded) {
+      return parent.getParentSpan(includeInternalSpans);
+    }
     return this.parent;
   }
 
-  /** Get the closest parent spanId that isn't an internal span */
+  /** Get the closest parent spanId that will reach exporters (unless includeInternalSpans) */
   public getParentSpanId(includeInternalSpans?: boolean): string | undefined {
     if (!this.parent) {
       // Return parent span ID if available (for root spans with external parent)
@@ -298,7 +313,7 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
     if (parentSpan) {
       return parentSpan.id;
     }
-    // All ancestors are internal, recurse to get root's parentSpanId
+    // All ancestors are internal/excluded, recurse to get root's parentSpanId
     return this.parent.getParentSpanId(includeInternalSpans);
   }
 

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -286,18 +286,18 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
   abstract get isValid(): boolean;
 
   /**
-   * Get the closest parent span, optionally skipping internal spans.
-   * When `includeInternalSpans` is false/undefined, also skips ancestors
-   * dropped by `excludeSpanTypes` so exported `parentSpanId` values point
-   * at spans that exporters actually receive.
+   * Get the closest parent span.
+   * Always skips ancestors dropped by `excludeSpanTypes` (`isExcluded`), so
+   * exported `parentSpanId` values never point at spans exporters omit.
+   * When `includeInternalSpans` is false/undefined, also skips `isInternal`
+   * ancestors.
    */
   public getParentSpan(includeInternalSpans?: boolean): AnySpan | undefined {
     if (!this.parent) {
       return undefined;
     }
-    if (includeInternalSpans) return this.parent;
     const parent = this.parent as AnyBaseSpan;
-    if (parent.isInternal || parent.isExcluded) {
+    if (parent.isExcluded || (!includeInternalSpans && parent.isInternal)) {
       return parent.getParentSpan(includeInternalSpans);
     }
     return this.parent;


### PR DESCRIPTION
## Summary
- `getParentSpan` / `getParentSpanId` now skip ancestors dropped by `excludeSpanTypes` (not only `isInternal`), so exported `parentSpanId` points at a span exporters actually receive.
- `getExternalParentId` follows the same rule.
- Regression test: tool call under excluded `MODEL_STEP` reparents to `MODEL_GENERATION` with zero orphaned exports.

Fixes #20818

## Test plan
- [x] `pnpm exec vitest run src/span-filtering.test.ts -t "reparent descendants"`
- [x] related `base.test.ts` parent-id cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a span is excluded, its child spans now connect to the nearest exported parent. This prevents exporters from losing tool calls that reference spans they did not receive.

## Changes

- Updated `getParentSpan`, `getParentSpanId`, and `getExternalParentId` to skip excluded ancestors.
- Preserved existing handling of internal ancestors.
- Reparented descendants of excluded `MODEL_STEP` spans to the nearest exported `MODEL_GENERATION`.
- Added regression coverage for tool calls under excluded spans, including internal-span exports.
- Verified that exported spans do not reference missing parents.
- Exposed `BaseSpan.isExcluded` for parent resolution.
- Added a patch changeset for `@mastra/observability`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->