### PR TITLE
Make ProviderModelsMap augmentable so custom gateways get typed model IDs

### DIFF
--- a/.changeset/tidy-moons-shine.md
+++ b/.changeset/tidy-moons-shine.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Make `ProviderModelsMap` augmentable so custom gateways can register their providers and models. It is now declared as an exported interface on `@mastra/core/llm`, so `declare module '@mastra/core/llm'` augmentation flows through to `Provider`, `ModelForProvider` and `ModelRouterModelId`.

--- a/docs/src/content/en/models/gateways/custom-gateways.mdx
+++ b/docs/src/content/en/models/gateways/custom-gateways.mdx
@@ -28,8 +28,8 @@ Create custom gateways to support:
 Implement `MastraModelGatewayInterface` for a plain object gateway, or extend `MastraModelGateway` when you want base class defaults.
 
 ```typescript
-import { type MastraModelGatewayInterface, type ProviderConfig } from '@mastra/core/llm';
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5';
+import { type MastraModelGatewayInterface, type ProviderConfig } from '@mastra/core/llm'
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5'
 
 const myPrivateGateway: MastraModelGatewayInterface = {
   id: 'private',
@@ -43,38 +43,38 @@ const myPrivateGateway: MastraModelGatewayInterface = {
         gateway: 'private',
         url: 'https://api.myprovider.com/v1',
       },
-    };
+    }
   },
   buildUrl() {
-    return 'https://api.myprovider.com/v1';
+    return 'https://api.myprovider.com/v1'
   },
   async getApiKey() {
-    return process.env.MY_API_KEY ?? '';
+    return process.env.MY_API_KEY ?? ''
   },
   async resolveLanguageModel({ modelId, providerId, apiKey }) {
     return createOpenAICompatible({
       name: providerId,
       apiKey,
       baseURL: 'https://api.myprovider.com/v1',
-    }).chatModel(modelId);
+    }).chatModel(modelId)
   },
-};
+}
 ```
 
 The following example extends the `MastraModelGateway` class:
 
 ```typescript
-import { MastraModelGateway, type ProviderConfig } from '@mastra/core/llm';
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5';
-import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { MastraModelGateway, type ProviderConfig } from '@mastra/core/llm'
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5'
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5'
 
 class MyPrivateGateway extends MastraModelGateway {
   // Required: Unique identifier for the gateway
   // This ID is used as the prefix for all providers from this gateway
-  readonly id = 'private';
+  readonly id = 'private'
 
   // Required: Human-readable name
-  readonly name = 'My Private Gateway';
+  readonly name = 'My Private Gateway'
 
   /**
    * Fetch provider configurations from your gateway
@@ -89,7 +89,7 @@ class MyPrivateGateway extends MastraModelGateway {
         gateway: this.id,
         url: 'https://api.myprovider.com/v1',
       },
-    };
+    }
   }
 
   /**
@@ -98,7 +98,7 @@ class MyPrivateGateway extends MastraModelGateway {
    * @param envVars - Environment variables (optional)
    */
   buildUrl(modelId: string, envVars?: Record<string, string>): string {
-    return 'https://api.myprovider.com/v1';
+    return 'https://api.myprovider.com/v1'
   }
 
   /**
@@ -106,11 +106,11 @@ class MyPrivateGateway extends MastraModelGateway {
    * @param modelId - Full model ID
    */
   async getApiKey(modelId: string): Promise<string> {
-    const apiKey = process.env.MY_API_KEY;
+    const apiKey = process.env.MY_API_KEY
     if (!apiKey) {
-      throw new Error(`Missing MY_API_KEY environment variable`);
+      throw new Error(`Missing MY_API_KEY environment variable`)
     }
-    return apiKey;
+    return apiKey
   }
 
   /**
@@ -122,18 +122,18 @@ class MyPrivateGateway extends MastraModelGateway {
     providerId,
     apiKey,
   }: {
-    modelId: string;
-    providerId: string;
-    apiKey: string;
+    modelId: string
+    providerId: string
+    apiKey: string
   }): Promise<LanguageModelV2> {
-    const baseURL = this.buildUrl(`${providerId}/${modelId}`);
+    const baseURL = this.buildUrl(`${providerId}/${modelId}`)
 
     return createOpenAICompatible({
       name: providerId,
       apiKey,
       baseURL,
       supportsStructuredOutputs: true,
-    }).chatModel(modelId);
+    }).chatModel(modelId)
   }
 }
 ```
@@ -146,10 +146,10 @@ Add `resolveAuth` when the gateway owns credential lookup. Mastra uses this hook
 const myPrivateGateway: MastraModelGatewayInterface = {
   // ...gateway fields and methods
   async resolveAuth() {
-    const apiKey = process.env.MY_API_KEY;
-    return apiKey ? { apiKey, source: 'gateway' } : undefined;
+    const apiKey = process.env.MY_API_KEY
+    return apiKey ? { apiKey, source: 'gateway' } : undefined
   },
-};
+}
 ```
 
 ## Registering Custom Gateways
@@ -159,14 +159,14 @@ const myPrivateGateway: MastraModelGatewayInterface = {
 Pass gateways as a record when creating your Mastra instance:
 
 ```typescript
-import { Mastra } from '@mastra/core';
+import { Mastra } from '@mastra/core'
 
 const mastra = new Mastra({
   gateways: {
     myGateway: new MyPrivateGateway(),
     anotherGateway: new AnotherGateway(),
   },
-});
+})
 ```
 
 ### After Initialization
@@ -174,13 +174,13 @@ const mastra = new Mastra({
 Add gateways dynamically using `addGateway`:
 
 ```typescript
-const mastra = new Mastra();
+const mastra = new Mastra()
 
 // Add with explicit key
-mastra.addGateway(new MyPrivateGateway(), 'myGateway');
+mastra.addGateway(new MyPrivateGateway(), 'myGateway')
 
 // Add using gateway's ID
-mastra.addGateway(new MyPrivateGateway());
+mastra.addGateway(new MyPrivateGateway())
 // Stored with key 'my-private-gateway' (the gateway's id)
 ```
 
@@ -189,16 +189,16 @@ mastra.addGateway(new MyPrivateGateway());
 Reference models from your custom gateway using the gateway ID as prefix:
 
 ```typescript
