### PR TITLE
fix(memory): keep observational memory running on approval-gated tool calls

### DIFF
--- a/.changeset/cozy-bushes-smell.md
+++ b/.changeset/cozy-bushes-smell.md
@@ -1,0 +1,7 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed a crash in Observational Memory token counting for tool calls that wait for approval. Threads that hold a tool invocation in the `approval-requested` or `approval-responded` state no longer throw `Unhandled tool-invocation state`, so memory extraction keeps running on approval-gated conversations.
+
+The counter also no longer stops on a tool-invocation state it does not know. A message that a different `@mastra/core` version wrote now gets an estimate instead of an error.

--- a/packages/memory/src/processors/observational-memory/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.test.ts
@@ -1,3 +1,4 @@
+import type { MastraToolInvocation } from '@mastra/core/agent/message-list';
 import probeImageSize from 'probe-image-size';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
@@ -14,6 +15,31 @@ function createMessage(content: any) {
     createdAt: new Date(),
     content,
   } as any;
+}
+
+const TOOL_NAME = 'findUserTool';
+const TOOL_ARGS = { name: 'Dero Israel' };
+
+/**
+ * One assistant message that holds a single tool invocation in the given state. `extra` overrides
+ * or adds invocation fields such as `approval`, `errorText`, `toolName` or `args`.
+ */
+function createToolInvocationMessage(state: MastraToolInvocation['state'], extra: Record<string, unknown> = {}) {
+  return createMessage({
+    format: 2,
+    parts: [
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state,
+          toolCallId: 'tool-1',
+          toolName: TOOL_NAME,
+          args: TOOL_ARGS,
+          ...extra,
+        },
+      },
+    ],
+  });
 }
 
 async function createToolResultPartFromExecutedTool({
@@ -1227,21 +1253,7 @@ describe('TokenCounter', () => {
     const DEFAULT_DECLINE_REASON = 'Tool call was not approved by the user';
 
     const createDeniedMessage = (approval?: { id: string; approved: boolean; reason?: string }) =>
-      createMessage({
-        format: 2,
-        parts: [
-          {
-            type: 'tool-invocation',
-            toolInvocation: {
-              state: 'output-denied',
-              toolCallId: 'tool-1',
-              toolName: 'findUserTool',
-              args: { name: 'Dero Israel' },
-              ...(approval ? { approval } : {}),
-            },
-          },
-        ],
-      });
+      createToolInvocationMessage('output-denied', approval ? { approval } : {});
 
     it('counts a declined approval by its approval reason instead of throwing', () => {
       const counter = new TokenCounter();
@@ -1283,20 +1295,10 @@ describe('TokenCounter', () => {
     it('counts the tool error instead of rejecting async message counting', async () => {
       const counter = new TokenCounter();
       const errorText = 'File not found: __intentional_missing_file_for_tool_error_test__';
-      const message = createMessage({
-        format: 2,
-        parts: [
-          {
-            type: 'tool-invocation',
-            toolInvocation: {
-              state: 'output-error',
-              toolCallId: 'tool-1',
-              toolName: 'view',
-              args: { path: '__intentional_missing_file_for_tool_error_test__' },
-              errorText,
-            },
-          },
-        ],
+      const message = createToolInvocationMessage('output-error', {
+        toolName: 'view',
+        args: { path: '__intentional_missing_file_for_tool_error_test__' },
+        errorText,
       });
 
       await expect(counter.countMessagesAsync([message])).resolves.toBeGreaterThan(0);
@@ -1304,6 +1306,84 @@ describe('TokenCounter', () => {
       const estimate = message.content.parts[0].providerMetadata?.mastra?.tokenEstimate;
       expect(estimate?.key).toContain('tool-result-error');
       expect(estimate?.tokens).toBe(counter.countString(errorText));
+    });
+  });
+
+  describe('pending approvals (approval-requested / approval-responded)', () => {
+    // Regression: a conversation that waits for approval persists as state 'approval-requested',
+    // and the reply to it persists as 'approval-responded'. The counter did not handle either
+    // state and threw ("Unhandled tool-invocation state ..."), so observational memory could not
+    // run on those threads at all.
+    // TOKENS_PER_MESSAGE is private, so read it from the class to keep the expected totals below
+    // exact instead of approximate.
+    const TOKENS_PER_MESSAGE = (TokenCounter as unknown as { TOKENS_PER_MESSAGE: number }).TOKENS_PER_MESSAGE;
+    // The counter discounts JSON tool arguments by this many tokens.
+    const JSON_ARGS_DISCOUNT = 12;
+
+    /** Payload tokens of the fixture: the role, the tool name and the JSON arguments. */
+    const signatureTokens = (counter: TokenCounter) =>
+      counter.countString('assistant') + counter.countString(TOOL_NAME) + counter.countString(JSON.stringify(TOOL_ARGS));
+
+    it('counts a pending approval exactly like the tool call it holds instead of throwing', () => {
+      const counter = new TokenCounter();
+      const pending = createToolInvocationMessage('approval-requested');
+      const call = createToolInvocationMessage('call');
+
+      expect(counter.countMessage(pending)).toBe(
+        Math.round(signatureTokens(counter) + TOKENS_PER_MESSAGE - JSON_ARGS_DISCOUNT),
+      );
+      expect(counter.countMessage(pending)).toBe(counter.countMessage(call));
+    });
+
+    it('charges an answered approval one extra message on top of the call it answers', async () => {
+      const counter = new TokenCounter();
+      const responded = createToolInvocationMessage('approval-responded', {
+        approval: { id: 'tool-1', approved: true },
+      });
+      const expected = Math.round(signatureTokens(counter) + 2 * TOKENS_PER_MESSAGE - JSON_ARGS_DISCOUNT);
+
+      expect(counter.countMessage(responded)).toBe(expected);
+      // The async path walks the same parts, so it must reach the same total.
+      await expect(counter.countMessagesAsync([responded])).resolves.toBe(counter.countMessages([responded]));
+    });
+
+    it('adds the approval reason text to an answered approval', () => {
+      const counter = new TokenCounter();
+      const reason = 'Manager approved this lookup for the on-call rotation';
+      const withReason = createToolInvocationMessage('approval-responded', {
+        approval: { id: 'tool-1', approved: true, reason },
+      });
+
+      expect(counter.countMessage(withReason)).toBe(
+        Math.round(
+          signatureTokens(counter) + counter.countString(reason) + 2 * TOKENS_PER_MESSAGE - JSON_ARGS_DISCOUNT,
+        ),
+      );
+    });
+
+    it('does not throw when the approval-responded invocation carries no approval object', () => {
+      const counter = new TokenCounter();
+      const message = createToolInvocationMessage('approval-responded');
+
+      expect(counter.countMessage(message)).toBe(
+        Math.round(signatureTokens(counter) + 2 * TOKENS_PER_MESSAGE - JSON_ARGS_DISCOUNT),
+      );
+    });
+
+    it('reuses the cached call estimate when the invocation moves from requested to responded', () => {
+      const counter = new TokenCounter();
+      // MessageMerger mutates one part in place as the approval progresses, so the cache kinds
+      // must not embed the state.
+      const message = createToolInvocationMessage('approval-requested');
+      counter.countMessage(message);
+      const keysAfterRequest = Object.keys(message.content.parts[0].providerMetadata.mastra.tokenEstimate);
+
+      message.content.parts[0].toolInvocation.state = 'approval-responded';
+      counter.countMessage(message);
+      const keysAfterResponse = Object.keys(message.content.parts[0].providerMetadata.mastra.tokenEstimate);
+
+      expect(keysAfterRequest.length).toBeGreaterThan(0);
+      expect(keysAfterResponse).toEqual(keysAfterRequest);
     });
   });
 

--- a/packages/memory/src/processors/observational-memory/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.test.ts
@@ -1379,11 +1379,15 @@ describe('TokenCounter', () => {
       const message = createToolInvocationMessage('approval-requested');
       counter.countMessage(message);
       const keysAfterRequest = Object.keys(message.content.parts[0].providerMetadata.mastra.tokenEstimate);
+      // Watch the second pass only, so a re-estimate of the call signature is visible.
+      const countString = vi.spyOn(counter, 'countString');
 
       message.content.parts[0].toolInvocation.state = 'approval-responded';
       counter.countMessage(message);
       const keysAfterResponse = Object.keys(message.content.parts[0].providerMetadata.mastra.tokenEstimate);
 
+      expect(countString).not.toHaveBeenCalledWith(TOOL_NAME);
+      expect(countString).not.toHaveBeenCalledWith(JSON.stringify(TOOL_ARGS));
       expect(keysAfterRequest.length).toBeGreaterThan(0);
       expect(keysAfterResponse).toEqual(keysAfterRequest);
     });

--- a/packages/memory/src/processors/observational-memory/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.test.ts
@@ -1322,7 +1322,9 @@ describe('TokenCounter', () => {
 
     /** Payload tokens of the fixture: the role, the tool name and the JSON arguments. */
     const signatureTokens = (counter: TokenCounter) =>
-      counter.countString('assistant') + counter.countString(TOOL_NAME) + counter.countString(JSON.stringify(TOOL_ARGS));
+      counter.countString('assistant') +
+      counter.countString(TOOL_NAME) +
+      counter.countString(JSON.stringify(TOOL_ARGS));
 
     it('counts a pending approval exactly like the tool call it holds instead of throwing', () => {
       const counter = new TokenCounter();

--- a/packages/memory/src/processors/observational-memory/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.test.ts
@@ -1391,6 +1391,15 @@ describe('TokenCounter', () => {
       expect(keysAfterRequest.length).toBeGreaterThan(0);
       expect(keysAfterResponse).toEqual(keysAfterRequest);
     });
+
+    it('falls back to generic serialization for invocation states written by a newer core version', async () => {
+      const counter = new TokenCounter();
+      const message = createToolInvocationMessage('future-state' as MastraToolInvocation['state']);
+
+      expect(counter.countMessage(message)).toBeGreaterThan(0);
+      await expect(counter.countMessagesAsync([message])).resolves.toBeGreaterThan(0);
+      expect(message.content.parts[0].providerMetadata?.mastra?.tokenEstimate).toBeTruthy();
+    });
   });
 
   describe('countObservations', () => {

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash } from 'node:crypto';
 import type { MastraDBMessage } from '@mastra/core/agent';
+import type { MastraToolInvocation } from '@mastra/core/agent/message-list';
 import imageSize from 'image-size';
 import { estimateTokenCount } from 'tokenx';
 
@@ -1697,41 +1698,78 @@ export class TokenCounter {
     return localTokens;
   }
 
+  /**
+   * Count the name and the arguments of a tool call. Every state before the tool produces an
+   * output holds the same call signature in the context window, so all of those states share
+   * these cache kinds. `buildEstimateKey` hashes the text, so a shared kind stays correct and
+   * keeps the estimate warm while the invocation moves from one state to the next.
+   */
+  private countToolCallSignature(
+    part: CacheablePart,
+    invocation: MastraToolInvocation,
+  ): { tokens: number; overheadDelta: number } {
+    let tokens = 0;
+    let overheadDelta = 0;
+
+    if (invocation.toolName) {
+      tokens += this.readOrPersistPartEstimate(part, 'tool-call-name', invocation.toolName);
+    }
+    if (invocation.args) {
+      if (typeof invocation.args === 'string') {
+        tokens += this.readOrPersistPartEstimate(part, 'tool-call-args', invocation.args);
+      } else {
+        const argsJson = JSON.stringify(invocation.args);
+        tokens += this.readOrPersistPartEstimate(part, 'tool-call-args-json', argsJson);
+        overheadDelta -= 12;
+      }
+    }
+
+    return { tokens, overheadDelta };
+  }
+
   private countNonAttachmentPart(part: CacheablePart): {
     tokens: number;
     overheadDelta: number;
-    toolResultDelta: number;
+    /** Number of extra messages this part costs, each charged one `TOKENS_PER_MESSAGE`. */
+    extraMessageDelta: number;
   } {
     let overheadDelta = 0;
-    let toolResultDelta = 0;
+    let extraMessageDelta = 0;
 
     if (part.type === 'text') {
-      return { tokens: this.readOrPersistPartEstimate(part, 'text', part.text), overheadDelta, toolResultDelta };
+      return { tokens: this.readOrPersistPartEstimate(part, 'text', part.text), overheadDelta, extraMessageDelta };
     }
 
     if (part.type === 'tool-invocation') {
-      const invocation = part.toolInvocation;
+      // Typed alias of the untyped part so the branches below narrow the state union down to
+      // `never`. A state added to the core type then breaks the build here.
+      const invocation: MastraToolInvocation = part.toolInvocation;
+      const state = invocation.state;
       let tokens = 0;
 
-      if (invocation.state === 'call' || invocation.state === 'partial-call') {
-        if (invocation.toolName) {
-          tokens += this.readOrPersistPartEstimate(part, `tool-${invocation.state}-name`, invocation.toolName);
-        }
-        if (invocation.args) {
-          if (typeof invocation.args === 'string') {
-            tokens += this.readOrPersistPartEstimate(part, `tool-${invocation.state}-args`, invocation.args);
-          } else {
-            const argsJson = JSON.stringify(invocation.args);
-            tokens += this.readOrPersistPartEstimate(part, `tool-${invocation.state}-args-json`, argsJson);
-            overheadDelta -= 12;
-          }
-        }
-
-        return { tokens, overheadDelta, toolResultDelta };
+      if (state === 'call' || state === 'partial-call' || state === 'approval-requested') {
+        // A call that waits for approval still holds its name and args in the context window
+        // exactly like a plain call, so it costs the same until the tool produces an output.
+        const signature = this.countToolCallSignature(part, invocation);
+        return { tokens: signature.tokens, overheadDelta: overheadDelta + signature.overheadDelta, extraMessageDelta };
       }
 
-      if (invocation.state === 'result') {
-        toolResultDelta++;
+      if (state === 'approval-responded') {
+        // The approval reply travels as its own tool message, so charge one more message of
+        // overhead on top of the call signature, plus the reason the user gave with the decision.
+        extraMessageDelta++;
+        const signature = this.countToolCallSignature(part, invocation);
+        tokens += signature.tokens;
+        overheadDelta += signature.overheadDelta;
+        const reason = invocation.approval?.reason;
+        if (reason) {
+          tokens += this.readOrPersistPartEstimate(part, 'tool-approval-reason', reason);
+        }
+        return { tokens, overheadDelta, extraMessageDelta };
+      }
+
+      if (state === 'result') {
+        extraMessageDelta++;
         const { value: resultForCounting, usingStoredModelOutput } = this.resolveToolResultForTokenCounting(
           part,
           invocation.result,
@@ -1756,46 +1794,45 @@ export class TokenCounter {
           }
         }
 
-        return { tokens, overheadDelta, toolResultDelta };
+        return { tokens, overheadDelta, extraMessageDelta };
       }
 
-      if (invocation.state === 'output-denied') {
+      if (state === 'output-denied') {
         // A declined approval carries no tool result; count its denial reason like a small result
-        // so token accounting stays consistent (and doesn't throw on the new state).
-        toolResultDelta++;
-        const reason =
-          (invocation as { approval?: { reason?: string } }).approval?.reason ??
-          'Tool call was not approved by the user';
+        // so token accounting stays consistent.
+        extraMessageDelta++;
+        const reason = invocation.approval?.reason ?? 'Tool call was not approved by the user';
         tokens += this.readOrPersistPartEstimate(part, 'tool-result-denied', reason);
-        return { tokens, overheadDelta, toolResultDelta };
+        return { tokens, overheadDelta, extraMessageDelta };
       }
 
-      if (invocation.state === 'output-error') {
-        toolResultDelta++;
-        const errorText = (invocation as { errorText?: unknown }).errorText;
-        const errorMessage = typeof errorText === 'string' ? errorText : 'Tool execution failed';
+      if (state === 'output-error') {
+        extraMessageDelta++;
+        const errorMessage = typeof invocation.errorText === 'string' ? invocation.errorText : 'Tool execution failed';
         tokens += this.readOrPersistPartEstimate(part, 'tool-result-error', errorMessage);
-        return { tokens, overheadDelta, toolResultDelta };
+        return { tokens, overheadDelta, extraMessageDelta };
       }
 
-      throw new Error(
-        `Unhandled tool-invocation state '${(part as any).toolInvocation?.state}' in token counting for part type '${part.type}'`,
-      );
+      // Compile-time exhaustiveness check only. This counter reads rows that another
+      // @mastra/core version may have written, so an unknown state must not stop the count.
+      // It falls through to the generic serializer below and yields an over-estimate instead.
+      const exhaustiveStateCheck: never = state;
+      void exhaustiveStateCheck;
     }
 
     if (typeof part.type === 'string' && part.type.startsWith('data-')) {
-      return { tokens: 0, overheadDelta, toolResultDelta };
+      return { tokens: 0, overheadDelta, extraMessageDelta };
     }
 
     if (part.type === 'reasoning') {
-      return { tokens: 0, overheadDelta, toolResultDelta };
+      return { tokens: 0, overheadDelta, extraMessageDelta };
     }
 
     const serialized = serializePartForTokenCounting(part);
     return {
       tokens: this.readOrPersistPartEstimate(part, `part-${part.type}`, serialized),
       overheadDelta,
-      toolResultDelta,
+      extraMessageDelta,
     };
   }
 
@@ -1805,7 +1842,7 @@ export class TokenCounter {
   countMessage(message: MastraDBMessage): number {
     let payloadTokens = this.countString(message.role);
     let overhead = TokenCounter.TOKENS_PER_MESSAGE;
-    let toolResultCount = 0;
+    let extraMessageCount = 0;
 
     if (typeof message.content === 'string') {
       payloadTokens += this.readOrPersistMessageEstimate(message, 'message-content', message.content);
@@ -1823,13 +1860,13 @@ export class TokenCounter {
           const result = this.countNonAttachmentPart(part);
           payloadTokens += result.tokens;
           overhead += result.overheadDelta;
-          toolResultCount += result.toolResultDelta;
+          extraMessageCount += result.extraMessageDelta;
         }
       }
     }
 
-    if (toolResultCount > 0) {
-      overhead += toolResultCount * TokenCounter.TOKENS_PER_MESSAGE;
+    if (extraMessageCount > 0) {
+      overhead += extraMessageCount * TokenCounter.TOKENS_PER_MESSAGE;
     }
 
     return Math.round(payloadTokens + overhead);
@@ -1838,7 +1875,7 @@ export class TokenCounter {
   async countMessageAsync(message: MastraDBMessage): Promise<number> {
     let payloadTokens = this.countString(message.role);
     let overhead = TokenCounter.TOKENS_PER_MESSAGE;
-    let toolResultCount = 0;
+    let extraMessageCount = 0;
 
     if (typeof message.content === 'string') {
       payloadTokens += this.readOrPersistMessageEstimate(message, 'message-content', message.content);
@@ -1856,13 +1893,13 @@ export class TokenCounter {
           const result = this.countNonAttachmentPart(part);
           payloadTokens += result.tokens;
           overhead += result.overheadDelta;
-          toolResultCount += result.toolResultDelta;
+          extraMessageCount += result.extraMessageDelta;
         }
       }
     }
 
-    if (toolResultCount > 0) {
-      overhead += toolResultCount * TokenCounter.TOKENS_PER_MESSAGE;
+    if (extraMessageCount > 0) {
+      overhead += extraMessageCount * TokenCounter.TOKENS_PER_MESSAGE;
     }
 
     return Math.round(payloadTokens + overhead);


### PR DESCRIPTION
**What was broken**

Observational Memory crashed on any thread that held a tool call in the `approval-requested` or `approval-responded` state. Token counting threw `Unhandled tool-invocation state`, so memory extraction stopped for the whole thread.

**Root cause**

`TokenCounter.countNonAttachmentPart` covered only `call`, `partial-call`, `result`, `output-denied` and `output-error`. Every other state hit a `throw` at the end of the chain (`packages/memory/src/processors/observational-memory/token-counter.ts:1781` on `main`). The two approval states are written by the approval flow and are read back from storage, so the counter aborted on data it had already persisted.

**The fix**

- `approval-requested` now counts like a plain `call`. The tool name and the arguments still occupy the context window until the tool produces an output.
- `approval-responded` counts the same call signature, plus one extra message of overhead for the approval reply, plus the `approval.reason` text.
- The `throw` is deleted. An unknown state falls through to the generic part serializer and yields an over-estimate. A token estimator reads rows that a different `@mastra/core` version can write, so it must not abort on a string it does not recognize. A compile-time `never` check keeps a newly added state a build error.
- The tool name and the arguments now share one cache kind across all call-like states. `buildEstimateKey` already hashes the text, so the shared kind keeps the estimate warm while an invocation moves from `call` to `approval-requested` to `approval-responded`.

Rejected alternative: counting nothing for `approval-responded`, as issue #20674 proposed. A part holds exactly one state at a time, so counting the call signature cannot double count against a separate `call` part, and it is the more accurate total.

**Testing**

```
pnpm --filter ./packages/memory test:unit
```

Result: 38 test files passed, 1295 tests passed, 1 todo. The narrow file run `src/processors/observational-memory/token-counter.test.ts` passes 56 tests.

The tests fail without the fix. With the source file reverted to `main` and the new tests kept:

```
FAIL src/processors/observational-memory/token-counter.test.ts
Error: Unhandled tool-invocation state 'approval-requested' in token counting for part type 'tool-invocation'
  at TokenCounter.countNonAttachmentPart token-counter.ts:1781:13
```

The new totals are absolute, not relative. Removing the extra message of overhead for `approval-responded` fails the suite with `expected 3 to be 7`.

**Notes**

- Do not run `pnpm --filter ./packages/memory test`. That script runs the integration suite first, and the integration workspace needs its own install. Use `test:unit`.
- `output-error` and `output-denied` already ship on `main`. This PR adds the two states that remained.
- Follow-up, not done here: `token-counter.ts` is more than 1900 lines and fuses four concerns - provider token-count calls, image dimension probing, the estimate cache, and the part walker. A later PR can split it into `token-estimate-cache.ts`, `provider-token-counts.ts` and `attachment-tokens.ts`.

Fixes #20674
Fixes #20607


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Observational Memory now counts tokens correctly when a tool call waits for approval, receives approval, or ends with an error. It also continues processing unfamiliar tool states instead of failing.

## Changes

- Added token counting for `approval-requested` and `approval-responded` tool states.
- Counted approval reasons and related message overhead.
- Reused cached estimates when a tool call changes state.
- Added fallback serialization for unknown tool-invocation states.
- Preserved compile-time exhaustiveness checks.
- Applied the updated overhead logic to synchronous and asynchronous counters.
- Added tests for approval states, missing metadata, errors, denied calls, asynchronous behavior, and cache reuse.
- Added a patch changeset for `@mastra/memory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->