### PR TITLE
feat(core): stamp the run traceId into assistant message metadata

### DIFF
--- a/.changeset/message-trace-id-19891.md
+++ b/.changeset/message-trace-id-19891.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Stamp the run's traceId into persisted assistant message metadata so a stored message can be correlated back to its trace

--- a/.changeset/message-trace-id-19891.md
+++ b/.changeset/message-trace-id-19891.md
@@ -2,4 +2,13 @@
 '@mastra/core': patch
 ---
 
-Stamp the run's traceId into persisted assistant message metadata so a stored message can be correlated back to its trace
+Stamp the run's traceId into persisted assistant message metadata so a stored message can be correlated back to its trace.
+
+Previously a caller holding only a `messageId` had no supported way to find the trace that produced it: message rows carry no `traceId` column and span records carry no `messageId`. The traceId now rides along in the metadata that already carried `modelId` and `provider`, on both the regular and the durable agent path.
+
+```typescript
+const { messages } = await memory.recall({ threadId, perPage: false })
+const traceId = messages.find(m => m.id === messageId)?.content.metadata?.traceId
+```
+
+This is forward-looking — messages persisted before this change have no traceId.

--- a/docs/src/content/en/docs/observability/feedback.mdx
+++ b/docs/src/content/en/docs/observability/feedback.mdx
@@ -41,7 +41,7 @@ await mastra.observability.addFeedback({
 
 ## Find the trace for a message
 
-Feedback is usually collected against a message a user just read, so you need the `traceId` for that message. Assistant messages carry it in `content.metadata`, both in the stream result and when the message is recalled later from memory:
+Feedback is usually collected against a message a user has already read, so you need the `traceId` for that message. Assistant messages carry it in `content.metadata`, both in the stream result and when the message is recalled later from memory:
 
 ```typescript title="src/mastra/message-trace.ts"
 const { messages } = await memory.recall({ threadId, perPage: false })

--- a/docs/src/content/en/docs/observability/feedback.mdx
+++ b/docs/src/content/en/docs/observability/feedback.mdx
@@ -39,6 +39,19 @@ await mastra.observability.addFeedback({
 })
 ```
 
+## Find the trace for a message
+
+Feedback is usually collected against a message a user just read, so you need the `traceId` for that message. Assistant messages carry it in `content.metadata`, both in the stream result and when the message is recalled later from memory:
+
+```typescript title="src/mastra/message-trace.ts"
+const { messages } = await memory.recall({ threadId, perPage: false })
+
+const message = messages.find(m => m.id === messageId)
+const traceId = message?.content.metadata?.traceId
+```
+
+The value is the same trace the run reports as `traceId` on its result, so feedback collected at generation time and feedback collected later against a stored message anchor to the same trace. Messages produced while tracing is disabled have no `traceId`.
+
 ## Create feedback
 
 Every `createFeedback()` requires `feedbackType` and `value`. Add `traceId` or `spanId` when the feedback should be anchored to a trace or a specific span. Use `feedbackSource` as optional string metadata, such as `user`, `qa`, `studio`, or `system`.

--- a/docs/src/content/en/docs/observability/feedback.mdx
+++ b/docs/src/content/en/docs/observability/feedback.mdx
@@ -44,7 +44,10 @@ await mastra.observability.addFeedback({
 Feedback is usually collected against a message a user has already read, so you need the `traceId` for that message. Assistant messages carry it in `content.metadata`, both in the stream result and when the message is recalled later from memory:
 
 ```typescript title="src/mastra/message-trace.ts"
-const { messages } = await memory.recall({ threadId, perPage: false })
+const agent = mastra.getAgent('weatherAgent')
+const memory = await agent.getMemory()
+
+const { messages } = await memory!.recall({ threadId, perPage: false })
 
 const message = messages.find(m => m.id === messageId)
 const traceId = message?.content.metadata?.traceId

--- a/observability/mastra/src/__snapshots__/agent-processors-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace-generate.json
@@ -543,7 +543,8 @@
                     "content": "Mock V2 generate response",
                     "metadata": {
                       "modelId": "mock-model-id",
-                      "provider": "mock-provider"
+                      "provider": "mock-provider",
+                      "traceId": "<trace-1>"
                     }
                   },
                   "createdAt": "<date>"

--- a/observability/mastra/src/__snapshots__/agent-processors-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace.json
@@ -541,7 +541,8 @@
                     "content": "Mock V2 stream response",
                     "metadata": {
                       "modelId": "mock-model-id",
-                      "provider": "mock-provider"
+                      "provider": "mock-provider",
+                      "traceId": "<trace-1>"
                     }
                   },
                   "createdAt": "<date>"

--- a/packages/core/src/agent/__tests__/message-trace-id.test.ts
+++ b/packages/core/src/agent/__tests__/message-trace-id.test.ts
@@ -1,0 +1,180 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { MockMemory } from '../../memory/mock';
+import { Agent } from '../agent';
+
+/**
+ * Regression test for #19891.
+ *
+ * A persisted assistant message and the trace that produced it had no link:
+ * `mastra_messages` has no traceId column and span records carry no messageId,
+ * so a caller holding a messageId (all the AI SDK chat route emits) could not
+ * find the matching trace to attach feedback or scores to.
+ *
+ * The assistant message's `content.metadata` — which already carries modelId
+ * and provider — now also carries the traceId of the run that produced it.
+ */
+
+const TRACE_ID = 'trace-id-for-message';
+
+function createMockSpan(name: string, parentSpan?: any) {
+  const span: Record<string, any> = {
+    id: `mock-${name}-id`,
+    traceId: TRACE_ID,
+    name,
+    type: name,
+    startTime: new Date(),
+    isInternal: false,
+    isEvent: false,
+    isValid: true,
+    isRootSpan: !parentSpan,
+    parent: parentSpan,
+
+    end: vi.fn(),
+    error: vi.fn(),
+    update: vi.fn(),
+    exportSpan: vi.fn(),
+    getParentSpanId: vi.fn(() => parentSpan?.id),
+    findParent: vi.fn(),
+    executeInContext: vi.fn(async (fn: () => Promise<any>) => fn()),
+    executeInContextSync: vi.fn((fn: () => any) => fn()),
+    get externalTraceId() {
+      return TRACE_ID;
+    },
+
+    createTracker: vi.fn(() => ({
+      // The real tracker hands back the MODEL_GENERATION span it owns.
+      getTracingContext: vi.fn(() => ({ currentSpan: span })),
+      reportGenerationError: vi.fn(),
+      endGeneration: vi.fn(),
+      updateGeneration: vi.fn(),
+      wrapStream: vi.fn(<T>(stream: T) => stream),
+      startStep: vi.fn(),
+      updateStep: vi.fn(),
+    })),
+    createChildSpan: vi.fn((opts: any) => createMockSpan(opts?.type ?? 'child', span)),
+    createEventSpan: vi.fn((opts: any) => createMockSpan(opts?.type ?? 'event', span)),
+    getCorrelationContext: vi.fn(),
+    observabilityInstance: {} as any,
+  };
+
+  return span;
+}
+
+async function mockTracedSpans() {
+  const mod = await import('../../observability/utils');
+  return vi.spyOn(mod, 'getOrCreateSpan').mockImplementation((opts: any) => {
+    return createMockSpan(opts.type ?? opts.name ?? 'unknown') as any;
+  });
+}
+
+function createModel() {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Dummy response' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+      ]),
+    }),
+  });
+}
+
+describe('assistant message trace correlation (#19891)', () => {
+  it('persists the traceId in assistant message content.metadata alongside modelId', async () => {
+    const spy = await mockTracedSpans();
+
+    try {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'trace-id-agent',
+        name: 'Trace Id Agent',
+        instructions: 'test',
+        model: createModel(),
+        memory: mockMemory,
+      });
+
+      const res = await agent.stream('hello', {
+        memory: { resource: 'user-1', thread: { id: 'thread-trace-id' } },
+      });
+
+      await res.consumeStream();
+
+      const { messages } = await mockMemory.recall({ threadId: 'thread-trace-id', perPage: false });
+      const assistantMessages = messages.filter(m => m.role === 'assistant');
+      expect(assistantMessages.length).toBeGreaterThan(0);
+
+      for (const msg of assistantMessages) {
+        // The traceId a caller would use to look the run up, next to the model
+        // metadata that already shipped.
+        expect(msg.content.metadata?.traceId).toBe(TRACE_ID);
+        expect(msg.content.metadata?.modelId).toBe('mock-model-id');
+      }
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('matches the traceId reported on the stream result', async () => {
+    const spy = await mockTracedSpans();
+
+    try {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'trace-id-agent-parity',
+        name: 'Trace Id Agent Parity',
+        instructions: 'test',
+        model: createModel(),
+        memory: mockMemory,
+      });
+
+      const res = await agent.stream('hello', {
+        memory: { resource: 'user-1', thread: { id: 'thread-trace-id-parity' } },
+      });
+
+      await res.consumeStream();
+
+      const { messages } = await mockMemory.recall({ threadId: 'thread-trace-id-parity', perPage: false });
+      const assistant = messages.filter(m => m.role === 'assistant');
+
+      expect(res.traceId).toBe(TRACE_ID);
+      for (const msg of assistant) {
+        expect(msg.content.metadata?.traceId).toBe(res.traceId);
+      }
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('omits traceId when the run is not traced', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'untraced-agent',
+      name: 'Untraced Agent',
+      instructions: 'test',
+      model: createModel(),
+      memory: mockMemory,
+    });
+
+    const res = await agent.stream('hello', {
+      memory: { resource: 'user-1', thread: { id: 'thread-untraced' } },
+    });
+
+    await res.consumeStream();
+
+    const { messages } = await mockMemory.recall({ threadId: 'thread-untraced', perPage: false });
+    const assistant = messages.filter(m => m.role === 'assistant');
+    expect(assistant.length).toBeGreaterThan(0);
+
+    for (const msg of assistant) {
+      expect(msg.content.metadata?.traceId).toBeUndefined();
+      // The metadata that already shipped is unaffected.
+      expect(msg.content.metadata?.modelId).toBe('mock-model-id');
+    }
+  });
+});

--- a/packages/core/src/agent/__tests__/message-trace-id.test.ts
+++ b/packages/core/src/agent/__tests__/message-trace-id.test.ts
@@ -1,7 +1,10 @@
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitterPubSub } from '../../events/event-emitter';
 import { MockMemory } from '../../memory/mock';
+import { InMemoryStore } from '../../storage';
 import { Agent } from '../agent';
+import { createDurableAgent } from '../durable/create-durable-agent';
 
 /**
  * Regression test for #19891.
@@ -13,6 +16,10 @@ import { Agent } from '../agent';
  *
  * The assistant message's `content.metadata` — which already carries modelId
  * and provider — now also carries the traceId of the run that produced it.
+ *
+ * Two execution paths build that metadata and both are covered here: the
+ * regular Agent loop (llm-execution-step.ts `buildResponseModelMetadata`) and
+ * the durable agent's mirror of it (durable/workflows/steps/llm-execution.ts).
  */
 
 const TRACE_ID = 'trace-id-for-message';
@@ -177,4 +184,75 @@ describe('assistant message trace correlation (#19891)', () => {
       expect(msg.content.metadata?.modelId).toBe('mock-model-id');
     }
   });
+});
+
+/**
+ * The durable agent builds its own response metadata rather than calling
+ * `buildResponseModelMetadata`, so the regular-loop tests above cannot cover it.
+ * A caller reading messages back has no idea which path produced them, so the
+ * traceId has to be there either way.
+ */
+describe('durable agent trace correlation (#19891)', () => {
+  let pubsub: EventEmitterPubSub;
+
+  beforeEach(() => {
+    pubsub = new EventEmitterPubSub();
+  });
+
+  afterEach(async () => {
+    await pubsub.close();
+  });
+
+  async function runDurableAgent(threadId: string, agentId: string) {
+    const storage = new InMemoryStore();
+    const memory = new MockMemory({ storage });
+
+    const baseAgent = new Agent({
+      id: agentId,
+      name: agentId,
+      instructions: 'test',
+      model: createModel(),
+      memory,
+    });
+
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+    const { cleanup } = await durableAgent.stream('hello', {
+      memory: { thread: threadId, resource: 'user-1' },
+    });
+
+    // Poll until the durable flush lands — a fixed sleep is timing-dependent
+    // under CI load (same shape as durable-agent-suspend-metadata.test.ts).
+    const store = await storage.getStore('memory');
+    let assistant: any;
+    for (let i = 0; i < 100 && !assistant; i++) {
+      const { messages } = await store!.listMessages({ threadId } as never);
+      assistant = messages.find((m: any) => m.role === 'assistant' && m.content?.metadata?.modelId);
+      if (!assistant) await new Promise(r => setTimeout(r, 100));
+    }
+    cleanup();
+
+    return assistant;
+  }
+
+  it('persists the traceId in assistant message content.metadata on the durable path', async () => {
+    const spy = await mockTracedSpans();
+
+    try {
+      const assistant = await runDurableAgent('thread-durable-trace-id', 'durable-trace-id-agent');
+
+      expect(assistant).toBeDefined();
+      expect(assistant.content.metadata?.traceId).toBe(TRACE_ID);
+      expect(assistant.content.metadata?.modelId).toBe('mock-model-id');
+    } finally {
+      spy.mockRestore();
+    }
+  }, 30000);
+
+  it('omits traceId when the durable run is not traced', async () => {
+    const assistant = await runDurableAgent('thread-durable-untraced', 'durable-untraced-agent');
+
+    expect(assistant).toBeDefined();
+    expect(assistant.content.metadata?.traceId).toBeUndefined();
+    expect(assistant.content.metadata?.modelId).toBe('mock-model-id');
+  }, 30000);
 });

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -23,7 +23,7 @@ import type {
   AnySpan,
 } from '../../../../observability';
 import { EntityType } from '../../../../observability';
-import { getStepAvailableToolNames } from '../../../../observability/utils';
+import { getRootExportSpan, getStepAvailableToolNames } from '../../../../observability/utils';
 import type { CachedLLMStepResponse } from '../../../../processors';
 import { PrepareStepProcessor } from '../../../../processors/processors/prepare-step';
 import { ProcessorRunner } from '../../../../processors/runner';
@@ -1508,13 +1508,20 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             // persisted assistant message carries the same content.metadata
             // (modelId/provider): prefer the static model, fall back to the
             // response-metadata chunk.
+            // The traceId link (#19891) mirrors it too: message rows carry no traceId
+            // column, so this metadata is the only way a stored assistant message can
+            // be correlated back to its trace.
             const responseModelId = currentModel.modelId ?? responseMetadata?.modelId;
+            const responseTraceId = getRootExportSpan(
+              modelSpanTracker?.getTracingContext()?.currentSpan ?? tracingContext?.currentSpan,
+            )?.externalTraceId;
             const responseModelMetadata =
-              responseModelId || currentModel.provider
+              responseModelId || currentModel.provider || responseTraceId
                 ? {
                     metadata: {
                       ...(responseModelId ? { modelId: responseModelId } : {}),
                       ...(currentModel.provider ? { provider: currentModel.provider } : {}),
+                      ...(responseTraceId ? { traceId: responseTraceId } : {}),
                     },
                   }
                 : undefined;

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -22,7 +22,7 @@ import type {
   ObservabilityContext,
   TracingContext,
 } from '../../../observability';
-import { executeWithContextSync, getStepAvailableToolNames } from '../../../observability/utils';
+import { executeWithContextSync, getRootExportSpan, getStepAvailableToolNames } from '../../../observability/utils';
 import type {
   CachedLLMStepResponse,
   InputProcessorOrWorkflow,
@@ -400,6 +400,7 @@ async function addToolPayloadTransformToChunk<OUTPUT>(
 function buildResponseModelMetadata(
   runState: AgenticRunState,
   model?: { provider?: string; modelId?: string },
+  tracingContext?: TracingContext,
 ): { metadata: Record<string, unknown> } | undefined {
   const metadata: Record<string, unknown> = {};
   const modelId = model?.modelId ?? runState.state.responseMetadata?.modelId;
@@ -410,6 +411,16 @@ function buildResponseModelMetadata(
 
   if (model?.provider) {
     metadata.provider = model.provider;
+  }
+
+  // Correlate the persisted message with its trace (#19891). Message rows carry no
+  // traceId column and spans carry no messageId, so this metadata is the only link
+  // between a stored assistant message and the trace that produced it. Use the same
+  // root export span the stream result uses for its own traceId so both agree.
+  const traceId = getRootExportSpan(tracingContext?.currentSpan)?.externalTraceId;
+
+  if (traceId) {
+    metadata.traceId = traceId;
   }
 
   return Object.keys(metadata).length > 0 ? { metadata } : undefined;
@@ -1716,7 +1727,11 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           const builtMessages = buildMessagesFromChunks({
             chunks: collectedChunks,
             messageId: currentStep.messageId,
-            responseModelMetadata: buildResponseModelMetadata(runState, currentStep.model),
+            responseModelMetadata: buildResponseModelMetadata(
+              runState,
+              currentStep.model,
+              modelSpanTracker?.getTracingContext() ?? tracingContext,
+            ),
             tools: currentStep.tools,
           });
           for (const msg of builtMessages) {


### PR DESCRIPTION
## Description

Persisted assistant messages now carry the `traceId` of the run that produced them, in the `content.metadata` blob that already carries `modelId` and `provider`.

## Context

A caller that has a `messageId` had no supported way to find the trace behind it. The two halves never met in the middle:

- `mastra_messages` has no `traceId` column (`packages/core/src/storage/constants.ts`) — messages relate to a run only through their thread.
- Span records carry `threadId`, `runId` and `resourceId` but never a `messageId` (`spanRecordSchema`, `packages/core/src/storage/domains/observability/tracing.ts`).
- The AI SDK chat route emits `messageId` on the `start` part and nothing else (`client-sdks/ai-sdk/src/chat-route.ts`).

So an app that wanted to attach feedback or a score to the message a user just read could only page traces by thread and guess. `/api/agents/{agentId}/generate` returns a `traceId`, which made the gap look like a documentation problem — there was no lookup to document.

The seam is small: `MastraModelOutput` already holds both the `traceId` and the `messageId`, and assistant messages already persist a metadata blob built right where the tracing context is in scope. Stamping the trace id there answers both the generation-time and the load-time question with no schema change, no migration, and no new endpoint. The existing messages API starts returning it.

## Changes

- `buildResponseModelMetadata` (`packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts`) takes the tracing context and adds `traceId` to the metadata.
- The durable agent builds the same metadata at `packages/core/src/agent/durable/workflows/steps/llm-execution.ts`, with a comment stating it deliberately mirrors the regular agent. It stamps the trace id too, so both execution paths agree.
- Both derive the id with `getRootExportSpan(...)?.externalTraceId`, the same call `MastraModelOutput` uses for the `traceId` it reports on the stream result. The persisted value and the streamed value are therefore always the same trace.
- Untraced runs are unchanged: no span means no `traceId` key, and the existing `modelId` and `provider` metadata is untouched.
- Docs: a short section in `docs/src/content/en/docs/observability/feedback.mdx` showing how to read the trace id off a recalled message, since anchoring feedback to a message is the use case that surfaced this.

## Test plan

New `packages/core/src/agent/__tests__/message-trace-id.test.ts`, three cases:

1. A traced run persists `traceId` in `content.metadata` next to `modelId`.
2. The persisted `traceId` equals the `traceId` the stream result reports, pinning the two derivations together.
3. An untraced run persists no `traceId` and its existing metadata is unaffected.

Fails before, passes after. On unmodified code cases 1 and 2 fail with `expected undefined to be 'trace-id-for-message'` and case 3 passes, which is the correct split. With the change all three pass.

Wider gates on `packages/core`:

- `vitest run src/agent/__tests__ src/agent/durable/__tests__ src/loop/workflows/agentic-execution` — 169 files, 1835 passed, 0 failed
- `tsc --noEmit` — clean
- `oxlint . && eslint .` — 0 warnings, 0 errors

Closes #19891


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Each assistant message now records the ID of the trace that created it. This makes it easier to connect feedback to the correct run. Untraced runs remain unchanged.

## Changes

- Added `traceId` to persisted assistant message metadata for regular and durable agent execution.
- Ensured the persisted `traceId` matches the stream result’s `traceId`.
- Kept `modelId` and `provider` metadata unchanged.
- Added documentation for reading `traceId` from recalled messages and associating feedback with the matching trace.
- Added tests for regular and durable traced runs, matching IDs, and untraced runs.
- Updated observability snapshots.
- Added a patch changeset for `@mastra/core`.
- No schema changes, migrations, or new endpoints were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->