### PR TITLE
chore(factory-ui): start the API and Vite from one dev command

### DIFF
--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -37,14 +37,10 @@ pnpm --dir mastracode/web dev
 
 Open `http://localhost:5873`.
 
-For UI work with hot module replacement, run these in separate terminals:
-
-```shell
-pnpm --dir mastracode/web api
-```
+For UI work with hot module replacement, run the API and the Vite dev server together:
 
 ```shell
 pnpm --filter ./mastracode/factory-ui web
 ```
 
-Open `http://localhost:5173`.
+Open `http://localhost:5173`. To run them in separate terminals instead, use `web:api` and `web:ui`.

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -43,4 +43,4 @@ For UI work with hot module replacement, run the API and the Vite dev server tog
 pnpm --filter ./mastracode/factory-ui web
 ```
 
-Open `http://localhost:5173`. To run them in separate terminals instead, use `web:api` and `web:ui`.
+Open `http://localhost:5173`. To run them in separate terminals instead, use `web:api` and `dev`.

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -43,4 +43,4 @@ For UI work with hot module replacement, run the API and the Vite dev server tog
 pnpm --filter ./mastracode/factory-ui web
 ```
 
-Open `http://localhost:5173`. To run them in separate terminals instead, use `web:api` and `dev`.
+Open `http://localhost:5173`. To run them in separate terminals instead, use `pnpm --filter ./mastracode/factory-ui web:api` and `pnpm --filter ./mastracode/factory-ui dev`.

--- a/mastracode/factory-ui/AGENTS.md
+++ b/mastracode/factory-ui/AGENTS.md
@@ -1,10 +1,10 @@
-Web UI (Vite against the web host API): `pnpm --filter ./mastracode/factory-ui web`
+Dev (API on :4111 + Vite on :5173): `pnpm --filter ./mastracode/factory-ui web`
 Build: `pnpm --filter ./mastracode/factory-ui build`
 Typecheck: `pnpm --filter ./mastracode/factory-ui typecheck`
 Unit tests: `pnpm --filter ./mastracode/factory-ui test:unit`
 MSW UI tests: `pnpm --filter ./mastracode/factory-ui test:msw`
 
-This package owns the MastraCode React SPA, client data layer, Vite config, and UI tests. Its build is bundled into the Mastra CLI, not used by the web host at runtime. For split UI/API development, run `pnpm --dir mastracode/web api`, then `pnpm --dir mastracode/factory-ui web`; Vite runs on :5173 and proxies to :4111.
+This package owns the MastraCode React SPA, client data layer, Vite config, and UI tests. Its build is bundled into the Mastra CLI, not used by the web host at runtime. The `web` script runs both processes: `web:api` (the `mastracode/web` host, a standalone pnpm project outside the workspace) and `web:ui` (Vite on :5173, proxying to :4111). Run either alone to restart one side independently.
 
 Build workspace dependencies with `pnpm turbo build --filter ./mastracode/factory-ui`.
 

--- a/mastracode/factory-ui/AGENTS.md
+++ b/mastracode/factory-ui/AGENTS.md
@@ -4,9 +4,9 @@ Typecheck: `pnpm --filter ./mastracode/factory-ui typecheck`
 Unit tests: `pnpm --filter ./mastracode/factory-ui test:unit`
 MSW UI tests: `pnpm --filter ./mastracode/factory-ui test:msw`
 
-This package owns the MastraCode React SPA, client data layer, Vite config, and UI tests. Its build is bundled into the Mastra CLI, not used by the web host at runtime. The `web` script runs both processes: `web:api` (the `mastracode/web` host, a standalone pnpm project outside the workspace) and `web:ui` (Vite on :5173, proxying to :4111). Run either alone to restart one side independently.
+This package owns the MastraCode React SPA, client data layer, Vite config, and UI tests. Its build is bundled into the Mastra CLI, not used by the web host at runtime. The `web` script runs both processes: `web:api` (the `mastracode/web` host, a standalone pnpm project outside the workspace) and `dev` (Vite on :5173, proxying to :4111). Run either alone to restart one side independently.
 
