### PR TITLE
feat(factory): durable /factory filesystem for sessions + Files browser

### DIFF
--- a/.changeset/hungry-sloths-peel.md
+++ b/.changeset/hungry-sloths-peel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Added a durable filesystem slot to MastraFactory. Passing a WorkspaceFilesystem as the new `filesystem` config (PlatformFilesystem on deployments, LocalFilesystem for local development) mounts a durable, factory-wide filesystem at /factory inside every Factory session workspace. Files written there through the workspace file tools survive sandbox teardown and are shared across sessions — useful for plans, notes, handoffs, or anything else that doesn't belong in version control. Each session sees the org-wide /factory/shared directory and its own project's directory only — other projects and other orgs stay invisible. The factory web UI gains a read-only "File System" page backed by new `/web/factory/fs/*` routes, where signed-in org members can browse the whole org tree with the current project's directory open by default.

--- a/mastracode/factory-ui/src/api/keys.ts
+++ b/mastracode/factory-ui/src/api/keys.ts
@@ -61,6 +61,8 @@ export const queryKeys = {
   om: (resourceId: string | undefined) => ['om', resourceId ?? null] as const,
   thinkingConfig: () => ['thinking-config'] as const,
   fsList: (path: string | undefined) => ['fs-list', path ?? null] as const,
+  factoryFsList: (factoryProjectId: string | undefined) => ['factory-fs', 'list', factoryProjectId ?? null] as const,
+  factoryFsFile: (path: string | undefined) => ['factory-fs', 'file', path ?? null] as const,
   artifactsList: (path: string | undefined) => ['artifacts-list', path ?? null] as const,
   workspaceRenderedList: (workspacePath: string | undefined, renderedRoot: string | undefined) =>
     ['workspace-rendered-list', workspacePath ?? null, renderedRoot ?? null] as const,

--- a/mastracode/factory-ui/src/api/types.ts
+++ b/mastracode/factory-ui/src/api/types.ts
@@ -18,6 +18,7 @@ import type {
   ThinkingConfigInfo,
   UpdateThinkingConfigResponse,
 } from '@mastra/factory/routes/config';
+import type { FactoryFsEntry, FactoryFsFile, FactoryFsListing } from '@mastra/factory/routes/factory-fs';
 import type {
   ArtifactEntry,
   ArtifactListing,
@@ -41,6 +42,7 @@ export type {
   ThinkingConfigInfo,
   UpdateThinkingConfigResponse,
 };
+export type { FactoryFsEntry, FactoryFsFile, FactoryFsListing };
 export type {
   ArtifactEntry,
   ArtifactListing,

--- a/mastracode/factory-ui/src/hooks/__tests__/use-factory-fs.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/use-factory-fs.msw.test.tsx
@@ -1,0 +1,104 @@
+import { waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import type { FactoryFsFile, FactoryFsListing } from '../../api/types';
+import { server } from '../../../e2e/ui/msw-server';
+import { TEST_BASE_URL, renderHookWithProviders } from '../../../e2e/ui/render';
+import { useFactoryFsFile, useFactoryFsListing } from '../use-factory-fs';
+
+const LIST_URL = `${TEST_BASE_URL}/web/factory/fs/list`;
+const FILE_URL = `${TEST_BASE_URL}/web/factory/fs/file`;
+
+const listing: FactoryFsListing = {
+  available: true,
+  projectDir: 'projects/Alpha Project',
+  entries: [
+    { name: 'shared', path: 'shared', type: 'directory', size: 0, updatedAt: '' },
+    { name: 'note.md', path: 'shared/note.md', type: 'file', size: 8, updatedAt: '2026-08-07T00:00:00.000Z' },
+  ],
+};
+
+describe('useFactoryFsListing', () => {
+  it('passes the project id and returns the org listing', async () => {
+    let seenProjectId: string | null = null;
+    server.use(
+      http.get(LIST_URL, ({ request }) => {
+        seenProjectId = new global.URL(request.url).searchParams.get('projectId');
+        return HttpResponse.json(listing);
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useFactoryFsListing('project-1'));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(seenProjectId).toBe('project-1');
+    expect(result.current.data?.projectDir).toBe('projects/Alpha Project');
+    expect(result.current.data?.entries).toHaveLength(2);
+  });
+
+  it('lists without a projectId when none is available', async () => {
+    let seenProjectId: string | null = 'unset';
+    server.use(
+      http.get(LIST_URL, ({ request }) => {
+        seenProjectId = new global.URL(request.url).searchParams.get('projectId');
+        return HttpResponse.json({ available: false, entries: [] } satisfies FactoryFsListing);
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useFactoryFsListing(undefined));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(seenProjectId).toBe(null);
+    expect(result.current.data?.available).toBe(false);
+  });
+
+  it('surfaces list errors', async () => {
+    server.use(http.get(LIST_URL, () => HttpResponse.json({ error: 'boom' }, { status: 500 })));
+
+    const { result } = renderHookWithProviders(() => useFactoryFsListing('project-1'));
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe('useFactoryFsFile', () => {
+  it('does not fetch until a path is selected', () => {
+    let called = false;
+    server.use(
+      http.get(FILE_URL, () => {
+        called = true;
+        return HttpResponse.json({});
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useFactoryFsFile(undefined));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(called).toBe(false);
+  });
+
+  it('fetches the selected file', async () => {
+    let seenPath: string | null = null;
+    server.use(
+      http.get(FILE_URL, ({ request }) => {
+        seenPath = new global.URL(request.url).searchParams.get('path');
+        return HttpResponse.json({
+          path: 'shared/note.md',
+          name: 'note.md',
+          size: 8,
+          updatedAt: '2026-08-07T00:00:00.000Z',
+          contentType: 'text',
+          content: 'org note',
+        } satisfies FactoryFsFile);
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useFactoryFsFile('shared/note.md'));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(seenPath).toBe('shared/note.md');
+    expect(result.current.data?.content).toBe('org note');
+  });
+});

--- a/mastracode/factory-ui/src/hooks/use-factory-fs.ts
+++ b/mastracode/factory-ui/src/hooks/use-factory-fs.ts
@@ -1,0 +1,39 @@
+import { skipToken, useQuery } from '@tanstack/react-query';
+
+import { useApiConfig } from '../api/config';
+import { queryKeys } from '../api/keys';
+import type { FactoryFsFile, FactoryFsListing } from '../api/types';
+
+function factoryFsListUrl(factoryProjectId: string | undefined) {
+  if (!factoryProjectId) return '/web/factory/fs/list';
+  return `/web/factory/fs/list?${new URLSearchParams({ projectId: factoryProjectId })}`;
+}
+
+function factoryFsFileUrl(path: string | undefined) {
+  if (!path) return undefined;
+  return `/web/factory/fs/file?${new URLSearchParams({ path })}`;
+}
+
+/**
+ * Org-wide listing of the durable factory filesystem (`GET /web/factory/fs/list`).
+ * Passing the current factory project id makes the response include
+ * `projectDir` so the page can focus the project's directory by default.
+ */
+export function useFactoryFsListing(factoryProjectId: string | undefined) {
+  const { client } = useApiConfig();
+  const url = factoryFsListUrl(factoryProjectId);
+  return useQuery<FactoryFsListing>({
+    queryKey: queryKeys.factoryFsList(factoryProjectId),
+    queryFn: () => client.get<FactoryFsListing>(url),
+  });
+}
+
+/** A single durable-filesystem file preview (`GET /web/factory/fs/file`). */
+export function useFactoryFsFile(path: string | undefined) {
+  const { client } = useApiConfig();
+  const url = factoryFsFileUrl(path);
+  return useQuery<FactoryFsFile>({
+    queryKey: queryKeys.factoryFsFile(path),
+    queryFn: url ? () => client.get<FactoryFsFile>(url) : skipToken,
+  });
+}

--- a/mastracode/factory-ui/src/ui/domains/factory-fs/components/FactoryFsBrowser.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory-fs/components/FactoryFsBrowser.tsx
@@ -1,0 +1,228 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { Tree } from '@mastra/playground-ui/components/Tree';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { File, FileCode, FileJson, FileText, Folder, FolderOpen, Image, RefreshCw } from 'lucide-react';
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+
+import type { FactoryFsEntry } from '../../../../api/types';
+
+function formatBytes(size: number) {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${Math.round(size / 1024)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getFileIcon(path: string): ReactNode {
+  const ext = path.split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'ts':
+    case 'tsx':
+    case 'js':
+    case 'jsx':
+      return <FileCode className="text-blue-400" />;
+    case 'json':
+      return <FileJson className="text-yellow-400" />;
+    case 'md':
+    case 'mdx':
+      return <FileText className="text-neutral4" />;
+    case 'png':
+    case 'jpg':
+    case 'jpeg':
+    case 'gif':
+    case 'svg':
+    case 'webp':
+      return <Image className="text-purple-400" />;
+    default:
+      return <File className="text-neutral4" />;
+  }
+}
+
+interface FactoryFsTreeNode {
+  path: string;
+  name: string;
+  type: FactoryFsEntry['type'];
+  size: number;
+  children: FactoryFsTreeNode[];
+}
+
+function ensureDirectory(nodes: FactoryFsTreeNode[], path: string, name: string): FactoryFsTreeNode {
+  const existing = nodes.find(node => node.path === path);
+  if (existing) return existing;
+
+  const directory = { path, name, type: 'directory', size: 0, children: [] } satisfies FactoryFsTreeNode;
+  nodes.push(directory);
+  return directory;
+}
+
+function addEntry(nodes: FactoryFsTreeNode[], entry: FactoryFsEntry) {
+  const segments = entry.path.split('/').filter(Boolean);
+  let siblings = nodes;
+  let currentPath = '';
+
+  segments.forEach((segment, index) => {
+    currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+    const isLeaf = index === segments.length - 1;
+
+    if (isLeaf) {
+      const existing = siblings.find(node => node.path === currentPath);
+      const node = {
+        path: entry.path,
+        name: segment,
+        type: entry.type,
+        size: entry.size,
+        children: existing?.children ?? [],
+      };
+      const existingIndex = siblings.findIndex(item => item.path === currentPath);
+      if (existingIndex === -1) siblings.push(node);
+      else siblings[existingIndex] = node;
+      return;
+    }
+
+    const directory = ensureDirectory(siblings, currentPath, segment);
+    siblings = directory.children;
+  });
+}
+
+function sortTree(nodes: FactoryFsTreeNode[]): FactoryFsTreeNode[] {
+  return nodes
+    .map(node => ({ ...node, children: sortTree(node.children) }))
+    .sort((a, b) => {
+      if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+function buildTree(entries: FactoryFsEntry[]): FactoryFsTreeNode[] {
+  const nodes: FactoryFsTreeNode[] = [];
+  entries.forEach(entry => addEntry(nodes, entry));
+  return sortTree(nodes);
+}
+
+/** Every ancestor directory of `dir` (inclusive), as open-by-default keys. */
+function defaultOpenFolders(dir: string | undefined): Record<string, boolean> {
+  const open: Record<string, boolean> = {};
+  if (!dir) return open;
+  let current = '';
+  for (const segment of dir.split('/').filter(Boolean)) {
+    current = current ? `${current}/${segment}` : segment;
+    open[current] = true;
+  }
+  return open;
+}
+
+function FactoryFsTreeItem({
+  node,
+  isOpen,
+  onFolderOpenChange,
+  renderChildren,
+}: {
+  node: FactoryFsTreeNode;
+  isOpen: (path: string) => boolean;
+  onFolderOpenChange: (path: string, open: boolean) => void;
+  renderChildren: (nodes: FactoryFsTreeNode[]) => ReactNode;
+}) {
+  if (node.type === 'directory') {
+    const open = isOpen(node.path);
+    return (
+      <Tree.Folder open={open} onOpenChange={(value: boolean) => onFolderOpenChange(node.path, value)}>
+        <Tree.FolderTrigger>
+          <Tree.Icon>{open ? <FolderOpen className="text-amber-400" /> : <Folder className="text-amber-400" />}</Tree.Icon>
+          <Tree.Label>{node.name}</Tree.Label>
+        </Tree.FolderTrigger>
+        <Tree.FolderContent>{renderChildren(node.children)}</Tree.FolderContent>
+      </Tree.Folder>
+    );
+  }
+
+  return (
+    <Tree.File id={node.path}>
+      <Tree.Icon>{getFileIcon(node.name)}</Tree.Icon>
+      <Tree.Label>{node.name}</Tree.Label>
+      <span className="text-icon3 ml-auto shrink-0 text-xs">{formatBytes(node.size)}</span>
+    </Tree.File>
+  );
+}
+
+interface FactoryFsBrowserProps {
+  entries: FactoryFsEntry[];
+  /** Org-relative directory to open by default (the current project's directory). */
+  defaultOpenDir?: string;
+  selectedFilePath?: string;
+  isLoading: boolean;
+  isRefreshing: boolean;
+  error?: Error;
+  onRefresh: () => void;
+  onFileSelect: (filePath: string) => void;
+}
+
+/**
+ * Tree browser over the durable factory filesystem's org-wide listing —
+ * `shared/` plus every `projects/<project>/` directory. Adapted from the
+ * session `WorkspaceFileBrowser`; the current project's directory chain is
+ * open by default and the user can navigate the rest of the org tree freely.
+ */
+export function FactoryFsBrowser({
+  entries,
+  defaultOpenDir,
+  selectedFilePath,
+  isLoading,
+  isRefreshing,
+  error,
+  onRefresh,
+  onFileSelect,
+}: FactoryFsBrowserProps) {
+  const [overrides, setOverrides] = useState<Record<string, boolean>>({});
+  const defaults = defaultOpenFolders(defaultOpenDir);
+  const nodes = buildTree(entries);
+
+  const isOpen = (path: string) => overrides[path] ?? defaults[path] ?? false;
+  const setFolderOpen = (path: string, open: boolean) => {
+    setOverrides(previous => ({ ...previous, [path]: open }));
+  };
+
+  const renderNodes = (items: FactoryFsTreeNode[]): ReactNode =>
+    items.map(node => (
+      <FactoryFsTreeItem
+        key={node.path}
+        node={node}
+        isOpen={isOpen}
+        onFolderOpenChange={setFolderOpen}
+        renderChildren={renderNodes}
+      />
+    ));
+
+  return (
+    <aside className="flex h-full min-h-0 w-full min-w-0 flex-col" aria-label="Factory files">
+      <div className="border-border1 flex items-center justify-between border-b px-3 py-2">
+        <Txt variant="ui-sm" className="text-icon6 font-medium">
+          Files
+        </Txt>
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          aria-label={isRefreshing ? 'Refreshing factory files' : 'Refresh factory files'}
+        >
+          {isRefreshing ? <Spinner size="sm" /> : <RefreshCw />}
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {isLoading ? <Txt className="text-icon3 px-2 py-3">Loading files…</Txt> : null}
+        {error ? <Txt className="text-icon4 px-2 py-3">Unable to load files.</Txt> : null}
+        {!isLoading && !error && nodes.length === 0 ? (
+          <Txt className="text-icon3 px-2 py-3" variant="ui-sm">
+            No files yet. Files agents save to /factory will appear here.
+          </Txt>
+        ) : null}
+        {!isLoading && !error && nodes.length > 0 ? (
+          <Tree selectedId={selectedFilePath} onSelect={onFileSelect}>
+            {renderNodes(nodes)}
+          </Tree>
+        ) : null}
+      </div>
+    </aside>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/factory-fs/components/__tests__/FactoryFsBrowser.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory-fs/components/__tests__/FactoryFsBrowser.msw.test.tsx
@@ -1,0 +1,73 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithProviders } from '../../../../../../e2e/ui/render';
+import type { FactoryFsEntry } from '../../../../../api/types';
+import { FactoryFsBrowser } from '../FactoryFsBrowser';
+
+const entries: FactoryFsEntry[] = [
+  { name: 'shared', path: 'shared', type: 'directory', size: 0, updatedAt: '' },
+  { name: 'org-note.md', path: 'shared/org-note.md', type: 'file', size: 8, updatedAt: '2026-08-07T00:00:00.000Z' },
+  { name: 'projects', path: 'projects', type: 'directory', size: 0, updatedAt: '' },
+  { name: 'Alpha', path: 'projects/Alpha', type: 'directory', size: 0, updatedAt: '' },
+  {
+    name: 'plan.md',
+    path: 'projects/Alpha/plans/plan.md',
+    type: 'file',
+    size: 20,
+    updatedAt: '2026-08-07T00:00:00.000Z',
+  },
+  { name: 'Beta', path: 'projects/Beta', type: 'directory', size: 0, updatedAt: '' },
+];
+
+function renderBrowser(props: Partial<Parameters<typeof FactoryFsBrowser>[0]> = {}) {
+  const selected: string[] = [];
+  renderWithProviders(
+    <FactoryFsBrowser
+      entries={entries}
+      isLoading={false}
+      isRefreshing={false}
+      onRefresh={() => {}}
+      onFileSelect={path => selected.push(path)}
+      {...props}
+    />,
+  );
+  return { selected };
+}
+
+describe('FactoryFsBrowser', () => {
+  it('opens the current project directory by default, keeping siblings closed', () => {
+    renderBrowser({ defaultOpenDir: 'projects/Alpha' });
+
+    // The default-open chain (projects → Alpha) is expanded…
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('plans')).toBeInTheDocument();
+    // …while closed folders keep their contents hidden.
+    expect(screen.queryByText('org-note.md')).not.toBeInTheDocument();
+    // Sibling projects are visible but closed.
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+  });
+
+  it('lets the user navigate up into other directories', async () => {
+    const user = userEvent.setup();
+    renderBrowser({ defaultOpenDir: 'projects/Alpha' });
+
+    await user.click(screen.getByText('shared'));
+    expect(screen.getByText('org-note.md')).toBeInTheDocument();
+  });
+
+  it('reports file selection with the org-relative path', async () => {
+    const user = userEvent.setup();
+    const { selected } = renderBrowser({ defaultOpenDir: 'projects/Alpha' });
+
+    await user.click(screen.getByText('plans'));
+    await user.click(screen.getByText('plan.md'));
+    expect(selected).toEqual(['projects/Alpha/plans/plan.md']);
+  });
+
+  it('shows an empty state when there are no files', () => {
+    renderBrowser({ entries: [] });
+    expect(screen.getByText(/No files yet/)).toBeInTheDocument();
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/factory/components/FactorySection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/FactorySection.tsx
@@ -1,6 +1,6 @@
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { ChartLine, GitPullRequest, ListChecks, ScrollText, SquareKanban } from 'lucide-react';
+import { ChartLine, FolderTree, GitPullRequest, ListChecks, ScrollText, SquareKanban } from 'lucide-react';
 import type { ComponentType, ReactNode } from 'react';
 import { NavLink, useLocation, useParams } from 'react-router';
 
@@ -31,6 +31,7 @@ export function FactorySection({ children }: { children?: ReactNode }) {
         <FactoryLink to={`/factories/${factoryId}/metrics`} icon={ChartLine} label="Metrics" />
         <FactoryLink to={`/factories/${factoryId}/rules`} icon={ListChecks} label="Rules" />
         <FactoryLink to={`/factories/${factoryId}/audit`} icon={ScrollText} label="Audit log" />
+        <FactoryLink to={`/factories/${factoryId}/files`} icon={FolderTree} label="Files" />
       </MainSidebar.NavList>
       {children}
     </nav>

--- a/mastracode/factory-ui/src/ui/pages/FileSystemPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/FileSystemPage.tsx
@@ -1,0 +1,69 @@
+import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
+import { Notice } from '@mastra/playground-ui/components/Notice';
+import { FolderTree } from 'lucide-react';
+import { useState } from 'react';
+
+import { useFactoryFsFile, useFactoryFsListing } from '../../hooks/use-factory-fs';
+import { FactoryPageShell } from '../domains/factory/components/FactoryPageShell';
+import { FactoryFsBrowser } from '../domains/factory-fs/components/FactoryFsBrowser';
+import { WorkspaceFileViewer } from '../domains/workspace-viewer/components/WorkspaceFileViewer';
+
+/**
+ * The durable factory filesystem (`/factory` in session workspaces), browsable
+ * org-wide: the current project's directory is open by default, and the user
+ * can navigate up to other projects and the org-wide `shared/` directory.
+ */
+export function FileSystemPage() {
+  return <FactoryPageShell>{factory => <FileSystemContent factoryProjectId={factory.id} />}</FactoryPageShell>;
+}
+
+function FileSystemContent({ factoryProjectId }: { factoryProjectId: string | undefined }) {
+  const [selectedFilePath, setSelectedFilePath] = useState<string | undefined>();
+  const listingQuery = useFactoryFsListing(factoryProjectId);
+  const fileQuery = useFactoryFsFile(selectedFilePath);
+
+  if (listingQuery.isError) {
+    const message = listingQuery.error instanceof Error ? listingQuery.error.message : 'Unable to load factory files.';
+    return <Notice variant="destructive">{message}</Notice>;
+  }
+
+  const listing = listingQuery.data;
+  if (listing && !listing.available) {
+    return (
+      <EmptyState
+        className="min-h-0 flex-1"
+        as="h2"
+        iconSlot={<FolderTree className="text-icon3 size-5" aria-hidden />}
+        titleSlot="No durable filesystem configured"
+        descriptionSlot="This deployment has no durable factory filesystem, so sessions have no /factory mount and there are no files to browse."
+      />
+    );
+  }
+
+  return (
+    <section
+      className="border-border1 grid min-h-0 flex-1 grid-cols-[minmax(220px,320px)_1fr] overflow-hidden rounded-lg border"
+      aria-label="Factory files"
+    >
+      <div className="border-border1 min-h-0 border-r">
+        <FactoryFsBrowser
+          entries={listing?.entries ?? []}
+          defaultOpenDir={listing?.projectDir}
+          selectedFilePath={selectedFilePath}
+          isLoading={listingQuery.isPending}
+          isRefreshing={listingQuery.isFetching && !listingQuery.isPending}
+          error={listingQuery.error ?? undefined}
+          onRefresh={() => void listingQuery.refetch()}
+          onFileSelect={setSelectedFilePath}
+        />
+      </div>
+      <WorkspaceFileViewer
+        filePath={selectedFilePath}
+        file={fileQuery.data ? { ...fileQuery.data, workspacePath: '' } : undefined}
+        isLoading={fileQuery.isLoading}
+        error={fileQuery.error ?? undefined}
+        onBack={() => setSelectedFilePath(undefined)}
+      />
+    </section>
+  );
+}

--- a/mastracode/factory-ui/src/ui/router.tsx
+++ b/mastracode/factory-ui/src/ui/router.tsx
@@ -17,6 +17,7 @@ import type { RouteObject } from 'react-router';
 import Chat from './domains/chat/Chat';
 import { RootGuards } from './domains/auth/components/RootGuards';
 import { AuditPage } from './pages/AuditPage';
+import { FileSystemPage } from './pages/FileSystemPage';
 import { ReviewBoardPage, WorkBoardPage } from './pages/BoardPage';
 import { CreateFactoryPage } from './pages/CreateFactoryPage';
 import { MetricsPage } from './pages/MetricsPage';
@@ -148,6 +149,7 @@ export function createAppRoutes(): RouteObject[] {
                 { path: 'metrics', element: <MetricsPage /> },
                 { path: 'rules', element: <RulesPage /> },
                 { path: 'audit', element: <AuditPage /> },
+                { path: 'files', element: <FileSystemPage /> },
                 {
                   path: 'settings',
                   children: [

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -10,6 +10,12 @@ A host calls `MastraFactory.prepare()`, constructs `new Mastra(...)`, then calls
 
 See `mastracode/web/src/mastra/index.ts` for the host implementation.
 
+## Durable factory filesystem (`filesystem`)
+
+Passing a `WorkspaceFilesystem` as `MastraFactoryConfig.filesystem` (`PlatformFilesystem` on deployments, `LocalFilesystem` in dev) mounts a durable filesystem at `/factory` in every Factory session workspace. Files written there survive sandbox teardown and are shared across sessions — a good home for anything that doesn't belong in version control (plans, notes, handoffs, scratch data); how it's organized is up to agents and users. The layout is `/factory/shared` (org-wide), `/factory/projects/<project>/shared`, and `/factory/projects/<project>/repos/<repo>`; a session only sees `/shared` and its own project's directory, and the backing store is namespaced per org. See `src/filesystem.ts`.
+
+The web UI exposes a read-only browser for this filesystem (the "Files" page, `/web/factory/fs/*` routes in `src/routes/factory-fs.ts`): signed-in org members can browse the whole org tree — the current project's directory opens by default.
+
 ## Development
 
 ```shell

--- a/mastracode/factory/factory-skills/factory-plan/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-plan/SKILL.md
@@ -42,6 +42,8 @@ Write the full plan into the conversation, structured as:
 
 The plan must be executable by someone with no access to this conversation beyond this message.
 
+When the workspace exposes the durable `/factory` mount (the filesystem instructions advertise it), also write the full plan there — e.g. `<your repo directory>/plans/<work-item>.md`, using your repo directory as advertised in the filesystem instructions and the work item's identifier (issue number or Linear ID) as the file name. Use the workspace file tools; shell commands cannot see the mount. Reference that path in the transition rationale so later sessions can find it. The plan message in this conversation stays the authoritative handoff; the file is a durable copy that survives sandbox teardown. Without the mount, skip this step.
+
 ## Phase 4: Transition
 
 End the run with a single `factory_transition_work_item` call. Take the current stage and `expectedRevision` from the `factory-phase` signal.

--- a/mastracode/factory/factory-skills/factory-triage/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-triage/SKILL.md
@@ -80,6 +80,8 @@ fi
 
 Set `COMMENT_BODY` to the marker followed by the handoff. Update the oldest marked comment authored by the current GitHub identity when duplicates exist; do not add another comment merely because a newer Factory comment exists. If a human deleted the marked comment, create it again.
 
+When the workspace exposes the durable `/factory` mount (the filesystem instructions advertise it), also persist the handoff there — e.g. `<your repo directory>/triage/<work-item>.md`, using your repo directory as advertised in the filesystem instructions and the work item's identifier as the file name. Use the workspace file tools; shell commands cannot see the mount. The file survives sandbox teardown so the planning session can read it back. Without the mount, skip this step.
+
 Post the same handoff as your final conversation message. Take the current stage and `expectedRevision` from the `factory-phase` signal.
 
 - When the current stage is **Intake** or **Triage**, make the terminal `factory_transition_work_item` call: valid/actionable issues go to `planning`; issues that should be closed go to `done` with the close rationale.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -29,7 +29,7 @@ import type { IMastraAuthProvider } from '@mastra/core/server';
 import type { FactoryStorage } from '@mastra/core/storage';
 import type { MastraVector } from '@mastra/core/vector';
 import { LocalSandbox } from '@mastra/core/workspace';
-import type { WorkspaceSandbox } from '@mastra/core/workspace';
+import type { WorkspaceFilesystem, WorkspaceSandbox } from '@mastra/core/workspace';
 import type { FactoryAuthUser } from './auth.js';
 import {
   buildAuthRoutes,
@@ -46,6 +46,7 @@ import { releaseWorkItemSandboxes } from './integrations/github/sandbox-release.
 import { PlatformGithubIntegration } from './integrations/platform/github/integration.js';
 import { PlatformLinearIntegration } from './integrations/platform/linear/integration.js';
 import { createCustomProvidersPrimer, registerCustomProvidersSource } from './routes/custom-provider-source.js';
+import { FactoryFsRoutes } from './routes/factory-fs.js';
 import { ProjectRoutes } from './routes/projects.js';
 import { assembleFactoryApiRoutes, buildIntegrationContext } from './routes/surface.js';
 import type { FactoryApiRoutesDeps } from './routes/surface.js';
@@ -142,6 +143,16 @@ export interface MastraFactoryConfig {
   allowedOrigins?: string[];
   /** Sandbox configuration. Omitted → repository sandboxes are disabled. */
   sandbox?: MastraFactorySandboxConfig;
+  /**
+   * Durable filesystem shared across the factory — exposed to session agents
+   * under the `/factory` mount. Files there survive sandbox teardown, making
+   * it a good home for anything that doesn't belong in version control
+   * (plans, notes, handoffs, scratch data — usage is up to agents and users).
+   * Any `WorkspaceFilesystem` instance — `PlatformFilesystem`
+   * (`@mastra/platform-workspace`) on deployments, `LocalFilesystem`
+   * (`@mastra/core/workspace`) for local dev. Omitted → no durable mount.
+   */
+  filesystem?: WorkspaceFilesystem;
   /** Background Factory dispatcher configuration. */
   dispatcher?: MastraFactoryDispatcherConfig;
   /**
@@ -413,6 +424,11 @@ export class MastraFactory {
         .filter(integration => integration.versionControl)
         .map(integration => integration.id),
     });
+    const factoryFsRoutes = new FactoryFsRoutes({
+      auth: routeAuth,
+      filesystem: this.#config.filesystem,
+      projects: factoryProjectsStorage,
+    });
     const auditDomain = new AuditDomain({
       auth: routeAuth,
       audit: auditStorage,
@@ -623,6 +639,7 @@ export class MastraFactory {
           ...(this.#config.sandbox ? { sandbox: this.#config.sandbox } : {}),
           ...(githubIntegration ? { github: githubIntegration } : {}),
           ...(workItemsStorage ? { workItems: workItemsStorage } : {}),
+          ...(this.#config.filesystem ? { filesystem: this.#config.filesystem, projects: factoryProjectsStorage } : {}),
           fleet,
         }),
         disableGithubSignals: true,
@@ -742,6 +759,7 @@ export class MastraFactory {
             },
           }),
           ...projectRoutes.routes(),
+          ...factoryFsRoutes.routes(),
           ...auditDomain.routes(),
         ],
         buildServerConfig: () => {

--- a/mastracode/factory/src/filesystem.test.ts
+++ b/mastracode/factory/src/filesystem.test.ts
@@ -1,0 +1,340 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  CopyOptions,
+  FileContent,
+  FileEntry,
+  FileStat,
+  ListOptions,
+  ReadOptions,
+  RemoveOptions,
+  WorkspaceFilesystem,
+  WriteOptions,
+} from '@mastra/core/workspace';
+import { DirectoryNotFoundError, FileNotFoundError, LocalFilesystem } from '@mastra/core/workspace';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { FACTORY_FS_MOUNT, FactoryFilesystem, repoDirName, sanitizePathSegment } from './filesystem.js';
+
+const ORG_ID = 'org-1111';
+const PROJECT_NAME = 'My Project';
+const REPO_SLUG = 'mastra-ai/mastra';
+const REPO_DIR = 'mastra-ai__mastra';
+
+/**
+ * Minimal stand-in for the session's SandboxFilesystem: stores files by the
+ * exact path it was given (the overlay must delegate paths untouched).
+ */
+class FakeSandboxFilesystem implements WorkspaceFilesystem {
+  readonly id = 'fake-sandbox-fs';
+  readonly name = 'FakeSandboxFilesystem';
+  readonly provider = 'fake-sandbox';
+  readonly basePath = '/workspace/owner/repo';
+  status = 'ready' as const;
+  files = new Map<string, string>();
+
+  async readFile(path: string, _options?: ReadOptions): Promise<string | Buffer> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new FileNotFoundError(path);
+    return content;
+  }
+  async writeFile(path: string, content: FileContent, _options?: WriteOptions): Promise<void> {
+    this.files.set(path, content.toString());
+  }
+  async appendFile(path: string, content: FileContent): Promise<void> {
+    this.files.set(path, (this.files.get(path) ?? '') + content.toString());
+  }
+  async deleteFile(path: string, options?: RemoveOptions): Promise<void> {
+    if (!this.files.delete(path) && !options?.force) throw new FileNotFoundError(path);
+  }
+  async copyFile(src: string, dest: string, _options?: CopyOptions): Promise<void> {
+    this.files.set(dest, String(await this.readFile(src)));
+  }
+  async moveFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
+    await this.copyFile(src, dest, options);
+    this.files.delete(src);
+  }
+  async mkdir(_path: string, _options?: { recursive?: boolean }): Promise<void> {}
+  async rmdir(_path: string, _options?: RemoveOptions): Promise<void> {}
+  async readdir(_path: string, _options?: ListOptions): Promise<FileEntry[]> {
+    return [...this.files.keys()].map(name => ({ name, type: 'file' as const }));
+  }
+  async exists(path: string): Promise<boolean> {
+    return this.files.has(path);
+  }
+  async stat(path: string): Promise<FileStat> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new FileNotFoundError(path);
+    return {
+      name: path.split('/').at(-1) ?? path,
+      path,
+      type: 'file',
+      size: content.length,
+      createdAt: new Date(0),
+      modifiedAt: new Date(0),
+    };
+  }
+  getInstructions(): string {
+    return `Files are stored in a remote sandbox at ${this.basePath}.`;
+  }
+}
+
+describe('FactoryFilesystem', () => {
+  let durableRoot: string;
+  let inner: FakeSandboxFilesystem;
+  let durable: LocalFilesystem;
+  let fs: FactoryFilesystem;
+
+  beforeEach(() => {
+    durableRoot = mkdtempSync(join(tmpdir(), 'factory-fs-durable-'));
+    inner = new FakeSandboxFilesystem();
+    durable = new LocalFilesystem({ basePath: durableRoot });
+    fs = new FactoryFilesystem({
+      inner,
+      durable,
+      orgId: ORG_ID,
+      projectName: PROJECT_NAME,
+      repoSlug: REPO_SLUG,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(durableRoot, { recursive: true, force: true });
+  });
+
+  describe('routing', () => {
+    it('routes mount paths to the durable backend under the org prefix', async () => {
+      await fs.writeFile(`${FACTORY_FS_MOUNT}/shared/note.md`, 'org note');
+      expect(await durable.readFile(`orgs/${ORG_ID}/shared/note.md`, { encoding: 'utf8' })).toBe('org note');
+      expect(await fs.readFile(`${FACTORY_FS_MOUNT}/shared/note.md`, { encoding: 'utf8' })).toBe('org note');
+      // Nothing leaked into the sandbox filesystem.
+      expect(inner.files.size).toBe(0);
+    });
+
+    it('routes own project and repo mount paths', async () => {
+      const planPath = `${FACTORY_FS_MOUNT}/projects/${PROJECT_NAME}/repos/${REPO_DIR}/plans/foo.md`;
+      await fs.writeFile(planPath, 'the plan');
+      expect(
+        await durable.readFile(`orgs/${ORG_ID}/projects/${PROJECT_NAME}/repos/${REPO_DIR}/plans/foo.md`, {
+          encoding: 'utf8',
+        }),
+      ).toBe('the plan');
+      expect(await fs.readFile(planPath, { encoding: 'utf8' })).toBe('the plan');
+    });
+
+    it('delegates non-mount paths to the inner filesystem verbatim', async () => {
+      await fs.writeFile('/src/index.ts', 'export {}');
+      expect(inner.files.get('/src/index.ts')).toBe('export {}');
+      expect(await durable.readdir('.')).toEqual([]);
+      expect(await fs.readFile('/src/index.ts')).toBe('export {}');
+    });
+
+    it('sends relative paths to the inner filesystem, even mount-looking ones', async () => {
+      await fs.writeFile('factory/nested.md', 'inner file');
+      expect(inner.files.get('factory/nested.md')).toBe('inner file');
+      expect(await durable.readdir('.')).toEqual([]);
+    });
+  });
+
+  describe('traversal guards', () => {
+    it('normalizes .. out of the mount prefix into the inner filesystem', async () => {
+      // /factory/../escape.md normalizes to /escape.md — routed to the
+      // inner filesystem (which applies its own workdir containment), never
+      // the durable backend. Paths are delegated verbatim.
+      await fs.writeFile(`${FACTORY_FS_MOUNT}/../escape.md`, 'escaped');
+      expect(inner.files.get(`${FACTORY_FS_MOUNT}/../escape.md`)).toBe('escaped');
+      expect(await durable.readdir('.')).toEqual([]);
+    });
+
+    it('cannot climb out of the org prefix with .. inside the mount subtree', async () => {
+      await durable.writeFile('orgs/other-org/secret.md', 'secret');
+      // /factory/shared/../../x normalizes to /x — inner, never the backend.
+      await expect(fs.readFile(`${FACTORY_FS_MOUNT}/shared/../../x`)).rejects.toThrow(FileNotFoundError);
+      // Every durable write stays under the session org.
+      await fs.writeFile(`${FACTORY_FS_MOUNT}/shared/a.md`, 'a');
+      const entries = await durable.readdir('orgs');
+      expect(entries.map(e => e.name).sort()).toEqual([ORG_ID, 'other-org']);
+    });
+
+    it('cannot reach a sibling project via .. through its own project dir', async () => {
+      await durable.writeFile(`orgs/${ORG_ID}/projects/other-project/notes.md`, 'other');
+      await expect(
+        fs.readFile(`${FACTORY_FS_MOUNT}/projects/${PROJECT_NAME}/../other-project/notes.md`),
+      ).rejects.toThrow(FileNotFoundError);
+      await expect(
+        fs.writeFile(`${FACTORY_FS_MOUNT}/projects/${PROJECT_NAME}/../other-project/inject.md`, 'x'),
+      ).rejects.toThrow(FileNotFoundError);
+    });
+
+    it('rejects backslash-bearing mount paths outright', async () => {
+      // posix.normalize does not treat `\` as a separator, but a Windows-hosted
+      // local backend would — never let one through to the backend.
+      await expect(fs.readFile(`${FACTORY_FS_MOUNT}/shared/..\\..\\..\\etc/passwd`)).rejects.toThrow(FileNotFoundError);
+      await expect(fs.writeFile(`${FACTORY_FS_MOUNT}/shared\\x.md`, 'x')).rejects.toThrow(FileNotFoundError);
+    });
+
+    it('denies copying repo files into a hidden sibling project', async () => {
+      inner.files.set('/src/secret.ts', 'code');
+      await expect(
+        fs.copyFile('/src/secret.ts', `${FACTORY_FS_MOUNT}/projects/other-project/exfil.ts`),
+      ).rejects.toThrow(FileNotFoundError);
+      await expect(
+        fs.moveFile('/src/secret.ts', `${FACTORY_FS_MOUNT}/projects/other-project/exfil.ts`),
+      ).rejects.toThrow(FileNotFoundError);
+      expect(await durable.exists(`orgs/${ORG_ID}/projects/other-project/exfil.ts`)).toBe(false);
+      // The move must not have deleted the source after the failed copy.
+      expect(inner.files.get('/src/secret.ts')).toBe('code');
+    });
+
+    it('refuses to overwrite reserved layout directories as files', async () => {
+      await expect(fs.writeFile(`${FACTORY_FS_MOUNT}/shared`, 'x')).rejects.toThrow(/[Rr]eserved/);
+      await expect(fs.appendFile(`${FACTORY_FS_MOUNT}/projects/${PROJECT_NAME}`, 'x')).rejects.toThrow(/[Rr]eserved/);
+      await expect(fs.deleteFile(`${FACTORY_FS_MOUNT}/shared`)).rejects.toThrow(/[Rr]eserved/);
+      // Writes beneath them still work afterwards.
+      await fs.writeFile(`${FACTORY_FS_MOUNT}/shared/ok.md`, 'ok');
+      expect(await fs.readFile(`${FACTORY_FS_MOUNT}/shared/ok.md`, { encoding: 'utf8' })).toBe('ok');
+    });
+  });
+
+  describe('project isolation', () => {
+    beforeEach(async () => {
+      await durable.writeFile(`orgs/${ORG_ID}/projects/other-project/notes.md`, 'other project doc');
+    });
+
+    it('denies reads of sibling project files as not-found', async () => {
+      await expect(fs.readFile(`${FACTORY_FS_MOUNT}/projects/other-project/notes.md`)).rejects.toThrow(
+        FileNotFoundError,
+      );
+      await expect(fs.stat(`${FACTORY_FS_MOUNT}/projects/other-project/notes.md`)).rejects.toThrow(FileNotFoundError);
+      expect(await fs.exists(`${FACTORY_FS_MOUNT}/projects/other-project/notes.md`)).toBe(false);
+      expect(await fs.exists(`${FACTORY_FS_MOUNT}/projects/other-project`)).toBe(false);
+    });
+
+    it('denies writes into sibling project dirs as not-found', async () => {
+      await expect(fs.writeFile(`${FACTORY_FS_MOUNT}/projects/other-project/inject.md`, 'x')).rejects.toThrow(
+        FileNotFoundError,
+      );
+      await expect(fs.deleteFile(`${FACTORY_FS_MOUNT}/projects/other-project/notes.md`)).rejects.toThrow(
+        FileNotFoundError,
+      );
+      expect(await durable.readFile(`orgs/${ORG_ID}/projects/other-project/notes.md`, { encoding: 'utf8' })).toBe(
+        'other project doc',
+      );
+    });
+
+    it('hides sibling projects from /projects listings', async () => {
+      const entries = await fs.readdir(`${FACTORY_FS_MOUNT}/projects`);
+      expect(entries).toEqual([{ name: PROJECT_NAME, type: 'directory' }]);
+    });
+
+    it('denies unknown top-level mount paths as not-found', async () => {
+      await expect(fs.writeFile(`${FACTORY_FS_MOUNT}/oops.md`, 'x')).rejects.toThrow(FileNotFoundError);
+      await expect(fs.readFile(`${FACTORY_FS_MOUNT}/oops.md`)).rejects.toThrow(FileNotFoundError);
+    });
+  });
+
+  describe('virtual directories', () => {
+    it('lists the layout at the mount root', async () => {
+      expect(await fs.readdir(FACTORY_FS_MOUNT)).toEqual([
+        { name: 'shared', type: 'directory' },
+        { name: 'projects', type: 'directory' },
+      ]);
+    });
+
+    it('lists layout directories as empty before any writes', async () => {
+      expect(await fs.readdir(`${FACTORY_FS_MOUNT}/shared`)).toEqual([]);
+      expect(await fs.readdir(`${FACTORY_FS_MOUNT}/projects/${PROJECT_NAME}`)).toEqual([]);
+      expect(await fs.readdir(`${FACTORY_FS_MOUNT}/projects/${PROJECT_NAME}/repos/${REPO_DIR}`)).toEqual([]);
+    });
+
+    it('still throws for unknown deep directories', async () => {
+      await expect(fs.readdir(`${FACTORY_FS_MOUNT}/shared/nope`)).rejects.toThrow(DirectoryNotFoundError);
+    });
+
+    it('reports layout directories as existing directories', async () => {
+      expect(await fs.exists(FACTORY_FS_MOUNT)).toBe(true);
+      expect(await fs.exists(`${FACTORY_FS_MOUNT}/shared`)).toBe(true);
+      const stat = await fs.stat(`${FACTORY_FS_MOUNT}/projects/${PROJECT_NAME}`);
+      expect(stat.type).toBe('directory');
+      expect(stat.path).toBe(`${FACTORY_FS_MOUNT}/projects/${PROJECT_NAME}`);
+    });
+
+    it('refuses to remove layout directories', async () => {
+      await expect(fs.rmdir(`${FACTORY_FS_MOUNT}/shared`, { recursive: true })).rejects.toThrow(/reserved/);
+    });
+  });
+
+  describe('stat', () => {
+    it('re-roots reported paths into the agent-visible namespace', async () => {
+      await fs.writeFile(`${FACTORY_FS_MOUNT}/shared/doc.md`, 'hi');
+      const stat = await fs.stat(`${FACTORY_FS_MOUNT}/shared/doc.md`);
+      expect(stat.path).toBe(`${FACTORY_FS_MOUNT}/shared/doc.md`);
+      expect(stat.type).toBe('file');
+    });
+  });
+
+  describe('cross-boundary copy/move', () => {
+    it('copies a file from the sandbox into the durable mount', async () => {
+      await inner.writeFile('/README.md', 'readme');
+      await fs.copyFile('/README.md', `${FACTORY_FS_MOUNT}/shared/README.md`);
+      expect(await fs.readFile(`${FACTORY_FS_MOUNT}/shared/README.md`, { encoding: 'utf8' })).toBe('readme');
+      expect(inner.files.has('/README.md')).toBe(true);
+    });
+
+    it('moves a file from the durable mount into the sandbox', async () => {
+      await fs.writeFile(`${FACTORY_FS_MOUNT}/shared/plan.md`, 'plan');
+      await fs.moveFile(`${FACTORY_FS_MOUNT}/shared/plan.md`, '/plan.md');
+      expect(inner.files.get('/plan.md')).toBe('plan');
+      expect(await fs.exists(`${FACTORY_FS_MOUNT}/shared/plan.md`)).toBe(false);
+    });
+  });
+
+  describe('instructions', () => {
+    it('merges inner instructions with the durable-mount blurb', () => {
+      const instructions = fs.getInstructions();
+      expect(instructions).toContain(inner.getInstructions());
+      expect(instructions).toContain(`${FACTORY_FS_MOUNT}/shared`);
+      expect(instructions).toContain(`${FACTORY_FS_MOUNT}/projects/${PROJECT_NAME}/shared`);
+      expect(instructions).toContain(`${FACTORY_FS_MOUNT}/projects/${PROJECT_NAME}/repos/${REPO_DIR}`);
+      expect(instructions).toContain('shell commands cannot see');
+    });
+  });
+
+  describe('lazy durable init', () => {
+    it('surfaces backend init failures per mount operation without breaking sandbox paths', async () => {
+      class BrokenFilesystem extends LocalFilesystem {
+        override async init(): Promise<void> {
+          throw new Error('bucket unavailable');
+        }
+      }
+      const broken = new FactoryFilesystem({
+        inner,
+        durable: new BrokenFilesystem({ basePath: durableRoot }),
+        orgId: ORG_ID,
+        projectName: PROJECT_NAME,
+        repoSlug: REPO_SLUG,
+      });
+      // Overlay init succeeds — only the inner filesystem initializes eagerly.
+      await expect(broken.init()).resolves.toBeUndefined();
+      await expect(broken.writeFile(`${FACTORY_FS_MOUNT}/shared/x.md`, 'x')).rejects.toThrow(/bucket unavailable/);
+      // Sandbox-side operations are unaffected.
+      await broken.writeFile('/ok.md', 'ok');
+      expect(inner.files.get('/ok.md')).toBe('ok');
+    });
+  });
+});
+
+describe('path segment helpers', () => {
+  it('sanitizes names into safe path segments', () => {
+    expect(sanitizePathSegment('My Project')).toBe('My Project');
+    expect(sanitizePathSegment('a/b\\c')).toBe('a-b-c');
+    expect(sanitizePathSegment('..')).toBe('_');
+    expect(sanitizePathSegment('  ')).toBe('_');
+    expect(sanitizePathSegment('with\u0000control\u001fchars')).toBe('withcontrolchars');
+  });
+
+  it('derives repo directory names from owner/repo slugs', () => {
+    expect(repoDirName('mastra-ai/mastra')).toBe('mastra-ai__mastra');
+    expect(repoDirName('solo')).toBe('solo');
+  });
+});

--- a/mastracode/factory/src/filesystem.ts
+++ b/mastracode/factory/src/filesystem.ts
@@ -1,0 +1,382 @@
+/**
+ * FactoryFilesystem — overlay that exposes a durable, factory-wide filesystem
+ * inside a Factory session workspace.
+ *
+ * Paths under the reserved absolute prefix `/factory` route to a durable
+ * backend (Platform bucket on deployments, LocalFilesystem in dev); every
+ * other path delegates to the session's SandboxFilesystem untouched, so the
+ * agent-visible repo paths and exec/cwd correspondence are preserved. Same
+ * prefix-routing approach as FactorySkillSource in `./workspace.ts`.
+ *
+ * Agent-visible layout under the mount:
+ *
+ *   /factory/shared                                   org-wide shared files
+ *   /factory/projects/<project>/shared                project-wide shared files
+ *   /factory/projects/<project>/repos/<repo>/...      per-repo files
+ *
+ * Tenancy and isolation:
+ * - The backing store nests everything under `orgs/<orgId>/` — that prefix is
+ *   the tenancy wall and is never visible to agents.
+ * - A session sees `/shared` and its own project's directory only. Sibling
+ *   projects are hidden from listings and denied with FileNotFoundError so
+ *   their existence doesn't leak.
+ *
+ * The durable backend is initialized lazily: MastraFilesystem providers call
+ * `ensureReady()` inside every operation, so a misconfigured bucket surfaces
+ * as a per-operation error instead of failing session materialization.
+ */
+
+import posixPath from 'node:path/posix';
+import type {
+  CopyOptions,
+  FileContent,
+  FileEntry,
+  FileStat,
+  FilesystemInfo,
+  ListOptions,
+  ReadOptions,
+  RemoveOptions,
+  WorkspaceFilesystem,
+  WriteOptions,
+} from '@mastra/core/workspace';
+import { DirectoryNotFoundError, FileNotFoundError } from '@mastra/core/workspace';
+
+/** Reserved agent-visible mount path for the durable factory filesystem. */
+export const FACTORY_FS_MOUNT = '/factory';
+
+/**
+ * Sanitize a name into a single safe path segment: strip control chars,
+ * collapse path separators, and refuse empty/dot segments.
+ */
+export function sanitizePathSegment(name: string): string {
+  const cleaned = name
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/[/\\]/g, '-')
+    .trim();
+  return cleaned === '' || cleaned === '.' || cleaned === '..' ? '_' : cleaned;
+}
+
+/** Directory name for a repository, derived from its `owner/repo` slug. */
+export function repoDirName(repoSlug: string): string {
+  return sanitizePathSegment(repoSlug.replace(/\//g, '__'));
+}
+
+export interface FactoryFilesystemOptions {
+  /** The session's sandbox filesystem — receives every non-mount path. */
+  inner: WorkspaceFilesystem;
+  /** Durable backend the files live in (PlatformFilesystem / LocalFilesystem). */
+  durable: WorkspaceFilesystem;
+  /** Session org — becomes the invisible `orgs/<orgId>/` tenancy prefix. */
+  orgId: string;
+  /** Factory project name — its sanitized form is the project directory. */
+  projectName: string;
+  /** Repository slug (`owner/repo`) — becomes the session's repo directory. */
+  repoSlug: string;
+}
+
+interface DurableRoute {
+  /** Path inside the durable backend (org prefix applied). */
+  backendPath: string;
+  /** Normalized agent-visible subpath below the mount ('' = mount root). */
+  subpath: string;
+}
+
+export class FactoryFilesystem implements WorkspaceFilesystem {
+  readonly id: string;
+  readonly name = 'FactoryFilesystem';
+  readonly provider = 'factory';
+  readonly basePath?: string;
+
+  readonly #inner: WorkspaceFilesystem;
+  readonly #durable: WorkspaceFilesystem;
+  readonly #orgDir: string;
+  readonly #projectDir: string;
+  readonly #repoDir: string;
+
+  constructor(options: FactoryFilesystemOptions) {
+    this.#inner = options.inner;
+    this.#durable = options.durable;
+    this.#orgDir = sanitizePathSegment(options.orgId);
+    this.#projectDir = sanitizePathSegment(options.projectName);
+    this.#repoDir = repoDirName(options.repoSlug);
+    this.id = `factory:${options.inner.id}`;
+    this.basePath = options.inner.basePath;
+  }
+
+  get status() {
+    return this.#inner.status;
+  }
+
+  // ── Routing ────────────────────────────────────────────────────────────
+
+  /**
+   * Resolve a path to its durable route, or null when it belongs to the inner
+   * filesystem. Normalizes first so `/factory/../etc` escapes the mount
+   * prefix (and therefore routes to the sandboxed inner filesystem) and `..`
+   * inside the mount subtree can never climb out of the org prefix.
+   */
+  #route(inputPath: string): DurableRoute | null {
+    if (!inputPath.startsWith('/')) return null;
+    const normalized = posixPath.normalize(inputPath);
+    if (normalized !== FACTORY_FS_MOUNT && !normalized.startsWith(`${FACTORY_FS_MOUNT}/`)) return null;
+    // Backslashes are not separators to posix.normalize, but a Windows-hosted
+    // local backend would treat `..\` as one — reject them outright so a mount
+    // path can never smuggle a traversal past the org prefix.
+    if (normalized.includes('\\')) throw new FileNotFoundError(inputPath);
+    let subpath = normalized.slice(FACTORY_FS_MOUNT.length);
+    if (subpath.startsWith('/')) subpath = subpath.slice(1);
+    if (subpath.endsWith('/')) subpath = subpath.slice(0, -1);
+    this.#assertVisible(subpath, inputPath);
+    return {
+      subpath,
+      // Relative on purpose: LocalFilesystem resolves relative paths against
+      // its basePath (absolute ones are host paths and get rejected), and
+      // PlatformFilesystem treats both forms as bucket-root-relative.
+      backendPath: posixPath.join('orgs', this.#orgDir, subpath),
+    };
+  }
+
+  /**
+   * Enforce the session's view: `/shared/**`, `/projects`, and
+   * `/projects/<own>/**` are visible; everything else under the mount is
+   * denied as not-found so other projects' existence doesn't leak.
+   */
+  #assertVisible(subpath: string, inputPath: string): void {
+    if (subpath === '') return;
+    const [head, second] = subpath.split('/');
+    if (head === 'shared') return;
+    if (head === 'projects') {
+      if (second === undefined || second === this.#projectDir) return;
+      throw new FileNotFoundError(inputPath);
+    }
+    throw new FileNotFoundError(inputPath);
+  }
+
+  /**
+   * Directories that exist by definition in the mount's layout even when the
+   * durable backend has no objects under them yet (bucket "directories" are
+   * virtual and empty ones don't exist).
+   */
+  #isVirtualDir(subpath: string): boolean {
+    return [
+      '',
+      'shared',
+      'projects',
+      `projects/${this.#projectDir}`,
+      `projects/${this.#projectDir}/shared`,
+      `projects/${this.#projectDir}/repos`,
+      `projects/${this.#projectDir}/repos/${this.#repoDir}`,
+    ].includes(subpath);
+  }
+
+  /**
+   * The layout's own directories must never be created/overwritten as files —
+   * on a local backend a file at `orgs/<org>/shared` would wedge every write
+   * under `/shared/…` with ENOTDIR until it is manually deleted.
+   */
+  #assertNotVirtualDir(subpath: string, inputPath: string): void {
+    if (this.#isVirtualDir(subpath)) {
+      throw new Error(`Reserved factory filesystem directory, not a file: ${inputPath}`);
+    }
+  }
+
+  #virtualDirStat(subpath: string): FileStat {
+    return {
+      name: subpath === '' ? 'factory' : posixPath.basename(subpath),
+      path: posixPath.join(FACTORY_FS_MOUNT, subpath),
+      type: 'directory',
+      size: 0,
+      createdAt: new Date(0),
+      modifiedAt: new Date(0),
+    };
+  }
+
+  #isNotFound(error: unknown): boolean {
+    return error instanceof FileNotFoundError || error instanceof DirectoryNotFoundError;
+  }
+
+  // ── Session path helpers (used for instructions/wiring) ────────────────
+
+  /** Agent-visible directory for this session's project. */
+  get projectPath(): string {
+    return `${FACTORY_FS_MOUNT}/projects/${this.#projectDir}`;
+  }
+
+  /** Agent-visible directory for this session's repository. */
+  get repoPath(): string {
+    return `${this.projectPath}/repos/${this.#repoDir}`;
+  }
+
+  // ── File operations ────────────────────────────────────────────────────
+
+  async readFile(path: string, options?: ReadOptions): Promise<string | Buffer> {
+    const route = this.#route(path);
+    return route ? this.#durable.readFile(route.backendPath, options) : this.#inner.readFile(path, options);
+  }
+
+  async writeFile(path: string, content: FileContent, options?: WriteOptions): Promise<void> {
+    const route = this.#route(path);
+    if (!route) return this.#inner.writeFile(path, content, options);
+    this.#assertNotVirtualDir(route.subpath, path);
+    return this.#durable.writeFile(route.backendPath, content, options);
+  }
+
+  async appendFile(path: string, content: FileContent): Promise<void> {
+    const route = this.#route(path);
+    if (!route) return this.#inner.appendFile(path, content);
+    this.#assertNotVirtualDir(route.subpath, path);
+    return this.#durable.appendFile(route.backendPath, content);
+  }
+
+  async deleteFile(path: string, options?: RemoveOptions): Promise<void> {
+    const route = this.#route(path);
+    if (!route) return this.#inner.deleteFile(path, options);
+    this.#assertNotVirtualDir(route.subpath, path);
+    return this.#durable.deleteFile(route.backendPath, options);
+  }
+
+  async copyFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
+    const srcRoute = this.#route(src);
+    const destRoute = this.#route(dest);
+    if (srcRoute && destRoute) return this.#durable.copyFile(srcRoute.backendPath, destRoute.backendPath, options);
+    if (!srcRoute && !destRoute) return this.#inner.copyFile(src, dest, options);
+    // Cross-boundary copy (sandbox ↔ mount): read from one side, write to the other.
+    if (options?.overwrite === false && (await this.exists(dest)))
+      throw new Error(`Destination already exists: ${dest}`);
+    const content = await this.readFile(src);
+    await this.writeFile(dest, content);
+  }
+
+  async moveFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
+    const srcRoute = this.#route(src);
+    const destRoute = this.#route(dest);
+    if (srcRoute && destRoute) return this.#durable.moveFile(srcRoute.backendPath, destRoute.backendPath, options);
+    if (!srcRoute && !destRoute) return this.#inner.moveFile(src, dest, options);
+    await this.copyFile(src, dest, options);
+    await this.deleteFile(src);
+  }
+
+  // ── Directory operations ───────────────────────────────────────────────
+
+  async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
+    const route = this.#route(path);
+    return route ? this.#durable.mkdir(route.backendPath, options) : this.#inner.mkdir(path, options);
+  }
+
+  async rmdir(path: string, options?: RemoveOptions): Promise<void> {
+    const route = this.#route(path);
+    if (!route) return this.#inner.rmdir(path, options);
+    // The layout's own directories are permanent — refuse to remove them.
+    if (this.#isVirtualDir(route.subpath))
+      throw new Error(`Cannot remove reserved factory filesystem directory: ${path}`);
+    return this.#durable.rmdir(route.backendPath, options);
+  }
+
+  async readdir(path: string, options?: ListOptions): Promise<FileEntry[]> {
+    const route = this.#route(path);
+    if (!route) return this.#inner.readdir(path, options);
+    // The mount root and /projects are synthesized: they always list the
+    // layout's directories and never expose sibling projects, regardless of
+    // what exists in the backend. (Recursion stops at this virtual level.)
+    if (route.subpath === '') {
+      return [
+        { name: 'shared', type: 'directory' },
+        { name: 'projects', type: 'directory' },
+      ];
+    }
+    if (route.subpath === 'projects') {
+      return [{ name: this.#projectDir, type: 'directory' }];
+    }
+    try {
+      return await this.#durable.readdir(route.backendPath, options);
+    } catch (error) {
+      // Layout directories exist by definition even when the backend has no
+      // objects under them yet.
+      if (this.#isNotFound(error) && this.#isVirtualDir(route.subpath)) return [];
+      throw error;
+    }
+  }
+
+  // ── Path operations ────────────────────────────────────────────────────
+
+  resolveAbsolutePath(path: string): string | undefined {
+    // Mount files live in a remote/durable backend — no host disk path to resolve.
+    if (this.#route(path)) return undefined;
+    return this.#inner.resolveAbsolutePath?.(path);
+  }
+
+  async realpath(path: string): Promise<string> {
+    const route = this.#route(path);
+    if (route) return posixPath.join(FACTORY_FS_MOUNT, route.subpath);
+    return this.#inner.realpath ? this.#inner.realpath(path) : path;
+  }
+
+  async exists(path: string): Promise<boolean> {
+    let route: DurableRoute;
+    try {
+      const resolved = this.#route(path);
+      if (!resolved) return this.#inner.exists(path);
+      route = resolved;
+    } catch (error) {
+      // Hidden sibling project (or unknown top-level mount path) — report
+      // absent rather than erroring so existence doesn't leak.
+      if (this.#isNotFound(error)) return false;
+      throw error;
+    }
+    if (this.#isVirtualDir(route.subpath)) return true;
+    return this.#durable.exists(route.backendPath);
+  }
+
+  async stat(path: string): Promise<FileStat> {
+    const route = this.#route(path);
+    if (!route) return this.#inner.stat(path);
+    try {
+      const stat = await this.#durable.stat(route.backendPath);
+      // Re-root the reported path into the agent-visible namespace.
+      return { ...stat, path: posixPath.join(FACTORY_FS_MOUNT, route.subpath) };
+    } catch (error) {
+      if (this.#isNotFound(error) && this.#isVirtualDir(route.subpath)) return this.#virtualDirStat(route.subpath);
+      throw error;
+    }
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────
+
+  async init(): Promise<void> {
+    // Only the inner filesystem is initialized eagerly. The durable backend
+    // self-initializes on first use (MastraFilesystem.ensureReady), keeping a
+    // misconfigured bucket from blocking session materialization.
+    await this.#inner.init?.();
+  }
+
+  async destroy(): Promise<void> {
+    await this.#inner.destroy?.();
+  }
+
+  async getInfo(): Promise<FilesystemInfo> {
+    return {
+      id: this.id,
+      name: this.name,
+      provider: this.provider,
+      status: this.status,
+      metadata: {
+        mount: FACTORY_FS_MOUNT,
+        inner: (await this.#inner.getInfo?.()) ?? null,
+        durableProvider: this.#durable.provider,
+      },
+    };
+  }
+
+  getInstructions(): string {
+    const innerInstructions =
+      this.#inner.getInstructions?.() ??
+      `Files are stored in a remote sandbox. Use absolute workspace paths like /src/index.ts.`;
+    return [
+      innerInstructions,
+      `Additionally, ${FACTORY_FS_MOUNT} is a DURABLE filesystem mount: files written there outlive this sandbox and are shared with other factory sessions. Anything worth persisting outside version control can live there — for example plans, notes, triage handoffs, or scratch data. How you organize it is up to you and the user.`,
+      `Your writable locations: ${FACTORY_FS_MOUNT}/shared (org-wide), ${this.projectPath}/shared (project-wide), and ${this.repoPath} (this repository).`,
+      `IMPORTANT: shell commands cannot see ${FACTORY_FS_MOUNT} — it is not a real directory in the sandbox. Read, write, list, and search it with the workspace file tools only.`,
+    ].join('\n');
+  }
+}

--- a/mastracode/factory/src/routes/factory-fs.test.ts
+++ b/mastracode/factory/src/routes/factory-fs.test.ts
@@ -1,0 +1,142 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { LocalFilesystem } from '@mastra/core/workspace';
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import type { FactoryFsFile, FactoryFsListing } from './factory-fs.js';
+import { FactoryFsRoutes } from './factory-fs.js';
+import { fakeRouteAuth, mountApiRoutes } from './test-utils.js';
+
+const ORG_ID = 'org-1';
+
+describe('FactoryFsRoutes', () => {
+  let durableRoot: string;
+  let durable: LocalFilesystem;
+
+  beforeEach(() => {
+    durableRoot = mkdtempSync(join(tmpdir(), 'factory-fs-routes-'));
+    durable = new LocalFilesystem({ basePath: durableRoot });
+  });
+
+  afterEach(() => {
+    rmSync(durableRoot, { recursive: true, force: true });
+  });
+
+  async function buildApp(options: {
+    filesystem?: LocalFilesystem;
+    user?: { workosId: string; organizationId?: string };
+  }) {
+    const seed = await createFactoryStorageForTests();
+    const app = new Hono();
+    app.use('*', async (context, next) => {
+      if (options.user) context.set('factoryAuthUser' as never, options.user as never);
+      await next();
+    });
+    mountApiRoutes(
+      app as never,
+      new FactoryFsRoutes({ auth: fakeRouteAuth(), filesystem: options.filesystem, projects: seed.projects }).routes(),
+    );
+    return { app, seed };
+  }
+
+  const asUser = { workosId: 'user-1', organizationId: ORG_ID };
+
+  it('requires a signed-in user with an organization', async () => {
+    const { app } = await buildApp({ filesystem: durable });
+    expect((await app.request('/web/factory/fs/list')).status).toBe(401);
+
+    const { app: orgless } = await buildApp({ filesystem: durable, user: { workosId: 'user-1' } });
+    expect((await orgless.request('/web/factory/fs/list')).status).toBe(403);
+    expect((await orgless.request('/web/factory/fs/file?path=shared/x.md')).status).toBe(403);
+  });
+
+  it('answers available:false when no durable filesystem is configured', async () => {
+    const { app } = await buildApp({ user: asUser });
+    const listing = (await (await app.request('/web/factory/fs/list')).json()) as FactoryFsListing;
+    expect(listing).toEqual({ available: false, entries: [] });
+    expect((await app.request('/web/factory/fs/file?path=shared/x.md')).status).toBe(404);
+  });
+
+  it('lists the org tree and reads files back', async () => {
+    await durable.writeFile(`orgs/${ORG_ID}/shared/note.md`, 'org note', { recursive: true });
+    await durable.writeFile(`orgs/${ORG_ID}/projects/Alpha/plans/issue-1.md`, '# plan', { recursive: true });
+    const { app } = await buildApp({ filesystem: durable, user: asUser });
+
+    const listing = (await (await app.request('/web/factory/fs/list')).json()) as FactoryFsListing;
+    expect(listing.available).toBe(true);
+    const paths = listing.entries.map(entry => entry.path).sort();
+    expect(paths).toEqual([
+      'projects',
+      'projects/Alpha',
+      'projects/Alpha/plans',
+      'projects/Alpha/plans/issue-1.md',
+      'shared',
+      'shared/note.md',
+    ]);
+    const note = listing.entries.find(entry => entry.path === 'shared/note.md')!;
+    expect(note.type).toBe('file');
+    expect(note.size).toBeGreaterThan(0);
+    expect(note.updatedAt).not.toBe('');
+
+    const file = (await (
+      await app.request('/web/factory/fs/file?path=projects/Alpha/plans/issue-1.md')
+    ).json()) as FactoryFsFile;
+    expect(file).toMatchObject({
+      path: 'projects/Alpha/plans/issue-1.md',
+      name: 'issue-1.md',
+      contentType: 'text',
+      content: '# plan',
+    });
+  });
+
+  it('resolves projectDir for the requesting project', async () => {
+    const { app, seed } = await buildApp({ filesystem: durable, user: asUser });
+    const project = await seed.projects.create({ orgId: ORG_ID, userId: 'user-1', input: { name: 'Alpha Project' } });
+
+    const listing = (await (
+      await app.request(`/web/factory/fs/list?projectId=${project.id}`)
+    ).json()) as FactoryFsListing;
+    expect(listing.projectDir).toBe('projects/Alpha Project');
+
+    // Unknown project id → listing still works, no projectDir.
+    const fallback = (await (
+      await app.request('/web/factory/fs/list?projectId=00000000-0000-4000-8000-000000000000')
+    ).json()) as FactoryFsListing;
+    expect(fallback.projectDir).toBeUndefined();
+  });
+
+  it('scopes everything to the caller org', async () => {
+    await durable.writeFile('orgs/org-2/shared/secret.md', 'other org', { recursive: true });
+    const { app } = await buildApp({ filesystem: durable, user: asUser });
+
+    const listing = (await (await app.request('/web/factory/fs/list')).json()) as FactoryFsListing;
+    expect(listing.entries).toEqual([]);
+    expect((await app.request('/web/factory/fs/file?path=../org-2/shared/secret.md')).status).toBe(400);
+    expect(
+      (await app.request(`/web/factory/fs/file?path=${encodeURIComponent('..\\org-2\\shared\\secret.md')}`)).status,
+    ).toBe(400);
+    expect(
+      (await app.request(`/web/factory/fs/file?path=${encodeURIComponent('/orgs/org-2/shared/secret.md')}`)).status,
+    ).toBe(400);
+  });
+
+  it('rejects missing paths and answers 404 for absent files', async () => {
+    const { app } = await buildApp({ filesystem: durable, user: asUser });
+    expect((await app.request('/web/factory/fs/file')).status).toBe(400);
+    expect((await app.request('/web/factory/fs/file?path=shared/missing.md')).status).toBe(404);
+  });
+
+  it('marks binary files as unsupported', async () => {
+    await durable.writeFile(`orgs/${ORG_ID}/shared/blob.bin`, Buffer.from([0xff, 0xfe, 0x00, 0xc3, 0x28]), {
+      recursive: true,
+    });
+    const { app } = await buildApp({ filesystem: durable, user: asUser });
+    const file = (await (await app.request('/web/factory/fs/file?path=shared/blob.bin')).json()) as FactoryFsFile;
+    expect(file.contentType).toBe('unsupported');
+    expect(file.content).toBeUndefined();
+  });
+});

--- a/mastracode/factory/src/routes/factory-fs.ts
+++ b/mastracode/factory/src/routes/factory-fs.ts
@@ -1,0 +1,230 @@
+/**
+ * Read-only HTTP surface for the durable factory filesystem (`/factory` in
+ * session workspaces), so the web UI can browse and preview the files agents
+ * persist there.
+ *
+ * Unlike session agents — whose view is confined to their own project — the
+ * UI serves signed-in org members, so these routes expose the whole org tree:
+ * `shared/` plus every `projects/<project>/` directory. Tenancy still comes
+ * from the authenticated org; backend paths reuse the exact same
+ * `orgs/<orgId>/...` mapping as `FactoryFilesystem`, so what the UI shows is
+ * precisely what sessions wrote. The `projectId` query lets the UI learn the
+ * current project's directory name so it can focus there by default.
+ */
+
+import { posix as posixPath } from 'node:path';
+
+import { registerApiRoute } from '@mastra/core/server';
+import type { ApiRoute } from '@mastra/core/server';
+import type { WorkspaceFilesystem } from '@mastra/core/workspace';
+import type { Context } from 'hono';
+
+import { sanitizePathSegment } from '../filesystem.js';
+import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
+import type { RouteDependencies } from './route.js';
+import { Route } from './route.js';
+
+export interface FactoryFsEntry {
+  name: string;
+  /** Path relative to the org root, e.g. `shared/notes.md` or `projects/Alpha/plans/x.md`. */
+  path: string;
+  type: 'file' | 'directory';
+  size: number;
+  updatedAt: string;
+}
+
+export interface FactoryFsListing {
+  /** False when no durable filesystem is configured on this deployment. */
+  available: boolean;
+  /** Org-relative directory of the requested project (e.g. `projects/Alpha`), when resolvable. */
+  projectDir?: string;
+  entries: FactoryFsEntry[];
+}
+
+export interface FactoryFsFile {
+  /** Org-relative file path. */
+  path: string;
+  name: string;
+  size: number;
+  updatedAt: string;
+  contentType: 'text' | 'unsupported';
+  content?: string;
+  truncated?: boolean;
+}
+
+const MAX_TEXT_FILE_BYTES = 512 * 1024;
+const MAX_LIST_ENTRIES = 2_000;
+const MAX_LIST_DEPTH = 16;
+const TEXT_DECODER = new TextDecoder('utf-8', { fatal: true });
+
+function loose(context: unknown): Context {
+  return context as Context;
+}
+
+/**
+ * Validate a client-supplied org-relative path: no absolute paths, no
+ * backslashes, and no `..` escaping the org prefix after normalization.
+ * Returns the normalized relative path or null when invalid.
+ */
+function normalizeRelativePath(input: string): string | null {
+  if (input.includes('\\') || input.startsWith('/')) return null;
+  const normalized = posixPath.normalize(input);
+  if (normalized === '.' || normalized === '..' || normalized.startsWith('../')) return null;
+  return normalized;
+}
+
+export interface FactoryFsRoutesDeps extends RouteDependencies {
+  /** The durable factory filesystem backend; omitted → routes answer `available: false`. */
+  filesystem?: WorkspaceFilesystem;
+  /** Projects domain — resolves the current project's directory name. */
+  projects: Pick<FactoryProjectsStorage, 'get' | 'ensureReady'>;
+}
+
+export class FactoryFsRoutes extends Route<FactoryFsRoutesDeps> {
+  async #resolveTenant(context: Context): Promise<{ orgId: string } | { response: Response }> {
+    await this.deps.auth.ensureUser(context);
+    const tenant = this.deps.auth.tenant(context);
+    if (!tenant) return { response: context.json({ error: 'unauthorized' }, 401) };
+    if (!tenant.orgId) {
+      return {
+        response: context.json(
+          { error: 'organization_required', message: 'The factory filesystem requires an organization.' },
+          403,
+        ),
+      };
+    }
+    return { orgId: tenant.orgId };
+  }
+
+  #orgRoot(orgId: string): string {
+    return posixPath.join('orgs', sanitizePathSegment(orgId));
+  }
+
+  /** Org-relative directory for a project id, when it resolves. */
+  async #projectDir(orgId: string, projectId: string | undefined): Promise<string | undefined> {
+    if (!projectId) return undefined;
+    try {
+      await this.deps.projects.ensureReady();
+      const project = await this.deps.projects.get({ orgId, id: projectId });
+      return project ? posixPath.join('projects', sanitizePathSegment(project.name)) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Recursively walk the org root, returning org-relative entries. */
+  async #walk(filesystem: WorkspaceFilesystem, orgRoot: string): Promise<FactoryFsEntry[]> {
+    const entries: FactoryFsEntry[] = [];
+    const queue: Array<{ relative: string; depth: number }> = [{ relative: '', depth: 0 }];
+
+    while (queue.length > 0 && entries.length < MAX_LIST_ENTRIES) {
+      const { relative, depth } = queue.shift()!;
+      let children;
+      try {
+        children = await filesystem.readdir(posixPath.join(orgRoot, relative));
+      } catch {
+        // Missing directory (virtual/empty bucket prefix) — nothing to list.
+        continue;
+      }
+      for (const child of children) {
+        if (entries.length >= MAX_LIST_ENTRIES) break;
+        const childRelative = relative ? `${relative}/${child.name}` : child.name;
+        if (child.type === 'directory') {
+          entries.push({ name: child.name, path: childRelative, type: 'directory', size: 0, updatedAt: '' });
+          if (depth + 1 < MAX_LIST_DEPTH) queue.push({ relative: childRelative, depth: depth + 1 });
+          continue;
+        }
+        let size = child.size ?? 0;
+        let updatedAt = '';
+        try {
+          const stat = await filesystem.stat(posixPath.join(orgRoot, childRelative));
+          size = stat.size;
+          updatedAt = stat.modifiedAt.toISOString();
+        } catch {
+          // Entry disappeared between readdir and stat — keep readdir's view.
+        }
+        entries.push({ name: child.name, path: childRelative, type: 'file', size, updatedAt });
+      }
+    }
+    return entries;
+  }
+
+  async #readFile(filesystem: WorkspaceFilesystem, orgRoot: string, relativePath: string): Promise<FactoryFsFile> {
+    const backendPath = posixPath.join(orgRoot, relativePath);
+    const stat = await filesystem.stat(backendPath);
+    const base = {
+      path: relativePath,
+      name: posixPath.basename(relativePath),
+      size: stat.size,
+      updatedAt: stat.modifiedAt.toISOString(),
+    };
+
+    const content = await filesystem.readFile(backendPath);
+    const bytes =
+      typeof content === 'string'
+        ? Buffer.from(content, 'utf8')
+        : Buffer.isBuffer(content)
+          ? content
+          : Buffer.from(content as Uint8Array);
+    const truncated = bytes.byteLength > MAX_TEXT_FILE_BYTES;
+    const sliced = truncated ? bytes.subarray(0, MAX_TEXT_FILE_BYTES) : bytes;
+    try {
+      const text = TEXT_DECODER.decode(sliced);
+      return { ...base, contentType: 'text', content: text, ...(truncated ? { truncated } : {}) };
+    } catch {
+      // Truncation can split a multi-byte sequence; a genuine binary file
+      // fails to decode either way.
+      return { ...base, contentType: 'unsupported' };
+    }
+  }
+
+  routes(): ApiRoute[] {
+    return [
+      registerApiRoute('/web/factory/fs/list', {
+        method: 'GET',
+        requiresAuth: false,
+        handler: async routeContext => {
+          const context = loose(routeContext);
+          const tenant = await this.#resolveTenant(context);
+          if ('response' in tenant) return tenant.response;
+
+          const projectDir = await this.#projectDir(tenant.orgId, context.req.query('projectId'));
+          const filesystem = this.deps.filesystem;
+          if (!filesystem) {
+            return context.json({ available: false, projectDir, entries: [] } satisfies FactoryFsListing);
+          }
+          try {
+            const entries = await this.#walk(filesystem, this.#orgRoot(tenant.orgId));
+            return context.json({ available: true, projectDir, entries } satisfies FactoryFsListing);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            return context.json({ error: message }, 500);
+          }
+        },
+      }),
+      registerApiRoute('/web/factory/fs/file', {
+        method: 'GET',
+        requiresAuth: false,
+        handler: async routeContext => {
+          const context = loose(routeContext);
+          const tenant = await this.#resolveTenant(context);
+          if ('response' in tenant) return tenant.response;
+
+          const rawPath = context.req.query('path');
+          if (!rawPath) return context.json({ error: 'missing_path' }, 400);
+          const relativePath = normalizeRelativePath(rawPath);
+          if (!relativePath) return context.json({ error: 'invalid_path' }, 400);
+
+          const filesystem = this.deps.filesystem;
+          if (!filesystem) return context.json({ error: 'filesystem_not_configured' }, 404);
+
+          try {
+            return context.json(await this.#readFile(filesystem, this.#orgRoot(tenant.orgId), relativePath));
+          } catch {
+            return context.json({ error: 'not_found' }, 404);
+          }
+        },
+      }),
+    ];
+  }
+}

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -4,8 +4,7 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getDynamicWorkspace } from '@mastra/code-sdk/agents/workspace';
 import { RequestContext } from '@mastra/core/request-context';
-import { LocalSandbox } from '@mastra/core/workspace';
-import type { LocalFilesystem } from '@mastra/core/workspace';
+import { LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -220,7 +219,7 @@ function fakeGithubIntegration() {
           return project
             ? {
                 id: project.id,
-                connectionId: 'connection-1',
+                connectionId: `connection-${project.id}`,
                 repositoryId: 'repository-1',
                 branch: project.defaultBranch,
                 sandboxWorkdir: project.sandboxWorkdir,
@@ -229,7 +228,13 @@ function fakeGithubIntegration() {
             : null;
         }),
       },
-      connections: { get: vi.fn(async () => ({ id: 'connection-1', installationId: 'installation-1' })) },
+      connections: {
+        get: vi.fn(async ({ id }: { id: string }) => ({
+          id,
+          installationId: 'installation-1',
+          factoryProjectId: id.replace(/^connection-/, ''),
+        })),
+      },
       repositories: {
         get: vi.fn(async () => {
           const project = mocks.projects[0];
@@ -456,7 +461,10 @@ describe('getFactoryWorkspace', () => {
 });
 
 describe('GitHub session workspace preparation', () => {
-  async function createLocalFactory(rootPrefix = 'mastracode-web-local-sessions-') {
+  async function createLocalFactory(
+    rootPrefix = 'mastracode-web-local-sessions-',
+    extras: Partial<Parameters<typeof createWorkspaceFactory>[0]> = {},
+  ) {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), rootPrefix));
     tempDirs.push(root);
     const machine = new LocalSandbox({ workingDirectory: root });
@@ -469,6 +477,7 @@ describe('GitHub session workspace preparation', () => {
         github: fakeGithubIntegration() as any,
         fleet,
         workItems: { findRunBindingBySession: mocks.findRunBindingBySession } as any,
+        ...extras,
       }),
     };
   }
@@ -615,6 +624,106 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.ensureSandbox).toHaveBeenCalledTimes(1);
     expect(mocks.materializeRepo).toHaveBeenCalledTimes(1);
     expect(mocks.checkoutSessionBranch).toHaveBeenCalledTimes(1);
+  });
+
+  describe('durable factory filesystem', () => {
+    const projectsStorage = {
+      get: async ({ id }: { orgId: string; id: string }) =>
+        id === 'project-1' ? { id, name: 'Alpha Project' } : id === 'project-2' ? { id, name: 'Beta Project' } : null,
+    } as any;
+
+    async function createDocsFactory() {
+      const durableRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'mastracode-factory-fs-'));
+      tempDirs.push(durableRoot);
+      const durable = new LocalFilesystem({ basePath: durableRoot });
+      const { workspace } = await createLocalFactory('mastracode-web-local-sessions-', {
+        filesystem: durable,
+        projects: projectsStorage,
+      });
+      return { durable, workspace };
+    }
+
+    it('exposes /factory and round-trips a file through the workspace filesystem', async () => {
+      const { durable, workspace } = await createDocsFactory();
+      addProject();
+      addSession({ id: 'session-a' });
+
+      const sessionWorkspace = await workspace({
+        requestContext: createGithubRequestContext('project-1', 'session-a'),
+      });
+      const filesystem = sessionWorkspace.filesystem!;
+
+      const planPath = '/factory/projects/Alpha Project/repos/octocat__hello/plans/foo.md';
+      await filesystem.writeFile(planPath, 'the plan');
+      expect(await filesystem.readFile(planPath, { encoding: 'utf8' })).toBe('the plan');
+      // Persisted in the durable backend under the tenancy prefix, not the sandbox.
+      expect(
+        await durable.readFile('orgs/org-1/projects/Alpha Project/repos/octocat__hello/plans/foo.md', {
+          encoding: 'utf8',
+        }),
+      ).toBe('the plan');
+      // Instructions advertise the mount and the session's own directories.
+      const instructions = filesystem.getInstructions?.() ?? '';
+      expect(instructions).toContain('/factory/shared');
+      expect(instructions).toContain('/factory/projects/Alpha Project/repos/octocat__hello');
+      expect(instructions).toContain('shell commands cannot see /factory');
+    });
+
+    it('shares files across sessions of the same project and hides sibling projects', async () => {
+      const { workspace } = await createDocsFactory();
+      addProject();
+      addProject({ id: 'project-2' });
+      addSession({ id: 'session-a', projectRepositoryId: 'project-1' });
+      addSession({ id: 'session-b', projectRepositoryId: 'project-1' });
+      addSession({ id: 'session-c', projectRepositoryId: 'project-2' });
+
+      const first = await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+      await first.filesystem!.writeFile('/factory/projects/Alpha Project/shared/note.md', 'alpha note');
+      await first.filesystem!.writeFile('/factory/shared/org-note.md', 'org note');
+
+      // A later session in the same project reads the doc back.
+      const second = await workspace({ requestContext: createGithubRequestContext('project-1', 'session-b') });
+      expect(
+        await second.filesystem!.readFile('/factory/projects/Alpha Project/shared/note.md', { encoding: 'utf8' }),
+      ).toBe('alpha note');
+
+      // A sibling-project session sees /shared but not Alpha Project's files.
+      const sibling = await workspace({ requestContext: createGithubRequestContext('project-2', 'session-c') });
+      expect(await sibling.filesystem!.readFile('/factory/shared/org-note.md', { encoding: 'utf8' })).toBe('org note');
+      expect(await sibling.filesystem!.readdir('/factory/projects')).toEqual([
+        { name: 'Beta Project', type: 'directory' },
+      ]);
+      await expect(sibling.filesystem!.readFile('/factory/projects/Alpha Project/shared/note.md')).rejects.toThrow();
+      expect(await sibling.filesystem!.exists('/factory/projects/Alpha Project/shared/note.md')).toBe(false);
+    });
+
+    it('isolates orgs in the durable backend', async () => {
+      const { durable, workspace } = await createDocsFactory();
+      addProject();
+      addSession({ id: 'session-a' });
+
+      const sessionWorkspace = await workspace({
+        requestContext: createGithubRequestContext('project-1', 'session-a'),
+      });
+      await sessionWorkspace.filesystem!.writeFile('/factory/shared/org-note.md', 'org-1 note');
+
+      // The doc lives under org-1's prefix; org-2's tree is empty.
+      expect(await durable.exists('orgs/org-1/shared/org-note.md')).toBe(true);
+      expect(await durable.exists('orgs/org-2/shared/org-note.md')).toBe(false);
+    });
+
+    it('keeps the plain sandbox filesystem when no durable filesystem is configured', async () => {
+      const { workspace } = await createLocalFactory();
+      addProject();
+      addSession({ id: 'session-a' });
+
+      const sessionWorkspace = await workspace({
+        requestContext: createGithubRequestContext('project-1', 'session-a'),
+      });
+      const instructions = sessionWorkspace.filesystem!.getInstructions?.() ?? '';
+      expect(sessionWorkspace.filesystem!.provider).not.toBe('factory');
+      expect(instructions).not.toContain('/factory');
+    });
   });
 
   function createRemoteFactory() {

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -9,10 +9,11 @@ import { DEFAULT_CONFIG_DIR } from '@mastra/code-sdk/constants';
 import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
 import { LocalSandbox, LocalSkillSource, Workspace } from '@mastra/core/workspace';
-import type { SkillSource, SkillSourceEntry, SkillSourceStat } from '@mastra/core/workspace';
+import type { SkillSource, SkillSourceEntry, SkillSourceStat, WorkspaceFilesystem } from '@mastra/core/workspace';
 import { getFactoryAuthUserId } from './auth.js';
 import type { FactoryAuthUser } from './auth.js';
 import type { MastraFactorySandboxConfig } from './factory.js';
+import { FactoryFilesystem } from './filesystem.js';
 import type { GithubIntegration } from './integrations/github/integration.js';
 import { getGithubPat } from './integrations/github/pat.js';
 import type { GithubPatKind } from './integrations/github/pat.js';
@@ -26,6 +27,7 @@ import {
 import { registerGithubPatKind, registerGithubTokenInjector } from './integrations/github/token-refresh.js';
 import { getFactorySessionAddress } from './rules/binding-context.js';
 import type { SandboxBindingStore, SandboxFleet } from './sandbox/fleet.js';
+import type { FactoryProjectsStorage } from './storage/domains/projects/base.js';
 import type { WorkItemsStorage } from './storage/domains/work-items/base.js';
 
 const WORKSPACE_ID_PREFIX = 'mfw';
@@ -125,10 +127,19 @@ export interface CreateWorkspaceFactoryOptions {
    * review-board sessions get the reviewer PAT as `GH_TOKEN`. Optional —
    * without it every session uses the default (worker) PAT. */
   workItems?: Pick<WorkItemsStorage, 'findRunBindingBySession'>;
+  /**
+   * Durable filesystem shared across factory sessions. When set, session
+   * workspaces overlay it at `/factory` on top of the sandbox filesystem
+   * (see `FactoryFilesystem`). Omitted → no durable mount.
+   */
+  filesystem?: WorkspaceFilesystem;
+  /** Projects storage used to name the session's `/factory` project
+   * directory. Without it the directory falls back to the project id. */
+  projects?: Pick<FactoryProjectsStorage, 'get'>;
 }
 
 export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = {}) {
-  const { sandbox: sandboxConfig, github, fleet, workItems } = options;
+  const { sandbox: sandboxConfig, github, fleet, workItems, filesystem: durableFilesystem, projects } = options;
   const isLocalSandbox = sandboxConfig?.machine instanceof LocalSandbox;
   const githubTokenInjectors = new Map<
     string,
@@ -353,7 +364,33 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       registerGithubTokenInjector(requestContext, injectGithubToken);
       registerGithubPatKind(requestContext, patKind);
 
-      const filesystem = new SandboxFilesystem({ sandbox, workdir });
+      const sandboxFilesystem = new SandboxFilesystem({ sandbox, workdir });
+      let filesystem: SandboxFilesystem | FactoryFilesystem = sandboxFilesystem;
+      if (durableFilesystem) {
+        // Name the project directory after the factory project. Best-effort:
+        // an unresolved project falls back to its id so the mount still works.
+        let projectName = connection.factoryProjectId;
+        if (projects) {
+          try {
+            const project = await projects.get({ orgId: session.orgId, id: connection.factoryProjectId });
+            if (project?.name) projectName = project.name;
+          } catch (error) {
+            // Fall back to the project id. Loud: files written under the id
+            // land in a directory later name-resolved sessions cannot see.
+            console.warn(
+              `[FactoryFilesystem] Could not resolve project ${connection.factoryProjectId} — using its id as the project directory`,
+              error,
+            );
+          }
+        }
+        filesystem = new FactoryFilesystem({
+          inner: sandboxFilesystem,
+          durable: durableFilesystem,
+          orgId: session.orgId,
+          projectName,
+          repoSlug: repoFullName,
+        });
+      }
       const projectSkillPaths = [path.join(configDir, 'skills'), '.claude/skills', '.agents/skills'];
       const skillPaths = [...(effectiveSkillExtension?.paths ?? []), ...projectSkillPaths];
       const workspace = new Workspace({

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -20,10 +20,10 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { Mastra } from '@mastra/core/mastra';
-import { LocalSandbox } from '@mastra/core/workspace';
+import { LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
 import { LibSQLFactoryStorage } from '@mastra/libsql';
 import { PgVector, PgFactoryStorage } from '@mastra/pg';
-import { InProcessSandboxAddressRegistry, PlatformSandbox } from '@mastra/platform-workspace';
+import { InProcessSandboxAddressRegistry, PlatformFilesystem, PlatformSandbox } from '@mastra/platform-workspace';
 import { RedisStreamsPubSub } from '@mastra/redis-streams';
 import { getDatabasePath } from '@mastra/code-sdk/utils/project';
 import { DEFAULT_RETENTION } from '@mastra/code-sdk/utils/storage-maintenance';
@@ -200,6 +200,29 @@ const sandbox = hasPlatformSandboxEnv
       env: localSandboxEnv(),
     });
 
+// Durable factory filesystem: platform bucket when the platform identity
+// AND a bucket are configured, otherwise a local folder so dev exercises the
+// same `/factory` code path. The platform sandbox env can be complete
+// while no bucket is attached — fall back to the local folder and say so
+// rather than failing the boot.
+const platformBucketName = process.env.MASTRA_PLATFORM_BUCKET_NAME?.trim();
+const factoryFsLocalRoot =
+  process.env.MASTRACODE_FACTORY_FS_ROOT?.trim() || join(homedir(), '.mastracode', 'web', 'factory-fs');
+const factoryFilesystem =
+  hasPlatformSandboxEnv && platformBucketName
+    ? new PlatformFilesystem({ bucketName: platformBucketName })
+    : new LocalFilesystem({ basePath: factoryFsLocalRoot });
+if (hasPlatformSandboxEnv && platformBucketName) {
+  console.log(`[FactoryFilesystem] MASTRA_PLATFORM_BUCKET_NAME set — durable /factory on the platform bucket.`);
+} else {
+  if (hasPlatformSandboxEnv) {
+    console.warn(
+      '[FactoryFilesystem] Platform sandbox env is set but MASTRA_PLATFORM_BUCKET_NAME is not — durable /factory falls back to a local folder, which does not survive replica moves.',
+    );
+  }
+  console.log(`[FactoryFilesystem] Durable /factory on local folder ${factoryFsLocalRoot}.`);
+}
+
 // One FactoryStorage backend powers agent storage, the factory app tables,
 // the distributed project lock, and better-auth. `DATABASE_URL` set →
 // Postgres (the paired PgVector rides the same database for recall search).
@@ -291,6 +314,9 @@ export const factory = new MastraFactory({
     // Per-replica cap on concurrently provisioned sandboxes. Unset → unlimited.
     maxSandboxes: positiveInt(process.env.MASTRACODE_MAX_SANDBOXES),
   },
+  // Durable factory-wide filesystem, mounted at /factory in every session
+  // workspace (see selection above: platform bucket or local folder).
+  filesystem: factoryFilesystem,
   // Per-replica cap on concurrent Factory background dispatches. Unset means
   // the dispatcher default; invalid and non-positive values are ignored.
   dispatcher: {


### PR DESCRIPTION
Factory sessions had nowhere to keep files that don't belong in version control — plans, triage handoffs, ops notes — that should survive sandbox teardown and be shareable across the agents working in a factory. This adds a durable filesystem slot to `MastraFactory` and mounts it at `/factory` inside every session workspace.

No config needed in the normal case: the web entry selects the backend from the environment the same way it picks `PlatformSandbox` vs `LocalSandbox` — `PlatformFilesystem` when the platform env (incl. the bucket) is present, otherwise a `LocalFilesystem` under `~/.mastracode/web/factory-fs` for local dev. The slot is there for custom hosts or backends:

```ts
new MastraFactory({
  filesystem: new PlatformFileSystem(), // optional — defaulted by the web entry
  // ...
});
```

Agents use the normal workspace file tools against the mount:

```
/factory/shared                          org-wide shared files
/factory/projects/<project>/shared       project-wide shared files
/factory/projects/<project>/repos/<repo> per-repo files
```

Isolation: a session sees `/factory/shared` and its own project's directory only — sibling projects are hidden from listings and denied as not-found, and the backing store nests everything under an `orgs/<orgId>/` prefix that agents never see. The overlay (`FactoryFilesystem`) is a prefix router: every non-`/factory` path delegates to the session's `SandboxFilesystem` untouched, so repo paths and exec/cwd behavior are unchanged. One caveat by design: shell commands can't see the mount (it isn't a real dir in the VM) — the mount instructions tell agents to use file tools.

The `factory-plan` and `factory-triage` skills now persist plans and triage handoffs to the mount when it's available.

There's also a read-only "Files" page in the Factory UI (new `/web/factory/fs/*` routes): signed-in org members can browse the whole org tree with the current project's directory open by default.

**Test plan**
- `@mastra/factory`: overlay unit tests (routing, org/project isolation, traversal guards, virtual dirs), workspace wiring tests (round-trip across sessions, sibling/org invisibility), route tests (auth, org scoping, listing, binary detection) — 70 tests
- factory-ui: MSW hook + browser component tests (default-open chain, navigation, file open, empty state); typecheck + vite build
- Manual smoke: session A writes a plan under its repo dir, sandbox recycled, session B reads it back
