### PR TITLE
feat: coalesce skill loader warmup probes

### DIFF
--- a/.changeset/lucky-peaches-add.md
+++ b/.changeset/lucky-peaches-add.md
@@ -1,5 +1,8 @@
 ---
 '@mastra/core': patch
+'@mastra/code-sdk': patch
 ---
 
-Added optional `warmup()` method to `SkillSource` interface. When provided, `WorkspaceSkillsImpl` calls it once before fanning out parallel skill discovery. This coalesces sandbox network warmup probes into a single operation, avoiding N redundant transport failures when loading skills from a cold sandbox.
+Added optional `warmup()` method to `SkillSource` interface for coalescing sandbox network warmup probes. When provided, `WorkspaceSkillsImpl` calls it once before fanning out parallel skill discovery, avoiding N redundant transport failures when loading skills from a cold sandbox.
+
+`SandboxFilesystem` now implements `warmup()` with a cheap `true` exec that exercises the transport layer before parallel skill loads begin.

--- a/.changeset/lucky-peaches-add.md
+++ b/.changeset/lucky-peaches-add.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added optional `warmup()` method to `SkillSource` interface. When provided, `WorkspaceSkillsImpl` calls it once before fanning out parallel skill discovery. This coalesces sandbox network warmup probes into a single operation, avoiding N redundant transport failures when loading skills from a cold sandbox.

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -103,6 +103,10 @@ class FactorySkillSource implements SkillSource {
     if (this.#isFactoryPath(skillPath)) return Promise.resolve(path.normalize(skillPath));
     return this.fallback.realpath ? this.fallback.realpath(skillPath) : Promise.resolve(skillPath);
   }
+
+  warmup(): Promise<void> {
+    return this.fallback.warmup ? this.fallback.warmup() : Promise.resolve();
+  }
 }
 
 const factorySkillExtension: WorkspaceSkillExtension = {

--- a/mastracode/sdk/src/agents/sandbox-filesystem.test.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.test.ts
@@ -265,4 +265,23 @@ describe('SandboxFilesystem', () => {
     expect(fs.id).toBe(`sandbox-fs:fake-sandbox:${WORKDIR}`);
     expect(fs.getInfo().metadata).toMatchObject({ basePath: WORKDIR, sandboxId: 'fake-sandbox' });
   });
+
+  describe('warmup', () => {
+    it('executes a cheap true command to exercise the transport', async () => {
+      const { sandbox, fs } = makeFs();
+      await fs.warmup();
+      expect(sandbox.calls).toContain('true');
+    });
+
+    it('does not throw when the exec succeeds', async () => {
+      const { fs } = makeFs(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+      await expect(fs.warmup()).resolves.toBeUndefined();
+    });
+
+    it('does not throw when the exec fails (errors swallowed by caller)', async () => {
+      const { fs } = makeFs(() => ({ exitCode: 1, stdout: '', stderr: 'error' }));
+      // warmup() itself doesn't throw - the caller (WorkspaceSkillsImpl) swallows errors
+      await expect(fs.warmup()).resolves.toBeUndefined();
+    });
+  });
 });

--- a/mastracode/sdk/src/agents/sandbox-filesystem.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.ts
@@ -484,6 +484,21 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
     return result.exitCode === 0;
   }
 
+  /**
+   * Warmup probe for skill discovery coalescing.
+   *
+   * When used as a SkillSource, WorkspaceSkillsImpl calls this once before
+   * fanning out parallel skill discovery. This lets the sandbox network settle
+   * (private-net dial, lease handshake) in a single probe rather than N
+   * parallel failures during cold-start.
+   *
+   * The probe is a cheap `true` command that exercises the exec transport
+   * without doing real work. Failures are swallowed by the caller.
+   */
+  async warmup(): Promise<void> {
+    await this.exec('true');
+  }
+
   getInfo(): FilesystemInfo {
     return {
       id: this.id,

--- a/packages/core/src/workspace/skills/skill-source.ts
+++ b/packages/core/src/workspace/skills/skill-source.ts
@@ -72,4 +72,20 @@ export interface SkillSource {
    * Sources without aliases or symlinks can return the input path unchanged.
    */
   realpath?(path: string): Promise<string>;
+
+  /**
+   * Optional warmup probe for sources backed by remote sandboxes.
+   *
+   * When provided, WorkspaceSkillsImpl calls this once before fanning out
+   * parallel skill discovery. This coalesces the "is the sandbox network
+   * ready?" check into a single probe, avoiding N parallel transport failures
+   * during sandbox warmup.
+   *
+   * Implementations should perform a cheap operation (e.g., `exists('.')` or
+   * a no-op exec) that exercises the transport layer. The result is ignored;
+   * the goal is to let the transport settle before parallel loads begin.
+   *
+   * Local filesystem sources should not implement this (no warmup needed).
+   */
+  warmup?(): Promise<void>;
 }

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -3132,4 +3132,98 @@ description: A skill referenced by an absolute path
       expect(result?.name).toBe('my-skill');
     });
   });
