### PR TITLE
feat(factory): add governed automation extension seams

### DIFF
--- a/.changeset/calm-factories-observe.md
+++ b/.changeset/calm-factories-observe.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Add governed automation commands for trusted integrations and verified GitHub webhook observers.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -693,6 +693,28 @@ describe('MastraFactory.prepare integrations', () => {
     expect(initialize.mock.calls[0]![0].storage.integrationId).toBe('custom-version-control');
   });
 
+  it('binds governed automation commands after the controller is mounted', async () => {
+    const initializeAutomation = vi.fn();
+    const controller = { setChannels: vi.fn(), createSession: vi.fn() };
+    prepareMock.mockResolvedValueOnce({
+      base: { controller },
+      mastraArgs: {},
+      finalize: vi.fn(async () => {}),
+    } as never);
+    const integration = fakeIntegration({ id: 'projects-v2', initializeAutomation });
+
+    await new MastraFactory({ storage: fakeStorage(), integrations: [integration] }).prepare();
+
+    expect(initializeAutomation).toHaveBeenCalledOnce();
+    expect(initializeAutomation).toHaveBeenCalledWith({
+      commands: expect.objectContaining({
+        startWorkItem: expect.any(Function),
+        transitionWorkItem: expect.any(Function),
+        getActiveRun: expect.any(Function),
+      }),
+    });
+  });
+
   it("folds a ready integration's routes into buildApiRoutes", async () => {
     const routes = vi.fn((_ctx: IntegrationContext) => [
       { path: '/web/custom/status', method: 'GET' as const, handler: () => new Response() },

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -54,6 +54,7 @@ import {
   primeTenantCredentials,
   registerTenantCredentialResolver,
 } from './routes/tenant-credentials.js';
+import { createFactoryAutomationCommands } from './rules/automation-commands.js';
 import { builtInFactoryRules } from './rules/defaults.js';
 import { FactoryDecisionDispatcher } from './rules/dispatcher.js';
 import { FactoryPhaseStateProcessor } from './rules/processor.js';
@@ -788,6 +789,22 @@ export class MastraFactory {
 
     this.#prepared = prepared;
     this.#factoryProcessor = factoryProcessor;
+
+    if (transitionService) {
+      for (const { integration, ready } of integrationRegistrations) {
+        if (!ready || !integration.initializeAutomation) continue;
+        integration.initializeAutomation({
+          commands: createFactoryAutomationCommands({
+            integrationId: integration.id,
+            controller: prepared.base.controller,
+            storage: workItemsStorage,
+            transitionService,
+            sourceControl: githubIntegration ? sourceControlStorage.forIntegration(githubIntegration.id) : undefined,
+            memorySettings: memorySettingsStorage,
+          }),
+        });
+      }
+    }
 
     // Chat-platform channels (Slack, Discord, …) contributed by integrations,
     // attached to the mounted controller so inbound platform messages reach

--- a/mastracode/factory/src/index.ts
+++ b/mastracode/factory/src/index.ts
@@ -16,6 +16,7 @@ export type {
   FactoryAutomationActiveRunRequest,
   FactoryAutomationCommands,
   FactoryAutomationTransitionRequest,
+  FactoryAutomationWorkItemRequest,
 } from './rules/automation-commands.js';
 export { createStateSigner } from './state-signing.js';
 export type { StateSigner, StateTenant } from './state-signing.js';

--- a/mastracode/factory/src/index.ts
+++ b/mastracode/factory/src/index.ts
@@ -11,6 +11,12 @@ export { FactoryProjectsStorage } from './storage/domains/projects/base.js';
 export type { FactoryProject } from './storage/domains/projects/base.js';
 export { WorkItemsStorage } from './storage/domains/work-items/base.js';
 export type { CreateWorkItemInput, WorkItemRow } from './storage/domains/work-items/base.js';
+export type {
+  FactoryAutomatedStartInput,
+  FactoryAutomationActiveRunRequest,
+  FactoryAutomationCommands,
+  FactoryAutomationTransitionRequest,
+} from './rules/automation-commands.js';
 export { createStateSigner } from './state-signing.js';
 export type { StateSigner, StateTenant } from './state-signing.js';
 export { createFactoryRouteAuth } from './auth.js';

--- a/mastracode/factory/src/integrations/base.ts
+++ b/mastracode/factory/src/integrations/base.ts
@@ -27,6 +27,7 @@ import type { MastraWorker } from '@mastra/core/worker';
 import type { Intake } from '../capabilities/intake.js';
 import type { VersionControl } from '../capabilities/version-control.js';
 import type { RouteAuth } from '../routes/route.js';
+import type { FactoryAutomationCommands } from '../rules/automation-commands.js';
 import type { FactoryRules } from '../rules/types.js';
 import type { SandboxFleet } from '../sandbox/fleet.js';
 import type { StateSigner } from '../state-signing.js';
@@ -178,6 +179,12 @@ export interface FactoryIntegration {
    * locator. Mirrors `sourceControl.initialize`.
    */
   initialize?(args: { storage: IntegrationStorageHandle; projects: FactoryProjectsStorage; auth: RouteAuth }): void;
+  /**
+   * Bind host-owned, governed work-item commands after the canonical controller
+   * and transition service exist. Integrations receive no storage handles or
+   * controller construction authority through this seam.
+   */
+  initializeAutomation?(args: { commands: FactoryAutomationCommands }): void;
   /**
    * The integration's full HTTP surface (status, OAuth, webhooks, feature
    * routes), as Mastra `apiRoutes`. Called once at boot; the factory folds

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -58,6 +58,7 @@ import {
   subscribeCurrentSessionToPullRequest,
 } from './session-subscriptions.js';
 import type { GithubSubscriptionStorage } from './subscriptions.js';
+import type { GithubVerifiedWebhookObserver } from './webhook.js';
 
 type InputOf<TMethod extends keyof VersionControl> = VersionControl[TMethod] extends (input: infer TInput) => unknown
   ? TInput
@@ -143,6 +144,8 @@ export interface GithubIntegrationConfig {
    * replica-stable OAuth/install `state` secret (see `./config.ts`).
    */
   webhookSecret?: string;
+  /** Trusted control-plane consumers of every signature-verified delivery. */
+  verifiedWebhookObservers?: readonly GithubVerifiedWebhookObserver[];
 }
 
 /** Human-readable names of the required config fields, for construction errors. */
@@ -316,6 +319,7 @@ export class GithubIntegration implements FactoryIntegration {
   readonly #clientSecret: string;
   readonly #slug: string;
   readonly #webhookSecret: string | undefined;
+  readonly #verifiedWebhookObservers: readonly GithubVerifiedWebhookObserver[];
   #storage: IntegrationContext['storage'] | undefined;
   #sourceControlStorage: IntegrationContext['storage']['sourceControl'] | undefined;
 
@@ -334,6 +338,7 @@ export class GithubIntegration implements FactoryIntegration {
     this.#clientSecret = config.clientSecret;
     this.#slug = config.slug;
     this.#webhookSecret = config.webhookSecret || undefined;
+    this.#verifiedWebhookObservers = [...(config.verifiedWebhookObservers ?? [])];
   }
 
   /** App slug — the URL name used to build the install URL. */
@@ -1099,6 +1104,7 @@ export class GithubIntegration implements FactoryIntegration {
       emitAudit: ctx.hooks?.emitAudit,
       projects: ctx.storage.projects,
       ingestFactoryEvent,
+      verifiedWebhookObservers: this.#verifiedWebhookObservers,
     });
   }
 

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -590,6 +590,7 @@ function buildApp(
     controller?: NonNullable<Parameters<typeof buildGithubRoutes>[0]>['controller'];
     runIssueTriage?: (input: any) => Promise<{ threadId?: string; projectPath?: string; branch?: string }>;
     stateSigner?: typeof stateSigner | null;
+    verifiedWebhookObservers?: NonNullable<Parameters<typeof buildGithubRoutes>[0]>['verifiedWebhookObservers'];
   } = {},
 ) {
   const app = new Hono();
@@ -700,6 +701,43 @@ function signedGithubWebhookRequest(event: string, payload: Record<string, unkno
 }
 
 describe('webhook route', () => {
+  it('fans out a verified unsupported delivery before the built-in event filter', async () => {
+    const verifiedWebhookObserver = vi.fn(async () => undefined);
+    const response = await buildApp(null, { verifiedWebhookObservers: [verifiedWebhookObserver] }).request(
+      signedGithubWebhookRequest('projects_v2_item', {
+        action: 'edited',
+        projects_v2_item: { id: 'PVTI_1' },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ ok: true, ignored: true });
+    expect(verifiedWebhookObserver).toHaveBeenCalledWith({
+      event: 'projects_v2_item',
+      deliveryId: expect.any(String),
+      payload: { action: 'edited', projects_v2_item: { id: 'PVTI_1' } },
+    });
+  });
+
+  it('never invokes verified observers for an invalid signature', async () => {
+    const verifiedWebhookObserver = vi.fn(async () => undefined);
+    const response = await buildApp(null, { verifiedWebhookObservers: [verifiedWebhookObserver] }).request(
+      '/web/github/webhook',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-github-event': 'projects_v2_item',
+          'x-github-delivery': 'delivery-invalid',
+          'x-hub-signature-256': `sha256=${'0'.repeat(64)}`,
+        },
+        body: JSON.stringify({ action: 'edited' }),
+      },
+    );
+
+    expect(response.status).toBe(401);
+    expect(verifiedWebhookObserver).not.toHaveBeenCalled();
+  });
   it('accepts a valid signed issues event without guessing a Factory project repository', async () => {
     seedMaterializedProject();
     const logSpy = vi.spyOn(console, 'info').mockImplementation(() => {});

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -74,7 +74,12 @@ function withSessionOperationLock<T>(sessionId: string, fn: () => Promise<T>): P
 }
 import { listPullRequestSubscriptionsForThread, subscribeToPullRequest } from './subscriptions.js';
 import { handleGithubWebhook } from './webhook.js';
-import type { GithubIssueTriageRunInput, GithubIssueTriageRunResult, ParsedGithubWebhook } from './webhook.js';
+import type {
+  GithubIssueTriageRunInput,
+  GithubIssueTriageRunResult,
+  GithubVerifiedWebhookObserver,
+  ParsedGithubWebhook,
+} from './webhook.js';
 
 /**
  * Loose Hono context accepted by the shared GitHub route helpers. The
@@ -130,6 +135,8 @@ export interface MountGithubRoutesOptions {
   projects?: FactoryProjectsStorage;
   /** Authoritative Factory rule ingress for normalized, signature-verified GitHub deliveries. */
   ingestFactoryEvent?: (event: ParsedGithubWebhook) => Promise<unknown>;
+  /** Additional consumers of every signature-verified GitHub delivery. */
+  verifiedWebhookObservers?: readonly GithubVerifiedWebhookObserver[];
 }
 
 function pullRequestNumberFromUrl(value: string, expectedRepo: string): number | undefined {
@@ -499,6 +506,7 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
           github,
           runIssueTriage: runBoardIssueTriage,
           ingestFactoryEvent: options.ingestFactoryEvent,
+          verifiedWebhookObservers: options.verifiedWebhookObservers,
           ...(options.controller
             ? {
                 controller: options.controller,

--- a/mastracode/factory/src/integrations/github/webhook.ts
+++ b/mastracode/factory/src/integrations/github/webhook.ts
@@ -20,7 +20,11 @@ export interface GithubWebhookHandlerOptions {
   github: GithubIntegration;
   runIssueTriage?: (input: GithubIssueTriageRunInput) => Promise<GithubIssueTriageRunResult>;
   ingestFactoryEvent?: (event: ParsedGithubWebhook) => Promise<unknown>;
+  /** Receives every signature-verified delivery, including unsupported event types. */
+  verifiedWebhookObservers?: readonly GithubVerifiedWebhookObserver[];
 }
+
+export type GithubVerifiedWebhookObserver = (event: ParsedGithubWebhook) => Promise<void>;
 
 const SUPPORTED_GITHUB_WEBHOOK_EVENTS = new Set([
   'issues',
@@ -485,6 +489,8 @@ export async function handleGithubWebhook(
 ): Promise<GithubWebhookResult> {
   const parsed = await parseGithubWebhook(c, options.github.webhookSecret);
   if ('status' in parsed) return parsed;
+
+  await Promise.all((options.verifiedWebhookObservers ?? []).map(observer => observer(parsed)));
 
   if (!SUPPORTED_GITHUB_WEBHOOK_EVENTS.has(parsed.event)) {
     return { status: 202, body: { ok: true, ignored: true } };

--- a/mastracode/factory/src/rules/automation-commands.test.ts
+++ b/mastracode/factory/src/rules/automation-commands.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const prepareStart = vi.hoisted(() => vi.fn());
+vi.mock('./start-coordinator.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./start-coordinator.js')>();
+  return {
+    ...actual,
+    FactoryStartCoordinator: class {
+      prepare = prepareStart;
+    },
+  };
+});
+
+import { createFactoryAutomationCommands } from './automation-commands.js';
+
+describe('Factory automation commands', () => {
+  it('validates repository ownership and creates a collision-safe Factory source session', async () => {
+    prepareStart.mockResolvedValueOnce({ workItemId: 'item-1' });
+    const create = vi.fn(async input => ({ ...input }));
+    const sourceControl = {
+      projectRepositories: {
+        get: vi.fn(async () => ({ id: 'repo-link-1', connectionId: 'connection-1', branch: 'develop' })),
+      },
+      connections: { get: vi.fn(async () => ({ factoryProjectId: 'project-1' })) },
+      sessions: { getForBranch: vi.fn(async () => null), create },
+    };
+    const commands = createFactoryAutomationCommands({
+      integrationId: 'github-projects',
+      controller: {} as never,
+      storage: {} as never,
+      transitionService: { transition: vi.fn() },
+      sourceControl: sourceControl as never,
+    });
+
+    await commands.startWorkItem({
+      orgId: 'org-1',
+      userId: 'automation-user',
+      factoryProjectId: 'project-1',
+      projectRepositoryId: 'repo-link-1',
+      projectItemNodeId: 'PVTI_1',
+      contentNodeId: 'I_global_42',
+      repositoryNameWithOwner: 'acme/api',
+      number: 42,
+      title: 'Fix auth',
+      url: 'https://github.com/acme/api/issues/42',
+      kickoffKey: 'delivery-1',
+      prompt: 'Implement the issue from its canonical URL.',
+      role: 'work',
+      destinationStage: 'execute',
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectRepositoryId: 'repo-link-1',
+        orgId: 'org-1',
+        userId: 'automation-user',
+        baseBranch: 'develop',
+        branch: expect.stringMatching(/^factory\/issue-42-[a-f0-9]{10}$/),
+      }),
+    );
+    expect(prepareStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: { type: 'system', id: 'integration:github-projects' },
+        sessionId: expect.any(String),
+        workItem: expect.objectContaining({
+          input: expect.objectContaining({
+            externalSource: expect.objectContaining({ externalId: 'I_global_42' }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('stamps transitions with the integration actor and a namespaced idempotency identity', async () => {
+    const transition = vi.fn(async input => ({
+      status: 'committed' as const,
+      transitionId: 'transition-1',
+      itemId: input.workItemId,
+      revision: 3,
+      stage: input.stage,
+      decisions: [],
+    }));
+    const commands = createFactoryAutomationCommands({
+      integrationId: 'github-projects',
+      controller: {} as never,
+      storage: { listRunBindings: vi.fn() } as never,
+      transitionService: { transition },
+    });
+
+    await commands.transitionWorkItem({
+      orgId: 'org-1',
+      factoryProjectId: 'project-1',
+      workItemId: 'item-1',
+      board: 'work',
+      stage: 'execute',
+      expectedRevision: 2,
+      cause: 'projects_v2_status_change',
+      idempotencyKey: 'delivery-1',
+    });
+
+    expect(transition).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      factoryProjectId: 'project-1',
+      workItemId: 'item-1',
+      board: 'work',
+      stage: 'execute',
+      expectedRevision: 2,
+      cause: 'projects_v2_status_change',
+      actor: { type: 'system', id: 'integration:github-projects' },
+      ingress: { type: 'rule', identity: 'automation:github-projects:delivery-1' },
+    });
+  });
+
+  it('returns only the newest active binding for the requested work item', async () => {
+    const revoked = { id: 'binding-1', status: 'revoked' };
+    const active = { id: 'binding-2', status: 'active' };
+    const listRunBindings = vi.fn(async () => [revoked, active]);
+    const commands = createFactoryAutomationCommands({
+      integrationId: 'github-projects',
+      controller: {} as never,
+      storage: { listRunBindings } as never,
+      transitionService: { transition: vi.fn() },
+    });
+
+    await expect(
+      commands.getActiveRun({ orgId: 'org-1', factoryProjectId: 'project-1', workItemId: 'item-1' }),
+    ).resolves.toBe(active);
+    expect(listRunBindings).toHaveBeenCalledWith('org-1', 'project-1', 'item-1');
+  });
+});

--- a/mastracode/factory/src/rules/automation-commands.test.ts
+++ b/mastracode/factory/src/rules/automation-commands.test.ts
@@ -127,4 +127,20 @@ describe('Factory automation commands', () => {
     ).resolves.toBe(active);
     expect(listRunBindings).toHaveBeenCalledWith('org-1', 'project-1', 'item-1');
   });
+
+  it('reads a work item only through its exact tenant and project boundary', async () => {
+    const item = { id: 'item-1', stages: ['review'] };
+    const getForProject = vi.fn(async () => item);
+    const commands = createFactoryAutomationCommands({
+      integrationId: 'github-projects',
+      controller: {} as never,
+      storage: { getForProject } as never,
+      transitionService: { transition: vi.fn() },
+    });
+
+    await expect(
+      commands.getWorkItem({ orgId: 'org-1', factoryProjectId: 'project-1', workItemId: 'item-1' }),
+    ).resolves.toBe(item);
+    expect(getForProject).toHaveBeenCalledWith('org-1', 'project-1', 'item-1');
+  });
 });

--- a/mastracode/factory/src/rules/automation-commands.ts
+++ b/mastracode/factory/src/rules/automation-commands.ts
@@ -1,0 +1,166 @@
+import { createHash, randomUUID } from 'node:crypto';
+import type { MastraCodeState } from '@mastra/code-sdk/schema';
+import type { AgentController } from '@mastra/core/agent-controller';
+import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
+import type { FactoryRunBindingRecord, WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import { FactoryStartCoordinator } from './start-coordinator.js';
+import type { FactoryStartPreparedResult, FactoryStartRequest } from './start-coordinator.js';
+import type { FactoryTransitionRequest, FactoryTransitionService } from './transition-service.js';
+import type { FactoryTransitionResult } from './types.js';
+
+export interface FactoryAutomationTransitionRequest extends Omit<FactoryTransitionRequest, 'actor' | 'ingress'> {
+  idempotencyKey: string;
+}
+
+export interface FactoryAutomatedStartInput {
+  orgId: string;
+  userId: string;
+  factoryProjectId: string;
+  projectRepositoryId: string;
+  projectItemNodeId: string;
+  contentNodeId: string;
+  repositoryNameWithOwner: string;
+  number: number;
+  title: string;
+  url: string;
+  kickoffKey: string;
+  prompt: string;
+  role: string;
+  destinationStage: FactoryStartRequest['destinationStage'];
+  defaultModelId?: string;
+  workItemId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface FactoryAutomationActiveRunRequest {
+  orgId: string;
+  factoryProjectId: string;
+  workItemId: string;
+}
+
+/** Governed host commands exposed to trusted control-plane integrations. */
+export interface FactoryAutomationCommands {
+  startWorkItem(request: FactoryAutomatedStartInput): Promise<FactoryStartPreparedResult>;
+  transitionWorkItem(request: FactoryAutomationTransitionRequest): Promise<FactoryTransitionResult>;
+  getActiveRun(request: FactoryAutomationActiveRunRequest): Promise<FactoryRunBindingRecord | null>;
+}
+
+export interface CreateFactoryAutomationCommandsOptions {
+  integrationId: string;
+  controller: AgentController<MastraCodeState>;
+  storage: WorkItemsStorage;
+  transitionService: Pick<FactoryTransitionService, 'transition'>;
+  sourceControl?: SourceControlStorageHandle;
+  memorySettings?: MemorySettingsStorage;
+}
+
+export function createFactoryAutomationCommands(
+  options: CreateFactoryAutomationCommandsOptions,
+): FactoryAutomationCommands {
+  const actor = { type: 'system' as const, id: `integration:${options.integrationId}` };
+  const coordinator = new FactoryStartCoordinator(
+    options.controller,
+    options.storage,
+    options.transitionService,
+    options.sourceControl,
+    options.memorySettings,
+  );
+
+  const startWorkItem = async (request: FactoryAutomatedStartInput): Promise<FactoryStartPreparedResult> => {
+    if (!options.sourceControl) throw new Error('Factory source control storage is unavailable');
+    const projectRepository = await options.sourceControl.projectRepositories.get({
+      orgId: request.orgId,
+      id: request.projectRepositoryId,
+    });
+    if (!projectRepository) throw new Error('Factory project repository not found');
+    const connection = await options.sourceControl.connections.get({
+      orgId: request.orgId,
+      id: projectRepository.connectionId,
+    });
+    if (!connection || connection.factoryProjectId !== request.factoryProjectId) {
+      throw new Error('Factory project repository does not belong to this project');
+    }
+
+    const identityHash = createHash('sha256').update(request.contentNodeId).digest('hex').slice(0, 10);
+    const branch = `factory/issue-${request.number}-${identityHash}`;
+    const existing = await options.sourceControl.sessions.getForBranch({
+      projectRepositoryId: request.projectRepositoryId,
+      userId: request.userId,
+      branch,
+    });
+    const sourceSession =
+      existing ??
+      (await options.sourceControl.sessions.create({
+        sessionId: randomUUID(),
+        projectRepositoryId: request.projectRepositoryId,
+        orgId: request.orgId,
+        userId: request.userId,
+        branch,
+        baseBranch: projectRepository.branch ?? 'main',
+      }));
+
+    return coordinator.prepare({
+      orgId: request.orgId,
+      userId: request.userId,
+      factoryProjectId: request.factoryProjectId,
+      sessionId: sourceSession.sessionId,
+      threadTitle: `${request.repositoryNameWithOwner}#${request.number}: ${request.title}`,
+      threadTags: {
+        role: request.role,
+        source: 'github-projects-v2',
+        projectItemNodeId: request.projectItemNodeId,
+        contentNodeId: request.contentNodeId,
+      },
+      kickoffKey: request.kickoffKey,
+      invocation: { type: 'prompt', prompt: request.prompt },
+      destinationStage: request.destinationStage,
+      defaultModelId: request.defaultModelId,
+      actor,
+      workItem: {
+        id: request.workItemId,
+        role: request.role,
+        input: {
+          externalSource: {
+            integrationId: 'github-projects-v2',
+            type: 'issue',
+            externalId: request.contentNodeId,
+            url: request.url,
+          },
+          title: request.title,
+          stages: ['intake'],
+          metadata: {
+            repositoryNameWithOwner: request.repositoryNameWithOwner,
+            issueNumber: request.number,
+            projectItemNodeId: request.projectItemNodeId,
+            contentNodeId: request.contentNodeId,
+            ...(request.metadata ?? {}),
+          },
+        },
+      },
+    });
+  };
+
+  return {
+    startWorkItem,
+    transitionWorkItem: request => {
+      const { idempotencyKey, ...transition } = request;
+      return options.transitionService.transition({
+        ...transition,
+        actor,
+        ingress: {
+          type: 'rule',
+          identity: `automation:${options.integrationId}:${idempotencyKey}`,
+        },
+      });
+    },
+    getActiveRun: async request => {
+      const bindings = await options.storage.listRunBindings(
+        request.orgId,
+        request.factoryProjectId,
+        request.workItemId,
+      );
+      return bindings.findLast(binding => binding.status === 'active') ?? null;
+    },
+  };
+}

--- a/mastracode/factory/src/rules/automation-commands.ts
+++ b/mastracode/factory/src/rules/automation-commands.ts
@@ -3,7 +3,7 @@ import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentController } from '@mastra/core/agent-controller';
 import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
-import type { FactoryRunBindingRecord, WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import type { FactoryRunBindingRecord, WorkItemRow, WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { FactoryStartCoordinator } from './start-coordinator.js';
 import type { FactoryStartPreparedResult, FactoryStartRequest } from './start-coordinator.js';
 import type { FactoryTransitionRequest, FactoryTransitionService } from './transition-service.js';
@@ -39,11 +39,14 @@ export interface FactoryAutomationActiveRunRequest {
   workItemId: string;
 }
 
+export type FactoryAutomationWorkItemRequest = FactoryAutomationActiveRunRequest;
+
 /** Governed host commands exposed to trusted control-plane integrations. */
 export interface FactoryAutomationCommands {
   startWorkItem(request: FactoryAutomatedStartInput): Promise<FactoryStartPreparedResult>;
   transitionWorkItem(request: FactoryAutomationTransitionRequest): Promise<FactoryTransitionResult>;
   getActiveRun(request: FactoryAutomationActiveRunRequest): Promise<FactoryRunBindingRecord | null>;
+  getWorkItem(request: FactoryAutomationWorkItemRequest): Promise<WorkItemRow | null>;
 }
 
 export interface CreateFactoryAutomationCommandsOptions {
@@ -162,5 +165,6 @@ export function createFactoryAutomationCommands(
       );
       return bindings.findLast(binding => binding.status === 'active') ?? null;
     },
+    getWorkItem: request => options.storage.getForProject(request.orgId, request.factoryProjectId, request.workItemId),
   };
 }

--- a/mastracode/factory/src/rules/start-coordinator.test.ts
+++ b/mastracode/factory/src/rules/start-coordinator.test.ts
@@ -267,6 +267,35 @@ describe('FactoryStartCoordinator', () => {
     expect((await storage.listPendingStarts('org-1', PROJECT_ID))[0]?.status).toBe('pending');
   });
 
+  it('uses an explicitly supplied automation actor for the governed start transition', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const transition = vi.fn(async () => ({
+      status: 'committed' as const,
+      transitionId: 'transition-1',
+      itemId: 'item-1',
+      revision: 2,
+      stage: 'execute' as const,
+      decisions: [],
+    }));
+    const { controller } = makeController();
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      { transition },
+      makeSourceControl() as never,
+    );
+
+    await coordinator.prepare({
+      ...startRequest(),
+      destinationStage: 'execute',
+      actor: { type: 'system', id: 'integration:github-projects' },
+    });
+
+    expect(transition).toHaveBeenCalledWith(
+      expect.objectContaining({ actor: { type: 'system', id: 'integration:github-projects' } }),
+    );
+  });
+
   it('binds the controller session to the exact Factory session thread', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const { controller, session } = makeController();

--- a/mastracode/factory/src/rules/start-coordinator.ts
+++ b/mastracode/factory/src/rules/start-coordinator.ts
@@ -8,7 +8,7 @@ import type { MemorySettingsStorage } from '../storage/domains/memory-settings/b
 import type { SourceControlSession, SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 import type { CreateWorkItemInput, WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import type { FactoryTransitionService } from './transition-service.js';
-import type { FactoryRuleStage, FactoryTransitionResult } from './types.js';
+import type { FactoryRuleActor, FactoryRuleStage, FactoryTransitionResult } from './types.js';
 
 export interface FactoryStartRequest {
   orgId: string;
@@ -20,6 +20,8 @@ export interface FactoryStartRequest {
   kickoffKey: string;
   invocation?: { type: 'prompt'; prompt: string } | { type: 'skill'; skillName: string; arguments: string };
   destinationStage: FactoryRuleStage;
+  /** Override used by host-owned automation. Human starts retain the default caller actor. */
+  actor?: FactoryRuleActor;
   defaultModelId?: string;
   workItem: {
     id?: string;
@@ -201,8 +203,18 @@ export class FactoryStartCoordinator {
         board: prepared.item.externalSource?.type === 'pull-request' ? 'review' : 'work',
         stage: request.destinationStage,
         expectedRevision: prepared.item.revision,
-        actor: { type: 'human', id: request.userId },
-        ingress: { type: 'human', identity: `start:${request.kickoffKey}:transition` },
+        actor: request.actor ?? { type: 'human', id: request.userId },
+        ingress: {
+          type:
+            request.actor?.type === 'agent'
+              ? 'agent'
+              : request.actor?.type === 'github'
+                ? 'github'
+                : request.actor?.type === 'system'
+                  ? 'rule'
+                  : 'human',
+          identity: `start:${request.kickoffKey}:transition`,
+        },
         cause: 'run_start',
       });
       if (transition.status === 'rejected') {


### PR DESCRIPTION
## What

- expose host-owned Factory automation commands to trusted integrations after the canonical controller and transition service are constructed
- stamp automated starts/transitions with integration-scoped system authority and idempotency identities
- expose active run lookup without handing integrations raw storage or controller authority
- let the existing GitHub integration fan out signature-verified webhook deliveries before its built-in event filter

## Why

Control-plane integrations need to start and transition governed Factory work without constructing a second controller/transition service, and Projects V2 events must pass through the one GitHub credential/signature owner even though they are not native Factory webhook events.

## Validation

- `pnpm --filter ./mastracode/factory check`
- focused Vitest: 187 passed
- `pnpm --filter ./mastracode/factory lint`
- `pnpm --filter ./mastracode/factory build:lib`
- `pnpm --filter ./mastracode/factory smoke:dist`
- full Factory suite: 1,308 passed; two unchanged LibSQL serialization tests time out at their existing 5s limit, reproduced in isolation
