### PR TITLE
Add persistent thread state storage to the Postgres store

### DIFF
--- a/.changeset/lucky-pumas-repeat.md
+++ b/.changeset/lucky-pumas-repeat.md
@@ -1,0 +1,15 @@
+---
+'@mastra/pg': patch
+---
+
+Add a persistent `threadState` domain to `PostgresStore`
+
+`PostgresStore` did not register a `threadState` domain, so durable task and goal
+state fell back to in-memory storage and was lost on restart. Anything relying on
+thread state (task tools, long-running agent goals) could not be backed by Postgres
+alone, and required composing a second adapter through `MastraCompositeStore`.
+
+`ThreadStatePG` now stores state as JSONB keyed by `(threadId, type)` with an atomic
+upsert that preserves `createdAt`, participates in `exportSchemas()` and `init()`, and
+supports retention pruning anchored on `updatedAtZ` so state for still-active threads
+survives age-based pruning.

--- a/docs/src/content/en/reference/storage/retention.mdx
+++ b/docs/src/content/en/reference/storage/retention.mdx
@@ -135,7 +135,7 @@ Each domain declares which of its tables can be age-pruned and which timestamp c
 - Experiments prune as whole units: an aged experiment's result rows are deleted together with it (results cascade with their parent), so a run is never left partially deleted. Retention doesn't have a separate `results` key.
 - For `schedules`, the growth table is the fire history (`schedule_triggers`, one row per fire): schedule definitions are config and aren't pruned.
 - On PostgreSQL, timestamp anchors use the timezone-aware mirror columns (for example `createdAtZ`, `completedAtZ`).
-- LibSQL supports all domains above; PostgreSQL and MongoDB support all except `threadState` and `harness`, which they don't implement.
+- LibSQL and PostgreSQL support all domains above except `harness`, which PostgreSQL doesn't implement. MongoDB supports all except `threadState` and `harness`.
 - The v-next PostgreSQL observability domain stores signal events in day-partitioned tables (`spans`, `metrics`, `logs`, `scores`, `feedback`). For it, `prune()` drops whole day partitions (or TimescaleDB chunks) that are entirely older than the cutoff instead of deleting rows: effective level of detail is one day, and a partition is only dropped once its entire day is past `maxAge`. `PruneResult.deleted` reports the number of rows in the dropped partitions.
 
 :::

