### PR TITLE
feat(docs): add markdown alternate link to every page head

### DIFF
--- a/docs/src/plugins/docusaurus-plugin-llms-txt/__tests__/head-link.test.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/__tests__/head-link.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { injectMarkdownAlternateLink, markdownUrlForRoute } from '../head-link'
+
+const SITE_URL = 'https://mastra.ai'
+
+/** Build a minimal document matching the shape of a built page */
+function makeHtml(head = ''): string {
+  return `<!doctype html><html><head><title>Docs</title>${head}</head><body><article>Hi</article></body></html>`
+}
+
+describe('markdownUrlForRoute', () => {
+  it('appends .md to a nested route', () => {
+    expect(markdownUrlForRoute('/docs/agents/overview', SITE_URL)).toBe('https://mastra.ai/docs/agents/overview.md')
+  })
+
+  it('appends .md to a top level route', () => {
+    expect(markdownUrlForRoute('/docs', SITE_URL)).toBe('https://mastra.ai/docs.md')
+  })
+
+  it('points the root route at the site index, because / has no .md form', () => {
+    expect(markdownUrlForRoute('/', SITE_URL)).toBe('https://mastra.ai/llms.txt')
+  })
+
+  it('drops a trailing slash before the extension', () => {
+    expect(markdownUrlForRoute('/docs/agents/', SITE_URL)).toBe('https://mastra.ai/docs/agents.md')
+  })
+
+  it('drops a trailing slash on the site URL', () => {
+    expect(markdownUrlForRoute('/docs', 'https://mastra.ai/')).toBe('https://mastra.ai/docs.md')
+  })
+})
+
+describe('injectMarkdownAlternateLink', () => {
+  it('inserts the alternate link into the head', () => {
+    const result = injectMarkdownAlternateLink(makeHtml(), 'https://mastra.ai/docs.md')
+
+    expect(result).toContain('<link rel="alternate" type="text/markdown" href="https://mastra.ai/docs.md">')
+  })
+
+  it('inserts the link before the head closes', () => {
+    const result = injectMarkdownAlternateLink(makeHtml(), 'https://mastra.ai/docs.md')
+
+    expect(result.indexOf('type="text/markdown"')).toBeLessThan(result.indexOf('</head>'))
+  })
+
+  it('leaves the body untouched', () => {
+    const result = injectMarkdownAlternateLink(makeHtml(), 'https://mastra.ai/docs.md')
+
+    expect(result).toContain('<body><article>Hi</article></body>')
+  })
+
+  it('does not add the tag twice', () => {
+    const once = injectMarkdownAlternateLink(makeHtml(), 'https://mastra.ai/docs.md')
+    const twice = injectMarkdownAlternateLink(once, 'https://mastra.ai/docs.md')
+
+    expect(twice).toBe(once)
+  })
+
+  it('returns the input when there is no head', () => {
+    const html = '<p>fragment</p>'
+
+    expect(injectMarkdownAlternateLink(html, 'https://mastra.ai/docs.md')).toBe(html)
+  })
+
+  it('escapes characters that would end the href early', () => {
+    const result = injectMarkdownAlternateLink(makeHtml(), 'https://mastra.ai/a"b&c.md')
+
+    expect(result).toContain('href="https://mastra.ai/a&quot;b&amp;c.md"')
+  })
+})

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/head-link.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/head-link.ts
@@ -1,0 +1,54 @@
+/**
+ * Markdown alternate link injection
+ *
+ * Each built page has a clean markdown twin. The HTML itself does not say so, which means agents and
+ * reader proxies convert the HTML again instead of reading the markdown we already generated. A
+ * `<link rel="alternate" type="text/markdown">` tag in the head advertises the markdown URL to any
+ * client that parses the page.
+ */
+
+/** Media type used for the markdown alternate. */
+const MARKDOWN_MEDIA_TYPE = 'text/markdown'
+
+/**
+ * Build the absolute markdown URL for a route.
+ *
+ * Every route is served as markdown at `<route>.md`. The root route has no `.md` form, so it points
+ * at the site-wide index instead.
+ */
+export function markdownUrlForRoute(route: string, siteUrl: string): string {
+  const base = siteUrl.replace(/\/$/, '')
+
+  if (route === '/') {
+    return `${base}/llms.txt`
+  }
+
+  return `${base}${route.replace(/\/$/, '')}.md`
+}
+
+/**
+ * Insert the markdown alternate link into an HTML document.
+ *
+ * Returns the HTML unchanged when the tag is already present or when there is no head to insert
+ * into, so running the plugin twice over the same output stays safe.
+ */
+export function injectMarkdownAlternateLink(html: string, markdownUrl: string): string {
+  if (html.includes(`type="${MARKDOWN_MEDIA_TYPE}"`)) {
+    return html
+  }
+
+  const closingHead = html.indexOf('</head>')
+
+  if (closingHead === -1) {
+    return html
+  }
+
+  const tag = `<link rel="alternate" type="${MARKDOWN_MEDIA_TYPE}" href="${escapeAttribute(markdownUrl)}">`
+
+  return html.slice(0, closingHead) + tag + html.slice(closingHead)
+}
+
+/** Escape the characters that would end the href attribute early. */
+function escapeAttribute(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/index.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/index.ts
@@ -11,6 +11,7 @@ import { glob } from 'tinyglobby'
 
 import { type LlmsTxtPluginOptions, resolveOptions, validateOptions } from './options'
 import { CacheManager, computeHash } from './cache-manager'
+import { injectMarkdownAlternateLink, markdownUrlForRoute } from './head-link'
 import { processHtml } from './html-processor'
 import { generateRootLlmsTxt, writeLlmsTxt, type RouteEntry } from './output-generator'
 import { generateManifest, writeManifest } from './manifest-generator'
@@ -73,6 +74,14 @@ export default function pluginLlmsTxt(_context: LoadContext, userOptions: LlmsTx
           const contentHash = computeHash(html)
 
           const llmsTxtPath = path.join(path.dirname(htmlPath), 'llms.txt')
+
+          // Point the HTML at its markdown twin. The cache key stays on the original HTML, and the
+          // injection is idempotent, so a repeated build cannot add the tag twice.
+          const htmlWithLink = injectMarkdownAlternateLink(html, markdownUrlForRoute(route, options.siteUrl))
+
+          if (htmlWithLink !== html) {
+            await fs.writeFile(htmlPath, htmlWithLink, 'utf-8')
+          }
 
           // Check cache
           if (cache.isValid(route, contentHash)) {


### PR DESCRIPTION
## Description

Every docs page already has a clean markdown version at `<route>.md`, generated by
`docusaurus-plugin-llms-txt`. The HTML never said so. The only pointer was the
`Link: </llms.txt>; rel="llms-txt"` response header set in `docs/vercel.json`, and agent tools hand
the model the response body, not the headers. A client holding the HTML had no way to find the
markdown.

Those clients convert the HTML themselves, and the result is worse than the file the docs already
publish. Fetching `mastra.ai/docs` through the r.jina.ai reader proxy returns 13,370 bytes of
re-derived markdown, including `[Skip to main content](...)` and other navigation artifacts. The
canonical file is 9,616 bytes and has none of that.

Content negotiation itself already works and is unchanged: a request with `Accept: text/markdown`
gets the markdown variant with `Vary: Accept`. This PR only makes the markdown URL discoverable from
the HTML.

`postBuild` now injects into each page it processes:

```html
<link rel="alternate" type="text/markdown" href="https://mastra.ai/docs/agents/overview.md">
```

The tag lives in the plugin rather than a theme component because the plugin already knows which
routes produced a markdown file, so the link cannot point at a missing page. The root route points
at `/llms.txt`, because `/` has no `.md` form (`/index.md` returns 404). Injection is idempotent and
runs after the cache hash is computed, so llms.txt caching is unaffected.

## Related issue(s)

None.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- `pnpm vitest run src/plugins/docusaurus-plugin-llms-txt/` — 42 passed, 11 new
- `pnpm build` — exit 0, 868 llms.txt files generated
- Confirmed 868 of 868 built `index.html` files carry exactly one alternate tag, with correct hrefs
  (`build/docs/index.html` to `https://mastra.ai/docs.md`)
- Confirmed `build/docs/llms.txt` is unchanged at 9,616 bytes, matching production byte for byte
- `oxfmt --check` and `tsc --noEmit` clean on the changed files

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Each documentation page now tells browsers where to find its Markdown version. The site root links to `/llms.txt`.

## Changes

- Added Markdown alternate-link generation in `docusaurus-plugin-llms-txt`.
- Added route handling for:
  - Standard routes with `.md` suffixes.
  - The root route with `/llms.txt`.
  - Trailing slashes.
- Added HTML escaping for generated URLs.
- Added idempotent `<head>` injection.
- Preserved existing content negotiation and `llms.txt` output.
- Kept cache hashing based on the original HTML.
- Added Vitest coverage for route conversion and HTML injection.
- Added a patch changeset.

## Validation

- Vitest passed.
- Documentation build passed.
- Formatting checks passed.
- TypeScript checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->