### PR TITLE
feat(factory): reconcile Work board cards with closed GitHub issues

### DIFF
--- a/.changeset/warm-issues-reconcile.md
+++ b/.changeset/warm-issues-reconcile.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Reconcile Work board cards with closed GitHub issues. The rules engine now handles the `issues` `closed` webhook (moving the card to Done, or Canceled for `not_planned`/`duplicate` closes), and the periodic GitHub reconcile sweep also checks issue-backed cards so closes missed while a deployment was unreachable are replayed through the same ingress.
+Work board cards now follow their GitHub issue when it closes: closing an issue moves its card to Done (or to Canceled when the issue was closed as `not_planned` or `duplicate`), and a card whose issue closed while the deployment was unreachable is caught up automatically by the periodic reconcile sweep. Previously these cards stayed on the board until moved by hand.

--- a/.changeset/warm-issues-reconcile.md
+++ b/.changeset/warm-issues-reconcile.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Reconcile Work board cards with closed GitHub issues. The rules engine now handles the `issues` `closed` webhook (moving the card to Done, or Canceled for `not_planned`/`duplicate` closes), and the periodic GitHub reconcile sweep also checks issue-backed cards so closes missed while a deployment was unreachable are replayed through the same ingress.

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -51,7 +51,7 @@ import { runGithubIssueTriage } from './issue-triage.js';
 import { GithubReconcileWorker } from './reconcile-worker.js';
 import { buildGithubRoutes } from './routes.js';
 import { attachGithubReconciler, attachGithubRules } from './rules.js';
