### PR TITLE
feat(mastracode): add thread delete action to the /threads selector

### DIFF
--- a/.changeset/dry-taxis-hang.md
+++ b/.changeset/dry-taxis-hang.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added a delete action to the /threads selector in Mastra Code. Press Ctrl+D on a highlighted thread to delete it after a confirmation prompt. Deleting the current thread clears the conversation view and gets you ready for a new one. Threads that belong to another resource cannot be deleted until you switch to them first.

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -148,6 +148,7 @@ import { taskPatchToolsScenario } from './task-patch-tools.js';
 import { taskProgressEventsScenario } from './task-progress-events.js';
 import { taskPromptContextNextTurnScenario } from './task-prompt-context-next-turn.js';
 import { terminalResizeReflowScenario } from './terminal-resize-reflow.js';
+import { threadDeleteScenario } from './thread-delete.js';
 import { threadHistoryScenario } from './thread-history.js';
 import { toolHistoryReloadScenario } from './tool-history-reload.js';
 import { toolSchemaCompatScenario } from './tool-schema-compat.js';
@@ -315,6 +316,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'task-progress-events': taskProgressEventsScenario,
   'task-prompt-context-next-turn': taskPromptContextNextTurnScenario,
   'terminal-resize-reflow': terminalResizeReflowScenario,
+  'thread-delete': threadDeleteScenario,
   'thread-history': threadHistoryScenario,
   'tool-history-reload': toolHistoryReloadScenario,
   'tool-schema-compat': toolSchemaCompatScenario,

--- a/mastracode/tui/e2e/tui/thread-delete.ts
+++ b/mastracode/tui/e2e/tui/thread-delete.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from 'node:child_process';
+import { expect } from './expect.js';
+import type { McE2eScenario } from './types.js';
+
+function quoteSql(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+const CTRL_D = '\u0004';
+
+export const threadDeleteScenario: McE2eScenario = {
+  name: 'thread-delete',
+  description:
+    'Delete a seeded thread from the /threads selector via Ctrl+D: foreign-resource threads are rejected, the current thread is deleted after confirmation, and the selector no longer lists it.',
+  testName: 'deletes a thread from the /threads selector with confirmation',
+  prepare({ dbPath, projectDir }) {
+    const now = new Date('2026-06-06T14:30:00.000Z');
+    const resourceId = 'mc-e2e-delete-resource';
+    const metadata = quoteSql(JSON.stringify({ projectPath: projectDir }));
+    const threads = [
+      { id: 'thread-mc-e2e-delete-target', title: 'E2E delete target fixture', text: 'Doomed thread message.' },
+      { id: 'thread-mc-e2e-delete-survivor', title: 'E2E delete survivor fixture', text: 'Surviving thread message.' },
+    ];
+    const sql = threads
+      .map(({ id, title, text }, index) => {
+        const createdAt = quoteSql(new Date(now.getTime() + index * 1000).toISOString());
+        const content = quoteSql(JSON.stringify({ format: 2, parts: [{ type: 'text', text }] }));
+        return `
+insert into mastra_threads (id, resourceId, title, metadata, createdAt, updatedAt)
+values (${quoteSql(id)}, ${quoteSql(resourceId)}, ${quoteSql(title)}, ${metadata}, ${createdAt}, ${createdAt});
+insert into mastra_messages (id, thread_id, content, role, type, createdAt, resourceId)
+values (${quoteSql(`msg-${id}`)}, ${quoteSql(id)}, ${content}, 'user', 'v2', ${createdAt}, ${quoteSql(resourceId)});
+`;
+      })
+      .join('\n');
+    execFileSync('sqlite3', [dbPath], { input: sql });
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/Mastra Code|Project:/i, terminal);
+
+    // Deleting a thread owned by another resource is rejected
+    terminal.submit('/threads');
+    await runtime.waitForScreenText(/E2E delete target fixture/i, terminal);
+    await runtime.waitForScreenText(/Ctrl\+D delete/i, terminal);
+    terminal.write('delete target');
+    await runtime.waitForScreenText(/E2E delete target fixture/i, terminal);
+    terminal.write(CTRL_D);
+    await runtime.waitForScreenText(/Cannot delete a thread that belongs to another resource/i, terminal);
+    runtime.printScreen('after foreign-resource delete rejection', terminal);
+
+    // Switch to the seeded thread so its resource becomes current
+    terminal.submit('/threads');
+    await runtime.waitForScreenText(/E2E delete target fixture/i, terminal);
+    terminal.write('delete target');
+    await runtime.waitForScreenText(/E2E delete target fixture/i, terminal);
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Switched to: E2E delete target fixture/i, terminal);
+    runtime.printScreen('after switch to delete target', terminal);
+
+    // Delete the (now current) thread via Ctrl+D and confirm
+    terminal.submit('/threads');
+    await runtime.waitForScreenText(/E2E delete target fixture/i, terminal);
+    terminal.write('delete target');
+    await runtime.waitForScreenText(/E2E delete target fixture/i, terminal);
+    terminal.write(CTRL_D);
+    await runtime.waitForScreenText(/Delete thread "E2E delete target fixture"\? This cannot be undone/i, terminal);
+    runtime.printScreen('delete confirmation modal', terminal);
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Deleted thread: E2E delete target fixture/i, terminal);
+    runtime.printScreen('after delete', terminal);
+
+    // The selector no longer lists the deleted thread
+    terminal.submit('/threads');
+    await runtime.waitForScreenText(/E2E delete survivor fixture/i, terminal);
+    expect(terminal.serialize().view).not.toContain('E2E delete target fixture');
+    runtime.printScreen('after reopening /threads', terminal);
+  },
+};

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -150,6 +150,7 @@ export type ScenarioName =
   | 'task-progress-events'
   | 'terminal-resize-reflow'
   | 'task-prompt-context-next-turn'
