### PR TITLE
fix(factory): reconcile cached GitHub PAT identity

### DIFF
--- a/.changeset/swift-yaks-count.md
+++ b/.changeset/swift-yaks-count.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed reused Factory workspaces retaining GitHub credentials from an outdated work or review assignment.

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -44,8 +44,9 @@ const mocks = vi.hoisted(() => ({
   githubReviewerPat: null as string | null,
   /** Run-binding role resolved for the session; null = no binding found. */
   runBindingRole: null as string | null,
+  runBindingStatus: 'active' as 'active' | 'revoked',
   findRunBindingBySession: vi.fn(async () =>
-    mocks.runBindingRole ? { role: mocks.runBindingRole, orgId: 'org-1' } : null,
+    mocks.runBindingRole ? { role: mocks.runBindingRole, status: mocks.runBindingStatus, orgId: 'org-1' } : null,
   ),
 }));
 
@@ -82,6 +83,7 @@ afterEach(async () => {
   mocks.githubPat = null;
   mocks.githubReviewerPat = null;
   mocks.runBindingRole = null;
+  mocks.runBindingStatus = 'active';
   mocks.findRunBindingBySession.mockClear();
 });
 
@@ -838,6 +840,212 @@ describe('GitHub session workspace preparation', () => {
     );
   });
 
