### PR TITLE
fix(server): catch rejected workflow /resume and /time-travel background runs

### DIFF
--- a/.changeset/tidy-flowers-guess.md
+++ b/.changeset/tidy-flowers-guess.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Catch rejected background Run.resume() and Run.timeTravel() in the workflow /resume and /time-travel routes so they cannot become unhandled rejections and terminate the server process

--- a/packages/server/src/server/handlers/workflows.test.ts
+++ b/packages/server/src/server/handlers/workflows.test.ts
@@ -25,6 +25,7 @@ import {
   CANCEL_WORKFLOW_RUN_ROUTE,
   LIST_WORKFLOW_RUNS_ROUTE,
   STREAM_WORKFLOW_ROUTE,
+  TIME_TRAVEL_WORKFLOW_ROUTE,
 } from './workflows';
 
 function createMockWorkflow(name: string) {
@@ -630,8 +631,11 @@ describe('vNext Workflow Handlers', () => {
       });
       await run.start({ inputData: {} });
 
+      // Plain function, not vi.fn(): vitest mocks track settled results by
+      // attaching a handler to returned promises, which would prevent the
+      // rejection from ever being reported as unhandled.
       const createRunSpy = vi.spyOn(mockWorkflow, 'createRun').mockResolvedValue({
-        start: vi.fn().mockRejectedValue(new Error('invalid workflow input')),
+        start: () => Promise.reject(new Error('invalid workflow input')),
       } as any);
 
       const unhandled: unknown[] = [];
@@ -860,6 +864,92 @@ describe('vNext Workflow Handlers', () => {
       // resourceId should be preserved after resume
       const runAfterResume = await freshWorkflow.getWorkflowRunById('test-run-with-resource');
       expect(runAfterResume?.resourceId).toBe(resourceId);
+    });
+
+    it('should not leave an unhandled rejection when run.resume() rejects', async () => {
+      const run = await reusableWorkflow.createRun({
+        runId: 'test-run-resume-reject',
+      });
+      await run.start({ inputData: {} });
+
+      // Plain function, not vi.fn(): vitest mocks track settled results by
+      // attaching a handler to returned promises, which would prevent the
+      // rejection from ever being reported as unhandled.
+      const createRunSpy = vi.spyOn(reusableWorkflow, 'createRun').mockResolvedValue({
+        resume: () => Promise.reject(new Error('resume failed')),
+      } as any);
+
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => {
+        unhandled.push(reason);
+      };
+      process.on('unhandledRejection', onUnhandled);
+
+      try {
+        const result = await RESUME_WORKFLOW_ROUTE.handler({
+          ...createTestServerContext({ mastra: mockMastra }),
+          workflowId: reusableWorkflow.name,
+          runId: 'test-run-resume-reject',
+          step: 'test-step',
+          resumeData: { test: 'data' },
+          tracingOptions,
+        } as any);
+
+        expect(result).toEqual({ message: 'Workflow run resumed' });
+
+        // Let the rejected promise settle; .catch on the route must swallow it.
+        await new Promise(resolve => setImmediate(resolve));
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+        createRunSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('TIME_TRAVEL_WORKFLOW_ROUTE', () => {
+    it('should not leave an unhandled rejection when run.timeTravel() rejects', async () => {
+      const run = await mockWorkflow.createRun({
+        runId: 'test-run-time-travel-reject',
+      });
+      await run.start({ inputData: {} });
+
+      // Plain function, not vi.fn(): vitest mocks track settled results by
+      // attaching a handler to returned promises, which would prevent the
+      // rejection from ever being reported as unhandled.
+      const createRunSpy = vi.spyOn(mockWorkflow, 'createRun').mockResolvedValue({
+        timeTravel: () => Promise.reject(new Error('time travel failed')),
+      } as any);
+
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => {
+        unhandled.push(reason);
+      };
+      process.on('unhandledRejection', onUnhandled);
+
+      try {
+        const result = await TIME_TRAVEL_WORKFLOW_ROUTE.handler({
+          ...createTestServerContext({ mastra: mockMastra }),
+          workflowId: 'test-workflow',
+          runId: 'test-run-time-travel-reject',
+          step: 'test-step',
+          inputData: {},
+          tracingOptions,
+        } as any);
+
+        expect(result).toEqual({ message: 'Workflow run time travel started' });
+
+        // Let the rejected promise settle; .catch on the route must swallow it.
+        await new Promise(resolve => setImmediate(resolve));
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+        createRunSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -805,7 +805,11 @@ export const RESUME_WORKFLOW_ROUTE = createRoute({
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
 
-      void _run.resume({ ...params, requestContext });
+      // Fire-and-forget: attach .catch so a rejected resume cannot become an
+      // unhandledRejection and tear down the process.
+      void _run.resume({ ...params, requestContext }).catch(error => {
+        mastra.getLogger().error('Failed to resume workflow run', { error, workflowId, runId });
+      });
 
       return { message: 'Workflow run resumed' };
     } catch (error) {
@@ -1065,7 +1069,11 @@ export const TIME_TRAVEL_WORKFLOW_ROUTE = createRoute({
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
 
-      void _run.timeTravel({ ...params, requestContext });
+      // Fire-and-forget: attach .catch so a rejected time travel cannot become
+      // an unhandledRejection and tear down the process.
+      void _run.timeTravel({ ...params, requestContext }).catch(error => {
+        mastra.getLogger().error('Failed to time travel workflow run', { error, workflowId, runId });
+      });
 
       return { message: 'Workflow run time travel started' };
     } catch (error) {


### PR DESCRIPTION
The `/workflows/:workflowId/resume` and `/workflows/:workflowId/time-travel` routes kick off their runs without awaiting, so a rejection that happens after the response is sent becomes an unhandledRejection and can terminate the Node process. This applies the same catch-and-log pattern already used by the `/start` (#20876) and `/restart` (#20473) routes.

Before:

```ts
void _run.resume({ ...params, requestContext });
```

After:

```ts
void _run.resume({ ...params, requestContext }).catch(error => {
  mastra.getLogger().error('Failed to resume workflow run', { error, workflowId, runId });
});
```

While writing the regression tests I found the existing `/start` test from #20876 passes even with the fix removed: `vi.fn().mockRejectedValue()` attaches an internal handler to the promise, so the rejection is never reported as unhandled. Swapping the mocks for plain rejecting functions makes all three tests fail without the fix and pass with it (verified by temporarily stripping the `/start` catch).

Test plan: `pnpm vitest run src/server/handlers/workflows.test.ts` in `packages/server` (58 passed), plus `tsc --noEmit` and eslint on the touched files.

Closes #20914

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a workflow continues after the server responds, errors could crash the process. This change catches and logs those errors for resume and time-travel actions.

## Changes

- Added rejection handling for background `Run.resume()` and `Run.timeTravel()` calls.
- Updated regression tests for `/start`, `/resume`, and `/time-travel`.
- Added coverage to confirm that rejected background runs do not emit `unhandledRejection` events.
- Added a patch changeset for `@mastra/server`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->