### PR TITLE
fix(docs): smooth contextual sidebar transitions

### DIFF
--- a/.changeset/smooth-contextual-sidebars.md
+++ b/.changeset/smooth-contextual-sidebars.md
@@ -1,0 +1,5 @@
+---
+'mastra-docs': patch
+---
+
+Improved docs sidebar transitions when opening and closing contextual menus.

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1196,7 +1196,7 @@ article p {
     }
   }
 
-  li[data-contextual-sidebar='true'] > .menu__list-item-collapsible > .menu__link::after {
+  li[data-contextual-sidebar='true'] > .menu__link::after {
     content: '';
     flex: 0 0 1.25rem;
     height: 1.25rem;

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1196,6 +1196,7 @@ article p {
     }
   }
 
+  /* stylelint-disable selector-class-pattern */
   li[data-contextual-sidebar='true'] > .menu__link::after {
     content: '';
     flex: 0 0 1.25rem;
@@ -1205,6 +1206,7 @@ article p {
     transform: rotate(90deg);
     transition: transform var(--ifm-transition-fast) linear;
   }
+  /* stylelint-enable selector-class-pattern */
 
   [class*='docSidebarContainer'] {
     width: 280px !important;

--- a/docs/src/theme/DocSidebar/ContextualContent/index.tsx
+++ b/docs/src/theme/DocSidebar/ContextualContent/index.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode, useRef } from 'react'
+import React, { type ComponentProps, type ReactNode, useRef } from 'react'
 import { ThemeClassNames } from '@docusaurus/theme-common'
 import DocSidebarItems from '@theme/DocSidebarItems'
 import type { PropSidebarItem } from '@docusaurus/plugin-content-docs'
@@ -15,7 +15,10 @@ type Props = Readonly<{
   onItemClick?: (item: PropSidebarItem) => void
   paneClassName?: string
   entryAnimationClassName?: string
+  exitAnimationClassName?: string
   animateEntry?: boolean
+  isExiting?: boolean
+  onExitAnimationEnd?: ComponentProps<'div'>['onAnimationEnd']
 }>
 
 export default function ContextualContent({
@@ -26,17 +29,29 @@ export default function ContextualContent({
   onItemClick,
   paneClassName,
   entryAnimationClassName,
+  exitAnimationClassName,
   animateEntry = false,
+  isExiting = false,
+  onExitAnimationEnd,
 }: Props): ReactNode {
   const shouldAnimateEntry = useRef(animateEntry).current
-  const contentClassName = cn(paneClassName, shouldAnimateEntry && entryAnimationClassName)
+  const contentClassName = cn(
+    paneClassName,
+    shouldAnimateEntry && entryAnimationClassName,
+    isExiting && exitAnimationClassName,
+  )
 
   return (
-    <>
+    <div
+      data-sidebar-panel-container="contextual"
+      className={contentClassName}
+      aria-hidden={isExiting || undefined}
+      inert={isExiting || undefined}
+      onAnimationEnd={onExitAnimationEnd}
+    >
       <div
         className={cn(
           styles.header,
-          contentClassName,
           'rounded-lg border-[0.5px] border-(--border) text-(--mastra-text-secondary) hover:bg-(--mastra-surface-2) dark:bg-(--mastra-surface-4) hover:text-(--mastra-text-primary)',
         )}
       >
@@ -46,13 +61,10 @@ export default function ContextualContent({
         </button>
       </div>
       <ContextualSidebarPaneProvider>
-        <ul
-          data-sidebar-panel="contextual"
-          className={cn(ThemeClassNames.docs.docSidebarMenu, 'menu__list', contentClassName)}
-        >
+        <ul data-sidebar-panel="contextual" className={cn(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
           <DocSidebarItems items={items} activePath={activePath} level={1} onItemClick={onItemClick} />
         </ul>
       </ContextualSidebarPaneProvider>
-    </>
+    </div>
   )
 }

--- a/docs/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/docs/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
-import { ThemeClassNames } from '@docusaurus/theme-common'
+import { prefersReducedMotion, ThemeClassNames } from '@docusaurus/theme-common'
 import { useAnnouncementBar, useScrollPosition } from '@docusaurus/theme-common/internal'
 import { translate } from '@docusaurus/Translate'
 import DocSidebarItems from '@theme/DocSidebarItems'
@@ -32,10 +32,11 @@ export default function DocSidebarDesktopContent({ path, sidebar, className }: P
   const versionControlRef = useRef<HTMLDivElement>(null)
   const { activateSidebar, clearSidebar, resolveSidebar } = useContextualSidebar()
   const contextualSidebar = resolveSidebar(sidebar)
+  const [exitingContextualSidebar, setExitingContextualSidebar] = useState<typeof contextualSidebar>()
+  const renderedContextualSidebar = exitingContextualSidebar ?? contextualSidebar
   const paneKey = contextualSidebar?.state.categoryHref ?? 'root'
   const previousPaneKey = useRef(paneKey)
   const shouldAnimateContextualEntry = previousPaneKey.current === 'root' && paneKey !== 'root'
-  const shouldAnimateRootEntry = previousPaneKey.current !== 'root' && paneKey === 'root'
 
   useLayoutEffect(() => {
     if (previousPaneKey.current !== paneKey) {
@@ -85,11 +86,28 @@ export default function DocSidebarDesktopContent({ path, sidebar, className }: P
       navigation.removeEventListener('scroll', updateBottomFade)
       resizeObserver.disconnect()
     }
-  }, [contextualSidebar, sidebar])
+  }, [renderedContextualSidebar, sidebar])
+
+  const finishContextualExit = () => {
+    setExitingContextualSidebar(undefined)
+    requestAnimationFrame(() => navigationRef.current?.focus())
+  }
 
   const handleBack = () => {
+    if (!contextualSidebar || prefersReducedMotion()) {
+      clearSidebar()
+      requestAnimationFrame(() => navigationRef.current?.focus())
+      return
+    }
+
+    setExitingContextualSidebar(contextualSidebar)
     clearSidebar()
-    requestAnimationFrame(() => navigationRef.current?.focus())
+  }
+
+  const handleContextualExitAnimationEnd: React.AnimationEventHandler<HTMLDivElement> = event => {
+    if (exitingContextualSidebar && event.target === event.currentTarget) {
+      finishContextualExit()
+    }
   }
 
   return (
@@ -116,21 +134,26 @@ export default function DocSidebarDesktopContent({ path, sidebar, className }: P
             ThemeClassNames.docs.docSidebarMenu,
             'menu__list',
             styles.pane,
-            contextualSidebar ? styles.rootPaneInactive : shouldAnimateRootEntry && styles.rootPaneEntry,
+            contextualSidebar && styles.rootPaneInactive,
           )}
+          aria-hidden={contextualSidebar ? true : undefined}
+          inert={contextualSidebar ? true : undefined}
         >
           <DocSidebarItems items={sidebar} activePath={path} level={1} />
         </ul>
-        {contextualSidebar && (
+        {renderedContextualSidebar && (
           <ContextualContent
             activePath={path}
-            items={contextualSidebar.items}
-            label={contextualSidebar.state.categoryLabel}
+            items={renderedContextualSidebar.items}
+            label={renderedContextualSidebar.state.categoryLabel}
             onBack={handleBack}
-            onItemClick={() => activateSidebar(contextualSidebar.state)}
+            onItemClick={() => activateSidebar(renderedContextualSidebar.state)}
             paneClassName={styles.pane}
-            entryAnimationClassName={styles.contextualPane}
+            entryAnimationClassName={styles.contextualPaneEnter}
+            exitAnimationClassName={styles.contextualPaneExit}
             animateEntry={shouldAnimateContextualEntry}
+            isExiting={Boolean(exitingContextualSidebar)}
+            onExitAnimationEnd={handleContextualExitAnimationEnd}
           />
         )}
         <div ref={versionControlRef} className={styles.versionControl}>

--- a/docs/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/docs/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -33,7 +33,8 @@ export default function DocSidebarDesktopContent({ path, sidebar, className }: P
   const { activateSidebar, clearSidebar, resolveSidebar } = useContextualSidebar()
   const contextualSidebar = resolveSidebar(sidebar)
   const [exitingContextualSidebar, setExitingContextualSidebar] = useState<typeof contextualSidebar>()
-  const renderedContextualSidebar = exitingContextualSidebar ?? contextualSidebar
+  const renderedContextualSidebar = contextualSidebar ?? exitingContextualSidebar
+  const isContextualSidebarExiting = !contextualSidebar && Boolean(exitingContextualSidebar)
   const paneKey = contextualSidebar?.state.categoryHref ?? 'root'
   const previousPaneKey = useRef(paneKey)
   const shouldAnimateContextualEntry = previousPaneKey.current === 'root' && paneKey !== 'root'
@@ -134,7 +135,7 @@ export default function DocSidebarDesktopContent({ path, sidebar, className }: P
             ThemeClassNames.docs.docSidebarMenu,
             'menu__list',
             styles.pane,
-            contextualSidebar && styles.rootPaneInactive,
+            contextualSidebar && styles['root-pane-inactive'],
           )}
           aria-hidden={contextualSidebar ? true : undefined}
           inert={contextualSidebar ? true : undefined}
@@ -143,16 +144,17 @@ export default function DocSidebarDesktopContent({ path, sidebar, className }: P
         </ul>
         {renderedContextualSidebar && (
           <ContextualContent
+            key={paneKey}
             activePath={path}
             items={renderedContextualSidebar.items}
             label={renderedContextualSidebar.state.categoryLabel}
             onBack={handleBack}
             onItemClick={() => activateSidebar(renderedContextualSidebar.state)}
             paneClassName={styles.pane}
-            entryAnimationClassName={styles.contextualPaneEnter}
-            exitAnimationClassName={styles.contextualPaneExit}
+            entryAnimationClassName={styles['contextual-pane-enter']}
+            exitAnimationClassName={styles['contextual-pane-exit']}
             animateEntry={shouldAnimateContextualEntry}
-            isExiting={Boolean(exitingContextualSidebar)}
+            isExiting={isContextualSidebarExiting}
             onExitAnimationEnd={handleContextualExitAnimationEnd}
           />
         )}

--- a/docs/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/docs/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -29,7 +29,7 @@
       opacity var(--sidebar-pane-duration) var(--sidebar-pane-easing);
   }
 
-  .rootPaneInactive {
+  .root-pane-inactive {
     position: absolute;
     inset: 0 max(0px, calc(1rem - var(--sidebar-scrollbar-gutter, 0px))) 0 1rem;
     overflow: hidden;
@@ -38,11 +38,11 @@
     transform: translate3d(calc(-1 * var(--sidebar-pane-shift)), 0, 0);
   }
 
-  .contextualPaneEnter {
+  .contextual-pane-enter {
     animation: contextual-pane-enter var(--sidebar-pane-duration) var(--sidebar-pane-easing);
   }
 
-  .contextualPaneExit {
+  .contextual-pane-exit {
     position: absolute;
     inset: 0 max(0px, calc(1rem - var(--sidebar-scrollbar-gutter, 0px))) 0 1rem;
     overflow: hidden;
@@ -111,8 +111,8 @@
     transition: none;
   }
 
-  .contextualPaneEnter,
-  .contextualPaneExit {
+  .contextual-pane-enter,
+  .contextual-pane-exit {
     animation: none;
   }
 }

--- a/docs/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/docs/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -9,6 +9,10 @@
   }
 
   .menu {
+    --sidebar-pane-duration: 180ms;
+    --sidebar-pane-easing: cubic-bezier(0.65, 0, 0.35, 1);
+    --sidebar-pane-shift: 1.25rem;
+
     position: relative;
     display: flex;
     flex-direction: column;
@@ -20,24 +24,30 @@
 
   .pane {
     flex-shrink: 0;
-  }
-
-  .rootPaneEntry {
-    animation: root-pane-enter 150ms cubic-bezier(0.175, 0.885, 0.32, 1.1) both;
+    transition:
+      transform var(--sidebar-pane-duration) var(--sidebar-pane-easing),
+      opacity var(--sidebar-pane-duration) var(--sidebar-pane-easing);
   }
 
   .rootPaneInactive {
     position: absolute;
-    inset: 0;
+    inset: 0 max(0px, calc(1rem - var(--sidebar-scrollbar-gutter, 0px))) 0 1rem;
     overflow: hidden;
     opacity: 0;
-    visibility: hidden;
     pointer-events: none;
-    transform: translateX(-0.5rem);
+    transform: translate3d(calc(-1 * var(--sidebar-pane-shift)), 0, 0);
   }
 
-  .contextualPane {
-    animation: contextual-pane-enter 150ms cubic-bezier(0.175, 0.885, 0.32, 1.1) both;
+  .contextualPaneEnter {
+    animation: contextual-pane-enter var(--sidebar-pane-duration) var(--sidebar-pane-easing);
+  }
+
+  .contextualPaneExit {
+    position: absolute;
+    inset: 0 max(0px, calc(1rem - var(--sidebar-scrollbar-gutter, 0px))) 0 1rem;
+    overflow: hidden;
+    pointer-events: none;
+    animation: contextual-pane-exit var(--sidebar-pane-duration) var(--sidebar-pane-easing) forwards;
   }
 
   .versionControl {
@@ -75,30 +85,34 @@
 @keyframes contextual-pane-enter {
   from {
     opacity: 0;
-    transform: translateX(0.5rem);
+    transform: translate3d(var(--sidebar-pane-shift), 0, 0);
   }
 
   to {
     opacity: 1;
-    transform: translateX(0);
+    transform: translate3d(0, 0, 0);
   }
 }
 
-@keyframes root-pane-enter {
+@keyframes contextual-pane-exit {
   from {
-    opacity: 0;
-    transform: translateX(-0.5rem);
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
   }
 
   to {
-    opacity: 1;
-    transform: translateX(0);
+    opacity: 0;
+    transform: translate3d(var(--sidebar-pane-shift), 0, 0);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .rootPaneEntry,
-  .contextualPane {
+  .pane {
+    transition: none;
+  }
+
+  .contextualPaneEnter,
+  .contextualPaneExit {
     animation: none;
   }
 }

--- a/docs/src/theme/DocSidebarItem/Category/index.tsx
+++ b/docs/src/theme/DocSidebarItem/Category/index.tsx
@@ -223,6 +223,26 @@ function DocSidebarItemCategoryCollapsible({
     }
   }
 
+  const categoryLink = (
+    <Link
+      className={clsx(styles.categoryLink, 'menu__link', {
+        'menu__link--sublist': collapsible && !isContextualSidebarCategory,
+        'menu__link--sublist-caret': !href && collapsible,
+        'menu__link--active': isActive,
+      })}
+      onClick={handleItemClick}
+      aria-current={isCurrentPage ? 'page' : undefined}
+      role={collapsible && !href ? 'button' : undefined}
+      aria-expanded={collapsible && !href ? !collapsed : undefined}
+      href={isContextualSidebarCategory ? href : collapsible ? (hrefWithSSRFallback ?? '#') : hrefWithSSRFallback}
+      {...props}
+    >
+      <span title={label} className={styles.categoryLinkLabel}>
+        {label} {badgeType && <SidebarBadge type={badgeType} />}
+      </span>
+    </Link>
+  )
+
   return (
     <li
       className={clsx(
@@ -236,39 +256,27 @@ function DocSidebarItemCategoryCollapsible({
       )}
       data-contextual-sidebar={isContextualSidebarCategory ? 'true' : undefined}
     >
-      <div
-        className={clsx('menu__list-item-collapsible', {
-          'menu__list-item-collapsible--active': isCurrentPage,
-        })}
-      >
-        <Link
-          className={clsx(styles.categoryLink, 'menu__link', {
-            'menu__link--sublist': collapsible && !isContextualSidebarCategory,
-            'menu__link--sublist-caret': !href && collapsible,
-            'menu__link--active': isActive,
+      {isContextualSidebarCategory ? (
+        categoryLink
+      ) : (
+        <div
+          className={clsx('menu__list-item-collapsible', {
+            'menu__list-item-collapsible--active': isCurrentPage,
           })}
-          onClick={handleItemClick}
-          aria-current={isCurrentPage ? 'page' : undefined}
-          role={collapsible && !href ? 'button' : undefined}
-          aria-expanded={collapsible && !href ? !collapsed : undefined}
-          href={isContextualSidebarCategory ? href : collapsible ? (hrefWithSSRFallback ?? '#') : hrefWithSSRFallback}
-          {...props}
         >
-          <span title={label} className={styles.categoryLinkLabel}>
-            {label} {badgeType && <SidebarBadge type={badgeType} />}
-          </span>
-        </Link>
-        {href && collapsible && !isContextualSidebarCategory && (
-          <CollapseButton
-            collapsed={collapsed}
-            categoryLabel={label}
-            onClick={e => {
-              e.preventDefault()
-              updateCollapsed()
-            }}
-          />
-        )}
-      </div>
+          {categoryLink}
+          {href && collapsible && (
+            <CollapseButton
+              collapsed={collapsed}
+              categoryLabel={label}
+              onClick={e => {
+                e.preventDefault()
+                updateCollapsed()
+              }}
+            />
+          )}
+        </div>
+      )}
 
       {!isContextualSidebarCategory && (
         <Collapsible lazy as="ul" className="menu__list" collapsed={collapsed}>

--- a/docs/tests/navigation.spec.ts
+++ b/docs/tests/navigation.spec.ts
@@ -230,7 +230,7 @@ function visibleSidebarPane(page: Page, pane: 'root' | 'contextual') {
 
 function contextualTopLevelLinks(pane: Locator) {
   return pane.locator(
-    ':scope > ul[data-sidebar-panel="contextual"] > li > a.menu__link, :scope > ul[data-sidebar-panel="contextual"] > li > .menu__list-item-collapsible > a.menu__link',
+    'ul[data-sidebar-panel="contextual"] > li > a.menu__link, ul[data-sidebar-panel="contextual"] > li > .menu__list-item-collapsible > a.menu__link',
   )
 }
 
@@ -269,6 +269,36 @@ async function openMobileSidebar(page: Page) {
 }
 
 test.describe('Contextual sidebar', () => {
+  test('desktop: contextual root links share the standard link hover layer', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'Desktop sidebar not rendered on mobile')
+
+    await page.goto('/docs', { waitUntil: 'domcontentloaded' })
+    const rootPane = visibleSidebarPane(page, 'root')
+    const standardLink = rootPane.getByRole('link', { name: 'Subagents', exact: true })
+    const contextualLink = rootPane.getByRole('link', { name: 'Sandbox', exact: true })
+
+    await standardLink.hover()
+    const standardHover = await standardLink.evaluate(link => ({
+      backgroundColor: getComputedStyle(link).backgroundColor,
+      transition: getComputedStyle(link).transition,
+    }))
+
+    await contextualLink.hover()
+    const contextualHover = await contextualLink.evaluate(link => ({
+      backgroundColor: getComputedStyle(link).backgroundColor,
+      transition: getComputedStyle(link).transition,
+      chevronContent: getComputedStyle(link, '::after').content,
+      parentTagName: link.parentElement?.tagName,
+    }))
+
+    expect(contextualHover).toMatchObject({
+      backgroundColor: standardHover.backgroundColor,
+      transition: standardHover.transition,
+      parentTagName: 'LI',
+    })
+    expect(contextualHover.chevronContent).not.toBe('none')
+  })
+
   test('desktop: navigates child links and restores root focus on Back', async ({ page, isMobile }) => {
     test.skip(isMobile, 'Desktop sidebar not rendered on mobile')
     const getErrors = trackJsErrors(page)
@@ -330,7 +360,16 @@ test.describe('Contextual sidebar', () => {
 
     const urlBeforeBack = page.url()
     await backButton.focus()
-    await backButton.press('Enter')
+    const exitTransition = await backButton.evaluate(button => {
+      const panel = button.closest<HTMLElement>('[data-sidebar-panel-container="contextual"]')
+      button.click()
+      return {
+        animationName: panel ? getComputedStyle(panel).animationName : 'none',
+        isConnected: panel?.isConnected ?? false,
+      }
+    })
+    expect(exitTransition.isConnected).toBe(true)
+    expect(exitTransition.animationName).not.toBe('none')
     const restoredRootPane = visibleSidebarPane(page, 'root')
     await expect(restoredRootPane).toBeVisible()
     await expect(page).toHaveURL(urlBeforeBack)

--- a/docs/tests/navigation.spec.ts
+++ b/docs/tests/navigation.spec.ts
@@ -320,8 +320,13 @@ test.describe('Contextual sidebar', () => {
 
         requestAnimationFrame(() => {
           document.documentElement.dataset.sidebarTransitionSample = JSON.stringify({
-            visibility: getComputedStyle(rootPanel).visibility,
-            activeAnimations: rootPanel.getAnimations().length,
+            rootAriaHidden: rootPanel.getAttribute('aria-hidden'),
+            rootInert: rootPanel.hasAttribute('inert'),
+            rootActiveAnimations: rootPanel.getAnimations().filter(animation => animation.playState === 'running')
+              .length,
+            contextualActiveAnimations: (contextualPanel.parentElement?.getAnimations() ?? []).filter(
+              animation => animation.playState === 'running',
+            ).length,
           })
           observer.disconnect()
         })
@@ -340,7 +345,12 @@ test.describe('Contextual sidebar', () => {
           return sample ? JSON.parse(sample) : undefined
         }),
       )
-      .toEqual({ visibility: 'hidden', activeAnimations: 0 })
+      .toMatchObject({ rootAriaHidden: 'true', rootInert: true })
+    const transitionSample = await page.evaluate(() =>
+      JSON.parse(document.documentElement.dataset.sidebarTransitionSample ?? '{}'),
+    )
+    expect(transitionSample.rootActiveAnimations).toBeGreaterThan(0)
+    expect(transitionSample.contextualActiveAnimations).toBeGreaterThan(0)
     const backButton = contextualPane.getByRole('button', { name: 'Back to global sidebar' })
     await expect(backButton).toHaveText('Agents')
     await expect(contextualPane.getByRole('heading', { name: 'Agents' })).toHaveCount(0)
@@ -453,12 +463,14 @@ test.describe('Contextual sidebar', () => {
         listRight: listRect.right - buttonRect.right,
         outerLeft: buttonRect.left - navigationRect.left,
         outerRight: navigationRect.right - buttonRect.right,
+        scrollbarGutter: element.offsetWidth - element.clientWidth,
       }
     })
     expect(Math.abs(alignment.listLeft)).toBeLessThan(1)
     expect(Math.abs(alignment.listRight)).toBeLessThan(1)
     expect(alignment.outerLeft).toBeCloseTo(16, 0)
-    expect(alignment.outerRight).toBeCloseTo(16, 0)
+    expect(alignment.outerRight).toBeGreaterThanOrEqual(alignment.outerLeft - 1)
+    expect(alignment.outerRight).toBeLessThanOrEqual(alignment.outerLeft + alignment.scrollbarGutter + 1)
 
     const initialBottom = await versionControl.evaluate(element => element.getBoundingClientRect().bottom)
     await rootPane.evaluate(element => {
@@ -526,7 +538,7 @@ test.describe('Contextual sidebar', () => {
     await expect
       .poll(() =>
         directContextualPane
-          .locator('ul[data-sidebar-panel="contextual"]')
+          .locator('[data-sidebar-panel-container="contextual"]')
           .evaluate(element => getComputedStyle(element).animationName),
       )
       .toBe('none')
@@ -541,7 +553,7 @@ test.describe('Contextual sidebar', () => {
     await expect
       .poll(() =>
         reenteredContextualPane
-          .locator('ul[data-sidebar-panel="contextual"]')
+          .locator('[data-sidebar-panel-container="contextual"]')
           .evaluate(element => getComputedStyle(element).animationName),
       )
       .not.toBe('none')


### PR DESCRIPTION
Follow-up to #20904.

Contextual sidebar navigation now keeps the outgoing pane mounted for a CSS exit animation and moves both panes on the same 180 ms shared-axis transition. The absolute panes use the scrollbar-aware menu inset, so their width stays fixed throughout the motion.

Contextual root categories now render their link directly instead of through Infima's collapsible wrapper. This gives chevron items the same hover behavior as ordinary sidebar links while preserving the chevron.

Validation:
- 14 contextual sidebar tests
- focused Playwright hover regression discovered successfully
- Chromium interaction and geometry regression
- React Doctor 100/100
- oxfmt and git diff checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The sidebar now changes menus smoothly instead of switching instantly. The old menu stays visible during its exit animation, while the layout remains stable.

## Changes

- Added shared 180 ms transitions for contextual sidebar panes.
- Kept exiting panes mounted until their animations finish.
- Added reduced-motion handling and inert states for inactive panes.
- Applied scrollbar-aware insets to preserve pane width.
- Rendered contextual category links without Infima’s collapsible wrapper.
- Preserved chevrons and standard sidebar link hover behavior.
- Added a patch changeset for `mastra-docs`.

## Validation

- Updated contextual sidebar navigation tests.
- Added hover, chevron, geometry, ARIA, inert-state, and exit-animation regression coverage.
- Ran React Doctor, `oxfmt`, and git diff checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->