### PR TITLE
refactor(factory-ui): single source of truth for pull request status icons

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/chat/components/PullRequestLinks.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/PullRequestLinks.tsx
@@ -1,24 +1,10 @@
 import { Button } from '@mastra/playground-ui/components/Button';
-import { GitMerge, GitPullRequest, GitPullRequestClosed } from 'lucide-react';
 
+import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 import type { PullRequestSubscription } from '../../factory/services/githubSubscriptions';
 import type { WorkItem } from '../../factory/services/workItems';
 import type { LinkedRepositoryPayload } from '../../workspaces/services/github';
 import { usePullRequestSubscriptions } from '../hooks/usePullRequestSubscriptions';
-
-function PullRequestIcon({ status }: { status: PullRequestSubscription['status'] }) {
-  const className = statusIconColor(status);
-
-  if (status === 'merged') return <GitMerge size={13} className={className} aria-hidden />;
-  if (status === 'closed') return <GitPullRequestClosed size={13} className={className} aria-hidden />;
-  return <GitPullRequest size={13} className={className} aria-hidden />;
-}
-
-function statusIconColor(status: PullRequestSubscription['status']): string {
-  if (status === 'merged') return 'text-accent3';
-  if (status === 'closed') return 'text-error';
-  return 'text-accent1';
-}
 
 interface PullRequestLinksProps {
   repository?: Pick<LinkedRepositoryPayload, 'slug'>;
@@ -96,7 +82,7 @@ export function PullRequestLinks({ repository, reviewItem, threadId, size = 'xs'
           rel="noreferrer"
           aria-label={`Open ${subscription.status} ${subscription.repoFullName} pull request ${subscription.pullRequestNumber}`}
         >
-          <PullRequestIcon status={subscription.status} />
+          <PullRequestStatusIcon status={subscription.status} size={13} decorative />
           <span>PR #{subscription.pullRequestNumber}</span>
         </Button>
       ))}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -13,23 +13,12 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { MessageFactory } from '@mastra/react/ui';
 import type { FilePart, MessageRoleRenderers, ReasoningPart, TextPart, ToolInvocationPart } from '@mastra/react/ui';
