### PR TITLE
fix(create-factory): stop advertising Railway sandboxes the template cannot select

### DIFF
--- a/.changeset/loud-poems-provision.md
+++ b/.changeset/loud-poems-provision.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Removed the Railway sandbox settings from the generated Factory template's `.env.schema` and README. They advertised a cloud sandbox provider the template cannot select, so setting `RAILWAY_API_TOKEN` quietly did nothing and projects kept running in the non-isolated local sandbox. Cloud sandboxes now come from Mastra Platform, and the sandbox docs say so. Also dropped `MASTRACODE_SANDBOX_PROVIDER` and `MASTRACODE_SANDBOX_IDLE_MINUTES`, which the template reads nowhere.

--- a/mastracode/mastra-factory/template/README.md
+++ b/mastracode/mastra-factory/template/README.md
@@ -38,7 +38,7 @@ Day-to-day configuration (model providers, integrations) happens in the web UI. 
 | Linear intake            | WorkOS + `LINEAR_CLIENT_ID`, `LINEAR_CLIENT_SECRET` + `APP_DATABASE_URL` + a state secret (`GITHUB_APP_WEBHOOK_SECRET` or `WORKOS_COOKIE_PASSWORD`) |
 | Slack channels           | `SLACK_APP_SIGNING_SECRET`, `SLACK_APP_BOT_TOKEN`, `SLACK_APP_CLIENT_ID`, `SLACK_APP_CLIENT_SECRET` + WorkOS + a state secret (see above)           |
 | Distributed event bus    | `REDIS_URL` (only needed for multi-process deployments)                                                                                             |
-| Cloud sandboxes          | `RAILWAY_API_TOKEN` (defaults to a local git sandbox otherwise)                                                                                     |
+| Cloud sandboxes          | `MASTRA_PLATFORM_SECRET_KEY`, `MASTRA_PROJECT_ID`, `MASTRA_ENVIRONMENT_ID` (defaults to a local git sandbox otherwise)                              |
 
 ### Database
 

--- a/mastracode/web/.env.schema
+++ b/mastracode/web/.env.schema
@@ -258,40 +258,29 @@ REDIS_URL=
 # ---------------------------------------------------------------------------
 # Sandbox provider (repo materialization)
 # GitHub-backed projects are materialized (cloned) into a sandbox on open. The
-# provider is selected automatically: if a Railway token is set we use an
-# isolated cloud VM per project; otherwise we fall back to a LOCAL provider
-# that runs git directly on the server host. So repos can always be opened
-# with no extra wiring. The sandbox must have `git` and `gh` (the GitHub CLI)
-# and outbound access to github.com; `gh` is only needed to open pull requests.
+# provider is selected automatically: when this deployment is configured for
+# Mastra Platform (see MASTRA_PLATFORM_SECRET_KEY / MASTRA_PROJECT_ID /
+# MASTRA_ENVIRONMENT_ID above) each project gets an isolated cloud VM;
+# otherwise we fall back to a LOCAL provider that runs git directly on the
+# server host. So repos can always be opened with no extra wiring. The sandbox
+# must have `git` and `gh` (the GitHub CLI) and outbound access to github.com;
+# `gh` is only needed to open pull requests.
 #
 # WARNING: the local provider has NO tenant isolation — every project's git
 # runs as the server process on the shared host filesystem. It is intended for
-# single-user local development only; configure Railway for shared
+# single-user local development only; configure Mastra Platform for shared
 # multi-tenant deployments.
 # ---------------------------------------------------------------------------
 
-# @required=eq($MASTRACODE_SANDBOX_PROVIDER, "railway")
-RAILWAY_API_TOKEN=
-# @public
-RAILWAY_ENVIRONMENT_ID=
-# Force a specific provider. Leave unset to auto-select: railway when
-# RAILWAY_API_TOKEN is set, else the non-isolated local provider (see the
-# warning above). Selecting "railway" without a token fails at boot.
-# @public @type=enum("", "railway", "local")
-MASTRACODE_SANDBOX_PROVIDER=
 # Checkout base inside remote sandboxes (nested owner/name per repo), default
 # /workspace. LocalSandbox ignores this in-sandbox path and always uses
 # MASTRACODE_LOCAL_SANDBOX_ROOT on the host.
 # @public
 MASTRACODE_SANDBOX_WORKDIR=/workspace
 # Host root for LocalSandbox checkouts (default ~/.mastracode/web/sandboxes);
-# only used when MASTRACODE_SANDBOX_PROVIDER=local.
+# only used by the local provider.
 # @public
 MASTRACODE_LOCAL_SANDBOX_ROOT=
-# Idle teardown window in minutes (default 30); the next open re-provisions
-# automatically if the VM was stopped.
-# @public @type=string(matches="^(|[1-9][0-9]*)$")
-MASTRACODE_SANDBOX_IDLE_MINUTES=30
 # Per-replica cap on concurrently live sandboxes. New provisioning beyond this
 # returns an actionable error; 0 / unset means unlimited.
 # @public @type=string(matches="^(|[0-9]+)$")


### PR DESCRIPTION
The Factory template's `.env.schema` and README told users to set `RAILWAY_API_TOKEN` to get isolated cloud sandboxes. Nothing in the generated project reads it. Setting it did nothing at all, and projects kept running in the local sandbox — which has no tenant isolation, the exact deployment shape the schema's own warning tells people to avoid.

Railway support predates Platform Sandbox and isn't a path we support, so this removes the advertisement rather than rebuilding the wiring behind it. The sandbox docs now point at Mastra Platform, which is where isolated cloud sandboxes actually come from.

## What changed

- `.env.schema`: dropped `RAILWAY_API_TOKEN` and `RAILWAY_ENVIRONMENT_ID`; the section intro and the no-tenant-isolation warning now name Mastra Platform.
- `.env.schema`: dropped `MASTRACODE_SANDBOX_PROVIDER` and `MASTRACODE_SANDBOX_IDLE_MINUTES` too — both are read nowhere in the template, so they were the same broken promise in a different shape. Happy to keep either if they're meant to come back.
- Template README: the Cloud sandboxes row now lists the Platform variables.

No code changes. `.env.example` is derived from `.env.schema` by the generator, so it follows automatically.

## Verification

- `mastracode/web`: 15 tests pass, `tsc --noEmit` clean.
- `mastracode/mastra-factory`: 51 tests pass.
- Ran the real generator and grepped its output: the generated template contains no `RAILWAY_*`, no `MASTRACODE_SANDBOX_PROVIDER`, no `MASTRACODE_SANDBOX_IDLE_MINUTES`, and its `.env.example` carries the Platform wording.

## Note on history

This PR originally restored the Railway selection ladder, which had been deleted as unstated collateral by e30dfe9403 (#19962) while its schema and README were left in place. Per @abhiaiyer91 that capability is superseded by Platform Sandbox, so it's now a documentation strip instead. The previous approach is still on my machine if it's ever wanted back.

Closes #20762


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates generated Factory projects to use Mastra Platform sandboxes instead of Railway sandboxes. It removes obsolete Railway settings and documents the required Mastra Platform credentials.

## Changes

- Removed Railway sandbox configuration from the generated Factory template.
- Removed unused Railway environment variables from `.env.schema`.
- Updated the template README to document:
  - `MASTRA_PLATFORM_SECRET_KEY`
  - `MASTRA_PROJECT_ID`
  - `MASTRA_ENVIRONMENT_ID`
- Clarified that cloud sandboxes are provided by Mastra Platform.
- Updated the changeset to reflect the documentation and configuration cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->