### PR TITLE
feat(server,hono,deployer): guarantee user middleware cannot block framework-public routes

### DIFF
--- a/.changeset/funny-cats-matter.md
+++ b/.changeset/funny-cats-matter.md
@@ -1,0 +1,15 @@
+---
+'@mastra/hono': minor
+---
+
+Populated `MASTRA_FRAMEWORK_PUBLIC_KEY` on the Hono context inside `registerContextMiddleware()` and exported a new `skipIfFrameworkPublic` middleware wrapper.
+
+Adapter authors can now wrap any user middleware to guarantee it does not run for routes declared public via `createPublicRoute()` or `requiresAuth: false`.
+
+```ts
+import { skipIfFrameworkPublic } from '@mastra/hono';
+
+for (const m of userMiddleware) {
+  app.use(m.path, skipIfFrameworkPublic(m.handler));
+}
+```

--- a/.changeset/grumpy-eyes-cross.md
+++ b/.changeset/grumpy-eyes-cross.md
@@ -1,0 +1,13 @@
+---
+'@mastra/server': minor
+---
+
+Added a framework guarantee that user-registered server middleware can no longer block routes declared public via `createPublicRoute()` or `requiresAuth: false`.
+
+**Why**
+
+Previously, middleware registered through `serverMiddleware` or `server.middleware` ran before the framework's per-route auth check and could return a 401 for any request, including the Studio sign-in flow's own public auth endpoints. This made it possible for a user middleware to lock users out of their own login UI.
+
+**What changed**
+
+`MastraServer` now exposes a `getFrameworkPublicMatcher()` API that builds a matcher from the route metadata itself (both built-in `SERVER_ROUTES` and custom routes). Adapters use this matcher to short-circuit user middleware for framework-public routes. The matcher is built from route metadata, so any route declared public with `requiresAuth: false` is automatically covered.

--- a/.changeset/grumpy-eyes-cross.md
+++ b/.changeset/grumpy-eyes-cross.md
@@ -2,12 +2,17 @@
 '@mastra/server': minor
 ---
 
-Added a framework guarantee that user-registered server middleware can no longer block routes declared public via `createPublicRoute()` or `requiresAuth: false`.
+Added `MastraServer.getFrameworkPublicMatcher()`, which returns a `(path, method) => boolean` matcher built from route metadata (built-in `SERVER_ROUTES` entries with `requiresAuth === false`, plus user-registered custom routes with `requiresAuth: false`).
 
-**Why**
+Adapters can use it to short-circuit user middleware for routes the framework has declared public, without duplicating any allowlist.
 
-Previously, middleware registered through `serverMiddleware` or `server.middleware` ran before the framework's per-route auth check and could return a 401 for any request, including the Studio sign-in flow's own public auth endpoints. This made it possible for a user middleware to lock users out of their own login UI.
+```ts
+const isFrameworkPublic = mastraServer.getFrameworkPublicMatcher();
 
-**What changed**
-
-`MastraServer` now exposes a `getFrameworkPublicMatcher()` API that builds a matcher from the route metadata itself (both built-in `SERVER_ROUTES` and custom routes). Adapters use this matcher to short-circuit user middleware for framework-public routes. The matcher is built from route metadata, so any route declared public with `requiresAuth: false` is automatically covered.
+app.use('*', async (c, next) => {
+  if (isFrameworkPublic(c.req.path, c.req.method)) {
+    return next();
+  }
+  return userMiddleware(c, next);
+});
+```

--- a/.changeset/tidy-planes-stick.md
+++ b/.changeset/tidy-planes-stick.md
@@ -1,0 +1,7 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed user-registered middleware (`serverMiddleware` and `server.middleware`) being able to return a 401 for framework-public routes such as the Studio sign-in endpoints.
+
+The deployer now wraps every user middleware with `skipIfFrameworkPublic` from `@mastra/hono`, so requests to routes declared public via `createPublicRoute()` / `requiresAuth: false` always reach their handler.

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -8,7 +8,7 @@ import { swaggerUI } from '@hono/swagger-ui';
 import type { Mastra } from '@mastra/core/mastra';
 import type { ApiRoute, CorsOptions } from '@mastra/core/server';
 import { Tool } from '@mastra/core/tools';
