### PR TITLE
Run self-hosted Studio without 'unsafe-eval' in its Content Security Policy

### DIFF
--- a/.changeset/loud-pandas-shave.md
+++ b/.changeset/loud-pandas-shave.md
@@ -1,0 +1,9 @@
+---
+'mastra': patch
+---
+
+Studio no longer requires `'unsafe-eval'` in its Content Security Policy.
+
+Studio built its dynamic forms (tool inputs, workflow trigger/resume/state schemas, request context schemas) by generating Zod source code from a JSON Schema and compiling it with `Function()`. That forced every self-hosted deployment to relax its CSP with `'unsafe-eval'` just to render a form.
+
+Those schemas are now constructed by calling the Zod API directly, so no string is ever compiled and Studio runs under a CSP without `'unsafe-eval'`.

--- a/packages/playground/src/domains/agents/components/AgentToolPanel.tsx
+++ b/packages/playground/src/domains/agents/components/AgentToolPanel.tsx
@@ -1,6 +1,5 @@
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { toast } from '@mastra/playground-ui/utils/toast';
-import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { useEffect } from 'react';
 import { parse } from 'superjson';
 import { z } from 'zod';
@@ -8,7 +7,7 @@ import { useAgent } from '../hooks/use-agent';
 import { useExecuteAgentTool } from '../hooks/use-execute-agent-tool';
 import { usePermissions } from '@/domains/auth/hooks/use-permissions';
 import ToolExecutor from '@/domains/tools/components/ToolExecutor';
-import { resolveSerializedZodOutput } from '@/lib/form/utils';
+import { jsonSchemaToZodRuntime } from '@/lib/form/json-schema-to-zod-runtime';
 import { usePlaygroundStore } from '@/store/playground-store';
 
 export interface AgentToolPanelProps {
@@ -53,9 +52,7 @@ export const AgentToolPanel = ({ toolId, agentId }: AgentToolPanelProps) => {
     });
   };
 
-  const zodInputSchema = tool?.inputSchema
-    ? resolveSerializedZodOutput(jsonSchemaToZod(parse(tool?.inputSchema)))
-    : z.object({});
+  const zodInputSchema = tool?.inputSchema ? jsonSchemaToZodRuntime(parse(tool?.inputSchema)) : z.object({});
 
   if (isAgentLoading || error) return null;
 

--- a/packages/playground/src/domains/agents/components/request-context-run-options.tsx
+++ b/packages/playground/src/domains/agents/components/request-context-run-options.tsx
@@ -3,7 +3,6 @@ import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { FileJson, FormInput } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
@@ -13,7 +12,7 @@ import { RequestContextLabel } from '@/domains/request-context/components/reques
 import { RequestContextSchemaForm } from '@/domains/request-context/components/request-context-schema-form';
 import { useSchemaRequestContext } from '@/domains/request-context/context/schema-request-context';
 import { DynamicForm } from '@/lib/form';
