### PR TITLE
fix(core): remap v2 tool-result media parts to v4 file parts in router adapter

### DIFF
--- a/packages/core/src/llm/model/aisdk/v7/model.test.ts
+++ b/packages/core/src/llm/model/aisdk/v7/model.test.ts
@@ -73,6 +73,49 @@ describe('AISDKV7LanguageModel', () => {
       expect(passed.tools[0].type).toBe('provider');
     });
 
+    it('remaps a v2 tool-result media part to a v4 file part in the router adapter', async () => {
+      const model = createMockV4Model();
+      const wrapped = new AISDKV7LanguageModel(model);
+
+      const options = {
+        prompt: [
+          {
+            role: 'assistant',
+            content: [{ type: 'tool-call', toolCallId: 'call_1', toolName: 'read_image', input: {} }],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_1',
+                toolName: 'read_image',
+                output: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'image result' },
+                    { type: 'media', data: 'iVBORw0KGgo=', mediaType: 'image/png' },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      } as unknown as LanguageModelV4CallOptions;
+
+      await wrapped.doStream(options);
+
+      const passed = (model.doStream as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      const toolMsg = passed.prompt.find((m: any) => m.role === 'tool');
+      const value = toolMsg.content[0].output.value;
+
+      expect(value[1]).toEqual({
+        type: 'file',
+        data: { type: 'data', data: 'iVBORw0KGgo=' },
+        mediaType: 'image/png',
+      });
+    });
+
     it('leaves function tools untouched', async () => {
       const model = createMockV4Model();
       const wrapped = new AISDKV7LanguageModel(model);

--- a/packages/core/src/llm/model/aisdk/v7/model.ts
+++ b/packages/core/src/llm/model/aisdk/v7/model.ts
@@ -73,6 +73,26 @@ function normalizeFileDataForV4(data: FileData): {
 function remapFilePartsToV4(options: LanguageModelV4CallOptions): LanguageModelV4CallOptions {
   let promptModified = false;
   const prompt = options.prompt.map(message => {
+    if (message.role === 'tool') {
+      let toolContentModified = false;
+      const content = message.content.map(part => {
+        if (part.type !== 'tool-result' || part.output?.type !== 'content') {
+          return part;
+        }
+        const value = part.output.value.map((v: any) => {
+          if (v.type !== 'media') return v;
+          toolContentModified = true;
+          return { type: 'file', data: { type: 'data', data: v.data }, mediaType: v.mediaType };
+        });
+        return toolContentModified ? { ...part, output: { ...part.output, value } } : part;
+      });
+      if (toolContentModified) {
+        promptModified = true;
+        return { ...message, content };
+      }
+      return message;
+    }
+
     if (message.role !== 'user' && message.role !== 'assistant') {
       return message;
     }
@@ -104,8 +124,6 @@ function remapFilePartsToV4(options: LanguageModelV4CallOptions): LanguageModelV
     return { ...message, content };
   });
 
-  // The map only replaces file parts with file parts, but TS widens the
-  // mapped message union across roles, so restore the prompt type.
   return promptModified ? { ...options, prompt: prompt as typeof options.prompt } : options;
 }
 

--- a/packages/core/src/llm/model/router-tool-result-media.test.ts
+++ b/packages/core/src/llm/model/router-tool-result-media.test.ts
@@ -1,0 +1,134 @@
+import type { LanguageModelV4 } from '@ai-sdk/provider-v7';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MastraModelGateway } from './gateways/base';
+import type { ProviderConfig, GatewayLanguageModel } from './gateways/base';
+import { ModelRouterLanguageModel } from './router';
+
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/20378
+ *
+ * ModelRouterLanguageModel hardcodes specificationVersion='v2', so the v2
+ * prompt-conversion path (aiV5PromptToAIV7Prompt) never runs when the
+ * resolved provider is a V4 model. The router then wraps that V4 model in
+ * AISDKV7LanguageModel, whose remapFilePartsToV4() only visits user/assistant
+ * messages and only touches existing 'file' parts — so a v2 tool-result
+ * media part (e.g. an image returned from a tool call) reaches the V4
+ * provider unchanged and gets silently dropped during serialization.
+ *
+ * This test exercises the full router dispatch path (not just the adapter
+ * directly) to confirm the fix covers the actual entry point agents use.
+ */
+
+function createMockV4Model(): LanguageModelV4 {
+  return {
+    specificationVersion: 'v4',
+    provider: 'openai',
+    modelId: 'gpt-test',
+    supportedUrls: {},
+    doGenerate: vi.fn().mockResolvedValue({
+      content: [],
+      finishReason: 'stop',
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      warnings: [],
+    }),
+    doStream: vi.fn().mockResolvedValue({
+      stream: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    }),
+  } as unknown as LanguageModelV4;
+}
+
+class V4Gateway extends MastraModelGateway {
+  readonly id = 'v4-gateway';
+  readonly name = 'V4 Gateway';
+
+  private mockModel: LanguageModelV4;
+
+  constructor(mockModel: LanguageModelV4) {
+    super();
+    this.mockModel = mockModel;
+  }
+
+  async fetchProviders(): Promise<Record<string, ProviderConfig>> {
+    return {
+      openai: {
+        name: 'OpenAI',
+        models: ['gpt-test'],
+        apiKeyEnvVar: 'OPENAI_API_KEY',
+        gateway: 'v4-gateway',
+      },
+    };
+  }
+
+  buildUrl(): string {
+    return 'https://api.openai.com';
+  }
+
+  async getApiKey(): Promise<string> {
+    return 'test-api-key';
+  }
+
+  async resolveLanguageModel(): Promise<GatewayLanguageModel> {
+    return this.mockModel;
+  }
+}
+
+describe('ModelRouterLanguageModel with V4 gateway and tool-result media (#20378)', () => {
+  let mockV4Model: LanguageModelV4;
+  let gateway: V4Gateway;
+
+  beforeEach(() => {
+    (ModelRouterLanguageModel as any)._clearCachesForTests();
+    mockV4Model = createMockV4Model();
+    gateway = new V4Gateway(mockV4Model);
+  });
+
+  it('remaps a v2 tool-result media part to a v4 file part when routed to a V4 provider via doStream', async () => {
+    const router = new ModelRouterLanguageModel({ id: 'v4-gateway/openai/gpt-test' as `${string}/${string}` }, [
+      gateway,
+    ]);
+
+    await router.doStream({
+      inputFormat: 'messages',
+      prompt: [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool-call', toolCallId: 'call_1', toolName: 'read_image', input: {} }],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_1',
+              toolName: 'read_image',
+              output: {
+                type: 'content',
+                value: [
+                  { type: 'text', text: 'image result' },
+                  { type: 'media', data: 'iVBORw0KGgo=', mediaType: 'image/png' },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    const doStreamCall = (mockV4Model.doStream as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(doStreamCall).toBeDefined();
+
+    const passedOptions = doStreamCall[0];
+    const toolMsg = passedOptions.prompt.find((m: any) => m.role === 'tool');
+    const value = toolMsg.content[0].output.value;
+
+    expect(value[1]).toEqual({
+      type: 'file',
+      data: { type: 'data', data: 'iVBORw0KGgo=' },
+      mediaType: 'image/png',
+    });
+  });
+});

--- a/packages/core/src/llm/model/router-tool-result-media.test.ts
+++ b/packages/core/src/llm/model/router-tool-result-media.test.ts
@@ -125,10 +125,13 @@ describe('ModelRouterLanguageModel with V4 gateway and tool-result media (#20378
     const toolMsg = passedOptions.prompt.find((m: any) => m.role === 'tool');
     const value = toolMsg.content[0].output.value;
 
-    expect(value[1]).toEqual({
-      type: 'file',
-      data: { type: 'data', data: 'iVBORw0KGgo=' },
-      mediaType: 'image/png',
-    });
+    expect(value).toEqual([
+      { type: 'text', text: 'image result' },
+      {
+        type: 'file',
+        data: { type: 'data', data: 'iVBORw0KGgo=' },
+        mediaType: 'image/png',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
Fixes #20378

## Problem
When ModelRouterLanguageModel (v2 spec) resolves to a native v4 provider,
AISDKV7LanguageModel's remapFilePartsToV4() only visited user/assistant
messages and only remapped existing `file` parts. A v2 tool-result with a
`media` output part (e.g. an image returned from a tool call) reached the
v4 provider unchanged, and got silently dropped during request serialization
— confirmed with the native OpenAI Responses provider, where the request
ended up text-only.

## Fix
Added a branch for `role === 'tool'` messages that maps over `tool-result`
parts, converting `type: 'media'` entries in `output.value` into v4 file
parts (`{ type: 'file', data: { type: 'data', data }, mediaType }`), mirroring
the existing pattern used elsewhere in the codebase for this conversion.

## Testing
Added a regression test confirming a v2 tool-result media part is correctly
remapped to a v4 file part when passed through the router adapter's doStream.
Full existing test suite (14 tests) still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a tool returns an image, the router now sends it correctly to newer providers. This prevents image results from being lost.

## Summary

- Convert v2 `tool-result` media parts to v4 tagged `file` parts.
- Preserve media data and MIME types.
- Add adapter and router-level regression tests through `ModelRouterLanguageModel` and `doStream`.

## Testing

- Existing test suite passes 14 tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->