### PR TITLE
feat(factory-ui): pin sidebar sessions

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -3,7 +3,7 @@ import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { HoverCard, HoverCardTrigger } from '@mastra/playground-ui/components/HoverCard';
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
-import { GitBranch, MoreHorizontal, Trash2 } from 'lucide-react';
+import { GitBranch, MoreHorizontal, Pin, PinOff, Trash2 } from 'lucide-react';
 
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 import { SessionPreviewCard } from './SessionPreviewCard';
@@ -25,7 +25,9 @@ export function SessionNavRow({
   status,
   merged,
   preview,
+  pinned = false,
   onSelect,
+  onPinChange,
   onDelete,
 }: {
   name: string;
@@ -40,7 +42,9 @@ export function SessionNavRow({
   merged?: boolean;
   status?: 'running' | 'attention';
   preview?: SessionPreviewDetails;
+  pinned?: boolean;
   onSelect: () => void;
+  onPinChange: (pinned: boolean) => void;
   onDelete: () => void;
 }) {
   const button = (
@@ -53,7 +57,10 @@ export function SessionNavRow({
       title={preview ? undefined : title}
     >
       <GitBranch />
-      <MainSidebar.NavLabel>{name}</MainSidebar.NavLabel>
+      <MainSidebar.NavLabel className="flex-initial">{name}</MainSidebar.NavLabel>
+      {pinned && !loading ? (
+        <Pin aria-label={`${name} pinned`} className="text-icon3/70 size-2 shrink-0 rotate-45" />
+      ) : null}
       {loading ? (
         <Spinner size="sm" aria-label={`Opening ${name}`} className="text-icon3 ml-auto shrink-0" />
       ) : status === 'running' ? (
@@ -99,6 +106,10 @@ export function SessionNavRow({
         }
       />
       <DropdownMenu.Content align="end" className="min-w-28">
+        <DropdownMenu.Item onClick={() => onPinChange(!pinned)}>
+          {pinned ? <PinOff /> : <Pin />}
+          {pinned ? 'Unpin' : 'Pin session'}
+        </DropdownMenu.Item>
         <DropdownMenu.Item variant="destructive" onClick={onDelete}>
           <Trash2 />
           Delete

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -16,6 +16,7 @@ import { useFactoryQuery } from '../../../../hooks/useFactories';
 import { removeCachedSession, useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
 import { createAgentControllerClient, requireAgentControllerSession } from '../../chat/services/agentControllerClient';
 import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
+import { usePinnedSessions } from '../hooks/usePinnedSessions';
 import { USER_SESSION_BRANCH_PREFIX, createUserSession, deleteUserSession } from '../services/github';
 import type { FactoryUserSession } from '../services/github';
 import { getUserSessionLabel } from '../services/sessionPresentation';
@@ -32,11 +33,14 @@ export function UserSessionsSection() {
   const [creating, setCreating] = useState(false);
   const [name, setName] = useState('');
   const [confirmDelete, setConfirmDelete] = useState<FactoryUserSession | null>(null);
+  const { pinnedSessions, setPinned } = usePinnedSessions();
 
   const repository = factoryQuery.data?.repositories[0];
   const sessionsEnabled = Boolean(repository);
   const sessionsQuery = useWorkspacesQuery(repository?.projectRepositoryId);
-  const sessions = sessionsQuery.data?.userSessions ?? [];
+  const sessions = [...(sessionsQuery.data?.userSessions ?? [])].sort(
+    (a, b) => Number(pinnedSessions.has(b.sessionId)) - Number(pinnedSessions.has(a.sessionId)),
+  );
 
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: queryKeys.sessions(repository?.projectRepositoryId) });
@@ -161,7 +165,9 @@ export function UserSessionsSection() {
                 url={url}
                 active={active}
                 disabled={pending}
+                pinned={pinnedSessions.has(session.sessionId)}
                 onSelect={() => openSession(session)}
+                onPinChange={pinned => setPinned(session.sessionId, pinned)}
                 onDelete={() => setConfirmDelete(session)}
               />
             );

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -15,6 +15,7 @@ import { createAgentControllerClient } from '../../chat/services/agentController
 import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 import { githubNumberForItem } from '../../factory/boardItems';
 import { relatedWorkItems, relationshipLabel } from '../../factory/services/relationships';
+import { usePinnedSessions } from '../hooks/usePinnedSessions';
 import type { FactoryUserSession } from '../services/github';
 import { getFactorySessionKind } from '../services/sessionPresentation';
 import { SessionNavRow } from './SessionNavRow';
@@ -43,6 +44,7 @@ export function WorkspacesSection() {
   });
   const deleteWorkspace = useDeleteWorkspaceMutation(factoryId, projectRepositoryId, session, scope);
   const [confirmDelete, setConfirmDelete] = useState<FactoryUserSession | null>(null);
+  const { pinnedSessions, setPinned } = usePinnedSessions();
   const workItems = useWorkItemsQuery(factoryId);
   const workspaceRows = workspaces.data?.workspaces ?? [];
   const activityOptions = {
@@ -96,12 +98,13 @@ export function WorkspacesSection() {
         threadId: workItemSession?.threadId,
         pullRequestNumber,
         knownMerged: pullRequest?.metadata.merged === true,
+        pinned: pinnedSessions.has(workspace.sessionId),
       },
     ];
   });
   const latestRows = (review: boolean) => {
-    const sorted = [...rows.filter(row => row.review === review)].sort((a, b) =>
-      b.updatedAt.localeCompare(a.updatedAt),
+    const sorted = [...rows.filter(row => row.review === review)].sort(
+      (a, b) => Number(b.pinned) - Number(a.pinned) || b.updatedAt.localeCompare(a.updatedAt),
     );
     const visible = sorted.slice(0, 5);
     for (const pinned of sorted.slice(5).filter(row => row.active || row.running || row.attention)) {
@@ -114,7 +117,10 @@ export function WorkspacesSection() {
       }
       if (replaceIndex >= 0) visible[replaceIndex] = pinned;
     }
-    return { visible: visible.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)), all: sorted };
+    return {
+      visible: visible.sort((a, b) => Number(b.pinned) - Number(a.pinned) || b.updatedAt.localeCompare(a.updatedAt)),
+      all: sorted,
+    };
   };
   const workRows = latestRows(false);
   const reviewRows = latestRows(true);
@@ -170,6 +176,7 @@ export function WorkspacesSection() {
           pending={pending}
           mergedByPath={mergedByPath}
           onSelect={openWorkspaceThread}
+          onPinChange={setPinned}
           onDelete={setConfirmDelete}
         />
       )}
@@ -183,6 +190,7 @@ export function WorkspacesSection() {
           pending={pending}
           mergedByPath={mergedByPath}
           onSelect={openWorkspaceThread}
+          onPinChange={setPinned}
           onDelete={setConfirmDelete}
         />
       )}
@@ -233,6 +241,7 @@ interface FactoryWorkspaceRow {
   threadId?: string;
   pullRequestNumber?: number;
   knownMerged: boolean;
+  pinned: boolean;
 }
 
 function WorkspaceGroup({
@@ -243,6 +252,7 @@ function WorkspaceGroup({
   pending,
   mergedByPath,
   onSelect,
+  onPinChange,
   onDelete,
 }: {
   title: 'Work Sessions' | 'Review Sessions';
@@ -252,6 +262,7 @@ function WorkspaceGroup({
   pending: boolean;
   mergedByPath: Record<string, boolean>;
   onSelect: (workspace: FactoryUserSession) => void;
+  onPinChange: (sessionId: string, pinned: boolean) => void;
   onDelete: (workspace: FactoryUserSession) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -278,6 +289,7 @@ function WorkspaceGroup({
             disabled={pending}
             merged={mergedByPath[row.workspace.sessionId] === true}
             status={workspaceStatus(row)}
+            pinned={row.pinned}
             preview={{
               kind,
               itemLabel: row.itemLabel,
@@ -287,6 +299,7 @@ function WorkspaceGroup({
               updatedAt: row.updatedAt,
             }}
             onSelect={() => onSelect(row.workspace)}
+            onPinChange={pinned => onPinChange(row.workspace.sessionId, pinned)}
             onDelete={() => onDelete(row.workspace)}
           />
         ))}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspacesSectionShowMore.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspacesSectionShowMore.msw.test.tsx
@@ -11,7 +11,7 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { server } from '../../../../../../e2e/ui/msw-server';
-import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
+import { TEST_BASE_URL, renderWithProviders, waitForMutationsIdle } from '../../../../../../e2e/ui/render';
 import { ChatSessionContext } from '../../../chat/context/ChatSessionContext';
 import type { FactoryUserSession } from '../../services/github';
 import { WorkspacesSection } from '../WorkspacesSection';
@@ -94,7 +94,8 @@ describe('Workspaces sidebar show more', () => {
     const user = userEvent.setup();
 
     const rendered = renderSection();
-    const group = await screen.findByRole('region', { name: 'Review Sessions' });
+    await waitForMutationsIdle(rendered.client);
+    const group = screen.getByRole('region', { name: 'Review Sessions' });
     await user.click(within(group).getByRole('button', { name: 'Show 3 more' }));
     await user.click(within(group).getByRole('button', { name: 'Session actions for factory/pr-20001' }));
     await user.click(await screen.findByRole('menuitem', { name: 'Pin session' }));

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspacesSectionShowMore.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspacesSectionShowMore.msw.test.tsx
@@ -8,7 +8,7 @@ import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { server } from '../../../../../../e2e/ui/msw-server';
 import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
@@ -66,6 +66,10 @@ function renderSection() {
 }
 
 describe('Workspaces sidebar show more', () => {
+  beforeEach(() => {
+    localStorage.removeItem('mastracode.pinnedSessions');
+  });
+
   it('caps a group at 5 sessions and expands to the full list on demand', async () => {
     stubSessions(Array.from({ length: 8 }, (_, index) => reviewSession(index + 1)));
     const user = userEvent.setup();
@@ -83,6 +87,33 @@ describe('Workspaces sidebar show more', () => {
 
     await user.click(within(group).getByRole('button', { name: 'Show less' }));
     expect(within(group).getAllByRole('button', { name: /^factory\/pr-200\d+$/ })).toHaveLength(5);
+  });
+
+  it('keeps a pinned session visible and persists the pin', async () => {
+    stubSessions(Array.from({ length: 8 }, (_, index) => reviewSession(index + 1)));
+    const user = userEvent.setup();
+
+    const rendered = renderSection();
+    const group = await screen.findByRole('region', { name: 'Review Sessions' });
+    await user.click(within(group).getByRole('button', { name: 'Show 3 more' }));
+    await user.click(within(group).getByRole('button', { name: 'Session actions for factory/pr-20001' }));
+    await user.click(await screen.findByRole('menuitem', { name: 'Pin session' }));
+
+    expect(within(group).getByLabelText('factory/pr-20001 pinned')).toBeInTheDocument();
+    await user.click(within(group).getByRole('button', { name: 'Show less' }));
+    expect(within(group).getAllByRole('button', { name: /^factory\/pr-200\d+$/ })[0]).toHaveAccessibleName(
+      'factory/pr-20001',
+    );
+
+    rendered.unmount();
+    renderSection();
+    const remountedGroup = await screen.findByRole('region', { name: 'Review Sessions' });
+    expect(within(remountedGroup).getByRole('button', { name: 'factory/pr-20001' })).toBeInTheDocument();
+    expect(within(remountedGroup).getByLabelText('factory/pr-20001 pinned')).toBeInTheDocument();
+
+    await user.click(within(remountedGroup).getByRole('button', { name: 'Session actions for factory/pr-20001' }));
+    await user.click(await screen.findByRole('menuitem', { name: 'Unpin' }));
+    expect(within(remountedGroup).queryByRole('button', { name: 'factory/pr-20001' })).not.toBeInTheDocument();
   });
 
   it('shows no toggle when a group fits within the cap', async () => {

--- a/mastracode/factory-ui/src/ui/domains/workspaces/hooks/usePinnedSessions.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/hooks/usePinnedSessions.msw.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePinnedSessions } from './usePinnedSessions';
+
+const STORAGE_KEY = 'mastracode.pinnedSessions';
+
+describe('usePinnedSessions', () => {
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preserves in-memory pins when localStorage writes fail', () => {
+    const { result } = renderHook(() => usePinnedSessions());
+    const setItem = vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('storage unavailable');
+    });
+
+    act(() => result.current.setPinned('session-1', true));
+
+    expect(result.current.pinnedSessions.has('session-1')).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    setItem.mockRestore();
+    act(() => result.current.setPinned('session-1', false));
+  });
+
+  it('preserves cached pins when localStorage reads fail', () => {
+    const { result } = renderHook(() => usePinnedSessions());
+
+    act(() => result.current.setPinned('session-1', true));
+
+    const getItem = vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('storage unavailable');
+    });
+    act(() => window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY })));
+
+    expect(result.current.pinnedSessions.has('session-1')).toBe(true);
+
+    getItem.mockRestore();
+    act(() => result.current.setPinned('session-1', false));
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/workspaces/hooks/usePinnedSessions.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/hooks/usePinnedSessions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useSyncExternalStore } from 'react';
+import { useSyncExternalStore } from 'react';
 
 const STORAGE_KEY = 'mastracode.pinnedSessions';
 const CHANGE_EVENT = 'mastracode:pinned-sessions-change';
@@ -53,12 +53,12 @@ function savePinnedSessions(sessions: Set<string>) {
 
 export function usePinnedSessions() {
   const pinnedSessions = useSyncExternalStore(subscribe, readPinnedSessions, () => new Set<string>());
-  const setPinned = useCallback((sessionId: string, pinned: boolean) => {
+  const setPinned = (sessionId: string, pinned: boolean) => {
     const next = new Set(readPinnedSessions());
     if (pinned) next.add(sessionId);
     else next.delete(sessionId);
     savePinnedSessions(next);
-  }, []);
+  };
 
   return { pinnedSessions, setPinned };
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/hooks/usePinnedSessions.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/hooks/usePinnedSessions.ts
@@ -5,17 +5,26 @@ const CHANGE_EVENT = 'mastracode:pinned-sessions-change';
 
 let cachedValue: string | null = null;
 let cachedSessions = new Set<string>();
+let storageUnavailable = false;
 
 function readPinnedSessions(): Set<string> {
-  try {
-    const value = localStorage.getItem(STORAGE_KEY);
-    if (value === cachedValue) return cachedSessions;
+  if (storageUnavailable) return cachedSessions;
 
-    cachedValue = value;
+  let value: string | null;
+  try {
+    value = localStorage.getItem(STORAGE_KEY);
+  } catch {
+    storageUnavailable = true;
+    return cachedSessions;
+  }
+
+  if (value === cachedValue) return cachedSessions;
+
+  cachedValue = value;
+  try {
     const parsed: unknown = value ? JSON.parse(value) : [];
     cachedSessions = new Set(Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : []);
   } catch {
-    cachedValue = null;
     cachedSessions = new Set();
   }
   return cachedSessions;
@@ -35,8 +44,9 @@ function savePinnedSessions(sessions: Set<string>) {
   cachedSessions = sessions;
   try {
     localStorage.setItem(STORAGE_KEY, cachedValue);
+    storageUnavailable = false;
   } catch {
-    // Pinning remains available for the current page when storage is unavailable.
+    storageUnavailable = true;
   }
   window.dispatchEvent(new Event(CHANGE_EVENT));
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/hooks/usePinnedSessions.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/hooks/usePinnedSessions.ts
@@ -1,0 +1,54 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+const STORAGE_KEY = 'mastracode.pinnedSessions';
+const CHANGE_EVENT = 'mastracode:pinned-sessions-change';
+
+let cachedValue: string | null = null;
+let cachedSessions = new Set<string>();
+
+function readPinnedSessions(): Set<string> {
+  try {
+    const value = localStorage.getItem(STORAGE_KEY);
+    if (value === cachedValue) return cachedSessions;
+
+    cachedValue = value;
+    const parsed: unknown = value ? JSON.parse(value) : [];
+    cachedSessions = new Set(Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : []);
+  } catch {
+    cachedValue = null;
+    cachedSessions = new Set();
+  }
+  return cachedSessions;
+}
+
+function subscribe(onStoreChange: () => void) {
+  window.addEventListener('storage', onStoreChange);
+  window.addEventListener(CHANGE_EVENT, onStoreChange);
+  return () => {
+    window.removeEventListener('storage', onStoreChange);
+    window.removeEventListener(CHANGE_EVENT, onStoreChange);
+  };
+}
+
+function savePinnedSessions(sessions: Set<string>) {
+  cachedValue = JSON.stringify([...sessions]);
+  cachedSessions = sessions;
+  try {
+    localStorage.setItem(STORAGE_KEY, cachedValue);
+  } catch {
+    // Pinning remains available for the current page when storage is unavailable.
+  }
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export function usePinnedSessions() {
+  const pinnedSessions = useSyncExternalStore(subscribe, readPinnedSessions, () => new Set<string>());
+  const setPinned = useCallback((sessionId: string, pinned: boolean) => {
+    const next = new Set(readPinnedSessions());
+    if (pinned) next.add(sessionId);
+    else next.delete(sessionId);
+    savePinnedSessions(next);
+  }, []);
+
+  return { pinnedSessions, setPinned };
+}


### PR DESCRIPTION
Adds Pin session and Unpin actions to sidebar session menus. Pinned Work, Review, and personal sessions are stored in local storage, shown with a small pin indicator, and prioritized at the top of their lists while preserving the existing collapsed-session behavior.

Verified with the full Factory UI MSW suite, typecheck, Oxlint, Prettier, and production build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Users can pin important sessions so they stay easy to find. Pinned sessions appear first, remain visible when the sidebar is collapsed, and stay pinned after the page reloads.

## Changes

- Added Pin and Unpin actions and pin indicators to session menus.
- Persisted pinned Work, Review, and personal sessions in `localStorage`.
- Added storage synchronization, invalid-value filtering, and in-memory fallback when storage operations fail.
- Reset fallback mode after a successful storage write.
- Prioritized pinned sessions while preserving active, running, attention, and collapsed-session behavior.
- Added regression coverage for pinning, unpinning, persistence, remounting, collapsed sidebar ordering, and storage failures.
- Verified the changes with 452 Factory UI MSW tests, focused tests, typecheck, Oxlint, Prettier, diff check, and production build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->