### PR TITLE
Identify the git worktree in session hook payloads

### DIFF
--- a/.changeset/wild-moons-shave.md
+++ b/.changeset/wild-moons-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Include worktree identity (`worktree_path`, `branch`, `main_repo_path`) in `SessionStart` and `SessionEnd` hook payloads when a session runs in a git worktree, so hooks can provision and tear down per-worktree resources.

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -361,6 +361,21 @@ Hooks are user-configured shell commands that run at specific lifecycle events. 
 | `SubagentStart` | When a subagent begins a delegated task | No |
 | `SubagentEnd` | When a subagent finishes its delegated task | No |
 
+`SessionStart` and `SessionEnd` also describe the checkout the session is running in. When the project directory is a git worktree, both events include `worktree_path`, and `branch` and `main_repo_path` when git can resolve them. The fields are omitted entirely in a main checkout, so a hook can tell the two apart and provision or tear down per-worktree resources such as a database, a bucket, or a dev server:
+
+```json
+{
+  "session_id": "thread-abc123",
+  "cwd": "/repos/myapp-worktrees/feature",
+  "hook_event_name": "SessionEnd",
+  "worktree_path": "/repos/myapp-worktrees/feature",
+  "branch": "feature/my-branch",
+  "main_repo_path": "/repos/myapp"
+}
+```
+
+These fire on session boundaries, not on worktree creation and removal. Mastra Code detects the worktree it is started in; it does not create or delete worktrees, so a session that ends is not necessarily a worktree that is going away.
+
 `UserPromptSubmit` runs before a non-command prompt is sent to the agent. If a hook blocks, the prompt is not sent.
 
 `PreToolUse` and `PostToolUse` are emitted by the agent tool hook wrapper around tool execution. Run, permission, interrupt, and subagent events are emitted by the TUI lifecycle dispatcher.

--- a/mastracode/sdk/src/hooks/manager.test.ts
+++ b/mastracode/sdk/src/hooks/manager.test.ts
@@ -273,3 +273,62 @@ describe('HookManager run_id propagation', () => {
     expect(endStdin.duration_ms).toBe(500);
   });
 });
+
+describe('HookManager session worktree identity', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach(mockFn => mockFn.mockReset());
+  });
+
+  function createWorktreeManager(hooksConfig: Record<string, unknown>) {
+    mocks.loadHooksConfig.mockReturnValue(hooksConfig);
+    mocks.runHooksForEvent.mockResolvedValue(createHookResult());
+    return new HookManager('/repos/main-worktrees/feature', 'session-wt', '.mastracode', undefined, {
+      path: '/repos/main-worktrees/feature',
+      branch: 'feature/my-branch',
+      mainRepoPath: '/repos/main',
+    });
+  }
+
+  it('describes the worktree on both session events, so a hook can provision on start and tear down on end', async () => {
+    const mgr = createWorktreeManager({
+      SessionStart: [{ type: 'command', command: 'worktree-up.sh' }],
+      SessionEnd: [{ type: 'command', command: 'worktree-down.sh' }],
+    });
+
+    await mgr.runSessionStart();
+    await mgr.runSessionEnd();
+
+    for (const [index, event] of ['SessionStart', 'SessionEnd'].entries()) {
+      const stdin = mocks.runHooksForEvent.mock.calls[index][1];
+      expect(stdin.hook_event_name).toBe(event);
+      expect(stdin.worktree_path).toBe('/repos/main-worktrees/feature');
+      expect(stdin.branch).toBe('feature/my-branch');
+      expect(stdin.main_repo_path).toBe('/repos/main');
+    }
+  });
+
+  it('omits worktree fields in a main checkout, so hooks can tell the two apart', async () => {
+    const mgr = createManager({ SessionStart: [{ type: 'command', command: 'echo test' }] });
+
+    await mgr.runSessionStart();
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.hook_event_name).toBe('SessionStart');
+    expect(stdin).not.toHaveProperty('worktree_path');
+    expect(stdin).not.toHaveProperty('branch');
+    expect(stdin).not.toHaveProperty('main_repo_path');
+  });
+
+  it('omits unresolved worktree details rather than sending empty values', async () => {
+    mocks.loadHooksConfig.mockReturnValue({ SessionEnd: [{ type: 'command', command: 'echo test' }] });
+    mocks.runHooksForEvent.mockResolvedValue(createHookResult());
+    const mgr = new HookManager('/wt', 'session-wt', '.mastracode', undefined, { path: '/wt' });
+
+    await mgr.runSessionEnd();
+
+    const stdin = mocks.runHooksForEvent.mock.calls[0][1];
+    expect(stdin.worktree_path).toBe('/wt');
+    expect(stdin).not.toHaveProperty('branch');
+    expect(stdin).not.toHaveProperty('main_repo_path');
+  });
+});

