### PR TITLE
fix(ai-sdk,core): keep the finish reason on UI message finish chunks

### DIFF
--- a/.changeset/proud-plums-sip.md
+++ b/.changeset/proud-plums-sip.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `convertFullStreamChunkToUIMessageStream` from `@mastra/core/stream` dropping the finish reason. The terminal `finish` chunk now carries `finishReason`, so a UI message stream built on this export can tell `stop`, `length`, `content-filter`, `tool-calls` and `other` apart. Fixes #20562.

--- a/.changeset/tiny-readers-end.md
+++ b/.changeset/tiny-readers-end.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed the finish reason dropping out of AI SDK UI message streams. The final `finish` chunk from `handleChatStream` and `toAISdkStream` now carries `finishReason`, so clients can tell `stop`, `length`, `content-filter`, `tool-calls` and `other` apart. This matches the AI SDK behavior. Fixes #20562.

--- a/client-sdks/ai-sdk/src/helpers.test.ts
+++ b/client-sdks/ai-sdk/src/helpers.test.ts
@@ -301,3 +301,53 @@ describe('tool-output-denied chunk conversion (issue #20880)', () => {
     });
   });
 });
+
+describe('finish reason on UI message chunks (issue #20562)', () => {
+  const mastraFinishChunk = (reason: string) =>
+    ({
+      type: 'finish',
+      runId: 'run-1',
+      from: ChunkFrom.AGENT,
+      payload: {
+        stepResult: { reason },
+        output: { usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 } },
+      },
+    }) as any;
+
+  it('keeps the v6 finish reason on the terminal UI chunk', () => {
+    const part = convertMastraChunkToAISDKv6({ chunk: mastraFinishChunk('content-filter') });
+
+    expect(
+      convertFullStreamChunkToUIMessageStream({
+        part: part as any,
+        sendFinish: true,
+        onError: String,
+      }),
+    ).toEqual({ type: 'finish', finishReason: 'content-filter' });
+  });
+
+  it('reports the Mastra-only tripwire reason as other on the terminal UI chunk', () => {
+    const part = convertMastraChunkToAISDKv6({ chunk: mastraFinishChunk('tripwire') });
+
+    expect(
+      convertFullStreamChunkToUIMessageStream({
+        part: part as any,
+        sendFinish: true,
+        onError: String,
+      }),
+    ).toEqual({ type: 'finish', finishReason: 'other' });
+  });
+
+  it('keeps the v5 finish reason on the terminal UI chunk', () => {
+    const part = convertMastraChunkToAISDKv5({ chunk: mastraFinishChunk('length') });
+
+    expect(
+      convertFullStreamChunkToUIMessageStream({
+        part: part as any,
+        sendFinish: true,
+        messageMetadataValue: { custom: true },
+        onError: String,
+      }),
+    ).toEqual({ type: 'finish', finishReason: 'length', messageMetadata: { custom: true } });
+  });
+});

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -826,6 +826,8 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
       if (sendFinish) {
         return {
           type: 'finish' as const,
+          // Matches the AI SDK UI converter, which keeps the finish reason on the terminal chunk.
+          ...(part.finishReason != null ? { finishReason: part.finishReason } : {}),
           ...(messageMetadataValue != null ? { messageMetadata: messageMetadataValue } : {}),
         } as InferUIMessageChunk<UI_MESSAGE>;
       }

--- a/packages/core/src/stream/aisdk/v5/compat.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat.test.ts
@@ -72,6 +72,25 @@ describe('convertFullStreamChunkToUIMessageStream', () => {
       url: 'https://example.com/generated.jpeg',
     });
   });
