### PR TITLE
Allow ToolSearchProcessor to search tools resolved per request

### DIFF
--- a/.changeset/tame-pugs-gather.md
+++ b/.changeset/tame-pugs-gather.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Add `includeResolvedTools` to `ToolSearchProcessor`, making per-request tools (MCP tools that need the caller's credentials, or anything returned by a dynamic `tools` function) searchable and withholding them from the prompt until the agent loads them. Previously only tools listed at construction could be searched, so dynamically resolved tools were always sent in full.

--- a/.changeset/tame-pugs-gather.md
+++ b/.changeset/tame-pugs-gather.md
@@ -3,3 +3,20 @@
 ---
 
 Add `includeResolvedTools` to `ToolSearchProcessor`, making per-request tools (MCP tools that need the caller's credentials, or anything returned by a dynamic `tools` function) searchable and withholding them from the prompt until the agent loads them. Previously only tools listed at construction could be searched, so dynamically resolved tools were always sent in full.
+
+```ts
+const toolSearch = new ToolSearchProcessor({
+  tools: staticTools,
+  includeResolvedTools: true,
+})
+
+const agent = new Agent({
+  id: 'mcp-agent',
+  name: 'mcp-agent',
+  instructions: 'Search for a tool when you need a capability you do not have.',
+  model: 'openai/gpt-5.6-sol',
+  // Resolved per request, then searchable alongside staticTools
+  tools: async ({ requestContext }) => mcpClient.getTools(requestContext.get('userToken')),
+  inputProcessors: [toolSearch],
+})
+```

--- a/docs/src/content/en/reference/processors/tool-search-processor.mdx
+++ b/docs/src/content/en/reference/processors/tool-search-processor.mdx
@@ -213,7 +213,7 @@ If the hook throws or rejects, `ToolSearchProcessor` treats the tool as disallow
 
 ## Searching request-resolved tools
 
-The `tools` option is fixed at construction, so tools that only exist per request — MCP tools that need the caller's credentials, or anything returned by a dynamic `tools` function — cannot be listed there. By default those tools bypass search and occupy prompt space on every turn.
+The `tools` option is fixed at construction, so you can't list tools that only exist per request (MCP tools that need the caller's credentials, or anything returned by a dynamic `tools` function). By default those tools bypass search and occupy prompt space on every turn.
 
 Set `includeResolvedTools: true` to index them for the request and withhold them from the prompt until the agent loads them:
 

--- a/docs/src/content/en/reference/processors/tool-search-processor.mdx
+++ b/docs/src/content/en/reference/processors/tool-search-processor.mdx
@@ -218,6 +218,9 @@ The `tools` option is fixed at construction, so you can't list tools that only e
 Set `includeResolvedTools: true` to index them for the request and withhold them from the prompt until the agent loads them:
 
 ```typescript title="src/mastra/agents/mcp-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { ToolSearchProcessor } from '@mastra/core/processors'
+
 const toolSearch = new ToolSearchProcessor({
   tools: staticTools,
   includeResolvedTools: true,
@@ -227,7 +230,7 @@ const agent = new Agent({
   id: 'mcp-agent',
   name: 'mcp-agent',
   instructions: 'Search for a tool when you need a capability you do not have.',
-  model: 'openai/gpt-4.1',
+  model: '__GATEWAY_OPENAI_MODEL__',
   // Resolved per request, then searchable alongside staticTools
   tools: async ({ requestContext }) => mcpClient.getTools(requestContext.get('userToken')),
   inputProcessors: [toolSearch],
@@ -235,6 +238,8 @@ const agent = new Agent({
 ```
 
 Each request is indexed on its own, so a tool loaded by one caller never resolves to another caller's instance of the same tool name.
+
+This option applies to every tool resolved for the request, including memory, workspace, skill, and browser tools. Only the `search_tools` and `load_tool` meta-tools stay in the prompt, so any tool the agent relies on implicitly must be found through search before it can be called.
 
 ## Extended usage example
 

--- a/docs/src/content/en/reference/processors/tool-search-processor.mdx
+++ b/docs/src/content/en/reference/processors/tool-search-processor.mdx
@@ -49,6 +49,14 @@ const toolSearch = new ToolSearchProcessor({
             isOptional: false,
           },
           {
+            name: 'includeResolvedTools',
+            type: 'boolean',
+            description:
+              "Also make the tools the agent resolved for this request (MCP tools requiring the caller's credentials, or anything returned by a dynamic tools function) searchable, and withhold them from the prompt until the agent loads them. The meta-tools are never withheld. Request-resolved tools are indexed per request, so each request searches and loads its own tool instances.",
+            isOptional: true,
+            default: 'false',
+          },
+          {
             name: 'search',
             type: '{ topK?: number; minScore?: number; autoLoad?: boolean }',
             description: 'Configuration for the search behavior.',
@@ -201,7 +209,32 @@ The `phase` value describes where the filter is being applied:
 - `load`: Blocks `load_tool` from loading disallowed tools.
 - `active`: Hides already-loaded tools from the current request if they're no longer allowed.
 
-If the hook throws or rejects, `ToolSearchProcessor` treats the tool as disallowed for that request. The hook may run for every matching search candidate, so keep async policy checks cheap or cached. The `search_tools` meta-tool is always available. `load_tool` is available unless `search.autoLoad` is enabled. Tools passed directly through the agent or `processInputStep` remain available unless you filter them outside `ToolSearchProcessor`.
+If the hook throws or rejects, `ToolSearchProcessor` treats the tool as disallowed for that request. The hook may run for every matching search candidate, so keep async policy checks cheap or cached. The `search_tools` meta-tool is always available. `load_tool` is available unless `search.autoLoad` is enabled. Tools passed directly through the agent or `processInputStep` remain available unless you filter them outside `ToolSearchProcessor`, or enable `includeResolvedTools`.
+
+## Searching request-resolved tools
+
+The `tools` option is fixed at construction, so tools that only exist per request — MCP tools that need the caller's credentials, or anything returned by a dynamic `tools` function — cannot be listed there. By default those tools bypass search and occupy prompt space on every turn.
+
+Set `includeResolvedTools: true` to index them for the request and withhold them from the prompt until the agent loads them:
+
+```typescript title="src/mastra/agents/mcp-agent.ts"
+const toolSearch = new ToolSearchProcessor({
+  tools: staticTools,
+  includeResolvedTools: true,
+})
+
+const agent = new Agent({
+  id: 'mcp-agent',
+  name: 'mcp-agent',
+  instructions: 'Search for a tool when you need a capability you do not have.',
+  model: 'openai/gpt-4.1',
+  // Resolved per request, then searchable alongside staticTools
+  tools: async ({ requestContext }) => mcpClient.getTools(requestContext.get('userToken')),
+  inputProcessors: [toolSearch],
+})
+```
+
+Each request is indexed on its own, so a tool loaded by one caller never resolves to another caller's instance of the same tool name.
 
 ## Extended usage example
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -301,6 +301,7 @@ type ResolvedModelSelection = MastraModelConfig | ModelFallbacks;
 type ProcessorLoadedToolsProvider = {
   getLoadedToolsForRequestContext?: (args: {
     requestContext: RequestContext;
+    tools?: Record<string, unknown>;
   }) => Record<string, ToolToConvert> | Promise<Record<string, ToolToConvert>>;
 };
 
@@ -4020,9 +4021,16 @@ export class Agent<
     outputWriter,
     autoResumeSuspendedTools,
     backgroundTaskEnabled,
+    tools,
     ...rest
   }: {
     processors: InputProcessorOrWorkflow[];
+    /**
+     * Tools already resolved for this request. A processor that made a
+     * request-scoped tool searchable needs them to rebuild its executor here,
+     * since the resumed run never re-enters processInputStep.
+     */
+    tools?: Record<string, unknown>;
     runId?: string;
     resourceId?: string;
     threadId?: string;
@@ -4048,7 +4056,7 @@ export class Agent<
         return;
       }
 
-      const loadedTools = await toolProvider.getLoadedToolsForRequestContext({ requestContext });
+      const loadedTools = await toolProvider.getLoadedToolsForRequestContext({ requestContext, tools });
       if (!loadedTools || Object.keys(loadedTools).length === 0) {
         return;
       }
@@ -6065,8 +6073,21 @@ export class Agent<
       backgroundTaskEnabled,
     });
 
