### PR TITLE
feat(mcp): elicitation on the 2026-07-28 protocol leg via multi round-trip requests

### DIFF
--- a/.changeset/mrtr-elicitation-modern-leg.md
+++ b/.changeset/mrtr-elicitation-modern-leg.md
@@ -16,6 +16,6 @@ execute: async (inputData, options) => {
 };
 ```
 
-On a `2026-07-28` request, the tool call returns an `input_required` result, the client answers it, and the call retries with the answer attached. The tool function re-executes from the top on each retry: keep side effects idempotent (or place them after the last elicitation) and keep the order of `sendRequest()` calls deterministic. Legacy connections keep the existing push-based `elicitation/create` flow unchanged.
+On a `2026-07-28` request, the tool call first returns an `input_required` result. After the client answers, the call retries with the answer attached. The tool function re-executes from the top on each retry, so keep side effects idempotent (or place them after the last elicitation) and keep the order of `sendRequest()` calls deterministic. Legacy connections keep the existing push-based `elicitation/create` flow unchanged.
 
 **Client** — a handler registered with `elicitation.onRequest()` now fires on both eras: on `2026-07-28` connections, embedded elicitation requests are dispatched through the same handler and the originating tool call retries automatically. The warning that elicitation only works on legacy connections is removed.

--- a/.changeset/mrtr-elicitation-modern-leg.md
+++ b/.changeset/mrtr-elicitation-modern-leg.md
@@ -1,0 +1,21 @@
+---
+'@mastra/mcp': minor
+---
+
+Added elicitation support on the `2026-07-28` protocol revision using the spec's multi round-trip mechanism, completing the opt-in `protocolVersion` support.
+
+**Server** — tools keep the same promise-shaped API on both eras:
+
+```typescript
+execute: async (inputData, options) => {
+  const answer = await options.mcp.elicitation.sendRequest({
+    message: "What is your favorite color?",
+    requestedSchema: { type: "object", properties: { color: { type: "string" } } },
+  });
+  // ...
+};
+```
+
+On a `2026-07-28` request, the tool call returns an `input_required` result, the client answers it, and the call retries with the answer attached. The tool function re-executes from the top on each retry: keep side effects idempotent (or place them after the last elicitation) and keep the order of `sendRequest()` calls deterministic. Legacy connections keep the existing push-based `elicitation/create` flow unchanged.
+
+**Client** — a handler registered with `elicitation.onRequest()` now fires on both eras: on `2026-07-28` connections, embedded elicitation requests are dispatched through the same handler and the originating tool call retries automatically. The warning that elicitation only works on legacy connections is removed.

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -180,7 +180,7 @@ Each server in the `servers` map is configured using the `MastraMCPServerDefinit
     type: "'auto' | '2026-07-28'",
     isOptional: true,
     description:
-      "Opt-in MCP protocol version negotiation. Omitted keeps the legacy (2025-era) connect sequence unchanged. 'auto' probes the server at connect time and uses the stateless '2026-07-28' revision when the server supports it, with a safe fallback to the legacy handshake. '2026-07-28' pins that revision exactly and fails with a typed error when the server does not offer it. Elicitation handlers currently only fire on legacy connections.",
+      "Opt-in MCP protocol version negotiation. Omitted keeps the legacy (2025-era) connect sequence unchanged. 'auto' probes the server at connect time and uses the stateless '2026-07-28' revision when the server supports it, with a safe fallback to the legacy handshake. '2026-07-28' pins that revision exactly and fails with a typed error when the server does not offer it. Elicitation handlers work on both eras: on a '2026-07-28' connection, embedded elicitation requests from input_required results are dispatched through the same registered handler and the originating call retries automatically.",
   },
 ]}
 />

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -212,7 +212,7 @@ By default, `MCPServer` speaks the legacy (2025-era) MCP protocol: sessionful st
 - Tool list, prompt list, resource list, and resource update notifications also reach `2026-07-28` clients through `subscriptions/listen`.
 - Tool log messages honor the caller's per-request `logLevel` opt-in instead of the session-level `logging/setLevel`.
 - Configured `cacheHints` are advertised on cacheable results such as `tools/list`.