+  it('switches a cached workspace to the reviewer PAT when the review binding appears after materialization', async () => {
+    mocks.githubPat = 'ghp_worker';
+    mocks.githubReviewerPat = 'ghp_reviewer';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+    expect(mocks.ensureSandbox).toHaveBeenCalledWith(
+      expect.any(Object),
+      { GH_TOKEN: 'ghp_worker' },
+      undefined,
+      expect.any(Object),
+    );
+
+    // StartCoordinator creates the session before prepareRunStart creates its
+    // review binding, so the first request can cache the worker PAT selection.
+    mocks.runBindingRole = 'review';
+    mocks.setEnvironmentVariable.mockClear();
+    await workspace({
+      requestContext: createGithubRequestContext('project-1', 'session-a'),
+      mastra: { getWorkspaceById: vi.fn(() => ({ setToolsConfig: vi.fn() })) } as any,
+    });
+
+    expect(mocks.setEnvironmentVariable).toHaveBeenCalledWith('GH_TOKEN', 'ghp_reviewer');
+  });
+
+  it('switches a cached workspace back to the worker PAT when a work binding replaces the review binding', async () => {
+    mocks.githubPat = 'ghp_worker';
+    mocks.githubReviewerPat = 'ghp_reviewer';
+    mocks.runBindingRole = 'review';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    const reviewerContext = createGithubRequestContext('project-1', 'session-a');
+
+    await workspace({ requestContext: reviewerContext });
+    expect(mocks.ensureSandbox).toHaveBeenCalledWith(
+      expect.any(Object),
+      { GH_TOKEN: 'ghp_reviewer' },
+      undefined,
+      expect.any(Object),
+    );
+
+    mocks.runBindingRole = 'work';
+    mocks.setEnvironmentVariable.mockClear();
+    await workspace({
+      requestContext: createGithubRequestContext('project-1', 'session-a'),
+      mastra: { getWorkspaceById: vi.fn(() => ({ setToolsConfig: vi.fn() })) } as any,
+    });
+
+    expect(mocks.setEnvironmentVariable).toHaveBeenCalledWith('GH_TOKEN', 'ghp_worker');
+    expect(() => injectGithubToken(reviewerContext, 'stale-reviewer-token')).toThrow(/no longer matches/);
+  });
+
+  it('replaces reviewer credentials with repository access when no worker PAT is configured', async () => {
+    mocks.githubReviewerPat = 'ghp_reviewer';
+    mocks.runBindingRole = 'review';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+
+    mocks.runBindingRole = 'work';
+    mocks.setEnvironmentVariable.mockClear();
+    await workspace({
+      requestContext: createGithubRequestContext('project-1', 'session-a'),
+      mastra: { getWorkspaceById: vi.fn(() => ({ setToolsConfig: vi.fn() })) } as any,
+    });
+
+    expect(mocks.setEnvironmentVariable).toHaveBeenCalledWith('GH_TOKEN', 'repo-token-repository-1');
+  });
+
+  it('fails closed when reviewer credentials cannot be replaced for a worker run', async () => {
+    mocks.githubPat = 'ghp_worker';
+    mocks.githubReviewerPat = 'ghp_reviewer';
+    mocks.runBindingRole = 'review';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    const reviewerContext = createGithubRequestContext('project-1', 'session-a');
+
+    await workspace({ requestContext: reviewerContext });
+
+    mocks.runBindingRole = 'work';
+    mocks.setEnvironmentVariable.mockImplementationOnce(() => {
+      throw new Error('runtime injection failed');
+    });
+    const destroy = vi.fn(async () => {});
+    const removeWorkspace = vi.fn(async () => true);
+    await expect(
+      workspace({
+        requestContext: createGithubRequestContext('project-1', 'session-a'),
+        mastra: {
+          getWorkspaceById: vi.fn(() => ({ setToolsConfig: vi.fn(), destroy })),
+          removeWorkspace,
+        } as any,
+      }),
+    ).rejects.toThrow('runtime injection failed');
+
+    expect(removeWorkspace).toHaveBeenCalledWith('mfw-project-1-session-a-web-factory');
+    expect(destroy).toHaveBeenCalled();
+    expect(() => injectGithubToken(reviewerContext, 'stale-reviewer-token')).toThrow(/no longer matches/);
+  });
+
+  it('keeps an unsafe reviewer workspace quarantined when eviction fails', async () => {
+    mocks.githubPat = 'ghp_worker';
+    mocks.githubReviewerPat = 'ghp_reviewer';
+    mocks.runBindingRole = 'review';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    const reviewerContext = createGithubRequestContext('project-1', 'session-a');
+
+    await workspace({ requestContext: reviewerContext });
+
+    mocks.runBindingRole = 'work';
+    mocks.setEnvironmentVariable.mockImplementationOnce(() => {
+      throw new Error('runtime injection failed');
+    });
+    const existing = {
+      setToolsConfig: vi.fn(),
+      destroy: vi.fn(async () => {
+        throw new Error('destroy failed');
+      }),
+    };
+    const mastra = {
+      getWorkspaceById: vi.fn(() => existing),
+      removeWorkspace: vi.fn(async () => {
+        throw new Error('remove failed');
+      }),
+    };
+
+    await expect(
+      workspace({ requestContext: createGithubRequestContext('project-1', 'session-a'), mastra: mastra as any }),
+    ).rejects.toThrow('runtime injection failed');
+    expect(() => injectGithubToken(reviewerContext, 'stale-reviewer-token')).toThrow(/no longer matches/);
+
+    mocks.setEnvironmentVariable.mockClear();
+    await expect(
+      workspace({ requestContext: createGithubRequestContext('project-1', 'session-a'), mastra: mastra as any }),
+    ).resolves.toBe(existing);
+    expect(mocks.setEnvironmentVariable).toHaveBeenCalledWith('GH_TOKEN', 'ghp_worker');
+  });
+
+  it('keeps same-role PAT refresh failures best-effort', async () => {
+    mocks.githubPat = 'ghp_worker_old';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+
+    mocks.githubPat = 'ghp_worker_current';
+    mocks.setEnvironmentVariable.mockImplementationOnce(() => {
+      throw new Error('runtime injection failed');
+    });
+    const existing = { setToolsConfig: vi.fn() };
+    await expect(
+      workspace({
+        requestContext: createGithubRequestContext('project-1', 'session-a'),
+        mastra: { getWorkspaceById: vi.fn(() => existing) } as any,
+      }),
+    ).resolves.toBe(existing);
+  });
+
+  it('reconciles the current role for callers reusing an inflight materialization', async () => {
+    mocks.githubPat = 'ghp_worker';
+    mocks.githubReviewerPat = 'ghp_reviewer';
+    let releaseMaterialization!: () => void;
+    mocks.materializeRepo.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          releaseMaterialization = resolve;
+        }),
+    );
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    const mastra = {
+      getWorkspaceById: vi.fn(() => {
+        throw new Error('Workspace not found');
+      }),
+      addWorkspace: vi.fn(),
+    };
+
+    const leader = workspace({
+      requestContext: createGithubRequestContext('project-1', 'session-a'),
+      mastra: mastra as any,
+    });
+    await vi.waitFor(() => expect(mocks.materializeRepo).toHaveBeenCalledTimes(1));
+
+    mocks.runBindingRole = 'review';
+    const follower = workspace({
+      requestContext: createGithubRequestContext('project-1', 'session-a'),
+      mastra: mastra as any,
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    releaseMaterialization();
+    await Promise.all([leader, follower]);
+
+    expect(mocks.ensureSandbox).toHaveBeenCalledTimes(1);
+    expect(mocks.setEnvironmentVariable).toHaveBeenCalledWith('GH_TOKEN', 'ghp_reviewer');
+  });
+
   it('falls back to the worker PAT for review sessions without a reviewer token', async () => {
     mocks.githubPat = 'ghp_worker';
     mocks.runBindingRole = 'review';
@@ -859,6 +1067,25 @@ describe('GitHub session workspace preparation', () => {
     mocks.githubPat = 'ghp_worker';
     mocks.githubReviewerPat = 'ghp_reviewer';
     mocks.runBindingRole = 'triage';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+
+    expect(mocks.ensureSandbox).toHaveBeenCalledWith(
+      expect.any(Object),
+      { GH_TOKEN: 'ghp_worker' },
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it('keeps the worker PAT when only a revoked review binding remains', async () => {
+    mocks.githubPat = 'ghp_worker';
+    mocks.githubReviewerPat = 'ghp_reviewer';
+    mocks.runBindingRole = 'review';
+    mocks.runBindingStatus = 'revoked';
     const { workspace } = await createLocalFactory();
     addProject();
     addSession({ id: 'session-a' });

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -129,10 +129,15 @@ export interface CreateWorkspaceFactoryOptions {
 export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = {}) {
   const { sandbox: sandboxConfig, github, fleet, workItems } = options;
   const isLocalSandbox = sandboxConfig?.machine instanceof LocalSandbox;
-  const githubTokenInjectors = new Map<
-    string,
-    { inject: (token: string) => void; patKind: GithubPatKind; ghToken: string }
-  >();
+  type GithubTokenRegistration = {
+    inject: (token: string) => void;
+    patKind: GithubPatKind;
+    ghToken: string;
+    generation: number;
+    tokenReplacementPending: boolean;
+  };
+  const githubTokenInjectors = new Map<string, GithubTokenRegistration>();
+  const githubTokenReconciliations = new Map<string, Promise<void>>();
   // Concurrent requests for the same session (thread list + activity polling +
   // chat) must not each provision a sandbox and clone the repository. The
   // first caller materializes; followers await the same promise.
@@ -212,31 +217,129 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     const extensionId = effectiveSkillExtension ? `-${effectiveSkillExtension.id}` : '';
     const workspaceId = `${WORKSPACE_ID_PREFIX}-${projectRepository.id}-${session.id}${extensionId}`;
     const configDir = sandboxConfig.workdir ?? DEFAULT_CONFIG_DIR;
-    try {
-      const existing = mastra?.getWorkspaceById(workspaceId) as Workspace | undefined;
-      if (existing) {
-        existing.setToolsConfig(MASTRACODE_WORKSPACE_TOOLS);
-        const registered = githubTokenInjectors.get(workspaceId);
-        if (registered) {
-          registerGithubTokenInjector(requestContext, registered.inject);
-          registerGithubPatKind(requestContext, registered.patKind);
-          // A PAT saved in Settings after this sandbox was provisioned must
-          // reach the running sandbox without a server restart — re-read it
-          // on every reuse and push it into the live sandbox when it changed.
-          // Best-effort: a failed read or inject keeps the installed token.
-          try {
-            const pat = await getGithubPat(() => github.integrationStorage, session.orgId, registered.patKind);
-            if (pat && pat !== registered.ghToken) {
-              registered.inject(pat);
+
+    const getRepositoryToken = async (): Promise<string> => {
+      const access = await github.versionControl.getRepositoryAccess({
+        orgId: session.orgId,
+        repositoryId: repository.id,
+      });
+      const token = access.authorization?.token;
+      if (!token) throw new Error('Repository access did not include a bearer token for the Factory session');
+      return token;
+    };
+    const resolveGithubPatKind = async (fallback: GithubPatKind): Promise<GithubPatKind> => {
+      if (!workItems) return 'default';
+      try {
+        const address = getFactorySessionAddress(requestContext);
+        const runBinding = address ? await workItems.findRunBindingBySession(address) : null;
+        return runBinding?.role === 'review' && runBinding.status === 'active' && runBinding.orgId === session.orgId
+          ? 'reviewer'
+          : 'default';
+      } catch {
+        // Preserve the installed role when binding storage is temporarily unavailable.
+        return fallback;
+      }
+    };
+    const registerGithubTokenContext = (registered: GithubTokenRegistration): void => {
+      const generation = registered.generation;
+      registerGithubTokenInjector(requestContext, token => {
+        if (githubTokenInjectors.get(workspaceId) !== registered || registered.generation !== generation) {
+          throw new Error('GitHub token refresh no longer matches the active Factory workspace role.');
+        }
+        registered.inject(token);
+      });
+      registerGithubPatKind(requestContext, registered.patKind);
+    };
+    const reconcileGithubToken = async (): Promise<void> => {
+      const previous = githubTokenReconciliations.get(workspaceId) ?? Promise.resolve();
+      const reconciliation = previous
+        .catch(() => {})
+        .then(async () => {
+          const registered = githubTokenInjectors.get(workspaceId);
+          if (!registered) return;
+
+          const previousPatKind = registered.patKind;
+          const patKind = await resolveGithubPatKind(previousPatKind);
+          if (githubTokenInjectors.get(workspaceId) !== registered) return;
+
+          if (patKind !== previousPatKind) {
+            registered.patKind = patKind;
+            registered.generation += 1;
+          }
+          if (patKind === 'reviewer') registered.tokenReplacementPending = false;
+          if (previousPatKind === 'reviewer' && patKind === 'default') {
+            // Invalidate reviewer refresh contexts before replacement I/O so
+            // they cannot restore reviewer credentials after a failed downgrade.
+            registered.tokenReplacementPending = true;
+          }
+
+          let token = await getGithubPat(() => github.integrationStorage, session.orgId, patKind);
+          if (!token && registered.tokenReplacementPending) token = await getRepositoryToken();
+          if (githubTokenInjectors.get(workspaceId) !== registered) return;
+
+          if (token && token !== registered.ghToken) {
+            try {
+              registered.inject(token);
+            } catch (error) {
+              if (registered.tokenReplacementPending) throw error;
+              // Same-role rotations and reviewer upgrades remain best-effort.
             }
+          }
+          if (token && token === registered.ghToken) registered.tokenReplacementPending = false;
+          registerGithubTokenContext(registered);
+        });
+      githubTokenReconciliations.set(workspaceId, reconciliation);
+      try {
+        await reconciliation;
+      } finally {
+        if (githubTokenReconciliations.get(workspaceId) === reconciliation) {
+          githubTokenReconciliations.delete(workspaceId);
+        }
+      }
+    };
+    const reconcileRegisteredWorkspace = async (workspace: Workspace): Promise<Workspace> => {
+      const registered = githubTokenInjectors.get(workspaceId);
+      try {
+        await reconcileGithubToken();
+      } catch (error) {
+        if (registered?.tokenReplacementPending && githubTokenInjectors.get(workspaceId) === registered) {
+          // The role generation already invalidated reviewer refresh contexts.
+          // Keep the pending registration so failed eviction cannot make a
+          // still-live reviewer workspace look safe on the next reuse.
+          let evicted = false;
+          try {
+            evicted = (await mastra?.removeWorkspace?.(workspaceId)) === true;
           } catch {
-            // Keep the token already installed in the sandbox.
+            // Preserve the credential-replacement error and retry on the next reuse.
+          }
+          try {
+            await workspace.destroy();
+            evicted = true;
+          } catch {
+            // The pending registration keeps the workspace quarantined if cleanup also fails.
+          }
+          if (evicted && githubTokenInjectors.get(workspaceId) === registered) {
+            githubTokenInjectors.delete(workspaceId);
           }
         }
-        return existing;
+        throw error;
       }
+      if (registered && githubTokenInjectors.get(workspaceId) !== registered) {
+        throw new Error('Factory workspace GitHub credential registration is no longer active.');
+      }
+      return workspace;
+    };
+
+    let existing: Workspace | undefined;
+    try {
+      existing = mastra?.getWorkspaceById(workspaceId) as Workspace | undefined;
+      existing?.setToolsConfig(MASTRACODE_WORKSPACE_TOOLS);
     } catch {
       // Not registered yet.
+      existing = undefined;
+    }
+    if (existing) {
+      return reconcileRegisteredWorkspace(existing);
     }
 
     const materialize = async (): Promise<Workspace> => {
@@ -264,12 +367,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         }
       }
 
-      const access = await github.versionControl.getRepositoryAccess({
-        orgId: session.orgId,
-        repositoryId: repository.id,
-      });
-      const token = access.authorization?.token;
-      if (!token) throw new Error('Repository access did not include a bearer token for the Factory session');
+      const token = await getRepositoryToken();
 
       // The `gh` CLI needs a PAT when the org configured one (installation
       // tokens 403 on integration-restricted endpoints); git clone/checkout
@@ -277,16 +375,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       // (run-binding role `review`) authenticate `gh` as the reviewer account
       // when a reviewer token is configured; everything else — including
       // sessions with no resolvable run binding — uses the worker token.
-      let patKind: GithubPatKind = 'default';
-      if (workItems) {
-        try {
-          const address = getFactorySessionAddress(requestContext);
-          const runBinding = address ? await workItems.findRunBindingBySession(address) : null;
-          if (runBinding?.role === 'review' && runBinding.orgId === session.orgId) patKind = 'reviewer';
-        } catch {
-          // No resolvable binding — worker token.
-        }
-      }
+      const patKind = await resolveGithubPatKind('default');
       const ghCliToken = (await getGithubPat(() => github.integrationStorage, session.orgId, patKind)) ?? token;
 
       const ensureSandbox = () =>
@@ -340,17 +429,21 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       });
       if (projectRepository.setupCommand) await runWorktreeSetup(sandbox, workdir, projectRepository.setupCommand);
 
-      const injectGithubToken = (freshToken: string) => {
-        if (!sandbox.setEnvironmentVariable) {
-          throw new Error('The active sandbox provider does not support runtime GitHub token refresh.');
-        }
-        sandbox.setEnvironmentVariable('GH_TOKEN', freshToken);
-        const registered = githubTokenInjectors.get(workspaceId);
-        if (registered) registered.ghToken = freshToken;
+      const registered: GithubTokenRegistration = {
+        inject: freshToken => {
+          if (!sandbox.setEnvironmentVariable) {
+            throw new Error('The active sandbox provider does not support runtime GitHub token refresh.');
+          }
+          sandbox.setEnvironmentVariable('GH_TOKEN', freshToken);
+          registered.ghToken = freshToken;
+        },
+        patKind,
+        ghToken: ghCliToken,
+        generation: 0,
+        tokenReplacementPending: false,
       };
-      githubTokenInjectors.set(workspaceId, { inject: injectGithubToken, patKind, ghToken: ghCliToken });
-      registerGithubTokenInjector(requestContext, injectGithubToken);
-      registerGithubPatKind(requestContext, patKind);
+      githubTokenInjectors.set(workspaceId, registered);
+      registerGithubTokenContext(registered);
 
       const filesystem = new SandboxFilesystem({ sandbox, workdir });
       const projectSkillPaths = [path.join(configDir, 'skills'), '.claude/skills', '.agents/skills'];
@@ -382,12 +475,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     const inflight = inflightMaterializations.get(workspaceId);
     if (inflight) {
       const workspace = await inflight;
-      const registered = githubTokenInjectors.get(workspaceId);
-      if (registered) {
-        registerGithubTokenInjector(requestContext, registered.inject);
-        registerGithubPatKind(requestContext, registered.patKind);
-      }
-      return workspace;
+      return reconcileRegisteredWorkspace(workspace);
     }
     const materialization = materialize();
     inflightMaterializations.set(workspaceId, materialization);


### PR DESCRIPTION
Cached Factory workspaces previously kept the GitHub identity selected when they were first materialized. If a session later moved between work and review roles, `GH_TOKEN` could remain tied to the stale worker or reviewer account.

This re-resolves the active binding whenever a workspace is reused, updates the sandbox token when the required identity changes, invalidates stale refresh contexts, and fails closed if reviewer credentials cannot be safely removed. It also preserves the existing worker fallback when no dedicated reviewer PAT is configured.

Verified with 44 workspace tests, Factory typechecking, lint, and formatting. The broader Factory suite passed 1,397 tests; its three remaining failures are the existing reconcile scope assertion and two LibSQL serialization timeouts.

Closes #20541.