### PR TITLE
fix(core): skip schedules store read when the scheduler cannot start

### DIFF
--- a/.changeset/clean-things-cheat.md
+++ b/.changeset/clean-things-cheat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `Mastra.startWorkers()` so it no longer reads the schedules store on boot when the scheduler cannot start. Boot now skips that read if you set `scheduler: { enabled: false }` or `workers: false`. Storage adapters that need request or tenant context no longer warn on every boot. Automatic detection of persisted agent schedules and deferred notifications is unchanged when you do not opt out.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1850,14 +1850,23 @@ export class Mastra<
     return findFsAgentScheduleHandler<Mastra>(this.#agents as Record<string, Agent<any>>, scheduleId);
   }
 
+  /**
+   * True when the app opted out of the scheduler for the whole instance,
+   * either with `workers: false` or with `scheduler: { enabled: false }`.
+   *
+   * `workers: false` disables all event processing in this instance, so never
+   * auto-inject scheduler / agent-schedule workers (even when a schedule is
+   * created at runtime). Standalone workers run the scheduler separately.
+   *
+   * Nothing can start the scheduler while this is true, so callers must also
+   * skip the storage reads that only exist to request it (see #20550).
+   */
+  #schedulerDisabled(): boolean {
+    return this.#workersDisabled || this.#schedulerConfig?.enabled === false;
+  }
+
   #shouldEnableScheduler(): boolean {
