### PR TITLE
feat(platform-workspace): split PlatformSandbox.stop() from destroy() to mirror @mastra/railway

### DIFF
--- a/.changeset/platform-sandbox-stop-destroy-split.md
+++ b/.changeset/platform-sandbox-stop-destroy-split.md
@@ -1,0 +1,18 @@
+---
+'@mastra/platform-workspace': minor
+---
+
+Split `PlatformSandbox.stop()` from `PlatformSandbox.destroy()` so the two lifecycle exits mirror `@mastra/railway` `RailwaySandbox`
+
+**Before:** `stop()` was an alias for `destroy()`, and `destroy()` only released the sandbox VM — the on-provider recovery checkpoint was never actively deleted. There was no way to end a hosted sandbox while preserving its checkpoint for a later resume, and destroyed sandboxes accumulated stray checkpoints until the upstream provider's own GC.
+
+**After:**
+
+- **`stop()`** — releases the VM but **preserves the recovery checkpoint**. Any in-flight capture is awaited first so the preserved checkpoint reflects the caller's latest state. Corresponds to `DELETE /v1/projects/:pid/sandbox/:sandboxId` on workspace-proxy, which by contract does not touch the checkpoint.
+- **`destroy()`** — releases the VM **and deletes the recovery checkpoint**. Cancels any in-flight capture (no reason to burn a capture on state we're releasing), asks the proxy to delete the checkpoint via `DELETE /v1/projects/:pid/sandbox/:sandboxId/checkpoint`, then releases the VM. Both remote operations are best-effort — an already-absent checkpoint or a transient checkpoint-delete failure does not block the VM teardown, since a half-torn-down sandbox is worse than a lingering checkpoint alone.
+
+Callers constructed without a recovery `id` skip the checkpoint DELETE and behave identically to `stop()`, because they have no on-provider checkpoint to release.
+
+This restores the "providers move in lockstep" invariant that broke after `@mastra/railway` gained its own `stop()`/`destroy()` split.
+
+**Requires** a matching workspace-proxy release that exposes `DELETE /v1/projects/:pid/sandbox/:sandboxId/checkpoint`. Callers on older workspace-proxy versions will see the checkpoint DELETE 404 and fall through to the VM DELETE — same net effect as the pre-split behavior.

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1806,6 +1806,275 @@ describe('PlatformSandbox', () => {
     });
   });
 
