### PR TITLE
fix(core): map step-array form resolves to null for falsy branch-arm output

### DIFF
--- a/.changeset/fix-workflow-map-step-array-falsy.md
+++ b/.changeset/fix-workflow-map-step-array-falsy.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix the workflow `.map()` step-array form resolving to `null` when the executed branch arm returns a falsy value. The mapping selected the executed arm with a truthiness/emptiness check, which dropped valid falsy outputs (`{}`, `0`, `false`, `""`) and left the mapping as `null`. It now selects the arm whose `getStepResult` is not `null`, matching how step results are marked.
+Fixed workflow `.map()` step arrays so they preserve branch results of `{}`, `0`, `false`, and empty strings instead of returning `null`.

--- a/.changeset/fix-workflow-map-step-array-falsy.md
+++ b/.changeset/fix-workflow-map-step-array-falsy.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix the workflow `.map()` step-array form resolving to `null` when the executed branch arm returns a falsy value. The mapping selected the executed arm with a truthiness/emptiness check, which dropped valid falsy outputs (`{}`, `0`, `false`, `""`) and left the mapping as `null`. It now selects the arm whose `getStepResult` is not `null`, matching how step results are marked.

--- a/packages/core/src/workflows/branch-map-bug.test.ts
+++ b/packages/core/src/workflows/branch-map-bug.test.ts
@@ -148,48 +148,4 @@ describe('Branch with Map Bug - Issue #10407', () => {
     expect(stepKeys).toContain('branch-alpha.step-a');
     expect(stepKeys).toContain('branch-alpha.step-b');
   });
-
-  it('maps a branch arm whose output is an empty object, not null', async () => {
-    const inputSchema = z.object({ route: z.string() });
-    // Arm output is a valid but "empty" object. The step-array map form must
-    // resolve to {} (the arm that actually ran), not null.
-    const emptyOutputSchema = z.object({});
-
-    const armEmpty = createStep({
-      id: 'arm-empty',
-      inputSchema,
-      outputSchema: emptyOutputSchema,
-      execute: async () => ({}),
-    });
-
-    const armOther = createStep({
-      id: 'arm-other',
-      inputSchema,
-      outputSchema: emptyOutputSchema,
-      execute: async () => ({}),
-    });
-
-    const wf = createWorkflow({
-      id: 'branch-map-empty-object',
-      inputSchema,
-      outputSchema: z.object({ picked: emptyOutputSchema }),
-    })
-      .branch([
-        [async ({ inputData }) => inputData.route === 'empty', armEmpty],
-        [async ({ inputData }) => inputData.route === 'other', armOther],
-      ])
-      .map({
-        picked: { step: [armEmpty, armOther], path: '.' },
-      })
-      .commit();
-
-    const run = await wf.createRun();
-    const result = await run.start({ inputData: { route: 'empty' } });
-
-    expect(result.status).toBe('success');
-    if (result.status === 'success') {
-      expect(result.result.picked).toEqual({});
-      expect(result.result.picked).not.toBeNull();
-    }
-  });
 });

--- a/packages/core/src/workflows/branch-map-bug.test.ts
+++ b/packages/core/src/workflows/branch-map-bug.test.ts
@@ -148,4 +148,48 @@ describe('Branch with Map Bug - Issue #10407', () => {
     expect(stepKeys).toContain('branch-alpha.step-a');
     expect(stepKeys).toContain('branch-alpha.step-b');
   });
+
+  it('maps a branch arm whose output is an empty object, not null', async () => {
+    const inputSchema = z.object({ route: z.string() });
+    // Arm output is a valid but "empty" object. The step-array map form must
+    // resolve to {} (the arm that actually ran), not null.
+    const emptyOutputSchema = z.object({});
+
+    const armEmpty = createStep({
+      id: 'arm-empty',
+      inputSchema,
+      outputSchema: emptyOutputSchema,
+      execute: async () => ({}),
+    });
+
+    const armOther = createStep({
+      id: 'arm-other',
+      inputSchema,
+      outputSchema: emptyOutputSchema,
+      execute: async () => ({}),
+    });
+
+    const wf = createWorkflow({
+      id: 'branch-map-empty-object',
+      inputSchema,
+      outputSchema: z.object({ picked: emptyOutputSchema }),
+    })
+      .branch([
+        [async ({ inputData }) => inputData.route === 'empty', armEmpty],
+        [async ({ inputData }) => inputData.route === 'other', armOther],
+      ])
+      .map({
+        picked: { step: [armEmpty, armOther], path: '.' },
+      })
+      .commit();
+
+    const run = await wf.createRun();
+    const result = await run.start({ inputData: { route: 'empty' } });
+
+    expect(result.status).toBe('success');
+    if (result.status === 'success') {
+      expect(result.result.picked).toEqual({});
+      expect(result.result.picked).not.toBeNull();
+    }
+  });
 });