+    const requestResolvedTools = {
+      ...assignedTools,
+      ...memoryTools,
+      ...toolsetTools,
+      ...clientSideTools,
+      ...agentTools,
+      ...workflowTools,
+      ...workspaceTools,
+      ...skillTools,
+      ...browserTools,
+    };
+
     const inputProcessorLoadedTools = await this.listInputProcessorLoadedTools({
       processors: configuredInputProcessors,
+      tools: requestResolvedTools,
       runId,
       resourceId,
       threadId,
@@ -6079,15 +6100,7 @@ export class Agent<
     });
 
     const allTools = {
-      ...assignedTools,
-      ...memoryTools,
-      ...toolsetTools,
-      ...clientSideTools,
-      ...agentTools,
-      ...workflowTools,
-      ...workspaceTools,
-      ...skillTools,
-      ...browserTools,
+      ...requestResolvedTools,
       ...inputProcessorLoadedTools,
     };
 

--- a/packages/core/src/processors/processors/tool-search-resolved-tools.test.ts
+++ b/packages/core/src/processors/processors/tool-search-resolved-tools.test.ts
@@ -68,6 +68,19 @@ describe('ToolSearchProcessor includeResolvedTools', () => {
     expect(results).toEqual([]);
   });
 
+  it('rebuilds a loaded resolved tool on the resume path', async () => {
+    const processor = new ToolSearchProcessor({ tools: {}, includeResolvedTools: true, storage: 'in-memory' });
+
+    const first = await processor.processInputStep(stepArgs(resolved));
+    expect((await load(first, 'fetch_invoice')).success).toBe(true);
+
+    // The approval-resume path re-enters without stepArgs, so the tools for the
+    // resumed request have to be handed in for the executor to be rebuilt.
+    const rebuilt = await processor.getLoadedToolsForRequestContext({ tools: resolved });
+
+    expect(rebuilt.fetch_invoice).toBe(resolved.fetch_invoice);
+  });
+
   it('uses the tool instance from the current request, not a cached one', async () => {
     const processor = new ToolSearchProcessor({ tools: {}, includeResolvedTools: true });
 

--- a/packages/core/src/processors/processors/tool-search-resolved-tools.test.ts
+++ b/packages/core/src/processors/processors/tool-search-resolved-tools.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { createTool } from '../../tools';
+import type { ProcessInputStepArgs } from '../index';
+import { ToolSearchProcessor } from './tool-search';
+
+/**
+ * Coverage for #14127: tools resolved per request (MCP tools needing the
+ * caller's auth token, or any dynamic `tools` function) arrive on
+ * `args.tools` and could not previously be searched.
+ */
+function tool(id: string, description: string) {
+  return createTool({ id, description, inputSchema: z.object({}), execute: async () => ({}) });
+}
+
+function stepArgs(tools: Record<string, unknown>): ProcessInputStepArgs {
+  const systemMessages: string[] = [];
+  return {
+    tools,
+    messageList: { addSystem: (m: string) => systemMessages.push(m) },
+  } as unknown as ProcessInputStepArgs;
+}
+
+/** The step result's tools, untyped for terse meta-tool invocation in tests. */
+function toolsOf(result: unknown): Record<string, any> {
+  return (result as { tools: Record<string, any> }).tools;
+}
+
+async function search(result: unknown, query: string) {
+  return toolsOf(result).search_tools.execute({ query }, {});
+}
+
+async function load(result: unknown, toolName: string) {
+  return toolsOf(result).load_tool.execute({ toolName }, {});
+}
+
+describe('ToolSearchProcessor includeResolvedTools', () => {
+  const resolved = { fetch_invoice: tool('fetch_invoice', 'Fetch an invoice from the billing system') };
+
+  it('makes request-resolved tools searchable and withholds them from the prompt', async () => {
+    const processor = new ToolSearchProcessor({ tools: {}, includeResolvedTools: true });
+
+    const result = await processor.processInputStep(stepArgs(resolved));
+
+    expect(Object.keys(toolsOf(result))).not.toContain('fetch_invoice');
+
+    const { results } = await search(result, 'invoice');
+    expect(results.map((r: any) => r.name)).toContain('fetch_invoice');
+  });
+
+  it('exposes a resolved tool once loaded', async () => {
+    const processor = new ToolSearchProcessor({ tools: {}, includeResolvedTools: true, storage: 'in-memory' });
+
+    const first = await processor.processInputStep(stepArgs(resolved));
+    expect((await load(first, 'fetch_invoice')).success).toBe(true);
+
+    const second = await processor.processInputStep(stepArgs(resolved));
+    expect(Object.keys(toolsOf(second))).toContain('fetch_invoice');
+  });
+
+  it('leaves resolved tools alone by default', async () => {
+    const processor = new ToolSearchProcessor({ tools: {} });
+
+    const result = await processor.processInputStep(stepArgs(resolved));
+
+    expect(Object.keys(toolsOf(result))).toContain('fetch_invoice');
+    const { results } = await search(result, 'invoice');
+    expect(results).toEqual([]);
+  });
+
+  it('uses the tool instance from the current request, not a cached one', async () => {
+    const processor = new ToolSearchProcessor({ tools: {}, includeResolvedTools: true });
+
+    const forUserA = { whoami: tool('whoami', 'Report the caller identity') };
+    const forUserB = { whoami: tool('whoami', 'Report the caller identity') };
+
+    const a = await processor.processInputStep(stepArgs(forUserA));
+    await load(a, 'whoami');
+    const b = await processor.processInputStep(stepArgs(forUserB));
+
+    expect(toolsOf(b).whoami).toBe(forUserB.whoami);
+  });
+});

--- a/packages/core/src/processors/processors/tool-search.ts
+++ b/packages/core/src/processors/processors/tool-search.ts
@@ -30,6 +30,23 @@ export interface ToolSearchProcessorOptions {
   tools: Record<string, Tool<any, any>>;
 
   /**
+   * Also make the tools the agent resolved for this request (`args.tools`)
+   * searchable instead of sending them to the model upfront.
+   *
+   * Tools resolved per request — MCP tools that need the caller's auth token,
+   * or anything returned by a dynamic `tools` function — cannot be listed in the
+   * constructor, so by default they bypass search entirely and occupy prompt
+   * space on every turn. With this enabled they are indexed for the duration of
+   * the request and withheld from the prompt until the model loads them, which
+   * is the same token saving static tools already get.
+   *
+   * The meta-tools (`search_tools` / `load_tool`) are never withheld.
+   *
+   * @default false
+   */
+  includeResolvedTools?: boolean;
+
+  /**
    * Configuration for the search behavior
    */
   search?: {
@@ -148,25 +165,63 @@ const TOOL_SEARCH_TOKENIZE_OPTIONS: TokenizeOptions = {
  * });
  * ```
  */
+/** Meta-tools this processor injects; never searchable, never withheld. */
+const META_TOOL_NAMES = new Set(['search_tools', 'load_tool']);
+
+/** A searchable set of tools: the tools themselves plus their BM25 index. */
+type ToolCatalog = {
+  tools: Record<string, Tool<any, any>>;
+  index: BM25Index;
+  /** Tool ID -> full description, for formatting search results. */
+  descriptions: Map<string, string>;
+};
+
+function buildToolCatalog(tools: Record<string, Tool<any, any>>): ToolCatalog {
+  const index = new BM25Index({}, TOOL_SEARCH_TOKENIZE_OPTIONS);
+  const descriptions = new Map<string, string>();
+
+  for (const tool of Object.values(tools)) {
+    const description = tool.description || '';
+    index.add(tool.id, `${tool.id} ${description}`);
+    descriptions.set(tool.id, description);
+  }
+
+  return { tools, index, descriptions };
+}
+
+/**
+ * Request-resolved tools that should become searchable. Typed loosely because
+ * `ProcessInputStepArgs.tools` is an untyped record at the step boundary.
+ */
+function searchableResolvedTools(tools: Record<string, unknown> | undefined): Record<string, Tool<any, any>> {
+  return Object.fromEntries(Object.entries(tools ?? {}).filter(([name]) => !META_TOOL_NAMES.has(name))) as Record<
+    string,
+    Tool<any, any>
+  >;
+}
+
+/** Request-resolved tools that stay in the prompt even when search is enabled. */
+function unsearchableResolvedTools(tools: Record<string, unknown> | undefined): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(tools ?? {}).filter(([name]) => META_TOOL_NAMES.has(name)));
+}
+
 export class ToolSearchProcessor implements Processor<'tool-search'> {
   readonly id = 'tool-search';
   readonly name = 'Tool Search Processor';
   readonly description = 'Enables dynamic tool discovery and loading via search';
 
-  private allTools: Record<string, Tool<any, any>>;
+  private includeResolvedTools: boolean;
   private searchConfig: Required<NonNullable<ToolSearchProcessorOptions['search']>>;
   private filter?: ToolSearchProcessorOptions['filter'];
 
   /** Pluggable backend for loaded-tool state. */
   private store: LoadedToolStore;
 
-  /** BM25 index for tool search */
-  private bm25Index: BM25Index;
-  /** Map from tool ID to full description (for result formatting) */
-  private toolDescriptions = new Map<string, string>();
+  /** Searchable set built from the constructor's `tools`. */
+  private staticCatalog: ToolCatalog;
 
   constructor(options: ToolSearchProcessorOptions) {
-    this.allTools = options.tools;
+    this.includeResolvedTools = options.includeResolvedTools ?? false;
     this.filter = options.filter;
     this.searchConfig = {
       topK: options.search?.topK ?? 5,
@@ -179,11 +234,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     this.store =
       storage === 'context' ? new ContextLoadedToolStore() : new LegacyMapLoadedToolStore({ ttl: options.ttl });
 
-    // Create BM25 index with tool-search-specific tokenization
-    this.bm25Index = new BM25Index({}, TOOL_SEARCH_TOKENIZE_OPTIONS);
-
-    // Index all tools
-    this.indexTools();
+    this.staticCatalog = buildToolCatalog(options.tools);
   }
 
   /**
@@ -198,14 +249,27 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     return { threadId: this.getThreadId(args), args };
   }
 
-  private findToolById(toolId: string): Tool<any, any> | undefined {
-    return Object.values(this.allTools).find(tool => tool.id === toolId);
+  private findToolById(catalog: ToolCatalog, toolId: string): Tool<any, any> | undefined {
+    return Object.values(catalog.tools).find(tool => tool.id === toolId);
   }
 
-  private findToolForDynamicName(toolName: string): Tool<any, any> | undefined {
-    const toolByKey = this.allTools[toolName];
-    const toolById = this.findToolById(toolName);
+  private findToolForDynamicName(catalog: ToolCatalog, toolName: string): Tool<any, any> | undefined {
+    const toolByKey = catalog.tools[toolName];
+    const toolById = this.findToolById(catalog, toolName);
     return this.filter ? (toolById ?? toolByKey) : (toolByKey ?? toolById);
+  }
+
+  /**
+   * The searchable set for one step. Request-resolved tools are indexed fresh
+   * each step rather than cached: two requests can expose the same tool names
+   * backed by different closures (per-user MCP credentials), so reusing an index
+   * across requests would hand one caller another caller's tool instance.
+   */
+  private catalogForStep(stepTools: Record<string, unknown> | undefined): ToolCatalog {
+    if (!this.includeResolvedTools) return this.staticCatalog;
+    const resolved = searchableResolvedTools(stepTools);
+    if (Object.keys(resolved).length === 0) return this.staticCatalog;
+    return buildToolCatalog({ ...this.staticCatalog.tools, ...resolved });
   }
 
   private async isToolAllowed(
@@ -224,20 +288,24 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     }
   }
 
-  private async getSuggestedToolNames(toolName: string, requestContext?: RequestContext): Promise<string[]> {
+  private async getSuggestedToolNames(
+    catalog: ToolCatalog,
+    toolName: string,
+    requestContext?: RequestContext,
+  ): Promise<string[]> {
     const matchesToolName = (name: string) =>
       name.toLowerCase().includes(toolName.toLowerCase()) || toolName.toLowerCase().includes(name.toLowerCase());
 
     if (!this.filter) {
-      return Object.keys(this.allTools).filter(matchesToolName);
+      return Object.keys(catalog.tools).filter(matchesToolName);
     }
 
     const allowedNames: string[] = [];
 
-    for (const name of Object.keys(this.allTools)) {
+    for (const name of Object.keys(catalog.tools)) {
       if (!matchesToolName(name)) continue;
 
-      const tool = this.findToolForDynamicName(name);
+      const tool = this.findToolForDynamicName(catalog, name);
       if (!tool) continue;
 
       const isAllowed = await this.isToolAllowed(tool, requestContext, 'load');
@@ -255,13 +323,14 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
    * Loaded names are resolved by the configured store.
    */
   private async getLoadedTools(
+    catalog: ToolCatalog,
     loadedNames: Set<string>,
     requestContext?: RequestContext,
   ): Promise<Record<string, Tool<any, any>>> {
     const loadedTools: Record<string, Tool<any, any>> = {};
 
     for (const toolName of loadedNames) {
-      const tool = this.findToolForDynamicName(toolName);
+      const tool = this.findToolForDynamicName(catalog, toolName);
       if (tool) {
         const isAllowed = await this.isToolAllowed(tool, requestContext, 'active');
         if (isAllowed) {
@@ -291,12 +360,16 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
       const loadedNames = await this.store.getLoadedNames(this.makeStoreContext(args.stepArgs));
       // Fall back to the step's own request context so active-phase filtering still
       // runs when the caller only supplies stepArgs.
-      return this.getLoadedTools(loadedNames, args.requestContext ?? args.stepArgs.requestContext);
+      return this.getLoadedTools(
+        this.catalogForStep(args.stepArgs.tools),
+        loadedNames,
+        args.requestContext ?? args.stepArgs.requestContext,
+      );
     }
 
     const threadId = (args?.requestContext?.get(MASTRA_THREAD_ID_KEY) as string | undefined) || undefined;
     const loadedNames = await this.store.getLoadedNames({ threadId, args: undefined });
-    return this.getLoadedTools(loadedNames, args?.requestContext);
+    return this.getLoadedTools(this.staticCatalog, loadedNames, args?.requestContext);
   }
 
   /**
@@ -345,32 +418,24 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
   }
 
   /**
-   * Index all tools into the BM25 index
-   */
-  private indexTools(): void {
-    for (const tool of Object.values(this.allTools)) {
-      const name = tool.id;
-      const description = tool.description || '';
-      this.bm25Index.add(name, `${name} ${description}`);
-      this.toolDescriptions.set(name, description);
-    }
-  }
-
-  /**
    * Search for tools matching the query using BM25 ranking
    * with name-match boosting.
    *
    * @param query - Search keywords
    * @returns Array of matching tools with scores, sorted by relevance
    */
-  private async searchTools(query: string, requestContext?: RequestContext): Promise<SearchResult[]> {
-    if (this.bm25Index.size === 0) return [];
+  private async searchTools(
+    catalog: ToolCatalog,
+    query: string,
+    requestContext?: RequestContext,
+  ): Promise<SearchResult[]> {
+    if (catalog.index.size === 0) return [];
 
     // Get BM25 results (request more than topK to allow for re-ranking after boosting).
     // When filtering is enabled, inspect every BM25 match so denied high-ranking tools
     // do not prevent lower-ranking allowed tools from filling the result set.
-    const searchLimit = this.filter ? this.bm25Index.size : this.searchConfig.topK * 2;
-    const bm25Results = this.bm25Index.search(query, searchLimit, 0);
+    const searchLimit = this.filter ? catalog.index.size : this.searchConfig.topK * 2;
+    const bm25Results = catalog.index.search(query, searchLimit, 0);
 
     if (bm25Results.length === 0) return [];
 
@@ -399,7 +464,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     for (const result of boostedResults.sort((a, b) => b.score - a.score)) {
       if (result.score <= this.searchConfig.minScore) continue;
 
-      const tool = this.findToolById(result.id);
+      const tool = this.findToolById(catalog, result.id);
       if (!tool) continue;
 
       const isAllowed = await this.isToolAllowed(tool, requestContext, 'search');
@@ -411,7 +476,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
 
     // Apply topK and format results.
     return filteredResults.slice(0, this.searchConfig.topK).map(r => {
-      const description = this.toolDescriptions.get(r.id) || '';
+      const description = catalog.descriptions.get(r.id) || '';
       return {
         name: r.id,
         description: description.length > 150 ? description.slice(0, 147) + '...' : description,
@@ -422,6 +487,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
 
   async processInputStep(args: ProcessInputStepArgs) {
     const { tools, messageList } = args;
+    const catalog = this.catalogForStep(tools);
     const storeContext = this.makeStoreContext(args);
     // Snapshot of names already loaded as of this step. Newly activated tools are
     // recorded via the store and become available on the model's next turn.
@@ -467,7 +533,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
       }),
       execute: async ({ query }) => {
         // Use BM25 search for relevance-ranked results
-        const results = await this.searchTools(query, args.requestContext);
+        const results = await this.searchTools(catalog, query, args.requestContext);
 
         if (results.length === 0) {
           return {
@@ -560,7 +626,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
 
         for (const name of toLoad) {
           // Check if tool exists
-          const matchingTool = this.findToolForDynamicName(name);
+          const matchingTool = this.findToolForDynamicName(catalog, name);
 
           if (!matchingTool) {
             notFound.push(name);
@@ -593,7 +659,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
           // Single-tool response (backward compatible shape)
           if (notFound.length > 0) {
             const name = toLoad[0]!;
-            const suggestions = await this.getSuggestedToolNames(name, args.requestContext);
+            const suggestions = await this.getSuggestedToolNames(catalog, name, args.requestContext);
             let message = `Tool "${name}" not found.`;
             if (suggestions.length > 0) {
               message += ` Did you mean: ${suggestions.slice(0, 3).join(', ')}?`;
@@ -634,7 +700,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     });
 
     // Get loaded tools as of this step's snapshot.
-    const loadedTools = await this.getLoadedTools(loadedToolNames, args.requestContext);
+    const loadedTools = await this.getLoadedTools(catalog, loadedToolNames, args.requestContext);
 
     // Return merged tools, ordered to keep the cacheable prefix stable:
     // meta-tool(s) first (always present, fixed position), then existing tools,
@@ -646,7 +712,10 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
         search_tools: searchTool,
         // load_tool is omitted in auto-load mode — search_tools activates matches directly.
         ...(autoLoad ? {} : { load_tool: loadTool }),
-        ...(tools ?? {}),
+        // When request-resolved tools are searchable they are withheld here:
+        // leaving them in would defeat the point, since they would still occupy
+        // prompt space. They come back through `loadedTools` once loaded.
+        ...(this.includeResolvedTools ? unsearchableResolvedTools(tools) : (tools ?? {})),
         ...loadedTools,
       },
     };

--- a/packages/core/src/processors/processors/tool-search.ts
+++ b/packages/core/src/processors/processors/tool-search.ts
@@ -180,10 +180,14 @@ function buildToolCatalog(tools: Record<string, Tool<any, any>>): ToolCatalog {
   const index = new BM25Index({}, TOOL_SEARCH_TOKENIZE_OPTIONS);
   const descriptions = new Map<string, string>();
 
-  for (const tool of Object.values(tools)) {
+  for (const [key, tool] of Object.entries(tools)) {
+    // Request-resolved tools arrive as converted tools, which only carry `id`
+    // when the original tool declared one. Fall back to the record key so an
+    // id-less tool is still searchable under the name the model calls.
+    const name = tool.id || key;
     const description = tool.description || '';
-    index.add(tool.id, `${tool.id} ${description}`);
-    descriptions.set(tool.id, description);
+    index.add(name, `${name} ${description}`);
+    descriptions.set(name, description);
   }
 
   return { tools, index, descriptions };
@@ -351,10 +355,15 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
    * - Otherwise (resume path) resolve from the store using the thread ID derived
    *   from the request context. The context store falls back to its same-process
    *   supplemental set.
+   *
+   * `tools` carries the resumed request's resolved tools. Without them a loaded
+   * request-scoped tool has no entry in the static catalog, so the approved call
+   * would resume with no executor.
    */
   public async getLoadedToolsForRequestContext(args?: {
     requestContext?: RequestContext;
     stepArgs?: ProcessInputStepArgs;
+    tools?: Record<string, unknown>;
   }): Promise<Record<string, Tool<any, any>>> {
     if (args?.stepArgs) {
       const loadedNames = await this.store.getLoadedNames(this.makeStoreContext(args.stepArgs));
@@ -369,7 +378,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
 
     const threadId = (args?.requestContext?.get(MASTRA_THREAD_ID_KEY) as string | undefined) || undefined;
     const loadedNames = await this.store.getLoadedNames({ threadId, args: undefined });
-    return this.getLoadedTools(this.staticCatalog, loadedNames, args?.requestContext);
+    return this.getLoadedTools(this.catalogForStep(args?.tools), loadedNames, args?.requestContext);
   }
 
   /**


### PR DESCRIPTION
## Summary

`ToolSearchProcessor` exists to keep large tool libraries out of the prompt: the agent searches for a capability, loads the tool, and only then does the definition cost tokens. That only worked for tools listed in the constructor.

Tools that are resolved per request cannot be listed there — MCP tools that need the caller's credentials, or anything returned by a dynamic `tools` function. Those tools arrived on `args.tools`, were ignored by the processor, and were sent to the model in full on every turn. An agent with a handful of static tools and twenty MCP tools got the savings on the wrong half of its toolset.

Setting `includeResolvedTools: true` makes the request's resolved tools searchable and withholds them from the prompt until the model loads them. The meta-tools are never withheld, and the default is off, so existing configurations behave exactly as before.

One deliberate choice worth flagging for review: the index for request-resolved tools is rebuilt each step rather than cached across requests. The same tool name can be backed by a different closure per caller, which is precisely the case this feature targets, so a shared index would let one caller load a tool and another caller execute that first caller's instance. Rebuilding costs a linear pass over a few dozen tools.

## Test plan

- New tests cover the four behaviors that matter: resolved tools become searchable, they are withheld from the prompt, they reappear once loaded, and a second request resolves its own instance rather than a cached one. The default path is asserted unchanged.
- Existing tool-search and durable tool-search suites pass unchanged (41 files, 1070 tests), confirming no behavior change when the option is off.
- Reference docs updated and `docs` validation passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

`ToolSearchProcessor` can now find tools that become available for a specific request. These tools stay out of the model prompt until needed, while each request keeps its own tool instances.

## Changes

- Added opt-in `includeResolvedTools` support.
- Indexed request-resolved tools, including MCP tools and tools returned by dynamic `tools` functions.
- Kept meta-tools available in the prompt.
- Restored loaded tools from the current request after resume.
- Rebuilt tool indexes for each step to prevent tool instances from being shared across callers.
- Used record keys for converted tools without IDs.
- Preserved the existing default behavior when `includeResolvedTools` is disabled.
- Added tests for searchability, prompt withholding, tool loading, per-request instances, resumed requests, id-less tools, and default behavior.
- Updated runnable reference documentation and added a changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->