### PR TITLE
feat(client): Metro-safe thread-signals client and headless hook

### DIFF
--- a/.changeset/fresh-thread-signals-client.md
+++ b/.changeset/fresh-thread-signals-client.md
@@ -1,0 +1,17 @@
+---
+'@mastra/client-js': minor
+---
+
+Added a platform-neutral thread-signals client for browsers and React Native. It subscribes to native thread runs, exposes run snapshots, reconnects, and provides message, queue, approval, abort, and history operations without web UI or Node-only runtime dependencies.
+
+```ts
+const subscription = await client.getAgent('supportAgent').subscribeToThread({
+  resourceId: 'user-1',
+  threadId: 'thread-1',
+});
+
+await subscription.processDataStream({
+  onChunk: chunk => console.log(chunk),
+  reconnect: true,
+});
+```

--- a/.changeset/fresh-thread-signals-react.md
+++ b/.changeset/fresh-thread-signals-react.md
@@ -1,0 +1,13 @@
+---
+'@mastra/react': minor
+---
+
+Added a headless React hook that subscribes before loading history and projects Mastra's native thread run state without importing web UI components.
+
+```tsx
+const { messages, snapshot, sendMessage, abort } = useThreadSignals({
+  client,
+  resourceId: 'user-1',
+  threadId: 'thread-1',
+});
+```

--- a/.changeset/fresh-thread-signals-server.md
+++ b/.changeset/fresh-thread-signals-server.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': minor
+---
+
+Thread subscriptions now emit an initial transient `data-thread-state` chunk so refreshed and secondary clients immediately receive the thread's running, suspended, or idle state.

--- a/.changeset/fresh-threads-signal.md
+++ b/.changeset/fresh-threads-signal.md
@@ -1,0 +1,9 @@
+---
+'@mastra/client-js': minor
+'@mastra/react': minor
+'@mastra/server': minor
+---
+
+Added a platform-neutral thread-signals client and headless React hook for browsers and React Native. The new conditional exports subscribe before loading history, expose the active run snapshot, reconnect through the native thread subscription, and provide native message, queue, approval, abort, and history operations without importing web UI or Node-only runtime code.
+
+Thread subscriptions now emit an initial transient `data-thread-state` chunk so a refreshed or second client immediately receives the thread's running, suspended, or idle state.

--- a/.changeset/fresh-threads-signal.md
+++ b/.changeset/fresh-threads-signal.md
@@ -1,9 +1,0 @@
----
-'@mastra/client-js': minor
-'@mastra/react': minor
-'@mastra/server': minor
----
-
-Added a platform-neutral thread-signals client and headless React hook for browsers and React Native. The new conditional exports subscribe before loading history, expose the active run snapshot, reconnect through the native thread subscription, and provide native message, queue, approval, abort, and history operations without importing web UI or Node-only runtime code.
-
-Thread subscriptions now emit an initial transient `data-thread-state` chunk so a refreshed or second client immediately receives the thread's running, suspended, or idle state.