+
+  it('keeps the finish reason on the terminal UI chunk', () => {
+    const result = convertFullStreamChunkToUIMessageStream({
+      part: {
+        type: 'finish',
+        finishReason: 'content-filter',
+        totalUsage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+      } as any,
+      sendFinish: true,
+      messageMetadataValue: { custom: true },
+      onError: error => `Error: ${error}`,
+    });
+
+    expect(result).toEqual({
+      type: 'finish',
+      finishReason: 'content-filter',
+      messageMetadata: { custom: true },
+    });
+  });
 });
 
 describe('isUrlString', () => {

--- a/packages/core/src/stream/aisdk/v5/compat/ui-message.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/ui-message.ts
@@ -220,6 +220,8 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
       if (sendFinish) {
         return {
           type: 'finish' as const,
+          // Matches the AI SDK UI converter, which keeps the finish reason on the terminal chunk.
+          ...(part.finishReason != null ? { finishReason: part.finishReason } : {}),
           ...(messageMetadataValue != null ? { messageMetadata: messageMetadataValue } : {}),
         } as InferUIMessageChunk<UI_MESSAGE>;
       }


### PR DESCRIPTION
**What was broken**

The final `finish` chunk of an AI SDK UI message stream had no `finishReason`. A client could not tell `stop`, `length`, `content-filter`, `tool-calls` and `other` apart, so it could not show a different message when the model stopped for a content filter or hit the token limit.

**Root cause**

`convertFullStreamChunkToUIMessageStream` built the terminal chunk from the chunk type and the optional message metadata only. It read `part.finishReason` from the source part and then discarded it. The repository holds two forked copies of this converter, and both had the same defect:

- `client-sdks/ai-sdk/src/helpers.ts:825` — the converter behind `handleChatStream` and `toAISdkStream`.
- `packages/core/src/stream/aisdk/v5/compat/ui-message.ts:219` — the copy exported publicly as `convertFullStreamChunkToUIMessageStream` from `@mastra/core/stream`.

**The fix**

Each copy now copies `part.finishReason` onto the terminal chunk, as the AI SDK UI converter does. The field uses the conditional-spread convention that every other optional field in the same function uses, so a part with no reason adds no key.

The fix is applied to both copies on purpose. A fix in one copy only would leave the `@mastra/core/stream` export broken and would widen the existing drift between the forks.

The change adds no other field. The issue puts `totalUsage` and `rawFinishReason` out of scope.

**Testing**

```
pnpm --filter ./client-sdks/ai-sdk test src/helpers.test.ts
pnpm --filter ./packages/core test src/stream/aisdk/v5/compat.test.ts
```

Both suites pass: 15 tests in `@mastra/ai-sdk`, 6 tests in `@mastra/core`, no type errors.

Evidence that the tests are real: with both source changes reverted to `main` and the tests kept, the `@mastra/ai-sdk` suite reports `3 failed | 12 passed` and the `@mastra/core` suite reports `1 failed | 5 passed`. Each failure is the missing `finishReason` key. The source changes were then restored and both suites pass again.

The new tests drive the production path, not a private helper. They build a Mastra finish chunk, pass it through `convertMastraChunkToAISDKv6` or `convertMastraChunkToAISDKv5`, then through the converter that `client-sdks/ai-sdk/src/transformers.ts:398` calls. One test covers `content-filter`, the reason named in the issue. One test covers the Mastra-only `tripwire` reason, which must reach the client as `other`. One test covers the v5 path together with `messageMetadata`.

`pnpm --filter ./client-sdks/ai-sdk lint` and `npx tsc --noEmit` in that package both pass.

**Notes**

- Two changesets, one per package, both `patch`.
- Follow-up worth filing: the two copies of `convertFullStreamChunkToUIMessageStream` are a ~220 line switch that has drifted. The core copy holds a URL-backed file fix that the `@mastra/ai-sdk` copy lacks; the `@mastra/ai-sdk` copy holds `sendReasoning` gating, a v6 return union and the Mastra-specific cases that the core copy lacks. Collapsing them so `@mastra/ai-sdk` delegates the standard part types to core would remove this bug class. That work changes behaviour across a published export, so it needs its own PR.

Fixes #20562


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a stream ends, clients now receive the reason it ended. This helps them distinguish normal completion from limits, content filters, tool calls, and other stop conditions.

## Changes

- Preserve `part.finishReason` on terminal UI message finish chunks in:
  - `@mastra/ai-sdk` v6 stream handling.
  - `@mastra/core/stream` v5 compatibility handling.
- Preserve existing message metadata.
- Normalize Mastra’s `tripwire` reason to `other`.
- Add patch changesets for both packages.

## Tests

- Added coverage for `content-filter`.
- Added coverage for `tripwire` normalization.
- Added v5 coverage with message metadata.
- Relevant tests, lint, and TypeScript checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->