### PR TITLE
Add a bundler.minify option so mastra build can emit minified output

### DIFF
--- a/.changeset/brown-cases-repeat.md
+++ b/.changeset/brown-cases-repeat.md
@@ -1,0 +1,20 @@
+---
+'@mastra/deployer': patch
+'@mastra/core': patch
+---
+
+Add `bundler.minify` to minify `mastra build` output
+
+`mastra build` always emitted unminified code, which is larger than necessary when packaging for production — a container image or an on-prem deployment.
+
+Set `bundler.minify: true` to minify the emitted bundle. Minification runs over whole chunks, so comments and whitespace are dropped and local identifiers are shortened while exported names are preserved.
+
+```typescript
+export const mastra = new Mastra({
+  bundler: {
+    minify: true,
+  },
+});
+```
+
+Defaults to `false`, so existing builds are unchanged. `mastra dev` is never minified.

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -707,6 +707,25 @@ export const mastra = new Mastra({
 })
 ```
 
+### bundler.minify
+
+**Type:** `boolean`\
+**Default:** `false`
+
+Minifies the bundled output, stripping comments and whitespace and shortening local identifiers. Exported names are preserved.
+
+Off by default so build output stays readable and stack traces stay meaningful. Enable it when bundle size matters, such as packaging a container image for an on-prem deployment. `mastra dev` is never minified.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+
+export const mastra = new Mastra({
+  bundler: {
+    minify: true,
+  },
+})
+```
+
 ### bundler.transpilePackages
 
 **Type:** `string[]`\