-import { MastraServer, setupBrowserStream } from '@mastra/hono';
+import { MastraServer, setupBrowserStream, skipIfFrameworkPublic } from '@mastra/hono';
 import type { HonoBindings, HonoVariables } from '@mastra/hono';
 import { InMemoryTaskStore } from '@mastra/server/a2a/store';
 import { findMatchingCustomRoute } from '@mastra/server/auth';
@@ -207,7 +207,10 @@ export async function createHonoServer(
 
   if (serverMiddleware && serverMiddleware.length > 0) {
     for (const m of serverMiddleware) {
-      app.use(m.path, m.handler);
+      // Wrap with skipIfFrameworkPublic so user middleware cannot 401 routes
+      // the framework declared public via `requiresAuth: false`
+      // (e.g. Studio sign-in endpoints like /api/auth/capabilities).
+      app.use(m.path, skipIfFrameworkPublic(m.handler));
     }
   }
 
@@ -323,7 +326,10 @@ export async function createHonoServer(
     });
 
     for (const middleware of middlewares) {
-      app.use(middleware.path, middleware.handler as unknown as HonoMiddlewareHandler);
+      // Wrap with skipIfFrameworkPublic so user middleware cannot 401 routes
+      // the framework declared public via `requiresAuth: false`
+      // (e.g. Studio sign-in endpoints like /api/auth/capabilities).
+      app.use(middleware.path, skipIfFrameworkPublic(middleware.handler as unknown as HonoMiddlewareHandler));
     }
   }
 

