### PR TITLE
fix(pg): read the message page and its total in one query

### DIFF
--- a/.changeset/eager-goats-retire.md
+++ b/.changeset/eager-goats-retire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Improved chat response time with PostgresStore. Message history now reads a page of messages and its total count in one query instead of two. When semantic recall is on, the recall read also starts at the same time as the page read. Each agent turn therefore makes fewer database round-trips, which is most noticeable on remote Postgres.

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -997,6 +997,55 @@ export class MemoryPG extends MemoryStorage {
     }
   }
 
+  /**
+   * Reads one page of messages together with the total row count.
+   *
+   * `COUNT(*) OVER ()` reports the count over the whole WHERE result on the same
+   * statement as the page, so the page costs one database round-trip instead of
+   * two. The page and the count also come from one snapshot, so the count always
+   * describes the returned rows. A separate `COUNT(*)` runs only when the page is
+   * empty and the caller asked for a page after the last row, because a window
+   * function has no row to carry the count on.
+   */
+  async #fetchMessagePage({
+    selectStatement,
+    tableName,
+    whereClause,
+    orderByStatement,
+    queryParams,
+    perPageInput,
+    perPage,
+    offset,
+  }: {
+    selectStatement: string;
+    tableName: string;
+    whereClause: string;
+    orderByStatement: string;
+    queryParams: any[];
+    perPageInput: number | false | undefined;
+    perPage: number;
+    offset: number;
+  }): Promise<{ total: number; messages: MessageRowFromDB[] }> {
+    // `perPageInput === false` means "every row", so no LIMIT is applied.
+    const limitClause =
+      perPageInput === false ? '' : ` LIMIT $${queryParams.length + 1} OFFSET $${queryParams.length + 2}`;
+    const dataParams = perPageInput === false ? queryParams : [...queryParams, perPage, offset];
+    const rows =
+      (await this.#db.client.manyOrNone<MessageRowFromDB & { __total?: string | number }>(
+        `${selectStatement}, COUNT(*) OVER () AS "__total" FROM ${tableName} ${whereClause} ${orderByStatement}${limitClause}`,
+        dataParams,
+      )) || [];
+
+    if (rows.length > 0) {
+      return { total: Number(rows[0]!.__total), messages: rows };
+    }
+    if (offset === 0) {
+      return { total: 0, messages: [] };
+    }
+    const countResult = await this.#db.client.one(`SELECT COUNT(*) FROM ${tableName} ${whereClause}`, queryParams);
+    return { total: parseInt(countResult.count, 10), messages: [] };
+  }
+
   public async listMessages(args: StorageListMessagesInput): Promise<StorageListMessagesOutput> {
     const { threadId, resourceId, include, filter, perPage: perPageInput, page = 0, orderBy } = args;
 
@@ -1086,6 +1135,18 @@ export class MemoryPG extends MemoryStorage {
         };
       }
 
+      // The included messages do not depend on the page, so start that read now and
+      // let it overlap the page read. The rejection is captured here so a failure of
+      // the page read cannot leave this promise unhandled.
+      let includeFailure: unknown;
+      const includePromise =
+        include && include.length > 0
+          ? this._getIncludedMessages({ include }).catch((error: unknown) => {
+              includeFailure = error;
+              return null;
+            })
+          : null;
+
       let total: number;
       let messages: MessageRowFromDB[];
       if (metadataFilter) {
@@ -1099,12 +1160,16 @@ export class MemoryPG extends MemoryStorage {
         total = filteredRows.length;
         messages = perPageInput === false ? filteredRows : filteredRows.slice(offset, offset + perPage);
       } else {
-        const countResult = await this.#db.client.one(`SELECT COUNT(*) FROM ${tableName} ${whereClause}`, queryParams);
-        total = parseInt(countResult.count, 10);
-        const limitValue = perPageInput === false ? total : perPage;
-        const dataQuery = `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement} LIMIT $${paramIndex++} OFFSET $${paramIndex++}`;
-        const rows = await this.#db.client.manyOrNone(dataQuery, [...queryParams, limitValue, offset]);
-        messages = [...(rows || [])];
+        ({ total, messages } = await this.#fetchMessagePage({
+          selectStatement,
+          tableName,
+          whereClause,
+          orderByStatement,
+          queryParams,
+          perPageInput,
+          perPage,
+          offset,
+        }));
       }
       const primaryPageCount = messages.length;
 
