### PR TITLE
feat(core): run dynamic skills resolvers inside a resolve-skills span

### DIFF
--- a/.changeset/skills-resolver-tracing-context.md
+++ b/.changeset/skills-resolver-tracing-context.md
@@ -1,0 +1,21 @@
+---
+'@mastra/core': minor
+---
+
+Added tracing to dynamic agent skills resolvers. The resolver now runs inside a `resolve-skills` span, so skills fetched from an external service show up in the agent's trace instead of disappearing, and it receives `tracingContext` for creating child spans of its own — the same pattern tools already use.
+
+```typescript
+const agent = new Agent({
+  skills: async ({ requestContext, tracingContext }) => {
+    const span = tracingContext?.currentSpan?.createChildSpan({
+      type: 'generic',
+      name: 'entitlements-lookup',
+    })
+    const skills = await fetchSkillsFor(requestContext.get('userId'))
+    span?.end()
+    return skills
+  },
+})
+```
+
+On metadata reads such as `agent.listSkills()` no agent is running, so `tracingContext.currentSpan` is `undefined` — guard span usage with `?.` as shown above.

--- a/docs/src/content/en/docs/agents/skills.mdx
+++ b/docs/src/content/en/docs/agents/skills.mdx
@@ -131,7 +131,21 @@ export const agent = new Agent({
 })
 ```
 
-The resolver function receives `{ requestContext }` and returns a `SkillInput[]` array or a `Promise<SkillInput[]>`.
+The resolver function receives `{ requestContext, tracingContext }` and returns a `SkillInput[]` array or a `Promise<SkillInput[]>`.
+
+The resolver runs once per `RequestContext`. During an agent execution it runs inside a `resolve-skills` span, and `tracingContext.currentSpan` lets you create child spans for your own work, the same way tools do. The resolver also runs on metadata reads such as `agent.listSkills()` and the server's agent endpoints, where no span exists and `tracingContext.currentSpan` is `undefined`, so keep it fast and guard any span usage:
+
+```typescript title="src/mastra/agents/index.ts"
+skills: async ({ requestContext, tracingContext }) => {
+  const span = tracingContext?.currentSpan?.createChildSpan({
+    type: 'generic',
+    name: 'entitlements-lookup',
+  })
+  const skills = await fetchSkillsFor(requestContext.get('userId'))
+  span?.end()
+  return skills
+}
+```
 
 See [Request Context](/docs/server/request-context) for more on using request context with agents and workflows.
 

--- a/packages/core/src/agent/__tests__/agent-skills-wiring.test.ts
+++ b/packages/core/src/agent/__tests__/agent-skills-wiring.test.ts
@@ -343,4 +343,41 @@ describe('Agent-level skills wiring', () => {
       expect(resolver).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('tracing context for dynamic resolvers', () => {
+    it('passes tracingContext to the resolver during an execution', async () => {
+      let seen: unknown = 'never-called';
+      const agent = new Agent({
+        id: 'dynamic-skills-tracing',
+        instructions: 'You have dynamic skills.',
+        model: mockModel,
+        skills: ({ tracingContext }) => {
+          seen = tracingContext;
+          return [];
+        },
+      });
+
+      await agent.generate('Hello');
+
+      expect(seen).toBeDefined();
+      expect(seen).toHaveProperty('currentSpan');
+    });
+
+    it('passes an empty tracingContext on metadata reads like listSkills', async () => {
+      let seen: unknown = 'never-called';
+      const agent = new Agent({
+        id: 'dynamic-skills-tracing-metadata',
+        instructions: 'You have dynamic skills.',
+        model: mockModel,
+        skills: ({ tracingContext }) => {
+          seen = tracingContext;
+          return [];
+        },
+      });
+
+      await agent.listSkills();
+
+      expect(seen).toHaveProperty('currentSpan', undefined);
+    });
+  });
 });

--- a/packages/core/src/agent/__tests__/agent-skills-wiring.test.ts
+++ b/packages/core/src/agent/__tests__/agent-skills-wiring.test.ts
@@ -9,6 +9,7 @@
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { executeWithContext, initContextStorage } from '../../observability/context-storage';
 import { RequestContext } from '../../request-context';
 import { createSkill } from '../../skills/create-skill';
 import type { Skill, SkillMetadata, WorkspaceSkills } from '../../workspace/skills';
@@ -345,22 +346,92 @@ describe('Agent-level skills wiring', () => {
   });
 
   describe('tracing context for dynamic resolvers', () => {
-    it('passes tracingContext to the resolver during an execution', async () => {
-      let seen: unknown = 'never-called';
+    function createRecordingSpan() {
+      const children: Array<{
+        options: any;
+        ended: boolean;
+        endOptions?: any;
+        errored: boolean;
+        errorOptions?: any;
+        span: any;
+      }> = [];
+      const parent: any = {
+        createChildSpan: vi.fn((options: any) => {
+          const record: any = { options, ended: false, errored: false };
+          record.span = {
+            end: vi.fn((endOptions?: any) => {
+              record.ended = true;
+              record.endOptions = endOptions;
+            }),
+            error: vi.fn((errorOptions?: any) => {
+              record.errored = true;
+              record.errorOptions = errorOptions;
+            }),
+          };
+          children.push(record);
+          return record.span;
+        }),
+      };
+      return { parent, children };
+    }
+
+    it('opens one resolve-skills span per request and hands it to the resolver', async () => {
+      initContextStorage();
+      const { parent, children } = createRecordingSpan();
+      const seenSpans: unknown[] = [];
+
       const agent = new Agent({
-        id: 'dynamic-skills-tracing',
+        id: 'skills-span',
         instructions: 'You have dynamic skills.',
         model: mockModel,
         skills: ({ tracingContext }) => {
-          seen = tracingContext;
-          return [];
+          seenSpans.push(tracingContext?.currentSpan);
+          return [createSkill({ name: 'traced', description: 'Traced skill.', instructions: 'Trace things.' })];
         },
       });
 
-      await agent.generate('Hello');
+      const requestContext = new RequestContext();
+      await executeWithContext({
+        span: parent,
+        fn: async () => {
+          await agent.listSkills({ requestContext });
+          await agent.listSkills({ requestContext });
+        },
+      });
 
-      expect(seen).toBeDefined();
-      expect(seen).toHaveProperty('currentSpan');
+      expect(parent.createChildSpan).toHaveBeenCalledTimes(1);
+      expect(children[0]!.options).toMatchObject({ name: 'resolve-skills', metadata: { agentId: 'skills-span' } });
+      expect(seenSpans).toEqual([children[0]!.span]);
+      expect(children[0]!.ended).toBe(true);
+      expect(children[0]!.endOptions).toMatchObject({ metadata: { skillCount: 1 } });
+    });
+
+    it('records a resolver failure on the span and opens a fresh one on retry', async () => {
+      initContextStorage();
+      const { parent, children } = createRecordingSpan();
+      const resolver = vi.fn().mockRejectedValueOnce(new Error('skills service unavailable')).mockResolvedValue([]);
+
+      const agent = new Agent({
+        id: 'skills-span-error',
+        instructions: 'You have dynamic skills.',
+        model: mockModel,
+        skills: resolver,
+      });
+
+      const requestContext = new RequestContext();
+      await executeWithContext({
+        span: parent,
+        fn: async () => {
+          await expect(agent.listSkills({ requestContext })).rejects.toThrow('skills service unavailable');
+          await expect(agent.listSkills({ requestContext })).resolves.toEqual([]);
+        },
+      });
+
+      expect(parent.createChildSpan).toHaveBeenCalledTimes(2);
+      expect(children[0]!.errored).toBe(true);
+      expect(children[0]!.errorOptions).toMatchObject({ endSpan: true });
+      expect(children[1]!.ended).toBe(true);
+      expect(children[1]!.endOptions).toMatchObject({ metadata: { skillCount: 0 } });
     });
 
     it('passes an empty tracingContext on metadata reads like listSkills', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -61,13 +61,21 @@ import {
   summarizeNotifications,
 } from '../notifications/signals';
 import type { SendNotificationSignalInput } from '../notifications/types';
-import type { DefinitionSource, TracingProperties, ObservabilityContext, TracingPolicy } from '../observability';
+import type {
+  DefinitionSource,
+  TracingProperties,
+  ObservabilityContext,
+  TracingContext,
+  TracingPolicy,
+} from '../observability';
 import {
   EntityType,
   InternalSpans,
   SpanType,
+  executeWithContext,
   getOrCreateSpan,
   createObservabilityContext,
+  resolveCurrentSpan,
   resolveObservabilityContext,
 } from '../observability';
 import type {
@@ -1291,6 +1299,7 @@ export class Agent<
   private async resolveSkills(
     requestContext?: RequestContext,
     workspaceOverride?: AnyWorkspace,
+    tracingContext?: TracingContext,
   ): Promise<WorkspaceSkills | undefined> {
     const rc = requestContext || new RequestContext();
 
@@ -1299,7 +1308,11 @@ export class Agent<
     if (this.#skills) {
       let resolvedInputs: SkillInput[];
       if (typeof this.#skills === 'function') {
-        resolvedInputs = await this.#resolveDynamicSkills(this.#skills, rc as RequestContext<TRequestContext>);
+        resolvedInputs = await this.#resolveDynamicSkills(
+          this.#skills,
+          rc as RequestContext<TRequestContext>,
+          tracingContext,
+        );
       } else {
         resolvedInputs = this.#skills;
       }
@@ -1329,14 +1342,31 @@ export class Agent<
   #resolveDynamicSkills(
     resolver: AgentSkillsResolver<TRequestContext>,
     requestContext: RequestContext<TRequestContext>,
+    tracingContext?: TracingContext,
   ): Promise<SkillInput[]> {
     const pending = this.#resolvedSkillsByRequest.get(requestContext);
     if (pending) return pending;
 
-    const resolution = Promise.resolve(resolver({ requestContext })).catch(error => {
-      this.#resolvedSkillsByRequest.delete(requestContext);
-      throw error;
+    const parentSpan = tracingContext?.currentSpan ?? resolveCurrentSpan();
+    const skillsSpan = parentSpan?.createChildSpan({
+      type: SpanType.GENERIC,
+      name: 'resolve-skills',
+      metadata: { agentId: this.id },
     });
+
+    const resolution = executeWithContext({
+      span: skillsSpan,
+      fn: async () => resolver({ requestContext, tracingContext: { currentSpan: skillsSpan } }),
+    })
+      .then(skills => {
+        skillsSpan?.end({ metadata: { skillCount: skills.length } });
+        return skills;
+      })
+      .catch(error => {
+        skillsSpan?.error({ error: error instanceof Error ? error : new Error(String(error)), endSpan: true });
+        this.#resolvedSkillsByRequest.delete(requestContext);
+        throw error;
+      });
 
     this.#resolvedSkillsByRequest.set(requestContext, resolution);
     return resolution;
@@ -3851,7 +3881,11 @@ export class Agent<
     const workspace = await this.getWorkspace({ requestContext });
 
     // Resolve skills from agent-level config and/or workspace (pass workspace to avoid double resolution)
-    const skills = await this.resolveSkills(requestContext, workspace ?? undefined);
+    const skills = await this.resolveSkills(
+      requestContext,
+      workspace ?? undefined,
+      observabilityContext.tracingContext,
+    );
     if (!skills) {
       return convertedSkillTools;
     }

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -5,6 +5,7 @@
  * or filesystem paths, without needing a full Workspace with filesystem/sandbox.
  */
 
+import type { TracingContext } from '../observability/types';
 import type { RequestContext } from '../request-context';
 import type { Skill, SkillMetadata, SkillFormat, WorkspaceSkills } from '../workspace/skills/types';
 
@@ -67,9 +68,14 @@ export type SkillInput = string | InlineSkill;
 
 /**
  * Context passed to a dynamic skills resolver.
+ *
+ * `tracingContext.currentSpan` is only set while skills resolve as part of an
+ * agent execution. Metadata reads such as `agent.listSkills()` run outside any
+ * span, so resolvers that create child spans must handle it being undefined.
  */
 export interface AgentSkillsContext<TRequestContext extends Record<string, any> | unknown = unknown> {
   requestContext: RequestContext<TRequestContext>;
+  tracingContext?: TracingContext;
 }
 
 /**


### PR DESCRIPTION
## Description

A dynamic `skills` resolver is a natural place to do I/O, but nothing traced it: no span wrapped the resolver, so work it did (like fetching skills from an external service) was invisible in the agent's trace. The resolver now runs inside a `resolve-skills` span and receives `tracingContext`, the same pattern tools and processors already use.

- Open a `resolve-skills` span (child of the active span) around the dynamic resolver and run it via `executeWithContext`, so auto-instrumented calls inside the resolver nest correctly
- Pass `tracingContext` in `AgentSkillsContext`, letting resolvers create child spans the way tool `execute` does
- On metadata reads such as `agent.listSkills()` no agent is running, so `tracingContext.currentSpan` is `undefined` and no span is created; documented with a guarded example
- The span ends with a `skillCount`; a resolver error is recorded on the span and the failed resolution is still evicted so a later call can retry
- With per-request memoization (#20921), exactly one `resolve-skills` span is exported per request

**Repro note on #20798:** the issue's specific claim (ambient span missing on served `POST /generate`) does not reproduce on the reporter's versions or current main; the span-less path is metadata reads (`GET /api/agents`), which cannot have a span since no agent is running. What this PR delivers is the issue's requested API (`tracingContext` on the resolver) plus a deterministic span contract on the execution path, which previously worked only by accident of the internal workflow's ambient context. Tests assert span name, single-span-per-request, resolver receiving the span, `skillCount` on end, and error recording with retry.

Verified with live OpenAI: exported to real Langfuse (correct hierarchy via its public API) and visible in Studio's trace view as `resolve-skills` → `entitlements-lookup` under the agent run, with zero spans on the metadata path.

## Related Issue(s)

Fixes #20798

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Dynamic skill lookups now show up in tracing data. This makes it easier to see how long lookups take, what they return, and why they fail.

## Changes

- Added a `resolve-skills` span for dynamic skill resolvers.
- Passed `tracingContext` to resolvers so they can create child spans.
- Recorded `skillCount` on successful resolutions.
- Recorded resolver errors on the span.
- Preserved retry behavior by clearing failed resolutions from the cache.
- Reused one span per request.
- Avoided creating spans for metadata reads without an active agent span.
- Updated public types and documentation.
- Added tests for span lifecycle, hierarchy, context propagation, errors, retries, memoization, and metadata reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->