-import {
-  Bell,
-  ChevronDown,
-  CircleDot,
-  CircleX,
-  ExternalLink,
-  GitMerge,
-  Info,
-  Layers,
-  Slack,
-  Wrench,
-  X,
-} from 'lucide-react';
+import { Bell, ChevronDown, CircleDot, ExternalLink, Info, Layers, Slack, Wrench, X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import { highlightCode, languageForPath } from '../../../ui/highlight';
+import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 import { useChatSessionContext } from '../context/useChatSessionContext';
 import { useChatTranscript } from '../context/useChatTranscript';
 import {
@@ -519,13 +508,13 @@ function notificationUrl(entry: NotificationEntry): string | undefined {
   return undefined;
 }
 
-function notificationPresentation(entry: NotificationEntry) {
+function notificationPresentation(entry: NotificationEntry): { state: string; icon: ReactNode; className?: string } {
   const action = entry.metadata?.action;
   if (entry.notifKind === 'pull-request-merged') {
-    return { state: 'merged', icon: <GitMerge size={13} />, className: 'text-accent3' };
+    return { state: 'merged', icon: <PullRequestStatusIcon status="merged" size={13} decorative /> };
   }
   if (entry.notifKind === 'pull-request-closed') {
-    return { state: 'closed', icon: <CircleX size={13} />, className: 'text-error' };
+    return { state: 'closed', icon: <PullRequestStatusIcon status="closed" size={13} decorative /> };
   }
   if (action === 'opened' || action === 'reopened') {
     return { state: 'open', icon: <CircleDot size={13} />, className: 'text-accent1' };

--- a/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
@@ -30,6 +30,17 @@ export function githubNumberForItem(item: Pick<WorkItem, 'source' | 'metadata'>)
   return itemNumber;
 }
 
+export type PullRequestStatus = 'draft' | 'open' | 'closed' | 'merged';
+
+export function pullRequestStatusForItem(item: Pick<WorkItem, 'metadata' | 'stages'>): PullRequestStatus {
+  if (item.metadata.merged === true) return 'merged';
+  if (item.metadata.state === 'closed') return 'closed';
+  if (item.metadata.state === 'open') return item.metadata.draft === true ? 'draft' : 'open';
+  if (item.stages.includes('done')) return 'merged';
+  if (item.stages.includes('canceled')) return 'closed';
+  return item.metadata.draft === true ? 'draft' : 'open';
+}
+
 export function candidateSourceKeyForItem(item: WorkItem): string | undefined {
   const itemNumber = githubNumberForItem(item);
   if (itemNumber === undefined) return;

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardIcons.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardIcons.tsx
@@ -2,18 +2,10 @@ import { GithubIcon } from '@mastra/playground-ui/icons/GithubIcon';
 import { LinearIcon } from '@mastra/playground-ui/icons/LinearIcon';
 import { SlackIcon } from '@mastra/playground-ui/icons/SlackIcon';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import {
-  CheckCircle2,
-  CircleDot,
-  CircleX,
-  GitMerge,
-  GitPullRequest,
-  GitPullRequestClosed,
-  GitPullRequestDraft,
-} from 'lucide-react';
+import { CheckCircle2, CircleDot, CircleX, GitPullRequest } from 'lucide-react';
 import type { ComponentType, SVGProps } from 'react';
 
-import type { WorkItem, WorkItemSource } from '../services/workItems';
+import type { WorkItemSource } from '../services/workItems';
 import type { BoardStageId } from '../stages';
 import { IntakeIcon } from './IntakeIcon';
 
@@ -29,26 +21,6 @@ const SOURCE_ICONS: Record<WorkItemSource, { icon: ComponentType<SVGProps<SVGSVG
 export function SourceIcon({ source, className }: { source: WorkItemSource; className?: string }) {
   const { icon: Icon, className: sourceClassName } = SOURCE_ICONS[source];
   return <Icon data-source={source} className={cn('size-4 shrink-0', sourceClassName, className)} aria-hidden />;
-}
-
-type PullRequestStatus = 'draft' | 'open' | 'closed' | 'merged';
-
-function pullRequestStatus(item: Pick<WorkItem, 'metadata' | 'stages'>): PullRequestStatus {
-  if (item.metadata.merged === true) return 'merged';
-  if (item.metadata.state === 'closed') return 'closed';
-  if (item.metadata.state === 'open') return item.metadata.draft === true ? 'draft' : 'open';
-  if (item.stages.includes('done')) return 'merged';
-  if (item.stages.includes('canceled')) return 'closed';
-  return item.metadata.draft === true ? 'draft' : 'open';
-}
-
-export function PullRequestStatusIcon({ item }: { item: Pick<WorkItem, 'metadata' | 'stages'> }) {
-  const status = pullRequestStatus(item);
-  const label = `${status[0]?.toUpperCase()}${status.slice(1)} pull request`;
-  if (status === 'merged') return <GitMerge size={16} className="shrink-0 text-purple-400" aria-label={label} />;
-  if (status === 'closed') return <GitPullRequestClosed size={16} className="text-error shrink-0" aria-label={label} />;
-  if (status === 'draft') return <GitPullRequestDraft size={16} className="text-icon3 shrink-0" aria-label={label} />;
-  return <GitPullRequest size={16} className="text-accent1 shrink-0" aria-label={label} />;
 }
 
 const STAGE_ICON_SOURCES: Partial<Record<BoardStageId, string>> = {

--- a/mastracode/factory-ui/src/ui/domains/factory/components/PullRequestStatusIcon.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/PullRequestStatusIcon.tsx
@@ -1,0 +1,53 @@
+import { cn } from '@mastra/playground-ui/utils/cn';
+import type { LucideIcon } from 'lucide-react';
+import { GitPullRequest, GitPullRequestClosed, GitPullRequestDraft } from 'lucide-react';
+
+import type { PullRequestStatus } from '../boardItems';
+
+// Colors are `!` so a container's icon styling (sidebar rows tint every svg) can't strip the status meaning
+const STATUS_PRESENTATION: Record<PullRequestStatus, { icon: LucideIcon; className: string; label: string }> = {
+  draft: {
+    icon: GitPullRequestDraft,
+    className: 'text-icon3!',
+    label: 'Draft pull request',
+  },
+  open: {
+    icon: GitPullRequest,
+    className: 'text-accent1!',
+    label: 'Open pull request',
+  },
+  closed: {
+    icon: GitPullRequestClosed,
+    className: 'text-error!',
+    label: 'Closed pull request',
+  },
+  merged: {
+    icon: GitPullRequest,
+    className: 'text-pr-merged!',
+    label: 'Merged pull request',
+  },
+};
+
+export function PullRequestStatusIcon({
+  status,
+  size = 16,
+  className,
+  decorative,
+}: {
+  status: PullRequestStatus;
+  size?: number;
+  className?: string;
+  /** Set when an ancestor already names the icon (labelled button, `role="img"` wrapper, sr-only row label). */
+  decorative?: boolean;
+}) {
+  const { icon: Icon, className: statusClassName, label } = STATUS_PRESENTATION[status];
+  return (
+    <Icon
+      size={size}
+      className={cn('shrink-0', statusClassName, className)}
+      role={decorative ? undefined : 'img'}
+      aria-label={decorative ? undefined : label}
+      aria-hidden={decorative || undefined}
+    />
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -18,7 +18,14 @@ import { Link, useParams } from 'react-router';
 
 import type { FactoryRunPhase } from '../../../../hooks/useStartFactoryRun';
 import { setDragPayload } from '../boardDrag';
-import { externalLinkLabel, itemThreadSession, liveSessions, metadataLabels, workItemMeta } from '../boardItems';
+import {
+  externalLinkLabel,
+  itemThreadSession,
+  liveSessions,
+  metadataLabels,
+  pullRequestStatusForItem,
+  workItemMeta,
+} from '../boardItems';
 import { RUN_PHASE_LABELS, itemRunSpec, itemSessionSpec } from '../boardRunSpecs';
 import type { ItemRunSpec, RunAction } from '../boardRunSpecs';
 import { itemStageLabel, itemStageOptions } from '../boardStages';
@@ -29,8 +36,9 @@ import type { WorkItem } from '../services/workItems';
 import type { BoardStageId } from '../stages';
 import { workItemActivity } from '../workItemActivity';
 import { CardLabels, CardTitleTooltip, SourceTitle } from './BoardCardParts';
-import { BoardStageIcon, PullRequestStatusIcon, SourceIcon } from './BoardIcons';
+import { BoardStageIcon, SourceIcon } from './BoardIcons';
 import { actionIcon } from './FactoryItemActions';
+import { PullRequestStatusIcon } from './PullRequestStatusIcon';
 import { WorkItemActivity } from './WorkItemActivity';
 
 function decisionStatusText(decision: FactoryDecisionSummary): string {
@@ -195,7 +203,11 @@ export function WorkItemCard({
         <div className="flex min-w-0 flex-col gap-1.5">
           <span className="text-ui-xs text-icon2 truncate pr-8">{workItemMeta(item)}</span>
           <div className="flex min-w-0 items-center gap-1.5">
-            {item.source === 'github-pr' ? <PullRequestStatusIcon item={item} /> : <SourceIcon source={item.source} />}
+            {item.source === 'github-pr' ? (
+              <PullRequestStatusIcon status={pullRequestStatusForItem(item)} />
+            ) : (
+              <SourceIcon source={item.source} />
+            )}
             <span className="text-ui-smd text-icon6 min-w-0 flex-1 truncate font-semibold">
               <SourceTitle source={item.source} title={item.title} />
             </span>

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -3,8 +3,9 @@ import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { HoverCard, HoverCardTrigger } from '@mastra/playground-ui/components/HoverCard';
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
-import { GitBranch, GitMerge, MoreHorizontal, Trash2 } from 'lucide-react';
+import { GitBranch, MoreHorizontal, Trash2 } from 'lucide-react';
 
+import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 import { SessionPreviewCard } from './SessionPreviewCard';
 import type { SessionPreviewDetails } from './SessionPreviewCard';
 
@@ -76,7 +77,7 @@ export function SessionNavRow({
           title="Pull request merged"
           className="ml-auto flex shrink-0 group-hover/session:opacity-0"
         >
-          <GitMerge aria-hidden className="text-accent3!" />
+          <PullRequestStatusIcon status="merged" className="size-3!" decorative />
         </span>
       ) : null}
     </button>
@@ -121,7 +122,7 @@ export function SessionNavRow({
   return (
     <HoverCard>
       {row}
-      <SessionPreviewCard name={name} status={status} details={preview} />
+      <SessionPreviewCard name={name} status={status} merged={merged} details={preview} />
     </HoverCard>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionPreviewCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionPreviewCard.tsx
@@ -1,10 +1,10 @@
 import { HoverCardContent } from '@mastra/playground-ui/components/HoverCard';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { CircleDot, GitBranch, GitMerge, GitPullRequest } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
+import { CircleDot, GitBranch, GitMerge } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 import { relativeTime } from '../../../../lib/date/relativeTime';
+import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 
 export interface SessionPreviewDetails {
   kind: 'Work session' | 'Review session';
@@ -22,10 +22,10 @@ function getStatusLabel(status: 'running' | 'attention' | undefined) {
 }
 
 /** The icon carries the meaning visually, so `label` names the row for screen readers. */
-function DetailRow({ icon: Icon, label, children }: { icon: LucideIcon; label: string; children: ReactNode }) {
+function DetailRow({ icon, label, children }: { icon: ReactNode; label: string; children: ReactNode }) {
   return (
     <div className="flex items-start gap-2">
-      <Icon size={14} className="text-icon3 mt-0.5 shrink-0" aria-hidden />
+      <span className="text-icon3 mt-0.5 flex shrink-0">{icon}</span>
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <span className="sr-only">{label}</span>
         {children}
@@ -37,17 +37,24 @@ function DetailRow({ icon: Icon, label, children }: { icon: LucideIcon; label: s
 export function SessionPreviewCard({
   name,
   status,
+  merged,
   details,
 }: {
   name: string;
   status?: 'running' | 'attention';
+  merged?: boolean;
   details: SessionPreviewDetails;
 }) {
   const statusLabel = getStatusLabel(status);
   const itemTitle = details.itemTitle?.trim();
   const subtitle = itemTitle && itemTitle !== name ? itemTitle : undefined;
   const updated = relativeTime(details.updatedAt);
-  const ItemIcon = details.kind === 'Review session' ? GitPullRequest : CircleDot;
+  const itemIcon =
+    details.kind === 'Review session' ? (
+      <PullRequestStatusIcon status={merged ? 'merged' : 'open'} size={14} decorative />
+    ) : (
+      <CircleDot size={14} aria-hidden />
+    );
 
   return (
     <HoverCardContent
@@ -77,7 +84,7 @@ export function SessionPreviewCard({
         </div>
         <div className="flex flex-col gap-1.5">
           {(details.itemLabel || subtitle) && (
-            <DetailRow icon={ItemIcon} label={details.kind === 'Review session' ? 'Pull request' : 'Work item'}>
+            <DetailRow icon={itemIcon} label={details.kind === 'Review session' ? 'Pull request' : 'Work item'}>
               {details.itemLabel && (
                 <Txt as="p" variant="ui-sm" className="text-icon5 m-0 truncate">
                   {details.itemLabel}
@@ -90,12 +97,12 @@ export function SessionPreviewCard({
               )}
             </DetailRow>
           )}
-          <DetailRow icon={GitBranch} label="Branch">
+          <DetailRow icon={<GitBranch size={14} aria-hidden />} label="Branch">
             <Txt as="p" variant="ui-sm" className="text-icon5 m-0 truncate">
               {details.branch}
             </Txt>
           </DetailRow>
-          <DetailRow icon={GitMerge} label="Base branch">
+          <DetailRow icon={<GitMerge size={14} aria-hidden />} label="Base branch">
             <Txt as="p" variant="ui-sm" className="text-icon5 m-0 truncate">
               {details.baseBranch}
             </Txt>

--- a/mastracode/factory-ui/src/ui/tailwind.css
+++ b/mastracode/factory-ui/src/ui/tailwind.css
@@ -27,6 +27,17 @@
   --color-icon4: var(--neutral4);
   --color-icon5: var(--neutral5);
   --color-icon6: var(--neutral6);
+  --color-pr-merged: var(--pr-merged);
+}
+
+/* Merged pull requests read purple everywhere; the DS accent ramp has no purple.
+ * Brightens on near-black, darkens on white so it stays legible in both themes. */
+:root {
+  --pr-merged: oklch(0.714 0.203 305.5);
+}
+
+html.light {
+  --pr-merged: oklch(0.496 0.265 302);
 }
 
 /* Keyframes must live inside @theme so Tailwind emits them alongside the


### PR DESCRIPTION
Pull request status icons were drawn four different ways in the Factory UI: the board card, the chat PR links, transcript notifications and the sidebar session row each picked their own icon and color. Merged showed up blue in three of them and purple in one, and closed was a plain cross in the transcript. Now a single `PullRequestStatusIcon` owns that mapping, with the status derivation (`PullRequestStatus`, `pullRequestStatusForItem`) sitting in `boardItems` next to the other work-item helpers, and every surface calls into it.

Merged reads purple everywhere. I added a `--pr-merged` token that darkens under `html.light` rather than reusing `text-purple-400`, which washed out badly on white — the design system accent ramp has no purple, so this lives app-side next to the metrics ramps that already do the same thing. Status colors carry `!` because sidebar rows tint every descendant `svg` neutral, and here the color is the meaning. In the sidebar the merged marker also switches to `GitPullRequest` at 12px: `GitMerge` sat right next to the `GitBranch` icon and the two glyphs read as the same shape at that size. The session hover card now reflects the merged state too, which it previously ignored.

One thing worth an eye before merging: because the mapping is shared, merged now uses the `GitPullRequest` glyph on board cards as well, where it used to be `GitMerge` — only the color separates merged from open there. If that reads worse on the board I can put `GitMerge` back for merged in the one table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes all Factory UI pull request icons use the same shared component. It also makes merged pull requests display a consistent purple icon across cards, chats, notifications, and session views.

## Changes

- Added `PullRequestStatusIcon` as the shared icon component.
- Added `PullRequestStatus` and `pullRequestStatusForItem` in `boardItems`.
- Updated pull request icons in:
  - Board cards
  - Chat links
  - Transcript notifications
  - Sidebar session rows
  - Session preview cards
- Added theme-aware `--pr-merged` color tokens.
- Changed merged pull request markers from `GitMerge` to `GitPullRequest`.
- Added accessible labels and decorative rendering options to the shared icon component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->