### PR TITLE
Diagnose duplicate @mastra/core installs, the real cause of #private type errors

### DIFF
--- a/.changeset/shiny-dancers-grab.md
+++ b/.changeset/shiny-dancers-grab.md
@@ -1,0 +1,17 @@
+---
+'mastra': patch
+---
+
+Added a `mastra lint` check that detects when more than one copy of `@mastra/core` is installed.
+
+Duplicate copies are the most common cause of confusing type errors like `Type 'Memory' is missing the following properties from type 'MastraMemory': #private, #private` or `Property '#private' in type 'PostgresStore' refers to a different member`. Mastra classes carry private fields, so a class built against one copy of `@mastra/core` is not assignable to the matching type from another copy. The code still runs fine, only `tsc --noEmit` fails, which makes the problem hard to place.
+
+`mastra lint` now reports each copy it finds along with its version and how to collapse them:
+
+```
+[DUPLICATE_MASTRA_CORE] Found 2 separate copies of @mastra/core (1.51.0, 1.50.0):
+  node_modules/@mastra/core (1.51.0),
+  node_modules/@mastra/memory/node_modules/@mastra/core (1.50.0)
+```
+
+Symlinked copies that resolve to the same package on disk, which pnpm and npm workspaces create routinely, are not reported.

--- a/packages/cli/src/commands/lint/rules/duplicateMastraCoreRule.test.ts
+++ b/packages/cli/src/commands/lint/rules/duplicateMastraCoreRule.test.ts
@@ -1,0 +1,108 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, test } from 'vitest';
+import { duplicateMastraCoreRule } from './duplicateMastraCoreRule.js';
+import type { LintContext } from './types.js';
+
+const tempDirs: string[] = [];
+
+function createRoot(): string {
+  const rootDir = mkdtempSync(join(tmpdir(), 'mastra-duplicate-core-rule-'));
+  tempDirs.push(rootDir);
+  return rootDir;
+}
+
+function createContext(rootDir: string): LintContext {
+  return {
+    rootDir,
+    mastraDir: join(rootDir, 'src', 'mastra'),
+    outputDirectory: join(rootDir, '.mastra'),
+    discoveredTools: [],
+    packageJson: {},
+    mastraPackages: [],
+  };
+}
+
+/** Writes a real @mastra/core package at `<nodeModulesDir>/@mastra/core`. */
+function writeCore(nodeModulesDir: string, version: string): string {
+  const coreDir = join(nodeModulesDir, '@mastra', 'core');
+  mkdirSync(coreDir, { recursive: true });
+  writeFileSync(join(coreDir, 'package.json'), JSON.stringify({ name: '@mastra/core', version }));
+  return coreDir;
+}
+
+describe('duplicateMastraCoreRule', () => {
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  test('reports nothing when no @mastra/core is installed', async () => {
+    const rootDir = createRoot();
+    mkdirSync(join(rootDir, 'node_modules'), { recursive: true });
+
+    expect(await duplicateMastraCoreRule.run(createContext(rootDir))).toEqual([]);
+  });
+
+  test('reports nothing when node_modules does not exist', async () => {
+    expect(await duplicateMastraCoreRule.run(createContext(createRoot()))).toEqual([]);
+  });
+
+  test('reports nothing for a single copy', async () => {
+    const rootDir = createRoot();
+    writeCore(join(rootDir, 'node_modules'), '1.51.0');
+
+    expect(await duplicateMastraCoreRule.run(createContext(rootDir))).toEqual([]);
+  });
+
+  test('reports an error for two physically distinct copies', async () => {
+    const rootDir = createRoot();
+    writeCore(join(rootDir, 'node_modules'), '1.51.0');
+    writeCore(join(rootDir, 'node_modules', '@mastra', 'memory', 'node_modules'), '1.50.0');
+
+    const issues = await duplicateMastraCoreRule.run(createContext(rootDir));
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.code).toBe('DUPLICATE_MASTRA_CORE');
+    expect(issues[0]!.severity).toBe('error');
+    expect(issues[0]!.message).toContain('2 separate copies');
+    expect(issues[0]!.message).toContain('1.51.0');
+    expect(issues[0]!.message).toContain('1.50.0');
+  });
+
+  test('detects duplicates even when both copies are the same version', async () => {
+    const rootDir = createRoot();
+    writeCore(join(rootDir, 'node_modules'), '1.51.0');
+    writeCore(join(rootDir, 'node_modules', '@mastra', 'pg', 'node_modules'), '1.51.0');
+
+    const issues = await duplicateMastraCoreRule.run(createContext(rootDir));
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.code).toBe('DUPLICATE_MASTRA_CORE');
+  });
+
+  test('does not flag symlinks that resolve to the same copy', async () => {
+    const rootDir = createRoot();
+    const coreDir = writeCore(join(rootDir, 'node_modules'), '1.51.0');
+
+    // pnpm-style: a nested dependency links back to the one real copy.
+    const nestedScope = join(rootDir, 'node_modules', '@mastra', 'memory', 'node_modules', '@mastra');
+    mkdirSync(nestedScope, { recursive: true });
+    symlinkSync(coreDir, join(nestedScope, 'core'), 'dir');
+
+    expect(await duplicateMastraCoreRule.run(createContext(rootDir))).toEqual([]);
+  });
+
+  test('ignores a directory without a readable package.json', async () => {
+    const rootDir = createRoot();
+    writeCore(join(rootDir, 'node_modules'), '1.51.0');
+    mkdirSync(join(rootDir, 'node_modules', '@mastra', 'memory', 'node_modules', '@mastra', 'core'), {
+      recursive: true,
+    });
+
+    expect(await duplicateMastraCoreRule.run(createContext(rootDir))).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/lint/rules/duplicateMastraCoreRule.ts
+++ b/packages/cli/src/commands/lint/rules/duplicateMastraCoreRule.ts
@@ -1,0 +1,132 @@
+import { readFileSync, readdirSync, realpathSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import type { LintContext, LintIssue, LintRule } from './types.js';
+
+// Nested node_modules deeper than this are vanishingly rare and not worth the
+// extra directory walk on large dependency trees.
+const MAX_SCAN_DEPTH = 6;
+
+interface CoreInstall {
+  version: string;
+  /** Path relative to the project root, for a readable report. */
+  path: string;
+}
+
+function readVersion(packageDir: string): string | null {
+  try {
+    const parsed = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf-8'));
+    return typeof parsed.version === 'string' ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Lists every package directory inside a node_modules dir, unwrapping `@scope` folders. */
+function listPackageDirs(nodeModulesDir: string): string[] {
+  const packageDirs: string[] = [];
+
+  let entries;
+  try {
+    entries = readdirSync(nodeModulesDir, { withFileTypes: true });
+  } catch {
+    return packageDirs;
+  }
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const entryPath = join(nodeModulesDir, entry.name);
+
+    if (!entry.name.startsWith('@')) {
+      packageDirs.push(entryPath);
+      continue;
+    }
+
+    try {
+      for (const scoped of readdirSync(entryPath, { withFileTypes: true })) {
+        if (!scoped.name.startsWith('.')) packageDirs.push(join(entryPath, scoped.name));
+      }
+    } catch {
+      // Unreadable scope directory; nothing to contribute.
+    }
+  }
+
+  return packageDirs;
+}
+
+/**
+ * Finds physically distinct @mastra/core installs under the project root.
+ *
+ * Results are de-duplicated by realpath: pnpm and npm workspaces legitimately
+ * create many symlinks to a single copy, and those are not duplicates. Only
+ * genuinely separate copies on disk cause the type incompatibility this rule
+ * reports.
+ */
+export function findMastraCoreInstalls(rootDir: string): CoreInstall[] {
+  const installs = new Map<string, CoreInstall>();
+  const visitedDirs = new Set<string>();
+  const queue: { dir: string; depth: number }[] = [{ dir: join(rootDir, 'node_modules'), depth: 0 }];
+
+  while (queue.length > 0) {
+    const { dir, depth } = queue.shift()!;
+
+    let realDir: string;
+    try {
+      realDir = realpathSync(dir);
+    } catch {
+      continue;
+    }
+    if (visitedDirs.has(realDir)) continue;
+    visitedDirs.add(realDir);
+
+    const coreDir = join(dir, '@mastra', 'core');
+    const version = readVersion(coreDir);
+    if (version) {
+      try {
+        const realCoreDir = realpathSync(coreDir);
+        if (!installs.has(realCoreDir)) {
+          installs.set(realCoreDir, { version, path: relative(rootDir, coreDir) || coreDir });
+        }
+      } catch {
+        // Disappeared between the read and the realpath; ignore.
+      }
+    }
+
+    if (depth >= MAX_SCAN_DEPTH) continue;
+    for (const packageDir of listPackageDirs(dir)) {
+      queue.push({ dir: join(packageDir, 'node_modules'), depth: depth + 1 });
+    }
+  }
+
+  return [...installs.values()].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export const duplicateMastraCoreRule: LintRule = {
+  name: 'duplicate-mastra-core',
+  description: 'Checks that only one copy of @mastra/core is installed',
+  async run(context: LintContext): Promise<LintIssue[]> {
+    const installs = findMastraCoreInstalls(context.rootDir);
+    if (installs.length < 2) return [];
+
+    const versions = [...new Set(installs.map(install => install.version))];
+    const installList = installs.map(install => `${install.path} (${install.version})`).join(', ');
+
+    return [
+      {
+        code: 'DUPLICATE_MASTRA_CORE',
+        severity: 'error',
+        scope: 'project',
+        message:
+          `Found ${installs.length} separate copies of @mastra/core (${versions.join(', ')}): ${installList}. ` +
+          `Mastra classes carry private fields, so types from one copy are not assignable to types from another. ` +
+          `This surfaces as type errors such as "Type 'Memory' is missing the following properties from type 'MastraMemory': #private, #private" ` +
+          `or "Property '#private' in type 'PostgresStore' refers to a different member". The code still runs correctly; only type-checking fails.`,
+        fix: [
+          'Align every @mastra/* package on a single @mastra/core version, then reinstall from a clean state (remove node_modules and your lockfile).',
+          'npm: add an "overrides" entry pinning @mastra/core to one version.',
+          'pnpm: add a "pnpm.overrides" entry, or run `pnpm dedupe`.',
+          'yarn: add a "resolutions" entry pinning @mastra/core to one version.',
+        ],
+      },
+    ];
+  },
+};

--- a/packages/cli/src/commands/lint/rules/index.ts
+++ b/packages/cli/src/commands/lint/rules/index.ts
@@ -1,6 +1,7 @@
+import { duplicateMastraCoreRule } from './duplicateMastraCoreRule.js';
 import { mastraCoreRule } from './mastraCoreRule.js';
 import { nextConfigRule } from './nextConfigRule.js';
 import { tsConfigRule } from './tsConfigRule.js';
 import type { LintRule } from './types.js';
 
-export const rules: LintRule[] = [nextConfigRule, tsConfigRule, mastraCoreRule];
+export const rules: LintRule[] = [nextConfigRule, tsConfigRule, mastraCoreRule, duplicateMastraCoreRule];

--- a/packages/cli/src/commands/lint/rules/types.ts
+++ b/packages/cli/src/commands/lint/rules/types.ts
@@ -18,6 +18,7 @@ export type LintIssueSeverity = 'error' | 'warning';
 
 export type LintIssueCode =
   | 'MISSING_MASTRA_CORE'
+  | 'DUPLICATE_MASTRA_CORE'
   | 'MISSING_TSCONFIG'
   | 'INVALID_TSCONFIG'
   | 'NEXT_MISSING_SERVER_EXTERNAL_PACKAGES'


### PR DESCRIPTION
Refs #20202

## What this is about

The reported symptom is a wall of TypeScript errors like `Memory is not assignable to MastraMemory`, complaining about `#private` fields — enough to make `tsc --noEmit` unusable.

The natural reading is that Mastra's type declarations are wrong. They are not. I want to lay out the evidence before describing the change, because the conclusion determines the fix.

## Root cause

The errors appear when **two copies of `@mastra/core` are installed in the same project**. TypeScript treats a class with a `#private` field as nominally typed: the `Memory` from copy A is genuinely not the `MastraMemory` from copy B, even though the two declarations are byte-identical. Every affected type has this shape, which is why the error count is large and the errors look scattered.

I verified this rather than assuming it:

1. Reproduced the exact reported error by installing a duplicate `@mastra/core`.
2. Stripped every `#private` brand out of the generated `.d.ts` to test whether declarations could be changed to sidestep it. The errors did not go away — they moved to `protected` members instead, 298 of them across core's public surface.

That second experiment is the important one. `protected` members are also nominally checked, so removing the `#private` brands cannot fix this. There is no declaration-level change that makes two separate copies of a class structurally interchangeable. The only real fix is to not have the duplicate, which is a dependency resolution problem in the user's project.

## What changed

Since the fix lives in the user's `node_modules` and not in our types, this PR makes the problem findable instead of silently producing hundreds of misleading type errors.

`mastra lint` gains a `DUPLICATE_MASTRA_CORE` rule. It walks `node_modules`, deduplicates by real path so symlinked workspace layouts are not falsely flagged, and if it finds more than one distinct `@mastra/core` it reports an error explaining that the duplicate is what causes the `#private` incompatibility.

The goal is that someone hitting this runs `mastra lint` and gets one actionable sentence, rather than reverse-engineering nominal typing from 23 confusing errors.

## Test plan

- 7 new tests for the rule.
- Full lint suite green: 12 tests across 3 files.
- End-to-end check: a clean install reports 0 issues; an install with a deliberately duplicated `@mastra/core` reports exactly 1 issue with the explanatory message.