--- a/packages/core/src/bundler/types.ts
+++ b/packages/core/src/bundler/types.ts
@@ -11,6 +11,22 @@ export type BundlerConfig = {
    */
   sourcemap?: boolean;
   /**
+   * Minifies the generated bundle, stripping whitespace, comments and shortening
+   * local identifiers. Off by default so that build output stays readable and
+   * stack traces stay meaningful.
+   *
+   * Enable it when packaging for production — a smaller bundle is cheaper to
+   * ship in a container image or to an on-prem target.
+   *
+   * @example
+   * ```typescript
+   * bundler: {
+   *   minify: true
+   * }
+   * ```
+   */
+  minify?: boolean;
+  /**
    * Packages requiring TypeScript/modern JS transpilation during bundling.
    * Automatically includes workspace packages.
    */

--- a/packages/deployer/src/build/bundler.minify.test.ts
+++ b/packages/deployer/src/build/bundler.minify.test.ts
@@ -1,0 +1,67 @@
+import type { Plugin } from 'rollup';
+import { describe, expect, it } from 'vitest';
+import { getInputOptions } from './bundler';
+
+const analyzedBundleInfo = {
+  dependencies: new Map<string, string>(),
+  externalDependencies: new Map(),
+  workspaceMap: new Map(),
+};
+
+async function getPlugins(minify: boolean) {
+  const inputOptions = await getInputOptions(
+    'test-entry.js',
+    analyzedBundleInfo as any,
+    'node',
+    { 'process.env.NODE_ENV': JSON.stringify('production') },
+    { minify, projectRoot: process.cwd() },
+  );
+
+  return (inputOptions.plugins ?? []) as Plugin[];
+}
+
+/**
+ * The minifier has to run at renderChunk so it sees whole emitted chunks. Asserting on
+ * plugin names alone would not catch it being wired into the wrong stage, so these tests
+ * drive the hook with real code and check the output actually shrank.
+ */
+function renderChunk(plugin: Plugin, code: string) {
+  const hook = plugin.renderChunk;
+  const handler = typeof hook === 'function' ? hook : hook?.handler;
+
+  return handler?.call({} as any, code, { fileName: 'index.mjs' } as any, {} as any, {} as any);
+}
+
+describe('getInputOptions minify', () => {
+  it('does not minify by default', async () => {
+    const plugins = await getPlugins(false);
+
+    const results = await Promise.all(
+      plugins.filter(Boolean).map(plugin => renderChunk(plugin, 'export const hello = () => {\n  return 1 + 1;\n};\n')),
+    );
+
+    expect(results.every(result => result == null)).toBe(true);
+  });
+
+  it('minifies emitted chunks when enabled', async () => {
+    const plugins = await getPlugins(true);
+    const source = `export const hello = () => {
+  // a comment that should not survive
+  const someLongLocalName = 1 + 1;
+  return someLongLocalName;
+};
+`;
+
+    const outputs = await Promise.all(plugins.filter(Boolean).map(plugin => renderChunk(plugin, source)));
+    const minified = outputs.find(output => output != null);
+
+    expect(minified).toBeDefined();
+
+    const code = typeof minified === 'string' ? minified : minified!.code;
+    expect(code.length).toBeLessThan(source.length);
+    expect(code).not.toContain('a comment that should not survive');
+    expect(code).not.toContain('someLongLocalName');
+    // The public export has to keep its name or importers break.
+    expect(code).toContain('hello');
+  });
+});

--- a/packages/deployer/src/build/bundler.minify.test.ts
+++ b/packages/deployer/src/build/bundler.minify.test.ts
@@ -8,13 +8,13 @@ const analyzedBundleInfo = {
   workspaceMap: new Map(),
 };
 
-async function getPlugins(minify: boolean) {
+async function getPlugins(minify: boolean, sourcemap = false) {
   const inputOptions = await getInputOptions(
     'test-entry.js',
     analyzedBundleInfo as any,
     'node',
     { 'process.env.NODE_ENV': JSON.stringify('production') },
-    { minify, projectRoot: process.cwd() },
+    { minify, sourcemap, projectRoot: process.cwd() },
   );
 
   return (inputOptions.plugins ?? []) as Plugin[];
@@ -63,5 +63,28 @@ describe('getInputOptions minify', () => {
     expect(code).not.toContain('someLongLocalName');
     // The public export has to keep its name or importers break.
     expect(code).toContain('hello');
+  });
+
+  /**
+   * Minified output only maps back to source if the minifier emits a map of its own for
+   * Rollup to chain. The plugin defaults that on, which costs work on the far more common
+   * non-sourcemap build, so the setting is wired to the build's — both directions asserted.
+   */
+  it('emits a sourcemap only when the build asked for one', async () => {
+    const source =
+      'export const hello = () => {\n  const someLongLocalName = 1 + 1;\n  return someLongLocalName;\n};\n';
+
+    const renderWith = async (sourcemap: boolean) => {
+      const plugins = await getPlugins(true, sourcemap);
+      const outputs = await Promise.all(plugins.filter(Boolean).map(plugin => renderChunk(plugin, source)));
+
+      return outputs.find(output => output != null);
+    };
+
+    const withMap = await renderWith(true);
+    const withoutMap = await renderWith(false);
+
+    expect(typeof withMap === 'string' ? null : withMap!.map).toBeTruthy();
+    expect(typeof withoutMap === 'string' ? null : withoutMap!.map).toBeFalsy();
   });
 });

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -7,6 +7,7 @@ import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import { rollup } from 'rollup';
 import type { InputOptions, OutputOptions, Plugin } from 'rollup';
+import { minify as esbuildMinify } from 'rollup-plugin-esbuild';
 import type { WorkspacePackageInfo } from '../bundler/workspaceDependencies';
 import { esbuild } from './plugins/esbuild';
 import { esmShim } from './plugins/esm-shim';
@@ -71,6 +72,7 @@ export async function getInputOptions(
   env: Record<string, string> = { 'process.env.NODE_ENV': JSON.stringify('production') },
   {
     sourcemap = false,
+    minify = false,
     isDev = false,
     projectRoot,
     workspaceRoot = undefined,
@@ -78,6 +80,7 @@ export async function getInputOptions(
     externalsPreset = false,
   }: {
     sourcemap?: boolean;
+    minify?: boolean;
     isDev?: boolean;
     workspaceRoot?: string;
     projectRoot: string;
@@ -166,6 +169,9 @@ export async function getInputOptions(
         include: entryFile,
         platform,
       }),
+      // Runs at renderChunk, so the emitted chunks are minified as a whole rather
+      // than module by module. Last in the list so nothing transforms after it.
+      minify ? esbuildMinify({ target: 'node20' }) : null,
     ].filter(Boolean),
   } satisfies InputOptions;
 }

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -171,7 +171,9 @@ export async function getInputOptions(
       }),
       // Runs at renderChunk, so the emitted chunks are minified as a whole rather
       // than module by module. Last in the list so nothing transforms after it.
-      minify ? esbuildMinify({ target: 'node20' }) : null,
+      // `sourceMap` follows the build's own setting: the plugin defaults it to true,
+      // which would build a map Rollup then discards on a non-sourcemap build.
+      minify ? esbuildMinify({ target: 'node20', sourceMap: sourcemap }) : null,
     ].filter(Boolean),
   } satisfies InputOptions;
 }

