### PR TITLE
fix(core): let embedders remap the SkillsProcessor location field

### DIFF
--- a/.changeset/skills-processor-location-override.md
+++ b/.changeset/skills-processor-location-override.md
@@ -11,4 +11,4 @@ new SkillsProcessor({
 });
 ```
 
-The skill-tool instruction now also tells the model that `location` may not exist on its filesystem, so it reads skill files with `skill_read` instead of filesystem tools. With the default location, the instruction notes that `location` also identifies a skill for the `skill` and `skill_read` tools; when a `formatLocation` override is set, remapped locations are not skill identifiers, so the instruction directs the model to refer to skills by name.
+Remapped locations remain valid skill identifiers: the processor registers each rendered location as an alias with the skills registry, so the `skill` and `skill_read` tools resolve it back to the underlying skill. The skill-tool instruction now also tells the model that `location` may not exist on its filesystem, so it reads skill files with `skill_read` instead of filesystem tools. If a custom `WorkspaceSkills` implementation does not support alias registration, the instruction falls back to directing the model to refer to skills by name.

--- a/.changeset/skills-processor-location-override.md
+++ b/.changeset/skills-processor-location-override.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': patch
+---
+
+Pass `formatLocation` to `SkillsProcessor` when skill files are not at `${skill.path}/SKILL.md` from the model's point of view, such as when the agent's filesystem tools run against a sandbox that mounts them elsewhere.
+
+```ts
+new SkillsProcessor({
+  workspace,
+  formatLocation: skill => `/opt/skills/${skill.name}/SKILL.md`,
+});
+```
+
+The skill-tool instruction now also tells the model that `location` identifies a skill for the `skill` and `skill_read` tools and may not exist on its filesystem, so it reads skill files with `skill_read` instead of filesystem tools.

--- a/.changeset/skills-processor-location-override.md
+++ b/.changeset/skills-processor-location-override.md
@@ -2,13 +2,13 @@
 '@mastra/core': patch
 ---
 
-Pass `formatLocation` to `SkillsProcessor` when skill files are not at `${skill.path}/SKILL.md` from the model's point of view, such as when the agent's filesystem tools run against a sandbox that mounts them elsewhere.
+Pass `formatLocation` to `SkillsProcessor` when skill files are not at `${skill.path}/SKILL.md` from the model's point of view, such as when the agent's filesystem tools run against a sandbox that mounts them elsewhere. Key the override on `skill.path` so skills that share a name still render distinct locations.
 
 ```ts
 new SkillsProcessor({
   workspace,
-  formatLocation: skill => `/opt/skills/${skill.name}/SKILL.md`,
+  formatLocation: skill => `/mnt/skills${skill.path}/SKILL.md`,
 });
 ```
 
-The skill-tool instruction now also tells the model that `location` identifies a skill for the `skill` and `skill_read` tools and may not exist on its filesystem, so it reads skill files with `skill_read` instead of filesystem tools.
+The skill-tool instruction now also tells the model that `location` may not exist on its filesystem, so it reads skill files with `skill_read` instead of filesystem tools. With the default location, the instruction notes that `location` also identifies a skill for the `skill` and `skill_read` tools; when a `formatLocation` override is set, remapped locations are not skill identifiers, so the instruction directs the model to refer to skills by name.

--- a/packages/core/src/processors/processors/skills.test.ts
+++ b/packages/core/src/processors/processors/skills.test.ts
@@ -280,10 +280,34 @@ describe('SkillsProcessor', () => {
       const contents = mockMessageList.addSystem.mock.calls.map(c => c[0].content).join('\n');
       expect(contents).toContain('The location field identifies a skill for the `skill` and `skill_read` tools');
       expect(contents).toContain('read skill files with `skill_read` rather than with filesystem tools');
-      expect(contents).toContain('use the skill path (shown in the location field)');
+      expect(contents).toContain('use the exact location (shown in the location field)');
     });
 
-    it('should not advertise remapped locations as skill identifiers when formatLocation is overridden', async () => {
+    it('should register remapped locations as aliases and keep the location a skill identifier', async () => {
+      const registerLocationAlias = vi.fn();
+      const aliasSkills: WorkspaceSkills = { ...createMockWorkspaceSkills(), registerLocationAlias };
+      const remappedProcessor = new SkillsProcessor({
+        skills: aliasSkills,
+        formatLocation: skill => `/mnt/bundle/${skill.name}/SKILL.md`,
+      });
+
+      await remappedProcessor.processInputStep({
+        messageList: mockMessageList as any,
+        tools: {},
+      } as any);
+
+      // Every rendered location is registered so tools can resolve it back to the skill.
+      expect(registerLocationAlias).toHaveBeenCalledWith('/mnt/bundle/code-review/SKILL.md', '/skills/code-review');
+      expect(registerLocationAlias).toHaveBeenCalledWith('/mnt/bundle/testing/SKILL.md', '/skills/testing');
+
+      const contents = mockMessageList.addSystem.mock.calls.map(c => c[0].content).join('\n');
+      expect(contents).toContain('The location field identifies a skill for the `skill` and `skill_read` tools');
+      expect(contents).not.toContain('refer to skills by name and read skill files');
+    });
+
+    it('should fall back to by-name guidance when the skills registry cannot register aliases', async () => {
+      // createMockWorkspaceSkills() does not implement registerLocationAlias,
+      // so remapped locations cannot round-trip through get()/has().
       const remappedProcessor = new SkillsProcessor({
         workspace: mockWorkspace,
         formatLocation: skill => `/mnt/bundle/${skill.name}/SKILL.md`,
@@ -295,10 +319,8 @@ describe('SkillsProcessor', () => {
       } as any);
 
       const contents = mockMessageList.addSystem.mock.calls.map(c => c[0].content).join('\n');
-      // Remapped locations do not resolve via WorkspaceSkills.get(), so the
-      // instruction must not present the location as a tool identifier.
       expect(contents).not.toContain('The location field identifies a skill');
-      expect(contents).not.toContain('use the skill path (shown in the location field)');
+      expect(contents).not.toContain('use the exact location (shown in the location field)');
       expect(contents).toContain('refer to skills by name');
       expect(contents).toContain('read skill files with `skill_read` rather than with filesystem tools');
     });

--- a/packages/core/src/processors/processors/skills.test.ts
+++ b/packages/core/src/processors/processors/skills.test.ts
@@ -236,6 +236,41 @@ describe('SkillsProcessor', () => {
       );
     });
 
+    it('should render default location as skill path + SKILL.md', async () => {
+      await processor.processInputStep({
+        messageList: mockMessageList as any,
+        tools: {},
+      } as any);
+
+      expect(mockMessageList.addSystem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: 'system',
+          content: expect.stringContaining('<location>/skills/code-review/SKILL.md</location>'),
+        }),
+      );
+    });
+
+    it('should render location via formatLocation override', async () => {
+      const remappedProcessor = new SkillsProcessor({
+        workspace: mockWorkspace,
+        formatLocation: skill => `/mnt/bundle/${skill.name}/SKILL.md`,
+      });
+
+      await remappedProcessor.processInputStep({
+        messageList: mockMessageList as any,
+        tools: {},
+      } as any);
+
+      expect(mockMessageList.addSystem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: 'system',
+          content: expect.stringContaining('<location>/mnt/bundle/code-review/SKILL.md</location>'),
+        }),
+      );
+      const contents = mockMessageList.addSystem.mock.calls.map(c => c[0].content).join('\n');
+      expect(contents).not.toContain('/skills/code-review/SKILL.md');
+    });
+
     it('should not inject skills when none are configured', async () => {
       const emptyMockSkills = {
         ...createMockWorkspaceSkills(),

--- a/packages/core/src/processors/processors/skills.test.ts
+++ b/packages/core/src/processors/processors/skills.test.ts
@@ -271,6 +271,38 @@ describe('SkillsProcessor', () => {
       expect(contents).not.toContain('/skills/code-review/SKILL.md');
     });
 
+    it('should instruct that the default location identifies a skill and files are read via skill_read', async () => {
+      await processor.processInputStep({
+        messageList: mockMessageList as any,
+        tools: {},
+      } as any);
+
+      const contents = mockMessageList.addSystem.mock.calls.map(c => c[0].content).join('\n');
+      expect(contents).toContain('The location field identifies a skill for the `skill` and `skill_read` tools');
+      expect(contents).toContain('read skill files with `skill_read` rather than with filesystem tools');
+      expect(contents).toContain('use the skill path (shown in the location field)');
+    });
+
+    it('should not advertise remapped locations as skill identifiers when formatLocation is overridden', async () => {
+      const remappedProcessor = new SkillsProcessor({
+        workspace: mockWorkspace,
+        formatLocation: skill => `/mnt/bundle/${skill.name}/SKILL.md`,
+      });
+
+      await remappedProcessor.processInputStep({
+        messageList: mockMessageList as any,
+        tools: {},
+      } as any);
+
+      const contents = mockMessageList.addSystem.mock.calls.map(c => c[0].content).join('\n');
+      // Remapped locations do not resolve via WorkspaceSkills.get(), so the
+      // instruction must not present the location as a tool identifier.
+      expect(contents).not.toContain('The location field identifies a skill');
+      expect(contents).not.toContain('use the skill path (shown in the location field)');
+      expect(contents).toContain('refer to skills by name');
+      expect(contents).toContain('read skill files with `skill_read` rather than with filesystem tools');
+    });
+
     it('should not inject skills when none are configured', async () => {
       const emptyMockSkills = {
         ...createMockWorkspaceSkills(),

--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -41,6 +41,13 @@ interface SkillsProcessorBaseOptions {
    * somewhere else (e.g. a sandbox workspace), that server path is
    * meaningless to the model. Override this to advertise a location the
    * model can actually reach, or a plain identifier.
+   *
+   * Note: the default location doubles as a skill identifier — the `skill`
+   * and `skill_read` tools resolve it back to the skill via its path.
+   * Overridden values do not get that treatment: unless the returned string
+   * is the skill's name or canonical path, tools cannot resolve it. When an
+   * override is set, the injected instruction therefore directs the model to
+   * refer to skills by name instead of by location.
    */
   formatLocation?: (skill: Skill) => string;
 }
@@ -229,14 +236,20 @@ ${skillsMd}`;
         });
       }
 