--- a/client-sdks/client-js/package.json
+++ b/client-sdks/client-js/package.json
@@ -21,6 +21,24 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./thread-signals": {
+      "react-native": {
+        "types": "./dist/thread-signals/index.d.ts",
+        "default": "./dist/thread-signals/index.js"
+      },
+      "browser": {
+        "types": "./dist/thread-signals/index.d.ts",
+        "default": "./dist/thread-signals/index.js"
+      },
+      "import": {
+        "types": "./dist/thread-signals/index.d.ts",
+        "default": "./dist/thread-signals/index.js"
+      },
+      "require": {
+        "types": "./dist/thread-signals/index.d.ts",
+        "default": "./dist/thread-signals/index.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "repository": {

--- a/client-sdks/client-js/src/thread-signals/client.ts
+++ b/client-sdks/client-js/src/thread-signals/client.ts
@@ -1,0 +1,236 @@
+import { processThreadSignalStream } from './stream';
+import type {
+  ProcessThreadSignalsOptions,
+  ThreadMessageAccepted,
+  ThreadMessageHistory,
+  ThreadMessageHistoryOptions,
+  ThreadMessageInput,
+  ThreadSignalChunk,
+  ThreadSignalRunSnapshot,
+  ThreadSignalsClientOptions,
+  ThreadSignalsSubscription,
+  ThreadTarget,
+  ThreadToolApprovalAccepted,
+  ThreadToolApprovalInput,
+} from './types';
+
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const THREAD_RUN_STATUSES = new Set(['idle', 'running', 'suspended', 'completed', 'failed', 'aborted']);
+
+function normalizePath(path: string): string {
+  const normalized = path.trim().replace(/\/+/g, '/').replace(/\/$/, '');
+  if (!normalized || normalized === '/') return '';
+  if (normalized.includes('..') || normalized.includes('?') || normalized.includes('#')) {
+    throw new Error(`Invalid API prefix: "${path}"`);
+  }
+  return normalized.startsWith('/') ? normalized : `/${normalized}`;
+}
+
+function encodeBase64Utf8(value: unknown): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  let result = '';
+  for (let index = 0; index < bytes.length; index += 3) {
+    const first = bytes[index] ?? 0;
+    const second = bytes[index + 1];
+    const third = bytes[index + 2];
+    const combined = (first << 16) | ((second ?? 0) << 8) | (third ?? 0);
+    result += BASE64_ALPHABET[(combined >> 18) & 63];
+    result += BASE64_ALPHABET[(combined >> 12) & 63];
+    result += second === undefined ? '=' : BASE64_ALPHABET[(combined >> 6) & 63];
+    result += third === undefined ? '=' : BASE64_ALPHABET[combined & 63];
+  }
+  return result;
+}
+
+function snapshotFromChunk(
+  current: ThreadSignalRunSnapshot,
+  chunk: ThreadSignalChunk,
+): ThreadSignalRunSnapshot | undefined {
+  if (
+    chunk.type === 'data-thread-state' &&
+    chunk.data &&
+    typeof chunk.data === 'object' &&
+    'status' in chunk.data &&
+    typeof chunk.data.status === 'string' &&
+    THREAD_RUN_STATUSES.has(chunk.data.status) &&
+    'updatedAt' in chunk.data &&
+    typeof chunk.data.updatedAt === 'string'
+  ) {
+    return chunk.data as unknown as ThreadSignalRunSnapshot;
+  }
+
+  const runId = typeof chunk.runId === 'string' ? chunk.runId : current.runId;
+  const updatedAt = new Date().toISOString();
+  if (chunk.type === 'start' || chunk.type === 'agent-execution-start') {
+    return { runId, status: 'running', updatedAt };
+  }
+  if (
+    chunk.type === 'suspended' ||
+    chunk.type === 'tool-call-suspended' ||
+    chunk.type === 'agent-execution-suspended'
+  ) {
+    return { runId, status: 'suspended', updatedAt };
+  }
+  if (chunk.type === 'finish' || chunk.type === 'agent-execution-end') {
+    return { runId, status: 'completed', updatedAt };
+  }
+  if (chunk.type === 'error') return { runId, status: 'failed', updatedAt };
+  if (chunk.type === 'abort' || chunk.type === 'agent-execution-abort') {
+    return { runId, status: 'aborted', updatedAt };
+  }
+  return undefined;
+}
+
+export class ThreadSignalsClient {
+  readonly #options: ThreadSignalsClientOptions;
+  readonly #apiPrefix: string;
+  readonly #fetch: typeof globalThis.fetch;
+
+  constructor(options: ThreadSignalsClientOptions) {
+    this.#options = options;
+    this.#apiPrefix = normalizePath(options.apiPrefix ?? '/api');
+    this.#fetch = options.fetch ?? globalThis.fetch;
+    if (!this.#fetch) {
+      throw new Error('ThreadSignalsClient requires a fetch implementation');
+    }
+  }
+
+  async #request<T>(path: string, init: RequestInit = {}, stream = false): Promise<T> {
+    const response = await this.#fetch(`${this.#options.baseUrl.replace(/\/$/, '')}${this.#apiPrefix}${path}`, {
+      ...init,
+      credentials: init.credentials ?? this.#options.credentials,
+      signal: init.signal ?? this.#options.abortSignal,
+      headers: {
+        ...(init.body ? { 'content-type': 'application/json' } : {}),
+        ...this.#options.headers,
+        ...init.headers,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Mastra thread request failed (${response.status}): ${await response.text()}`);
+    }
+    return (stream ? response : await response.json()) as T;
+  }
+
+  sendMessage(params: ThreadMessageInput): Promise<ThreadMessageAccepted> {
+    return this.#request(`/agents/${this.#options.agentId}/send-message`, {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  queueMessage(params: ThreadMessageInput): Promise<ThreadMessageAccepted> {
+    return this.#request(`/agents/${this.#options.agentId}/queue-message`, {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  sendToolApproval(params: ThreadToolApprovalInput): Promise<ThreadToolApprovalAccepted> {
+    return this.#request(`/agents/${this.#options.agentId}/send-tool-approval`, {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  listMessages<TMessage = unknown>(
+    threadId: string,
+    options: ThreadMessageHistoryOptions = {},
+  ): Promise<ThreadMessageHistory<TMessage>> {
+    const { requestContext, ...queryOptions } = options;
+    const query = new URLSearchParams();
+    query.set('agentId', this.#options.agentId);
+    for (const [key, value] of Object.entries(queryOptions)) {
+      if (value === undefined) continue;
+      query.set(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
+    }
+    if (requestContext) query.set('requestContext', encodeBase64Utf8(requestContext));
+    return this.#request(`/memory/threads/${encodeURIComponent(threadId)}/messages?${query.toString()}`);
+  }
+
+  async subscribeToThread(target: ThreadTarget): Promise<ThreadSignalsSubscription> {
+    const localAbort = new AbortController();
+    let unsubscribed = false;
+    let response = await this.#openSubscription(target, localAbort.signal);
+    let snapshot: ThreadSignalRunSnapshot = {
+      status: 'idle',
+      updatedAt: new Date().toISOString(),
+    };
+
+    const subscription: ThreadSignalsSubscription = {
+      get snapshot() {
+        return snapshot;
+      },
+      processDataStream: async options => {
+        const reconnect =
+          options.reconnect === true
+            ? { maxRetries: Infinity, delayMs: 1000 }
+            : options.reconnect
+              ? {
+                  maxRetries: options.reconnect.maxRetries ?? Infinity,
+                  delayMs: options.reconnect.delayMs ?? 1000,
+                }
+              : undefined;
+        let attempts = 0;
+
+        while (!unsubscribed) {
+          if (!response.body) throw new Error('Mastra thread subscription returned no response body');
+          try {
+            await processThreadSignalStream({
+              stream: response.body,
+              signal: localAbort.signal,
+              onChunk: async chunk => {
+                const nextSnapshot = snapshotFromChunk(snapshot, chunk);
+                if (nextSnapshot) {
+                  snapshot = nextSnapshot;
+                  await options.onSnapshot?.(snapshot);
+                }
+                await options.onChunk(chunk);
+              },
+            });
+          } catch (error) {
+            if (unsubscribed || localAbort.signal.aborted) return;
+            if (!reconnect || attempts >= reconnect.maxRetries) throw error;
+          }
+
+          if (!reconnect || attempts >= reconnect.maxRetries) return;
+          attempts += 1;
+          await new Promise(resolve => setTimeout(resolve, reconnect.delayMs));
+          if (unsubscribed || localAbort.signal.aborted) return;
+          response = await this.#openSubscription(target, localAbort.signal);
+        }
+      },
+      abort: async () => {
+        const result = await this.#request<{ aborted: boolean }>(`/agents/${this.#options.agentId}/threads/abort`, {
+          method: 'POST',
+          body: JSON.stringify(target),
+        });
+        return result.aborted;
+      },
+      unsubscribe: () => {
+        if (unsubscribed) return;
+        unsubscribed = true;
+        localAbort.abort();
+        void response.body?.cancel().catch(() => {});
+      },
+    };
+
+    return subscription;
+  }
+
+  #openSubscription(target: ThreadTarget, signal: AbortSignal): Promise<Response> {
+    return this.#request(
+      `/agents/${this.#options.agentId}/threads/subscribe`,
+      {
+        method: 'POST',
+        body: JSON.stringify(target),
+        signal,
+      },
+      true,
+    );
+  }
+}
+
+export function createThreadSignalsClient(options: ThreadSignalsClientOptions): ThreadSignalsClient {
+  return new ThreadSignalsClient(options);
+}

