### PR TITLE
Cancelling one Inngest workflow run no longer cancels every other run

### DIFF
--- a/.changeset/quick-jars-listen.md
+++ b/.changeset/quick-jars-listen.md
@@ -2,4 +2,4 @@
 '@mastra/inngest': patch
 ---
 
-Scope Inngest workflow cancellation to the run being cancelled. The workflow function registered its cancel event without a `match` expression, so cancelling one run cancelled every in-flight run of that function — and because all durable agents share a single function, one `cancel()` call tore down unrelated runs across the deployment while only the targeted run's snapshot was marked canceled.
+Fixed Inngest workflow cancellation so it only stops the run you asked to cancel. Canceling one durable agent run no longer tears down other active runs of the same workflow.

--- a/.changeset/quick-jars-listen.md
+++ b/.changeset/quick-jars-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Scope Inngest workflow cancellation to the run being cancelled. The workflow function registered its cancel event without a `match` expression, so cancelling one run cancelled every in-flight run of that function — and because all durable agents share a single function, one `cancel()` call tore down unrelated runs across the deployment while only the targeted run's snapshot was marked canceled.

--- a/workflows/inngest/src/cancel-scoping.test.ts
+++ b/workflows/inngest/src/cancel-scoping.test.ts
@@ -7,6 +7,8 @@
  * every other run in the deployment — and only the targeted run's snapshot was
  * marked canceled, so the rest died silently.
  */
+import { Mastra } from '@mastra/core/mastra';
+import { MockStore } from '@mastra/core/storage';
 import { Inngest } from 'inngest';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -61,5 +63,78 @@ describe('inngest cancel event scoping', () => {
     const [cancelOn] = config.cancelOn;
     expect(cancelOn.match).toBe('data.runId');
     expect(config.triggers).toEqual({ event: 'workflow.field-workflow' });
+  });
+
+  // `match: 'data.runId'` compares the cancel event against the *trigger* event,
+  // so a run is only cancellable if its trigger named it. The run id generated
+  // inside the function never reaches the trigger event, so these tests pin the
+  // property the match expression depends on: the trigger carries the same run
+  // id that `cancel()` later sends.
+  it('names the run on the trigger event so the cancel event can pair with it', async () => {
+    const inngest = new Inngest({ id: 'cancel-pairing-test' });
+    const { createWorkflow, createStep } = init(inngest);
+
+    const step = createStep({
+      id: 's',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      execute: async ({ inputData }) => inputData,
+    });
+    const workflow = createWorkflow({
+      id: 'pairing-workflow',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      steps: [step],
+    })
+      .then(step)
+      .commit();
+
+    const mastra = new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: { 'pairing-workflow': workflow as any },
+    });
+    workflow.__registerMastra(mastra);
+
+    const run = await workflow.createRun();
+    // start() awaits getRunOutput, which polls a live Inngest server.
+    vi.spyOn(run as any, 'getRunOutput').mockResolvedValue({ output: { result: { status: 'success' } } });
+    const sendSpy = vi.spyOn(inngest, 'send').mockResolvedValue({ ids: ['evt-1'] } as any);
+
+    await run.start({ inputData: { value: 'ok' } });
+    const trigger = sendSpy.mock.calls[0]![0] as any;
+
+    sendSpy.mockClear();
+    await run.cancel();
+    const cancel = sendSpy.mock.calls[0]![0] as any;
+
+    expect(trigger.name).toBe('workflow.pairing-workflow');
+    expect(cancel.name).toBe('cancel.workflow.pairing-workflow');
+    // The field named by `match` has to be present and equal on both events.
+    expect(trigger.data.runId).toBe(run.runId);
+    expect(cancel.data.runId).toBe(run.runId);
+  });
+
+  it('warns that a run triggered without a runId cannot be cancelled by id', async () => {
+    const { workflow } = createFunctionConfigs('unnamed-run-workflow');
+    const warn = vi.fn();
+    (workflow as any).__setLogger({ warn, debug: vi.fn(), info: vi.fn(), error: vi.fn() });
+    workflow.getFunction();
+
+    // Drive the generated-runId branch through the registered handler.
+    const registered = workflow.getFunction() as any;
+    const fn = registered.rest[0];
+    const step: any = {
+      run: async (id: string, cb: () => Promise<any>) => {
+        if (id.endsWith('.runIdGen')) return cb();
+        throw new Error(`stop-after-runIdGen:${id}`);
+      },
+    };
+
+    await expect(fn({ event: { data: { inputData: { value: 'x' } } }, step, attempt: 0 })).rejects.toThrow(
+      /stop-after-runIdGen/,
+    );
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('cannot be cancelled by id'));
   });
 });