-import { Agent } from '@mastra/core/agent';
+import { Agent } from '@mastra/core/agent'
 
 const agent = new Agent({
   id: 'my-agent',
   name: 'My Agent',
   instructions: 'You are a helpful assistant',
   model: 'private/my-provider/__GATEWAY_OPENAI_MODEL__', // Uses MyPrivateGateway
-});
+})
 
-mastra.addAgent(agent, 'myAgent');
+mastra.addAgent(agent, 'myAgent')
 ```
 
 When you create an agent or use a model, Mastra's model router automatically selects the appropriate gateway based on the model ID. The gateway ID serves as the prefix. If no custom gateways match, it falls back to the built-in gateways.
@@ -220,7 +220,7 @@ When running in development mode (`MASTRA_DEV=true`), Mastra automatically gener
      gateways: {
        myGateway: new MyPrivateGateway(),
      },
-   });
+   })
    ```
 
 1. **Types are generated automatically**:
@@ -233,12 +233,13 @@ When running in development mode (`MASTRA_DEV=true`), Mastra automatically gener
    ```typescript
    const agent = new Agent({
      model: 'my-gateway-id/my-provider/model-1', // Full autocomplete!
-   });
+   })
    ```
 
 #### How it works
 
 The GatewayRegistry runs an hourly sync that:
+
 - Calls `fetchProviders()` on all registered gateways
 - Generates TypeScript type definitions
 - Writes them to both global cache and your project's `dist/` directory
@@ -253,42 +254,49 @@ The first time you add a gateway, it may take a few seconds for types to generat
 If you're not running in development mode or need immediate type updates:
 
 **Option 1: Use type assertion (simplest)**
+
 ```typescript
 const agent = new Agent({
   id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant',
   model: 'private/my-provider/model-1' as any, // Bypass type checking
-});
+})
 ```
 
 **Option 2: Create a custom type union (type-safe)**
+
 ```typescript
-import type { ModelRouterModelId } from '@mastra/core/llm';
+import type { ModelRouterModelId } from '@mastra/core/llm'
 
 // Define your custom model IDs
 type CustomModelId =
   | 'private/my-provider/model-1'
   | 'private/my-provider/model-2'
-  | 'private/my-provider/model-3';
+  | 'private/my-provider/model-3'
 
 // Combine with built-in models
-type AllModelIds = ModelRouterModelId | CustomModelId;
+type AllModelIds = ModelRouterModelId | CustomModelId
 
 const agent = new Agent({
   id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant',
   model: 'private/my-provider/model-1' satisfies AllModelIds,
-});
+})
 ```
 
 **Option 3: Extend ModelRouterModelId globally (advanced)**
+
 ```typescript
 // In a types.d.ts file in your project
+// The import is required: it makes this file a module, so the block below
+// merges into the existing types instead of replacing the module.
+import '@mastra/core/llm'
+
 declare module '@mastra/core/llm' {
   interface ProviderModelsMap {
-    'my-provider': readonly ['model-1', 'model-2', 'model-3'];
+    'my-provider': readonly ['model-1', 'model-2', 'model-3']
   }
 }
 ```
@@ -302,8 +310,8 @@ This extends the built-in type to include your custom models, giving you full au
 Retrieve a gateway by its registration key:
 
 ```typescript
-const gateway = mastra.getGateway('myGateway');
-console.log(gateway.name); // 'My Private Gateway'
+const gateway = mastra.getGateway('myGateway')
+console.log(gateway.name) // 'My Private Gateway'
 ```
 
 ### getGatewayById(id)
@@ -311,11 +319,12 @@ console.log(gateway.name); // 'My Private Gateway'
 Retrieve a gateway by its unique ID:
 
 ```typescript
-const gateway = mastra.getGatewayById('my-private-gateway');
-console.log(gateway.name); // 'My Private Gateway'
+const gateway = mastra.getGatewayById('my-private-gateway')
+console.log(gateway.name) // 'My Private Gateway'
 ```
 
 This is useful when:
+
 - Gateways have explicit IDs different from their registration keys
 - You need to find a gateway by its ID across different instances
 - Supporting gateway versioning (e.g., `'gateway-v1'`, `'gateway-v2'`)
@@ -325,8 +334,8 @@ This is useful when:
 Get all registered gateways:
 
 ```typescript
-const gateways = mastra.listGateways();
-console.log(Object.keys(gateways)); // ['myGateway', 'anotherGateway']
+const gateways = mastra.listGateways()
+console.log(Object.keys(gateways)) // ['myGateway', 'anotherGateway']
 ```
 
 ## Gateway Properties
@@ -334,14 +343,14 @@ console.log(Object.keys(gateways)); // ['myGateway', 'anotherGateway']
 ### Required
 
 | Property | Type | Description |
-|----------|------|-------------|
+| - | - | - |
 | `id` | `string` | Unique identifier for the gateway, used as the gateway prefix for the model string |
 | `name` | `string` | Human-readable gateway name |
 
 ### Methods
 
 | Method | Description |
-|--------|-------------|
+| - | - |
 | `fetchProviders()` | Fetch provider configurations |
 | `buildUrl(modelId, envVars?)` | Build API URL for a model |
 | `getApiKey(modelId)` | Get API key for authentication |
@@ -354,13 +363,13 @@ The `fetchProviders()` method returns a record of `ProviderConfig` objects:
 
 ```typescript
 interface ProviderConfig {
-  name: string;                    // Display name
-  models: string[];                // Available model IDs
-  apiKeyEnvVar: string | string[]; // Environment variable(s) for API key
-  gateway: string;                 // Gateway identifier
-  url?: string;                    // Optional API base URL
-  apiKeyHeader?: string;           // Optional custom auth header
-  docUrl?: string;                 // Optional documentation URL
+  name: string // Display name
+  models: string[] // Available model IDs
+  apiKeyEnvVar: string | string[] // Environment variable(s) for API key
+  gateway: string // Gateway identifier
+  url?: string // Optional API base URL
+  apiKeyHeader?: string // Optional custom auth header
+  docUrl?: string // Optional documentation URL
 }
 ```
 