-Build workspace dependencies with `pnpm turbo build --filter ./mastracode/factory-ui`.
+Build workspace dependencies with `pnpm turbo build --filter ./mastracode/factory-ui`, or `pnpm turbo run dev --filter ./mastracode/factory-ui` to build them and start Vite in one step.
 
 Primary tests use Vitest, MSW, real `@mastra/client-js`, and React Query. Mock only the network boundary—never our hooks, services, or auth gating. Unit tests run from `vitest.config.ts`; MSW UI tests use `e2e/ui/vitest.config.ts`, `e2e/ui/msw-server.ts`, and `e2e/ui/render.tsx`. Use `waitForMutationsIdle` for query chains.
 

--- a/mastracode/factory-ui/README.md
+++ b/mastracode/factory-ui/README.md
@@ -10,7 +10,7 @@ Complete the [repository setup](../README.md#setup) and [GitHub App setup](../we
 pnpm --filter ./mastracode/factory-ui web
 ```
 
-Open `http://localhost:5173`. To restart one side without losing the other, run `web:api` and `web:ui` in separate terminals.
+Open `http://localhost:5173`. To restart one side without losing the other, run `web:api` and `dev` in separate terminals.
 
 Keep policy, validation, and persistence in [`@mastra/factory`](../factory/README.md), not in React.
 

--- a/mastracode/factory-ui/README.md
+++ b/mastracode/factory-ui/README.md
@@ -10,7 +10,7 @@ Complete the [repository setup](../README.md#setup) and [GitHub App setup](../we
 pnpm --filter ./mastracode/factory-ui web
 ```
 
-Open `http://localhost:5173`. To restart one side without losing the other, run `web:api` and `dev` in separate terminals.
+Open `http://localhost:5173`. To restart one side without losing the other, run `pnpm --filter ./mastracode/factory-ui web:api` and `pnpm --filter ./mastracode/factory-ui dev` in separate terminals.
 
 Keep policy, validation, and persistence in [`@mastra/factory`](../factory/README.md), not in React.
 

--- a/mastracode/factory-ui/README.md
+++ b/mastracode/factory-ui/README.md
@@ -4,17 +4,13 @@
 
 ## Development
 
-Complete the [repository setup](../README.md#setup) and [GitHub App setup](../web/README.md#configure-local-onboarding). Then run these in separate terminals:
-
-```shell
-pnpm --dir mastracode/web api
-```
+Complete the [repository setup](../README.md#setup) and [GitHub App setup](../web/README.md#configure-local-onboarding). Then start the API and the Vite dev server:
 
 ```shell
 pnpm --filter ./mastracode/factory-ui web
 ```
 
-Open `http://localhost:5173`.
+Open `http://localhost:5173`. To restart one side without losing the other, run `web:api` and `web:ui` in separate terminals.
 
 Keep policy, validation, and persistence in [`@mastra/factory`](../factory/README.md), not in React.
 

--- a/mastracode/factory-ui/package.json
+++ b/mastracode/factory-ui/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "description": "Browser application for MastraCode: React SPA, client data layer, Vite config, and UI tests. Produces the Factory SPA bundled by the Mastra CLI.",
   "scripts": {
-    "dev": "vite --config src/vite.config.ts",
-    "web": "MASTRACODE_ENV_DIR=../web MASTRACODE_API_TARGET=${MASTRACODE_API_TARGET:-http://localhost:4111} MASTRACODE_UI_PORT=${MASTRACODE_UI_PORT:-5173} vite --config src/vite.config.ts",
+    "web": "run-p --print-label --race web:ui web:api",
+    "web:ui": "MASTRACODE_ENV_DIR=../web vite --config src/vite.config.ts",
+    "web:api": "pnpm --dir ../web api",
     "build": "vite --config src/vite.config.ts build",
     "typecheck": "tsc --noEmit -p src/ui/tsconfig.json",
     "test": "vitest run",

--- a/mastracode/factory-ui/package.json
+++ b/mastracode/factory-ui/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "description": "Browser application for MastraCode: React SPA, client data layer, Vite config, and UI tests. Produces the Factory SPA bundled by the Mastra CLI.",
   "scripts": {
-    "web": "run-p --print-label --race web:ui web:api",
-    "web:ui": "MASTRACODE_ENV_DIR=../web vite --config src/vite.config.ts",
+    "dev": "MASTRACODE_ENV_DIR=../web vite --config src/vite.config.ts",
+    "web": "run-p --print-label --race dev web:api",
     "web:api": "pnpm --dir ../web api",
     "build": "vite --config src/vite.config.ts build",
     "typecheck": "tsc --noEmit -p src/ui/tsconfig.json",

--- a/mastracode/web/README.md
+++ b/mastracode/web/README.md
@@ -64,17 +64,14 @@ Open `http://localhost:5873`.
 
 ### Split UI mode
 
-Use this for UI work. Run these in separate terminals:
-
-```shell
-pnpm --dir mastracode/web api
-```
+Use this for UI work. One command starts the API on :4111 and Vite on :5173:
 
 ```shell
 pnpm --filter ./mastracode/factory-ui web
 ```
 
-Open `http://localhost:5173`.
+Open `http://localhost:5173`. To restart one side without losing the other, run
+`web:api` and `web:ui` in separate terminals.
 
 ### Slack channels (optional)
 

--- a/mastracode/web/README.md
+++ b/mastracode/web/README.md
@@ -71,7 +71,7 @@ pnpm --filter ./mastracode/factory-ui web
 ```
 
 Open `http://localhost:5173`. To restart one side without losing the other, run
-`web:api` and `web:ui` in separate terminals.
+`web:api` and `dev` in separate terminals.
 
 ### Slack channels (optional)
 

--- a/mastracode/web/README.md
+++ b/mastracode/web/README.md
@@ -71,7 +71,8 @@ pnpm --filter ./mastracode/factory-ui web
 ```
 
 Open `http://localhost:5173`. To restart one side without losing the other, run
-`web:api` and `dev` in separate terminals.
+`pnpm --filter ./mastracode/factory-ui web:api` and
+`pnpm --filter ./mastracode/factory-ui dev` in separate terminals.
 
 ### Slack channels (optional)
 


### PR DESCRIPTION
Doing UI work on Factory meant two terminals: `pnpm --dir mastracode/web api` for the host, then `pnpm --filter ./mastracode/factory-ui web` for Vite. Now the second command does both — `web` runs `dev` and `web:api` in parallel with run-p, labelled output, and `--race` so a dying API takes Vite down with it instead of leaving a UI proxying into nothing. Both halves stay runnable on their own when you want to restart one side without losing the other.

I used run-p rather than turbo because `mastracode/web` is not a pnpm workspace member, so it is not in turbo's package graph at all — turbo cannot run its `api` script. Adding it to the workspace to make turbo work would change how a deliberately standalone, deployable project resolves its dependencies, which is a lot of blast radius for one dev command. run-p is already a root devDependency and `docs/` uses npm-run-all the same way, so nothing new is installed. `dev` stays Vite-only and keeps its turbo entry point, so `turbo run dev --filter ./mastracode/factory-ui` still builds the workspace dependencies before serving; naming the combined script `dev` would have made a repo-wide `turbo run dev` boot the API, which is why the pair lives under `web`.

Two small cleanups came along. `dev` now loads its env from `mastracode/web` like `web` always did, instead of looking in the package root. And the `MASTRACODE_API_TARGET`/`MASTRACODE_UI_PORT` prefixes are gone — they restated the defaults already in `vite.config.ts`, and a shell default silently overriding the config default is a drift trap. I verified run-p resolves and labels package scripts from factory-ui and that turbo still plans 38 dependency builds ahead of the dev task, but I have not booted the pair end-to-end — that needs the local GitHub App env and a free :4111.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The `web` command now starts the Factory UI and API together. Separate commands remain available when either process must run alone.

## Changes

- Updated Factory UI scripts:
  - `web` runs the API and Vite in parallel with labelled output.
  - `--race` stops both processes if either process exits.
  - `web:api` and `dev` remain available for separate workflows.
  - `dev` remains the Vite-only Turbo entry point.
- Removed redundant environment-variable prefixes.
- Updated documentation with:
  - Combined startup instructions.
  - API port `4111` and Vite port `5173`.
  - Separate restart commands.
  - Turbo usage for building dependencies before starting Vite.
- No tests were added.
- End-to-end startup was not verified because required GitHub App environment variables and port `4111` were unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->