### PR TITLE
Stop suspended-run snapshots from growing with the number of steps

### DIFF
--- a/.changeset/olive-pandas-shake.md
+++ b/.changeset/olive-pandas-shake.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Stop suspended-run snapshots from growing with step count
+
+A single suspended run persisted one full copy of the model request per step. The request body holds the tool schemas and system instruction, which are invariant across a run, so a HITL agent that made a dozen tool calls before its first approval could push its snapshot past MongoDB's hard 16 MB per-document limit — the write failed, the run was never saved, and the later resume could not find it.
+
+The buffered step state now stores each distinct request once and references it per step, and snapshot pruning drops the request body from retained step history. Snapshot size no longer scales with the number of steps taken before suspending. Snapshots written by earlier versions still load unchanged.

--- a/.changeset/olive-pandas-shake.md
+++ b/.changeset/olive-pandas-shake.md
@@ -2,8 +2,6 @@
 '@mastra/core': patch
 ---
 
-Stop suspended-run snapshots from growing with step count
+Fixed suspended runs that could fail to save after repeated tool calls.
 
-A single suspended run persisted one full copy of the model request per step. The request body holds the tool schemas and system instruction, which are invariant across a run, so a HITL agent that made a dozen tool calls before its first approval could push its snapshot past MongoDB's hard 16 MB per-document limit — the write failed, the run was never saved, and the later resume could not find it.
-
-The buffered step state now stores each distinct request once and references it per step, and snapshot pruning drops the request body from retained step history. Snapshot size no longer scales with the number of steps taken before suspending. Snapshots written by earlier versions still load unchanged.
+A run's snapshot no longer grows with every step it took before suspending, which keeps agents that make many tool calls before their first approval prompt under MongoDB's 16 MB per-document limit — past it, the snapshot was never written and the resume reported the run as missing. Runs suspended by earlier versions still load.