@@ -373,24 +382,24 @@ Understanding the distinction:
 
 ```typescript
 class VersionedGateway extends MastraModelGateway {
-  readonly id = 'my-gateway-v2';     // Unique ID for versioning and prefixing
-  readonly name = 'My Gateway';       // Display name
+  readonly id = 'my-gateway-v2' // Unique ID for versioning and prefixing
+  readonly name = 'My Gateway' // Display name
 }
 
 const mastra = new Mastra({
   gateways: {
     currentGateway: new VersionedGateway(), // Key: 'currentGateway'
   },
-});
+})
 
 // Retrieve by key
-const byKey = mastra.getGateway('currentGateway');
+const byKey = mastra.getGateway('currentGateway')
 
 // Retrieve by ID
-const byId = mastra.getGatewayById('my-gateway-v2');
+const byId = mastra.getGatewayById('my-gateway-v2')
 
 // Both return the same gateway
-console.log(byKey === byId); // true
+console.log(byKey === byId) // true
 ```
 
 ## Model ID Format
@@ -402,6 +411,7 @@ Models accessed through custom gateways follow this format:
 ```
 
 Examples:
+
 - `private/my-provider/model-1`
 
 ## Advanced example
@@ -410,14 +420,14 @@ Token-based gateway with caching:
 
 ```typescript
 class TokenGateway extends MastraModelGateway {
-  readonly id = 'token-gateway-v1';
-  readonly name = 'Token Gateway';
+  readonly id = 'token-gateway-v1'
+  readonly name = 'Token Gateway'
 
-  private tokenCache: Map<string, { token: string; expiresAt: number }> = new Map();
+  private tokenCache: Map<string, { token: string; expiresAt: number }> = new Map()
 
   async fetchProviders(): Promise<Record<string, ProviderConfig>> {
-    const response = await fetch('https://api.gateway.com/providers');
-    const data = await response.json();
+    const response = await fetch('https://api.gateway.com/providers')
+    const data = await response.json()
 
     return {
       provider: {
@@ -426,55 +436,59 @@ class TokenGateway extends MastraModelGateway {
         apiKeyEnvVar: 'GATEWAY_TOKEN',
         gateway: this.id,
       },
-    };
+    }
   }
 
   async buildUrl(modelId: string, envVars?: Record<string, string>): Promise<string> {
-    const token = await this.getApiKey(modelId);
-    const siteId = envVars?.SITE_ID || process.env.SITE_ID;
+    const token = await this.getApiKey(modelId)
+    const siteId = envVars?.SITE_ID || process.env.SITE_ID
 
     const response = await fetch(`https://api.gateway.com/sites/${siteId}/token`, {
       headers: { Authorization: `Bearer ${token}` },
-    });
+    })
 
-    const { url } = await response.json();
-    return url;
+    const { url } = await response.json()
+    return url
   }
 
   async getApiKey(modelId: string): Promise<string> {
-    const cached = this.tokenCache.get(modelId);
+    const cached = this.tokenCache.get(modelId)
 
     if (cached && cached.expiresAt > Date.now()) {
-      return cached.token;
+      return cached.token
     }
 
-    const token = process.env.GATEWAY_TOKEN;
+    const token = process.env.GATEWAY_TOKEN
     if (!token) {
-      throw new Error('Missing GATEWAY_TOKEN');
+      throw new Error('Missing GATEWAY_TOKEN')
     }
 
     // Cache token for 1 hour
     this.tokenCache.set(modelId, {
       token,
       expiresAt: Date.now() + 3600000,
-    });
+    })
 
-    return token;
+    return token
   }
 
-  async resolveLanguageModel({ modelId, providerId, apiKey }: {
-    modelId: string;
-    providerId: string;
-    apiKey: string;
+  async resolveLanguageModel({
+    modelId,
+    providerId,
+    apiKey,
+  }: {
+    modelId: string
+    providerId: string
+    apiKey: string
   }): Promise<LanguageModelV2> {
-    const baseURL = await this.buildUrl(`${providerId}/${modelId}`);
+    const baseURL = await this.buildUrl(`${providerId}/${modelId}`)
 
     return createOpenAICompatible({
       name: providerId,
       apiKey,
       baseURL,
       supportsStructuredOutputs: true,
-    }).chatModel(modelId);
+    }).chatModel(modelId)
   }
 }
 ```
@@ -488,29 +502,29 @@ class RobustGateway extends MastraModelGateway {
   // ... properties
 
   async getApiKey(modelId: string): Promise<string> {
-    const apiKey = process.env.MY_API_KEY;
+    const apiKey = process.env.MY_API_KEY
 
     if (!apiKey) {
       throw new Error(
         `Missing MY_API_KEY environment variable for model: ${modelId}. ` +
-        `Please set MY_API_KEY in your environment.`
-      );
+          `Please set MY_API_KEY in your environment.`,
+      )
     }
 
-    return apiKey;
+    return apiKey
   }
 
   async buildUrl(modelId: string, envVars?: Record<string, string>): Promise<string> {
-    const baseUrl = envVars?.BASE_URL || process.env.BASE_URL;
+    const baseUrl = envVars?.BASE_URL || process.env.BASE_URL
 
     if (!baseUrl) {
       throw new Error(
         `No base URL configured for model: ${modelId}. ` +
-        `Set BASE_URL environment variable or pass it in envVars.`
-      );
+          `Set BASE_URL environment variable or pass it in envVars.`,
+      )
     }
 
-    return baseUrl;
+    return baseUrl
   }
 }
 ```
