### PR TITLE
fix: patch @manypkg/tools so the versioning CLI survives the js-yaml 5 override

### DIFF
--- a/patches/@manypkg__tools@2.1.1.patch
+++ b/patches/@manypkg__tools@2.1.1.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/manypkg-tools.js b/dist/manypkg-tools.js
+index d005c29314a2d425664fdf7836872ad2082f1a79..f167637049f7cb0ed3997d2770a41e0395dff4b2 100644
+--- a/dist/manypkg-tools.js
++++ b/dist/manypkg-tools.js
+@@ -6,7 +6,8 @@ import * as fsp from 'node:fs/promises';
+ import fsp__default from 'node:fs/promises';
+ import { F_OK } from 'node:constants';
+ import { glob, globSync } from 'tinyglobby';
+-import yaml from 'js-yaml';
++// js-yaml >= 5 is ESM-only and dropped its default export; `load` is a named export there.
++import * as yaml from 'js-yaml';
+ import jju from 'jju';
+ 
+ /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,7 @@ packageExtensionsChecksum: sha256-xGYNP5bHLPlbBT+RiHXWlNCiUtPhW6W9ntBiVM/duy4=
 patchedDependencies:
   '@changesets/get-dependents-graph@2.1.4': eb65c5cbf43c61ce6dcb0c77fa30d9aebcdffa3a70dee1faefc4cde4125f28fa
   '@earendil-works/pi-tui@0.80.6': 88572df39a8452647fa073db5bc0907de3f1cb04c52c4559c8cc6e662973818b
+  '@manypkg/tools@2.1.1': 6d493cdb757f34ceacd3b1a081f91d3c2bbe777930133424ef34d222b7fcfd7b
   gray-matter@4.0.3: 058d8be9f17b95a6f86e58debce82671ee3f258e44883a9da932cf16a717ebb8
   read-yaml-file@1.1.0: 834a9a43c1785ff0b4911ae833daf9fc54055df0834080003b572e6cf4131eb9
 
@@ -3367,7 +3368,7 @@ importers:
         version: 3.1.0
       '@manypkg/tools':
         specifier: ^2.1.1
-        version: 2.1.1
+        version: 2.1.1(patch_hash=6d493cdb757f34ceacd3b1a081f91d3c2bbe777930133424ef34d222b7fcfd7b)
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -39662,7 +39663,7 @@ snapshots:
 
   '@manypkg/find-root@3.1.0':
     dependencies:
-      '@manypkg/tools': 2.1.1
+      '@manypkg/tools': 2.1.1(patch_hash=6d493cdb757f34ceacd3b1a081f91d3c2bbe777930133424ef34d222b7fcfd7b)
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
@@ -39676,9 +39677,9 @@ snapshots:
   '@manypkg/get-packages@3.1.0':
     dependencies:
       '@manypkg/find-root': 3.1.0
-      '@manypkg/tools': 2.1.1
+      '@manypkg/tools': 2.1.1(patch_hash=6d493cdb757f34ceacd3b1a081f91d3c2bbe777930133424ef34d222b7fcfd7b)
 
-  '@manypkg/tools@2.1.1':
+  '@manypkg/tools@2.1.1(patch_hash=6d493cdb757f34ceacd3b1a081f91d3c2bbe777930133424ef34d222b7fcfd7b)':
     dependencies:
       jju: 1.4.0
       js-yaml: 5.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,6 +51,7 @@ catalog:
 patchedDependencies:
   '@changesets/get-dependents-graph@2.1.4': patches/@changesets__get-dependents-graph@2.1.4.patch
   '@earendil-works/pi-tui@0.80.6': patches/@earendil-works__pi-tui@0.80.6.patch
+  '@manypkg/tools@2.1.1': patches/@manypkg__tools@2.1.1.patch
   gray-matter@4.0.3: patches/gray-matter@4.0.3.patch
   read-yaml-file@1.1.0: patches/read-yaml-file@1.1.0.patch
 


### PR DESCRIPTION
## Description

Patches `@manypkg/tools@2.1.1` to use a namespace import for `js-yaml`, so the package can be imported again under the repo-wide js-yaml 5 override.

## Context

`pnpm-workspace.yaml` pins js-yaml to `^5.2.2` repo-wide as a Renovate security update, and `pnpm why js-yaml -r` confirms a single resolved version in the tree (`5.2.3`).

js-yaml 5 is ESM-only and no longer ships a default export. Its `exports["."].import` resolves to `dist/js-yaml.mjs`, which exports only a named list (`load`, `dump`, `Schema`, ...).

`@manypkg/tools@2.1.1` declares `js-yaml: ^4.1.0` but receives v5 from the override, and its ESM build default-imports it:

```js
// dist/manypkg-tools.js:9
import yaml from 'js-yaml';
```

Under ESM that is a link-time error, so every import of `@manypkg/tools` throws before any code runs:

```
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
```

This is not limited to tests. `packages/_changeset-cli/src/versions/getNewVersionForPackage.ts` imports `PnpmTool` from `@manypkg/tools`, so the versioning CLI is broken on `main` when run from source.

The package only calls `yaml.load` (`dist/manypkg-tools.js:380` and `:383`), which is a named export in v5, so a namespace import is sufficient and behaviour is unchanged. The alternative — scoping the override away from `@manypkg/tools` — would put the vulnerable version back in the tree, so this follows the patch route the repo already uses for the same js-yaml migration in `patches/read-yaml-file@1.1.0.patch` and `patches/gray-matter@4.0.3.patch` (#20865).

No changeset: this only changes how a third-party dependency is patched, matching #20865.

## Test plan

Before the patch, on `main`:

```
$ pnpm --filter @internal/changeset-cli exec vitest run src/versions/updatePeerDependencies.test.ts
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
Test Files  1 failed (1)
     Tests  no tests
```

After the patch:

```
Test Files  1 passed (1)
     Tests  10 passed (10)
```

Import and real usage verified directly, not only through the test:

```
$ node --input-type=module -e "const t = await import('@manypkg/tools'); console.log(Object.keys(t).join(','))"
BunTool,InvalidMonorepoError,LernaTool,NpmTool,PnpmTool,RootTool,RushTool,YarnTool

$ node --input-type=module -e "const { PnpmTool } = await import('@manypkg/tools'); const r = await PnpmTool.getPackages(process.cwd()); console.log(r.packages.length, r.tool.type)"
172 pnpm
```

`pnpm typecheck` and `pnpm lint` pass in `packages/_changeset-cli`.

Closes #20943


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The repository uses a newer `js-yaml` version that no longer supports the import style used by `@manypkg/tools`. This patch changes the import so `@internal/changeset-cli` can load and run again.

## Changes

- Added a pnpm patch for `@manypkg/tools@2.1.1`.
- Replaced the default `js-yaml` import with a namespace import.
- Preserved the security-pinned `js-yaml` override.
- Restored `@internal/changeset-cli` imports and `PnpmTool` usage.
- Added no changeset because this change only patches a third-party dependency.

## Validation

- Targeted tests pass: 10 tests.
- Direct import and usage were verified.
- Typecheck and lint pass for `packages/_changeset-cli`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->