### PR TITLE
fix(platform-workspace): defer address registry until sidecar /health succeeds

### DIFF
--- a/.changeset/platform-sandbox-sidecar-probe.md
+++ b/.changeset/platform-sandbox-sidecar-probe.md
@@ -1,0 +1,9 @@
+---
+'@mastra/platform-workspace': patch
+---
+
+Defer address registry population until sidecar /health probe succeeds.
+
+Previously, `PlatformSandbox.start()` immediately populated the address registry with the `instanceUrl` from the workspace-proxy response, causing early execs to race the sidecar's boot window and fail with transport errors (~20-30 per fresh sandbox).
+
+Now, `start()` fires a detached probe that polls the sidecar's `/health` endpoint before populating the registry. Early execs fall back to the lease path until the probe succeeds, eliminating the transport error burst during sandbox warmup.

--- a/.changeset/platform-sandbox-sidecar-probe.md
+++ b/.changeset/platform-sandbox-sidecar-probe.md
@@ -2,8 +2,4 @@
 '@mastra/platform-workspace': patch
 ---
 
-Defer address registry population until sidecar /health probe succeeds.
-
-Previously, `PlatformSandbox.start()` immediately populated the address registry with the `instanceUrl` from the workspace-proxy response, causing early execs to race the sidecar's boot window and fail with transport errors (~20-30 per fresh sandbox).
-
-Now, `start()` fires a detached probe that polls the sidecar's `/health` endpoint before populating the registry. Early execs fall back to the lease path until the probe succeeds, eliminating the transport error burst during sandbox warmup.
+Fixed Platform Sandbox startup so commands use a reliable connection while a new sandbox is starting.

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1393,7 +1393,7 @@ describe('PlatformSandbox', () => {
       expect(entries.has('sbx_1')).toBe(false);
     });
 