-      // Add instruction to use the skill tool
+      // Add instruction to use the skill tool. When a formatLocation override
+      // is set, the rendered location is display metadata that tools cannot
+      // resolve back to a skill, so direct the model to refer to skills by
+      // name instead of by location.
+      const locationGuidance = this._formatLocation
+        ? 'The location field is informational metadata: it is not guaranteed to exist on your workspace filesystem and is not a skill identifier, so refer to skills by name and read skill files with `skill_read` rather than with filesystem tools. '
+        : 'If multiple skills share the same name, use the skill path (shown in the location field) instead of the name to disambiguate. ' +
+          'The location field identifies a skill for the `skill` and `skill_read` tools; it is not guaranteed to exist on your workspace filesystem, so read skill files with `skill_read` rather than with filesystem tools. ';
       messageList.addSystem({
         role: 'system',
         content:
           'IMPORTANT: Skills are NOT tools. Do not call skill names directly as tool names. ' +
           'To use a skill, call the `skill` tool with the skill name as the "name" parameter. ' +
-          'If multiple skills share the same name, use the skill path (shown in the location field) instead of the name to disambiguate. ' +
-          'The location field identifies a skill for the `skill` and `skill_read` tools; it is not guaranteed to exist on your workspace filesystem, so read skill files with `skill_read` rather than with filesystem tools. ' +
+          locationGuidance +
           'When a user asks about a topic covered by an available skill, activate it immediately without asking for permission first.',
       });
     }

