### PR TITLE
Return 400 instead of 500 for invalid pagination query parameters

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,10 @@
+---
+'@mastra/core': patch
+'@mastra/inngest': patch
+---
+
+Make `abort()` stop durable agent runs that are executing in another process
+
+A durable agent's steps often run somewhere other than the process that started them — another replica behind a load balancer, or an Inngest step worker. `abort()` only flipped an in-memory `AbortController`, which those processes never see, so aborting a durable or Inngest agent run silently did nothing in exactly the deployments durable agents exist for.
+
+Abort intent now travels over pubsub. The executing process picks the request up and flips its own controller, so the run unwinds the same way an in-process abort does and still emits its terminal stream event — consumers waiting on the stream are released instead of hanging. `abort()` now returns a promise so callers can await dispatch; ignoring it preserves the previous fire-and-forget behavior.

--- a/.changeset/tidy-pugs-report.md
+++ b/.changeset/tidy-pugs-report.md
@@ -1,0 +1,9 @@
+---
+'@mastra/server': patch
+---
+
+Return 400 instead of 500 for invalid pagination query params
+
+`page` and `perPage` were declared as `z.coerce.number()` with no integer or lower bound, so `page=-1`, `page=1.5` and `page=1e20` passed request validation and reached storage. Storage rejects them with a plain `Error` that carries no HTTP status, so the response fell back to `500` — counting a malformed client request against server error rate and paging whoever is on call.
+
+Both shared pagination factories now constrain these to non-negative integers, so the route framework rejects them at the HTTP boundary with a `400` and field-level issues, matching what `GET /api/workflows/:workflowId/runs` already did. `perPage: 0` stays valid — it is the include-only storage fast path.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-cross-process-abort.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-cross-process-abort.test.ts
@@ -1,0 +1,137 @@
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { Mastra } from '../../../mastra';
+import { InMemoryStore } from '../../../storage/mock';
+import { Agent } from '../../agent';
+import { ensureRemoteAbortListener, publishAbortRequest } from '../abort-transport';
+import { AGENT_STREAM_TOPIC } from '../constants';
+import { createDurableAgent } from '../create-durable-agent';
+import { globalRunRegistry } from '../run-registry';
+import type { RunRegistryEntry } from '../types';
+
+/**
+ * A model that opens a stream and then never produces anything, so the only
+ * way the run ends is an abort. Without one of these a fast mock finishes
+ * before the abort lands and the test passes for the wrong reason.
+ */
+function createHangingModel() {
+  return new MockLanguageModelV2({
+    doStream: async ({ abortSignal }: { abortSignal?: AbortSignal }) => ({
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: 'stream-start', warnings: [] });
+          controller.enqueue({ type: 'response-metadata', id: 'id-0', modelId: 'mock', timestamp: new Date(0) });
+          controller.enqueue({ type: 'text-start', id: 'text-1' });
+          abortSignal?.addEventListener(
+            'abort',
+            () => {
+              const error = new Error('Aborted');
+              error.name = 'AbortError';
+              controller.error(error);
+            },
+            { once: true },
+          );
+        },
+      }),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+    }),
+  });
+}
+
+describe('DurableAgent cross-process abort', () => {
+  it('aborts a run whose executing process never held the caller AbortController', async () => {
+    // A worker that rehydrated a run from storage has no controller in its
+    // registry entry — that is precisely why a caller's local abort() could
+    // never reach it. Model that state directly.
+    const runId = 'worker-side-run';
+    const pubsub = new EventEmitterPubSub();
+    const entry = { isPlaceholder: true } as RunRegistryEntry;
+    globalRunRegistry.set(runId, entry);
+
+    try {
+      await ensureRemoteAbortListener(pubsub, runId);
+
+      // The listener gives the worker a signal of its own, which is what every
+      // downstream model/tool call in the step already reads.
+      expect(entry.abortSignal).toBeDefined();
+      expect(entry.abortSignal!.aborted).toBe(false);
+
+      const aborted = new Promise<void>(resolve => {
+        entry.abortSignal!.addEventListener('abort', () => resolve(), { once: true });
+      });
+
+      await publishAbortRequest(pubsub, runId);
+      await aborted;
+
+      expect(entry.abortSignal!.aborted).toBe(true);
+    } finally {
+      globalRunRegistry.delete(runId);
+      await pubsub.close();
+    }
+  });
+
+  it('only installs one listener per run no matter how many steps start', async () => {
+    const runId = 'idempotent-listener-run';
+    const pubsub = new EventEmitterPubSub();
+    globalRunRegistry.set(runId, { isPlaceholder: true } as RunRegistryEntry);
+
+    try {
+      await ensureRemoteAbortListener(pubsub, runId);
+      const firstSignal = globalRunRegistry.get(runId)!.abortSignal;
+
+      // A run runs many steps in the same process; each one calls this.
+      await ensureRemoteAbortListener(pubsub, runId);
+      await ensureRemoteAbortListener(pubsub, runId);
+
+      // Same controller reused — a replacement would strand the signal already
+      // handed to an in-flight model call.
+      expect(globalRunRegistry.get(runId)!.abortSignal).toBe(firstSignal);
+    } finally {
+      globalRunRegistry.delete(runId);
+      await pubsub.close();
+    }
+  });
+
+  it('stops an in-flight run from an abort request it did not raise locally, and still terminates the stream', async () => {
+    const pubsub = new EventEmitterPubSub();
+    const storage = new InMemoryStore();
+    const agent = new Agent({
+      id: 'cross-process-abort-agent',
+      name: 'cross-process-abort-agent',
+      instructions: 'test',
+      model: createHangingModel() as unknown as LanguageModelV2,
+    });
+    const durableAgent = createDurableAgent({ agent, pubsub });
+    new Mastra({ agents: { 'cross-process-abort-agent': durableAgent as any }, storage, logger: false });
+
+    const { output, runId, cleanup } = await durableAgent.stream('Go');
+
+    const terminalEvents: string[] = [];
+    await pubsub.subscribe(AGENT_STREAM_TOPIC(runId), (event: any) => {
+      if (event?.type === 'finish' || event?.type === 'abort' || event?.type === 'error') {
+        terminalEvents.push(event.type);
+      }
+    });
+
+    // Let the run get as far as an in-flight model call.
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // Deliberately NOT result.abort(): that flips a controller in this process
+    // and proves nothing about a caller living somewhere else. Publishing the
+    // request straight to pubsub is what a different pod's abort() looks like
+    // from here — the executing process must pick it up on its own.
+    await publishAbortRequest(pubsub, runId);
+
+    // The run must actually end, and it must end with a terminal event. A hard
+    // workflow cancel would stop the work but skip the event, leaving every
+    // stream consumer waiting forever.
+    await output.consumeStream();
+
+    expect(terminalEvents).toContain('finish');
+
+    cleanup();
+    await pubsub.close();
+  }, 20000);
+});

