### PR TITLE
fix(code-sdk): unwrap better-auth user shape in tenant credential resolution

### DIFF
--- a/.changeset/code-sdk-better-auth-tenant.md
+++ b/.changeset/code-sdk-better-auth-tenant.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed tenant credential resolution when the request context carries a better-auth `{ session, user }` wrapper. Background Factory runs no longer fail closed with "Not logged in" despite valid stored credentials. Fixes [#20887](https://github.com/mastra-ai/mastra/issues/20887).

--- a/mastracode/sdk/src/agents/credential-resolver.test.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.test.ts
@@ -77,10 +77,52 @@ describe('credential store provider registry', () => {
     expect(resolveTenantFromRequestContext(ctx)).toEqual({ orgId: undefined, userId: 'prov_2' });
   });
 
+  it('reads a session-shaped user, whose org lives on the session half', () => {
+    const ctx = new RequestContext();
+    ctx.set('user', { session: { activeOrganizationId: 'org_1' }, user: { id: 'prov_3' } });
+    expect(resolveTenantFromRequestContext(ctx)).toEqual({ orgId: 'org_1', userId: 'prov_3' });
+  });
+
+  it('takes a session-shaped user org from the session half only, never the inner user', () => {
+    const ctx = new RequestContext();
+    ctx.set('user', { session: {}, user: { id: 'prov_4', organizationId: 'org_9' } });
+    // `toFactoryAuthUser` in `@mastra/factory` reads the session half and nothing
+    // else. Falling back to the inner user here would resolve a tenant the
+    // Factory refuses, and the two would disagree about who the caller is.
+    expect(resolveTenantFromRequestContext(ctx)).toEqual({ orgId: undefined, userId: 'prov_4' });
+  });
+
   it('ignores malformed user values', () => {
     const ctx = new RequestContext();
     ctx.set('user', 'not-a-user');
     expect(resolveTenantFromRequestContext(ctx)).toBeUndefined();
+  });
+
+  it('refuses a tenant whose resolved user id is not a string', () => {
+    const ctx = new RequestContext();
+    ctx.set('user', { session: { activeOrganizationId: 'org_1' }, user: { id: 7 } });
+    expect(resolveTenantFromRequestContext(ctx)).toBeUndefined();
+  });
+
+  it('refuses a tenant whose resolved org id is not a string', () => {
+    const ctx = new RequestContext();
+    ctx.set('user', { session: { activeOrganizationId: 7 }, user: { id: 'prov_5' } });
+    expect(resolveTenantFromRequestContext(ctx)).toBeUndefined();
+  });
+
+  it('resolves the tenant store for a session-shaped authenticated user', () => {
+    const store = fakeStore({});
+    let seenTenant: unknown;
+    setCredentialStoreProvider(tenant => {
+      seenTenant = tenant;
+      return store;
+    });
+
+    const ctx = new RequestContext();
+    ctx.set('user', { session: { activeOrganizationId: 'org_ba' }, user: { id: 'user_ba' } });
+
+    expect(resolveCredentialStore(ctx)).toBe(store);
+    expect(seenTenant).toEqual({ orgId: 'org_ba', userId: 'user_ba' });
   });
 });
 

--- a/mastracode/sdk/src/agents/credential-resolver.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.ts
@@ -69,16 +69,42 @@ interface RequestContextUser {
 }
 
 /**
+ * Session-shaped `authenticateToken` results (better-auth) arrive as a wrapper
+ * whose active org lives on the session half rather than on the user.
+ */
+interface RequestContextSession {
+  user?: RequestContextUser;
+  session?: { activeOrganizationId?: string };
+}
+
+/**
  * Derive the calling tenant from a request context, if an authenticated web
  * user was stashed on it. Mirrors the web layer's stable-id resolution
  * (`workosId` falling back to the provider `id`).
+ *
+ * The value under `user` is whatever the active auth provider's
+ * `authenticateToken` returned, so its shape follows the provider: a flat user
+ * (WorkOS) or a `{ session, user }` wrapper (better-auth). Reading only the
+ * flat shape resolves no tenant at all for the wrapper, which in deployed mode
+ * fails closed to an empty credential store.
  */
 export function resolveTenantFromRequestContext(requestContext?: RequestContext): CredentialTenant | undefined {
-  const user = requestContext?.get('user') as RequestContextUser | undefined;
-  if (!user || typeof user !== 'object') return undefined;
+  const raw = requestContext?.get('user') as (RequestContextUser & RequestContextSession) | undefined;
+  if (!raw || typeof raw !== 'object') return undefined;
+
+  // Precedence matches `toFactoryAuthUser` in `@mastra/factory`: a wrapper's org
+  // comes from the session half only, never from the inner user. The two parsers
+  // cannot share code across the package boundary, so they must agree by rule.
+  const wrapped = Boolean(raw.user && typeof raw.user === 'object' && raw.session && typeof raw.session === 'object');
+  const user = wrapped ? (raw.user as RequestContextUser) : raw;
+  const orgId = wrapped ? raw.session?.activeOrganizationId : user.organizationId;
   const userId = user.workosId ?? user.id;
-  if (!userId) return undefined;
-  return { orgId: user.organizationId, userId };
+  // The slot holds whatever the provider returned, so the declared string
+  // types are hopes, not guarantees. A non-string id must refuse the tenant
+  // (fail closed), not flow onward as a mistyped key.
+  if (typeof userId !== 'string' || !userId) return undefined;
+  if (orgId !== undefined && typeof orgId !== 'string') return undefined;
+  return { orgId, userId };
 }
 
 /**


### PR DESCRIPTION
Fixes #20887

`@mastra/auth-better-auth` returns `{ session, user }` from `authenticateToken`, and `@mastra/server` stores that wrapper under the request context `user` slot. `resolveTenantFromRequestContext` only read the flat WorkOS shape (`workosId`/`id`/`organizationId` on the top level), so better-auth callers resolved no tenant and deployed mode failed closed to an empty credential store — background Factory runs then died with "Not logged in" despite valid stored credentials.

This teaches the code-sdk resolver the same two shapes `toFactoryAuthUser` in `@mastra/factory` already understands: flat users stay as-is; session-shaped wrappers take the id from the inner user and the org from `session.activeOrganizationId` only (never the inner user's `organizationId`), so the two packages cannot disagree about who the caller is. Non-string ids refuse the tenant.

Scoped to `@mastra/code-sdk` only — factory workspace reads of the same slot are covered by #20688 / a separate fix path.

**Tests:** `pnpm --filter ./mastracode/sdk exec vitest run src/agents/credential-resolver.test.ts` — 15/15 passed (session-shaped tenant, org precedence from session half only, non-string id/org refuse, store resolution for session-shaped user).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The code now understands both old and new login information formats. This prevents valid users from losing access to their credentials in deployed environments.

## Changes

- Added tenant resolution for `{ session, user }` contexts from `@mastra/auth-better-auth`.
- Uses the inner user’s string ID.
- Uses `session.activeOrganizationId` for the organization ID.
- Keeps support for flat user objects.
- Rejects non-string or empty user and organization IDs.
- Added tests for tenant resolution and credential-store resolution.
- Added a patch changeset for `@mastra/code-sdk`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->