### PR TITLE
Surface the silently dropped bundler.externals default, and correct its documentation

### DIFF
--- a/.changeset/lemon-crabs-relate.md
+++ b/.changeset/lemon-crabs-relate.md
@@ -1,0 +1,11 @@
+---
+'mastra': patch
+---
+
+Warn when `bundler.externals` is unset but other bundler options are
+
+The `externals: true` build default only applies when a project sets no bundler options at all. Setting any unrelated option, such as `sourcemap` or `entries`, drops it back to `[]` and switches the build from externalizing dependencies to bundling them.
+
+Nothing surfaced that, and the difference usually only shows up at runtime, when a package that cannot be bundled — a native module, for example — fails inside the container.
+
+`mastra build` now warns when a bundler config omits `externals`, pointing at the explicit setting. Build output is unchanged; the reference docs have been corrected to describe the actual default.

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -668,11 +668,9 @@ Entry names can contain `/` to nest the output. They can't be `index`, which is 
 ### bundler.externals
 
 **Type:** `boolean | string[]`\
-**Default:** `true`
+**Default:** `true` if your config sets no bundler options at all, otherwise `[]`
 
 When `mastra build` is run, Mastra bundles your project into the `.mastra/output` directory. This option controls which packages are excluded from the bundle (marked as "external") and installed separately through a package manager. This is useful when the internal Mastra bundler ([Rollup](https://rollupjs.org/configuration-options/#external)) has trouble bundling packages.
-
-By default, `mastra build` sets this option to `true`.
 
 The values have these meanings:
 
@@ -689,6 +687,23 @@ export const mastra = new Mastra({
   },
 })
 ```
+
+:::caution
+
+The `true` default applies only to projects that set **no** bundler options. Setting any other bundler option, such as `sourcemap` or `entries`, drops the default back to `[]` and bundles your dependencies instead. `mastra build` warns when this happens.
+
+This matters most for packages that can't be bundled at all, such as native modules, which then fail at runtime rather than at build time. Set `externals` explicitly alongside any other bundler option:
+
+```typescript title="src/mastra/index.ts"
+export const mastra = new Mastra({
+  bundler: {
+    sourcemap: true,
+    externals: true,
+  },
+})
+```
+
+:::
 
 ### bundler.sourcemap
 

--- a/packages/cli/src/commands/build/BuildBundler.test.ts
+++ b/packages/cli/src/commands/build/BuildBundler.test.ts
@@ -107,6 +107,50 @@ describe('BuildBundler', () => {
       expect(options.externals).toBeUndefined();
     });
 
+    it('warns when a bundler config omits externals, since the default silently does not apply', async () => {
+      const { Bundler } = await import('@mastra/deployer/bundler');
+      vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({ sourcemap: true });
+      const { BuildBundler } = await import('./BuildBundler');
+      const bundler = new BuildBundler();
+      const warn = vi.spyOn((bundler as any).logger, 'warn').mockImplementation(() => {});
+
+      await (bundler as any).getUserBundlerOptions('/entry.ts', '/output');
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]![0]).toContain('bundler.externals');
+    });
+
+    it('does not warn when externals is set explicitly', async () => {
+      const { Bundler } = await import('@mastra/deployer/bundler');
+      vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({
+        externals: [],
+        sourcemap: true,
+      });
+      const { BuildBundler } = await import('./BuildBundler');
+      const bundler = new BuildBundler();
+      const warn = vi.spyOn((bundler as any).logger, 'warn').mockImplementation(() => {});
+
+      await (bundler as any).getUserBundlerOptions('/entry.ts', '/output');
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when there is no bundler config, since the default applies', async () => {
+      const { Bundler, IS_DEFAULT } = await import('@mastra/deployer/bundler');
+      vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({
+        externals: [],
+        [IS_DEFAULT]: true,
+      });
+      const { BuildBundler } = await import('./BuildBundler');
+      const bundler = new BuildBundler();
+      const warn = vi.spyOn((bundler as any).logger, 'warn').mockImplementation(() => {});
+
+      const options = await (bundler as any).getUserBundlerOptions('/entry.ts', '/output');
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(options.externals).toBe(true);
+    });
+
     it('preserves explicit externals true in a custom bundler config', async () => {
       const { Bundler } = await import('@mastra/deployer/bundler');
       vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -23,6 +23,19 @@ export class BuildBundler extends Bundler {
     const bundlerOptions = await super.getUserBundlerOptions(mastraEntryFile, outputDirectory);
 
     if (!bundlerOptions?.[IS_DEFAULT]) {
+      // The `externals: true` build default only applies when no bundler config exists at
+      // all, so supplying any unrelated option silently opts you out of it and flips the
+      // build to bundling every dependency. Nothing else surfaces that, and the result
+      // only fails later at runtime — typically on a native module that cannot be bundled.
+      if (bundlerOptions?.externals === undefined) {
+        this.logger.warn(
+          'bundler.externals is not set, so dependencies will be bundled rather than installed. ' +
+            'The externals default only applies to projects with no bundler config at all. ' +
+            'Set bundler.externals explicitly to choose, e.g. `externals: true` to keep packages ' +
+            'that cannot be bundled, such as native modules, out of the bundle.',
+        );
+      }
+
       return bundlerOptions;
     }
 


### PR DESCRIPTION
## Context

This takes the second of the two paths #20879 offers, because a maintainer has already ruled on the first one.

The issue reports that `bundler.externals: true` is applied all-or-nothing: it only takes effect when a project sets no bundler options at all, so adding an unrelated option like `sourcemap` silently flips the build from externalizing dependencies to bundling them.

The direct behavioural fix was implemented in #20891 and declined — the `IS_DEFAULT` marker is there deliberately to hold legacy behaviour in place, and the coupling is to be undone in the next major. The issue is labelled `status: blocked` for that reason.

So this PR does **not** change what `mastra build` produces. It closes the gap the issue calls out as the fallback if the behaviour stays: the failure is invisible, and the reference docs describe a default that only holds in one case.

## What changed

**The docs were wrong.** `configuration.mdx` stated `bundler.externals` has a **Default:** of `true`. That is only true for configs with no `bundler` block. The default is now stated accurately, with a caution explaining when it does not apply and how to opt back in.

**The failure is now visible.** `mastra build` warns when a bundler config omits `externals`, naming the option to set. Previously the build succeeded, produced quietly different output, and only failed later at runtime — typically on a package that cannot be bundled, such as a native module, which fails inside the container rather than at build time.

This is reachable from a documented path: `bundler.entries` exists primarily for LiveKit voice workers, which depend on native binaries. Following that documentation means adding a bundler option, which is exactly what drops the default.

## Verification

Three tests cover the warning: fires when a config omits `externals`, silent when `externals` is set explicitly, silent when there is no bundler config at all and the default genuinely applies.

The existing tests that pin the current behaviour — `optimizes dependencies when a bundler config omits externals` and `preserves explicit externals true in a custom bundler config` — are untouched and still pass, which is the point: 15/15 in `BuildBundler.test.ts`. Confirmed the new tests fail without the warning.

Docs validation passes across 568 files.

Relates to #20879 — deliberately left open for the behavioural fix in the next major.