--- a/workflows/inngest/src/cancel-scoping.test.ts
+++ b/workflows/inngest/src/cancel-scoping.test.ts
@@ -12,6 +12,7 @@ import { MockStore } from '@mastra/core/storage';
 import { Inngest } from 'inngest';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+import { InngestExecutionEngine } from './execution-engine';
 import { init } from './index';
 
 function createFunctionConfigs(workflowId: string, opts: Record<string, unknown> = {}) {
@@ -137,4 +138,68 @@ describe('inngest cancel event scoping', () => {
 
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('cannot be cancelled by id'));
   });
+
+  // A nested workflow is invoked by the parent's execution engine, not by a user
+  // sending an event. If that invoke omits `data.runId`, the child lands in the
+  // unnamed-run branch: it warns advice nobody can act on, and `match` can never
+  // pair a cancel event with it, so nested runs stop being cancellable at all.
+  it('names the run when a parent invokes a nested workflow', async () => {
+    const { workflow } = createFunctionConfigs('nested-child-workflow');
+    const warn = vi.fn();
+    (workflow as any).__setLogger({ warn, debug: vi.fn(), info: vi.fn(), error: vi.fn() });
+
+    const registered = workflow.getFunction() as any;
+    const fn = registered.rest[0];
+    const step: any = {
+      run: async (id: string, cb: () => Promise<any>) => {
+        if (id.endsWith('.runIdGen')) return cb();
+        throw new Error(`stop-after-runIdGen:${id}`);
+      },
+    };
+
+    // Captured from the real engine rather than hand-copied, so this test still
+    // reflects the payload if the invoke block changes.
+    const nestedInvokeData = await captureNestedInvokeData(workflow);
+
+    await expect(fn({ event: { data: nestedInvokeData }, step, attempt: 0 })).rejects.toThrow(/stop-after/);
+
+    expect(nestedInvokeData.runId).toBeTruthy();
+    expect(warn).not.toHaveBeenCalled();
+  });
 });
+
+/**
+ * Runs the parent-side nested-workflow invoke and returns the `data` block it
+ * hands to Inngest, driving the plain (non-resume, non-time-travel) branch.
+ */
+async function captureNestedInvokeData(childWorkflow: any): Promise<Record<string, any>> {
+  let captured: Record<string, any> | undefined;
+  const inngestStep: any = {
+    invoke: async (_id: string, opts: any) => {
+      captured = opts.data;
+      return { result: { status: 'success', result: {}, state: {} }, runId: 'child-run' };
+    },
+    run: async (_id: string, cb: () => Promise<any>) => cb(),
+  };
+
+  const mastra = new Mastra({
+    logger: false,
+    storage: new MockStore(),
+    workflows: { [childWorkflow.id]: childWorkflow },
+  });
+  childWorkflow.__registerMastra(mastra);
+
+  const engine = new InngestExecutionEngine(mastra, inngestStep, 0, {} as any);
+  await engine.executeWorkflowStep({
+    step: childWorkflow,
+    stepResults: {},
+    executionContext: { workflowId: 'parent-workflow', runId: 'parent-run', state: {} } as any,
+    prevOutput: {},
+    inputData: { value: 'x' },
+    pubsub: { publish: async () => {}, subscribe: async () => {}, flush: async () => {} } as any,
+    startedAt: Date.now(),
+  });
+
+  if (!captured) throw new Error('nested invoke was never issued');
+  return captured;
+}

