### PR TITLE
fix(server): return 400 for invalid pagination query params

### DIFF
--- a/.changeset/spotty-buttons-repeat.md
+++ b/.changeset/spotty-buttons-repeat.md
@@ -1,0 +1,24 @@
+---
+'@mastra/server': patch
+---
+
+Fixed invalid pagination query parameters returning a 500 instead of a 400.
+
+Requests such as `?page=-1`, `?page=1.5`, or `?perPage=-5` used to pass request validation and were only rejected deep in the storage layer, which surfaced them as `500 Internal Server Error`. Malformed client input is now rejected at the request boundary and returns `400 Bad Request` naming the offending field, matching what `GET /api/workflows/:workflowId/runs` already did.
+
+**Before**
+
+```
+GET /api/memory/threads?resourceId=user-1&page=-1
+→ 500 Internal Server Error   { "error": "page must be >= 0" }
+```
+
+**After**
+
+```
+GET /api/memory/threads?resourceId=user-1&page=-1
+→ 400 Bad Request
+  { "error": "Invalid query parameters", "issues": [{ "field": "page", "message": "..." }] }
+```
+
+This affects every paginated endpoint built on the shared pagination schemas, including memory, logs, MCP, and the stored agent/skill/scorer routes. `perPage=0` stays valid, since storage uses it as the include-only fast path.

--- a/packages/server/src/server/schemas/common.test.ts
+++ b/packages/server/src/server/schemas/common.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { createCombinedPaginationSchema, createPagePaginationSchema } from './common';
+
+/**
+ * Regression tests for GitHub Issue #21006
+ *
+ * `page` and `perPage` were declared as bare `z.coerce.number()`, which only
+ * rejects values that coerce to `NaN`. Negative, fractional, and unsafe-integer
+ * values therefore passed request validation and were rejected much later by the
+ * storage layer, which throws a plain `Error`. `handleError` cannot derive a
+ * status from a plain `Error`, so a malformed client request surfaced as a 500
+ * instead of a 400.
+ *
+ * Rejecting them here keeps them a 400: the route framework turns a
+ * query-schema `ZodError` into a 400 with field-level issues.
+ */
+describe('pagination query schemas', () => {
+  describe('createPagePaginationSchema', () => {
+    const schema = createPagePaginationSchema(100);
+
+    it.each([
+      ['negative page', { page: '-1' }],
+      ['fractional page', { page: '1.5' }],
+      ['page beyond the safe integer range', { page: '99999999999999999999' }],
+      ['negative perPage', { perPage: '-5' }],
+      ['fractional perPage', { perPage: '2.5' }],
+      ['non-numeric page', { page: 'abc' }],
+    ])('rejects %s', (_label, input) => {
+      expect(schema.safeParse(input).success).toBe(false);
+    });
+
+    it('reports the offending field so the 400 body is actionable', () => {
+      const result = schema.safeParse({ page: '-1' });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.path).toEqual(['page']);
+      }
+    });
+
+    it('still accepts perPage: 0, which storage uses as the include-only fast path', () => {
+      const result = schema.safeParse({ perPage: '0' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.perPage).toBe(0);
+      }
+    });
+
+    it('accepts valid coerced pagination', () => {
+      const result = schema.safeParse({ page: '2', perPage: '25' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ page: 2, perPage: 25 });
+      }
+    });
+
+    it('keeps the existing defaults when the params are omitted', () => {
+      const result = schema.safeParse({});
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ page: 0, perPage: 100 });
+      }
+    });
+
+    it('leaves perPage undefined when the factory is built without a default', () => {
+      const result = createPagePaginationSchema().safeParse({});
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.page).toBe(0);
+        expect(result.data.perPage).toBeUndefined();
+      }
+    });
+  });
+
+  describe('createCombinedPaginationSchema', () => {
+    const schema = createCombinedPaginationSchema();
+
+    it.each([
+      ['negative page', { page: '-1' }],
+      ['fractional perPage', { perPage: '2.5' }],
+      ['negative offset', { offset: '-10' }],
+      ['fractional limit', { limit: '1.5' }],
+    ])('rejects %s', (_label, input) => {
+      expect(schema.safeParse(input).success).toBe(false);
+    });
+
+    it('accepts the deprecated limit/offset pair', () => {
+      const result = schema.safeParse({ limit: '10', offset: '20' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ limit: 10, offset: 20 });
+      }
+    });
+
+    it('leaves every field optional', () => {
+      const result = schema.safeParse({});
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({});
+      }
+    });
+  });
+});

--- a/packages/server/src/server/schemas/common.ts
+++ b/packages/server/src/server/schemas/common.ts
@@ -48,23 +48,35 @@ export const paginationInfoSchema = z.object({
 });
 
 /**
+ * Pagination values are non-negative integers. Constraining them here keeps
+ * malformed input a 400 at the request boundary: without `.int().min(0)`,
+ * `z.coerce.number()` only rejects values that coerce to `NaN`, so `page=-1`
+ * and `perPage=2.5` reach the storage layer, which rejects them with a plain
+ * `Error` that `handleError` can only report as a 500.
+ *
+ * The lower bound is 0 rather than 1 because `perPage: 0` is a supported
+ * storage contract (the include-only fast path).
+ */
+const paginationNumber = () => z.coerce.number().int().min(0);
+
+/**
  * Factory function for page/perPage pagination query params
  * @param defaultPerPage - Default value for perPage (omit for no default)
  */
 export const createPagePaginationSchema = (defaultPerPage?: number) => {
   const baseSchema = {
-    page: z.coerce.number().optional().default(0),
+    page: paginationNumber().optional().default(0),
   };
 
   if (defaultPerPage !== undefined) {
     return z.object({
       ...baseSchema,
-      perPage: z.coerce.number().optional().default(defaultPerPage),
+      perPage: paginationNumber().optional().default(defaultPerPage),
     });
   } else {
     return z.object({
       ...baseSchema,
-      perPage: z.coerce.number().optional(),
+      perPage: paginationNumber().optional(),
     });
   }
 };