--- a/packages/core/src/agent/__tests__/suspended-snapshot-request-dedupe.test.ts
+++ b/packages/core/src/agent/__tests__/suspended-snapshot-request-dedupe.test.ts
@@ -1,0 +1,124 @@
+/**
+ * A suspended run must not persist one full copy of the invariant request per
+ * step.
+ *
+ * Every buffered step stores the request that produced it, and that request's
+ * body carries the tool schemas plus the system instruction — identical across
+ * the steps of a run. A HITL agent that makes a dozen tool calls before its
+ * first approval suspend therefore wrote a dozen copies of the same blob into a
+ * single workflow snapshot, which on MongoDB exceeds the hard 16 MB
+ * per-document limit: the write fails, the suspended run is never saved, and
+ * the later resume cannot find it.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { createTool } from '../../tools';
+import { Agent } from '../agent';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from './mock-model';
+
+// Stands in for the tool-schema + system-instruction blob a provider echoes
+// back on every step. Distinctive so it can be counted in the snapshot.
+const INVARIANT_BODY = `TOOL-SCHEMA-BLOB-${'x'.repeat(2000)}`;
+const STEPS_BEFORE_SUSPEND = 8;
+
+function createNoopTool() {
+  return createTool({
+    id: 'noop',
+    description: 'Does nothing.',
+    inputSchema: z.object({ n: z.number() }),
+    execute: async () => ({ ok: true }),
+  });
+}
+
+function createApprovalTool() {
+  return createTool({
+    id: 'approve',
+    description: 'Requires approval.',
+    inputSchema: z.object({ n: z.number() }),
+    requireApproval: true,
+    execute: async () => ({ approved: true }),
+  });
+}
+
+// Calls the no-op tool STEPS_BEFORE_SUSPEND times, then the approval tool,
+// which suspends the run. Every response carries the same `request.body`.
+function createSteppingModel() {
+  let call = 0;
+  return new MockLanguageModelV2({
+    doStream: async () => {
+      call++;
+      const isLast = call > STEPS_BEFORE_SUSPEND;
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        request: { body: INVARIANT_BODY },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: `id-${call}`, modelId: 'mock-model-id', timestamp: new Date(0) },
+          {
+            type: 'tool-call',
+            toolCallId: `call-${call}`,
+            toolName: isLast ? 'approve' : 'noop',
+            input: JSON.stringify({ n: call }),
+            providerExecuted: false,
+          },
+          {
+            type: 'finish',
+            finishReason: 'tool-calls',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+      } as any;
+    },
+  });
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    count++;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+describe('suspended snapshot request dedupe', () => {
+  it('persists the invariant request once, not once per step', async () => {
+    const storage = new InMemoryStore();
+    const persisted: string[] = [];
+    const workflowsStore: any = await storage.getStore('workflows');
+    const originalPersist = workflowsStore.persistWorkflowSnapshot.bind(workflowsStore);
+    vi.spyOn(workflowsStore, 'persistWorkflowSnapshot').mockImplementation(async (args: any) => {
+      persisted.push(JSON.stringify(args.snapshot));
+      return originalPersist(args);
+    });
+
+    const agent = new Agent({
+      id: 'hitl',
+      name: 'hitl',
+      instructions: 'Call the noop tool repeatedly, then the approve tool.',
+      model: createSteppingModel(),
+      tools: { noop: createNoopTool(), approve: createApprovalTool() },
+    });
+    new Mastra({ logger: false, storage, agents: { hitl: agent } });
+
+    const stream = await agent.stream('go', { maxSteps: STEPS_BEFORE_SUSPEND + 2 });
+    for await (const _ of stream.fullStream) {
+      // drain until the approval suspends the run
+    }
+
+    const suspendedSnapshot = persisted.find(s => s.includes(INVARIANT_BODY));
+    expect(suspendedSnapshot).toBeDefined();
+
+    // Before the fix this run wrote 27 copies: one per step in the buffered
+    // step state and again in the step-history output, doubled by the
+    // propagated foreach metadata. What survives is one shared copy per
+    // __streamState (the request table and the run-level request), which does
+    // not grow with step count.
+    const copies = countOccurrences(suspendedSnapshot!, INVARIANT_BODY);
+    expect(copies).toBeLessThanOrEqual(4);
+  });
+});

--- a/packages/core/src/loop/workflows/prune-snapshot.ts
+++ b/packages/core/src/loop/workflows/prune-snapshot.ts
@@ -103,6 +103,20 @@ function stripTerminalOutputFields<T>(value: T): T {
   if (isPlainObject(pruned.output)) {
     const output = { ...pruned.output };
     delete output.messages;
+    // The step history has to survive (resume re-reads it), but each entry
+    // carries the request that produced it, whose body is the tool schemas plus
+    // the system instruction — invariant across the run and re-serialized in
+    // full for every step. That is what pushed a single suspended run past
+    // MongoDB's 16 MB document limit. Resume only reads step number, stopWhen
+    // input and processor history from these entries, and the sibling
+    // `metadata.request` is already dropped above, so the body goes too.
+    if (Array.isArray(output.steps)) {
+      output.steps = output.steps.map((step: unknown) => {
+        if (!isPlainObject(step) || !isPlainObject(step.request) || !('body' in step.request)) return step;
+        const { body: _body, ...request } = step.request;
+        return { ...step, request };
+      });
+    }
     pruned.output = output;
   }
 

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -30,6 +30,7 @@ import type {
 import { safeClose, safeEnqueue } from './input';
 import { createJsonTextStreamTransformer, createObjectStreamTransformer } from './output-format-handlers';
 import { getTransformedSchema } from './schema';
+import { dedupeStepRequests, rehydrateStepRequests } from './step-request-dedupe';
 
 /**
  * Helper function to create a destructurable version of MastraModelOutput.
@@ -1954,9 +1955,11 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
   }
 
   serializeState() {
+    const { steps, requests } = dedupeStepRequests(this.#bufferedSteps);
     return {
       status: this.#status,
-      bufferedSteps: this.#bufferedSteps,
+      bufferedSteps: steps,
+      bufferedStepRequests: requests,
       bufferedReasoningDetails: this.#bufferedReasoningDetails,
       bufferedByStep: this.#bufferedByStep,
       bufferedText: this.#bufferedText,
@@ -1981,7 +1984,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
 
   deserializeState(state: any) {
     this.#status = state.status;
-    this.#bufferedSteps = state.bufferedSteps;
+    this.#bufferedSteps = rehydrateStepRequests(state.bufferedSteps, state.bufferedStepRequests);
     this.#bufferedReasoningDetails = state.bufferedReasoningDetails;
     this.#bufferedByStep = state.bufferedByStep;
     this.#bufferedText = state.bufferedText;

--- a/packages/core/src/stream/base/step-request-dedupe.test.ts
+++ b/packages/core/src/stream/base/step-request-dedupe.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { dedupeStepRequests, rehydrateStepRequests } from './step-request-dedupe';
+
+describe('step request dedupe', () => {
+  const invariantRequest = { body: 'x'.repeat(10_000) };
+  const makeSteps = (count: number, request: unknown = invariantRequest) =>
+    Array.from({ length: count }, (_, i) => ({
+      stepType: `step-${i}`,
+      text: `t${i}`,
+      request: { ...(request as any) },
+    }));
+
+  it('stores one copy of a request shared by every step and restores it per step', () => {
+    const steps = makeSteps(13);
+    const { steps: packed, requests } = dedupeStepRequests(steps);
+
+    expect(requests).toHaveLength(1);
+    expect(packed.every(s => !('request' in s))).toBe(true);
+
+    const restored = rehydrateStepRequests(packed, requests);
+    expect(restored).toEqual(steps);
+  });
+
+  it('shrinks the serialized snapshot instead of growing it with step count', () => {
+    const steps = makeSteps(13);
+    const before = JSON.stringify({ bufferedSteps: steps }).length;
+    const { steps: packed, requests } = dedupeStepRequests(steps);
+    const after = JSON.stringify({ bufferedSteps: packed, bufferedStepRequests: requests }).length;
+
+    // 13 copies of a 10 KB body collapse to one; the rest is step scaffolding.
+    expect(after).toBeLessThan(before / 10);
+  });
+
+  it('keeps distinct requests distinct', () => {
+    const steps = [
+      { stepType: 'a', request: { body: 'one' } },
+      { stepType: 'b', request: { body: 'two' } },
+      { stepType: 'c', request: { body: 'one' } },
+    ];
+    const { steps: packed, requests } = dedupeStepRequests(steps);
+
+    expect(requests).toEqual([{ body: 'one' }, { body: 'two' }]);
+    expect(rehydrateStepRequests(packed, requests)).toEqual(steps);
+  });
+
+  it('leaves the steps untouched when nothing is shared', () => {
+    const steps = [
+      { stepType: 'a', request: { body: 'one' } },
+      { stepType: 'b', request: { body: 'two' } },
+    ];
+    const result = dedupeStepRequests(steps);
+
+    expect(result.requests).toBeUndefined();
+    expect(result.steps).toBe(steps);
+  });
+
+  it('leaves a single step alone', () => {
+    const steps = makeSteps(1);
+    const result = dedupeStepRequests(steps);
+
+    expect(result.requests).toBeUndefined();
+    expect(result.steps).toBe(steps);
+  });
+
+  it('reads back a snapshot written before dedupe existed', () => {
+    const steps = makeSteps(3);
+    // No request table: every step still carries its request inline.
+    expect(rehydrateStepRequests(steps, undefined)).toBe(steps);
+  });
+
+  it('keeps a non-serializable request inline rather than dropping it', () => {
+    const cyclic: any = { body: 'shared' };
+    cyclic.self = cyclic;
+    const steps = [
+      { stepType: 'a', request: cyclic },
+      { stepType: 'b', request: cyclic },
+    ];
+
+    const { steps: packed, requests } = dedupeStepRequests(steps);
+    expect(requests).toBeUndefined();
+    expect(packed[0]!.request).toBe(cyclic);
+  });
+
+  it('preserves steps that have no request at all', () => {
+    const steps = [
+      { stepType: 'a', request: { body: 'shared' } },
+      { stepType: 'b' },
+      { stepType: 'c', request: { body: 'shared' } },
+    ];
+    const { steps: packed, requests } = dedupeStepRequests(steps);
+
+    expect(rehydrateStepRequests(packed, requests)).toEqual(steps);
+  });
+});

--- a/packages/core/src/stream/base/step-request-dedupe.test.ts
+++ b/packages/core/src/stream/base/step-request-dedupe.test.ts
@@ -81,6 +81,65 @@ describe('step request dedupe', () => {
     expect(packed[0]!.request).toBe(cyclic);
   });
 
+  // JSON renders every one of these as `{}`, so keying on JSON text would fuse
+  // two different requests into one and resume a step against the other's.
+  // The persistence codec carries these types, so the collision is reachable.
+  it.each([
+    ['Map', () => new Map([['a', 1]]), () => new Map([['b', 2]])],
+    ['Set', () => new Set(['a']), () => new Set(['b'])],
+    ['Error', () => new Error('first'), () => new Error('second')],
+  ])('keeps requests with distinct %s bodies apart', (_name, first, second) => {
+    const steps = [
+      { stepType: 'a', request: { body: first() } },
+      { stepType: 'b', request: { body: second() } },
+    ];
+
+    const { steps: packed, requests } = dedupeStepRequests(steps);
+
+    expect(requests).toBeUndefined();
+    expect(packed).toBe(steps);
+    expect(rehydrateStepRequests(packed, requests)).toEqual(steps);
+  });
+
+  it('does not fuse a dropped key with an absent one', () => {
+    // `{ body: undefined }` and `{}` both render as `{}`.
+    const steps = [
+      { stepType: 'a', request: { body: undefined } },
+      { stepType: 'b', request: {} },
+    ];
+
+    const { steps: packed, requests } = dedupeStepRequests(steps);
+
+    expect(requests).toBeUndefined();
+    expect(packed[0]!.request).toEqual({ body: undefined });
+    expect(packed[1]!.request).toEqual({});
+  });
+
+  it('still dedupes a request holding a Date', () => {
+    // A Date renders lossily but injectively, so it is safe to key on.
+    const at = new Date('2020-01-01T00:00:00.000Z');
+    const steps = [
+      { stepType: 'a', request: { body: 'shared', at } },
+      { stepType: 'b', request: { body: 'shared', at } },
+    ];
+
+    const { steps: packed, requests } = dedupeStepRequests(steps);
+
+    expect(requests).toHaveLength(1);
+    expect(rehydrateStepRequests(packed, requests)).toEqual(steps);
+  });
+
+  it('keeps requests with distinct Dates apart', () => {
+    const steps = [
+      { stepType: 'a', request: { at: new Date('2020-01-01T00:00:00.000Z') } },
+      { stepType: 'b', request: { at: new Date('2021-01-01T00:00:00.000Z') } },
+    ];
+
+    const { steps: packed, requests } = dedupeStepRequests(steps);
+
+    expect(rehydrateStepRequests(packed, requests)).toEqual(steps);
+  });
+
   it('preserves steps that have no request at all', () => {
     const steps = [
       { stepType: 'a', request: { body: 'shared' } },

--- a/packages/core/src/stream/base/step-request-dedupe.ts
+++ b/packages/core/src/stream/base/step-request-dedupe.ts
@@ -1,0 +1,70 @@
+/**
+ * Every buffered step of a run carries the request that produced it, and that
+ * request's `body` holds the tool schemas plus the system instruction — data
+ * that is invariant across the steps of a single run and, in practice,
+ * byte-identical. Persisting a full copy per step made a suspended snapshot
+ * grow linearly with step count, and a HITL agent that takes a dozen tool calls
+ * before its first approval could push a single document past MongoDB's hard
+ * 16 MB limit, failing the write and stranding the run.
+ *
+ * So the snapshot stores each distinct request once and has the steps point at
+ * it. This is purely a storage representation: callers still see a `request` on
+ * every step after rehydration.
+ */
+
+const REQUEST_REF = '__requestRef' as const;
+
+type StepLike = { request?: unknown };
+
+export function dedupeStepRequests<T extends StepLike>(steps: T[]): { steps: T[]; requests: unknown[] | undefined } {
+  // With fewer than two steps there is nothing to share, and the extra table
+  // would only add noise to the snapshot.
+  if (!Array.isArray(steps) || steps.length < 2) return { steps, requests: undefined };
+
+  const requests: unknown[] = [];
+  const indexByKey = new Map<string, number>();
+  let sharedAny = false;
+
+  const rewritten = steps.map(step => {
+    if (!step || typeof step !== 'object' || step.request === undefined) return step;
+
+    let key: string;
+    try {
+      key = JSON.stringify(step.request) ?? 'undefined';
+    } catch {
+      // A request that will not serialize (cycles, BigInt) cannot be compared
+      // by value; leave it inline and let the existing behavior stand.
+      return step;
+    }
+
+    let index = indexByKey.get(key);
+    if (index === undefined) {
+      index = requests.length;
+      indexByKey.set(key, index);
+      requests.push(step.request);
+    } else {
+      sharedAny = true;
+    }
+
+    const { request: _dropped, ...rest } = step as StepLike & Record<string, unknown>;
+    return { ...rest, [REQUEST_REF]: index } as unknown as T;
+  });
+
+  // If no two steps shared a request, the table is the same size as the inline
+  // copies were — keep the simpler shape.
+  if (!sharedAny) return { steps, requests: undefined };
+
+  return { steps: rewritten, requests };
+}
+
+export function rehydrateStepRequests<T extends StepLike>(steps: T[], requests: unknown[] | undefined): T[] {
+  // Snapshots written before this change (and runs with nothing to share) store
+  // the request inline on every step and need no rehydration.
+  if (!Array.isArray(steps) || !Array.isArray(requests)) return steps;
+
+  return steps.map(step => {
+    if (!step || typeof step !== 'object' || !(REQUEST_REF in step)) return step;
+    const { [REQUEST_REF]: index, ...rest } = step as Record<string, unknown>;
+    return { ...rest, request: requests[index as number] } as unknown as T;
+  });
+}