--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -30,12 +30,28 @@ import type { ProcessInputStepArgs, Processor } from '../index';
 // =============================================================================
 
 /**
+ * Options shared by both SkillsProcessor configuration shapes.
+ */
+interface SkillsProcessorBaseOptions {
+  format?: SkillFormat;
+  /**
+   * Override how a skill's `location` field is rendered in the injected
+   * metadata. Defaults to `${skill.path}/SKILL.md`, which is a path on the
+   * server running the agent. When the model's filesystem tools operate
+   * somewhere else (e.g. a sandbox workspace), that server path is
+   * meaningless to the model. Override this to advertise a location the
+   * model can actually reach, or a plain identifier.
+   */
+  formatLocation?: (skill: Skill) => string;
+}
+
+/**
  * Configuration options for SkillsProcessor.
  * Provide either `skills` (WorkspaceSkills directly) or `workspace` (skills resolved via workspace.skills), not both.
  */
 export type SkillsProcessorOptions =
-  | { skills: WorkspaceSkills; workspace?: never; format?: SkillFormat }
-  | { workspace: Workspace; skills?: never; format?: SkillFormat };
+  | ({ skills: WorkspaceSkills; workspace?: never } & SkillsProcessorBaseOptions)
+  | ({ workspace: Workspace; skills?: never } & SkillsProcessorBaseOptions);
 
 // =============================================================================
 // SkillsProcessor
