### PR TITLE
Fix workflow stream cache dying with the client connection

### DIFF
--- a/.changeset/witty-melons-clap.md
+++ b/.changeset/witty-melons-clap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fix workflow stream caching being tied to a single client connection. Cached chunks are now written per run rather than per subscriber, so `/observe` replays a complete history after a client disconnects mid-run, and concurrent subscribers to the same run no longer cache every chunk twice.

--- a/packages/server/src/server/handlers/workflow-stream-cache.test.ts
+++ b/packages/server/src/server/handlers/workflow-stream-cache.test.ts
@@ -1,0 +1,93 @@
+import { Mastra } from '@mastra/core';
+import { InMemoryServerCache } from '@mastra/core/cache';
+import { MockStore } from '@mastra/core/storage';
+import type { ChunkType } from '@mastra/core/workflows';
+import { createStep, createWorkflow } from '@mastra/core/workflows';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { z } from 'zod';
+import { STREAM_WORKFLOW_ROUTE } from './workflows';
+
+/**
+ * Coverage for #20188: the cached chunk history belongs to the run, not to the
+ * client that happens to be watching it. `/observe` replays from this cache, so
+ * it has to be complete and duplicate-free however many clients attach or leave.
+ */
+function makeWorkflow() {
+  const step = createStep({
+    id: 'test-step',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ result: z.string() }),
+    execute: async () => ({ result: 'success' }),
+  });
+
+  return createWorkflow({
+    id: 'test-workflow',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ result: z.string() }),
+    steps: [step],
+  })
+    .then(step)
+    .commit();
+}
+
+async function streamRun(mastra: Mastra, runId: string): Promise<ReadableStream<ChunkType>> {
+  return (await STREAM_WORKFLOW_ROUTE.handler({
+    mastra,
+    workflowId: 'test-workflow',
+    runId,
+    inputData: {},
+  } as any)) as ReadableStream<ChunkType>;
+}
+
+/** Wait for the run's cached history to be complete. */
+async function settledCache(cache: InMemoryServerCache, runId: string): Promise<ChunkType[]> {
+  for (let i = 0; i < 200; i++) {
+    const chunks = (await cache.listFromTo(runId, 0)) as ChunkType[];
+    if (chunks.some(chunk => chunk.type === 'workflow-finish')) return chunks;
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+  return (await cache.listFromTo(runId, 0)) as ChunkType[];
+}
+
+describe('workflow stream caching', () => {
+  let mastra: Mastra;
+  let cache: InMemoryServerCache;
+
+  beforeEach(() => {
+    cache = new InMemoryServerCache();
+    mastra = new Mastra({
+      logger: false,
+      workflows: { 'test-workflow': makeWorkflow() },
+      storage: new MockStore(),
+      cache,
+    });
+  });
+
+  it('caches the full run after the client disconnects', async () => {
+    const runId = 'run-disconnect';
+    const stream = await streamRun(mastra, runId);
+
+    // Read one chunk, then walk away — the client is gone before the run ends.
+    const reader = stream.getReader();
+    await reader.read();
+    await reader.cancel();
+
+    const cached = await settledCache(cache, runId);
+    expect(cached.map(chunk => chunk.type)).toContain('workflow-finish');
+  });
+
+  it('caches each chunk once when a run is streamed concurrently', async () => {
+    const runId = 'run-concurrent';
+
+    const [first, second] = await Promise.all([streamRun(mastra, runId), streamRun(mastra, runId)]);
+    const drain = async (stream: ReadableStream<ChunkType>) => {
+      const seen: ChunkType[] = [];
+      for await (const chunk of stream as any) seen.push(chunk);
+      return seen;
+    };
+    const [seenByFirst] = await Promise.all([drain(first), drain(second)]);
+
+    const cached = await settledCache(cache, runId);
+    expect(cached.length).toBe(seenByFirst.length);
+  });
+});

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -1,7 +1,8 @@
 import type { Mastra } from '@mastra/core';
+import type { MastraServerCache } from '@mastra/core/cache';
 import type { RequestContext } from '@mastra/core/di';
 import type { Event } from '@mastra/core/events';
-import { createCachingTransformStream, createReplayStream } from '@mastra/core/stream';
+import { createReplayStream } from '@mastra/core/stream';
 import type {
   WorkflowInfo,
   ChunkType,
@@ -48,6 +49,61 @@ import { getEffectiveResourceId, validateRunOwnership } from './utils';
  * in the workflow's run map, and a finished run has already been dropped from it.
  */
 const TERMINAL_RUN_STATUSES: WorkflowRunStatus[] = ['success', 'failed', 'canceled', 'tripwire'];
+
+/**
+ * Runs whose chunks are already being written to the cache in this process,
+ * keyed by runId. A run has exactly one writer: without this, two concurrent
+ * requests for the same runId each cache every chunk and the replayed history
+ * comes back duplicated.
+ */
+const activeRunStreamCachers = new Set<string>();
+
+/**
+ * Cache a run's chunks for later replay and return the stream to hand the client.
+ *
+ * The cached history belongs to the run, not to whoever happens to be watching,
+ * so the caching side is driven by its own reader rather than by the client's
+ * consumption. If the client disconnects mid-run its branch is cancelled while
+ * this reader keeps draining, so `/observe` still replays a complete history —
+ * the failure that makes reconnection necessary is exactly the one the cache has
+ * to survive. Chunks buffer in the tee while a client lags, bounded by the run's
+ * own length.
+ */
+function cacheRunStream({
+  cache,
+  runId,
+  source,
+}: {
+  cache: MastraServerCache;
+  runId: string;
+  source: ReadableStream<ChunkType>;
+}): ReadableStream<ChunkType> {
+  if (activeRunStreamCachers.has(runId)) {
+    return source;
+  }
+
+  const [toCache, toClient] = source.tee();
+  activeRunStreamCachers.add(runId);
+
+  void (async () => {
+    const reader = toCache.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        // Cache failures must not take down the run being streamed.
+        await cache.listPush(runId, value).catch(() => {});
+      }
+    } catch {
+      // The source errored; the client's branch surfaces it.
+    } finally {
+      reader.releaseLock();
+      activeRunStreamCachers.delete(runId);
+    }
+  })();
+
+  return toClient;
+}
 
 export interface WorkflowContext extends Context {
   workflowId?: string;
@@ -538,11 +594,7 @@ export const STREAM_WORKFLOW_ROUTE = createRoute({
       const result = run.stream({ ...params, requestContext });
 
       if (serverCache) {
-        const { transform } = createCachingTransformStream<ChunkType>({
-          cache: serverCache,
-          cacheKey: runId,
-        });
-        return result.fullStream.pipeThrough(transform);
+        return cacheRunStream({ cache: serverCache, runId, source: result.fullStream });
       }
 
       return result.fullStream;
@@ -596,11 +648,7 @@ export const RESUME_STREAM_WORKFLOW_ROUTE = createRoute({
       const resumeResult = _run.resumeStream({ ...params, requestContext });
 
       if (serverCache) {
-        const { transform } = createCachingTransformStream<ChunkType>({
-          cache: serverCache,
-          cacheKey: runId,
-        });
-        return resumeResult.fullStream.pipeThrough(transform);
+        return cacheRunStream({ cache: serverCache, runId, source: resumeResult.fullStream });
       }
 
       return resumeResult.fullStream;
@@ -1228,11 +1276,7 @@ export const TIME_TRAVEL_STREAM_WORKFLOW_ROUTE = createRoute({
       const result = run.timeTravelStream({ ...params, requestContext });
 
       if (serverCache) {
-        const { transform } = createCachingTransformStream<ChunkType>({
-          cache: serverCache,
-          cacheKey: runId,
-        });
-        return result.fullStream.pipeThrough(transform);
+        return cacheRunStream({ cache: serverCache, runId, source: result.fullStream });
       }
 
       return result.fullStream;


### PR DESCRIPTION
## Summary

Workflow stream routes cached chunks by piping the run's stream through a caching transform on the way to the client. That tied the cache to one HTTP connection, and `/observe` — the endpoint whose whole job is letting a client reconnect — reads from that cache.

Two things followed. Concurrent subscribers to the same runId each attached their own transform under the same cache key, so every chunk was stored twice and the replayed history was duplicated. More seriously, when a client disconnected its transform stopped receiving, so nothing more was cached: `/observe` then replayed a truncated history with no `workflow-finish` for a run that had completed successfully. The cache could not survive the exact failure that makes reconnection necessary.

The caching side is now driven by its own reader on a tee of the run's stream, independent of whether anyone is still listening, and a run has a single writer so concurrent subscribers cannot double-cache. Applied to all three streaming routes (`/stream`, `/resume-stream`, `/time-travel-stream`), which shared the same pattern.

Trade-off worth reviewing: teeing means chunks buffer for a lagging client instead of applying backpressure to the run. That is bounded by the run's own chunk count and is the price of the cache not depending on client liveness, which is the property the issue asks for.

## Test plan

- Two new tests, both confirmed failing before the change: the cache contains the full run including `workflow-finish` after the client disconnects mid-stream, and a concurrently streamed run caches each chunk exactly once (previously 8 cached for 4 chunks seen).
- Full `packages/server` suite passes apart from 4 pre-existing failures in `agents.test.ts`, which depend on ambient provider env vars and fail identically on a clean tree.

Closes #20188.