--- a/client-sdks/client-js/src/thread-signals/index.ts
+++ b/client-sdks/client-js/src/thread-signals/index.ts
@@ -1,0 +1,17 @@
+export { createThreadSignalsClient, ThreadSignalsClient } from './client';
+export { processThreadSignalStream } from './stream';
+export type {
+  ProcessThreadSignalsOptions,
+  ThreadMessageAccepted,
+  ThreadMessageHistory,
+  ThreadMessageHistoryOptions,
+  ThreadMessageInput,
+  ThreadSignalChunk,
+  ThreadSignalRunSnapshot,
+  ThreadSignalRunStatus,
+  ThreadSignalsClientOptions,
+  ThreadSignalsSubscription,
+  ThreadTarget,
+  ThreadToolApprovalAccepted,
+  ThreadToolApprovalInput,
+} from './types';

--- a/client-sdks/client-js/src/thread-signals/stream.ts
+++ b/client-sdks/client-js/src/thread-signals/stream.ts
@@ -1,0 +1,48 @@
+import type { ThreadSignalChunk } from './types';
+
+function parseEventBlock(block: string): ThreadSignalChunk | 'done' | undefined {
+  const data = block
+    .split(/\r?\n/)
+    .filter(line => line.startsWith('data:'))
+    .map(line => line.slice(5).trimStart())
+    .join('\n');
+  if (!data) return undefined;
+  if (data === '[DONE]') return 'done';
+  return JSON.parse(data) as ThreadSignalChunk;
+}
+
+export async function processThreadSignalStream(options: {
+  stream: ReadableStream<Uint8Array>;
+  onChunk: (chunk: ThreadSignalChunk) => void | Promise<void>;
+  signal?: AbortSignal;
+}): Promise<void> {
+  const reader = options.stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const abort = () => void reader.cancel();
+
+  if (options.signal?.aborted) abort();
+  else options.signal?.addEventListener('abort', abort, { once: true });
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      buffer += decoder.decode(value, { stream: !done });
+      const blocks = buffer.split(/\r?\n\r?\n/);
+      buffer = blocks.pop() ?? '';
+
+      for (const block of blocks) {
+        const event = parseEventBlock(block);
+        if (event === 'done') return;
+        if (event) await options.onChunk(event);
+      }
+      if (done) break;
+    }
+
+    const finalEvent = parseEventBlock(buffer);
+    if (finalEvent && finalEvent !== 'done') await options.onChunk(finalEvent);
+  } finally {
+    options.signal?.removeEventListener('abort', abort);
+    reader.releaseLock();
+  }
+}

