### PR TITLE
feat(core): add resolveSession and onStaleToolApproval hooks to Agent…

### DIFF
--- a/.changeset/agent-controller-channels-hooks.md
+++ b/.changeset/agent-controller-channels-hooks.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Add `resolveSession` and `onStaleToolApproval` hooks to `AgentControllerChannels`, and pass `RequestContext` into `getSessionForThread` during approval continuations.

--- a/packages/core/src/channels/__tests__/agent-controller-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-controller-channels.test.ts
@@ -126,7 +126,9 @@ async function createSetup({
   toolDisplay,
   stateSchema,
   agentMemory,
+  resolveSession,
   onSessionStart,
+  onStaleToolApproval,
 }: {
   responseText?: string;
   model?: MockLanguageModelV2;
@@ -135,7 +137,9 @@ async function createSetup({
   stateSchema?: z.ZodTypeAny;
   /** Memory for the mode agent — required for signal persistence assertions. */
   agentMemory?: MockMemory;
+  resolveSession?: (ctx: any) => any;
   onSessionStart?: (ctx: any) => void | Promise<void>;
+  onStaleToolApproval?: (ctx: any) => void | Promise<void>;
 } = {}) {
   const adapter = createMockAdapter('discord');
   const agent = new Agent({
@@ -155,7 +159,9 @@ async function createSetup({
     defaultModeId: 'build',
     channels: {
       adapters: { discord: toolDisplay ? { adapter, toolDisplay } : adapter },
+      ...(resolveSession ? { resolveSession } : {}),
       ...(onSessionStart ? { onSessionStart } : {}),
+      ...(onStaleToolApproval ? { onStaleToolApproval } : {}),
     },
     ...(stateSchema ? { stateSchema } : {}),
   });
@@ -748,6 +754,147 @@ describe('AgentControllerChannels', () => {
 
       const renderContext = await channels.buildRenderContextForThread(mapped!.id);
       expect(renderContext).not.toBeNull();
+    }, 30_000);
+  });
+
+  describe('resolveSession and onStaleToolApproval hooks (issue #21025)', () => {
+    it('uses resolveSession to create/resolve a custom session before default session creation', async () => {
+      let resolveCalled = false;
+      const resolveSession = vi.fn(async ({ controller, thread, requestContext }) => {
+        resolveCalled = true;
+        // Verify controller, thread, and requestContext are passed in
+        expect(controller).toBeDefined();
+        expect(thread.resourceId).toBe('channel:chan-1:t-custom');
+        expect(requestContext).toBeDefined();
+        return controller.createSession({
+          resourceId: thread.resourceId,
+          id: thread.resourceId,
+          ownerId: controller.id,
+          requestContext,
+        });
+      });
+
+      const { adapter, mastra, channels, controller } = await createSetup({
+        resolveSession,
+      });
+      const chatThread = createChatThread(adapter, 'chan-1:t-custom');
+
+      const reqCtx = new RequestContext();
+      reqCtx.set('user', 'custom-user');
+
+      await (channels as any).processChatMessage(
+        chatThread,
+        createMessage('m-1', 'hello custom session'),
+        mastra,
+        reqCtx,
+      );
+
+      expect(resolveCalled).toBe(true);
+      expect(resolveSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          controller,
+          thread: expect.objectContaining({ resourceId: 'channel:chan-1:t-custom' }),
+          requestContext: reqCtx,
+        }),
+      );
+      const session = await controller.getSessionByResource('channel:chan-1:t-custom');
+      expect(session).toBeDefined();
+    }, 30_000);
+
+    it('fails closed when resolveSession throws an authorization error (no session created or run executed)', async () => {
+      const resolveSession = vi.fn(() => {
+        throw new Error('Unauthorized channel request context');
+      });
+
+      const { adapter, mastra, channels, controller } = await createSetup({
+        resolveSession,
+      });
+      const chatThread = createChatThread(adapter, 'chan-1:t-blocked');
+
+      await expect(
+        (channels as any).processChatMessage(
+          chatThread,
+          createMessage('m-1', 'hello blocked'),
+          mastra,
+          new RequestContext(),
+        ),
+      ).rejects.toThrow('Unauthorized channel request context');
+
+      // Fail-closed: No session created
+      const session = await controller.getSessionByResource('channel:chan-1:t-blocked');
+      expect(session).toBeUndefined();
+    }, 30_000);
+
+    it('passes requestContext to resolveSession during approval continuation', async () => {
+      const resolveSessionCalls: any[] = [];
+      const resolveSession = vi.fn(async ({ controller, thread, requestContext }) => {
+        resolveSessionCalls.push({ threadId: thread.id, resourceId: thread.resourceId, requestContext });
+        return controller.createSession({
+          resourceId: thread.resourceId,
+          id: thread.resourceId,
+          ownerId: controller.id,
+          requestContext,
+        });
+      });
+
+      const { tool } = createDeployTool();
+      const { adapter, controller, mastra, channels } = await createSetup({
+        model: createApprovalFlowModel(),
+        tools: { deployTool: tool },
+        resolveSession,
+      });
+      const chatThread = createChatThread(adapter, 'chan-1:t-approval-ctx');
+
+      const reqCtx = new RequestContext();
+      reqCtx.set('authToken', 'valid-approval-token');
+
+      await (channels as any).processChatMessage(chatThread, createMessage('m-1', 'deploy now'), mastra, reqCtx);
+
+      const session = (await controller.getSessionByResource('channel:chan-1:t-approval-ctx'))!;
+      await waitFor(() => session.approval.isArmed(), { what: 'approval gate armed' });
+
+      // First call (inbound message) passed reqCtx
+      expect(resolveSessionCalls[0].requestContext).toBe(reqCtx);
+
+      const toolCallId = session.approval.getToolCallId()!;
+      await simulateAction(channels, adapter, 'chan-1:t-approval-ctx', `tool_approve:${toolCallId}`);
+
+      // Continuation call for approval also passed requestContext into getSessionForThread & resolveSession!
+      expect(resolveSessionCalls.length).toBeGreaterThan(1);
+      const continuationCall = resolveSessionCalls[resolveSessionCalls.length - 1];
+      expect(continuationCall.requestContext).toBeDefined();
+    }, 30_000);
+
+    it('invokes onStaleToolApproval when an approval action targets an unarmed approval gate', async () => {
+      const onStaleToolApproval = vi.fn(async (ctx: any) => {
+        expect(ctx.decision).toBe('approve');
+        expect(ctx.toolCallId).toBe('call-stale-999');
+        expect(ctx.runId).toBe('run-stale-111');
+        expect(ctx.memory).toMatchObject({ thread: expect.any(String), resource: 'channel:stale-res' });
+        expect(ctx.session).toBeDefined();
+      });
+
+      const { channels, controller } = await createSetup({
+        onStaleToolApproval,
+      });
+
+      const session = await controller.createSession({
+        resourceId: 'channel:stale-res',
+        id: 'channel:stale-res',
+        ownerId: controller.id,
+      });
+      const threadId = session.thread.getId();
+
+      const reqCtx = new RequestContext();
+      await (channels as any).respondToSessionApproval({
+        decision: 'approve',
+        runId: 'run-stale-111',
+        toolCallId: 'call-stale-999',
+        requestContext: reqCtx,
+        memory: { thread: threadId, resource: 'channel:stale-res' },
+      });
+
+      expect(onStaleToolApproval).toHaveBeenCalledTimes(1);
     }, 30_000);
   });
 });

