### PR TITLE
feat(core): add catalog discovery mode to ToolSearchProcessor

### DIFF
--- a/.changeset/floppy-tools-accept.md
+++ b/.changeset/floppy-tools-accept.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added catalog discovery mode to ToolSearchProcessor so agents can see every tool id and description while loading schemas on demand.

--- a/.changeset/floppy-tools-accept.md
+++ b/.changeset/floppy-tools-accept.md
@@ -2,4 +2,11 @@
 '@mastra/core': minor
 ---
 
-Added catalog discovery mode to ToolSearchProcessor so agents can see every tool id and description while loading schemas on demand.
+Added `mode: 'catalog'` to `ToolSearchProcessor`. Agents can see available tool IDs and short descriptions while full schemas load only for selected tools.
+
+```ts
+const toolSearch = new ToolSearchProcessor({
+  tools: allTools,
+  mode: 'catalog',
+})
+```

--- a/docs/src/content/en/reference/processors/tool-search-processor.mdx
+++ b/docs/src/content/en/reference/processors/tool-search-processor.mdx
@@ -7,7 +7,7 @@ packages:
 
 # ToolSearchProcessor
 
-The `ToolSearchProcessor` is an **input processor** that enables runtime-defined tool discovery and loading. Instead of providing all tools to the agent upfront, it gives the agent two meta-tools (`search_tools` and `load_tool`) that let it find and load tools on demand. This reduces context token usage when working with large tool libraries.
+The `ToolSearchProcessor` is an **input processor** that enables runtime-defined tool discovery and loading. Instead of providing every tool schema to the agent upfront, it can expose keyword search or a thin catalog of tool IDs and descriptions. Full schemas are added only after tools are loaded. This reduces context token usage when working with large tool libraries.
 
 ## Usage example
 
