### PR TITLE
fix(memory): delete observation vectors with the thread

### DIFF
--- a/.changeset/flat-pens-argue.md
+++ b/.changeset/flat-pens-argue.md
@@ -1,0 +1,7 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed thread deletion so it also removes observational memory vectors. Deleting a thread now clears its vectors from both the message indexes and the observation indexes, so text from a deleted thread is no longer returned by resource-scoped search. Deleting a single message still touches only the message indexes.
+
+Improved the report of a failed cleanup. If a vector store cannot delete from one index, thread deletion still succeeds and now logs a warning that names the index and the thread.

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -2754,6 +2754,36 @@ describe('Memory', () => {
       });
     });
 
+    it('should wait for an earlier cleanup that a later delete overlaps', async () => {
+      const memory = createMemoryWithMockVector('_', ['memory_messages']);
+      let releaseFirstDelete: () => void = () => {};
+      const firstDeleteStarted = new Promise<void>(resolveStarted => {
+        memory.mockVector.deleteVectors.mockImplementationOnce(
+          () =>
+            new Promise<void>(resolveDelete => {
+              releaseFirstDelete = resolveDelete;
+              resolveStarted();
+            }),
+        );
+      });
+
+      await memory.deleteThread('thread-slow');
+      await firstDeleteStarted;
+      await memory.deleteMessages(['msg-fast']);
+
+      let flushed = false;
+      const flush = memory.flushVectorCleanup().then(() => {
+        flushed = true;
+      });
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(flushed).toBe(false);
+
+      releaseFirstDelete();
+      await flush;
+
+      expect(memory.deletedIndexNames()).toEqual(['memory_messages', 'memory_messages']);
+    });
+
     it('should not throw when no vector store is configured', async () => {
       const memory = new Memory({ storage: new InMemoryStore() });
 

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -2588,10 +2588,10 @@ describe('Memory', () => {
   });
 
   describe('Vector Deletion', () => {
-    function createMemoryWithMockVector(indexSeparator = '_') {
+    function createMemoryWithMockVector(indexSeparator = '_', indexes = [`memory${indexSeparator}messages`]) {
       const mockVector = {
         deleteVectors: vi.fn(),
-        listIndexes: vi.fn().mockResolvedValue([`memory${indexSeparator}messages`]),
+        listIndexes: vi.fn().mockResolvedValue(indexes),
         query: vi.fn(),
         upsert: vi.fn(),
         createIndex: vi.fn(),
@@ -2606,10 +2606,23 @@ describe('Memory', () => {
       class MemoryWithMockVector extends Memory {
         public mockVector = mockVector;
 
+        /** Warnings that the background vector cleanup reported. */
+        public warnSpy = vi.spyOn(this.logger, 'warn').mockImplementation(() => {});
+
         constructor() {
           super({ storage: new InMemoryStore() });
           // @ts-expect-error - injecting mock vector
           this.vector = this.mockVector;
+        }
+
+        /** Waits for the background vector cleanup that deleteThread or deleteMessages started. */
+        public flushVectorCleanup(): Promise<void> {
+          return (this as unknown as { pendingVectorCleanup: Promise<void> }).pendingVectorCleanup;
+        }
+
+        /** Names of the indexes that received a delete, in call order. */
+        public deletedIndexNames(): string[] {
+          return this.mockVector.deleteVectors.mock.calls.map(([args]) => args.indexName);
         }
       }
 
@@ -2621,12 +2634,11 @@ describe('Memory', () => {
       const messageId = 'msg-123';
 
       await memory.deleteMessages([messageId]);
+      await memory.flushVectorCleanup();
 
-      await vi.waitFor(() => {
-        expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
-          indexName: 'memory_messages',
-          filter: { message_id: { $in: [messageId] } },
-        });
+      expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
+        indexName: 'memory_messages',
+        filter: { message_id: { $in: [messageId] } },
       });
     });
 
@@ -2635,12 +2647,11 @@ describe('Memory', () => {
       const threadId = 'thread-123';
 
       await memory.deleteThread(threadId);
+      await memory.flushVectorCleanup();
 
-      await vi.waitFor(() => {
-        expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
-          indexName: 'memory_messages',
-          filter: { thread_id: threadId },
-        });
+      expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
+        indexName: 'memory_messages',
+        filter: { thread_id: threadId },
       });
     });
 
@@ -2649,12 +2660,11 @@ describe('Memory', () => {
       const messageId = 'msg-456';
 
       await memory.deleteMessages([messageId]);
+      await memory.flushVectorCleanup();
 
-      await vi.waitFor(() => {
-        expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
-          indexName: 'memory-messages',
-          filter: { message_id: { $in: [messageId] } },
-        });
+      expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
+        indexName: 'memory-messages',
+        filter: { message_id: { $in: [messageId] } },
       });
     });
 
@@ -2663,12 +2673,84 @@ describe('Memory', () => {
       const threadId = 'thread-456';
 
       await memory.deleteThread(threadId);
+      await memory.flushVectorCleanup();
 
-      await vi.waitFor(() => {
-        expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
-          indexName: 'memory-messages',
-          filter: { thread_id: threadId },
-        });
+      expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
+        indexName: 'memory-messages',
+        filter: { thread_id: threadId },
+      });
+    });
+
+    it('should delete observation vectors when deleting a thread', async () => {
+      const memory = createMemoryWithMockVector('_', ['memory_messages', 'memory_observations_384']);
+      const threadId = 'thread-with-observations';
+
+      await memory.deleteThread(threadId);
+      await memory.flushVectorCleanup();
+
+      expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
+        indexName: 'memory_observations_384',
+        filter: { thread_id: threadId },
+      });
+      expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
+        indexName: 'memory_messages',
+        filter: { thread_id: threadId },
+      });
+    });
+
+    it('should delete observation vectors with dash separator (Pinecone/Vectorize)', async () => {
+      const memory = createMemoryWithMockVector('-', ['memory-messages', 'memory-observations-1536']);
+      const threadId = 'thread-with-observations';
+
+      await memory.deleteThread(threadId);
+      await memory.flushVectorCleanup();
+
+      expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
+        indexName: 'memory-observations-1536',
+        filter: { thread_id: threadId },
+      });
+    });
+
+    it('should not touch observation vectors when deleting a single message', async () => {
+      const memory = createMemoryWithMockVector('_', ['memory_messages', 'memory_observations_384']);
+      const messageId = 'msg-123';
+
+      await memory.deleteMessages([messageId]);
+      await memory.flushVectorCleanup();
+
+      expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
+        indexName: 'memory_messages',
+        filter: { message_id: { $in: [messageId] } },
+      });
+      expect(memory.deletedIndexNames()).toEqual(['memory_messages']);
+    });
+
+    it('should not throw when the observation index does not exist', async () => {
+      const memory = createMemoryWithMockVector('_', ['memory_messages']);
+
+      await expect(memory.deleteThread('thread-without-observations')).resolves.not.toThrow();
+      await memory.flushVectorCleanup();
+
+      expect(memory.deletedIndexNames()).toEqual(['memory_messages']);
+    });
+
+    it('should keep deleting other indexes when one index delete fails', async () => {
+      const memory = createMemoryWithMockVector('_', ['memory_messages', 'memory_observations_384']);
+      const threadId = 'thread-with-failing-index';
+      memory.mockVector.deleteVectors.mockImplementation(({ indexName }: { indexName: string }) =>
+        indexName === 'memory_observations_384' ? Promise.reject(new Error('index unavailable')) : Promise.resolve(),
+      );
+
+      await expect(memory.deleteThread(threadId)).resolves.not.toThrow();
+      await expect(memory.flushVectorCleanup()).resolves.toBeUndefined();
+
+      expect(memory.mockVector.deleteVectors).toHaveBeenCalledWith({
+        indexName: 'memory_messages',
+        filter: { thread_id: threadId },
+      });
+      expect(memory.warnSpy).toHaveBeenCalledWith('Failed to delete vectors of the deleted thread from index', {
+        threadId,
+        indexName: 'memory_observations_384',
       });
     });
 

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -276,10 +276,18 @@ export class Memory extends MastraMemory {
   private _mastraInstance: Mastra | undefined;
 
   /**
-   * The vector cleanup that deleteThread or deleteMessages started in the background.
+   * Every vector cleanup that deleteThread or deleteMessages started in the background.
    * Callers do not wait for the cleanup, so this handle is the only join point.
    */
   private pendingVectorCleanup: Promise<void> = Promise.resolve();
+
+  /**
+   * Adds a background vector cleanup to the join handle.
+   * The handle keeps the earlier cleanups, so it settles only after all of them end.
+   */
+  private trackVectorCleanup(cleanup: Promise<void>): void {
+    this.pendingVectorCleanup = Promise.allSettled([this.pendingVectorCleanup, cleanup]).then(() => undefined);
+  }
 
   /** The shared ObservationalMemory engine. Lazily created on first access. */
   get omEngine(): Promise<ObservationalMemory | null> {
@@ -743,7 +751,7 @@ export class Memory extends MastraMemory {
       await memoryStore.clearObservationalMemory(threadId, thread.resourceId);
     }
     if (this.vector) {
-      this.pendingVectorCleanup = this.deleteThreadVectors(threadId);
+      this.trackVectorCleanup(this.deleteThreadVectors(threadId));
     }
   }
 
@@ -2594,7 +2602,7 @@ Notes:
 
       await memoryStore.deleteMessages(messageIds);
       if (this.vector) {
-        this.pendingVectorCleanup = this.deleteMessageVectors(messageIds);
+        this.trackVectorCleanup(this.deleteMessageVectors(messageIds));
       }
 
       span?.end({ output: { success: true }, attributes: { messageCount: messageIds.length } });

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -275,6 +275,12 @@ export class Memory extends MastraMemory {
   private _omEngineInstance: ObservationalMemory | null | undefined;
   private _mastraInstance: Mastra | undefined;
 
+  /**
+   * The vector cleanup that deleteThread or deleteMessages started in the background.
+   * Callers do not wait for the cleanup, so this handle is the only join point.
+   */
+  private pendingVectorCleanup: Promise<void> = Promise.resolve();
+
   /** The shared ObservationalMemory engine. Lazily created on first access. */
   get omEngine(): Promise<ObservationalMemory | null> {
     if (!this._omEngine) {
@@ -737,31 +743,47 @@ export class Memory extends MastraMemory {
       await memoryStore.clearObservationalMemory(threadId, thread.resourceId);
     }
     if (this.vector) {
-      void this.deleteThreadVectors(threadId);
+      this.pendingVectorCleanup = this.deleteThreadVectors(threadId);
     }
   }
 
   /**
-   * Lists all vector indexes that match the memory messages prefix.
-   * Handles separator differences across vector store backends (e.g. '_' vs '-').
+   * Prefix shared by every message index. The index for the default embedding
+   * dimension is named with the bare prefix; other dimensions add a suffix.
    */
-  private async getMemoryVectorIndexes(): Promise<string[]> {
+  private get messageIndexPrefix(): string {
+    return this.getEmbeddingIndexName();
+  }
+
+  /**
+   * Prefix shared by every observation index. Each observation index adds a dimension suffix.
+   */
+  private get observationIndexPrefix(): string {
+    const separator = this.vector?.indexSeparator ?? '_';
+    return `memory${separator}observations`;
+  }
+
+  /**
+   * Lists the vector indexes whose name starts with one of the given prefixes.
+   * Index names can carry a dimension suffix, so discovery matches on the prefix.
+   */
+  private async getMemoryVectorIndexes(prefixes: string[]): Promise<string[]> {
     if (!this.vector) return [];
-    const separator = this.vector.indexSeparator ?? '_';
-    const prefix = `memory${separator}messages`;
     const indexes = await this.vector.listIndexes();
-    return indexes.filter(name => name.startsWith(prefix));
+    return indexes.filter(name => prefixes.some(prefix => name.startsWith(prefix)));
   }
 
   /**
    * Deletes all vector embeddings associated with a thread.
    * This is called internally by deleteThread to clean up orphaned vectors.
+   * Both message and observation vectors are removed, so no text of the deleted
+   * thread stays reachable through resource-scoped retrieval.
    *
    * @param threadId - The ID of the thread whose vectors should be deleted
    */
   private async deleteThreadVectors(threadId: string): Promise<void> {
     try {
-      const memoryIndexes = await this.getMemoryVectorIndexes();
+      const memoryIndexes = await this.getMemoryVectorIndexes([this.messageIndexPrefix, this.observationIndexPrefix]);
 
       await Promise.all(
         memoryIndexes.map(async (indexName: string) => {
@@ -771,12 +793,13 @@ export class Memory extends MastraMemory {
               filter: { thread_id: threadId },
             });
           } catch {
-            this.logger.debug('Failed to delete vectors for thread, skipping', { threadId, indexName });
+            // The index keeps the vectors of the deleted thread, so report which one.
+            this.logger.warn('Failed to delete vectors of the deleted thread from index', { threadId, indexName });
           }
         }),
       );
     } catch {
-      this.logger.debug('Failed to clean up vectors for thread', { threadId });
+      this.logger.warn('Failed to clean up vectors of the deleted thread', { threadId });
     }
   }
 
@@ -1912,7 +1935,7 @@ Notes:
     const defaultDimensions = 384;
     const usedDimensions = dimensions ?? defaultDimensions;
     const separator = this.vector?.indexSeparator ?? '_';
-    return `memory${separator}observations${separator}${usedDimensions}`;
+    return `${this.observationIndexPrefix}${separator}${usedDimensions}`;
   }
 
   private async createObservationEmbeddingIndex(dimensions?: number): Promise<{ indexName: string }> {
@@ -2471,7 +2494,7 @@ Notes:
 
         if (messageIdsNeedingDeletion.size > 0) {
           try {
-            const memoryIndexes = await this.getMemoryVectorIndexes();
+            const memoryIndexes = await this.getMemoryVectorIndexes([this.messageIndexPrefix]);
             const idsToDelete = [...messageIdsNeedingDeletion];
 
             await Promise.all(
@@ -2571,7 +2594,7 @@ Notes:
 
       await memoryStore.deleteMessages(messageIds);
       if (this.vector) {
-        void this.deleteMessageVectors(messageIds);
+        this.pendingVectorCleanup = this.deleteMessageVectors(messageIds);
       }
 
       span?.end({ output: { success: true }, attributes: { messageCount: messageIds.length } });
@@ -2584,12 +2607,14 @@ Notes:
   /**
    * Deletes vector embeddings for specific messages.
    * This is called internally by deleteMessages to clean up orphaned vectors.
+   * Only the message indexes are touched, because observation vectors can hold
+   * text of other messages of the thread.
    *
    * @param messageIds - The IDs of the messages whose vectors should be deleted
    */
   private async deleteMessageVectors(messageIds: string[]): Promise<void> {
     try {
-      const memoryIndexes = await this.getMemoryVectorIndexes();
+      const memoryIndexes = await this.getMemoryVectorIndexes([this.messageIndexPrefix]);
 
       await Promise.all(
         memoryIndexes.map(async (indexName: string) => {


### PR DESCRIPTION
**What was broken**

Deleting a thread did not remove the observational memory vectors of that thread. Text of the deleted thread stayed in the vector store and came back from resource-scoped search.

**Root cause**

`getMemoryVectorIndexes` matched only the message index prefix (`packages/memory/src/index.ts:751`, before this change):

```ts
const prefix = `memory${separator}messages`;
```

Observation vectors go to a different index family. `getObservationEmbeddingIndexName` writes them to `memory<sep>observations<sep><dimensions>` and gives each vector `thread_id` metadata. The delete path did not know about that family, so `deleteThreadVectors` skipped it.

**The fix**

- `deleteThreadVectors` now asks for both index families and deletes the vectors of the thread from each one with the filter `{ thread_id }`.
- Two private getters, `messageIndexPrefix` and `observationIndexPrefix`, give the index names one source. `messageIndexPrefix` reuses the inherited `getEmbeddingIndexName()`, and `getObservationEmbeddingIndexName` now builds its name from `observationIndexPrefix`. Discovery can no longer drift away from the write path.
- `getMemoryVectorIndexes(prefixes)` takes the prefixes as a required argument, so each call site states its scope. The `MemoryVectorIndexKind` type and its hidden `['messages']` default are removed.
- Deletion of a single message still touches only the message indexes. Observation vectors can hold text of other messages of the thread, so a narrow delete stays correct.
- A failed delete stays tolerated, but the two catch blocks now log at `warn` and name the index and the thread. Silent data retention on an explicit delete is now visible to an operator.
- Alternative rejected: a match on the exact index name. Observation index names carry a dimension suffix, so a prefix match is necessary.

**Testing**

```
pnpm --filter ./packages/memory exec vitest run src/index.test.ts --bail=0
```

Result after the fix:

```
 Test Files  1 passed (1)
      Tests  106 passed (106)
```

Evidence that the tests fail without the fix. I put back the old scope (`getMemoryVectorIndexes([this.messageIndexPrefix])` in `deleteThreadVectors`) and ran the same file:

```
 FAIL  |unit:packages/memory| src/index.test.ts > Memory > Vector Deletion > should delete observation vectors when deleting a thread
AssertionError: expected "vi.fn()" to be called with arguments: [ { …(2) } ]

Received:

  1st vi.fn() call:

  [
    {
      "filter": {
        "thread_id": "thread-with-observations",
      },
-     "indexName": "memory_observations_384",
+     "indexName": "memory_messages",
    },
  ]
```

The dash-separator test (`memory-observations-1536`) fails the same way. I then restored the fix and confirmed the 106 tests pass again.

Also run: `pnpm --filter ./packages/memory check` (tsc, clean), `pnpm --filter ./packages/memory build:lib` (clean), oxlint and Prettier on the two changed files (clean).

**Notes**

- The tests no longer race the background cleanup. `deleteThread` and `deleteMessages` keep the cleanup promise in `pendingVectorCleanup`, and the tests await that handle instead of `vi.waitFor`. The scope test now asserts the exact set of indexes that received a delete.
- A new test makes `deleteVectors` reject for the observation index. It proves that one failing index does not stop the cleanup of the other index and that the warning names the failing index.
- Follow-up (not in this PR): the write, query and delete code for observation vectors sits about 1200 lines apart in `packages/memory/src/index.ts`. Extracting an `observation-vectors.ts` module would keep those sides visible against each other, but it is a restructuring and does not belong in this bugfix.

Fixes #20509


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a thread is deleted, its message data and observation data are also removed from memory search indexes. This prevents deleted content from remaining searchable.

## Changes

- Delete thread vectors from message and observation indexes.
- Keep individual message deletion limited to message indexes.
- Track overlapping background cleanup operations.
- Log failed vector deletions at `warn` level with the index and thread.
- Add regression tests for cleanup scope, index naming, missing indexes, failures, and overlapping cleanup.
- Add a patch changeset for `@mastra/memory`.

## Validation

- Memory package tests pass with 106 tests.
- Type checking, build, linting, and formatting pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->