### PR TITLE
Document step-level scorers and retries configuration

### DIFF
--- a/docs/src/content/en/docs/evals/overview.mdx
+++ b/docs/src/content/en/docs/evals/overview.mdx
@@ -65,7 +65,7 @@ export const evaluatedAgent = new Agent({
 
 ### Adding scorers to workflow steps
 
-You can also add scorers to individual workflow steps to evaluate outputs at specific points in your process:
+You can also add scorers to individual workflow steps to evaluate outputs at specific points in your process. Each scorer receives that step's own input and output, so you can measure where quality changes across a multi-step or RAG workflow instead of only scoring the final answer:
 
 ```typescript title="src/mastra/workflows/content-generation.ts" prettier:false
 import { createWorkflow, createStep } from "@mastra/core/workflows";
@@ -73,21 +73,33 @@ import { z } from "zod";
 import { customStepScorer } from "../scorers/custom-step-scorer";
 
 const contentStep = createStep({
+  id: "content-step",
+  inputSchema: z.object({ topic: z.string() }),
+  outputSchema: z.object({ content: z.string() }),
   scorers: {
     customStepScorer: {
       scorer: customStepScorer(),
       sampling: {
         type: "ratio",
         rate: 1, // Score every step execution
-      }
-    }
+      },
+    },
+  },
+  execute: async ({ inputData }) => {
+    return { content: await generateContent(inputData.topic) };
   },
 });
 
-export const contentWorkflow = createWorkflow({ ... })
+export const contentWorkflow = createWorkflow({
+  id: "content-workflow",
+  inputSchema: z.object({ topic: z.string() }),
+  outputSchema: z.object({ content: z.string() }),
+})
   .then(contentStep)
   .commit();
 ```
+
+For the step-level `scorers` API, see the [Step class reference](/reference/workflows/step#scoring-step-output).
 
 ### How live evaluations work
 

--- a/docs/src/content/en/docs/evals/overview.mdx
+++ b/docs/src/content/en/docs/evals/overview.mdx
@@ -65,7 +65,7 @@ export const evaluatedAgent = new Agent({
 
 ### Adding scorers to workflow steps
 
-You can also add scorers to individual workflow steps to evaluate outputs at specific points in your process. Each scorer receives that step's own input and output, so you can measure where quality changes across a multi-step or RAG workflow instead of only scoring the final answer:
+You can also add scorers to individual workflow steps to evaluate outputs at specific points in your process. Each scorer receives that step's own input and output, so you can measure quality at each step instead of only scoring the final answer:
 
 ```typescript title="src/mastra/workflows/content-generation.ts" prettier:false
 import { createWorkflow, createStep } from "@mastra/core/workflows";

--- a/docs/src/content/en/reference/workflows/step.mdx
+++ b/docs/src/content/en/reference/workflows/step.mdx
@@ -310,7 +310,7 @@ const agentStep = createStep(testAgent, {
     name: 'scorers',
     type: 'MastraScorers | (({ requestContext }) => MastraScorers | Promise<MastraScorers>)',
     description:
-      "Scorers that run automatically after the step completes successfully. Each scorer evaluates the step's own input and output, and the results are stored and attached to the step's trace. Provide a map of `{ [name]: { scorer, sampling? } }`, or a function that returns one. Scoring runs asynchronously and does not block the workflow. See [Scoring step output](#scoring-step-output).",
+      "Scorers that run automatically after the step completes successfully. Each scorer evaluates the step's own input and output, and the results are stored and attached to the step's trace. Provide a map of `{ [name]: { scorer, sampling? } }`, or a function that returns one. Scoring runs asynchronously and doesn't block the workflow. See [Scoring step output](#scoring-step-output).",
     required: false,
   },
   {
@@ -333,7 +333,7 @@ const agentStep = createStep(testAgent, {
 
 Attach `scorers` to a step to evaluate that step's output automatically, at the point it runs, instead of only scoring the workflow's final answer. This is useful for multi-step and RAG workflows, where you want to see which step degraded quality, for example whether a retrieval step returned relevant chunks before later steps reason over them.
 
-Each scorer receives the step's own `input` and `output`, runs asynchronously after the step succeeds, and stores its result against the step's trace. Use `sampling` to control how often a scorer runs.
+Each scorer receives the step's own `input` and `output`. Scoring runs asynchronously after the step succeeds, and the result is stored against the step's trace. Use `sampling` to control how often a scorer runs.
 
 The following example attaches a scorer to a retrieval step so every execution is scored:
 

--- a/docs/src/content/en/reference/workflows/step.mdx
+++ b/docs/src/content/en/reference/workflows/step.mdx
@@ -307,6 +307,19 @@ const agentStep = createStep(testAgent, {
     ],
   },
   {
+    name: 'scorers',
+    type: 'MastraScorers | (({ requestContext }) => MastraScorers | Promise<MastraScorers>)',
+    description:
+      "Scorers that run automatically after the step completes successfully. Each scorer evaluates the step's own input and output, and the results are stored and attached to the step's trace. Provide a map of `{ [name]: { scorer, sampling? } }`, or a function that returns one. Scoring runs asynchronously and does not block the workflow. See [Scoring step output](#scoring-step-output).",
+    required: false,
+  },
+  {
+    name: 'retries',
+    type: 'number',
+    description: "Number of times to retry the step's `execute` function if it throws.",
+    required: false,
+  },
+  {
     name: 'metadata',
     type: 'Record<string, any>',
     description:
@@ -315,6 +328,44 @@ const agentStep = createStep(testAgent, {
   },
 ]}
 />
+
+## Scoring step output
+
+Attach `scorers` to a step to evaluate that step's output automatically, at the point it runs, instead of only scoring the workflow's final answer. This is useful for multi-step and RAG workflows, where you want to see which step degraded quality, for example whether a retrieval step returned relevant chunks before later steps reason over them.
+
+Each scorer receives the step's own `input` and `output`, runs asynchronously after the step succeeds, and stores its result against the step's trace. Use `sampling` to control how often a scorer runs.
+
+The following example attaches a scorer to a retrieval step so every execution is scored:
+
+```typescript title="src/mastra/workflows/rag-workflow.ts" prettier:false
+import { createStep } from '@mastra/core/workflows'
+import { z } from 'zod'
+import { retrievalRelevanceScorer } from '../scorers/retrieval-relevance'
+
+const retrievalStep = createStep({
+  id: 'retrieval',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.object({ query: z.string(), chunks: z.array(z.string()) }),
+  scorers: {
+    retrievalRelevance: {
+      scorer: retrievalRelevanceScorer(),
+      sampling: { type: 'ratio', rate: 1 },
+    },
+  },
+  execute: async ({ inputData }) => {
+    const chunks = await retrieve(inputData.query)
+    return { query: inputData.query, chunks }
+  },
+})
+```
+
+Attach a scorer to each step you want to measure to build per-step scores across a multi-step workflow. Because scoring is scoped to a single step, you don't need a dedicated cross-step metric to see where quality changes.
+
+Agent and tool steps added with [`Workflow.agent()`](/reference/workflows/workflow-methods/agent) and [`Workflow.tool()`](/reference/workflows/workflow-methods/tool) accept the same `scorers` option in their step options.
+
+:::note
+Visit the [Scorers overview](/docs/evals/overview) to learn how live evaluations run and where results are stored, and [Custom scorers](/docs/evals/custom-scorers) to build your own.
+:::
 
 ## Related
 


### PR DESCRIPTION
## Description

This PR adds documentation for two new step configuration options in the Mastra workflows API:

1. **`scorers`** - Allows attaching scorers to individual workflow steps to evaluate outputs at specific points in multi-step and RAG workflows, rather than only scoring the final answer. Scorers run asynchronously after step completion and store results against the step's trace.

2. **`retries`** - Configures the number of retry attempts for a step's `execute` function if it throws an error.

The changes include:
- Added parameter documentation for both options in the Step reference
- New "Scoring step output" section in the Step reference with a practical example showing how to attach a scorer to a retrieval step
- Updated the Evals overview documentation with a more complete example of step-level scorers and clarification that each scorer receives the step's own input/output
- Cross-references between the Step reference and Evals documentation

## Related issue(s)

<!-- Link to the issue this addresses -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test Plan

N/A - Documentation only changes

https://claude.ai/code/session_01R16b52bK6mtEmB4ibwRGtb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR explains how to configure retries and scoring for workflow steps. It shows how scorers evaluate each step’s input and output.

## Documentation changes

- Documented the `scorers` and `retries` parameters in the Step reference.
- Added an example for scoring step output, including sampling and agent/tool-created steps.
- Expanded the Evals overview with typed `createStep` and `createWorkflow` examples.
- Clarified that scorers receive each step’s own input and output.
- Added cross-references between the Step and Evals documentation.

No tests were added because this change only updates documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->