@@ -47,6 +47,14 @@ const toolSearch = new ToolSearchProcessor({
             description:
               'All tools that can be searched and loaded dynamically. These tools are not immediately available to the agent — they must be discovered via search and loaded on demand.',
             isOptional: false,
+          },
+          {
+            name: 'mode',
+            type: "'search' | 'catalog'",
+            description:
+              "Controls tool discovery. 'search' exposes search_tools for keyword discovery. 'catalog' injects a deterministic list of every allowed tool ID and short description, omits search_tools, and keeps schemas deferred until load_tool receives an exact ID.",
+            isOptional: true,
+            default: "'search'",
           },
           {
             name: 'search',
@@ -96,7 +104,7 @@ const toolSearch = new ToolSearchProcessor({
             name: 'filter',
             type: '(args: ToolSearchFilterArgs) => boolean | Promise<boolean>',
             description:
-              'Optional request-aware hook for hiding tools from search results, blocking tool loading, or hiding already-loaded tools for the current request.',
+              'Optional request-aware hook for hiding tools from search results or the catalog, blocking tool loading, or hiding already-loaded tools for the current request.',
             isOptional: true,
           },
         ],
@@ -126,7 +134,7 @@ const toolSearch = new ToolSearchProcessor({
     name: 'processInputStep',
     type: '(args: ProcessInputStepArgs) => Promise<ProcessInputStepResult>',
     description:
-      "Processes each step to inject search/load meta-tools and any previously loaded tools into the agent's tool set.",
+      "Processes each step to inject discovery instructions, load/search meta-tools as configured, and any previously loaded tools into the agent's tool set.",
     isOptional: false,
   },
 ]}
@@ -197,11 +205,11 @@ const toolSearch = new ToolSearchProcessor({
 
 The `phase` value describes where the filter is being applied:
 
-- `search`: Filters results returned by `search_tools`.
+- `search`: Filters results returned by `search_tools` or entries included in the catalog.
 - `load`: Blocks `load_tool` from loading disallowed tools.
 - `active`: Hides already-loaded tools from the current request if they're no longer allowed.
 
-If the hook throws or rejects, `ToolSearchProcessor` treats the tool as disallowed for that request. The hook may run for every matching search candidate, so keep async policy checks cheap or cached. The `search_tools` meta-tool is always available. `load_tool` is available unless `search.autoLoad` is enabled. Tools passed directly through the agent or `processInputStep` remain available unless you filter them outside `ToolSearchProcessor`.
+If the hook throws or rejects, `ToolSearchProcessor` treats the tool as disallowed for that request. The hook may run for every matching search candidate or catalog entry, so keep async policy checks cheap or cached. The `search_tools` meta-tool is available in search mode. `load_tool` is available unless `search.autoLoad` is enabled. Tools passed directly through the agent or `processInputStep` remain available unless you filter them outside `ToolSearchProcessor`.
 
 ## Extended usage example
 
@@ -243,6 +251,28 @@ The agent workflow is:
 1. Agent reviews results and calls `load_tool` with the tool name
 1. The loaded tool becomes available on the next turn
 1. Agent uses the loaded tool normally
+
+## Catalog discovery
+
+Set `mode` to `'catalog'` when the model should immediately see every available tool instead of discovering tools with keyword queries. The processor injects a deterministic, ID-sorted catalog containing only exact tool IDs and short descriptions. It doesn't expose `search_tools`, and full tool schemas remain out of context until the model calls `load_tool`.
+
+```typescript
+const toolSearch = new ToolSearchProcessor({
+  tools: allTools,
+  mode: 'catalog',
+  storage: 'context',
+})
+```
+
+The catalog workflow is:
+
+1. Agent receives a user message together with the thin tool catalog
+1. Agent selects an exact tool ID from the catalog
+1. Agent calls `load_tool` with that ID
+1. The loaded tool and its full schema become available on the next turn
+1. Agent uses the loaded tool normally
+
+Catalog descriptions are limited to 150 characters and XML-escaped. The `filter` hook runs with `phase: 'search'` before each catalog entry is included, then runs again with `phase: 'load'` and `phase: 'active'` at those boundaries. Catalog mode can't be combined with `search.autoLoad` because the model must explicitly choose which listed schema to load.
 
 ## Single-step discovery with `autoLoad`
 

--- a/docs/src/content/en/reference/processors/tool-search-processor.mdx
+++ b/docs/src/content/en/reference/processors/tool-search-processor.mdx
@@ -184,7 +184,7 @@ Returns: `number`: the count of threads cleaned up.
 
 ## Request-aware filtering
 
-Use `filter` to apply request-specific policy to runtime-defined tools. The hook receives the resolved tool ID as `toolName`, the tool, request context, and phase. `toolName` is the ID returned by `search_tools`, which may differ from the key used in the `tools` object.
+Use `filter` to apply request-specific policy to runtime-defined tools. The hook receives the resolved tool ID as `toolName`, the tool, request context, and phase. `toolName` is the ID returned in search results or listed in the catalog, which may differ from the key used in the `tools` object.
 
 ```typescript
 import { ToolSearchProcessor } from '@mastra/core/processors'

--- a/packages/core/src/processors/processors/index.ts
+++ b/packages/core/src/processors/processors/index.ts
@@ -67,6 +67,7 @@ export { AgentsMDInjector, type ToolResultReminderOptions, type ReminderFileRead
 
 export {
   ToolSearchProcessor,
+  type ToolDiscoveryMode,
   type ToolSearchFilterArgs,
   type ToolSearchFilterPhase,
   type ToolSearchProcessorOptions,

--- a/packages/core/src/processors/processors/tool-search.test.ts
+++ b/packages/core/src/processors/processors/tool-search.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { z } from 'zod/v4';
 
 import { MessageList } from '../../agent/message-list';
 import { RequestContext, MASTRA_THREAD_ID_KEY } from '../../request-context';
@@ -60,6 +61,103 @@ describe('ToolSearchProcessor', () => {
       });
 
       expect(processor).toBeDefined();
+    });
+
+    it('should reject autoLoad in catalog mode', () => {
+      expect(
+        () =>
+          new ToolSearchProcessor({
+            tools: {},
+            mode: 'catalog',
+            search: { autoLoad: true },
+          }),
+      ).toThrow('autoLoad');
+    });
+  });
+
+  describe('catalog discovery mode', () => {
+    it('should expose every tool id and description without exposing schemas', async () => {
+      const processor = new ToolSearchProcessor({
+        mode: 'catalog',
+        tools: {
+          zeta: createTool({
+            id: 'zeta_tool',
+            description: 'Use Zeta <carefully>',
+            inputSchema: z.object({ secretSchemaField: z.string() }),
+            execute: async () => ({ success: true }),
+          }),
+          alpha: createMockTool('alpha_tool', 'Use Alpha & friends'),
+        },
+      });
+
+      const args = createMockArgs('catalog-thread');
+      const result = await processor.processInputStep(args);
+      const systemText = args.messageList
+        .getAllSystemMessages()
+        .map(message => message.content)
+        .join('\n');
+
+      expect(result.tools?.search_tools).toBeUndefined();
+      expect(result.tools?.load_tool).toBeDefined();
+      expect(systemText).toContain('<tool_catalog>');
+      expect(systemText).toContain('<tool id="alpha_tool">Use Alpha &amp; friends</tool>');
+      expect(systemText).toContain('<tool id="zeta_tool">Use Zeta &lt;carefully&gt;</tool>');
+      expect(systemText.indexOf('alpha_tool')).toBeLessThan(systemText.indexOf('zeta_tool'));
+      expect(systemText).not.toContain('secretSchemaField');
+    });
+
+    it('should apply the search-phase filter before listing tools', async () => {
+      const processor = new ToolSearchProcessor({
+        mode: 'catalog',
+        tools: {
+          public_weather: createMockTool('public_weather', 'Public weather'),
+          premium_weather: createMockTool('premium_weather', 'Premium weather'),
+        },
+        filter: ({ toolName, phase }) => phase !== 'search' || toolName === 'public_weather',
+      });
+
+      const args = createMockArgs('catalog-filter-thread');
+      await processor.processInputStep(args);
+      const systemText = args.messageList
+        .getAllSystemMessages()
+        .map(message => message.content)
+        .join('\n');
+
+      expect(systemText).toContain('public_weather');
+      expect(systemText).not.toContain('premium_weather');
+    });
+
+    it('should load a catalog tool by exact id and expose it on the next step', async () => {
+      const processor = new ToolSearchProcessor({
+        mode: 'catalog',
+        tools: {
+          weather: createMockTool('weather_forecast', 'Get a weather forecast'),
+        },
+      });
+
+      const firstStep = await processor.processInputStep(createMockArgs('catalog-load-thread'));
+      const loadResult = await firstStep.tools?.load_tool!.execute?.({ toolName: 'weather_forecast' }, undefined);
+      const secondStep = await processor.processInputStep(createMockArgs('catalog-load-thread'));
+
+      expect(loadResult.success).toBe(true);
+      expect(secondStep.tools?.weather_forecast).toBeDefined();
+      expect(secondStep.tools?.search_tools).toBeUndefined();
+    });
+
+    it('should suggest catalog ids rather than tools object keys', async () => {
+      const processor = new ToolSearchProcessor({
+        mode: 'catalog',
+        tools: {
+          weather: createMockTool('weather_forecast', 'Get a weather forecast'),
+        },
+      });
+
+      const step = await processor.processInputStep(createMockArgs('catalog-suggestion-thread'));
+      const loadResult = await step.tools?.load_tool!.execute?.({ toolName: 'weather_fore' }, undefined);
+
+      expect(loadResult.success).toBe(false);
+      expect(loadResult.message).toContain('Did you mean: weather_forecast?');
+      expect(loadResult.message).not.toContain('Did you mean: weather?');
     });
   });
 

--- a/packages/core/src/processors/processors/tool-search.test.ts
+++ b/packages/core/src/processors/processors/tool-search.test.ts
@@ -159,6 +159,26 @@ describe('ToolSearchProcessor', () => {
       expect(loadResult.message).toContain('Did you mean: weather_forecast?');
       expect(loadResult.message).not.toContain('Did you mean: weather?');
     });
+
+    it('should resolve catalog selections by tool id when a record key collides', async () => {
+      const catalogTool = createMockTool('catalog_tool', 'The tool selected from the catalog');
+      const collidingKeyTool = createMockTool('different_tool', 'A different tool stored under a colliding key');
+      const processor = new ToolSearchProcessor({
+        mode: 'catalog',
+        tools: {
+          catalog_tool: collidingKeyTool,
+          actual_catalog_tool: catalogTool,
+        },
+      });
+
+      const firstStep = await processor.processInputStep(createMockArgs('catalog-collision-thread'));
+      const loadResult = await firstStep.tools?.load_tool!.execute?.({ toolName: 'catalog_tool' }, undefined);
+      const secondStep = await processor.processInputStep(createMockArgs('catalog-collision-thread'));
+
+      expect(loadResult.success).toBe(true);
+      expect(secondStep.tools?.catalog_tool).toBe(catalogTool);
+      expect(secondStep.tools?.catalog_tool).not.toBe(collidingKeyTool);
+    });
   });
 
   describe('BM25 search functionality', () => {

--- a/packages/core/src/processors/processors/tool-search.ts
+++ b/packages/core/src/processors/processors/tool-search.ts
@@ -500,10 +500,10 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
       const catalog = await this.getToolCatalog(args.requestContext);
       messageList.addSystem(
         `${catalog}\n` +
-          'The catalog above contains every tool available for this request. ' +
+          'The catalog above contains tools available for dynamic loading in this request. ' +
           'To add one or more tools to the conversation, call load_tool with an exact id as toolName ' +
           'or an array of exact ids as toolNames. Full tool schemas are provided only after loading. ' +
-          'Tools must be loaded before they can be used.',
+          'Catalog tools must be loaded before they can be used.',
       );
     } else {
       messageList.addSystem(

--- a/packages/core/src/processors/processors/tool-search.ts
+++ b/packages/core/src/processors/processors/tool-search.ts
@@ -222,6 +222,9 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
   private findToolForDynamicName(toolName: string): Tool<any, any> | undefined {
     const toolByKey = this.allTools[toolName];
     const toolById = this.findToolById(toolName);
+    if (this.mode === 'catalog') {
+      return toolById;
+    }
     return this.filter ? (toolById ?? toolByKey) : (toolByKey ?? toolById);
   }
 

--- a/packages/core/src/processors/processors/tool-search.ts
+++ b/packages/core/src/processors/processors/tool-search.ts
@@ -10,6 +10,7 @@ import type { LoadedToolStore, LoadedToolStoreContext } from './tool-search-stor
 import { LegacyMapLoadedToolStore, ContextLoadedToolStore } from './tool-search-stores';
 
 export type ToolSearchFilterPhase = 'search' | 'load' | 'active';
+export type ToolDiscoveryMode = 'search' | 'catalog';
 
 export type ToolSearchFilterArgs = {
   /** The resolved tool id. */
@@ -28,6 +29,18 @@ export interface ToolSearchProcessorOptions {
    * These tools are not immediately available - they must be discovered via search and loaded on demand.
    */
   tools: Record<string, Tool<any, any>>;
+
+  /**
+   * How the model discovers tools before loading them.
+   *
+   * - `'search'` (default): expose `search_tools` for keyword discovery.
+   * - `'catalog'`: inject a deterministic catalog containing every allowed
+   *   tool's exact id and short description, while keeping full schemas deferred
+   *   until the model calls `load_tool` with an exact id.
+   *
+   * @default 'search'
+   */
+  mode?: ToolDiscoveryMode;
 
   /**
    * Configuration for the search behavior
@@ -121,11 +134,9 @@ const TOOL_SEARCH_TOKENIZE_OPTIONS: TokenizeOptions = {
 /**
  * Processor that enables dynamic tool discovery and loading.
  *
- * Instead of providing all tools to the agent upfront, this processor:
- * 1. Gives the agent two meta-tools: search_tools and load_tool
- * 2. Agent searches for relevant tools using keywords
- * 3. Agent loads specific tools into the conversation on demand
- * 4. Loaded tools become immediately available for use
+ * Instead of providing all tool schemas to the agent upfront, this processor
+ * supports keyword search or a thin catalog of exact ids and descriptions.
+ * The agent then loads specific tools into the conversation on demand.
  *
  * This pattern dramatically reduces context usage when working with many tools (100+).
  *
@@ -151,9 +162,10 @@ const TOOL_SEARCH_TOKENIZE_OPTIONS: TokenizeOptions = {
 export class ToolSearchProcessor implements Processor<'tool-search'> {
   readonly id = 'tool-search';
   readonly name = 'Tool Search Processor';
-  readonly description = 'Enables dynamic tool discovery and loading via search';
+  readonly description = 'Enables dynamic tool discovery and loading';
 
   private allTools: Record<string, Tool<any, any>>;
+  private mode: ToolDiscoveryMode;
   private searchConfig: Required<NonNullable<ToolSearchProcessorOptions['search']>>;
   private filter?: ToolSearchProcessorOptions['filter'];
 
@@ -167,12 +179,17 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
 
   constructor(options: ToolSearchProcessorOptions) {
     this.allTools = options.tools;
+    this.mode = options.mode ?? 'search';
     this.filter = options.filter;
     this.searchConfig = {
       topK: options.search?.topK ?? 5,
       minScore: options.search?.minScore ?? 0,
       autoLoad: options.search?.autoLoad ?? false,
     };
+
+    if (this.mode === 'catalog' && this.searchConfig.autoLoad) {
+      throw new Error('ToolSearchProcessor search.autoLoad cannot be used in catalog mode.');
+    }
 
     const storage = options.storage ?? 'in-memory';
 
@@ -224,17 +241,62 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     }
   }
 
+  private escapeXml(value: string): string {
+    return value
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&apos;');
+  }
+
+  private formatDescription(description: string): string {
+    return description.length > 150 ? description.slice(0, 147) + '...' : description;
+  }
+
+  /**
+   * Build a deterministic, request-filtered catalog. Only ids and short
+   * descriptions are projected; tool schemas remain deferred until load_tool.
+   */
+  private async getToolCatalog(requestContext?: RequestContext): Promise<string> {
+    const visibleTools: Tool<any, any>[] = [];
+    const seenIds = new Set<string>();
+
+    for (const tool of Object.values(this.allTools)) {
+      if (seenIds.has(tool.id)) continue;
+      if (!(await this.isToolAllowed(tool, requestContext, 'search'))) continue;
+
+      seenIds.add(tool.id);
+      visibleTools.push(tool);
+    }
+
+    visibleTools.sort((left, right) => left.id.localeCompare(right.id));
+
+    const entries = visibleTools.map(tool => {
+      const id = this.escapeXml(tool.id);
+      const description = this.escapeXml(this.formatDescription(tool.description || ''));
+      return `  <tool id="${id}">${description}</tool>`;
+    });
+
+    return ['<tool_catalog>', ...entries, '</tool_catalog>'].join('\n');
+  }
+
   private async getSuggestedToolNames(toolName: string, requestContext?: RequestContext): Promise<string[]> {
     const matchesToolName = (name: string) =>
       name.toLowerCase().includes(toolName.toLowerCase()) || toolName.toLowerCase().includes(name.toLowerCase());
 
+    const availableNames =
+      this.mode === 'catalog'
+        ? Array.from(new Set(Object.values(this.allTools).map(tool => tool.id)))
+        : Object.keys(this.allTools);
+
     if (!this.filter) {
-      return Object.keys(this.allTools).filter(matchesToolName);
+      return availableNames.filter(matchesToolName);
     }
 
     const allowedNames: string[] = [];
 
-    for (const name of Object.keys(this.allTools)) {
+    for (const name of availableNames) {
       if (!matchesToolName(name)) continue;
 
       const tool = this.findToolForDynamicName(name);
@@ -414,7 +476,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
       const description = this.toolDescriptions.get(r.id) || '';
       return {
         name: r.id,
-        description: description.length > 150 ? description.slice(0, 147) + '...' : description,
+        description: this.formatDescription(description),
         score: Math.round(r.score * 100) / 100,
       };
     });
@@ -428,17 +490,29 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     const loadedToolNames = await this.store.getLoadedNames(storeContext);
 
     const autoLoad = this.searchConfig.autoLoad;
+    const catalogMode = this.mode === 'catalog';
 
-    // Add system instruction about the meta-tools
-    messageList.addSystem(
-      autoLoad
-        ? 'To discover available tools, call search_tools with a keyword query. ' +
-            'Matching tools are loaded automatically and become available on your next turn — ' +
-            'there is no separate load step. After searching, use the tool directly.'
-        : 'To discover available tools, call search_tools with a keyword query. ' +
-            'To add one or more tools to the conversation, call load_tool with a toolName or toolNames array. ' +
-            'Tools must be loaded before they can be used.',
-    );
+    // Add system instruction about the selected discovery mode and meta-tools.
+    if (catalogMode) {
+      const catalog = await this.getToolCatalog(args.requestContext);
+      messageList.addSystem(
+        `${catalog}\n` +
+          'The catalog above contains every tool available for this request. ' +
+          'To add one or more tools to the conversation, call load_tool with an exact id as toolName ' +
+          'or an array of exact ids as toolNames. Full tool schemas are provided only after loading. ' +
+          'Tools must be loaded before they can be used.',
+      );
+    } else {
+      messageList.addSystem(
+        autoLoad
+          ? 'To discover available tools, call search_tools with a keyword query. ' +
+              'Matching tools are loaded automatically and become available on your next turn — ' +
+              'there is no separate load step. After searching, use the tool directly.'
+          : 'To discover available tools, call search_tools with a keyword query. ' +
+              'To add one or more tools to the conversation, call load_tool with a toolName or toolNames array. ' +
+              'Tools must be loaded before they can be used.',
+      );
+    }
 
     // Create the search tool with BM25 ranking
     const searchTool = createTool({
@@ -509,17 +583,31 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     // In auto-load mode this meta-tool is not exposed (search_tools activates matches itself).
     const loadTool = createTool({
       id: 'load_tool',
-      description:
-        'Load one or more tools into your context. ' +
-        'Call this after finding tools with search_tools. ' +
-        'Once loaded, tools will be available for use. ' +
-        'Pass a single toolName or an array of toolNames to load multiple tools at once.',
+      description: catalogMode
+        ? 'Load one or more tools from the tool catalog into your context by exact id. ' +
+          'Once loaded, tools will be available for use. ' +
+          'Pass a single toolName or an array of toolNames to load multiple tools at once.'
+        : 'Load one or more tools into your context. ' +
+          'Call this after finding tools with search_tools. ' +
+          'Once loaded, tools will be available for use. ' +
+          'Pass a single toolName or an array of toolNames to load multiple tools at once.',
       inputSchema: z.object({
-        toolName: z.string().optional().describe('The exact name of a tool to load (from search results)'),
+        toolName: z
+          .string()
+          .optional()
+          .describe(
+            catalogMode
+              ? 'The exact id of a tool to load (from the tool catalog)'
+              : 'The exact name of a tool to load (from search results)',
+          ),
         toolNames: z
           .array(z.string())
           .optional()
-          .describe('Array of exact tool names to load in one call (from search results)'),
+          .describe(
+            catalogMode
+              ? 'Array of exact tool ids to load in one call (from the tool catalog)'
+              : 'Array of exact tool names to load in one call (from search results)',
+          ),
       }),
       outputSchema: z.object({
         success: z.boolean(),
@@ -598,7 +686,9 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
             if (suggestions.length > 0) {
               message += ` Did you mean: ${suggestions.slice(0, 3).join(', ')}?`;
             } else {
-              message += ' Use search_tools to find available tools.';
+              message += catalogMode
+                ? ' Use an exact id from the tool catalog.'
+                : ' Use search_tools to find available tools.';
             }
             return { success: false, message, toolName: name };
           }
@@ -643,7 +733,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     // not invalidated when a tool is loaded mid-conversation.
     return {
       tools: {
-        search_tools: searchTool,
+        ...(catalogMode ? {} : { search_tools: searchTool }),
         // load_tool is omitted in auto-load mode — search_tools activates matches directly.
         ...(autoLoad ? {} : { load_tool: loadTool }),
         ...(tools ?? {}),


### PR DESCRIPTION
## Description

Adds an opt-in `mode: 'catalog'` to `ToolSearchProcessor`. Catalog mode injects a deterministic, request-filtered list of every available tool ID and a short description, omits `search_tools`, and keeps full schemas deferred until the model selects an exact ID with `load_tool`.

Keyword search remains the default and is unchanged. Catalog mode preserves the existing load/active policy checks, storage backends, resume behavior, and cache-friendly append order. It rejects `search.autoLoad` because catalog selection is intentionally explicit.

This supports large tool collections where the model should see the complete capability index immediately without paying for every full schema or depending on keyword retrieval.

## Related issue(s)

Addresses #16463.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Validation

- `pnpm build:core`
- `pnpm exec vitest run packages/core/src/processors/processors/tool-search.test.ts` (77 tests)
- `pnpm --filter @mastra/core typecheck`
- Focused Oxlint and ESLint on the changed core files
- `oxfmt-mdx --check` on the changed reference page

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This change lets `ToolSearchProcessor` show a simple list of available tools before loading their full details. The model can choose an exact tool, which makes tool selection predictable and reduces unnecessary data.

## What Changed

- Added opt-in `mode: 'catalog'` to `ToolSearchProcessor`.
- Catalog mode:
  - Lists request-filtered, ID-sorted tool IDs and short XML-escaped descriptions.
  - Limits descriptions to 150 characters.
  - Omits `search_tools`.
  - Loads full schemas only after an exact `load_tool` selection.
  - Rejects incompatible `search.autoLoad` configuration.
- Preserved keyword search as the default mode.
- Preserved existing policy checks, storage backends, resume behavior, and cache-friendly append order.
- Exported the new `ToolDiscoveryMode` type.
- Added documentation, examples, constraints, a changeset, and focused catalog-mode tests.

## Validation

- Core builds passed.
- Type checking, linting, and formatting passed.
- 76 focused tests passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