@@ -520,44 +534,44 @@ class RobustGateway extends MastraModelGateway {
 Example test structure:
 
 ```typescript
-import { describe, it, expect, beforeEach } from 'vitest';
-import { Mastra } from '@mastra/core';
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Mastra } from '@mastra/core'
 
 describe('MyPrivateGateway', () => {
   beforeEach(() => {
-    process.env.MY_API_KEY = 'test-key';
-  });
+    process.env.MY_API_KEY = 'test-key'
+  })
 
   it('should fetch providers', async () => {
-    const gateway = new MyPrivateGateway();
-    const providers = await gateway.fetchProviders();
+    const gateway = new MyPrivateGateway()
+    const providers = await gateway.fetchProviders()
 
-    expect(providers['my-provider']).toBeDefined();
-    expect(providers['my-provider'].models).toContain('model-1');
-  });
+    expect(providers['my-provider']).toBeDefined()
+    expect(providers['my-provider'].models).toContain('model-1')
+  })
 
   it('should integrate with Mastra', () => {
     const mastra = new Mastra({
       gateways: {
         private: new MyPrivateGateway(),
       },
-    });
+    })
 
-    const gateway = mastra.getGateway('private');
-    expect(gateway.name).toBe('My Private Gateway');
-  });
+    const gateway = mastra.getGateway('private')
+    expect(gateway.name).toBe('My Private Gateway')
+  })
 
   it('should resolve models by ID', () => {
     const mastra = new Mastra({
       gateways: {
         key: new MyPrivateGateway(),
       },
-    });
+    })
 
-    const gateway = mastra.getGatewayById('my-private-gateway');
-    expect(gateway).toBeDefined();
-  });
-});
+    const gateway = mastra.getGatewayById('my-private-gateway')
+    expect(gateway).toBeDefined()
+  })
+})
 ```
 
 ## Best practices

--- a/docs/src/content/en/models/gateways/custom-gateways.mdx
+++ b/docs/src/content/en/models/gateways/custom-gateways.mdx
@@ -28,8 +28,8 @@ Create custom gateways to support:
 Implement `MastraModelGatewayInterface` for a plain object gateway, or extend `MastraModelGateway` when you want base class defaults.
 
 ```typescript
-import { type MastraModelGatewayInterface, type ProviderConfig } from '@mastra/core/llm'
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5'
+import { type MastraModelGatewayInterface, type ProviderConfig } from '@mastra/core/llm';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5';
 
 const myPrivateGateway: MastraModelGatewayInterface = {
   id: 'private',
@@ -43,38 +43,38 @@ const myPrivateGateway: MastraModelGatewayInterface = {
         gateway: 'private',
         url: 'https://api.myprovider.com/v1',
       },
-    }
+    };
   },
   buildUrl() {
-    return 'https://api.myprovider.com/v1'
+    return 'https://api.myprovider.com/v1';
   },
   async getApiKey() {
-    return process.env.MY_API_KEY ?? ''
+    return process.env.MY_API_KEY ?? '';
   },
   async resolveLanguageModel({ modelId, providerId, apiKey }) {
     return createOpenAICompatible({
       name: providerId,
       apiKey,
       baseURL: 'https://api.myprovider.com/v1',
-    }).chatModel(modelId)
+    }).chatModel(modelId);
   },
-}
+};
 ```
 
 The following example extends the `MastraModelGateway` class:
 
 ```typescript
-import { MastraModelGateway, type ProviderConfig } from '@mastra/core/llm'
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5'
-import type { LanguageModelV2 } from '@ai-sdk/provider-v5'
+import { MastraModelGateway, type ProviderConfig } from '@mastra/core/llm';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5';
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 
 class MyPrivateGateway extends MastraModelGateway {
   // Required: Unique identifier for the gateway
   // This ID is used as the prefix for all providers from this gateway
-  readonly id = 'private'
+  readonly id = 'private';
 
   // Required: Human-readable name
-  readonly name = 'My Private Gateway'
+  readonly name = 'My Private Gateway';
 
   /**
    * Fetch provider configurations from your gateway
@@ -89,7 +89,7 @@ class MyPrivateGateway extends MastraModelGateway {
         gateway: this.id,
         url: 'https://api.myprovider.com/v1',
       },
-    }
+    };
   }
 
   /**
@@ -98,7 +98,7 @@ class MyPrivateGateway extends MastraModelGateway {
    * @param envVars - Environment variables (optional)
    */
   buildUrl(modelId: string, envVars?: Record<string, string>): string {
-    return 'https://api.myprovider.com/v1'
+    return 'https://api.myprovider.com/v1';
   }
 
   /**
@@ -106,11 +106,11 @@ class MyPrivateGateway extends MastraModelGateway {
    * @param modelId - Full model ID
    */
   async getApiKey(modelId: string): Promise<string> {
-    const apiKey = process.env.MY_API_KEY
+    const apiKey = process.env.MY_API_KEY;
     if (!apiKey) {
-      throw new Error(`Missing MY_API_KEY environment variable`)
+      throw new Error(`Missing MY_API_KEY environment variable`);
     }
-    return apiKey
+    return apiKey;
   }
 
   /**
@@ -122,18 +122,18 @@ class MyPrivateGateway extends MastraModelGateway {
     providerId,
     apiKey,
   }: {
-    modelId: string
-    providerId: string
-    apiKey: string
+    modelId: string;
+    providerId: string;
+    apiKey: string;
   }): Promise<LanguageModelV2> {
-    const baseURL = this.buildUrl(`${providerId}/${modelId}`)
+    const baseURL = this.buildUrl(`${providerId}/${modelId}`);
 
     return createOpenAICompatible({
       name: providerId,
       apiKey,
       baseURL,
       supportsStructuredOutputs: true,
-    }).chatModel(modelId)
+    }).chatModel(modelId);
   }
 }
 ```
@@ -146,10 +146,10 @@ Add `resolveAuth` when the gateway owns credential lookup. Mastra uses this hook
 const myPrivateGateway: MastraModelGatewayInterface = {
   // ...gateway fields and methods
   async resolveAuth() {
-    const apiKey = process.env.MY_API_KEY
-    return apiKey ? { apiKey, source: 'gateway' } : undefined
+    const apiKey = process.env.MY_API_KEY;
+    return apiKey ? { apiKey, source: 'gateway' } : undefined;
   },
-}
+};
 ```
 
 ## Registering Custom Gateways
@@ -159,14 +159,14 @@ const myPrivateGateway: MastraModelGatewayInterface = {
 Pass gateways as a record when creating your Mastra instance:
 
 ```typescript