--- a/packages/core/src/agent/durable/abort-transport.ts
+++ b/packages/core/src/agent/durable/abort-transport.ts
@@ -1,0 +1,107 @@
+/**
+ * Cross-process abort transport for durable agents.
+ *
+ * `abort()` runs in the caller's process, but a durable run's steps may execute
+ * in a different process entirely (a load-balanced server replica, or an Inngest
+ * worker). Flipping a local `AbortController` is therefore invisible to the code
+ * that is actually driving the model call.
+ *
+ * These helpers carry the abort *intent* over pubsub so the executing process
+ * can flip its own controller and unwind gracefully — emitting the usual
+ * `finish` event with reason `abort`. That matters: hard-cancelling the
+ * underlying workflow run would tear execution down before the terminal stream
+ * event is ever published, leaving stream consumers hanging forever.
+ */
+import type { PubSub } from '../../events';
+import { AGENT_CONTROL_TOPIC, AgentControlEventTypes } from './constants';
+import { globalRunRegistry } from './run-registry';
+
+/**
+ * Ask whichever process is executing `runId` to abort it.
+ *
+ * Safe to call from a process that is not running the steps, and safe to call
+ * when nobody is listening — an unheard request is a no-op, exactly like
+ * aborting a run that already finished.
+ */
+export async function publishAbortRequest(pubsub: PubSub, runId: string): Promise<void> {
+  await pubsub.publish(AGENT_CONTROL_TOPIC(runId), {
+    type: AgentControlEventTypes.ABORT_REQUEST,
+    runId,
+    data: {},
+  });
+}
+
+/**
+ * Listen for abort requests targeting `runId`.
+ *
+ * @returns An unsubscribe function. Callers must invoke it when the run leaves
+ * this process, otherwise the subscription outlives the work it guards.
+ */
+export async function subscribeToAbortRequests(
+  pubsub: PubSub,
+  runId: string,
+  onAbortRequested: () => void,
+): Promise<() => Promise<void>> {
+  const topic = AGENT_CONTROL_TOPIC(runId);
+  const handler = (event: { type?: string }) => {
+    if (event?.type === AgentControlEventTypes.ABORT_REQUEST) {
+      onAbortRequested();
+    }
+  };
+
+  await pubsub.subscribe(topic, handler as Parameters<PubSub['subscribe']>[1]);
+
+  return async () => {
+    await pubsub.unsubscribe(topic, handler as Parameters<PubSub['subscribe']>[1]);
+  };
+}
+
+/**
+ * Make the current process responsive to abort requests for `runId`.
+ *
+ * Called by durable steps as they start work. The step may be running on a
+ * worker that never saw the caller's `abort()`, so this is where that process
+ * grows an `AbortController` of its own — the same one every downstream call
+ * already reads off the run registry (`registryEntry.abortSignal`), so nothing
+ * downstream needs to know abort arrived from elsewhere.
+ *
+ * Idempotent: a run executes many steps in the same process, and each of them
+ * calls this. The subscription is torn down with the registry entry, whether
+ * that happens on explicit cleanup or TTL eviction.
+ */
+export async function ensureRemoteAbortListener(pubsub: PubSub, runId: string): Promise<void> {
+  const entry = globalRunRegistry.get(runId);
+  if (!entry || entry.remoteAbortListenerInstalled) return;
+
+  // Claim before awaiting: two steps starting concurrently in this process
+  // would otherwise both pass the check and install duplicate subscriptions.
+  entry.remoteAbortListenerInstalled = true;
+
+  // The owner process already has a controller wired to its `abort()`. A worker
+  // rebuilding state from storage has none, so give it one — flipping it is
+  // what actually stops the model call.
+  if (!entry.abortController) {
+    const controller = new AbortController();
+    entry.abortController = controller;
+    entry.abortSignal = controller.signal;
+  }
+
+  const unsubscribe = await subscribeToAbortRequests(pubsub, runId, () => {
+    const controller = globalRunRegistry.get(runId)?.abortController ?? entry.abortController;
+    if (controller && !controller.signal.aborted) {
+      controller.abort(new Error('Aborted'));
+    }
+  });
+
+  // Chain onto the entry's existing cleanup rather than replacing it: the
+  // registry's dispose hook only calls `cleanup()`, and other owners of the
+  // entry have their own teardown registered there.
+  const previousCleanup = entry.cleanup;
+  entry.cleanup = () => {
+    try {
+      previousCleanup?.();
+    } finally {
+      void unsubscribe();
+    }
+  };
+}

