### PR TITLE
feat(channels): post agent replies as markdown by default

### DIFF
--- a/.changeset/tidy-rivers-render.md
+++ b/.changeset/tidy-rivers-render.md
@@ -1,0 +1,20 @@
+---
+'@mastra/core': minor
+---
+
+Channel agent replies now post as markdown by default, so Slack renders bold text, links, and tables natively and other chat platforms convert the reply to their own format. Previously the final reply was posted as literal plain text, which made standard markdown show up as raw `**bold**` and `[title](url)` characters in Slack while the same reply rendered correctly in Studio.
+
+This is a behavior change for every channel agent. If your agent was prompted to emit a platform dialect such as Slack mrkdwn to work around the old behavior, either remove those prompt instructions (recommended) or set the new `textFormat: 'plain'` option on the channel adapter config to keep posting literal plain text:
+
+```typescript
+channels: {
+  adapters: {
+    slack: {
+      adapter: createSlackAdapter(),
+      textFormat: 'plain',
+    },
+  },
+},
+```
+
+`textFormat` applies to final reply text only. Tool cards, error messages, tripwire notices, and native streaming (which was already markdown) are unchanged. Postable channel messages now also accept a `{ markdown: string }` object alongside strings and card elements.

--- a/.changeset/wise-otters-reply.md
+++ b/.changeset/wise-otters-reply.md
@@ -3,3 +3,10 @@
 ---
 
 `SlackProvider` now accepts the `textFormat` option and passes it through to the Slack adapter config, so provider users can set `textFormat: 'plain'` to post agent replies as literal plain text instead of the new markdown default. When unset, the option is omitted and the core markdown default applies.
+
+```typescript
+const slack = new SlackProvider({
+  refreshToken: process.env.SLACK_APP_CONFIG_REFRESH_TOKEN,
+  textFormat: 'plain',
+});
+```

--- a/.changeset/wise-otters-reply.md
+++ b/.changeset/wise-otters-reply.md
@@ -1,0 +1,5 @@
+---
+'@mastra/slack': patch
+---
+
+`SlackProvider` now accepts the `textFormat` option and passes it through to the Slack adapter config, so provider users can set `textFormat: 'plain'` to post agent replies as literal plain text instead of the new markdown default. When unset, the option is omitted and the core markdown default applies.

