### PR TITLE
fix(schema-compat): accept z.record() in OpenAI structured output schemas

### DIFF
--- a/.changeset/chilly-forks-strive.md
+++ b/.changeset/chilly-forks-strive.md
@@ -1,0 +1,7 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed OpenAI structured output requests failing when a schema uses `z.record()`. The OpenAI compatibility layer now removes the `propertyNames` keyword, which OpenAI strict mode does not permit. Requests that used to fail with "Invalid schema ... 'propertyNames' is not permitted" are now accepted.
+
+**Known limitation.** OpenAI strict mode cannot express an open-ended map. A `z.record()` field is still sent as a plain object with no value schema, so the model is not told what keys or values to produce. Use an explicit `z.object({ ... })` shape when you need the model to fill a map. See [#19273](https://github.com/mastra-ai/mastra/issues/19273).

--- a/packages/schema-compat/src/provider-compats/openai-reasoning.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai-reasoning.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ModelInformation } from '../types';
 import { OpenAIReasoningSchemaCompatLayer } from './openai-reasoning';
-import { createSuite } from './test-suite';
+import { createSuite, createOpenAISuite } from './test-suite';
 
 describe('OpenAIReasoningSchemaCompatLayer', () => {
   const modelInfo: ModelInformation = {
@@ -12,6 +12,7 @@ describe('OpenAIReasoningSchemaCompatLayer', () => {
 
   const compat = new OpenAIReasoningSchemaCompatLayer(modelInfo);
   createSuite(compat);
+  createOpenAISuite(compat);
 
   describe('shouldApply', () => {
     it('should apply for OpenAI models without structured outputs', () => {

--- a/packages/schema-compat/src/provider-compats/openai.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai.test.ts
@@ -27,6 +27,22 @@ describe('OpenAISchemaCompatLayer', () => {
   createSuite(compat);
   createOpenAISuite(compat);
 
+  // OpenAI strict mode rejects `propertyNames`, which z.record() emits for its key type.
+  // See https://github.com/mastra-ai/mastra/issues/19273
+  describe('z.record() under strict mode', () => {
+    it('drops propertyNames from a top-level record', () => {
+      const json = compat.processToJSONSchema(z.record(z.string(), z.string()));
+
+      expect(json).not.toHaveProperty('propertyNames');
+    });
+
+    it('drops propertyNames from a nested record', () => {
+      const json = compat.processToJSONSchema(z.object({ flags: z.record(z.string(), z.string()) }));
+
+      expect(json.properties!['flags']).not.toHaveProperty('propertyNames');
+    });
+  });
+
   describe('shouldApply', () => {
     it('should apply for OpenAI models without structured outputs', () => {
       const modelInfo: ModelInformation = {

--- a/packages/schema-compat/src/provider-compats/openai.ts
+++ b/packages/schema-compat/src/provider-compats/openai.ts
@@ -245,6 +245,9 @@ export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
     if (isObjectSchema(schema)) {
       schema.additionalProperties = false;
 
+      // OpenAI strict mode rejects `propertyNames`, which z.record() emits for its key type.
+      delete schema.propertyNames;
+
       if (schema.properties) {
         for (const key of Object.keys(schema.properties)) {
           const prop = schema.properties[key] as JSONSchema7;

--- a/packages/schema-compat/src/provider-compats/test-suite.ts
+++ b/packages/schema-compat/src/provider-compats/test-suite.ts
@@ -995,6 +995,24 @@ export function createOpenAISuite(layer: SchemaCompatLayer) {
     });
   });
 
+  // OpenAI strict mode rejects `propertyNames`, which z.record() emits for its key type.
+  // See https://github.com/mastra-ai/mastra/issues/19273
+  describe('z.record() under strict mode', () => {
+    it('emits a record node that strict mode permits', () => {
+      const schema = z.object({ flags: z.record(z.string(), z.string()) });
+
+      const json = layer.processToJSONSchema(schema);
+
+      // Strict mode cannot express an open-ended map, so the value schema is not kept either.
+      // Assert the whole node, so that record support must update this expectation on purpose.
+      expect(json.properties!['flags']).toEqual({
+        type: 'object',
+        additionalProperties: false,
+        required: [],
+      });
+    });
+  });
+
   describe('Workspace tool schemas', () => {
     it('file_stat - no optional fields', () => {
       const schema = z.object({ path: z.string() });


### PR DESCRIPTION
**What was broken**

An agent or tool schema that contains a `z.record()` field made every OpenAI structured output request fail. The API returned `Invalid schema ... 'propertyNames' is not permitted`.

**Root cause**

`z.record()` emits the `propertyNames` JSON Schema keyword for its key type. OpenAI Structured Outputs strict mode does not permit that keyword. The object branch of `postProcessJSONNode` in `packages/schema-compat/src/provider-compats/openai.ts:245` set `additionalProperties: false` but kept `propertyNames`, so the illegal keyword reached the API.

**The fix**

`postProcessJSONNode` now deletes `propertyNames` from every object node. This matches the Google compatibility layer, which already deletes the same keyword at `packages/schema-compat/src/provider-compats/google.ts:310`. The OpenAI reasoning layer inherits `postProcessJSONNode`, so it gets the same fix.

A reviewer proposed a larger change: detect the record shape and re-encode it as an array of key and value entries. That is a new feature, it needs a matching inverse transform on the model response, and it is out of scope for this bugfix. See the note below.

**Testing**

```
pnpm --filter ./packages/schema-compat test src/provider-compats
```

Result: 11 files passed, 379 tests passed.

The regression test lives in `createOpenAISuite`, so one fixture covers the OpenAI layer, the Groq layer, and the OpenAI reasoning layer. It asserts the complete emitted node, not a substring. To prove the test is real, I removed the `delete schema.propertyNames` line and ran the same command. All three layers failed with:

```
- Expected
+ Received
  {
    "additionalProperties": false,
+   "propertyNames": {
+     "type": "string",
+   },
    "required": [],
    "type": "object",
  }
```

I then restored the line and confirmed the working tree was clean.

**Notes**

OpenAI strict mode still cannot express an open-ended map. A `z.record()` field is sent as `{"type":"object","additionalProperties":false,"required":[]}`, so the model gets no key or value schema. This limitation exists on `main` too: the pre-existing `schema.additionalProperties = false` on the line above already replaced the record value schema. This PR only makes the node legal, so the request is accepted instead of rejected.

The changeset states this limitation and tells developers to use an explicit `z.object({ ... })` shape when the model must fill a map. Full record support for OpenAI needs a deliberate encoding plus an inverse transform in `#traverse`, and is worth a follow-up issue.

Fixes #19273


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Some OpenAI requests rejected schemas created from `z.record()`. This change removes the unsupported schema detail and adds tests to prevent the issue from returning.

## Changes

- Remove `propertyNames` from OpenAI object schemas.
- Apply the same fix to the OpenAI reasoning compatibility layer.
- Add strict-mode regression tests for OpenAI, Groq, and OpenAI reasoning.
- Add a patch changeset for `@mastra/schema-compat`.

Open-ended maps do not receive full value-schema support. Use explicit `z.object()` shapes when models must populate map values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->