### PR TITLE
fix(core): preserve nested tool approval details in agent-as-tool str…

### DIFF
--- a/.changeset/fix-agent-as-tool-nested-approval-details.md
+++ b/.changeset/fix-agent-as-tool-nested-approval-details.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix agent-as-tool streaming wrapper discarding nested tool approval details (#20934)
+Fixed nested agent-as-tool approvals so users see the inner tool and arguments while resumes retain the parent delegation identity (#20934).

--- a/.changeset/fix-agent-as-tool-nested-approval-details.md
+++ b/.changeset/fix-agent-as-tool-nested-approval-details.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix agent-as-tool streaming wrapper discarding nested tool approval details (#20934)

--- a/packages/core/src/agent/__tests__/parallel-delegation-approval.test.ts
+++ b/packages/core/src/agent/__tests__/parallel-delegation-approval.test.ts
@@ -155,6 +155,7 @@ function buildSupervisor(subAgent: Agent) {
 
 interface ApprovalSeen {
   toolCallId: string;
+  toolName: string;
   argsText: string;
 }
 
@@ -165,6 +166,7 @@ async function collectApprovals(stream: any): Promise<ApprovalSeen[]> {
       const p: any = (chunk as any).payload ?? {};
       approvals.push({
         toolCallId: String(p.toolCallId ?? ''),
+        toolName: String(p.toolName ?? ''),
         argsText: JSON.stringify(p.args ?? p.input ?? {}),
       });
     }
@@ -190,11 +192,13 @@ describe('parallel sub-agent delegation (suspend/resume)', () => {
 
     const approvals = await collectApprovals(stream);
 
-    // Emission is correct: two approvals, one per order, with distinct ids.
-    expect(approvals.length).toBe(2);
+    // Keep the outer delegation ids for targeted resume, but disclose the inner
+    // approval target so the user sees the actual action and arguments.
+    expect(approvals).toHaveLength(2);
+    expect(approvals.every(a => a.toolName === 'process-order')).toBe(true);
     expect(approvals.some(a => a.argsText.includes(ORDER_A))).toBe(true);
     expect(approvals.some(a => a.argsText.includes(ORDER_B))).toBe(true);
-    expect(new Set(approvals.map(a => a.toolCallId)).size).toBe(2);
+    expect(new Set(approvals.map(a => a.toolCallId))).toEqual(new Set(['sup-tc-A', 'sup-tc-B']));
   });
 
   it('rejects a targeted approval when that tool call is not actually suspended', async () => {
@@ -247,10 +251,10 @@ describe('parallel sub-agent delegation (suspend/resume)', () => {
     const [{ toolCalls }] = (await supervisor.listSuspendedRuns()).runs;
     const suspendedToolCallIds = toolCalls.map(toolCall => toolCall.toolCallId).sort();
     expect(suspendedToolCallIds).toEqual(['sup-tc-A', 'sup-tc-B']);
-    for (const toolCall of toolCalls) {
-      expect(toolCall.toolName).toBe('agent-subAgent');
-      expect(toolCall.requiresApproval).toBe(true);
-    }
+    expect(toolCalls.every(toolCall => toolCall.toolName === 'process-order')).toBe(true);
+    expect(toolCalls.some(toolCall => JSON.stringify(toolCall.args).includes(ORDER_A))).toBe(true);
+    expect(toolCalls.some(toolCall => JSON.stringify(toolCall.args).includes(ORDER_B))).toBe(true);
+    expect(toolCalls.every(toolCall => toolCall.requiresApproval)).toBe(true);
   });
 
   it('approving the delegations OUT OF ORDER (B first) processes both orders correctly', async () => {
@@ -320,7 +324,17 @@ describe('parallel sub-agent delegation (suspend/resume)', () => {
 
     // First instance: emit the two approvals, then discard the instance entirely.
     let approvals: ApprovalSeen[];
-    const persistedTargets = new Map<string, { runId: string; delegatedRunId?: string }>();
+    const persistedTargets = new Map<
+      string,
+      {
+        runId: string;
+        delegatedRunId?: string;
+        toolName?: string;
+        args?: unknown;
+        parentToolName?: string;
+        parentArgs?: unknown;
+      }
+    >();
     {
       const supervisor = buildSupervisorAgent(storage);
       const stream = await supervisor.stream('Process both orders in parallel.', {
@@ -341,6 +355,10 @@ describe('parallel sub-agent delegation (suspend/resume)', () => {
         const pending = (metadata?.pendingToolApprovals ?? {}) as Record<string, unknown>;
         for (const entry of Object.values(pending) as Array<{
           toolCallId?: string;
+          toolName?: string;
+          args?: unknown;
+          parentToolName?: string;
+          parentArgs?: unknown;
           runId?: string;
           delegatedRunId?: string;
         }>) {
@@ -348,6 +366,10 @@ describe('parallel sub-agent delegation (suspend/resume)', () => {
             persistedTargets.set(entry.toolCallId, {
               runId: entry.runId,
               delegatedRunId: entry.delegatedRunId,
+              toolName: entry.toolName,
+              args: entry.args,
+              parentToolName: entry.parentToolName,
+              parentArgs: entry.parentArgs,
             });
           }
         }
@@ -355,6 +377,16 @@ describe('parallel sub-agent delegation (suspend/resume)', () => {
 
       expect([...persistedTargets.keys()].sort()).toEqual(approvals.map(approval => approval.toolCallId).sort());
       expect([...persistedTargets.values()].every(target => target.runId === stream.runId)).toBe(true);
+      expect([...persistedTargets.values()].every(target => target.toolName === 'process-order')).toBe(true);
+      expect([...persistedTargets.values()].every(target => target.parentToolName === 'agent-subAgent')).toBe(true);
+      expect([...persistedTargets.values()].some(target => JSON.stringify(target.args).includes(ORDER_A))).toBe(true);
+      expect([...persistedTargets.values()].some(target => JSON.stringify(target.args).includes(ORDER_B))).toBe(true);
+      expect([...persistedTargets.values()].some(target => JSON.stringify(target.parentArgs).includes(ORDER_A))).toBe(
+        true,
+      );
+      expect([...persistedTargets.values()].some(target => JSON.stringify(target.parentArgs).includes(ORDER_B))).toBe(
+        true,
+      );
       const delegatedRunIds = [...persistedTargets.values()].map(target => target.delegatedRunId);
       expect(delegatedRunIds.every(Boolean)).toBe(true);
       expect(new Set(delegatedRunIds).size).toBe(2);

--- a/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
+++ b/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
@@ -658,11 +658,13 @@ describe('suspended-run discovery', () => {
 
       const scoped = await supervisor.listSuspendedRuns({ threadId: 'thread-1', resourceId: 'resource-1' });
       expect(scoped.runs.map(run => run.runId)).toEqual([stream.runId]);
+      // The outer resumable run retains its own toolCallId, but discloses the
+      // actual inner approval target and arguments to the user.
       expect(scoped.runs[0]!.toolCalls).toEqual([
         {
           toolCallId: 'sup-call-1',
-          toolName: 'agent-billing-agent',
-          args: { message: 'Find Dero Israel' },
+          toolName: 'findUserTool',
+          args: { name: 'Dero Israel' },
           requiresApproval: true,
         },
       ]);
@@ -703,16 +705,16 @@ describe('suspended-run discovery', () => {
         // consume until suspension
       }
 
-      // Each agent in the chain sees only its own suspended run.
+      // Each agent in the chain sees only its own suspended run. Every layer
+      // discloses the leaf approval target while retaining its layer's resumable
+      // toolCallId internally.
       const supervisorRuns = await supervisor.listSuspendedRuns();
       expect(supervisorRuns.runs.map(run => run.runId)).toEqual([stream.runId]);
-      // The supervisor's resumable run shows the delegation call to mid, not the
-      // real approval tool (which lives on the leaf's run).
       expect(supervisorRuns.runs[0]!.toolCalls).toEqual([
         {
           toolCallId: 'sup-call-1',
-          toolName: 'agent-mid-agent',
-          args: { message: 'Find Dero Israel' },
+          toolName: 'findUserTool',
+          args: { name: 'Dero Israel' },
           requiresApproval: true,
         },
       ]);
@@ -720,11 +722,13 @@ describe('suspended-run discovery', () => {
       const midRuns = await mid.listSuspendedRuns();
       expect(midRuns.runs).toHaveLength(1);
       expect(midRuns.runs[0]!.runId).not.toBe(stream.runId);
-      expect(midRuns.runs[0]!.toolCalls[0]!.toolName).toBe('agent-leaf-agent');
+      expect(midRuns.runs[0]!.toolCalls[0]).toMatchObject({
+        toolName: 'findUserTool',
+        args: { name: 'Dero Israel' },
+      });
 
       const leafRuns = await leaf.listSuspendedRuns();
       expect(leafRuns.runs).toHaveLength(1);
-      // Only the innermost (leaf) run surfaces the actual approval tool + args.
       expect(leafRuns.runs[0]!.toolCalls).toEqual([
         {
           toolCallId: expect.any(String),

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5228,27 +5228,27 @@ export class Agent<
                     if (chunk.type.startsWith('data-')) {
                       // Write data chunks directly to original stream to bubble up
                       await context.writer.custom(chunk as any);
-                      if (chunk.type === 'data-tool-call-approval') {
-                        suspendedPayload = {};
-                        requireToolApproval = true;
-                      }
-
-                      if (chunk.type === 'data-tool-call-suspended') {
-                        suspendedPayload = chunk.data.suspendPayload;
-                        resumeSchema = chunk.data.resumeSchema;
-                      }
                     } else {
                       await context.writer.write(chunk);
-                      if (chunk.type === 'tool-call-approval') {
-                        suspendedPayload = {};
-                        requireToolApproval = true;
-                      }
-
-                      if (chunk.type === 'tool-call-suspended') {
-                        suspendedPayload = chunk.payload.suspendPayload;
-                        resumeSchema = chunk.payload.resumeSchema;
-                      }
                     }
+                  }
+
+                  if (chunk.type === 'data-tool-call-approval') {
+                    requireToolApproval = (chunk as any).data ?? true;
+                    suspendedPayload = {
+                      requireToolApproval: (chunk as any).data ?? {},
+                    };
+                  } else if (chunk.type === 'data-tool-call-suspended') {
+                    suspendedPayload = chunk.data.suspendPayload;
+                    resumeSchema = chunk.data.resumeSchema;
+                  } else if (chunk.type === 'tool-call-approval') {
+                    requireToolApproval = chunk.payload ?? true;
+                    suspendedPayload = {
+                      requireToolApproval: chunk.payload ?? {},
+                    };
+                  } else if (chunk.type === 'tool-call-suspended') {
+                    suspendedPayload = chunk.payload.suspendPayload;
+                    resumeSchema = chunk.payload.resumeSchema;
                   }
                 }
 

--- a/packages/core/src/agent/durable/workflows/steps/tool-call-nested-approval.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call-nested-approval.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PUBSUB_SYMBOL } from '../../../../workflows/constants';
+import { globalRunRegistry } from '../../run-registry';
+import { emitChunkEvent, emitSuspendedEvent } from '../../stream-adapter';
+import { createDurableToolCallStep } from './tool-call';
+
+vi.mock('../../utils/resolve-runtime', () => ({
+  resolveTool: vi.fn(),
+  toolRequiresApproval: vi.fn().mockResolvedValue(false),
+  rebuildRunToolsFromMastra: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../stream-adapter', () => ({
+  emitChunkEvent: vi.fn().mockResolvedValue(undefined),
+  emitSuspendedEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const RUN_ID = 'outer-run';
+const TOOL_CALL_ID = 'outer-tool-call';
+const OUTER_TOOL_NAME = 'agent-billing';
+const OUTER_ARGS = { prompt: 'Charge the customer' };
+const INNER_APPROVAL = {
+  toolCallId: 'inner-tool-call',
+  toolName: 'charge-card',
+  args: { amountCents: 500 },
+};
+
+afterEach(() => {
+  globalRunRegistry.delete(RUN_ID);
+  vi.clearAllMocks();
+});
+
+describe('durable agent-as-tool nested approval details', () => {
+  it('emits inner tool details while preserving the outer tool call id for resume', async () => {
+    const suspend = vi.fn().mockResolvedValue(undefined);
+    const execute = vi.fn(async (_args: unknown, options: any) => {
+      await options.suspend(
+        { requireToolApproval: INNER_APPROVAL },
+        { requireToolApproval: true, runId: 'inner-run', isAgentSuspend: true },
+      );
+    });
+    globalRunRegistry.set(RUN_ID, { tools: { [OUTER_TOOL_NAME]: { execute } } } as any);
+
+    await (createDurableToolCallStep() as any).execute({
+      inputData: { toolCallId: TOOL_CALL_ID, toolName: OUTER_TOOL_NAME, args: OUTER_ARGS },
+      mastra: { getLogger: () => undefined },
+      suspend,
+      requestContext: new Map(),
+      getInitData: () => ({ runId: RUN_ID, agentId: 'supervisor', options: {}, state: {} }),
+      [PUBSUB_SYMBOL]: { publish: vi.fn(), subscribe: vi.fn(), unsubscribe: vi.fn(), flush: vi.fn() },
+    });
+
+    expect(emitChunkEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      RUN_ID,
+      expect.objectContaining({
+        type: 'tool-call-approval',
+        payload: expect.objectContaining({
+          toolCallId: TOOL_CALL_ID,
+          toolName: INNER_APPROVAL.toolName,
+          args: INNER_APPROVAL.args,
+        }),
+      }),
+    );
+    expect(emitSuspendedEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      RUN_ID,
+      expect.objectContaining({
+        toolCallId: TOOL_CALL_ID,
+        toolName: INNER_APPROVAL.toolName,
+        args: INNER_APPROVAL.args,
+        type: 'approval',
+      }),
+    );
+    expect(suspend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requireToolApproval: {
+          toolCallId: TOOL_CALL_ID,
+          toolName: INNER_APPROVAL.toolName,
+          args: INNER_APPROVAL.args,
+        },
+        suspendedToolRunId: 'inner-run',
+      }),
+      { resumeLabel: TOOL_CALL_ID },
+    );
+  });
+});

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -872,6 +872,16 @@ export function createDurableToolCallStep() {
               ? suspendOptions.runId
               : undefined;
           if (suspendOptions?.requireToolApproval) {
+            const innerApproval =
+              typeof suspendOptions.requireToolApproval === 'object' && suspendOptions.requireToolApproval
+                ? suspendOptions.requireToolApproval
+                : typeof suspendPayload?.requireToolApproval === 'object' && suspendPayload?.requireToolApproval
+                  ? suspendPayload.requireToolApproval
+                  : null;
+
+            const approvalToolName = innerApproval?.toolName ?? toolName;
+            const approvalArgs = innerApproval?.args !== undefined ? innerApproval.args : args;
+
             // Tool is requesting approval during execution
             const approvalResumeSchema = JSON.stringify({
               type: 'object',
@@ -888,15 +898,20 @@ export function createDurableToolCallStep() {
                 type: 'tool-call-approval',
                 runId,
                 from: ChunkFrom.AGENT,
-                payload: { toolCallId, toolName, args, resumeSchema: approvalResumeSchema },
+                payload: {
+                  toolCallId,
+                  toolName: approvalToolName,
+                  args: approvalArgs,
+                  resumeSchema: approvalResumeSchema,
+                },
               });
             }
 
             if (pubsub) {
               await emitSuspendedEvent(pubsub, runId, {
                 toolCallId,
-                toolName,
-                args,
+                toolName: approvalToolName,
+                args: approvalArgs,
                 type: 'approval',
                 resumeSchema: approvalResumeSchema,
               });
@@ -907,12 +922,12 @@ export function createDurableToolCallStep() {
 
             await doFlush();
 
-            endSpansAsSuspended({ toolCallId, toolName, reason: 'approval' });
+            endSpansAsSuspended({ toolCallId, toolName: approvalToolName, reason: 'approval' });
 
             return suspend(
               {
                 type: 'approval',
-                requireToolApproval: { toolCallId, toolName, args },
+                requireToolApproval: { toolCallId, toolName: approvalToolName, args: approvalArgs },
                 // Persist the inner suspended run id in the workflow snapshot,
                 // partitioned per tool call (resumeLabel = toolCallId), so the
                 // resume leg can recover it even if message metadata is stale.

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -506,13 +506,16 @@ export function createDurableToolCallStep() {
         resumeSchema?: string;
         suspendPayload?: unknown;
         delegatedRunId?: string;
+        approvalToolName?: string;
+        approvalArgs?: unknown;
       }) => {
         if (!messageList) return;
         const metadataKey = opts.type === 'suspension' ? 'suspendedTools' : 'pendingToolApprovals';
         const entry = {
           toolCallId,
-          toolName,
-          args,
+          toolName: opts.approvalToolName ?? toolName,
+          args: opts.approvalArgs ?? args,
+          ...(opts.approvalToolName ? { parentToolName: toolName, parentArgs: args } : {}),
           type: opts.type,
           // `runId` is the outer resumable durable run. When a delegated
           // sub-agent/workflow suspends, its inner suspended run is preserved
@@ -590,7 +593,7 @@ export function createDurableToolCallStep() {
           return (
             !!meta?.[metadataKey]?.[toolCallId] ||
             Object.values(meta?.[metadataKey] ?? {}).some(
-              (e: any) => e?.toolCallId === toolCallId || e?.toolName === toolName,
+              (e: any) => e?.toolCallId === toolCallId || e?.parentToolName === toolName || e?.toolName === toolName,
             )
           );
         });
@@ -605,7 +608,9 @@ export function createDurableToolCallStep() {
         const key = entries[toolCallId]
           ? toolCallId
           : (Object.keys(entries).find(k => entries[k]?.toolCallId === toolCallId) ??
-            Object.keys(entries).find(k => entries[k]?.toolName === toolName) ??
+            Object.keys(entries).find(
+              k => entries[k]?.parentToolName === toolName || entries[k]?.toolName === toolName,
+            ) ??
             (entries[toolName] ? toolName : undefined));
         if (key) {
           delete entries[key];
@@ -918,7 +923,12 @@ export function createDurableToolCallStep() {
             }
 
             // Add approval metadata to message before persisting
-            addToolMetadata({ type: 'approval', resumeSchema: approvalResumeSchema, delegatedRunId });
+            addToolMetadata({
+              type: 'approval',
+              resumeSchema: approvalResumeSchema,
+              delegatedRunId,
+              ...(innerApproval ? { approvalToolName, approvalArgs } : {}),
+            });
 
             await doFlush();
 

--- a/packages/core/src/loop/shared/auto-resume-system-message.test.ts
+++ b/packages/core/src/loop/shared/auto-resume-system-message.test.ts
@@ -78,6 +78,32 @@ describe('extractSuspendedToolsFromMessages', () => {
     ]);
   });
 
+  it('uses the parent delegation identity for auto-resume while preserving inner approval details', () => {
+    const pending = {
+      'tc-1': {
+        toolCallId: 'tc-1',
+        toolName: 'charge-card',
+        args: { amountCents: 500 },
+        parentToolName: 'agent-billing',
+        parentArgs: { prompt: 'Charge the customer' },
+        runId: 'outer-run',
+        delegatedRunId: 'inner-run',
+      },
+    };
+    const messages = [makeAssistantMessage({ metadata: { pendingToolApprovals: pending } })];
+
+    expect(extractSuspendedToolsFromMessages(messages)).toEqual([
+      {
+        toolCallId: 'tc-1',
+        toolName: 'agent-billing',
+        args: { prompt: 'Charge the customer' },
+        approvalToolName: 'charge-card',
+        approvalArgs: { amountCents: 500 },
+        runId: 'inner-run',
+      },
+    ]);
+  });
+
   it('keeps runId untouched for non-delegated entries', () => {
     const pending = { 'tc-2': { toolCallId: 'tc-2', toolName: 'directTool', runId: 'run-1' } };
     const messages = [makeAssistantMessage({ metadata: { pendingToolApprovals: pending } })];

--- a/packages/core/src/loop/shared/auto-resume-system-message.ts
+++ b/packages/core/src/loop/shared/auto-resume-system-message.ts
@@ -84,8 +84,18 @@ export function extractSuspendedToolsFromMessages(
   // inner run as `delegatedRunId`, so surface the inner run under `runId` here.
   return Object.values(suspendedToolObj).map(entry => {
     if (!entry || typeof entry !== 'object') return entry as Record<string, unknown>;
-    const { delegatedRunId, ...rest } = entry as Record<string, unknown>;
-    return typeof delegatedRunId === 'string' ? { ...rest, runId: delegatedRunId } : rest;
+    const { delegatedRunId, parentToolName, parentArgs, ...rest } = entry as Record<string, unknown>;
+    const resumableEntry =
+      typeof parentToolName === 'string'
+        ? {
+            ...rest,
+            approvalToolName: rest.toolName,
+            approvalArgs: rest.args,
+            toolName: parentToolName,
+            args: parentArgs,
+          }
+        : rest;
+    return typeof delegatedRunId === 'string' ? { ...resumableEntry, runId: delegatedRunId } : resumableEntry;
   });
 }
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -51,6 +51,8 @@ type AddToolMetadataOptions = {
   toolCallId: string;
   toolName: string;
   args: unknown;
+  parentToolName?: string;
+  parentArgs?: unknown;
   resumeSchema: string;
   suspendedToolRunId?: string;
   metadata?: Record<string, unknown>;
@@ -154,6 +156,8 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         toolCallId,
         toolName,
         args,
+        parentToolName,
+        parentArgs,
         suspendPayload,
         resumeSchema,
         type,
@@ -186,6 +190,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           toolCallId,
           toolName,
           args: transformedArgs,
+          ...(parentToolName ? { parentToolName, parentArgs } : {}),
           type,
           // Store the OUTER (resumable) runId so clients can resume after page refresh or
           // server restart via `resumeStream({ runId, toolCallId })`. For delegated sub-agent /
@@ -267,7 +272,9 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           if (entries[toolCallId]) return toolCallId;
           const byCallId = Object.keys(entries).find(key => entries[key]?.toolCallId === toolCallId);
           if (byCallId) return byCallId;
-          const byName = Object.keys(entries).find(key => entries[key]?.toolName === toolName);
+          const byName = Object.keys(entries).find(
+            key => entries[key]?.parentToolName === toolName || entries[key]?.toolName === toolName,
+          );
           if (byName) return byName;
           return entries[toolName] ? toolName : undefined;
         };
@@ -737,6 +744,9 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                 toolCallId: inputData.toolCallId,
                 toolName: approvalToolName,
                 args: approvalArgs,
+                ...(approvalToolName !== inputData.toolName || approvalArgs !== inputData.args
+                  ? { parentToolName: inputData.toolName, parentArgs: inputData.args }
+                  : {}),
                 type: 'approval',
                 suspendedToolRunId: options.runId,
                 resumeSchema: JSON.stringify(

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -685,6 +685,16 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           })(),
           suspend: async (suspendPayload: any, options?: SuspendOptions) => {
             if (options?.requireToolApproval) {
+              const innerApproval =
+                typeof options.requireToolApproval === 'object' && options.requireToolApproval
+                  ? options.requireToolApproval
+                  : typeof suspendPayload?.requireToolApproval === 'object' && suspendPayload?.requireToolApproval
+                    ? suspendPayload.requireToolApproval
+                    : null;
+
+              const approvalToolName = innerApproval?.toolName ?? inputData.toolName;
+              const approvalArgs = innerApproval?.args !== undefined ? innerApproval.args : inputData.args;
+
               await stopGoalActivity({
                 agentId,
                 runId,
@@ -697,8 +707,8 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                   from: ChunkFrom.AGENT,
                   payload: {
                     toolCallId: inputData.toolCallId,
-                    toolName: inputData.toolName,
-                    args: inputData.args,
+                    toolName: approvalToolName,
+                    args: approvalArgs,
                     resumeSchema: JSON.stringify(
                       standardSchemaToJSONSchema(
                         toStandardSchema(
@@ -725,8 +735,8 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               // Add approval metadata to message before persisting
               addToolMetadata({
                 toolCallId: inputData.toolCallId,
-                toolName: inputData.toolName,
-                args: inputData.args,
+                toolName: approvalToolName,
+                args: approvalArgs,
                 type: 'approval',
                 suspendedToolRunId: options.runId,
                 resumeSchema: JSON.stringify(
@@ -752,8 +762,8 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                 {
                   requireToolApproval: {
                     toolCallId: inputData.toolCallId,
-                    toolName: inputData.toolName,
-                    args: inputData.args,
+                    toolName: approvalToolName,
+                    args: approvalArgs,
                   },
                   __streamState: streamState.serialize(),
                   __agentId: agentId,


### PR DESCRIPTION
## Description

When a sub-agent executes a tool with `requireApproval: true`, the streaming agent-as-tool wrapper discarded the inner tool approval payload, setting `suspendedPayload = {}`. As a result, the top-level approval chunk identified the outer delegate call instead of the inner tool name and arguments.

This update extracts the inner approval payload during agent-as-tool streaming and surfaces the inner tool details in approval events and metadata.

## Related issue(s)

Fixes #20934

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a nested agent asks for permission to use a tool, the system now shows the actual tool and its arguments. It also preserves the context needed to resume or decline the correct operation.

## Changes

- Preserve nested approval payloads during agent-as-tool streaming.
- Support current and legacy approval and suspension chunk formats.
- Use the inner tool name and arguments in approval events, metadata, spans, and suspension payloads.
- Keep outer delegation metadata separate from the inner approval identity.
- Preserve the correct resume and cleanup identity.
- Apply the fix to regular, durable, parallel, cold-reload, and auto-resume paths.
- Preserve existing behavior for direct gated tools.
- Add regression coverage for nested, durable, resumable, and suspended-run flows.
- Add a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->