### PR TITLE
fix(voice-google): restore speech-to-text on Node 22 and newer

### DIFF
--- a/.changeset/beige-worlds-train.md
+++ b/.changeset/beige-worlds-train.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-google': patch
+---
+
+Fixed speech-to-text failing with ERR_STREAM_PREMATURE_CLOSE on Node 22 and newer. `GoogleVoice.listen()` now uses `@google-cloud/speech` v7, which shares the same authentication stack as the text-to-speech client. Transcription with Application Default Credentials works again. Fixes [#19206](https://github.com/mastra-ai/mastra/issues/19206).

--- a/.changeset/beige-worlds-train.md
+++ b/.changeset/beige-worlds-train.md
@@ -2,4 +2,4 @@
 '@mastra/voice-google': patch
 ---
 
-Fixed speech-to-text failing with ERR_STREAM_PREMATURE_CLOSE on Node 22 and newer. `GoogleVoice.listen()` now uses `@google-cloud/speech` v7, which shares the same authentication stack as the text-to-speech client. Transcription with Application Default Credentials works again. Fixes [#19206](https://github.com/mastra-ai/mastra/issues/19206).
+Fixed `GoogleVoice.listen()` failing with `ERR_STREAM_PREMATURE_CLOSE` on Node 22 and newer. Speech-to-text with Application Default Credentials now transcribes again. Fixes [#19206](https://github.com/mastra-ai/mastra/issues/19206).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,7 +611,7 @@ importers:
     dependencies:
       firebase-admin:
         specifier: ^13.7.0
-        version: 13.9.0
+        version: 13.9.0(encoding@0.1.13)
     devDependencies:
       '@internal/auth':
         specifier: workspace:*
@@ -8210,8 +8210,8 @@ importers:
   voice/google:
     dependencies:
       '@google-cloud/speech':
-        specifier: ^6.7.1
-        version: 6.7.1(encoding@0.1.13)
+        specifier: ^7.5.0
+        version: 7.5.0
       '@google-cloud/text-to-speech':
         specifier: ^6.4.1
         version: 6.4.1
@@ -14025,10 +14025,6 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
-  '@google-cloud/common@5.0.2':
-    resolution: {integrity: sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==}
-    engines: {node: '>=14.0.0'}
-
   '@google-cloud/common@6.0.0':
     resolution: {integrity: sha512-IXh04DlkLMxWgYLIUYuHHKXKOUwPDzDgke1ykkkJPe48cGIS9kkL2U/o0pm4ankHLlvzLF/ma1eO86n/bkumIA==}
     engines: {node: '>=18'}
@@ -14087,9 +14083,9 @@ packages:
     resolution: {integrity: sha512-BvFYGKzvxZlLcJWBKuZagpcel6xIiu3Ai8K11OG4SddMA3eqWLCW958N+fZSFVCsnrZtL+zdAf3gIwhEl9k4IQ==}
     engines: {node: '>=18'}
 
-  '@google-cloud/speech@6.7.1':
-    resolution: {integrity: sha512-KgI2xmO8jHStYyoblj5FQ1G1Lk9JuvsR3wUpNSjxJP89yKA+Y/TBgGFvvu+mwm/f5x2ldLLY4So1VGNXZ+yzKg==}
-    engines: {node: '>=14.0.0'}
+  '@google-cloud/speech@7.5.0':
+    resolution: {integrity: sha512-Tvn9yvNNTGj+AcUVtTBgOASXuUfwqU3L2ugHAORhzPtj0G/Bxstlut9WhDl96FR/rihbJ6mvTMEijsbuOREDPA==}
+    engines: {node: '>=18'}
 
   '@google-cloud/storage@7.21.0':
     resolution: {integrity: sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==}
@@ -38336,21 +38332,6 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@google-cloud/common@5.0.2(encoding@0.1.13)':
-    dependencies:
-      '@google-cloud/projectify': 4.0.0
-      '@google-cloud/promisify': 4.1.0
-      arrify: 2.0.1
-      duplexify: 4.1.3
-      extend: 3.0.2
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      html-entities: 2.6.0
-      retry-request: 7.0.2(encoding@0.1.13)
-      teeny-request: 9.0.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   '@google-cloud/common@6.0.0':
     dependencies:
       '@google-cloud/projectify': 4.0.0
@@ -38365,7 +38346,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google-cloud/firestore@7.11.6':
+  '@google-cloud/firestore@7.11.6(encoding@0.1.13)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       fast-deep-equal: 3.1.3
@@ -38477,16 +38458,14 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/speech@6.7.1(encoding@0.1.13)':
+  '@google-cloud/speech@7.5.0':
     dependencies:
-      '@google-cloud/common': 5.0.2(encoding@0.1.13)
+      '@google-cloud/common': 6.0.0
       '@types/pumpify': 1.4.4
-      google-gax: 4.6.1(encoding@0.1.13)
+      google-gax: 5.0.6
       pumpify: 2.0.1
       stream-events: 1.0.5
-      uuid: 11.1.1
     transitivePeerDependencies:
-      - encoding
       - supports-color
 
   '@google-cloud/storage@7.21.0(encoding@0.1.13)':
@@ -45433,7 +45412,8 @@ snapshots:
       '@types/koa-compose': 3.2.8
       '@types/node': 22.19.15
 
-  '@types/long@4.0.2': {}
+  '@types/long@4.0.2':
+    optional: true
 
   '@types/lru-cache@7.10.10':
     dependencies:
@@ -50249,7 +50229,7 @@ snapshots:
       pkg-types: 1.3.1
       yaml: 2.9.0
 
-  firebase-admin@13.9.0:
+  firebase-admin@13.9.0(encoding@0.1.13):
     dependencies:
       '@fastify/busboy': 3.2.0
       '@firebase/database-compat': 2.1.0
@@ -50262,7 +50242,7 @@ snapshots:
       node-forge: 1.4.0
       uuid: 11.1.1
     optionalDependencies:
-      '@google-cloud/firestore': 7.11.6
+      '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
       '@google-cloud/storage': 7.21.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
@@ -50657,6 +50637,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    optional: true
 
   google-gax@5.0.6:
     dependencies:

--- a/voice/google/package.json
+++ b/voice/google/package.json
@@ -32,7 +32,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@google-cloud/speech": "^6.7.1",
+    "@google-cloud/speech": "^7.5.0",
     "@google-cloud/text-to-speech": "^6.4.1"
   },
   "devDependencies": {

--- a/voice/google/src/speech-dependency.test.ts
+++ b/voice/google/src/speech-dependency.test.ts
@@ -1,0 +1,48 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression guard for https://github.com/mastra-ai/mastra/issues/19206.
+ *
+ * `@google-cloud/speech` v6 depends on `google-gax` v4, which depends on `gaxios` v6.
+ * On Node 22 and newer, that `gaxios` version aborts the Application Default Credentials
+ * token exchange with ERR_STREAM_PREMATURE_CLOSE, so `GoogleVoice.listen()` always fails.
+ * `@google-cloud/speech` v7 depends on `google-gax` v5, which uses `gaxios` v7 and works.
+ *
+ * The unit tests in `index.test.ts` replace `@google-cloud/speech` with `vi.mock`, so they
+ * pass on the broken version as well. These assertions read package metadata from disk
+ * instead, outside the mock boundary, and go red if the dependency moves back to v6.
+ */
+const require = createRequire(import.meta.url);
+
+const MINIMUM_SPEECH_MAJOR = 7;
+const MINIMUM_GAX_MAJOR = 5;
+
+/** Returns the lowest major version that a caret or exact range accepts. */
+function lowestMajor(range: string): number {
+  const match = /^\^?(\d+)\./.exec(range.trim());
+  if (!match) {
+    throw new Error(`Unsupported version range: ${range}`);
+  }
+  return Number(match[1]);
+}
+
+describe('@google-cloud/speech dependency', () => {
+  it('declares a range that excludes the broken v6 client', () => {
+    const ownManifest = require('../package.json') as { dependencies: Record<string, string> };
+    const range = ownManifest.dependencies['@google-cloud/speech'];
+
+    expect(range).toBeDefined();
+    expect(lowestMajor(range)).toBeGreaterThanOrEqual(MINIMUM_SPEECH_MAJOR);
+  });
+
+  it('resolves to a client that uses the fixed google-gax major', () => {
+    const speechManifest = require('@google-cloud/speech/package.json') as {
+      version: string;
+      dependencies: Record<string, string>;
+    };
+
+    expect(lowestMajor(speechManifest.version)).toBeGreaterThanOrEqual(MINIMUM_SPEECH_MAJOR);
+    expect(lowestMajor(speechManifest.dependencies['google-gax'])).toBeGreaterThanOrEqual(MINIMUM_GAX_MAJOR);
+  });
+});


### PR DESCRIPTION
**What was broken**

`GoogleVoice.listen()` always failed on Node 22 and newer. The call threw `ERR_STREAM_PREMATURE_CLOSE` before any audio reached Google. Text-to-speech was not affected.

**Root cause**

`voice/google/package.json:35` declared `"@google-cloud/speech": "^6.7.1"`. That client depends on `google-gax` v4, which depends on `gaxios` v6. On Node 22 and newer, `gaxios` v6 aborts the Application Default Credentials token exchange, so the speech client never gets a credential.

`@google-cloud/text-to-speech` v6 already depends on `google-gax` v5 and `gaxios` v7. Only the speech-to-text path used the broken chain.

**The fix**

Raise the dependency to `"@google-cloud/speech": "^7.5.0"`. Version 7 depends on `google-gax` v5, so both voice clients now share `gaxios` v7 and one working authentication stack.

No source file changed. Version 7 still exports `SpeechClient`, `v2.SpeechClient`, and the proto types that `voice/google/src/index.ts` uses, so the public API of `@mastra/voice-google` is the same.

Rejected alternative: pinning `gaxios` with a package manager override. That hides the real dependency and breaks again on the next install from a clean lockfile.

**Testing**

```
pnpm --filter ./voice/google test src/speech-dependency.test.ts
```

Result on this branch: `Test Files 1 passed (1)`, `Tests 2 passed (2)`.

The new file `voice/google/src/speech-dependency.test.ts` is a regression guard. It reads package metadata from disk, so `vi.mock('@google-cloud/speech', ...)` in `index.test.ts` cannot hide the real version. One test checks the declared range. The other test checks the installed client version and its declared `google-gax` range.

Proof that the test fails without the fix: set the range back to `^6.7.1` and run the same command. Both tests fail with `AssertionError: expected 6 to be greater than or equal to 7`.

**Notes**

- The package suite still reports 5 failures. They come from the `GoogleVoice Integration Tests` block, which calls live Google APIs with no credential guard. Those 5 failures also occur on `main`, so this branch does not cause them.
- Follow-up 1: guard that block with `describe.skipIf(!process.env.GOOGLE_APPLICATION_CREDENTIALS)` so the package can run green without credentials.
- Follow-up 2: `voice/google/src/index.ts:4` imports proto types from `@google-cloud/speech/build/protos/protos`. That deep path works only because the vendor package has no `exports` map. Both vendor packages re-export the same `protos` namespace from their root entry, so the deep import can be removed.

Fixes #19206


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Google speech recognition stopped working on Node 22 and newer because its supporting libraries were too old. This update uses newer compatible libraries and adds a test to help prevent the problem from returning.

## Changes

- Upgraded `@google-cloud/speech` in `voice/google` from `^6.7.1` to `^7.5.0`.
- Aligns the speech-to-text dependency chain with text-to-speech by using `google-gax` v5 and `gaxios` v7.
- Restores `GoogleVoice.listen()` support for Node 22 and newer.
- Added regression tests for the speech and `google-gax` dependency versions.
- Added a patch changeset for `@mastra/voice-google`.
- Preserved existing public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->