-    it('populates the registry from the create response instanceUrl field on a fresh provision', async () => {
+    it('populates the registry after the sidecar /health probe succeeds on fresh provision', async () => {
       vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
       const fetchMock = vi.fn().mockResolvedValueOnce(
         json({
@@ -1402,6 +1402,8 @@ describe('PlatformSandbox', () => {
           instanceUrl: 'http://[fd12:752d:16f5:1:d000:41:e7de:188c]:47000',
         }),
       );
+      // Sidecar health probe succeeds immediately.
+      const privateNetFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
       const { registry, sets, entries } = fakeAddressRegistry();
 
       const sandbox = new PlatformSandbox({
@@ -1409,19 +1411,27 @@ describe('PlatformSandbox', () => {
         projectId: 'proj_123',
         environmentId: 'env_123',
         fetch: fetchMock,
+        privateNetFetch,
         addressRegistry: registry,
       });
       await sandbox._start();
 
-      // The one `set` came from the create response — no discovery exec,
-      // no side channel. Field copy, that's it.
+      // Registry is NOT populated immediately — the fire-and-forget probe
+      // runs asynchronously. Wait for the probe to resolve.
+      await vi.waitFor(() => expect(sets.length).toBeGreaterThan(0));
+
       expect(sets).toEqual([
         { sandboxId: 'sbx_fresh', instanceUrl: 'http://[fd12:752d:16f5:1:d000:41:e7de:188c]:47000' },
       ]);
       expect(entries.get('sbx_fresh')).toBe('http://[fd12:752d:16f5:1:d000:41:e7de:188c]:47000');
+      // The probe called /health on the sidecar.
+      expect(privateNetFetch).toHaveBeenCalledWith(
+        'http://[fd12:752d:16f5:1:d000:41:e7de:188c]:47000/health',
+        expect.objectContaining({ method: 'GET' }),
+      );
     });
 
-    it('populates the registry from the reattach GET response instanceUrl on session recovery', async () => {
+    it('populates the registry after the sidecar /health probe succeeds on session recovery', async () => {
       vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
       // Reattach path: GET /sandbox/:id succeeds with the proxy-cached
       // instanceUrl for a live sandbox. No POST /sandbox is issued.
@@ -1432,6 +1442,8 @@ describe('PlatformSandbox', () => {
           instanceUrl: 'http://[fd12::abcd]:47000',
         }),
       );
+      // Sidecar health probe succeeds immediately.
+      const privateNetFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
       const { registry, sets } = fakeAddressRegistry();
 
       const sandbox = new PlatformSandbox({
@@ -1439,12 +1451,16 @@ describe('PlatformSandbox', () => {
         projectId: 'proj_123',
         sandboxId: 'sbx_existing',
         fetch: fetchMock,
+        privateNetFetch,
         addressRegistry: registry,
       });
       await sandbox._start();
 
-      // Only the reattach GET fired — proxy's cached instanceUrl went
-      // straight into the registry with no extra round-trip.
+      // Wait for the fire-and-forget probe to resolve.
+      await vi.waitFor(() => expect(sets.length).toBeGreaterThan(0));
+
+      // Only the reattach GET fired — proxy's cached instanceUrl went into
+      // the registry after the sidecar health probe succeeded.
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_existing');
       expect(sets).toEqual([{ sandboxId: 'sbx_existing', instanceUrl: 'http://[fd12::abcd]:47000' }]);
@@ -1543,16 +1559,21 @@ describe('PlatformSandbox', () => {
           instanceUrl: 'http://[fd12::1]:47000',
         }),
       );
-      const { registry } = fakeAddressRegistry();
+      // Sidecar probe succeeds immediately.
+      const privateNetFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+      const { registry, sets } = fakeAddressRegistry();
 
       const sandbox = new PlatformSandbox({
         accessToken: 'sk_test',
         projectId: 'proj_123',
         environmentId: 'env_123',
         fetch: fetchMock,
+        privateNetFetch,
         addressRegistry: registry,
       });
       await sandbox._start();
+      // Wait for the fire-and-forget probe to populate the registry.
+      await vi.waitFor(() => expect(sets.length).toBeGreaterThan(0));
 
       const info = await sandbox.getInfo();
 
@@ -1653,6 +1674,113 @@ describe('PlatformSandbox', () => {
       await sandbox.getInfo();
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox/sbx_1');
+    });
+
+    describe('sidecar probe', () => {
+      it('retries the /health probe until it succeeds', async () => {
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi.fn().mockResolvedValueOnce(
+          json({
+            id: 'sbx_probe',
+            createdAt: '2026-06-26T00:00:00.000Z',
+            instanceUrl: 'http://[fd12::1]:47000',
+          }),
+        );
+        // Sidecar returns 503 twice, then 200.
+        const privateNetFetch = vi
+          .fn()
+          .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+          .mockResolvedValueOnce(new Response('', { status: 503 }))
+          .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+        const { registry, sets } = fakeAddressRegistry();
+
+        const sandbox = new PlatformSandbox({
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          fetch: fetchMock,
+          privateNetFetch,
+          addressRegistry: registry,
+        });
+        await sandbox._start();
+
+        // Wait for the probe to succeed after retries.
+        await vi.waitFor(() => expect(sets.length).toBeGreaterThan(0));
+
+        expect(sets).toEqual([{ sandboxId: 'sbx_probe', instanceUrl: 'http://[fd12::1]:47000' }]);
+        // Three /health attempts: connection refused, 503, 200.
+        expect(privateNetFetch).toHaveBeenCalledTimes(3);
+      });
+
+      it('leaves the registry empty when the probe times out', async () => {
+        vi.useFakeTimers();
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi.fn().mockResolvedValueOnce(
+          json({
+            id: 'sbx_timeout',
+            createdAt: '2026-06-26T00:00:00.000Z',
+            instanceUrl: 'http://[fd12::1]:47000',
+          }),
+        );
+        // Sidecar never responds with 200.
+        const privateNetFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+        const { registry, sets, entries } = fakeAddressRegistry();
+
+        const sandbox = new PlatformSandbox({
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          fetch: fetchMock,
+          privateNetFetch,
+          addressRegistry: registry,
+        });
+        await sandbox._start();
+
+        // Advance past the probe timeout (30s).
+        await vi.advanceTimersByTimeAsync(35_000);
+
+        // Registry was never populated.
+        expect(sets).toEqual([]);
+        expect(entries.size).toBe(0);
+        vi.useRealTimers();
+      });
+
+      it('does not block start() while the probe is running', async () => {
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi.fn().mockResolvedValueOnce(
+          json({
+            id: 'sbx_nonblock',
+            createdAt: '2026-06-26T00:00:00.000Z',
+            instanceUrl: 'http://[fd12::1]:47000',
+          }),
+        );
+        // Sidecar probe takes a while to respond.
+        let resolveProbe: (value: Response) => void;
+        const probePromise = new Promise<Response>(r => {
+          resolveProbe = r;
+        });
+        const privateNetFetch = vi.fn().mockReturnValue(probePromise);
+        const { registry, sets } = fakeAddressRegistry();
+
+        const sandbox = new PlatformSandbox({
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          fetch: fetchMock,
+          privateNetFetch,
+          addressRegistry: registry,
+        });
+
+        // start() resolves immediately — does not wait for probe.
+        await sandbox._start();
+        expect(sandbox.status).toBe('running');
+        expect(sets).toEqual([]); // Registry not yet populated.
+
+        // Now resolve the probe.
+        resolveProbe!(new Response('ok', { status: 200 }));
+        await vi.waitFor(() => expect(sets.length).toBeGreaterThan(0));
+        expect(sets).toEqual([{ sandboxId: 'sbx_nonblock', instanceUrl: 'http://[fd12::1]:47000' }]);
+      });
     });
   });
 

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1782,6 +1782,43 @@ describe('PlatformSandbox', () => {
         expect(sets).toEqual([{ sandboxId: 'sbx_nonblock', instanceUrl: 'http://[fd12::1]:47000' }]);
       });
 
+      it('clears a stale registry entry before starting the probe', async () => {
+        // On reattach, the registry may have the old sandbox's address. The
+        // entry should be deleted immediately so execs fall back to lease
+        // during the probe window rather than dialing the stale address.
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi.fn().mockResolvedValueOnce(
+          json({
+            id: 'sbx_stale',
+            createdAt: '2026-06-26T00:00:00.000Z',
+            instanceUrl: 'http://[fd12::2]:47000', // new address
+          }),
+        );
+        // Probe hangs — we just want to verify the delete happens before it.
+        const privateNetFetch = vi.fn().mockReturnValue(new Promise(() => {}));
+        // Seed the registry with a stale entry for the same sandbox id.
+        const { registry, sets, deletes, entries } = fakeAddressRegistry({
+          sbx_stale: 'http://[fd12::1]:47000', // old address
+        });
+
+        const sandbox = new PlatformSandbox({
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          fetch: fetchMock,
+          privateNetFetch,
+          addressRegistry: registry,
+        });
+
+        await sandbox._start();
+
+        // Stale entry was deleted before probe started.
+        expect(deletes).toEqual(['sbx_stale']);
+        // Registry is now empty (probe hasn't resolved yet).
+        expect(entries.size).toBe(0);
+        expect(sets).toEqual([]);
+      });
+
       it('does not re-populate registry when teardown races the probe', async () => {
         // Regression test: if destroy() runs while the probe is pending, the
         // probe should NOT re-populate the registry when it eventually resolves.
@@ -1821,9 +1858,10 @@ describe('PlatformSandbox', () => {
         await sandbox._start();
         expect(sets).toEqual([]);
 
-        // Destroy while probe is pending.
+        // Destroy while probe is pending. Two deletes: one from start()
+        // (clearing any stale entry before probe) and one from destroy().
         await sandbox.destroy();
-        expect(deletes).toEqual(['sbx_race']);
+        expect(deletes).toEqual(['sbx_race', 'sbx_race']);
 
         // Now resolve the probe with 200. The probe should detect the
         // generation mismatch and NOT call set().

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1781,6 +1781,60 @@ describe('PlatformSandbox', () => {
         await vi.waitFor(() => expect(sets.length).toBeGreaterThan(0));
         expect(sets).toEqual([{ sandboxId: 'sbx_nonblock', instanceUrl: 'http://[fd12::1]:47000' }]);
       });
+
+      it('does not re-populate registry when teardown races the probe', async () => {
+        // Regression test: if destroy() runs while the probe is pending, the
+        // probe should NOT re-populate the registry when it eventually resolves.
+        // Otherwise we'd have a leaked registry entry pointing to a deleted VM.
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi
+          .fn()
+          // create sandbox
+          .mockResolvedValueOnce(
+            json({
+              id: 'sbx_race',
+              createdAt: '2026-06-26T00:00:00.000Z',
+              instanceUrl: 'http://[fd12::1]:47000',
+            }),
+          )
+          // destroy sandbox
+          .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+        // Probe hangs until we resolve it manually.
+        let resolveProbe: (value: Response) => void;
+        const probePromise = new Promise<Response>(r => {
+          resolveProbe = r;
+        });
+        const privateNetFetch = vi.fn().mockReturnValue(probePromise);
+        const { registry, sets, deletes } = fakeAddressRegistry();
+
+        const sandbox = new PlatformSandbox({
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          fetch: fetchMock,
+          privateNetFetch,
+          addressRegistry: registry,
+        });
+
+        // Start the sandbox — probe is now in-flight but hasn't resolved.
+        await sandbox._start();
+        expect(sets).toEqual([]);
+
+        // Destroy while probe is pending.
+        await sandbox.destroy();
+        expect(deletes).toEqual(['sbx_race']);
+
+        // Now resolve the probe with 200. The probe should detect the
+        // generation mismatch and NOT call set().
+        resolveProbe!(new Response('ok', { status: 200 }));
+
+        // Give any pending microtasks a chance to run.
+        await new Promise(r => setTimeout(r, 50));
+
+        // Registry should still be empty — no stale entry for the destroyed sandbox.
+        expect(sets).toEqual([]);
+      });
     });
   });
 

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1874,6 +1874,153 @@ describe('PlatformSandbox', () => {
         expect(sets).toEqual([]);
       });
     });
+
+    describe('transport warmup coalescing', () => {
+      it('execs wait for the probe before proceeding', async () => {
+        // When an exec arrives during the sidecar boot window, it should wait
+        // for the probe rather than immediately racing to the lease path.
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi.fn().mockResolvedValueOnce(
+          json({
+            id: 'sbx_coalesce',
+            createdAt: '2026-06-26T00:00:00.000Z',
+            instanceUrl: 'http://[fd12::1]:47000',
+          }),
+        );
+
+        // Manual control over probe resolution.
+        let resolveProbe: (value: Response) => void;
+        const probePromise = new Promise<Response>(r => {
+          resolveProbe = r;
+        });
+        let probeCallCount = 0;
+
+        // Streaming mock for exec calls (NDJSON format expected by sidecar).
+        const priv = streamingPrivateNetFetch();
+
+        // Intercept both /health (probe) and /exec calls.
+        const privateNetFetch = vi.fn().mockImplementation((url: string) => {
+          if (url.includes('/health')) {
+            probeCallCount++;
+            return probePromise;
+          }
+          // For /exec, delegate to streaming mock.
+          return priv.fetch(url, undefined);
+        });
+
+        const { registry } = fakeAddressRegistry();
+
+        const sandbox = new PlatformSandbox({
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          fetch: fetchMock,
+          privateNetFetch,
+          addressRegistry: registry,
+        });
+
+        await sandbox._start();
+
+        // Verify probe was started.
+        expect(probeCallCount).toBe(1);
+
+        // Fire an exec while probe is pending.
+        const execPromise = sandbox.executeCommand('echo 1');
+
+        // Give it a moment to start waiting.
+        await new Promise(r => setTimeout(r, 10));
+
+        // No /exec calls yet — exec is waiting on probe.
+        expect(priv.calls.length).toBe(0);
+
+        // Resolve the probe — sidecar is ready.
+        resolveProbe!(new Response('ok', { status: 200 }));
+
+        // Give exec a moment to proceed after probe resolves.
+        await new Promise(r => setTimeout(r, 10));
+
+        // Now the exec should have called /exec.
+        expect(priv.calls.length).toBe(1);
+        expect(priv.calls[0]!.url).toContain('/exec');
+
+        // Push NDJSON frames to complete the exec.
+        priv.push('{"type":"stdout","data":"hello\\n"}\n');
+        priv.push('{"type":"exit","code":0}\n');
+        priv.end();
+
+        // Exec should complete via private-net.
+        const result = await execPromise;
+        expect(result.success).toBe(true);
+        expect(result.stdout).toBe('hello\n');
+
+        // Verify no lease was minted (no /exec-lease calls to the workspace proxy).
+        const execLeaseCalls = fetchMock.mock.calls.filter((c: unknown[]) => String(c[0]).includes('/exec-lease'));
+        expect(execLeaseCalls).toHaveLength(0);
+      });
+
+      it('proceeds to lease after transport ready timeout', async () => {
+        // If the sidecar probe takes too long, execs should proceed to the
+        // lease path after TRANSPORT_READY_WAIT_MS rather than blocking forever.
+        vi.useFakeTimers();
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi
+          .fn()
+          // create sandbox
+          .mockResolvedValueOnce(
+            json({
+              id: 'sbx_timeout',
+              createdAt: '2026-06-26T00:00:00.000Z',
+              instanceUrl: 'http://[fd12::1]:47000',
+            }),
+          )
+          // exec-lease
+          .mockResolvedValueOnce(
+            json({
+              provider: 'railway',
+              sandboxId: 'sbx_timeout',
+              providerResourceId: 'prov_1',
+              jwt: 'jwt_test',
+              wsEndpoint: 'wss://test.railway.app/exec',
+              subprotocol: 'railway-exec-v1',
+              expiresAt: null,
+            }),
+          );
+        // Probe never resolves (simulates slow/unresponsive sidecar).
+        const privateNetFetch = vi.fn().mockReturnValue(new Promise(() => {}));
+        const { registry } = fakeAddressRegistry();
+        const { factory: wsFactory, sockets } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
+
+        const sandbox = new PlatformSandbox({
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          fetch: fetchMock,
+          privateNetFetch,
+          addressRegistry: registry,
+          webSocketFactory: wsFactory,
+        });
+
+        await sandbox._start();
+
+        // Fire an exec — it will wait for transport ready.
+        const execPromise = sandbox.executeCommand('echo test');
+
+        // Advance past the transport ready timeout (5s).
+        await vi.advanceTimersByTimeAsync(6_000);
+
+        // Exec should complete via lease.
+        const result = await execPromise;
+        expect(result.success).toBe(true);
+
+        // Verify a lease was minted (exec-lease call made).
+        const execLeaseCalls = fetchMock.mock.calls.filter((c: unknown[]) => String(c[0]).includes('/exec-lease'));
+        expect(execLeaseCalls.length).toBeGreaterThan(0);
+        // WebSocket was used.
+        expect(sockets.length).toBeGreaterThan(0);
+
+        vi.useRealTimers();
+      });
+    });
   });
 
   describe('clone', () => {

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -387,6 +387,13 @@ export class PlatformSandbox extends MastraSandbox {
    * Mirrors OSS `@mastra/railway` `RailwaySandbox._startInFlight`.
    */
   private _startInFlight: Promise<void> | null = null;
+  /**
+   * Generation token for the sidecar probe. Incremented on every `start()`
+   * and on teardown. The probe captures this value when it begins; if the
+   * generation has changed by the time the probe succeeds, the probe skips
+   * the `set()` to avoid re-populating a deleted or superseded sandbox entry.
+   */
+  private _probeGeneration = 0;
 
   constructor(options: PlatformSandboxOptions = {}) {
     super({ ...options, name: 'PlatformSandbox', processes: new PlatformProcessManager() });
@@ -556,7 +563,9 @@ export class PlatformSandbox extends MastraSandbox {
     if (!json.instanceUrl) return;
     // Fire-and-forget: probe the sidecar's /health endpoint before populating
     // the registry. Early execs fall back to lease until the probe succeeds.
-    void this._probeSidecarThenRegister(json.id, json.instanceUrl);
+    // Capture the current generation so the probe can detect teardown races.
+    const generation = ++this._probeGeneration;
+    void this._probeSidecarThenRegister(json.id, json.instanceUrl, generation);
   }
 
   /**
@@ -568,19 +577,31 @@ export class PlatformSandbox extends MastraSandbox {
    * If the sidecar never comes up within {@link SIDECAR_PROBE_TIMEOUT_MS},
    * the registry stays unpopulated and all execs go via lease for this
    * sandbox's lifetime (or until a future `start()` re-runs the probe).
+   *
+   * @param generation - The probe generation captured at call time. If this
+   *   no longer matches `_probeGeneration` when the probe succeeds, the probe
+   *   was superseded by a teardown or a new `start()`, so we skip the `set()`.
    */
-  private async _probeSidecarThenRegister(sandboxId: string, instanceUrl: string): Promise<void> {
+  private async _probeSidecarThenRegister(
+    sandboxId: string,
+    instanceUrl: string,
+    generation: number,
+  ): Promise<void> {
     const deadline = Date.now() + SIDECAR_PROBE_TIMEOUT_MS;
     const fetchFn = this._privateNetFetch ?? fetch;
     while (Date.now() < deadline) {
+      // Teardown or new start() superseded this probe — bail out early.
+      if (generation !== this._probeGeneration) return;
       try {
         const res = await fetchFn(`${instanceUrl}/health`, {
           method: 'GET',
           signal: AbortSignal.timeout(1_000),
         });
         if (res.ok) {
-          // Sidecar is listening. Only now is the address safe to publish.
-          this._addressRegistry?.set(sandboxId, instanceUrl);
+          // Sidecar is listening. Only populate if this probe is still current.
+          if (generation === this._probeGeneration && this._sandboxId === sandboxId) {
+            this._addressRegistry?.set(sandboxId, instanceUrl);
+          }
           return;
         }
       } catch {
@@ -681,6 +702,10 @@ export class PlatformSandbox extends MastraSandbox {
   private async _teardownSandbox(): Promise<void> {
     if (!this._sandboxId) return;
     const destroyedSandboxId = this._sandboxId;
+    // Invalidate any in-flight probe so it doesn't re-populate the registry
+    // after we've deleted the entry below. The probe checks this generation
+    // before calling set().
+    this._probeGeneration++;
     await this._client.request(`/sandbox/${encodeURIComponent(destroyedSandboxId)}`, { method: 'DELETE' });
     // Clear local state so a subsequent start() creates a fresh remote sandbox
     // instead of taking the reattach branch and pointing exec at a deleted resource.

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -561,6 +561,10 @@ export class PlatformSandbox extends MastraSandbox {
   private _populateAddressFromResponse(json: CreateSandboxResponse): void {
     if (!this._addressRegistry) return;
     if (!json.instanceUrl) return;
+    // Clear any stale entry before probing. On reattach, the registry may have
+    // the old sandbox's address; execs should fall back to lease until the new
+    // probe succeeds rather than dialing the stale address.
+    this._addressRegistry.delete(json.id);
     // Fire-and-forget: probe the sidecar's /health endpoint before populating
     // the registry. Early execs fall back to lease until the probe succeeds.
     // Capture the current generation so the probe can detect teardown races.

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -593,7 +593,10 @@ export class PlatformSandbox extends MastraSandbox {
           method: 'GET',
           signal: AbortSignal.timeout(1_000),
         });
-        if (res.ok) {
+        const ok = res.ok;
+        // Release the response body so the connection returns to the pool.
+        await res.body?.cancel().catch(() => {});
+        if (ok) {
           // Sidecar is listening. Only populate if this probe is still current.
           if (generation === this._probeGeneration && this._sandboxId === sandboxId) {
             this._addressRegistry?.set(sandboxId, instanceUrl);

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -134,6 +134,14 @@ const CREATE_RETRY_BASE_DELAY_MS = 2_000;
 const SIDECAR_PROBE_TIMEOUT_MS = 30_000;
 /** Delay between sidecar probe attempts. */
 const SIDECAR_PROBE_INTERVAL_MS = 250;
+/**
+ * How long `executeCommand` waits for the transport to become ready before
+ * falling back to the lease path. This is much shorter than
+ * `SIDECAR_PROBE_TIMEOUT_MS` because we want execs to proceed quickly if
+ * the sidecar is slow to boot — the probe continues in the background and
+ * later execs will use private-net once it succeeds.
+ */
+const TRANSPORT_READY_WAIT_MS = 5_000;
 
 /**
  * Diagnostic error thrown when the direct-exec WebSocket transport fails
@@ -394,6 +402,15 @@ export class PlatformSandbox extends MastraSandbox {
    * the `set()` to avoid re-populating a deleted or superseded sandbox entry.
    */
   private _probeGeneration = 0;
+  /**
+   * In-flight sidecar probe promise. Concurrent `executeCommand` callers that
+   * arrive before the registry is populated all await this single promise so
+   * we don't fire N independent lease requests during the sidecar boot window.
+   * Once the probe resolves (success or timeout), callers check the registry
+   * and proceed — either via private-net (probe succeeded) or via lease (probe
+   * failed/timed out, but now coalesced via `_leaseInFlight`).
+   */
+  private _transportReadyPromise: Promise<void> | null = null;
 
   constructor(options: PlatformSandboxOptions = {}) {
     super({ ...options, name: 'PlatformSandbox', processes: new PlatformProcessManager() });
@@ -565,11 +582,11 @@ export class PlatformSandbox extends MastraSandbox {
     // the old sandbox's address; execs should fall back to lease until the new
     // probe succeeds rather than dialing the stale address.
     this._addressRegistry.delete(json.id);
-    // Fire-and-forget: probe the sidecar's /health endpoint before populating
-    // the registry. Early execs fall back to lease until the probe succeeds.
-    // Capture the current generation so the probe can detect teardown races.
+    // Start the sidecar probe and expose it so executeCommand can await it.
+    // Early execs wait for the probe (up to TRANSPORT_READY_WAIT_MS) rather
+    // than all racing to the lease path independently.
     const generation = ++this._probeGeneration;
-    void this._probeSidecarThenRegister(json.id, json.instanceUrl, generation);
+    this._transportReadyPromise = this._probeSidecarThenRegister(json.id, json.instanceUrl, generation);
   }
 
   /**
@@ -614,6 +631,32 @@ export class PlatformSandbox extends MastraSandbox {
     }
     // Sidecar never came up. Leave registry entry unset — every exec goes lease.
     this.logger.warn('Sidecar never answered /health within probe window', { sandboxId });
+  }
+
+  /**
+   * Wait for the transport to become ready (sidecar probe succeeds) or time
+   * out. Concurrent callers all await the same probe promise, coalescing the
+   * cold-start storm into a single warmup attempt.
+   *
+   * If no probe is in flight (no registry, or registry already populated),
+   * this returns immediately. After the wait (success or timeout), callers
+   * check the registry and proceed — either via private-net or lease. The
+   * lease path is still coalesced via `_leaseInFlight`, so even if the probe
+   * times out, we only mint one lease for all concurrent execs.
+   */
+  private async _awaitTransportReady(): Promise<void> {
+    // Fast path: registry already has an entry, transport is warm.
+    if (this._sandboxId && this._addressRegistry?.get(this._sandboxId)) {
+      return;
+    }
+    // No probe in flight — nothing to wait for, proceed to lease path.
+    if (!this._transportReadyPromise) {
+      return;
+    }
+    // Race the probe against a timeout. We don't want to block execs forever
+    // if the sidecar is slow to boot — they can proceed via lease after a
+    // short wait, and later execs will use private-net once the probe succeeds.
+    await Promise.race([this._transportReadyPromise, new Promise<void>(r => setTimeout(r, TRANSPORT_READY_WAIT_MS))]);
   }
 
   /**
@@ -880,6 +923,14 @@ export class PlatformSandbox extends MastraSandbox {
     // default. `_runDirectExec` omits `timeoutMs` from the exec payload when
     // the value is 0, which disables the client-side timer entirely.
     const effectiveTimeout = options?.timeout ?? this._timeout;
+
+    // Wait for the transport to become ready before proceeding. During the
+    // sidecar boot window (immediately after start()), concurrent execs all
+    // await the same probe promise rather than each independently racing to
+    // the lease path — this coalesces the cold-start storm into a single
+    // warmup attempt. Once the probe resolves (or times out after
+    // TRANSPORT_READY_WAIT_MS), we check the registry and proceed.
+    await this._awaitTransportReady();
 
     // Preferred path: dial the in-sandbox sidecar over Railway's private
     // network (~16 ms p50). No GraphQL, no lease mint, no public tcp-proxy.

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -582,11 +582,7 @@ export class PlatformSandbox extends MastraSandbox {
    *   no longer matches `_probeGeneration` when the probe succeeds, the probe
    *   was superseded by a teardown or a new `start()`, so we skip the `set()`.
    */
-  private async _probeSidecarThenRegister(
-    sandboxId: string,
-    instanceUrl: string,
-    generation: number,
-  ): Promise<void> {
+  private async _probeSidecarThenRegister(sandboxId: string, instanceUrl: string, generation: number): Promise<void> {
     const deadline = Date.now() + SIDECAR_PROBE_TIMEOUT_MS;
     const fetchFn = this._privateNetFetch ?? fetch;
     while (Date.now() < deadline) {

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -125,6 +125,17 @@ const CREATE_MAX_ATTEMPTS = 3;
 const CREATE_RETRY_BASE_DELAY_MS = 2_000;
 
 /**
+ * How long to wait for the in-sandbox sidecar's `/health` endpoint to respond
+ * before giving up and leaving the address registry unpopulated (execs fall
+ * back to the lease path). This bounds the fire-and-forget probe that runs
+ * after `start()` resolves; the sandbox is usable immediately — the probe
+ * only controls whether early execs go via private-net or lease.
+ */
+const SIDECAR_PROBE_TIMEOUT_MS = 30_000;
+/** Delay between sidecar probe attempts. */
+const SIDECAR_PROBE_INTERVAL_MS = 250;
+
+/**
  * Diagnostic error thrown when the direct-exec WebSocket transport fails
  * twice in a row (opening handshake refused or socket closed mid-stream
  * without an `exit` frame). Distinguishes "the sandbox transport is broken"
@@ -543,7 +554,42 @@ export class PlatformSandbox extends MastraSandbox {
   private _populateAddressFromResponse(json: CreateSandboxResponse): void {
     if (!this._addressRegistry) return;
     if (!json.instanceUrl) return;
-    this._addressRegistry.set(json.id, json.instanceUrl);
+    // Fire-and-forget: probe the sidecar's /health endpoint before populating
+    // the registry. Early execs fall back to lease until the probe succeeds.
+    void this._probeSidecarThenRegister(json.id, json.instanceUrl);
+  }
+
+  /**
+   * Fire-and-forget probe that polls the sidecar's `/health` endpoint until
+   * it responds, then populates the address registry. Runs detached from
+   * `start()` so sandbox provision latency is unchanged; early execs simply
+   * fall back to the lease path until the probe succeeds.
+   *
+   * If the sidecar never comes up within {@link SIDECAR_PROBE_TIMEOUT_MS},
+   * the registry stays unpopulated and all execs go via lease for this
+   * sandbox's lifetime (or until a future `start()` re-runs the probe).
+   */
+  private async _probeSidecarThenRegister(sandboxId: string, instanceUrl: string): Promise<void> {
+    const deadline = Date.now() + SIDECAR_PROBE_TIMEOUT_MS;
+    const fetchFn = this._privateNetFetch ?? fetch;
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetchFn(`${instanceUrl}/health`, {
+          method: 'GET',
+          signal: AbortSignal.timeout(1_000),
+        });
+        if (res.ok) {
+          // Sidecar is listening. Only now is the address safe to publish.
+          this._addressRegistry?.set(sandboxId, instanceUrl);
+          return;
+        }
+      } catch {
+        // Connection refused / timeout — keep polling.
+      }
+      await new Promise(r => setTimeout(r, SIDECAR_PROBE_INTERVAL_MS));
+    }
+    // Sidecar never came up. Leave registry entry unset — every exec goes lease.
+    this.logger.warn('Sidecar never answered /health within probe window', { sandboxId });
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes parallel skill loads (and all early execs) racing sandbox network warmup on session start, causing ~20-30 transport errors per fresh sandbox in the first 20s.

## Root Cause

`PlatformSandbox.start()` immediately populated the address registry with the `instanceUrl` from the workspace-proxy response. The sidecar wasn't listening yet, so early execs that tried the private-net path got ECONNREFUSED, evicted the registry entry, and fell back to lease — but the damage was done: N parallel execs = N failures logged.

## Fix

Two parts:

### 1. Defer registry population until the sidecar answers `/health`

1. `_populateAddressFromResponse()` fires a probe instead of immediately setting the registry
2. The probe polls `GET /health` on the sidecar URL until it returns 200 (or times out after 30s)
3. Only after the probe succeeds is the registry populated
4. A generation token prevents a pending probe from re-populating the registry after teardown

### 2. Coalesce concurrent execs behind the probe

Deferring the registry alone wasn't enough: during the probe window, N concurrent execs would each independently fall to the lease path — still a storm.

- `executeCommand` now calls `_awaitTransportReady()` before checking the registry
- All concurrent execs await the **same** in-flight probe promise (racing a 5s timeout)
- Probe succeeds → execs proceed via private-net
- Probe slow/failed → execs proceed via lease, still coalesced into a single mint via `_leaseInFlight`

## Expected Effect

| Metric | Before | After |
|--------|--------|-------|
| Transport errors in first 20s | ~20-30 | 0 |
| Lease mints in first 60s | ~20-30 | 0-1 |
| Session start latency | unchanged | unchanged |

## Test Plan

- [x] `registry entry is set only after /health returns 200` — probe gates registry population
- [x] `does not block start() while the probe is running` — probe is non-blocking for start
- [x] `does not re-populate the registry if the sandbox is destroyed while the probe is pending` — teardown race
- [x] `clears stale registry entry before probing` — reattach staleness
- [x] `execs wait for the probe before proceeding` — exec coalescing, private-net path used after probe resolves, zero lease mints
- [x] `proceeds to lease after transport ready timeout` — 5s fallback to lease path
- [x] All 127 platform-workspace tests pass