--- a/channels/slack/src/provider.test.ts
+++ b/channels/slack/src/provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { SlackProvider, stripTrailingSlash } from './provider';
+import { SlackProvider, stripTrailingSlash, resolveSlackAdapterConfig } from './provider';
 
 describe('connect object form', () => {
   it('requires a name when connecting without an agent id', async () => {
@@ -32,5 +32,17 @@ describe('stripTrailingSlash', () => {
   it('produces a clean OAuth callback URL when joined', () => {
     const baseUrl = stripTrailingSlash('https://mastra-demo.calebbarnes.ca/');
     expect(`${baseUrl}/slack/oauth/callback`).toBe('https://mastra-demo.calebbarnes.ca/slack/oauth/callback');
+  });
+});
+
+describe('resolveSlackAdapterConfig', () => {
+  it('carries textFormat through to the resolved adapter config', () => {
+    const resolved = resolveSlackAdapterConfig({ textFormat: 'plain' });
+    expect(resolved.textFormat).toBe('plain');
+  });
+
+  it('omits textFormat when unset so the core default governs', () => {
+    const resolved = resolveSlackAdapterConfig({});
+    expect('textFormat' in resolved).toBe(false);
   });
 });

--- a/channels/slack/src/provider.ts
+++ b/channels/slack/src/provider.ts
@@ -46,6 +46,55 @@ export function stripTrailingSlash(url: string): string {
 }
 
 /**
+ * Resolve the per-adapter config applied to the Slack entry in
+ * `AgentChannels.adapters`. Top-level fields on `SlackProviderConfig` win;
+ * the deprecated `adapterConfig` is merged in as a fallback for backwards
+ * compatibility. Undefined values are filtered so they don't clobber the
+ * fallback or preserved options.
+ */
+export function resolveSlackAdapterConfig(channelConfig: SlackProviderConfig): SlackAdapterChannelConfig {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional read of deprecated alias for back-compat
+  const {
+    adapterConfig,
+    cors,
+    gateway,
+    formatError,
+    streaming: topLevelStreaming,
+    textFormat,
+    typingStatus,
+    toolDisplay: topLevelToolDisplay,
+  } = channelConfig;
+  const topLevel = {
+    cors,
+    gateway,
+    formatError,
+    streaming: topLevelStreaming,
+    textFormat,
+    typingStatus,
+    toolDisplay: topLevelToolDisplay,
+  };
+  const filteredTopLevel = Object.fromEntries(Object.entries(topLevel).filter(([, value]) => value !== undefined));
+  const filteredAdapterConfig = Object.fromEntries(
+    Object.entries(adapterConfig ?? {}).filter(([, value]) => value !== undefined),
+  );
+  // SlackProvider opinionated defaults — these render well in Slack's AI Assistant UI
+  // but aren't appropriate for every platform, so they live here rather than in core.
+  //   - `streaming: true`         — Slack supports native message streaming.
+  //   - `toolDisplay: 'grouped'`  — tools collapse into a single "Thinking Steps" widget (streaming only).
+  // Users can opt out of any of these by passing the field at the top level (or via `adapterConfig`).
+  // Keep in sync with the `@default` JSDoc on `SlackAdapterChannelConfig` in ./types.ts.
+  const merged = { ...filteredAdapterConfig, ...filteredTopLevel } as Partial<SlackAdapterChannelConfig>;
+  const streaming = merged.streaming ?? true;
+  // `'grouped'` requires streaming; fall back to `'cards'` when streaming is off.
+  const toolDisplay = merged.toolDisplay ?? (streaming ? 'grouped' : 'cards');
+  return {
+    ...merged,
+    streaming,
+    toolDisplay,
+  } as SlackAdapterChannelConfig;
+}
+
+/**
  * Create a hash of the agent config for change detection.
  * Uses the resolved app name (config.name ?? agentName) to detect renames.
  */
@@ -788,51 +837,9 @@ export class SlackProvider implements ChannelProvider {
     return Object.fromEntries(Object.entries(candidate).filter(([, value]) => value !== undefined));
   }
 
-  /**
-   * Resolve the per-adapter config applied to the Slack entry in
-   * `AgentChannels.adapters`. Top-level fields on `SlackProviderConfig` win;
-   * the deprecated `adapterConfig` is merged in as a fallback for backwards
-   * compatibility. Undefined values are filtered so they don't clobber the
-   * fallback or preserved options.
-   */
+  /** See {@link resolveSlackAdapterConfig}. */
   #resolveSlackAdapterConfig(): SlackAdapterChannelConfig {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional read of deprecated alias for back-compat
-    const {
-      adapterConfig,
-      cors,
-      gateway,
-      formatError,
-      streaming: topLevelStreaming,
-      typingStatus,
-      toolDisplay: topLevelToolDisplay,
-    } = this.#channelConfig;
-    const topLevel = {
-      cors,
-      gateway,
-      formatError,
-      streaming: topLevelStreaming,
-      typingStatus,
-      toolDisplay: topLevelToolDisplay,
-    };
-    const filteredTopLevel = Object.fromEntries(Object.entries(topLevel).filter(([, value]) => value !== undefined));
-    const filteredAdapterConfig = Object.fromEntries(
-      Object.entries(adapterConfig ?? {}).filter(([, value]) => value !== undefined),
-    );
-    // SlackProvider opinionated defaults — these render well in Slack's AI Assistant UI
-    // but aren't appropriate for every platform, so they live here rather than in core.
-    //   - `streaming: true`         — Slack supports native message streaming.
-    //   - `toolDisplay: 'grouped'`  — tools collapse into a single "Thinking Steps" widget (streaming only).
-    // Users can opt out of any of these by passing the field at the top level (or via `adapterConfig`).
-    // Keep in sync with the `@default` JSDoc on `SlackAdapterChannelConfig` in ./types.ts.
-    const merged = { ...filteredAdapterConfig, ...filteredTopLevel } as Partial<SlackAdapterChannelConfig>;
-    const streaming = merged.streaming ?? true;
-    // `'grouped'` requires streaming; fall back to `'cards'` when streaming is off.
-    const toolDisplay = merged.toolDisplay ?? (streaming ? 'grouped' : 'cards');
-    return {
-      ...merged,
-      streaming,
-      toolDisplay,
-    } as SlackAdapterChannelConfig;
+    return resolveSlackAdapterConfig(this.#channelConfig);
   }
 
   /**

--- a/channels/slack/src/types.ts
+++ b/channels/slack/src/types.ts
@@ -27,6 +27,15 @@ interface SlackAdapterChannelConfigBase {
   formatError?: ChannelAdapterConfig['formatError'];
 
   /**
+   * Dialect for the agent's final reply text. See `ChannelAdapterConfig['textFormat']`.
+   * `'markdown'` (default) posts replies as markdown for native Slack rendering;
+   * `'plain'` posts literal plain text (escape hatch for agents prompted to emit
+   * Slack mrkdwn). Applies to the static driver and the streaming fallback;
+   * native streaming is always markdown.
+   */
+  textFormat?: ChannelAdapterConfig['textFormat'];
+
+  /**
    * Control Slack typing indicators and Assistant-mode status text.
    *
    * - `true` — use built-in defaults: `"is typing…"` while generating text,

--- a/docs/src/content/en/docs/capabilities/channels/overview.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/overview.mdx
@@ -148,7 +148,7 @@ Set `toolDisplay: 'text'` on an adapter to render tool calls as plain text inste
 
 ## Reply formatting
 
-Agent replies post as markdown by default. Platforms with native markdown rendering, such as Slack, render bold text, links, and tables directly; other platforms convert the markdown to their own format. Agents write standard markdown and it renders correctly everywhere, matching how the same reply renders in Studio.
+Agent replies post as markdown by default. Platforms with native markdown rendering, such as Slack, render bold text, links, and tables directly. Other platforms convert the markdown to their own format. Agents write standard markdown and it renders correctly everywhere, matching how the same reply renders in Studio.
 
 Set `textFormat: 'plain'` on an adapter to post replies as literal plain text instead:
 
@@ -163,7 +163,7 @@ channels: {
 },
 ```
 
-Use this escape hatch if your agent is prompted to emit a platform-specific dialect, such as Slack mrkdwn, instead of standard markdown. If you added such prompt instructions to work around markdown rendering literally, remove them instead; the default now renders standard markdown natively. `textFormat` affects final reply text only. Tool cards, error messages, and natively streamed text are unaffected.
+Use this escape hatch if your agent is prompted to emit a platform-specific dialect, such as Slack mrkdwn, instead of standard markdown. If you added such prompt instructions to work around markdown rendering literally, remove them instead. The default now renders standard markdown natively. `textFormat` affects final reply text only. Tool cards, error messages, and natively streamed text are unaffected.
 
 ## Multi-user awareness
 

--- a/docs/src/content/en/docs/capabilities/channels/overview.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/overview.mdx
@@ -146,6 +146,25 @@ When the agent calls this tool, users see a card with the tool name, arguments, 
 
 Set `toolDisplay: 'text'` on an adapter to render tool calls as plain text instead of interactive cards. In `'hidden'` mode, `autoResumeSuspendedTools` can resume suspended tools when a later user message arrives on the same thread. This requires memory. Hidden mode only suppresses the approval buttons.
 
+## Reply formatting
+
+Agent replies post as markdown by default. Platforms with native markdown rendering, such as Slack, render bold text, links, and tables directly; other platforms convert the markdown to their own format. Agents write standard markdown and it renders correctly everywhere, matching how the same reply renders in Studio.
+
+Set `textFormat: 'plain'` on an adapter to post replies as literal plain text instead:
+
+```typescript title="src/mastra/agents/your-agent.ts"
+channels: {
+  adapters: {
+    slack: {
+      adapter: createSlackAdapter(),
+      textFormat: 'plain',
+    },
+  },
+},
+```
+
+Use this escape hatch if your agent is prompted to emit a platform-specific dialect, such as Slack mrkdwn, instead of standard markdown. If you added such prompt instructions to work around markdown rendering literally, remove them instead; the default now renders standard markdown natively. `textFormat` affects final reply text only. Tool cards, error messages, and streamed text are unaffected.
+
 ## Multi-user awareness
 
 In group conversations, Mastra prefixes each message with the sender's name and platform ID so the agent can distinguish between speakers:

--- a/docs/src/content/en/docs/capabilities/channels/overview.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/overview.mdx
@@ -163,7 +163,7 @@ channels: {
 },
 ```
 
-Use this escape hatch if your agent is prompted to emit a platform-specific dialect, such as Slack mrkdwn, instead of standard markdown. If you added such prompt instructions to work around markdown rendering literally, remove them instead; the default now renders standard markdown natively. `textFormat` affects final reply text only. Tool cards, error messages, and streamed text are unaffected.
+Use this escape hatch if your agent is prompted to emit a platform-specific dialect, such as Slack mrkdwn, instead of standard markdown. If you added such prompt instructions to work around markdown rendering literally, remove them instead; the default now renders standard markdown natively. `textFormat` affects final reply text only. Tool cards, error messages, and natively streamed text are unaffected.
 
 ## Multi-user awareness
 

--- a/docs/src/content/en/reference/agents/channels.mdx
+++ b/docs/src/content/en/reference/agents/channels.mdx
@@ -221,6 +221,14 @@ const agent = new Agent({
       'Stream agent text deltas to the channel as the agent generates them instead of buffering and posting once per step. Requires the underlying adapter to support post-and-edit streaming. Slack defaults to `true`; other adapters default to `false`.',
   },
   {
+    name: 'textFormat',
+    type: "'markdown' | 'plain'",
+    isOptional: true,
+    defaultValue: "'markdown'",
+    description:
+      "Dialect for the agent's final reply text. `'markdown'` (the default) posts replies as markdown: adapters with native markdown rendering (Slack) render it directly, others convert it to their platform format. `'plain'` posts replies as literal plain text, restoring the pre-markdown behavior for agents prompted to emit a platform dialect such as Slack mrkdwn. Applies to final reply text only; tool cards, error messages, and tripwire notices are unaffected. Native streaming is always markdown regardless of this setting.",
+  },
+  {
     name: 'toolDisplay',
     type: "'cards' | 'text' | 'timeline' | 'grouped' | 'hidden' | ToolDisplayFn",
     isOptional: true,

--- a/docs/src/content/en/reference/channels/slack-provider.mdx
+++ b/docs/src/content/en/reference/channels/slack-provider.mdx
@@ -101,6 +101,14 @@ await slack.configure({
       "Stream agent text deltas to Slack as they're generated. Pass `{ updateIntervalMs }` to customize the post-and-edit interval, or `false` to buffer text until step-finish. Disabling streaming restricts `toolDisplay` to static modes.",
   },
   {
+    name: 'textFormat',
+    type: "'markdown' | 'plain'",
+    isOptional: true,
+    defaultValue: "'markdown'",
+    description:
+      "Dialect for the agent's final reply text, forwarded to the Slack adapter. `'markdown'` (the default) posts replies as markdown so Slack renders bold text, links, and tables natively. `'plain'` posts literal plain text, the escape hatch for agents prompted to emit Slack mrkdwn. Applies to buffered replies (`streaming: false`) and the streaming fallback; native streaming is always markdown.",
+  },
+  {
     name: 'toolDisplay',
     type: 'ToolDisplay',
     isOptional: true,

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -1985,6 +1985,7 @@ export const API_ROUTE_METADATA = {
       "threadId",
       "timestamp",
       "traceId",
+      "traceIds",
       "userId"
     ],
     "bodyParams": [],

--- a/packages/core/src/channels/__tests__/output-processor.test.ts
+++ b/packages/core/src/channels/__tests__/output-processor.test.ts
@@ -995,6 +995,56 @@ describe('ChatChannelOutputProcessor', () => {
       expect(calls.filter(c => c.kind === 'post')).toHaveLength(0);
     });
 
+    it('streaming toolDisplay fn returning empty { markdown } posts nothing', async () => {
+      const { channels, calls, chatThread } = makeChannels({
+        streaming: true,
+        toolDisplay: event => {
+          if (event.kind === 'result') return { kind: 'post', message: { markdown: '' } };
+          return undefined;
+        },
+      });
+      await drive(
+        channels,
+        [
+          { type: 'tool-call', payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } } },
+          {
+            type: 'tool-result',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' }, result: 'sunny' },
+          },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+      );
+
+      expect(calls.filter(c => c.kind === 'post')).toHaveLength(0);
+      expect(calls.filter(c => c.kind === 'editMessage')).toHaveLength(0);
+    });
+
+    it('streaming toolDisplay fn returning whitespace-only { markdown } posts nothing', async () => {
+      const { channels, calls, chatThread } = makeChannels({
+        streaming: true,
+        toolDisplay: event => {
+          if (event.kind === 'result') return { kind: 'post', message: { markdown: '  \n\t ' } };
+          return undefined;
+        },
+      });
+      await drive(
+        channels,
+        [
+          { type: 'tool-call', payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } } },
+          {
+            type: 'tool-result',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' }, result: 'sunny' },
+          },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+      );
+
+      expect(calls.filter(c => c.kind === 'post')).toHaveLength(0);
+      expect(calls.filter(c => c.kind === 'editMessage')).toHaveLength(0);
+    });
+
     it('toolDisplay fn returning non-empty { markdown } posts it through unchanged', async () => {
       const { channels, calls, chatThread } = makeChannels({
         streaming: false,

--- a/packages/core/src/channels/__tests__/output-processor.test.ts
+++ b/packages/core/src/channels/__tests__/output-processor.test.ts
@@ -839,6 +839,80 @@ describe('ChatChannelOutputProcessor', () => {
       expect(posts).toHaveLength(1);
     });
 
+    it('toolDisplay fn returning empty { markdown } posts nothing (empty-markdown guard)', async () => {
+      const { channels, calls, chatThread } = makeChannels({
+        streaming: false,
+        toolDisplay: event => {
+          if (event.kind === 'result') return { kind: 'post', message: { markdown: '' } };
+          return undefined;
+        },
+      });
+      await drive(
+        channels,
+        [
+          { type: 'tool-call', payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } } },
+          {
+            type: 'tool-result',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' }, result: 'sunny' },
+          },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+      );
+
+      expect(calls.filter(c => c.kind === 'post')).toHaveLength(0);
+    });
+
+    it('toolDisplay fn returning whitespace-only { markdown } posts nothing', async () => {
+      const { channels, calls, chatThread } = makeChannels({
+        streaming: false,
+        toolDisplay: event => {
+          if (event.kind === 'result') return { kind: 'post', message: { markdown: '  \n\t ' } };
+          return undefined;
+        },
+      });
+      await drive(
+        channels,
+        [
+          { type: 'tool-call', payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } } },
+          {
+            type: 'tool-result',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' }, result: 'sunny' },
+          },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+      );
+
+      expect(calls.filter(c => c.kind === 'post')).toHaveLength(0);
+    });
+
+    it('toolDisplay fn returning non-empty { markdown } posts it through unchanged', async () => {
+      const { channels, calls, chatThread } = makeChannels({
+        streaming: false,
+        toolDisplay: event => {
+          if (event.kind === 'result') return { kind: 'post', message: { markdown: '**done**' } };
+          return undefined;
+        },
+      });
+      await drive(
+        channels,
+        [
+          { type: 'tool-call', payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } } },
+          {
+            type: 'tool-result',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' }, result: 'sunny' },
+          },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+      );
+
+      const posts = calls.filter(c => c.kind === 'post');
+      expect(posts).toHaveLength(1);
+      expect((posts[0] as any).arg).toEqual({ markdown: '**done**' });
+    });
+
     it('deprecated formatToolCall shims into toolDisplay fn for result events', async () => {
       const { channels, calls, chatThread } = makeChannels({
         streaming: false,

--- a/packages/core/src/channels/__tests__/output-processor.test.ts
+++ b/packages/core/src/channels/__tests__/output-processor.test.ts
@@ -64,6 +64,7 @@ function createRecording() {
 function makeChannels(
   opts: {
     streaming?: boolean | { updateIntervalMs?: number };
+    textFormat?: 'markdown' | 'plain';
     toolDisplay?: 'cards' | 'text' | 'timeline' | 'grouped' | 'hidden' | ((event: any, ctx: any) => any);
     typingStatus?: boolean | ((chunk: any, ctx: any) => any);
     cards?: boolean;
@@ -81,6 +82,7 @@ function makeChannels(
     adapter: recording.adapter,
     streaming: opts.streaming ?? false,
   };
+  if (opts.textFormat !== undefined) adapterConfig.textFormat = opts.textFormat;
   if (opts.toolDisplay !== undefined) adapterConfig.toolDisplay = opts.toolDisplay;
   if (opts.typingStatus !== undefined) adapterConfig.typingStatus = opts.typingStatus;
   if (opts.cards !== undefined) adapterConfig.cards = opts.cards;
@@ -160,7 +162,7 @@ describe('ChatChannelOutputProcessor', () => {
       );
 
       const posts = calls.filter(c => c.kind === 'post');
-      expect(posts).toEqual([{ kind: 'post', arg: 'Hello, world!' }]);
+      expect(posts).toEqual([{ kind: 'post', arg: { markdown: 'Hello, world!' } }]);
     });
 
     it('strips zero-width characters before posting', async () => {
@@ -174,7 +176,7 @@ describe('ChatChannelOutputProcessor', () => {
         ],
         chatThread,
       );
-      expect(calls.filter(c => c.kind === 'post')).toEqual([{ kind: 'post', arg: 'Hi' }]);
+      expect(calls.filter(c => c.kind === 'post')).toEqual([{ kind: 'post', arg: { markdown: 'Hi' } }]);
     });
 
     it('skips empty/whitespace-only buffers', async () => {
@@ -189,6 +191,112 @@ describe('ChatChannelOutputProcessor', () => {
         chatThread,
       );
       expect(calls.filter(c => c.kind === 'post')).toEqual([]);
+    });
+  });
+
+  describe('textFormat reply dialect', () => {
+    it('static driver with no textFormat posts the final reply as { markdown } (default)', async () => {
+      const { channels, calls, chatThread } = makeChannels({ streaming: false });
+      await drive(
+        channels,
+        [
+          { type: 'text-delta', payload: { text: '**bold** reply' } },
+          { type: 'step-finish', payload: {} },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+      );
+
+      expect(calls.filter(c => c.kind === 'post')).toEqual([{ kind: 'post', arg: { markdown: '**bold** reply' } }]);
+    });
+
+    it("static driver with textFormat: 'plain' posts the final reply as a bare string", async () => {
+      const { channels, calls, chatThread } = makeChannels({ streaming: false, textFormat: 'plain' });
+      await drive(
+        channels,
+        [
+          { type: 'text-delta', payload: { text: '**bold** reply' } },
+          { type: 'step-finish', payload: {} },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+      );
+
+      expect(calls.filter(c => c.kind === 'post')).toEqual([{ kind: 'post', arg: '**bold** reply' }]);
+    });
+
+    it('streaming buffered fallback posts { markdown } by default when the streaming post fails', async () => {
+      const { channels, calls, chatThread } = makeChannels({ streaming: true });
+      const { StreamingPlan } = await getChatModule();
+      chatThread.post.mockImplementation(async (content: unknown) => {
+        if (content instanceof StreamingPlan) {
+          throw new Error('streaming unsupported');
+        }
+        calls.push({ kind: 'post', arg: content });
+        return { id: 'fallback-1', text: '' };
+      });
+
+      await drive(
+        channels,
+        [
+          { type: 'text-delta', payload: { text: 'Hel' } },
+          { type: 'text-delta', payload: { text: 'lo!' } },
+          { type: 'step-finish', payload: {} },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+      );
+
+      expect(calls.filter(c => c.kind === 'post')).toEqual([{ kind: 'post', arg: { markdown: 'Hello!' } }]);
+    });
+
+    it("streaming buffered fallback posts a bare string under textFormat: 'plain'", async () => {
+      const { channels, calls, chatThread } = makeChannels({ streaming: true, textFormat: 'plain' });
+      const { StreamingPlan } = await getChatModule();
+      chatThread.post.mockImplementation(async (content: unknown) => {
+        if (content instanceof StreamingPlan) {
+          throw new Error('streaming unsupported');
+        }
+        calls.push({ kind: 'post', arg: content });
+        return { id: 'fallback-1', text: '' };
+      });
+
+      await drive(
+        channels,
+        [
+          { type: 'text-delta', payload: { text: 'Hel' } },
+          { type: 'text-delta', payload: { text: 'lo!' } },
+          { type: 'step-finish', payload: {} },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+      );
+
+      expect(calls.filter(c => c.kind === 'post')).toEqual([{ kind: 'post', arg: 'Hello!' }]);
+    });
+
+    it('static driver whitespace-only reply in markdown mode posts nothing', async () => {
+      const { channels, calls, chatThread } = makeChannels({ streaming: false });
+      await drive(
+        channels,
+        [
+          { type: 'text-delta', payload: { text: ' \u200B \n ' } },
+          { type: 'step-finish', payload: {} },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+      );
+
+      expect(calls.filter(c => c.kind === 'post')).toEqual([]);
+    });
+
+    it('error posts stay a plain string regardless of textFormat', async () => {
+      const { channels, calls, chatThread } = makeChannels({ streaming: false });
+      await drive(channels, [{ type: 'error', payload: { error: new Error('boom') } }], chatThread);
+
+      const posts = calls.filter(c => c.kind === 'post');
+      expect(posts).toHaveLength(1);
+      expect((posts[0] as any).arg).toBe('❌ Error: boom');
     });
   });
 
@@ -1642,7 +1750,10 @@ describe('ChatChannelOutputProcessor', () => {
         ],
         chatThread,
       );
-      expect(calls.filter(c => c.kind === 'post').map(c => (c as any).arg)).toEqual(['pending', 'next run']);
+      expect(calls.filter(c => c.kind === 'post').map(c => (c as any).arg)).toEqual([
+        { markdown: 'pending' },
+        { markdown: 'next run' },
+      ]);
     });
 
     it('posts a friendly error message on error chunks and resets state', async () => {
@@ -1667,7 +1778,8 @@ describe('ChatChannelOutputProcessor', () => {
         chatThread,
       );
       const postArgs = calls.filter(c => c.kind === 'post').map(c => (c as any).arg);
-      expect(postArgs).toEqual(['partial', '❌ Error: boom', 'recovery']);
+      // Reply text posts as markdown; the error post stays a plain string.
+      expect(postArgs).toEqual([{ markdown: 'partial' }, '❌ Error: boom', { markdown: 'recovery' }]);
     });
 
     it('does not post anything on abort but still flushes pending text', async () => {
@@ -1681,7 +1793,7 @@ describe('ChatChannelOutputProcessor', () => {
         chatThread,
       );
       const postArgs = calls.filter(c => c.kind === 'post').map(c => (c as any).arg);
-      expect(postArgs).toEqual(['partial']);
+      expect(postArgs).toEqual([{ markdown: 'partial' }]);
     });
   });
 
@@ -1714,7 +1826,7 @@ describe('ChatChannelOutputProcessor', () => {
         chatThread,
       );
       const postArgs = calls.filter(c => c.kind === 'post').map(c => (c as any).arg);
-      expect(postArgs).toEqual(['shorter take']);
+      expect(postArgs).toEqual([{ markdown: 'shorter take' }]);
     });
   });
 
@@ -1733,7 +1845,7 @@ describe('ChatChannelOutputProcessor', () => {
         chatThread,
       );
       const postArgs = calls.filter(c => c.kind === 'post').map(c => (c as any).arg);
-      expect(postArgs).toEqual(['reply']);
+      expect(postArgs).toEqual([{ markdown: 'reply' }]);
     });
   });
 
@@ -1770,9 +1882,8 @@ describe('ChatChannelOutputProcessor', () => {
         chatThread,
       );
       const postArgs = calls.filter(c => c.kind === 'post').map(c => (c as any).arg);
-      expect(typeof postArgs[0]).toBe('string');
-      expect(postArgs[0]).toBe('here you go');
-      expect(typeof postArgs[1]).toBe('object');
+      expect(postArgs[0]).toEqual({ markdown: 'here you go' });
+      expect((postArgs[1] as any).files).toHaveLength(1);
     });
   });
 });
@@ -1867,7 +1978,7 @@ describe('ChatChannelOutputProcessor fallback render context', () => {
     });
 
     const posts = calls.filter(c => c.kind === 'post');
-    expect(posts).toEqual([{ kind: 'post', arg: 'schedule says hi' }]);
+    expect(posts).toEqual([{ kind: 'post', arg: { markdown: 'schedule says hi' } }]);
   });
 
   it('passes through when the thread has no channel metadata', async () => {
@@ -1932,6 +2043,6 @@ describe('ChatChannelOutputProcessor fallback render context', () => {
     });
 
     const posts = calls.filter(c => c.kind === 'post');
-    expect(posts).toEqual([{ kind: 'post', arg: 'inbound message' }]);
+    expect(posts).toEqual([{ kind: 'post', arg: { markdown: 'inbound message' } }]);
   });
 });

--- a/packages/core/src/channels/__tests__/stream-helpers.test.ts
+++ b/packages/core/src/channels/__tests__/stream-helpers.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-import { ToolTracker, extractErrorMessage } from '../stream-helpers';
+import { ToolTracker, editOrPostMessage, extractErrorMessage, postFileAttachment } from '../stream-helpers';
 
 describe('ToolTracker', () => {
   it('tracks a tool start and returns enrichment', () => {
@@ -113,6 +113,60 @@ describe('ToolTracker', () => {
     tracker.trackStart({ toolCallId: 't2', toolName: 'weather', args: {} });
     tracker.reset();
     expect(tracker.inFlightCount).toBe(0);
+  });
+});
+
+describe('editOrPostMessage', () => {
+  it('passes a { markdown } message through to editMessage unchanged', async () => {
+    const editMessage = vi.fn().mockResolvedValue({});
+    const post = vi.fn().mockResolvedValue({ id: 'new' });
+    const message = { markdown: '**bold** update' };
+
+    const id = await editOrPostMessage({
+      adapter: { editMessage },
+      chatThread: { id: 'thread-1', post },
+      messageId: 'm1',
+      message,
+    });
+
+    expect(id).toBe('m1');
+    expect(editMessage).toHaveBeenCalledWith('thread-1', 'm1', message);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('passes a { markdown } message through to post unchanged when there is no messageId', async () => {
+    const editMessage = vi.fn();
+    const post = vi.fn().mockResolvedValue({ id: 'new' });
+    const message = { markdown: '**bold** post' };
+
+    const id = await editOrPostMessage({
+      adapter: { editMessage },
+      chatThread: { id: 'thread-1', post },
+      messageId: undefined,
+      message,
+    });
+
+    expect(id).toBe('new');
+    expect(editMessage).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledWith(message);
+  });
+});
+
+describe('postFileAttachment', () => {
+  it('posts the file as a markdown-shaped payload without a cast', async () => {
+    const post = vi.fn().mockResolvedValue({});
+
+    await postFileAttachment({
+      chunk: { type: 'file', payload: { data: Buffer.from('abc').toString('base64'), mimeType: 'image/png' } } as any,
+      chatThread: { post },
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const arg = post.mock.calls[0]![0];
+    expect(arg.markdown).toBe(' ');
+    expect(arg.files).toHaveLength(1);
+    expect(arg.files[0].filename).toBe('generated.png');
+    expect(arg.files[0].mimeType).toBe('image/png');
   });
 });
 

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -1344,6 +1344,7 @@ export class AgentChannels {
       wrapStream: stream => this.withTypingStatus(stream, chatThread, platform, adapterConfig, typingGate),
       typingGate,
       formatError: adapterConfig?.formatError,
+      textFormat: adapterConfig?.textFormat,
       approvalContext,
     };
   }

--- a/packages/core/src/channels/chat-driver-static.ts
+++ b/packages/core/src/channels/chat-driver-static.ts
@@ -76,6 +76,13 @@ export async function runStaticDriver({
         // post an empty message into the chat.
         if (result.message == null) return null;
         if (typeof result.message === 'string' && result.message.length === 0) return null;
+        if (
+          typeof result.message === 'object' &&
+          'markdown' in result.message &&
+          result.message.markdown.trim().length === 0
+        ) {
+          return null;
+        }
         return result.message;
       }
       if (result.kind === 'stream') return chunkToFallbackMessage(result.chunk);

--- a/packages/core/src/channels/chat-driver-static.ts
+++ b/packages/core/src/channels/chat-driver-static.ts
@@ -33,6 +33,11 @@ export interface StaticDriverArgs {
   takePendingApproval: (toolCallId: string) => PendingApprovalRecord | undefined;
   /** Optional adapter-supplied formatter for `error` chunks; defaults to a plain prefix. */
   formatError?: (error: Error) => unknown;
+  /**
+   * Dialect for the final reply text. `'markdown'` (the absent-value default)
+   * posts the buffered reply as `{ markdown }`; `'plain'` posts the bare string.
+   */
+  textFormat?: 'markdown' | 'plain';
 }
 
 /**
@@ -57,6 +62,7 @@ export async function runStaticDriver({
   getPendingApproval,
   takePendingApproval,
   formatError,
+  textFormat,
 }: StaticDriverArgs): Promise<void> {
   const platform = adapter.name;
 
@@ -107,7 +113,7 @@ export async function runStaticDriver({
     const cleaned = textBuffer.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
     if (cleaned) {
       try {
-        await chatThread.post(cleaned);
+        await chatThread.post(textFormat === 'plain' ? cleaned : { markdown: cleaned });
       } catch (e) {
         logger?.debug('[CHANNEL] Failed to post buffered text', { error: e });
       }

--- a/packages/core/src/channels/chat-driver-streaming.ts
+++ b/packages/core/src/channels/chat-driver-streaming.ts
@@ -65,6 +65,12 @@ export interface StreamingDriverArgs {
   typingGate: { active: boolean };
   /** Optional adapter-supplied formatter for `error` chunks; defaults to a plain prefix. */
   formatError?: (error: Error) => unknown;
+  /**
+   * Dialect for the final reply text on the buffered fallback path.
+   * `'markdown'` (the absent-value default) posts `{ markdown }`; `'plain'`
+   * posts the bare string. The native streaming path is always markdown.
+   */
+  textFormat?: 'markdown' | 'plain';
 }
 
 interface StreamingSession {
@@ -95,6 +101,7 @@ export async function runStreamingDriver({
   takePendingApproval,
   typingGate,
   formatError,
+  textFormat,
 }: StreamingDriverArgs): Promise<void> {
   const platform = adapter.name;
 
@@ -197,7 +204,7 @@ export async function runStreamingDriver({
         const cleaned = fallback.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
         if (cleaned) {
           try {
-            await chatThread.post(cleaned);
+            await chatThread.post(textFormat === 'plain' ? cleaned : { markdown: cleaned });
           } catch (postErr) {
             logger?.debug('[CHANNEL] buffered fallback also failed', { error: postErr });
           }

--- a/packages/core/src/channels/chat-driver-streaming.ts
+++ b/packages/core/src/channels/chat-driver-streaming.ts
@@ -289,6 +289,16 @@ export async function runStreamingDriver({
    * chunk reopen a fresh session. Used for `'cards'`/`'text'` tool events
    * and `ToolDisplayFn` `{ kind: 'post' }` returns.
    */
+  /**
+   * Skip blank tool posts so a fn that intentionally returns "" or an empty
+   * `{ markdown }` doesn't post or edit in an empty platform message.
+   * Mirrors the static driver's guard in `renderToolEvent`.
+   */
+  const isBlankToolMessage = (message: PostableMessage): boolean => {
+    if (typeof message === 'string') return message.length === 0;
+    return 'markdown' in message && message.markdown.trim().length === 0;
+  };
+
   const postOutOfBand = async (message: PostableMessage): Promise<string | undefined> => {
     await closeSession();
     try {
@@ -323,7 +333,8 @@ export async function runStreamingDriver({
         return { posted: false };
       }
       // kind === 'post'
-      const id = result.message != null ? await postOutOfBand(result.message) : undefined;
+      const id =
+        result.message != null && !isBlankToolMessage(result.message) ? await postOutOfBand(result.message) : undefined;
       return { posted: true, messageId: id };
     }
     if (rendersToolsInPlan || toolDisplay === 'hidden') {
@@ -585,7 +596,8 @@ export async function runStreamingDriver({
             pushToolDisplayResult(result);
             continue;
           }
-          if (result.message != null) await editOrPost(messageId, result.message);
+          if (result.message != null && !isBlankToolMessage(result.message))
+            await editOrPost(messageId, result.message);
           continue;
         }
         const message = renderBuiltInToolEvent(
@@ -657,7 +669,8 @@ export async function runStreamingDriver({
             pushToolDisplayResult(result);
             continue;
           }
-          if (result.message != null) await editOrPost(messageId, result.message);
+          if (result.message != null && !isBlankToolMessage(result.message))
+            await editOrPost(messageId, result.message);
           continue;
         }
         const message = renderBuiltInToolEvent(

--- a/packages/core/src/channels/output-processor.ts
+++ b/packages/core/src/channels/output-processor.ts
@@ -38,6 +38,8 @@ export interface ChatChannelRenderContext {
   wrapStream: (stream: AsyncIterable<AgentChunkType<any>>) => AsyncIterable<AgentChunkType<any>>;
   typingGate: { active: boolean };
   formatError?: (error: Error) => unknown;
+  /** Dialect for the final reply text. Absent means `'markdown'` (driver-level default). */
+  textFormat?: 'markdown' | 'plain';
   approvalContext?: { toolCallId: string; messageId: string };
 }
 
@@ -263,6 +265,7 @@ export class ChatChannelOutputProcessor {
             takePendingApproval: render.takePendingApproval,
             typingGate: render.typingGate,
             formatError: render.formatError,
+            textFormat: render.textFormat,
           })
         : runStaticDriver({
             stream: wrapped,
@@ -276,6 +279,7 @@ export class ChatChannelOutputProcessor {
             getPendingApproval: render.getPendingApproval,
             takePendingApproval: render.takePendingApproval,
             formatError: render.formatError,
+            textFormat: render.textFormat,
           })
     ).catch(err => {
       // Prevent unhandled rejection if the driver fails before a terminal chunk

--- a/packages/core/src/channels/stream-helpers.ts
+++ b/packages/core/src/channels/stream-helpers.ts
@@ -285,9 +285,7 @@ export async function postFileAttachment(args: {
   const binary =
     typeof data === 'string' ? Buffer.from(data, 'base64') : data instanceof Uint8Array ? Buffer.from(data) : data;
   try {
-    await chatThread.post({ markdown: ' ', files: [{ data: binary, filename, mimeType }] } as Parameters<
-      Thread['post']
-    >[0]);
+    await chatThread.post({ markdown: ' ', files: [{ data: binary, filename, mimeType }] });
   } catch (e) {
     logger?.debug?.('[CHANNEL] Failed to post file attachment', { error: e, mimeType, filename });
   }

--- a/packages/core/src/channels/types.ts
+++ b/packages/core/src/channels/types.ts
@@ -13,8 +13,17 @@ export type { InlineLinkEntry } from './inline-media';
 // Agent-side configuration types (consumer-facing)
 // =============================================================================
 
-/** Message content that can be posted to a channel. */
-export type PostableMessage = string | CardElement;
+/**
+ * Message content that can be posted to a channel.
+ *
+ * - `string` - posted as literal plain text (the adapter does not interpret
+ *   markdown in it).
+ * - `CardElement` - rendered as a rich card (e.g. Slack Block Kit).
+ * - `{ markdown: string }` - converted by the adapter to its platform format
+ *   (e.g. Slack `markdown_text`); adapters without native markdown rendering
+ *   convert it to their own dialect.
+ */
+export type PostableMessage = string | CardElement | { markdown: string };
 
 /** Per-adapter configuration shared across all `toolDisplay` modes. */
 export interface ChannelAdapterBaseConfig {

--- a/packages/core/src/channels/types.ts
+++ b/packages/core/src/channels/types.ts
@@ -51,6 +51,19 @@ export interface ChannelAdapterBaseConfig {
   formatError?: (error: Error) => PostableMessage;
 
   /**
+   * Dialect for the agent's final reply text.
+   * - `'markdown'` (default) - replies post as `{ markdown }`; adapters with native
+   *   markdown rendering (Slack `markdown_text`) use it, others convert to their
+   *   platform format.
+   * - `'plain'` - replies post as literal plain text (the pre-1.x-behavior escape
+   *   hatch for agents prompted to emit a platform dialect such as Slack mrkdwn).
+   *
+   * Applies to final reply text only; tool cards, error messages, and tripwire
+   * notices are unaffected.
+   */
+  textFormat?: 'markdown' | 'plain';
+
+  /**
    * Show platform typing indicators (and adaptive status text where supported,
    * e.g. Slack Assistant mode displays `<App Name> <status>`).
    *

--- a/packages/core/src/channels/types.ts
+++ b/packages/core/src/channels/types.ts
@@ -16,8 +16,8 @@ export type { InlineLinkEntry } from './inline-media';
 /**
  * Message content that can be posted to a channel.
  *
- * - `string` - posted as literal plain text (the adapter does not interpret
- *   markdown in it).
+ * - `string` - posted as-is; standard markdown is not converted, though the
+ *   platform may still apply its own dialect (e.g. Slack mrkdwn).
  * - `CardElement` - rendered as a rich card (e.g. Slack Block Kit).
  * - `{ markdown: string }` - converted by the adapter to its platform format
  *   (e.g. Slack `markdown_text`); adapters without native markdown rendering

--- a/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
+++ b/packages/playground/src/domains/workflows/components/workflows-list/workflows-list.tsx
@@ -39,7 +39,7 @@ function TreeConnector({ guides, isLastChild }: { guides: boolean[]; isLastChild
       ))}
       <span className="relative w-6">
         <span className={cn('absolute left-0 top-0 border-l border-border1', isLastChild ? 'h-1/2' : 'h-full')} />
-        <span className="absolute left-0 top-1/2 w-3.5 border-b border-border1" />
+        <span className="border-border1 absolute top-1/2 left-0 w-3.5 border-b" />
       </span>
     </span>
   );
@@ -71,7 +71,7 @@ function TreeToggleCell({
           type="button"
           aria-expanded={isExpanded}
           aria-label={`${isExpanded ? 'Collapse' : 'Expand'} nested workflows of ${workflowName}`}
-          className="relative grid size-5 shrink-0 place-items-center text-neutral4 hover:text-neutral2 before:absolute before:-inset-1.5 before:content-['']"
+          className="text-neutral4 hover:text-neutral2 relative grid size-5 shrink-0 place-items-center before:absolute before:-inset-1.5 before:content-['']"
           onClick={onToggle}
         >
           <ChevronRightIcon className={cn('size-4 transition-transform', isExpanded && 'rotate-90')} />
@@ -152,14 +152,14 @@ export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsLi
           return (
             <EntityList.RowWrapper key={`workflow-${row.pathKey}`}>
               <TreeToggleCell row={row} isExpanded={isExpanded} onToggle={toggle} />
-              <div className="col-start-2 col-span-5 grid grid-cols-subgrid gap-8 px-5">
+              <div className="col-span-5 col-start-2 grid grid-cols-subgrid gap-8 px-5">
                 <EntityList.NameCell>
                   <span className="flex items-center gap-1.5">
                     <TreeConnector guides={row.guides} isLastChild={row.isLastChild} />
                     <span className="truncate">{truncateString(row.stepId, 50)}</span>
                     <span
                       title="Nested workflow not registered standalone"
-                      className="shrink-0 text-ui-smd text-neutral4"
+                      className="text-ui-smd text-neutral4 shrink-0"
                     >
                       inline
                     </span>
@@ -198,7 +198,7 @@ export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsLi
                   {hasNested ? (
                     <span
                       title={`Nested workflows: ${nestedIds.join(', ')}`}
-                      className="inline-flex shrink-0 items-center gap-1 text-ui-smd text-neutral4"
+                      className="text-ui-smd text-neutral4 inline-flex shrink-0 items-center gap-1"
                     >
                       <WorkflowIcon aria-hidden className="size-3.5" />
                       {nestedIds.length}
@@ -210,10 +210,10 @@ export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsLi
               <EntityList.TextCell className="text-center">
                 {runningCount > 0 ? (
                   <span
-                    className="inline-flex items-center gap-1.5 text-positive1"
+                    className="text-positive1 inline-flex items-center gap-1.5"
                     aria-label={`${runningCount} run${runningCount === 1 ? '' : 's'} in progress`}
                   >
-                    <span aria-hidden className="size-2 rounded-full bg-positive1 motion-safe:animate-pulse" />
+                    <span aria-hidden className="bg-positive1 size-2 rounded-full motion-safe:animate-pulse" />
                     {runningCount}
                   </span>
                 ) : (
@@ -223,7 +223,7 @@ export function WorkflowsList({ workflows, isLoading, search = '' }: WorkflowsLi
               <EntityList.TextCell className="text-center">
                 {suspendedCount > 0 ? (
                   <span
-                    className="inline-flex items-center gap-1.5 text-warning1"
+                    className="text-warning1 inline-flex items-center gap-1.5"
                     aria-label={`${suspendedCount} run${suspendedCount === 1 ? '' : 's'} awaiting input`}
                   >
                     <PauseIcon aria-hidden className="size-3.5" />


### PR DESCRIPTION
Agent channel replies were posted as literal plain text, so standard markdown in a reply rendered as raw characters in Slack: `**bold**`, `[Mastra](https://mastra.ai)`, and table pipes all showed up verbatim, while the same reply rendered correctly in Studio. Prompting the agent to emit Slack mrkdwn instead breaks Studio and the native streaming path, which already send standard markdown.

Replies now post as markdown by default. Adapters with native markdown rendering (Slack) render bold, links, and tables directly; other platforms convert the markdown to their own format. The same reply that previously looked like this in Slack:

```
**bold**
[Mastra](https://mastra.ai)
| fruit | count |
```

now renders as native bold text, a real link, and an actual table.

A new per-adapter `textFormat` option is the escape hatch for anyone relying on the old behavior (for example agents prompted to emit Slack mrkdwn):

```ts
channels: {
  adapters: {
    slack: {
      adapter: createSlackAdapter(),
      textFormat: 'plain',
    },
  },
},
```

`textFormat` is also accepted by `@mastra/slack`'s `SlackProvider` and passed through to the adapter config. It applies to final reply text only: tool cards, error messages, tripwire notices, and native streaming (already markdown) are unchanged. `PostableMessage` now accepts `{ markdown: string }` alongside strings and card elements.

Verified with the core channels suite (287 tests, including red-verified coverage of the markdown default, the plain escape hatch, and the streaming buffered fallback) plus a live red/green capture against a real Slack workspace: the same demo message rendered literally on main and natively on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Agent replies now use standard Markdown by default, so Slack displays bold text, links, and tables correctly. Integrations can set `textFormat: 'plain'` to keep the previous behavior.

## Changes

- Added Markdown support to `PostableMessage` with `{ markdown: string }`.
- Applied Markdown formatting to static replies and streaming fallback replies.
- Prevented empty or whitespace-only Markdown tool messages.
- Preserved native streaming, tool cards, errors, and tripwire notices.
- Added per-adapter `textFormat: 'markdown' | 'plain'` configuration.
- Added `textFormat` support to `@mastra/slack`’s `SlackProvider`.
- Added shared Slack adapter configuration resolution.
- Updated channel and Slack provider documentation and changesets.
- Added tests for Markdown output, plain-text output, streaming fallback, Slack configuration, message helpers, and empty-message handling.
- Reordered unrelated playground CSS utility classes without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->