--- a/packages/core/src/workflows/entry-executors/run-mapping-entry.test.ts
+++ b/packages/core/src/workflows/entry-executors/run-mapping-entry.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MappingStepEntry } from '../types';
+import { runMappingEntry } from './run-mapping-entry';
+import type { EntryExecuteContext } from './types';
+
+const falsyOutputs: Array<{
+  name: string;
+  output: Record<string, never> | 0 | false | '';
+}> = [
+  { name: 'an empty object', output: {} },
+  { name: 'zero', output: 0 },
+  { name: 'false', output: false },
+  { name: 'an empty string', output: '' },
+];
+
+describe('runMappingEntry', () => {
+  it.each(falsyOutputs)('preserves $name from the successful step in an array', async ({ output }) => {
+    const skippedStep = { id: 'skipped-step' };
+    const successfulStep = { id: 'successful-step' };
+    const getStepResult = vi.fn((step: { id: string }) => (step === successfulStep ? output : null));
+    const entry = {
+      type: 'mapping',
+      id: 'mapping-step',
+      mapConfig: {
+        picked: { step: [skippedStep, successfulStep], path: '.' },
+      },
+    } as unknown as MappingStepEntry;
+    const ctx = {
+      getStepResult,
+      getInitData: vi.fn(),
+      requestContext: { get: vi.fn() },
+    } as unknown as EntryExecuteContext;
+
+    await expect(runMappingEntry(entry, ctx)).resolves.toEqual({ picked: output });
+    expect(getStepResult).toHaveBeenCalledWith(successfulStep);
+  });
+});

--- a/packages/core/src/workflows/entry-executors/run-mapping-entry.ts
+++ b/packages/core/src/workflows/entry-executors/run-mapping-entry.ts
@@ -43,13 +43,11 @@ export async function runMappingEntry(entry: MappingStepEntry, ctx: EntryExecute
       ? getInitData()
       : getStepResult(
           Array.isArray(m.step)
-            ? m.step.find((s: any) => {
-                const stepRes = getStepResult(s);
-                if (typeof stepRes === 'object' && stepRes !== null) {
-                  return Object.keys(stepRes).length > 0;
-                }
-                return stepRes;
-              })
+            ? // getStepResult returns null for any arm that did not run successfully,
+              // and the arm's real output (including {}, 0, false, '') for the one that
+              // did. So `!== null` is the correct "which arm executed" test; a
+              // truthiness/emptiness check drops valid falsy outputs. See #20894.
+              m.step.find((s: any) => getStepResult(s) !== null)
             : m.step,
         );
 


### PR DESCRIPTION
Fixes #20894

## Description

The array form of a workflow `.map()` mapping (`{ step: [armA, armB], path }`, used after `.branch()` to pick whichever arm ran) resolved to `null` instead of the real output whenever the executed arm returned a falsy-but-valid value: `{}`, `0`, `false`, or `""`. This is silent data loss in the workflow output.

## Root cause

In `packages/core/src/workflows/entry-executors/run-mapping-entry.ts`, the `.find` that selects the executed arm filtered on truthiness / non-empty-object, so an arm returning `{}` (empty-object check) or `0`/`false`/`""` (truthiness check) was skipped. `.find` then returned `undefined` and the mapping resolved to `null`.

`getStepResult` (`workflows/step.ts:192`) already returns `null` for any arm that did not run successfully, and the arm's real `output` (including the falsy values above) for the one that did. So the correct "which arm executed" test is `getStepResult(s) !== null`.

## Fix

Select the executed arm with `getStepResult(s) !== null` instead of the truthiness/emptiness proxy.

## Tests

Adds a regression test to `branch-map-bug.test.ts`: a `.branch` whose executed arm outputs `{}`, followed by a `.map({ picked: { step: [arms], path: '.' } })`, must resolve `picked` to `{}` (not `null`). Verified failing before the fix and passing after. The full `src/workflows` suite (1145 tests) passes; the new file type-checks clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Workflow mappings now keep valid results such as `{}`, `0`, `false`, and `""` instead of replacing them with `null`. The fix correctly identifies which branch ran.

## Changes

- Updated `runMappingEntry` to select the executed step when `getStepResult(s) !== null`.
- Added regression tests for all supported falsy outputs.
- Added a patch changeset for `@mastra/core`.

## Validation

- Workflow test suite passes.
- Type checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->