-import { Mastra } from '@mastra/core'
+import { Mastra } from '@mastra/core';
 
 const mastra = new Mastra({
   gateways: {
     myGateway: new MyPrivateGateway(),
     anotherGateway: new AnotherGateway(),
   },
-})
+});
 ```
 
 ### After Initialization
@@ -174,13 +174,13 @@ const mastra = new Mastra({
 Add gateways dynamically using `addGateway`:
 
 ```typescript
-const mastra = new Mastra()
+const mastra = new Mastra();
 
 // Add with explicit key
-mastra.addGateway(new MyPrivateGateway(), 'myGateway')
+mastra.addGateway(new MyPrivateGateway(), 'myGateway');
 
 // Add using gateway's ID
-mastra.addGateway(new MyPrivateGateway())
+mastra.addGateway(new MyPrivateGateway());
 // Stored with key 'my-private-gateway' (the gateway's id)
 ```
 
@@ -189,16 +189,16 @@ mastra.addGateway(new MyPrivateGateway())
 Reference models from your custom gateway using the gateway ID as prefix:
 
 ```typescript
-import { Agent } from '@mastra/core/agent'
+import { Agent } from '@mastra/core/agent';
 
 const agent = new Agent({
   id: 'my-agent',
   name: 'My Agent',
   instructions: 'You are a helpful assistant',
   model: 'private/my-provider/__GATEWAY_OPENAI_MODEL__', // Uses MyPrivateGateway
-})
+});
 
-mastra.addAgent(agent, 'myAgent')
+mastra.addAgent(agent, 'myAgent');
 ```
 
 When you create an agent or use a model, Mastra's model router automatically selects the appropriate gateway based on the model ID. The gateway ID serves as the prefix. If no custom gateways match, it falls back to the built-in gateways.
@@ -220,7 +220,7 @@ When running in development mode (`MASTRA_DEV=true`), Mastra automatically gener
      gateways: {
        myGateway: new MyPrivateGateway(),
      },
-   })
+   });
    ```
 
 1. **Types are generated automatically**:
@@ -233,13 +233,12 @@ When running in development mode (`MASTRA_DEV=true`), Mastra automatically gener
    ```typescript
    const agent = new Agent({
      model: 'my-gateway-id/my-provider/model-1', // Full autocomplete!
-   })
+   });
    ```
 
 #### How it works
 
 The GatewayRegistry runs an hourly sync that:
-
 - Calls `fetchProviders()` on all registered gateways
 - Generates TypeScript type definitions
 - Writes them to both global cache and your project's `dist/` directory
@@ -254,49 +253,46 @@ The first time you add a gateway, it may take a few seconds for types to generat
 If you're not running in development mode or need immediate type updates:
 
 **Option 1: Use type assertion (simplest)**
-
 ```typescript
 const agent = new Agent({
   id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant',
   model: 'private/my-provider/model-1' as any, // Bypass type checking
-})
+});
 ```
 
 **Option 2: Create a custom type union (type-safe)**
-
 ```typescript
-import type { ModelRouterModelId } from '@mastra/core/llm'
+import type { ModelRouterModelId } from '@mastra/core/llm';
 
 // Define your custom model IDs
 type CustomModelId =
   | 'private/my-provider/model-1'
   | 'private/my-provider/model-2'
-  | 'private/my-provider/model-3'
+  | 'private/my-provider/model-3';
 
 // Combine with built-in models
-type AllModelIds = ModelRouterModelId | CustomModelId
+type AllModelIds = ModelRouterModelId | CustomModelId;
 
 const agent = new Agent({
   id: 'my-agent',
   name: 'my-agent',
   instructions: 'You are a helpful assistant',
   model: 'private/my-provider/model-1' satisfies AllModelIds,
-})
+});
 ```
 
 **Option 3: Extend ModelRouterModelId globally (advanced)**
-
 ```typescript
 // In a types.d.ts file in your project
 // The import is required: it makes this file a module, so the block below
 // merges into the existing types instead of replacing the module.
-import '@mastra/core/llm'
+import '@mastra/core/llm';
 
 declare module '@mastra/core/llm' {
   interface ProviderModelsMap {
-    'my-provider': readonly ['model-1', 'model-2', 'model-3']
+    'my-provider': readonly ['model-1', 'model-2', 'model-3'];
   }
 }
 ```
@@ -310,8 +306,8 @@ This extends the built-in type to include your custom models, giving you full au
 Retrieve a gateway by its registration key:
 
 ```typescript
-const gateway = mastra.getGateway('myGateway')
-console.log(gateway.name) // 'My Private Gateway'
+const gateway = mastra.getGateway('myGateway');
+console.log(gateway.name); // 'My Private Gateway'
 ```
 
 ### getGatewayById(id)
@@ -319,12 +315,11 @@ console.log(gateway.name) // 'My Private Gateway'
 Retrieve a gateway by its unique ID:
 
 ```typescript
-const gateway = mastra.getGatewayById('my-private-gateway')
-console.log(gateway.name) // 'My Private Gateway'
+const gateway = mastra.getGatewayById('my-private-gateway');
+console.log(gateway.name); // 'My Private Gateway'
 ```
 
 This is useful when:
-
 - Gateways have explicit IDs different from their registration keys
 - You need to find a gateway by its ID across different instances
 - Supporting gateway versioning (e.g., `'gateway-v1'`, `'gateway-v2'`)
@@ -334,8 +329,8 @@ This is useful when:
 Get all registered gateways:
 
 ```typescript
-const gateways = mastra.listGateways()
-console.log(Object.keys(gateways)) // ['myGateway', 'anotherGateway']
+const gateways = mastra.listGateways();
+console.log(Object.keys(gateways)); // ['myGateway', 'anotherGateway']
 ```
 
 ## Gateway Properties
@@ -343,14 +338,14 @@ console.log(Object.keys(gateways)) // ['myGateway', 'anotherGateway']
 ### Required
 
 | Property | Type | Description |
-| - | - | - |
+|----------|------|-------------|
 | `id` | `string` | Unique identifier for the gateway, used as the gateway prefix for the model string |
 | `name` | `string` | Human-readable gateway name |
 
 ### Methods
 
 | Method | Description |
