### PR TITLE
docs(factory): add CONTEXT.md and AGENTS.md

### DIFF
--- a/mastracode/factory/AGENTS.md
+++ b/mastracode/factory/AGENTS.md
@@ -5,7 +5,6 @@ vocabulary before touching factory code.
 
 ## Commands
 
-- Build: `pnpm --filter ./mastracode/factory build`
 - Test: `pnpm --filter ./mastracode/factory test`
 - Typecheck: `pnpm --filter ./mastracode/factory check`
 - Lint: `pnpm --filter ./mastracode/factory lint`
@@ -14,41 +13,30 @@ Colocated `*.test.ts` in `src/`.
 
 ## Rules
 
-1. **Providers move in lockstep.** Any capability on `RailwaySandbox` must
-   land on `PlatformSandbox` in the same shape, and vice versa. They are
-   behaviourally interchangeable from the factory's point of view.
+1. **Providers move in lockstep.** Any capability on `RailwaySandbox`
+   must land on `PlatformSandbox` in the same shape, and vice versa.
 
-2. **Provider owns HOW, factory owns WHEN.** Providers expose transport
-   (`captureCheckpoint()`, internal refresh timer). The factory decides
-   when to call it (turn-end, session-idle, pre-teardown). Do not put
-   scheduling logic in a provider. Do not put Railway HTTP details in
-   the factory.
+2. **Provider owns HOW, factory owns WHEN.** Providers own transport
+   (`captureCheckpoint()`, refresh timer). The factory decides when to
+   call it (turn-end, session-idle, teardown). No scheduling in a
+   provider; no Railway HTTP in the factory.
 
-3. **Never fail a turn because a capture failed.** The turn-end hook logs
-   and swallows. The provider's refresh is the fallback.
+3. **Never fail a turn because a capture failed.** The turn-end hook
+   logs and swallows. The provider's refresh is the fallback.
 
-4. **Cache-hit does not re-subscribe.** In `workspace.ts`, per-session
-   subscriptions (e.g. turn-end checkpoint) attach on Materialization only.
-   Attaching on cache-hit produces duplicate subscribers.
+4. **Cache-hit does not re-subscribe.** Per-session subscriptions in
+   `workspace.ts` attach on Materialization only.
 
-5. **Feature-detect optional sandbox methods.** `captureCheckpoint()` is
-   optional on `MaterializationSandbox`; `LocalSandbox` omits it. Callers
-   must check for its presence.
+5. **Feature-detect optional sandbox methods.** `captureCheckpoint()`
+   is optional on `MaterializationSandbox`.
 
-6. **Say the package name.** `@mastra/railway`, not "Mastra Railway"
-   (voice-dictation trap). "The OSS Railway provider" is fine.
+6. **Say the package name.** `@mastra/railway`, not "Mastra Railway".
 
-7. **`RailwaySandboxProvisioner` is platform-only.** Do not reference it
-   as if it lives in this repo. OSS `RailwaySandbox` calls Railway inline.
+7. **`RailwaySandboxProvisioner` is platform-only.** OSS
+   `RailwaySandbox` calls Railway inline; there is no OSS provisioner.
 
 ## Related repos
 
 Platform-side code lives in the private `mastra-ai/platform` monorepo:
-
-- workspace-proxy server: `servers/workspace-proxy/src/`
-- `@platform/workspaces` service: `services/workspaces/src/`
-- `RailwaySandboxProvisioner`: `services/workspaces/src/railway/sandbox-provisioner.ts`
-- Checkpoint endpoint: `POST /v1/projects/:projectId/sandbox/:sandboxId/checkpoint`
-
-Do not modify the platform repo from an OSS PR. Cross-repo work ships as
-two PRs; cross-link them.
+`servers/workspace-proxy/`, `services/workspaces/` (contains
+`RailwaySandboxProvisioner`). Cross-repo work ships as two PRs.