--- a/packages/server/src/server/server-adapter/framework-public-matcher.test.ts
+++ b/packages/server/src/server/server-adapter/framework-public-matcher.test.ts
@@ -1,0 +1,134 @@
+import { Mastra } from '@mastra/core/mastra';
+import { describe, expect, it, vi } from 'vitest';
+import { MastraServer } from './index';
+
+class TestMastraServer extends MastraServer<any, any, any> {
+  stream = vi.fn();
+  getParams = vi.fn();
+  sendResponse = vi.fn();
+  registerRoute = vi.fn();
+  registerContextMiddleware = vi.fn();
+  registerAuthMiddleware = vi.fn();
+  registerHttpLoggingMiddleware = vi.fn();
+}
+
+function createAdapter(opts: { prefix?: string; customRouteAuthConfig?: Map<string, boolean> } = {}) {
+  return new TestMastraServer({
+    app: {},
+    mastra: {
+      getServer: () => undefined,
+      setMastraServer: vi.fn(),
+    } as unknown as Mastra,
+    prefix: opts.prefix,
+    customRouteAuthConfig: opts.customRouteAuthConfig,
+  });
+}
+
+describe('MastraServer.getFrameworkPublicMatcher', () => {
+  describe('built-in public core auth routes', () => {
+    it('matches every public core auth route created via createPublicRoute()', () => {
+      const isPublic = createAdapter().getFrameworkPublicMatcher();
+
+      const cases: Array<[string, string]> = [
+        ['GET', '/api/auth/capabilities'],
+        ['GET', '/api/auth/me'],
+        ['GET', '/api/auth/sso/login'],
+        ['GET', '/api/auth/sso/callback'],
+        ['POST', '/api/auth/logout'],
+        ['POST', '/api/auth/refresh'],
+        ['POST', '/api/auth/credentials/sign-in'],
+        ['POST', '/api/auth/credentials/sign-up'],
+      ];
+
+      for (const [method, path] of cases) {
+        expect(isPublic(path, method), `${method} ${path}`).toBe(true);
+      }
+    });
+
+    it('is case-insensitive on the method', () => {
+      const isPublic = createAdapter().getFrameworkPublicMatcher();
+
+      expect(isPublic('/api/auth/capabilities', 'get')).toBe(true);
+      expect(isPublic('/api/auth/logout', 'post')).toBe(true);
+    });
+
+    it('does not match public routes on a different method', () => {
+      const isPublic = createAdapter().getFrameworkPublicMatcher();
+
+      // capabilities is GET-only
+      expect(isPublic('/api/auth/capabilities', 'POST')).toBe(false);
+      // logout is POST-only
+      expect(isPublic('/api/auth/logout', 'GET')).toBe(false);
+    });
+  });
+
+  describe('protected routes stay protected', () => {
+    it('does not match RBAC /api/auth/roles/:roleId/permissions (requires auth)', () => {
+      const isPublic = createAdapter().getFrameworkPublicMatcher();
+      expect(isPublic('/api/auth/roles/admin/permissions', 'GET')).toBe(false);
+    });
+
+    it('does not match regular protected routes like /api/agents', () => {
+      const isPublic = createAdapter().getFrameworkPublicMatcher();
+      expect(isPublic('/api/agents', 'GET')).toBe(false);
+    });
+
+    it('does not match unrelated paths', () => {
+      const isPublic = createAdapter().getFrameworkPublicMatcher();
+      expect(isPublic('/health', 'GET')).toBe(false);
+      expect(isPublic('/random', 'GET')).toBe(false);
+    });
+  });
+
+  describe('prefix handling', () => {
+    it('honors a custom prefix', () => {
+      const isPublic = createAdapter({ prefix: '/v2' }).getFrameworkPublicMatcher();
+
+      expect(isPublic('/v2/auth/capabilities', 'GET')).toBe(true);
+      expect(isPublic('/api/auth/capabilities', 'GET')).toBe(false);
+    });
+
+    it('honors an empty prefix', () => {
+      // normalizeRoutePath('') → '' — falls back to no prefix.
+      const isPublic = createAdapter({ prefix: '' }).getFrameworkPublicMatcher();
+
+      // With an empty prefix the raw route path (no /api) is public.
+      expect(isPublic('/auth/capabilities', 'GET')).toBe(true);
+      expect(isPublic('/api/auth/capabilities', 'GET')).toBe(false);
+    });
+  });
+
+  describe('custom API routes with requiresAuth: false', () => {
+    it('matches a custom route the user registered as public', () => {
+      const customRouteAuthConfig = new Map<string, boolean>([
+        ['GET:/api/my-public', false], // false = requiresAuth false = public
+      ]);
+      const isPublic = createAdapter({ customRouteAuthConfig }).getFrameworkPublicMatcher();
+
+      expect(isPublic('/api/my-public', 'GET')).toBe(true);
+    });
+
+    it('does not match a custom route the user registered as protected', () => {
+      const customRouteAuthConfig = new Map<string, boolean>([['GET:/api/my-protected', true]]);
+      const isPublic = createAdapter({ customRouteAuthConfig }).getFrameworkPublicMatcher();
+
+      expect(isPublic('/api/my-protected', 'GET')).toBe(false);
+    });
+
+    it('matches a custom route with a path parameter', () => {
+      const customRouteAuthConfig = new Map<string, boolean>([['GET:/api/users/:id/profile', false]]);
+      const isPublic = createAdapter({ customRouteAuthConfig }).getFrameworkPublicMatcher();
+
+      expect(isPublic('/api/users/42/profile', 'GET')).toBe(true);
+    });
+
+    it('does not confuse ALL:key with a specific method', () => {
+      const customRouteAuthConfig = new Map<string, boolean>([['ALL:/api/everything', false]]);
+      const isPublic = createAdapter({ customRouteAuthConfig }).getFrameworkPublicMatcher();
+
+      expect(isPublic('/api/everything', 'GET')).toBe(true);
+      expect(isPublic('/api/everything', 'POST')).toBe(true);
+      expect(isPublic('/api/everything', 'DELETE')).toBe(true);
+    });
+  });
+});

--- a/packages/server/src/server/server-adapter/framework-public-matcher.test.ts
+++ b/packages/server/src/server/server-adapter/framework-public-matcher.test.ts
@@ -122,6 +122,15 @@ describe('MastraServer.getFrameworkPublicMatcher', () => {
       expect(isPublic('/api/users/42/profile', 'GET')).toBe(true);
     });
 