+  | 'thread-delete'
   | 'thread-history'
   | 'tool-history-reload'
   | 'plugins-streaming-tool-output'

--- a/mastracode/tui/src/tui/commands/__tests__/threads.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/threads.test.ts
@@ -1,6 +1,7 @@
 import type { AgentControllerThread, MastraDBMessage } from '@mastra/core/agent-controller';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { askModalQuestion } from '../../modal-question.js';
+import { confirmDeleteThread, resetUIAfterCurrentThreadDelete } from '../delete-thread.js';
 import { handleThreadsCommand, showThreadLockPrompt } from '../threads.js';
 import type { SlashCommandContext } from '../types.js';
 
@@ -16,6 +17,11 @@ vi.mock('../clone.js', () => ({
   askCloneName: vi.fn(),
   confirmClone: vi.fn(),
   resetUIAfterClone: vi.fn(),
+}));
+
+vi.mock('../delete-thread.js', () => ({
+  confirmDeleteThread: vi.fn(),
+  resetUIAfterCurrentThreadDelete: vi.fn(),
 }));
 
 vi.mock('../../modal-question.js', () => ({
@@ -74,9 +80,10 @@ function createContext(threads: AgentControllerThread[]) {
     session: {
       identity: { getResourceId: vi.fn(() => 'resource-1') },
       thread: {
-        getId: vi.fn(() => null),
+        getId: vi.fn((): string | null => null),
         list: vi.fn(async () => threads),
         firstUserMessages: vi.fn(async () => new Map()),
+        delete: vi.fn(async () => {}),
       },
       mode: { get: vi.fn(() => 'build') },
     },
@@ -192,5 +199,94 @@ describe('handleThreadsCommand thread listing', () => {
       resourceId: 'resource-1',
       mode: 'build',
     });
+  });
+});
+
+describe('handleThreadsCommand thread deletion', () => {
+  beforeEach(() => {
+    selectorInstances.length = 0;
+    vi.mocked(confirmDeleteThread).mockReset();
+    vi.mocked(resetUIAfterCurrentThreadDelete).mockReset();
+    vi.mocked(confirmDeleteThread).mockResolvedValue(true);
+  });
+
+  async function openSelector(ctx: SlashCommandContext) {
+    const commandPromise = handleThreadsCommand(ctx);
+    await Promise.resolve();
+    const selector = selectorInstances[0];
+    expect(selector).toBeDefined();
+    return { commandPromise, selector };
+  }
+
+  it('deletes a non-current thread after confirmation and clears its cached preview', async () => {
+    const threads = [createThread('thread-1', '2026-03-17T15:10:00.000Z')];
+    const { ctx, state } = createContext(threads);
+    state.threadPreviewCache.set('thread-1', { preview: 'Cached', updatedAt: threads[0]!.updatedAt.getTime() });
+    state.attemptedThreadPreviewIds.add('thread-1');
+
+    const { commandPromise, selector } = await openSelector(ctx);
+    await selector.options.onDelete(threads[0]);
+    await commandPromise;
+
+    expect(confirmDeleteThread).toHaveBeenCalledWith(state, 'New Thread');
+    expect(state.session.thread.delete).toHaveBeenCalledWith({ threadId: 'thread-1' });
+    expect(state.threadPreviewCache.has('thread-1')).toBe(false);
+    expect(state.attemptedThreadPreviewIds.has('thread-1')).toBe(false);
+    expect(resetUIAfterCurrentThreadDelete).not.toHaveBeenCalled();
+    expect(ctx.showInfo).toHaveBeenCalledWith('Deleted thread: New Thread');
+  });
+
+  it('does not delete when the confirmation is declined', async () => {
+    vi.mocked(confirmDeleteThread).mockResolvedValue(false);
+    const threads = [createThread('thread-1', '2026-03-17T15:10:00.000Z')];
+    const { ctx, state } = createContext(threads);
+
+    const { commandPromise, selector } = await openSelector(ctx);
+    await selector.options.onDelete(threads[0]);
+    await commandPromise;
+
+    expect(state.session.thread.delete).not.toHaveBeenCalled();
+    expect(ctx.showInfo).not.toHaveBeenCalled();
+  });
+
+  it('resets the UI when deleting the current thread', async () => {
+    const threads = [createThread('thread-1', '2026-03-17T15:10:00.000Z')];
+    const { ctx, state } = createContext(threads);
+    state.session.thread.getId.mockReturnValue('thread-1');
+
+    const { commandPromise, selector } = await openSelector(ctx);
+    await selector.options.onDelete(threads[0]);
+    await commandPromise;
+
+    expect(state.session.thread.delete).toHaveBeenCalledWith({ threadId: 'thread-1' });
+    expect(resetUIAfterCurrentThreadDelete).toHaveBeenCalledWith(ctx);
+  });
+
+  it('rejects deleting a thread that belongs to another resource', async () => {
+    const foreignThread = { ...createThread('thread-1', '2026-03-17T15:10:00.000Z'), resourceId: 'resource-2' };
+    const { ctx, state } = createContext([foreignThread]);
+
+    const { commandPromise, selector } = await openSelector(ctx);
+    await selector.options.onDelete(foreignThread);
+    await commandPromise;
+
+    expect(confirmDeleteThread).not.toHaveBeenCalled();
+    expect(state.session.thread.delete).not.toHaveBeenCalled();
+    expect(ctx.showError).toHaveBeenCalledWith(
+      'Cannot delete a thread that belongs to another resource. Switch to it first.',
+    );
+  });
+
+  it('shows an error when the deletion fails', async () => {
+    const threads = [createThread('thread-1', '2026-03-17T15:10:00.000Z')];
+    const { ctx, state } = createContext(threads);
+    state.session.thread.delete.mockRejectedValue(new Error('Thread not found: thread-1'));
+
+    const { commandPromise, selector } = await openSelector(ctx);
+    await selector.options.onDelete(threads[0]);
+    await commandPromise;
+
+    expect(ctx.showError).toHaveBeenCalledWith('Failed to delete thread: Thread not found: thread-1');
+    expect(resetUIAfterCurrentThreadDelete).not.toHaveBeenCalled();
   });
 });

