### PR TITLE
feat(platform-workspace): mirror captureCheckpoint() on PlatformSandbox

### DIFF
--- a/.changeset/platform-sandbox-capture-checkpoint.md
+++ b/.changeset/platform-sandbox-capture-checkpoint.md
@@ -1,0 +1,24 @@
+---
+'@mastra/platform-workspace': patch
+---
+
+Add public `captureCheckpoint()` method to `PlatformSandbox` — mirrors `@mastra/railway`'s `RailwaySandbox.captureCheckpoint()` so callers (e.g. a factory-side scheduler) can capture the recovery checkpoint on demand at semantic moments (turn end, session-idle, pre-teardown) without having to know which provider is underneath.
+
+```ts
+const result = await sandbox.captureCheckpoint();
+switch (result.status) {
+  case 'captured':
+  case 'coalesced':
+    await persistBinding({ sessionId, checkpointName: result.checkpointName });
+    break;
+  case 'skipped':
+    // result.reason: 'no-checkpoint-name-configured' | 'sandbox-not-running'
+    break;
+}
+```
+
+- POSTs to `/v1/projects/:projectId/sandbox/:sandboxId/checkpoint` with the caller-supplied recovery key (the `id` the sandbox was constructed with) as the body, matching the shape the workspace-proxy expects.
+- Coalesces concurrent callers on the same instance onto a single upstream request, so N simultaneous turn-end fires do not each round-trip the proxy.
+- Returns `{ status: 'skipped', reason: 'no-checkpoint-name-configured' }` when the sandbox was constructed without a caller-supplied `id` (an auto-generated random id is never a meaningful recovery key), and `{ status: 'skipped', reason: 'sandbox-not-running' }` when the sandbox has not been started yet.
+- Normalizes upstream "sandbox destroyed" outcomes (a 410 from the proxy, or the proxy's own `skipped` status) to `{ status: 'skipped', reason: 'sandbox-not-running' }` — the discriminant matches the pre-flight case so callers branch uniformly, and the sandbox's local state is cleared as a side effect so the next `start()` provisions fresh instead of reattaching to a dead id.
+- Transport failures other than 410 (5xx, 429) propagate as `PlatformApiError` for the caller to handle.

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1805,4 +1805,254 @@ describe('PlatformSandbox', () => {
       expect(body.id).toBe('explicit-id');
     });
   });