+
+  describe('warmup coalescing', () => {
+    it('calls source.warmup() once before parallel skill discovery', async () => {
+      const warmup = vi.fn().mockResolvedValue(undefined);
+      const filesystem = createMockFilesystem({
+        'skills/skill-a/SKILL.md': VALID_SKILL_MD,
+        'skills/skill-b/SKILL.md': VALID_SKILL_MD.replace('test-skill', 'skill-b'),
+      });
+      // Add warmup to the mock source
+      const sourceWithWarmup = { ...filesystem, warmup };
+
+      const skills = new WorkspaceSkillsImpl({
+        source: sourceWithWarmup,
+        skills: ['skills'],
+      });
+
+      await skills.list();
+
+      expect(warmup).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fail discovery if warmup throws', async () => {
+      const warmup = vi.fn().mockRejectedValue(new Error('Sandbox not ready'));
+      const filesystem = createMockFilesystem({
+        'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+      });
+      const sourceWithWarmup = { ...filesystem, warmup };
+
+      const skills = new WorkspaceSkillsImpl({
+        source: sourceWithWarmup,
+        skills: ['skills'],
+      });
+
+      // Should not throw, discovery proceeds anyway
+      const result = await skills.list();
+      expect(result).toHaveLength(1);
+      expect(result[0]?.name).toBe('test-skill');
+      expect(warmup).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call warmup if source does not provide it', async () => {
+      const filesystem = createMockFilesystem({
+        'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+      });
+
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        skills: ['skills'],
+      });
+
+      // Should work normally without warmup
+      const result = await skills.list();
+      expect(result).toHaveLength(1);
+    });
+
+    it('calls warmup only once per discovery, not per skill', async () => {
+      const warmup = vi.fn().mockResolvedValue(undefined);
+      const filesystem = createMockFilesystem({
+        'skills/skill-a/SKILL.md': VALID_SKILL_MD,
+        'skills/skill-b/SKILL.md': VALID_SKILL_MD.replace('test-skill', 'skill-b'),
+        'skills/skill-c/SKILL.md': VALID_SKILL_MD.replace('test-skill', 'skill-c'),
+      });
+      const sourceWithWarmup = { ...filesystem, warmup };
+
+      const skills = new WorkspaceSkillsImpl({
+        source: sourceWithWarmup,
+        skills: ['skills'],
+      });
+
+      await skills.list();
+
+      // Warmup called once, not 3 times (once per skill)
+      expect(warmup).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls warmup again on refresh()', async () => {
+      const warmup = vi.fn().mockResolvedValue(undefined);
+      const filesystem = createMockFilesystem({
+        'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+      });
+      const sourceWithWarmup = { ...filesystem, warmup };
+
+      const skills = new WorkspaceSkillsImpl({
+        source: sourceWithWarmup,
+        skills: ['skills'],
+      });
+
+      await skills.list();
+      expect(warmup).toHaveBeenCalledTimes(1);
+
+      await skills.refresh();
+      expect(warmup).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -658,6 +658,19 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
     this.#globDirCache.clear();
     this.#globResolveTimes.clear();
 
+    // Run warmup probe if the source provides one. This coalesces the "is the
+    // sandbox network ready?" check into a single operation before fanning out
+    // parallel skill loads, avoiding N redundant transport failures on cold
+    // sandboxes. Failures are swallowed — if warmup fails, discovery proceeds
+    // anyway and individual skill loads will report their own errors.
+    if (this.#source.warmup) {
+      try {
+        await this.#source.warmup();
+      } catch {
+        // Warmup failed — proceed with discovery; individual loads will error if needed
+      }
+    }
+
     // Adapt SkillSource.readdir to the ReaddirEntry interface used by resolvePathPattern
     const readdir = async (dir: string): Promise<ReaddirEntry[]> => {
       const entries = await this.#source.readdir(dir);


### PR DESCRIPTION
## Summary

Fixes parallel skill loads racing sandbox network warmup on session start, causing ~20-30 transport errors per fresh sandbox in the first 20s.

## Changes

1. **`@mastra/core`**: Added optional `warmup()` method to `SkillSource` interface. `WorkspaceSkillsImpl` calls it once before fanning out parallel skill discovery, coalescing the "is the sandbox ready?" probe into a single operation.

2. **`@mastra/code-sdk`**: Implemented `warmup()` in `SandboxFilesystem` - runs a cheap `true` command to exercise the sandbox transport layer before parallel loads begin.

3. **`@internal/factory`**: `FactorySkillSource.warmup()` delegates to its fallback source (the `SandboxFilesystem`).

## Expected Effect

Instead of N parallel execs racing the cold sandbox network:
- **Before**: ~20-30 transport errors in first 20s of session start
- **After**: 1 warmup exec absorbs network warmup latency, then N parallel skill loads proceed cleanly (0-1 errors)

## Test Plan

- [x] Core warmup coalescing tests (5 tests) - verify warmup is called once before discovery, errors are swallowed, coalescing works
- [x] SDK sandbox-filesystem warmup tests (3 tests) - verify `true` command is executed
- [x] Typecheck passes for core, sdk, and factory packages