--- a/mastracode/sdk/src/hooks/manager.ts
+++ b/mastracode/sdk/src/hooks/manager.ts
@@ -24,6 +24,7 @@ import type {
   PermissionKind,
   PermissionDecision,
   InterruptReason,
+  SessionWorktreeInfo,
 } from './types.js';
 
 const emptyResult = (): HookEventResult => ({ allowed: true, results: [], warnings: [] });
@@ -35,8 +36,16 @@ export class HookManager {
   private configDirName: string;
   private homeDir?: string;
   private runId?: string;
+  private worktree?: SessionWorktreeInfo;
 
-  constructor(projectDir: string, sessionId: string, configDirName = DEFAULT_CONFIG_DIR, homeDir?: string) {
+  constructor(
+    projectDir: string,
+    sessionId: string,
+    configDirName = DEFAULT_CONFIG_DIR,
+    homeDir?: string,
+    worktree?: SessionWorktreeInfo,
+  ) {
+    this.worktree = worktree;
     this.projectDir = projectDir;
     this.sessionId = sessionId;
     this.configDirName = configDirName;
@@ -104,6 +113,21 @@ export class HookManager {
     };
     if (this.runId) base.run_id = this.runId;
     return base;
+  }
+
+  /**
+   * Session stdin, carrying worktree identity when there is one. Emitted on both
+   * session events so a hook that provisions on start can tear down on end using
+   * the same fields.
+   */
+  private sessionStdin(hook_event_name: 'SessionStart' | 'SessionEnd'): HookStdinSession {
+    const stdin: HookStdinSession = this.baseStdinFields(hook_event_name);
+    if (this.worktree) {
+      stdin.worktree_path = this.worktree.path;
+      if (this.worktree.branch) stdin.branch = this.worktree.branch;
+      if (this.worktree.mainRepoPath) stdin.main_repo_path = this.worktree.mainRepoPath;
+    }
+    return stdin;
   }
 
   // =========================================================================
@@ -185,9 +209,7 @@ export class HookManager {
       return emptyResult();
     }
 
-    const stdin: HookStdinSession = {
-      ...this.baseStdinFields('SessionStart'),
-    };
+    const stdin: HookStdinSession = this.sessionStdin('SessionStart');
 
     return runHooksForEvent(hooks, stdin);
   }
@@ -197,9 +219,7 @@ export class HookManager {
       return emptyResult();
     }
 
-    const stdin: HookStdinSession = {
-      ...this.baseStdinFields('SessionEnd'),
-    };
+    const stdin: HookStdinSession = this.sessionStdin('SessionEnd');
 
     return runHooksForEvent(hooks, stdin);
   }

--- a/mastracode/sdk/src/hooks/types.ts
+++ b/mastracode/sdk/src/hooks/types.ts
@@ -110,8 +110,29 @@ export interface HookStdinStop extends HookStdinBase {
   assistant_message?: string;
   stop_reason: 'complete' | 'aborted' | 'error';
 }
