### PR TITLE
fix(create-factory): wire WORKOS_* env into an auth provider in the template server entry

### DIFF
--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -56,6 +56,7 @@ if (customOutOverlapsMonorepo) {
 }
 
 const RUNTIME_DEPENDENCIES = [
+  '@mastra/auth-workos',
   '@mastra/code-sdk',
   '@mastra/core',
   '@mastra/factory',

--- a/mastracode/mastra-factory/src/sync-template.test.ts
+++ b/mastracode/mastra-factory/src/sync-template.test.ts
@@ -12,6 +12,7 @@ const pkgRoot = path.resolve(here, '..');
 const webRoot = path.resolve(pkgRoot, '../web');
 const script = path.join(pkgRoot, 'scripts', 'sync-template.mjs');
 const TEMPLATE_LINKED_DEPENDENCIES = [
+  '@mastra/auth-workos',
   '@mastra/code-sdk',
   '@mastra/core',
   '@mastra/factory',
@@ -155,6 +156,7 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     }
 
     expect(Object.keys(pkg.dependencies).sort()).toEqual([
+      '@mastra/auth-workos',
       '@mastra/code-sdk',
       '@mastra/core',
       '@mastra/factory',

--- a/mastracode/web/.env.schema
+++ b/mastracode/web/.env.schema
@@ -64,9 +64,9 @@ MASTRACODE_UI_DIST=
 # ---------------------------------------------------------------------------
 # Mastra platform auth (highest precedence)
 # When MASTRA_SHARED_API_URL is set, this instance defers all identity to a
-# Mastra platform API (e.g. https://platform.mastra.ai/v1). No WorkOS/WorkOS
+# Mastra platform API (e.g. https://platform.mastra.ai/v1). No WorkOS/better-auth
 # secrets are needed here — the platform owns them. Takes precedence over
-# WORKOS_* and BETTER_AUTH_SECRET below, so a platform-deferred deployment
+# WORKOS_* and BETTER_AUTH_SECRET below, so a deployment that sets this var
 # never falls back to its own credentials by accident.
 # ---------------------------------------------------------------------------
 

--- a/mastracode/web/.env.schema
+++ b/mastracode/web/.env.schema
@@ -78,13 +78,15 @@ MASTRACODE_UI_DIST=
 MASTRA_SHARED_API_URL=
 # Optional: pin this deployment to a specific WorkOS organization. Users
 # whose memberships don't include this org are rejected. Leave unset for
-# multi-org deployments.
+# multi-org deployments. Only honored on the platform-deferred auth path;
+# the self-managed WORKOS_* path below does not enforce it.
 # @public
 MASTRA_ORGANIZATION_ID=
 # Optional: parent cookie domain (e.g. `.mastra.cloud`) for the sealed
 # session cookie this deployment sets after callback. Auto-detected from
 # MASTRA_SHARED_API_URL for `*.mastra.ai` hosts; otherwise the cookie is
-# host-only (fine for localhost dev on different ports).
+# host-only (fine for localhost dev on different ports). Only applies to the
+# platform-deferred auth path, not the self-managed WORKOS_* path below.
 # @public
 MASTRA_COOKIE_DOMAIN=
 

--- a/mastracode/web/package.json
+++ b/mastracode/web/package.json
@@ -8,7 +8,7 @@
     "check": "tsc --noEmit",
     "db:up": "docker compose up -d --wait",
     "db:down": "docker compose down",
-    "prebuild": "cd ../.. && pnpm turbo build --filter ./mastracode/sdk --filter ./mastracode/factory --filter ./client-sdks/client-js --filter ./stores/libsql --filter ./stores/pg --filter ./server-adapters/hono --filter ./workspaces/platform-workspace --filter ./pubsub/redis-streams --filter ./packages/cli",
+    "prebuild": "cd ../.. && pnpm turbo build --filter ./mastracode/sdk --filter ./mastracode/factory --filter ./auth/workos --filter ./client-sdks/client-js --filter ./stores/libsql --filter ./stores/pg --filter ./server-adapters/hono --filter ./workspaces/platform-workspace --filter ./pubsub/redis-streams --filter ./packages/cli",
     "api": "PORT=${PORT:-4111} MASTRACODE_PUBLIC_URL=${MASTRACODE_PUBLIC_URL:-http://localhost:5173} MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra factory dev --dir src/mastra",
     "dev": "PORT=5873 MASTRACODE_PUBLIC_URL=${MASTRACODE_PUBLIC_URL:-http://localhost:5873} MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra factory dev --dir src/mastra",
     "dev:github": "pnpm db:up && pnpm dev",
@@ -22,6 +22,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
+    "@mastra/auth-workos": "link:../../auth/workos",
     "@mastra/code-sdk": "link:../sdk",
     "@mastra/core": "link:../../packages/core",
     "@mastra/factory": "link:../factory",

--- a/mastracode/web/pnpm-lock.yaml
+++ b/mastracode/web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@mastra/auth-workos':
+        specifier: link:../../auth/workos
+        version: link:../../auth/workos
       '@mastra/code-sdk':
         specifier: link:../sdk
         version: link:../sdk

--- a/mastracode/web/src/mastra/index.test.ts
+++ b/mastracode/web/src/mastra/index.test.ts
@@ -309,23 +309,19 @@ describe('platform entry (src/mastra/index.ts)', () => {
       },
     );
 
-    it(
-      'boots on the default auth path when only WORKOS_API_KEY is set',
-      { timeout: 60_000 },
-      async () => {
-        // varlock rejects an API-key-only env at the dev-script level; this
-        // guards direct boot paths that bypass it. A half-configured pair must
-        // not construct the provider (which would throw on the missing
-        // clientId) — boot survives on the default platform-backed path.
-        vi.stubEnv('WORKOS_API_KEY', 'sk_test_fake');
-        const mod = await import('./index.js');
-        expect(mod.mastra).toBeDefined();
-        // Half a pair falls through to the platform-backed default, so login
-        // still rides the studio provider's shared API.
-        const location = await loginRedirect(mod);
-        expect(location).toContain('platform.mastra.ai');
-      },
-    );
+    it('boots on the default auth path when only WORKOS_API_KEY is set', { timeout: 60_000 }, async () => {
+      // varlock rejects an API-key-only env at the dev-script level; this
+      // guards direct boot paths that bypass it. A half-configured pair must
+      // not construct the provider (which would throw on the missing
+      // clientId) — boot survives on the default platform-backed path.
+      vi.stubEnv('WORKOS_API_KEY', 'sk_test_fake');
+      const mod = await import('./index.js');
+      expect(mod.mastra).toBeDefined();
+      // Half a pair falls through to the platform-backed default, so login
+      // still rides the studio provider's shared API.
+      const location = await loginRedirect(mod);
+      expect(location).toContain('platform.mastra.ai');
+    });
 
     it(
       'defers to the platform when MASTRA_SHARED_API_URL is set, warning that WORKOS_* is ignored',
@@ -341,7 +337,9 @@ describe('platform entry (src/mastra/index.ts)', () => {
           // contract: the studio provider wins and login rides the shared API.
           expect(location).toContain('shared.example.com');
           expect(
-            warn.mock.calls.some(call => String(call[0]).includes('WORKOS') && String(call[0]).includes('MASTRA_SHARED_API_URL')),
+            warn.mock.calls.some(
+              call => String(call[0]).includes('WORKOS') && String(call[0]).includes('MASTRA_SHARED_API_URL'),
+            ),
           ).toBe(true);
         } finally {
           warn.mockRestore();

--- a/mastracode/web/src/mastra/index.test.ts
+++ b/mastracode/web/src/mastra/index.test.ts
@@ -292,12 +292,20 @@ describe('platform entry (src/mastra/index.ts)', () => {
       { timeout: 60_000 },
       async () => {
         stubWorkosPair();
-        const mod = await import('./index.js');
-        const location = await loginRedirect(mod);
-        // The redirect must target WorkOS, not the platform's shared login —
-        // self-hosted deploys have no allowed redirect_uri on platform.mastra.ai.
-        expect(location).not.toContain('platform.mastra.ai');
-        expect(location).toContain('client_id=client_fake');
+        const warn = vi.spyOn(console, 'warn');
+        try {
+          const mod = await import('./index.js');
+          const location = await loginRedirect(mod);
+          // The redirect must target WorkOS, not the platform's shared login —
+          // self-hosted deploys have no allowed redirect_uri on platform.mastra.ai.
+          expect(location).not.toContain('platform.mastra.ai');
+          expect(location).toContain('client_id=client_fake');
+          // The precedence warning belongs to the deferral branch only — a
+          // healthy WorkOS boot must not claim its own config is ignored.
+          expect(warn.mock.calls.some(call => String(call[0]).includes('ignored'))).toBe(false);
+        } finally {
+          warn.mockRestore();
+        }
       },
     );
 
@@ -312,6 +320,10 @@ describe('platform entry (src/mastra/index.ts)', () => {
         vi.stubEnv('WORKOS_API_KEY', 'sk_test_fake');
         const mod = await import('./index.js');
         expect(mod.mastra).toBeDefined();
+        // Half a pair falls through to the platform-backed default, so login
+        // still rides the studio provider's shared API.
+        const location = await loginRedirect(mod);
+        expect(location).toContain('platform.mastra.ai');
       },
     );
 

--- a/mastracode/web/src/mastra/index.test.ts
+++ b/mastracode/web/src/mastra/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Hono } from 'hono';
 import { resolveFactoryGithubRule } from '@mastra/factory/rules/resolve';
 
 /**
@@ -9,11 +10,35 @@ import { resolveFactoryGithubRule } from '@mastra/factory/rules/resolve';
  * the module exports a `mastra` instance and that instance carries the web
  * `apiRoutes` (auth + `/web/*`) the deployer's generated Hono server mounts.
  *
- * Web auth is left disabled (no WORKOS_* env), so there is no gate/dispatcher
- * middleware and no auth routes — matching the "auth disabled" branch of the
- * entry. The custom `/web/*` routes are still present.
+ * With no auth env configured the entry leaves `auth` undefined, so the
+ * factory installs its default platform-backed provider (`MastraAuthStudio`)
+ * and the public `/auth/*` routes ride along on `apiRoutes`. The custom
+ * `/web/*` routes are always present.
  */
 describe('platform entry (src/mastra/index.ts)', () => {
+  // Every test in this file imports the real entry, and the entry's auth
+  // selection reads WORKOS_*/MASTRA_* directly from the environment. Blank
+  // them at file scope so a runner with real credentials exported can't flip
+  // the entry into a different auth branch (or crash tests that stub a short
+  // WORKOS_COOKIE_PASSWORD); each test states its own env on top of this.
+  beforeEach(() => {
+    for (const name of [
+      'WORKOS_API_KEY',
+      'WORKOS_CLIENT_ID',
+      'WORKOS_COOKIE_PASSWORD',
+      'MASTRA_SHARED_API_URL',
+      'MASTRA_PLATFORM_SECRET_KEY',
+    ]) {
+      vi.stubEnv(name, '');
+    }
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
   it('exports a booted Mastra with the web apiRoutes folded onto server config', { timeout: 60_000 }, async () => {
     const mod = await import('./index.js');
 
@@ -89,9 +114,9 @@ describe('platform entry (src/mastra/index.ts)', () => {
     expect(item.stages).toEqual(['planning']);
   });
 
-  // Integration env groups are all-or-nothing: setting ANY var of a group
-  // means you intend to enable the integration, so a partial set must fail
-  // the boot loudly (listing what's missing) instead of silently disabling.
+  // Integration env groups are all-or-nothing: a partial set means the
+  // integration stays un-wired, but boot must survive so the diagnostics
+  // surface can report exactly which vars are missing.
   describe('integration env groups', () => {
     beforeEach(() => {
       for (const name of [
@@ -232,6 +257,100 @@ describe('platform entry (src/mastra/index.ts)', () => {
         vi.stubEnv('WORKOS_COOKIE_PASSWORD', '');
         const mod = await import('./index.js');
         expect(mod.mastra.getAgentController('code')?.getChannels()).toBeDefined();
+      },
+    );
+  });
+
+  describe('WorkOS auth env group', () => {
+    // Mount the entry's `/auth/login` route on a throwaway Hono app and return
+    // the redirect target. The handlers built by `buildAuthRoutes` are
+    // self-contained closures over the provider, so no server context is
+    // needed, and `getLoginUrl` only builds a URL — no network involved.
+    async function loginRedirect(mod: typeof import('./index.js')): Promise<string> {
+      const routes = mod.mastra.getServer()?.apiRoutes ?? [];
+      const login = routes.find(route => route.path === '/auth/login');
+      expect(login, 'expected /auth/login to be registered on apiRoutes').toBeDefined();
+      const app = new Hono();
+      app.get('/auth/login', c => (login as any).handler(c));
+      const res = await app.request('/auth/login');
+      expect(res.status).toBeGreaterThanOrEqual(300);
+      expect(res.status).toBeLessThan(400);
+      return res.headers.get('location') ?? '';
+    }
+
+    const stubWorkosPair = () => {
+      vi.stubEnv('WORKOS_API_KEY', 'sk_test_fake');
+      vi.stubEnv('WORKOS_CLIENT_ID', 'client_fake');
+      vi.stubEnv('WORKOS_COOKIE_PASSWORD', 'a-replica-stable-secret-of-32-plus-chars');
+      // Lets MastraAuthWorkos.init() derive the /auth/callback redirect the
+      // way a real deployment's publicUrl does.
+      vi.stubEnv('MASTRACODE_PUBLIC_URL', 'http://localhost:5873');
+    };
+
+    it(
+      'routes /auth/login to WorkOS hosted login when the WORKOS_* pair is configured',
+      { timeout: 60_000 },
+      async () => {
+        stubWorkosPair();
+        const mod = await import('./index.js');
+        const location = await loginRedirect(mod);
+        // The redirect must target WorkOS, not the platform's shared login —
+        // self-hosted deploys have no allowed redirect_uri on platform.mastra.ai.
+        expect(location).not.toContain('platform.mastra.ai');
+        expect(location).toContain('client_id=client_fake');
+      },
+    );
+
+    it(
+      'boots on the default auth path when only WORKOS_API_KEY is set',
+      { timeout: 60_000 },
+      async () => {
+        // varlock rejects an API-key-only env at the dev-script level; this
+        // guards direct boot paths that bypass it. A half-configured pair must
+        // not construct the provider (which would throw on the missing
+        // clientId) — boot survives on the default platform-backed path.
+        vi.stubEnv('WORKOS_API_KEY', 'sk_test_fake');
+        const mod = await import('./index.js');
+        expect(mod.mastra).toBeDefined();
+      },
+    );
+
+    it(
+      'defers to the platform when MASTRA_SHARED_API_URL is set, warning that WORKOS_* is ignored',
+      { timeout: 60_000 },
+      async () => {
+        stubWorkosPair();
+        vi.stubEnv('MASTRA_SHARED_API_URL', 'https://shared.example.com/v1');
+        const warn = vi.spyOn(console, 'warn');
+        try {
+          const mod = await import('./index.js');
+          const location = await loginRedirect(mod);
+          // Explicit platform deferral is the schema's highest-precedence
+          // contract: the studio provider wins and login rides the shared API.
+          expect(location).toContain('shared.example.com');
+          expect(
+            warn.mock.calls.some(call => String(call[0]).includes('WORKOS') && String(call[0]).includes('MASTRA_SHARED_API_URL')),
+          ).toBe(true);
+        } finally {
+          warn.mockRestore();
+        }
+      },
+    );
+
+    it(
+      'keeps WorkOS auth when MASTRA_PLATFORM_SECRET_KEY is set without MASTRA_SHARED_API_URL',
+      { timeout: 60_000 },
+      async () => {
+        // The platform secret key is a compute/integration credential, not an
+        // identity signal: a self-hosted deployment can use platform sandboxes
+        // for compute while running its own WorkOS sign-in. Explicit identity
+        // config must win over the inferred platform association.
+        stubWorkosPair();
+        vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'sk_platform_fake');
+        const mod = await import('./index.js');
+        const location = await loginRedirect(mod);
+        expect(location).not.toContain('platform.mastra.ai');
+        expect(location).toContain('client_id=client_fake');
       },
     );
   });

--- a/mastracode/web/src/mastra/index.test.ts
+++ b/mastracode/web/src/mastra/index.test.ts
@@ -23,6 +23,7 @@ describe('platform entry (src/mastra/index.ts)', () => {
   // WORKOS_COOKIE_PASSWORD); each test states its own env on top of this.
   beforeEach(() => {
     for (const name of [
+      'MASTRACODE_AUTH_DISABLED',
       'WORKOS_API_KEY',
       'WORKOS_CLIENT_ID',
       'WORKOS_COOKIE_PASSWORD',
@@ -300,6 +301,10 @@ describe('platform entry (src/mastra/index.ts)', () => {
           // self-hosted deploys have no allowed redirect_uri on platform.mastra.ai.
           expect(location).not.toContain('platform.mastra.ai');
           expect(location).toContain('client_id=client_fake');
+          // WORKOS_REDIRECT_URI is unset here, so this also pins init()'s
+          // derivation of the callback from the deployment's public URL — a
+          // wrong callback still reaches WorkOS but breaks the OAuth return.
+          expect(new URL(location).searchParams.get('redirect_uri')).toBe('http://localhost:5873/auth/callback');
           // The precedence warning belongs to the deferral branch only — a
           // healthy WorkOS boot must not claim its own config is ignored.
           expect(warn.mock.calls.some(call => String(call[0]).includes('ignored'))).toBe(false);

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -27,6 +27,7 @@ import { InProcessSandboxAddressRegistry, PlatformSandbox } from '@mastra/platfo
 import { RedisStreamsPubSub } from '@mastra/redis-streams';
 import { getDatabasePath } from '@mastra/code-sdk/utils/project';
 import { DEFAULT_RETENTION } from '@mastra/code-sdk/utils/storage-maintenance';
+import { MastraAuthWorkos } from '@mastra/auth-workos';
 import { MastraFactory } from '@mastra/factory';
 import { defaultFactoryRules } from '@mastra/factory/rules/defaults';
 import type { FactoryStageRuleContext } from '@mastra/factory/rules/types';
@@ -78,13 +79,38 @@ if (redisUrl) {
   console.log(`[PubSub] REDIS_URL set — event bus on Redis Streams (${redisTarget}), cross-process leases enabled.`);
 }
 
-// Factory dev is auth-less by default. Production can opt out explicitly;
-// otherwise MastraFactory installs its platform-backed auth provider.
+// Auth selection, ordered by how explicit the operator's intent is:
+//   1. MASTRACODE_AUTH_DISABLED=1 — explicit opt-out, auth off entirely.
+//   2. MASTRA_SHARED_API_URL — explicit platform deferral; identity rides the
+//      shared platform API (`.env.schema` names this the highest-precedence
+//      auth config), so it wins even over a configured WORKOS_* pair — but
+//      loudly, because silently ignoring sign-in config is how self-hosted
+//      logins end up 302-ing somewhere that rejects their redirect_uri.
+//   3. WORKOS_API_KEY + WORKOS_CLIENT_ID — self-managed WorkOS sign-in. The
+//      constructor reads the rest of the WORKOS_* group from env, and
+//      `init()` derives the /auth/callback redirect from the deployment's
+//      publicUrl when WORKOS_REDIRECT_URI is unset. `fetchMemberships` lets
+//      token auth resolve the user's organization so the bootstrapped
+//      personal org works without re-auth. Note MASTRA_PLATFORM_SECRET_KEY
+//      does NOT defer to the platform here: it is a compute/integration
+//      credential (sandboxes, GitHub/Linear slots), not an identity signal —
+//      platform compute plus self-managed sign-in is a supported combination.
+//   4. Nothing configured — leave undefined and MastraFactory installs its
+//      platform-backed default provider.
 const authDisabled = process.env.MASTRACODE_AUTH_DISABLED === '1';
+const workosConfigured = Boolean(process.env.WORKOS_API_KEY?.trim() && process.env.WORKOS_CLIENT_ID?.trim());
 let auth: IMastraAuthProvider | null | undefined;
 
 if (authDisabled) {
   auth = null;
+} else if (process.env.MASTRA_SHARED_API_URL?.trim()) {
+  if (workosConfigured) {
+    console.warn(
+      '[Auth] WORKOS_API_KEY/WORKOS_CLIENT_ID are set but ignored: MASTRA_SHARED_API_URL takes precedence, so sign-in defers to the platform. Unset MASTRA_SHARED_API_URL to use self-managed WorkOS auth.',
+    );
+  }
+} else if (workosConfigured) {
+  auth = new MastraAuthWorkos({ fetchMemberships: true });
 }
 
 // Direct GitHub App fallback: when the platform-backed integration isn't in


### PR DESCRIPTION
Closes #20761

A Factory scaffolded with `create-factory --no-platform` documents `WORKOS_API_KEY` / `WORKOS_CLIENT_ID` as its sign-in configuration, in the README and in `.env.schema`, but the generated server entry never built an auth provider out of them. With no provider configured, `MastraFactory` falls back to its platform-backed studio provider, so `GET /auth/login` on a self-hosted deployment redirects to `platform.mastra.ai` and fails with `redirect_uri host not allowed`. Nothing at boot mentioned that the WorkOS config was ignored.

The template entry now selects its auth provider explicitly:

```ts
if (process.env.MASTRACODE_AUTH_DISABLED === '1') {
  auth = null;
} else if (process.env.MASTRA_SHARED_API_URL?.trim()) {
  // platform deferral wins, but says so when WORKOS_* is also set
} else if (workosConfigured) {
  auth = new MastraAuthWorkos({ fetchMemberships: true });
}
```

The provider reads the rest of the `WORKOS_*` group from env itself, and `init()` derives the `/auth/callback` redirect from the deployment's public URL when `WORKOS_REDIRECT_URI` is unset. `fetchMemberships` is what lets the bootstrapped personal org resolve without a second sign-in, matching what `mountFactoryAuth` already does for the local dev path.

On precedence: `MASTRA_SHARED_API_URL` is documented as highest precedence and still wins, now with a warning naming the config it is overriding. `MASTRA_PLATFORM_SECRET_KEY` deliberately does not defer — it is a compute and integrations credential, not an identity signal, so a deployment using platform sandboxes with its own WorkOS sign-in keeps its WorkOS sign-in. Worth a maintainer opinion, since it means a platform-provisioned project where someone hand-adds a `WORKOS_*` pair switches to self-managed auth.

The template itself is generated from `mastracode/web` by the sync workflow, so `@mastra/auth-workos` is added to the runtime dependency allow-list in `sync-template.mjs` for the generated `package.json` to carry it.

Two smaller things came along with it. `.env.schema` claimed `MASTRA_ORGANIZATION_ID` and `MASTRA_COOKIE_DOMAIN` apply generally; `MastraAuthWorkos` honors neither, so those claims are now scoped to the platform path. An operator setting `MASTRA_ORGANIZATION_ID` alongside a WorkOS pair gets no org enforcement, which is a real gap worth filing separately. And a `WORKOS_COOKIE_PASSWORD` that is declared but empty reaches the provider as an empty string and throws on the 32 character minimum, turning a previously silent misconfiguration into a boot failure. That exposure already exists on the dev path; this change makes it reachable from a deployed template.

Out of scope, called out so they are not lost: `RAILWAY_*` and `MASTRACODE_SANDBOX_PROVIDER` are documented and unwired in the same file (#20762), `BETTER_AUTH_SECRET` has no wiring behind it, and `prepare()` in `@mastra/factory` still defaults to studio auth while `mountFactoryAuth` env-falls-back to WorkOS. That asymmetry is left alone here because changing it would move behavior for every `MastraFactory` consumer, not just this template.

No changeset: `create-factory` publishes only `dist` and `CHANGELOG.md`, the touched files sit outside that, and `mastracode-web` is private. The template reaches users through the sync workflow on merge rather than a release.

Test plan: four tests in `mastracode/web/src/mastra/index.test.ts` boot the real entry and follow `/auth/login`. A configured WorkOS pair redirects to WorkOS with no ignore-warning; a half-configured pair falls through to the platform default; `MASTRA_SHARED_API_URL` defers with the warning; `MASTRA_PLATFORM_SECRET_KEY` alone does not defer. The first and last fail on main against the `platform.mastra.ai` redirect. The `MASTRA_SHARED_API_URL` case is a guard rather than a red test, since the platform path was already the behavior there; its warning assertion is the part that was red. The suite's env scrub was widened to blank the WorkOS and platform variables so a developer's real credentials cannot change which branch the tests exercise. `sync-template.test.ts` covers the new dependency end to end. Both suites and both typechecks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes generated Mastra apps choose the correct sign-in method. Self-hosted apps can now use WorkOS instead of being redirected to the Mastra platform.

## Changes

- Added explicit authentication selection in the generated server entry:
  - Disables authentication when `MASTRACODE_AUTH_DISABLED=1`.
  - Uses platform authentication when `MASTRA_SHARED_API_URL` is set.
  - Warns when platform authentication takes precedence over WorkOS settings.
  - Creates `MastraAuthWorkos` when `WORKOS_API_KEY` and `WORKOS_CLIENT_ID` are set.
  - Uses WorkOS membership fetching.
  - Uses `WORKOS_REDIRECT_URI` or derives `/auth/callback` from the public deployment URL.
  - Keeps `MASTRA_PLATFORM_SECRET_KEY` from triggering platform authentication.
  - Preserves the factory default when no explicit authentication settings exist.
- Added `@mastra/auth-workos` to generated runtime dependencies.
- Updated the web build to build and link `@mastra/auth-workos`.
- Scoped platform-only `.env.schema` settings to platform-deferred authentication.
- Added tests for authentication redirects, precedence, warnings, environment isolation, partial integration configuration, dependency synchronization, and typechecks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->