--- a/mastracode/factory/AGENTS.md
+++ b/mastracode/factory/AGENTS.md
@@ -1,0 +1,54 @@
+# @mastra/factory — AGENTS.md
+
+Inherits from `mastracode/AGENTS.md`. Read [CONTEXT.md](./CONTEXT.md) for
+vocabulary before touching factory code.
+
+## Commands
+
+- Build: `pnpm --filter ./mastracode/factory build`
+- Test: `pnpm --filter ./mastracode/factory test`
+- Typecheck: `pnpm --filter ./mastracode/factory check`
+- Lint: `pnpm --filter ./mastracode/factory lint`
+
+Colocated `*.test.ts` in `src/`.
+
+## Rules
+
+1. **Providers move in lockstep.** Any capability on `RailwaySandbox` must
+   land on `PlatformSandbox` in the same shape, and vice versa. They are
+   behaviourally interchangeable from the factory's point of view.
+
+2. **Provider owns HOW, factory owns WHEN.** Providers expose transport
+   (`captureCheckpoint()`, internal refresh timer). The factory decides
+   when to call it (turn-end, session-idle, pre-teardown). Do not put
+   scheduling logic in a provider. Do not put Railway HTTP details in
+   the factory.
+
+3. **Never fail a turn because a capture failed.** The turn-end hook logs
+   and swallows. The provider's refresh is the fallback.
+
+4. **Cache-hit does not re-subscribe.** In `workspace.ts`, per-session
+   subscriptions (e.g. turn-end checkpoint) attach on Materialization only.
+   Attaching on cache-hit produces duplicate subscribers.
+
+5. **Feature-detect optional sandbox methods.** `captureCheckpoint()` is
+   optional on `MaterializationSandbox`; `LocalSandbox` omits it. Callers
+   must check for its presence.
+
+6. **Say the package name.** `@mastra/railway`, not "Mastra Railway"
+   (voice-dictation trap). "The OSS Railway provider" is fine.
+
+7. **`RailwaySandboxProvisioner` is platform-only.** Do not reference it
+   as if it lives in this repo. OSS `RailwaySandbox` calls Railway inline.
+
+## Related repos
+
+Platform-side code lives in the private `mastra-ai/platform` monorepo:
+
+- workspace-proxy server: `servers/workspace-proxy/src/`
+- `@platform/workspaces` service: `services/workspaces/src/`
+- `RailwaySandboxProvisioner`: `services/workspaces/src/railway/sandbox-provisioner.ts`
+- Checkpoint endpoint: `POST /v1/projects/:projectId/sandbox/:sandboxId/checkpoint`
+
+Do not modify the platform repo from an OSS PR. Cross-repo work ships as
+two PRs; cross-link them.

--- a/mastracode/factory/CONTEXT.md
+++ b/mastracode/factory/CONTEXT.md
@@ -1,0 +1,94 @@
+# @mastra/factory
+
+The factory runs agent sessions on remote sandboxes. It is provider-agnostic — it holds a sandbox as `WorkspaceSandbox` and does not know whether that sandbox talks to Railway directly or via the hosted platform's proxy.
+
+## Language
+
+### Runtime shape
+
+**Session**:
+One conversation with one agent on one `AgentController`. Emits lifecycle events (`agent_start`, `agent_end`, …). Keyed by `(resourceId, scope)`.
+_Avoid_: conversation, chat, run, request.
+
+**Turn**:
+One user message and the agent's full response to it, delimited by `agent_start` and `agent_end` events on the Session.
+_Avoid_: request, exchange, round.
+
+**Turn-end**:
+The `agent_end` event on a Session. The moment a turn's work is complete.
+_Avoid_: completion, response-end.
+
+**Session-idle**:
+N minutes elapsed on a Session with no incoming `sendMessage`. Not yet implemented.
+_Avoid_: quiet, dormant.
+
+**Workspace**:
+The factory's per-session bundle of git materialization state plus the sandbox it runs in. Cached per session, materialized lazily.
+_Avoid_: environment, project, workdir.
+
+**Materialization**:
+The act of building a fresh Workspace for a Session (as opposed to a cache hit). Per-session subscriptions attach on materialization only.
+_Avoid_: initialization, setup, hydration.
+
+### Sandbox layer
+
+**Sandbox**:
+A remote VM where the agent's code and tools run. Typed as `WorkspaceSandbox` inside the factory.
+_Avoid_: VM, container, machine (except when referring to the config field below), runner.
+
+**Machine**:
+The template sandbox passed into `MastraFactorySandboxConfig.machine`. Never started; each Session gets a Sandbox `clone()`d from it.
+_Avoid_: template, prototype.
+
+**Provider**:
+A concrete implementation of `WorkspaceSandbox` — currently `RailwaySandbox` (OSS) or `PlatformSandbox` (hosted).
+_Avoid_: backend, driver, adapter.
+
+**OSS path**:
+Factory → `@mastra/railway` `RailwaySandbox` → Railway. Talks to Railway directly with the user's own Railway token. Used when self-hosting.
+_Avoid_: local path, direct path.
+
+**Hosted path**:
+Factory → `@mastra/platform-workspace` `PlatformSandbox` → workspace-proxy → `@platform/workspaces` `RailwaySandboxProvisioner` → Railway. Exists because the platform's Railway token cannot be injected into user servers.
+_Avoid_: platform path, cloud path, proxied path.
+
+**Why two providers**:
+Users self-hosting the factory own their Railway account and pass their own Railway token; the hosted platform runs the factory with the platform's Railway token. Because the platform's token cannot be injected into user servers, the two deployments cannot share a provisioning path. The two `WorkspaceSandbox` implementations must stay behaviourally interchangeable from the factory's point of view — the factory holds either as `WorkspaceSandbox` and never branches on which is present. Any new provider capability must land on both implementations with identical shape.
+
+**SandboxFleet**:
+Owns sandbox provisioning, reattachment, and teardown. Does not hold session-id → sandbox bindings; those live in the workspace layer via `SandboxBindingStore`.
+_Avoid_: pool, manager, registry.
+
+**MaterializationSandbox**:
+The minimal sandbox surface fleet consumers depend on: `id`, `start`, `executeCommand`, `getInfo`, optional `stop`, optional `captureCheckpoint`. Built by `toMaterializationSandbox()` which duck-types optional methods off the underlying provider.
+_Avoid_: LiveSandbox, ActiveSandbox.
+
+**RailwaySandboxProvisioner**:
+The platform-side class in `@platform/workspaces` that calls Railway with the platform's token on behalf of `PlatformSandbox`. **Exists only on the platform side.** The OSS `RailwaySandbox` calls Railway inline; there is no OSS "provisioner".
+_Avoid_: using "provisioner" as a generic term for anything that provisions sandboxes.
+
+### Checkpoint mechanics
+
+**Checkpoint**:
+Railway's mechanism for preserving a sandbox's filesystem so it can be recovered after idle-destroy.
+_Avoid_: snapshot, backup, save.
+
+**Capture**:
+An on-demand, one-shot checkpoint write triggered explicitly via `sandbox.captureCheckpoint()`. Both providers expose this identically.
+_Avoid_: save, write, snapshot.
+
+**Refresh**:
+The provider's internal timer-driven checkpoint write, scheduled shortly before Railway's idle-destroy window. Providers own refresh; the factory never schedules one.
+_Avoid_: renewal, tick.
+
+**Safety-net margin**:
+The seconds before Railway's idle-destroy that Refresh fires. Currently 180s.
+_Avoid_: window, buffer, lead-time.
+
+**CaptureCheckpointResult**:
+Discriminated union returned by `captureCheckpoint()`: `{ status: 'captured' | 'coalesced' | 'skipped', … }`. Identical shape on both providers so the factory logs it uniformly without provider-awareness.
+_Avoid_: CheckpointOutcome, CaptureResult.
+
+**Coalesce**:
+Merge concurrent capture attempts into one upstream Railway call. Handled inside each provider; the factory never coalesces at its own layer.
+_Avoid_: dedupe, batch, join.