-| - | - |
+|--------|-------------|
 | `fetchProviders()` | Fetch provider configurations |
 | `buildUrl(modelId, envVars?)` | Build API URL for a model |
 | `getApiKey(modelId)` | Get API key for authentication |
@@ -363,13 +358,13 @@ The `fetchProviders()` method returns a record of `ProviderConfig` objects:
 
 ```typescript
 interface ProviderConfig {
-  name: string // Display name
-  models: string[] // Available model IDs
-  apiKeyEnvVar: string | string[] // Environment variable(s) for API key
-  gateway: string // Gateway identifier
-  url?: string // Optional API base URL
-  apiKeyHeader?: string // Optional custom auth header
-  docUrl?: string // Optional documentation URL
+  name: string;                    // Display name
+  models: string[];                // Available model IDs
+  apiKeyEnvVar: string | string[]; // Environment variable(s) for API key
+  gateway: string;                 // Gateway identifier
+  url?: string;                    // Optional API base URL
+  apiKeyHeader?: string;           // Optional custom auth header
+  docUrl?: string;                 // Optional documentation URL
 }
 ```
 
@@ -382,24 +377,24 @@ Understanding the distinction:
 
 ```typescript
 class VersionedGateway extends MastraModelGateway {
-  readonly id = 'my-gateway-v2' // Unique ID for versioning and prefixing
-  readonly name = 'My Gateway' // Display name
+  readonly id = 'my-gateway-v2';     // Unique ID for versioning and prefixing
+  readonly name = 'My Gateway';       // Display name
 }
 
 const mastra = new Mastra({
   gateways: {
     currentGateway: new VersionedGateway(), // Key: 'currentGateway'
   },
-})
+});
 
 // Retrieve by key
-const byKey = mastra.getGateway('currentGateway')
+const byKey = mastra.getGateway('currentGateway');
 
 // Retrieve by ID
-const byId = mastra.getGatewayById('my-gateway-v2')
+const byId = mastra.getGatewayById('my-gateway-v2');
 
 // Both return the same gateway
-console.log(byKey === byId) // true
+console.log(byKey === byId); // true
 ```
 
 ## Model ID Format
@@ -411,7 +406,6 @@ Models accessed through custom gateways follow this format:
 ```
 
 Examples:
-
 - `private/my-provider/model-1`
 
 ## Advanced example
@@ -420,14 +414,14 @@ Token-based gateway with caching:
 
 ```typescript
 class TokenGateway extends MastraModelGateway {
-  readonly id = 'token-gateway-v1'
-  readonly name = 'Token Gateway'
+  readonly id = 'token-gateway-v1';
+  readonly name = 'Token Gateway';
 
-  private tokenCache: Map<string, { token: string; expiresAt: number }> = new Map()
+  private tokenCache: Map<string, { token: string; expiresAt: number }> = new Map();
 
   async fetchProviders(): Promise<Record<string, ProviderConfig>> {
-    const response = await fetch('https://api.gateway.com/providers')
-    const data = await response.json()
+    const response = await fetch('https://api.gateway.com/providers');
+    const data = await response.json();
 
     return {
       provider: {
@@ -436,59 +430,55 @@ class TokenGateway extends MastraModelGateway {
         apiKeyEnvVar: 'GATEWAY_TOKEN',
         gateway: this.id,
       },
-    }
+    };
   }
 
   async buildUrl(modelId: string, envVars?: Record<string, string>): Promise<string> {
-    const token = await this.getApiKey(modelId)
-    const siteId = envVars?.SITE_ID || process.env.SITE_ID
+    const token = await this.getApiKey(modelId);
+    const siteId = envVars?.SITE_ID || process.env.SITE_ID;
 
     const response = await fetch(`https://api.gateway.com/sites/${siteId}/token`, {
       headers: { Authorization: `Bearer ${token}` },
-    })
+    });
 
-    const { url } = await response.json()
-    return url
+    const { url } = await response.json();
+    return url;
   }
 
   async getApiKey(modelId: string): Promise<string> {
-    const cached = this.tokenCache.get(modelId)
+    const cached = this.tokenCache.get(modelId);
 
     if (cached && cached.expiresAt > Date.now()) {
-      return cached.token
+      return cached.token;
     }
 
-    const token = process.env.GATEWAY_TOKEN
+    const token = process.env.GATEWAY_TOKEN;
     if (!token) {
-      throw new Error('Missing GATEWAY_TOKEN')
+      throw new Error('Missing GATEWAY_TOKEN');
     }
 
     // Cache token for 1 hour
     this.tokenCache.set(modelId, {
       token,
       expiresAt: Date.now() + 3600000,
-    })
+    });
 
-    return token
+    return token;
   }
 
-  async resolveLanguageModel({
-    modelId,
-    providerId,
-    apiKey,
-  }: {
-    modelId: string
-    providerId: string
-    apiKey: string
+  async resolveLanguageModel({ modelId, providerId, apiKey }: {
+    modelId: string;
+    providerId: string;
+    apiKey: string;
   }): Promise<LanguageModelV2> {
-    const baseURL = await this.buildUrl(`${providerId}/${modelId}`)
+    const baseURL = await this.buildUrl(`${providerId}/${modelId}`);
 
     return createOpenAICompatible({
       name: providerId,
       apiKey,
       baseURL,
       supportsStructuredOutputs: true,
-    }).chatModel(modelId)
+    }).chatModel(modelId);
   }
 }
 ```
@@ -502,29 +492,29 @@ class RobustGateway extends MastraModelGateway {
   // ... properties
 
   async getApiKey(modelId: string): Promise<string> {
-    const apiKey = process.env.MY_API_KEY
+    const apiKey = process.env.MY_API_KEY;
 
     if (!apiKey) {
       throw new Error(
         `Missing MY_API_KEY environment variable for model: ${modelId}. ` +
-          `Please set MY_API_KEY in your environment.`,
-      )
+        `Please set MY_API_KEY in your environment.`
+      );
     }
 
-    return apiKey
+    return apiKey;
   }
 
   async buildUrl(modelId: string, envVars?: Record<string, string>): Promise<string> {
-    const baseUrl = envVars?.BASE_URL || process.env.BASE_URL
+    const baseUrl = envVars?.BASE_URL || process.env.BASE_URL;
 
     if (!baseUrl) {
       throw new Error(
         `No base URL configured for model: ${modelId}. ` +
-          `Set BASE_URL environment variable or pass it in envVars.`,
-      )
+        `Set BASE_URL environment variable or pass it in envVars.`
+      );
     }
 
-    return baseUrl
+    return baseUrl;
   }
 }
 ```
