### PR TITLE
fix(observability): stop deepClean from silently deleting user data by key name

### DIFF
--- a/.changeset/deepclean-strip-at-source.md
+++ b/.changeset/deepclean-strip-at-source.md
@@ -1,0 +1,22 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed tracing silently deleting user data whose keys happened to match internal names like `steps`, `execute`, `validate`, or `providerMetadata`.
+
+`deepClean` stripped a hardcoded set of keys from every object at every depth of a span's input, output, attributes, and metadata. Those are common domain words, so a tool whose args contained `recipe.steps` — or a planner, workflow, or wizard tool with a `steps`/`validate` field — had that field removed from the recorded trace with no marker. The trace read as if the caller never sent it.
+
+Now user-authored payloads (tool args and results, workflow step input/output) round-trip into traces intact. The verbose AI-SDK result artifacts (`steps`, provider metadata) are still stripped, but only on the framework's own LLM/model spans where they originate — never from user data.
+
+**Before**
+
+```ts
+// tool input: { plan: { title: 'Trip', steps: [...], validate: true } }
+// recorded span input: { plan: { title: 'Trip' } }   // steps + validate silently gone
+```
+
+**After**
+
+```ts
+// recorded span input: { plan: { title: 'Trip', steps: [...], validate: true } }   // intact
+```

--- a/observability/mastra/src/spans/base.test.ts
+++ b/observability/mastra/src/spans/base.test.ts
@@ -4,7 +4,13 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { DefaultObservabilityInstance } from '../instances';
 import { getExternalParentId } from './base';
-import { deepClean, DEFAULT_DEEP_CLEAN_OPTIONS, isSerializedMap, reconstructSerializedMap } from './serialization';
+import {
+  deepClean,
+  DEFAULT_DEEP_CLEAN_OPTIONS,
+  FRAMEWORK_PAYLOAD_KEYS_TO_STRIP,
+  isSerializedMap,
+  reconstructSerializedMap,
+} from './serialization';
 
 // Simple test exporter for capturing events
 class TestExporter implements ObservabilityExporter {
@@ -634,6 +640,46 @@ describe('Span', () => {
     });
   });
 