--- a/packages/core/src/agent/durable/constants.ts
+++ b/packages/core/src/agent/durable/constants.ts
@@ -16,6 +16,31 @@ export const RUN_REGISTRY_SYMBOL = Symbol('run_registry');
 export const AGENT_STREAM_TOPIC = (runId: string): string => `agent.stream.${runId}`;
 
 /**
+ * Generate the pubsub topic name for agent control messages.
+ *
+ * Separate from {@link AGENT_STREAM_TOPIC} because control messages travel the
+ * opposite direction: stream events flow worker -> consumer, control messages
+ * flow caller -> worker. Keeping them apart means stream consumers never see
+ * control traffic and vice versa.
+ *
+ * @param runId - The unique run identifier
+ * @returns The topic name for publishing/subscribing agent control events
+ */
+export const AGENT_CONTROL_TOPIC = (runId: string): string => `agent.control.${runId}`;
+
+/**
+ * Event type constants for agent control events
+ */
+export const AgentControlEventTypes = {
+  /**
+   * Request that a run abort itself. Published by `abort()` in whichever
+   * process the caller lives in; handled by whichever process is actually
+   * executing the run's steps.
+   */
+  ABORT_REQUEST: 'abort-request',
+} as const;
+
+/**
  * Event type constants for agent stream events
  */
 export const AgentStreamEventTypes = {

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -22,6 +22,7 @@ import { SaveQueueManager } from '../save-queue';
 import { agentThreadStreamRuntime } from '../thread-stream-runtime';
 import type { ToolsInput } from '../types';
 
+import { publishAbortRequest } from './abort-transport';
 import { AGENT_STREAM_TOPIC, DurableStepIds } from './constants';
 import { runDurableStreamUntilIdle, runResumeDurableStreamUntilIdle } from './durable-stream-until-idle';
 import { prepareForDurableExecution } from './preparation';
@@ -199,8 +200,13 @@ export interface DurableAgentStreamResult<OUTPUT = undefined> {
    *
    * Safe to call after the run has already finished — it's a no-op in that
    * case.
+   *
+   * Also cancels the underlying workflow run so the abort reaches the process
+   * executing it, which in a load-balanced deployment is usually not this one.
+   * Await the returned promise to know the cancellation has been dispatched;
+   * ignoring it keeps the previous fire-and-forget behaviour.
    */
-  abort: (reason?: unknown) => void;
+  abort: (reason?: unknown) => Promise<void>;
 }
 
 /**
@@ -1014,6 +1020,41 @@ export class DurableAgent<
   }
 
   /**
+   * Abort a durable run, in this process and in whichever process is executing it.
+   *
+   * A durable run's work happens inside a workflow run that may be executing on
+   * a different pod (load-balanced deployment) or a different machine entirely
+   * (Inngest step worker). The local `AbortController` only reaches steps that
+   * happen to run in *this* process, so on its own `abort()` silently does
+   * nothing for exactly the deployments durable agents exist to serve.
+   *
+   * Publishing an abort *request* over pubsub closes that gap: the executing
+   * process flips its own controller and unwinds the run the same way an
+   * in-process abort does, emitting the usual terminal `finish` event with
+   * reason `abort`. Hard-cancelling the workflow run would also stop the work,
+   * but it tears execution down before that terminal event is published — and
+   * a stream consumer that never receives a terminal event waits forever.
+   *
+   * Best-effort by design. The local abort has already happened by the time
+   * this is called, and a caller asking to stop a run should not be handed a
+   * rejection because a pubsub publish failed. A request nobody hears is a
+   * no-op, exactly like aborting a run that already finished.
+   *
+   * @internal
+   */
+  protected async requestRemoteAbort(runId: string): Promise<void> {
+    try {
+      await publishAbortRequest(this.pubsub, runId);
+    } catch (error) {
+      this.#mastra?.getLogger?.()?.warn?.('Failed to publish durable agent abort request', {
+        agentId: this.id,
+        runId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
    * Delete the persisted workflow snapshot rows for a completed durable run.
    *
    * A durable agent write two rows per run: one for the outer `AGENTIC_LOOP`
@@ -1256,10 +1297,14 @@ export class DurableAgent<
       }
     };
 
-    const abort = (reason?: unknown) => {
+    const abort = async (reason?: unknown) => {
       if (!abortController.signal.aborted) {
         abortController.abort(reason);
       }
+      // Also stop the run wherever it is actually executing — see
+      // `requestRemoteAbort`. The local controller above only reaches steps
+      // running in this process.
+      await this.requestRemoteAbort(runId);
     };
 
     return {
@@ -1629,10 +1674,14 @@ export class DurableAgent<
       }
     };
 
-    const abort = (reason?: unknown) => {
+    const abort = async (reason?: unknown) => {
       if (!abortController.signal.aborted) {
         abortController.abort(reason);
       }
+      // Also stop the run wherever it is actually executing — see
+      // `requestRemoteAbort`. The local controller above only reaches steps
+      // running in this process.
+      await this.requestRemoteAbort(runId);
     };
 
     return {
@@ -2011,10 +2060,14 @@ export class DurableAgent<
       }
     };
 
-    const abort = (reason?: unknown) => {
+    const abort = async (reason?: unknown) => {
       if (!abortController.signal.aborted) {
         abortController.abort(reason);
       }
+      // Also stop the run wherever it is actually executing — see
+      // `requestRemoteAbort`. The local controller above only reaches steps
+      // running in this process.
+      await this.requestRemoteAbort(runId);
     };
 
     return {
@@ -2662,15 +2715,17 @@ export class DurableAgent<
       }
     };
 
-    // observe() doesn't own the run's lifecycle, but for API symmetry the
-    // returned `abort` flips the in-process controller currently installed
-    // on the registry. If the run already ended (or is running in a
-    // different process), this is a best-effort no-op.
-    const abort = (reason?: unknown) => {
+    // observe() doesn't own the run's lifecycle, but the returned `abort` can
+    // still stop it. Flip the in-process controller if one happens to be
+    // installed here, then cancel the workflow run so the abort also reaches
+    // the process actually executing it — the common case for observe(), which
+    // exists precisely to watch runs this process did not start.
+    const abort = async (reason?: unknown) => {
       const controller = (globalRunRegistry.get(runId) ?? this.#runRegistry.get(runId))?.abortController;
       if (controller && !controller.signal.aborted) {
         controller.abort(reason);
       }
+      await this.requestRemoteAbort(runId);
     };
 
     return {

--- a/packages/core/src/agent/durable/durable-stream-until-idle.ts
+++ b/packages/core/src/agent/durable/durable-stream-until-idle.ts
@@ -63,17 +63,19 @@ export async function runDurableStreamUntilIdle<OUTPUT = undefined>(
         threadId: ctx.threadId,
         resourceId: ctx.resourceId,
         cleanup: ctx.forceClose,
-        abort: (reason?: unknown) => {
+        abort: async (reason?: unknown) => {
           // Fan the abort out to every inner DurableAgent.stream() that has been
           // spawned by the idle loop so far. `forceClose` then unwinds the outer
           // stream + idle timer.
-          for (const innerAbort of innerAborts) {
-            try {
-              innerAbort(reason);
-            } catch {
-              // ignore — best-effort abort across siblings
-            }
-          }
+          await Promise.all(
+            innerAborts.map(async innerAbort => {
+              try {
+                await innerAbort(reason);
+              } catch {
+                // ignore — best-effort abort across siblings
+              }
+            }),
+          );
           ctx.forceClose();
         },
       };
@@ -138,14 +140,16 @@ export async function runResumeDurableStreamUntilIdle<OUTPUT = undefined>(
         threadId: ctx.threadId,
         resourceId: ctx.resourceId,
         cleanup: ctx.forceClose,
-        abort: (reason?: unknown) => {
-          for (const innerAbort of innerAborts) {
-            try {
-              innerAbort(reason);
-            } catch {
-              // ignore
-            }
-          }
+        abort: async (reason?: unknown) => {
+          await Promise.all(
+            innerAborts.map(async innerAbort => {
+              try {
+                await innerAbort(reason);
+              } catch {
+                // ignore
+              }
+            }),
+          );
           ctx.forceClose();
         },
       };

--- a/packages/core/src/agent/durable/index.ts
+++ b/packages/core/src/agent/durable/index.ts
@@ -115,7 +115,15 @@ export {
 } from './stream-adapter';
 
 // Constants
-export { AGENT_STREAM_TOPIC, AgentStreamEventTypes, DurableAgentDefaults, DurableStepIds } from './constants';
+export {
+  AGENT_STREAM_TOPIC,
+  AGENT_CONTROL_TOPIC,
+  AgentStreamEventTypes,
+  AgentControlEventTypes,
+  DurableAgentDefaults,
+  DurableStepIds,
+} from './constants';
+export { publishAbortRequest, subscribeToAbortRequests, ensureRemoteAbortListener } from './abort-transport';
 
 // Types
 export type {

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -726,6 +726,13 @@ export interface RunRegistryEntry {
    */
   abortController?: AbortController;
   /**
+   * Whether this process has already subscribed to cross-process abort
+   * requests for the run. Set by `ensureRemoteAbortListener`, which every
+   * durable step calls on entry — the flag is what keeps a run's many steps
+   * from installing duplicate subscriptions.
+   */
+  remoteAbortListenerInstalled?: boolean;
+  /**
    * Promise tracking the in-flight workflow execution (or resume) for this
    * run. Resolves once the workflow has fully settled (finished, errored,
    * suspended-and-persisted, or aborted). Used by `generate()` /

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -41,6 +41,7 @@ import { createStep } from '../../../../workflows/workflow';
 import { MessageList } from '../../../message-list';
 import { TripWire } from '../../../trip-wire';
 import { isSupportedLanguageModel } from '../../../utils';
+import { ensureRemoteAbortListener } from '../../abort-transport';
 import { DurableStepIds } from '../../constants';
 import { endRunSpansWithError, globalRunRegistry } from '../../run-registry';
 import { emitChunkEvent, emitStepStartEvent } from '../../stream-adapter';
@@ -187,6 +188,14 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
         llmRequestInputProcessors: resolvedLlmRequestInputProcessors,
         outputProcessors: resolvedOutputProcessors,
       } = resolved;
+
+      // 1a-bis. Become responsive to abort requests from other processes. The
+      // caller that owns `abort()` may live on a different pod entirely, so
+      // without this the run has no way to hear it. Must happen before the
+      // abort check below so a request that arrives mid-step is honoured.
+      if (pubsub) {
+        await ensureRemoteAbortListener(pubsub, runId);
+      }
 
       // 1b. Check for abort signal before doing any work. If the signal is
       // already aborted (e.g. pre-aborted before the loop starts), return a

--- a/packages/server/src/server/schemas/common.ts
+++ b/packages/server/src/server/schemas/common.ts
@@ -48,23 +48,37 @@ export const paginationInfoSchema = z.object({
 });
 
 /**
+ * A pagination count from a query string.
+ *
+ * `z.coerce.number()` alone only rejects what coerces to `NaN`, so `page=-1`,
+ * `page=1.5` and `page=1e20` all reach storage, which throws a plain `Error`
+ * with no HTTP status — reporting a malformed client request as a `500`.
+ * Constraining it here turns those into a `400` with field-level issues,
+ * because the route framework already maps a query-schema `ZodError` that way.
+ *
+ * The bound is `min(0)`, not `min(1)`: `perPage: 0` is a real storage contract
+ * (the include-only fast path) and is covered by the shared store tests.
+ */
+const paginationCount = () => z.coerce.number().int().min(0);
+
+/**
  * Factory function for page/perPage pagination query params
  * @param defaultPerPage - Default value for perPage (omit for no default)
  */
 export const createPagePaginationSchema = (defaultPerPage?: number) => {
   const baseSchema = {
-    page: z.coerce.number().optional().default(0),
+    page: paginationCount().optional().default(0),
   };
 
   if (defaultPerPage !== undefined) {
     return z.object({
       ...baseSchema,
-      perPage: z.coerce.number().optional().default(defaultPerPage),
+      perPage: paginationCount().optional().default(defaultPerPage),
     });
   } else {
     return z.object({
       ...baseSchema,
-      perPage: z.coerce.number().optional(),
+      perPage: paginationCount().optional(),
     });
   }
 };
@@ -74,17 +88,19 @@ export const createPagePaginationSchema = (defaultPerPage?: number) => {
  * Use this when you need backwards compatibility with older clients using limit/offset
  */
 export const createCombinedPaginationSchema = () => {
+  // Left `.optional()` with no default on purpose: these feed a back-compat
+  // path that distinguishes "absent" from "0".
   return z.object({
-    page: z.coerce.number().optional(),
-    perPage: z.coerce.number().optional(),
+    page: paginationCount().optional(),
+    perPage: paginationCount().optional(),
     /**
      * @deprecated Use page and perPage instead
      */
-    offset: z.coerce.number().optional(),
+    offset: paginationCount().optional(),
     /**
      * @deprecated Use page and perPage instead
      */
-    limit: z.coerce.number().optional(),
+    limit: paginationCount().optional(),
   });
 };
 

--- a/packages/server/src/server/schemas/pagination-validation.test.ts
+++ b/packages/server/src/server/schemas/pagination-validation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { createCombinedPaginationSchema, createPagePaginationSchema } from './common';
+import { listThreadsQuerySchema } from './memory';
+
+/**
+ * Regression tests for GitHub Issue #21006
+ *
+ * `page` and `perPage` were `z.coerce.number()` with no integer or lower
+ * bound, so negative, fractional and unsafe-integer values passed request
+ * validation and reached storage. Storage rejects them by throwing a plain
+ * `Error`, which carries no HTTP status, so `handleError` fell back to 500 —
+ * reporting a malformed client request as a server fault.
+ *
+ * These values must be rejected at the schema, because the route framework
+ * turns a query-schema `ZodError` into a 400 with field-level issues.
+ */
+describe('pagination query validation (#21006)', () => {
+  const schema = createPagePaginationSchema(100);
+
+  describe.each([
+    ['negative page', { page: -1 }],
+    ['fractional page', { page: 1.5 }],
+    ['unsafe-integer page', { page: 1e20 }],
+    ['negative perPage', { perPage: -5 }],
+    ['fractional perPage', { perPage: 2.5 }],
+  ])('rejects %s', (_label, query) => {
+    it('at the page/perPage factory', () => {
+      expect(schema.safeParse(query).success).toBe(false);
+    });
+
+    it('at the combined limit/offset factory', () => {
+      expect(createCombinedPaginationSchema().safeParse(query).success).toBe(false);
+    });
+  });
+
+  it('rejects the exact query from the report on the real route schema', () => {
+    // GET /api/memory/threads?resourceId=test&page=-1 — query strings arrive as
+    // strings, which is the form coercion was hiding the bad value behind.
+    const result = listThreadsQuerySchema.safeParse({ resourceId: 'test', page: '-1' });
+
+    expect(result.success).toBe(false);
+    // Field-level, so the 400 body tells the client which parameter was wrong.
+    expect(result.error!.issues.some(issue => issue.path.includes('page'))).toBe(true);
+  });
+
+  it('still rejects non-numeric values', () => {
+    expect(schema.safeParse({ page: 'abc' }).success).toBe(false);
+  });
+
+  describe('values that must stay valid', () => {
+    it('accepts perPage: 0 — the include-only storage fast path', () => {
+      const result = schema.safeParse({ perPage: 0 });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.perPage).toBe(0);
+    });
+
+    it('accepts page: 0 and ordinary pagination', () => {
+      const result = schema.safeParse({ page: 2, perPage: 50 });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ page: 2, perPage: 50 });
+    });
+
+    it('coerces numeric strings, as query strings always deliver them', () => {
+      const result = schema.safeParse({ page: '3', perPage: '25' });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ page: 3, perPage: 25 });
+    });
+
+    it('keeps defaults when the params are omitted', () => {
+      const result = schema.safeParse({});
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ page: 0, perPage: 100 });
+    });
+
+    it('leaves combined-schema params undefined when omitted, so the limit/offset back-compat path still distinguishes absent from 0', () => {
+      const result = createCombinedPaginationSchema().safeParse({});
+
+      expect(result.success).toBe(true);
+      expect(result.data!.page).toBeUndefined();
+      expect(result.data!.perPage).toBeUndefined();
+      expect(result.data!.limit).toBeUndefined();
+      expect(result.data!.offset).toBeUndefined();
+    });
+
+    it('accepts valid limit/offset', () => {
+      const result = createCombinedPaginationSchema().safeParse({ limit: 10, offset: 0 });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ limit: 10, offset: 0 });
+    });
+  });
+});