--- a/client-sdks/client-js/src/thread-signals/stream.ts
+++ b/client-sdks/client-js/src/thread-signals/stream.ts
@@ -27,11 +27,13 @@ export async function processThreadSignalStream(options: {
   try {
     while (true) {
       const { done, value } = await reader.read();
+      if (options.signal?.aborted) return;
       buffer += decoder.decode(value, { stream: !done });
       const blocks = buffer.split(/\r?\n\r?\n/);
       buffer = blocks.pop() ?? '';
 
       for (const block of blocks) {
+        if (options.signal?.aborted) return;
         const event = parseEventBlock(block);
         if (event === 'done') return;
         if (event) await options.onChunk(event);
@@ -39,6 +41,7 @@ export async function processThreadSignalStream(options: {
       if (done) break;
     }
 
+    if (options.signal?.aborted) return;
     const finalEvent = parseEventBlock(buffer);
     if (finalEvent && finalEvent !== 'done') await options.onChunk(finalEvent);
   } finally {

--- a/client-sdks/client-js/src/thread-signals/thread-signals.test.ts
+++ b/client-sdks/client-js/src/thread-signals/thread-signals.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createThreadSignalsClient } from './client';
+import { processThreadSignalStream } from './stream';
+
+function sseResponse(events: string[]): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const event of events) controller.enqueue(encoder.encode(event));
+        controller.close();
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+describe('thread signals client', () => {
+  it('parses fragmented SSE events without a platform-specific decoder', async () => {
+    const chunks: unknown[] = [];
+    await processThreadSignalStream({
+      stream: sseResponse([
+        'data: {"type":"start","runId":"run-1"}\r',
+        '\n\r\ndata: {"type":"text-delta","payload":{"text":"hello"}}\n\n',
+      ]).body!,
+      onChunk: chunk => {
+        chunks.push(chunk);
+      },
+    });
+
+    expect(chunks).toEqual([
+      { type: 'start', runId: 'run-1' },
+      { type: 'text-delta', payload: { text: 'hello' } },
+    ]);
+  });
+
+  it('exposes the initial active-run snapshot on subscription', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(
+        sseResponse([
+          'data: {"type":"data-thread-state","data":{"runId":"run-1","status":"running","updatedAt":"2026-08-07T00:00:00.000Z"}}\n\n',
+        ]),
+      );
+    const client = createThreadSignalsClient({
+      baseUrl: 'https://example.com',
+      agentId: 'agent-1',
+      fetch,
+    });
+    const subscription = await client.subscribeToThread({ threadId: 'thread-1' });
+    const snapshots: unknown[] = [];
+
+    await subscription.processDataStream({
+      onChunk: () => {},
+      onSnapshot: snapshot => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    expect(subscription.snapshot).toMatchObject({ runId: 'run-1', status: 'running' });
+    expect(snapshots).toHaveLength(1);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.com/api/agents/agent-1/threads/subscribe',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('uses native message, queue, approval, and abort routes', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockImplementation(async (_input, init) => {
+      if (String(_input).endsWith('/threads/subscribe')) return sseResponse([]);
+      const body = JSON.parse(String(init?.body)) as { toolCallId?: string };
+      if (String(_input).endsWith('/threads/abort')) {
+        return Response.json({ aborted: true });
+      }
+      return Response.json({
+        accepted: true,
+        runId: 'run-1',
+        ...(body.toolCallId ? { toolCallId: body.toolCallId } : {}),
+      });
+    });
+    const client = createThreadSignalsClient({
+      baseUrl: 'https://example.com',
+      agentId: 'agent-1',
+      fetch,
+    });
+
+    await expect(client.sendMessage({ threadId: 'thread-1', message: 'start' })).resolves.toMatchObject({
+      accepted: true,
+    });
+    await expect(client.queueMessage({ threadId: 'thread-1', message: 'next' })).resolves.toMatchObject({
+      accepted: true,
+    });
+    await expect(
+      client.sendToolApproval({
+        threadId: 'thread-1',
+        toolCallId: 'tool-1',
+        approved: true,
+      }),
+    ).resolves.toMatchObject({ toolCallId: 'tool-1' });
+    const subscription = await client.subscribeToThread({ threadId: 'thread-1' });
+    await expect(subscription.abort()).resolves.toBe(true);
+    subscription.unsubscribe();
+  });
+});

--- a/client-sdks/client-js/src/thread-signals/thread-signals.test.ts
+++ b/client-sdks/client-js/src/thread-signals/thread-signals.test.ts
@@ -34,6 +34,24 @@ describe('thread signals client', () => {
     ]);
   });
 
+  it('stops dispatching buffered events after the stream is aborted', async () => {
+    const controller = new AbortController();
+    const chunks: unknown[] = [];
+
+    await processThreadSignalStream({
+      stream: sseResponse([
+        'data: {"type":"start","runId":"run-1"}\n\ndata: {"type":"text-delta","payload":{"text":"late"}}\n\n',
+      ]).body!,
+      signal: controller.signal,
+      onChunk: chunk => {
+        chunks.push(chunk);
+        controller.abort();
+      },
+    });
+
+    expect(chunks).toEqual([{ type: 'start', runId: 'run-1' }]);
+  });
+
   it('exposes the initial active-run snapshot on subscription', async () => {
     const fetch = vi
       .fn<typeof globalThis.fetch>()
@@ -100,5 +118,13 @@ describe('thread signals client', () => {
     const subscription = await client.subscribeToThread({ threadId: 'thread-1' });
     await expect(subscription.abort()).resolves.toBe(true);
     subscription.unsubscribe();
+
+    expect(fetch.mock.calls.map(([input]) => String(input))).toEqual([
+      'https://example.com/api/agents/agent-1/send-message',
+      'https://example.com/api/agents/agent-1/queue-message',
+      'https://example.com/api/agents/agent-1/send-tool-approval',
+      'https://example.com/api/agents/agent-1/threads/subscribe',
+      'https://example.com/api/agents/agent-1/threads/abort',
+    ]);
   });
 });

--- a/client-sdks/client-js/src/thread-signals/types.ts
+++ b/client-sdks/client-js/src/thread-signals/types.ts
@@ -1,0 +1,92 @@
+export type ThreadSignalRunStatus = 'idle' | 'running' | 'suspended' | 'completed' | 'failed' | 'aborted';
+
+export interface ThreadSignalRunSnapshot {
+  runId?: string;
+  status: ThreadSignalRunStatus;
+  updatedAt: string;
+}
+
+export interface ThreadSignalChunk {
+  type: string;
+  runId?: string;
+  payload?: unknown;
+  data?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ThreadSignalsClientOptions {
+  baseUrl: string;
+  agentId: string;
+  apiPrefix?: string;
+  headers?: Record<string, string>;
+  credentials?: 'omit' | 'same-origin' | 'include';
+  fetch?: typeof globalThis.fetch;
+  abortSignal?: AbortSignal;
+}
+
+export interface ThreadTarget {
+  resourceId?: string;
+  threadId: string;
+}
+
+export interface ThreadMessageInput {
+  message: unknown;
+  resourceId?: string;
+  threadId: string;
+  [key: string]: unknown;
+}
+
+export interface ThreadToolApprovalInput extends ThreadTarget {
+  toolCallId: string;
+  approved: boolean;
+  requestContext?: Record<string, unknown>;
+  messages?: unknown;
+  streamOptions?: Record<string, unknown>;
+}
+
+export interface ThreadMessageAccepted {
+  accepted: true;
+  runId: string;
+  signal?: unknown;
+}
+
+export interface ThreadToolApprovalAccepted extends ThreadMessageAccepted {
+  toolCallId: string;
+}
+
+export interface ThreadMessageHistoryOptions {
+  resourceId?: string;
+  page?: number;
+  perPage?: number;
+  orderBy?: Record<string, unknown>;
+  filter?: Record<string, unknown>;
+  include?: Record<string, unknown>;
+  includeSystemReminders?: boolean;
+  requestContext?: Record<string, unknown>;
+}
+
+export interface ThreadMessageHistory<TMessage = unknown> {
+  messages: TMessage[];
+  total: number;
+  page: number;
+  perPage: number;
+  hasMore: boolean;
+}
+
+export interface ProcessThreadSignalsOptions {
+  onChunk: (chunk: ThreadSignalChunk) => void | Promise<void>;
+  onSnapshot?: (snapshot: ThreadSignalRunSnapshot) => void | Promise<void>;
+  reconnect?:
+    | boolean
+    | {
+        maxRetries?: number;
+        delayMs?: number;
+      };
+}
+
+export interface ThreadSignalsSubscription {
+  readonly snapshot: ThreadSignalRunSnapshot;
+  processDataStream(options: ProcessThreadSignalsOptions): Promise<void>;
+  abort(): Promise<boolean>;
+  unsubscribe(): void;
+}

--- a/client-sdks/client-js/tsdown.config.ts
+++ b/client-sdks/client-js/tsdown.config.ts
@@ -2,7 +2,7 @@ import { generateTypes } from '@internal/types-builder';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/thread-signals/index.ts'],
   format: ['esm', 'cjs'],
   fixedExtension: false,
   nodeProtocol: 'strip',

--- a/client-sdks/react/package.json
+++ b/client-sdks/react/package.json
@@ -36,6 +36,24 @@
         "default": "./dist/ui/index.cjs"
       }
     },
