### PR TITLE
fix(core): stop CommonJS projects crashing with "is not a function"

### DIFF
--- a/.changeset/swift-jokes-report.md
+++ b/.changeset/swift-jokes-report.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `@mastra/core` crashing when a project loads Mastra as CommonJS. Several ESM-only dependencies were read as a module object instead of a function, so the calls threw.
+
+**What failed before**
+
+- `new MCPServer(...)` threw `slugify is not a function`.
+- `mastra.schedules.create()` threw the same error.
+- Workspace search, workspace file indexing, and batch trace scoring threw `p_map.default is not a function`.
+
+All of these paths now run under CommonJS and ESM. See [#20354](https://github.com/mastra-ai/mastra/issues/20354).

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -118,6 +118,7 @@ import type {
 import type { DynamicArgument } from '../types';
 import { makeCoreTool, createMastraProxy, ensureToolProperties, deepMerge } from '../utils';
 import type { ToolOptions } from '../utils';
+import { slugify } from '../utils/slugify';
 import type { MastraVoice } from '../voice';
 import { DefaultVoice } from '../voice';
 import { createWorkflow } from '../workflows/create';
@@ -4815,7 +4816,6 @@ export class Agent<
 
             // Generate sub-agent thread and resource IDs early (before any rejection)
             // These are needed for both successful execution and rejection cases
-            const slugify = await import(`@sindresorhus/slugify`);
             const subAgentThreadId = inputData.threadId
               ? `${inputData.threadId}-${randomUUID()}`
               : context?.mastra?.generateId({
@@ -4831,7 +4831,7 @@ export class Agent<
                   idType: 'generic',
                   source: 'agent',
                   entityId: agentName,
-                }) || `${slugify.default(this.id)}-${agentName}`;
+                }) || `${slugify(this.id)}-${agentName}`;
 
             // Call onDelegationStart before resolving the sub-agent's runtime
             // config so mutations of the delegated run's context in the hook

--- a/packages/core/src/evals/scoreTraces/scoreTracesWorkflow.ts
+++ b/packages/core/src/evals/scoreTraces/scoreTracesWorkflow.ts
@@ -1,8 +1,8 @@
-import pMap from 'p-map';
 import { z } from 'zod/v4';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import { getEntityTypeForSpan, InternalSpans } from '../../observability';
 import type { SpanRecord, TraceRecord, MastraStorage } from '../../storage';
+import { pMap } from '../../utils/p-map';
 import { createStep, createWorkflow } from '../../workflows/evented';
 import type { MastraScorer, ScorerRun } from '../base';
 import type { ScoreRowData } from '../types';

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import slugify from '@sindresorhus/slugify';
 import type { ToolsInput } from '../agent';
 import { MastraBase } from '../base';
 import { MastraError } from '../error';
@@ -7,6 +6,7 @@ import { RegisteredLogger } from '../logger';
 import type { Mastra } from '../mastra';
 import type { RequestContext } from '../request-context';
 import type { InternalCoreTool, MCPToolType } from '../tools';