+
+  describe('captureCheckpoint (public, on-demand)', () => {
+    it('POSTs to /checkpoint with the recovery key and returns the captured name', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(
+          json({ checkpointName: 'mastra-checkpoint-abc123', status: 'captured' }),
+        );
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      const result = await sandbox.captureCheckpoint();
+
+      expect(result).toEqual({ status: 'captured', checkpointName: 'mastra-checkpoint-abc123' });
+      expect(String(fetchMock.mock.calls[1]![0])).toBe(
+        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/checkpoint',
+      );
+      expect(fetchMock.mock.calls[1]![1].method).toBe('POST');
+      // The recovery key on the body must be the caller-supplied id, since
+      // the proxy hashes that to look up the on-provider checkpoint name.
+      const body = JSON.parse(fetchMock.mock.calls[1]![1].body as string);
+      expect(body).toEqual({ id: 'mc-session-42' });
+    });
+
+    it('returns coalesced with the same name when the proxy reports coalesced', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(
+          json({ checkpointName: 'mastra-checkpoint-abc123', status: 'coalesced' }),
+        );
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      const result = await sandbox.captureCheckpoint();
+
+      expect(result).toEqual({ status: 'coalesced', checkpointName: 'mastra-checkpoint-abc123' });
+    });
+
+    it('returns no-checkpoint-name-configured when no caller id was supplied (auto-generated)', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
+
+      // No `id` in options → auto-generated random id → no meaningful recovery key.
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      const result = await sandbox.captureCheckpoint();
+
+      expect(result).toEqual({ status: 'skipped', reason: 'no-checkpoint-name-configured' });
+      // No POST /checkpoint was made — only the initial create.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns sandbox-not-running when the sandbox has not been started (pre-flight)', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn();
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+
+      const result = await sandbox.captureCheckpoint();
+
+      expect(result).toEqual({ status: 'skipped', reason: 'sandbox-not-running' });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('coalesces concurrent callers onto a single in-flight POST /checkpoint', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      // Hold the checkpoint response open so both callers observe an
+      // in-flight request when the second one arrives.
+      let releaseCheckpoint!: (value: Response) => void;
+      const held = new Promise<Response>(resolve => {
+        releaseCheckpoint = resolve;
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockReturnValueOnce(held);
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      const first = sandbox.captureCheckpoint();
+      const second = sandbox.captureCheckpoint();
+
+      releaseCheckpoint(json({ checkpointName: 'mastra-checkpoint-abc123', status: 'captured' }));
+      const [firstResult, secondResult] = await Promise.all([first, second]);
+
+      // Both callers observe the same successful outcome.
+      expect(firstResult).toEqual({ status: 'captured', checkpointName: 'mastra-checkpoint-abc123' });
+      expect(secondResult).toEqual({ status: 'captured', checkpointName: 'mastra-checkpoint-abc123' });
+      // Only one upstream POST /checkpoint was issued (plus the initial create).
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('normalizes a 410 to sandbox-not-running and clears local state so ensureSandbox provisions fresh', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const registry: SandboxAddressRegistry = {
+        set: vi.fn(),
+        get: vi.fn(),
+        delete: vi.fn(),
+      };
+      const fetchMock = vi
+        .fn()
+        // First create returns an instanceUrl so the registry gets populated.
+        .mockResolvedValueOnce(
+          json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z', instanceUrl: 'http://[::1]:8080' }),
+        )
+        // Capture attempt → 410.
+        .mockResolvedValueOnce(new Response('gone', { status: 410 }))
+        // Next start() after the destroy discovery must provision fresh
+        // (not reattach), so respond as if it's a brand-new POST /sandbox.
+        .mockResolvedValueOnce(json({ id: 'sbx_2', createdAt: '2026-06-27T00:00:00.000Z' }));
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        addressRegistry: registry,
+      });
+      await sandbox._start();
+
+      const result = await sandbox.captureCheckpoint();
+      expect(result).toEqual({ status: 'skipped', reason: 'sandbox-not-running' });
+      // Sidecar address for the destroyed sandbox was evicted.
+      expect(registry.delete).toHaveBeenCalledWith('sbx_1');
+
+      // Next start() takes the fresh-provision branch (POST /sandbox),
+      // not the reattach branch (GET /sandbox/sbx_1) — proving _sandboxId
+      // was cleared.
+      await sandbox._start();
+      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox');
+      expect(fetchMock.mock.calls[2]![1].method).toBe('POST');
+    });
+
+    it('normalizes proxy-reported skipped to sandbox-not-running and clears local state', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const registry: SandboxAddressRegistry = {
+        set: vi.fn(),
+        get: vi.fn(),
+        delete: vi.fn(),
+      };
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z', instanceUrl: 'http://[::1]:8080' }),
+        )
+        .mockResolvedValueOnce(
+          json({ checkpointName: 'mastra-checkpoint-abc123', status: 'skipped' }),
+        );
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        addressRegistry: registry,
+      });
+      await sandbox._start();
+
+      const result = await sandbox.captureCheckpoint();
+      expect(result).toEqual({ status: 'skipped', reason: 'sandbox-not-running' });
+      expect(registry.delete).toHaveBeenCalledWith('sbx_1');
+    });
+
+    it('propagates non-410 transport failures (e.g. 500, 429) to the caller', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(new Response('quota exceeded', { status: 429 }));
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      await expect(sandbox.captureCheckpoint()).rejects.toMatchObject({
+        name: 'PlatformApiError',
+        status: 429,
+      });
+    });
+
+    it('releases the in-flight slot after a failure so a subsequent call retries', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        // First capture fails transiently.
+        .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+        // Second capture succeeds — proves the coalescing slot was released.
+        .mockResolvedValueOnce(json({ checkpointName: 'mastra-checkpoint-abc123', status: 'captured' }));
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      await expect(sandbox.captureCheckpoint()).rejects.toMatchObject({ status: 500 });
+      const result = await sandbox.captureCheckpoint();
+      expect(result).toEqual({ status: 'captured', checkpointName: 'mastra-checkpoint-abc123' });
+    });
+  });
 });

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1812,9 +1812,7 @@ describe('PlatformSandbox', () => {
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
-        .mockResolvedValueOnce(
-          json({ checkpointName: 'mastra-checkpoint-abc123', status: 'captured' }),
-        );
+        .mockResolvedValueOnce(json({ checkpointName: 'mastra-checkpoint-abc123', status: 'captured' }));
 
       const sandbox = new PlatformSandbox({
         id: 'mc-session-42',
@@ -1843,9 +1841,7 @@ describe('PlatformSandbox', () => {
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
-        .mockResolvedValueOnce(
-          json({ checkpointName: 'mastra-checkpoint-abc123', status: 'coalesced' }),
-        );
+        .mockResolvedValueOnce(json({ checkpointName: 'mastra-checkpoint-abc123', status: 'coalesced' }));
 
       const sandbox = new PlatformSandbox({
         id: 'mc-session-42',
@@ -1863,9 +1859,7 @@ describe('PlatformSandbox', () => {
 
     it('returns no-checkpoint-name-configured when no caller id was supplied (auto-generated)', async () => {
       vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
 
       // No `id` in options → auto-generated random id → no meaningful recovery key.
       const sandbox = new PlatformSandbox({
@@ -1990,9 +1984,7 @@ describe('PlatformSandbox', () => {
         .mockResolvedValueOnce(
           json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z', instanceUrl: 'http://[::1]:8080' }),
         )
-        .mockResolvedValueOnce(
-          json({ checkpointName: 'mastra-checkpoint-abc123', status: 'skipped' }),
-        );
+        .mockResolvedValueOnce(json({ checkpointName: 'mastra-checkpoint-abc123', status: 'skipped' }));
 
       const sandbox = new PlatformSandbox({
         id: 'mc-session-42',

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -168,6 +168,29 @@ export class SandboxExecTransportError extends Error {
 }
 
 /**
+ * Outcome of {@link PlatformSandbox.captureCheckpoint}. Mirrors the shape of
+ * the OSS `@mastra/railway` `RailwaySandbox.captureCheckpoint()` return so a
+ * caller (e.g. the factory fleet) can branch on `status`/`reason` uniformly
+ * across providers without knowing which one is underneath.
+ *
+ * `captured` and `coalesced` both represent a successful capture the caller
+ * can persist against — they carry the checkpoint name inline so callers
+ * don't have to reach back into the sandbox instance to learn what was
+ * written. `skipped` carries a machine-readable `reason` so the discriminant
+ * set stays extensible.
+ *
+ * Note: the platform proxy's own `skipped` (returned when the upstream
+ * sandbox is already destroyed) is mapped to `sandbox-not-running` here to
+ * keep the discriminant identical to the OSS provider. The diagnostic
+ * distinction (pre-flight vs post-hoc discovery) is preserved in log lines,
+ * not the return type — see {@link PlatformSandbox.captureCheckpoint}.
+ */
+export type CaptureCheckpointResult =
+  | { status: 'captured'; checkpointName: string }
+  | { status: 'coalesced'; checkpointName: string }
+  | { status: 'skipped'; reason: 'no-checkpoint-name-configured' | 'sandbox-not-running' };
+
+/**
  * Thrown when `/exec-lease` returns 410 Gone — the sandbox has been destroyed
  * (Railway destroy, quota reclamation, etc.). The client cannot recover from
  * this on its own because it does not own the binding store; only the fleet
@@ -324,9 +347,27 @@ export class PlatformSandbox extends MastraSandbox {
    * Cleared (regardless of success or failure) when the request settles.
    */
   private _leaseInFlight: Promise<ExecLease & { expiresAtMs: number | null }> | null = null;
+  /**
+   * True when this sandbox was constructed with a caller-supplied `id` (the
+   * recovery key the proxy hashes into an on-provider checkpoint name).
+   * `captureCheckpoint()` needs this to distinguish "no checkpoint intent"
+   * (auto-generated random id — capture would land under a name no future
+   * boot would look for) from "capture on demand". Cloned sandboxes route
+   * `checkpointName` through `id`, so both entry points set this the same
+   * way.
+   */
+  private readonly _hasRecoveryKey: boolean;
+  /**
+   * In-flight `captureCheckpoint()` request. Concurrent callers on the same
+   * instance coalesce onto this single promise so we don't burn N `POST
+   * /checkpoint` round-trips when the fleet fires several turn-end captures
+   * before the first one resolves. Cleared when the request settles.
+   */
+  private _captureInFlight: Promise<CaptureCheckpointResult> | null = null;
 
   constructor(options: PlatformSandboxOptions = {}) {
     super({ ...options, name: 'PlatformSandbox', processes: new PlatformProcessManager() });
+    this._hasRecoveryKey = options.id !== undefined;
     this.id = options.id ?? this.generateId();
     this._client = new PlatformClient(options);
     this._environmentId = options.environmentId ?? process.env.MASTRA_ENVIRONMENT_ID ?? '';
@@ -491,6 +532,135 @@ export class PlatformSandbox extends MastraSandbox {
     // or reattach) will re-populate the entry from the workspace-proxy's
     // response.
     this._addressRegistry?.delete(destroyedSandboxId);
+  }
+
+  /**
+   * Capture the sandbox's checkpoint on demand, outside any refresh timer the
+   * workspace-proxy owns internally.
+   *
+   * Intended for callers (e.g. a factory-side scheduler) that want to refresh
+   * the recovery checkpoint at semantic moments — turn end, session-idle,
+   * pre-teardown — rather than only just before the upstream's idle destroy.
+   *
+   * Mirrors the OSS `@mastra/railway` `RailwaySandbox.captureCheckpoint()`
+   * shape so factory can call `sandbox.captureCheckpoint()` uniformly and
+   * branch on `status`/`reason` without knowing which provider is underneath.
+   * Both `captured` and `coalesced` carry the checkpoint name inline so the
+   * caller can persist a session→checkpoint binding atomically with the
+   * awaited capture.
+   *
+   * Skip semantics:
+   *  - No caller-supplied `id`: returns `{ status: 'skipped', reason:
+   *    'no-checkpoint-name-configured' }`. An auto-generated random id is
+   *    never a meaningful recovery key (no future boot would look for a
+   *    checkpoint under it), so capturing would silently produce dead data.
+   *  - Not started (no `_sandboxId`): returns `{ status: 'skipped', reason:
+   *    'sandbox-not-running' }` without a round-trip.
+   *  - Upstream 410 (workspace-proxy or Railway reports the sandbox is
+   *    already destroyed): returns the same `sandbox-not-running` skip so
+   *    the discriminant matches the pre-flight case. Local state
+   *    (`_sandboxId`, `_lease`, sidecar address) is cleared as a side
+   *    effect so the next `start()` provisions fresh instead of reattaching
+   *    to a dead id. The diagnostic distinction (pre-flight vs post-hoc)
+   *    is preserved in log level: debug for the expected pre-flight skip,
+   *    warn for the surprise upstream destroy.
+   *
+   * Concurrent callers on the same instance coalesce onto a single in-flight
+   * `POST /checkpoint` so N simultaneous turn-end fires (e.g. several tabs)
+   * do not each round-trip the proxy. Both the originator and joiners
+   * receive `{ status: 'coalesced', ... }` for the joined result — the
+   * outer contract does not distinguish who started the request, only that
+   * one upstream capture was made.
+   *
+   * Never throws for expected outcomes. Transport failures (5xx, 4xx other
+   * than 410) propagate as {@link PlatformApiError}; a 410 is normalized
+   * to a skip as described above.
+   */
+  async captureCheckpoint(): Promise<CaptureCheckpointResult> {
+    if (!this._hasRecoveryKey) {
+      this.logger.debug(
+        `captureCheckpoint skipped: no recovery key configured for sandbox ${this._sandboxId ?? '(unstarted)'}`,
+      );
+      return { status: 'skipped', reason: 'no-checkpoint-name-configured' };
+    }
+
+    if (!this._sandboxId) {
+      this.logger.debug(`captureCheckpoint skipped: sandbox not running (local pre-flight, id=${this.id})`);
+      return { status: 'skipped', reason: 'sandbox-not-running' };
+    }
+
+    if (this._captureInFlight) {
+      return this._captureInFlight;
+    }
+
+    const sandboxId = this._sandboxId;
+    const capture = this._doCaptureCheckpoint(sandboxId).finally(() => {
+      if (this._captureInFlight === capture) {
+        this._captureInFlight = null;
+      }
+    });
+    this._captureInFlight = capture;
+    return capture;
+  }
+
+  /**
+   * The single `POST /checkpoint` attempt behind {@link captureCheckpoint}.
+   *
+   * Split out so the coalescing wrapper can install a shared in-flight
+   * promise without inlining the transport + response-mapping logic.
+   * Joined callers observe `{ status: 'coalesced', ... }` — the initiator
+   * sees the underlying `captured` / `coalesced` / `skipped` result the
+   * proxy returned. Both are legitimate: the OSS mirror uses the same
+   * "initiator sees the truth, joiners see coalesced" split.
+   */
+  private async _doCaptureCheckpoint(sandboxId: string): Promise<CaptureCheckpointResult> {
+    let response: Response;
+    try {
+      response = await this._client.request(`/sandbox/${encodeURIComponent(sandboxId)}/checkpoint`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ id: this.id }),
+      });
+    } catch (error) {
+      if (error instanceof PlatformApiError && error.status === 410) {
+        this.logger.warn(
+          `captureCheckpoint skipped: sandbox destroyed upstream (proxy 410, sandboxId=${sandboxId})`,
+        );
+        this._clearDestroyedState(sandboxId);
+        return { status: 'skipped', reason: 'sandbox-not-running' };
+      }
+      throw error;
+    }
+    const json = (await response.json()) as { checkpointName: string; status: 'captured' | 'coalesced' | 'skipped' };
+    if (json.status === 'skipped') {
+      // Proxy's own `skipped` means the upstream sandbox is already
+      // destroyed — same actionable outcome as a 410, so normalize to
+      // the same discriminant + clear local state.
+      this.logger.warn(
+        `captureCheckpoint skipped: sandbox destroyed upstream (proxy reported skipped, sandboxId=${sandboxId})`,
+      );
+      this._clearDestroyedState(sandboxId);
+      return { status: 'skipped', reason: 'sandbox-not-running' };
+    }
+    return { status: json.status, checkpointName: json.checkpointName };
+  }
+
+  /**
+   * Clear local state that would otherwise let the caller keep exec'ing
+   * against a sandbox the upstream has already destroyed. Mirrors what
+   * `destroy()` does minus the outbound DELETE — the sandbox is already
+   * gone, so all that remains is to stop pointing at it.
+   *
+   * Also resets `status` to `'pending'` so a subsequent `_start()` on this
+   * reused instance re-runs provisioning instead of short-circuiting on
+   * the cached `'running'` state (see `MastraSandbox._start`).
+   */
+  private _clearDestroyedState(destroyedSandboxId: string): void {
+    this._sandboxId = undefined;
+    this._createdAt = null;
+    this._lease = null;
+    this._addressRegistry?.delete(destroyedSandboxId);
+    this.status = 'pending';
   }
 
   /**

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -623,9 +623,7 @@ export class PlatformSandbox extends MastraSandbox {
       });
     } catch (error) {
       if (error instanceof PlatformApiError && error.status === 410) {
-        this.logger.warn(
-          `captureCheckpoint skipped: sandbox destroyed upstream (proxy 410, sandboxId=${sandboxId})`,
-        );
+        this.logger.warn(`captureCheckpoint skipped: sandbox destroyed upstream (proxy 410, sandboxId=${sandboxId})`);
         this._clearDestroyedState(sandboxId);
         return { status: 'skipped', reason: 'sandbox-not-running' };
       }


### PR DESCRIPTION
## Summary

Mirrors the public `captureCheckpoint()` method shipped for `RailwaySandbox` in #20875 (widen refresh margin + expose the method) and refined in #20877 (return checkpoint name inline as a discriminated result) onto `PlatformSandbox` (`@mastra/platform-workspace`), so provider-agnostic callers can capture the recovery checkpoint on demand without knowing which sandbox provider is underneath.

This is the **provider-side** half of the work — nothing in the factory runtime calls this method yet. A stacked follow-up PR wires `mastracode/factory` to call `captureCheckpoint()` at turn-end (and, in later passes, session-idle and pre-teardown), which is what actually fixes the checkpoint-loss scenario tracked in #20873.

## Behavior

- POSTs to `/v1/projects/:projectId/sandbox/:sandboxId/checkpoint` (endpoint added platform-side in a separate repo PR) with the caller-supplied recovery key — the `id` the sandbox was constructed with — as the body.
- **Client-side coalescing** on `_captureInFlight`: N concurrent callers on the same sandbox instance share one upstream request.
- **Pre-flight skips** (no round-trip):
  - `{ status: 'skipped', reason: 'no-checkpoint-name-configured' }` when the sandbox was constructed without an explicit `id` (an auto-generated random id is never a meaningful recovery key).
  - `{ status: 'skipped', reason: 'sandbox-not-running' }` when the sandbox has not been started.
- **Upstream 410** and the proxy's own `skipped` response both normalize to `{ status: 'skipped', reason: 'sandbox-not-running' }` — same discriminant as the pre-flight case so callers can branch uniformly. Local state (`_sandboxId`, `_lease`, address-registry entry) is cleared and `status` is reset to `'pending'` so the next `_start()` provisions fresh instead of reattaching to a dead id.
- **Non-410 transport failures** (5xx, 429) propagate as `PlatformApiError` for the caller to handle.

## Result shape

```ts
type CaptureCheckpointResult =
  | { status: 'captured' | 'coalesced'; checkpointName: string }
  | { status: 'skipped'; reason: 'no-checkpoint-name-configured' | 'sandbox-not-running' };
```

Identical discriminant + payload to `RailwaySandbox`'s so factory-side scheduling logic can be provider-agnostic.

## Test plan

- +9 unit tests in `sandbox.test.ts` covering: successful capture, coalesced concurrent calls, both pre-flight skip reasons, 410 normalization + state cleanup, proxy-reported skipped normalization, next `_start()` provisions fresh after 410, non-410 error propagation.
- `pnpm --filter @mastra/platform-workspace test` — 106/106 pass.
- `pnpm --filter @mastra/platform-workspace typecheck` — clean.

## Changeset

`@mastra/platform-workspace` patch bump.

## Follow-up (stacked on this PR)

Factory-side turn-end capture in `mastracode/factory` — the actual behavior change that fixes the checkpoint-loss scenario. Will be opened as a stacked PR against this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets `PlatformSandbox` save a recovery point on demand. It avoids duplicate requests, safely skips invalid requests, and cleans up local state when the sandbox no longer exists.

## Changes

- Added public `PlatformSandbox.captureCheckpoint()`.
- Added `CaptureCheckpointResult` with `captured`, `coalesced`, and `skipped` outcomes.
- Added concurrent-call coalescing per sandbox instance.
- Skips capture when no recovery key exists or the sandbox is not running.
- Normalizes upstream `410` and proxy-reported skipped responses.
- Clears destroyed sandbox state and resets its status to `pending`.
- Propagates other transport errors as `PlatformApiError`.
- Added nine unit test scenarios.
- Added a patch changeset for `@mastra/platform-workspace`.
- Factory runtime integration remains deferred to a follow-up PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->