### PR TITLE
fix(build): preserve default externals with custom options

### DIFF
--- a/packages/cli/src/commands/build/BuildBundler.test.ts
+++ b/packages/cli/src/commands/build/BuildBundler.test.ts
@@ -93,7 +93,7 @@ describe('BuildBundler', () => {
       });
     });
 
-    it('optimizes dependencies when a bundler config omits externals', async () => {
+    it('defaults externals to true when a bundler config omits externals', async () => {
       const { Bundler } = await import('@mastra/deployer/bundler');
       vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({ sourcemap: true });
       const { BuildBundler } = await import('./BuildBundler');
@@ -103,8 +103,8 @@ describe('BuildBundler', () => {
 
       expect(options).toEqual({
         sourcemap: true,
+        externals: true,
       });
-      expect(options.externals).toBeUndefined();
     });
 
     it('preserves explicit externals true in a custom bundler config', async () => {
@@ -120,6 +120,26 @@ describe('BuildBundler', () => {
 
       expect(options).toEqual({
         externals: true,
+        sourcemap: true,
+      });
+    });
+
+    it.each([
+      { label: 'false', externals: false },
+      { label: 'an empty array', externals: [] },
+    ])('preserves explicit externals $label in a custom bundler config', async ({ externals }) => {
+      const { Bundler } = await import('@mastra/deployer/bundler');
+      vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({
+        externals,
+        sourcemap: true,
+      });
+      const { BuildBundler } = await import('./BuildBundler');
+      const bundler = new BuildBundler();
+
+      const options = await (bundler as any).getUserBundlerOptions('/entry.ts', '/output');
+
+      expect(options).toEqual({
+        externals,
         sourcemap: true,
       });
     });

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -22,7 +22,7 @@ export class BuildBundler extends Bundler {
   ): Promise<NonNullable<Config['bundler']>> {
     const bundlerOptions = await super.getUserBundlerOptions(mastraEntryFile, outputDirectory);
 
-    if (!bundlerOptions?.[IS_DEFAULT]) {
+    if (!bundlerOptions?.[IS_DEFAULT] && bundlerOptions?.externals !== undefined) {
       return bundlerOptions;
     }
 


### PR DESCRIPTION
## Problem

`mastra build` can silently lose its documented `bundler.externals: true` default when a user sets an unrelated bundler option such as `sourcemap`. This can change the build from externalizing dependencies to bundling them.

## Root Cause

`BuildBundler.getUserBundlerOptions` only adds `externals: true` when the parent bundler returns the `IS_DEFAULT` marker. A custom bundler object without an `externals` key bypasses that branch.

## Solution

Apply the default per option: preserve any explicit `externals` value, and set `externals: true` when it is omitted, regardless of whether other bundler options are present.

## Changes

- Updated `BuildBundler.getUserBundlerOptions` to default only a missing `externals` value.
- Updated the regression test for custom options without `externals`.
- Added coverage that explicit `false` and `[]` values remain unchanged.

## Testing

- `pnpm exec prettier --check packages/cli/src/commands/build/BuildBundler.ts packages/cli/src/commands/build/BuildBundler.test.ts` — passed.
- `git diff --check` — passed.
- Focused Vitest: `pnpm exec vitest run src/commands/build/BuildBundler.test.ts` — not verified locally: all 14 tests stop during module loading because this checkout's generated workspace artifact is missing `@internal/core/error` from `packages/core/dist/error/index.js`.
- `pnpm --filter mastra typecheck` — not verified: the current workspace also reports pre-existing generated-package/alias errors, including missing internal AI SDK modules and logger symbols.
- Full suite/build — not run; out of scope for this focused fix.

## Compatibility/Risk

Low. Explicit `externals: true`, `false`, and `[]` remain unchanged. The fix restores the documented default only when the key is omitted.

## Notes for Reviewer

The issue triage identified this as a valid bug and confirmed the affected surface is `mastra build` (`BuildBundler`). The implementation is intentionally limited to that surface. Please pay particular attention to the explicit opt-out cases in the added test.

## Linked Issue

Closes #20879


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When users change one build setting, Mastra no longer accidentally bundles dependencies that should stay separate. Dependencies remain external unless users explicitly choose another setting.

## Changes

- Preserve `externals: true` when users omit `externals`.
- Preserve explicit `externals` values, including `false` and `[]`.
- Add regression tests for custom bundler options and explicit opt-out values.
- Formatting and diff checks passed.
- Focused tests and typechecking were not verified because generated workspace artifacts were missing and package alias errors already existed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->