--- a/packages/core/src/channels/agent-controller-channels.ts
+++ b/packages/core/src/channels/agent-controller-channels.ts
@@ -12,6 +12,23 @@ import type { RequestContext } from '../request-context';
 import { AgentChannels } from './agent-channels';
 import type { ChannelConfig } from './types';
 
+/** Context passed to {@link AgentControllerChannelsConfig.resolveSession}. */
+export interface ChannelSessionResolveContext {
+  /** The controller instance managing this channel interface. */
+  controller: AgentController<any>;
+  /** The mapped Mastra thread the session will be bound to. */
+  thread: Pick<StorageThreadType, 'id' | 'resourceId'>;
+  /** Request context of the inbound message or approval continuation. */
+  requestContext?: RequestContext;
+}
+
+/**
+ * Resolve or create a controller session before default session creation.
+ * Allows host applications to validate request context, select session identity,
+ * workspace, mode, and tags, or fail closed by throwing an error.
+ */
+export type ChannelSessionResolve = (ctx: ChannelSessionResolveContext) => Session<any> | Promise<Session<any>>;
+
 /** Context passed to {@link AgentControllerChannelsConfig.onSessionStart}. */
 export interface ChannelSessionStartContext {
   /**
@@ -41,8 +58,36 @@ export interface ChannelSessionStartContext {
  */
 export type ChannelSessionStart = (ctx: ChannelSessionStartContext) => void | Promise<void>;
 
+/** Context passed to {@link AgentControllerChannelsConfig.onStaleToolApproval}. */
+export interface ChannelStaleToolApprovalContext {
+  /** The user's approval decision. */
+  decision: 'approve' | 'decline';
+  /** The run ID associated with the approval action. */
+  runId: string;
+  /** The tool call ID being approved or declined. */
+  toolCallId: string;
+  /** Request context of the approval action. */
+  requestContext?: RequestContext;
+  /** Memory identifiers for the thread and resource. */
+  memory: { thread: string; resource: string };
+  /** The session instance, if resolved. */
+  session?: Session<any>;
+}
+
+/**
+ * Hook invoked when an approval action is received for a tool call without a matching live gate
+ * (e.g. after server restart). Errors propagate to allow durable hosts to reconcile state.
+ */
+export type ChannelStaleToolApproval = (ctx: ChannelStaleToolApprovalContext) => void | Promise<void>;
+
 /** Configuration for {@link AgentControllerChannels}. */
 export interface AgentControllerChannelsConfig extends ChannelConfig {
+  /**
+   * Called before creating a default session for a channel thread. Allows the
+   * host to inspect request context and return a custom session. Errors propagate
+   * so authorization and routing fail closed.
+   */
+  resolveSession?: ChannelSessionResolve;
   /**
    * Called once per session per process, after the session is bound to its
    * thread and before the first message dispatches. Concurrent messages on a
@@ -50,6 +95,11 @@ export interface AgentControllerChannelsConfig extends ChannelConfig {
    * unconfigured session. See {@link ChannelSessionStart}.
    */
   onSessionStart?: ChannelSessionStart;
+  /**
+   * Called when an approval action arrives but no live approval gate exists for
+   * the specified tool call. Allows durable host systems to reconcile state.
+   */
+  onStaleToolApproval?: ChannelStaleToolApproval;
 }
 
 /**
@@ -80,8 +130,14 @@ export class AgentControllerChannels extends AgentChannels {
    */
   private autoApproveResourceIds = new Set<string>();
 
+  /** See {@link AgentControllerChannelsConfig.resolveSession}. */
+  private readonly resolveSessionHook: ChannelSessionResolve | undefined;
+
   /** See {@link AgentControllerChannelsConfig.onSessionStart}. */
   private readonly onSessionStart: ChannelSessionStart | undefined;
+
+  /** See {@link AgentControllerChannelsConfig.onStaleToolApproval}. */
+  private readonly onStaleToolApprovalHook: ChannelStaleToolApproval | undefined;
 
   /**
    * One start-hook invocation per session resourceId. A map of promises rather
@@ -95,7 +151,9 @@ export class AgentControllerChannels extends AgentChannels {
 
   constructor(config: AgentControllerChannelsConfig) {
     super(config);
+    this.resolveSessionHook = config.resolveSession;
     this.onSessionStart = config.onSessionStart;
+    this.onStaleToolApprovalHook = config.onStaleToolApproval;
   }
 
   /** @internal Called by AgentController's constructor to bind itself. */
@@ -233,29 +291,38 @@ export class AgentControllerChannels extends AgentChannels {
   /**
    * Shared approve/decline path. Never calls the session's internal
    * `approveToolCall`/`declineToolCall` executors directly — the engine parked
-   * at the gate owns the resume. `respondToToolApproval` is a silent no-op
-   * when nothing is armed or the toolCallId mismatches, so staleness is
-   * pre-checked explicitly (an armed gate does not survive process restarts,
-   * so restart-recovered approvals are always stale — consistent with the
-   * v1 long-lived-server scope).
+   * at the gate owns the resume. When nothing is armed or the toolCallId
+   * mismatches, `onStaleToolApproval` is invoked if configured.
    */
   private async respondToSessionApproval({
     decision,
+    runId,
     toolCallId,
     requestContext,
     memory,
   }: {
     decision: 'approve' | 'decline';
+    runId: string;
     toolCallId: string;
     requestContext: RequestContext;
     memory: { thread: string; resource: string };
   }): Promise<void> {
-    const session = await this.getSessionForThread({ id: memory.thread, resourceId: memory.resource });
+    const session = await this.getSessionForThread({ id: memory.thread, resourceId: memory.resource }, requestContext);
     if (!session.approval.isArmed() || session.approval.getToolCallId() !== toolCallId) {
       this.log(
         'info',
         `Ignoring stale tool ${decision === 'approve' ? 'approval' : 'denial'} action (no matching parked approval for toolCallId=${toolCallId})`,
       );
+      if (this.onStaleToolApprovalHook) {
+        await this.onStaleToolApprovalHook({
+          decision,
+          runId,
+          toolCallId,
+          requestContext,
+          memory,
+          session,
+        });
+      }
       return;
     }
     // The requestContext carries the channel render context, so the resumed
@@ -275,17 +342,26 @@ export class AgentControllerChannels extends AgentChannels {
   ): Promise<Session<any>> {
     const controller = this.requireController();
     const channelResourceId = thread.resourceId;
-    // `createSession` is get-or-create keyed by resourceId, so follow-up messages
-    // on the same thread reuse the cached session bound to this thread. The
-    // dispatch requestContext must flow in: a dynamic workspace factory is
-    // resolved once at session creation with THIS context, and it may need the
-    // stamped tenant (`user`) to authorize a repo-backed session workspace.
-    const session = await controller.createSession({
-      resourceId: channelResourceId,
-      id: channelResourceId,
-      ownerId: controller.id,
-      requestContext,
-    });
+    let session: Session<any>;
+    if (this.resolveSessionHook) {
+      session = await this.resolveSessionHook({
+        controller,
+        thread,
+        requestContext,
+      });
+    } else {
+      // `createSession` is get-or-create keyed by resourceId, so follow-up messages
+      // on the same thread reuse the cached session bound to this thread. The
+      // dispatch requestContext must flow in: a dynamic workspace factory is
+      // resolved once at session creation with THIS context, and it may need the
+      // stamped tenant (`user`) to authorize a repo-backed session workspace.
+      session = await controller.createSession({
+        resourceId: channelResourceId,
+        id: channelResourceId,
+        ownerId: controller.id,
+        requestContext,
+      });
+    }
     // Bind the mapped thread. Guard is mandatory: `switch` aborts any active
     // run, so never re-switch when the session is already on this thread.
     if (session.thread.getId() !== thread.id) {

--- a/packages/core/src/channels/index.ts
+++ b/packages/core/src/channels/index.ts
@@ -2,8 +2,12 @@ export { AgentChannels } from './agent-channels';
 export { AgentControllerChannels } from './agent-controller-channels';
 export type {
   AgentControllerChannelsConfig,
+  ChannelSessionResolve,
+  ChannelSessionResolveContext,
   ChannelSessionStart,
   ChannelSessionStartContext,
+  ChannelStaleToolApproval,
+  ChannelStaleToolApprovalContext,
 } from './agent-controller-channels';
 export { ChatChannelProcessor } from './processor';
 export { MastraStateAdapter } from './state-adapter';


### PR DESCRIPTION
feat(core): add resolveSession and onStaleToolApproval hooks to AgentControllerChannels

Add resolveSession and onStaleToolApproval hooks to AgentControllerChannels. Pass RequestContext into getSessionForThread during approval continuations so host resolvers can validate principals.

Closes #21025

## Description

Adds optional `resolveSession` and `onStaleToolApproval` hooks to `AgentControllerChannels`, and passes `RequestContext` into `getSessionForThread` during approval continuations.

### Why this change was made (Motivation)

1. **Pre-Session Fail-Closed Authorization**: `AgentControllerChannels` previously created default controller sessions before any host hook ran. The existing `onSessionStart` hook ran post-creation and swallowed errors, making fail-closed auth and dynamic routing impossible. `resolveSession` allows hosts to inspect `RequestContext` and fail closed *before* any session side effects occur.
2. **Principal Validation on Approval Continuations**: `dispatchApproval` and `dispatchDecline` previously called `getSessionForThread` without `RequestContext`, preventing host resolvers from verifying execution principals on approve/decline continuations.
3. **Durable Run Reconciliation**: Approval gates are in-memory and lost on server restart. When users click approval buttons post-restart, core previously swallowed the event silently. `onStaleToolApproval` provides host orchestrators with a reconciliation signal to settle durable runs (e.g. marking them interrupted/retryable).

### Usage Example

```ts
const channels = new AgentControllerChannels({
  adapters: { slack: slackAdapter },
  resolveSession: async ({ controller, thread, requestContext }) => {
    // Validate request context and return custom session before default session creation
    return controller.createSession({ resourceId: thread.resourceId, id: thread.resourceId, requestContext });
  },
  onStaleToolApproval: async ({ decision, runId, toolCallId, session }) => {
    // Reconcile durable run state when an approval targets an unarmed gate
  },
});
```

## Related issue(s)

Closes #21025

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Hosts can now control how sessions are created and handle approval requests that refer to tools no longer available after a restart. The changes also improve authorization checks during approval decisions.

## Changes

- Added `resolveSession` to validate `RequestContext` and configure session routing before session creation.
- Added `onStaleToolApproval` to notify hosts about unavailable in-memory approval gates.
- Prevented stale approvals from executing actions or calling `respondToToolApproval`.
- Passed `RequestContext` to `getSessionForThread` during approval and decline continuations.
- Exported the new hook types and added documentation.
- Added tests for session resolution, authorization failures, context propagation, and stale approvals.
- Added a minor release changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->