### PR TITLE
test: stabilize Datadog teardown and trace detail navigation

### DIFF
--- a/observability/datadog/src/compliance.test.ts
+++ b/observability/datadog/src/compliance.test.ts
@@ -70,7 +70,8 @@ beforeAll(async () => {
   exporter = new DatadogExporter({ mlApp: 'compliance', apiKey: 'fake-key', agentless: true });
 });
 
-afterAll(() => {
+afterAll(async () => {
+  await exporter.shutdown();
   SpanWriter.prototype.append = origAppend;
   SpanWriter.prototype.flush = origFlush;
 });

--- a/packages/playground/e2e/tests/traces/$traceId/page.spec.ts
+++ b/packages/playground/e2e/tests/traces/$traceId/page.spec.ts
@@ -191,15 +191,7 @@ test.describe('Trace detail page', () => {
     test('keeps the timeline and span details independently scrollable within the page', async ({ page }) => {
       await page.setViewportSize({ width: 1280, height: 800 });
       await mockLongTrace(page);
-      // Warm the mocked trace query, then remount the route with the final span selected through the URL.
-      await page.goto(`/traces/${LONG_TRACE_ID}`);
-      await expect(page.getByRole('button', { name: 'tool call 60', exact: true })).toBeAttached();
-      await page.getByRole('navigation', { name: 'Main' }).getByRole('link', { name: 'Traces' }).click();
-      await expect(page).toHaveURL(/\/observability$/);
-      await page.evaluate(url => {
-        window.history.pushState(null, '', url);
-        window.dispatchEvent(new PopStateEvent('popstate'));
-      }, `/traces/${LONG_TRACE_ID}?spanId=${SELECTED_SPAN_ID}`);
+      await page.goto(`/traces/${LONG_TRACE_ID}?spanId=${SELECTED_SPAN_ID}`);
       await expect(page).toHaveURL(new RegExp(`spanId=${SELECTED_SPAN_ID}`));
 
       const timelinePanel = page.locator('section').filter({


### PR DESCRIPTION
## Summary
- shut down the shared Datadog compliance exporter before Vitest tears down the environment
- navigate directly to the selected span in the long-trace Playwright test instead of synthesizing a popstate transition

## Test plan
- `pnpm test -- --run src/compliance.test.ts` in `observability/datadog` (189 tests passed across the package)
- targeted ESLint and Prettier checks for both changed test files
- Playwright startup attempted; blocked locally because the kitchen-sink server could not resolve `@modelcontextprotocol/sdk` from the prebuilt MCP package

These changes address the deterministic Datadog teardown and trace-navigation flakes observed in PR #19701 CI. The separate memory recording failures require refreshed LLM recordings rather than a test-code workaround.