--- a/stores/pg/src/storage/domains/thread-state/index.test.ts
+++ b/stores/pg/src/storage/domains/thread-state/index.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { PostgresStore } from '../..';
+import { TEST_CONFIG } from '../../test-utils';
+import { ThreadStatePG } from './index';
+
+interface Task {
+  id: string;
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed';
+  activeForm: string;
+}
+
+const tasks = (): Task[] => [
+  { id: 't1', content: 'First', status: 'pending', activeForm: 'Doing first' },
+  { id: 't2', content: 'Second', status: 'in_progress', activeForm: 'Doing second' },
+];
+
+describe('ThreadStatePG', () => {
+  let store: PostgresStore;
+  let threadState: ThreadStatePG;
+
+  beforeAll(async () => {
+    store = new PostgresStore(TEST_CONFIG);
+    await store.init();
+    threadState = new ThreadStatePG({ client: store.db });
+    await threadState.init();
+  });
+
+  afterAll(async () => {
+    try {
+      await store.close();
+    } catch {}
+  });
+
+  beforeEach(async () => {
+    await threadState.dangerouslyClearAll();
+  });
+
+  it('is registered on PostgresStore as the threadState domain', async () => {
+    const domain = await store.getStore('threadState');
+    expect(domain).toBeInstanceOf(ThreadStatePG);
+  });
+
+  it('returns undefined for an unset (threadId, type)', async () => {
+    expect(await threadState.getState({ threadId: 'thread-1', type: 'task' })).toBeUndefined();
+  });
+
+  it('round-trips a JSON value', async () => {
+    await threadState.setState({ threadId: 'thread-1', type: 'task', value: tasks() });
+    expect(await threadState.getState({ threadId: 'thread-1', type: 'task' })).toEqual(tasks());
+  });
+
+  it('replaces the value on a subsequent set (upsert)', async () => {
+    await threadState.setState({ threadId: 'thread-1', type: 'task', value: tasks() });
+    const next: Task[] = [{ id: 't3', content: 'Third', status: 'completed', activeForm: 'Done third' }];
+    await threadState.setState({ threadId: 'thread-1', type: 'task', value: next });
+
+    expect(await threadState.getState({ threadId: 'thread-1', type: 'task' })).toEqual(next);
+    const rows = await store.db.any(`SELECT 1 FROM mastra_thread_state WHERE "threadId" = 'thread-1'`);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('preserves createdAt and advances updatedAt across an upsert', async () => {
+    await threadState.setState({ threadId: 'thread-1', type: 'task', value: tasks() });
+    const before = await store.db.one<{ createdAt: Date; updatedAt: Date }>(
+      `SELECT "createdAt", "updatedAt" FROM mastra_thread_state WHERE "threadId" = 'thread-1' AND "type" = 'task'`,
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+    await threadState.setState({ threadId: 'thread-1', type: 'task', value: [] });
+
+    const after = await store.db.one<{ createdAt: Date; updatedAt: Date }>(
+      `SELECT "createdAt", "updatedAt" FROM mastra_thread_state WHERE "threadId" = 'thread-1' AND "type" = 'task'`,
+    );
+    expect(after.createdAt.getTime()).toBe(before.createdAt.getTime());
+    expect(after.updatedAt.getTime()).toBeGreaterThan(before.updatedAt.getTime());
+  });
+
+  it('scopes state per thread and per type', async () => {
+    await threadState.setState({ threadId: 'thread-1', type: 'task', value: tasks() });
+    await threadState.setState({ threadId: 'thread-1', type: 'goal', value: { objective: 'ship' } });
+
+    expect(await threadState.getState({ threadId: 'thread-2', type: 'task' })).toBeUndefined();
+    expect(await threadState.getState({ threadId: 'thread-1', type: 'goal' })).toEqual({ objective: 'ship' });
+    expect(await threadState.getState({ threadId: 'thread-1', type: 'task' })).toEqual(tasks());
+  });
+
+  it('deletes only the targeted (threadId, type)', async () => {
+    await threadState.setState({ threadId: 'thread-1', type: 'task', value: tasks() });
+    await threadState.setState({ threadId: 'thread-1', type: 'goal', value: { objective: 'ship' } });
+
+    await threadState.deleteState({ threadId: 'thread-1', type: 'task' });
+
+    expect(await threadState.getState({ threadId: 'thread-1', type: 'task' })).toBeUndefined();
+    expect(await threadState.getState({ threadId: 'thread-1', type: 'goal' })).toEqual({ objective: 'ship' });
+  });
+
+  it('deleting an unset slot is a no-op', async () => {
+    await expect(threadState.deleteState({ threadId: 'nope', type: 'task' })).resolves.toBeUndefined();
+  });
+
+  it('stores the value as queryable jsonb rather than an opaque string', async () => {
+    await threadState.setState({ threadId: 'thread-1', type: 'goal', value: { objective: 'ship', runsUsed: 3 } });
+
+    const row = await store.db.one<{ objective: string }>(
+      `SELECT "value"->>'objective' AS objective FROM mastra_thread_state
+       WHERE "threadId" = 'thread-1' AND "type" = 'goal'`,
+    );
+    expect(row.objective).toBe('ship');
+  });
+
+  it('round-trips values that are not objects', async () => {
+    await threadState.setState({ threadId: 'thread-1', type: 'count', value: 42 });
+    await threadState.setState({ threadId: 'thread-1', type: 'flag', value: false });
+
+    expect(await threadState.getState({ threadId: 'thread-1', type: 'count' })).toBe(42);
+    expect(await threadState.getState({ threadId: 'thread-1', type: 'flag' })).toBe(false);
+  });
+
+  it('persists across store instances (durability across a process restart)', async () => {
+    await threadState.setState({ threadId: 'thread-1', type: 'task', value: tasks() });
+
+    const reopened = new ThreadStatePG({ client: store.db });
+    await reopened.init();
+    expect(await reopened.getState({ threadId: 'thread-1', type: 'task' })).toEqual(tasks());
+  });
+
+  it('includes its table in the exported schema DDL', () => {
+    const ddl = ThreadStatePG.getExportDDL().join('\n');
+    expect(ddl).toContain('mastra_thread_state');
+    expect(ddl).toContain('PRIMARY KEY ("threadId", "type")');
+  });
+});

--- a/stores/pg/src/storage/domains/thread-state/index.ts
+++ b/stores/pg/src/storage/domains/thread-state/index.ts
@@ -1,0 +1,189 @@
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ThreadStateStorage, createStorageErrorId, TABLE_THREAD_STATE, TABLE_SCHEMAS } from '@mastra/core/storage';
+import type {
+  PruneOptions,
+  PruneResult,
+  RetentionTablesDescriptor,
+  TableRetentionPolicy,
+  TABLE_NAMES,
+} from '@mastra/core/storage';
+
+import { PgDB, resolvePgConfig, generateTableSQL } from '../../db';
+import type { PgDomainConfig } from '../../db';
+import { runPrune, resolveTargets } from '../../retention';
+import { getSchemaName, getTableName } from '../utils';
+
+const COMPOSITE_PRIMARY_KEY = ['threadId', 'type'];
+
+/**
+ * PostgreSQL implementation of {@link ThreadStateStorage}.
+ *
+ * Stores per-thread, per-type state in `mastra_thread_state`, keyed by the
+ * composite primary key `(threadId, type)`. The `value` column is `jsonb`, so
+ * payloads (the task list for `type = 'task'`, the goal objective for
+ * `type = 'goal'`) come back already parsed.
+ */
+export class ThreadStatePG extends ThreadStateStorage {
+  #db: PgDB;
+  #schema: string;
+
+  static readonly MANAGED_TABLES = [TABLE_THREAD_STATE] as const;
+
+  /**
+   * `thread_state` grows as a side effect of thread activity (one row per
+   * thread per state type). It anchors on `updatedAtZ` (last activity), so
+   * state for a thread that is still being written to is not pruned by
+   * creation age.
+   */
+  static override readonly retentionTables: RetentionTablesDescriptor = {
+    threadState: { table: TABLE_THREAD_STATE, column: 'updatedAtZ', indexed: true },
+  };
+
+  constructor(config: PgDomainConfig) {
+    super();
+    const { client, schemaName, skipDefaultIndexes } = resolvePgConfig(config);
+    this.#db = new PgDB({ client, schemaName, skipDefaultIndexes });
+    this.#schema = schemaName || 'public';
+  }
+
+  static getExportDDL(schemaName?: string): string[] {
+    return [
+      generateTableSQL({
+        tableName: TABLE_THREAD_STATE,
+        schema: TABLE_SCHEMAS[TABLE_THREAD_STATE],
+        schemaName,
+        compositePrimaryKey: COMPOSITE_PRIMARY_KEY,
+        includeAllConstraints: true,
+      }),
+    ];
+  }
+
+  async init(): Promise<void> {
+    await this.#db.createTable({
+      tableName: TABLE_THREAD_STATE,
+      schema: TABLE_SCHEMAS[TABLE_THREAD_STATE],
+      compositePrimaryKey: COMPOSITE_PRIMARY_KEY,
+    });
+  }
+
+  get #table(): string {
+    return getTableName({ indexName: TABLE_THREAD_STATE, schemaName: getSchemaName(this.#schema) });
+  }
+
+  /**
+   * Create the retention index on demand, mirroring the other PG domains: only
+   * deployments that configure retention pay for the extra index. Best-effort —
+   * a failure here leaves pruning correct, just slower.
+   */
+  async #ensureRetentionIndexes(policies: Record<string, TableRetentionPolicy>): Promise<void> {
+    const prefix = this.#schema && this.#schema !== 'public' ? `${this.#schema}_` : '';
+    for (const [key, entry] of Object.entries(ThreadStatePG.retentionTables)) {
+      if (!entry.indexed || !policies[key]) continue;
+      try {
+        await this.#db.ensureIndex({
+          indexName: `${prefix}mastra_${key}_retention_idx`,
+          tableName: entry.table as TABLE_NAMES,
+          column: entry.column,
+        });
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create retention index for ${entry.table}:`, error);
+      }
+    }
+  }
+
+  /** Delete thread state older than the `threadState` policy's `maxAge`, batched. */
+  async prune(policies: Record<string, TableRetentionPolicy>, options?: PruneOptions): Promise<PruneResult[]> {
+    await this.#ensureRetentionIndexes(policies);
+    const targets = resolveTargets({
+      policies,
+      descriptor: ThreadStatePG.retentionTables,
+      order: ['threadState'],
+    });
+    return runPrune({ db: this.#db, domain: 'threadState', targets, options });
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    try {
+      await this.#db.client.none(`DELETE FROM ${this.#table}`);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'THREAD_STATE_CLEAR_ALL', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async getState<T = unknown>({ threadId, type }: { threadId: string; type: string }): Promise<T | undefined> {
+    try {
+      const row = await this.#db.client.oneOrNone<{ value: unknown }>(
+        `SELECT "value" FROM ${this.#table} WHERE "threadId" = $1 AND "type" = $2 LIMIT 1`,
+        [threadId, type],
+      );
+      if (!row || row.value === null || row.value === undefined) return undefined;
+      // jsonb comes back parsed; a string column (or a driver that hands back
+      // raw text) still needs a parse.
+      return (typeof row.value === 'string' ? JSON.parse(row.value) : row.value) as T;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'THREAD_STATE_GET', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { threadId, type },
+        },
+        error,
+      );
+    }
+  }
+
+  async setState<T = unknown>({ threadId, type, value }: { threadId: string; type: string; value: T }): Promise<void> {
+    const now = new Date().toISOString();
+    const serialized = JSON.stringify(value ?? null);
+    try {
+      // Single-statement upsert: concurrent writers to the same slot resolve on
+      // the primary key rather than racing a read-then-write. `createdAt` is
+      // left untouched on conflict so it keeps meaning "first written".
+      await this.#db.client.none(
+        `INSERT INTO ${this.#table} ("threadId", "type", "value", "createdAt", "createdAtZ", "updatedAt", "updatedAtZ")
+         VALUES ($1, $2, $3::jsonb, $4::timestamp, $5::timestamptz, $4::timestamp, $5::timestamptz)
+         ON CONFLICT ("threadId", "type")
+         DO UPDATE SET "value" = EXCLUDED."value",
+                       "updatedAt" = EXCLUDED."updatedAt",
+                       "updatedAtZ" = EXCLUDED."updatedAtZ"`,
+        // `now` is bound twice because the naive and timezone-aware mirror
+        // columns deduce different parameter types from a shared placeholder.
+        [threadId, type, serialized, now, now],
+      );
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'THREAD_STATE_SET', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { threadId, type },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteState({ threadId, type }: { threadId: string; type: string }): Promise<void> {
+    try {
+      await this.#db.client.none(`DELETE FROM ${this.#table} WHERE "threadId" = $1 AND "type" = $2`, [threadId, type]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'THREAD_STATE_DELETE', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { threadId, type },
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -37,6 +37,7 @@ import { SchedulesPG } from './domains/schedules';
 import { ScorerDefinitionsPG } from './domains/scorer-definitions';
 import { ScoresPG } from './domains/scores';
 import { SkillsPG } from './domains/skills';
+import { ThreadStatePG } from './domains/thread-state';
 import { ToolProviderConnectionsPG } from './domains/tool-provider-connections';
 import { WorkflowDefinitionsPG } from './domains/workflow-definitions';
 import { WorkflowsPG } from './domains/workflows';
@@ -113,6 +114,7 @@ const ALL_DOMAINS = [
   FavoritesPG,
   ChannelsPG,
   SchedulesPG,
+  ThreadStatePG,
 ] as const;
 
 /**
@@ -155,6 +157,7 @@ export {
   SchedulesPG,
   SkillsPG,
   FavoritesPG,
+  ThreadStatePG,
   ToolProviderConnectionsPG,
   WorkflowsPG,
   WorkflowDefinitionsPG,
@@ -252,6 +255,7 @@ export class PostgresStore extends MastraCompositeStore {
         backgroundTasks: new BackgroundTasksPG(domainConfig),
         channels: new ChannelsPG(domainConfig),
         schedules: new SchedulesPG(domainConfig),
+        threadState: new ThreadStatePG(domainConfig),
       };
     } catch (e) {
       throw new MastraError(


### PR DESCRIPTION
Closes #20204

## What this is about

Some Mastra features need to remember a small piece of state that belongs to a single conversation thread — things like a running task record or a goal objective. That state lives in a storage domain called `threadState`.

LibSQL implemented it. Postgres did not. So anyone running Mastra on Postgres lost this state whenever the process restarted, and had to hand-roll their own store and splice it in with `MastraCompositeStore` as a workaround.

## What changed

`PostgresStore` now ships a real `threadState` domain, so it behaves the same as LibSQL out of the box.

- State is stored in `mastra_thread_state`, keyed by `(threadId, type)` with the value held as JSONB.
- Writes are a single atomic upsert. Re-saving state for an existing key replaces the value and moves `updatedAt` forward while preserving the original `createdAt`, so "when was this first created" stays meaningful.
- State is scoped per thread and per type, so unrelated threads and unrelated state types never read each other's data.
- The domain participates in `exportSchemas()` and `init()` like every other Postgres domain, and supports retention pruning anchored on `updatedAtZ`.

One Postgres-specific wrinkle worth noting: the schema stores both timestamp and timestamptz columns, and the timestamp trigger only applies to the spans table. The upsert therefore writes both variants explicitly, using separately cast parameters — reusing one parameter across both column types makes Postgres refuse the statement outright with "inconsistent types deduced for parameter".

## Test plan

- 12 new tests running against real Postgres: reading unset state, JSON round-trip, upsert replacement, per-thread and per-type scoping, single-key deletion, and durability across store instances.
- Full `@mastra/pg` suite green: 1329 passed, 4 skipped.
- `build:lib` and lint clean.
- Updated the storage retention reference doc, which previously listed `threadState` as unsupported on Postgres.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

PostgreSQL can now remember task and goal state across restarts. It stores each state separately by thread and type, so updates do not overwrite unrelated data.

## Changes

- Added `ThreadStatePG` with:
  - JSONB state storage in `mastra_thread_state`
  - `getState`, `setState`, `deleteState`, and `dangerouslyClearAll`
  - Atomic upserts that preserve `createdAt` and update `updatedAt`
  - Isolation by `(threadId, type)`
  - Retention pruning based on `updatedAtZ`
  - PostgreSQL timestamp and timestamptz handling
  - Schema export and initialization support
  - Operation-specific `MastraError` handling
- Registered and exported `ThreadStatePG` through `PostgresStore`.
- Added PostgreSQL integration tests for lifecycle operations, isolation, persistence, JSONB queries, timestamps, deletion, and schema export.
- Updated retention documentation for PostgreSQL support.
- Added a patch changeset for `@mastra/pg`.

## Validation

- `@mastra/pg` test suite passes.
- Library build passes.
- Lint passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->