### PR TITLE
fix(factory): let SPA reach public core auth routes through the factory auth gate

### DIFF
--- a/.changeset/few-masks-follow.md
+++ b/.changeset/few-masks-follow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the factory auth gate returning 401 for the SPA sign-in flow. The gate now lets Mastra core's public auth routes (`/api/auth/capabilities`, `/api/auth/me`, `/api/auth/sso/login`, `/api/auth/sso/callback`, `/api/auth/logout`, `/api/auth/refresh`, `/api/auth/credentials/sign-in`, `/api/auth/credentials/sign-up`) reach their handlers before a session exists. Previously the SPA could not fetch its capabilities on load and stayed stuck at "unauthorized".

--- a/mastracode/factory/src/auth.test.ts
+++ b/mastracode/factory/src/auth.test.ts
@@ -145,6 +145,48 @@ describe('mountFactoryAuth gate (enabled)', () => {
     expect(await res.json()).toEqual({ error: 'unauthorized' });
   });
 
+  // The mastra core adapter marks these routes with `requiresAuth: false` via
+  // `createPublicRoute()` (see packages/server/src/server/handlers/auth.ts).
+  // The factory gate runs as Hono `use()` middleware — before route matching —
+  // so it cannot read that per-route metadata. It must explicitly pass through
+  // the same public routes, or the SPA sign-in flow (which fetches
+  // `/api/auth/capabilities` before login) receives a 401 and cannot render.
+  it('lets unauthenticated requests reach the public core auth routes exposed under /api/auth', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const { app } = buildApp();
+
+    const cases: Array<{ path: string; method: 'GET' | 'POST' }> = [
+      { path: '/api/auth/capabilities', method: 'GET' },
+      { path: '/api/auth/me', method: 'GET' },
+      { path: '/api/auth/sso/login', method: 'GET' },
+      { path: '/api/auth/sso/callback', method: 'GET' },
+      { path: '/api/auth/logout', method: 'POST' },
+      { path: '/api/auth/refresh', method: 'POST' },
+      { path: '/api/auth/credentials/sign-in', method: 'POST' },
+      { path: '/api/auth/credentials/sign-up', method: 'POST' },
+    ];
+    for (const { path, method } of cases) {
+      const res = await app.request(path, { method, headers: { Accept: 'application/json' } });
+      expect(res.status, `${method} ${path}`).toBe(200);
+      expect(await res.text(), `${method} ${path}`).toBe('ok');
+    }
+    expect(mockAuthenticate).not.toHaveBeenCalled();
+  });
+
+  it('still protects unrelated /api/auth-prefixed paths that are not public core routes', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const { app } = buildApp();
+
+    // Guard the whitelist against becoming a blanket `/api/auth` pass:
+    // routes such as `/api/auth/roles/:roleId/permissions` are protected in
+    // core (no `createPublicRoute`) and must stay behind the gate here too.
+    const res = await app.request('/api/auth/roles/admin/permissions', {
+      headers: { Accept: 'application/json' },
+    });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'unauthorized' });
+  });
+
   it('lets unauthenticated GitHub webhook deliveries reach the route handler', async () => {
     mockAuthenticate.mockResolvedValue(null);
     const { app } = buildApp();

--- a/mastracode/factory/src/auth.ts
+++ b/mastracode/factory/src/auth.ts
@@ -686,6 +686,35 @@ export function buildAuthRoutes(provider: IMastraAuthProvider, options: { public
 const SIGNATURE_VERIFYING_CHANNEL_WEBHOOK = /^\/api\/agent-controllers\/[^/]+\/channels\/slack\/webhook$/;
 
 /**
+ * Core auth routes declared with `createPublicRoute()` in
+ * `@mastra/server` (see `packages/server/src/server/handlers/auth.ts`), served
+ * under the mastra adapter's `/api` prefix. They set `requiresAuth: false`
+ * because the SPA needs to reach them before a session exists — capabilities
+ * discovery, SSO start/callback, credentials sign-in/up, logout, refresh, and
+ * the "who am I" probe.
+ *
+ * This gate is Hono `use()` middleware, so it runs before route matching and
+ * cannot read per-route `requiresAuth` metadata. Without an explicit
+ * allowlist the gate returns 401 on `/api/auth/capabilities`, the SPA sign-in
+ * page cannot render, and the user is stuck at "unauthorized".
+ *
+ * Kept as a small, hand-maintained allowlist keyed to `(method, path)` — the
+ * long-term fix is for the gate to consult the same public-route metadata
+ * mastra core uses (`canAccessPublicly`), but that requires reading the
+ * adapter's route table from middleware and is out of scope here.
+ */
+const PUBLIC_CORE_AUTH_ROUTES = new Set<string>([
+  'GET /api/auth/capabilities',
+  'GET /api/auth/me',
+  'GET /api/auth/sso/login',
+  'GET /api/auth/sso/callback',
+  'POST /api/auth/logout',
+  'POST /api/auth/refresh',
+  'POST /api/auth/credentials/sign-in',
+  'POST /api/auth/credentials/sign-up',
+]);
+
+/**
  * Build the auth gate as a plain Hono middleware handler `(c, next)`. Protects
  * everything that is not a public `/auth/*` route: authenticated requests stash
  * the user on the context and continue; unauthenticated navigations redirect to
@@ -730,6 +759,11 @@ export function createFactoryAuthGate(provider: IMastraAuthProvider) {
       path === '/manifest.webmanifest' ||
       path === '/mastra.svg'
     ) {
+      return next();
+    }
+    // Mastra core's public auth routes (see PUBLIC_CORE_AUTH_ROUTES above)
+    // need to be reachable before a session exists.
+    if (PUBLIC_CORE_AUTH_ROUTES.has(`${c.req.method} ${path}`)) {
       return next();
     }
 


### PR DESCRIPTION
## What

When a factory-built server has an auth provider configured, the Studio SPA is stuck at "unauthorized" the moment it loads. It can't even render the sign-in form.

The reason: `createFactoryAuthGate` is registered as Hono `use()` middleware, so it runs **before** route matching and cannot see per-route `requiresAuth: false` metadata. Its allowlist previously covered only static assets, `/signin`, and a few webhooks — every `/api/auth/*` request fell through to `authenticateRequest` and got 401, including the endpoints mastra core explicitly declares with `createPublicRoute()`.

The visible symptom: SPA loads `/signin` → calls `GET /api/auth/capabilities` to decide which login form to render → gets 401 → SPA renders "unauthorized" instead of a sign-in form. Same effect on SSO redirects, credential sign-in/up, refresh, and logout.

## How

Added a small hand-maintained allowlist in `createFactoryAuthGate` for the 8 core auth routes declared with `createPublicRoute()` in `packages/server/src/server/handlers/auth.ts`, keyed by `METHOD /path`:

- `GET  /api/auth/capabilities`
- `GET  /api/auth/me`
- `GET  /api/auth/sso/login`
- `GET  /api/auth/sso/callback`
- `POST /api/auth/logout`
- `POST /api/auth/refresh`
- `POST /api/auth/credentials/sign-in`
- `POST /api/auth/credentials/sign-up`

Requests matching that set skip `authenticateRequest` and hit the handler directly. Each handler is safe to reach without a session — either it needs to run pre-session (capabilities, SSO start/callback, credentials sign-in/up), gracefully returns `null` when there's no session (`/me`), or does its own session check and returns 401 itself (`refresh`, `logout`).

The gate still blocks every other `/api/auth/*` path — RBAC role management, permissions, etc. remain authenticated.

## Why an allowlist and not `requiresAuth: false`?

Ideally the gate would consult the same public-route metadata mastra core uses (`canAccessPublicly` / the adapter's route table), but the gate is `use()` middleware that runs before route matching, so it doesn't have the matched route in hand. That's the real defect — this PR is the minimum patch. I've left a comment in `auth.ts` calling out the longer-term fix.

## Test plan

- Added `mastracode/factory/src/auth.test.ts` cases:
  - **Positive**: all 8 public core auth routes pass through the gate unauthenticated (200 / 405 depending on downstream, never 401 from the gate).
  - **Negative**: `POST /api/auth/roles/:roleId/permissions` still 401s — guards the allowlist against becoming a blanket `/api/auth/*` bypass.
- `pnpm --filter ./mastracode/factory test`: 87/87 pass.
- `pnpm --filter ./mastracode/factory lint`: clean.
- `tsc --noEmit`: clean.

## Changeset

`.changeset/few-masks-follow.md` — patch on `@mastra/factory`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The authentication gate now lets users reach the public sign-in and session routes before they log in. This allows the Studio SPA to display authentication forms and complete sign-in flows.

## Changes

- Added an allowlist for eight public `/api/auth` routes:
  - `GET /api/auth/capabilities`
  - `GET /api/auth/me`
  - `GET /api/auth/sso/login`
  - `GET /api/auth/sso/callback`
  - `POST /api/auth/logout`
  - `POST /api/auth/refresh`
  - `POST /api/auth/credentials/sign-in`
  - `POST /api/auth/credentials/sign-up`
- Updated the factory authentication middleware to bypass authentication for these method and path combinations.
- Kept all other `/api/auth/*` routes protected, including role and permission management routes.
- Added tests for all public routes and for protected routes returning `401`.
- Added a patch changeset for `@mastra/factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->