### PR TITLE
fix(playground): open agent auth links in popup windows

### DIFF
--- a/.changeset/strict-pears-cough.md
+++ b/.changeset/strict-pears-cough.md
@@ -3,3 +3,7 @@
 ---
 
 Added configurable popup-window handling for external Markdown links.
+
+```tsx
+<MarkdownRenderer externalLinkTarget="window">{'[Authorize](https://example.com/authorize)'}</MarkdownRenderer>
+```

--- a/.changeset/strict-pears-cough.md
+++ b/.changeset/strict-pears-cough.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed external Markdown links to open in a new tab.
+Added configurable popup-window handling for external Markdown links.

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { TooltipProvider } from '../Tooltip';
@@ -21,6 +21,7 @@ vi.mock('@/ds/components/CodeEditor/highlight', () => ({
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe('MarkdownRenderer', () => {
@@ -59,6 +60,40 @@ describe('MarkdownRenderer', () => {
 
     const link = screen.getByRole<HTMLAnchorElement>('link', { name: 'Authorize Gmail' });
 
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toBe('noopener noreferrer');
+  });
+
+  it('requests a separate browser window for external links when configured', () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(window);
+    render(
+      <MarkdownRenderer externalLinkTarget="window">
+        {'[Authorize Gmail](https://connect.composio.dev/link)'}
+      </MarkdownRenderer>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Authorize Gmail' }));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://connect.composio.dev/link',
+      '_blank',
+      expect.stringContaining('popup=yes'),
+    );
+  });
+
+  it('falls back to a new tab when the browser blocks the requested window', () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+    render(
+      <MarkdownRenderer externalLinkTarget="window">
+        {'[Authorize Gmail](https://connect.composio.dev/link)'}
+      </MarkdownRenderer>,
+    );
+
+    const link = screen.getByRole<HTMLAnchorElement>('link', { name: 'Authorize Gmail' });
+    const defaultAllowed = fireEvent.click(link);
+
+    expect(openSpy).toHaveBeenCalledOnce();
+    expect(defaultAllowed).toBe(true);
     expect(link.target).toBe('_blank');
     expect(link.rel).toBe('noopener noreferrer');
   });

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
@@ -7,15 +7,19 @@ import { Code } from '@/ds/components/Code';
 import { CopyButton } from '@/ds/components/CopyButton';
 import { cn } from '@/lib/utils';
 
+export type MarkdownExternalLinkTarget = 'tab' | 'window';
+
 export type MarkdownRendererProps = {
   children: string;
+  externalLinkTarget?: MarkdownExternalLinkTarget;
 };
 
-export function MarkdownRenderer({ children }: MarkdownRendererProps) {
+export function MarkdownRenderer({ children, externalLinkTarget = 'tab' }: MarkdownRendererProps) {
   const processedText = children.replace(/\\n/g, '\n');
+  const components = externalLinkTarget === 'window' ? WINDOW_COMPONENTS : COMPONENTS;
 
   return (
-    <Markdown remarkPlugins={[remarkGfm]} components={COMPONENTS} className="space-y-3">
+    <Markdown remarkPlugins={[remarkGfm]} components={components} className="space-y-3">
       {processedText}
     </Markdown>
   );
@@ -64,6 +68,48 @@ function childrenTakeAllStringContents(element: any): string {
   return '';
 }
 
+const POPUP_WINDOW_FEATURES = 'popup=yes,width=720,height=800,resizable=yes,scrollbars=yes';
+
+const createMarkdownLink =
+  (externalLinkTarget: MarkdownExternalLinkTarget): NonNullable<Components['a']> =>
+  ({ children, href, onClick, ...props }) => {
+    const isExternal = /^https?:\/\//i.test(href ?? '');
+    const handleClick: React.MouseEventHandler<HTMLAnchorElement> = event => {
+      onClick?.(event);
+      if (
+        event.defaultPrevented ||
+        !isExternal ||
+        externalLinkTarget !== 'window' ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+
+      const popup = window.open(href, '_blank', POPUP_WINDOW_FEATURES);
+      if (!popup) return;
+
+      popup.opener = null;
+      event.preventDefault();
+    };
+
+    return (
+      <a
+        className="underline underline-offset-2"
+        href={href}
+        {...props}
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noopener noreferrer' : undefined}
+        onClick={handleClick}
+      >
+        {children}
+      </a>
+    );
+  };
+
 // Create component wrappers with className
 const COMPONENTS: Components = {
   h1: ({ children, ...props }) => (
@@ -96,21 +142,7 @@ const COMPONENTS: Components = {
       {children}
     </strong>
   ),
-  a: ({ children, href, ...props }) => {
-    const isExternal = /^https?:\/\//i.test(href ?? '');
-
-    return (
-      <a
-        className="underline underline-offset-2"
-        href={href}
-        {...props}
-        target={isExternal ? '_blank' : undefined}
-        rel={isExternal ? 'noopener noreferrer' : undefined}
-      >
-        {children}
-      </a>
-    );
-  },
+  a: createMarkdownLink('tab'),
   blockquote: ({ children, ...props }) => (
     <blockquote className="border-neutral6 border-l-2 pl-4" {...props}>
       {children}
@@ -181,6 +213,11 @@ const COMPONENTS: Components = {
     </p>
   ),
   hr: ({ ...props }) => <hr className="border-neutral6/20" {...props} />,
+};
+
+const WINDOW_COMPONENTS: Components = {
+  ...COMPONENTS,
+  a: createMarkdownLink('window'),
 };
 
 export default MarkdownRenderer;

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/messages.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/messages.test.tsx
@@ -250,6 +250,25 @@ describe('MessageRow dynamic-tool rendering', () => {
     });
   });
 
+  describe('when system text contains an external link', () => {
+    it('keeps the default new-tab target', () => {
+      const { getByRole } = renderMessage({
+        id: 'system-link-1',
+        role: 'system',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: '[System reference](https://example.com/reference)' }],
+        },
+      } as unknown as MastraDBMessage);
+
+      const link = getByRole('link', { name: 'System reference' });
+
+      expect(link.getAttribute('target')).toBe('_blank');
+      expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+    });
+  });
+
   it('routes assistant text through the shared MessageText error-prefix handling', () => {
     const { container } = renderMessage(buildMessage([{ type: 'text', text: 'Error: it broke' } as ToolPart]));
 

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/messages.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/messages.test.tsx
@@ -132,6 +132,7 @@ describe('MessageRow dynamic-tool rendering', () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
   });
 
   it('renders persisted signal user text as a user message', () => {
@@ -228,6 +229,25 @@ describe('MessageRow dynamic-tool rendering', () => {
     const { container } = renderMessage(buildMessage([{ type: 'text', text: 'reply **bold**' } as ToolPart]));
 
     expect(container.querySelector('strong')?.textContent).toBe('bold');
+  });
+
+  describe('when assistant text contains an external authorization link', () => {
+    it('requests a separate browser window', () => {
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(window);
+      const part: MastraMessagePart = {
+        type: 'text',
+        text: '[Authorize Gmail](https://connect.composio.dev/link)',
+      };
+
+      const { getByRole } = renderMessage(buildMessage([part]));
+      fireEvent.click(getByRole('link', { name: 'Authorize Gmail' }));
+
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://connect.composio.dev/link',
+        '_blank',
+        expect.stringContaining('popup=yes'),
+      );
+    });
   });
 
   it('routes assistant text through the shared MessageText error-prefix handling', () => {

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
@@ -284,7 +284,7 @@ export const Txtmessage = ({
         className="text-neutral4 max-w-[80%] [&_li]:!my-0 [&_li]:!leading-normal [&_ol]:!space-y-1 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_ul]:!space-y-1"
         as="div"
       >
-        <MessageText text={txt} metadata={metadata} externalLinkTarget="window" />
+        <MessageText text={txt} metadata={metadata} externalLinkTarget={role === 'assistant' ? 'window' : undefined} />
       </Txt>
     );
   }

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
@@ -284,7 +284,7 @@ export const Txtmessage = ({
         className="text-neutral4 max-w-[80%] [&_li]:!my-0 [&_li]:!leading-normal [&_ol]:!space-y-1 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_ul]:!space-y-1"
         as="div"
       >
-        <MessageText text={txt} metadata={metadata} />
+        <MessageText text={txt} metadata={metadata} externalLinkTarget="window" />
       </Txt>
     );
   }

--- a/packages/playground/src/lib/ai-ui/messages/renderers/message-text.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/message-text.tsx
@@ -1,5 +1,5 @@
 import { Badge } from '@mastra/playground-ui/components/Badge';
-import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
+import { MarkdownRenderer, type MarkdownExternalLinkTarget } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
@@ -12,6 +12,7 @@ import { TripwireNotice } from '../tripwire-notice';
 export interface MessageTextProps {
   text: string;
   metadata: MessageMetadata | undefined;
+  externalLinkTarget?: MarkdownExternalLinkTarget;
 }
 
 /**
@@ -19,7 +20,7 @@ export interface MessageTextProps {
  * error/completion handling previously in `ErrorAwareText` (which read part
  * metadata).
  */
-export const MessageText = ({ text, metadata }: MessageTextProps) => {
+export const MessageText = ({ text, metadata, externalLinkTarget }: MessageTextProps) => {
   const [collapsedCompletionCheck, setCollapsedCompletionCheck] = useState(false);
 
   if (metadata?.status === 'tripwire') {
@@ -54,7 +55,7 @@ export const MessageText = ({ text, metadata }: MessageTextProps) => {
         </button>
         {!collapsedCompletionCheck && (
           <Notice variant="info" title={taskCompleteResult?.passed ? 'Complete' : 'Not Complete'}>
-            <MarkdownRenderer>{text}</MarkdownRenderer>
+            <MarkdownRenderer externalLinkTarget={externalLinkTarget}>{text}</MarkdownRenderer>
           </Notice>
         )}
       </div>
@@ -77,5 +78,5 @@ export const MessageText = ({ text, metadata }: MessageTextProps) => {
     );
   }
 
-  return <MarkdownRenderer>{text}</MarkdownRenderer>;
+  return <MarkdownRenderer externalLinkTarget={externalLinkTarget}>{text}</MarkdownRenderer>;
 };


### PR DESCRIPTION
Follow-up to #21004.

Agent Builder authorization links currently open in a new tab, which preserves Studio but separates the OAuth flow from the chat. This adds an opt-in popup mode to the shared Markdown renderer and enables it only for Agent Builder assistant messages. If the browser blocks the popup, the existing secure new-tab behavior remains available. Internal links and other Markdown renderer consumers are unchanged.

Before, Agent Builder used the default external-link behavior:

```tsx
<MessageText text={text} metadata={metadata} />
```

Now its assistant messages explicitly request a popup window:

```tsx
<MessageText text={text} metadata={metadata} externalLinkTarget="window" />
```

Tests: 779 @mastra/playground-ui tests and 1,820 @internal/playground tests passed, with 2 existing skips. Both package typechecks and the playground dependency-graph build passed. Focused regression coverage verifies the popup request, secure blocked-popup fallback, and Agent Builder integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Agent Builder authorization links now open in a popup. The Studio chat stays visible, and blocked popups use a secure new-tab fallback.

## Changes

- Added the optional `externalLinkTarget` prop to `MarkdownRenderer` and `MessageText`.
- Added opt-in popup behavior for external Markdown links.
- Enabled popup links for Agent Builder assistant messages only.
- Preserved existing behavior for internal links and other renderer consumers.
- Preserved modified-click, non-left-click, prevented-event, and popup-blocked handling.
- Added regression tests for popup requests, blocked-popup fallback, and Agent Builder integration.
- Updated the changeset description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->