### PR TITLE
docs: add warning for server.apiPrefix and auth defaults interaction

### DIFF
--- a/docs/src/content/en/docs/server/auth/index.mdx
+++ b/docs/src/content/en/docs/server/auth/index.mdx
@@ -22,6 +22,10 @@ Authentication is optional. If no auth is configured, all routes and Studio are 
 
 See [Custom API Routes](/docs/server/custom-api-routes#authentication) for controlling authentication on custom endpoints. Visit the [Studio Auth docs](/docs/studio/auth) for more on securing your Studio deployment.
 
+:::warning
+The default auth configuration protects `/api/*` and treats `/api`, `/api/auth/*` as public. When you set a custom `server.apiPrefix`, those defaults no longer match and built-in routes fall outside the protected pattern. Update `server.auth.protected` and `server.auth.public` to reference your new prefix.
+:::
+
 :::note
 
 Authentication for Studio is currently supported by the following providers: Simple Auth, JWT, WorkOS, Better Auth, and Google.

--- a/docs/src/content/en/reference/server/register-api-route.mdx
+++ b/docs/src/content/en/reference/server/register-api-route.mdx
@@ -29,6 +29,10 @@ registerApiRoute("/items/:itemId", { ... })
 
 Custom route paths can't start with the server's configured `apiPrefix` (default: `/api`), as that prefix is reserved for built-in Mastra routes. If you set a custom `apiPrefix`, only that prefix is reserved. For example, with `apiPrefix: '/mastra/api'`, paths like `/api/my-endpoint` are allowed.
 
+:::warning
+The default auth configuration protects `/api/*` and treats `/api`, `/api/auth/*` as public. When you change `apiPrefix`, those defaults no longer match and built-in routes fall outside the protected pattern. Update `server.auth.protected` and `server.auth.public` to reference the new prefix, and update any client code (including `MastraClient` `apiPrefix`) that hits `/api/*`.
+:::
+
 ### options
 
 <PropertiesTable


### PR DESCRIPTION
Document that changing `server.apiPrefix` requires updating `server.auth.protected` and `server.auth.public` so built-in routes remain protected.

## Description

The default auth configuration protects `/api/*` and treats `/api` and `/api/auth/*` as public. When `server.apiPrefix` is modified, built-in Mastra routes fall outside the `/api/*` default pattern and become unprotected. This PR adds warning callouts to `reference/server/register-api-route.mdx` and `docs/server/auth/index.mdx` so users changing `apiPrefix` or configuring authentication are aware that `server.auth.protected` and `server.auth.public` must be updated.

## Related issue(s)

Fixes #21023

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

If users change the API URL prefix, the default security rules may no longer protect built-in routes. This PR adds warnings that explain which authentication settings users must update.

## Changes

- Added guidance to `docs/server/auth/index.mdx`.
- Added a warning to the `path` parameter documentation in `docs/src/content/en/reference/server/register-api-route.mdx`.
- Explained that custom `server.apiPrefix` values require updates to:
  - `server.auth.protected`
  - `server.auth.public`
- Noted that client `apiPrefix` usage may also require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->