+/**
+ * Describes the git worktree a session is running in. Absent for sessions
+ * started in an ordinary checkout.
+ */
+export interface SessionWorktreeInfo {
+  /** Absolute path to the worktree root. */
+  path: string;
+  /** Branch checked out in the worktree, when it can be resolved. */
+  branch?: string;
+  /** Absolute path to the main repository the worktree is linked to. */
+  mainRepoPath?: string;
+}
+
 export interface HookStdinSession extends HookStdinBase {
   hook_event_name: 'SessionStart' | 'SessionEnd';
+  /**
+   * Set only when the session's project directory is a git worktree, so a hook
+   * can provision or tear down per-worktree resources (a database, a bucket, a
+   * dev server) and distinguish that from a session in the main checkout.
+   */
+  worktree_path?: string;
+  branch?: string;
+  main_repo_path?: string;
 }
 
 export interface HookStdinNotification extends HookStdinBase {

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -629,7 +629,15 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
   // Hooks
   const hookManager = config?.disableHooks
     ? undefined
-    : new HookManager(project.rootPath, 'session-init', configDir, homeDir);
+    : new HookManager(
+        project.rootPath,
+        'session-init',
+        configDir,
+        homeDir,
+        project.isWorktree
+          ? { path: project.rootPath, branch: project.gitBranch, mainRepoPath: project.mainRepoPath }
+          : undefined,
+      );
 
   const pluginManager = config?.disablePlugins
     ? undefined


### PR DESCRIPTION
## What the issue asks for, and what turned out to be possible

#18173 asks for `WorktreeCreate` and `WorktreeRemove` hook events, so that per-worktree resources — a database, a MinIO bucket, a dev server — are provisioned and cleaned up automatically instead of leaking.

Those two events cannot be implemented as specified, because **Mastra Code never creates or removes a worktree.** Searching the whole `mastracode/` tree for a worktree lifecycle turns up exactly two things:

- `detectProject()` in `sdk/src/utils/project.ts`, which *detects* that the current directory is a worktree by comparing `git-dir` against `git-common-dir`, and
- `factory/src/integrations/github/sandbox.ts`, which runs `git worktree add` / `git worktree remove` **inside a remote sandbox**, on the Factory server.

Worktrees a user runs Mastra Code in are created by something else — Superset, a shell alias, plain `git worktree add`. There is no moment in the local process at which a `WorktreeCreate` could fire, and at the moment a worktree is removed Mastra Code has usually already exited. The hooks executor spawns `/bin/sh` on the user's own machine, so wiring these to the Factory's sandbox path would run the user's cleanup script in the wrong place entirely.

Inventing the two events would produce hooks that either never fire or fire in a sandbox the user's script knows nothing about.

## What this PR does instead

It closes the gap in the underlying need using the boundary that does exist.

`SessionStart` and `SessionEnd` already fire at exactly the points where a worktree session begins and ends, but their payload was `session_id`, `cwd` and `hook_event_name` — nothing that identifies the worktree. A hook could not tell a worktree session from a main-checkout session, so it could not safely provision or drop a per-worktree database.

Both events now carry `worktree_path`, plus `branch` and `main_repo_path` when git can resolve them. The fields are **omitted entirely** in a main checkout, which is the signal a hook needs to distinguish the two cases. Everything comes from the `ProjectInfo` that is already computed at startup, so there is no new git invocation.

The example from the issue now works:

```json
{
  "SessionStart": [{ "type": "command", "command": "$PROJECT_DIR/.mastracode/hooks/worktree-up.sh" }],
  "SessionEnd":   [{ "type": "command", "command": "$PROJECT_DIR/.mastracode/hooks/worktree-down.sh" }]
}
```

with the script reading `worktree_path` and exiting early when it is absent.

## The honest limitation

This is session-scoped, not worktree-scoped. Opening two sessions in one worktree fires the pair twice, and a worktree deleted while Mastra Code is not running fires nothing. Teardown scripts should therefore be idempotent. The docs state this directly rather than implying worktree-lifecycle semantics the events do not have.

I have left #18173 open and commented with this reasoning. Genuine `WorktreeCreate` / `WorktreeRemove` events require Mastra Code to own worktree creation and removal — a real feature, and a larger one than a hook event.

## Verification

Three tests in `manager.test.ts`: both session events describe the worktree, a main checkout omits all three fields, and unresolved details are omitted rather than sent as empty strings. Confirmed failing before the change. Hooks suite 24/24, `tsc --noEmit` clean, docs validation passes across 568 files.

Relates to #18173