+  it('keeps user-authored keys on tool spans, strips framework result keys on model spans', () => {
+    const tracing = new DefaultObservabilityInstance({
+      serviceName: 'test-tracing',
+      name: 'test-instance',
+      sampling: { type: SamplingStrategyType.ALWAYS },
+      exporters: [testExporter],
+    });
+
+    // A planner tool whose args legitimately contain `steps` and `validate`.
+    // These must round-trip into the trace, not be silently deleted.
+    const toolSpan = tracing.startSpan({
+      type: SpanType.TOOL_CALL,
+      name: "tool: 'planTrip'",
+      input: {
+        plan: {
+          title: 'Weekend trip',
+          steps: [{ id: 'fly' }, { id: 'stay' }],
+          validate: true,
+        },
+      },
+    });
+    expect(toolSpan.input).toEqual({
+      plan: {
+        title: 'Weekend trip',
+        steps: [{ id: 'fly' }, { id: 'stay' }],
+        validate: true,
+      },
+    });
+
+    // A framework model span still strips the verbose AI-SDK result artifacts.
+    const modelSpan = tracing.startSpan({
+      type: SpanType.MODEL_GENERATION,
+      name: 'llm-call',
+    });
+    modelSpan.end({
+      output: { text: 'hi', steps: [{ big: 'history' }], providerMetadata: { cache: 1 } },
+    });
+    expect(modelSpan.output).toEqual({ text: 'hi' });
+  });
+
   describe('deepClean', () => {
     it('should preserve Date objects as-is', () => {
       const date = new Date('2024-01-15T12:30:00.000Z');
@@ -678,20 +724,40 @@ describe('Span', () => {
       expect(result.self).toBe('[Circular]');
     });
 
-    it('should strip specified keys', () => {
+    it('preserves all keys by default — no depth-blind stripping of user data', () => {
+      // These are common domain words the old default silently deleted from
+      // user payloads (e.g. a planner tool with a `steps` array).
       const input = {
         name: 'test',
-        logger: { level: 'info' },
-        tracingContext: { traceId: '123' },
+        steps: [{ id: 'fly' }, { id: 'stay' }],
+        validate: true,
+        providerMetadata: { note: 'user data' },
+        nested: { steps: ['keep me too'] },
         data: 'keep this',
       };
 
       const result = deepClean(input);
 
+      expect(result).toEqual(input);
+    });
+
+    it('strips only the keys listed in keysToStrip, at every depth', () => {
+      const input = {
+        name: 'test',
+        steps: 'framework',
+        nested: { steps: 'framework', keep: 1 },
+        data: 'keep this',
+      };
+
+      const result = deepClean(input, {
+        ...DEFAULT_DEEP_CLEAN_OPTIONS,
+        keysToStrip: FRAMEWORK_PAYLOAD_KEYS_TO_STRIP,
+      });
+
       expect(result.name).toBe('test');
       expect(result.data).toBe('keep this');
-      expect(result.logger).toBeUndefined();
-      expect(result.tracingContext).toBeUndefined();
+      expect(result.steps).toBeUndefined();
+      expect(result.nested).toEqual({ keep: 1 });
     });
 
     it("should honor an object's serializeForSpan() method so private fields are not walked", () => {
@@ -963,16 +1029,24 @@ describe('Span', () => {
       expect(result.map.__truncated).toBe('3 more keys omitted');
     });
 
-    it('should strip matching string Map keys before truncation', () => {
+    it('keeps all string Map keys by default; strips only keysToStrip before truncation', () => {
       const map = new Map<any, any>([
-        ['logger', 'omit'],
+        ['steps', 'kept-by-default'],
         ['visible', 1],
         [2, 'keep-number-key'],
       ]);
 
-      const result = deepClean({ map });
+      // Default: nothing stripped — the map key round-trips.
+      const kept = deepClean({ map });
+      expect(kept.map.__map_entries).toEqual([
+        ['string', 'steps', 'kept-by-default'],
+        ['string', 'visible', 1],
+        ['number', 2, 'keep-number-key'],
+      ]);
 
-      expect(result.map.__map_entries).toEqual([
+      // Explicit keysToStrip: matching string keys removed.
+      const stripped = deepClean({ map }, { ...DEFAULT_DEEP_CLEAN_OPTIONS, keysToStrip: new Set(['steps']) });
+      expect(stripped.map.__map_entries).toEqual([
         ['string', 'visible', 1],
         ['number', 2, 'keep-number-key'],
       ]);

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -20,7 +20,22 @@ import type {
 } from '@mastra/core/observability';
 
 import { ModelSpanTracker } from '../model-tracing';
-import { deepClean, mergeSerializationOptions } from './serialization';
+import { deepClean, FRAMEWORK_PAYLOAD_KEYS_TO_STRIP, mergeSerializationOptions } from './serialization';
+
+/**
+ * Span types whose payloads are produced by the framework's LLM/model layer
+ * (not by user code). Only these strip AI-SDK result artifacts
+ * (`FRAMEWORK_PAYLOAD_KEYS_TO_STRIP`); user-authored spans (tool_call,
+ * workflow_step, mapping, …) keep every key so their input/output round-trips
+ * into the trace intact.
+ */
+const FRAMEWORK_PAYLOAD_SPAN_TYPES = new Set<SpanType>([
+  SpanType.AGENT_RUN,
+  SpanType.MODEL_GENERATION,
+  SpanType.MODEL_STEP,
+  SpanType.MODEL_INFERENCE,
+  SpanType.MODEL_CHUNK,
+]);
 import type { DeepCleanOptions } from './serialization';
 
 /** Extended span type that includes getParentSpan method available on BaseSpan instances */
@@ -185,11 +200,18 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
   constructor(options: CreateSpanOptions<TType>, observabilityInstance: ObservabilityInstance) {
     // Get serialization options from observability instance config
     const observabilityConfig = observabilityInstance.getConfig();
-    this.deepCleanOptions = mergeSerializationOptions(observabilityConfig.serializationOptions);
 
     this.name = options.name;
     this.type = options.type;
     this.isInternal = isSpanInternal(this.type, options.tracingPolicy?.internal);
+
+    // Framework-produced LLM/model spans strip their verbose AI-SDK result
+    // artifacts (`steps`, provider metadata); user-authored spans strip nothing
+    // so their input/output round-trips into the trace intact.
+    const serializationOptions = mergeSerializationOptions(observabilityConfig.serializationOptions);
+    this.deepCleanOptions = FRAMEWORK_PAYLOAD_SPAN_TYPES.has(this.type)
+      ? { ...serializationOptions, keysToStrip: FRAMEWORK_PAYLOAD_KEYS_TO_STRIP }
+      : serializationOptions;
 
     // Determine up front whether this span will ever reach exporters.
     // getSpanForExport() drops these same spans before export, so we can

--- a/observability/mastra/src/spans/serialization.ts
+++ b/observability/mastra/src/spans/serialization.ts
@@ -27,17 +27,33 @@
  */
 
 /**
- * Default keys to strip from objects during deep cleaning.
- * These are typically internal/sensitive fields that shouldn't be traced.
+ * Default keys to strip during deep cleaning: none.
+ *
+ * `deepClean` used to remove a hardcoded key set (`steps`, `providerMetadata`,
+ * `execute`, `validate`, …) from every object at every depth. Those are common
+ * domain words, so a user's `recipe.steps` or `plan.validate` was silently
+ * deleted from the recorded span input with no marker — the trace claimed the
+ * caller never sent the field. User payloads must round-trip into traces intact,
+ * so the default now strips nothing. Framework-produced LLM/model spans still
+ * strip their own verbose result artifacts via `FRAMEWORK_PAYLOAD_KEYS_TO_STRIP`
+ * (applied by `base.ts` for those span types only).
  */
-export const DEFAULT_KEYS_TO_STRIP = new Set([
-  'logger',
-  'experimental_providerMetadata',
-  'providerMetadata',
+export const DEFAULT_KEYS_TO_STRIP = new Set<string>();
+
+/**
+ * Keys stripped only from framework-produced LLM/model span payloads.
+ *
+ * These are AI-SDK result artifacts — the full per-step history (`steps`) and
+ * verbose provider metadata — that bloat traces without adding signal the
+ * curated span fields don't already carry. They only ever appear on
+ * framework-authored model/agent spans, so `base.ts` applies this set to those
+ * span types and nowhere else. On user-authored payloads (tool args/results,
+ * workflow step input/output) the same words are ordinary data and are kept.
+ */
+export const FRAMEWORK_PAYLOAD_KEYS_TO_STRIP = new Set<string>([
   'steps',
-  'tracingContext',
-  'execute', // Tool execute functions
-  'validate', // Schema validate functions
+  'providerMetadata',
+  'experimental_providerMetadata',
 ]);
 
 export interface DeepCleanOptions {


### PR DESCRIPTION
## Description

`deepClean` stripped a hardcoded key set — `steps`, `providerMetadata`, `experimental_providerMetadata`, `execute`, `validate`, `logger`, `tracingContext` — from **every object at every depth** of a span's input, output, attributes, and metadata. Those are common domain words, so a tool whose args contained `recipe.steps`, or any planner/workflow/wizard tool with a `steps`/`validate` field, had that field silently removed from the recorded trace **with no marker** — the trace read as if the caller never sent it. It wasn't overridable, and (unlike the size limits, which leave a `__truncated` marker) the deletion was invisible.

This scopes the stripping to where those keys actually originate.

**The two concerns the old list conflated**

The single strip list was doing two unrelated jobs:
- Removing **AI-SDK result artifacts** (`steps`, provider metadata) that bloat the framework's *own* model/agent span payloads.
- Removing framework plumbing (`logger`, `tracingContext`) and functions (`execute`, `validate`) that used to leak from wrapper objects.

Applying both, depth-blind, to *user* input/output is what deleted domain data.

**The fix**

- `deepClean`'s default now strips **nothing** — user-authored payloads (tool args/results, workflow step input/output) round-trip into traces intact.
- The AI-SDK result keys are stripped **only on framework-produced LLM/model spans** (`AGENT_RUN`, `MODEL_GENERATION`, `MODEL_STEP`, `MODEL_INFERENCE`, `MODEL_CHUNK`), via a new `FRAMEWORK_PAYLOAD_KEYS_TO_STRIP` set applied per span type in `base.ts`. Those payloads are entirely framework-authored, so depth-blind stripping there is safe and still catches provider metadata nested inside message arrays.
- `logger` / `tracingContext` / `execute` / `validate` are dropped from stripping entirely: they don't appear in real span payloads under the full end-to-end tracing suite, functions already render as `[Function]`, and circular refs (a leaked `tracingContext` holds the live span) are caught by deepClean's existing ancestor guard.

```ts
// tool input: { plan: { title: 'Trip', steps: [...], validate: true } }
// before → recorded span input: { plan: { title: 'Trip' } }              // steps + validate silently gone
// after  → recorded span input: { plan: { title: 'Trip', steps: [...], validate: true } }   // intact
```

## How the boundary was found

Emptying the strip set and running the suite: the **only** key that actually leaks into real span payloads is `steps`, and only on `span.output` of the nested model spans (82 assertions in `integration-tests.test.ts`). `providerMetadata` isn't exercised by the mock models but is real in production, so it's kept in the framework set proactively; the rest showed no live leak site.

## Related issue(s)

Fixes the reported `deepClean` silent-deletion bug (user tool args with a `steps` field vanishing from traces). Follow-up to the request-context-in-traces hardening work.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Tests: default preserves all keys (incl. nested); explicit `keysToStrip` still strips at depth; Map keys kept by default; span-level regression — a `tool_call` keeps user `steps`/`validate`, a `MODEL_GENERATION` strips `steps`/`providerMetadata` on output.

## Verification

- `@mastra/observability` full suite: **986 passed / 2 skipped**, including the end-to-end `integration-tests.test.ts` (which green-lights that model spans still strip `steps`).

## Open items / to discuss

- **Span-type scoping vs literal source-site edits.** You framed (b2) as stripping "where the framework records its model/stream results." I found those sites are scattered across the loop/agent code and `providerMetadata` is nested inside message arrays, so per-site omits would be fragile and miss the nested cases. I scoped by span *provenance* instead (one control point in `base.ts`) — functionally "framework spans strip, user spans don't." Flagging in case you specifically wanted the literal per-recording-site approach.
- **Downstream snapshots.** The `@mastra/core` loop/evals snapshot tests weren't re-run here; CI will confirm they're unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_015rmrtWcDSwFW3bxFLrv5w7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The observability cleaner now leaves user data unchanged by default. It removes framework-only data from LLM and model spans while preserving user fields in tools and workflows.

## Changes

- Changed `deepClean` to preserve all keys by default.
- Added `FRAMEWORK_PAYLOAD_KEYS_TO_STRIP` for AI SDK artifacts:
  - `steps`
  - `providerMetadata`
  - `experimental_providerMetadata`
- Applied framework key stripping only to framework-generated LLM and model spans.
- Removed `logger`, `tracingContext`, `execute`, and `validate` from the default stripping configuration.
- Preserved function rendering as `[Function]`.
- Preserved circular-reference handling through the existing ancestor guard.
- Added tests for nested user keys, `Map` keys, explicit stripping, tool-call spans, and model spans.
- Added a patch changeset for `@mastra/observability`.
- Observability tests: 986 passed, 2 skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->