--- a/mastracode/tui/src/tui/commands/delete-thread.ts
+++ b/mastracode/tui/src/tui/commands/delete-thread.ts
@@ -1,0 +1,55 @@
+import { askModalQuestion } from '../modal-question.js';
+import type { TUIState } from '../state.js';
+
+/** Minimal interface accepted by resetUIAfterCurrentThreadDelete so it works
+ *  from both slash-command handlers (SlashCommandContext) and the MastraTUI class. */
+interface DeleteResetContext {
+  state: TUIState;
+  updateStatusLine: () => void;
+}
+
+/**
+ * Confirm whether the user wants to permanently delete a thread. Returns true
+ * if confirmed, false on cancel.
+ */
+export async function confirmDeleteThread(state: TUIState, threadLabel: string): Promise<boolean> {
+  const answer = await askModalQuestion(state.ui, {
+    question: `Delete thread "${threadLabel}"? This cannot be undone.`,
+    options: [
+      { label: 'Delete', description: 'Permanently delete this thread' },
+      { label: 'Cancel', description: 'Keep the thread' },
+    ],
+  });
+  return answer === 'Delete';
+}
+
+/**
+ * UI reset after deleting the *current* thread. The session has already
+ * released the lock and cleared the thread binding
+ * (`session.thread.delete()`), so the TUI mirrors `/new`: clear the chat and
+ * per-thread ephemeral state, then defer thread creation until the next
+ * message.
+ */
+export async function resetUIAfterCurrentThreadDelete(ctx: DeleteResetContext): Promise<void> {
+  const { state } = ctx;
+  state.pendingNewThread = true;
+  state.chatContainer.clear();
+  state.pendingTools.clear();
+  state.pendingTaskToolIds?.clear();
+  state.allToolComponents = [];
+  state.allSlashCommandComponents = [];
+  state.allSystemReminderComponents = [];
+  state.messageComponentsById.clear();
+  state.allShellComponents = [];
+  state.session.displayState.clearModifiedFiles();
+  // Clear per-thread ephemeral state from the global controller state
+  await state.session.state.set({ tasks: [], activePlan: null, sandboxAllowedPaths: [] });
+  state.previousPlanSnapshot = undefined;
+  if (state.taskProgress) {
+    state.taskProgress.updateTasks([]);
+  }
+  state.taskToolInsertIndex = -1;
+
+  ctx.updateStatusLine();
+  state.ui.requestRender();
+}