@@ -1120,7 +1185,8 @@ export class MemoryPG extends MemoryStorage {
 
       const messageIds = new Set(messages.map(m => m.id));
       if (include && include.length > 0) {
-        const includeMessages = await this._getIncludedMessages({ include });
+        const includeMessages = await includePromise;
+        if (includeFailure) throw includeFailure;
         if (includeMessages) {
           for (const includeMsg of includeMessages) {
             if (!messageIds.has(includeMsg.id)) {
@@ -1277,6 +1343,18 @@ export class MemoryPG extends MemoryStorage {
         };
       }
 
+      // The included messages do not depend on the page, so start that read now and
+      // let it overlap the page read. The rejection is captured here so a failure of
+      // the page read cannot leave this promise unhandled.
+      let includeFailure: unknown;
+      const includePromise =
+        include && include.length > 0
+          ? this._getIncludedMessages({ include }).catch((error: unknown) => {
+              includeFailure = error;
+              return null;
+            })
+          : null;
+
       let total: number;
       let messages: MessageRowFromDB[];
       if (metadataFilter) {
@@ -1290,12 +1368,16 @@ export class MemoryPG extends MemoryStorage {
         total = filteredRows.length;
         messages = perPageInput === false ? filteredRows : filteredRows.slice(offset, offset + perPage);
       } else {
-        const countResult = await this.#db.client.one(`SELECT COUNT(*) FROM ${tableName} ${whereClause}`, queryParams);
-        total = parseInt(countResult.count, 10);
-        const limitValue = perPageInput === false ? total : perPage;
-        const dataQuery = `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement} LIMIT $${paramIndex++} OFFSET $${paramIndex++}`;
-        const rows = await this.#db.client.manyOrNone(dataQuery, [...queryParams, limitValue, offset]);
-        messages = [...(rows || [])];
+        ({ total, messages } = await this.#fetchMessagePage({
+          selectStatement,
+          tableName,
+          whereClause,
+          orderByStatement,
+          queryParams,
+          perPageInput,
+          perPage,
+          offset,
+        }));
       }
 
       if (total === 0 && messages.length === 0 && (!include || include.length === 0)) {
@@ -1310,7 +1392,8 @@ export class MemoryPG extends MemoryStorage {
 
       const messageIds = new Set(messages.map(m => m.id));
       if (include && include.length > 0) {
-        const includeMessages = await this._getIncludedMessages({ include });
+        const includeMessages = await includePromise;
+        if (includeFailure) throw includeFailure;
         if (includeMessages) {
           for (const includeMsg of includeMessages) {
             if (!messageIds.has(includeMsg.id)) {

--- a/stores/pg/src/storage/domains/memory/list-messages-round-trips.test.ts
+++ b/stores/pg/src/storage/domains/memory/list-messages-round-trips.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import type { QueryValues } from '../../client';
+import { RecordingDbClientBase } from './test-utils';
+import { MemoryPG } from './index';
+
+/**
+ * Fake client that answers the three queries the message paging code can send:
+ * the page query with the window count, the fallback `COUNT(*)`, and the two
+ * queries of the include (semantic recall) read.
+ *
+ * `block()` holds every `manyOrNone` result until `release()`. A test uses that
+ * to look at the queries that are in flight at the same time.
+ */
+class MessageQueryClient extends RecordingDbClientBase {
+  pageRows: Record<string, unknown>[] = [];
+  windowTotal = 0;
+  fallbackCount = 0;
+  includeRows: Record<string, unknown>[] = [];
+
+  #gate: Promise<void> = Promise.resolve();
+  #openGate: () => void = () => {};
+
+  block(): void {
+    this.#gate = new Promise<void>(resolve => {
+      this.#openGate = resolve;
+    });
+  }
+
+  release(): void {
+    this.#openGate();
+  }
+
+  override async one<T = any>(query: string, values?: QueryValues): Promise<T> {
+    this.queries.push({ query, values });
+    return { count: String(this.fallbackCount) } as T;
+  }
+
+  override async manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+    this.queries.push({ query, values });
+    await this.#gate;
+    if (query.includes('COUNT(*) OVER ()')) {
+      return this.pageRows.map(row => ({ ...row, __total: String(this.windowTotal) })) as T[];
+    }
+    if (query.includes('thread_id, "createdAt" FROM')) {
+      return this.includeRows.map(row => ({
+        id: row.id,
+        thread_id: row.threadId,
+        createdAt: row.createdAt,
+      })) as T[];
+    }
+    return this.includeRows as T[];
+  }
+}
+
+function createRow(id: string, createdAt: string) {
+  return {
+    id,
+    content: JSON.stringify({ format: 2, parts: [{ type: 'text', text: `message ${id}` }] }),
+    role: 'user',
+    type: 'v2',
+    createdAt,
+    createdAtZ: createdAt,
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+  };
+}
+
+/** Lets every already-started promise chain run up to its next real await. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    await Promise.resolve();
+  }
+}
+
+const pageRows = [
+  createRow('message-1', '2025-01-01T00:00:00.000Z'),
+  createRow('message-2', '2025-01-01T00:00:01.000Z'),
+];
+
+describe('MemoryPG message paging round-trips', () => {
+  it('reads the page and the total in one query in listMessages', async () => {
+    const client = new MessageQueryClient();
+    client.pageRows = pageRows;
+    client.windowTotal = 7;
+    const memory = new MemoryPG({ client });
+
+    const result = await memory.listMessages({ threadId: 'thread-1', perPage: 10, page: 0 });
+
+    expect(client.queries).toHaveLength(1);
+    const [pageQuery] = client.queries;
+    expect(pageQuery!.query).toContain('COUNT(*) OVER () AS "__total"');
+    expect(pageQuery!.query).toContain('LIMIT $2 OFFSET $3');
+    expect(pageQuery!.values).toEqual(['thread-1', 10, 0]);
+    expect(result.total).toBe(7);
+    expect(result.messages).toHaveLength(2);
+    // The window count must not reach the caller as a message field.
+    expect(result.messages[0]).not.toHaveProperty('__total');
+  });
+
+  it('reads the page and the total in one query in listMessagesByResourceId', async () => {
+    const client = new MessageQueryClient();
+    client.pageRows = pageRows;
+    client.windowTotal = 7;
+    const memory = new MemoryPG({ client });
+
+    const result = await memory.listMessagesByResourceId({ resourceId: 'resource-1', perPage: 10, page: 0 });
+
+    expect(client.queries).toHaveLength(1);
+    const [pageQuery] = client.queries;
+    expect(pageQuery!.query).toContain('COUNT(*) OVER () AS "__total"');
+    expect(pageQuery!.query).toContain('LIMIT $2 OFFSET $3');
+    expect(pageQuery!.values).toEqual(['resource-1', 10, 0]);
+    expect(result.total).toBe(7);
+    expect(result.messages).toHaveLength(2);
+  });
+
+  it('omits LIMIT and OFFSET when perPage is false', async () => {
+    const client = new MessageQueryClient();
+    client.pageRows = pageRows;
+    client.windowTotal = 2;
+    const memory = new MemoryPG({ client });
+
+    const result = await memory.listMessages({ threadId: 'thread-1', perPage: false });
+
+    expect(client.queries).toHaveLength(1);
+    const [pageQuery] = client.queries;
+    expect(pageQuery!.query).not.toContain('LIMIT');
+    expect(pageQuery!.values).toEqual(['thread-1']);
+    expect(result.total).toBe(2);
+    expect(result.messages).toHaveLength(2);
+    expect(result.perPage).toBe(false);
+  });
+
+  it('reports total 0 without a second query when the first page is empty', async () => {
+    const client = new MessageQueryClient();
+    const memory = new MemoryPG({ client });
+
+    const result = await memory.listMessages({ threadId: 'thread-1', perPage: 10, page: 0 });
+
+    expect(client.queries).toHaveLength(1);
+    expect(result.total).toBe(0);
+    expect(result.messages).toEqual([]);
+  });
+
+  it('sends a COUNT query only for a page after the last row', async () => {
+    const client = new MessageQueryClient();
+    client.fallbackCount = 5;
+    const memory = new MemoryPG({ client });
+
+    const result = await memory.listMessages({ threadId: 'thread-1', perPage: 10, page: 2 });
+
+    expect(client.queries).toHaveLength(2);
+    expect(client.queries[0]!.query).toContain('COUNT(*) OVER () AS "__total"');
+    expect(client.queries[1]!.query).toContain('SELECT COUNT(*) FROM');
+    expect(result.total).toBe(5);
+    expect(result.messages).toEqual([]);
+  });
+
+  it('starts the include read before the page read finishes', async () => {
+    const client = new MessageQueryClient();
+    client.pageRows = pageRows;
+    client.windowTotal = 2;
+    client.includeRows = [createRow('message-9', '2025-01-01T00:00:09.000Z')];
+    const memory = new MemoryPG({ client });
+
+    client.block();
+    const pending = memory.listMessages({
+      threadId: 'thread-1',
+      perPage: 10,
+      page: 0,
+      include: [{ id: 'message-9' }],
+    });
+    await flushMicrotasks();
+    const inFlight = client.queries.map(recorded => recorded.query);
+    client.release();
+    const result = await pending;
+
+    expect(inFlight).toHaveLength(2);
+    expect(inFlight.some(query => query.includes('COUNT(*) OVER () AS "__total"'))).toBe(true);
+    expect(inFlight.some(query => query.includes('thread_id, "createdAt" FROM'))).toBe(true);
+    expect(result.messages.map(message => message.id)).toEqual(['message-1', 'message-2', 'message-9']);
+  });
+});

--- a/stores/pg/src/storage/domains/memory/save-messages.test.ts
+++ b/stores/pg/src/storage/domains/memory/save-messages.test.ts
@@ -1,13 +1,10 @@
 import type { MastraDBMessage } from '@mastra/core/memory';
 import type { QueryResult } from 'pg';
 import { describe, expect, it } from 'vitest';
-import type { DbClient, QueryValues, TxClient } from '../../client';
+import type { QueryValues, TxClient } from '../../client';
+import type { RecordedQuery } from './test-utils';
+import { RecordingDbClientBase } from './test-utils';
 import { MemoryPG } from './index';
-
-type RecordedQuery = {
-  query: string;
-  values?: QueryValues;
-};
 
 class RecordingTxClient implements TxClient {
   queries: RecordedQuery[] = [];
@@ -47,16 +44,15 @@ class RecordingTxClient implements TxClient {
   }
 }
 
-class RecordingDbClient implements DbClient {
-  readonly $pool = {} as DbClient['$pool'];
+class RecordingDbClient extends RecordingDbClientBase {
   readonly txClient = new RecordingTxClient();
   readonly threads = new Map<string, Record<string, unknown>>();
-  readonly queries: RecordedQuery[] = [];
 
   constructor({
     thread,
     threads,
   }: { thread?: Record<string, unknown> | null; threads?: Record<string, unknown>[] } = {}) {
+    super();
     const defaultThread = {
       id: 'thread-1',
       resourceId: 'resource-1',
@@ -71,42 +67,22 @@ class RecordingDbClient implements DbClient {
     }
   }
 
-  connect(): Promise<never> {
-    throw new Error('not implemented');
-  }
-
-  async none(query: string, values?: QueryValues): Promise<null> {
+  override async none(query: string, values?: QueryValues): Promise<null> {
     this.queries.push({ query, values });
     return null;
   }
 
-  async one<T = any>(): Promise<T> {
-    throw new Error('not implemented');
-  }
-
-  async oneOrNone<T = any>(_query?: string, values?: QueryValues): Promise<T | null> {
+  override async oneOrNone<T = any>(_query: string, values?: QueryValues): Promise<T | null> {
     const id = Array.isArray(values) ? values[0] : undefined;
     return id ? ((this.threads.get(String(id)) as T | undefined) ?? null) : null;
   }
 
-  async any<T = any>(): Promise<T[]> {
-    throw new Error('not implemented');
-  }
-
-  async manyOrNone<T = any>(query?: string): Promise<T[]> {
+  override async manyOrNone<T = any>(query: string): Promise<T[]> {
     if (query?.includes('information_schema.columns')) return [];
     throw new Error('not implemented');
   }
 
-  async many<T = any>(): Promise<T[]> {
-    throw new Error('not implemented');
-  }
-
-  async query(): Promise<QueryResult> {
-    throw new Error('not implemented');
-  }
-
-  async tx<T>(callback: (t: TxClient) => Promise<T>): Promise<T> {
+  override async tx<T>(callback: (t: TxClient) => Promise<T>): Promise<T> {
     return callback(this.txClient);
   }
 }

--- a/stores/pg/src/storage/domains/memory/test-utils.ts
+++ b/stores/pg/src/storage/domains/memory/test-utils.ts
@@ -1,0 +1,58 @@
+import type { QueryResult } from 'pg';
+import type { DbClient, QueryValues, TxClient } from '../../client';
+
+/**
+ * One query that a fake client received.
+ */
+export type RecordedQuery = {
+  query: string;
+  values?: QueryValues;
+};
+
+/**
+ * Base fake `DbClient` for the memory-domain tests.
+ *
+ * Every method throws by default. A test subclass overrides only the methods
+ * that the code path under test calls, so a new method on the `DbClient`
+ * interface has to be added here once instead of once per test file.
+ */
+export class RecordingDbClientBase implements DbClient {
+  readonly $pool = {} as DbClient['$pool'];
+  readonly queries: RecordedQuery[] = [];
+
+  connect(): Promise<never> {
+    throw new Error('not implemented');
+  }
+
+  async none(_query: string, _values?: QueryValues): Promise<null> {
+    throw new Error('not implemented');
+  }
+
+  async one<T = any>(_query: string, _values?: QueryValues): Promise<T> {
+    throw new Error('not implemented');
+  }
+
+  async oneOrNone<T = any>(_query: string, _values?: QueryValues): Promise<T | null> {
+    throw new Error('not implemented');
+  }
+
+  async any<T = any>(_query: string, _values?: QueryValues): Promise<T[]> {
+    throw new Error('not implemented');
+  }
+
+  async manyOrNone<T = any>(_query: string, _values?: QueryValues): Promise<T[]> {
+    throw new Error('not implemented');
+  }
+
+  async many<T = any>(_query: string, _values?: QueryValues): Promise<T[]> {
+    throw new Error('not implemented');
+  }
+
+  async query(_query: string, _values?: QueryValues): Promise<QueryResult> {
+    throw new Error('not implemented');
+  }
+
+  async tx<T>(_callback: (t: TxClient) => Promise<T>): Promise<T> {
+    throw new Error('not implemented');
+  }
+}


### PR DESCRIPTION
**What was broken**

Every agent turn that reads message history from `PostgresStore` waited for two database round-trips instead of one. On remote Postgres this added measurable delay before the first token.

**Root cause**

`listMessages` awaited `SELECT COUNT(*)`, then awaited the page query, at `stores/pg/src/storage/domains/memory/index.ts:1102`. `listMessagesByResourceId` had the same shape at line 1293. The page query bound `LIMIT` to the counted total, so the second query could not start until the first one returned.

**The fix**

- The page SELECT now carries `COUNT(*) OVER () AS "__total"`. One statement returns the rows and the total, so the second statement is gone.
- The page and the total come from one snapshot. The total therefore always describes the returned rows.
- A plain `SELECT COUNT(*)` runs only when the page is empty and the caller asked for a page after the last row. A window function has no row to carry the count in that case.
- The include (semantic recall) read starts before the page read and is awaited after it. This removes the last serial round-trip on the hot path.
- Both methods call one new private helper, `#fetchMessagePage`. The block existed twice before.

Rejected alternative: run the count and the page with `Promise.all`. That keeps two statements, takes two pool connections per call, and re-serialises when the pool is full.

`parseRow` builds its result from a fixed field list, so `__total` never reaches the caller.

**Testing**

```
pnpm --filter ./stores/pg test src/storage/domains/memory src/storage/index.test.ts
```

Result: 6 files passed, 1314 tests passed, 4 skipped. This includes 153 `listMessages` tests that run against a real Postgres container.

Evidence that the test fails without the fix: with `stores/pg/src/storage/domains/memory/index.ts` restored from `main`, `npx vitest run src/storage/domains/memory/list-messages-round-trips.test.ts` reports 6 failed of 6. The first failure is `expected 'SELECT COUNT(*) FROM "public"."mastra_messages" WHERE thread_id IN ($1)' to contain 'COUNT(*) OVER () AS "__total"'`. The source was restored afterwards and the tree is clean.

The new tests use no timers. They assert the number of queries that the store sends, so a return to two statements fails them.

**Notes**

- Postgres must read every matching row before it applies `LIMIT`, because of the window function. The old code already read every matching row for the `COUNT(*)`, so the server does the same amount of work and sends one message less.
- Follow-up, not in this PR: the same serial shape stays in `listThreadsByResourceId` (`stores/pg/src/storage/domains/memory/index.ts:590`) and in the libsql store (`stores/libsql/src/storage/domains/memory/index.ts:473` and `:648`). A shared SQL page-query helper would suit those call sites.

Fixes #20253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Message-history reads now use one database query instead of two. This reduces latency and ensures that the message page and total count come from the same data snapshot.

## Changes

- Added shared `#fetchMessagePage` logic for `listMessages` and `listMessagesByResourceId`.
- Combined page results and total counts with `COUNT(*) OVER ()`.
- Added a fallback `COUNT(*)` query only when an empty page follows the final row.
- Started semantic-recall reads before the page query and awaited them afterward.
- Preserved the existing pagination response.
- Removed internal `__total` data from parsed messages.
- Added paging and concurrency tests.
- Added shared `RecordingDbClientBase` and `RecordedQuery` test utilities.
- Added a patch changeset for `@mastra/pg`.
- Tests passed: 1,314 tests across 6 files, with 4 skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->