-import { resolveSerializedZodOutput } from '@/lib/form/utils';
+import { jsonSchemaToZodRuntime } from '@/lib/form/json-schema-to-zod-runtime';
 
 interface AgentRequestContextRunOptionsProps {
   requestContextSchema?: string;
@@ -46,7 +45,7 @@ function VariablesRequestContextForm({
 
   const zodSchema = useMemo(() => {
     try {
-      return resolveSerializedZodOutput(jsonSchemaToZod(variablesSchema as Parameters<typeof jsonSchemaToZod>[0]));
+      return jsonSchemaToZodRuntime(variablesSchema as Parameters<typeof jsonSchemaToZodRuntime>[0]);
     } catch (error) {
       console.error('Failed to parse variables schema:', error);
       return null;

--- a/packages/playground/src/domains/datasets/components/experiment-trigger/experiment-trigger-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/experiment-trigger/experiment-trigger-dialog.tsx
@@ -11,7 +11,6 @@ import {
 } from '@mastra/playground-ui/components/Dialog';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
-import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { format } from 'date-fns';
 import { useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -20,7 +19,7 @@ import { ScorerSelector } from './scorer-selector';
 import type { TargetType } from './target-selector';
 import { TargetSelector } from './target-selector';
 import { DynamicForm } from '@/lib/form';
-import { resolveSerializedZodOutput } from '@/lib/form/utils';
+import { jsonSchemaToZodRuntime } from '@/lib/form/json-schema-to-zod-runtime';
 
 export interface ExperimentTriggerDialogProps {
   datasetId: string;
@@ -44,7 +43,7 @@ function RequestContextForm({
 }) {
   const zodSchema = useMemo(() => {
     try {
-      return resolveSerializedZodOutput(jsonSchemaToZod(requestContextSchema as Parameters<typeof jsonSchemaToZod>[0]));
+      return jsonSchemaToZodRuntime(requestContextSchema as Parameters<typeof jsonSchemaToZodRuntime>[0]);
     } catch (error) {
       console.error('Failed to parse requestContextSchema:', error);
       return null;

--- a/packages/playground/src/domains/datasets/utils/csv-validation.ts
+++ b/packages/playground/src/domains/datasets/utils/csv-validation.ts
@@ -3,9 +3,8 @@
  * Validates mapped data before import, including schema validation
  */
 
-import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import type { ZodSchema, ZodError, ZodIssue } from 'zod';
-import { resolveSerializedZodOutput } from '@/lib/form/utils';
+import { jsonSchemaToZodRuntime } from '@/lib/form/json-schema-to-zod-runtime';
 
 /** Column mapping configuration */
 export type ColumnMapping = Record<string, 'input' | 'groundTruth' | 'metadata' | 'ignore'>;
@@ -49,11 +48,9 @@ export interface CsvValidationResult {
 
 /**
  * Convert JSON Schema to runtime Zod schema.
- * Uses existing resolveSerializedZodOutput from lib/form/utils.
  */
 function compileSchema(jsonSchema: Record<string, unknown>): ZodSchema {
-  const zodString = jsonSchemaToZod(jsonSchema);
-  return resolveSerializedZodOutput(zodString);
+  return jsonSchemaToZodRuntime(jsonSchema);
 }
 
 /**

--- a/packages/playground/src/domains/mcps/components/MCPToolPanel.tsx
+++ b/packages/playground/src/domains/mcps/components/MCPToolPanel.tsx
@@ -3,7 +3,6 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useMastraClient } from '@mastra/react';
 import type { JsonSchema } from '@mastra/schema-compat/json-to-zod';
-import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect } from 'react';
 import { z } from 'zod';
@@ -11,7 +10,7 @@ import { McpAppViewer } from './mcp-app-viewer';
 import { usePermissions } from '@/domains/auth/hooks/use-permissions';
 import { useExecuteMCPTool, useMCPServerTool } from '@/domains/mcps/hooks/use-mcp-server-tool';
 import ToolExecutor from '@/domains/tools/components/ToolExecutor';
-import { resolveSerializedZodOutput } from '@/lib/form/utils';
+import { jsonSchemaToZodRuntime } from '@/lib/form/json-schema-to-zod-runtime';
 
 export interface MCPToolPanelProps {
   toolId: string;
@@ -103,7 +102,7 @@ export const MCPToolPanel = ({ toolId, serverId }: MCPToolPanelProps) => {
 
   let zodInputSchema;
   try {
-    zodInputSchema = resolveSerializedZodOutput(jsonSchemaToZod(tool.inputSchema as unknown as JsonSchema));
+    zodInputSchema = jsonSchemaToZodRuntime(tool.inputSchema as unknown as JsonSchema);
   } catch (e) {
     console.error('Error processing input schema:', e);
     toast.error('Failed to process tool input schema.');

--- a/packages/playground/src/domains/request-context/components/request-context-schema-form.tsx
+++ b/packages/playground/src/domains/request-context/components/request-context-schema-form.tsx
@@ -1,12 +1,11 @@
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { useMemo } from 'react';
 import { parse } from 'superjson';
 import { useSchemaRequestContext } from '../context/schema-request-context';
 import { RequestContextLabel } from './request-context-label';
 import { DynamicForm } from '@/lib/form';
-import { resolveSerializedZodOutput } from '@/lib/form/utils';
+import { jsonSchemaToZodRuntime } from '@/lib/form/json-schema-to-zod-runtime';
 
 export interface RequestContextSchemaFormProps {
   /**
@@ -34,8 +33,8 @@ export const RequestContextSchemaForm = ({ labelTooltip, requestContextSchema }:
   // Parse the schema
   const zodSchema = useMemo(() => {
     try {
-      const jsonSchema = parse(requestContextSchema) as Parameters<typeof jsonSchemaToZod>[0];
-      return resolveSerializedZodOutput(jsonSchemaToZod(jsonSchema));
+      const jsonSchema = parse(requestContextSchema) as Parameters<typeof jsonSchemaToZodRuntime>[0];
+      return jsonSchemaToZodRuntime(jsonSchema);
     } catch (error) {
       console.error('Failed to parse requestContextSchema:', error);
       return null;

--- a/packages/playground/src/domains/tools/components/ToolPanel.tsx
+++ b/packages/playground/src/domains/tools/components/ToolPanel.tsx
@@ -1,7 +1,6 @@
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { toast } from '@mastra/playground-ui/utils/toast';
-import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { useMemo, useEffect } from 'react';
 import { parse } from 'superjson';
 import { z } from 'zod';
@@ -10,7 +9,7 @@ import { useAgents } from '@/domains/agents/hooks/use-agents';
 import { usePermissions } from '@/domains/auth/hooks/use-permissions';
 import { useTool } from '@/domains/tools/hooks';
 import { useExecuteTool } from '@/domains/tools/hooks/use-execute-tool';
-import { resolveSerializedZodOutput } from '@/lib/form/utils';
+import { jsonSchemaToZodRuntime } from '@/lib/form/json-schema-to-zod-runtime';
 import { usePlaygroundStore } from '@/store/playground-store';
 
 export interface ToolPanelProps {
@@ -69,9 +68,7 @@ export const ToolPanel = ({ toolId }: ToolPanelProps) => {
     });
   };
 
-  const zodInputSchema = tool?.inputSchema
-    ? resolveSerializedZodOutput(jsonSchemaToZod(parse(tool?.inputSchema)))
-    : z.object({});
+  const zodInputSchema = tool?.inputSchema ? jsonSchemaToZodRuntime(parse(tool?.inputSchema)) : z.object({});
 
   if (isLoading) {
     return (

--- a/packages/playground/src/domains/workflows/workflow/use-workflow-trigger.ts
+++ b/packages/playground/src/domains/workflows/workflow/use-workflow-trigger.ts
@@ -1,5 +1,4 @@
 import type { GetWorkflowResponse, TimeTravelParams } from '@mastra/client-js';
-import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { useCallback, useContext, useMemo } from 'react';
 import { parse } from 'superjson';
 import { z } from 'zod';
@@ -19,7 +18,7 @@ import {
 import { WORKFLOW_STEP_NODE_TYPE } from './workflow-step-node-utils';
 import type { ResumeStepParams } from './workflow-suspended-steps';
 import { useMergedRequestContext } from '@/domains/request-context/context/schema-request-context';
-import { resolveSerializedZodOutput } from '@/lib/form/utils';
+import { jsonSchemaToZodRuntime } from '@/lib/form/json-schema-to-zod-runtime';
 
 export interface SuspendedStep {
   stepId: string;
@@ -47,13 +46,13 @@ export function useWorkflowSchemas(workflow?: GetWorkflowResponse) {
     const triggerSchema = workflow?.inputSchema;
     const stateSchema = workflow?.stateSchema;
 
-    const zodInputSchema = triggerSchema ? resolveSerializedZodOutput(jsonSchemaToZod(parse(triggerSchema))) : null;
-    const zodStateSchema = stateSchema ? resolveSerializedZodOutput(jsonSchemaToZod(parse(stateSchema))) : null;
+    const zodInputSchema = triggerSchema ? jsonSchemaToZodRuntime(parse(triggerSchema)) : null;
+    const zodStateSchema = stateSchema ? jsonSchemaToZodRuntime(parse(stateSchema)) : null;
 
     return {
       zodSchemaToUse: zodStateSchema
         ? z.object({
-            inputData: zodInputSchema,
+            inputData: zodInputSchema ?? z.any(),
             initialState: zodStateSchema.optional(),
           })
         : zodInputSchema,

--- a/packages/playground/src/domains/workflows/workflow/workflow-suspended-steps.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-suspended-steps.tsx
@@ -5,7 +5,6 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/pla
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { ChevronRight, CirclePause, MoveDownLeft, MoveUpRight, Play } from 'lucide-react';
 import { useState } from 'react';
 import { parse } from 'superjson';
@@ -14,7 +13,7 @@ import { z } from 'zod';
 import type { SuspendedStep } from './use-workflow-trigger';
 import { WorkflowInputData } from './workflow-input-data';
 
-import { resolveSerializedZodOutput } from '@/lib/form/utils';
+import { jsonSchemaToZodRuntime } from '@/lib/form/json-schema-to-zod-runtime';
 
 export interface ResumeStepParams {
   stepId: string | string[];
@@ -76,7 +75,7 @@ export function WorkflowSuspendedSteps({
         if (!stepDefinition || stepDefinition.isWorkflow) return null;
 
         const stepSchema = stepDefinition?.resumeSchema
-          ? resolveSerializedZodOutput(jsonSchemaToZod(parse(stepDefinition.resumeSchema)))
+          ? jsonSchemaToZodRuntime(parse(stepDefinition.resumeSchema))
           : z.record(z.string(), z.any());
 
         return (

--- a/packages/playground/src/domains/workflows/workflow/workflow-time-travel-form.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-time-travel-form.tsx
@@ -7,7 +7,6 @@ import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clip
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { formatJSON, isValidJson } from '@mastra/playground-ui/utils/formatting';
-import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import CodeMirror from '@uiw/react-codemirror';
 import { Braces, ChevronDown, CopyIcon, EyeIcon, EyeOffIcon } from 'lucide-react';
 import { useContext, useMemo, useState } from 'react';
@@ -16,7 +15,7 @@ import { z } from 'zod';
 import { WorkflowRunContext } from '../context/workflow-run-context';
 import { WorkflowInputData } from './workflow-input-data';
 import { useMergedRequestContext } from '@/domains/request-context/context/schema-request-context';
-import { resolveSerializedZodOutput } from '@/lib/form/utils';
+import { jsonSchemaToZodRuntime } from '@/lib/form/json-schema-to-zod-runtime';
 
 const buttonClass = 'text-neutral3 hover:text-neutral6';
 
@@ -227,11 +226,9 @@ export const WorkflowTimeTravelForm = ({
 
     try {
       const parsed = parse(stepDefinition.inputSchema);
-      const zodStateSchema = workflow?.stateSchema
-        ? resolveSerializedZodOutput(jsonSchemaToZod(parse(workflow.stateSchema)))
-        : null;
+      const zodStateSchema = workflow?.stateSchema ? jsonSchemaToZodRuntime(parse(workflow.stateSchema)) : null;
 
-      const zodStepSchema = resolveSerializedZodOutput(jsonSchemaToZod(parsed as any));
+      const zodStepSchema = jsonSchemaToZodRuntime(parsed as any);
 
       const schemaToUse = zodStateSchema
         ? z.object({

--- a/packages/playground/src/lib/form/__tests__/json-schema-to-zod-runtime.test.ts
+++ b/packages/playground/src/lib/form/__tests__/json-schema-to-zod-runtime.test.ts
@@ -1,0 +1,188 @@
+import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { jsonSchemaToZodRuntime } from '../json-schema-to-zod-runtime';
+import { getBaseSchema } from '../zod-provider/compat';
+import { inferFieldType } from '../zod-provider/field-type-inference';
+
+/**
+ * The behavior being replaced: generate Zod source and evaluate it. Kept here
+ * only as the reference implementation these tests compare against, so the
+ * runtime converter is pinned to what Studio does today rather than to an
+ * assumption about it.
+ */
+function resolveViaEval(jsonSchema: unknown): z.ZodTypeAny {
+  return Function('z', `"use strict";return (${jsonSchemaToZod(jsonSchema as any)});`)(z);
+}
+
+/** Schemas Studio realistically receives from tools, workflows and request context. */
+const schemas: Record<string, Record<string, any>> = {
+  'a required and an optional field': {
+    type: 'object',
+    properties: { name: { type: 'string' }, age: { type: 'number' } },
+    required: ['name'],
+  },
+  'a nested object': {
+    type: 'object',
+    properties: {
+      user: { type: 'object', properties: { email: { type: 'string' } }, required: ['email'] },
+    },
+    required: ['user'],
+  },
+  'an array of objects': {
+    type: 'object',
+    properties: { items: { type: 'array', items: { type: 'object', properties: { id: { type: 'string' } } } } },
+  },
+  'a string enum': { type: 'object', properties: { color: { type: 'string', enum: ['red', 'green'] } } },
+  'a nullable field': { type: 'object', properties: { v: { type: ['string', 'null'] } } },
+  'string constraints': {
+    type: 'object',
+    properties: { s: { type: 'string', minLength: 2, maxLength: 5, pattern: '^[a-z]+$' } },
+  },
+  'number constraints': {
+    type: 'object',
+    properties: { n: { type: 'number', minimum: 1, maximum: 10 }, i: { type: 'integer' } },
+  },
+  'a default value': { type: 'object', properties: { d: { type: 'string', default: 'hi' } } },
+  'a described field': { type: 'object', properties: { d: { type: 'string', description: 'a field' } } },
+  'an anyOf union': { type: 'object', properties: { v: { anyOf: [{ type: 'string' }, { type: 'number' }] } } },
+  'a boolean': { type: 'object', properties: { b: { type: 'boolean' } } },
+  'a date-time string': { type: 'object', properties: { t: { type: 'string', format: 'date-time' } } },
+  'an email string': { type: 'object', properties: { e: { type: 'string', format: 'email' } } },
+  'a dictionary of strings': {
+    type: 'object',
+    properties: { m: { type: 'object', additionalProperties: { type: 'string' } } },
+  },
+  'no properties at all': { type: 'object', properties: {} },
+  'a deeply nested shape': {
+    type: 'object',
+    properties: { a: { type: 'object', properties: { b: { type: 'array', items: { type: 'string' } } } } },
+  },
+};
+
+/** Values spanning valid, invalid and absent for the fields above. */
+const values: unknown[] = [
+  {},
+  { name: 'x' },
+  { name: 'x', age: 3 },
+  { name: 'x', age: 'not-a-number' },
+  { user: { email: 'a@b.com' } },
+  { items: [{ id: '1' }] },
+  { items: 'not-an-array' },
+  { color: 'red' },
+  { color: 'blue' },
+  { v: null },
+  { v: 'str' },
+  { v: 5 },
+  { s: 'abc' },
+  { s: 'a' },
+  { s: 'ABCD' },
+  { n: 5 },
+  { n: 50 },
+  { i: 2 },
+  { i: 2.5 },
+  { d: 'hi' },
+  { b: true },
+  { b: 'yes' },
+  { t: '2024-01-01T00:00:00Z' },
+  { t: 'not-a-date' },
+  { e: 'a@b.com' },
+  { e: 'nope' },
+  { m: { k: 'v' } },
+  { m: { k: 1 } },
+  { a: { b: ['x'] } },
+];
+
+describe('jsonSchemaToZodRuntime', () => {
+  describe('when given the schemas Studio receives', () => {
+    it.each(Object.entries(schemas))(
+      'accepts and rejects the same values as the evaluated schema for %s',
+      (_name, jsonSchema) => {
+        const evaluated = resolveViaEval(jsonSchema);
+        const runtime = jsonSchemaToZodRuntime(jsonSchema);
+
+        for (const value of values) {
+          expect({ value, valid: runtime.safeParse(value).success }).toEqual({
+            value,
+            valid: evaluated.safeParse(value).success,
+          });
+        }
+      },
+    );
+
+    it.each(Object.entries(schemas))(
+      'infers the same form field types as the evaluated schema for %s',
+      (_name, jsonSchema) => {
+        const evaluatedShape = (resolveViaEval(jsonSchema) as z.ZodObject<any>).shape;
+        const runtimeShape = (jsonSchemaToZodRuntime(jsonSchema) as z.ZodObject<any>).shape;
+
+        expect(Object.keys(runtimeShape)).toEqual(Object.keys(evaluatedShape));
+        for (const key of Object.keys(evaluatedShape)) {
+          expect({ key, type: inferFieldType(runtimeShape[key]) }).toEqual({
+            key,
+            type: inferFieldType(evaluatedShape[key]),
+          });
+        }
+      },
+    );
+  });
+
+  describe('when the field drives specialized form rendering', () => {
+    it('keeps a date-time string a date field rather than a plain text field', () => {
+      const shape = (jsonSchemaToZodRuntime(schemas['a date-time string']!) as z.ZodObject<any>).shape;
+
+      expect(inferFieldType(getBaseSchema(shape.t))).toBe('date');
+    });
+
+    it('keeps a dictionary a record field, so its entries are not discarded', () => {
+      const shape = (jsonSchemaToZodRuntime(schemas['a dictionary of strings']!) as z.ZodObject<any>).shape;
+
+      expect(inferFieldType(getBaseSchema(shape.m))).toBe('record');
+      expect(jsonSchemaToZodRuntime(schemas['a dictionary of strings']!).parse({ m: { k: 'v' } })).toEqual({
+        m: { k: 'v' },
+      });
+    });
+
+    it('keeps an anyOf a union rather than an intersection', () => {
+      const shape = (jsonSchemaToZodRuntime(schemas['an anyOf union']!) as z.ZodObject<any>).shape;
+
+      expect(inferFieldType(getBaseSchema(shape.v))).toBe('union');
+    });
+  });
+
+  describe('when the schema is unusable', () => {
+    it('falls back to a permissive field instead of throwing, matching the generator', () => {
+      expect(jsonSchemaToZodRuntime(undefined).safeParse('anything').success).toBe(true);
+      expect(jsonSchemaToZodRuntime({ type: 'not-a-real-type' }).safeParse(123).success).toBe(true);
+    });
+
+    it('ignores a pattern that is not a valid JavaScript regex', () => {
+      const schema = jsonSchemaToZodRuntime({ type: 'string', pattern: '(' });
+
+      expect(schema.safeParse('anything').success).toBe(true);
+    });
+  });
+
+  describe('when building the schema', () => {
+    it('never compiles a string, so Studio does not need unsafe-eval', () => {
+      const originalFunction = globalThis.Function;
+      const calls: unknown[] = [];
+      // @ts-expect-error deliberately replacing the constructor for the assertion
+      globalThis.Function = (...args: unknown[]) => {
+        calls.push(args);
+        throw new Error('Function() was called');
+      };
+
+      try {
+        for (const jsonSchema of Object.values(schemas)) {
+          jsonSchemaToZodRuntime(jsonSchema);
+        }
+      } finally {
+        globalThis.Function = originalFunction;
+      }
+
+      expect(calls).toEqual([]);
+    });
+  });
+});

--- a/packages/playground/src/lib/form/json-schema-to-zod-runtime.ts
+++ b/packages/playground/src/lib/form/json-schema-to-zod-runtime.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod';
+
+/**
+ * Build a Zod schema from a JSON Schema at runtime.
+ *
+ * Studio previously produced its form schemas by generating Zod *source code*
+ * with `json-schema-to-zod` and evaluating it through `Function()`. That works,
+ * but it forces every self-hosted deployment to relax its Content Security
+ * Policy with `'unsafe-eval'`, which is a poor trade for building a form.
+ *
+ * This constructs the same schemas by calling the Zod API directly, so no
+ * string is ever compiled. The supported surface is deliberately matched to
+ * what the generator emitted for the schemas Studio receives — tool inputs,
+ * workflow trigger/resume/state schemas, and request context schemas — and
+ * `json-schema-to-zod-parity.test.ts` pins that equivalence.
+ *
+ * Anything unrecognized degrades to `z.any()`, which is what the generator did
+ * too: an unusual schema renders a permissive field rather than breaking Studio.
+ */
+
+type JsonSchema = Record<string, any>;
+
+const STRING_FORMATS: Record<string, (s: z.ZodString) => z.ZodString> = {
+  'date-time': s => s.datetime(),
+  email: s => s.email(),
+  uri: s => s.url(),
+  url: s => s.url(),
+  uuid: s => s.uuid(),
+  ipv4: s => s.ip({ version: 'v4' }),
+  ipv6: s => s.ip({ version: 'v6' }),
+};
+
+function buildString(schema: JsonSchema): z.ZodTypeAny {
+  let out = z.string();
+  const format = typeof schema.format === 'string' ? STRING_FORMATS[schema.format] : undefined;
+  if (format) out = format(out);
+  if (typeof schema.minLength === 'number') out = out.min(schema.minLength);
+  if (typeof schema.maxLength === 'number') out = out.max(schema.maxLength);
+  if (typeof schema.pattern === 'string') {
+    try {
+      out = out.regex(new RegExp(schema.pattern));
+    } catch {
+      // An invalid or non-JS-compatible pattern should not break the form; the
+      // rest of the field's validation still applies.
+    }
+  }
+  return out;
+}
+
+function buildNumber(schema: JsonSchema, integer: boolean): z.ZodTypeAny {
+  let out = z.number();
+  if (integer) out = out.int();
+  if (typeof schema.minimum === 'number') out = out.min(schema.minimum);
+  if (typeof schema.maximum === 'number') out = out.max(schema.maximum);
+  if (typeof schema.exclusiveMinimum === 'number') out = out.gt(schema.exclusiveMinimum);
+  if (typeof schema.exclusiveMaximum === 'number') out = out.lt(schema.exclusiveMaximum);
+  if (typeof schema.multipleOf === 'number') out = out.multipleOf(schema.multipleOf);
+  return out;
+}
+
+function buildArray(schema: JsonSchema): z.ZodTypeAny {
+  const items = schema.items && !Array.isArray(schema.items) ? convert(schema.items) : z.any();
+  let out = z.array(items);
+  if (typeof schema.minItems === 'number') out = out.min(schema.minItems);
+  if (typeof schema.maxItems === 'number') out = out.max(schema.maxItems);
+  return out;
+}
+
+function buildObject(schema: JsonSchema): z.ZodTypeAny {
+  const properties = schema.properties as Record<string, JsonSchema> | undefined;
+  const additional = schema.additionalProperties;
+
+  // An object with no declared properties but a schema for additional ones is a
+  // dictionary. Studio renders these with its record field, so they must not
+  // collapse into an empty object — that would silently discard every entry.
+  if (!properties || Object.keys(properties).length === 0) {
+    if (additional && typeof additional === 'object') {
+      return z.record(convert(additional));
+    }
+    if (additional === true) {
+      return z.record(z.any());
+    }
+    return z.object({});
+  }
+
+  const required = Array.isArray(schema.required) ? schema.required : [];
+  const shape: Record<string, z.ZodTypeAny> = {};
+
+  for (const [key, propSchema] of Object.entries(properties)) {
+    let field = convert(propSchema);
+    const hasDefault = propSchema && typeof propSchema === 'object' && propSchema.default !== undefined;
+    // A property with a default is satisfiable without the caller supplying it,
+    // so it is not marked optional on top of the default.
+    if (!hasDefault && !required.includes(key)) field = field.optional();
+    shape[key] = field;
+  }
+
+  const out = z.object(shape);
+  return additional && typeof additional === 'object' ? out.catchall(convert(additional)) : out;
+}
+
+function buildComposite(schemas: JsonSchema[]): z.ZodTypeAny {
+  const options = schemas.map(convert);
+  if (options.length === 0) return z.any();
+  if (options.length === 1) return options[0]!;
+  return z.union(options as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]);
+}
+
+function buildForType(schema: JsonSchema, type: string): z.ZodTypeAny {
+  switch (type) {
+    case 'string':
+      return buildString(schema);
+    case 'number':
+      return buildNumber(schema, false);
+    case 'integer':
+      return buildNumber(schema, true);
+    case 'boolean':
+      return z.boolean();
+    case 'null':
+      return z.null();
+    case 'array':
+      return buildArray(schema);
+    case 'object':
+      return buildObject(schema);
+    default:
+      return z.any();
+  }
+}
+
+function convert(schema: JsonSchema | boolean | undefined): z.ZodTypeAny {
+  if (schema === undefined || schema === true) return z.any();
+  if (schema === false) return z.never();
+  if (typeof schema !== 'object') return z.any();
+
+  let out: z.ZodTypeAny;
+
+  if (schema.const !== undefined) {
+    out = z.literal(schema.const);
+  } else if (Array.isArray(schema.enum)) {
+    const values = schema.enum;
+    out = values.every((v: unknown) => typeof v === 'string')
+      ? z.enum(values as [string, ...string[]])
+      : buildComposite(values.map((v: unknown) => ({ const: v })));
+  } else if (Array.isArray(schema.anyOf)) {
+    out = buildComposite(schema.anyOf);
+  } else if (Array.isArray(schema.oneOf)) {
+    out = buildComposite(schema.oneOf);
+  } else if (Array.isArray(schema.allOf)) {
+    // Intersections of more than two members nest pairwise.
+    const parts = schema.allOf.map(convert);
+    out = parts.length ? parts.reduce((left, right) => z.intersection(left, right)) : z.any();
+  } else if (Array.isArray(schema.type)) {
+    out = buildComposite(schema.type.map((t: string) => ({ ...schema, type: t })));
+  } else if (typeof schema.type === 'string') {
+    out = buildForType(schema, schema.type);
+  } else {
+    out = z.any();
+  }
+
+  if (typeof schema.description === 'string') out = out.describe(schema.description);
+  if (schema.default !== undefined) out = out.default(schema.default);
+
+  return out;
+}
+
+/**
+ * Convert a JSON Schema into a Zod schema without evaluating generated code.
+ */
+export function jsonSchemaToZodRuntime(schema: JsonSchema | boolean | undefined): z.ZodTypeAny {
+  return convert(schema);
+}

--- a/packages/playground/src/lib/form/json-schema-to-zod-runtime.ts
+++ b/packages/playground/src/lib/form/json-schema-to-zod-runtime.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
  * string is ever compiled. The supported surface is deliberately matched to
  * what the generator emitted for the schemas Studio receives — tool inputs,
  * workflow trigger/resume/state schemas, and request context schemas — and
- * `json-schema-to-zod-parity.test.ts` pins that equivalence.
+ * `__tests__/json-schema-to-zod-runtime.test.ts` pins that equivalence.
  *
  * Anything unrecognized degrades to `z.any()`, which is what the generator did
  * too: an unusual schema renders a permissive field rather than breaking Studio.

--- a/packages/playground/src/lib/form/utils.ts
+++ b/packages/playground/src/lib/form/utils.ts
@@ -1,6 +1,5 @@
 import type { FieldConfig } from '@autoform/core';
 import { buildZodFieldConfig } from '@autoform/react';
-import { z } from 'zod';
 import type { FieldTypes } from './auto-form';
 
 // @ts-expect-error - TODO
@@ -45,15 +44,4 @@ export function removeEmptyValues<T extends Record<string, any>>(values: T): Par
   }
 
   return result;
-}
-
-/**
- * Resolve serialized zod output - This function takes the string output of the `jsonSchemaToZod` function
- * and instantiates the zod object correctly.
- *
- * @param obj - serialized zod object
- * @returns resolved zod object
- */
-export function resolveSerializedZodOutput(obj: any) {
-  return Function('z', `"use strict";return (${obj});`)(z);
 }


### PR DESCRIPTION
## What this changes

Self-hosted Studio could not run under a Content Security Policy that omits `'unsafe-eval'`. This removes the reason it needed one.

Studio builds forms dynamically — tool inputs, workflow trigger/resume/state schemas, request context schemas, dataset CSV validation. It did that by generating Zod **source code** from the incoming JSON Schema and then compiling that string at runtime with `Function()`. Compiling a string is exactly what `'unsafe-eval'` permits, so every deployment had to weaken its CSP for the entire app just to render a form.

Those schemas are now built by calling the Zod API directly, so no string is ever compiled.

## Why it is safe to swap the converter

The risk here is not whether a form appears, it is whether it appears *the same*. A converter that quietly loses a constraint would still render, while silently accepting bad input or dropping data.

So the new converter is pinned against the old eval-based one. `json-schema-to-zod-runtime.test.ts` runs both over the schema shapes Studio actually receives and asserts they agree on:

- **validation** — 29 values spanning valid, invalid and absent are accepted/rejected identically by both.
- **form rendering** — every field infers the same Studio field type from both.

Building that harness caught three regressions that a naive swap would have shipped:

| Schema | Naive swap | Consequence |
|---|---|---|
| `format: 'date-time'` | check dropped | date picker degrades to a text box |
| `additionalProperties: { … }` | became an empty object | **every entry silently discarded on submit** |
| `anyOf` | became an intersection | union field renders as an object |

All three are handled and have their own regression tests.

## Proof the CSP requirement is actually gone

Counting compiled-string sites in the built Studio bundle:

- before: `1`
- after: `0`

A test also swaps out `globalThis.Function` and builds every schema in the corpus, so a future change that reintroduces compilation fails rather than quietly restoring the CSP requirement.

## Scope

Playground only. `resolveSerializedZodOutput` in `packages/core` runs server-side in Node, never reaches the browser, and is exported API — it is untouched, since removing it is a breaking change unrelated to CSP.

## Test plan

- `pnpm --filter ./packages/playground test` — 255 files, 1857 passed
- `pnpm --filter ./packages/playground typecheck` — clean
- `pnpm --filter ./packages/playground build` — succeeds, bundle verified free of compiled strings

Closes #16992