+    "./thread-signals": {
+      "react-native": {
+        "types": "./dist/thread-signals/index.d.ts",
+        "default": "./dist/thread-signals/index.js"
+      },
+      "browser": {
+        "types": "./dist/thread-signals/index.d.ts",
+        "default": "./dist/thread-signals/index.js"
+      },
+      "import": {
+        "types": "./dist/thread-signals/index.d.ts",
+        "default": "./dist/thread-signals/index.js"
+      },
+      "require": {
+        "types": "./dist/thread-signals/index.d.ts",
+        "default": "./dist/thread-signals/index.cjs"
+      }
+    },
     "./styles.css": "./dist/react.css"
   },
   "scripts": {
@@ -68,6 +86,17 @@
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",
     "zod": "^3.25.0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@mastra/core": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "zod": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/client-sdks/react/src/thread-signals/index.ts
+++ b/client-sdks/react/src/thread-signals/index.ts
@@ -1,0 +1,18 @@
+export { useThreadSignals } from './use-thread-signals';
+export type { UseThreadSignalsOptions, UseThreadSignalsResult } from './use-thread-signals';
+export { createThreadSignalsClient, ThreadSignalsClient } from '@mastra/client-js/thread-signals';
+export type {
+  ProcessThreadSignalsOptions,
+  ThreadMessageAccepted,
+  ThreadMessageHistory,
+  ThreadMessageHistoryOptions,
+  ThreadMessageInput,
+  ThreadSignalChunk,
+  ThreadSignalRunSnapshot,
+  ThreadSignalRunStatus,
+  ThreadSignalsClientOptions,
+  ThreadSignalsSubscription,
+  ThreadTarget,
+  ThreadToolApprovalAccepted,
+  ThreadToolApprovalInput,
+} from '@mastra/client-js/thread-signals';

--- a/client-sdks/react/src/thread-signals/use-thread-signals.test.tsx
+++ b/client-sdks/react/src/thread-signals/use-thread-signals.test.tsx
@@ -63,4 +63,74 @@ describe('useThreadSignals', () => {
     unmount();
     expect(unsubscribe).toHaveBeenCalledOnce();
   });
+
+  it('clears old messages and ignores stale history after switching threads', async () => {
+    const historyResolvers = new Map<
+      string,
+      (value: {
+        messages: Array<{ id: string }>;
+        total: number;
+        page: number;
+        perPage: number;
+        hasMore: boolean;
+      }) => void
+    >();
+    const subscriptions: ThreadSignalsSubscription[] = [];
+    const client = {
+      subscribeToThread: vi.fn(async () => {
+        const subscription: ThreadSignalsSubscription = {
+          snapshot: { status: 'idle', updatedAt: '2026-08-07T00:00:00.000Z' },
+          processDataStream: vi.fn(async () => {}),
+          abort: vi.fn(async () => true),
+          unsubscribe: vi.fn(),
+        };
+        subscriptions.push(subscription);
+        return subscription;
+      }),
+      listMessages: vi.fn(
+        (threadId: string) =>
+          new Promise(resolve => {
+            historyResolvers.set(threadId, resolve);
+          }),
+      ),
+      sendMessage: vi.fn(),
+      queueMessage: vi.fn(),
+      sendToolApproval: vi.fn(),
+    } as unknown as ThreadSignalsClient;
+
+    const { result, rerender } = renderHook(
+      ({ threadId }) => useThreadSignals<{ id: string }>({ client, threadId }),
+      { initialProps: { threadId: 'thread-1' } },
+    );
+
+    await waitFor(() => expect(historyResolvers.has('thread-1')).toBe(true));
+    rerender({ threadId: 'thread-2' });
+
+    expect(result.current.messages).toEqual([]);
+    await waitFor(() => expect(historyResolvers.has('thread-2')).toBe(true));
+
+    await act(async () => {
+      historyResolvers.get('thread-2')?.({
+        messages: [{ id: 'message-2' }],
+        total: 1,
+        page: 0,
+        perPage: 100,
+        hasMore: false,
+      });
+    });
+    await waitFor(() => expect(result.current.messages).toEqual([{ id: 'message-2' }]));
+
+    await act(async () => {
+      historyResolvers.get('thread-1')?.({
+        messages: [{ id: 'message-1' }],
+        total: 1,
+        page: 0,
+        perPage: 100,
+        hasMore: false,
+      });
+    });
+
+    expect(result.current.messages).toEqual([{ id: 'message-2' }]);
+    expect(subscriptions[0]?.unsubscribe).toHaveBeenCalledOnce();
+  });
 });

