### PR TITLE
test: stabilize the arize exporter snapshot and the lance index-metric tests

### DIFF
--- a/observability/arize/src/tracing.test.ts
+++ b/observability/arize/src/tracing.test.ts
@@ -159,6 +159,11 @@ describe('ArizeExporter', () => {
     expect(exporter).toBeDefined();
     expect(exportedSpans.length).toBe(1);
 
+    // The attribute shape below is dictated by @arizeai/openinference-genai, not by us. Two details
+    // are owned by that package rather than this exporter: tool messages carry a flat
+    // `message.content` (not the nested `contents.0.message_content` shape the other roles use), and
+    // `llm.system` is emitted alongside `llm.provider`. Both arrived in 0.3.0. If this snapshot
+    // fails after a dependency bump, diff it against that package before assuming a regression here.
     expect(exportedSpans[0].attributes).toMatchInlineSnapshot(`
       {
         "input.mime_type": "application/json",
@@ -175,8 +180,7 @@ describe('ArizeExporter', () => {
         "llm.input_messages.2.message.tool_calls.0.tool_call.function.arguments": ""{\\"city\\":\\"Tokyo\\"}"",
         "llm.input_messages.2.message.tool_calls.0.tool_call.function.name": "weatherTool",
         "llm.input_messages.2.message.tool_calls.0.tool_call.id": "weatherTool-1",
-        "llm.input_messages.3.message.contents.0.message_content.text": "{"city":"Tokyo","temperature":70,"condition":"sunny"}",
-        "llm.input_messages.3.message.contents.0.message_content.type": "text",
+        "llm.input_messages.3.message.content": "{"city":"Tokyo","temperature":70,"condition":"sunny"}",
         "llm.input_messages.3.message.role": "tool",
         "llm.input_messages.3.message.tool_call_id": "weatherTool-1",
         "llm.invocation_parameters": "{"model":"gpt-4"}",
@@ -185,6 +189,7 @@ describe('ArizeExporter', () => {
         "llm.output_messages.0.message.contents.0.message_content.type": "text",
         "llm.output_messages.0.message.role": "assistant",
         "llm.provider": "openai",
+        "llm.system": "openai",
         "llm.token_count.completion": 5,
         "llm.token_count.prompt": 10,
         "llm.token_count.total": 15,

--- a/stores/lance/src/vector/index.test.ts
+++ b/stores/lance/src/vector/index.test.ts
@@ -2304,15 +2304,24 @@ describe('Lance vector store tests', () => {
     it('resolves the metric from the table index when metric is omitted', async () => {
       const tableName = 'score_semantics_index_metric_' + Date.now();
       // 256+ rows are required for index creation; place the exact/far vectors deterministically.
+      //
+      // The far position is seeded ten times (ids 2-11) rather than once. The index built below is
+      // an HNSW approximation: it does not promise to return every row even when topK covers the
+      // whole table, and a lone orthogonal outlier is precisely what graph traversal drops. Seeding
+      // a small cluster of near-identical far rows, each with a slight offset so they are distinct
+      // graph nodes, keeps the euclidean-vs-cosine discriminator below without making the assertion
+      // depend on any one row surviving recall.
+      const FAR_ROW_COUNT = 10;
       const rows = Array.from({ length: 300 }, (_, i) => ({
         id: String(i + 1),
         vector:
           i === 0
             ? [1, 0, 0, 0, 0, 0, 0, 0]
-            : i === 1
-              ? [0, 1, 0, 0, 0, 0, 0, 0]
+            : i <= FAR_ROW_COUNT
+              ? [0, 1, i / 1000, 0, 0, 0, 0, 0]
               : [0.2, 0.2, 0.2 + i / 1000, 0, 0, 0, 0, 0],
       }));
+      const farIds = new Set(Array.from({ length: FAR_ROW_COUNT }, (_, i) => String(i + 2)));
       await vectorDB.createTable(tableName, rows);
       await vectorDB.createIndex({ tableName, indexName: 'vector', dimension: 8, metric: 'euclidean' });
 
@@ -2325,7 +2334,7 @@ describe('Lance vector store tests', () => {
       });
 
       const exact = results.find(r => r.id === '1')!;
-      const far = results.find(r => r.id === '2')!;
+      const far = results.find(r => farIds.has(r.id))!;
       expect(exact).toBeDefined();
       expect(far).toBeDefined();
       expect(exact.score).toBeGreaterThan(far.score);
@@ -2341,15 +2350,19 @@ describe('Lance vector store tests', () => {
 
     it('uses the Lance index metric when an explicit query metric conflicts', async () => {
       const tableName = 'score_semantics_index_metric_conflict_' + Date.now();
+      // Far rows are seeded as a cluster for the same reason as the test above: HNSW recall is
+      // approximate, so a single orthogonal outlier is not guaranteed to come back.
+      const FAR_ROW_COUNT = 10;
       const rows = Array.from({ length: 300 }, (_, i) => ({
         id: String(i + 1),
         vector:
           i === 0
             ? [1, 0, 0, 0, 0, 0, 0, 0]
-            : i === 1
-              ? [0, 1, 0, 0, 0, 0, 0, 0]
+            : i <= FAR_ROW_COUNT
+              ? [0, 1, i / 1000, 0, 0, 0, 0, 0]
               : [0.2, 0.2, 0.2 + i / 1000, 0, 0, 0, 0, 0],
       }));
+      const farIds = new Set(Array.from({ length: FAR_ROW_COUNT }, (_, i) => String(i + 2)));
       await vectorDB.createTable(tableName, rows);
       await vectorDB.createIndex({ tableName, indexName: 'vector', dimension: 8, metric: 'euclidean' });
 
@@ -2362,7 +2375,9 @@ describe('Lance vector store tests', () => {
       });
 
       const exact = results.find(r => r.id === '1')!;
-      const far = results.find(r => r.id === '2')!;
+      const far = results.find(r => farIds.has(r.id))!;
+      expect(exact).toBeDefined();
+      expect(far).toBeDefined();
       expect(exact.score).toBeGreaterThan(far.score);
       expect(exact.score).toBeGreaterThan(0.9);
       expect(far.score).toBeGreaterThan(0.3);


### PR DESCRIPTION
## Description

Two test suites were failing or intermittently failing on `main`. Neither was caused by a product bug, and neither is fixed by changing product code. This PR fixes both tests and explains, in each file, why the shape is what it is so the next person does not re-diagnose them from scratch.

Closes #20944
Closes #20945

## arize: the snapshot was stale, not catching a regression

`observability/arize/src/tracing.test.ts` asserts the exporter's output attributes in an inline snapshot. That snapshot has been failing on `main` since `e7109ee6f7` ("chore(deps): update observability providers", #19783), which bumped `@arizeai/openinference-genai` from 0.2.0 to 0.3.0.

Reading the 0.3.0 source confirms both differences are deliberate upstream behavior, not a break on our side:

- `mapProviderAndSystem` now sets `LLM_SYSTEM`, producing the new `llm.system` attribute alongside the existing `llm.provider`
- `setToolCallResponseMessage` now writes tool message content as a flat `message.content` rather than the nested `contents.0.message_content.text` shape used by the other roles

So the correct fix is to refresh the snapshot. The regenerated diff contains exactly those two changes and nothing else, which is the check that the bump did not quietly alter anything beyond what was expected.

I added a comment above the assertion recording that this attribute shape is owned by the dependency rather than by this exporter, with a pointer to diff against that package first if the snapshot fails after a future bump.

## lance: the tests asserted against a single row of an approximate index

Two tests in `stores/lance/src/vector/index.test.ts` were intermittently failing. Both build an HNSW index over 300 rows, query with `topK: 300`, and then look for one specific row: a deliberately orthogonal outlier.

An HNSW index is an approximation. It does not promise to return every row even when `topK` covers the whole table, and a lone outlier is precisely what graph traversal drops first. Measured over 40 runs against unmodified `main`:

```
rows returned (of 300):  283 to 300, varying per run
outlier (id 2) absent:   1 of 40 runs
test outcome:            38 of 40 passing
```

The failure I reproduced locally is `AssertionError: expected undefined to be defined`. CI has also produced a second symptom on the same test, `expected 0.5857... to be greater than 0.5857...`, which I did not reproduce and so am not claiming to have explained; it is the same test depending on the same nondeterministic result set.

Importantly, the metric resolution the tests are actually about never flaked. `resolveQueryMetric` read `euclidean` back from the index stats on 40 of 40 runs. There is no product bug here, and no product code is touched by this PR.

The fix seeds the far position as a small cluster of distinct-but-equivalent rows instead of a single point, so the assertion no longer depends on any one row surviving recall. The euclidean-vs-cosine discriminator that gives the test its meaning is unchanged.

The second test (`uses the Lance index metric when an explicit query metric conflicts`) had the identical latent problem and additionally lacked a `toBeDefined()` guard, so on a miss it would throw a `TypeError` rather than fail as an assertion. Fixed alongside, since leaving it would just page someone later for the same reason.

## Alternatives rejected

For the lance fix, so a reviewer can redirect cheaply:

- **Bounded retry until the outlier appears.** Smaller diff, but it hides the nondeterminism instead of naming it.
- **Expose LanceDB's `bypassVectorIndex()` through `query()`.** This is the only option that makes the test fully deterministic *and* gives users a real exhaustive-search escape hatch. It is also a public API addition with a genuine design argument attached, which does not belong in a test-stabilization PR. Happy to open it separately if that is wanted.

## Verification

```
arize:  full suite 24/24 passing
lance:  full vector suite 58/58 passing
        40-run loop on the metric tests: 40/40 passing (baseline was 38/40)
both:   tsc --noEmit clean, oxlint 0 warnings 0 errors
diff:   2 files, both test files, no product source
```

No changeset: test-only, no shipped behavior change, matching #20946.

## Related

While tracing the arize failure I filed #20950. The dependency bump that caused it ran 12 CI checks and none of them were unit tests, so the breakage reached `main` and surfaced days later on an unrelated contributor's PR. That is a CI coverage gap rather than something to fix here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates tests to match an intentional dependency change and makes Lance index tests less sensitive to approximate search results. Product code remains unchanged.

## Changes

- Refreshed the Arize inline snapshot:
  - Added `llm.system`.
  - Updated tool messages to use flat `message.content`.
- Stabilized two Lance metric tests:
  - Seeded multiple equivalent far vectors.
  - Accepted any matching far-row ID returned by the approximate HNSW index.
  - Added guards for defined values and index readiness.

## Verification

- Arize tests: 24/24 passed.
- Lance vector tests: 58/58 passed.
- Repeated metric tests: 40/40 passed.
- TypeScript checks passed.
- Oxlint reported no warnings or errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->