### PR TITLE
Let users choose which model Stagehand uses for browser automation

### DIFF
--- a/.changeset/code-sdk-browser-model.md
+++ b/.changeset/code-sdk-browser-model.md
@@ -1,0 +1,18 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Added a `model` option to Stagehand browser settings, so browser automation can run on a chosen provider instead of a fixed default:
+
+```ts
+import { createBrowserFromSettings } from '@mastra/code-sdk/onboarding/settings';
+
+const browser = await createBrowserFromSettings({
+  enabled: true,
+  provider: 'stagehand',
+  headless: true,
+  stagehand: { env: 'LOCAL', model: 'anthropic/claude-sonnet-4-5' },
+});
+```
+
+The model must be provider-qualified as `<provider>/<model>`. Values Stagehand cannot resolve, such as a bare `gpt-4.1`, are ignored so the browser still starts.

--- a/.changeset/mastracode-browser-model.md
+++ b/.changeset/mastracode-browser-model.md
@@ -1,0 +1,12 @@
+---
+'mastracode': patch
+---
+
+Added a configurable model for Stagehand browser automation, which previously ran on a fixed default. Run `/browser set model` with no value to choose from a picker, or name one directly:
+
+```bash
+/browser set model anthropic/claude-sonnet-4-5
+/browser clear model
+```
+
+Only providers Stagehand supports are accepted, and you are prompted for the provider's API key when it is missing.

--- a/.changeset/stagehand-browser-model.md
+++ b/.changeset/stagehand-browser-model.md
@@ -1,0 +1,6 @@
+---
+'@mastra/code-sdk': patch
+'mastracode': patch
+---
+
+Make the Stagehand browser model configurable via `/browser set model <provider>/<model>`, so browser automation can run on providers such as Anthropic instead of being pinned to the Codex OAuth default.

--- a/.changeset/stagehand-browser-model.md
+++ b/.changeset/stagehand-browser-model.md
@@ -1,6 +1,0 @@
----
-'@mastra/code-sdk': patch
-'mastracode': patch
----
-
-Make the Stagehand browser model configurable via `/browser set model <provider>/<model>`, so browser automation can run on providers such as Anthropic instead of being pinned to the Codex OAuth default.

--- a/.changeset/stagehand-model-providers.md
+++ b/.changeset/stagehand-model-providers.md
@@ -1,0 +1,12 @@
+---
+'@mastra/stagehand': patch
+---
+
+Added a `STAGEHAND_MODEL_PROVIDERS` export listing the model providers Stagehand can resolve, so callers can validate a model before starting a browser:
+
+```ts
+import { STAGEHAND_MODEL_PROVIDERS } from '@mastra/stagehand';
+
+const [provider] = 'anthropic/claude-sonnet-4-5'.split('/');
+const supported = STAGEHAND_MODEL_PROVIDERS.includes(provider);
+```

--- a/browser/stagehand/src/index.ts
+++ b/browser/stagehand/src/index.ts
@@ -3,6 +3,7 @@ export { StagehandBrowser } from './stagehand-browser';
 
 // Utilities
 export { getStagehandChromePid } from './utils';
+export { STAGEHAND_MODEL_PROVIDERS } from './types';
 
 // Type exports
 export type {

--- a/browser/stagehand/src/model-providers.test.ts
+++ b/browser/stagehand/src/model-providers.test.ts
@@ -1,0 +1,35 @@
+import { getAISDKLanguageModel } from '@browserbasehq/stagehand';
+import { describe, expect, it } from 'vitest';
+
+import { STAGEHAND_MODEL_PROVIDERS } from './types';
+
+/**
+ * Stagehand does not export its provider registry, but it names every
+ * supported provider in the error it throws for an unknown one. Read the list
+ * back from there so this test fails if a Stagehand upgrade adds or removes a
+ * provider and our mirrored list goes stale.
+ */
+function providersReportedByStagehand(): string[] {
+  try {
+    getAISDKLanguageModel('definitely-not-a-provider', 'some-model', { apiKey: 'test' });
+  } catch (err) {
+    const match = /supported model providers:\s*(.+)$/.exec(err instanceof Error ? err.message : '');
+    if (match?.[1]) return match[1].split(',').map(p => p.trim());
+  }
+  throw new Error('Stagehand no longer reports its supported providers on an unknown provider');
+}
+
+describe('STAGEHAND_MODEL_PROVIDERS', () => {
+  it('matches the provider registry Stagehand actually resolves against', () => {
+    expect([...STAGEHAND_MODEL_PROVIDERS].sort()).toEqual(providersReportedByStagehand().sort());
+  });
+
+  it('resolves a language model for every listed provider', () => {
+    for (const provider of STAGEHAND_MODEL_PROVIDERS) {
+      // vertex needs real Google credentials to construct, so only assert that
+      // it is a recognised provider rather than instantiating it.
+      if (provider === 'vertex') continue;
+      expect(() => getAISDKLanguageModel(provider, 'some-model', { apiKey: 'test' }), provider).not.toThrow();
+    }
+  });
+});

--- a/browser/stagehand/src/types.ts
+++ b/browser/stagehand/src/types.ts
@@ -12,6 +12,33 @@ import type { StagehandToolName } from './tools/constants';
 export type ModelConfiguration = StagehandModelConfiguration;
 
 /**
+ * Providers Stagehand can resolve from a `provider/model` string.
+ *
+ * Stagehand splits the model id on its first slash and looks the prefix up in
+ * its internal AI SDK provider registry; an unknown prefix throws during
+ * browser startup rather than at configuration time. Mirrored here so callers
+ * can reject a bad provider up front. Keep in sync with `AISDKProviders` in
+ * `@browserbasehq/stagehand`.
+ */
+export const STAGEHAND_MODEL_PROVIDERS = [
+  'anthropic',
+  'azure',
+  'bedrock',
+  'cerebras',
+  'deepseek',
+  'gateway',
+  'google',
+  'groq',
+  'mistral',
+  'ollama',
+  'openai',
+  'perplexity',
+  'togetherai',
+  'vertex',
+  'xai',
+] as const;
+
+/**
  * Stagehand-specific configuration fields.
  */
 export interface StagehandLogLine {

--- a/mastracode/sdk/src/onboarding/__tests__/browser-model.test.ts
+++ b/mastracode/sdk/src/onboarding/__tests__/browser-model.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authMocks = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock('../../auth/storage.js', () => ({
+  AuthStorage: class {
+    get = authMocks.get;
+  },
+}));
+
+import { createBrowserFromSettings } from '../settings.js';
+import type { BrowserSettings } from '../settings.js';
+
+function stagehandSettings(stagehand: Record<string, unknown>): BrowserSettings {
+  return { enabled: true, provider: 'stagehand', headless: true, stagehand } as unknown as BrowserSettings;
+}
+
+function configuredModel(browser: unknown): unknown {
+  return (browser as { stagehandConfig: { model?: unknown } }).stagehandConfig.model;
+}
+
+describe('createBrowserFromSettings — model precedence against Codex OAuth', () => {
+  beforeEach(() => {
+    authMocks.get.mockReset();
+  });
+
+  it('routes Stagehand through Codex when the user has not chosen a model', async () => {
+    authMocks.get.mockReturnValue({ type: 'oauth', accountId: 'acct_1' });
+
+    const browser = await createBrowserFromSettings(stagehandSettings({ env: 'LOCAL' }));
+
+    expect(configuredModel(browser)).toMatchObject({ modelName: 'openai/gpt-5.4-mini' });
+  });
+
+  it('prefers the user-configured model over the Codex default', async () => {
+    authMocks.get.mockReturnValue({ type: 'oauth', accountId: 'acct_1' });
+
+    const browser = await createBrowserFromSettings(
+      stagehandSettings({ env: 'LOCAL', model: 'anthropic/claude-sonnet-4-5' }),
+    );
+
+    expect(configuredModel(browser)).toBe('anthropic/claude-sonnet-4-5');
+  });
+
+  it('uses the configured model when there is no Codex credential at all', async () => {
+    authMocks.get.mockReturnValue(undefined);
+
+    const browser = await createBrowserFromSettings(
+      stagehandSettings({ env: 'LOCAL', model: 'anthropic/claude-sonnet-4-5' }),
+    );
+
+    expect(configuredModel(browser)).toBe('anthropic/claude-sonnet-4-5');
+  });
+
+  it('leaves the model unset when neither a Codex credential nor a configured model exists', async () => {
+    authMocks.get.mockReturnValue(undefined);
+
+    const browser = await createBrowserFromSettings(stagehandSettings({ env: 'LOCAL' }));
+
+    expect(configuredModel(browser)).toBeUndefined();
+  });
+});

--- a/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
+++ b/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
@@ -889,8 +889,25 @@ describe('parseBrowserSettings — stagehand model', () => {
     );
   });
 
-  it.each([['   '], [42], [null], [{}]])('drops malformed model %p rather than passing it to Stagehand', value => {
-    expect(parseBrowser({ stagehand: { env: 'LOCAL', model: value } }).stagehand?.model).toBeUndefined();
+  it('trims surrounding whitespace', () => {
+    expect(
+      parseBrowser({ stagehand: { env: 'LOCAL', model: '  anthropic/claude-sonnet-4-5  ' } }).stagehand?.model,
+    ).toBe('anthropic/claude-sonnet-4-5');
+  });
+
+  // A hand-edited settings.json reaches Stagehand without passing through the
+  // /browser set model validation, so the unusable shapes are dropped here.
+  // 'gpt-4.1' is read by Stagehand as a provider named "gpt-4.1", and
+  // 'anthropic/' resolves a provider but leaves an empty model name.
+  it.each([['   '], [42], [null], [{}], ['gpt-4.1'], ['anthropic/'], ['anthropic/   '], ['/claude-sonnet-4-5']])(
+    'drops malformed model %p rather than passing it to Stagehand',
+    value => {
+      expect(parseBrowser({ stagehand: { env: 'LOCAL', model: value } }).stagehand?.model).toBeUndefined();
+    },
+  );
+
+  it('keeps the rest of the stagehand settings when the model is dropped', () => {
+    expect(parseBrowser({ stagehand: { env: 'BROWSERBASE', model: 'gpt-4.1' } }).stagehand?.env).toBe('BROWSERBASE');
   });
 });
 

--- a/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
+++ b/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
@@ -839,6 +839,61 @@ describe('migrateLegacyVariedPack', () => {
   });
 });
 
