### PR TITLE
chore(github-signals): format index.ts

### DIFF
--- a/signals/github/src/index.ts
+++ b/signals/github/src/index.ts
@@ -1599,8 +1599,7 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
     const generation = this.#pollingGeneration;
     const threadGeneration = this.#pollingThreadGenerations.get(key) ?? 0;
     const isCurrentGeneration = () =>
-      this.#pollingGeneration === generation &&
-      (this.#pollingThreadGenerations.get(key) ?? 0) === threadGeneration;
+      this.#pollingGeneration === generation && (this.#pollingThreadGenerations.get(key) ?? 0) === threadGeneration;
     if (state) state.running = true;
     this.#notifyPollingChanged({ threadId: input.threadId, resourceId: input.resourceId, running: true });
 
@@ -1917,10 +1916,16 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
     for (const comment of comments) {
       if (isCurrentGeneration && !isCurrentGeneration()) return snapshot;
       if (
-        !(await this.#isAuthorizedAuthor(owner, repo, comment.author, {
-          authorType: comment.authorType,
-          isBot: comment.isBot,
-        }, isCurrentGeneration))
+        !(await this.#isAuthorizedAuthor(
+          owner,
+          repo,
+          comment.author,
+          {
+            authorType: comment.authorType,
+            isBot: comment.isBot,
+          },
+          isCurrentGeneration,
+        ))
       ) {
         continue;
       }


### PR DESCRIPTION
The root `lint:format` task has been failing on main since #20593 landed: `oxfmt --check` rejects `signals/github/src/index.ts`, which fails the Lint job on every open PR regardless of what that PR touches. This is just the formatter's own output on that file, argument indentation and one line rejoin, no behaviour change.

Opening it as a draft since it's someone else's package and they may prefer to fold it into their own follow-up. Happy to close it if so, but main is red until one of the two happens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes the formatting in `signals/github/src/index.ts`. It helps the lint check pass without changing how the code works.

## Changes

- Applied `oxfmt` formatting.
- Reformatted the polling generation check.
- Reformatted the unauthorized-comment authorization call.
- Rejoined one line.
- Added no tests because behavior did not change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->