### PR TITLE
Let delegation hooks correct a misleading subagent result before the parent responds

### DIFF
--- a/.changeset/olive-hoops-invite.md
+++ b/.changeset/olive-hoops-invite.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': patch
+---
+
+Let `onDelegationComplete` correct a delegation result within the current run
+
+A subagent that stops on a tool-calls step returns empty text, which the parent model
+reads as a successful but empty delegation and narrates around ("I'll report back once
+it returns"). The `feedback` returned from `onDelegationComplete` is persisted to the
+parent's memory, so it only reaches the model on the next turn — after the parent has
+already answered.
+
+The hook can now return `resultText`, which replaces the tool result text the parent
+model sees for that delegation in the run that is still executing.

--- a/docs/src/content/en/docs/capabilities/subagents.mdx
+++ b/docs/src/content/en/docs/capabilities/subagents.mdx
@@ -148,6 +148,9 @@ Called after a delegation finishes. Use it to inspect results or provide feedbac
 
 - `context.bail()`: Stop the parent agent's loop immediately
 - Return `{ feedback: '...' }`: Add feedback that gets saved to the parent agent's memory and is visible to subsequent iterations
+- Return `{ resultText: '...' }`: Replace the tool result text the parent model sees for this delegation, within the current run
+
+Use `resultText` when the subagent's own result would mislead the parent immediately. For example, a subagent that stops on a tool-calls step returns empty text, which the parent model reads as a successful but empty delegation. Unlike `feedback`, which only reaches the model on the next turn, `resultText` changes what the parent reasons on right away.
 
 ```typescript title="src/mastra/agents/parent-agent.ts"
 const stream = await parentAgent.stream('Research AI trends', {

--- a/docs/src/content/en/docs/capabilities/subagents.mdx
+++ b/docs/src/content/en/docs/capabilities/subagents.mdx
@@ -127,7 +127,7 @@ The `context` object includes:
 
 ### Request context at the delegation boundary
 
-Each delegation receives a request context whose entries are shallowly copied from the parent run, excluding run-scoped identity keys. Setting or deleting entries during the subagent run does not affect the parent's context. Set entries on `context.requestContext` in `onDelegationStart` to pass values to the delegated run:
+Each delegation receives a request context whose entries are shallowly copied from the parent run, excluding run-scoped identity keys. Setting or deleting entries during the subagent run doesn't affect the parent's context. Set entries on `context.requestContext` in `onDelegationStart` to pass values to the delegated run:
 
 ```typescript title="src/mastra/agents/parent-agent.ts"
 const stream = await parentAgent.stream('Research AI trends', {

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -300,6 +300,64 @@ describe('Supervisor Pattern Integration Tests', () => {
       );
     });
 
+    it('should let onDelegationComplete replace the tool result the parent sees in the same run', async () => {
+      // Sub-agent stops without producing text, which reads to the parent as an empty success.
+      const subAgent = makeSubAgent('silent-agent', '');
+      const promptsSeenByParent: string[] = [];
+
+      const supervisorModel = new MockLanguageModelV2({
+        doGenerate: async ({ prompt }) => {
+          promptsSeenByParent.push(JSON.stringify(prompt));
+          if (promptsSeenByParent.length === 1) {
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'tool-calls' as const,
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              text: '',
+              content: [
+                {
+                  type: 'tool-call' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'agent-silentAgent',
+                  input: JSON.stringify({ prompt: 'do the thing' }),
+                },
+              ],
+              warnings: [],
+            };
+          }
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            text: 'Done',
+            content: [{ type: 'text' as const, text: 'Done' }],
+            warnings: [],
+          };
+        },
+      });
+
+      const supervisorAgent = new Agent({
+        id: 'supervisor',
+        name: 'supervisor',
+        instructions: 'You orchestrate sub-agents.',
+        model: supervisorModel,
+        agents: { silentAgent: subAgent },
+        memory: new MockMemory(),
+      });
+
+      await supervisorAgent.generate('Do the thing', {
+        maxSteps: 3,
+        delegation: {
+          onDelegationComplete: ({ result }) =>
+            result.text ? undefined : { resultText: 'The sub-agent failed to produce a result.' },
+        },
+      });
+
+      // The second model call carries the tool result, and it must show the replacement.
+      expect(promptsSeenByParent).toHaveLength(2);
+      expect(promptsSeenByParent[1]).toContain('The sub-agent failed to produce a result.');
+    });
+
     it('should skip sub-agent when onDelegationStart returns proceed: false', async () => {
       const subAgentGenerate = vi.fn();
       const subAgent = makeSubAgent('blocked-agent', 'Should not be called');

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5407,6 +5407,12 @@ export class Agent<
                     requestContext.set('__mastra_delegationBailed', true);
                   }
 
+                  // Apply an in-run replacement for the text the parent model sees,
+                  // so the hook can correct a misleading result before the parent reasons on it.
+                  if (typeof completeResult?.resultText === 'string') {
+                    result = { ...result, text: completeResult.resultText };
+                  }
+
                   // Handle feedback if provided
                   if (completeResult?.feedback) {
                     const feedbackMessage: MastraDBMessage = {

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -194,6 +194,17 @@ export interface DelegationCompleteContext {
 export interface DelegationCompleteResult {
   /** Optional feedback to add to the conversation */
   feedback?: string;
+  /**
+   * Replaces the text the parent model sees as this delegation's tool result,
+   * within the current run.
+   *
+   * `feedback` is persisted to the parent's memory and therefore only reaches the
+   * model on the next turn. Use `resultText` when the sub-agent's own result would
+   * mislead the parent right now — for example when the sub-agent stopped on a
+   * tool-calls step and returned empty text, which reads to the model as a
+   * successful but empty delegation.
+   */
+  resultText?: string;
 }
 
 /**


### PR DESCRIPTION
## Problem

When a parent agent delegates to a subagent, the subagent can finish without producing any text — for example when its own stop condition fires on a tool-calls step. The delegation tool then hands the parent a successful tool result whose text is empty. The parent model has nothing to reason about, so it confabulates: it narrates that work is still in progress and it will report back later, even though the delegation already finished.

The existing escape hatch, returning `feedback` from `onDelegationComplete`, is written to the parent agent's memory. That means it only reaches the model on the **next** turn, by which point the parent has already given its wrong answer.

## What changed

`onDelegationComplete` can now return `resultText`, which replaces the tool result text the parent model sees for that delegation **within the run that is still executing**:

```ts
delegation: {
  onDelegationComplete: ({ result }) =>
    result.text ? undefined : { resultText: "The subagent failed to produce a result." },
}
```

`feedback` is unchanged and still available for next-turn guidance.

Closes #20179

## Test plan

- New integration test asserting the parent model's follow-up call actually contains the replacement text, driving a subagent that returns empty text. Red before the change, green after.
- `@mastra/core` agent suite: 296 files, 3502 tests, no type errors.
- Docs updated in the subagents guide.