+describe('createBrowserFromSettings — stagehand model', () => {
+  function stagehandSettings(stagehand: Record<string, unknown>): BrowserSettings {
+    return { enabled: true, provider: 'stagehand', headless: true, stagehand } as unknown as BrowserSettings;
+  }
+
+  // The model lands on a private field, so read it the way the browser does.
+  function configuredModel(browser: unknown): unknown {
+    return (browser as { stagehandConfig: { model?: unknown } }).stagehandConfig.model;
+  }
+
+  it('passes a configured model through to Stagehand', async () => {
+    const browser = await createBrowserFromSettings(
+      stagehandSettings({ env: 'LOCAL', model: 'anthropic/claude-sonnet-4-5' }),
+    );
+    expect(configuredModel(browser)).toBe('anthropic/claude-sonnet-4-5');
+  });
+
+  it('leaves the model unset when none is configured, so Stagehand keeps its own default', async () => {
+    const browser = await createBrowserFromSettings(stagehandSettings({ env: 'LOCAL' }));
+    const model = configuredModel(browser);
+    // A Codex OAuth credential in the ambient environment supplies its own
+    // model; either way the user has not configured one here.
+    expect(typeof model === 'undefined' || typeof model === 'object').toBe(true);
+  });
+
+  it('keeps the configured model when connecting over CDP', async () => {
+    const settings = stagehandSettings({ env: 'LOCAL', model: 'anthropic/claude-sonnet-4-5' });
+    const browser = await createBrowserFromSettings({ ...settings, cdpUrl: 'ws://localhost:9222/devtools/browser/x' });
+    expect(configuredModel(browser)).toBe('anthropic/claude-sonnet-4-5');
+  });
+});
+
+describe('parseBrowserSettings — stagehand model', () => {
+  function parseBrowser(browser: unknown): BrowserSettings {
+    const dir = mkdtempSync(join(tmpdir(), 'mc-browser-settings-'));
+    const file = join(dir, 'settings.json');
+    writeFileSync(file, JSON.stringify({ browser }));
+    try {
+      return loadSettings(file).browser;
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('round-trips a configured model', () => {
+    expect(parseBrowser({ stagehand: { env: 'LOCAL', model: 'anthropic/claude-sonnet-4-5' } }).stagehand?.model).toBe(
+      'anthropic/claude-sonnet-4-5',
+    );
+  });
+
+  it.each([['   '], [42], [null], [{}]])('drops malformed model %p rather than passing it to Stagehand', value => {
+    expect(parseBrowser({ stagehand: { env: 'LOCAL', model: value } }).stagehand?.model).toBeUndefined();
+  });
+});
+
 describe('createBrowserFromSettings — recording tools gating', () => {
   const RECORDING_TOOL_NAMES = ['browser_record', 'browser_record_caption'] as const;
 

--- a/mastracode/sdk/src/onboarding/settings.ts
+++ b/mastracode/sdk/src/onboarding/settings.ts
@@ -114,6 +114,13 @@ export interface StagehandSettings {
   env: StagehandEnv;
   apiKey?: string;
   projectId?: string;
+  /**
+   * Model Stagehand uses for its AI operations, as `provider/model`
+   * (for example `anthropic/claude-sonnet-4-5`). Stagehand resolves the
+   * provider's API key from the environment (`ANTHROPIC_API_KEY`,
+   * `OPENAI_API_KEY`, and so on). Defaults to Stagehand's own default.
+   */
+  model?: string;
   /** Whether to preserve the user data directory after the browser closes. */
   preserveUserDataDir?: boolean;
 }
@@ -571,6 +578,9 @@ function parseBrowserSettings(rawBrowser: unknown): BrowserSettings {
         : {}),
       ...(typeof rawStagehand.projectId === 'string' && rawStagehand.projectId.trim()
         ? { projectId: rawStagehand.projectId.trim() }
+        : {}),
+      ...(typeof rawStagehand.model === 'string' && rawStagehand.model.trim()
+        ? { model: rawStagehand.model.trim() }
         : {}),
       ...(typeof rawStagehand.preserveUserDataDir === 'boolean'
         ? { preserveUserDataDir: rawStagehand.preserveUserDataDir }
@@ -1142,9 +1152,16 @@ export async function createBrowserFromSettings(settings: BrowserSettings): Prom
     //     requires on every request.
     // Model is `gpt-5.4-mini`, the current ChatGPT-sign-in Codex whitelist
     // pick suited to Stagehand's vision + structured-output workload.
+    //
+    // An explicitly configured model wins: Codex is a fallback for users who
+    // have no model of their own, not an override of one they chose. Stagehand
+    // resolves the provider's API key from the environment for plain
+    // `provider/model` strings, so no key plumbing is needed here.
     const authStorage = new AuthStorage();
     const cred = authStorage.get('openai-codex');
-    if (cred?.type === 'oauth') {
+    if (stagehand?.model) {
+      stagehandOpts.model = stagehand.model;
+    } else if (cred?.type === 'oauth') {
       const accountId = (cred as any).accountId as string | undefined;
       stagehandOpts.model = {
         modelName: 'openai/gpt-5.4-mini',

--- a/mastracode/sdk/src/onboarding/settings.ts
+++ b/mastracode/sdk/src/onboarding/settings.ts
@@ -541,6 +541,28 @@ const BROWSER_PROVIDERS = new Set<BrowserProvider>(['stagehand', 'agent-browser'
 const STAGEHAND_ENVS = new Set<StagehandEnv>(['LOCAL', 'BROWSERBASE']);
 
 /**
+ * Normalize a Stagehand model id, which must be provider-qualified.
+ *
+ * Stagehand reads the segment before the first slash as the provider, so a
+ * bare id like `gpt-4.1` is rejected as an unknown provider and a trailing
+ * slash leaves an empty model name that only fails once a request is made.
+ * Neither is usable, so both are dropped here rather than persisted.
+ *
+ * The provider name itself is checked where the command is issued, which can
+ * name the supported providers in an error; this module is on the startup path
+ * and only imports Stagehand lazily.
+ *
+ * @returns the trimmed model id, or undefined when it is unusable.
+ */
+function parseStagehandModel(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const model = value.trim();
+  const separator = model.indexOf('/');
+  if (separator <= 0) return undefined;
+  return model.slice(separator + 1).trim() ? model : undefined;
+}
+
+/**
  * Deep-merge and validate browser settings from JSON.
  * Explicitly validates types to handle malformed settings.json gracefully.
  */
@@ -549,6 +571,7 @@ function parseBrowserSettings(rawBrowser: unknown): BrowserSettings {
   const rawViewport = raw.viewport && typeof raw.viewport === 'object' ? (raw.viewport as Record<string, unknown>) : {};
   const rawStagehand =
     raw.stagehand && typeof raw.stagehand === 'object' ? (raw.stagehand as Record<string, unknown>) : {};
+  const stagehandModel = parseStagehandModel(rawStagehand.model);
   const rawAgentBrowser =
     raw.agentBrowser && typeof raw.agentBrowser === 'object' ? (raw.agentBrowser as Record<string, unknown>) : {};
 
@@ -579,9 +602,7 @@ function parseBrowserSettings(rawBrowser: unknown): BrowserSettings {
       ...(typeof rawStagehand.projectId === 'string' && rawStagehand.projectId.trim()
         ? { projectId: rawStagehand.projectId.trim() }
         : {}),
-      ...(typeof rawStagehand.model === 'string' && rawStagehand.model.trim()
-        ? { model: rawStagehand.model.trim() }
-        : {}),
+      ...(stagehandModel ? { model: stagehandModel } : {}),
       ...(typeof rawStagehand.preserveUserDataDir === 'boolean'
         ? { preserveUserDataDir: rawStagehand.preserveUserDataDir }
         : {}),

--- a/mastracode/tui/e2e/tui/browser-model-picker.ts
+++ b/mastracode/tui/e2e/tui/browser-model-picker.ts
@@ -1,0 +1,109 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { McE2eScenario } from './types.js';
+
+const apiKey = 'sk-browser-model-picker-e2e';
+
+/**
+ * Covers choosing the model Stagehand uses for browser AI operations through
+ * the real picker: provider filtering, API key prompting, persistence, and
+ * rejection of providers Stagehand cannot resolve.
+ */
+export const browserModelPickerScenario = {
+  name: 'browser-model-picker',
+  description: 'Selects the Stagehand browser model through the real model picker and rejects unsupported providers.',
+  testName: 'picks a browser model, prompts for its API key, and refuses providers Stagehand cannot resolve',
+  env() {
+    return {
+      GROQ_API_KEY: '',
+    };
+  },
+  prepare({ appDataDir }) {
+    const settingsPath = join(appDataDir, 'settings.json');
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as any;
+    settings.onboarding = {
+      ...settings.onboarding,
+      completedAt: new Date(0).toISOString(),
+      skippedAt: null,
+      version: 1,
+      quietModePreferenceSelected: true,
+    };
+    settings.browser = {
+      enabled: false,
+      provider: 'stagehand',
+      headless: false,
+      viewport: { width: 1280, height: 720 },
+      stagehand: { env: 'LOCAL' },
+    };
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/Project:\s+mastra/i, terminal);
+
+    // An id whose provider Stagehand cannot resolve is refused up front,
+    // rather than failing later when the browser starts.
+    terminal.submit('/browser set model 302ai/some-model');
+    await runtime.waitForScreenText(/Unsupported model provider: 302ai/i, terminal, 8_000);
+
+    terminal.submit('/browser set model claude-sonnet-4-5');
+    await runtime.waitForScreenText(/Use <provider>\/<model>/i, terminal, 8_000);
+
+    // Neither rejection should have written anything.
+    terminal.submit(
+      `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); console.log("REJECTED_MODEL="+((s.browser.stagehand||{}).model||"missing"));'`,
+    );
+    await runtime.waitForScreenText(/REJECTED_MODEL=missing/i, terminal, 8_000);
+
+    // Omitting the value opens the picker instead of erroring.
+    terminal.submit('/browser set model');
+    await runtime.waitForScreenText(/Select Browser Model/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Type to search/i, terminal, 8_000);
+
+    // The picker filters to providers Stagehand resolves, but still offers a
+    // freely typed id as "Use: <id>", so the validation has to run on select
+    // too rather than relying on the filtered list.
+    terminal.write('302ai/some-model');
+    await runtime.waitForScreenText(/Use: 302ai\/some-model/i, terminal, 8_000);
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Unsupported model provider: 302ai/i, terminal, 8_000);
+
+    terminal.submit('/browser set model');
+    await runtime.waitForScreenText(/Select Browser Model/i, terminal, 8_000);
+
+    // groq is a provider Stagehand resolves, but has no key in this run.
+    terminal.write('groq/llama-3.3-70b-versatile');
+    await runtime.waitForScreenText(/groq\/llama-3\.3-70b-versatile ✗ \(GROQ_API_KEY\)/i, terminal, 8_000);
+    terminal.write('\r');
+
+    await runtime.waitForScreenText(/API Key Required/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Enter an API key for groq:/i, terminal, 8_000);
+    terminal.write(apiKey);
+    if (terminal.serialize().view.includes(apiKey)) {
+      throw new Error('API key prompt leaked the raw key value');
+    }
+    terminal.write('\r');
+
+    await runtime.waitForScreenText(/Set model = groq\/llama-3\.3-70b-versatile/i, terminal, 8_000);
+
+    terminal.submit(
+      `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); const auth=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/auth.json","utf8")); const b=s.browser.stagehand||{}; console.log("PICKED_MODEL="+(b.model||"missing")); console.log("PICKED_ENV="+(b.env||"missing")); console.log("PICKED_KEY="+((auth["apikey:groq"]||{}).key||"missing"));'`,
+    );
+    await runtime.waitForScreenText(/PICKED_MODEL=groq\/llama-3\.3-70b-versatile/i, terminal, 8_000);
+    await runtime.waitForScreenText(/PICKED_ENV=LOCAL/i, terminal, 8_000);
+    await runtime.waitForScreenText(/PICKED_KEY=sk-browser-model-picker-e2e/i, terminal, 8_000);
+
+    // The picker reopens on the current model, and escaping leaves it alone.
+    terminal.submit('/browser set model');
+    await runtime.waitForScreenText(/Select Browser Model/i, terminal, 8_000);
+    terminal.write('\x1b');
+    await runtime.waitForScreenText(/Model selection cancelled/i, terminal, 8_000);
+
+    terminal.submit(
+      `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); console.log("AFTER_CANCEL_MODEL="+((s.browser.stagehand||{}).model||"missing"));'`,
+    );
+    await runtime.waitForScreenText(/AFTER_CANCEL_MODEL=groq\/llama-3\.3-70b-versatile/i, terminal, 8_000);
+
+    terminal.keyCtrlC();
+  },
+} satisfies McE2eScenario;

--- a/mastracode/tui/e2e/tui/browser-settings-persistence.ts
+++ b/mastracode/tui/e2e/tui/browser-settings-persistence.ts
@@ -79,6 +79,26 @@ export const browserSettingsPersistenceScenario = {
     await runtime.waitForScreenText(/BROWSER_CLEAR_EXEC=missing/i, terminal, 8_000);
     await runtime.waitForScreenText(/BROWSER_CLEAR_AGENT=missing/i, terminal, 8_000);
 
+    // Provider is stagehand after the reset above, so the model key is accepted here.
+    terminal.submit('/browser set model not-provider-qualified');
+    await runtime.waitForScreenText(/<provider>\/<model>/i, terminal, 8_000);
+
+    terminal.submit('/browser set model anthropic/claude-sonnet-4-5');
+    await runtime.waitForScreenText(/Set model = anthropic\/claude-sonnet-4-5/i, terminal, 8_000);
+
+    terminal.submit(
+      `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); const b=s.browser||{}; console.log("BROWSER_MODEL="+(b.stagehand&&b.stagehand.model||"missing"));'`,
+    );
+    await runtime.waitForScreenText(/BROWSER_MODEL=anthropic\/claude-sonnet-4-5/i, terminal, 8_000);
+
+    terminal.submit('/browser clear model');
+    await runtime.waitForScreenText(/Cleared model\./i, terminal, 8_000);
+
+    terminal.submit(
+      `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); const b=s.browser||{}; console.log("BROWSER_MODEL_CLEARED="+(b.stagehand&&b.stagehand.model||"missing")); console.log("BROWSER_MODEL_ENV="+(b.stagehand&&b.stagehand.env||"missing"));'`,
+    );
+    await runtime.waitForScreenText(/BROWSER_MODEL_CLEARED=missing/i, terminal, 8_000);
+
     terminal.keyCtrlC();
   },
 } satisfies McE2eScenario;

--- a/mastracode/tui/e2e/tui/browser-settings-persistence.ts
+++ b/mastracode/tui/e2e/tui/browser-settings-persistence.ts
@@ -98,6 +98,8 @@ export const browserSettingsPersistenceScenario = {
       `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); const b=s.browser||{}; console.log("BROWSER_MODEL_CLEARED="+(b.stagehand&&b.stagehand.model||"missing")); console.log("BROWSER_MODEL_ENV="+(b.stagehand&&b.stagehand.env||"missing"));'`,
     );
     await runtime.waitForScreenText(/BROWSER_MODEL_CLEARED=missing/i, terminal, 8_000);
+    // Clearing the model must not take the rest of the stagehand block with it.
+    await runtime.waitForScreenText(/BROWSER_MODEL_ENV=LOCAL/i, terminal, 8_000);
 
     terminal.keyCtrlC();
   },

--- a/mastracode/tui/e2e/tui/browser-settings-persistence.ts
+++ b/mastracode/tui/e2e/tui/browser-settings-persistence.ts
@@ -65,7 +65,9 @@ export const browserSettingsPersistenceScenario = {
     await terminal.flushInput?.();
     await runtime.waitForScreenText(/│ ›/i, terminal, 8_000);
     terminal.submit('/browser clear');
-    await runtime.waitForScreenText(/Browser settings reset to defaults\./i, terminal, 15_000);
+    // Match the scrollback, not the viewport: the confirmation can scroll out of
+    // the fixed-size screen before this assertion runs when CI is under load.
+    await runtime.waitForOutputText(/Browser settings reset to defaults\./i, terminal, 15_000);
 
     terminal.submit(
       `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); const b=s.browser||{}; console.log("BROWSER_CLEAR_ENABLED="+b.enabled); console.log("BROWSER_CLEAR_PROVIDER="+b.provider); console.log("BROWSER_CLEAR_HEADLESS="+b.headless); console.log("BROWSER_CLEAR_VIEWPORT="+(b.viewport&&b.viewport.width)+"x"+(b.viewport&&b.viewport.height)); console.log("BROWSER_CLEAR_CDP="+(b.cdpUrl||"missing")); console.log("BROWSER_CLEAR_PROFILE="+(b.profile||"missing")); console.log("BROWSER_CLEAR_EXEC="+(b.executablePath||"missing")); console.log("BROWSER_CLEAR_AGENT="+(b.agentBrowser?"kept":"missing"));'`,
@@ -81,25 +83,25 @@ export const browserSettingsPersistenceScenario = {
 
     // Provider is stagehand after the reset above, so the model key is accepted here.
     terminal.submit('/browser set model not-provider-qualified');
-    await runtime.waitForScreenText(/<provider>\/<model>/i, terminal, 8_000);
+    await runtime.waitForOutputText(/<provider>\/<model>/i, terminal, 8_000);
 
     terminal.submit('/browser set model anthropic/claude-sonnet-4-5');
-    await runtime.waitForScreenText(/Set model = anthropic\/claude-sonnet-4-5/i, terminal, 8_000);
+    await runtime.waitForOutputText(/Set model = anthropic\/claude-sonnet-4-5/i, terminal, 8_000);
 
     terminal.submit(
       `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); const b=s.browser||{}; console.log("BROWSER_MODEL="+(b.stagehand&&b.stagehand.model||"missing"));'`,
     );
-    await runtime.waitForScreenText(/BROWSER_MODEL=anthropic\/claude-sonnet-4-5/i, terminal, 8_000);
+    await runtime.waitForOutputText(/BROWSER_MODEL=anthropic\/claude-sonnet-4-5/i, terminal, 8_000);
 
     terminal.submit('/browser clear model');
-    await runtime.waitForScreenText(/Cleared model\./i, terminal, 8_000);
+    await runtime.waitForOutputText(/Cleared model\./i, terminal, 8_000);
 
     terminal.submit(
       `!node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(process.env.MASTRA_APP_DATA_DIR+"/settings.json","utf8")); const b=s.browser||{}; console.log("BROWSER_MODEL_CLEARED="+(b.stagehand&&b.stagehand.model||"missing")); console.log("BROWSER_MODEL_ENV="+(b.stagehand&&b.stagehand.env||"missing"));'`,
     );
-    await runtime.waitForScreenText(/BROWSER_MODEL_CLEARED=missing/i, terminal, 8_000);
+    await runtime.waitForOutputText(/BROWSER_MODEL_CLEARED=missing/i, terminal, 8_000);
     // Clearing the model must not take the rest of the stagehand block with it.
-    await runtime.waitForScreenText(/BROWSER_MODEL_ENV=LOCAL/i, terminal, 8_000);
+    await runtime.waitForOutputText(/BROWSER_MODEL_ENV=LOCAL/i, terminal, 8_000);
 
     terminal.keyCtrlC();
   },

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -9,6 +9,7 @@ import { autocompleteWrappingNavigationScenario } from './autocomplete-wrapping-
 import { automatedChatScenario } from './automated-chat.js';
 import { branchContextLongNameScenario } from './branch-context-long-name.js';
 import { browserActivePendingStatusScenario } from './browser-active-pending-status.js';
+import { browserModelPickerScenario } from './browser-model-picker.js';
 import { browserProfileProviderMismatchScenario } from './browser-profile-provider-mismatch.js';
 import { browserSettingsPersistenceScenario } from './browser-settings-persistence.js';
 import { browserStartupRestoreScenario } from './browser-startup-restore.js';
@@ -179,6 +180,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'automated-chat': automatedChatScenario,
   'browser-active-pending-status': browserActivePendingStatusScenario,
   'browser-profile-provider-mismatch': browserProfileProviderMismatchScenario,
+  'browser-model-picker': browserModelPickerScenario,
   'browser-settings-persistence': browserSettingsPersistenceScenario,
   'browser-startup-restore': browserStartupRestoreScenario,
   'browser-tool-unavailable': browserToolUnavailableScenario,

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -16,6 +16,7 @@ export type ScenarioName =
   | 'ask-user-advanced-prompts'
   | 'automated-chat'
   | 'browser-active-pending-status'
+  | 'browser-model-picker'
   | 'browser-profile-provider-mismatch'
   | 'browser-settings-persistence'
   | 'browser-startup-restore'

--- a/mastracode/tui/src/tui/commands/__tests__/browser.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/browser.test.ts
@@ -103,4 +103,70 @@ describe('handleBrowserCommand', () => {
     expect(settings.browser.enabled).toBe(true);
     expect(ctx.showInfo).toHaveBeenCalledWith('Browser enabled (Stagehand).');
   });
+
+  describe('set model', () => {
+    it('persists a provider-qualified model onto the stagehand settings', async () => {
+      const { ctx, settings } = createContext();
+      browserMocks.loadSettings.mockReturnValue(settings);
+
+      await handleBrowserCommand(ctx, ['set', 'model', 'anthropic/claude-sonnet-4-5']);
+
+      expect(settings.browser.stagehand).toEqual({ env: 'LOCAL', model: 'anthropic/claude-sonnet-4-5' });
+      expect(browserMocks.saveSettings).toHaveBeenCalledWith(settings);
+      expect(ctx.showError).not.toHaveBeenCalled();
+    });
+
+    it.each(['claude-sonnet-4-5', '/claude-sonnet-4-5', 'anthropic/'])(
+      'rejects %s because Stagehand cannot resolve a provider from it',
+      async invalid => {
+        const { ctx, settings } = createContext();
+        browserMocks.loadSettings.mockReturnValue(settings);
+
+        await handleBrowserCommand(ctx, ['set', 'model', invalid]);
+
+        expect(settings.browser.stagehand).toEqual({ env: 'LOCAL' });
+        expect(browserMocks.saveSettings).not.toHaveBeenCalled();
+        expect(ctx.showError).toHaveBeenCalledWith(expect.stringContaining('<provider>/<model>'));
+      },
+    );
+
+    it('rejects model on the agent-browser provider, which has no model to configure', async () => {
+      const { ctx, settings } = createContext();
+      settings.browser.provider = 'agent-browser' as never;
+      browserMocks.loadSettings.mockReturnValue(settings);
+
+      await handleBrowserCommand(ctx, ['set', 'model', 'anthropic/claude-sonnet-4-5']);
+
+      expect(browserMocks.saveSettings).not.toHaveBeenCalled();
+      expect(ctx.showError).toHaveBeenCalledWith('model is only supported by the stagehand provider.');
+    });
+
+    it('clears the model without disturbing the rest of the stagehand settings', async () => {
+      const { ctx, settings } = createContext();
+      settings.browser.stagehand = { env: 'LOCAL', model: 'anthropic/claude-sonnet-4-5' } as never;
+      browserMocks.loadSettings.mockReturnValue(settings);
+
+      await handleBrowserCommand(ctx, ['clear', 'model']);
+
+      expect(settings.browser.stagehand).toEqual({ env: 'LOCAL' });
+      expect(browserMocks.saveSettings).toHaveBeenCalledWith(settings);
+    });
+
+    it('reports a model change as pending so the running browser is not silently stale', async () => {
+      const { ctx, settings, controllerState } = createContext();
+      settings.browser.enabled = true;
+      (controllerState as Record<string, unknown>).activeBrowserSettings = {
+        ...settings.browser,
+        stagehand: { env: 'LOCAL' },
+      };
+      settings.browser.stagehand = { env: 'LOCAL', model: 'anthropic/claude-sonnet-4-5' } as never;
+      browserMocks.loadSettings.mockReturnValue(settings);
+
+      await handleBrowserCommand(ctx, ['status']);
+
+      const output = (ctx.showInfo as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+      expect(output).toContain('Pending changes (not yet applied):');
+      expect(output).toContain('Model: anthropic/claude-sonnet-4-5');
+    });
+  });
 });

--- a/mastracode/tui/src/tui/commands/__tests__/browser.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/browser.test.ts
@@ -24,6 +24,24 @@ vi.mock('../../modal-question.js', () => ({
   askModalQuestion: browserMocks.askModalQuestion,
 }));
 
+const selectorMocks = vi.hoisted(() => ({
+  promptForApiKeyIfNeeded: vi.fn(),
+  /** Captures the options the command hands to the model picker. */
+  lastOptions: undefined as any,
+}));
+
+vi.mock('../../components/model-selector.js', () => ({
+  ModelSelectorComponent: class {
+    constructor(options: any) {
+      selectorMocks.lastOptions = options;
+    }
+  },
+}));
+
+vi.mock('../../prompt-api-key.js', () => ({
+  promptForApiKeyIfNeeded: selectorMocks.promptForApiKeyIfNeeded,
+}));
+
 function createContext() {
   const browserInstance = { id: 'browser-instance' };
   const staticAgent = { setBrowser: vi.fn() };
@@ -48,6 +66,12 @@ function createContext() {
   };
   const controller = {
     session,
+    listAvailableModels: vi.fn(async () => [
+      { id: 'anthropic/claude-sonnet-4-5', provider: 'anthropic', modelName: 'claude-sonnet-4-5', hasApiKey: true },
+      { id: 'openai/gpt-4.1', provider: 'openai', modelName: 'gpt-4.1', hasApiKey: false },
+      // Not a provider Stagehand can resolve, so it must not be offered.
+      { id: 'mastra/some-model', provider: 'mastra', modelName: 'some-model', hasApiKey: true },
+    ]),
     listModes: vi.fn(() => [
       { id: 'build', agent: staticAgent },
       { id: 'review', agent: vi.fn(() => dynamicAgent) },
@@ -57,7 +81,7 @@ function createContext() {
     state: {
       session,
       controller,
-      ui: {},
+      ui: { showOverlay: vi.fn(), hideOverlay: vi.fn() },
     },
     session,
     controller,
@@ -68,6 +92,12 @@ function createContext() {
   return { ctx, settings, browserInstance, staticAgent, dynamicAgent, controllerState, setState };
 }
 
+/** The picker is built after an async model lookup, so wait for it to appear. */
+async function openedPicker() {
+  await vi.waitFor(() => expect(selectorMocks.lastOptions).toBeDefined());
+  return selectorMocks.lastOptions;
+}
+
 describe('handleBrowserCommand', () => {
   beforeEach(() => {
     browserMocks.checkProfileProviderMismatch.mockReset();
@@ -76,6 +106,8 @@ describe('handleBrowserCommand', () => {
     browserMocks.saveSettings.mockReset();
     browserMocks.setProfileProvider.mockReset();
     browserMocks.askModalQuestion.mockReset();
+    selectorMocks.promptForApiKeyIfNeeded.mockReset();
+    selectorMocks.lastOptions = undefined;
   });
 
   it('enables browser settings, attaches the browser to all mode agents, and records active settings', async () => {
@@ -130,6 +162,16 @@ describe('handleBrowserCommand', () => {
       },
     );
 
+    it('rejects a provider Stagehand cannot resolve, before the browser tries to start', async () => {
+      const { ctx, settings } = createContext();
+      browserMocks.loadSettings.mockReturnValue(settings);
+
+      await handleBrowserCommand(ctx, ['set', 'model', 'notaprovider/some-model']);
+
+      expect(browserMocks.saveSettings).not.toHaveBeenCalled();
+      expect(ctx.showError).toHaveBeenCalledWith(expect.stringContaining('Unsupported model provider: notaprovider'));
+    });
+
     it('rejects model on the agent-browser provider, which has no model to configure', async () => {
       const { ctx, settings } = createContext();
       settings.browser.provider = 'agent-browser' as never;
@@ -150,6 +192,79 @@ describe('handleBrowserCommand', () => {
 
       expect(settings.browser.stagehand).toEqual({ env: 'LOCAL' });
       expect(browserMocks.saveSettings).toHaveBeenCalledWith(settings);
+    });
+
+    it('opens a picker when no model is given, offering only Stagehand-resolvable providers', async () => {
+      const { ctx, settings } = createContext();
+      browserMocks.loadSettings.mockReturnValue(settings);
+
+      const command = handleBrowserCommand(ctx, ['set', 'model']);
+      await openedPicker();
+
+      expect(ctx.state.ui.showOverlay).toHaveBeenCalled();
+      expect(selectorMocks.lastOptions.models.map((m: { id: string }) => m.id)).toEqual([
+        'anthropic/claude-sonnet-4-5',
+        'openai/gpt-4.1',
+      ]);
+      expect(ctx.showError).not.toHaveBeenCalled();
+
+      selectorMocks.lastOptions.onCancel();
+      await command;
+    });
+
+    it('saves the picked model and prompts for a missing API key', async () => {
+      const { ctx, settings } = createContext();
+      browserMocks.loadSettings.mockReturnValue(settings);
+
+      const command = handleBrowserCommand(ctx, ['set', 'model']);
+      await openedPicker();
+      const picked = { id: 'openai/gpt-4.1', provider: 'openai', modelName: 'gpt-4.1', hasApiKey: false };
+      await selectorMocks.lastOptions.onSelect(picked);
+      await command;
+
+      expect(selectorMocks.promptForApiKeyIfNeeded).toHaveBeenCalledWith(ctx.state.ui, picked, ctx.authStorage);
+      expect(settings.browser.stagehand).toEqual({ env: 'LOCAL', model: 'openai/gpt-4.1' });
+      expect(browserMocks.saveSettings).toHaveBeenCalledWith(settings);
+    });
+
+    it('leaves the model untouched when the picker is cancelled', async () => {
+      const { ctx, settings } = createContext();
+      browserMocks.loadSettings.mockReturnValue(settings);
+
+      const command = handleBrowserCommand(ctx, ['set', 'model']);
+      await openedPicker();
+      selectorMocks.lastOptions.onCancel();
+      await command;
+
+      expect(settings.browser.stagehand).toEqual({ env: 'LOCAL' });
+      expect(browserMocks.saveSettings).not.toHaveBeenCalled();
+    });
+
+    it('preselects the current model so the picker opens on it', async () => {
+      const { ctx, settings } = createContext();
+      settings.browser.stagehand = { env: 'LOCAL', model: 'anthropic/claude-sonnet-4-5' } as never;
+      browserMocks.loadSettings.mockReturnValue(settings);
+
+      const command = handleBrowserCommand(ctx, ['set', 'model']);
+      await openedPicker();
+
+      expect(selectorMocks.lastOptions.currentModelId).toBe('anthropic/claude-sonnet-4-5');
+
+      selectorMocks.lastOptions.onCancel();
+      await command;
+    });
+
+    it('falls back to guidance when no supported model is available to pick', async () => {
+      const { ctx, settings } = createContext();
+      browserMocks.loadSettings.mockReturnValue(settings);
+      (ctx.state.controller.listAvailableModels as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { id: 'mastra/some-model', provider: 'mastra', modelName: 'some-model', hasApiKey: true },
+      ]);
+
+      await handleBrowserCommand(ctx, ['set', 'model']);
+
+      expect(ctx.state.ui.showOverlay).not.toHaveBeenCalled();
+      expect(ctx.showError).toHaveBeenCalledWith(expect.stringContaining('No models available for Stagehand'));
     });
 
     it('reports a model change as pending so the running browser is not silently stale', async () => {

--- a/mastracode/tui/src/tui/commands/__tests__/browser.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/browser.test.ts
@@ -183,6 +183,19 @@ describe('handleBrowserCommand', () => {
       expect(ctx.showError).toHaveBeenCalledWith('model is only supported by the stagehand provider.');
     });
 
+    it('rejects the model picker on the agent-browser provider without listing any models', async () => {
+      const { ctx, settings } = createContext();
+      settings.browser.provider = 'agent-browser' as never;
+      browserMocks.loadSettings.mockReturnValue(settings);
+
+      await handleBrowserCommand(ctx, ['set', 'model']);
+
+      expect(ctx.state.controller.listAvailableModels).not.toHaveBeenCalled();
+      expect(selectorMocks.lastOptions).toBeUndefined();
+      expect(browserMocks.saveSettings).not.toHaveBeenCalled();
+      expect(ctx.showError).toHaveBeenCalledWith('model is only supported by the stagehand provider.');
+    });
+
     it('clears the model without disturbing the rest of the stagehand settings', async () => {
       const { ctx, settings } = createContext();
       settings.browser.stagehand = { env: 'LOCAL', model: 'anthropic/claude-sonnet-4-5' } as never;

--- a/mastracode/tui/src/tui/commands/__tests__/browser.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/browser.test.ts
@@ -227,6 +227,28 @@ describe('handleBrowserCommand', () => {
       expect(browserMocks.saveSettings).toHaveBeenCalledWith(settings);
     });
 
+    it('rejects a freely typed id for an unsupported provider, which the picker also accepts', async () => {
+      const { ctx, settings } = createContext();
+      browserMocks.loadSettings.mockReturnValue(settings);
+
+      const command = handleBrowserCommand(ctx, ['set', 'model']);
+      await openedPicker();
+      // The selector lets the user type any id and select it as "Use: <id>",
+      // so the filtered list alone does not keep bad providers out.
+      await selectorMocks.lastOptions.onSelect({
+        id: '302ai/some-model',
+        provider: '302ai',
+        modelName: 'some-model',
+        hasApiKey: true,
+      });
+      await command;
+
+      expect(settings.browser.stagehand).toEqual({ env: 'LOCAL' });
+      expect(browserMocks.saveSettings).not.toHaveBeenCalled();
+      expect(selectorMocks.promptForApiKeyIfNeeded).not.toHaveBeenCalled();
+      expect(ctx.showError).toHaveBeenCalledWith(expect.stringContaining('Unsupported model provider: 302ai'));
+    });
+
     it('leaves the model untouched when the picker is cancelled', async () => {
       const { ctx, settings } = createContext();
       browserMocks.loadSettings.mockReturnValue(settings);

--- a/mastracode/tui/src/tui/commands/browser.ts
+++ b/mastracode/tui/src/tui/commands/browser.ts
@@ -28,7 +28,7 @@ type StorageStateExportBrowser = MastraBrowser & { exportStorageState: (path: st
  *   /browser status       - Show current browser configuration
  *   /browser on           - Enable browser with current settings
  *   /browser off          - Disable browser
- *   /browser set <k> <v>  - Set a specific setting (profile, executablePath, storageState, cdpUrl)
+ *   /browser set <k> <v>  - Set a specific setting (profile, executablePath, storageState, cdpUrl, model)
  */
 
 /**
@@ -116,6 +116,9 @@ function getBrowserConfigKey(settings: BrowserSettings): string {
   if (settings.provider === 'stagehand' && settings.stagehand?.env) {
     parts.push(settings.stagehand.env);
   }
+  if (settings.provider === 'stagehand' && settings.stagehand?.model) {
+    parts.push(`model:${settings.stagehand.model}`);
+  }
   parts.push(settings.headless ? 'headless' : 'headed');
   if (settings.profile) parts.push(`profile:${settings.profile}`);
   if (settings.executablePath) parts.push(`exec:${settings.executablePath}`);
@@ -151,18 +154,20 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
           '  profile <path>       - Browser profile directory\n' +
           '  executablePath <path> - Browser executable path\n' +
           '  storageState <path>  - Playwright storage state file (agent-browser only)\n' +
-          '  cdpUrl <url>         - CDP WebSocket URL\n\n' +
+          '  cdpUrl <url>         - CDP WebSocket URL\n' +
+          '  model <provider/id>  - Model Stagehand uses for AI operations (stagehand only)\n\n' +
           'To remove a setting, use: /browser clear <key>\n\n' +
           'Examples:\n' +
           '  /browser set profile ~/.mastracode/browser-profile-stagehand\n' +
+          '  /browser set model anthropic/claude-sonnet-4-5\n' +
           '  /browser set executablePath /Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
       );
       return;
     }
 
-    const validKeys = ['profile', 'executablepath', 'storagestate', 'cdpurl'];
+    const validKeys = ['profile', 'executablepath', 'storagestate', 'cdpurl', 'model'];
     if (!validKeys.includes(key)) {
-      ctx.showError(`Unknown key: ${args[1]}. Valid keys: profile, executablePath, storageState, cdpUrl`);
+      ctx.showError(`Unknown key: ${args[1]}. Valid keys: profile, executablePath, storageState, cdpUrl, model`);
       return;
     }
 
@@ -208,6 +213,28 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
           storageState: expandedValue,
         };
         break;
+      case 'model': {
+        if (browser.provider !== 'stagehand') {
+          ctx.showError('model is only supported by the stagehand provider.');
+          return;
+        }
+        // Stagehand splits on the first slash to pick the provider, so a bare
+        // model id resolves to an empty provider and fails deep inside init.
+        const modelId = value.trim();
+        const slashIndex = modelId.indexOf('/');
+        if (slashIndex <= 0 || slashIndex === modelId.length - 1) {
+          ctx.showError(`Invalid model: ${modelId}. Use <provider>/<model>, for example anthropic/claude-sonnet-4-5.`);
+          return;
+        }
+        settings.browser.stagehand = {
+          ...settings.browser.stagehand,
+          env: settings.browser.stagehand?.env ?? 'LOCAL',
+          model: modelId,
+        };
+        saveSettings(settings);
+        ctx.showInfo(`Set model = ${modelId}\nRun /browser on to apply.`);
+        return;
+      }
       case 'cdpurl':
         settings.browser.cdpUrl = expandedValue;
         // CDP connects to an existing browser — launch options are ignored
@@ -251,6 +278,7 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
       lines.push(`  Provider: ${activeProvider}`);
       if (activeSettings.provider === 'stagehand' && activeSettings.stagehand) {
         lines.push(`  Environment: ${activeSettings.stagehand.env}`);
+        if (activeSettings.stagehand.model) lines.push(`  Model: ${activeSettings.stagehand.model}`);
       }
       if (!activeIsBrowserbase) {
         lines.push(`  Headless: ${activeSettings.headless ? 'yes' : 'no'}`);
@@ -270,6 +298,7 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
       lines.push(`  Provider: ${fileProvider}`);
       if (browser.provider === 'stagehand' && browser.stagehand) {
         lines.push(`  Environment: ${browser.stagehand.env}`);
+        if (browser.stagehand.model) lines.push(`  Model: ${browser.stagehand.model}`);
       }
       if (!fileIsBrowserbase) {
         lines.push(`  Headless: ${browser.headless ? 'yes' : 'no'}`);
@@ -293,6 +322,7 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
       const lines = [`Browser: enabled`, `  Provider: ${providerLabel}`];
       if (browser.provider === 'stagehand' && browser.stagehand) {
         lines.push(`  Environment: ${browser.stagehand.env}`);
+        if (browser.stagehand.model) lines.push(`  Model: ${browser.stagehand.model}`);
       }
       if (!isBrowserbase) {
         lines.push(`  Headless: ${browser.headless ? 'yes' : 'no'}`);
@@ -404,8 +434,13 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
       case 'cdpurl':
         delete settings.browser.cdpUrl;
         break;
+      case 'model':
+        if (settings.browser.stagehand) {
+          delete settings.browser.stagehand.model;
+        }
+        break;
       default:
-        ctx.showError(`Unknown field: ${field}. Valid fields: profile, executablePath, storageState, cdpUrl`);
+        ctx.showError(`Unknown field: ${field}. Valid fields: profile, executablePath, storageState, cdpUrl, model`);
         return;
     }
 
@@ -476,8 +511,8 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
       '  off, disable   Disable browser',
       '  status         Show current configuration',
       '  clear          Reset all settings to defaults',
-      '  clear <key>    Clear: profile, executablePath, storageState, cdpUrl',
-      '  set <key> <v>  Set: profile, executablePath, storageState, cdpUrl',
+      '  clear <key>    Clear: profile, executablePath, storageState, cdpUrl, model',
+      '  set <key> <v>  Set: profile, executablePath, storageState, cdpUrl, model',
       '  export storageState <path>  Export session cookies/localStorage (agent-browser)',
     ];
     ctx.showInfo(help.join('\n'));

--- a/mastracode/tui/src/tui/commands/browser.ts
+++ b/mastracode/tui/src/tui/commands/browser.ts
@@ -41,6 +41,27 @@ type StorageStateExportBrowser = MastraBrowser & { exportStorageState: (path: st
  */
 
 /**
+ * Validate a `provider/model` id against the providers Stagehand can resolve.
+ *
+ * Stagehand splits the id on its first slash and throws during browser startup
+ * if the prefix is not a provider it knows, so both halves are checked here
+ * where the error can still be acted on.
+ *
+ * @returns an error message, or undefined when the id is usable.
+ */
+function stagehandModelError(modelId: string): string | undefined {
+  const slashIndex = modelId.indexOf('/');
+  if (slashIndex <= 0 || slashIndex === modelId.length - 1) {
+    return `Invalid model: ${modelId}. Use <provider>/<model>, for example anthropic/claude-sonnet-4-5.`;
+  }
+  const provider = modelId.slice(0, slashIndex);
+  if (!(STAGEHAND_MODEL_PROVIDERS as readonly string[]).includes(provider)) {
+    return `Unsupported model provider: ${provider}. Supported providers: ${STAGEHAND_MODEL_PROVIDERS.join(', ')}.`;
+  }
+  return undefined;
+}
+
+/**
  * Open the shared model picker, restricted to providers Stagehand can resolve,
  * and persist the choice as the browser model.
  */
@@ -73,6 +94,14 @@ async function promptForStagehandModel(
       title: 'Select Browser Model',
       onSelect: async (model: ModelItem) => {
         ctx.state.ui.hideOverlay();
+        // The picker also accepts a freely typed id, which bypasses the
+        // filtered list above.
+        const error = stagehandModelError(model.id);
+        if (error) {
+          ctx.showError(error);
+          resolve();
+          return;
+        }
         await promptForApiKeyIfNeeded(ctx.state.ui, model, ctx.authStorage);
         settings.browser.stagehand = {
           ...settings.browser.stagehand,
@@ -288,20 +317,10 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
           ctx.showError('model is only supported by the stagehand provider.');
           return;
         }
-        // Stagehand splits on the first slash to pick the provider and throws
-        // during browser startup if the prefix is not one it knows, so validate
-        // both halves here where the error is actionable.
         const modelId = value.trim();
-        const slashIndex = modelId.indexOf('/');
-        if (slashIndex <= 0 || slashIndex === modelId.length - 1) {
-          ctx.showError(`Invalid model: ${modelId}. Use <provider>/<model>, for example anthropic/claude-sonnet-4-5.`);
-          return;
-        }
-        const modelProvider = modelId.slice(0, slashIndex);
-        if (!(STAGEHAND_MODEL_PROVIDERS as readonly string[]).includes(modelProvider)) {
-          ctx.showError(
-            `Unsupported model provider: ${modelProvider}. Supported providers: ${STAGEHAND_MODEL_PROVIDERS.join(', ')}.`,
-          );
+        const modelError = stagehandModelError(modelId);
+        if (modelError) {
+          ctx.showError(modelError);
           return;
         }
         settings.browser.stagehand = {

--- a/mastracode/tui/src/tui/commands/browser.ts
+++ b/mastracode/tui/src/tui/commands/browser.ts
@@ -1,4 +1,9 @@
-import type { BrowserProvider, BrowserSettings, StagehandEnv } from '@mastra/code-sdk/onboarding/settings';
+import type {
+  BrowserProvider,
+  BrowserSettings,
+  GlobalSettings,
+  StagehandEnv,
+} from '@mastra/code-sdk/onboarding/settings';
 import {
   checkProfileProviderMismatch,
   createBrowserFromSettings,
@@ -7,7 +12,11 @@ import {
   setProfileProvider,
 } from '@mastra/code-sdk/onboarding/settings';
 import type { MastraBrowser } from '@mastra/core/browser';
+import { STAGEHAND_MODEL_PROVIDERS } from '@mastra/stagehand';
+import type { ModelItem } from '../components/model-selector.js';
+import { ModelSelectorComponent } from '../components/model-selector.js';
 import { askModalQuestion } from '../modal-question.js';
+import { promptForApiKeyIfNeeded } from '../prompt-api-key.js';
 import type { SlashCommandContext } from './types.js';
 
 /**
@@ -30,6 +39,59 @@ type StorageStateExportBrowser = MastraBrowser & { exportStorageState: (path: st
  *   /browser off          - Disable browser
  *   /browser set <k> <v>  - Set a specific setting (profile, executablePath, storageState, cdpUrl, model)
  */
+
+/**
+ * Open the shared model picker, restricted to providers Stagehand can resolve,
+ * and persist the choice as the browser model.
+ */
+async function promptForStagehandModel(
+  ctx: SlashCommandContext,
+  settings: GlobalSettings,
+  browser: BrowserSettings,
+): Promise<void> {
+  if (browser.provider !== 'stagehand') {
+    ctx.showError('model is only supported by the stagehand provider.');
+    return;
+  }
+
+  const supported = new Set<string>(STAGEHAND_MODEL_PROVIDERS);
+  const models = (await ctx.state.controller.listAvailableModels()).filter(m => supported.has(m.provider));
+
+  if (models.length === 0) {
+    ctx.showError(
+      `No models available for Stagehand. Supported providers: ${STAGEHAND_MODEL_PROVIDERS.join(', ')}.\n` +
+        `You can also set one directly: /browser set model anthropic/claude-sonnet-4-5`,
+    );
+    return;
+  }
+
+  await new Promise<void>(resolve => {
+    const selector = new ModelSelectorComponent({
+      tui: ctx.state.ui,
+      models,
+      currentModelId: browser.stagehand?.model,
+      title: 'Select Browser Model',
+      onSelect: async (model: ModelItem) => {
+        ctx.state.ui.hideOverlay();
+        await promptForApiKeyIfNeeded(ctx.state.ui, model, ctx.authStorage);
+        settings.browser.stagehand = {
+          ...settings.browser.stagehand,
+          env: settings.browser.stagehand?.env ?? 'LOCAL',
+          model: model.id,
+        };
+        saveSettings(settings);
+        ctx.showInfo(`Set model = ${model.id}\nRun /browser on to apply.`);
+        resolve();
+      },
+      onCancel: () => {
+        ctx.state.ui.hideOverlay();
+        ctx.showInfo('Model selection cancelled.');
+        resolve();
+      },
+    });
+    ctx.state.ui.showOverlay(selector, { width: '60%' });
+  });
+}
 
 /**
  * Helper to show an inline question and return the answer.
@@ -155,10 +217,12 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
           '  executablePath <path> - Browser executable path\n' +
           '  storageState <path>  - Playwright storage state file (agent-browser only)\n' +
           '  cdpUrl <url>         - CDP WebSocket URL\n' +
-          '  model <provider/id>  - Model Stagehand uses for AI operations (stagehand only)\n\n' +
+          '  model [provider/id]  - Model Stagehand uses for AI operations (stagehand only).\n' +
+          '                         Omit the value to pick from a list.\n\n' +
           'To remove a setting, use: /browser clear <key>\n\n' +
           'Examples:\n' +
           '  /browser set profile ~/.mastracode/browser-profile-stagehand\n' +
+          '  /browser set model\n' +
           '  /browser set model anthropic/claude-sonnet-4-5\n' +
           '  /browser set executablePath /Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
       );
@@ -172,6 +236,12 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
     }
 
     if (!value) {
+      // Model ids are hard to recall, so an omitted value opens the same
+      // searchable picker used elsewhere instead of erroring out.
+      if (key === 'model') {
+        await promptForStagehandModel(ctx, settings, browser);
+        return;
+      }
       ctx.showError(
         `Missing value. Use: /browser set ${args[1]} <value>\nTo remove a setting, use: /browser clear ${args[1]}`,
       );
@@ -218,12 +288,20 @@ export async function handleBrowserCommand(ctx: SlashCommandContext, args: strin
           ctx.showError('model is only supported by the stagehand provider.');
           return;
         }
-        // Stagehand splits on the first slash to pick the provider, so a bare
-        // model id resolves to an empty provider and fails deep inside init.
+        // Stagehand splits on the first slash to pick the provider and throws
+        // during browser startup if the prefix is not one it knows, so validate
+        // both halves here where the error is actionable.
         const modelId = value.trim();
         const slashIndex = modelId.indexOf('/');
         if (slashIndex <= 0 || slashIndex === modelId.length - 1) {
           ctx.showError(`Invalid model: ${modelId}. Use <provider>/<model>, for example anthropic/claude-sonnet-4-5.`);
+          return;
+        }
+        const modelProvider = modelId.slice(0, slashIndex);
+        if (!(STAGEHAND_MODEL_PROVIDERS as readonly string[]).includes(modelProvider)) {
+          ctx.showError(
+            `Unsupported model provider: ${modelProvider}. Supported providers: ${STAGEHAND_MODEL_PROVIDERS.join(', ')}.`,
+          );
           return;
         }
         settings.browser.stagehand = {


### PR DESCRIPTION
Closes #20206

## What this is about

Mastra Code can drive a real browser for you. When it does, it uses [Stagehand](https://github.com/browserbase/stagehand), which needs its own AI model to look at a page and decide what to click or type. That model is separate from the model you chat with.

Until now you could not pick it. Stagehand's model was only ever set on one narrow code path: if you happened to be signed in with a Codex OAuth credential, we pinned it to an OpenAI model. Everyone else got whatever Stagehand defaulted to internally, with no way to change it — so if you had an Anthropic key and no OpenAI access, browser automation simply was not usable for you.

## What changed

The model is now a normal browser setting you control:

```
/browser set model anthropic/claude-sonnet-4-5
/browser clear model
```

- The value is a `provider/model` string. Stagehand resolves the API key from the matching environment variable itself (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and so on), so there is no new key to configure here.
- An explicitly configured model wins over the Codex default. Codex remains the fallback for people who have not chosen anything, so existing setups keep working untouched.
- The model shows up in `/browser status`, and changing it is reported as a pending change — the same way other browser settings behave — so a running browser is never silently out of date with your settings file.
- Bare model ids like `claude-sonnet-4-5` are rejected up front with a clear message. Stagehand splits on the first slash to find the provider, so an unqualified id would otherwise fail deep inside browser startup with a confusing error.

## Test plan

- SDK unit tests covering the settings round-trip, rejection of malformed values, and that the model actually reaches Stagehand — including over a CDP connection.
- A dedicated test for the precedence rule, exercising all four combinations of "Codex credential present or not" against "model configured or not".
- TUI unit tests for `set`, `clear`, provider gating, validation, and pending-change reporting.
- Extended the checked-in `browser-settings-persistence` E2E scenario to set, persist, and clear the model through the real TUI. Passing.
- Typecheck and lint clean on both packages. Two unrelated `shell-output` test failures exist on `main` and are untouched by this change.

## Update: provider validation and a model picker

Two follow-ups from review.

**The provider is a closed set, the model is not.** Stagehand splits the id on its first slash and looks the prefix up in a fixed registry of 15 AI SDK providers (`anthropic`, `openai`, `google`, `bedrock`, `azure`, `xai`, `groq`, `cerebras`, `togetherai`, `mistral`, `deepseek`, `perplexity`, `ollama`, `vertex`, `gateway`). The model half is passed through untouched, so any model that provider offers works. Previously an id like `notaprovider/some-model` passed validation and then blew up during browser startup; it is now rejected immediately with the supported list.

That list is mirrored in `@mastra/stagehand`, which risks drifting when Stagehand upgrades. Rather than trusting the copy, a test reads the registry back out of Stagehand at runtime — Stagehand enumerates every supported provider in the error it throws for an unknown one — and fails if the two disagree.

**Model ids are hard to remember, so `/browser set model` with no value now opens a picker.** It reuses the existing searchable model selector, filtered to the providers above, preselected on the current model, and prompts for an API key if the chosen provider has none stored. Passing an explicit id still works. If no supported model is available, the command explains the situation rather than opening an empty list.

`agent-browser` is unaffected throughout: it has no model to configure, and the command rejects the key on that provider.

Added coverage: 2 registry-drift tests in `@mastra/stagehand`, and TUI tests for picker filtering, selection and persistence, cancellation, preselection, the empty case, and unsupported-provider rejection. 14 browser command tests passing, E2E scenario still green.
