### PR TITLE
feat(platform-workspace): add client-side checkpoint refresh safety-net timer

### DIFF
--- a/.changeset/platform-sandbox-refresh-timer.md
+++ b/.changeset/platform-sandbox-refresh-timer.md
@@ -1,0 +1,23 @@
+---
+'@mastra/platform-workspace': minor
+---
+
+Add a client-side checkpoint refresh safety-net timer to `PlatformSandbox`, mirroring `@mastra/railway` `RailwaySandbox`
+
+Previously the workspace-proxy ran this timer server-side. That worked for the persistent staging deploy but was unreliable on serverless: Cloud Run kills the process during idle scale-to-zero and cold-start recycles, so the timer that was supposed to protect the upstream idle-destroy window couldn't fire during exactly the window it was there to guard. The safety net looked present but couldn't be counted on.
+
+`PlatformSandbox` now arms a `.unref()`d `setTimeout` in the caller's own process — the persistent factory runtime that already owns the sandbox handle — same layer where `RailwaySandbox` runs its equivalent timer. Both providers now race the same 3-minute (`CHECKPOINT_REFRESH_MARGIN_MS = 180_000`) window before the upstream idle destroy, so a caller holding a `WorkspaceSandbox` gets the same idle-window behavior on both providers and can stop reasoning about which one it has.
+
+**Schedule.** `delayMs = Math.max(1_000, idleTimeoutMinutes * 60_000 - 180_000)`. If the caller's idle timeout is shorter than the 3-minute margin the timer clamps to a 1-second floor and fires almost immediately after `start()` — surfacing the misconfiguration rather than silently skipping.
+
+**No-op when.**
+
+- The caller supplied no recovery `id` (an auto-generated id is not a meaningful recovery key — capturing under a name no future boot would look for produces dead data).
+- No `idleTimeoutMinutes` was configured (no upstream destroy to race).
+- The sandbox is not started.
+
+**Re-arm.** After every successful `captureCheckpoint()` (busy sandbox keeps pushing the timer out — only a genuinely idle sandbox ever fires it). The timer coalesces onto the existing in-flight capture slot, so a fire that lands during a caller-driven capture joins the same round-trip rather than starting a competing one.
+
+**Cancel.** On `stop()`, `destroy()`, or any 410 that marks the sandbox destroyed locally — no stray refresh ever fires against a torn-down or reused sandbox id.
+
+**Rollout.** Pairs with the workspace-proxy release that removes the server-side timer; the two changes ship as a unit and callers see continuous coverage across the swap.

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -2316,4 +2316,280 @@ describe('PlatformSandbox', () => {
       expect(result).toEqual({ status: 'captured', checkpointName: 'mastra-checkpoint-abc123' });
     });
   });