--- a/workflows/inngest/src/cancel-scoping.test.ts
+++ b/workflows/inngest/src/cancel-scoping.test.ts
@@ -1,0 +1,65 @@
+/**
+ * A cancel event must only cancel the run it names.
+ *
+ * The Inngest function registered `cancelOn: [{ event: 'cancel.workflow.<id>' }]`
+ * with no `match`, so the event cancelled every in-flight run of the function.
+ * All durable agents share a single function, so cancelling one run tore down
+ * every other run in the deployment — and only the targeted run's snapshot was
+ * marked canceled, so the rest died silently.
+ */
+import { Inngest } from 'inngest';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { init } from './index';
+
+function createFunctionConfigs(workflowId: string, opts: Record<string, unknown> = {}) {
+  const inngest = new Inngest({ id: 'cancel-scoping-test' });
+  const configs: any[] = [];
+  vi.spyOn(inngest, 'createFunction').mockImplementation(((config: any, ...rest: any[]) => {
+    configs.push(config);
+    return { id: config.id, rest } as any;
+  }) as any);
+
+  const { createWorkflow, createStep } = init(inngest);
+  const step = createStep({
+    id: 'step1',
+    inputSchema: z.object({ value: z.string() }),
+    outputSchema: z.object({ value: z.string() }),
+    execute: async ({ inputData }) => inputData,
+  });
+  const workflow = createWorkflow({
+    id: workflowId,
+    inputSchema: z.object({ value: z.string() }),
+    outputSchema: z.object({ value: z.string() }),
+    steps: [step],
+    ...opts,
+  } as any)
+    .then(step)
+    .commit();
+
+  return { workflow: workflow as any, configs };
+}
+
+describe('inngest cancel event scoping', () => {
+  it('scopes cancellation to the run named by the cancel event', () => {
+    const { workflow, configs } = createFunctionConfigs('scoped-workflow');
+    workflow.getFunction();
+
+    const config = configs.find(c => c.id === 'workflow.scoped-workflow');
+    expect(config).toBeDefined();
+    expect(config.cancelOn).toEqual([{ event: 'cancel.workflow.scoped-workflow', match: 'data.runId' }]);
+  });
+
+  it('matches on the same field the run sends when cancelling', async () => {
+    // `Run.cancel()` sends `{ name: 'cancel.workflow.<id>', data: { runId } }`,
+    // so the match expression has to point at `data.runId` for Inngest to pair
+    // the cancel event with the run's trigger event.
+    const { workflow, configs } = createFunctionConfigs('field-workflow');
+    workflow.getFunction();
+
+    const config = configs.find(c => c.id === 'workflow.field-workflow');
+    const [cancelOn] = config.cancelOn;
+    expect(cancelOn.match).toBe('data.runId');
+    expect(config.triggers).toEqual({ event: 'workflow.field-workflow' });
+  });
+});