-    // Honour an explicit `workers: false` opt-out — the user disabled all
-    // event processing in this instance, so never auto-inject scheduler /
-    // agent-schedule workers (even when scheduler.enabled is true or a
-    // schedule is created at runtime). Standalone workers are expected to
-    // run the scheduler separately.
-    if (this.#workersDisabled) return false;
-    if (this.#schedulerConfig?.enabled === false) return false;
+    if (this.#schedulerDisabled()) return false;
     if (this.#schedulerConfig?.enabled === true) return true;
     return (
       this.#hasScheduledWorkflow ||
@@ -5032,8 +5041,7 @@ export class Mastra<
   async __ensureNotificationDispatchReady(): Promise<void> {
     if (this.#notificationDispatchReady) return;
     if (this.#notificationDispatchConfig?.enabled === false) return;
-    if (this.#workersDisabled) return;
-    if (this.#schedulerConfig?.enabled === false) return;
+    if (this.#schedulerDisabled()) return;
     if (!this.#storage) return;
 
     try {
@@ -5128,49 +5136,38 @@ export class Mastra<
   }
 
   /**
-   * Detect agent-schedule rows in storage on boot. Used by
-   * `#shouldEnableScheduler` to flip the scheduler-requested flag when
-   * imperative agent schedules persisted from a previous process exist —
-   * without this, a fresh boot with only DB-side agent schedules would skip
-   * starting the scheduler and agent-schedule workers entirely.
+   * Detect schedule rows that a previous process persisted, and flip the
+   * scheduler-requested flag that `#shouldEnableScheduler` reads. Without
+   * this, a fresh boot with only DB-side work would skip injecting the
+   * scheduler and agent-schedule workers entirely. Two rows count:
+   *
+   * - agent-schedule rows created imperatively through `schedules.create()`;
+   * - the notification dispatcher row that `__ensureNotificationDispatchReady()`
+   *   upserts when a deferred notification is created, so pending deferred
+   *   notifications still get dispatched after a restart.
+   *
+   * Callers must skip this probe when the scheduler can never start; see
+   * `#schedulerDisabled()`.
    *
    * @internal
    */
-  async #detectExistingAgentSchedules(): Promise<void> {
-    if (this.#schedulerRequested) return;
+  async #detectPersistedSchedulerWork(): Promise<void> {
     if (!this.#storage) return;
     try {
       const schedulesStore = await this.#storage.getStore('schedules');
       if (!schedulesStore) return;
-      const existing = await schedulesStore.listSchedules({ ownerType: 'agent' });
-      if (existing.length === 0) return;
-      this.#schedulerRequested = true;
-    } catch (err) {
-      this.#logger?.warn?.('Failed to detect existing agent schedules on boot', err as any);
-    }
-  }
 
-  /**
-   * Detect the lazily-created notification dispatcher schedule row on boot.
-   * A previous process upserts the row via `__ensureNotificationDispatchReady()`
-   * when a deferred notification is created; a fresh boot must then start the
-   * scheduler so pending deferred notifications still get dispatched.
-   * Mirrors `#detectExistingAgentSchedules`.
-   *
-   * @internal
-   */
-  async #detectExistingNotificationDispatch(): Promise<void> {
-    if (this.#schedulerRequested) return;
-    if (this.#notificationDispatchConfig?.enabled === false) return;
-    if (!this.#storage) return;
-    try {
-      const schedulesStore = await this.#storage.getStore('schedules');
-      if (!schedulesStore) return;
-      const existing = await schedulesStore.getSchedule(NOTIFICATION_DISPATCH_SCHEDULE_ROW_ID);
-      if (!existing) return;
-      this.#schedulerRequested = true;
+      const agentSchedules = await schedulesStore.listSchedules({ ownerType: 'agent' });
+      if (agentSchedules.length > 0) {
+        this.#schedulerRequested = true;
+        return;
+      }
+
+      if (this.#notificationDispatchConfig?.enabled === false) return;
+      const dispatchRow = await schedulesStore.getSchedule(NOTIFICATION_DISPATCH_SCHEDULE_ROW_ID);
+      if (dispatchRow) this.#schedulerRequested = true;
     } catch (err) {
-      this.#logger?.warn?.('Failed to detect existing notification dispatch schedule on boot', err as any);
+      this.#logger?.warn?.('Failed to detect persisted scheduler work on boot', err as any);
     }
   }
 
@@ -5844,18 +5841,19 @@ export class Mastra<
       await this.#storage.init();
     }
 
-    // Flip the scheduler-requested flag if any agent-schedule rows
-    // exist in storage from a previous boot. Without this, a process
-    // that boots with only DB-side agent schedules (no in-code declarative
-    // schedules and no imperative `schedules.create()` calls yet) would
-    // skip injecting the scheduler + agent-schedule workers entirely. This
-    // reads the schedules store, so it must run after storage.init() above.
-    if (!name) {
-      await this.#detectExistingAgentSchedules();
-      // Same idea for the notification dispatcher: a previous process may
-      // have lazily created the dispatcher schedule row because deferred
-      // notifications were in play.
-      await this.#detectExistingNotificationDispatch();
+    // Flip the scheduler-requested flag if schedule rows exist in storage from
+    // a previous boot. Without this, a process that boots with only DB-side
+    // work (no in-code declarative schedules and no imperative
+    // `schedules.create()` calls yet) would skip injecting the scheduler +
+    // agent-schedule workers entirely. This reads the schedules store, so it
+    // must run after storage.init() above.
+    //
+    // Skip the read when the flag cannot change the outcome: it is already
+    // set, or the app opted out of the scheduler and nothing may start it.
+    // Reading the store anyway is a useless boot-time query, and storage
+    // adapters that need request/tenant context warn on it (see #20550).
+    if (!name && !this.#schedulerRequested && !this.#schedulerDisabled()) {
+      await this.#detectPersistedSchedulerWork();
     }
 
     // Lazily inject the SchedulerWorker + AgentScheduleWorker if the

--- a/packages/core/src/mastra/scheduler-integration.test.ts
+++ b/packages/core/src/mastra/scheduler-integration.test.ts
@@ -33,6 +33,25 @@ async function flushAsyncInit(): Promise<void> {
 
 const withoutNotificationDispatch = { notifications: { dispatch: { enabled: false } } } as const;
 
+/**
+ * Wrap every method of a store and record its name on each call. Lets a test
+ * assert that boot touched the store not at all, instead of naming the one
+ * method it happens to know about today.
+ */
+function recordStoreCalls(store: object): string[] {
+  const calls: string[] = [];
+  for (const method of Object.getOwnPropertyNames(Object.getPrototypeOf(store))) {
+    if (method === 'constructor') continue;
+    const original = (store as Record<string, unknown>)[method];
+    if (typeof original !== 'function') continue;
+    vi.spyOn(store as never, method as never).mockImplementation(((...args: unknown[]) => {
+      calls.push(method);
+      return (original as (...a: unknown[]) => unknown).apply(store, args);
+    }) as never);
+  }
+  return calls;
+}
+
 describe('Mastra — workflow scheduler integration', () => {
   it('auto-instantiates the scheduler when a workflow declares a schedule', async () => {
     const wf = createEventedWorkflow({
@@ -722,6 +741,84 @@ describe('Mastra — workflow scheduler integration', () => {
       // still in flight → "no such table". After the fix, init() is awaited
       // first, so no write ever lands on an uninitialized store.
       expect(storage.sawWriteBeforeInit).toBe(false);
+
+      await mastra.shutdown();
+    });
+  });
+
+  describe('explicit scheduler opt-out (#20550)', () => {
+    // Default notification dispatch on purpose: it is the configuration most
+    // apps run, and it drove a second boot-time read of the same store.
+    it('does not touch the schedules store on boot when scheduler.enabled is false', async () => {
+      const storage = new MockStore();
+      const schedulesStore = (await storage.getStore('schedules'))!;
+      const calls = recordStoreCalls(schedulesStore);
+
+      const mastra = new Mastra({
+        logger: false,
+        storage,
+        scheduler: { enabled: false },
+      });
+
+      await mastra.startWorkers();
+      await flushAsyncInit();
+
+      expect(calls).toEqual([]);
+      expect(mastra.scheduler).toBeUndefined();
+
+      await mastra.shutdown();
+    });
+
+    it('does not touch the schedules store on boot when workers are disabled', async () => {
+      const storage = new MockStore();
+      const schedulesStore = (await storage.getStore('schedules'))!;
+      const calls = recordStoreCalls(schedulesStore);
+
+      const mastra = new Mastra({
+        logger: false,
+        storage,
+        workers: false,
+      });
+
+      await mastra.startWorkers();
+      await flushAsyncInit();
+
+      expect(calls).toEqual([]);
+      expect(mastra.scheduler).toBeUndefined();
+
+      await mastra.shutdown();
+    });
+
+    it('still detects existing agent schedules when the scheduler is not explicitly disabled', async () => {
+      const storage = new MockStore();
+      const schedulesStore = (await storage.getStore('schedules'))!;
+      const listSchedules = vi.spyOn(schedulesStore, 'listSchedules');
+      // Row persisted by a previous process — the whole point of the boot probe.
+      const future = Date.now() + 3_600_000;
+      await schedulesStore.createSchedule({
+        id: 'cold-boot-agent-sched',
+        target: { type: 'agent', agentId: 'a1', prompt: 'check in' },
+        cron: '0 0 1 1 *',
+        status: 'active',
+        nextFireAt: future,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        ownerType: 'agent',
+        ownerId: 'a1',
+      });
+
+      const mastra = new Mastra({
+        logger: false,
+        ...withoutNotificationDispatch,
+        storage,
+        scheduler: { tickIntervalMs: 600_000 },
+      });
+
+      await mastra.startWorkers();
+      await waitForScheduler(mastra);
+
+      expect(listSchedules).toHaveBeenCalledWith({ ownerType: 'agent' });
+      expect(mastra.scheduler).toBeDefined();
 
       await mastra.shutdown();
     });


### PR DESCRIPTION
**What was broken**

`Mastra.startWorkers()` read the schedules store on every boot, even when the application had disabled the scheduler with `scheduler: { enabled: false }` or `workers: false`. Storage adapters that need request or tenant context warned on each boot, and the query changed nothing.

**Root cause**

Two boot probes, `#detectExistingAgentSchedules()` (`packages/core/src/mastra/index.ts:5139`) and `#detectExistingNotificationDispatch()` (`packages/core/src/mastra/index.ts:5162`), each read the store and set a scheduler-requested flag. `#shouldEnableScheduler()` ignores that flag when the application opted out, so both reads were dead work. `startWorkers()` called them unconditionally at `packages/core/src/mastra/index.ts:5854`.

**The fix**

- Added `#schedulerDisabled()`, one predicate for `workers: false` and `scheduler: { enabled: false }`. `#shouldEnableScheduler()` and `__ensureNotificationDispatchReady()` now reuse it, which removes a third and fourth copy of the same rule.
- Gated the boot probe at its single call site in `startWorkers()`: it runs only when the flag is not set yet and the scheduler is not disabled.
- Merged the two near-identical probes into `#detectPersistedSchedulerWork()`. It resolves `getStore('schedules')` once and stops before the dispatcher read when agent schedule rows already exist, so a cold start makes one store lookup instead of two.

An earlier attempt put the opt-out check inside one probe only. That was rejected: the sibling probe still read the same store on the same boot under the default notification configuration, so the reported symptom stayed.

**Testing**

```
pnpm --filter ./packages/core test src/mastra/scheduler-integration.test.ts
```

24 tests pass. Two of them are new and both fail on the unfixed source. To prove this, restore `packages/core/src/mastra/index.ts` from the parent commit and run the command again:

```
AssertionError: expected [ 'listSchedules', 'getSchedule' ] to deeply equal []
Tests  2 failed | 22 passed (24)
```

The tests wrap every method of the schedules store and record each call, then expect an empty list. One test uses `scheduler: { enabled: false }` and the DEFAULT notification configuration, so a read from either probe fails it. The other uses `workers: false`. A third test seeds an agent schedule row and asserts that auto-detection still starts the scheduler, so an over-broad fix also fails.

`pnpm --filter ./packages/core test src/mastra src/schedules` passes (440 passed, 1 skipped). `pnpm turbo build --filter ./packages/core` succeeds.

**Notes**

The merged probe uses one `try`/`catch`. A schedules store that throws on the agent-schedule read now also skips the dispatcher read, where before each read had its own guard. The failure stays non-fatal, the logger still warns, and `startWorkers()` continues.

Fixes #20550


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When scheduling is turned off, Mastra no longer checks storage for schedules during startup. This prevents unnecessary warnings while preserving automatic schedule detection when scheduling is enabled.

## Changes

- Added a shared `#schedulerDisabled()` predicate.
- Skipped the startup schedules-store probe when `scheduler: { enabled: false }` or `workers: false` is configured.
- Merged persisted agent-schedule and notification-dispatch detection into `#detectPersistedSchedulerWork()`.
- Preserved automatic scheduler enablement when persisted work exists.
- Added regression tests for disabled scheduler configurations and persisted agent schedules.
- Added a patch changeset.

## Validation

- Focused tests: 24 passed.
- Core tests: 440 passed, 1 skipped.
- Core build succeeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->