### PR TITLE
fix(editor): support caller-scoped Composio auth flows

### DIFF
--- a/.changeset/olive-nails-teach.md
+++ b/.changeset/olive-nails-teach.md
@@ -1,0 +1,5 @@
+---
+'@mastra/editor': patch
+---
+
+Fixed caller-scoped Composio connection management in stored agents.

--- a/.changeset/strict-pears-cough.md
+++ b/.changeset/strict-pears-cough.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed external Markdown links to open in a new tab.

--- a/docs/src/content/en/reference/editor/tool-provider.mdx
+++ b/docs/src/content/en/reference/editor/tool-provider.mdx
@@ -183,7 +183,32 @@ Composio tools use uppercase slug format: `GITHUB_CREATE_ISSUE`, `SLACK_SEND_MES
 
 ### Authentication
 
-Connections use per-author scope by default. Set `defaultScope: 'caller-supplied'` to bucket authorization by the caller identity resolved from request context.
+Connections use per-author scope by default. Set `defaultScope: 'caller-supplied'` to bucket authorization by the caller identity resolved from `MASTRA_RESOURCE_ID_KEY` in request context. Ensure each authenticated request provides a stable, unique resource ID. When using `MastraAuthWorkos`, configure `mapUserToResourceId` to set this value from the authenticated user.
+
+### Connection management tools
+
+Composio provides tools for starting and monitoring authorization from an agent chat. When `allowedToolkits` is set, include `composio` to make these tools available:
+
+```typescript title="src/mastra/index.ts"
+const editor = new MastraEditor({
+  toolProviders: {
+    composio: new ComposioToolProvider({
+      apiKey: process.env.COMPOSIO_API_KEY!,
+      allowedToolkits: ['composio', 'gmail'],
+      defaultScope: 'caller-supplied',
+    }),
+  },
+})
+```
+
+Add only the connection management tools that the agent needs:
+
+| Tool | Behavior |
+| - | - |
+| `COMPOSIO_MANAGE_CONNECTIONS` | Creates an authorization link in chat through a session owned by the caller. |
+| `COMPOSIO_WAIT_FOR_CONNECTIONS` | Waits for the caller to finish authorization before the agent continues. |
+
+`COMPOSIO_WAIT_FOR_CONNECTIONS` is optional. Without it, complete authorization and return to the chat. Then ask the agent to continue. The connected account remains associated with the caller resource ID for later requests.
 
 ---
 

--- a/packages/editor/src/providers/composio.test.ts
+++ b/packages/editor/src/providers/composio.test.ts
@@ -12,6 +12,7 @@ const { composioInstances, makeFakeComposio } = vi.hoisted(() => {
     hasProvider: boolean;
     toolkits: { get: ReturnType<typeof vi.fn>; getConnectedAccountInitiationFields: ReturnType<typeof vi.fn> };
     tools: { get: ReturnType<typeof vi.fn>; getRawComposioTools: ReturnType<typeof vi.fn> };
+    sessions: { create: ReturnType<typeof vi.fn> };
     connectedAccounts: {
       initiate: ReturnType<typeof vi.fn>;
       link: ReturnType<typeof vi.fn>;
@@ -30,6 +31,7 @@ const { composioInstances, makeFakeComposio } = vi.hoisted(() => {
       hasProvider: Boolean(opts.provider),
       toolkits: { get: vi.fn(), getConnectedAccountInitiationFields: vi.fn() },
       tools: { get: vi.fn(), getRawComposioTools: vi.fn() },
+      sessions: { create: vi.fn() },
       connectedAccounts: { initiate: vi.fn(), link: vi.fn(), get: vi.fn(), list: vi.fn(), delete: vi.fn() },
       authConfigs: { list: vi.fn() },
     };
@@ -332,6 +334,163 @@ describe('ComposioToolProvider — resolveTools', () => {
     });
 
     expect(mastra.tools.get.mock.calls[0]![0]).toBe('author_owner');
+  });
+
+  it('resolves connection-management tools from a caller-scoped session and filters the session catalog', async () => {
+    const integration = new ComposioToolProvider({ apiKey: 'k' });
+
+    await integration.resolveToolsVNext({ toolSlugs: ['a'], toolMeta: {}, connectionId: 'ca_1' });
+    const mastra = getMastraInstance();
+    mastra.tools.get.mockClear();
+
+    const manageTool = { id: 'COMPOSIO_MANAGE_CONNECTIONS', outputSchema: { type: 'object' } };
+    const sessionTools = vi.fn().mockResolvedValue({
+      COMPOSIO_MANAGE_CONNECTIONS: manageTool,
+      COMPOSIO_WAIT_FOR_CONNECTIONS: { id: 'COMPOSIO_WAIT_FOR_CONNECTIONS' },
+      COMPOSIO_SEARCH_TOOLS: { id: 'COMPOSIO_SEARCH_TOOLS' },
+    });
+    mastra.sessions.create.mockResolvedValue({ tools: sessionTools });
+
+    const result = await integration.resolveToolsVNext({
+      toolSlugs: ['COMPOSIO_MANAGE_CONNECTIONS'],
+      toolMeta: {
+        COMPOSIO_MANAGE_CONNECTIONS: { toolkit: 'composio' },
+        GMAIL_FETCH_EMAILS: { toolkit: 'gmail' },
+        GITHUB_GET_REPOSITORY: { toolkit: 'github' },
+      },
+      connectionId: 'tenant_7',
+      authorId: 'agent_author_should_not_win',
+      scope: 'caller-supplied',
+      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'tenant_7' },
+    });
+
+    expect(mastra.tools.get).not.toHaveBeenCalled();
+    expect(mastra.sessions.create).toHaveBeenCalledWith('tenant_7', {
+      toolkits: ['gmail', 'github'],
+      manageConnections: { enable: true, waitForConnections: true },
+      sandbox: { enable: false },
+    });
+    expect(sessionTools).toHaveBeenCalledOnce();
+    expect(Object.keys(result)).toEqual(['COMPOSIO_MANAGE_CONNECTIONS']);
+    expect((result.COMPOSIO_MANAGE_CONNECTIONS as unknown as typeof manageTool).outputSchema).toBeUndefined();
+  });
+
+  it('creates distinct sessions for two callers using the same provider', async () => {
+    const integration = new ComposioToolProvider({ apiKey: 'k' });
+
+    await integration.resolveToolsVNext({ toolSlugs: ['a'], toolMeta: {}, connectionId: 'ca_1' });
+    const mastra = getMastraInstance();
+    mastra.tools.get.mockClear();
+
+    const sessionToolsByCaller: Array<ReturnType<typeof vi.fn>> = [];
+    mastra.sessions.create.mockImplementation(async (callerPrincipalId: string) => {
+      const tools = vi.fn().mockResolvedValue({
+        COMPOSIO_MANAGE_CONNECTIONS: { id: 'COMPOSIO_MANAGE_CONNECTIONS', callerPrincipalId },
+      });
+      sessionToolsByCaller.push(tools);
+      return { tools };
+    });
+
+    const resolveForCaller = (callerPrincipalId: string) =>
+      integration.resolveToolsVNext({
+        toolSlugs: ['COMPOSIO_MANAGE_CONNECTIONS'],
+        toolMeta: { COMPOSIO_MANAGE_CONNECTIONS: { toolkit: 'composio' } },
+        connectionId: callerPrincipalId,
+        authorId: callerPrincipalId,
+        scope: 'caller-supplied',
+        requestContext: { [MASTRA_RESOURCE_ID_KEY]: callerPrincipalId },
+      });
+
+    const [callerATools, callerBTools] = await Promise.all([
+      resolveForCaller('caller_a'),
+      resolveForCaller('caller_b'),
+    ]);
+
+    expect(mastra.sessions.create.mock.calls.map(call => call[0])).toEqual(['caller_a', 'caller_b']);
+    expect(sessionToolsByCaller).toHaveLength(2);
+    expect(sessionToolsByCaller[0]).not.toBe(sessionToolsByCaller[1]);
+    expect(callerATools.COMPOSIO_MANAGE_CONNECTIONS).not.toBe(callerBTools.COMPOSIO_MANAGE_CONNECTIONS);
+    expect(mastra.tools.get).not.toHaveBeenCalled();
+  });
+
+  it('merges direct and session tools and applies overrides to both paths', async () => {
+    const integration = new ComposioToolProvider({ apiKey: 'k' });
+
+    await integration.resolveToolsVNext({ toolSlugs: ['a'], toolMeta: {}, connectionId: 'ca_1' });
+    const mastra = getMastraInstance();
+    mastra.tools.get.mockClear();
+
+    const gmailTool = { id: 'GMAIL_FETCH_EMAILS', description: 'gmail original', outputSchema: {} };
+    const waitTool = {
+      id: 'COMPOSIO_WAIT_FOR_CONNECTIONS',
+      description: 'wait original',
+      outputSchema: {},
+    };
+    mastra.tools.get.mockResolvedValue({ GMAIL_FETCH_EMAILS: gmailTool });
+    mastra.sessions.create.mockResolvedValue({
+      tools: vi.fn().mockResolvedValue({ COMPOSIO_WAIT_FOR_CONNECTIONS: waitTool }),
+    });
+
+    const result = await integration.resolveToolsVNext({
+      toolSlugs: ['GMAIL_FETCH_EMAILS', 'COMPOSIO_WAIT_FOR_CONNECTIONS'],
+      toolMeta: {
+        GMAIL_FETCH_EMAILS: { toolkit: 'gmail', description: 'gmail override' },
+        COMPOSIO_WAIT_FOR_CONNECTIONS: { toolkit: 'composio', description: 'wait override' },
+      },
+      connectionId: 'ca_1',
+      authorId: 'author_1',
+      scope: 'per-author',
+    });
+
+    expect(mastra.tools.get).toHaveBeenCalledWith('author_1', { tools: ['GMAIL_FETCH_EMAILS'] }, expect.any(Object));
+    expect(mastra.sessions.create).toHaveBeenCalledWith('author_1', {
+      toolkits: ['gmail'],
+      manageConnections: { enable: true, waitForConnections: true },
+      sandbox: { enable: false },
+    });
+    expect(Object.keys(result)).toEqual(['GMAIL_FETCH_EMAILS', 'COMPOSIO_WAIT_FOR_CONNECTIONS']);
+    expect(gmailTool).toMatchObject({ description: 'gmail override', outputSchema: undefined });
+    expect(waitTool).toMatchObject({ description: 'wait override', outputSchema: undefined });
+
+    const modifiers = mastra.tools.get.mock.calls[0]![2] as {
+      beforeExecute: (a: { params: { connectedAccountId?: string } }) => unknown;
+    };
+    const params: { connectedAccountId?: string } = {};
+    modifiers.beforeExecute({ params });
+    expect(params.connectedAccountId).toBe('ca_1');
+  });
+
+  it.each([
+    {
+      name: 'session creation',
+      arrange: (mastra: FakeComposioInstance) =>
+        mastra.sessions.create.mockRejectedValue(new Error('session unavailable')),
+    },
+    {
+      name: 'session tool resolution',
+      arrange: (mastra: FakeComposioInstance) =>
+        mastra.sessions.create.mockResolvedValue({
+          tools: vi.fn().mockRejectedValue(new Error('session unavailable')),
+        }),
+    },
+  ])('surfaces $name errors without falling back to direct tools', async ({ arrange }) => {
+    const integration = new ComposioToolProvider({ apiKey: 'k' });
+
+    await integration.resolveToolsVNext({ toolSlugs: ['a'], toolMeta: {}, connectionId: 'ca_1' });
+    const mastra = getMastraInstance();
+    mastra.tools.get.mockClear();
+    arrange(mastra);
+
+    await expect(
+      integration.resolveToolsVNext({
+        toolSlugs: ['COMPOSIO_MANAGE_CONNECTIONS'],
+        toolMeta: { COMPOSIO_MANAGE_CONNECTIONS: { toolkit: 'composio' } },
+        connectionId: 'tenant_7',
+        authorId: 'tenant_7',
+        scope: 'caller-supplied',
+      }),
+    ).rejects.toThrow('session unavailable');
+    expect(mastra.tools.get).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/editor/src/providers/composio.ts
+++ b/packages/editor/src/providers/composio.ts
@@ -35,16 +35,17 @@ export interface ComposioToolProviderConfig extends BaseToolProviderOptions {
 
 const COMPOSIO_PROVIDER_ID = 'composio' as const;
 const DEFAULT_INTERNAL_USER_ID = 'default';
+const COMPOSIO_CONNECTION_MANAGEMENT_TOOLS = new Set(['COMPOSIO_MANAGE_CONNECTIONS', 'COMPOSIO_WAIT_FOR_CONNECTIONS']);
 
 /**
  * Composio implementation of the {@link BaseToolProvider} contract.
  *
  * Discovery (`listAllToolkits`, `listAllTools`) uses the raw Composio
  * client. Runtime (`resolveToolsVNext`) uses {@link MastraProvider} so resolved
- * tools are already in `createTool()` shape; each tool gets a
- * `beforeExecute` modifier that injects
- * `connectedAccountId = connectionId`, and `outputSchema` is cleared
- * because Composio returns union schemas that Mastra's runtime rejects.
+ * tools are already in `createTool()` shape. Ordinary tools use Composio's
+ * direct-tools API, while connection-management tools use a caller-scoped
+ * Tool Router session. `outputSchema` is cleared because Composio returns
+ * union schemas that Mastra's runtime rejects.
  *
  * Allowlist filtering is layered by {@link BaseToolProvider}; this class
  * never reads `allowedToolkits` / `allowedTools` directly.
@@ -165,41 +166,73 @@ export class ComposioToolProvider extends BaseToolProvider {
   async resolveToolsVNext(opts: ResolveToolsOpts): Promise<Record<string, ToolAction<any, any, any>>> {
     if (opts.toolSlugs.length === 0) return {};
 
-    // For author-bound connections, the runtime fan-out passes the agent's
-    // author id explicitly. Use it as the Composio user bucket so the pin
-    // resolves for any invoker (not just the original author).
-    const internalUserId =
-      opts.authorId && opts.authorId.length > 0 ? opts.authorId : resolveInternalUserId(opts.requestContext);
+    // Caller-supplied scope is always owned by the authenticated caller's
+    // resource id. Author-bound connections use the agent author's id so the
+    // same pin resolves for every invoker of that agent.
+    const callerPrincipalId =
+      opts.scope === 'caller-supplied'
+        ? resolveInternalUserId(opts.requestContext)
+        : opts.authorId && opts.authorId.length > 0
+          ? opts.authorId
+          : resolveInternalUserId(opts.requestContext);
     const composio = this.getMastraClient();
+    const sessionToolSlugs = opts.toolSlugs.filter(slug => COMPOSIO_CONNECTION_MANAGEMENT_TOOLS.has(slug));
+    const directToolSlugs = opts.toolSlugs.filter(slug => !COMPOSIO_CONNECTION_MANAGEMENT_TOOLS.has(slug));
+    const mastraTools: MastraToolCollection = {};
 
-    const modifiers = {
-      // `connectedAccountId` is not threaded through Composio's `execute`
-      // option bag in @composio/mastra; the only documented per-call hook
-      // is `beforeExecute`, which receives the params object that flows
-      // into the API call. Mutating `params.connectedAccountId` routes
-      // the call to a specific account.
-      beforeExecute: ({ params }: { params: { connectedAccountId?: string; userId?: string } }) => {
-        // Under `caller-supplied` scope the user bucket (`internalUserId`,
-        // resolved from the host app's resourceId) already scopes the call to
-        // the right tenant. Pinning a specific `connectedAccountId` would defeat
-        // Composio's per-user-bucket auto-resolve, so we let Composio pick the
-        // connected account within the bucket instead of forcing one.
-        if (opts.scope !== 'caller-supplied') {
-          params.connectedAccountId = opts.connectionId;
-        }
-        return params;
-      },
-    };
+    if (directToolSlugs.length > 0) {
+      const modifiers = {
+        // `connectedAccountId` is not threaded through Composio's `execute`
+        // option bag in @composio/mastra; the only documented per-call hook
+        // is `beforeExecute`, which receives the params object that flows
+        // into the API call. Mutating `params.connectedAccountId` routes
+        // the call to a specific account.
+        beforeExecute: ({ params }: { params: { connectedAccountId?: string; userId?: string } }) => {
+          // Under `caller-supplied` scope the user bucket (`callerPrincipalId`,
+          // resolved from the host app's resourceId) already scopes the call to
+          // the right tenant. Pinning a specific `connectedAccountId` would defeat
+          // Composio's per-user-bucket auto-resolve, so we let Composio pick the
+          // connected account within the bucket instead of forcing one.
+          if (opts.scope !== 'caller-supplied') {
+            params.connectedAccountId = opts.connectionId;
+          }
+          return params;
+        },
+      };
 
-    const mastraTools = (await composio.tools.get(
-      internalUserId,
-      { tools: opts.toolSlugs },
-      modifiers,
-    )) as MastraToolCollection;
+      Object.assign(
+        mastraTools,
+        (await composio.tools.get(callerPrincipalId, { tools: directToolSlugs }, modifiers)) as MastraToolCollection,
+      );
+    }
+
+    if (sessionToolSlugs.length > 0) {
+      const selectedToolkits = [
+        ...new Set(
+          Object.values(opts.toolMeta)
+            .map(meta => meta.toolkit)
+            .filter(
+              (toolkit): toolkit is string =>
+                typeof toolkit === 'string' && toolkit.toLowerCase() !== COMPOSIO_PROVIDER_ID,
+            ),
+        ),
+      ];
+      const session = await composio.sessions.create(callerPrincipalId, {
+        ...(selectedToolkits.length > 0 ? { toolkits: selectedToolkits } : {}),
+        manageConnections: { enable: true, waitForConnections: true },
+        sandbox: { enable: false },
+      });
+      const sessionTools = (await session.tools()) as MastraToolCollection;
+
+      for (const slug of sessionToolSlugs) {
+        const tool = sessionTools[slug];
+        if (tool) mastraTools[slug] = tool;
+      }
+    }
 
     const result: Record<string, ToolAction<any, any, any>> = {};
 
-    for (const [key, tool] of Object.entries(mastraTools ?? {})) {
+    for (const [key, tool] of Object.entries(mastraTools)) {
       if (!tool) continue;
       const slug = (tool as { id?: string }).id ?? key;
 

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
@@ -53,4 +53,22 @@ describe('MarkdownRenderer', () => {
     expect(inline.querySelector('.shiki-token')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Copy to clipboard' })).toBeNull();
   });
+
+  it('opens external links in a new tab without granting opener access', () => {
+    render(<MarkdownRenderer>{'[Authorize Gmail](https://connect.composio.dev/link)'}</MarkdownRenderer>);
+
+    const link = screen.getByRole<HTMLAnchorElement>('link', { name: 'Authorize Gmail' });
+
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toBe('noopener noreferrer');
+  });
+
+  it('keeps internal links in the current tab', () => {
+    render(<MarkdownRenderer>{'[Agent settings](/agents/settings)'}</MarkdownRenderer>);
+
+    const link = screen.getByRole<HTMLAnchorElement>('link', { name: 'Agent settings' });
+
+    expect(link.target).toBe('');
+    expect(link.rel).toBe('');
+  });
 });

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
@@ -96,11 +96,21 @@ const COMPONENTS: Components = {
       {children}
     </strong>
   ),
-  a: ({ children, ...props }) => (
-    <a className="underline underline-offset-2" {...props}>
-      {children}
-    </a>
-  ),
+  a: ({ children, href, ...props }) => {
+    const isExternal = /^https?:\/\//i.test(href ?? '');
+
+    return (
+      <a
+        className="underline underline-offset-2"
+        href={href}
+        {...props}
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noopener noreferrer' : undefined}
+      >
+        {children}
+      </a>
+    );
+  },
   blockquote: ({ children, ...props }) => (
     <blockquote className="border-neutral6 border-l-2 pl-4" {...props}>
       {children}


### PR DESCRIPTION
Fixes #20951.

Composio connection-management tools were being resolved through the direct-tools API, so in-chat authentication failed because those tools require a Tool Router session. This routes manage/wait tools through a fresh session owned by the authenticated caller, filters the session catalog to explicitly requested tools, and preserves direct resolution for ordinary toolkit tools. External Markdown authorization links in Agent Builder now open in a popup window so OAuth does not replace Studio, with a new-tab fallback when the browser blocks popups. The ToolProvider reference documents caller identity, allowlisting, and the optional wait flow.

Before, connection management followed the ordinary direct-tools path:

```ts
await composio.tools.get(callerId, { tools: ['COMPOSIO_MANAGE_CONNECTIONS'] });
```

Now it is resolved from a caller-scoped session while ordinary tools continue using the direct path:

```ts
const session = await composio.sessions.create(callerId, {
  manageConnections: { enable: true, waitForConnections: true },
});
await session.tools();
```

Tests: full @mastra/editor, @mastra/playground-ui, and internal playground test suites, package typechecks, package builds, oxlint, playground-ui lint, documentation formatting and prose checks, documentation validation, and the documentation production build. Also manually verified the caller-supplied Agent Builder flow against Composio by completing Gmail authorization and executing a Gmail tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Composio now keeps each caller’s connection information separate. Users can authorize integrations in the editor without leaving Studio. Regular tools continue to work as before.

## Changes

- Route connection-management tools through caller-scoped Tool Router sessions.
- Isolate sessions by caller, author, or request context.
- Preserve only the tools requested by the caller.
- Keep ordinary Composio tools on the direct-resolution path.
- Merge session and direct tools while preserving metadata and execution modifiers.
- Propagate session creation and resolution errors without falling back to direct tools.
- Open Agent Builder external Markdown links in a popup window, with a secure new-tab fallback.
- Document caller-supplied Composio configuration and connection-management flows.
- Add tests for session isolation, tool resolution, error handling, and Markdown link behavior.
- Add patch changesets for `@mastra/editor` and `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