@@ -534,44 +524,44 @@ class RobustGateway extends MastraModelGateway {
 Example test structure:
 
 ```typescript
-import { describe, it, expect, beforeEach } from 'vitest'
-import { Mastra } from '@mastra/core'
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Mastra } from '@mastra/core';
 
 describe('MyPrivateGateway', () => {
   beforeEach(() => {
-    process.env.MY_API_KEY = 'test-key'
-  })
+    process.env.MY_API_KEY = 'test-key';
+  });
 
   it('should fetch providers', async () => {
-    const gateway = new MyPrivateGateway()
-    const providers = await gateway.fetchProviders()
+    const gateway = new MyPrivateGateway();
+    const providers = await gateway.fetchProviders();
 
-    expect(providers['my-provider']).toBeDefined()
-    expect(providers['my-provider'].models).toContain('model-1')
-  })
+    expect(providers['my-provider']).toBeDefined();
+    expect(providers['my-provider'].models).toContain('model-1');
+  });
 
   it('should integrate with Mastra', () => {
     const mastra = new Mastra({
       gateways: {
         private: new MyPrivateGateway(),
       },
-    })
+    });
 
-    const gateway = mastra.getGateway('private')
-    expect(gateway.name).toBe('My Private Gateway')
-  })
+    const gateway = mastra.getGateway('private');
+    expect(gateway.name).toBe('My Private Gateway');
+  });
 
   it('should resolve models by ID', () => {
     const mastra = new Mastra({
       gateways: {
         key: new MyPrivateGateway(),
       },
-    })
+    });
 
-    const gateway = mastra.getGatewayById('my-private-gateway')
-    expect(gateway).toBeDefined()
-  })
-})
+    const gateway = mastra.getGatewayById('my-private-gateway');
+    expect(gateway).toBeDefined();
+  });
+});
 ```
 
 ## Best practices

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -21,6 +21,7 @@ import type { RequestContext } from '../request-context';
 import type { Run } from '../run/types';
 import type { StandardSchemaWithJSON } from '../schema';
 import type { CoreTool } from '../tools/types';
+import type { ProviderModelsMap as GeneratedProviderModelsMap } from './model/provider-types.generated.js';
 import type { MastraLanguageModel } from './model/shared.types';
 
 export type LanguageModel = MastraLanguageModel;
@@ -86,12 +87,48 @@ export {
   modelSupportsStructuredOutput,
   modelSupportsTemperature,
 } from './model/provider-registry.js';
-export type {
-  ModelRouterModelId,
-  Provider,
-  ModelForProvider,
-  AttachmentCapabilities,
-} from './model/provider-registry.js';
+export type { AttachmentCapabilities } from './model/provider-registry.js';
+
+/**
+ * Map of provider ID to the models that provider serves.
+ *
+ * Declared as an interface so it can be extended through declaration merging.
+ * Custom gateways register their providers and models by augmenting this module,
+ * which flows through to {@link Provider}, {@link ModelForProvider} and
+ * {@link ModelRouterModelId}:
+ *
+ * ```ts
+ * import '@mastra/core/llm';
+ *
+ * declare module '@mastra/core/llm' {
+ *   interface ProviderModelsMap {
+ *     'my-provider': readonly ['model-1', 'model-2'];
+ *   }
+ * }
+ * ```
+ */
+export interface ProviderModelsMap extends GeneratedProviderModelsMap {}
+
+/**
+ * Union type of all registered provider IDs, including augmented ones.
+ */
+export type Provider = keyof ProviderModelsMap;
+
+/**
+ * Model IDs served by a specific provider.
+ * Example: `ModelForProvider<'openai'>` = `'gpt-4o' | 'gpt-4-turbo' | ...`
+ */
+export type ModelForProvider<P extends Provider> = ProviderModelsMap[P][number];
+
+/**
+ * Full `provider/model` paths, e.g. `"openai/gpt-4o"`.
+ */
+export type ModelRouterModelId =
+  | {
+      [P in Provider]: `${P}/${ProviderModelsMap[P][number]}`;
+    }[Provider]
+  | `mastra/${ProviderModelsMap['openrouter'][number]}`
+  | (string & {});
 export { resolveModelConfig } from './model/resolve-model';
 
 export type OutputType = StructuredOutput | StandardSchemaWithJSON | undefined;

--- a/packages/core/src/llm/model/provider-models-map-augmentation.test-d.ts
+++ b/packages/core/src/llm/model/provider-models-map-augmentation.test-d.ts
@@ -10,6 +10,11 @@ declare module '../index.js' {
   }
 }
 