@@ -75,16 +87,16 @@ export const createPagePaginationSchema = (defaultPerPage?: number) => {
  */
 export const createCombinedPaginationSchema = () => {
   return z.object({
-    page: z.coerce.number().optional(),
-    perPage: z.coerce.number().optional(),
+    page: paginationNumber().optional(),
+    perPage: paginationNumber().optional(),
     /**
      * @deprecated Use page and perPage instead
      */
-    offset: z.coerce.number().optional(),
+    offset: paginationNumber().optional(),
     /**
      * @deprecated Use page and perPage instead
      */
-    limit: z.coerce.number().optional(),
+    limit: paginationNumber().optional(),
   });
 };
 


### PR DESCRIPTION
## Description

Invalid pagination query parameters returned `500 Internal Server Error` instead of `400 Bad Request` on most paginated endpoints.

`page` and `perPage` are validated by the two shared factories in `packages/server/src/server/schemas/common.ts`, which declared both fields as a bare `z.coerce.number()`. That only rejects values coercing to `NaN`, so negative, fractional, and unsafe-integer values passed request validation and reached the storage layer. Storage rejects them by throwing a plain `Error`, which carries no HTTP status, so `handleError` fell back to `500` — reporting malformed client input as a server fault.

This aligns the implementation with behaviour that is already documented and already implemented elsewhere in the repo:

- The route reference documents `400 | Bad Request - Invalid parameters`.
- `listWorkflowRuns` already validates the same two parameters by hand and returns `400`, so `GET /api/workflows/:workflowId/runs?page=-1` was a `400` while `GET /api/memory/threads?page=-1` was a `500`, for the same class of input.

**Before**

```
GET /api/memory/threads?resourceId=user-1&page=-1
→ 500 Internal Server Error
  { "error": "page must be >= 0" }
```

**After**

```
GET /api/memory/threads?resourceId=user-1&page=-1
→ 400 Bad Request
  { "error": "Invalid query parameters",
    "issues": [{ "field": "page", "message": "Too small: expected number to be >=0" }] }
```

### What changed

Both pagination factories now build their numeric fields through one helper:

```ts
const paginationNumber = () => z.coerce.number().int().min(0);
```

No handler changes were needed — the route framework already converts a query-schema `ZodError` into a `400` with field-level issues via `resolveValidationError`. This covers every route family built on the shared schemas: memory, logs, MCP, the stored agents/skills/scorers/workspaces/MCP-clients/prompt-blocks routes, version-common, and the `limit`/`offset` back-compat path in workflows.

Two deliberate choices:

- **The lower bound is `0`, not `1`.** `perPage: 0` is a supported storage contract (the include-only fast path) and is covered by the shared store tests, so raising the bound would break existing behaviour.
- **Storage-level validation is left untouched.** Callers that reach storage programmatically rather than over HTTP keep exactly the same guarantees; this only adds the missing check at the request boundary.

## Related issue(s)

Fixes #21006

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Testing

Added `packages/server/src/server/schemas/common.test.ts` (17 tests):

- rejects negative, fractional, and beyond-safe-integer `page` / `perPage`, plus non-numeric input
- asserts the `ZodError` path is the offending field, so the 400 body names it
- **`perPage: 0` still parses** — regression guard for the include-only fast path
- existing defaults are unchanged (`{ page: 0, perPage: 100 }`, and `perPage` stays `undefined` when the factory is built without a default)
- combined schema: `offset` / `limit` are constrained and every field stays optional

```
Test Files  1 passed (1)
     Tests  17 passed (17)
```

Full `packages/server` suite compared before and after the change: the set of failures is identical (all pre-existing and unrelated), and passing tests go from 710 to 727 — exactly the 17 added here.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable) — not applicable: `reference/server/routes` already documents `400 - Bad Request - Invalid parameters`; this change makes the implementation match it
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR — will do once it has run

## Notes for maintainers

Two unrelated things I hit while working on this, in case they are useful:

1. `pnpm changeset` fails locally with `SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'` thrown from `@manypkg/tools` — the same symptom as #20943, which is closed. I wrote the changeset file by hand in the existing format.
2. #21006 was auto-labeled `Memory` / `Workflows`, but the change is confined to the `packages/server` schemas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Invalid page numbers now return a clear `400 Bad Request` instead of causing a server error. Valid values, including `perPage: 0`, continue to work.

## Changes

- Added non-negative integer validation for shared `page` and `perPage` query parameters.
- Rejected negative, fractional, unsafe-integer, and non-numeric values at the HTTP boundary.
- Preserved optional fields, existing defaults, deprecated `limit`/`offset` support, and `perPage: 0`.
- Applied the validation across all endpoints that use the shared pagination schemas.
- Added 17 regression tests for validation, errors, defaults, optional fields, combined schemas, and valid zero-page sizes.
- Added a patch changeset for `@mastra/server`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->