+import { slugify } from '../utils/slugify';
 import type {
   MCPServerConfig,
   MCPServerHonoSSEOptions,

--- a/packages/core/src/schedules/schedules.ts
+++ b/packages/core/src/schedules/schedules.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
-import slugify from '@sindresorhus/slugify';
 import type { AgentSignalAttributes, AgentSignalType } from '../agent/signals';
 import { ErrorCategory, ErrorDomain, MastraError } from '../error';
 import type { Mastra } from '../mastra';
 import type { Schedule, SchedulesStorage } from '../storage/domains/schedules/base';
+import { slugify } from '../utils/slugify';
 import { computeNextFireAt, validateCron } from '../workflows/scheduler/cron';
 import type { ScheduleIfActive, ScheduleIfIdle } from './types';
 import { AGENT_SCHEDULE_PREFIX, WORKFLOW_SCHEDULE_PREFIX } from './types';

--- a/packages/core/src/utils/interop.test.ts
+++ b/packages/core/src/utils/interop.test.ts
@@ -1,0 +1,51 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+import { interopDefault } from './interop';
+import { pMap } from './p-map';
+import { slugify } from './slugify';
+
+const requireFromHere = createRequire(import.meta.url);
+
+/**
+ * `require()` of an ESM-only package returns the module namespace. The bundler
+ * interop helper in the CommonJS build sets `default` on that namespace to the
+ * namespace itself, so a default import gives this object and not the exported
+ * function. Load the real namespace here instead of a hand-written mock.
+ */
+function requireNamespace(specifier: string): unknown {
+  const namespace = requireFromHere(specifier);
+  if (typeof namespace !== 'object' || namespace === null) {
+    throw new Error(`Expected a module namespace for ${specifier}, got ${typeof namespace}`);
+  }
+  return namespace;
+}
+
+describe('interopDefault', () => {
+  it('returns the export when the default import is already the function', () => {
+    const fn = () => 'called';
+
+    expect(interopDefault(fn)).toBe(fn);
+  });
+
+  it('unwraps the module namespace of @sindresorhus/slugify', () => {
+    const namespace = requireNamespace('@sindresorhus/slugify') as { default: typeof slugify };
+
+    expect(interopDefault(namespace)('My Server Id')).toBe('my-server-id');
+  });
+
+  it('unwraps the module namespace of p-map', async () => {
+    const namespace = requireNamespace('p-map') as { default: typeof pMap };
+
+    await expect(interopDefault(namespace)([1, 2], async value => value * 2)).resolves.toEqual([2, 4]);
+  });
+});
+
+describe('shared ESM-only wrappers', () => {
+  it('exports slugify as a function', () => {
+    expect(slugify('My Server Id')).toBe('my-server-id');
+  });
+
+  it('exports pMap as a function', async () => {
+    await expect(pMap([1, 2], async value => value * 2)).resolves.toEqual([2, 4]);
+  });
+});

--- a/packages/core/src/utils/interop.ts
+++ b/packages/core/src/utils/interop.ts
@@ -1,0 +1,22 @@
+/**
+ * Read the default export of an ESM-only dependency in a way that also works in
+ * the CommonJS build.
+ *
+ * Node returns the module namespace when CommonJS code requires an ESM-only
+ * package. The bundler then applies its ESM interop helper to that namespace and
+ * sets `default` to the namespace itself, so the default import is the namespace
+ * object instead of the exported value. Calls through such an import throw
+ * `<name> is not a function`.
+ *
+ * Wrap each ESM-only default import with this helper. It returns the value under
+ * both module systems, and it also survives a change of the interop shape.
+ *
+ * @example
+ * ```typescript
+ * import slugifyModule from '@sindresorhus/slugify';
+ * export const slugify = interopDefault(slugifyModule);
+ * ```
+ */
+export function interopDefault<T extends (...args: never[]) => unknown>(moduleExport: T | { default: T }): T {
+  return typeof moduleExport === 'function' ? moduleExport : moduleExport.default;
+}

--- a/packages/core/src/utils/p-map.ts
+++ b/packages/core/src/utils/p-map.ts
@@ -1,0 +1,11 @@
+import pMapModule from 'p-map';
+import { interopDefault } from './interop';
+
+export { pMapSkip } from 'p-map';
+
+/**
+ * `p-map` is ESM-only. Import pMap from here, not from the package, so that the
+ * CommonJS build gets the function instead of the module namespace. See
+ * {@link interopDefault}.
+ */
+export const pMap = interopDefault(pMapModule);

--- a/packages/core/src/utils/slugify.ts
+++ b/packages/core/src/utils/slugify.ts
@@ -1,0 +1,9 @@
+import slugifyModule from '@sindresorhus/slugify';
+import { interopDefault } from './interop';
+
+/**
+ * `@sindresorhus/slugify` is ESM-only. Import slugify from here, not from the
+ * package, so that the CommonJS build gets the function instead of the module
+ * namespace. See {@link interopDefault}.
+ */
+export const slugify = interopDefault(slugifyModule);

--- a/packages/core/src/workspace/search/search-engine.ts
+++ b/packages/core/src/workspace/search/search-engine.ts
@@ -5,8 +5,7 @@
  * semantic (vector), and combined hybrid search across indexed content.
  */
 
-import pMap from 'p-map';
-
+import { pMap } from '../../utils/p-map';
 import type { MastraVector, VectorFilter } from '../../vector';
 import type { LineRange } from '../line-utils';
 

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -31,10 +31,10 @@
  */
 
 import * as path from 'node:path';
-import pMap, { pMapSkip } from 'p-map';
 import type { MastraBrowser } from '../browser';
 import type { IMastraLogger } from '../logger';
 import { RequestContext } from '../request-context';
+import { pMap, pMapSkip } from '../utils/p-map';
 import type { MastraVector } from '../vector';
 
 import { WorkspaceError, SearchNotAvailableError, WorkspaceNotReadyError } from './errors';


### PR DESCRIPTION
**What was broken**

A project that loads Mastra as CommonJS crashed on `new MCPServer(...)` with `slugify is not a function`. `mastra.schedules.create()` failed the same way. Workspace search, workspace file indexing, and batch trace scoring failed with `p_map.default is not a function`.

**Root cause**

`packages/core` default-imports two ESM-only packages. Before this change, `packages/core/src/mcp/index.ts:2` held `import slugify from '@sindresorhus/slugify'` and `packages/core/src/workspace/workspace.ts:34` held `import pMap from 'p-map'`.

Node returns the module namespace when CommonJS code requires an ESM-only package. The bundler then applies its interop helper and force-defines `default` on that namespace to the namespace itself, so the copy step skips the module's own `default`. The emitted CommonJS therefore reads an object where a function is expected. The pre-fix bundle showed both halves:

```
dist/workspace-ja2wx2nj.cjs:19  let p_map = require("p-map");
dist/workspace-ja2wx2nj.cjs:20  p_map = __toESM(p_map, 1);
dist/workspace-ja2wx2nj.cjs:5285 ... p_map.default(...)
```

Replaying that exact expression in Node gives `TypeError: p_map.default is not a function` and `TypeError: s.default is not a function`.

**The fix**

`packages/core/src/utils/interop.ts` adds one generic helper, `interopDefault`, that returns the default export under both module systems. `packages/core/src/utils/slugify.ts` and `packages/core/src/utils/p-map.ts` call it once per dependency. All five default-import sites now read from those two modules: `mcp/index.ts`, `schedules/schedules.ts`, `agent/agent.ts`, `workspace/workspace.ts`, `workspace/search/search-engine.ts`, and `evals/scoreTraces/scoreTracesWorkflow.ts`. The sub-agent path in `agent/agent.ts` used a third idiom, an unconditional `await import()`, and now uses the same shared import.

A reviewer proposed the alternative of adding both packages to `deps.alwaysBundle` in `packages/core/tsdown.config.ts`. That route is also a per-package allowlist, it leaves no unit-level guard, and it inlines third-party runtime code into the published bundle, so this PR keeps the source-level helper.

**Testing**

```
pnpm --filter ./packages/core test src/utils/interop.test.ts src/workspace/workspace.test.ts src/workspace/search/search-engine.test.ts src/schedules/ src/mcp/ src/evals/scoreTraces/
```

Result: 12 files passed, 366 tests passed, no type errors.

`packages/core/src/utils/interop.test.ts` loads the real module namespace with `createRequire(import.meta.url)`, not a hand-written mock, so it asserts against the object the CommonJS bundle actually passes to the call sites.

Evidence that the test fails without the fix: with `interopDefault` neutralised to a pass-through, two tests fail.

```
 FAIL  src/utils/interop.test.ts > interopDefault > unwraps the module namespace of @sindresorhus/slugify
TypeError: interopDefault(...) is not a function
 FAIL  src/utils/interop.test.ts > interopDefault > unwraps the module namespace of p-map
TypeError: interopDefault(...) is not a function
```

Artifact check, run by hand after `pnpm turbo build --filter ./packages/core`. A real `.cjs` file requires the built output and exercises both paths:

```
MCPServer id = my-server-id
pMap result  = [2,4]
```

A scan of the whole `dist` tree for the broken pattern (`p_map.default(` and `_sindresorhus_slugify.default(`) returns no matches.

**Notes**

- No automated artifact test guards this class of defect. Vitest runs the ESM source, where the broken imports work, so only a post-build check can catch a repeat. `packages/core` has no post-build test harness today. Adding one is worth a follow-up.
- `@mastra/deployer` has the same latent defect. It is also `"type": "module"`, also builds both formats, and default-imports `@sindresorhus/slugify` at `packages/deployer/src/bundler/workspaceDependencies.ts:3`. It is not reachable from this repro and needs its own changeset, so it is left for a follow-up PR.

Fixes #20354


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes crashes when CommonJS code uses `@mastra/core` with ESM-only packages. It adds shared wrappers so both CommonJS and ESM can use slugification and parallel mapping correctly.

## Changes

- Added the shared `interopDefault` helper.
- Added CommonJS-compatible `slugify` and `pMap` utilities.
- Updated MCP servers, schedules, workspace search and indexing, agent resource IDs, and batch trace scoring to use these utilities.
- Re-exported `pMapSkip`.
- Added interoperability and integration tests.
- Added a patch changeset for `@mastra/core`.

## Validation

- 366 tests passed across 12 files.
- Type checks passed.
- Verified the built CommonJS artifact for MCP server creation and `pMap` execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->