--- a/workflows/inngest/src/execution-engine.ts
+++ b/workflows/inngest/src/execution-engine.ts
@@ -603,12 +603,18 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
         runId = invokeResp.runId;
         executionContext.state = invokeResp.result.state;
       } else {
+        // Name the child run on its trigger event. `cancelOn` matches a cancel
+        // event against `data.runId` on the trigger, so a nested run invoked
+        // without one cannot be cancelled by id — and it would take the
+        // unnamed-run branch, warning about advice the caller cannot act on.
+        const nestedRunId = randomUUID();
         const invokeResp = (await this.inngestStep.invoke(`workflow.${executionContext.workflowId}.step.${step.id}`, {
           function: step.getFunction(),
           data: {
             inputData,
             initialState: executionContext.state ?? {},
             requestContext: forwardedRequestContext,
+            runId: nestedRunId,
             outputOptions: { includeState: true },
             nestedWorkflowOutputMode: NESTED_WORKFLOW_OUTPUT_MODE.COMPACT,
             perStep,

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -356,8 +356,8 @@ export class InngestWorkflow<
         const shouldCompactNestedWorkflowOutput = nestedWorkflowOutputMode === NESTED_WORKFLOW_OUTPUT_MODE.COMPACT;
 
         if (!runId) {
-          // Reached only when something sends the trigger event directly instead
-          // of going through `createRun()`, which always supplies a run id.
+          // Reached when a trigger event arrives without a run id — an event sent
+          // directly rather than through `createRun()`, which always supplies one.
           // The id generated here never reaches the trigger event that `cancelOn`
           // matches against, so `cancel.workflow.${this.id}` cannot target this
           // run. Warn rather than reject: an unnamed run is still a valid way to

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -281,6 +281,9 @@ export class InngestWorkflow<
       {
         id: `workflow.${this.id}.cron`,
         retries: 0,
+        // Not scoped by `match` like the event-triggered function above: a cron
+        // trigger carries no event data to match a runId against, and the run
+        // is created inside the function, so the canceller has no id to name.
         cancelOn: [{ event: `cancel.workflow.${this.id}` }],
         triggers: { cron: this.cronConfig?.cron ?? '' },
         ...this.flowControlConfig,
@@ -316,7 +319,14 @@ export class InngestWorkflow<
       {
         id: `workflow.${this.id}`,
         retries: 0,
-        cancelOn: [{ event: `cancel.workflow.${this.id}` }],
+        // `match` scopes the cancellation to the run the cancel event names.
+        // Without it Inngest cancels every in-flight run of this function, and
+        // since all durable agents share one function, cancelling a single run
+        // tore down every other run in the deployment — only the targeted run's
+        // snapshot was marked canceled, so the rest simply vanished.
+        // Every event that triggers this function carries `data.runId`, and
+        // `Run.cancel()` sends the same field.
+        cancelOn: [{ event: `cancel.workflow.${this.id}`, match: 'data.runId' }],
         triggers: { event: `workflow.${this.id}` },
         // Spread flow control configuration
         ...this.flowControlConfig,

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -356,9 +356,19 @@ export class InngestWorkflow<
         const shouldCompactNestedWorkflowOutput = nestedWorkflowOutputMode === NESTED_WORKFLOW_OUTPUT_MODE.COMPACT;
 
         if (!runId) {
+          // Reached only when something sends the trigger event directly instead
+          // of going through `createRun()`, which always supplies a run id.
+          // The id generated here never reaches the trigger event that `cancelOn`
+          // matches against, so `cancel.workflow.${this.id}` cannot target this
+          // run. Warn rather than reject: an unnamed run is still a valid way to
+          // start a workflow, it just can't be cancelled by id afterwards.
           runId = await step.run(`workflow.${this.id}.runIdGen`, async () => {
             return randomUUID();
           });
+          this.logger.warn?.(
+            `Workflow "${this.id}" was triggered without a runId, so run "${runId}" cannot be cancelled by id. ` +
+              `Send \`data.runId\` on the trigger event (or start the run with createRun()) to make it cancellable.`,
+          );
         }
 
         // Create InngestPubSub instance. Publishes go through `inngest.realtime.publish()`


### PR DESCRIPTION
Fixes #19883

Supersedes #19882 (closed unmerged). Related: #19869 — this covers item 2 (cancel blast radius) only; cross-process `abort()` is #21009.

## What was happening

Cancelling a single workflow run cancelled unrelated runs.

Mastra registers one Inngest function per workflow, and it listened for a cancellation signal without saying *which* run the signal was about. Inngest interprets an unscoped cancellation as "cancel everything currently running for this function", so a request to stop one run stopped all of them.

Durable agents make this sharp: they all run through a single shared function, so aborting one agent conversation could kill every other conversation in the deployment. The damage was also invisible — only the run you asked to cancel got its snapshot marked canceled. The rest simply stopped, with no stored record explaining why.

## The fix

The cancellation signal already carries the id of the run it targets, and every event that starts a run carries that same id. Telling Inngest to match on it means a cancellation now pairs with exactly one run and leaves the others alone.

The cron-triggered variant of the function is deliberately left as-is: a scheduled trigger carries no event data to match against, and its run id is created inside the function, so there is nothing for a caller to name. That is noted in a comment where the decision lives.

## Scope

This addresses the run-scoping half of #19869. The other half — making `abort()` work when the caller and the worker are different processes — is a larger cross-package change and is not included here.

## Test plan

- New `workflows/inngest/src/cancel-scoping.test.ts` inspects the registered function config and asserts the cancellation is scoped to the run id, and that it matches the exact field the cancel path sends. Both tests fail without the change and pass with it.
- `@mastra/inngest` typecheck clean; cancel-scoping, serve, connect, and actor-signal suites pass (27 tests).

Relates to #19869 (does not fully close it — see Scope above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When one workflow run stops, only that run stops. Other runs that use the same workflow function continue running.

## Changes

- Scope event-triggered cancellation with `data.runId`.
- Warn when an event-triggered workflow starts without a `runId`.
- Assign generated `runId` values to nested workflow invocations.
- Keep cron-triggered cancellation unscoped because cron events do not provide run data.
- Add tests for cancellation matching, missing run IDs, and nested workflow run IDs.
- Add a patch changeset for `@mastra/inngest`.

This PR does not add cross-process `abort()` support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->