### PR TITLE
fix(react): consume denied tool output chunks

### DIFF
--- a/.changeset/tidy-tools-resolve.md
+++ b/.changeset/tidy-tools-resolve.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': patch
+---
+
+Fixed denied tool approvals remaining pending in React streaming message state.

--- a/client-sdks/react/src/lib/mastra-db/accumulator.test.ts
+++ b/client-sdks/react/src/lib/mastra-db/accumulator.test.ts
@@ -165,6 +165,24 @@ const toolErrorChunk = (toolCallId: string, error: string): ChunkType =>
     payload: { toolCallId, error },
   }) as unknown as ChunkType;
 
+const toolOutputDeniedChunk = (
+  toolCallId: string,
+  toolName: string,
+  args: Record<string, unknown>,
+  reason?: string,
+): ChunkType =>
+  ({
+    type: 'tool-output-denied',
+    runId: RUN_ID,
+    from: 'AGENT',
+    payload: {
+      toolCallId,
+      toolName,
+      args,
+      approval: { id: 'approval-1', approved: false, ...(reason ? { reason } : {}) },
+    },
+  }) as unknown as ChunkType;
+
 const toolCallApprovalChunk = (toolCallId: string, toolName: string, args: Record<string, unknown>): ChunkType =>
   ({
     type: 'tool-call-approval',
@@ -819,6 +837,22 @@ describe('accumulateChunk - tool calls', () => {
       state: 'output-error',
       toolCallId: 'tc-1',
       errorText: 'boom',
+    });
+  });
+
+  it('tool-output-denied transitions to output-denied with approval details', () => {
+    const out = reduce([
+      startChunk(),
+      toolCallChunk('tc-1', 'sendMail', { to: 'x' }),
+      toolOutputDeniedChunk('tc-1', 'sendMail', { to: 'x' }, 'Not now'),
+    ]);
+    const toolPart = out[0].content.parts.find(p => p.type === 'tool-invocation') as MastraToolInvocationPart;
+    expect(toolPart.toolInvocation).toMatchObject({
+      state: 'output-denied',
+      toolCallId: 'tc-1',
+      toolName: 'sendMail',
+      args: { to: 'x' },
+      approval: { id: 'approval-1', approved: false, reason: 'Not now' },
     });
   });
 

--- a/client-sdks/react/src/lib/mastra-db/accumulator.ts
+++ b/client-sdks/react/src/lib/mastra-db/accumulator.ts
@@ -1008,6 +1008,31 @@ export const accumulateChunk = ({ chunk, conversation, metadata }: AccumulateChu
       return replaceAt(result, messageIndex, withParts(targetMessage, parts));
     }
 
+    case 'tool-output-denied': {
+      const location = locateToolPart(result, chunk.payload.toolCallId, false);
+      if (!location || location.toolPartIndex < 0) return result;
+      const { messageIndex, toolPartIndex } = location;
+      const targetMessage = result[messageIndex];
+      if (!targetMessage || targetMessage.role !== 'assistant') return result;
+
+      const parts = [...targetMessage.content.parts];
+      const toolPart = parts[toolPartIndex];
+      if (!isToolPart(toolPart)) return result;
+
+      parts[toolPartIndex] = {
+        ...toolPart,
+        toolInvocation: {
+          ...toolPart.toolInvocation,
+          state: 'output-denied',
+          toolName: chunk.payload.toolName,
+          args: chunk.payload.args ?? toolPart.toolInvocation.args,
+          approval: chunk.payload.approval,
+        },
+      } as MastraMessagePart;
+
+      return replaceAt(result, messageIndex, withParts(targetMessage, parts));
+    }
+
     case 'tool-error':
     case 'tool-result':
     case 'background-task-completed':


### PR DESCRIPTION
## Summary
- handle `tool-output-denied` in the React DB-message stream accumulator
- transition the matching tool invocation to `output-denied` with approval details
- add regression coverage and a patch changeset for `@mastra/react`

This fixes the `@mastra/react#build:js` TypeScript failure currently blocking the alpha release PR #20769.

## Test plan
- `pnpm --filter ./client-sdks/react test:unit` (275 passed)
- `pnpm --filter ./client-sdks/react lint`
- `pnpm --filter ./client-sdks/react build:js`
- `pnpm exec oxfmt --check client-sdks/react/src/lib/mastra-db/accumulator.ts client-sdks/react/src/lib/mastra-db/accumulator.test.ts .changeset/tidy-tools-resolve.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a tool approval is denied, the React message state now records the denial instead of leaving the tool stuck as pending. This keeps the displayed stream accurate and restores the React package build.

## Changes

- Handle `tool-output-denied` chunks in `accumulateChunk`.
- Set matching tool invocations to `output-denied`.
- Preserve tool arguments and approval details, including denial reasoning.
- Add regression tests for denied tool approvals.
- Add a patch changeset for `@mastra/react`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->