### PR TITLE
Update suspended-run TTL test to match storage-backed resume behavior

### DIFF
--- a/packages/core/src/agent/__tests__/suspended-run-ttl-resume.test.ts
+++ b/packages/core/src/agent/__tests__/suspended-run-ttl-resume.test.ts
@@ -204,29 +204,22 @@ describe('suspended agent runs are released from memory after a TTL', () => {
     // The transcript is gone and the thread is unblocked: a follow-up turn no
     // longer waits behind a suspend nobody is coming back for.
     expect(agent.getActiveThreadRunId({ threadId: SUSPENDED_THREAD_ID, resourceId: RESOURCE_ID })).toBeUndefined();
-    // Resume paths that only consult warm state now report the run as gone...
-    await expect(
-      agent.sendStreamResume({
-        threadId: SUSPENDED_THREAD_ID,
-        resourceId: RESOURCE_ID,
-        runId,
-        toolCallId,
-        resumeData: { approved: true },
-      }),
-    ).rejects.toMatchObject({ id: 'AGENT_SEND_STREAM_RESUME_NO_SUSPENDED_THREAD_RUN' });
-
-    // ...but the run itself is untouched: it is still durably suspended, and the
-    // approval paths that fall back to storage still resume it to completion.
+    // The run itself is untouched: dropping warm state only releases memory, so
+    // the run is still durably suspended and discoverable.
     const { runs } = await agent.listSuspendedRuns({ threadId: SUSPENDED_THREAD_ID });
     expect(runs.map(run => run.runId)).toEqual([runId]);
 
-    const approval = await agent.sendToolApproval({
+    // Resume recovers the run from its snapshot rather than requiring warm
+    // state, which is what also lets a resume land on a restarted process or a
+    // different server instance than the one that suspended the run.
+    const resumed = await agent.sendStreamResume({
       threadId: SUSPENDED_THREAD_ID,
       resourceId: RESOURCE_ID,
+      runId,
       toolCallId,
-      approved: true,
+      resumeData: { approved: true },
     });
-    expect(approval).toEqual({ accepted: true, runId, toolCallId });
+    expect(resumed).toEqual({ accepted: true, runId, toolCallId });
 
     const workflowsStore = (await storage.getStore('workflows'))!;
     await vi.waitFor(


### PR DESCRIPTION
## What

Fixes a failing test on `main`: `suspended-run-ttl-resume.test.ts` > "drops warm state past the TTL and resumes the run from its durable snapshot".

## Why

The test asserted that resuming a run whose warm in-memory state had been swept by the TTL would *reject*. That was correct when the test was written — losing warm state meant losing the run.

PR #20602 then added a storage-recovery fallback: `sendStreamResume` now rehydrates the run from its durable snapshot instead of failing. That is the intended, better behavior, and it made the test's expectation obsolete. The test had been encoding the old limitation rather than the desired contract.

## What changed

The test now asserts the run successfully resumes from its durable snapshot after the TTL sweep, which is what the test name already described.

No production code changes.

## Test plan

`packages/core/src/agent/__tests__/suspended-run-ttl-resume.test.ts` — 2 passed. Typecheck clean.