+  describe('stop / destroy (checkpoint lifecycle)', () => {
+    // These tests pin down the semantic split between stop() and destroy()
+    // that mirrors @mastra/railway RailwaySandbox after mastra#20739:
+    //   stop()    -> preserve checkpoint (VM DELETE only)
+    //   destroy() -> release checkpoint (checkpoint DELETE + VM DELETE)
+    // The old behavior — stop() aliasing destroy() with no checkpoint delete
+    // in either — is the invariant break the split fixes.
+    it('stop() releases the VM without touching the checkpoint (DELETE /sandbox/:id only)', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      const sandbox = new PlatformSandbox({
+        // Explicit id so _hasRecoveryKey is true — the destroy() path guards
+        // on this, and we want to prove stop() does *not* branch on it.
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      await sandbox.stop();
+
+      // Exactly two upstream calls: the create and the sandbox DELETE.
+      // Anything else (in particular a DELETE /checkpoint) is a regression
+      // — stop() must not release the recovery checkpoint.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1]![1].method).toBe('DELETE');
+      expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1');
+    });
+
+    it('destroy() releases the checkpoint (DELETE /sandbox/:id/checkpoint) and then the VM', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        // DELETE /checkpoint -> 204
+        .mockResolvedValueOnce(new Response(null, { status: 204 }))
+        // DELETE /sandbox -> 204
+        .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      await sandbox.destroy();
+
+      // The checkpoint DELETE must land *before* the VM DELETE so the
+      // upstream provisioner can look up the checkpoint on a sandbox that
+      // still exists. Reversing the order can leave a leaked checkpoint if
+      // the checkpoint delete fails after the VM is already gone.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(String(fetchMock.mock.calls[1]![0])).toBe(
+        'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/checkpoint',
+      );
+      expect(fetchMock.mock.calls[1]![1].method).toBe('DELETE');
+      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1');
+      expect(fetchMock.mock.calls[2]![1].method).toBe('DELETE');
+    });
+
+    it('destroy() sends the recovery id on the checkpoint DELETE body so the proxy can locate the right checkpoint', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(new Response(null, { status: 204 }))
+        .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+      await sandbox.destroy();
+
+      const checkpointDeleteBody = JSON.parse(fetchMock.mock.calls[1]![1].body as string);
+      // Mirrors the shape of POST /checkpoint's request body so the proxy
+      // hashes the same recovery key into the same on-provider checkpoint
+      // name for both capture and delete.
+      expect(checkpointDeleteBody).toEqual({ id: 'mc-session-42' });
+    });
+
+    it('destroy() without a recovery id skips the checkpoint DELETE (no checkpoint to release)', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      // No `id` supplied — the auto-generated id is not a recovery key, so
+      // no checkpoint was ever registered against it. destroy() must not
+      // fire a delete against a name the proxy has no record of.
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      await sandbox.destroy();
+
+      // Only create + VM DELETE — no /checkpoint call.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1');
+    });
+
+    it('destroy() continues to VM teardown when the checkpoint DELETE 404s (idempotent)', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        // Checkpoint already gone (idle GC, prior delete). Proxy 404.
+        .mockResolvedValueOnce(new Response('not found', { status: 404 }))
+        .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      // Must not throw — an already-absent checkpoint is a successful
+      // destroy from the caller's perspective (that's the state they asked
+      // for). The VM DELETE must still fire, otherwise a stale sandbox
+      // record would linger.
+      await sandbox.destroy();
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1');
+    });
+
+    it('destroy() continues to VM teardown when the checkpoint DELETE fails with 5xx (best-effort)', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        // Proxy failed to delete the checkpoint (transient).
+        .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+        .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      // A transient upstream failure on the checkpoint delete must not
+      // block the VM DELETE — leaving the VM running with a lingering
+      // checkpoint is worse than a lingering checkpoint alone. The failure
+      // is logged; the caller sees success.
+      await sandbox.destroy();
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1');
+    });
+
+    it('destroy() is a no-op when the sandbox was never started (idempotent)', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn();
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+
+      // Never started — no _sandboxId, so nothing upstream to release.
+      await sandbox.destroy();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('stop() awaits an in-flight capture before tearing down so the preserved checkpoint reflects it', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+
+      // Gate the capture response so the test can control ordering.
+      let releaseCapture!: (value: Response) => void;
+      const capturePending = new Promise<Response>(resolve => {
+        releaseCapture = resolve;
+      });
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockReturnValueOnce(capturePending)
+        .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      // Kick off a capture, then a stop while it's still in flight.
+      const capturePromise = sandbox.captureCheckpoint();
+      const stopPromise = sandbox.stop();
+
+      // stop() must not have progressed to the VM DELETE yet — only the
+      // create + the in-flight POST /checkpoint should be observable.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      releaseCapture(json({ checkpointName: 'mastra-checkpoint-abc123', status: 'captured' }));
+
+      await Promise.all([capturePromise, stopPromise]);
+
+      // Now the VM DELETE has fired, but no checkpoint DELETE (this is
+      // stop(), not destroy()).
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1');
+      expect(fetchMock.mock.calls[2]![1].method).toBe('DELETE');
+    });
+
+    it('stop() proceeds to teardown even if the in-flight capture fails (best-effort flush)', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        // Capture blows up with a transport error.
+        .mockResolvedValueOnce(new Response('quota exceeded', { status: 429 }))
+        .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+
+      // Start the capture and let it fail before stop() runs — this puts
+      // the rejection on the in-flight promise stop() will await/catch.
+      const capturePromise = sandbox.captureCheckpoint();
+      await expect(capturePromise).rejects.toMatchObject({ status: 429 });
+
+      // A failed capture must not leave the caller unable to release the
+      // sandbox. The proxy's safety-net timer is the fallback for the
+      // checkpoint state.
+      await sandbox.stop();
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(String(fetchMock.mock.calls[2]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1');
+    });
+  });
+
   describe('captureCheckpoint (public, on-demand)', () => {
     it('POSTs to /checkpoint with the recovery key and returns the captured name', async () => {
       vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -510,11 +510,93 @@ export class PlatformSandbox extends MastraSandbox {
     this._addressRegistry.set(json.id, json.instanceUrl);
   }
 
+  /**
+   * Stop the sandbox while **preserving its recovery checkpoint**.
+   *
+   * Semantic parity with `@mastra/railway` `RailwaySandbox.stop()`: the VM
+   * is released but the on-provider checkpoint survives, so a subsequent
+   * `start()` on a sandbox constructed with the same `id` can restore from
+   * it. Any in-flight capture is awaited first so the preserved checkpoint
+   * reflects the latest disk state we asked for.
+   *
+   * Corresponds to `DELETE /v1/projects/:pid/sandbox/:sandboxId` on
+   * workspace-proxy, which by contract does not touch the checkpoint. Use
+   * {@link destroy} when you want the checkpoint released too.
+   */
   async stop(): Promise<void> {
-    await this.destroy();
+    // Await any in-flight capture so the preserved checkpoint reflects the
+    // latest capture the caller triggered. Never rethrow — a failing capture
+    // must not block teardown; the proxy's safety-net refresh timer is a
+    // fallback for the checkpoint state.
+    if (this._captureInFlight) {
+      await this._captureInFlight.catch(error => {
+        this.logger.warn(`stop(): failed to flush in-flight capture before teardown:`, error);
+      });
+    }
+    await this._teardownSandbox();
   }
 
+  /**
+   * Destroy the sandbox **and release its recovery checkpoint**.
+   *
+   * Semantic parity with `@mastra/railway` `RailwaySandbox.destroy()`:
+   * cancels any in-flight capture (the checkpoint is about to be deleted
+   * — no reason to burn a capture on state we're releasing), asks the
+   * proxy to delete the checkpoint, then releases the VM. Both remote
+   * operations are best-effort logged failures — a stray checkpoint or a
+   * transient proxy error must not leave the caller with a half-torn-down
+   * sandbox they can't safely retry.
+   *
+   * Requires the caller to have constructed with a recovery `id` (there is
+   * no checkpoint to delete otherwise); callers without one skip the
+   * checkpoint DELETE and behave identically to {@link stop}.
+   */
   async destroy(): Promise<void> {
+    if (!this._sandboxId) return;
+    const destroyedSandboxId = this._sandboxId;
+
+    // Drop the in-flight capture promise — we're about to delete the
+    // checkpoint, so completing an in-flight capture is at best a wasted
+    // round-trip and at worst races with the delete. Callers get whatever
+    // resolution the pending capture already had; we don't rethrow.
+    this._captureInFlight = null;
+
+    if (this._hasRecoveryKey) {
+      // Body mirrors the POST /checkpoint shape (`{ id }`) so the proxy
+      // can hash the same recovery key into the same checkpoint name.
+      // Best-effort: a proxy 404/410 means the checkpoint is already
+      // absent (idle GC, prior delete) and we can proceed with the VM
+      // teardown; other failures are surfaced in logs but do not abort
+      // — the VM DELETE below is the operation the caller most needs.
+      try {
+        await this._client.request(`/sandbox/${encodeURIComponent(destroyedSandboxId)}/checkpoint`, {
+          method: 'DELETE',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ id: this.id }),
+        });
+      } catch (error) {
+        if (error instanceof PlatformApiError && (error.status === 404 || error.status === 410)) {
+          this.logger.debug(`destroy(): checkpoint already absent upstream (status=${error.status})`);
+        } else {
+          this.logger.warn(`destroy(): failed to delete checkpoint upstream:`, error);
+        }
+      }
+    }
+
+    await this._teardownSandbox();
+  }
+
+  /**
+   * Release the remote sandbox VM and clear the local state pointing at it.
+   *
+   * Shared body of {@link stop} and {@link destroy} — both funnel through
+   * here after they've dealt with the checkpoint (preserve vs release).
+   * The VM DELETE is safe to issue in either mode: the proxy's DELETE
+   * route does not touch the checkpoint on its own, so `stop()` correctly
+   * leaves the checkpoint intact and `destroy()` has already removed it
+   * before this call.
+   */
+  private async _teardownSandbox(): Promise<void> {
     if (!this._sandboxId) return;
     const destroyedSandboxId = this._sandboxId;
     await this._client.request(`/sandbox/${encodeURIComponent(destroyedSandboxId)}`, { method: 'DELETE' });


### PR DESCRIPTION
## Summary

Splits `PlatformSandbox.stop()` from `PlatformSandbox.destroy()` in `@mastra/platform-workspace` so the two lifecycle exits carry the same semantic difference they now carry in `@mastra/railway` (`RailwaySandbox`).

Before this change, `stop()` was an alias for `destroy()`, and `destroy()` only released the sandbox VM without touching the on-provider recovery checkpoint. That broke the "providers move in lockstep" invariant after mastra-ai/mastra#20739 introduced the semantic split on `RailwaySandbox`, and left every long-lived hosted project accumulating stray recovery checkpoints until upstream GC.

## What changes

- **`stop()`** — preserves the recovery checkpoint. Any in-flight capture is awaited first so the preserved checkpoint reflects the caller's latest state. Issues `DELETE /v1/projects/:pid/sandbox/:sandboxId` only.
- **`destroy()`** — releases the recovery checkpoint *and* the VM. Cancels any in-flight capture (no reason to burn a capture on state we're releasing, issues  with  in the body (mirroring the shape of the capture route so the proxy hashes the same key), then releases the VM.
- Both remote calls in  are best-effort with logged failures: an already-absent checkpoint (404 / ) or a transient proxy 5xx must not leave a half-torn-down sandbox that the caller cannot safely retry.
- Callers constructed without a recovery uid=501(ryanhansen) gid=20(staff) groups=20(staff),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),98(_lpadmin),701(com.apple.sharepoint.group.1),33(_appstore),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh),400(com.apple.access_remote_ae) skip the checkpoint delete and behave identically to  — there is no on-provider checkpoint to release.

Shared VM-teardown body factored into a private  so both paths converge on the same clean-up sequence (DELETE, clear  /  / addressRegistry entry, reset status).

## Depends on

- **mastra-ai/platform#1939** (already approved) — adds  on workspace-proxy. This PR calls that endpoint from . Once #1939 is deployed to workspace-proxy, this PR is functionally complete.

Against older workspace-proxy versions the checkpoint DELETE will 404 and this PR falls through to the VM DELETE — same net effect as the current pre-split behavior. So it is safe to merge this before the proxy release ships, though the intended new behavior only takes effect once both are in place.

## What did **not** change

-  public surface: same two methods (, ) with the same zero-arg signatures. Only the runtime behavior differs.
-  (mastra-ai/mastra#20882): unchanged.  now awaits its in-flight promise;  still cancels it.
- : not touched. This is the mirror-side change.

## Test plan

9 new tests in  under a  describe block:

-  preserves checkpoint — VM DELETE only, no checkpoint DELETE
-  releases checkpoint before VM — DELETE order pinned
- Body of checkpoint DELETE carries recovery id
- No-recovery-id destroy skips the checkpoint DELETE entirely
- Checkpoint DELETE 404 /  is idempotent — VM DELETE still fires
- Checkpoint DELETE 5xx logs at warn and still tears down the VM
-  on a never-started sandbox is a no-op
-  flushes an in-flight capture before tearing down
-  proceeds when in-flight capture rejects (log-and-continue)

**Verification against `main`:**
- `pnpm --filter @mastra/platform-workspace test` — 115 / 115 pass (all suites)
- `pnpm exec tsc --noEmit` in `workspaces/platform-workspace` — clean
- `pnpm --filter @mastra/platform-workspace lint` — 0 warnings, 0 errors
- `pnpm exec oxfmt --check` on touched files — clean

## Related

- mastra-ai/mastra#20739 — RailwaySandbox stop/destroy split (the change this mirrors)
- mastra-ai/mastra#20882 —  mirrored on  (merged; this PR builds on top)
- mastra-ai/platform#1939 — server-side  endpoint (dependency)
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR gives `stop()` and `destroy()` separate cleanup behavior. `stop()` keeps the recovery checkpoint for later use, while `destroy()` removes it and fully cleans up the sandbox.

## Changes

- `PlatformSandbox.stop()` now:
  - Waits for active checkpoint captures.
  - Preserves the recovery checkpoint.
  - Deletes only the sandbox VM.

- `PlatformSandbox.destroy()` now:
  - Cancels active checkpoint captures.
  - Deletes the recovery checkpoint when a recovery ID exists.
  - Deletes the sandbox VM after checkpoint cleanup.
  - Continues cleanup when checkpoint deletion fails.

- Shared VM teardown logic now uses a private `_teardownSandbox()` helper.
- Checkpoint deletion supports older workspace-proxy versions by continuing after a `404`.
- Added nine tests for lifecycle behavior, cleanup ordering, request bodies, missing checkpoints, failures, and active captures.
- Added a minor changeset for the lifecycle split.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->