+// `ModelRouterModelId` ends in a `(string & {})` arm so arbitrary strings stay
+// assignable, which makes a plain `toExtend<ModelRouterModelId>` check vacuous.
+// Drop that arm so the assertions below test the generated/augmented paths.
+type KnownModelRouterModelId<T = ModelRouterModelId> = T extends string ? (string extends T ? never : T) : never;
+
 describe('ProviderModelsMap augmentation', () => {
   it('adds the augmented provider to Provider', () => {
     expectTypeOf<'augmentation-test-provider'>().toExtend<Provider>();
@@ -20,11 +25,14 @@ describe('ProviderModelsMap augmentation', () => {
   });
 
   it('includes augmented provider/model paths in ModelRouterModelId', () => {
-    expectTypeOf<'augmentation-test-provider/model-1'>().toExtend<ModelRouterModelId>();
+    expectTypeOf<'augmentation-test-provider/model-1'>().toExtend<KnownModelRouterModelId>();
+    expectTypeOf<'augmentation-test-provider/model-2'>().toExtend<KnownModelRouterModelId>();
+    expectTypeOf<'augmentation-test-provider/not-a-model'>().not.toExtend<KnownModelRouterModelId>();
   });
 
   it('keeps generated providers intact', () => {
     expectTypeOf<'openai'>().toExtend<Provider>();
-    expectTypeOf<ModelForProvider<'openai'>>().toExtend<string>();
+    expectTypeOf<ModelForProvider<'openai'>>().not.toBeNever();
+    expectTypeOf<'not-a-real-provider'>().not.toExtend<Provider>();
   });
 });

--- a/packages/core/src/llm/model/provider-models-map-augmentation.test-d.ts
+++ b/packages/core/src/llm/model/provider-models-map-augmentation.test-d.ts
@@ -1,0 +1,30 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { ModelForProvider, ModelRouterModelId, Provider } from '../index.js';
+
+// Custom gateways register their providers by augmenting the package entry point.
+// This mirrors the documented pattern for custom gateways, where users write
+// `declare module '@mastra/core/llm'`.
+declare module '../index.js' {
+  interface ProviderModelsMap {
+    'augmentation-test-provider': readonly ['model-1', 'model-2'];
+  }
+}
+
+describe('ProviderModelsMap augmentation', () => {
+  it('adds the augmented provider to Provider', () => {
+    expectTypeOf<'augmentation-test-provider'>().toExtend<Provider>();
+  });
+
+  it('resolves the augmented provider models through ModelForProvider', () => {
+    expectTypeOf<ModelForProvider<'augmentation-test-provider'>>().toEqualTypeOf<'model-1' | 'model-2'>();
+  });
+
+  it('includes augmented provider/model paths in ModelRouterModelId', () => {
+    expectTypeOf<'augmentation-test-provider/model-1'>().toExtend<ModelRouterModelId>();
+  });
+
+  it('keeps generated providers intact', () => {
+    expectTypeOf<'openai'>().toExtend<Provider>();
+    expectTypeOf<ModelForProvider<'openai'>>().toExtend<string>();
+  });
+});

--- a/packages/core/src/llm/model/provider-registry.ts
+++ b/packages/core/src/llm/model/provider-registry.ts
@@ -7,6 +7,7 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
+import type { Provider, ModelForProvider, ModelRouterModelId } from '../index.js';
 import { getCapabilityFileName } from './capability-file.js';
 import type { ProviderConfig, MastraModelGatewayInterface } from './gateways/base.js';
 import { getGatewayId, shouldEnableGateway } from './gateways/gateway-helpers.js';
@@ -14,7 +15,9 @@ import { MastraGateway } from './gateways/mastra.js';
 import { ModelsDevGateway } from './gateways/models-dev.js';
 import { NetlifyGateway } from './gateways/netlify.js';
 import staticRegistryJson from './provider-registry.json';
-import type { Provider, ModelForProvider, ModelRouterModelId, ProviderModels } from './provider-types.generated.js';
+// Sourced from the package entry point so that `ProviderModelsMap` augmentations
+// declared against `@mastra/core/llm` flow into these derived types.
+import type { ProviderModels } from './provider-types.generated.js';
 
 // Re-export types for convenience
 export type { Provider, ModelForProvider, ModelRouterModelId, ProviderModels };

--- a/packages/core/src/llm/model/registry-generator.ts
+++ b/packages/core/src/llm/model/registry-generator.ts
@@ -223,6 +223,11 @@ export function generateTypesContent(models: Record<string, string[]>): string {
     })
     .join('\n');
 
+  // The Provider / ModelForProvider / ModelRouterModelId types emitted below cover
+  // the built-in providers only. The public, augmentable versions live in
+  // `src/llm/index.ts`, which re-derives them from the `ProviderModelsMap`
+  // interface so custom gateways can extend them. Keep the two in sync, and
+  // import from `@mastra/core/llm` rather than from the generated file.
   return `/**
  * THIS FILE IS AUTO-GENERATED - DO NOT EDIT
  * Generated from model gateway providers


### PR DESCRIPTION
## Summary

Mastra lets you plug in your own model gateway. The docs tell you that once you do, you can teach TypeScript about your provider's models by augmenting the Mastra module, so that `agent.model` autocompletes your models the same way it does for built-in providers.

That never worked. The map of providers to models is code-generated as a *type alias*, and type aliases cannot be extended through declaration merging — nor was the map exported from the package entry point at all. So the documented augmentation silently did nothing, and `Provider`, `ModelForProvider` and `ModelRouterModelId` stayed limited to the built-in providers.

This PR makes the documented pattern actually work. `ProviderModelsMap` is now an exported interface on `@mastra/core/llm` that extends the generated map, and the public provider types are derived from it. Augmenting the module now flows through to every derived type, while the generated registry remains the source of truth for built-in providers.

```ts
declare module '@mastra/core/llm' {
  interface ProviderModelsMap {
    'my-provider': readonly ['model-1', 'model-2'];
  }
}
```

Closes #21040

## Test plan

- New type-level regression test `provider-models-map-augmentation.test-d.ts` proves an augmented provider reaches `Provider`, `ModelForProvider` and `ModelRouterModelId`, and that generated providers are unaffected. Confirmed failing before the change and passing after.
- `packages/core` typecheck clean (`tsc --noEmit`).
- `packages/core` llm suite: 36 files, 439 tests passing, no type errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Custom model gateways can now add their own providers and models to Mastra’s type system. This lets TypeScript recognize custom model IDs while preserving all generated provider support.

## Changes

- Exported `ProviderModelsMap` as an augmentable interface from `@mastra/core/llm`.
- Derived `Provider`, `ModelForProvider`, and `ModelRouterModelId` from the augmentable map.
- Preserved generated providers as the source of truth.
- Added support for custom provider and model declaration merging.
- Updated custom gateway documentation with the required side-effect import.
- Added a compile-time regression test for custom providers, valid models, invalid models, and generated-provider behavior.
- Added a patch changeset for `@mastra/core`.

## Validation

- Core typechecking passes.
- The LLM test suite passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->