--- a/mastracode/tui/src/tui/commands/threads.ts
+++ b/mastracode/tui/src/tui/commands/threads.ts
@@ -3,6 +3,7 @@ import { ThreadSelectorComponent } from '../components/thread-selector.js';
 import { askModalQuestion } from '../modal-question.js';
 import { showModalOverlay } from '../overlay.js';
 import { askCloneName, confirmClone, resetUIAfterClone } from './clone.js';
+import { confirmDeleteThread, resetUIAfterCurrentThreadDelete } from './delete-thread.js';
 import type { SlashCommandContext } from './types.js';
 
 export function showThreadLockPrompt(
@@ -160,6 +161,34 @@ export async function handleThreadsCommand(ctx: SlashCommandContext): Promise<vo
           await resetUIAfterClone(ctx, clonedThread.title || clonedThread.id);
         } catch (error) {
           ctx.showError(`Failed to clone thread: ${error instanceof Error ? error.message : String(error)}`);
+        }
+        resolve();
+      },
+      onDelete: async thread => {
+        state.ui.hideOverlay();
+
+        if (thread.resourceId !== currentResourceId) {
+          ctx.showError('Cannot delete a thread that belongs to another resource. Switch to it first.');
+          resolve();
+          return;
+        }
+
+        if (!(await confirmDeleteThread(state, thread.title || thread.id))) {
+          resolve();
+          return;
+        }
+
+        try {
+          const deletingCurrent = thread.id === currentId;
+          await state.session.thread.delete({ threadId: thread.id });
+          state.threadPreviewCache.delete(thread.id);
+          state.attemptedThreadPreviewIds.delete(thread.id);
+          if (deletingCurrent) {
+            await resetUIAfterCurrentThreadDelete(ctx);
+          }
+          ctx.showInfo(`Deleted thread: ${thread.title || thread.id}`);
+        } catch (error) {
+          ctx.showError(`Failed to delete thread: ${error instanceof Error ? error.message : String(error)}`);
         }
         resolve();
       },

--- a/mastracode/tui/src/tui/components/__tests__/thread-selector.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/thread-selector.test.ts
@@ -80,6 +80,7 @@ vi.mock('@earendil-works/pi-tui', () => {
     }),
     matchesKey: (data: string, keyId: string) => {
       if (keyId === 'tab') return data === '\t' || data === 'TAB';
+      if (keyId === 'ctrl+d') return data === '\u0004' || data === 'CTRL+D';
       return false;
     },
   };
