### PR TITLE
feat(factory): persist workspace file lists

### DIFF
--- a/.changeset/persisted-factory-workspace-files.md
+++ b/.changeset/persisted-factory-workspace-files.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Added persisted workspace file lists for Factory threads. The Files view now keeps a thread's captured file list available after an agent run while file contents continue to load from its live sandbox.

--- a/client-sdks/react/src/lib/mastra-db/accumulator.ts
+++ b/client-sdks/react/src/lib/mastra-db/accumulator.ts
@@ -1579,7 +1579,7 @@ export const accumulateChunk = ({ chunk, conversation, metadata }: AccumulateChu
 
     default:
       // Exhaustiveness check: any new `ChunkType` variant must be added above.
-      return assertExhaustive(chunk, result);
+      return assertExhaustive(chunk as never, result);
   }
 };
 

--- a/mastracode/factory-ui/src/api/keys.ts
+++ b/mastracode/factory-ui/src/api/keys.ts
@@ -64,8 +64,10 @@ export const queryKeys = {
   artifactsList: (path: string | undefined) => ['artifacts-list', path ?? null] as const,
   workspaceRenderedList: (workspacePath: string | undefined, renderedRoot: string | undefined) =>
     ['workspace-rendered-list', workspacePath ?? null, renderedRoot ?? null] as const,
-  workspaceFile: (workspacePath: string | undefined, filePath: string | undefined) =>
-    ['workspace-file', workspacePath ?? null, filePath ?? null] as const,
+  workspaceFiles: (workspacePath: string | undefined, threadId: string | undefined) =>
+    ['workspace-files', workspacePath ?? null, threadId ?? null] as const,
+  workspaceFile: (workspacePath: string | undefined, filePath: string | undefined, threadId?: string) =>
+    ['workspace-file', workspacePath ?? null, filePath ?? null, threadId ?? null] as const,
   workspaceChanges: (workspacePath: string | undefined) => ['workspace-changes', workspacePath ?? null] as const,
   workspaceDiff: (
     workspacePath: string | undefined,

--- a/mastracode/factory-ui/src/api/types.ts
+++ b/mastracode/factory-ui/src/api/types.ts
@@ -28,6 +28,7 @@ import type {
   WorkspaceChangeStatus,
   WorkspaceDiff,
   WorkspaceFile,
+  WorkspaceFilesListing,
   WorkspaceRenderedEntry,
   WorkspaceRenderedListing,
 } from '@mastra/factory/routes/fs';
@@ -51,6 +52,7 @@ export type {
   WorkspaceChangeStatus,
   WorkspaceDiff,
   WorkspaceFile,
+  WorkspaceFilesListing,
   WorkspaceRenderedEntry,
   WorkspaceRenderedListing,
 };

--- a/mastracode/factory-ui/src/hooks/__tests__/use-fs.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/use-fs.msw.test.tsx
@@ -202,7 +202,10 @@ describe('useWorkspaceFiles', () => {
 });
 
 describe('useWorkspaceFile', () => {
-  it('does not fetch when disabled', () => {
+  it.each([
+    ['disabled', THREAD, { enabled: false }],
+    ['without a thread ID', undefined, undefined],
+  ])('does not fetch when %s', (_reason, threadId, options) => {
     let called = false;
     server.use(
       http.get(WORKSPACE_FILE_URL, () => {
@@ -220,7 +223,7 @@ describe('useWorkspaceFile', () => {
     );
 
     const { result } = renderHookWithProviders(() =>
-      useWorkspaceFile('/home/user/project', '.artifacts/file.md', THREAD, { enabled: false }),
+      useWorkspaceFile('/home/user/project', '.artifacts/file.md', threadId, options),
     );
 
     expect(result.current.fetchStatus).toBe('idle');

--- a/mastracode/factory-ui/src/hooks/__tests__/use-fs.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/use-fs.msw.test.tsx
@@ -4,7 +4,13 @@ import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../e2e/ui/msw-server';
 import { TEST_BASE_URL, renderHookWithProviders } from '../../../e2e/ui/render';
-import { useArtifactListing, useDirectoryListing, useWorkspaceFile, useWorkspaceRenderedListing } from '../use-fs';
+import {
+  useArtifactListing,
+  useDirectoryListing,
+  useWorkspaceFile,
+  useWorkspaceFiles,
+  useWorkspaceRenderedListing,
+} from '../use-fs';
 import { listing } from './fixtures/fs';
 
 const URL = `${TEST_BASE_URL}/web/fs/list`;
@@ -113,7 +119,9 @@ describe('useArtifactListing', () => {
 });
 
 const WORKSPACE_RENDERED_URL = `${TEST_BASE_URL}/web/workspace/rendered/list`;
+const WORKSPACE_FILES_URL = `${TEST_BASE_URL}/web/workspace/files`;
 const WORKSPACE_FILE_URL = `${TEST_BASE_URL}/web/workspace/file`;
+const THREAD = 'thread-1';
 
 describe('useWorkspaceRenderedListing', () => {
   it('does not fetch until workspace path and root are available', () => {
@@ -165,6 +173,34 @@ describe('useWorkspaceRenderedListing', () => {
   });
 });
 
+describe('useWorkspaceFiles', () => {
+  describe('when a workspace and thread are available', () => {
+    it('requests the persisted file list for that exact scope', async () => {
+      let seenWorkspacePath: string | null = null;
+      let seenThreadId: string | null = null;
+      server.use(
+        http.get(WORKSPACE_FILES_URL, ({ request }) => {
+          const url = new global.URL(request.url);
+          seenWorkspacePath = url.searchParams.get('workspacePath');
+          seenThreadId = url.searchParams.get('threadId');
+          return HttpResponse.json({
+            workspacePath: seenWorkspacePath,
+            threadId: seenThreadId,
+            files: [{ path: 'src/agent.ts', filename: 'agent.ts' }],
+          });
+        }),
+      );
+
+      const { result } = renderHookWithProviders(() => useWorkspaceFiles('session-1', THREAD));
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(seenWorkspacePath).toBe('session-1');
+      expect(seenThreadId).toBe(THREAD);
+      expect(result.current.data?.files).toEqual([{ path: 'src/agent.ts', filename: 'agent.ts' }]);
+    });
+  });
+});
+
 describe('useWorkspaceFile', () => {
   it('does not fetch when disabled', () => {
     let called = false;
@@ -184,7 +220,7 @@ describe('useWorkspaceFile', () => {
     );
 
     const { result } = renderHookWithProviders(() =>
-      useWorkspaceFile('/home/user/project', '.artifacts/file.md', { enabled: false }),
+      useWorkspaceFile('/home/user/project', '.artifacts/file.md', THREAD, { enabled: false }),
     );
 
     expect(result.current.fetchStatus).toBe('idle');
@@ -212,7 +248,7 @@ describe('useWorkspaceFile', () => {
     );
 
     const { result } = renderHookWithProviders(() =>
-      useWorkspaceFile('/home/user/project', '.artifacts/understand-pr/HISTORY.md'),
+      useWorkspaceFile('/home/user/project', '.artifacts/understand-pr/HISTORY.md', THREAD),
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/mastracode/factory-ui/src/hooks/__tests__/use-fs.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/use-fs.msw.test.tsx
@@ -186,7 +186,7 @@ describe('useWorkspaceFiles', () => {
           return HttpResponse.json({
             workspacePath: seenWorkspacePath,
             threadId: seenThreadId,
-            files: [{ path: 'src/agent.ts', filename: 'agent.ts' }],
+            files: [{ path: 'src/agent.ts' }],
           });
         }),
       );
@@ -196,7 +196,7 @@ describe('useWorkspaceFiles', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(seenWorkspacePath).toBe('session-1');
       expect(seenThreadId).toBe(THREAD);
-      expect(result.current.data?.files).toEqual([{ path: 'src/agent.ts', filename: 'agent.ts' }]);
+      expect(result.current.data?.files).toEqual([{ path: 'src/agent.ts' }]);
     });
   });
 });

--- a/mastracode/factory-ui/src/hooks/use-fs.ts
+++ b/mastracode/factory-ui/src/hooks/use-fs.ts
@@ -95,7 +95,8 @@ export function useWorkspaceFiles(
   { enabled = true }: { enabled?: boolean } = {},
 ) {
   const { client } = useApiConfig();
-  const url = workspacePath && threadId ? `/web/workspace/files?${new URLSearchParams({ workspacePath, threadId })}` : undefined;
+  const url =
+    workspacePath && threadId ? `/web/workspace/files?${new URLSearchParams({ workspacePath, threadId })}` : undefined;
   return useQuery<WorkspaceFilesListing>({
     queryKey: queryKeys.workspaceFiles(workspacePath, threadId),
     enabled,

--- a/mastracode/factory-ui/src/hooks/use-fs.ts
+++ b/mastracode/factory-ui/src/hooks/use-fs.ts
@@ -8,6 +8,7 @@ import type {
   WorkspaceChanges,
   WorkspaceDiff,
   WorkspaceFile,
+  WorkspaceFilesListing,
   WorkspaceRenderedListing,
 } from '../api/types';
 
@@ -27,9 +28,11 @@ function workspaceRenderedListingUrl(workspacePath: string | undefined, root: st
   return `/web/workspace/rendered/list?${new URLSearchParams({ workspacePath, root })}`;
 }
 
-function workspaceFileUrl(workspacePath: string | undefined, path: string | undefined) {
+function workspaceFileUrl(workspacePath: string | undefined, path: string | undefined, threadId?: string) {
   if (!workspacePath || !path) return undefined;
-  return `/web/workspace/file?${new URLSearchParams({ workspacePath, path })}`;
+  const params = new URLSearchParams({ workspacePath, path });
+  if (threadId) params.set('threadId', threadId);
+  return `/web/workspace/file?${params}`;
 }
 
 function workspaceChangesUrl(workspacePath: string | undefined) {
@@ -88,15 +91,30 @@ export function useWorkspaceRenderedListing(
   });
 }
 
-export function useWorkspaceFile(
+export function useWorkspaceFiles(
   workspacePath: string | undefined,
-  filePath: string | undefined,
+  threadId: string | undefined,
   { enabled = true }: { enabled?: boolean } = {},
 ) {
   const { client } = useApiConfig();
-  const url = workspaceFileUrl(workspacePath, filePath);
+  const url = workspacePath && threadId ? `/web/workspace/files?${new URLSearchParams({ workspacePath, threadId })}` : undefined;
+  return useQuery<WorkspaceFilesListing>({
+    queryKey: queryKeys.workspaceFiles(workspacePath, threadId),
+    enabled,
+    queryFn: url ? () => client.get<WorkspaceFilesListing>(url) : skipToken,
+  });
+}
+
+export function useWorkspaceFile(
+  workspacePath: string | undefined,
+  filePath: string | undefined,
+  threadId: string | undefined,
+  { enabled = true }: { enabled?: boolean } = {},
+) {
+  const { client } = useApiConfig();
+  const url = workspaceFileUrl(workspacePath, filePath, threadId);
   return useQuery<WorkspaceFile>({
-    queryKey: queryKeys.workspaceFile(workspacePath, filePath),
+    queryKey: queryKeys.workspaceFile(workspacePath, filePath, threadId),
     enabled,
     queryFn: url ? () => client.get<WorkspaceFile>(url) : skipToken,
   });

--- a/mastracode/factory-ui/src/hooks/use-fs.ts
+++ b/mastracode/factory-ui/src/hooks/use-fs.ts
@@ -28,11 +28,9 @@ function workspaceRenderedListingUrl(workspacePath: string | undefined, root: st
   return `/web/workspace/rendered/list?${new URLSearchParams({ workspacePath, root })}`;
 }
 
-function workspaceFileUrl(workspacePath: string | undefined, path: string | undefined, threadId?: string) {
-  if (!workspacePath || !path) return undefined;
-  const params = new URLSearchParams({ workspacePath, path });
-  if (threadId) params.set('threadId', threadId);
-  return `/web/workspace/file?${params}`;
+function workspaceFileUrl(workspacePath: string | undefined, path: string | undefined, threadId: string | undefined) {
+  if (!workspacePath || !path || !threadId) return undefined;
+  return `/web/workspace/file?${new URLSearchParams({ workspacePath, path, threadId })}`;
 }
 
 function workspaceChangesUrl(workspacePath: string | undefined) {

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/__tests__/useInvalidateWorkspaceChangesOnRunCompletion.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/__tests__/useInvalidateWorkspaceChangesOnRunCompletion.msw.test.tsx
@@ -1,0 +1,30 @@
+import { waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { queryKeys } from '../../../../api/keys';
+import { renderHookWithProviders } from '../../../../../e2e/ui/render';
+import { useInvalidateWorkspaceChangesOnRunCompletion } from '../useInvalidateWorkspaceChangesOnRunCompletion';
+
+const WORKSPACE = 'session-1';
+const THREAD = 'thread-1';
+
+describe('useInvalidateWorkspaceChangesOnRunCompletion', () => {
+  it('invalidates workspace changes and persisted files when the agent becomes idle', async () => {
+    const { client, rerender } = renderHookWithProviders(
+      ({ busy }) => useInvalidateWorkspaceChangesOnRunCompletion(WORKSPACE, THREAD, busy),
+      { initialProps: { busy: false } },
+    );
+    const changesKey = queryKeys.workspaceChanges(WORKSPACE);
+    const filesKey = queryKeys.workspaceFiles(WORKSPACE, THREAD);
+    client.setQueryData(changesKey, { workspacePath: WORKSPACE, available: true, changes: [] });
+    client.setQueryData(filesKey, { workspacePath: WORKSPACE, threadId: THREAD, files: [] });
+
+    rerender({ busy: true });
+    rerender({ busy: false });
+
+    await waitFor(() => {
+      expect(client.getQueryState(changesKey)?.isInvalidated).toBe(true);
+      expect(client.getQueryState(filesKey)?.isInvalidated).toBe(true);
+    });
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
@@ -3,29 +3,9 @@ import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Tab, TabList, Tabs } from '@mastra/playground-ui/components/Tabs';
 import { Tree } from '@mastra/playground-ui/components/Tree';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import {
-  File,
-  FileCode,
-  FileDiff,
-  FileJson,
-  FileText,
-  Folder,
-  FolderOpen,
-  Image,
-  NotepadText,
-  RefreshCw,
-} from 'lucide-react';
+import { File, FileCode, FileDiff, FileJson, FileText, Folder, FolderOpen, Image, NotepadText, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 import type { ReactNode } from 'react';
-
-import type { WorkspaceRenderedEntry, WorkspaceRenderedListing } from '../../../../api/types';
-import type { RenderedWorkspacePath } from '../config';
-
-function formatBytes(size: number) {
-  if (size < 1024) return `${size} B`;
-  if (size < 1024 * 1024) return `${Math.round(size / 1024)} KB`;
-  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
-}
 
 function getFileIcon(path: string): ReactNode {
   const ext = path.split('.').pop()?.toLowerCase();
@@ -59,77 +39,58 @@ function getFolderIcon(isOpen: boolean): ReactNode {
 interface WorkspaceTreeNode {
   path: string;
   name: string;
-  type: WorkspaceRenderedEntry['type'];
-  size: number;
+  type: 'file' | 'directory';
   children: WorkspaceTreeNode[];
+}
+
+interface WorkspaceFileEntry {
+  path: string;
+  filename: string;
 }
 
 function ensureDirectory(nodes: WorkspaceTreeNode[], path: string, name: string): WorkspaceTreeNode {
   const existing = nodes.find(node => node.path === path);
   if (existing) return existing;
 
-  const directory = { path, name, type: 'directory', size: 0, children: [] } satisfies WorkspaceTreeNode;
+  const directory = { path, name, type: 'directory', children: [] } satisfies WorkspaceTreeNode;
   nodes.push(directory);
   return directory;
 }
 
-function addEntry(nodes: WorkspaceTreeNode[], entry: WorkspaceRenderedEntry) {
-  const segments = entry.path.split('/').filter(Boolean);
+function addFile(nodes: WorkspaceTreeNode[], file: WorkspaceFileEntry) {
+  const segments = file.path.split('/').filter(Boolean);
   let siblings = nodes;
   let currentPath = '';
 
   segments.forEach((segment, index) => {
     currentPath = currentPath ? `${currentPath}/${segment}` : segment;
-    const isLeaf = index === segments.length - 1;
-
-    if (isLeaf) {
-      const existing = siblings.find(node => node.path === currentPath);
-      const node = {
-        path: entry.path,
-        name: segment,
-        type: entry.type,
-        size: entry.size,
-        children: existing?.children ?? [],
-      };
-      const existingIndex = siblings.findIndex(item => item.path === currentPath);
-      if (existingIndex === -1) siblings.push(node);
-      else siblings[existingIndex] = node;
+    if (index === segments.length - 1) {
+      siblings.push({ path: file.path, name: file.filename, type: 'file', children: [] });
       return;
     }
-
-    const directory = ensureDirectory(siblings, currentPath, segment);
-    siblings = directory.children;
+    siblings = ensureDirectory(siblings, currentPath, segment).children;
   });
 }
 
 function sortTree(nodes: WorkspaceTreeNode[]): WorkspaceTreeNode[] {
-  return nodes
-    .map(node => ({ ...node, children: sortTree(node.children) }))
-    .sort((a, b) => {
-      if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
-      return a.name.localeCompare(b.name);
-    });
+  return [...nodes.map(node => ({ ...node, children: sortTree(node.children) }))].sort((a, b) => {
+    if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
 }
 
-function buildTree(entries: WorkspaceRenderedEntry[]): WorkspaceTreeNode[] {
+function buildTree(files: WorkspaceFileEntry[]): WorkspaceTreeNode[] {
   const nodes: WorkspaceTreeNode[] = [];
-  entries.forEach(entry => addEntry(nodes, entry));
+  files.forEach(file => addFile(nodes, file));
   return sortTree(nodes);
-}
-
-function emptyStateCopy(path: RenderedWorkspacePath) {
-  if (path.root === '.artifacts') return 'No artifacts yet. Session files created will appear here.';
-  return `No files in ${path.label}.`;
 }
 
 function WorkspaceTreeItem({
   node,
-  root,
   openFolders,
   onFolderOpenChange,
 }: {
   node: WorkspaceTreeNode;
-  root: string;
   openFolders: Record<string, boolean>;
   onFolderOpenChange: (path: string, open: boolean) => void;
 }) {
@@ -146,7 +107,6 @@ function WorkspaceTreeItem({
             <WorkspaceTreeItem
               key={child.path}
               node={child}
-              root={root}
               openFolders={openFolders}
               onFolderOpenChange={onFolderOpenChange}
             />
@@ -157,43 +117,38 @@ function WorkspaceTreeItem({
   }
 
   return (
-    <Tree.File id={`${root}/${node.path}`}>
+    <Tree.File id={node.path}>
       <Tree.Icon>{getFileIcon(node.name)}</Tree.Icon>
       <Tree.Label>{node.name}</Tree.Label>
-      <span className="text-icon3 ml-auto shrink-0 text-xs">{formatBytes(node.size)}</span>
     </Tree.File>
   );
 }
 
 interface WorkspaceFileBrowserProps {
-  renderedPaths: RenderedWorkspacePath[];
-  selectedPath: RenderedWorkspacePath;
+  files?: WorkspaceFileEntry[];
   selectedFilePath?: string;
-  listing?: WorkspaceRenderedListing;
   isLoading: boolean;
   isRefreshing: boolean;
   error?: Error;
   onRefresh: () => void;
-  onRenderedPathChange: (path: RenderedWorkspacePath) => void;
   onFileSelect: (filePath: string) => void;
   onShowChanges: () => void;
 }
 
 export function WorkspaceFileBrowser({
-  renderedPaths,
-  selectedPath,
+  files,
   selectedFilePath,
-  listing,
   isLoading,
   isRefreshing,
   error,
   onRefresh,
-  onRenderedPathChange,
   onFileSelect,
   onShowChanges,
 }: WorkspaceFileBrowserProps) {
   const [openFolders, setOpenFolders] = useState<Record<string, boolean>>({});
-  const nodes = buildTree(listing?.entries ?? []);
+  const persistedFiles = files ?? [];
+  const filePaths = new Set(persistedFiles.map(file => file.path));
+  const nodes = buildTree(persistedFiles);
 
   const setFolderOpen = (path: string, open: boolean) => {
     setOpenFolders(previous => ({ ...previous, [path]: open }));
@@ -220,70 +175,41 @@ export function WorkspaceFileBrowser({
             </Tab>
           </TabList>
         </Tabs>
+        <Button
+          className="ml-auto"
+          size="icon-xs"
+          variant="ghost"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          aria-label={isRefreshing ? 'Refreshing workspace files' : 'Refresh workspace files'}
+        >
+          {isRefreshing ? <Spinner size="sm" /> : <RefreshCw />}
+        </Button>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-2">
         <Tree
-          selectedId={selectedFilePath ? `${selectedPath.root}/${selectedFilePath}` : undefined}
+          selectedId={selectedFilePath}
           onSelect={id => {
-            const selectedRootPrefix = `${selectedPath.root}/`;
-            if (id.startsWith(selectedRootPrefix)) onFileSelect(id.slice(selectedRootPrefix.length));
+            if (filePaths.has(id)) onFileSelect(id);
           }}
         >
-          {renderedPaths.map(path => {
-            const isSelectedRoot = path.id === selectedPath.id;
-            const isOpen = openFolders[path.root] ?? false;
-            return (
-              <Tree.Folder
-                key={path.id}
-                open={isOpen}
-                onOpenChange={(open: boolean) => {
-                  onRenderedPathChange(path);
-                  setFolderOpen(path.root, open);
-                }}
-              >
-                <Tree.FolderTrigger
-                  actions={
-                    isSelectedRoot ? (
-                      <Button
-                        size="icon-xs"
-                        variant="ghost"
-                        onClick={onRefresh}
-                        disabled={isRefreshing}
-                        aria-label={isRefreshing ? 'Refreshing workspace files' : 'Refresh workspace files'}
-                      >
-                        {isRefreshing ? <Spinner size="sm" /> : <RefreshCw />}
-                      </Button>
-                    ) : null
-                  }
-                >
-                  <Tree.Icon>{getFolderIcon(isOpen)}</Tree.Icon>
-                  <Tree.Label>{path.label}</Tree.Label>
-                </Tree.FolderTrigger>
-                {isSelectedRoot ? (
-                  <Tree.FolderContent>
-                    {isLoading ? <Txt className="text-icon3 px-2 py-3">Loading files…</Txt> : null}
-                    {error ? <Txt className="text-icon4 px-2 py-3">Unable to load files.</Txt> : null}
-                    {!isLoading && !error && nodes.length === 0 ? (
-                      <Txt className="text-icon3 px-2 py-3" variant="ui-sm">
-                        {emptyStateCopy(path)}
-                      </Txt>
-                    ) : null}
-                    {!isLoading && !error
-                      ? nodes.map(node => (
-                          <WorkspaceTreeItem
-                            key={node.path}
-                            node={node}
-                            root={selectedPath.root}
-                            openFolders={openFolders}
-                            onFolderOpenChange={setFolderOpen}
-                          />
-                        ))
-                      : null}
-                  </Tree.FolderContent>
-                ) : null}
-              </Tree.Folder>
-            );
-          })}
+          {isLoading ? <Txt className="text-icon3 px-2 py-3">Loading files…</Txt> : null}
+          {error ? <Txt className="text-icon4 px-2 py-3">Unable to load files.</Txt> : null}
+          {!isLoading && !error && nodes.length === 0 ? (
+            <Txt className="text-icon3 px-2 py-3" variant="ui-sm">
+              No files captured for this run yet.
+            </Txt>
+          ) : null}
+          {!isLoading && !error
+            ? nodes.map(node => (
+                <WorkspaceTreeItem
+                  key={node.path}
+                  node={node}
+                  openFolders={openFolders}
+                  onFolderOpenChange={setFolderOpen}
+                />
+              ))
+            : null}
         </Tree>
       </div>
     </aside>

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFileBrowser.tsx
@@ -3,7 +3,18 @@ import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Tab, TabList, Tabs } from '@mastra/playground-ui/components/Tabs';
 import { Tree } from '@mastra/playground-ui/components/Tree';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { File, FileCode, FileDiff, FileJson, FileText, Folder, FolderOpen, Image, NotepadText, RefreshCw } from 'lucide-react';
+import {
+  File,
+  FileCode,
+  FileDiff,
+  FileJson,
+  FileText,
+  Folder,
+  FolderOpen,
+  Image,
+  NotepadText,
+  RefreshCw,
+} from 'lucide-react';
 import { useState } from 'react';
 import type { ReactNode } from 'react';
 
@@ -45,7 +56,6 @@ interface WorkspaceTreeNode {
 
 interface WorkspaceFileEntry {
   path: string;
-  filename: string;
 }
 
 function ensureDirectory(nodes: WorkspaceTreeNode[], path: string, name: string): WorkspaceTreeNode {
@@ -65,7 +75,7 @@ function addFile(nodes: WorkspaceTreeNode[], file: WorkspaceFileEntry) {
   segments.forEach((segment, index) => {
     currentPath = currentPath ? `${currentPath}/${segment}` : segment;
     if (index === segments.length - 1) {
-      siblings.push({ path: file.path, name: file.filename, type: 'file', children: [] });
+      siblings.push({ path: file.path, name: segment, type: 'file', children: [] });
       return;
     }
     siblings = ensureDirectory(siblings, currentPath, segment).children;

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFilesContent.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFilesContent.tsx
@@ -1,15 +1,14 @@
-import { renderedPaths } from '../config';
 import { useWorkspaceFiles } from '../context/useWorkspaceFiles';
 import { WorkspaceViewerPanel } from './WorkspaceViewerPanel';
 
 export function WorkspaceFilesContent() {
-  const { open, workspacePath, setViewingFile } = useWorkspaceFiles();
-  if (!workspacePath) return null;
+  const { open, workspacePath, threadId, setViewingFile } = useWorkspaceFiles();
+  if (!workspacePath || !threadId) return null;
 
   return (
     <WorkspaceViewerPanel
       workspacePath={workspacePath}
-      renderedPaths={renderedPaths}
+      threadId={threadId}
       onExpandedChange={setViewingFile}
       visible={open}
     />

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceViewerPanel.tsx
@@ -1,33 +1,25 @@
 import { useState } from 'react';
 
-import { useWorkspaceFile, useWorkspaceRenderedListing } from '../../../../hooks/use-fs';
-import type { RenderedWorkspacePath } from '../config';
+import { useWorkspaceFile, useWorkspaceFiles } from '../../../../hooks/use-fs';
 import { WorkspaceChangesPanel } from './WorkspaceChangesPanel';
 import { WorkspaceFileBrowser } from './WorkspaceFileBrowser';
 import { WorkspaceFileViewer } from './WorkspaceFileViewer';
 
 interface WorkspaceViewerPanelProps {
   workspacePath: string;
-  renderedPaths: RenderedWorkspacePath[];
+  threadId: string;
   /** Fires when the file viewer opens or closes, so a floating host can widen its surface. */
   onExpandedChange?: (expanded: boolean) => void;
-  /** Listing wakes the session's sandbox — a host that keeps the panel mounted off-screen passes `false`. */
+  /** A host that keeps the panel mounted off-screen passes false to keep queries dormant. */
   visible?: boolean;
 }
 
-export function WorkspaceViewerPanel({
-  workspacePath,
-  renderedPaths,
-  visible = true,
-  ...props
-}: WorkspaceViewerPanelProps) {
-  const resetKey = [workspacePath, ...renderedPaths.map(path => `${path.id}:${path.root}`)].join('|');
-
+export function WorkspaceViewerPanel({ workspacePath, threadId, visible = true, ...props }: WorkspaceViewerPanelProps) {
   return (
     <WorkspaceViewerPanelReset
-      key={resetKey}
+      key={`${workspacePath}|${threadId}`}
       workspacePath={workspacePath}
-      renderedPaths={renderedPaths}
+      threadId={threadId}
       visible={visible}
       {...props}
     />
@@ -54,22 +46,16 @@ function WorkspaceViewerPanelReset(props: MountedPanelProps) {
 
 function WorkspaceViewerPanelInner({
   workspacePath,
-  renderedPaths,
+  threadId,
   onExpandedChange,
   onShowChanges,
   visible,
 }: MountedPanelProps & { onShowChanges: () => void }) {
-  const [selectedRenderedPathId, setSelectedRenderedPathId] = useState(renderedPaths[0]?.id ?? '');
   const [selectedFilePath, setSelectedFilePath] = useState<string | undefined>();
   const [viewerOpen, setViewerOpenState] = useState(false);
-
-  const selectedRenderedPath = renderedPaths.find(path => path.id === selectedRenderedPathId) ?? renderedPaths[0];
-  const selectedFileRequestPath = selectedFilePath ? `${selectedRenderedPath?.root}/${selectedFilePath}` : undefined;
-  const listing = useWorkspaceRenderedListing(workspacePath, selectedRenderedPath?.root, { enabled: visible });
-  const file = useWorkspaceFile(workspacePath, selectedFileRequestPath, { enabled: visible && viewerOpen });
-  const selectedFile = file.data?.path === selectedFileRequestPath ? file.data : undefined;
-
-  if (!selectedRenderedPath) return null;
+  const listing = useWorkspaceFiles(workspacePath, threadId, { enabled: visible });
+  const file = useWorkspaceFile(workspacePath, selectedFilePath, threadId, { enabled: visible && viewerOpen });
+  const selectedFile = file.data?.path === selectedFilePath ? file.data : undefined;
 
   const setViewerOpen = (open: boolean) => {
     setViewerOpenState(open);
@@ -80,7 +66,7 @@ function WorkspaceViewerPanelInner({
     <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden" data-testid="workspace-viewer-panel">
       {viewerOpen ? (
         <WorkspaceFileViewer
-          key={selectedFileRequestPath}
+          key={selectedFilePath}
           filePath={selectedFilePath}
           file={selectedFile}
           isLoading={file.isLoading || (file.isFetching && !selectedFile)}
@@ -89,19 +75,12 @@ function WorkspaceViewerPanelInner({
         />
       ) : (
         <WorkspaceFileBrowser
-          renderedPaths={renderedPaths}
-          selectedPath={selectedRenderedPath}
+          files={listing.data?.files}
           selectedFilePath={selectedFilePath}
-          listing={listing.data}
           isLoading={listing.isLoading}
           isRefreshing={listing.isFetching}
           error={listing.error instanceof Error ? listing.error : undefined}
           onRefresh={() => listing.refetch()}
-          onRenderedPathChange={path => {
-            setSelectedRenderedPathId(path.id);
-            setSelectedFilePath(undefined);
-            setViewerOpen(false);
-          }}
           onFileSelect={filePath => {
             setSelectedFilePath(filePath);
             setViewerOpen(true);

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceFiles.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceFiles.msw.test.tsx
@@ -1,11 +1,11 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { server } from '../../../../../../e2e/ui/msw-server';
-import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
+import { TEST_BASE_URL, renderWithProviders, waitForMutationsIdle } from '../../../../../../e2e/ui/render';
 import { WorkspaceFilesProvider } from '../../context/WorkspaceFilesProvider';
 import { WorkspaceFilesSurface } from '../WorkspaceFilesSurface';
 import { WorkspaceFilesToggle } from '../WorkspaceFilesToggle';
@@ -48,7 +48,7 @@ function renderPanel() {
     }),
   );
 
-  renderWithProviders(
+  const { client } = renderWithProviders(
     <MemoryRouter initialEntries={[`/factories/factory-1/workspaces/${WORKSPACE}/threads/thread-1`]}>
       <Routes>
         <Route
@@ -64,7 +64,7 @@ function renderPanel() {
     </MemoryRouter>,
   );
 
-  return { listRequests };
+  return { client, listRequests };
 }
 
 describe('WorkspaceFiles', () => {
@@ -72,7 +72,7 @@ describe('WorkspaceFiles', () => {
     it('leaves the card closed and off the network until the header toggle asks for it', async () => {
       stubContainerWidth(1200);
       const user = userEvent.setup();
-      const { listRequests } = renderPanel();
+      const { client, listRequests } = renderPanel();
 
       const card = await screen.findByTestId('workspace-files-card');
       const toggle = screen.getByRole('button', { name: 'Workspace files' });
@@ -84,7 +84,8 @@ describe('WorkspaceFiles', () => {
 
       expect(card).not.toHaveAttribute('inert');
       expect(await screen.findByRole('tab', { name: 'Files' })).toBeInTheDocument();
-      await waitFor(() => expect(listRequests).toEqual([{ workspacePath: WORKSPACE, threadId: 'thread-1' }]));
+      await waitForMutationsIdle(client);
+      expect(listRequests).toEqual([{ workspacePath: WORKSPACE, threadId: 'thread-1' }]);
     });
   });
 

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceFiles.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceFiles.msw.test.tsx
@@ -39,7 +39,10 @@ function renderPanel() {
   server.use(
     http.get(LIST_URL, ({ request }) => {
       const url = new URL(request.url);
-      listRequests.push({ workspacePath: url.searchParams.get('workspacePath'), threadId: url.searchParams.get('threadId') });
+      listRequests.push({
+        workspacePath: url.searchParams.get('workspacePath'),
+        threadId: url.searchParams.get('threadId'),
+      });
       return HttpResponse.json({
         workspacePath: WORKSPACE,
         threadId: 'thread-1',

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceFiles.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceFiles.msw.test.tsx
@@ -10,7 +10,7 @@ import { WorkspaceFilesProvider } from '../../context/WorkspaceFilesProvider';
 import { WorkspaceFilesSurface } from '../WorkspaceFilesSurface';
 import { WorkspaceFilesToggle } from '../WorkspaceFilesToggle';
 
-const LIST_URL = `${TEST_BASE_URL}/web/workspace/rendered/list`;
+const LIST_URL = `${TEST_BASE_URL}/web/workspace/files`;
 const WORKSPACE = 'session-1';
 
 const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
@@ -35,15 +35,15 @@ afterEach(() => {
 });
 
 function renderPanel() {
-  const listedRoots: string[] = [];
+  const listRequests: Array<{ workspacePath: string | null; threadId: string | null }> = [];
   server.use(
     http.get(LIST_URL, ({ request }) => {
-      listedRoots.push(new URL(request.url).searchParams.get('root') ?? '');
+      const url = new URL(request.url);
+      listRequests.push({ workspacePath: url.searchParams.get('workspacePath'), threadId: url.searchParams.get('threadId') });
       return HttpResponse.json({
         workspacePath: WORKSPACE,
-        root: '.artifacts',
-        rootPath: `${WORKSPACE}/.artifacts`,
-        entries: [],
+        threadId: 'thread-1',
+        files: [],
       });
     }),
   );
@@ -64,7 +64,7 @@ function renderPanel() {
     </MemoryRouter>,
   );
 
-  return { listedRoots };
+  return { listRequests };
 }
 
 describe('WorkspaceFiles', () => {
@@ -72,18 +72,19 @@ describe('WorkspaceFiles', () => {
     it('leaves the card closed and off the network until the header toggle asks for it', async () => {
       stubContainerWidth(1200);
       const user = userEvent.setup();
-      const { listedRoots } = renderPanel();
+      const { listRequests } = renderPanel();
 
       const card = await screen.findByTestId('workspace-files-card');
       const toggle = screen.getByRole('button', { name: 'Workspace files' });
       expect(card).toHaveAttribute('inert');
       expect(toggle).toHaveAttribute('aria-pressed', 'false');
-      expect(listedRoots).toEqual([]);
+      expect(listRequests).toEqual([]);
 
       await user.click(toggle);
 
       expect(card).not.toHaveAttribute('inert');
-      await waitFor(() => expect(listedRoots).toEqual(['.artifacts']));
+      expect(await screen.findByRole('tab', { name: 'Files' })).toBeInTheDocument();
+      await waitFor(() => expect(listRequests).toEqual([{ workspacePath: WORKSPACE, threadId: 'thread-1' }]));
     });
   });
 
@@ -94,11 +95,11 @@ describe('WorkspaceFiles', () => {
       renderPanel();
 
       expect(screen.queryByTestId('workspace-files-card')).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Artifacts' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: 'Files' })).not.toBeInTheDocument();
 
       await user.click(screen.getByRole('button', { name: 'Workspace files' }));
 
-      expect(await screen.findByRole('button', { name: 'Artifacts' })).toBeInTheDocument();
+      expect(await screen.findByRole('tab', { name: 'Files' })).toBeInTheDocument();
     });
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceViewerPanel.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceViewerPanel.msw.test.tsx
@@ -20,10 +20,7 @@ function installHandlers() {
       return HttpResponse.json({
         workspacePath: url.searchParams.get('workspacePath'),
         threadId: url.searchParams.get('threadId'),
-        files: [
-          { path: 'src/agent.ts', filename: 'agent.ts' },
-          { path: 'README.md', filename: 'README.md' },
-        ],
+        files: [{ path: 'src/agent.ts' }, { path: 'README.md' }],
       });
     }),
     http.get(FILE_URL, ({ request }) => {
@@ -74,9 +71,7 @@ describe('WorkspaceViewerPanel', () => {
   describe('when no terminal file capture exists', () => {
     it('explains that the file list is captured after a run ends', async () => {
       server.use(
-        http.get(FILES_URL, () =>
-          HttpResponse.json({ workspacePath: WORKSPACE, threadId: THREAD, files: [] }),
-        ),
+        http.get(FILES_URL, () => HttpResponse.json({ workspacePath: WORKSPACE, threadId: THREAD, files: [] })),
       );
 
       renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} threadId={THREAD} />);

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceViewerPanel.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/__tests__/WorkspaceViewerPanel.msw.test.tsx
@@ -1,75 +1,44 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../../../../e2e/ui/msw-server';
 import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
-import { workspaceChangesFixture, workspaceDiffFixture } from './fixtures/workspace-changes';
 import { WorkspaceViewerPanel } from '../WorkspaceViewerPanel';
-import { useInvalidateWorkspaceChangesOnRunCompletion } from '../../useInvalidateWorkspaceChangesOnRunCompletion';
 
-const LIST_URL = `${TEST_BASE_URL}/web/workspace/rendered/list`;
+const FILES_URL = `${TEST_BASE_URL}/web/workspace/files`;
 const FILE_URL = `${TEST_BASE_URL}/web/workspace/file`;
-const CHANGES_URL = `${TEST_BASE_URL}/web/workspace/changes`;
-const DIFF_URL = `${TEST_BASE_URL}/web/workspace/changes/diff`;
-const WORKSPACE = '/home/user/project';
-
-const renderedPaths = [{ id: 'artifacts', label: 'Artifacts', root: '.artifacts' }];
-
-function WorkspaceChangesRunHarness({ busy }: { busy: boolean }) {
-  useInvalidateWorkspaceChangesOnRunCompletion(WORKSPACE, busy);
-  return <WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />;
-}
+const WORKSPACE = 'session-1';
+const THREAD = 'thread-1';
 
 function installHandlers() {
-  const fileRequests: string[] = [];
+  const fileRequests: Array<{ path: string | null; threadId: string | null }> = [];
   server.use(
-    http.get(LIST_URL, ({ request }) => {
-      const root = new URL(request.url).searchParams.get('root');
-      if (root === '.reports') {
-        return HttpResponse.json({
-          workspacePath: WORKSPACE,
-          root: '.reports',
-          rootPath: `${WORKSPACE}/.reports`,
-          entries: [
-            { name: 'summary.md', path: 'summary.md', type: 'file', size: 7, updatedAt: '2026-07-16T00:00:00.000Z' },
-          ],
-        });
-      }
+    http.get(FILES_URL, ({ request }) => {
+      const url = new URL(request.url);
       return HttpResponse.json({
-        workspacePath: WORKSPACE,
-        root: '.artifacts',
-        rootPath: `${WORKSPACE}/.artifacts`,
-        entries: [
-          {
-            name: 'understand-pr',
-            path: 'understand-pr',
-            type: 'directory',
-            size: 0,
-            updatedAt: '2026-07-16T00:00:00.000Z',
-          },
-          {
-            name: 'HISTORY.md',
-            path: 'understand-pr/HISTORY.md',
-            type: 'file',
-            size: 7,
-            updatedAt: '2026-07-16T00:00:00.000Z',
-          },
+        workspacePath: url.searchParams.get('workspacePath'),
+        threadId: url.searchParams.get('threadId'),
+        files: [
+          { path: 'src/agent.ts', filename: 'agent.ts' },
+          { path: 'README.md', filename: 'README.md' },
         ],
       });
     }),
     http.get(FILE_URL, ({ request }) => {
-      const path = new URL(request.url).searchParams.get('path');
-      if (path) fileRequests.push(path);
+      const url = new URL(request.url);
+      const path = url.searchParams.get('path');
+      const threadId = url.searchParams.get('threadId');
+      fileRequests.push({ path, threadId });
       return HttpResponse.json({
         workspacePath: WORKSPACE,
         path,
-        name: path?.split('/').pop() ?? 'file.md',
-        size: 7,
-        updatedAt: '2026-07-16T00:00:00.000Z',
+        name: path?.split('/').pop() ?? 'file.ts',
+        size: 13,
+        updatedAt: '2026-08-07T00:00:00.000Z',
         contentType: 'text',
-        content: '# Notes',
+        content: 'export {}\n',
       });
     }),
   );
@@ -77,328 +46,42 @@ function installHandlers() {
 }
 
 describe('WorkspaceViewerPanel', () => {
-  it('shows an empty state for configured paths with no files', async () => {
-    server.use(
-      http.get(LIST_URL, () =>
-        HttpResponse.json({
-          workspacePath: WORKSPACE,
-          root: '.artifacts',
-          rootPath: `${WORKSPACE}/.artifacts`,
-          entries: [],
-        }),
-      ),
-    );
+  describe('when a thread has persisted workspace files', () => {
+    it('renders the persisted paths instead of enumerating the sandbox', async () => {
+      installHandlers();
 
-    renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />);
+      renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} threadId={THREAD} />);
 
-    await userEvent.click(await screen.findByRole('button', { name: 'Artifacts' }));
-    expect(await screen.findByText('No artifacts yet. Session files created will appear here.')).toBeInTheDocument();
-  });
-
-  it('expands folders inline and swaps the browser for the selected file viewer', async () => {
-    const fileRequests = installHandlers();
-    const user = userEvent.setup();
-    renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />);
-
-    const root = await screen.findByRole('button', { name: 'Artifacts' });
-    expect(root).toHaveAttribute('aria-expanded', 'false');
-    await user.click(root);
-    expect(root).toHaveAttribute('aria-expanded', 'true');
-
-    const folder = await screen.findByRole('button', { name: 'understand-pr' });
-    expect(folder).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.queryByText('HISTORY.md')).not.toBeInTheDocument();
-
-    await user.click(folder);
-
-    expect(folder).toHaveAttribute('aria-expanded', 'true');
-    await user.click(folder);
-    expect(folder).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.queryByText('HISTORY.md')).not.toBeInTheDocument();
-
-    await user.click(folder);
-    expect(folder).toHaveAttribute('aria-expanded', 'true');
-    await user.click(await screen.findByText('HISTORY.md'));
-
-    const viewer = await screen.findByLabelText('Workspace file viewer');
-    expect(viewer).toBeInTheDocument();
-    expect(await screen.findByText('Notes')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Workspace files')).not.toBeInTheDocument();
-    expect(fileRequests).toContain('.artifacts/understand-pr/HISTORY.md');
-    expect(fileRequests).not.toContain('understand-pr/HISTORY.md');
-  });
-
-  it('can switch between configured rendered roots', async () => {
-    installHandlers();
-    const user = userEvent.setup();
-    renderWithProviders(
-      <WorkspaceViewerPanel
-        workspacePath={WORKSPACE}
-        renderedPaths={[...renderedPaths, { id: 'reports', label: 'Reports', root: '.reports' }]}
-      />,
-    );
-
-    await user.click(await screen.findByRole('button', { name: 'Reports' }));
-
-    expect(await screen.findByText('summary.md')).toBeInTheDocument();
-  });
-
-  it('returns from file content to the file browser', async () => {
-    installHandlers();
-    const user = userEvent.setup();
-    renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />);
-
-    await user.click(await screen.findByRole('button', { name: 'Artifacts' }));
-    await user.click(await screen.findByRole('button', { name: 'understand-pr' }));
-    await user.click(await screen.findByText('HISTORY.md'));
-
-    expect(await screen.findByLabelText('Workspace file viewer')).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Back to workspace files' }));
-
-    expect(screen.queryByLabelText('Workspace file viewer')).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Workspace files')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Artifacts' })).toHaveAttribute('aria-expanded', 'false');
-  });
-
-  it('shows progress while refreshing the current listing', async () => {
-    let calls = 0;
-    let delayRefresh = false;
-    let releaseRefresh = () => {};
-    const refreshGate = new Promise<void>(resolve => {
-      releaseRefresh = resolve;
+      expect(await screen.findByText('README.md')).toBeInTheDocument();
+      expect(screen.getByText('src')).toBeInTheDocument();
+      expect(screen.queryByText('Artifacts')).not.toBeInTheDocument();
     });
-    server.use(
-      http.get(LIST_URL, async () => {
-        calls += 1;
-        if (delayRefresh) await refreshGate;
-        return HttpResponse.json({
-          workspacePath: WORKSPACE,
-          root: '.artifacts',
-          rootPath: `${WORKSPACE}/.artifacts`,
-          entries: [],
-        });
-      }),
-    );
-    const user = userEvent.setup();
-    renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />);
 
-    await user.click(await screen.findByRole('button', { name: 'Artifacts' }));
-    await screen.findByText('No artifacts yet. Session files created will appear here.');
-    delayRefresh = true;
-    await user.click(screen.getByRole('button', { name: 'Refresh workspace files' }));
+    it('reads the selected persisted path from the live workspace filesystem', async () => {
+      const fileRequests = installHandlers();
+      const user = userEvent.setup();
+      renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} threadId={THREAD} />);
 
-    expect(await screen.findByRole('button', { name: 'Refreshing workspace files' })).toBeDisabled();
-    releaseRefresh();
-    expect(await screen.findByRole('button', { name: 'Refresh workspace files' })).toBeEnabled();
-    expect(calls).toBeGreaterThan(1);
-  });
+      await user.click(await screen.findByRole('button', { name: 'src' }));
+      await user.click(await screen.findByText('agent.ts'));
 
-  it('colors changed files while keeping their folders neutral', async () => {
-    server.use(
-      http.get(CHANGES_URL, () =>
-        HttpResponse.json({
-          workspacePath: WORKSPACE,
-          available: true,
-          additions: 3,
-          deletions: 1,
-          changes: [{ path: 'docs/README.md', status: 'modified', additions: 3, deletions: 1 }],
-        }),
-      ),
-    );
-    const user = userEvent.setup();
-    renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />);
-
-    await user.click(screen.getByRole('tab', { name: 'Changes' }));
-
-    expect(await screen.findByText('docs')).toHaveClass('text-neutral4!');
-    expect(screen.getByText('README.md')).toHaveClass('text-notice-info/70!');
-  });
-
-  it('requests both paths and renders the rename diff for a renamed file', async () => {
-    let requestedPreviousPath: string | undefined;
-    server.use(
-      http.get(CHANGES_URL, () =>
-        HttpResponse.json({
-          workspacePath: WORKSPACE,
-          available: true,
-          additions: 4,
-          deletions: 2,
-          changes: [
-            {
-              path: 'src/new-name.ts',
-              previousPath: 'src/old-name.ts',
-              status: 'renamed',
-              additions: 4,
-              deletions: 2,
-            },
-          ],
-        }),
-      ),
-      http.get(DIFF_URL, ({ request }) => {
-        requestedPreviousPath = new URL(request.url).searchParams.get('previousPath') ?? undefined;
-        return HttpResponse.json({
-          ...workspaceDiffFixture,
-          path: 'src/new-name.ts',
-          patch: '@@ -1 +1 @@\n-old name\n+new name',
-        });
-      }),
-    );
-    const user = userEvent.setup();
-    renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />);
-
-    await user.click(screen.getByRole('tab', { name: 'Changes' }));
-    await user.click(await screen.findByRole('treeitem', { name: /^old-name\.ts → new-name\.ts.*Renamed/ }));
-
-    expect(await screen.findByText('+new name')).toBeInTheDocument();
-    expect(requestedPreviousPath).toBe('src/old-name.ts');
-  });
-
-  it('loads a selected pending diff on demand', async () => {
-    const diffRequests: string[] = [];
-    server.use(
-      http.get(CHANGES_URL, () => HttpResponse.json(workspaceChangesFixture)),
-      http.get(DIFF_URL, ({ request }) => {
-        const path = new URL(request.url).searchParams.get('path');
-        if (path) diffRequests.push(path);
-        if (path === 'src/new.ts') {
-          return HttpResponse.json({
-            ...workspaceDiffFixture,
-            path,
-            patch: '@@ -0,0 +1 @@\n+new file contents',
-          });
-        }
-        return HttpResponse.json(workspaceDiffFixture);
-      }),
-    );
-    const user = userEvent.setup();
-    renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />);
-
-    await user.click(screen.getByRole('tab', { name: 'Changes' }));
-    expect(await screen.findByText('Changes (2)')).toBeInTheDocument();
-    expect(screen.getByText('2 files changed')).toBeInTheDocument();
-    expect(screen.getByLabelText('8 additions and 1 deletion')).toBeInTheDocument();
-    expect(screen.getByLabelText('3 additions and 1 deletion')).toBeInTheDocument();
-    expect(screen.getByLabelText('5 additions and 0 deletions')).toBeInTheDocument();
-    expect(diffRequests).toEqual([]);
-
-    expect(screen.getByText('src')).toHaveClass('text-neutral4!');
-    expect(screen.getByText('edited.ts')).toHaveClass('text-notice-info/70!');
-    expect(screen.getByText('new.ts')).toHaveClass('text-notice-success/70!');
-    const srcFolder = screen.getByText('src').closest('[role="treeitem"]');
-    expect(srcFolder).toHaveAttribute('aria-expanded', 'true');
-    await user.click(screen.getByText('src'));
-    expect(srcFolder).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.queryByRole('treeitem', { name: /edited\.ts.*Modified/ })).not.toBeInTheDocument();
-    await user.click(screen.getByText('src'));
-
-    const editedFile = screen.getByRole('treeitem', { name: /^edited\.ts.*Modified/ });
-    await user.click(editedFile);
-
-    expect(await screen.findByText('-old value')).toBeInTheDocument();
-    expect(screen.getByTestId('workspace-preview-interactive')).toHaveAttribute('data-drawer-content');
-    expect(screen.getByText('+new value')).toHaveClass('whitespace-pre-wrap', 'break-words');
-    expect(screen.queryByText(/diff --git/)).not.toBeInTheDocument();
-    expect(screen.getByRole('treeitem', { name: /^edited\.ts.*Modified/ })).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByRole('button', { name: 'Refresh changes' }).parentElement).toHaveClass('pr-12');
-
-    await user.click(screen.getByRole('button', { name: 'Open full-screen changes viewer' }));
-    expect(screen.getByRole('dialog')).toHaveClass('w-[calc(100vw-3.5rem)]');
-    await user.click(screen.getByRole('button', { name: 'Exit full-screen changes viewer' }));
-    expect(screen.getByRole('button', { name: 'Open full-screen changes viewer' })).toBeVisible();
-    expect(screen.getByRole('tab', { name: 'Changes (2)' })).toBeVisible();
-    expect(diffRequests).toEqual(['src/edited.ts']);
-
-    const newFile = screen.getByRole('treeitem', { name: /^new\.ts.*Untracked/ });
-    await user.click(newFile);
-    await waitFor(() => expect(diffRequests).toEqual(['src/edited.ts', 'src/new.ts']));
-    expect(await screen.findByText('+new file contents')).toBeInTheDocument();
-    expect(screen.queryByText('-old value')).not.toBeInTheDocument();
-    expect(newFile).toHaveAttribute('aria-selected', 'true');
-  });
-
-  it('preserves added and deleted content that resembles diff headers', async () => {
-    server.use(
-      http.get(CHANGES_URL, () => HttpResponse.json(workspaceChangesFixture)),
-      http.get(DIFF_URL, () =>
-        HttpResponse.json({
-          ...workspaceDiffFixture,
-          patch: [
-            'diff --git a/src/edited.ts b/src/edited.ts',
-            '--- a/src/edited.ts',
-            '+++ b/src/edited.ts',
-            '@@ -1 +1 @@',
-            '--- removed content',
-            '+++ added content',
-          ].join('\n'),
-        }),
-      ),
-    );
-    const user = userEvent.setup();
-    renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />);
-
-    await user.click(screen.getByRole('tab', { name: 'Changes' }));
-    await user.click(await screen.findByRole('treeitem', { name: /^edited\.ts.*Modified/ }));
-
-    expect(await screen.findByText('--- removed content')).toBeInTheDocument();
-    expect(screen.getByText('+++ added content')).toBeInTheDocument();
-    expect(screen.queryByText('--- a/src/edited.ts')).not.toBeInTheDocument();
-    expect(screen.queryByText('+++ b/src/edited.ts')).not.toBeInTheDocument();
-  });
-
-  it('refreshes pending changes when an agent run completes', async () => {
-    let requests = 0;
-    server.use(
-      http.get(CHANGES_URL, () => {
-        requests += 1;
-        return HttpResponse.json({
-          workspacePath: WORKSPACE,
-          available: true,
-          additions: requests === 1 ? 3 : 8,
-          deletions: 1,
-          changes:
-            requests === 1
-              ? [{ path: 'src/edited.ts', status: 'modified', additions: 3, deletions: 1 }]
-              : [
-                  { path: 'src/edited.ts', status: 'modified', additions: 3, deletions: 1 },
-                  { path: 'src/new.ts', status: 'untracked', additions: 5, deletions: 0 },
-                ],
-        });
-      }),
-    );
-    const user = userEvent.setup();
-    const { rerender } = renderWithProviders(<WorkspaceChangesRunHarness busy={false} />);
-    await user.click(screen.getByRole('tab', { name: 'Changes' }));
-    expect(await screen.findByText('Changes (1)')).toBeInTheDocument();
-
-    rerender(<WorkspaceChangesRunHarness busy />);
-    rerender(<WorkspaceChangesRunHarness busy={false} />);
-
-    expect(await screen.findByText('Changes (2)')).toBeInTheDocument();
-    expect(requests).toBe(2);
-  });
-
-  it('shows progress while refreshing pending changes', async () => {
-    let delayRefresh = false;
-    let releaseRefresh = () => {};
-    const refreshGate = new Promise<void>(resolve => {
-      releaseRefresh = resolve;
+      const viewer = await screen.findByLabelText('Workspace file viewer');
+      expect(viewer).toHaveTextContent('export {}');
+      expect(fileRequests).toEqual([{ path: 'src/agent.ts', threadId: THREAD }]);
     });
-    server.use(
-      http.get(CHANGES_URL, async () => {
-        if (delayRefresh) await refreshGate;
-        return HttpResponse.json(workspaceChangesFixture);
-      }),
-    );
-    const user = userEvent.setup();
-    renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} renderedPaths={renderedPaths} />);
+  });
 
-    await user.click(screen.getByRole('tab', { name: 'Changes' }));
-    await screen.findByText('Changes (2)');
-    delayRefresh = true;
-    await user.click(screen.getByRole('button', { name: 'Refresh changes' }));
+  describe('when no terminal file capture exists', () => {
+    it('explains that the file list is captured after a run ends', async () => {
+      server.use(
+        http.get(FILES_URL, () =>
+          HttpResponse.json({ workspacePath: WORKSPACE, threadId: THREAD, files: [] }),
+        ),
+      );
 
-    expect(await screen.findByRole('button', { name: 'Refreshing changes' })).toBeDisabled();
-    releaseRefresh();
-    expect(await screen.findByRole('button', { name: 'Refresh changes' })).toBeEnabled();
+      renderWithProviders(<WorkspaceViewerPanel workspacePath={WORKSPACE} threadId={THREAD} />);
+
+      expect(await screen.findByText('No files captured for this run yet.')).toBeInTheDocument();
+    });
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/config.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/config.ts
@@ -1,7 +1,0 @@
-export interface RenderedWorkspacePath {
-  id: string;
-  label: string;
-  root: string;
-}
-
-export const renderedPaths: RenderedWorkspacePath[] = [{ id: 'artifacts', label: 'Artifacts', root: '.artifacts' }];

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/context/WorkspaceFilesContext.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/context/WorkspaceFilesContext.ts
@@ -4,6 +4,7 @@ export interface WorkspaceFilesApi {
   open: boolean;
   setOpen: (open: boolean) => void;
   workspacePath?: string;
+  threadId?: string;
   viewingFile: boolean;
   setViewingFile: (viewing: boolean) => void;
   canDock: boolean;

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/context/WorkspaceFilesProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/context/WorkspaceFilesProvider.tsx
@@ -9,7 +9,7 @@ import { WorkspaceFilesContext } from './WorkspaceFilesContext';
 
 /** Owns the box the card measures itself against, and shares its state with the session header. */
 export function WorkspaceFilesProvider({ children }: { children: ReactNode }) {
-  const { workspacePath } = useThreadWorkspacePath();
+  const { workspacePath, threadId } = useThreadWorkspacePath();
   const chatRef = useRef<HTMLDivElement>(null);
   const canDock = useWiderThan(chatRef, DOCK_MIN_REM);
   const [toggled, setToggled] = useState<{ whileDocked: boolean; open: boolean }>();
@@ -25,7 +25,7 @@ export function WorkspaceFilesProvider({ children }: { children: ReactNode }) {
   const claimsSpace = open && canDock && Boolean(workspacePath);
 
   return (
-    <WorkspaceFilesContext.Provider value={{ open, setOpen, workspacePath, viewingFile, setViewingFile, canDock }}>
+    <WorkspaceFilesContext.Provider value={{ open, setOpen, workspacePath, threadId, viewingFile, setViewingFile, canDock }}>
       <div
         ref={chatRef}
         className={cn(

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/context/WorkspaceFilesProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/context/WorkspaceFilesProvider.tsx
@@ -25,7 +25,9 @@ export function WorkspaceFilesProvider({ children }: { children: ReactNode }) {
   const claimsSpace = open && canDock && Boolean(workspacePath);
 
   return (
-    <WorkspaceFilesContext.Provider value={{ open, setOpen, workspacePath, threadId, viewingFile, setViewingFile, canDock }}>
+    <WorkspaceFilesContext.Provider
+      value={{ open, setOpen, workspacePath, threadId, viewingFile, setViewingFile, canDock }}
+    >
       <div
         ref={chatRef}
         className={cn(

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/hooks/useThreadWorkspacePath.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/hooks/useThreadWorkspacePath.ts
@@ -10,6 +10,7 @@ export function useThreadWorkspacePath() {
 
   return {
     workspacePath: isUserThreadRoute ? userSession.data?.sessionId : sessionId,
+    threadId,
     isPending: isUserThreadRoute && userSession.isPending,
   };
 }

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/index.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/index.ts
@@ -1,3 +1,1 @@
-export { renderedPaths } from './config';
-export type { RenderedWorkspacePath } from './config';
 export { WorkspaceViewerPanel } from './components/WorkspaceViewerPanel';

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/useInvalidateWorkspaceChangesOnRunCompletion.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/useInvalidateWorkspaceChangesOnRunCompletion.ts
@@ -3,7 +3,11 @@ import { useEffect, useRef } from 'react';
 
 import { queryKeys } from '../../../api/keys';
 
-export function useInvalidateWorkspaceChangesOnRunCompletion(workspacePath: string | undefined, busy: boolean) {
+export function useInvalidateWorkspaceChangesOnRunCompletion(
+  workspacePath: string | undefined,
+  threadId: string | undefined,
+  busy: boolean,
+) {
   const queryClient = useQueryClient();
   const previous = useRef({ workspacePath, busy });
 
@@ -13,6 +17,9 @@ export function useInvalidateWorkspaceChangesOnRunCompletion(workspacePath: stri
 
     if (runCompleted && workspacePath) {
       void queryClient.invalidateQueries({ queryKey: queryKeys.workspaceChanges(workspacePath) });
+      if (threadId) {
+        void queryClient.invalidateQueries({ queryKey: queryKeys.workspaceFiles(workspacePath, threadId) });
+      }
     }
-  }, [busy, queryClient, workspacePath]);
+  }, [busy, queryClient, threadId, workspacePath]);
 }

--- a/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
@@ -56,7 +56,7 @@ export function ThreadPage() {
         ) : (
           <ChatSessionBoundary threadId={threadId}>
             <WorkspaceFilesProvider>
-              <ThreadPageMain workspacePath={workspace.workspacePath} />
+              <ThreadPageMain workspacePath={workspace.workspacePath} threadId={workspace.threadId} />
             </WorkspaceFilesProvider>
           </ChatSessionBoundary>
         )
@@ -65,14 +65,20 @@ export function ThreadPage() {
   );
 }
 
-function ThreadPageMain({ workspacePath }: { workspacePath: string | undefined }) {
+function ThreadPageMain({
+  workspacePath,
+  threadId,
+}: {
+  workspacePath: string | undefined;
+  threadId: string | undefined;
+}) {
   useGlobalShortcuts();
   useRouteThreadSync();
   const railBoxRef = useRef<HTMLDivElement>(null);
   const railFits = useWiderThan(railBoxRef, RAIL_MIN_REM);
 
   return (
-    <ThreadShell workspacePath={workspacePath}>
+    <ThreadShell workspacePath={workspacePath} threadId={threadId}>
       <ChatShell.Bar>
         <FactorySessionHeader />
       </ChatShell.Bar>
@@ -110,9 +116,17 @@ function ThreadPageMain({ workspacePath }: { workspacePath: string | undefined }
 
 // Reads the transcript so its caller does not: the context republishes on every
 // streamed chunk, and children passed through keep their element identity.
-function ThreadShell({ workspacePath, children }: { workspacePath: string | undefined; children: ReactNode }) {
+function ThreadShell({
+  workspacePath,
+  threadId,
+  children,
+}: {
+  workspacePath: string | undefined;
+  threadId: string | undefined;
+  children: ReactNode;
+}) {
   const { busy, loadMore } = useChatTranscript();
-  useInvalidateWorkspaceChangesOnRunCompletion(workspacePath, busy);
+  useInvalidateWorkspaceChangesOnRunCompletion(workspacePath, threadId, busy);
   const canLoadMore = loadMore.hasMore && !loadMore.isLoading;
 
   return (

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -33,8 +33,13 @@ function fakeStorage(): LibSQLFactoryStorage {
  * mocked — full-boot coverage lives in `../mastra/index.test.ts`.
  */
 
+const controllerMock = {
+  onSessionCreated: vi.fn(),
+  setChannels: vi.fn(),
+};
+
 const prepareMock = vi.fn(async (config: Record<string, unknown>) => ({
-  base: '/agents',
+  base: { controller: controllerMock },
   mastraArgs: { __capturedConfig: config },
   finalize: vi.fn(async () => {}),
 }));
@@ -239,6 +244,7 @@ describe('MastraFactory.prepare', () => {
       'queue-health',
       'integrations',
       'projects',
+      'filesystem',
       'source-control',
       'channel-identity',
     ]);
@@ -868,7 +874,7 @@ describe('MastraFactory.prepare integrations', () => {
     function withController() {
       const setChannels = vi.fn();
       prepareMock.mockResolvedValueOnce({
-        base: { controller: { setChannels } },
+        base: { controller: { onSessionCreated: vi.fn(), setChannels } },
         mastraArgs: {},
         finalize: vi.fn(async () => {}),
       } as never);

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -403,6 +403,7 @@ export class MastraFactory {
       modelPacks: modelPacksStorage,
       memorySettings: memorySettingsStorage,
       customProviders: customProvidersStorage,
+      filesystem: filesystemStorage,
       projects: factoryProjectsStorage,
       queueHealth: queueHealthStorage,
       workItems: workItemsStorage,

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -64,6 +64,7 @@ import { assertFactoryRules } from './rules/validation.js';
 import { SandboxFleet } from './sandbox/fleet.js';
 import { registerSandboxReattach } from './sandbox/reattach.js';
 import { handleServerError } from './server-error.js';
+import { observeSessionFilesystem } from './session/filesystem-capture.js';
 import { createSpaStaticMiddleware, resolveUiDistDir } from './spa-static.js';
 import { createStateSigner } from './state-signing.js';
 import { observeAgentGitAction } from './storage/domains/audit/agent-audit.js';
@@ -72,6 +73,7 @@ import { AuditDomain } from './storage/domains/audit/domain.js';
 import { ChannelIdentityStorage } from './storage/domains/channel-identity/base.js';
 import { ModelCredentialsStorage } from './storage/domains/credentials/base.js';
 import { CustomProvidersStorage } from './storage/domains/custom-providers/base.js';
+import { FilesystemStorage } from './storage/domains/filesystem/base.js';
 import { IntakeStorage } from './storage/domains/intake/base.js';
 import { IntegrationStorage } from './storage/domains/integrations/base.js';
 import { MemorySettingsStorage } from './storage/domains/memory-settings/base.js';
@@ -388,6 +390,7 @@ export class MastraFactory {
     // default persistence surface for integrations without a bespoke domain.
     const integrationStorage = storage.registerDomain(new IntegrationStorage());
     const factoryProjectsStorage = storage.registerDomain(new FactoryProjectsStorage());
+    const filesystemStorage = storage.registerDomain(new FilesystemStorage());
     const sourceControlStorage = storage.registerDomain(new SourceControlStorage());
     // Reverse index from a platform sender (Slack/Discord/...) to a Mastra
     // tenant, so inbound channel events can resolve the sender's model creds.
@@ -805,6 +808,13 @@ export class MastraFactory {
         },
       }),
     );
+
+    prepared.base.controller.onSessionCreated(session => {
+      observeSessionFilesystem(session, {
+        filesystem: filesystemStorage,
+        sourceControl: sourceControlStorage.forIntegration('github'),
+      });
+    });
 
     this.#prepared = prepared;
     this.#factoryProcessor = factoryProcessor;

--- a/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
@@ -26,6 +26,7 @@ const harness = vi.hoisted(() => {
     getMastra: vi.fn(() => mastra),
     getSessionByResource: vi.fn(async () => session),
     createSession: vi.fn(async () => session),
+    onSessionCreated: vi.fn(),
     // Mastra's constructor probes each controller for channels wiring.
     getChannels: vi.fn(() => undefined),
   };

--- a/mastracode/factory/src/routes/fs.test.ts
+++ b/mastracode/factory/src/routes/fs.test.ts
@@ -307,6 +307,20 @@ describe('persisted session workspace files routes', () => {
     expect(listFiles).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['/web/workspace/files', `?workspacePath=${makeSession().sessionId}&threadId=%20`],
+    ['/web/workspace/file', `?workspacePath=${makeSession().sessionId}&threadId=%20&path=src/agent.ts`],
+  ])('rejects a whitespace-only thread id on %s', async (route, query) => {
+    const { deps, ensureUser, listFiles } = makeSessionFs();
+    const request = await requestSessionRoute(route, deps);
+
+    const response = await request(query);
+
+    expect(response.status).toBe(400);
+    expect(ensureUser).not.toHaveBeenCalled();
+    expect(listFiles).not.toHaveBeenCalled();
+  });
+
   it('isolates rows for a different thread', async () => {
     const { deps, listFiles } = makeSessionFs({ files: [] });
     const request = await requestSessionRoute('/web/workspace/files', deps);

--- a/mastracode/factory/src/routes/fs.test.ts
+++ b/mastracode/factory/src/routes/fs.test.ts
@@ -247,10 +247,10 @@ function makeFleet(
 
 function makeSessionFs({
   session = makeSession(),
-  files = [{ path: 'src/agent.ts', filename: 'agent.ts' }],
+  files = [{ path: 'src/agent.ts' }],
 }: {
   session?: SourceControlSession;
-  files?: Array<{ path: string; filename: string }>;
+  files?: Array<{ path: string }>;
 } = {}) {
   const ensureUser = vi.fn(async () => undefined);
   const listFiles = vi.fn(async () => files);
@@ -291,7 +291,7 @@ describe('persisted session workspace files routes', () => {
     expect(await response.json()).toEqual({
       workspacePath: makeSession().sessionId,
       threadId: 'thread-1',
-      files: [{ path: 'src/agent.ts', filename: 'agent.ts' }],
+      files: [{ path: 'src/agent.ts' }],
     });
     expect(ensureUser).toHaveBeenCalledTimes(1);
     expect(listFiles).toHaveBeenCalledWith({ resourceId: makeSession().sessionId, threadId: 'thread-1' });

--- a/mastracode/factory/src/routes/fs.test.ts
+++ b/mastracode/factory/src/routes/fs.test.ts
@@ -2,11 +2,13 @@ import { mkdtemp, mkdir, realpath, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { Hono } from 'hono';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { SandboxFleet } from '../sandbox/fleet.js';
 import type { SourceControlSession } from '../storage/domains/source-control/base.js';
 import {
+  buildFsRoutes,
   listArtifacts,
   listSessionRenderedPath,
   listSessionWorkspaceChanges,
@@ -242,6 +244,89 @@ function makeFleet(
   } as unknown as SandboxFleet;
   return { fleet, executeCommand };
 }
+
+function makeSessionFs({
+  session = makeSession(),
+  files = [{ path: 'src/agent.ts', filename: 'agent.ts' }],
+}: {
+  session?: SourceControlSession;
+  files?: Array<{ path: string; filename: string }>;
+} = {}) {
+  const ensureUser = vi.fn(async () => undefined);
+  const listFiles = vi.fn(async () => files);
+  return {
+    ensureUser,
+    listFiles,
+    deps: {
+      auth: {
+        enabled: () => true,
+        ensureUser,
+        tenant: () => ({ orgId: session.orgId, userId: session.userId }),
+        isOrganizationAdmin: async () => false,
+      },
+      fleet: makeFleet(() => ({ exitCode: 0, stdout: '' })).fleet,
+      sessions: { getBySessionId: vi.fn(async () => session) },
+      filesystem: { listFiles },
+    },
+  };
+}
+
+async function requestSessionRoute(path: string, sessionFs: ReturnType<typeof makeSessionFs>['deps']) {
+  const route = buildFsRoutes({ sessionFs }).find(candidate => candidate.path === path);
+  if (!route || !('handler' in route)) throw new Error(`Missing route: ${path}`);
+
+  const app = new Hono<any>();
+  app.get('/', context => route.handler(context as never, async () => {}));
+  return (query: string) => app.request(`http://localhost/${query}`);
+}
+
+describe('persisted session workspace files routes', () => {
+  it('authorizes before reading the persisted list and scopes it to the requested thread', async () => {
+    const { deps, ensureUser, listFiles } = makeSessionFs();
+    const request = await requestSessionRoute('/web/workspace/files', deps);
+
+    const response = await request(`?workspacePath=${makeSession().sessionId}&threadId=thread-1`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      workspacePath: makeSession().sessionId,
+      threadId: 'thread-1',
+      files: [{ path: 'src/agent.ts', filename: 'agent.ts' }],
+    });
+    expect(ensureUser).toHaveBeenCalledTimes(1);
+    expect(listFiles).toHaveBeenCalledWith({ resourceId: makeSession().sessionId, threadId: 'thread-1' });
+  });
+
+  it('rejects a missing thread id without querying the database', async () => {
+    const { deps, listFiles } = makeSessionFs();
+    const request = await requestSessionRoute('/web/workspace/files', deps);
+
+    const response = await request(`?workspacePath=${makeSession().sessionId}`);
+
+    expect(response.status).toBe(400);
+    expect(listFiles).not.toHaveBeenCalled();
+  });
+
+  it('isolates rows for a different thread', async () => {
+    const { deps, listFiles } = makeSessionFs({ files: [] });
+    const request = await requestSessionRoute('/web/workspace/files', deps);
+
+    const response = await request(`?workspacePath=${makeSession().sessionId}&threadId=thread-2`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ workspacePath: makeSession().sessionId, threadId: 'thread-2', files: [] });
+    expect(listFiles).toHaveBeenCalledWith({ resourceId: makeSession().sessionId, threadId: 'thread-2' });
+  });
+
+  it('rejects an unlisted path before accessing the sandbox', async () => {
+    const { deps } = makeSessionFs();
+    const request = await requestSessionRoute('/web/workspace/file', deps);
+
+    const response = await request(`?workspacePath=${makeSession().sessionId}&threadId=thread-1&path=secret.env`);
+
+    expect(response.status).toBe(404);
+  });
+});
 
 describe('listSessionRenderedPath', () => {
   it('lists rendered entries from the session sandbox in one command', async () => {

--- a/mastracode/factory/src/routes/fs.ts
+++ b/mastracode/factory/src/routes/fs.ts
@@ -872,7 +872,7 @@ export function buildFsRoutes(options: { root?: string; sessionFs?: SessionFsDep
       requiresAuth: false,
       handler: async c => {
         const workspacePath = c.req.query('workspacePath');
-        const threadId = c.req.query('threadId');
+        const threadId = c.req.query('threadId')?.trim();
         if (!workspacePath) return c.json({ error: 'Missing required query param: workspacePath' }, 400);
         if (!threadId) return c.json({ error: 'Missing required query param: threadId' }, 400);
         try {
@@ -931,9 +931,13 @@ export function buildFsRoutes(options: { root?: string; sessionFs?: SessionFsDep
       handler: async c => {
         const workspacePath = c.req.query('workspacePath');
         const path = c.req.query('path');
-        const threadId = c.req.query('threadId');
+        const requestedThreadId = c.req.query('threadId');
+        const threadId = requestedThreadId?.trim();
         if (!workspacePath) return c.json({ error: 'Missing required query param: workspacePath' }, 400);
         if (!path) return c.json({ error: 'Missing required query param: path' }, 400);
+        if (requestedThreadId !== undefined && !threadId) {
+          return c.json({ error: 'Missing required query param: threadId' }, 400);
+        }
         try {
           const session = await resolveAuthorizedSession(loose(c), sessionFs, workspacePath);
           if (session && sessionFs) {

--- a/mastracode/factory/src/routes/fs.ts
+++ b/mastracode/factory/src/routes/fs.ts
@@ -9,6 +9,7 @@ import type { ApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
 
 import type { MaterializationSandbox, SandboxFleet } from '../sandbox/fleet.js';
+import type { FilesystemStorage } from '../storage/domains/filesystem/base.js';
 import type { SourceControlSession } from '../storage/domains/source-control/base.js';
 import type { RouteAuth } from './route.js';
 
@@ -72,6 +73,14 @@ export interface WorkspaceFile {
   contentType: 'text' | 'unsupported';
   content?: string;
   truncated?: boolean;
+}
+
+export interface WorkspaceFilesListing {
+  /** The Factory session resource id. */
+  workspacePath: string;
+  /** The agent thread whose terminal file list was captured. */
+  threadId: string;
+  files: Array<{ path: string; filename: string }>;
 }
 
 export type WorkspaceChangeStatus =
@@ -414,6 +423,7 @@ export interface SessionFsDeps {
   auth: RouteAuth;
   fleet: SandboxFleet;
   sessions: { getBySessionId(sessionId: string): Promise<SourceControlSession | null> };
+  filesystem: Pick<FilesystemStorage, 'listFiles'>;
 }
 
 /**
@@ -438,6 +448,21 @@ async function resolveAuthorizedSession(
     }
   }
   return session;
+}
+
+export async function listSessionFilesystemFiles(
+  filesystem: Pick<FilesystemStorage, 'listFiles'>,
+  session: SourceControlSession,
+  threadId: string,
+): Promise<WorkspaceFilesListing> {
+  const safeThreadId = threadId.trim();
+  if (!safeThreadId) throw new Error('Missing required query param: threadId');
+
+  return {
+    workspacePath: session.sessionId,
+    threadId: safeThreadId,
+    files: await filesystem.listFiles({ resourceId: session.sessionId, threadId: safeThreadId }),
+  };
 }
 
 interface SessionSandboxHandle {
@@ -521,14 +546,15 @@ export async function listSessionRenderedPath(
   return { workspacePath: session.sessionId, root: safeRoot, rootPath, entries };
 }
 
-/** Read a file under an approved rendered root inside a session's sandbox. */
+/** Read a file inside a session's sandbox. Paths outside rendered roots require a persisted-file allowlist check in the route. */
 export async function readSessionWorkspaceFile(
   fleet: SandboxFleet,
   session: SourceControlSession,
   path: string,
+  options: { allowUnapprovedPath?: boolean } = {},
 ): Promise<WorkspaceFile> {
   const safePath = assertRelativePath(path, 'path');
-  assertApprovedRenderedRoot(safePath.split('/')[0] ?? '');
+  if (!options.allowUnapprovedPath) assertApprovedRenderedRoot(safePath.split('/')[0] ?? '');
 
   const handle = await sessionSandbox(fleet, session);
   if (!handle) throw new Error('Session workspace is not available');
@@ -841,6 +867,25 @@ export function buildFsRoutes(options: { root?: string; sessionFs?: SessionFsDep
         }
       },
     }),
+    registerApiRoute('/web/workspace/files', {
+      method: 'GET',
+      requiresAuth: false,
+      handler: async c => {
+        const workspacePath = c.req.query('workspacePath');
+        const threadId = c.req.query('threadId');
+        if (!workspacePath) return c.json({ error: 'Missing required query param: workspacePath' }, 400);
+        if (!threadId) return c.json({ error: 'Missing required query param: threadId' }, 400);
+        try {
+          const session = await resolveAuthorizedSession(loose(c), sessionFs, workspacePath);
+          if (!session || !sessionFs) return c.json({ error: 'Session workspace is not available' }, 403);
+          return c.json(await listSessionFilesystemFiles(sessionFs.filesystem, session, threadId));
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          const status = message.includes('not available') ? 403 : 500;
+          return c.json({ error: message }, status);
+        }
+      },
+    }),
     registerApiRoute('/web/workspace/changes', {
       method: 'GET',
       requiresAuth: false,
@@ -886,13 +931,25 @@ export function buildFsRoutes(options: { root?: string; sessionFs?: SessionFsDep
       handler: async c => {
         const workspacePath = c.req.query('workspacePath');
         const path = c.req.query('path');
+        const threadId = c.req.query('threadId');
         if (!workspacePath) return c.json({ error: 'Missing required query param: workspacePath' }, 400);
         if (!path) return c.json({ error: 'Missing required query param: path' }, 400);
         try {
           const session = await resolveAuthorizedSession(loose(c), sessionFs, workspacePath);
           if (session && sessionFs) {
+            if (threadId) {
+              const safePath = assertRelativePath(path, 'path');
+              const listing = await listSessionFilesystemFiles(sessionFs.filesystem, session, threadId);
+              if (!listing.files.some(file => file.path === safePath)) {
+                return c.json({ error: 'Path is not available for this thread' }, 404);
+              }
+              return c.json(
+                await readSessionWorkspaceFile(sessionFs.fleet, session, safePath, { allowUnapprovedPath: true }),
+              );
+            }
             return c.json(await readSessionWorkspaceFile(sessionFs.fleet, session, path));
           }
+          if (threadId) return c.json({ error: 'Session workspace is not available' }, 403);
           return c.json(await readWorkspaceFile(root, workspacePath, path));
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);

--- a/mastracode/factory/src/routes/fs.ts
+++ b/mastracode/factory/src/routes/fs.ts
@@ -80,7 +80,7 @@ export interface WorkspaceFilesListing {
   workspacePath: string;
   /** The agent thread whose terminal file list was captured. */
   threadId: string;
-  files: Array<{ path: string; filename: string }>;
+  files: Array<{ path: string }>;
 }
 
 export type WorkspaceChangeStatus =

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -19,6 +19,7 @@ import type { AuditEmitter } from '../storage/domains/audit/domain.js';
 import type { ChannelIdentityStorage } from '../storage/domains/channel-identity/base.js';
 import type { ModelCredentialsStorage } from '../storage/domains/credentials/base.js';
 import type { CustomProvidersStorage } from '../storage/domains/custom-providers/base.js';
+import type { FilesystemStorage } from '../storage/domains/filesystem/base.js';
 import type { IntakeStorage } from '../storage/domains/intake/base.js';
 import type { IntegrationStorage } from '../storage/domains/integrations/base.js';
 import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
@@ -65,6 +66,7 @@ export interface FactoryApiRoutesDeps {
     modelCredentials: ModelCredentialsStorage;
     memorySettings: MemorySettingsStorage;
     customProviders: CustomProvidersStorage;
+    filesystem: FilesystemStorage;
     modelPacks: ModelPacksStorage;
     projects: FactoryProjectsStorage;
     queueHealth: QueueHealthStorage;
@@ -399,6 +401,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
         auth: deps.auth,
         fleet: deps.fleet,
         sessions: deps.sourceControlStorage.forIntegration('github').sessions,
+        filesystem: deps.domains.filesystem,
       },
     }),
     ...new ConfigRoutes({

--- a/mastracode/factory/src/session/filesystem-capture.test.ts
+++ b/mastracode/factory/src/session/filesystem-capture.test.ts
@@ -20,8 +20,11 @@ function commandResult(overrides: Partial<{ exitCode: number; stdout: string; st
   };
 }
 
-function createSession(result = commandResult()) {
-  const executeCommand = vi.fn().mockResolvedValue(result);
+function createSession(results = [commandResult(), commandResult()]) {
+  const executeCommand = vi
+    .fn()
+    .mockResolvedValueOnce(results[0] ?? commandResult())
+    .mockResolvedValueOnce(results[1] ?? commandResult());
   const listeners: AgentControllerEventListener[] = [];
   const session: FilesystemCaptureSession = {
     identity: { getResourceId: () => 'resource-1' },
@@ -87,28 +90,39 @@ describe('parseFilesystemCaptureFiles', () => {
 });
 
 describe('captureSessionFilesystem', () => {
-  it('captures Git status with the source-control workdir and replaces persisted files', async () => {
-    const { session, executeCommand } = createSession(commandResult({ stdout: ' M src/app.ts\0?? new.txt\0' }));
+  it('captures Git changes and ignored workspace artifacts', async () => {
+    const { session, executeCommand } = createSession([
+      commandResult({ stdout: ' M src/app.ts\0?? new.txt\0' }),
+      commandResult({ stdout: './.artifacts/hello-world.md\0' }),
+    ]);
     const dependencies = createDependencies();
 
     await captureSessionFilesystem(session, dependencies);
 
-    expect(executeCommand).toHaveBeenCalledWith(
+    expect(executeCommand).toHaveBeenNthCalledWith(
+      1,
       'git',
       ['-C', '/worktree', 'status', '--porcelain=v1', '-z', '--untracked-files=all'],
+      { timeout: 30_000 },
+    );
+    expect(executeCommand).toHaveBeenNthCalledWith(
+      2,
+      'sh',
+      ['-c', 'cd "$1" && test -d .artifacts && find .artifacts -type f -print0 || true', 'sh', '/worktree'],
       { timeout: 30_000 },
     );
     expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledWith({
       resourceId: 'resource-1',
       threadId: 'thread-1',
       files: [
+        { path: '.artifacts/hello-world.md', filename: 'hello-world.md' },
         { path: 'new.txt', filename: 'new.txt' },
         { path: 'src/app.ts', filename: 'app.ts' },
       ],
     });
   });
 
-  it('clears persisted files after a successful empty Git status', async () => {
+  it('clears persisted files after successful empty Git and artifact listings', async () => {
     const { session } = createSession();
     const dependencies = createDependencies();
 
@@ -132,7 +146,7 @@ describe('captureSessionFilesystem', () => {
     expect(unavailable.executeCommand).not.toHaveBeenCalled();
     expect(unavailableDependencies.filesystem.replaceFiles).not.toHaveBeenCalled();
 
-    const failed = createSession(commandResult({ exitCode: 1, stderr: 'not a repository' }));
+    const failed = createSession([commandResult({ exitCode: 1, stderr: 'not a repository' })]);
     const failedDependencies = createDependencies();
     await captureSessionFilesystem(failed.session, failedDependencies);
 

--- a/mastracode/factory/src/session/filesystem-capture.test.ts
+++ b/mastracode/factory/src/session/filesystem-capture.test.ts
@@ -1,0 +1,169 @@
+import type { AgentControllerEventListener } from '@mastra/core/agent-controller';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  captureSessionFilesystem,
+  observeSessionFilesystem,
+  parseFilesystemCaptureFiles,
+  type FilesystemCaptureDependencies,
+  type FilesystemCaptureSession,
+} from './filesystem-capture.js';
+
+function commandResult(overrides: Partial<{ exitCode: number; stdout: string; stderr: string }> = {}) {
+  return {
+    success: (overrides.exitCode ?? 0) === 0,
+    exitCode: 0,
+    stdout: '',
+    stderr: '',
+    executionTimeMs: 1,
+    ...overrides,
+  };
+}
+
+function createSession(result = commandResult()) {
+  const executeCommand = vi.fn().mockResolvedValue(result);
+  const listeners: AgentControllerEventListener[] = [];
+  const session: FilesystemCaptureSession = {
+    identity: { getResourceId: () => 'resource-1' },
+    thread: { requireId: () => 'thread-1' },
+    getWorkspace: () => ({
+      sandbox: {
+        id: 'sandbox-1',
+        name: 'Test sandbox',
+        provider: 'test',
+        executeCommand,
+      },
+    }),
+    subscribe: listener => {
+      listeners.push(listener);
+      return () => {
+        const index = listeners.indexOf(listener);
+        if (index !== -1) listeners.splice(index, 1);
+      };
+    },
+  };
+
+  return { session, executeCommand, listeners };
+}
+
+function createDependencies(): FilesystemCaptureDependencies {
+  return {
+    filesystem: { replaceFiles: vi.fn().mockResolvedValue(undefined) },
+    sourceControl: {
+      sessions: {
+        getBySessionId: vi.fn().mockResolvedValue({
+          id: 'source-session-1',
+          sessionId: 'resource-1',
+          projectRepositoryId: 'project-repository-1',
+          orgId: 'org-1',
+          userId: 'user-1',
+          branch: 'main',
+          baseBranch: 'main',
+          sandboxId: 'sandbox-1',
+          sandboxWorkdir: '/worktree',
+          materializedAt: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      },
+    },
+  };
+}
+
+describe('parseFilesystemCaptureFiles', () => {
+  it('keeps current on-disk paths and omits deleted paths', () => {
+    expect(
+      parseFilesystemCaptureFiles(
+        ' M src/app.ts\0?? notes/todo.md\0R  src/renamed.ts\0src/old.ts\0C  copy.ts\0source.ts\0 D removed.ts\0DD gone.ts\0UU conflict.ts\0',
+      ),
+    ).toEqual([
+      { path: 'conflict.ts', filename: 'conflict.ts' },
+      { path: 'copy.ts', filename: 'copy.ts' },
+      { path: 'notes/todo.md', filename: 'todo.md' },
+      { path: 'src/app.ts', filename: 'app.ts' },
+      { path: 'src/renamed.ts', filename: 'renamed.ts' },
+    ]);
+  });
+});
+
+describe('captureSessionFilesystem', () => {
+  it('captures Git status with the source-control workdir and replaces persisted files', async () => {
+    const { session, executeCommand } = createSession(commandResult({ stdout: ' M src/app.ts\0?? new.txt\0' }));
+    const dependencies = createDependencies();
+
+    await captureSessionFilesystem(session, dependencies);
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      'git',
+      ['-C', '/worktree', 'status', '--porcelain=v1', '-z', '--untracked-files=all'],
+      { timeout: 30_000 },
+    );
+    expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledWith({
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      files: [
+        { path: 'new.txt', filename: 'new.txt' },
+        { path: 'src/app.ts', filename: 'app.ts' },
+      ],
+    });
+  });
+
+  it('clears persisted files after a successful empty Git status', async () => {
+    const { session } = createSession();
+    const dependencies = createDependencies();
+
+    await captureSessionFilesystem(session, dependencies);
+
+    expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledWith({
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      files: [],
+    });
+  });
+
+  it('preserves persisted files when the source workspace is unavailable or Git fails', async () => {
+    const unavailable = createSession();
+    const unavailableDependencies = createDependencies();
+    unavailableDependencies.sourceControl.sessions.getBySessionId = vi.fn().mockResolvedValue(null);
+    const error = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await captureSessionFilesystem(unavailable.session, unavailableDependencies);
+
+    expect(unavailable.executeCommand).not.toHaveBeenCalled();
+    expect(unavailableDependencies.filesystem.replaceFiles).not.toHaveBeenCalled();
+
+    const failed = createSession(commandResult({ exitCode: 1, stderr: 'not a repository' }));
+    const failedDependencies = createDependencies();
+    await captureSessionFilesystem(failed.session, failedDependencies);
+
+    expect(failedDependencies.filesystem.replaceFiles).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      '[Factory filesystem capture] Unable to inspect Git status.',
+      'not a repository',
+    );
+    error.mockRestore();
+  });
+});
+
+describe('observeSessionFilesystem', () => {
+  it.each(['complete', 'aborted', 'error', 'suspended'] as const)('captures on %s agent-end events', async reason => {
+    const { session, listeners } = createSession();
+    const dependencies = createDependencies();
+    observeSessionFilesystem(session, dependencies);
+
+    listeners[0]!({ type: 'agent_end', reason });
+
+    await vi.waitFor(() => expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(1));
+  });
+
+  it('ignores non-terminal events', async () => {
+    const { session, listeners } = createSession();
+    const dependencies = createDependencies();
+    observeSessionFilesystem(session, dependencies);
+
+    listeners[0]!({ type: 'workspace_status_changed', status: 'ready' });
+    await Promise.resolve();
+
+    expect(dependencies.filesystem.replaceFiles).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/factory/src/session/filesystem-capture.test.ts
+++ b/mastracode/factory/src/session/filesystem-capture.test.ts
@@ -1,4 +1,4 @@
-import type { AgentControllerEventListener } from '@mastra/core/agent-controller';
+import type { SessionBeforeAgentEndListener } from '@mastra/core/agent-controller';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -21,11 +21,8 @@ function commandResult(overrides: Partial<{ exitCode: number; stdout: string; st
 }
 
 function createSession(results = [commandResult(), commandResult()]) {
-  const executeCommand = vi
-    .fn()
-    .mockResolvedValueOnce(results[0] ?? commandResult())
-    .mockResolvedValueOnce(results[1] ?? commandResult());
-  const listeners: AgentControllerEventListener[] = [];
+  const executeCommand = vi.fn(async () => results.shift() ?? commandResult());
+  const listeners: SessionBeforeAgentEndListener[] = [];
   const session: FilesystemCaptureSession = {
     identity: { getResourceId: () => 'resource-1' },
     thread: { requireId: () => 'thread-1' },
@@ -37,7 +34,7 @@ function createSession(results = [commandResult(), commandResult()]) {
         executeCommand,
       },
     }),
-    subscribe: listener => {
+    onBeforeAgentEnd: listener => {
       listeners.push(listener);
       return () => {
         const index = listeners.indexOf(listener);
@@ -160,24 +157,42 @@ describe('captureSessionFilesystem', () => {
 });
 
 describe('observeSessionFilesystem', () => {
-  it.each(['complete', 'aborted', 'error', 'suspended'] as const)('captures on %s agent-end events', async reason => {
-    const { session, listeners } = createSession();
+  it.each(['complete', 'aborted', 'error', 'suspended'] as const)(
+    'captures before %s agent-end events',
+    async reason => {
+      const { session, listeners } = createSession();
+      const dependencies = createDependencies();
+      observeSessionFilesystem(session, dependencies);
+
+      await listeners[0]!({ type: 'agent_end', reason });
+
+      expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('serializes captures when terminal events arrive before the prior capture finishes', async () => {
+    const { session, listeners } = createSession([commandResult(), commandResult(), commandResult(), commandResult()]);
+    let completeFirstCapture: (() => void) | undefined;
     const dependencies = createDependencies();
+    dependencies.filesystem.replaceFiles = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          completeFirstCapture = resolve;
+        }),
+    );
     observeSessionFilesystem(session, dependencies);
 
-    listeners[0]!({ type: 'agent_end', reason });
-
+    const first = listeners[0]!({ type: 'agent_end', reason: 'complete' });
     await vi.waitFor(() => expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(1));
-  });
 
-  it('ignores non-terminal events', async () => {
-    const { session, listeners } = createSession();
-    const dependencies = createDependencies();
-    observeSessionFilesystem(session, dependencies);
-
-    listeners[0]!({ type: 'workspace_status_changed', status: 'ready' });
+    const second = listeners[0]!({ type: 'agent_end', reason: 'complete' });
     await Promise.resolve();
+    expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(1);
 
-    expect(dependencies.filesystem.replaceFiles).not.toHaveBeenCalled();
+    completeFirstCapture?.();
+    await first;
+    await vi.waitFor(() => expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(2));
+    completeFirstCapture?.();
+    await second;
   });
 });

--- a/mastracode/factory/src/session/filesystem-capture.test.ts
+++ b/mastracode/factory/src/session/filesystem-capture.test.ts
@@ -77,11 +77,11 @@ describe('parseFilesystemCaptureFiles', () => {
         ' M src/app.ts\0?? notes/todo.md\0R  src/renamed.ts\0src/old.ts\0C  copy.ts\0source.ts\0 D removed.ts\0DD gone.ts\0UU conflict.ts\0',
       ),
     ).toEqual([
-      { path: 'conflict.ts', filename: 'conflict.ts' },
-      { path: 'copy.ts', filename: 'copy.ts' },
-      { path: 'notes/todo.md', filename: 'todo.md' },
-      { path: 'src/app.ts', filename: 'app.ts' },
-      { path: 'src/renamed.ts', filename: 'renamed.ts' },
+      { path: 'conflict.ts' },
+      { path: 'copy.ts' },
+      { path: 'notes/todo.md' },
+      { path: 'src/app.ts' },
+      { path: 'src/renamed.ts' },
     ]);
   });
 });
@@ -111,11 +111,7 @@ describe('captureSessionFilesystem', () => {
     expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledWith({
       resourceId: 'resource-1',
       threadId: 'thread-1',
-      files: [
-        { path: '.artifacts/hello-world.md', filename: 'hello-world.md' },
-        { path: 'new.txt', filename: 'new.txt' },
-        { path: 'src/app.ts', filename: 'app.ts' },
-      ],
+      files: [{ path: '.artifacts/hello-world.md' }, { path: 'new.txt' }, { path: 'src/app.ts' }],
     });
   });
 

--- a/mastracode/factory/src/session/filesystem-capture.ts
+++ b/mastracode/factory/src/session/filesystem-capture.ts
@@ -5,6 +5,7 @@ import type { FilesystemFile, FilesystemStorage } from '../storage/domains/files
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 
 const GIT_STATUS_ARGS = ['status', '--porcelain=v1', '-z', '--untracked-files=all'];
+const ARTIFACTS_LIST_COMMAND = 'cd "$1" && test -d .artifacts && find .artifacts -type f -print0 || true';
 
 export interface FilesystemCaptureSession {
   readonly identity: { getResourceId(): string };
@@ -60,10 +61,31 @@ export async function captureSessionFilesystem(
       return;
     }
 
+    const artifacts = await sandbox.executeCommand(
+      'sh',
+      ['-c', ARTIFACTS_LIST_COMMAND, 'sh', sourceSession.sandboxWorkdir],
+      { timeout: 30_000 },
+    );
+    if (artifacts.exitCode !== 0) {
+      console.warn('[Factory filesystem capture] Unable to list workspace artifacts.', artifacts.stderr);
+      return;
+    }
+
+    const files = new Map(parseFilesystemCaptureFiles(result.stdout).map(file => [file.path, file]));
+    for (const path of artifacts.stdout.split('\0')) {
+      const normalizedPath = path.replace(/^\.\//, '');
+      if (normalizedPath) {
+        files.set(normalizedPath, {
+          path: normalizedPath,
+          filename: normalizedPath.slice(normalizedPath.lastIndexOf('/') + 1),
+        });
+      }
+    }
+
     await filesystem.replaceFiles({
       resourceId,
       threadId,
-      files: parseFilesystemCaptureFiles(result.stdout),
+      files: [...files.values()].toSorted((a, b) => a.path.localeCompare(b.path)),
     });
   } catch (error) {
     console.warn('[Factory filesystem capture] Unable to persist files.', error);

--- a/mastracode/factory/src/session/filesystem-capture.ts
+++ b/mastracode/factory/src/session/filesystem-capture.ts
@@ -1,4 +1,4 @@
-import type { AgentControllerEventListener } from '@mastra/core/agent-controller';
+import type { SessionBeforeAgentEndListener } from '@mastra/core/agent-controller';
 import type { WorkspaceSandbox } from '@mastra/core/workspace';
 
 import type { FilesystemFile, FilesystemStorage } from '../storage/domains/filesystem/base.js';
@@ -11,7 +11,7 @@ export interface FilesystemCaptureSession {
   readonly identity: { getResourceId(): string };
   readonly thread: { requireId(): string };
   getWorkspace(): { sandbox?: Pick<WorkspaceSandbox, 'executeCommand'> };
-  subscribe(listener: AgentControllerEventListener): () => void;
+  onBeforeAgentEnd(listener: SessionBeforeAgentEndListener): () => void;
 }
 
 export interface FilesystemCaptureDependencies {
@@ -96,9 +96,9 @@ export function observeSessionFilesystem(
   session: FilesystemCaptureSession,
   dependencies: FilesystemCaptureDependencies,
 ): () => void {
-  return session.subscribe(event => {
-    if (event.type === 'agent_end') {
-      void captureSessionFilesystem(session, dependencies);
-    }
+  let capture = Promise.resolve();
+  return session.onBeforeAgentEnd(() => {
+    capture = capture.then(() => captureSessionFilesystem(session, dependencies));
+    return capture;
   });
 }

--- a/mastracode/factory/src/session/filesystem-capture.ts
+++ b/mastracode/factory/src/session/filesystem-capture.ts
@@ -36,7 +36,7 @@ export function parseFilesystemCaptureFiles(output: string): FilesystemFile[] {
     if (path.startsWith('./')) path = path.slice(2);
     if (!path || (!code.includes('U') && code.includes('D') && !moved)) continue;
 
-    files.set(path, { path, filename: path.slice(path.lastIndexOf('/') + 1) });
+    files.set(path, { path });
   }
 
   return [...files.values()].toSorted((a, b) => a.path.localeCompare(b.path));
@@ -75,10 +75,7 @@ export async function captureSessionFilesystem(
     for (const path of artifacts.stdout.split('\0')) {
       const normalizedPath = path.replace(/^\.\//, '');
       if (normalizedPath) {
-        files.set(normalizedPath, {
-          path: normalizedPath,
-          filename: normalizedPath.slice(normalizedPath.lastIndexOf('/') + 1),
-        });
+        files.set(normalizedPath, { path: normalizedPath });
       }
     }
 

--- a/mastracode/factory/src/session/filesystem-capture.ts
+++ b/mastracode/factory/src/session/filesystem-capture.ts
@@ -1,0 +1,82 @@
+import type { AgentControllerEventListener } from '@mastra/core/agent-controller';
+import type { WorkspaceSandbox } from '@mastra/core/workspace';
+
+import type { FilesystemFile, FilesystemStorage } from '../storage/domains/filesystem/base.js';
+import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
+
+const GIT_STATUS_ARGS = ['status', '--porcelain=v1', '-z', '--untracked-files=all'];
+
+export interface FilesystemCaptureSession {
+  readonly identity: { getResourceId(): string };
+  readonly thread: { requireId(): string };
+  getWorkspace(): { sandbox?: Pick<WorkspaceSandbox, 'executeCommand'> };
+  subscribe(listener: AgentControllerEventListener): () => void;
+}
+
+export interface FilesystemCaptureDependencies {
+  filesystem: Pick<FilesystemStorage, 'replaceFiles'>;
+  sourceControl: {
+    sessions: Pick<SourceControlStorageHandle['sessions'], 'getBySessionId'>;
+  };
+}
+
+export function parseFilesystemCaptureFiles(output: string): FilesystemFile[] {
+  const files = new Map<string, FilesystemFile>();
+  const records = output.split('\0');
+
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record || record.length < 4) continue;
+
+    const code = record.slice(0, 2);
+    let path = record.slice(3);
+    const moved = code.includes('R') || code.includes('C');
+    if (moved) index += 1;
+    if (path.startsWith('./')) path = path.slice(2);
+    if (!path || (!code.includes('U') && code.includes('D') && !moved)) continue;
+
+    files.set(path, { path, filename: path.slice(path.lastIndexOf('/') + 1) });
+  }
+
+  return [...files.values()].toSorted((a, b) => a.path.localeCompare(b.path));
+}
+
+export async function captureSessionFilesystem(
+  session: FilesystemCaptureSession,
+  { filesystem, sourceControl }: FilesystemCaptureDependencies,
+): Promise<void> {
+  try {
+    const resourceId = session.identity.getResourceId();
+    const threadId = session.thread.requireId();
+    const sourceSession = await sourceControl.sessions.getBySessionId(resourceId);
+    const sandbox = session.getWorkspace().sandbox;
+    if (!sourceSession?.sandboxWorkdir || !sandbox?.executeCommand) return;
+
+    const result = await sandbox.executeCommand('git', ['-C', sourceSession.sandboxWorkdir, ...GIT_STATUS_ARGS], {
+      timeout: 30_000,
+    });
+    if (result.exitCode !== 0) {
+      console.warn('[Factory filesystem capture] Unable to inspect Git status.', result.stderr);
+      return;
+    }
+
+    await filesystem.replaceFiles({
+      resourceId,
+      threadId,
+      files: parseFilesystemCaptureFiles(result.stdout),
+    });
+  } catch (error) {
+    console.warn('[Factory filesystem capture] Unable to persist files.', error);
+  }
+}
+
+export function observeSessionFilesystem(
+  session: FilesystemCaptureSession,
+  dependencies: FilesystemCaptureDependencies,
+): () => void {
+  return session.subscribe(event => {
+    if (event.type === 'agent_end') {
+      void captureSessionFilesystem(session, dependencies);
+    }
+  });
+}

--- a/mastracode/factory/src/storage/domains/filesystem/base.test.ts
+++ b/mastracode/factory/src/storage/domains/filesystem/base.test.ts
@@ -1,0 +1,147 @@
+import { LibSQLFactoryStorage } from '@mastra/libsql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { FilesystemStorage } from './base.js';
+
+describe('FilesystemStorage', () => {
+  let backend: LibSQLFactoryStorage;
+  let domain: FilesystemStorage;
+
+  beforeEach(async () => {
+    backend = new LibSQLFactoryStorage({ id: 'filesystem-test', url: ':memory:' });
+    domain = backend.registerDomain(new FilesystemStorage());
+    await backend.init();
+  });
+
+  afterEach(async () => {
+    await backend.close();
+  });
+
+  it('round trips root and nested files sorted by path', async () => {
+    await domain.replaceFiles({
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      files: [
+        { path: 'src/index.ts', filename: 'index.ts' },
+        { path: 'README.md', filename: 'README.md' },
+        { path: 'assets/logo.svg', filename: 'logo.svg' },
+      ],
+    });
+
+    await expect(domain.listFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toEqual([
+      { path: 'assets/logo.svg', filename: 'logo.svg' },
+      { path: 'README.md', filename: 'README.md' },
+      { path: 'src/index.ts', filename: 'index.ts' },
+    ]);
+  });
+
+  it('replaces a thread file list without retaining stale rows', async () => {
+    await domain.replaceFiles({
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      files: [
+        { path: 'stale.ts', filename: 'stale.ts' },
+        { path: 'also-stale.ts', filename: 'also-stale.ts' },
+      ],
+    });
+    await domain.replaceFiles({
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      files: [{ path: 'current.ts', filename: 'current.ts' }],
+    });
+
+    await expect(domain.listFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toEqual([
+      { path: 'current.ts', filename: 'current.ts' },
+    ]);
+
+    await domain.replaceFiles({ resourceId: 'resource-1', threadId: 'thread-1', files: [] });
+    await expect(domain.listFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toEqual([]);
+  });
+
+  it('isolates equal thread ids under different resources', async () => {
+    await domain.replaceFiles({
+      resourceId: 'resource-a',
+      threadId: 'thread-1',
+      files: [{ path: 'a.ts', filename: 'a.ts' }],
+    });
+    await domain.replaceFiles({
+      resourceId: 'resource-b',
+      threadId: 'thread-1',
+      files: [{ path: 'b.ts', filename: 'b.ts' }],
+    });
+
+    await expect(domain.listFiles({ resourceId: 'resource-a', threadId: 'thread-1' })).resolves.toEqual([
+      { path: 'a.ts', filename: 'a.ts' },
+    ]);
+    await expect(domain.listFiles({ resourceId: 'resource-b', threadId: 'thread-1' })).resolves.toEqual([
+      { path: 'b.ts', filename: 'b.ts' },
+    ]);
+  });
+
+  it('rejects empty identifiers and invalid files', async () => {
+    await expect(domain.listFiles({ resourceId: '', threadId: 'thread-1' })).rejects.toThrow(
+      'resourceId must not be empty',
+    );
+    await expect(
+      domain.replaceFiles({
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        files: [{ path: '../file.ts', filename: 'file.ts' }],
+      }),
+    ).rejects.toThrow('relative path');
+    await expect(
+      domain.replaceFiles({
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        files: [{ path: 'file.ts', filename: 'other.ts' }],
+      }),
+    ).rejects.toThrow('filename must match');
+    await expect(
+      domain.replaceFiles({
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        files: [
+          { path: 'same.ts', filename: 'same.ts' },
+          { path: 'same.ts', filename: 'same.ts' },
+        ],
+      }),
+    ).rejects.toThrow('duplicate file path');
+  });
+
+  it('deletes only the selected thread files', async () => {
+    await domain.replaceFiles({
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      files: [{ path: 'first.ts', filename: 'first.ts' }],
+    });
+    await domain.replaceFiles({
+      resourceId: 'resource-1',
+      threadId: 'thread-2',
+      files: [{ path: 'second.ts', filename: 'second.ts' }],
+    });
+
+    await expect(domain.deleteFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toBe(1);
+    await expect(domain.listFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toEqual([]);
+    await expect(domain.listFiles({ resourceId: 'resource-1', threadId: 'thread-2' })).resolves.toEqual([
+      { path: 'second.ts', filename: 'second.ts' },
+    ]);
+  });
+
+  it('clears all files', async () => {
+    await domain.replaceFiles({
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      files: [{ path: 'first.ts', filename: 'first.ts' }],
+    });
+    await domain.replaceFiles({
+      resourceId: 'resource-2',
+      threadId: 'thread-2',
+      files: [{ path: 'second.ts', filename: 'second.ts' }],
+    });
+
+    await domain.dangerouslyClearAll();
+
+    await expect(domain.listFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toEqual([]);
+    await expect(domain.listFiles({ resourceId: 'resource-2', threadId: 'thread-2' })).resolves.toEqual([]);
+  });
+});

--- a/mastracode/factory/src/storage/domains/filesystem/base.test.ts
+++ b/mastracode/factory/src/storage/domains/filesystem/base.test.ts
@@ -1,7 +1,7 @@
 import { LibSQLFactoryStorage } from '@mastra/libsql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { FilesystemStorage } from './base.js';
+import { FILESYSTEM_SCHEMAS, FilesystemStorage } from './base.js';
 
 describe('FilesystemStorage', () => {
   let backend: LibSQLFactoryStorage;
@@ -17,41 +17,35 @@ describe('FilesystemStorage', () => {
     await backend.close();
   });
 
-  it('round trips root and nested files sorted by path', async () => {
+  it('stores one JSON snapshot per resource and thread', async () => {
     await domain.replaceFiles({
       resourceId: 'resource-1',
       threadId: 'thread-1',
-      files: [
-        { path: 'src/index.ts', filename: 'index.ts' },
-        { path: 'README.md', filename: 'README.md' },
-        { path: 'assets/logo.svg', filename: 'logo.svg' },
-      ],
+      files: [{ path: 'src/index.ts' }, { path: 'README.md' }, { path: 'assets/logo.svg' }],
     });
 
     await expect(domain.listFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toEqual([
-      { path: 'assets/logo.svg', filename: 'logo.svg' },
-      { path: 'README.md', filename: 'README.md' },
-      { path: 'src/index.ts', filename: 'index.ts' },
+      { path: 'assets/logo.svg' },
+      { path: 'README.md' },
+      { path: 'src/index.ts' },
     ]);
+    await expect(domain.deleteFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toBe(1);
   });
 
-  it('replaces a thread file list without retaining stale rows', async () => {
+  it('replaces the existing snapshot without retaining stale files', async () => {
     await domain.replaceFiles({
       resourceId: 'resource-1',
       threadId: 'thread-1',
-      files: [
-        { path: 'stale.ts', filename: 'stale.ts' },
-        { path: 'also-stale.ts', filename: 'also-stale.ts' },
-      ],
+      files: [{ path: 'stale.ts' }, { path: 'also-stale.ts' }],
     });
     await domain.replaceFiles({
       resourceId: 'resource-1',
       threadId: 'thread-1',
-      files: [{ path: 'current.ts', filename: 'current.ts' }],
+      files: [{ path: 'current.ts' }],
     });
 
     await expect(domain.listFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toEqual([
-      { path: 'current.ts', filename: 'current.ts' },
+      { path: 'current.ts' },
     ]);
 
     await domain.replaceFiles({ resourceId: 'resource-1', threadId: 'thread-1', files: [] });
@@ -59,89 +53,60 @@ describe('FilesystemStorage', () => {
   });
 
   it('isolates equal thread ids under different resources', async () => {
-    await domain.replaceFiles({
-      resourceId: 'resource-a',
-      threadId: 'thread-1',
-      files: [{ path: 'a.ts', filename: 'a.ts' }],
-    });
-    await domain.replaceFiles({
-      resourceId: 'resource-b',
-      threadId: 'thread-1',
-      files: [{ path: 'b.ts', filename: 'b.ts' }],
-    });
+    await domain.replaceFiles({ resourceId: 'resource-a', threadId: 'thread-1', files: [{ path: 'a.ts' }] });
+    await domain.replaceFiles({ resourceId: 'resource-b', threadId: 'thread-1', files: [{ path: 'b.ts' }] });
 
     await expect(domain.listFiles({ resourceId: 'resource-a', threadId: 'thread-1' })).resolves.toEqual([
-      { path: 'a.ts', filename: 'a.ts' },
+      { path: 'a.ts' },
     ]);
     await expect(domain.listFiles({ resourceId: 'resource-b', threadId: 'thread-1' })).resolves.toEqual([
-      { path: 'b.ts', filename: 'b.ts' },
+      { path: 'b.ts' },
     ]);
   });
 
-  it('rejects empty identifiers and invalid files', async () => {
+  it('rejects empty identifiers, unsafe paths, and duplicate paths', async () => {
     await expect(domain.listFiles({ resourceId: '', threadId: 'thread-1' })).rejects.toThrow(
       'resourceId must not be empty',
     );
     await expect(
-      domain.replaceFiles({
-        resourceId: 'resource-1',
-        threadId: 'thread-1',
-        files: [{ path: '../file.ts', filename: 'file.ts' }],
-      }),
+      domain.replaceFiles({ resourceId: 'resource-1', threadId: 'thread-1', files: [{ path: '../file.ts' }] }),
     ).rejects.toThrow('relative path');
     await expect(
       domain.replaceFiles({
         resourceId: 'resource-1',
         threadId: 'thread-1',
-        files: [{ path: 'file.ts', filename: 'other.ts' }],
-      }),
-    ).rejects.toThrow('filename must match');
-    await expect(
-      domain.replaceFiles({
-        resourceId: 'resource-1',
-        threadId: 'thread-1',
-        files: [
-          { path: 'same.ts', filename: 'same.ts' },
-          { path: 'same.ts', filename: 'same.ts' },
-        ],
+        files: [{ path: 'same.ts' }, { path: 'same.ts' }],
       }),
     ).rejects.toThrow('duplicate file path');
   });
 
-  it('deletes only the selected thread files', async () => {
-    await domain.replaceFiles({
-      resourceId: 'resource-1',
-      threadId: 'thread-1',
-      files: [{ path: 'first.ts', filename: 'first.ts' }],
-    });
-    await domain.replaceFiles({
-      resourceId: 'resource-1',
-      threadId: 'thread-2',
-      files: [{ path: 'second.ts', filename: 'second.ts' }],
-    });
+  it('deletes only the selected thread snapshot', async () => {
+    await domain.replaceFiles({ resourceId: 'resource-1', threadId: 'thread-1', files: [{ path: 'first.ts' }] });
+    await domain.replaceFiles({ resourceId: 'resource-1', threadId: 'thread-2', files: [{ path: 'second.ts' }] });
 
     await expect(domain.deleteFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toBe(1);
     await expect(domain.listFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toEqual([]);
     await expect(domain.listFiles({ resourceId: 'resource-1', threadId: 'thread-2' })).resolves.toEqual([
-      { path: 'second.ts', filename: 'second.ts' },
+      { path: 'second.ts' },
     ]);
   });
 
-  it('clears all files', async () => {
-    await domain.replaceFiles({
-      resourceId: 'resource-1',
-      threadId: 'thread-1',
-      files: [{ path: 'first.ts', filename: 'first.ts' }],
-    });
-    await domain.replaceFiles({
-      resourceId: 'resource-2',
-      threadId: 'thread-2',
-      files: [{ path: 'second.ts', filename: 'second.ts' }],
-    });
+  it('clears all snapshots', async () => {
+    await domain.replaceFiles({ resourceId: 'resource-1', threadId: 'thread-1', files: [{ path: 'first.ts' }] });
+    await domain.replaceFiles({ resourceId: 'resource-2', threadId: 'thread-2', files: [{ path: 'second.ts' }] });
 
     await domain.dangerouslyClearAll();
 
     await expect(domain.listFiles({ resourceId: 'resource-1', threadId: 'thread-1' })).resolves.toEqual([]);
     await expect(domain.listFiles({ resourceId: 'resource-2', threadId: 'thread-2' })).resolves.toEqual([]);
+  });
+
+  it('declares a JSON snapshot with a capture timestamp', () => {
+    expect(FILESYSTEM_SCHEMAS).toContainEqual(
+      expect.objectContaining({
+        name: 'filesystem_snapshots',
+        columns: expect.objectContaining({ files: { type: 'json' }, captured_at: { type: 'timestamp' } }),
+      }),
+    );
   });
 });

--- a/mastracode/factory/src/storage/domains/filesystem/base.ts
+++ b/mastracode/factory/src/storage/domains/filesystem/base.ts
@@ -1,0 +1,124 @@
+import { FactoryStorageDomain } from '@mastra/core/storage';
+import type { CollectionSchema } from '@mastra/core/storage';
+
+const FILES = 'filesystem_files';
+
+export interface FilesystemFile {
+  path: string;
+  filename: string;
+}
+
+export interface ReplaceFilesystemFilesInput {
+  resourceId: string;
+  threadId: string;
+  files: FilesystemFile[];
+}
+
+export const FILESYSTEM_SCHEMAS: CollectionSchema[] = [
+  {
+    name: FILES,
+    columns: {
+      id: { type: 'uuid-pk' },
+      resource_id: { type: 'text' },
+      thread_id: { type: 'text' },
+      path: { type: 'text' },
+      filename: { type: 'text' },
+    },
+    uniqueIndexes: [
+      {
+        name: 'filesystem_files_resource_thread_path_unique',
+        columns: ['resource_id', 'thread_id', 'path'],
+      },
+    ],
+  },
+];
+
+interface FilesystemFileDbRow extends Record<string, unknown> {
+  id: string;
+  resource_id: string;
+  thread_id: string;
+  path: string;
+  filename: string;
+}
+
+function assertIdentifier(value: string, label: string): void {
+  if (!value.trim()) throw new Error(`[FilesystemStorage] ${label} must not be empty.`);
+}
+
+function assertRelativePath(value: string): void {
+  if (
+    !value ||
+    value.startsWith('/') ||
+    value.split('/').some(segment => !segment || segment === '.' || segment === '..')
+  ) {
+    throw new Error('[FilesystemStorage] path must be a non-empty relative path.');
+  }
+}
+
+function assertScope(args: { resourceId: string; threadId: string }): void {
+  assertIdentifier(args.resourceId, 'resourceId');
+  assertIdentifier(args.threadId, 'threadId');
+}
+
+function validateFiles(files: FilesystemFile[]): void {
+  const paths = new Set<string>();
+
+  for (const file of files) {
+    assertRelativePath(file.path);
+    if (!file.filename.trim()) throw new Error('[FilesystemStorage] filename must not be empty.');
+    if (file.filename !== file.path.slice(file.path.lastIndexOf('/') + 1)) {
+      throw new Error('[FilesystemStorage] filename must match the leaf of path.');
+    }
+    if (paths.has(file.path)) throw new Error(`[FilesystemStorage] duplicate file path: ${file.path}`);
+    paths.add(file.path);
+  }
+}
+
+function toFilesystemFile(row: FilesystemFileDbRow): FilesystemFile {
+  return { path: row.path, filename: row.filename };
+}
+
+export class FilesystemStorage extends FactoryStorageDomain {
+  constructor() {
+    super('filesystem');
+  }
+
+  async init(): Promise<void> {
+    await this.ensureCollections(FILESYSTEM_SCHEMAS);
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.ops.deleteMany(FILES, {});
+  }
+
+  async replaceFiles(input: ReplaceFilesystemFilesInput): Promise<void> {
+    assertScope(input);
+    validateFiles(input.files);
+
+    await this.storage.withTransaction(async ops => {
+      await ops.deleteMany(FILES, { resource_id: input.resourceId, thread_id: input.threadId });
+      for (const file of input.files) {
+        await ops.insertOne<FilesystemFileDbRow>(FILES, {
+          resource_id: input.resourceId,
+          thread_id: input.threadId,
+          path: file.path,
+          filename: file.filename,
+        });
+      }
+    });
+  }
+
+  async listFiles(args: { resourceId: string; threadId: string }): Promise<FilesystemFile[]> {
+    assertScope(args);
+    const files = await this.ops.findMany<FilesystemFileDbRow>(FILES, {
+      resource_id: args.resourceId,
+      thread_id: args.threadId,
+    });
+    return files.map(toFilesystemFile).toSorted((a, b) => a.path.localeCompare(b.path));
+  }
+
+  async deleteFiles(args: { resourceId: string; threadId: string }): Promise<number> {
+    assertScope(args);
+    return this.ops.deleteMany(FILES, { resource_id: args.resourceId, thread_id: args.threadId });
+  }
+}

--- a/mastracode/factory/src/storage/domains/filesystem/base.ts
+++ b/mastracode/factory/src/storage/domains/filesystem/base.ts
@@ -1,11 +1,10 @@
 import { FactoryStorageDomain } from '@mastra/core/storage';
 import type { CollectionSchema } from '@mastra/core/storage';
 
-const FILES = 'filesystem_files';
+const SNAPSHOTS = 'filesystem_snapshots';
 
 export interface FilesystemFile {
   path: string;
-  filename: string;
 }
 
 export interface ReplaceFilesystemFilesInput {
@@ -16,29 +15,29 @@ export interface ReplaceFilesystemFilesInput {
 
 export const FILESYSTEM_SCHEMAS: CollectionSchema[] = [
   {
-    name: FILES,
+    name: SNAPSHOTS,
     columns: {
       id: { type: 'uuid-pk' },
       resource_id: { type: 'text' },
       thread_id: { type: 'text' },
-      path: { type: 'text' },
-      filename: { type: 'text' },
+      files: { type: 'json' },
+      captured_at: { type: 'timestamp' },
     },
     uniqueIndexes: [
       {
-        name: 'filesystem_files_resource_thread_path_unique',
-        columns: ['resource_id', 'thread_id', 'path'],
+        name: 'filesystem_snapshots_resource_thread_unique',
+        columns: ['resource_id', 'thread_id'],
       },
     ],
   },
 ];
 
-interface FilesystemFileDbRow extends Record<string, unknown> {
+interface FilesystemSnapshotDbRow extends Record<string, unknown> {
   id: string;
   resource_id: string;
   thread_id: string;
-  path: string;
-  filename: string;
+  files: FilesystemFile[];
+  captured_at: Date;
 }
 
 function assertIdentifier(value: string, label: string): void {
@@ -65,17 +64,9 @@ function validateFiles(files: FilesystemFile[]): void {
 
   for (const file of files) {
     assertRelativePath(file.path);
-    if (!file.filename.trim()) throw new Error('[FilesystemStorage] filename must not be empty.');
-    if (file.filename !== file.path.slice(file.path.lastIndexOf('/') + 1)) {
-      throw new Error('[FilesystemStorage] filename must match the leaf of path.');
-    }
     if (paths.has(file.path)) throw new Error(`[FilesystemStorage] duplicate file path: ${file.path}`);
     paths.add(file.path);
   }
-}
-
-function toFilesystemFile(row: FilesystemFileDbRow): FilesystemFile {
-  return { path: row.path, filename: row.filename };
 }
 
 export class FilesystemStorage extends FactoryStorageDomain {
@@ -88,37 +79,32 @@ export class FilesystemStorage extends FactoryStorageDomain {
   }
 
   async dangerouslyClearAll(): Promise<void> {
-    await this.ops.deleteMany(FILES, {});
+    await this.ops.deleteMany(SNAPSHOTS, {});
   }
 
   async replaceFiles(input: ReplaceFilesystemFilesInput): Promise<void> {
     assertScope(input);
     validateFiles(input.files);
 
-    await this.storage.withTransaction(async ops => {
-      await ops.deleteMany(FILES, { resource_id: input.resourceId, thread_id: input.threadId });
-      for (const file of input.files) {
-        await ops.insertOne<FilesystemFileDbRow>(FILES, {
-          resource_id: input.resourceId,
-          thread_id: input.threadId,
-          path: file.path,
-          filename: file.filename,
-        });
-      }
+    await this.ops.upsertOne<FilesystemSnapshotDbRow>(SNAPSHOTS, ['resource_id', 'thread_id'], {
+      resource_id: input.resourceId,
+      thread_id: input.threadId,
+      files: input.files.toSorted((a, b) => a.path.localeCompare(b.path)),
+      captured_at: new Date(),
     });
   }
 
   async listFiles(args: { resourceId: string; threadId: string }): Promise<FilesystemFile[]> {
     assertScope(args);
-    const files = await this.ops.findMany<FilesystemFileDbRow>(FILES, {
+    const snapshot = await this.ops.findOne<FilesystemSnapshotDbRow>(SNAPSHOTS, {
       resource_id: args.resourceId,
       thread_id: args.threadId,
     });
-    return files.map(toFilesystemFile).toSorted((a, b) => a.path.localeCompare(b.path));
+    return snapshot?.files ?? [];
   }
 
   async deleteFiles(args: { resourceId: string; threadId: string }): Promise<number> {
     assertScope(args);
-    return this.ops.deleteMany(FILES, { resource_id: args.resourceId, thread_id: args.threadId });
+    return this.ops.deleteMany(SNAPSHOTS, { resource_id: args.resourceId, thread_id: args.threadId });
   }
 }

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -1985,6 +1985,7 @@ export const API_ROUTE_METADATA = {
       "threadId",
       "timestamp",
       "traceId",
+      "traceIds",
       "userId"
     ],
     "bodyParams": [],

--- a/packages/core/src/agent-controller/__tests__/agent-controller-session-created.test.ts
+++ b/packages/core/src/agent-controller/__tests__/agent-controller-session-created.test.ts
@@ -105,4 +105,29 @@ describe('AgentController.onSessionCreated', () => {
     expect(error).toHaveBeenCalledTimes(4);
     error.mockRestore();
   });
+
+  it('awaits before-agent-end listeners before exposing the terminal event', async () => {
+    const { controller } = createController(new InMemoryStore());
+    await controller.init();
+    const session = await controller.createSession({ resourceId: 'resource-1' });
+    const events: string[] = [];
+    let release: (() => void) | undefined;
+    session.subscribe(event => {
+      if (event.type === 'agent_end') events.push(event.reason ?? 'complete');
+    });
+    session.onBeforeAgentEnd(
+      () =>
+        new Promise<void>(resolve => {
+          release = resolve;
+        }),
+    );
+
+    const completion = session.finishAgentRun('complete');
+    await Promise.resolve();
+    expect(events).toEqual([]);
+
+    release?.();
+    await completion;
+    expect(events).toEqual(['complete']);
+  });
 });

--- a/packages/core/src/agent-controller/__tests__/agent-controller-session-created.test.ts
+++ b/packages/core/src/agent-controller/__tests__/agent-controller-session-created.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Agent } from '../../agent';
+import { InMemoryStore } from '../../storage/mock';
+import { createMockModel } from '../../test-utils/llm-mock';
+import { AgentController } from '../agent-controller';
+import { createMockWorkspace } from '../test-utils';
+
+function createController(storage: InMemoryStore) {
+  const workspace = createMockWorkspace();
+  const agent = new Agent({
+    id: 'test-agent',
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: createMockModel({ mockText: 'ok' }),
+  });
+
+  return {
+    controller: new AgentController({
+      id: 'test-controller',
+      storage,
+      workspace,
+      modes: [{ id: 'build', name: 'Build', default: true, agent, defaultModelId: 'openai/gpt-4o' }],
+    }),
+    workspace,
+  };
+}
+
+describe('AgentController.onSessionCreated', () => {
+  it('notifies with a fully initialized session', async () => {
+    const { controller, workspace } = createController(new InMemoryStore());
+    await controller.init();
+    const created: Awaited<ReturnType<typeof controller.createSession>>[] = [];
+    controller.onSessionCreated(session => {
+      created.push(session);
+    });
+
+    const session = await controller.createSession({ resourceId: 'resource-1' });
+
+    expect(created).toEqual([session]);
+    expect(session.thread.requireId()).toBeDefined();
+    expect(session.getWorkspace()).toBe(workspace);
+    expect(session.identity.getResourceId()).toBe('resource-1');
+  });
+
+  it('notifies when a stored thread is materialized by a new controller', async () => {
+    const storage = new InMemoryStore();
+    const first = createController(storage);
+    await first.controller.init();
+    const firstSession = await first.controller.createSession({ resourceId: 'resource-1' });
+    const threadId = firstSession.thread.requireId();
+
+    const restarted = createController(storage);
+    await restarted.controller.init();
+    const created: Awaited<ReturnType<typeof restarted.controller.createSession>>[] = [];
+    restarted.controller.onSessionCreated(session => {
+      created.push(session);
+    });
+
+    const resumed = await restarted.controller.createSession({ resourceId: 'resource-1' });
+
+    expect(created).toEqual([resumed]);
+    expect(resumed.thread.requireId()).toBe(threadId);
+  });
+
+  it('notifies once for cached and concurrent get-or-create calls', async () => {
+    const { controller } = createController(new InMemoryStore());
+    await controller.init();
+    const created: Awaited<ReturnType<typeof controller.createSession>>[] = [];
+    controller.onSessionCreated(session => {
+      created.push(session);
+    });
+
+    const [first, second, third] = await Promise.all([
+      controller.createSession({ resourceId: 'resource-1' }),
+      controller.createSession({ resourceId: 'resource-1' }),
+      controller.createSession({ resourceId: 'resource-1' }),
+    ]);
+    const cached = await controller.createSession({ resourceId: 'resource-1' });
+
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+    expect(third).toBe(cached);
+    expect(created).toEqual([first]);
+  });
+
+  it('stops notifications after unsubscribe and isolates listener failures', async () => {
+    const { controller } = createController(new InMemoryStore());
+    await controller.init();
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const received = vi.fn();
+    controller.onSessionCreated(() => {
+      throw new Error('sync failure');
+    });
+    controller.onSessionCreated(async () => {
+      throw new Error('async failure');
+    });
+    const unsubscribe = controller.onSessionCreated(received);
+
+    await controller.createSession({ resourceId: 'resource-1' });
+    await Promise.resolve();
+    unsubscribe();
+    await controller.createSession({ resourceId: 'resource-2' });
+
+    expect(received).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledTimes(4);
+    error.mockRestore();
+  });
+});

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -38,6 +38,7 @@ import type {
   AgentControllerMode,
   AgentControllerRequestContext,
   AgentControllerRequestStateUpdater,
+  AgentControllerSessionCreatedListener,
   AgentControllerThread,
   ModelAuthStatus,
   ToolCategory,
@@ -195,6 +196,7 @@ export class AgentController<TState = {}> {
    * that session's model/mode/state instead of an arbitrary one.
    */
   readonly #sessionsByResource = new Map<string, Promise<Session<TState>>>();
+  readonly #sessionCreatedListeners: AgentControllerSessionCreatedListener<TState>[] = [];
   /**
    * The scope each live session was created under, so re-keying operations
    * (e.g. {@link setResourceId}) preserve the session's registry scope.
@@ -246,6 +248,33 @@ export class AgentController<TState = {}> {
 
     this.workspace = config.workspace;
     this.browser = config.browser;
+  }
+
+  /**
+   * Subscribe to process-local notifications for newly materialized sessions.
+   * Cached `createSession()` calls do not notify listeners again.
+   */
+  onSessionCreated(listener: AgentControllerSessionCreatedListener<TState>): () => void {
+    this.#sessionCreatedListeners.push(listener);
+    return () => {
+      const index = this.#sessionCreatedListeners.indexOf(listener);
+      if (index !== -1) {
+        this.#sessionCreatedListeners.splice(index, 1);
+      }
+    };
+  }
+
+  #notifySessionCreated(session: Session<TState>): void {
+    for (const listener of [...this.#sessionCreatedListeners]) {
+      try {
+        const result = listener(session);
+        if (result && typeof result === 'object' && 'catch' in result) {
+          (result as Promise<void>).catch(error => console.error('Error in session-created listener:', error));
+        }
+      } catch (error) {
+        console.error('Error in session-created listener:', error);
+      }
+    }
   }
 
   /**
@@ -579,6 +608,7 @@ export class AgentController<TState = {}> {
       }
     }
 
+    this.#notifySessionCreated(session);
     return session;
   }
 

--- a/packages/core/src/agent-controller/index.ts
+++ b/packages/core/src/agent-controller/index.ts
@@ -7,6 +7,7 @@
  */
 export { AgentController } from './agent-controller';
 export { Session } from './session';
+export type { SessionBeforeAgentEndListener } from './session';
 export {
   askUserTool,
   assignTaskIds,

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -467,16 +467,15 @@ export class SessionRunEngine {
       this.#session.emit({ type: 'error', error: new Error(state.terminalError) });
     }
 
-    this.#session.emit({
-      type: 'agent_end',
-      reason: error
+    await this.#session.finishAgentRun(
+      error
         ? 'error'
         : result.suspended
           ? 'suspended'
           : aborted || this.#session.run.isAbortRequested()
             ? 'aborted'
             : 'complete',
-    });
+    );
 
     this.#session.run.reset();
     await this.#session.drainFollowUpQueue();
@@ -1173,17 +1172,17 @@ export class SessionRunEngine {
         : aborted || this.#session.run.isAbortRequested()
           ? 'aborted'
           : 'complete';
-    this.#session.emit({ type: 'agent_end', reason });
+    await this.#session.finishAgentRun(reason);
     this.#session.run.reset();
     await this.#session.drainFollowUpQueue();
   }
 
   private async handleSubscribedStreamError(error: unknown): Promise<void> {
     if (error instanceof Error && error.name === 'AbortError') {
-      this.#session.emit({ type: 'agent_end', reason: 'aborted' });
+      await this.#session.finishAgentRun('aborted');
     } else {
       this.#session.emit({ type: 'error', error: getErrorFromUnknown(error) });
-      this.#session.emit({ type: 'agent_end', reason: 'error' });
+      await this.#session.finishAgentRun('error');
     }
     this.#session.stream.detach();
     this.#session.run.reset();

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -54,6 +54,11 @@ export interface ThreadSettingsStore {
   set(key: string, value: unknown): Promise<void>;
 }
 
+/** Process-local listener awaited before a terminal agent event is emitted. */
+export type SessionBeforeAgentEndListener = (
+  event: Extract<AgentControllerEvent, { type: 'agent_end' }>,
+) => void | Promise<void>;
+
 /** Options for {@link Session.sendNotificationSignal}. */
 export type SessionSendNotificationSignalOptions = {
   ifActive?: SendAgentNotificationSignalOptions['ifActive'];
@@ -2692,6 +2697,8 @@ export class SessionBus {
 export class Session<TState = unknown> {
   /** This session's event bus. Constructed first so every subsystem can route its events here. */
   readonly #bus = new SessionBus();
+  /** Process-local hooks that must finish before the session exposes a terminal agent event. */
+  readonly #beforeAgentEndListeners = new Set<SessionBeforeAgentEndListener>();
   /** Tool categories the user has granted "allow" for the lifetime of this session. */
   readonly #grantedCategories = new Set<string>();
   /** Individual tool names the user has granted "allow" for the lifetime of this session. */
@@ -2832,6 +2839,27 @@ export class Session<TState = unknown> {
    */
   subscribe(listener: AgentControllerEventListener): () => void {
     return this.#bus.subscribe(listener);
+  }
+
+  /** Subscribe to work that must complete before the terminal agent event is exposed. */
+  onBeforeAgentEnd(listener: SessionBeforeAgentEndListener): () => void {
+    this.#beforeAgentEndListeners.add(listener);
+    return () => this.#beforeAgentEndListeners.delete(listener);
+  }
+
+  /** Await terminal hooks, then emit the terminal event to subscribers. */
+  async finishAgentRun(
+    reason: NonNullable<Extract<AgentControllerEvent, { type: 'agent_end' }>['reason']>,
+  ): Promise<void> {
+    const event = { type: 'agent_end', reason } as const;
+    for (const listener of this.#beforeAgentEndListeners) {
+      try {
+        await listener(event);
+      } catch (error) {
+        console.error('Error in before-agent-end listener:', error);
+      }
+    }
+    this.emit(event);
   }
 
   /**
@@ -3546,7 +3574,7 @@ export class Session<TState = unknown> {
     } catch (error) {
       const err = getErrorFromUnknown(error);
       this.emit({ type: 'error', error: err });
-      this.emit({ type: 'agent_end', reason: 'error' });
+      await this.finishAgentRun('error');
     }
   }
 

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -13,6 +13,7 @@ import type { MastraCompositeStore } from '../storage/base';
 import type { GoalEvaluationPayload } from '../stream/types';
 import type { DynamicArgument } from '../types';
 import type { Workspace, WorkspaceStatus } from '../workspace';
+import type { Session } from './session';
 import type { TaskItemSnapshot } from './tools';
 
 // =============================================================================
@@ -220,6 +221,9 @@ export type BuiltinToolId =
   | 'task_complete'
   | 'task_check'
   | 'subagent';
+
+/** Process-local listener notified after AgentController materializes a live session. */
+export type AgentControllerSessionCreatedListener<TState = {}> = (session: Session<TState>) => void | Promise<void>;
 
 export interface AgentControllerConfig<TState = {}> {
   /** Unique identifier for this controller instance */

--- a/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
+++ b/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
@@ -39,7 +39,7 @@ function TreeConnector({ guides, isLastChild }: { guides: boolean[]; isLastChild
       ))}
       <span className="relative w-6">
         <span className={cn('absolute left-0 top-0 border-l border-border1', isLastChild ? 'h-1/2' : 'h-full')} />
-        <span className="absolute left-0 top-1/2 w-3.5 border-b border-border1" />
+        <span className="border-border1 absolute top-1/2 left-0 w-3.5 border-b" />
       </span>
     </span>
   );
@@ -71,7 +71,7 @@ function TreeToggleCell({
           type="button"
           aria-expanded={isExpanded}
           aria-label={`${isExpanded ? 'Collapse' : 'Expand'} nested workflows of ${workflowName}`}
-          className="relative grid size-5 shrink-0 place-items-center text-neutral4 hover:text-neutral2 before:absolute before:-inset-1.5 before:content-['']"
+          className="text-neutral4 hover:text-neutral2 relative grid size-5 shrink-0 place-items-center before:absolute before:-inset-1.5 before:content-['']"
           onClick={onToggle}
         >
           <ChevronRightIcon className={cn('size-4 transition-transform', isExpanded && 'rotate-90')} />
@@ -152,14 +152,14 @@ export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsLi
           return (
             <EntityList.RowWrapper key={`workflow-${row.pathKey}`}>
               <TreeToggleCell row={row} isExpanded={isExpanded} onToggle={toggle} />
-              <div className="col-start-2 col-span-5 grid grid-cols-subgrid gap-8 px-5">
+              <div className="col-span-5 col-start-2 grid grid-cols-subgrid gap-8 px-5">
                 <EntityList.NameCell>
                   <span className="flex items-center gap-1.5">
                     <TreeConnector guides={row.guides} isLastChild={row.isLastChild} />
                     <span className="truncate">{truncateString(row.stepId, 50)}</span>
                     <span
                       title="Nested workflow not registered standalone"
-                      className="shrink-0 text-ui-smd text-neutral4"
+                      className="text-ui-smd text-neutral4 shrink-0"
                     >
                       inline
                     </span>
@@ -198,7 +198,7 @@ export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsLi
                   {hasNested ? (
                     <span
                       title={`Nested workflows: ${nestedIds.join(', ')}`}
-                      className="inline-flex shrink-0 items-center gap-1 text-ui-smd text-neutral4"
+                      className="text-ui-smd text-neutral4 inline-flex shrink-0 items-center gap-1"
                     >
                       <WorkflowIcon aria-hidden className="size-3.5" />
                       {nestedIds.length}
@@ -210,10 +210,10 @@ export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsLi
               <EntityList.TextCell className="text-center">
                 {runningCount > 0 ? (
                   <span
-                    className="inline-flex items-center gap-1.5 text-positive1"
+                    className="text-positive1 inline-flex items-center gap-1.5"
                     aria-label={`${runningCount} run${runningCount === 1 ? '' : 's'} in progress`}
                   >
-                    <span aria-hidden className="size-2 rounded-full bg-positive1 motion-safe:animate-pulse" />
+                    <span aria-hidden className="bg-positive1 size-2 rounded-full motion-safe:animate-pulse" />
                     {runningCount}
                   </span>
                 ) : (
@@ -223,7 +223,7 @@ export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsLi
               <EntityList.TextCell className="text-center">
                 {suspendedCount > 0 ? (
                   <span
-                    className="inline-flex items-center gap-1.5 text-warning1"
+                    className="text-warning1 inline-flex items-center gap-1.5"
                     aria-label={`${suspendedCount} run${suspendedCount === 1 ? '' : 's'} awaiting input`}
                   >
                     <PauseIcon aria-hidden className="size-3.5" />


### PR DESCRIPTION
Factory now keeps each thread’s captured workspace file list in storage after an agent run, so the Files view remains available without re-enumerating the sandbox. Selecting a stored file still reads its current bytes from the sandbox and rejects paths outside that thread’s captured list.

For example, `GET /web/workspace/files?workspacePath=<sessionId>&threadId=<threadId>` returns the captured file entries, and `GET /web/workspace/file?...&threadId=<threadId>` reads only one of those entries.

Focused Factory and Factory UI tests, typechecks, linting, and builds pass. A real local sandbox smoke test could not run because this checkout has no configured GitHub App/model credentials or running Factory host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

After an agent run, Factory saves the workspace file list for that thread. The Files view can show this saved list later, while file contents still come from the current sandbox and only approved paths can be read.

## Changes

- Added thread-scoped filesystem snapshot storage.
- Captured changed and ignored workspace files before terminal agent events.
- Added session lifecycle hooks for filesystem capture.
- Added `/web/workspace/files` for persisted file listings.
- Extended `/web/workspace/file` with thread validation and persisted-path checks.
- Updated the Factory UI to:
  - Load files by workspace path and thread ID.
  - Build a workspace tree from persisted file paths.
  - Refresh file listings after completed agent runs.
  - Load selected file contents from the live sandbox.
- Added validation for blank thread IDs and cross-thread file isolation.
- Added focused tests for storage, capture, routes, session lifecycle, and UI behavior.
- Added a minor changeset for `@mastra/factory`.
- Updated a React exhaustiveness cast for TypeScript formatter compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->