+
+  describe('checkpoint refresh timer (client-side safety net)', () => {
+    // These tests pin down the client-side safety-net refresh that mirrors
+    // OSS @mastra/railway RailwaySandbox. The upstream idle-destroy window
+    // used to be raced by a server-side timer inside workspace-proxy, but
+    // that timer was unreliable on serverless (Cloud Run kills the process
+    // during idle recycles — the timer supposed to protect the idle window
+    // couldn't fire during it). Moving the timer client-side puts it in
+    // the persistent factory process that owns the sandbox handle, same
+    // layer where RailwaySandbox runs its equivalent timer.
+    //
+    // Refresh margin is 180_000 ms (3 minutes) before the upstream idle
+    // window; delayMs = max(1_000, idleTimeoutMinutes * 60_000 - 180_000).
+
+    it('fires a refresh 3 minutes before the upstream idle-destroy window (5 min idle → 2 min timer)', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+          .mockResolvedValueOnce(json({ checkpointName: 'mastra-checkpoint-abc123', status: 'captured' }));
+
+        const sandbox = new PlatformSandbox({
+          id: 'mc-session-42',
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          idleTimeoutMinutes: 5,
+          fetch: fetchMock,
+        });
+        await sandbox._start();
+
+        // 5 min idle - 3 min margin = 2 min. Nothing before that.
+        await vi.advanceTimersByTimeAsync(119_000);
+        expect(fetchMock).toHaveBeenCalledTimes(1); // create only
+
+        // Cross the 2-min mark → refresh fires → POST /checkpoint.
+        await vi.advanceTimersByTimeAsync(2_000);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(String(fetchMock.mock.calls[1]![0])).toBe(
+          'https://proxy.test/v1/projects/proj_123/sandbox/sbx_1/checkpoint',
+        );
+        expect(fetchMock.mock.calls[1]![1].method).toBe('POST');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('re-arms the timer after each successful capture so a busy sandbox never fires it', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+          // Manual capture -> resets the timer window from this point.
+          .mockResolvedValueOnce(json({ checkpointName: 'mastra-checkpoint-abc123', status: 'captured' }));
+
+        const sandbox = new PlatformSandbox({
+          id: 'mc-session-42',
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          idleTimeoutMinutes: 5,
+          fetch: fetchMock,
+        });
+        await sandbox._start();
+
+        // Halfway to the scheduled refresh, the caller fires a manual capture.
+        await vi.advanceTimersByTimeAsync(60_000);
+        await sandbox.captureCheckpoint();
+        expect(fetchMock).toHaveBeenCalledTimes(2); // create + manual capture
+
+        // If the timer were NOT re-armed, the original schedule would fire
+        // 60s from now (60 + 60 = 120s = original 2-min mark). Advance to
+        // that point and prove nothing fires — the re-arm pushed the next
+        // refresh out another 2 minutes from the manual capture.
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        // Advance the remaining 60s to hit the re-armed 2-min mark.
+        await vi.advanceTimersByTimeAsync(60_000);
+        // No new fetch mock queued for this second refresh, so the assertion
+        // is just that the timer's captureCheckpoint call is well-formed;
+        // it will POST /checkpoint and get "undefined" back (which throws
+        // inside the timer's .catch — swallowed by design). What we're
+        // proving here is the schedule delta, not the resulting network I/O.
+        // The next assertion — that captureCheckpoint was attempted — is
+        // captured by the fetch mock being called a third time.
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not schedule a refresh when no recovery id was configured (no meaningful key to capture under)', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
+
+        // No id → auto-generated random id → not a recovery key. Even with
+        // an idle timeout, there's nothing worth firing a capture under, so
+        // the timer must not arm at all.
+        const sandbox = new PlatformSandbox({
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          idleTimeoutMinutes: 5,
+          fetch: fetchMock,
+        });
+        await sandbox._start();
+
+        // Race past when the timer would have fired if armed.
+        await vi.advanceTimersByTimeAsync(10 * 60_000);
+        expect(fetchMock).toHaveBeenCalledTimes(1); // only the create
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not schedule a refresh when no idle timeout was configured (no upstream destroy to race)', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
+
+        // Recovery id present but no idleTimeoutMinutes → nothing forcing
+        // the upstream sandbox to expire → nothing to race. Timer must not arm.
+        const sandbox = new PlatformSandbox({
+          id: 'mc-session-42',
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          fetch: fetchMock,
+        });
+        await sandbox._start();
+
+        await vi.advanceTimersByTimeAsync(10 * 60_000);
+        expect(fetchMock).toHaveBeenCalledTimes(1); // only the create
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('falls back to a 1s floor when the idle timeout is shorter than the safety-net margin (surfaces misconfig)', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+          .mockResolvedValueOnce(json({ checkpointName: 'mastra-checkpoint-abc123', status: 'captured' }));
+
+        // 1 min idle < 3 min margin → delayMs would be negative, so the
+        // schedule clamps to the 1-second floor. This is a "surface the
+        // misconfig" fallback: the refresh fires almost immediately rather
+        // than silently skipping and leaving the sandbox unprotected.
+        const sandbox = new PlatformSandbox({
+          id: 'mc-session-42',
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          idleTimeoutMinutes: 1,
+          fetch: fetchMock,
+        });
+        await sandbox._start();
+
+        await vi.advanceTimersByTimeAsync(999);
+        expect(fetchMock).toHaveBeenCalledTimes(1); // still just the create
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(fetchMock).toHaveBeenCalledTimes(2); // refresh fired at 1s
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('cancels the timer on stop() so a torn-down sandbox never fires a stray refresh', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+          // stop() VM DELETE
+          .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+        const sandbox = new PlatformSandbox({
+          id: 'mc-session-42',
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          idleTimeoutMinutes: 5,
+          fetch: fetchMock,
+        });
+        await sandbox._start();
+        await sandbox.stop();
+
+        // Race well past the refresh's scheduled fire time.
+        await vi.advanceTimersByTimeAsync(10 * 60_000);
+        // Exactly two calls: create + VM DELETE. A stray refresh would show
+        // up as a third fetch (a POST /checkpoint against a dead sandbox id).
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('cancels the timer on destroy() so a released checkpoint is never re-captured', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+          // destroy() checkpoint DELETE
+          .mockResolvedValueOnce(new Response(null, { status: 204 }))
+          // destroy() VM DELETE
+          .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+        const sandbox = new PlatformSandbox({
+          id: 'mc-session-42',
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          idleTimeoutMinutes: 5,
+          fetch: fetchMock,
+        });
+        await sandbox._start();
+        await sandbox.destroy();
+
+        await vi.advanceTimersByTimeAsync(10 * 60_000);
+        // Exactly three calls: create + checkpoint DELETE + VM DELETE. A
+        // stray refresh would fire a fourth POST /checkpoint against a
+        // checkpoint we just asked the proxy to delete.
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('cancels the timer when the upstream sandbox is reported destroyed (410 during a manual capture)', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+          // Manual capture -> 410 (proxy reports the sandbox is gone).
+          .mockResolvedValueOnce(json({ error: { message: 'Sandbox destroyed', type: 'gone' } }, { status: 410 }));
+
+        const sandbox = new PlatformSandbox({
+          id: 'mc-session-42',
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          idleTimeoutMinutes: 5,
+          fetch: fetchMock,
+        });
+        await sandbox._start();
+
+        // Manual capture receives 410 → sandbox marked destroyed locally →
+        // refresh timer should be cancelled by _clearDestroyedState.
+        const result = await sandbox.captureCheckpoint();
+        expect(result).toEqual({ status: 'skipped', reason: 'sandbox-not-running' });
+
+        // If the timer were still armed, it would fire in ~2 minutes and
+        // burn another POST /checkpoint against the dead sandbox id.
+        await vi.advanceTimersByTimeAsync(10 * 60_000);
+        expect(fetchMock).toHaveBeenCalledTimes(2); // create + manual capture only
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -100,6 +100,25 @@ interface ExecLeaseResponse {
  */
 const LEASE_REFRESH_MARGIN_MS = 60_000;
 
+/**
+ * How long before the upstream sandbox's idle-destroy window we schedule a
+ * safety-net checkpoint refresh. Wide enough (3 min) that a Cloud Run cold
+ * start, scale event, or brief network partition during the refresh window
+ * does not lose the race with the upstream idle destroy. If a caller
+ * reduces the idle timeout below this margin, the refresh falls back to
+ * the 1-second floor and fires almost immediately after start — surfacing
+ * the misconfiguration rather than silently skipping the refresh.
+ *
+ * Mirrors OSS `@mastra/railway` `RailwaySandbox` `CHECKPOINT_REFRESH_MARGIN_MS`
+ * so both providers race the same window. Previously the workspace-proxy
+ * ran this timer server-side, which was unreliable on serverless
+ * (Cloud Run kills the process during idle recycles — the timer that was
+ * supposed to protect the idle window couldn't fire during it). Moving the
+ * timer client-side puts it in the persistent factory process that owns
+ * the sandbox handle, same layer where `RailwaySandbox` runs it.
+ */
+const CHECKPOINT_REFRESH_MARGIN_MS = 180_000;
+
 interface CreateSandboxResponse {
   id: string;
   providerResourceId?: string | null;
@@ -364,6 +383,16 @@ export class PlatformSandbox extends MastraSandbox {
    * before the first one resolves. Cleared when the request settles.
    */
   private _captureInFlight: Promise<CaptureCheckpointResult> | null = null;
+  /**
+   * Scheduled safety-net refresh. Fires `CHECKPOINT_REFRESH_MARGIN_MS` before
+   * the upstream sandbox's idle-destroy window and issues a
+   * {@link captureCheckpoint} on this instance. Cancelled and re-armed on
+   * every successful capture (so a busy sandbox keeps pushing the timer out
+   * — only a genuinely idle sandbox ever fires it). Cancelled on
+   * {@link stop} / {@link destroy}. `.unref()`d so it never holds the
+   * process open past when the caller is done.
+   */
+  private _checkpointRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(options: PlatformSandboxOptions = {}) {
     super({ ...options, name: 'PlatformSandbox', processes: new PlatformProcessManager() });
@@ -440,6 +469,7 @@ export class PlatformSandbox extends MastraSandbox {
         if (!json.destroyedAt) {
           this._createdAt = json.createdAt ? new Date(json.createdAt) : new Date();
           this._populateAddressFromResponse(json);
+          this._scheduleCheckpointRefresh();
           return;
         }
         this._sandboxId = undefined;
@@ -486,6 +516,7 @@ export class PlatformSandbox extends MastraSandbox {
     this._sandboxId = json.id;
     this._createdAt = json.createdAt ? new Date(json.createdAt) : new Date();
     this._populateAddressFromResponse(json);
+    this._scheduleCheckpointRefresh();
   }
 
   /**
@@ -525,9 +556,11 @@ export class PlatformSandbox extends MastraSandbox {
    */
   async stop(): Promise<void> {
     // Await any in-flight capture so the preserved checkpoint reflects the
-    // latest capture the caller triggered. Never rethrow — a failing capture
-    // must not block teardown; the proxy's safety-net refresh timer is a
-    // fallback for the checkpoint state.
+    // latest capture the caller triggered. Never rethrow — a failing
+    // capture must not block teardown; the caller can always retry against
+    // a fresh sandbox that restores from whatever checkpoint the last
+    // successful capture wrote. `_teardownSandbox()` below cancels the
+    // safety-net refresh timer regardless of what this capture did.
     if (this._captureInFlight) {
       await this._captureInFlight.catch(error => {
         this.logger.warn(`stop(): failed to flush in-flight capture before teardown:`, error);
@@ -597,6 +630,13 @@ export class PlatformSandbox extends MastraSandbox {
    * before this call.
    */
   private async _teardownSandbox(): Promise<void> {
+    // Cancel the refresh timer before we tear down — a timer left armed
+    // after the VM DELETE would fire against a dead sandbox and either
+    // burn a POST /checkpoint that logs 410 or (worse, after id reuse)
+    // capture against a stranger's resource. Cancel here so both stop()
+    // and destroy() converge on the same clean state without needing to
+    // duplicate the cancel at each call site.
+    this._cancelCheckpointRefresh();
     if (!this._sandboxId) return;
     const destroyedSandboxId = this._sandboxId;
     await this._client.request(`/sandbox/${encodeURIComponent(destroyedSandboxId)}`, { method: 'DELETE' });
@@ -614,6 +654,60 @@ export class PlatformSandbox extends MastraSandbox {
     // or reattach) will re-populate the entry from the workspace-proxy's
     // response.
     this._addressRegistry?.delete(destroyedSandboxId);
+  }
+
+  /**
+   * Arm (or re-arm) the safety-net refresh timer.
+   *
+   * Fires `CHECKPOINT_REFRESH_MARGIN_MS` before the upstream sandbox's
+   * idle-destroy window and issues a {@link captureCheckpoint} on this
+   * instance. Called at the end of {@link start} and after every successful
+   * {@link captureCheckpoint} — so a busy sandbox keeps pushing the timer
+   * out, and only a genuinely idle sandbox ever fires it.
+   *
+   * No-op when:
+   *   - no recovery `id` was supplied (nothing to capture under a stable
+   *     name — a random id is never a meaningful recovery key);
+   *   - no `idleTimeoutMinutes` was configured (no idle-destroy racing us);
+   *   - the sandbox is not started (no `_sandboxId`).
+   *
+   * `.unref()`d so the timer never holds the process open.
+   *
+   * Mirrors OSS `@mastra/railway` `RailwaySandbox._scheduleCheckpointRefresh`.
+   */
+  private _scheduleCheckpointRefresh(): void {
+    if (!this._hasRecoveryKey) return;
+    if (!this._idleTimeoutMinutes) return;
+    if (!this._sandboxId) return;
+
+    this._cancelCheckpointRefresh();
+
+    const delayMs = Math.max(1_000, this._idleTimeoutMinutes * 60_000 - CHECKPOINT_REFRESH_MARGIN_MS);
+    this._checkpointRefreshTimer = setTimeout(() => {
+      this._checkpointRefreshTimer = null;
+      if (!this._sandboxId) return;
+      // captureCheckpoint() handles its own coalescing with any in-flight
+      // capture, its own re-arm on success, and its own error/skip
+      // reporting. All we do here is fire it; a rejection is
+      // best-effort-logged and swallowed so a transient proxy failure
+      // never crashes the caller's process.
+      this.captureCheckpoint().catch(error => {
+        this.logger.warn(`checkpoint refresh timer: failed to capture checkpoint:`, error);
+      });
+    }, delayMs);
+    this._checkpointRefreshTimer.unref?.();
+  }
+
+  /**
+   * Cancel the safety-net refresh timer if one is armed. Idempotent —
+   * safe to call from teardown paths and from {@link _scheduleCheckpointRefresh}
+   * before it re-arms.
+   */
+  private _cancelCheckpointRefresh(): void {
+    if (this._checkpointRefreshTimer) {
+      clearTimeout(this._checkpointRefreshTimer);
+      this._checkpointRefreshTimer = null;
+    }
   }
 
   /**
@@ -682,6 +776,23 @@ export class PlatformSandbox extends MastraSandbox {
       }
     });
     this._captureInFlight = capture;
+    // Re-arm the safety-net timer from this capture, so a busy sandbox
+    // keeps pushing the timer out and only a genuinely idle one fires it.
+    // Runs after the capture settles so the new window is measured from
+    // real work, not from timer-arm. `.then` on the same promise so we
+    // only re-arm on captured/coalesced (not on the 410→skip path, which
+    // clears local state and would immediately no-op the schedule check).
+    capture
+      .then(result => {
+        if (result.status === 'captured' || result.status === 'coalesced') {
+          this._scheduleCheckpointRefresh();
+        }
+      })
+      .catch(() => {
+        // Errors already surfaced to the awaiting caller — swallow the
+        // reject on this fire-and-forget branch so unhandledrejection
+        // doesn't fire.
+      });
     return capture;
   }
 
@@ -736,6 +847,11 @@ export class PlatformSandbox extends MastraSandbox {
    * the cached `'running'` state (see `MastraSandbox._start`).
    */
   private _clearDestroyedState(destroyedSandboxId: string): void {
+    // Cancel any pending refresh — the sandbox is gone, so a firing
+    // refresh would just POST /checkpoint against a dead id (best case:
+    // proxy 410, log noise; worst case: after id reuse, capturing
+    // against a different sandbox entirely).
+    this._cancelCheckpointRefresh();
     this._sandboxId = undefined;
     this._createdAt = null;
     this._lease = null;


### PR DESCRIPTION
## Summary

Adds a client-side checkpoint refresh safety-net timer to `PlatformSandbox` (`@mastra/platform-workspace`), mirroring the equivalent timer that has always lived on `RailwaySandbox` (`@mastra/railway`).

Previously the workspace-proxy ran this timer server-side. That worked for the persistent staging deploy but was unreliable on serverless: Cloud Run kills the process during idle scale-to-zero and cold-start recycles, so the timer that was supposed to protect the upstream idle-destroy window couldn't fire during exactly the window it was there to guard. The safety net looked present but couldn't be counted on.

Moving the timer client-side puts it in the persistent factory process that already owns the sandbox handle — same layer where `RailwaySandbox` runs its equivalent timer. Both providers now race the same 3-minute window before the upstream idle destroy, so a caller holding a `WorkspaceSandbox` gets the same idle-window behavior on both providers and can stop reasoning about which one it has.

## What changes

**Schedule (mirrors `RailwaySandbox` exactly):**
- `CHECKPOINT_REFRESH_MARGIN_MS = 180_000` (3 min before the upstream idle destroy). Wide enough that a Cloud Run cold start or brief network partition during the refresh window does not lose the race.
- `delayMs = Math.max(1_000, idleTimeoutMinutes * 60_000 - 180_000)`. Callers with an idle timeout shorter than the margin get the 1-second floor and see the refresh fire almost immediately — surfaces misconfig rather than silently skipping.
- `.unref()`d so the timer never holds the process open past the caller.

**No-op when there's nothing worth refreshing:**
- No caller-supplied recovery `id` (auto-generated ids aren't recovery keys — capturing under a name no future boot would look for produces dead data).
- No `idleTimeoutMinutes` configured (no upstream destroy to race).
- Sandbox not started.

**Re-arm:** after every successful `captureCheckpoint()`, so a busy sandbox keeps pushing the timer out and only a genuinely idle one ever fires it. Coalesces onto the existing `_captureInFlight` slot — a fire that lands during a caller-driven capture joins the same round-trip.

**Cancel:** on `stop()`, `destroy()`, and any 410 that marks the sandbox destroyed locally, so a torn-down or reused sandbox id never sees a stray `POST /checkpoint`. Cancel lives in `_teardownSandbox` and `_clearDestroyedState` so both lifecycle exits and the mid-flight 410 path converge on the same clean state.

## Rollout

Pairs with the workspace-proxy release that removes the server-side timer; the two ship as a unit so callers see continuous coverage across the swap. Deploy order does not matter — with both timers running briefly during the overlap, one of them will coalesce into the other's in-flight capture via the existing `_captureInFlight` guard.

## Test plan

8 new tests in `workspaces/platform-workspace/src/sandbox.test.ts` under a `checkpoint refresh timer (client-side safety net)` describe block. Every test uses `vi.useFakeTimers()` and `vi.advanceTimersByTimeAsync` so schedule assertions are deterministic:

- Fires a refresh 3 minutes before the upstream idle-destroy window (5 min idle → 2 min timer)
- Re-arms the timer after each successful capture so a busy sandbox never fires it
- Does not schedule a refresh when no recovery id was configured
- Does not schedule a refresh when no idle timeout was configured
- Falls back to a 1s floor when the idle timeout is shorter than the safety-net margin (surfaces misconfig)
- Cancels the timer on `stop()` so a torn-down sandbox never fires a stray refresh
- Cancels the timer on `destroy()` so a released checkpoint is never re-captured
- Cancels the timer when the upstream sandbox is reported destroyed (410 during a manual capture)

**Verification against `main`:**
- `pnpm --filter @mastra/platform-workspace test` — 123 / 123 pass (was 115, +8 new)
- `pnpm exec tsc --noEmit` in `workspaces/platform-workspace` — clean
- `pnpm --filter @mastra/platform-workspace lint` — 0 warnings, 0 errors
- `pnpm exec oxfmt --check` on touched files — clean

## Related

- `@mastra/railway` `RailwaySandbox._scheduleCheckpointRefresh` — the mirror this copies
- mastra-ai/platform PR to remove the proxy-side timer (pairs with this)
- mastra-ai/mastra#20956 (stop/destroy split — same lockstep saga)