-- Tool elicitation (`options.mcp.elicitation.sendRequest()`) works on both eras. On `2026-07-28` requests it uses the protocol's multi round-trip mechanism: the tool call returns an `input_required` result, the client answers it, and the call retries with the answer attached. The `sendRequest()` promise API is unchanged, but the tool function re-executes from the top on each retry, so keep side effects idempotent (or place them after the last elicitation) and keep the order of `sendRequest()` calls deterministic for a given input.
+- Tool elicitation (`options.mcp.elicitation.sendRequest()`) works on both eras. On `2026-07-28` requests, it uses the protocol's multi round-trip mechanism. The tool call first returns an `input_required` result. After the client answers, the call retries with the answer attached. The `sendRequest()` promise API is unchanged, but the tool function re-executes from the top on each retry, so keep side effects idempotent (or place them after the last elicitation) and keep the order of `sendRequest()` calls deterministic for a given input.
 
 ```typescript
 const server = new MCPServer({

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -212,6 +212,7 @@ By default, `MCPServer` speaks the legacy (2025-era) MCP protocol: sessionful st
 - Tool list, prompt list, resource list, and resource update notifications also reach `2026-07-28` clients through `subscriptions/listen`.
 - Tool log messages honor the caller's per-request `logLevel` opt-in instead of the session-level `logging/setLevel`.
 - Configured `cacheHints` are advertised on cacheable results such as `tools/list`.
+- Tool elicitation (`options.mcp.elicitation.sendRequest()`) works on both eras. On `2026-07-28` requests it uses the protocol's multi round-trip mechanism: the tool call returns an `input_required` result, the client answers it, and the call retries with the answer attached. The `sendRequest()` promise API is unchanged, but the tool function re-executes from the top on each retry, so keep side effects idempotent (or place them after the last elicitation) and keep the order of `sendRequest()` calls deterministic for a given input.
 
 ```typescript
 const server = new MCPServer({

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -1214,16 +1214,11 @@ export class InternalMastraMCPClient extends MastraBase {
 
   setElicitationRequestHandler(handler: ElicitationHandler): void {
     this.log('debug', 'Setting elicitation request handler');
-    if (this.serverConfig.protocolVersion !== undefined) {
-      // The elicitation/create request handler below only fires on legacy (2025-era)
-      // connections. On a negotiated 2026-07-28 connection, server-side input requests
-      // use the multi-round-trip mechanism, which this client does not drive yet.
-      this.log(
-        'warning',
-        `An elicitation handler is registered while protocolVersion is set ('${this.serverConfig.protocolVersion}'). ` +
-          'Elicitation only works on legacy connections; it will not fire on a negotiated 2026-07-28 connection.',
-      );
-    }
+    // The handler serves both protocol eras: on legacy (2025-era) connections it
+    // answers elicitation/create wire requests; on negotiated 2026-07-28
+    // connections the SDK's multi-round-trip driver dispatches embedded
+    // elicitation requests from input_required results through the same
+    // registered handler and retries the originating call automatically.
     if (!this.hasElicitationCapability) {
       try {
         this.client.registerCapabilities({ elicitation: { form: {} } });

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -300,9 +300,10 @@ export type BaseServerOptions = {
    * - `'2026-07-28'`: pin to that revision exactly. Connecting to a server that
    *   does not offer it fails loudly with a typed error — no fallback.
    *
-   * Note: elicitation handlers currently only fire on legacy connections; on a
-   * negotiated `2026-07-28` connection, server-side input requests use the
-   * multi-round-trip mechanism, which this client does not drive yet.
+   * Elicitation handlers work on both eras: on a negotiated `2026-07-28`
+   * connection, embedded elicitation requests from `input_required` results are
+   * dispatched through the same registered handler and the originating call is
+   * retried automatically.
    *
    * @example
    * ```typescript

--- a/packages/mcp/src/server/mrtrElicitation.ts
+++ b/packages/mcp/src/server/mrtrElicitation.ts
@@ -1,0 +1,141 @@
+import type { MCPServerContext } from '@mastra/core/tools';
+import type { ElicitRequest, ElicitResult, InputRequiredResult } from '@modelcontextprotocol/server';
+
+import type { ElicitationActions } from './types';
+
+/**
+ * Elicitation on the 2026-07-28 protocol revision (multi-round-trip requests).
+ *
+ * The modern era has no server→client request channel, so `server.elicitInput()`
+ * throws there by design. Instead, the `tools/call` handler must RETURN an
+ * `input_required` result carrying the embedded elicitation request; the client
+ * answers it locally and RETRIES the call with the response attached
+ * (`inputResponses`). This module keeps the promise-shaped
+ * `elicitation.sendRequest()` API tools already use by replaying the tool:
+ *
+ * 1. Each `sendRequest` call is assigned a deterministic sequence key.
+ * 2. If the current (retried) request carries an answer for that key — either in
+ *    this round's `inputResponses` or in the accumulated `requestState` from
+ *    prior rounds — the promise resolves with it immediately.
+ * 3. Otherwise a {@link ElicitationReplayInterrupt} is thrown; the `tools/call`
+ *    handler converts it into an {@link InputRequiredResult} return, and the
+ *    client's retry re-executes the tool from the top.
+ *
+ * Consequences tools must live with on the modern leg:
+ * - Code before an unanswered elicitation re-executes on every round; keep side
+ *   effects idempotent or place them after the last elicitation.
+ * - Elicitation order must be deterministic for a given input, since answers are
+ *   matched by call sequence.
+ */
+
+const ELICIT_KEY_PREFIX = 'mastra_elicit_';
+
+/**
+ * Thrown by the replay-based `sendRequest` when the current round carries no
+ * answer for the elicitation. Never surfaces to tools or clients: the
+ * `tools/call` handler converts it into an `input_required` result.
+ */
+export class ElicitationReplayInterrupt extends Error {
+  constructor(
+    public readonly key: string,
+    public readonly params: ElicitRequest['params'],
+    public readonly answered: Record<string, ElicitResult>,
+  ) {
+    super(`Elicitation '${key}' requires client input (multi-round-trip)`);
+    this.name = 'ElicitationReplayInterrupt';
+  }
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const looksLikeElicitResult = (value: unknown): value is ElicitResult =>
+  isPlainObject(value) && typeof value.action === 'string';
+
+/**
+ * Decodes the accumulated prior-round answers from the request's opaque
+ * `requestState` echo. The state round-trips through the client, so it is
+ * attacker-controlled input on re-entry — but its only content is the client's
+ * own past elicitation answers, which are untrusted user input either way, so
+ * tampering grants the client nothing it does not already control. Anything
+ * that does not parse as a map of elicitation results is discarded.
+ */
+const decodePriorAnswers = (extra: MCPServerContext): Record<string, ElicitResult> => {
+  const raw = extra.mcpReq.requestState();
+  if (typeof raw !== 'string' || raw.length === 0) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (!isPlainObject(parsed)) return {};
+    const answers: Record<string, ElicitResult> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (key.startsWith(ELICIT_KEY_PREFIX) && looksLikeElicitResult(value)) answers[key] = value;
+    }
+    return answers;
+  } catch {
+    return {};
+  }
+};
+
+/** This round's bare responses that answer our elicitation keys. */
+const currentRoundAnswers = (extra: MCPServerContext): Record<string, ElicitResult> => {
+  const answers: Record<string, ElicitResult> = {};
+  for (const [key, value] of Object.entries(extra.mcpReq.inputResponses ?? {})) {
+    if (key.startsWith(ELICIT_KEY_PREFIX) && looksLikeElicitResult(value)) answers[key] = value;
+  }
+  return answers;
+};
+
+/**
+ * Whether this request is served on the 2026-07-28 era. Modern clients always
+ * attach the reserved per-request `_meta` envelope (the 2026 codec enforces the
+ * required keys at dispatch); legacy requests never carry it.
+ */
+export const isModernEraRequest = (extra: MCPServerContext): boolean => extra.mcpReq.envelope !== undefined;
+
+/**
+ * Builds the replay-based {@link ElicitationActions} for one modern-era tool
+ * execution. Answers already provided by the client resolve immediately; the
+ * first unanswered elicitation throws {@link ElicitationReplayInterrupt}.
+ *
+ * The interrupt is also reported through `onInterrupt` before it is thrown:
+ * tool wrappers (e.g. Mastra's tool builder) re-wrap thrown errors, so the
+ * `tools/call` handler cannot rely on `instanceof` on whatever escapes the
+ * tool — the out-of-band capture is the authoritative signal.
+ */
+export const createReplayElicitation = (
+  extra: MCPServerContext,
+  onInterrupt: (interrupt: ElicitationReplayInterrupt) => void,
+): ElicitationActions => {
+  const prior = decodePriorAnswers(extra);
+  const current = currentRoundAnswers(extra);
+  const answered: Record<string, ElicitResult> = { ...prior, ...current };
+  let sequence = 0;
+
+  return {
+    sendRequest: async (request: ElicitRequest['params']): Promise<ElicitResult> => {
+      const key = `${ELICIT_KEY_PREFIX}${sequence++}`;
+      const answer = answered[key];
+      if (answer !== undefined) return answer;
+      const interrupt = new ElicitationReplayInterrupt(key, request, answered);
+      onInterrupt(interrupt);
+      throw interrupt;
+    },
+  };
+};
+
+/**
+ * Converts a caught {@link ElicitationReplayInterrupt} into the
+ * `input_required` result the `tools/call` handler returns to the client.
+ * Prior answers travel in `requestState` because each retry only carries the
+ * current round's `inputResponses`.
+ */
+export const replayInterruptToInputRequired = (interrupt: ElicitationReplayInterrupt): InputRequiredResult => {
+  const params = { mode: 'form' as const, ...interrupt.params };
+  return {
+    resultType: 'input_required',
+    inputRequests: {
+      [interrupt.key]: { method: 'elicitation/create', params } as never,
+    },
+    ...(Object.keys(interrupt.answered).length > 0 ? { requestState: JSON.stringify(interrupt.answered) } : {}),
+  };
+};

--- a/packages/mcp/src/server/server-modern-era-http.test.ts
+++ b/packages/mcp/src/server/server-modern-era-http.test.ts
@@ -421,3 +421,156 @@ describe('MCPServer without protocolVersion (legacy default)', () => {
     await client.disconnect().catch(() => {});
   });
 });
+
+describe('MCPServer elicitation on the 2026-07-28 leg (multi-round-trip)', () => {
+  let server: MCPServer;
+  let httpServer: http.Server;
+  let baseUrl: URL;
+  const executions = { ask: 0, twoStep: 0 };
+
+  beforeAll(async () => {
+    server = new MCPServer({
+      name: 'MRTR Elicitation Server',
+      version: '1.0.0',
+      protocolVersion: '2026-07-28',
+      tools: {
+        askTool: createTool({
+          id: 'askTool',
+          description: 'Asks the user for their favorite color',
+          inputSchema: z.object({}),
+          execute: async (_inputData, options) => {
+            executions.ask += 1;
+            const result = await options!.mcp!.elicitation.sendRequest({
+              message: 'What is your favorite color?',
+              requestedSchema: {
+                type: 'object',
+                properties: { color: { type: 'string' } },
+                required: ['color'],
+              },
+            });
+            if (result.action !== 'accept') return 'declined';
+            return `color: ${(result.content as { color: string }).color}`;
+          },
+        }),
+        twoStepTool: createTool({
+          id: 'twoStepTool',
+          description: 'Asks the user two sequential questions',
+          inputSchema: z.object({}),
+          execute: async (_inputData, options) => {
+            executions.twoStep += 1;
+            const sendRequest = options!.mcp!.elicitation.sendRequest;
+            const first = await sendRequest({
+              message: 'first',
+              requestedSchema: { type: 'object', properties: { answer: { type: 'string' } }, required: ['answer'] },
+            });
+            const second = await sendRequest({
+              message: 'second',
+              requestedSchema: { type: 'object', properties: { answer: { type: 'string' } }, required: ['answer'] },
+            });
+            const a = (first.content as { answer: string }).answer;
+            const b = (second.content as { answer: string }).answer;
+            return `${a}+${b}`;
+          },
+        }),
+      },
+    });
+    httpServer = http.createServer(async (req, res) => {
+      await server.startHTTP({
+        url: new URL(req.url || '', 'http://localhost'),
+        httpPath: '/mcp',
+        req,
+        res,
+      });
+    });
+    const port = await listenOnFreePort(httpServer);
+    baseUrl = new URL(`http://localhost:${port}/mcp`);
+  });
+
+  afterAll(async () => {
+    await server?.close();
+    await new Promise<void>(resolve => httpServer.close(() => resolve()));
+  });
+
+  const makeModernElicitingClient = (answers: Record<string, string>) => {
+    const client = new Client(
+      { name: 'elicit-client', version: '1.0.0' },
+      {
+        capabilities: { elicitation: { form: {} } },
+        versionNegotiation: { mode: { pin: '2026-07-28' } },
+      },
+    );
+    client.setRequestHandler('elicitation/create', async request => {
+      const key = request.params.message;
+      const answer = answers[key];
+      if (answer === undefined) return { action: 'decline' as const };
+      const field = 'color' in ((request.params as any).requestedSchema?.properties ?? {}) ? 'color' : 'answer';
+      return { action: 'accept' as const, content: { [field]: answer } };
+    });
+    return client;
+  };
+
+  it('completes a tool that elicits: the client answers and retries transparently', async () => {
+    executions.ask = 0;
+    const client = makeModernElicitingClient({ 'What is your favorite color?': 'blue' });
+    await client.connect(new StreamableHTTPClientTransport(baseUrl));
+    try {
+      const result = await client.callTool({ name: 'askTool', arguments: {} });
+      expect((result as any).isError).toBeFalsy();
+      expect((result as any).content[0].text).toBe('color: blue');
+      // Round 1 interrupts, round 2 replays with the answer.
+      expect(executions.ask).toBe(2);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('supports sequential elicitations across rounds via requestState accumulation', async () => {
+    executions.twoStep = 0;
+    const client = makeModernElicitingClient({ first: 'one', second: 'two' });
+    await client.connect(new StreamableHTTPClientTransport(baseUrl));
+    try {
+      const result = await client.callTool({ name: 'twoStepTool', arguments: {} });
+      expect((result as any).isError).toBeFalsy();
+      expect((result as any).content[0].text).toBe('one+two');
+      // Three rounds: interrupt on first, interrupt on second (first answered
+      // from requestState), then complete.
+      expect(executions.twoStep).toBe(3);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('surfaces a declined elicitation to the tool', async () => {
+    executions.ask = 0;
+    const client = makeModernElicitingClient({});
+    await client.connect(new StreamableHTTPClientTransport(baseUrl));
+    try {
+      const result = await client.callTool({ name: 'askTool', arguments: {} });
+      expect((result as any).content[0].text).toBe('declined');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('works through the Mastra client with a pinned protocolVersion and an elicitation handler', async () => {
+    const client = new InternalMastraMCPClient({
+      name: 'mastra-elicit-client',
+      server: {
+        url: baseUrl,
+        protocolVersion: '2026-07-28',
+      },
+    });
+    client.elicitation.onRequest(async request => {
+      expect(request.message).toBe('What is your favorite color?');
+      return { action: 'accept', content: { color: 'green' } };
+    });
+    await client.connect();
+    try {
+      const tools = await client.tools();
+      const result = await tools.askTool.execute!({}, {} as any);
+      expect(JSON.stringify(result)).toContain('color: green');
+    } finally {
+      await client.disconnect();
+    }
+  });
+});

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -46,6 +46,12 @@ import { streamSSE } from 'hono/streaming';
 import { SSETransport } from 'hono-mcp-server-sse-transport';
 
 import { withMastraToolStrictMeta } from '../shared/mastra-tool-meta';
+import {
+  createReplayElicitation,
+  ElicitationReplayInterrupt,
+  isModernEraRequest,
+  replayInterruptToInputRequired,
+} from './mrtrElicitation';
 import { broadcastNotification } from './notificationBroadcast';
 import { ServerPromptActions } from './promptActions';
 import { ServerResourceActions } from './resourceActions';
@@ -1033,6 +1039,7 @@ export class MCPServer extends MCPServerBase {
     serverInstance.setRequestHandler('tools/call', async (request, ctx) => {
       const startTime = Date.now();
       const extra = toMCPRequestHandlerExtra(ctx);
+      let replayInterrupt: ElicitationReplayInterrupt | undefined;
       try {
         const tool = this.convertedTools[request.params.name];
         if (!tool) {
@@ -1078,12 +1085,20 @@ export class MCPServer extends MCPServerBase {
           };
         }
 
-        // Create session-aware elicitation for this tool execution
-        const sessionElicitation: ElicitationActions = {
-          sendRequest: async (request: ElicitRequest['params'], options?: RequestOptions) => {
-            return this.handleElicitationRequest(request, serverInstance, options);
-          },
-        };
+        // Create session-aware elicitation for this tool execution.
+        // On a 2026-07-28 request there is no server→client request channel, so
+        // elicitation runs through the multi-round-trip replay seam instead of
+        // the legacy elicitation/create push. The interrupt is captured out of
+        // band because tool wrappers re-wrap thrown errors.
+        const sessionElicitation: ElicitationActions = isModernEraRequest(extra)
+          ? createReplayElicitation(extra, interrupt => {
+              replayInterrupt = interrupt;
+            })
+          : {
+              sendRequest: async (request: ElicitRequest['params'], options?: RequestOptions) => {
+                return this.handleElicitationRequest(request, serverInstance, options);
+              },
+            };
 
         const proxiedContext = await this.createProxiedRequestContext(extra);
 
@@ -1222,6 +1237,16 @@ export class MCPServer extends MCPServerBase {
 
         return response;
       } catch (error) {
+        // Tool wrappers may re-wrap the interrupt (e.g. into MastraError), so the
+        // out-of-band capture — not instanceof on the thrown error — is the signal.
+        if (replayInterrupt !== undefined) {
+          // Not an error: the tool asked for user input on a 2026-07-28 request.
+          // Return input_required so the client answers and retries the call.
+          this.logger.debug(`CallTool: Tool '${request.params.name}' requires client input (multi-round-trip).`, {
+            key: replayInterrupt.key,
+          });
+          return replayInterruptToInputRequired(replayInterrupt);
+        }
         const duration = Date.now() - startTime;
         if (error instanceof Error && 'issues' in error && Array.isArray((error as any).issues)) {
           const issues: Array<{ path: string[]; message: string }> = (error as any).issues;


### PR DESCRIPTION
## Summary

**Stacked on #20929** (`mcp/protocol-version-2026-07-28`) — retarget to `main` once that merges.

This PR completes the opt-in `protocolVersion: '2026-07-28'` support by making elicitation work on the modern leg. The `2026-07-28` MCP revision removes the server→client request channel, so `server.elicitInput()` throws there by design; the replacement is the spec's multi round-trip (MRTR) mechanism: the tool call returns an `input_required` result, the client answers the embedded elicitation request, and the call retries with the answer attached.

### Design: keep `sendRequest()`, replay the tool

Tools keep the exact promise-shaped API they already use (`options.mcp.elicitation.sendRequest(...)`) on both eras. On a `2026-07-28` request (`src/server/mrtrElicitation.ts`):

- Each `sendRequest` call gets a deterministic sequence key. If the (retried) request carries an answer for that key — in this round's `inputResponses` or in the `requestState` accumulation of prior rounds — the promise resolves immediately.
- The first unanswered call raises an interrupt, captured out of band (tool wrappers re-wrap thrown errors, so `instanceof` on the escaping error is not reliable). The `tools/call` handler converts it into an `input_required` return.
- Prior answers travel in the opaque `requestState` echo because each retry only carries the current round's responses. The state's only content is the client's own past elicitation answers — untrusted user input either way — so tampering grants the client nothing it does not already control; undecodable state is discarded.

Documented consequence: the tool function re-executes from the top on each round, so tools should keep side effects idempotent (or after the last elicitation) and elicit in a deterministic order.

### Client

The SDK's MRTR auto-fulfilment driver (on by default) dispatches embedded `elicitation/create` requests through the **same registered request handler** our `setElicitationRequestHandler` / `elicitation.onRequest()` already installs and retries the originating call automatically — so a registered handler now works on both eras with no API change. The PR 1 warning ("elicitation only works on legacy connections") is removed.

Legacy connections keep the push-based `elicitation/create` flow byte-identical.

## Test plan

- New modern-era tests in `server-modern-http.test.ts`: single elicitation round-trip (asserts 2 executions: interrupt + replay); two sequential elicitations across 3 rounds (asserts `requestState` accumulation); declined elicitation surfaces to the tool; end-to-end through the Mastra client with pinned `protocolVersion` and `elicitation.onRequest()`.
- Legacy regression: full suites pass unchanged — `test:server` 139/139, `test:client` 222/222, `test:integration` 10/10 (existing legacy elicitation tests included).
- `build:lib`, `tsc --noEmit`, lint, and docs `validate` all clean.