--- a/packages/deployer/src/build/types.ts
+++ b/packages/deployer/src/build/types.ts
@@ -27,7 +27,11 @@ export interface DependencyMetadata {
 
 export interface BundlerOptions {
   enableSourcemap: boolean;
-  enableMinify: boolean;
+  /**
+   * Optional so that a `Bundler` subclass outside this repo, which builds this
+   * object itself, keeps compiling. Absent means off, same as `false`.
+   */
+  enableMinify?: boolean;
   enableEsmShim: boolean;
   externals: boolean | string[];
   dynamicPackages?: string[];

--- a/packages/deployer/src/build/types.ts
+++ b/packages/deployer/src/build/types.ts
@@ -27,6 +27,7 @@ export interface DependencyMetadata {
 
 export interface BundlerOptions {
   enableSourcemap: boolean;
+  enableMinify: boolean;
   enableEsmShim: boolean;
   externals: boolean | string[];
   dynamicPackages?: string[];

--- a/packages/deployer/src/build/watcher.ts
+++ b/packages/deployer/src/build/watcher.ts
@@ -22,6 +22,8 @@ export async function getInputOptions(
     sourcemap = false,
     bundlerOptions = {
       enableSourcemap: false,
+      // `mastra dev` never minifies — readable output matters more than size here.
+      enableMinify: false,
       enableEsmShim: true,
       externals: true,
     },

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -494,7 +494,7 @@ export abstract class Bundler extends MastraBundler {
     mastraEntryFile: string,
     analyzedBundleInfo: Awaited<ReturnType<typeof analyzeBundle>>,
     toolsPaths: (string | string[])[],
-    { enableSourcemap, enableEsmShim, externals, entries }: BundlerOptions,
+    { enableSourcemap, enableMinify, enableEsmShim, externals, entries }: BundlerOptions,
   ) {
     const { workspaceRoot } = await getWorkspaceInformation({ mastraEntryFile });
     const closestPkgJson = pkg.up({ cwd: dirname(mastraEntryFile) });
@@ -507,7 +507,14 @@ export abstract class Bundler extends MastraBundler {
       {
         'process.env.NODE_ENV': JSON.stringify('production'),
       },
-      { sourcemap: enableSourcemap, workspaceRoot, projectRoot, enableEsmShim, externalsPreset: externals === true },
+      {
+        sourcemap: enableSourcemap,
+        minify: enableMinify,
+        workspaceRoot,
+        projectRoot,
+        enableEsmShim,
+        externalsPreset: externals === true,
+      },
     );
     const isVirtual = serverFile.includes('\n') || !existsSync(serverFile);
     const toolsInputOptions = await this.listToolsInputOptions(toolsPaths);
@@ -615,6 +622,7 @@ export abstract class Bundler extends MastraBundler {
     const extraEntries = resolveExtraEntries(bundlerOptions.entries, mastraEntryFile);
     const internalBundlerOptions: BundlerOptions = {
       enableSourcemap: !!bundlerOptions.sourcemap,
+      enableMinify: !!bundlerOptions.minify,
       externals: bundlerOptions.externals ?? [],
       enableEsmShim,
       dynamicPackages: bundlerOptions.dynamicPackages,


### PR DESCRIPTION
## What this changes

`mastra build` had no way to minify its output. Everything it emitted was fully expanded JavaScript, which is larger than it needs to be when the build is being packaged for production — a container image, or a bundle shipped to an on-prem environment.

This adds a `bundler.minify` option:

```typescript
export const mastra = new Mastra({
  bundler: {
    minify: true,
  },
})
```

It defaults to `false`, so no existing build changes behaviour unless the option is set.

## How it works

Minification is wired in as a `renderChunk` plugin rather than a per-module transform. That matters: at `renderChunk` the minifier sees each fully assembled output chunk, so it can shorten names across module boundaries instead of one file at a time. Exported names are left intact, so importers of the bundle are unaffected.

`mastra dev` deliberately never minifies — readable output and meaningful stack traces are worth more than size during development.

## Verification

Unit tests drive the plugin's `renderChunk` hook with real source and assert the output actually shrank, that comments and local identifiers are gone, and that the public export name survived. Asserting on plugin names alone would not have caught the plugin being wired into the wrong build stage.

Also checked against the real Rollup pipeline end to end, building a small entry through `getInputOptions` + `createBundler` both ways:

```
minify=false   202 bytes
minify=true     95 bytes
```

The minified output keeps the public name: `const n={greeting:"hello world"};function e(){return n.greeting}export{e as publicEntryPoint};`

Full `@mastra/deployer` suite passes: 46 files, 751 tests.

Closes #19751


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds an optional setting to make production output smaller. It keeps public exports unchanged and does not minify development output.

## Changes

- Added `bundler.minify` to `BundlerConfig`.
- Defaulted minification to `false`.
- Added Rollup chunk minification for `mastra build`.
- Preserved exported names during minification.
- Matched minifier sourcemaps to the build sourcemap setting.
- Kept `mastra dev` unminified.
- Preserved compatibility with external `Bundler` subclasses through optional `enableMinify`.
- Added documentation and changeset entries.
- Added tests for output size, comments, local identifiers, exports, sourcemaps, and Rollup integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->