@@ -56,9 +72,13 @@ export class SkillsProcessor implements Processor<'skills-processor'> {
   /** Format for skill injection */
   private readonly _format: SkillFormat;
 
+  /** Optional override for rendering the location field */
+  private readonly _formatLocation: ((skill: Skill) => string) | undefined;
+
   constructor(opts: SkillsProcessorOptions) {
     this._skills = 'skills' in opts && opts.skills ? opts.skills : opts.workspace?.skills;
     this._format = opts.format ?? 'xml';
+    this._formatLocation = opts.formatLocation;
   }
 
   /**
@@ -90,7 +110,7 @@ export class SkillsProcessor implements Processor<'skills-processor'> {
    * Format skill location (path to SKILL.md file)
    */
   private formatLocation(skill: Skill): string {
-    return `${skill.path}/SKILL.md`;
+    return this._formatLocation ? this._formatLocation(skill) : `${skill.path}/SKILL.md`;
   }
 
   /**
@@ -216,6 +236,7 @@ ${skillsMd}`;
           'IMPORTANT: Skills are NOT tools. Do not call skill names directly as tool names. ' +
           'To use a skill, call the `skill` tool with the skill name as the "name" parameter. ' +
           'If multiple skills share the same name, use the skill path (shown in the location field) instead of the name to disambiguate. ' +
+          'The location field identifies a skill for the `skill` and `skill_read` tools; it is not guaranteed to exist on your workspace filesystem, so read skill files with `skill_read` rather than with filesystem tools. ' +
           'When a user asks about a topic covered by an available skill, activate it immediately without asking for permission first.',
       });
     }

--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -42,12 +42,13 @@ interface SkillsProcessorBaseOptions {
    * meaningless to the model. Override this to advertise a location the
    * model can actually reach, or a plain identifier.
    *
-   * Note: the default location doubles as a skill identifier — the `skill`
-   * and `skill_read` tools resolve it back to the skill via its path.
-   * Overridden values do not get that treatment: unless the returned string
-   * is the skill's name or canonical path, tools cannot resolve it. When an
-   * override is set, the injected instruction therefore directs the model to
-   * refer to skills by name instead of by location.
+   * Remapped locations remain valid skill identifiers: the processor
+   * registers each rendered location as an alias with the skills registry
+   * (via `WorkspaceSkills.registerLocationAlias`), so the `skill` and
+   * `skill_read` tools resolve it back to the underlying skill. If a custom
+   * `WorkspaceSkills` implementation does not support alias registration,
+   * the injected instruction instead directs the model to refer to skills
+   * by name.
    */
   formatLocation?: (skill: Skill) => string;
 }