@@ -192,5 +193,63 @@ describe('ThreadSelectorComponent preview caching', () => {
     expect(getMessagePreviews).toHaveBeenCalledTimes(1);
 
     vi.useRealTimers();
+  });
+});
+
+describe('ThreadSelectorComponent delete action', () => {
+  function createSelector(options: {
+    onDelete?: (thread: AgentControllerThread) => void;
+    threads?: AgentControllerThread[];
+  }) {
+    return new ThreadSelectorComponent({
+      tui: { requestRender: vi.fn() } as any,
+      threads: options.threads ?? [createThread('thread-1', 0), createThread('thread-2', 1)],
+      currentThreadId: null,
+      currentResourceId: 'resource-1',
+      currentProjectPath: undefined,
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+      onDelete: options.onDelete,
+    });
+  }
+
+  it('invokes onDelete with the selected thread when Ctrl+D is pressed', () => {
+    const onDelete = vi.fn();
+    const selector = createSelector({ onDelete });
+
+    selector.handleInput('DOWN');
+    selector.handleInput('CTRL+D');
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete.mock.calls[0]![0].id).toBe('thread-2');
+  });
+
+  it('does not invoke onDelete when the filtered list is empty', () => {
+    const onDelete = vi.fn();
+    const selector = createSelector({ onDelete, threads: [] });
+
+    selector.handleInput('CTRL+D');
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('does not throw on Ctrl+D when no onDelete callback is provided', () => {
+    const selector = createSelector({});
+
+    expect(() => selector.handleInput('CTRL+D')).not.toThrow();
+  });
+
+  it('shows the delete hint only when onDelete is provided', () => {
+    const withDelete = createSelector({ onDelete: vi.fn() });
+    const withoutDelete = createSelector({});
+
+    const hintText = (selector: ThreadSelectorComponent) =>
+      ((selector as any).children as Array<{ text?: string }>)
+        .map(child => child.text)
+        .filter(Boolean)
+        .join('\n');
+
+    expect(hintText(withDelete)).toContain('Ctrl+D delete');
+    expect(hintText(withoutDelete)).not.toContain('Ctrl+D delete');
   });
 });

--- a/mastracode/tui/src/tui/components/thread-selector.ts
+++ b/mastracode/tui/src/tui/components/thread-selector.ts
@@ -24,6 +24,8 @@ export interface ThreadSelectorOptions {
   onCancel: () => void;
   /** Called when user presses Tab to clone the selected thread */
   onClone?: (thread: AgentControllerThread) => void;
+  /** Called when user presses Ctrl+D to delete the selected thread */
+  onDelete?: (thread: AgentControllerThread) => void;
   /** Function to fetch message previews for currently visible threads */
   getMessagePreviews?: (threadIds: string[]) => Promise<Map<string, string>>;
   initialMessagePreviews?: Map<string, string>;
@@ -54,6 +56,7 @@ export class ThreadSelectorComponent extends Box implements Focusable {
   private onSelectCallback: (thread: AgentControllerThread) => void;
   private onCancelCallback: () => void;
   private onCloneCallback: ((thread: AgentControllerThread) => void) | undefined;
+  private onDeleteCallback: ((thread: AgentControllerThread) => void) | undefined;
   private tui: TUI;
   private getMessagePreviews: ((threadIds: string[]) => Promise<Map<string, string>>) | undefined;
   private onMessagePreviewsLoaded:
@@ -86,6 +89,7 @@ export class ThreadSelectorComponent extends Box implements Focusable {
     this.onSelectCallback = options.onSelect;
     this.onCancelCallback = options.onCancel;
     this.onCloneCallback = options.onClone;
+    this.onDeleteCallback = options.onDelete;
     this.getMessagePreviews = options.getMessagePreviews;
     this.onMessagePreviewsLoaded = options.onMessagePreviewsLoaded;
     this.messagePreviews = new Map(options.initialMessagePreviews ?? []);
@@ -196,8 +200,13 @@ export class ThreadSelectorComponent extends Box implements Focusable {
     this.addChild(new Text(theme.bold(theme.fg('accent', 'Select Thread')), 0, 0));
     this.addChild(new Spacer(1));
     const cloneHint = this.onCloneCallback ? ' • Tab clone active thread' : '';
+    const deleteHint = this.onDeleteCallback ? ' • Ctrl+D delete' : '';
     this.addChild(
-      new Text(theme.fg('muted', `Type to search • ↑↓ navigate • Enter select${cloneHint} • Esc cancel`), 0, 0),
+      new Text(
+        theme.fg('muted', `Type to search • ↑↓ navigate • Enter select${cloneHint}${deleteHint} • Esc cancel`),
+        0,
+        0,
+      ),
     );
     this.addChild(new Spacer(1));
 
@@ -354,6 +363,11 @@ export class ThreadSelectorComponent extends Box implements Focusable {
       const selected = this.filteredThreads[this.selectedIndex];
       if (selected) {
         this.onCloneCallback(selected);
+      }
+    } else if (matchesKey(keyData, 'ctrl+d') && this.onDeleteCallback) {
+      const selected = this.filteredThreads[this.selectedIndex];
+      if (selected) {
+        this.onDeleteCallback(selected);
       }
     } else {
       this.searchInput.handleInput(keyData);


### PR DESCRIPTION
## Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Users can now delete threads from the `/threads` selector in Mastra Code. The action asks for confirmation and protects threads that belong to another resource.

## Changes

- Added `Ctrl+D` support to the thread selector.
- Added confirmation before permanent deletion.
- Cleared the current thread and related UI state after deletion.
- Removed deleted-thread preview caches.
- Added success and failure messages.
- Blocked deletion of threads from another resource.
- Added unit tests and an end-to-end test scenario for thread deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->