### PR DESCRIPTION
## Summary

Adds documentation for the factory's sandbox layer so agents (and humans) working in `mastracode/factory` have a shared vocabulary before touching code. Follows the existing per-package `AGENTS.md` convention already used across this repo (`packages/core`, `packages/memory`, `packages/server`, etc.), plus a new `CONTEXT.md` that acts as the glossary the `AGENTS.md` file leans on.

Two files, ~150 lines total, no code changes.

## Files

**`mastracode/factory/CONTEXT.md`** — glossary in `term` + `_Avoid_:` format. Twenty entries across three sections:

- **Runtime shape:** `Session`, `Turn`, `Turn-end`, `Session-idle`, `Workspace`, `Materialization`
- **Sandbox layer:** `Sandbox`, `Machine`, `Provider`, `OSS path`, `Hosted path`, `Why two providers`, `SandboxFleet`, `MaterializationSandbox`, `RailwaySandboxProvisioner`
- **Checkpoint mechanics:** `Checkpoint`, `Capture`, `Refresh`, `Safety-net margin`, `CaptureCheckpointResult`, `Coalesce`

Each entry pairs the accepted term with the near-synonyms agents keep reaching for instead. The `Why two providers` entry explains the load-bearing constraint (the platform's Railway token cannot be injected into user servers) that forces the OSS-vs-hosted split.

**`mastracode/factory/AGENTS.md`** — package-local rules + commands. Points at `CONTEXT.md` for vocabulary. Codifies the seven rules that were repeatedly broken during recent checkpoint-lifecycle work:

1. Providers move in lockstep.
2. Provider owns HOW, factory owns WHEN.
3. Never fail a turn because a capture failed.
4. Cache-hit does not re-subscribe.
5. Feature-detect optional provider methods.
6. Say the package name (`@mastra/railway`, `@mastra/platform-workspace`) — not "Mastra Railway" (voice-dictation trap) or "the Railway one".
7. `RailwaySandboxProvisioner` is a platform-side concept; it does not exist in this repo.

## Why now

The recent lockstep work on checkpoint capture / refresh / stop-destroy / start-coalescing (#20956, #20959, #20960) surfaced that agents and reviewers were routinely confused about:

- Which sandbox is which — `RailwaySandbox` vs `PlatformSandbox` vs `RailwaySandboxProvisioner` are three "Railway"-adjacent things that live in three different packages across two repos.
- Who owns scheduling vs transport — the refresh timer landed in the wrong layer more than once before settling.
- What "turn-end" means — the `agent_end` event on the Session, not the HTTP response for `/skills/execute`.
- Whether providers must match behaviours — yes, and the invariant was silently broken until #20956 restored it.

Writing this down while the vocabulary is fresh so the next contributor does not relearn the same footguns.

## What did NOT change

- Zero source, test, or build changes.
- No changeset — docs-only, no user-visible package change.
- No changes to the top-level repo `AGENTS.md`; this is package-local.

## Verification

- `AGENTS.md` follows the same shape as other per-package `AGENTS.md` files already in this repo.
- `CONTEXT.md` matches the `mastracode/AGENTS.md` inheritance model.
- Both files render cleanly on GitHub (checked locally).

## Related

The lockstep saga this documents:

- mastra-ai/mastra#20956 (`stop()` / `destroy()` split)
- mastra-ai/mastra#20959 (client-side refresh timer)
- mastra-ai/mastra#20960 (`start()` coalescing)