--- a/client-sdks/react/src/thread-signals/use-thread-signals.test.tsx
+++ b/client-sdks/react/src/thread-signals/use-thread-signals.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import type { ThreadSignalsClient, ThreadSignalsSubscription } from '@mastra/client-js/thread-signals';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useThreadSignals } from './use-thread-signals';
+
+describe('useThreadSignals', () => {
+  it('subscribes before loading history and projects the native run snapshot', async () => {
+    const calls: string[] = [];
+    const unsubscribe = vi.fn();
+    const subscription: ThreadSignalsSubscription = {
+      snapshot: { status: 'idle', updatedAt: '2026-08-07T00:00:00.000Z' },
+      processDataStream: vi.fn(async options => {
+        await options.onSnapshot?.({
+          runId: 'run-1',
+          status: 'running',
+          updatedAt: '2026-08-07T00:00:01.000Z',
+        });
+        await options.onChunk({ type: 'start', runId: 'run-1' });
+      }),
+      abort: vi.fn(async () => true),
+      unsubscribe,
+    };
+    const client = {
+      subscribeToThread: vi.fn(async () => {
+        calls.push('subscribe');
+        return subscription;
+      }),
+      listMessages: vi.fn(async () => {
+        calls.push('history');
+        return {
+          messages: [{ id: 'message-1' }],
+          total: 1,
+          page: 0,
+          perPage: 100,
+          hasMore: false,
+        };
+      }),
+      sendMessage: vi.fn(async () => ({ accepted: true, runId: 'run-1' })),
+      queueMessage: vi.fn(async () => ({ accepted: true, runId: 'run-1' })),
+      sendToolApproval: vi.fn(async () => ({
+        accepted: true,
+        runId: 'run-1',
+        toolCallId: 'tool-1',
+      })),
+    } as unknown as ThreadSignalsClient;
+
+    const { result, unmount } = renderHook(() =>
+      useThreadSignals<{ id: string }>({
+        client,
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+      }),
+    );
+
+    await waitFor(() => expect(result.current.snapshot.status).toBe('running'));
+    expect(calls).toEqual(['subscribe', 'history']);
+    expect(result.current.messages).toEqual([{ id: 'message-1' }]);
+    expect(result.current.chunks).toEqual([{ type: 'start', runId: 'run-1' }]);
+
+    await act(() => result.current.abort());
+    expect(subscription.abort).toHaveBeenCalledOnce();
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+});

--- a/client-sdks/react/src/thread-signals/use-thread-signals.ts
+++ b/client-sdks/react/src/thread-signals/use-thread-signals.ts
@@ -1,0 +1,148 @@
+import type {
+  ProcessThreadSignalsOptions,
+  ThreadMessageAccepted,
+  ThreadMessageHistoryOptions,
+  ThreadMessageInput,
+  ThreadSignalChunk,
+  ThreadSignalRunSnapshot,
+  ThreadSignalsClient,
+  ThreadSignalsSubscription,
+  ThreadToolApprovalAccepted,
+  ThreadToolApprovalInput,
+} from '@mastra/client-js/thread-signals';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseThreadSignalsOptions<TMessage = unknown> {
+  client: ThreadSignalsClient;
+  threadId: string;
+  resourceId?: string;
+  history?: ThreadMessageHistoryOptions | false;
+  reconnect?: ProcessThreadSignalsOptions['reconnect'];
+  onChunk?: (chunk: ThreadSignalChunk) => void | Promise<void>;
+}
+
+export interface UseThreadSignalsResult<TMessage = unknown> {
+  snapshot: ThreadSignalRunSnapshot;
+  messages: TMessage[];
+  chunks: ThreadSignalChunk[];
+  isLoadingHistory: boolean;
+  error: Error | undefined;
+  reloadHistory(): Promise<void>;
+  sendMessage(params: Omit<ThreadMessageInput, 'threadId' | 'resourceId'>): Promise<ThreadMessageAccepted>;
+  queueMessage(params: Omit<ThreadMessageInput, 'threadId' | 'resourceId'>): Promise<ThreadMessageAccepted>;
+  sendToolApproval(
+    params: Omit<ThreadToolApprovalInput, 'threadId' | 'resourceId'>,
+  ): Promise<ThreadToolApprovalAccepted>;
+  abort(): Promise<boolean>;
+}
+
+const IDLE_SNAPSHOT: ThreadSignalRunSnapshot = {
+  status: 'idle',
+  updatedAt: new Date(0).toISOString(),
+};
+const EMPTY_HISTORY: ThreadMessageHistoryOptions = {};
+
+export function useThreadSignals<TMessage = unknown>(
+  options: UseThreadSignalsOptions<TMessage>,
+): UseThreadSignalsResult<TMessage> {
+  const { client, threadId, resourceId, history = EMPTY_HISTORY, reconnect = true, onChunk } = options;
+  const subscriptionRef = useRef<ThreadSignalsSubscription | undefined>(undefined);
+  const onChunkRef = useRef(onChunk);
+  const historyRef = useRef(history);
+  const reconnectRef = useRef(reconnect);
+  const [snapshot, setSnapshot] = useState<ThreadSignalRunSnapshot>(IDLE_SNAPSHOT);
+  const [messages, setMessages] = useState<TMessage[]>([]);
+  const [chunks, setChunks] = useState<ThreadSignalChunk[]>([]);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(history !== false);
+  const [error, setError] = useState<Error>();
+  onChunkRef.current = onChunk;
+  historyRef.current = history;
+  reconnectRef.current = reconnect;
+
+  const reloadHistory = useCallback(async () => {
+    const currentHistory = historyRef.current;
+    if (currentHistory === false) return;
+    setIsLoadingHistory(true);
+    try {
+      const result = await client.listMessages<TMessage>(threadId, {
+        ...currentHistory,
+        resourceId: currentHistory.resourceId ?? resourceId,
+      });
+      setMessages(result.messages);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught : new Error(String(caught)));
+    } finally {
+      setIsLoadingHistory(false);
+    }
+  }, [client, resourceId, threadId]);
+
+  useEffect(() => {
+    let mounted = true;
+    setSnapshot(IDLE_SNAPSHOT);
+    setChunks([]);
+    setError(undefined);
+
+    void (async () => {
+      try {
+        const subscription = await client.subscribeToThread({ resourceId, threadId });
+        if (!mounted) {
+          subscription.unsubscribe();
+          return;
+        }
+        subscriptionRef.current = subscription;
+        void subscription
+          .processDataStream({
+            reconnect: reconnectRef.current,
+            onSnapshot: next => {
+              if (mounted) setSnapshot(next);
+            },
+            onChunk: async chunk => {
+              if (!mounted) return;
+              if (chunk.type !== 'data-thread-state') setChunks(current => [...current, chunk]);
+              await onChunkRef.current?.(chunk);
+            },
+          })
+          .catch(caught => {
+            if (mounted) setError(caught instanceof Error ? caught : new Error(String(caught)));
+          });
+        await reloadHistory();
+      } catch (caught) {
+        if (mounted) setError(caught instanceof Error ? caught : new Error(String(caught)));
+      }
+    })();
+
+    return () => {
+      mounted = false;
+      subscriptionRef.current?.unsubscribe();
+      subscriptionRef.current = undefined;
+    };
+  }, [client, reloadHistory, resourceId, threadId]);
+
+  return {
+    snapshot,
+    messages,
+    chunks,
+    isLoadingHistory,
+    error,
+    reloadHistory,
+    sendMessage: params =>
+      client.sendMessage({
+        ...params,
+        threadId,
+        ...(resourceId ? { resourceId } : {}),
+      }),
+    queueMessage: params =>
+      client.queueMessage({
+        ...params,
+        threadId,
+        ...(resourceId ? { resourceId } : {}),
+      }),
+    sendToolApproval: params =>
+      client.sendToolApproval({
+        ...params,
+        threadId,
+        ...(resourceId ? { resourceId } : {}),
+      }),
+    abort: async () => subscriptionRef.current?.abort() ?? false,
+  };
+}

--- a/client-sdks/react/src/thread-signals/use-thread-signals.ts
+++ b/client-sdks/react/src/thread-signals/use-thread-signals.ts
@@ -21,6 +21,9 @@ export interface UseThreadSignalsOptions<TMessage = unknown> {
   onChunk?: (chunk: ThreadSignalChunk) => void | Promise<void>;
 }
 
+type ThreadMessageHookInput = Omit<ThreadMessageInput, 'threadId' | 'resourceId'> &
+  Pick<ThreadMessageInput, 'message'>;
+
 export interface UseThreadSignalsResult<TMessage = unknown> {
   snapshot: ThreadSignalRunSnapshot;
   messages: TMessage[];
@@ -28,8 +31,8 @@ export interface UseThreadSignalsResult<TMessage = unknown> {
   isLoadingHistory: boolean;
   error: Error | undefined;
   reloadHistory(): Promise<void>;
-  sendMessage(params: Omit<ThreadMessageInput, 'threadId' | 'resourceId'>): Promise<ThreadMessageAccepted>;
-  queueMessage(params: Omit<ThreadMessageInput, 'threadId' | 'resourceId'>): Promise<ThreadMessageAccepted>;
+  sendMessage(params: ThreadMessageHookInput): Promise<ThreadMessageAccepted>;
+  queueMessage(params: ThreadMessageHookInput): Promise<ThreadMessageAccepted>;
   sendToolApproval(
     params: Omit<ThreadToolApprovalInput, 'threadId' | 'resourceId'>,
   ): Promise<ThreadToolApprovalAccepted>;
@@ -47,6 +50,7 @@ export function useThreadSignals<TMessage = unknown>(
 ): UseThreadSignalsResult<TMessage> {
   const { client, threadId, resourceId, history = EMPTY_HISTORY, reconnect = true, onChunk } = options;
   const subscriptionRef = useRef<ThreadSignalsSubscription | undefined>(undefined);
+  const historyRequestRef = useRef(0);
   const onChunkRef = useRef(onChunk);
   const historyRef = useRef(history);
   const reconnectRef = useRef(reconnect);
@@ -60,26 +64,35 @@ export function useThreadSignals<TMessage = unknown>(
   reconnectRef.current = reconnect;
 
   const reloadHistory = useCallback(async () => {
+    const requestId = ++historyRequestRef.current;
     const currentHistory = historyRef.current;
-    if (currentHistory === false) return;
+    if (currentHistory === false) {
+      setIsLoadingHistory(false);
+      return;
+    }
     setIsLoadingHistory(true);
     try {
       const result = await client.listMessages<TMessage>(threadId, {
         ...currentHistory,
         resourceId: currentHistory.resourceId ?? resourceId,
       });
-      setMessages(result.messages);
+      if (requestId === historyRequestRef.current) setMessages(result.messages);
     } catch (caught) {
-      setError(caught instanceof Error ? caught : new Error(String(caught)));
+      if (requestId === historyRequestRef.current) {
+        setError(caught instanceof Error ? caught : new Error(String(caught)));
+      }
     } finally {
-      setIsLoadingHistory(false);
+      if (requestId === historyRequestRef.current) setIsLoadingHistory(false);
     }
   }, [client, resourceId, threadId]);
 
   useEffect(() => {
     let mounted = true;
+    historyRequestRef.current += 1;
     setSnapshot(IDLE_SNAPSHOT);
+    setMessages([]);
     setChunks([]);
+    setIsLoadingHistory(historyRef.current !== false);
     setError(undefined);
 
     void (async () => {
@@ -113,6 +126,7 @@ export function useThreadSignals<TMessage = unknown>(
 
     return () => {
       mounted = false;
+      historyRequestRef.current += 1;
       subscriptionRef.current?.unsubscribe();
       subscriptionRef.current = undefined;
     };

--- a/client-sdks/react/tsdown.config.ts
+++ b/client-sdks/react/tsdown.config.ts
@@ -37,7 +37,7 @@ async function rewritePathAliases(rootDir: string) {
 }
 
 export default defineConfig(options => ({
-  entry: ['src/index.ts', 'src/ui/index.ts'],
+  entry: ['src/index.ts', 'src/thread-signals/index.ts', 'src/ui/index.ts'],
   format: ['esm', 'cjs'],
   fixedExtension: false,
   nodeProtocol: 'strip',

--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -2573,6 +2573,48 @@ describe('Agent Routes Authorization', () => {
       expect(unsubscribe).toHaveBeenCalledTimes(1);
     });
 
+    it('should prefer the live subscription run over stored suspended history', async () => {
+      await mockMemory.createThread({
+        threadId: 'subscribe-thread-live-run',
+        resourceId: 'user-a',
+        title: 'Live Run Thread',
+      });
+      const listSuspendedRuns = vi.fn(async () => ({
+        runs: [{ runId: 'stale-suspended-run' }],
+        total: 1,
+      }));
+      (mockAgent as any).listSuspendedRuns = listSuspendedRuns;
+      (mockAgent as any).subscribeToThread = vi.fn(async () => ({
+        activeRunId: () => 'live-run',
+        abort: vi.fn(() => true),
+        unsubscribe: vi.fn(),
+        stream: (async function* () {
+          await new Promise(() => {});
+        })(),
+      }));
+
+      const stream = (await SUBSCRIBE_AGENT_THREAD_ROUTE.handler({
+        mastra,
+        agentId: 'test-agent',
+        requestContext: createContextWithReservedKeys({ resourceId: 'user-a' }),
+        abortSignal: new AbortController().signal,
+        resourceId: 'user-a',
+        threadId: 'subscribe-thread-live-run',
+      } as any)) as ReadableStream;
+
+      const reader = stream.getReader();
+      await expect(reader.read()).resolves.toMatchObject({
+        value: {
+          type: 'data-thread-state',
+          data: { runId: 'live-run', status: 'running' },
+          transient: true,
+        },
+        done: false,
+      });
+      expect(listSuspendedRuns).not.toHaveBeenCalled();
+      await reader.cancel();
+    });
+
     it('should emit heartbeat comments while a subscription stream is idle', async () => {
       vi.useFakeTimers();
       try {

--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -2532,7 +2532,7 @@ describe('Agent Routes Authorization', () => {
       (mockAgent as any).subscribeToThread = vi.fn(async target => {
         capturedTarget = target;
         return {
-          activeRunId: () => null,
+          activeRunId: () => 'subscribed-run-id',
           abort,
           unsubscribe,
           stream: (async function* () {
@@ -2553,6 +2553,18 @@ describe('Agent Routes Authorization', () => {
 
       expect(capturedTarget).toEqual({ resourceId: 'user-a', threadId: 'subscribe-thread-from-context' });
       const reader = stream.getReader();
+      await expect(reader.read()).resolves.toEqual({
+        value: {
+          type: 'data-thread-state',
+          data: {
+            runId: 'subscribed-run-id',
+            status: 'running',
+            updatedAt: expect.any(String),
+          },
+          transient: true,
+        },
+        done: false,
+      });
       await expect(reader.read()).resolves.toEqual({ value: chunk, done: false });
       expect(abort).not.toHaveBeenCalled();
       expect(unsubscribe).not.toHaveBeenCalled();
@@ -2591,6 +2603,14 @@ describe('Agent Routes Authorization', () => {
         } as any)) as ReadableStream;
 
         const reader = stream.getReader();
+        await expect(reader.read()).resolves.toMatchObject({
+          value: {
+            type: 'data-thread-state',
+            data: { status: 'idle' },
+            transient: true,
+          },
+          done: false,
+        });
         const read = reader.read();
         await vi.advanceTimersByTimeAsync(25_000);
 
@@ -2632,6 +2652,14 @@ describe('Agent Routes Authorization', () => {
         } as any)) as ReadableStream;
 
         const reader = stream.getReader();
+        await expect(reader.read()).resolves.toMatchObject({
+          value: {
+            type: 'data-thread-state',
+            data: { status: 'idle' },
+            transient: true,
+          },
+          done: false,
+        });
         abortController.abort();
         await Promise.resolve();
 

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -2267,6 +2267,54 @@ export const SUBSCRIBE_AGENT_THREAD_ROUTE = createRoute({
           scheduleHeartbeat();
 
           try {
+            let activeRunId = subscription.activeRunId() ?? undefined;
+            let status: 'idle' | 'running' | 'suspended' = activeRunId ? 'running' : 'idle';
+            const suspendedRuns = await agent
+              .listSuspendedRuns({
+                resourceId: effectiveResourceId,
+                threadId: effectiveThreadId,
+                perPage: 1,
+                page: 0,
+              })
+              .then(result => result.runs)
+              .catch(() => []);
+            const suspendedRun = suspendedRuns[0];
+            if (suspendedRun) {
+              activeRunId = suspendedRun.runId;
+              status = 'suspended';
+            } else if (!activeRunId) {
+              const durableAgent = agent as unknown as {
+                listActiveRuns?: (options: {
+                  resourceId?: string;
+                  threadId: string;
+                  perPage: number;
+                  page: number;
+                }) => Promise<{ runs: Array<{ runId: string }> }>;
+              };
+              const activeRuns = await durableAgent
+                .listActiveRuns?.({
+                  resourceId: effectiveResourceId,
+                  threadId: effectiveThreadId,
+                  perPage: 1,
+                  page: 0,
+                })
+                .then(result => result.runs)
+                .catch(() => []);
+              if (activeRuns?.[0]) {
+                activeRunId = activeRuns[0].runId;
+                status = 'running';
+              }
+            }
+
+            controller.enqueue({
+              type: 'data-thread-state',
+              data: {
+                ...(activeRunId ? { runId: activeRunId } : {}),
+                status,
+                updatedAt: new Date().toISOString(),
+              },
+              transient: true,
+            });
             for await (const part of subscription.stream) {
               controller.enqueue(part);
               scheduleHeartbeat();

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -2269,15 +2269,17 @@ export const SUBSCRIBE_AGENT_THREAD_ROUTE = createRoute({
           try {
             let activeRunId = subscription.activeRunId() ?? undefined;
             let status: 'idle' | 'running' | 'suspended' = activeRunId ? 'running' : 'idle';
-            const suspendedRuns = await agent
-              .listSuspendedRuns({
-                resourceId: effectiveResourceId,
-                threadId: effectiveThreadId,
-                perPage: 1,
-                page: 0,
-              })
-              .then(result => result.runs)
-              .catch(() => []);
+            const suspendedRuns = activeRunId
+              ? []
+              : await agent
+                  .listSuspendedRuns({
+                    resourceId: effectiveResourceId,
+                    threadId: effectiveThreadId,
+                    perPage: 1,
+                    page: 0,
+                  })
+                  .then(result => result.runs)
+                  .catch(() => []);
             const suspendedRun = suspendedRuns[0];
             if (suspendedRun) {
               activeRunId = suspendedRun.runId;


### PR DESCRIPTION
## Summary
- Add `@mastra/client-js/thread-signals` and `@mastra/react/thread-signals` conditional exports that stay free of web UI / Node-only runtime for Expo Metro.
- Emit an initial transient `data-thread-state` chunk from thread subscribe so refresh and second devices immediately see running/suspended/idle.
- Cover SSE parsing, active-run snapshot, native send/queue/approval/abort, and headless React subscribe-before-history behavior with focused tests.

Fixes #20964.

## Test plan
- [x] `pnpm --dir client-js` focused thread-signals unit tests green
- [x] `@mastra/react/thread-signals` headless hook covered
- [ ] CI changed-test gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a simple way for Expo and React Native apps to watch thread activity without loading web-only or Node-only code. Apps receive the current thread state immediately, then can send messages, approve tools, queue work, or stop runs.

## Summary

- Added the Metro-safe `@mastra/client-js/thread-signals` export.
- Added the headless `@mastra/react/thread-signals` export with `useThreadSignals`.
- Added SSE parsing, reconnection, run snapshots, message history, and thread operations.
- Added an initial transient `data-thread-state` event for `running`, `suspended`, or `idle` threads.
- Ensured live active runs take precedence over stored suspended history.
- Added focused client, React hook, and server regression tests.
- Added changesets for `@mastra/client-js`, `@mastra/react`, and `@mastra/server`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->