@@ -114,10 +115,15 @@ export class SkillsProcessor implements Processor<'skills-processor'> {
   // ===========================================================================
 
   /**
-   * Format skill location (path to SKILL.md file)
+   * Format skill location (path to SKILL.md file).
+   * Remapped locations are registered as aliases with the skills registry so
+   * the `skill` and `skill_read` tools can resolve them back to the skill.
    */
   private formatLocation(skill: Skill): string {
-    return this._formatLocation ? this._formatLocation(skill) : `${skill.path}/SKILL.md`;
+    if (!this._formatLocation) return `${skill.path}/SKILL.md`;
+    const location = this._formatLocation(skill);
+    this._skills?.registerLocationAlias?.(location, skill.path);
+    return location;
   }
 
   /**
@@ -236,14 +242,15 @@ ${skillsMd}`;
         });
       }
 
-      // Add instruction to use the skill tool. When a formatLocation override
-      // is set, the rendered location is display metadata that tools cannot
-      // resolve back to a skill, so direct the model to refer to skills by
-      // name instead of by location.
-      const locationGuidance = this._formatLocation
-        ? 'The location field is informational metadata: it is not guaranteed to exist on your workspace filesystem and is not a skill identifier, so refer to skills by name and read skill files with `skill_read` rather than with filesystem tools. '
-        : 'If multiple skills share the same name, use the skill path (shown in the location field) instead of the name to disambiguate. ' +
-          'The location field identifies a skill for the `skill` and `skill_read` tools; it is not guaranteed to exist on your workspace filesystem, so read skill files with `skill_read` rather than with filesystem tools. ';
+      // Add instruction to use the skill tool. Remapped locations are
+      // registered as aliases with the skills registry, so the location field
+      // stays a valid tool identifier. Only when the skills implementation
+      // cannot register aliases does the guidance fall back to by-name usage.
+      const locationResolvable = !this._formatLocation || typeof this._skills?.registerLocationAlias === 'function';
+      const locationGuidance = locationResolvable
+        ? 'If multiple skills share the same name, use the exact location (shown in the location field) instead of the name to disambiguate. ' +
+          'The location field identifies a skill for the `skill` and `skill_read` tools; it is not guaranteed to exist on your workspace filesystem, so read skill files with `skill_read` rather than with filesystem tools. '
+        : 'The location field is informational metadata: it is not guaranteed to exist on your workspace filesystem and is not a skill identifier, so refer to skills by name and read skill files with `skill_read` rather than with filesystem tools. ';
       messageList.addSystem({
         role: 'system',
         content:

--- a/packages/core/src/skills/agent-skills-resolver.test.ts
+++ b/packages/core/src/skills/agent-skills-resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { resolveAgentSkills } from './agent-skills-resolver';
+import { mergeWorkspaceSkills, resolveAgentSkills } from './agent-skills-resolver';
 import { createSkill } from './create-skill';
 
 describe('resolveAgentSkills', () => {
@@ -120,5 +120,35 @@ describe('resolveAgentSkills', () => {
     const ws = resolveAgentSkills([]);
     const list = await ws.list();
     expect(list).toHaveLength(0);
+  });
+});
+
+describe('mergeWorkspaceSkills', () => {
+  it('forwards registerLocationAlias so remapped locations resolve on either side', async () => {
+    const agentSkills = resolveAgentSkills([
+      createSkill({
+        name: 'agent-skill',
+        description: 'Agent-level skill.',
+        instructions: 'Do agent things.',
+      }),
+    ]);
+    const workspaceSkills = resolveAgentSkills([
+      createSkill({
+        name: 'workspace-skill',
+        description: 'Workspace-level skill.',
+        instructions: 'Do workspace things.',
+      }),
+    ]);
+
+    const { merged } = await mergeWorkspaceSkills(agentSkills, workspaceSkills);
+
+    merged.registerLocationAlias?.('/mnt/bundle/agent-skill/SKILL.md', 'inline/agent-skill');
+    merged.registerLocationAlias?.('/mnt/bundle/workspace-skill/SKILL.md', 'inline/workspace-skill');
+
+    const fromPrimary = await merged.get('/mnt/bundle/agent-skill/SKILL.md');
+    expect(fromPrimary?.name).toBe('agent-skill');
+
+    const fromSecondary = await merged.get('/mnt/bundle/workspace-skill/SKILL.md');
+    expect(fromSecondary?.name).toBe('workspace-skill');
   });
 });

--- a/packages/core/src/skills/agent-skills-resolver.ts
+++ b/packages/core/src/skills/agent-skills-resolver.ts
@@ -162,6 +162,13 @@ class MergedWorkspaceSkills implements WorkspaceSkills {
     return (await this.#primary.has(name)) || (await this.#secondary.has(name));
   }
 
+  registerLocationAlias(location: string, skillPath: string): void {
+    // Forward to both sides: resolution validates the target path exists, so
+    // registering on the side that doesn't own the skill is harmless.
+    this.#primary.registerLocationAlias?.(location, skillPath);
+    this.#secondary.registerLocationAlias?.(location, skillPath);
+  }
+
   async refresh() {
     await Promise.all([this.#primary.refresh(), this.#secondary.refresh()]);
   }

--- a/packages/core/src/workspace/skills/types.ts
+++ b/packages/core/src/workspace/skills/types.ts
@@ -251,6 +251,17 @@ export interface WorkspaceSkills {
   has(name: string): Promise<boolean>;
 
   /**
+   * Register an alternate location string that resolves to the skill at `skillPath`.
+   *
+   * `SkillsProcessor` calls this when a `formatLocation` override remaps the
+   * advertised location, so the `skill` and `skill_read` tools can resolve the
+   * remapped location back to the underlying skill. Optional: implementations
+   * that omit it do not support remapped-location lookups, and the processor
+   * falls back to by-name guidance in its injected instruction.
+   */
+  registerLocationAlias?(location: string, skillPath: string): void;
+
+  /**
    * Refresh skills from filesystem (re-scan skills)
    */
   refresh(): Promise<void>;

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -405,6 +405,104 @@ user-invocable: false
     });
   });
 
