### PR TITLE
fix(factory-ui): keep the workspace files panel dormant until opened

### DIFF
--- a/mastracode/factory-ui/src/hooks/use-fs.ts
+++ b/mastracode/factory-ui/src/hooks/use-fs.ts
@@ -39,11 +39,15 @@ export function useArtifactListing(path: string | undefined) {
   });
 }
 
-export function useWorkspaceRenderedListing(workspacePath: string | undefined, renderedRoot: string | undefined) {
+export function useWorkspaceRenderedListing(
+  workspacePath: string | undefined,
+  renderedRoot: string | undefined,
+  options: { enabled?: boolean } = {},
+) {
   const { client } = useApiConfig();
   return useQuery<WorkspaceRenderedListing>({
     queryKey: queryKeys.workspaceRenderedList(workspacePath, renderedRoot),
-    enabled: Boolean(workspacePath && renderedRoot),
+    enabled: Boolean(workspacePath && renderedRoot && (options.enabled ?? true)),
     queryFn: () =>
       client.get<WorkspaceRenderedListing>(
         `/web/workspace/rendered/list?workspacePath=${encodeURIComponent(workspacePath ?? '')}&root=${encodeURIComponent(renderedRoot ?? '')}`,

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceChangesPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceChangesPanel.tsx
@@ -360,16 +360,18 @@ function DiffViewer({
 export function WorkspaceChangesPanel({
   workspacePath,
   onShowFiles,
+  visible,
 }: {
   workspacePath: string;
   onShowFiles: () => void;
+  visible: boolean;
 }) {
   const [selectedPath, setSelectedPath] = useState<string | undefined>();
   const [openFolders, setOpenFolders] = useState<Record<string, boolean>>({});
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const changes = useWorkspaceChanges(workspacePath);
+  const changes = useWorkspaceChanges(workspacePath, { enabled: visible });
   const selectedChange = changes.data?.changes.find(change => change.path === selectedPath);
-  const diff = useWorkspaceDiff(workspacePath, selectedPath, selectedChange?.previousPath);
+  const diff = useWorkspaceDiff(workspacePath, selectedPath, selectedChange?.previousPath, { enabled: visible });
   const selectedDiff = diff.data?.path === selectedPath ? diff.data : undefined;
   const changeTree = buildChangeTree(changes.data?.changes ?? []);
 

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFilesContent.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFilesContent.tsx
@@ -3,7 +3,7 @@ import { useWorkspaceFiles } from '../context/useWorkspaceFiles';
 import { WorkspaceViewerPanel } from './WorkspaceViewerPanel';
 
 export function WorkspaceFilesContent() {
-  const { workspacePath, setViewingFile } = useWorkspaceFiles();
+  const { open, workspacePath, setViewingFile } = useWorkspaceFiles();
   if (!workspacePath) return null;
 
   return (
@@ -11,6 +11,7 @@ export function WorkspaceFilesContent() {
       workspacePath={workspacePath}
       renderedPaths={renderedPaths}
       onExpandedChange={setViewingFile}
+      visible={open}
     />
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFilesSurface.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFilesSurface.tsx
@@ -3,7 +3,7 @@ import { cn } from '@mastra/playground-ui/utils/cn';
 import { useWorkspaceFiles } from '../context/useWorkspaceFiles';
 import { WorkspaceFilesContent } from './WorkspaceFilesContent';
 
-/** The docked card. Stays mounted while hidden so the tree keeps its expanded folders. */
+/** The docked card. Stays mounted but dormant while hidden so the tree keeps its expanded folders. */
 export function WorkspaceFilesSurface() {
   const { open, workspacePath, viewingFile, canDock } = useWorkspaceFiles();
 

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
@@ -11,6 +11,8 @@ interface WorkspaceViewerPanelProps {
   renderedPaths: RenderedWorkspacePath[];
   /** Fires when the file viewer opens or closes, so a floating host can widen its surface. */
   onExpandedChange?: (expanded: boolean) => void;
+  /** Listing wakes the session's sandbox — a host that keeps the panel mounted off-screen passes `false`. */
+  visible?: boolean;
 }
 
 export function WorkspaceViewerPanel({ workspacePath, renderedPaths, ...props }: WorkspaceViewerPanelProps) {
@@ -36,6 +38,7 @@ function WorkspaceViewerPanelInner({
   renderedPaths,
   onExpandedChange,
   onShowChanges,
+  visible = true,
 }: WorkspaceViewerPanelProps & { onShowChanges: () => void }) {
   const [selectedRenderedPathId, setSelectedRenderedPathId] = useState(renderedPaths[0]?.id ?? '');
   const [selectedFilePath, setSelectedFilePath] = useState<string | undefined>();
@@ -43,8 +46,8 @@ function WorkspaceViewerPanelInner({
 
   const selectedRenderedPath = renderedPaths.find(path => path.id === selectedRenderedPathId) ?? renderedPaths[0];
   const selectedFileRequestPath = selectedFilePath ? `${selectedRenderedPath?.root}/${selectedFilePath}` : undefined;
-  const listing = useWorkspaceRenderedListing(workspacePath, selectedRenderedPath?.root);
-  const file = useWorkspaceFile(workspacePath, selectedFileRequestPath, { enabled: viewerOpen });
+  const listing = useWorkspaceRenderedListing(workspacePath, selectedRenderedPath?.root, { enabled: visible });
+  const file = useWorkspaceFile(workspacePath, selectedFileRequestPath, { enabled: visible && viewerOpen });
   const selectedFile = file.data?.path === selectedFileRequestPath ? file.data : undefined;
 
   if (!selectedRenderedPath) return null;

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
@@ -15,19 +15,38 @@ interface WorkspaceViewerPanelProps {
   visible?: boolean;
 }
 
-export function WorkspaceViewerPanel({ workspacePath, renderedPaths, ...props }: WorkspaceViewerPanelProps) {
+export function WorkspaceViewerPanel({
+  workspacePath,
+  renderedPaths,
+  visible = true,
+  ...props
+}: WorkspaceViewerPanelProps) {
   const resetKey = [workspacePath, ...renderedPaths.map(path => `${path.id}:${path.root}`)].join('|');
 
   return (
-    <WorkspaceViewerPanelReset key={resetKey} workspacePath={workspacePath} renderedPaths={renderedPaths} {...props} />
+    <WorkspaceViewerPanelReset
+      key={resetKey}
+      workspacePath={workspacePath}
+      renderedPaths={renderedPaths}
+      visible={visible}
+      {...props}
+    />
   );
 }
 
-function WorkspaceViewerPanelReset(props: WorkspaceViewerPanelProps) {
+type MountedPanelProps = Omit<WorkspaceViewerPanelProps, 'visible'> & { visible: boolean };
+
+function WorkspaceViewerPanelReset(props: MountedPanelProps) {
   const [view, setView] = useState<'files' | 'changes'>('files');
 
   if (view === 'changes') {
-    return <WorkspaceChangesPanel workspacePath={props.workspacePath} onShowFiles={() => setView('files')} />;
+    return (
+      <WorkspaceChangesPanel
+        workspacePath={props.workspacePath}
+        visible={props.visible}
+        onShowFiles={() => setView('files')}
+      />
+    );
   }
 
   return <WorkspaceViewerPanelInner {...props} onShowChanges={() => setView('changes')} />;
@@ -38,8 +57,8 @@ function WorkspaceViewerPanelInner({
   renderedPaths,
   onExpandedChange,
   onShowChanges,
-  visible = true,
-}: WorkspaceViewerPanelProps & { onShowChanges: () => void }) {
+  visible,
+}: MountedPanelProps & { onShowChanges: () => void }) {
   const [selectedRenderedPathId, setSelectedRenderedPathId] = useState(renderedPaths[0]?.id ?? '');
   const [selectedFilePath, setSelectedFilePath] = useState<string | undefined>();
   const [viewerOpen, setViewerOpenState] = useState(false);

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceFiles.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceFiles.msw.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter, Route, Routes } from 'react-router';
@@ -35,18 +35,20 @@ afterEach(() => {
 });
 
 function renderPanel() {
+  const listedRoots: string[] = [];
   server.use(
-    http.get(LIST_URL, () =>
-      HttpResponse.json({
+    http.get(LIST_URL, ({ request }) => {
+      listedRoots.push(new URL(request.url).searchParams.get('root') ?? '');
+      return HttpResponse.json({
         workspacePath: WORKSPACE,
         root: '.artifacts',
         rootPath: `${WORKSPACE}/.artifacts`,
         entries: [],
-      }),
-    ),
+      });
+    }),
   );
 
-  return renderWithProviders(
+  renderWithProviders(
     <MemoryRouter initialEntries={[`/factories/factory-1/workspaces/${WORKSPACE}/threads/thread-1`]}>
       <Routes>
         <Route
@@ -61,24 +63,27 @@ function renderPanel() {
       </Routes>
     </MemoryRouter>,
   );
+
+  return { listedRoots };
 }
 
 describe('WorkspaceFiles', () => {
   describe('given a chat wide enough for the card beside the transcript', () => {
-    it('docks the card without interaction, and the header toggle hides it', async () => {
+    it('leaves the card closed and off the network until the header toggle asks for it', async () => {
       stubContainerWidth(1200);
       const user = userEvent.setup();
-      renderPanel();
+      const { listedRoots } = renderPanel();
 
-      expect(await screen.findByRole('button', { name: 'Artifacts' })).toBeInTheDocument();
-      const card = screen.getByTestId('workspace-files-card');
-      expect(card).not.toHaveAttribute('inert');
-
+      const card = await screen.findByTestId('workspace-files-card');
       const toggle = screen.getByRole('button', { name: 'Workspace files' });
-      await user.click(toggle);
-
       expect(card).toHaveAttribute('inert');
       expect(toggle).toHaveAttribute('aria-pressed', 'false');
+      expect(listedRoots).toEqual([]);
+
+      await user.click(toggle);
+
+      expect(card).not.toHaveAttribute('inert');
+      await waitFor(() => expect(listedRoots).toEqual(['.artifacts']));
     });
   });
 

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/context/WorkspaceFilesProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/context/WorkspaceFilesProvider.tsx
@@ -16,8 +16,10 @@ export function WorkspaceFilesProvider({ children }: { children: ReactNode }) {
   const [viewingFile, setViewingFile] = useState(false);
 
   // Toggle records the layout it was made in — crossing the threshold discards it, so a popover
-  // left open closes itself and the docked card comes back.
-  const open = toggled?.whileDocked === canDock ? toggled.open : canDock;
+  // left open closes itself instead of reopening as a docked card.
+  // TODO(COR-1075): dock open by default again once file names and metadata come from the
+  // database — today the first paint would list the pod and wake a sandbox nobody asked for.
+  const open = toggled?.whileDocked === canDock ? toggled.open : false;
   const setOpen = (next: boolean) => setToggled({ whileDocked: canDock, open: next });
 
   const claimsSpace = open && canDock && Boolean(workspacePath);


### PR DESCRIPTION
Opening a thread in MastraCode Web used to start a VM. On wide screens the workspace files card was docked open from the first paint, and even after you toggled it off it stayed mounted with its listing query live, so just scrolling back through old messages listed the pod and woke the sandbox. Now the card starts closed and its listing is disabled while it's hidden, so nothing touches the workspace until you click the toggle. It still stays mounted behind that, so reopening keeps whatever folders you had expanded.

The trade-off is that the panel no longer greets you on desktop, and the first click still wakes the sandbox. I left a TODO on the default pointing at COR-1075: once file names and metadata live in the database we can dock it open again and render the tree without a VM, which is where I'd like this to land. This is just the half that stops the eager wake.

I did look at opening by default only when the sandbox is already awake, but the session API exposes sandboxId and materializedAt and no liveness, so that needs server work regardless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The workspace files panel now starts closed and does not load workspace data until you open it. This prevents hidden panels from starting or reconnecting a sandbox.

## Changes

- Added query enable controls to `useWorkspaceRenderedListing`.
- Disabled workspace listing, changes, and diff queries while the panel is hidden.
- Kept the panel mounted while closed to preserve expanded folders.
- Changed the default panel state to closed when the docking mode changes.
- Added visibility handling through `WorkspaceViewerPanel` and `WorkspaceChangesPanel`.
- Updated tests to verify that the panel starts closed, makes no request, and fetches data after opening.
- Added a TODO for restoring the default-open behavior after file metadata can load without starting a VM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->