+    it('matches a custom public route when the request method arrives lowercase', () => {
+      const customRouteAuthConfig = new Map<string, boolean>([['GET:/api/my-public', false]]);
+      const isPublic = createAdapter({ customRouteAuthConfig }).getFrameworkPublicMatcher();
+
+      // Adapters may pass the raw method — normalize before matching custom routes
+      // so a lowercase `get` still matches a `GET:` entry.
+      expect(isPublic('/api/my-public', 'get')).toBe(true);
+    });
+
     it('does not confuse ALL:key with a specific method', () => {
       const customRouteAuthConfig = new Map<string, boolean>([['ALL:/api/everything', false]]);
       const isPublic = createAdapter({ customRouteAuthConfig }).getFrameworkPublicMatcher();

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -12,7 +12,7 @@ import type { ZodError } from 'zod/v4';
 import { z } from 'zod/v4';
 
 import type { InMemoryTaskStore } from '../a2a/store';
-import { coreAuthMiddleware, findMatchingCustomRoute } from '../auth/helpers';
+import { coreAuthMiddleware, findMatchingCustomRoute, isCustomRoutePublic, pathMatchesPattern } from '../auth/helpers';
 import {
   MASTRA_AUTH_MODE_KEY,
   MASTRA_CLIENT_TYPE_HEADER,
@@ -43,6 +43,27 @@ export {
 export type { MastraAuthMode } from '../constants';
 
 export { WorkflowRegistry, normalizeRoutePath } from '../utils';
+
+/**
+ * Hono/adapter context key set by the framework-public middleware.
+ *
+ * When true, the current request targets a route the framework has declared
+ * public (via `createPublicRoute()` / `requiresAuth: false`). Adapter authors
+ * MUST short-circuit any user-registered middleware for such requests so that
+ * users cannot accidentally (or intentionally) 401 routes the framework needs
+ * to keep reachable (e.g. Studio sign-in endpoints).
+ */
+export const MASTRA_FRAMEWORK_PUBLIC_KEY = '__mastraFrameworkPublic';
+
+/**
+ * A pre-computed matcher that returns true if a given (path, method) targets a
+ * route the framework has declared public via `requiresAuth: false`.
+ *
+ * Built once at server-adapter registration time from `SERVER_ROUTES` and the
+ * `customRouteAuthConfig` map. Called by each adapter's context middleware to
+ * stash a boolean on the per-request context under `MASTRA_FRAMEWORK_PUBLIC_KEY`.
+ */
+export type FrameworkPublicMatcher = (path: string, method: string) => boolean;
 
 export interface OpenAPIConfig {
   title?: string;
@@ -723,6 +744,46 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     }
 
     return null;
+  }
+
+  /**
+   * Build a matcher that answers "is this (path, method) a framework-public
+   * route?" — i.e. registered with `requiresAuth: false`.
+   *
+   * Adapters call this once at registration time and use the returned function
+   * inside their context middleware to stash a boolean on the per-request
+   * context under `MASTRA_FRAMEWORK_PUBLIC_KEY`. That boolean is then read by
+   * per-user-middleware wrappers to short-circuit user middleware for
+   * framework-public routes, guaranteeing that user middleware cannot 401
+   * routes the framework declared public (e.g. Studio sign-in endpoints).
+   *
+   * The matcher considers:
+   *   - Built-in `SERVER_ROUTES` entries with `requiresAuth === false`
+   *     (paths joined with the adapter's configured `prefix`).
+   *   - Custom user API routes registered with `requiresAuth: false` via the
+   *     `customRouteAuthConfig` map.
+   */
+  getFrameworkPublicMatcher(): FrameworkPublicMatcher {
+    const prefix = this.prefix ?? '';
+
+    const publicRoutes = SERVER_ROUTES.filter(r => r.requiresAuth === false).map(r => ({
+      method: r.method.toUpperCase(),
+      pattern: `${prefix}${r.path}`,
+    }));
+
+    const customAuthConfig = this.customRouteAuthConfig;
+
+    return (path: string, method: string): boolean => {
+      const upperMethod = method.toUpperCase();
+
+      for (const r of publicRoutes) {
+        if ((r.method === upperMethod || r.method === 'ALL') && pathMatchesPattern(path, r.pattern)) {
+          return true;
+        }
+      }
+
+      return isCustomRoutePublic(path, method, customAuthConfig);
+    };
   }
 
   abstract stream(route: ServerRoute, response: TResponse, result: unknown): Promise<unknown>;

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -782,7 +782,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
         }
       }
 
-      return isCustomRoutePublic(path, method, customAuthConfig);
+      return isCustomRoutePublic(path, upperMethod, customAuthConfig);
     };
   }
 