+  describe('registerLocationAlias()', () => {
+    it('should resolve a registered alias via get() and has()', async () => {
+      const filesystem = createMockFilesystem({
+        'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+      });
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        skills: ['skills'],
+      });
+
+      skills.registerLocationAlias('/mnt/bundle/test-skill/SKILL.md', 'skills/test-skill');
+
+      const result = await skills.get('/mnt/bundle/test-skill/SKILL.md');
+      expect(result?.name).toBe('test-skill');
+      expect(await skills.has('/mnt/bundle/test-skill/SKILL.md')).toBe(true);
+    });
+
+    it('should resolve an alias whether or not the /SKILL.md suffix is preserved', async () => {
+      const filesystem = createMockFilesystem({
+        'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+      });
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        skills: ['skills'],
+      });
+
+      skills.registerLocationAlias('/mnt/bundle/test-skill/SKILL.md', 'skills/test-skill');
+
+      // Model stripped the suffix from the advertised location
+      expect((await skills.get('/mnt/bundle/test-skill'))?.name).toBe('test-skill');
+
+      // Alias registered without suffix, model appends it
+      skills.registerLocationAlias('/opt/skills/test-skill', 'skills/test-skill');
+      expect((await skills.get('/opt/skills/test-skill/SKILL.md'))?.name).toBe('test-skill');
+    });
+
+    it('should let canonical names and paths win over aliases', async () => {
+      const otherSkillMd = VALID_SKILL_MD.replace('name: test-skill', 'name: other-skill');
+      const filesystem = createMockFilesystem({
+        'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+        'skills/other-skill/SKILL.md': otherSkillMd,
+      });
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        skills: ['skills'],
+      });
+
+      // Alias collides with a real skill name — the real skill must win
+      skills.registerLocationAlias('other-skill', 'skills/test-skill');
+      expect((await skills.get('other-skill'))?.name).toBe('other-skill');
+
+      // Alias collides with a real skill path — the real skill must win
+      skills.registerLocationAlias('skills/other-skill', 'skills/test-skill');
+      expect((await skills.get('skills/other-skill'))?.name).toBe('other-skill');
+    });
+
+    it('should return null when an alias points at a path that no longer exists', async () => {
+      const filesystem = createMockFilesystem({
+        'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+      });
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        skills: ['skills'],
+      });
+
+      skills.registerLocationAlias('/mnt/bundle/gone/SKILL.md', 'skills/gone');
+
+      expect(await skills.get('/mnt/bundle/gone/SKILL.md')).toBeNull();
+      expect(await skills.has('/mnt/bundle/gone/SKILL.md')).toBe(false);
+    });
+
+    it('should round-trip SkillsProcessor formatLocation overrides back to the skill', async () => {
+      const { SkillsProcessor } = await import('../../processors/processors/skills');
+      const filesystem = createMockFilesystem({
+        'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+      });
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        skills: ['skills'],
+      });
+
+      const processor = new SkillsProcessor({
+        skills,
+        formatLocation: skill => `/mnt/bundle/${skill.name}/SKILL.md`,
+      });
+      const addSystem = vi.fn();
+      await processor.processInputStep({ messageList: { addSystem }, tools: {} } as any);
+
+      // The advertised location is the remapped one...
+      const contents = addSystem.mock.calls.map(c => c[0].content).join('\n');
+      expect(contents).toContain('/mnt/bundle/test-skill/SKILL.md');
+
+      // ...and it resolves back to the skill via get() (what the skill/skill_read tools call)
+      const resolved = await skills.get('/mnt/bundle/test-skill/SKILL.md');
+      expect(resolved?.name).toBe('test-skill');
+    });
+  });
+
   describe('refresh()', () => {
     it('should re-discover skills after refresh', async () => {
       const filesystem = createMockFilesystem({

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -92,6 +92,9 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
   /** Map of skill name -> array of candidates (supports same-named skills from different sources) */
   #skills: Map<string, InternalSkill[]> = new Map();
 
+  /** Map of remapped location -> skill path, registered by SkillsProcessor formatLocation overrides */
+  #locationAliases: Map<string, string> = new Map();
+
   /** Whether skills have been discovered */
   #initialized = false;
 
@@ -146,8 +149,9 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
 
   async get(name: string): Promise<Skill | null> {
     await this.#ensureInitialized();
-    // Try name-based lookup first, then fall back to path-based (escape hatch)
-    const skill = (await this.#resolveByName(name)) ?? this.#resolveByPath(name);
+    // Try name-based lookup first, then fall back to path-based (escape hatch),
+    // then to registered location aliases (formatLocation overrides)
+    const skill = (await this.#resolveByName(name)) ?? this.#resolveByPath(name) ?? this.#resolveByAlias(name);
     if (!skill) return null;
 
     // Return without internal indexableContent field
@@ -157,7 +161,24 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
 
   async has(name: string): Promise<boolean> {
     await this.#ensureInitialized();
-    return ((await this.#resolveByName(name)) ?? this.#resolveByPath(name)) !== null;
+    return ((await this.#resolveByName(name)) ?? this.#resolveByPath(name) ?? this.#resolveByAlias(name)) !== null;
+  }
+
+  /**
+   * Register an alternate location string that resolves to the skill at `skillPath`.
+   * Called by SkillsProcessor when a `formatLocation` override remaps the advertised
+   * location, so the `skill` and `skill_read` tools can resolve the remapped
+   * location back to the underlying skill.
+   *
+   * Both the exact location and its `/SKILL.md`-stripped form are registered so
+   * lookups succeed whether or not the model preserves the suffix.
+   */
+  registerLocationAlias(location: string, skillPath: string): void {
+    this.#locationAliases.set(location, skillPath);
+    const normalized = location.replace(/\/SKILL\.md$/, '');
+    if (normalized !== location) {
+      this.#locationAliases.set(normalized, skillPath);
+    }
   }
 
   // ===========================================================================
@@ -187,6 +208,17 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
       if (match) return match;
     }
     return null;
+  }
+
+  /**
+   * Resolve a skill via a registered location alias (formatLocation override).
+   * Tried last so canonical names and paths always win over aliases.
+   */
+  #resolveByAlias(location: string): InternalSkill | null {
+    const target =
+      this.#locationAliases.get(location) ?? this.#locationAliases.get(location.replace(/\/SKILL\.md$/, ''));
+    if (!target) return null;
+    return this.#resolveByPath(target);
   }
 
   async #getCanonicalSkillPath(skillPath: string): Promise<string> {


### PR DESCRIPTION
## Description

Let embedders control the `location` field `SkillsProcessor` injects, and stop the accompanying instruction from steering the model into filesystem tools.

`location` is always rendered as a path on the server running the agent:

https://github.com/mastra-ai/mastra/blob/8e23a0b207f34b84bd28f3bf554c6931d8025b97/packages/core/src/processors/processors/skills.ts#L88-L94

That holds only when the model's filesystem tools see the same filesystem as the agent process. When they do not, for example when workspace tools run against a sandbox that mounts skill files under a different prefix, the advertised path does not exist from the model's point of view and nothing can change it.

The fixed instruction shipped alongside it compounds the problem by pointing the model at that path:

https://github.com/mastra-ai/mastra/blob/8e23a0b207f34b84bd28f3bf554c6931d8025b97/packages/core/src/processors/processors/skills.ts#L214-L221

The model is told to use the location to disambiguate skills, sees what looks like a filesystem path, and calls filesystem tools with it. Those calls fail and it has to recover.

**Change:**

- new `formatLocation` option on `SkillsProcessorOptions`:

```ts
new SkillsProcessor({
  workspace,
  formatLocation: skill => `/opt/skills/${skill.name}/SKILL.md`,
});
```

  Unset, it falls back to `${skill.path}/SKILL.md`, so **existing behaviour is unchanged**.

- the instruction now states that `location` identifies a skill for the `skill` and `skill_read` tools and is not guaranteed to exist on the model's filesystem, so skill files should be read with `skill_read`. This stands on its own: it is true whether or not an embedder overrides the location, and it removes the wrong inference rather than only enabling a workaround.

The two options shapes were factored into a shared `SkillsProcessorBaseOptions` so the new option applies to both without duplicating it.

**Tests.** Cases added to `skills.test.ts` covering the override, the unchanged default, and the presence of the clarified guidance. `skills.test.ts` (17) passes, no type errors.

## Related issue(s)

Fixes #20508

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable). The new option carries a TSDoc block, and a changeset is included.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This change lets applications choose the skill location shown to the model. If no custom location is set, the existing location remains unchanged. The instructions tell the model to use `skill_read` and the skill name when custom locations cannot be resolved.

## Changes

- Added optional `formatLocation` to `SkillsProcessorOptions`.
- Applied the shared option type to both processor option variants.
- Preserved the default `${skill.path}/SKILL.md` location format.
- Added location aliases for custom locations when the skill collection supports them.
- Added alias resolution for workspace and merged agent skills.
- Added fallback guidance for custom locations that cannot be resolved as aliases.
- Directed models to use skill names and `skill_read` for skill files.
- Added tests for default and custom locations, alias resolution, merged skills, and guidance variants.
- Added a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->