--- a/packages/core/src/stream/base/step-request-dedupe.ts
+++ b/packages/core/src/stream/base/step-request-dedupe.ts
@@ -16,6 +16,61 @@ const REQUEST_REF = '__requestRef' as const;
 
 type StepLike = { request?: unknown };
 
+/**
+ * Whether a value's JSON text identifies it uniquely.
+ *
+ * Two steps are treated as sharing a request when their JSON text matches, so
+ * the text has to be injective over the values we compare. It is not, for the
+ * types JSON has no representation of: `Map`, `Set`, `Error` and class
+ * instances all render as `{}`, and a key whose value is `undefined` or a
+ * function disappears entirely — so two genuinely different requests would
+ * collide and one step would resume against the other's request.
+ *
+ * `Date` is allowed: it renders lossily, but distinct instants still render
+ * distinctly, so it cannot collide. Anything else falls back to storing the
+ * request inline, which is what every snapshot did before this change.
+ */
+function hasInjectiveJson(value: unknown, seen = new Set<object>()): boolean {
+  if (value === null) return true;
+
+  const type = typeof value;
+  if (type === 'string' || type === 'boolean') return true;
+  // NaN and ±Infinity all render as `null`.
+  if (type === 'number') return Number.isFinite(value);
+  if (type !== 'object') return false;
+
+  const object = value as object;
+  // A cycle would throw in `JSON.stringify` anyway; refuse it up front rather
+  // than paying for the throw.
+  if (seen.has(object)) return false;
+  seen.add(object);
+
+  try {
+    if (object instanceof Date) return true;
+
+    if (Array.isArray(object)) {
+      // A hole and an explicit `undefined` both render as `null`, as does any
+      // element JSON drops.
+      return object.every((element, index) => index in object && hasInjectiveJson(element, seen));
+    }
+
+    const prototype = Object.getPrototypeOf(object);
+    if (prototype !== Object.prototype && prototype !== null) return false;
+
+    // `toJSON` replaces the value with something we have not inspected.
+    if ('toJSON' in object) return false;
+
+    return Reflect.ownKeys(object).every(key => {
+      // A symbol key is dropped silently; a symbol or function value makes the
+      // whole entry disappear.
+      if (typeof key === 'symbol') return false;
+      return hasInjectiveJson((object as Record<string, unknown>)[key], seen);
+    });
+  } finally {
+    seen.delete(object);
+  }
+}
+
 export function dedupeStepRequests<T extends StepLike>(steps: T[]): { steps: T[]; requests: unknown[] | undefined } {
   // With fewer than two steps there is nothing to share, and the extra table
   // would only add noise to the snapshot.
@@ -28,12 +83,18 @@ export function dedupeStepRequests<T extends StepLike>(steps: T[]): { steps: T[]
   const rewritten = steps.map(step => {
     if (!step || typeof step !== 'object' || step.request === undefined) return step;
 
+    // The persistence codec preserves types JSON does not (Date, Error, Map,
+    // Set), so a request can legitimately hold one and survive the round trip.
+    // JSON text cannot tell two of those apart, so requests carrying one are
+    // left inline rather than deduplicated against each other.
+    if (!hasInjectiveJson(step.request)) return step;
+
     let key: string;
     try {
       key = JSON.stringify(step.request) ?? 'undefined';
     } catch {
-      // A request that will not serialize (cycles, BigInt) cannot be compared
-      // by value; leave it inline and let the existing behavior stand.
+      // Defensive: `hasInjectiveJson` already rejects the values that throw
+      // (cycles, BigInt). Leave the request inline if one slips through.
       return step;
     }
 


### PR DESCRIPTION
## What this fixes

When an agent run pauses — say, to wait for a human to approve a tool call — Mastra saves a snapshot of the run so it can be picked up again later. That snapshot was much larger than it needed to be, and it grew with every step the agent took before pausing.

On MongoDB, which caps a single document at 16 MB, this is a hard failure: the write throws, the paused run is never saved, and the later resume reports that it cannot find the run. An agent that made a dozen tool calls before its first approval prompt was enough to hit it. On Postgres the same data showed up as oversized, slow rows.

## Why it happened

Every step of a run records the request that produced it. That request's body is mostly the tool schemas and the system instruction — the same bytes on every step of the run. They were stored in full, once per step, in two places: the buffered step state and the retained step history. Both were then duplicated again by the metadata a suspended run propagates upward.

A previous fix (#18862) removed the growth *across* repeated suspensions. This is the remaining growth *within* a single suspension, which is driven by step count rather than by suspend/resume cycles.

## The change

- The buffered step state stores each distinct request once and has the steps reference it. This is purely how the snapshot is written — callers still see a `request` on every step after loading.
- Snapshot pruning drops the request body from the step history it must keep for resume. Resume reads the step number, `stopWhen` input and processor history from those entries, not the request body, and the neighbouring `metadata.request` was already being pruned.

Snapshot size no longer scales with the number of steps taken before suspending. Snapshots written by earlier versions store the request inline on every step and are loaded unchanged, so an in-flight suspended run survives the upgrade.

### One thing deliberately not done

The issue also suggested dropping the second copy of the step state held under `__workflow_meta.foreachOutput[...]`. That copy is load-bearing: the evented engine reads a specific iteration's payload from it so parallel suspensions do not read a sibling's resume state (#19450). Deduplicating the contents shrinks that copy too, without the correctness risk of removing it.

## Test plan

- New end-to-end test runs a HITL agent through several tool calls to a suspend, captures the persisted snapshot, and counts copies of a marker request body. It went from 27 copies to a small constant that does not grow with step count; the test fails on the previous behavior.
- New unit tests cover the storage representation: shared requests collapse to one entry and round-trip exactly, distinct requests stay distinct, a single step and a run with nothing shared are left untouched, a non-serializable request stays inline rather than being dropped, and a snapshot written before this change loads as-is.
- Full `@mastra/core` suite passes: 854 files, 13377 tests, no type errors.

Closes #20288


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Suspended workflows no longer store the same large request many times. They store it once and reuse it, which keeps snapshots small enough to save and resume.

## Changes

- Deduplicates repeated serializable step requests in suspended-run snapshots.
- Stores requests in a shared table and stores references from buffered steps.
- Removes request bodies from retained terminal step history.
- Keeps workflow metadata requests required for resuming parallel suspensions.
- Preserves inline requests that are distinct or non-serializable.
- Rehydrates deduplicated requests during snapshot loading.
- Supports snapshots created by earlier versions without a request table.

## Tests

- Added coverage for deduplication, snapshot size reduction, distinct requests, missing requests, and non-serializable requests.
- Added backward-compatibility and end-to-end HITL coverage.
- Full `@mastra/core` suite passes: 854 files and 13,377 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->