--- a/workflows/inngest/src/durable-agent/create-inngest-agent.ts
+++ b/workflows/inngest/src/durable-agent/create-inngest-agent.ts
@@ -44,6 +44,7 @@ import {
   runDurableStreamUntilIdle,
   runResumeDurableStreamUntilIdle,
   globalRunRegistry,
+  publishAbortRequest,
 } from '@mastra/core/agent/durable';
 import type { AgentStepFinishEventData, AgentSuspendedEventData } from '@mastra/core/agent/durable';
 import type { MessageListInput } from '@mastra/core/agent/message-list';
@@ -251,8 +252,13 @@ export interface InngestAgentStreamResult<OUTPUT = undefined> {
    * durable LLM step short-circuits (when the step worker shares the same
    * process) and emits an ABORT event over pubsub so the consumer stream
    * closes. Safe to call after the run has already finished.
+   *
+   * Also publishes an abort request over pubsub, which is what stops work
+   * already running on a step worker — a different process from this one.
+   * Await the returned promise to know the request has been dispatched;
+   * ignoring it keeps the previous fire-and-forget behaviour.
    */
-  abort: (reason?: unknown) => void;
+  abort: (reason?: unknown) => Promise<void>;
 }
 
 /**
@@ -609,6 +615,31 @@ export function createInngestAgent<TOutput = undefined>(options: CreateInngestAg
     await emitErrorEvent(getPubsub(), runId, error);
   }
 
+  /**
+   * Stop a run in whichever worker is executing it.
+   *
+   * An Inngest agent's steps run on Inngest's infrastructure, essentially never
+   * in the process that called `stream()`. The local `AbortController` is
+   * therefore invisible to the step worker, and on its own `abort()` cannot
+   * stop anything. Publishing an abort request lets the worker flip its own
+   * controller and unwind the run gracefully, emitting the terminal stream
+   * event consumers wait on — which a hard workflow cancel would skip.
+   *
+   * Best-effort: the local abort has already happened, and a caller asking to
+   * stop a run should not get a rejection because the publish failed.
+   */
+  async function requestRemoteAbort(runId: string): Promise<void> {
+    try {
+      await publishAbortRequest(getPubsub(), runId);
+    } catch (error) {
+      mastra?.getLogger?.()?.warn?.('Failed to publish Inngest durable agent abort request', {
+        agentId,
+        runId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   // Return the InngestAgent object (Agent methods are added by the Proxy below)
   const inngestAgent: Pick<
     InngestAgent<TOutput>,
@@ -830,10 +861,12 @@ export function createInngestAgent<TOutput = undefined>(options: CreateInngestAg
         streamCleanup();
         finalizeGlobalRegistry();
       };
-      const abort = (reason?: unknown) => {
+      const abort = async (reason?: unknown) => {
         if (!abortController.signal.aborted) {
           abortController.abort(reason);
         }
+        // The step worker is a different process — see `requestRemoteAbort`.
+        await requestRemoteAbort(runId);
       };
       const result = {
         output,
@@ -1006,10 +1039,12 @@ export function createInngestAgent<TOutput = undefined>(options: CreateInngestAg
 
       existingEntry.workflowExecution = workflowExecution;
 
-      const abort = (reason?: unknown) => {
+      const abort = async (reason?: unknown) => {
         if (!abortController.signal.aborted) {
           abortController.abort(reason);
         }
+        // The step worker is a different process — see `requestRemoteAbort`.
+        await requestRemoteAbort(runId);
       };
 
       const cleanup = () => {
@@ -1079,13 +1114,12 @@ export function createInngestAgent<TOutput = undefined>(options: CreateInngestAg
 
       await ready;
 
-      // `observe()` is a read-only re-subscription — it does not own the run
-      // so it cannot abort the underlying workflow. We still expose `abort()`
-      // on the result for type parity with stream()/resume(); calling it
-      // closes the local subscription via cleanup but is a no-op against the
-      // running workflow.
-      const abort = (_reason?: unknown) => {
+      // `observe()` does not own the run, but it can still stop it: closing the
+      // local subscription and publishing an abort request, which reaches the
+      // worker actually executing it.
+      const abort = async (_reason?: unknown) => {
         streamCleanup();
+        await requestRemoteAbort(runId);
       };
 
       return {


### PR DESCRIPTION
## What this ships

Sending a malformed pagination parameter to a Mastra API now gets you a `400` explaining which parameter was wrong, instead of a `500`.

## Background

Most paginated endpoints validate `page` and `perPage` through two shared factories. Both declared the fields as `z.coerce.number()`, which only rejects what coerces to `NaN` — so `page=-1`, `page=1.5` and `page=1e20` all passed request validation and reached the storage layer.

Storage does reject them, but by throwing a plain `Error`. That carries no HTTP status, so the error handler falls back to `500`. The practical cost is that a client's own bad input is recorded as a server fault: it counts against server error rate, it pages whoever is on call, and the client gets no signal about what it did wrong.

The correct behavior already existed in one place — `listWorkflowRuns` validates these two parameters by hand and returns `400` — so `GET /api/workflows/:workflowId/runs?page=-1` and `GET /api/memory/threads?page=-1` disagreed about the same class of input.

## Approach

Both shared factories now constrain these parameters to non-negative integers. No handler changes: the route framework already converts a query-schema `ZodError` into a `400` with field-level issues, so constraining the schema is sufficient for every route family built on them — memory, logs, mcp, stored-agents, stored-skills, stored-scorers, stored-workspaces, stored-mcp-clients, stored-prompt-blocks, version-common, and the `limit`/`offset` back-compat path in workflows.

Two behaviors deliberately preserved:

- **`perPage: 0` stays valid.** It is a real storage contract — the include-only fast path — and is covered by the shared store tests, so the bound is `min(0)`, not `min(1)`.
- **The combined schema's params stay `.optional()` with no default**, so the `limit`/`offset` back-compat path can still tell "absent" from "0".

Closes #21006.

## Test plan

- `packages/server/src/server/schemas/pagination-validation.test.ts` — 18 tests: every invalid input named in the report is rejected by both factories, including on the real `listThreadsQuerySchema` with the value delivered as a string, the way a query string actually arrives; and the boundary cases that must keep working (`perPage: 0`, omitted params keeping their defaults, numeric-string coercion, valid `limit`/`offset`). 11 of the 18 fail without the change.
- Full `@mastra/server` suite: 2097 passing. The 4 failures in `agents.test.ts` are pre-existing and environment-dependent (provider env-var detection) — they fail identically on a clean tree.