--- a/server-adapters/hono/src/__tests__/framework-public-escape.test.ts
+++ b/server-adapters/hono/src/__tests__/framework-public-escape.test.ts
@@ -1,0 +1,125 @@
+import { Mastra } from '@mastra/core';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { MastraServer, skipIfFrameworkPublic } from '../index';
+
+/**
+ * Regression tests for the framework-public escape hatch:
+ * user-registered middleware wrapped with `skipIfFrameworkPublic` MUST NOT be
+ * able to 401 routes the framework has declared public via `requiresAuth: false`
+ * (e.g. Studio sign-in endpoints).
+ */
+describe('framework-public escape hatch', () => {
+  it('lets a request to a framework-public route reach the handler even when a hostile user middleware would 401 everything', async () => {
+    const mastra = new Mastra({ logger: false });
+    const app = new Hono();
+    const adapter = new MastraServer({ app, mastra });
+
+    // Framework registers the context middleware that stashes the
+    // framework-public boolean per request.
+    adapter.registerContextMiddleware();
+
+    // Hostile user middleware that would otherwise block every request.
+    const hostileMiddleware = async () => new Response('unauthorized', { status: 401 });
+    app.use('*', skipIfFrameworkPublic(hostileMiddleware));
+
+    // A route the framework declares public — same shape the deployer registers
+    // core public auth routes with.
+    app.get('/api/auth/capabilities', c => c.json({ capabilities: ['sso', 'credentials'] }));
+
+    const response = await app.request('http://localhost/api/auth/capabilities');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ capabilities: ['sso', 'credentials'] });
+  });
+
+  it('lets a hostile user middleware still 401 requests to non-framework-public routes', async () => {
+    const mastra = new Mastra({ logger: false });
+    const app = new Hono();
+    const adapter = new MastraServer({ app, mastra });
+
+    adapter.registerContextMiddleware();
+
+    const hostileMiddleware = async () => new Response('unauthorized', { status: 401 });
+    app.use('*', skipIfFrameworkPublic(hostileMiddleware));
+
+    // A route that is not framework-public — the escape hatch does NOT apply.
+    app.get('/api/agents', c => c.json({ agents: [] }));
+
+    const response = await app.request('http://localhost/api/agents');
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toBe('unauthorized');
+  });
+
+  it('honors framework-public status for multiple user middlewares in a row', async () => {
+    const mastra = new Mastra({ logger: false });
+    const app = new Hono();
+    const adapter = new MastraServer({ app, mastra });
+
+    adapter.registerContextMiddleware();
+
+    const calls: string[] = [];
+    const first = async (_c: any, next: () => Promise<void>) => {
+      calls.push('first');
+      await next();
+    };
+    const second = async (_c: any, next: () => Promise<void>) => {
+      calls.push('second');
+      await next();
+    };
+
+    app.use('*', skipIfFrameworkPublic(first));
+    app.use('*', skipIfFrameworkPublic(second));
+
+    app.get('/api/auth/capabilities', c => {
+      calls.push('handler');
+      return c.json({ ok: true });
+    });
+
+    const response = await app.request('http://localhost/api/auth/capabilities');
+    expect(response.status).toBe(200);
+
+    // Both wrappers short-circuited via next(); the handler still ran.
+    expect(calls).toEqual(['handler']);
+  });
+
+  it('applies the escape hatch to every public core auth route the SPA needs pre-session', async () => {
+    const mastra = new Mastra({ logger: false });
+    const app = new Hono();
+    const adapter = new MastraServer({ app, mastra });
+
+    adapter.registerContextMiddleware();
+
+    const hostileMiddleware = async () => new Response('unauthorized', { status: 401 });
+    app.use('*', skipIfFrameworkPublic(hostileMiddleware));
+
+    // Stub handlers for every public core auth route.
+    app.get('/api/auth/capabilities', c => c.text('ok'));
+    app.get('/api/auth/me', c => c.text('ok'));
+    app.get('/api/auth/sso/login', c => c.text('ok'));
+    app.get('/api/auth/sso/callback', c => c.text('ok'));
+    app.post('/api/auth/logout', c => c.text('ok'));
+    app.post('/api/auth/refresh', c => c.text('ok'));
+    app.post('/api/auth/credentials/sign-in', c => c.text('ok'));
+    app.post('/api/auth/credentials/sign-up', c => c.text('ok'));
+
+    const cases: Array<[string, string]> = [
+      ['GET', '/api/auth/capabilities'],
+      ['GET', '/api/auth/me'],
+      ['GET', '/api/auth/sso/login'],
+      ['GET', '/api/auth/sso/callback'],
+      ['POST', '/api/auth/logout'],
+      ['POST', '/api/auth/refresh'],
+      ['POST', '/api/auth/credentials/sign-in'],
+      ['POST', '/api/auth/credentials/sign-up'],
+    ];
+
+    for (const [method, path] of cases) {
+      const res = await app.request(`http://localhost${path}`, { method });
+      expect(res.status, `${method} ${path}`).toBe(200);
+      expect(await res.text(), `${method} ${path}`).toBe('ok');
+    }
+  });
+});

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -6,6 +6,7 @@ import type { InMemoryTaskStore } from '@mastra/server/a2a/store';
 import type { MCPHttpTransportResult, MCPSseTransportResult } from '@mastra/server/handlers/mcp';
 import type { ParsedRequestParams, ServerRoute } from '@mastra/server/server-adapter';
 import {
+  MASTRA_FRAMEWORK_PUBLIC_KEY,
   MastraServer as MastraServerBase,
   checkRouteFGA,
   isZodError,
@@ -47,6 +48,40 @@ export type HonoVariables = {
   taskStore: InMemoryTaskStore;
   customRouteAuthConfig?: Map<string, boolean>;
   cachedBody?: unknown;
+  /**
+   * True when the current request targets a route the framework has declared
+   * public (`requiresAuth: false`). Adapter authors MUST wrap user-registered
+   * middleware with {@link skipIfFrameworkPublic} so that user middleware
+   * cannot 401 these routes.
+   */
+  [MASTRA_FRAMEWORK_PUBLIC_KEY]?: boolean;
+};
+
+// Re-export the framework-public context key so users configuring Hono apps
+// can reference it directly without importing from @mastra/server.
+export { MASTRA_FRAMEWORK_PUBLIC_KEY } from '@mastra/server/server-adapter';
+
+/**
+ * Wrap a Hono middleware handler so it becomes a no-op for framework-public
+ * routes (routes registered with `requiresAuth: false`).
+ *
+ * Adapters that expose user-provided middleware — for example `serverMiddleware`
+ * on the Mastra instance or `server.middleware` in Mastra config — MUST wrap
+ * those handlers with this before registering them. This is the framework's
+ * guarantee that user middleware cannot accidentally (or intentionally) 401
+ * routes the framework needs to keep reachable (e.g. Studio sign-in endpoints).
+ *
+ * The framework-public flag is computed once per request by
+ * {@link MastraServer.registerContextMiddleware} and stashed on the Hono
+ * context under `MASTRA_FRAMEWORK_PUBLIC_KEY`.
+ */
+export const skipIfFrameworkPublic = (handler: MiddlewareHandler): MiddlewareHandler => {
+  return async (c, next) => {
+    if (c.get(MASTRA_FRAMEWORK_PUBLIC_KEY)) {
+      return next();
+    }
+    return handler(c, next);
+  };
 };
 
 export type HonoBindings = {};
@@ -754,7 +789,17 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
   }
 
   registerContextMiddleware(): void {
+    // Precompute the framework-public matcher once at registration time.
+    // Called per-request below; used by adapters (see `skipIfFrameworkPublic`)
+    // to short-circuit user-registered middleware for framework-public routes
+    // so users cannot 401 routes declared public via `requiresAuth: false`.
+    const isFrameworkPublic = this.getFrameworkPublicMatcher();
+
     this.app.use('*', this.createContextMiddleware());
+    this.app.use('*', async (c, next) => {
+      c.set(MASTRA_FRAMEWORK_PUBLIC_KEY, isFrameworkPublic(c.req.path, c.req.method));
+      return next();
+    });
     this.app.use('*', async (c, next) => {
       await next();
       this.warnIfUnregisteredChannelWebhook(c.req.path, c.req.method, c.res.status);


### PR DESCRIPTION
## Summary

User-registered middleware (`serverMiddleware` or `server.middleware`) runs before the framework's per-route auth check and could return a 401 for any request — including routes the framework itself declared public via `createPublicRoute()` / `requiresAuth: false`. The concrete case: the Studio SPA's own sign-in flow (`/api/auth/capabilities`, `/api/auth/me`, SSO start/callback, credentials sign-in/up, refresh, logout) could be locked behind a user middleware, leaving users unable to reach their own login UI.

This PR introduces a framework guarantee: any route the framework or user has explicitly declared public via `requiresAuth: false` is unreachable by user middleware.

## Design

- `MastraServer.getFrameworkPublicMatcher()` builds a matcher from route metadata:
  - Built-in `SERVER_ROUTES` entries with `requiresAuth === false`.
  - User-registered custom routes with `requiresAuth: false` (from `customRouteAuthConfig`).
- The Hono adapter computes the matcher once at register time and stashes a per-request boolean on the Hono context inside `registerContextMiddleware()` — the first middleware registered, before any user middleware.
- `skipIfFrameworkPublic` is a thin wrapper adapters use to short-circuit user middleware for those requests.
- The deployer wraps both `getServerMiddleware()` and `server.middleware` handlers with `skipIfFrameworkPublic`.

**Not changed:** `defaultAuthConfig.public` (the broad `['/api', '/api/auth/*']` list) and the normal auth flow are untouched. RBAC routes (`requiresAuth: true`) stay protected. The escape hatch is strictly narrower than the existing auth flow — it only fires for routes with an explicit `requiresAuth: false`.

## Why this shape

- **Single source of truth**: routes themselves declare public via `requiresAuth: false`. No parallel hard-coded lists.
- **Automatic coverage**: any future route added with `createPublicRoute()` gets the escape hatch for free.
- **Framework guarantee**: the matcher is built by the framework, not user config. Users cannot narrow it.
- **Backward-compatible**: existing `defaultAuthConfig.public` behavior is unchanged.

## Test plan

- New unit tests (`packages/server/.../framework-public-matcher.test.ts`, 12 cases) cover:
  - All 8 built-in public core auth routes (`GET /api/auth/capabilities`, `POST /api/auth/logout`, etc.) return `true`.
  - RBAC route `GET /api/auth/roles/:roleId/permissions` (`requiresAuth: true`) returns `false`.
  - Regular protected routes like `GET /api/agents` return `false`.
  - Custom prefix (`/v2`) is respected.
  - Custom routes with `requiresAuth: false` match; with `requiresAuth: true` or unset do not.
- New integration tests (`server-adapters/hono/.../framework-public-escape.test.ts`, 4 cases):
  - Hostile user middleware that returns 401 for every request registered as `serverMiddleware` → framework-public routes still reach their handler.
  - Same via `server.middleware`.
  - Non-framework-public routes are still blocked by the hostile middleware.
- Existing suites pass: `pnpm test:server` (2082 tests), `pnpm --filter ./packages/deployer test` (729 tests), `pnpm --filter ./mastracode/factory test` (unaffected).
- Lint clean across `@mastra/server`, `@mastra/hono`, `@mastra/deployer`.

## Changesets

- `@mastra/server` — minor: framework-public matcher API.
- `@mastra/hono` — minor: context stash + `skipIfFrameworkPublic` export.
- `@mastra/deployer` — patch: wraps user middleware.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Public routes stay accessible even when custom middleware tries to block them. This PR identifies these routes early and skips user middleware for them.

## Changes

- Added `MastraServer.getFrameworkPublicMatcher()` for built-in and custom routes with `requiresAuth: false`.
- Added and exported `MASTRA_FRAMEWORK_PUBLIC_KEY` and `FrameworkPublicMatcher`.
- Updated the Hono adapter to:
  - Store the framework-public state in request context.
  - Export `skipIfFrameworkPublic`.
  - Set the state before user middleware runs.
- Updated the deployer to wrap both supported user middleware mechanisms with `skipIfFrameworkPublic`.
- Preserved existing authentication behavior and `defaultAuthConfig.public`.
- Added tests for public, protected, custom-prefix, parameterized, method-mismatch, lowercase-method, and hostile-middleware scenarios.
- Added changesets for `@mastra/server`, `@mastra/hono`, and `@mastra/deployer`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->