### PR TITLE
fix(core): clear workflow.events.v2 topic on durable agent cleanup

### DIFF
--- a/.changeset/durable-clear-workflow-events-v2.md
+++ b/.changeset/durable-clear-workflow-events-v2.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed DurableAgent terminal cleanup so it also clears `workflow.events.v2.<runId>`, preventing orphaned no-TTL counter keys on persistent caches (#20786).

--- a/packages/core/src/agent/durable/__tests__/durable-agent-workflow-events-cleanup.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-workflow-events-cleanup.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression for #20786.
+ *
+ * Durable agents run on the default workflow engine, so the evented engine's
+ * terminal `workflow.events.v2.<runId>` cleanup never fires. Terminal durable
+ * cleanup must clear that topic itself (alongside `agent.stream.<runId>`),
+ * otherwise a persistent CachingPubSub orphans a no-TTL counter key per run.
+ */
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { Agent } from '../../agent';
+import { AGENT_STREAM_TOPIC } from '../constants';
+import { createDurableAgent } from '../create-durable-agent';
+
+describe('DurableAgent workflow.events.v2 topic cleanup (#20786)', () => {
+  it('clears workflow.events.v2.<runId> when cleanup() runs', async () => {
+    const pubsub = new EventEmitterPubSub();
+
+    const mockModel = new MockLanguageModelV2({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'hi' },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+      }),
+    });
+
+    const baseAgent = new Agent({
+      id: 'cleanup-agent',
+      name: 'Cleanup Agent',
+      instructions: 'test',
+      model: mockModel as LanguageModelV2,
+    });
+    const durableAgent = createDurableAgent({
+      agent: baseAgent,
+      pubsub,
+      cleanupTimeoutMs: 0,
+    });
+
+    // Spy the agent-facing pubsub (CachingPubSub wrapper), which is what
+    // #clearPubsubTopic calls — not the inner EventEmitterPubSub alone.
+    const clearTopic = vi.spyOn(durableAgent.pubsub, 'clearTopic');
+
+    const { runId, cleanup } = await durableAgent.stream('hi');
+    // cleanup() is what #clearPubsubTopic is wired through; no need to drain.
+    cleanup();
+
+    expect(clearTopic).toHaveBeenCalledWith(AGENT_STREAM_TOPIC(runId));
+    expect(clearTopic).toHaveBeenCalledWith(`workflow.events.v2.${runId}`);
+
+    await pubsub.close();
+  });
+});

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -2687,9 +2687,14 @@ export class DurableAgent<
   }
 
   /**
-   * Clear retained pubsub state for a run's topic (cached history and, for
+   * Clear retained pubsub state for a run's topics (cached history and, for
    * persistent transports, the underlying stream). Fire-and-forget: the
    * `clearTopic` contract is best-effort and non-throwing.
+   *
+   * Clears both the agent stream topic and `workflow.events.v2.<runId>`. The
+   * durable agentic loop runs on the default workflow engine, so the evented
+   * engine's terminal topic cleanup never runs for these runs — without this,
+   * CachingPubSub permanently orphans a no-TTL counter key per completed run.
    *
    * Unlike the evented workflow engine's per-run topic cleanup, this needs no
    * restart guard: cleanup timers arm only on terminal outcomes
@@ -2700,6 +2705,7 @@ export class DurableAgent<
    */
   #clearPubsubTopic(runId: string): void {
     void this.pubsub.clearTopic(AGENT_STREAM_TOPIC(runId));
+    void this.pubsub.clearTopic(`workflow.events.v2.${runId}`);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Durable agents build their agentic loop with plain `createWorkflow` (default engine), so the evented engine's terminal `workflow.events.v2.<runId>` cleanup never runs.
- `#clearPubsubTopic` already clears `agent.stream.<runId>`; also clear `workflow.events.v2.<runId>` so persistent `CachingPubSub` does not orphan a no-TTL counter key per completed run.
- Adds a regression test that asserts both topics are cleared via `cleanup()`.

Fixes #20786

## Test plan
- [ ] `vitest run src/agent/durable/__tests__/durable-agent-workflow-events-cleanup.test.ts` in `packages/core`
- [ ] Durable agent stream to terminal FINISH/ERROR/ABORT with a Redis-backed `CachingPubSub` and confirm `workflow.events.v2.<runId>:counter` is removed after cleanup


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a durable agent finishes, this PR removes all temporary run data. This prevents completed runs from leaving unused cache entries behind.

## Changes

- Update durable-agent cleanup to clear both:
  - `agent.stream.<runId>`
  - `workflow.events.v2.<runId>`
- Add a regression test that verifies both topics are cleared.
- Add a patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->