### PR TITLE
chore(docs): stop formatting generated model docs on commit

### DIFF
--- a/docs/lint-staged.config.mjs
+++ b/docs/lint-staged.config.mjs
@@ -1,4 +1,9 @@
+const isGeneratedModelDoc = file => file.includes('/src/content/en/models/')
+
 export default {
   '*.{ts,tsx,js,jsx,json,md,yml,yaml,css}': ['oxfmt --no-error-on-unmatched-pattern'],
-  '*.mdx': ['oxfmt-mdx --write'],
+  '*.mdx': files => {
+    const editable = files.filter(file => !isGeneratedModelDoc(file))
+    return editable.length ? [`oxfmt-mdx --write ${editable.join(' ')}`] : []
+  },
 }


### PR DESCRIPTION
The model provider pages under `docs/src/content/en/models` are generated by `generate-model-docs.ts` and carry a `DO NOT EDIT MANUALLY` banner, which is why the `format:mdx` script only points oxfmt-mdx at `docs`, `guides` and `reference`. The pre-commit hook didn't know that: its glob was plain `*.mdx`, so it formatted whatever was staged. That's harmless on a normal commit, where you only stage what you touched, but a merge commit stages everything that came in with the merge. Resolving a conflict on #20958 staged 323 files and the hook rewrote ~17k lines of generated docs, quotes and semicolons and table separators, which then rode into main.

The fix makes the hook mirror the script: staged `.mdx` files under `src/content/en/models` are skipped, everything else is formatted as before. I checked the model lists survived the incident intact (162 providers before and after, identical model data), and the generated files heal themselves on the next regeneration run, so nothing needs reverting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The pre-commit hook no longer reformats generated model documentation. It continues to format editable `.mdx` files, which prevents large generated-file changes during merges.

## Changes

- Exclude `docs/src/content/en/models` from staged MDX formatting.
- Run `oxfmt-mdx --write` only when editable MDX files remain.
- Preserve existing formatting for other supported file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->