-import type { ReconcilePullRequestState } from './rules.js';
+import type { ReconcileIssueState, ReconcilePullRequestState } from './rules.js';
 import {
   createGithubSubscriptionTools,
   parseCreatedPullRequest,
@@ -1110,7 +1110,12 @@ export class GithubIntegration implements FactoryIntegration {
    */
   workers(ctx: IntegrationContext): MastraWorker[] {
     if (process.env.MASTRACODE_GITHUB_RECONCILE_ENABLED?.trim().toLowerCase() === 'false') return [];
-    const reconcile = attachGithubReconciler(this, ctx, input => this.fetchPullRequestState(input));
+    const reconcile = attachGithubReconciler(
+      this,
+      ctx,
+      input => this.fetchPullRequestState(input),
+      input => this.fetchIssueState(input),
+    );
     if (!reconcile) return [];
     const intervalMs = Number(process.env.MASTRACODE_GITHUB_RECONCILE_INTERVAL_MS);
     return [
@@ -1150,6 +1155,43 @@ export class GithubIntegration implements FactoryIntegration {
         baseBranch: pullRequest.baseBranch,
         ...(pullRequest.author ? { author: pullRequest.author } : {}),
         ...(pullRequest.createdAt ? { createdAt: pullRequest.createdAt } : {}),
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Reads live issue state for the reconciler. Returns undefined when the
+   * issue cannot be resolved (missing, is actually a PR, API error) so a
+   * sweep never fabricates a close.
+   */
+  async fetchIssueState(input: {
+    installationId: number;
+    repository: string;
+    number: number;
+  }): Promise<ReconcileIssueState | undefined> {
+    const parts = splitRepoFullName(input.repository);
+    if (!parts) return undefined;
+    try {
+      const octokit = this.getInstallationOctokit(input.installationId);
+      const { data: issue } = await octokit.issues.get({
+        owner: parts.owner,
+        repo: parts.repo,
+        issue_number: input.number,
+      });
+      if (issue.pull_request) return undefined;
+      return {
+        title: issue.title,
+        url: issue.html_url,
+        state: issue.state === 'closed' ? 'closed' : 'open',
+        ...(issue.state_reason ? { stateReason: issue.state_reason } : {}),
+        assignees: (issue.assignees ?? [])
+          .map(user => user.login)
+          .filter((login): login is string => Boolean(login)),
+        ...(issue.user?.login ? { author: issue.user.login } : {}),
+        createdAt: issue.created_at,
+        updatedAt: issue.updated_at,
       };
     } catch {
       return undefined;

--- a/mastracode/factory/src/integrations/github/reconcile-worker.test.ts
+++ b/mastracode/factory/src/integrations/github/reconcile-worker.test.ts
@@ -10,6 +10,8 @@ const EMPTY_SUMMARY: ReconcileSweepSummary = {
   checked: 1,
   merged: 0,
   closed: 0,
+  issuesChecked: 0,
+  issuesClosed: 0,
   failed: 0,
   errors: [],
 };

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -1588,6 +1588,36 @@ describe('createGithubPullRequestReconciler', () => {
     ]);
   });
 
+  it('sweeps cards whose URL predates a repository rename via the stamped repository id', async () => {
+    const context = await setup('read');
+    // Renamed repository: the card URL still carries the old owner/name, but
+    // the intake-stamped repository id is stable and confirms ownership.
+    const renamed = await createIssueCard(context, {
+      number: 42,
+      url: 'https://github.com/acme/old-name/issues/42',
+      metadata: { githubRepositoryId: 10 },
+    });
+    // Genuinely foreign card: URL and stamped id both point elsewhere.
+    await createIssueCard(context, {
+      number: 43,
+      url: 'https://github.com/acme/other/issues/43',
+      metadata: { githubRepositoryId: 999 },
+    });
+    const fetchIssue = vi.fn(async () => closedIssueState(42, 'completed'));
+    const reconcile = createReconciler(context, vi.fn(async () => undefined), fetchIssue);
+
+    await expect(reconcile([repositoryTarget])).resolves.toMatchObject({ issuesChecked: 1, issuesClosed: 1 });
+    expect(fetchIssue).toHaveBeenCalledTimes(1);
+    expect(fetchIssue).toHaveBeenCalledWith({ installationId: 7, repository: 'acme/repo', number: 42 });
+    const decisions = await context.workItems.listDeferredDecisions('org-1', context.project.id);
+    expect(decisions).toEqual([
+      expect.objectContaining({
+        workItemId: renamed.item.id,
+        decision: expect.objectContaining({ type: 'transition', board: 'work', stage: 'done' }),
+      }),
+    ]);
+  });
+
   it('skips terminal issue cards and commits nothing for issues still open', async () => {
     const context = await setup('read');
     await createIssueCard(context, { number: 41, stages: ['done'] });

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -6,7 +6,7 @@ import { FactoryTransitionService } from '../../rules/transition-service.js';
 import { createFactoryStorageForTests } from '../../storage/test-utils.js';
 import type { GithubIntegration } from './integration.js';
 import { createGithubPullRequestReconciler, GithubRules } from './rules.js';
-import type { ReconcilePullRequestState } from './rules.js';
+import type { ReconcileIssueState, ReconcilePullRequestState } from './rules.js';
 import { changeRequestTargetKey } from './subscriptions.js';
 
 async function setup(permission: string | undefined) {
@@ -78,6 +78,26 @@ function issueOpened(deliveryId = 'delivery-1', createdAt = '2030-01-01T00:00:00
         title: 'Issue 42',
         html_url: 'https://github.com/acme/repo/issues/42',
         created_at: createdAt,
+      },
+    },
+  };
+}
+
+function issueClosed(deliveryId = 'delivery-closed-1', stateReason?: string) {
+  return {
+    event: 'issues',
+    deliveryId,
+    payload: {
+      action: 'closed',
+      installation: { id: 7 },
+      repository: { id: 10, full_name: 'acme/repo' },
+      sender: { login: 'maintainer' },
+      issue: {
+        number: 42,
+        title: 'Issue 42',
+        html_url: 'https://github.com/acme/repo/issues/42',
+        state: 'closed',
+        ...(stateReason ? { state_reason: stateReason } : {}),
       },
     },
   };
@@ -184,6 +204,83 @@ describe('GithubRules', () => {
     expect(decisions).toHaveLength(1);
     expect(decisions[0]?.actor).toMatchObject({ type: 'github', login: 'maintainer', trusted: true });
     expect(decisions[0]?.decision).toMatchObject({ type: 'upsertLinkedWorkItem', source: 'github-issue' });
+  });
+
+  it('moves an issue-backed work card to done when its issue closes as completed', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    await createLinkedIssue(workItems, project.id);
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await expect(service.ingest(issueClosed('delivery-closed-done', 'completed'))).resolves.toEqual({
+      status: 'committed',
+    });
+    await expect(service.ingest(issueClosed('delivery-closed-done', 'completed'))).resolves.toEqual({
+      status: 'replayed',
+    });
+
+    const decisions = await workItems.listDeferredDecisions('org-1', project.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toMatchObject({ type: 'transition', board: 'work', stage: 'done' });
+  });
+
+  it('cancels an issue-backed work card when its issue closes as not planned', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    await createLinkedIssue(workItems, project.id);
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await expect(service.ingest(issueClosed('delivery-closed-np', 'not_planned'))).resolves.toEqual({
+      status: 'committed',
+    });
+
+    const decisions = await workItems.listDeferredDecisions('org-1', project.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toMatchObject({ type: 'transition', board: 'work', stage: 'canceled' });
+  });
+
+  it('commits nothing when the closed issue card is already off the board', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue',
+          externalId: 'github-issue:42',
+          url: 'https://github.com/acme/repo/issues/42',
+        },
+        title: 'Issue 42',
+        stages: ['done'],
+        sessions: {},
+        metadata: {},
+      },
+    });
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await expect(service.ingest(issueClosed('delivery-closed-terminal'))).resolves.toEqual({ status: 'committed' });
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toHaveLength(0);
   });
 
   it('retriages a human comment containing the handoff marker', async () => {
@@ -998,7 +1095,11 @@ describe('createGithubPullRequestReconciler', () => {
     });
   }
 
-  function createReconciler(context: Awaited<ReturnType<typeof setup>>, fetchPullRequest: ReturnType<typeof vi.fn>) {
+  function createReconciler(
+    context: Awaited<ReturnType<typeof setup>>,
+    fetchPullRequest: ReturnType<typeof vi.fn>,
+    fetchIssue?: ReturnType<typeof vi.fn>,
+  ) {
     return createGithubPullRequestReconciler(
       {
         github: context.github,
@@ -1009,7 +1110,42 @@ describe('createGithubPullRequestReconciler', () => {
         rules: builtInFactoryRules(),
       },
       fetchPullRequest as never,
+      fetchIssue as never,
     );
+  }
+
+  async function createIssueCard(
+    context: Awaited<ReturnType<typeof setup>>,
+    input: { number: number; stages?: string[] },
+  ) {
+    return context.workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: context.project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue',
+          externalId: `github-issue:${input.number}`,
+          url: `https://github.com/acme/repo/issues/${input.number}`,
+        },
+        title: `Issue ${input.number}`,
+        stages: input.stages ?? ['planning'],
+        sessions: {},
+        metadata: {},
+      },
+    });
+  }
+
+  function closedIssueState(number: number, stateReason?: string): ReconcileIssueState {
+    return {
+      title: `Issue ${number}`,
+      url: `https://github.com/acme/repo/issues/${number}`,
+      state: 'closed',
+      ...(stateReason ? { stateReason } : {}),
+      assignees: [],
+      author: 'maintainer',
+    };
   }
 
   it('replays a missed merge through the ingress exactly once', async () => {
@@ -1023,6 +1159,8 @@ describe('createGithubPullRequestReconciler', () => {
       checked: 1,
       merged: 1,
       closed: 0,
+      issuesChecked: 0,
+      issuesClosed: 0,
       failed: 0,
       errors: [],
     });
@@ -1042,6 +1180,8 @@ describe('createGithubPullRequestReconciler', () => {
       checked: 1,
       merged: 1,
       closed: 0,
+      issuesChecked: 0,
+      issuesClosed: 0,
       failed: 0,
       errors: [],
     });
@@ -1071,6 +1211,8 @@ describe('createGithubPullRequestReconciler', () => {
       checked: 1,
       merged: 0,
       closed: 0,
+      issuesChecked: 0,
+      issuesClosed: 0,
       failed: 0,
       errors: [],
     });
@@ -1161,6 +1303,8 @@ describe('createGithubPullRequestReconciler', () => {
       checked: 2,
       merged: 0,
       closed: 0,
+      issuesChecked: 0,
+      issuesClosed: 0,
       failed: 0,
       errors: [],
     });
@@ -1227,6 +1371,8 @@ describe('createGithubPullRequestReconciler', () => {
       checked: 0,
       merged: 0,
       closed: 0,
+      issuesChecked: 0,
+      issuesClosed: 0,
       failed: 0,
       errors: [],
     });
@@ -1244,6 +1390,8 @@ describe('createGithubPullRequestReconciler', () => {
       checked: 1,
       merged: 0,
       closed: 1,
+      issuesChecked: 0,
+      issuesClosed: 0,
       failed: 0,
       errors: [],
     });
@@ -1275,6 +1423,8 @@ describe('createGithubPullRequestReconciler', () => {
       checked: 1,
       merged: 1,
       closed: 0,
+      issuesChecked: 0,
+      issuesClosed: 0,
       failed: 1,
       errors: [
         {
@@ -1310,6 +1460,8 @@ describe('createGithubPullRequestReconciler', () => {
       checked: 0,
       merged: 0,
       closed: 0,
+      issuesChecked: 0,
+      issuesClosed: 0,
       failed: 0,
       errors: [],
     });
@@ -1320,10 +1472,113 @@ describe('createGithubPullRequestReconciler', () => {
       checked: 1,
       merged: 1,
       closed: 0,
+      issuesChecked: 0,
+      issuesClosed: 0,
       failed: 0,
       errors: [],
     });
     expect(fetchPullRequest).toHaveBeenCalledTimes(1);
     expect(fetchPullRequest).toHaveBeenCalledWith({ installationId: 7, repository: 'acme/repo', number: 17 });
+  });
+
+  it('replays a missed issue close and moves the work card to done exactly once', async () => {
+    const context = await setup('read');
+    const card = await createIssueCard(context, { number: 42 });
+    const fetchPullRequest = vi.fn(async () => undefined);
+    const fetchIssue = vi.fn(async () => closedIssueState(42, 'completed'));
+    const reconcile = createReconciler(context, fetchPullRequest, fetchIssue);
+
+    await expect(reconcile([repositoryTarget])).resolves.toEqual({
+      repositories: 1,
+      checked: 0,
+      merged: 0,
+      closed: 0,
+      issuesChecked: 1,
+      issuesClosed: 1,
+      failed: 0,
+      errors: [],
+    });
+    expect(fetchIssue).toHaveBeenCalledWith({ installationId: 7, repository: 'acme/repo', number: 42 });
+    const decisions = await context.workItems.listDeferredDecisions('org-1', context.project.id);
+    expect(decisions).toEqual([
+      expect.objectContaining({
+        workItemId: card.item.id,
+        decision: expect.objectContaining({ type: 'transition', board: 'work', stage: 'done' }),
+      }),
+    ]);
+
+    // The ingress dedupe makes a second sweep replay without new decisions.
+    await reconcile([repositoryTarget]);
+    expect(await context.workItems.listDeferredDecisions('org-1', context.project.id)).toHaveLength(1);
+  });
+
+  it('cancels the work card when the issue was closed as not planned', async () => {
+    const context = await setup('read');
+    const card = await createIssueCard(context, { number: 42 });
+    const fetchIssue = vi.fn(async () => closedIssueState(42, 'not_planned'));
+    const reconcile = createReconciler(context, vi.fn(async () => undefined), fetchIssue);
+
+    await reconcile([repositoryTarget]);
+
+    const decisions = await context.workItems.listDeferredDecisions('org-1', context.project.id);
+    expect(decisions).toEqual([
+      expect.objectContaining({
+        workItemId: card.item.id,
+        decision: expect.objectContaining({ type: 'transition', board: 'work', stage: 'canceled' }),
+      }),
+    ]);
+  });
+
+  it('skips terminal issue cards and commits nothing for issues still open', async () => {
+    const context = await setup('read');
+    await createIssueCard(context, { number: 41, stages: ['done'] });
+    await createIssueCard(context, { number: 42 });
+    const fetchIssue = vi.fn(async () => ({ ...closedIssueState(42), state: 'open' as const }));
+    const reconcile = createReconciler(context, vi.fn(async () => undefined), fetchIssue);
+
+    await expect(reconcile([repositoryTarget])).resolves.toEqual({
+      repositories: 1,
+      checked: 0,
+      merged: 0,
+      closed: 0,
+      issuesChecked: 1,
+      issuesClosed: 0,
+      failed: 0,
+      errors: [],
+    });
+    expect(fetchIssue).toHaveBeenCalledTimes(1);
+    expect(fetchIssue).toHaveBeenCalledWith({ installationId: 7, repository: 'acme/repo', number: 42 });
+    expect(await context.workItems.listDeferredDecisions('org-1', context.project.id)).toHaveLength(0);
+  });
+
+  it('never checks issue cards without an issue fetcher and reports issue fetch failures', async () => {
+    const context = await setup('read');
+    await createIssueCard(context, { number: 42 });
+    const fetchIssue = vi.fn(async () => {
+      throw new Error('Platform API request failed: 500 Internal Server Error');
+    });
+
+    // No fetcher wired: issue cards are ignored entirely.
+    await expect(createReconciler(context, vi.fn(async () => undefined))([repositoryTarget])).resolves.toMatchObject({
+      issuesChecked: 0,
+      issuesClosed: 0,
+      failed: 0,
+    });
+
+    // Wired but failing: the sweep records the failure with issue context.
+    await expect(
+      createReconciler(context, vi.fn(async () => undefined), fetchIssue)([repositoryTarget]),
+    ).resolves.toMatchObject({
+      issuesChecked: 0,
+      issuesClosed: 0,
+      failed: 1,
+      errors: [
+        {
+          repository: 'acme/repo',
+          issueNumber: 42,
+          error: 'Platform API request failed: 500 Internal Server Error',
+        },
+      ],
+    });
   });
 });

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -251,6 +251,42 @@ describe('GithubRules', () => {
     expect(decisions[0]?.decision).toMatchObject({ type: 'transition', board: 'work', stage: 'canceled' });
   });
 
+  it('never binds a close to another linked repository card with the same issue number', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    // Same canonical key (`github-issue:42`) but the card tracks other/repo#42.
+    await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue',
+          externalId: 'github-issue:42',
+          url: 'https://github.com/other/repo/issues/42',
+        },
+        title: 'Issue 42 (other repo)',
+        stages: ['planning'],
+        sessions: {},
+        metadata: { githubRepositoryId: 999 },
+      },
+    });
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    // acme/repo#42 closing must not move the other/repo#42 card.
+    await expect(service.ingest(issueClosed('delivery-closed-cross-repo', 'completed'))).resolves.toEqual({
+      status: 'committed',
+    });
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toHaveLength(0);
+  });
+
   it('commits nothing when the closed issue card is already off the board', async () => {
     const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
     await workItems.upsert({
@@ -1116,7 +1152,7 @@ describe('createGithubPullRequestReconciler', () => {
 
   async function createIssueCard(
     context: Awaited<ReturnType<typeof setup>>,
-    input: { number: number; stages?: string[] },
+    input: { number: number; stages?: string[]; url?: string | null; metadata?: Record<string, unknown> },
   ) {
     return context.workItems.upsert({
       orgId: 'org-1',
@@ -1127,12 +1163,12 @@ describe('createGithubPullRequestReconciler', () => {
           integrationId: 'github',
           type: 'issue',
           externalId: `github-issue:${input.number}`,
-          url: `https://github.com/acme/repo/issues/${input.number}`,
+          url: input.url === null ? undefined : (input.url ?? `https://github.com/acme/repo/issues/${input.number}`),
         },
         title: `Issue ${input.number}`,
         stages: input.stages ?? ['planning'],
         sessions: {},
-        metadata: {},
+        metadata: input.metadata ?? {},
       },
     });
   }
@@ -1525,6 +1561,29 @@ describe('createGithubPullRequestReconciler', () => {
       expect.objectContaining({
         workItemId: card.item.id,
         decision: expect.objectContaining({ type: 'transition', board: 'work', stage: 'canceled' }),
+      }),
+    ]);
+  });
+
+  it('only trusts URL-less canonical issue cards whose stamped repository matches', async () => {
+    const context = await setup('read');
+    // Card intaken from this repository: URL lost, but repository id stamped.
+    const ours = await createIssueCard(context, { number: 42, url: null, metadata: { githubRepositoryId: 10 } });
+    // Same number in another linked repository: must never be swept here.
+    await createIssueCard(context, { number: 43, url: null, metadata: { githubRepositoryId: 999 } });
+    // No repository signal at all: ambiguous, so the sweep must not guess.
+    await createIssueCard(context, { number: 44, url: null });
+    const fetchIssue = vi.fn(async () => closedIssueState(42, 'completed'));
+    const reconcile = createReconciler(context, vi.fn(async () => undefined), fetchIssue);
+
+    await expect(reconcile([repositoryTarget])).resolves.toMatchObject({ issuesChecked: 1, issuesClosed: 1 });
+    expect(fetchIssue).toHaveBeenCalledTimes(1);
+    expect(fetchIssue).toHaveBeenCalledWith({ installationId: 7, repository: 'acme/repo', number: 42 });
+    const decisions = await context.workItems.listDeferredDecisions('org-1', context.project.id);
+    expect(decisions).toEqual([
+      expect.objectContaining({
+        workItemId: ours.item.id,
+        decision: expect.objectContaining({ type: 'transition', board: 'work', stage: 'done' }),
       }),
     ]);
   });

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -68,6 +68,7 @@ function eventName(parsed: ParsedGithubWebhook): FactoryGithubEventName | undefi
     const changes = object(parsed.payload.changes);
     return object(changes?.title) || object(changes?.body) ? 'issueEdited' : undefined;
   }
+  if (parsed.event === 'issues' && action === 'closed') return 'issueClosed';
   if (parsed.event === 'issue_comment') {
     const issue = object(parsed.payload.issue);
     if (object(issue?.pull_request)) return undefined;
@@ -274,6 +275,10 @@ export class GithubRules {
               ...(string(issue?.created_at) ? { createdAt: string(issue?.created_at) } : {}),
               ...(string(issue?.updated_at) ? { updatedAt: string(issue?.updated_at) } : {}),
               assignees: actorLogins(issue?.assignees),
+              ...(string(issue?.state) === 'closed' || string(issue?.state) === 'open'
+                ? { state: string(issue?.state) as 'open' | 'closed' }
+                : {}),
+              ...(string(issue?.state_reason) ? { stateReason: string(issue?.state_reason) } : {}),
             },
           }
         : {}),
@@ -431,6 +436,24 @@ export type GithubPullRequestFetcher = (input: {
   number: number;
 }) => Promise<ReconcilePullRequestState | undefined>;
 
+export interface ReconcileIssueState {
+  title: string;
+  url: string;
+  state: 'open' | 'closed';
+  /** GitHub close reason: `completed`, `not_planned`, or `duplicate`. */
+  stateReason?: string;
+  assignees?: string[];
+  author?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export type GithubIssueFetcher = (input: {
+  installationId: number;
+  repository: string;
+  number: number;
+}) => Promise<ReconcileIssueState | undefined>;
+
 export interface ReconcileRepository {
   id: number;
   fullName: string;
@@ -446,10 +469,14 @@ export interface ReconcileSweepSummary {
   merged: number;
   /** Missed closes-without-merge replayed through the rules ingress. */
   closed: number;
-  /** PRs (or whole repositories) skipped because of an error. */
+  /** Issue-backed work cards whose live state was fetched from GitHub. */
+  issuesChecked: number;
+  /** Missed issue closes replayed through the rules ingress. */
+  issuesClosed: number;
+  /** PRs/issues (or whole repositories) skipped because of an error. */
   failed: number;
   /** Error samples with context, capped at {@link RECONCILE_ERROR_SAMPLE_LIMIT}. */
-  errors: Array<{ repository: string; pullRequestNumber?: number; error: string }>;
+  errors: Array<{ repository: string; pullRequestNumber?: number; issueNumber?: number; error: string }>;
 }
 
 export type GithubPullRequestReconciler = (repositories: ReconcileRepository[]) => Promise<ReconcileSweepSummary>;
@@ -485,6 +512,55 @@ function reconcilablePullRequestNumber(item: WorkItemRow, repository: ReconcileR
   if (legacy) return Number(legacy[1]) === repository.id ? Number(legacy[2]) : undefined;
   const canonical = /^github-pr:(\d+)$/.exec(externalId);
   return canonical ? Number(canonical[1]) : undefined;
+}
+
+/**
+ * Extracts the issue number a work item tracks, but only when the item
+ * belongs to the given repository — same repository-pinning contract as
+ * {@link reconcilablePullRequestNumber}.
+ */
+function reconcilableIssueNumber(item: WorkItemRow, repository: ReconcileRepository): number | undefined {
+  if (item.externalSource?.type !== 'issue') return undefined;
+  const url = item.externalSource.url;
+  if (url) {
+    const match = /^https?:\/\/[^/]+\/(.+)\/issues\/(\d+)(?:[/?#]|$)/.exec(url);
+    if (!match) return undefined;
+    return match[1] === repository.fullName ? Number(match[2]) : undefined;
+  }
+  const externalId = item.externalSource.externalId;
+  const legacy = /^github:(\d+):issue:(\d+)$/.exec(externalId);
+  if (legacy) return Number(legacy[1]) === repository.id ? Number(legacy[2]) : undefined;
+  const canonical = /^github-issue:(\d+)$/.exec(externalId);
+  return canonical ? Number(canonical[1]) : undefined;
+}
+
+export function reconciledIssueClosedEvent(
+  repository: ReconcileRepository,
+  issueNumber: number,
+  state: ReconcileIssueState,
+): ParsedGithubWebhook {
+  return {
+    event: 'issues',
+    // Stable per (repository, issue): the ingress dedupe makes repeat
+    // reconcile cycles replay instead of re-committing decisions.
+    deliveryId: `reconcile:${repository.id}:issue:${issueNumber}:closed`,
+    payload: {
+      action: 'closed',
+      installation: { id: repository.installationId },
+      repository: { id: repository.id, full_name: repository.fullName },
+      sender: { login: state.author ?? 'github' },
+      issue: {
+        number: issueNumber,
+        title: state.title,
+        html_url: state.url,
+        state: 'closed',
+        ...(state.stateReason ? { state_reason: state.stateReason } : {}),
+        ...(state.createdAt ? { created_at: state.createdAt } : {}),
+        ...(state.updatedAt ? { updated_at: state.updatedAt } : {}),
+        assignees: (state.assignees ?? []).map(login => ({ login })),
+      },
+    },
+  };
 }
 
 export function reconciledClosedEvent(
@@ -552,16 +628,31 @@ async function retireReconciledSubscriptions(
 export function createGithubPullRequestReconciler(
   options: GithubRulesOptions,
   fetchPullRequest: GithubPullRequestFetcher,
+  fetchIssue?: GithubIssueFetcher,
 ): GithubPullRequestReconciler {
   const rules = new GithubRules(options);
   return async repositories => {
-    const summary: ReconcileSweepSummary = { repositories: 0, checked: 0, merged: 0, closed: 0, failed: 0, errors: [] };
-    const recordFailure = (repository: ReconcileRepository, error: unknown, pullRequestNumber?: number) => {
+    const summary: ReconcileSweepSummary = {
+      repositories: 0,
+      checked: 0,
+      merged: 0,
+      closed: 0,
+      issuesChecked: 0,
+      issuesClosed: 0,
+      failed: 0,
+      errors: [],
+    };
+    const recordFailure = (
+      repository: ReconcileRepository,
+      error: unknown,
+      numbers?: { pullRequestNumber?: number; issueNumber?: number },
+    ) => {
       summary.failed += 1;
       if (summary.errors.length < RECONCILE_ERROR_SAMPLE_LIMIT) {
         summary.errors.push({
           repository: repository.fullName,
-          ...(pullRequestNumber === undefined ? {} : { pullRequestNumber }),
+          ...(numbers?.pullRequestNumber === undefined ? {} : { pullRequestNumber: numbers.pullRequestNumber }),
+          ...(numbers?.issueNumber === undefined ? {} : { issueNumber: numbers.issueNumber }),
           error: error instanceof Error ? error.message : String(error),
         });
       }
@@ -582,6 +673,7 @@ export function createGithubPullRequestReconciler(
       // One broken repository (or a failing token exchange for its
       // installation) must not abort the sweep for the others.
       let cardsByNumber: Map<number, WorkItemRow[]>;
+      const issueNumbers = new Set<number>();
       try {
         const projects = await options.sourceControl.projectRepositories.listByExternalRepository({
           installationExternalId: String(repository.installationId),
@@ -595,9 +687,15 @@ export function createGithubPullRequestReconciler(
             factoryProjectId: project.factoryProjectId,
           });
           for (const item of items) {
+            const stage = item.stages[0];
+            if (fetchIssue) {
+              const issueNumber = reconcilableIssueNumber(item, repository);
+              // Issue cards need no metadata sync: only cards still on the
+              // board can have missed a close, so terminal stages are final.
+              if (issueNumber && stage !== 'done' && stage !== 'canceled') issueNumbers.add(issueNumber);
+            }
             const pullRequestNumber = reconcilablePullRequestNumber(item, repository);
             if (!pullRequestNumber) continue;
-            const stage = item.stages[0];
             const metadata = item.metadata ?? {};
             const hasReconciledMetadata =
               (metadata.state === 'open' || metadata.state === 'closed') &&
@@ -650,7 +748,7 @@ export function createGithubPullRequestReconciler(
                 },
               });
             } catch (error) {
-              recordFailure(repository, error, pullRequestNumber);
+              recordFailure(repository, error, { pullRequestNumber });
             }
           }
           if (state.state !== 'closed') continue;
@@ -659,7 +757,23 @@ export function createGithubPullRequestReconciler(
           if (state.merged) summary.merged += 1;
           else summary.closed += 1;
         } catch (error) {
-          recordFailure(repository, error, pullRequestNumber);
+          recordFailure(repository, error, { pullRequestNumber });
+        }
+      }
+      if (!fetchIssue) continue;
+      for (const issueNumber of issueNumbers) {
+        try {
+          const state = await fetchIssue({
+            installationId: repository.installationId,
+            repository: repository.fullName,
+            number: issueNumber,
+          });
+          summary.issuesChecked += 1;
+          if (!state || state.state !== 'closed') continue;
+          await rules.ingest(reconciledIssueClosedEvent(repository, issueNumber, state));
+          summary.issuesClosed += 1;
+        } catch (error) {
+          recordFailure(repository, error, { issueNumber });
         }
       }
     }
@@ -696,8 +810,9 @@ export function attachGithubReconciler(
   github: GithubRulesIntegration,
   context: IntegrationContext,
   fetchPullRequest: GithubPullRequestFetcher,
+  fetchIssue?: GithubIssueFetcher,
 ): GithubPullRequestReconciler | undefined {
   const options = githubRulesOptions(github, context);
   if (!options) return undefined;
-  return createGithubPullRequestReconciler(options, fetchPullRequest);
+  return createGithubPullRequestReconciler(options, fetchPullRequest, fetchIssue);
 }

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -85,6 +85,22 @@ function eventName(parsed: ParsedGithubWebhook): FactoryGithubEventName | undefi
   return undefined;
 }
 
+/**
+ * Canonical source keys (`github-issue:N`, `github-pr:N`) do not identify a
+ * repository, so a project linked to several repositories could bind repo A's
+ * event to repo B's same-numbered card. The card's intake-stamped URL is
+ * authoritative; the intake-stamped `githubRepositoryId` covers URL-less
+ * cards. A card with neither signal cannot be attributed by number alone.
+ */
+function cardBelongsToRepository(item: WorkItemRow, repositoryId: number, repositoryFullName: string): boolean {
+  const url = item.externalSource?.url;
+  if (url) {
+    const match = /^https?:\/\/[^/]+\/(.+)\/(?:issues|pull)\/\d+(?:[/?#]|$)/.exec(url);
+    if (match) return match[1] === repositoryFullName;
+  }
+  return item.metadata?.githubRepositoryId === repositoryId;
+}
+
 function canonicalSourceKey(kind: 'issue' | 'pull-request', itemNumber: number): string {
   return kind === 'issue' ? `github-issue:${itemNumber}` : `github-pr:${itemNumber}`;
 }
@@ -221,6 +237,7 @@ export class GithubRules {
       project.orgId,
       project.factoryProjectId,
       repositoryId,
+      repositoryName,
       issueNumber,
       pullRequestNumber,
       string(object(pullRequest?.head)?.ref),
@@ -378,6 +395,7 @@ export class GithubRules {
     orgId: string,
     projectId: string,
     repositoryId: number,
+    repositoryFullName: string,
     issueNumber: number | undefined,
     pullRequestNumber: number | undefined,
     pullRequestHeadBranch: string | undefined,
@@ -387,13 +405,20 @@ export class GithubRules {
     if (provenance) return items.find(item => item.id === provenance.workItemId);
     if (issueNumber) {
       return (
-        items.find(item => item.externalSource?.externalId === canonicalSourceKey('issue', issueNumber)) ??
-        items.find(item => item.externalSource?.externalId === legacySourceKey(repositoryId, 'issue', issueNumber))
+        items.find(
+          item =>
+            item.externalSource?.externalId === canonicalSourceKey('issue', issueNumber) &&
+            cardBelongsToRepository(item, repositoryId, repositoryFullName),
+        ) ?? items.find(item => item.externalSource?.externalId === legacySourceKey(repositoryId, 'issue', issueNumber))
       );
     }
     if (pullRequestNumber) {
       return (
-        items.find(item => item.externalSource?.externalId === canonicalSourceKey('pull-request', pullRequestNumber)) ??
+        items.find(
+          item =>
+            item.externalSource?.externalId === canonicalSourceKey('pull-request', pullRequestNumber) &&
+            cardBelongsToRepository(item, repositoryId, repositoryFullName),
+        ) ??
         items.find(
           item => item.externalSource?.externalId === legacySourceKey(repositoryId, 'pull-request', pullRequestNumber),
         ) ??
@@ -516,8 +541,10 @@ function reconcilablePullRequestNumber(item: WorkItemRow, repository: ReconcileR
 
 /**
  * Extracts the issue number a work item tracks, but only when the item
- * belongs to the given repository — same repository-pinning contract as
- * {@link reconcilablePullRequestNumber}.
+ * belongs to the given repository. Stricter than
+ * {@link reconcilablePullRequestNumber}: a canonical key with no URL is only
+ * trusted when the intake-stamped `githubRepositoryId` confirms the
+ * repository, because the sweep initiates closes on its own.
  */
 function reconcilableIssueNumber(item: WorkItemRow, repository: ReconcileRepository): number | undefined {
   if (item.externalSource?.type !== 'issue') return undefined;
@@ -531,7 +558,11 @@ function reconcilableIssueNumber(item: WorkItemRow, repository: ReconcileReposit
   const legacy = /^github:(\d+):issue:(\d+)$/.exec(externalId);
   if (legacy) return Number(legacy[1]) === repository.id ? Number(legacy[2]) : undefined;
   const canonical = /^github-issue:(\d+)$/.exec(externalId);
-  return canonical ? Number(canonical[1]) : undefined;
+  if (!canonical) return undefined;
+  // Canonical keys carry no repository; only the intake-stamped repository id
+  // can attribute a URL-less card, and guessing would let a multi-repo
+  // project close repo B's card because repo A's same-numbered issue closed.
+  return item.metadata?.githubRepositoryId === repository.id ? Number(canonical[1]) : undefined;
 }
 
 export function reconciledIssueClosedEvent(

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -96,8 +96,10 @@ function cardBelongsToRepository(item: WorkItemRow, repositoryId: number, reposi
   const url = item.externalSource?.url;
   if (url) {
     const match = /^https?:\/\/[^/]+\/(.+)\/(?:issues|pull)\/\d+(?:[/?#]|$)/.exec(url);
-    if (match) return match[1] === repositoryFullName;
+    if (match && match[1] === repositoryFullName) return true;
   }
+  // A renamed repository leaves the old owner/name in the card URL, so a URL
+  // mismatch still defers to the stable intake-stamped repository id.
   return item.metadata?.githubRepositoryId === repositoryId;
 }
 
@@ -552,7 +554,10 @@ function reconcilableIssueNumber(item: WorkItemRow, repository: ReconcileReposit
   if (url) {
     const match = /^https?:\/\/[^/]+\/(.+)\/issues\/(\d+)(?:[/?#]|$)/.exec(url);
     if (!match) return undefined;
-    return match[1] === repository.fullName ? Number(match[2]) : undefined;
+    // A renamed repository leaves the old owner/name in the card URL, so a
+    // URL mismatch still defers to the stable intake-stamped repository id.
+    const belongs = match[1] === repository.fullName || item.metadata?.githubRepositoryId === repository.id;
+    return belongs ? Number(match[2]) : undefined;
   }
   const externalId = item.externalSource.externalId;
   const legacy = /^github:(\d+):issue:(\d+)$/.exec(externalId);

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -48,7 +48,7 @@ import type { GithubIssueTriageInput, GithubIssueTriageResult } from '../../gith
 import { runGithubIssueTriage } from '../../github/issue-triage.js';
 import { buildGithubRoutes } from '../../github/routes.js';
 import { attachGithubReconciler, attachGithubRules } from '../../github/rules.js';
-import type { ReconcilePullRequestState } from '../../github/rules.js';
+import type { ReconcileIssueState, ReconcilePullRequestState } from '../../github/rules.js';
 import {
   createGithubSubscriptionTools,
   parseCreatedPullRequest,
@@ -705,7 +705,12 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         storage: ctx.storage.generic as unknown as PlatformGithubEventStorage,
         ingestFactoryEvent: attachGithubRules(this, ctx),
         reconcileFactoryState: this.#reconcileEnabled
-          ? attachGithubReconciler(this, ctx, input => this.fetchPullRequestState(input))
+          ? attachGithubReconciler(
+              this,
+              ctx,
+              input => this.fetchPullRequestState(input),
+              input => this.fetchIssueState(input),
+            )
           : undefined,
         pollEventsEnabled: this.#pollingEnabled,
         intervalMs: this.#pollingIntervalMs,
@@ -762,6 +767,53 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         ...(result.user?.login ? { author: result.user.login } : {}),
         ...(result.created_at ? { createdAt: result.created_at } : {}),
         ...(result.merged_by?.login ? { mergedBy: result.merged_by.login } : {}),
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Reads live issue state through the Platform GitHub proxy for the
+   * reconciler. Returns undefined when the issue cannot be resolved (missing,
+   * is actually a PR, proxy error) so a sweep never fabricates a close.
+   */
+  async fetchIssueState(input: {
+    installationId: number;
+    repository: string;
+    number: number;
+  }): Promise<ReconcileIssueState | undefined> {
+    let repository: { owner: string; repo: string };
+    try {
+      repository = splitRepository(input.repository);
+    } catch {
+      return undefined;
+    }
+    try {
+      const result = await this.#client.request<{
+        title?: string;
+        html_url?: string;
+        state?: string;
+        state_reason?: string | null;
+        created_at?: string;
+        updated_at?: string;
+        user?: { login?: string } | null;
+        assignees?: Array<{ login?: string }> | null;
+        pull_request?: unknown;
+      }>(
+        'GET',
+        `${API_PREFIX}/github/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/issues/${input.number}`,
+      );
+      if (result.pull_request) return undefined;
+      return {
+        title: result.title ?? `Issue ${input.number}`,
+        url: result.html_url ?? `https://github.com/${input.repository}/issues/${input.number}`,
+        state: result.state === 'closed' ? 'closed' : 'open',
+        ...(result.state_reason ? { stateReason: result.state_reason } : {}),
+        assignees: (result.assignees ?? []).flatMap(assignee => (assignee.login ? [assignee.login] : [])),
+        ...(result.user?.login ? { author: result.user.login } : {}),
+        ...(result.created_at ? { createdAt: result.created_at } : {}),
+        ...(result.updated_at ? { updatedAt: result.updated_at } : {}),
       };
     } catch {
       return undefined;

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -161,6 +161,29 @@ function issueOpened(context: FactoryGithubRuleContext) {
   } as const;
 }
 
+function issueClosed(context: FactoryGithubRuleContext) {
+  if (!context.item || context.item.source !== 'github-issue' || !context.issue) return;
+  if (context.board !== 'work') return;
+  // Already off the board: nothing to reconcile.
+  if (context.item.stages.some(stage => stage === 'done' || stage === 'canceled')) return;
+  // Issue closure is a repository fact, not third-party input — no actor trust
+  // gate. `not_planned` (and `duplicate`) means abandoned, everything else is
+  // completed work.
+  const canceled = context.issue.stateReason === 'not_planned' || context.issue.stateReason === 'duplicate';
+  return {
+    type: 'transition',
+    idempotencyKey: `${context.ingress.id}:issue-closed`,
+    board: 'work',
+    stage: canceled ? 'canceled' : 'done',
+    message: {
+      text:
+        `GitHub issue #${context.issue.number} was closed` +
+        `${context.issue.stateReason ? ` (${context.issue.stateReason})` : ''}; ` +
+        `this Work card was moved to ${canceled ? 'Canceled' : 'Done'}.`,
+    },
+  } as const;
+}
+
 function pullRequestOpened(context: FactoryGithubRuleContext) {
   if (!context.pullRequest) return;
   return {
@@ -303,6 +326,7 @@ const BUILT_IN_DEFAULTS: FactoryRulesOverrides = {
   github: {
     issueOpened: { onEvent: issueOpened },
     issueEdited: { onEvent: retriageGithubIssue },
+    issueClosed: { onEvent: issueClosed },
     issueCommentCreated: { onEvent: retriageGithubIssue },
     issueCommentEdited: { onEvent: retriageGithubIssue },
     issueCommentDeleted: { onEvent: retriageGithubIssue },

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -12,6 +12,7 @@ export type FactoryRuleSource = (typeof FACTORY_RULE_SOURCES)[number];
 export const FACTORY_GITHUB_EVENTS = [
   'issueOpened',
   'issueEdited',
+  'issueClosed',
   'issueCommentCreated',
   'issueCommentEdited',
   'issueCommentDeleted',
@@ -108,6 +109,9 @@ export interface FactoryGithubRuleContext extends FactoryRuleContextBase {
     createdAt?: string;
     updatedAt?: string;
     assignees?: string[];
+    state?: 'open' | 'closed';
+    /** GitHub close reason: `completed`, `not_planned`, or `duplicate`. */
+    stateReason?: string;
   };
   issueChange?: { title: boolean; body: boolean };
   issueComment?: {


### PR DESCRIPTION
## Summary

Work items on the Factory Work board that are backed by GitHub issues currently stay on the board forever, even after the issue is closed. This happens for two reasons:

1. The Factory rules engine ignores `issues`/`closed` webhooks entirely — the event was never mapped, so a live close does nothing.
2. The periodic GitHub reconcile sweep (which recovers missed PR merge/close webhooks) only checks PR-backed cards, so a close missed while a deployment was unreachable is never recovered for issues.

This PR fixes both paths:

- **New `issueClosed` event**: `issues`/`closed` webhooks map to a new `issueClosed` Factory event; the issue rule context now carries `state` and `stateReason`.
- **Default rule**: an `issueClosed` event moves the issue-backed Work card to **Done**, or **Canceled** when the issue was closed as `not_planned` or `duplicate`. Cards already in a terminal stage are skipped. No actor-trust gating is applied since issue closure state is a repository fact.
- **Reconcile sweep**: the existing GitHub reconciler now also collects open issue-backed cards, fetches live issue state, and replays a synthetic `issueClosed` event with a stable delivery id (`reconcile:{repo}:issue:{n}:closed`) so repeat sweeps dedupe through the normal event ingress. The sweep summary gains `issuesChecked`/`issuesClosed` counters.
- **Integrations**: `fetchIssueState` is wired in both the self-hosted GitHub integration (octokit) and the platform integration (proxy API) and passed to the reconcile worker.

Existing stale cards are cleaned up automatically on the next reconcile cycle after deploying.

## Test plan

- `rules.test.ts`: 35/35 — new tests covering the `issueClosed` rule (done / canceled / terminal-skip), the reconciler replaying missed closes, `not_planned` cancellation, skipping terminal and still-open cards, and failure reporting
- `reconcile-worker.test.ts` updated for the extended sweep summary
- Full `@mastra/factory` suite: 1309/1311 (2 pre-existing `work-items/base.test.ts` locking-timeout failures reproduce on a clean tree)
- `tsc --noEmit` and lint clean
- Changeset: `@mastra/factory` patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a GitHub issue closes, this PR updates the matching Factory Work card. It also checks for missed closures so the board stays accurate and does not mix up issues from different repositories.

## Changes

- Added the `issueClosed` GitHub event with issue `state` and `stateReason`.
- Moves linked Work cards to `done` when issues close.
- Moves cards to `canceled` for `not_planned` and `duplicate` closures.
- Skips cards that are already in a terminal state.
- Reconciles open issue-backed cards during the GitHub sweep.
- Uses the issue URL or intake-stamped repository ID to verify the repository, including after repository renames.
- Replays missed issue closures with stable delivery IDs.
- Added `fetchIssueState` to self-hosted and platform GitHub integrations.
- Added `issuesChecked` and `issuesClosed` reconciliation counters.
- Added tests and a patch changeset.
- TypeScript and lint checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->