### PR TITLE
Trigger Observational Memory compaction on large tool results instead of overflowing the model context

### DIFF
--- a/.changeset/olive-pumas-shave.md
+++ b/.changeset/olive-pumas-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fix Observational Memory undercounting large tool results. Token accounting now serializes tool results in full instead of reusing the Observer-facing representation, which is truncated to 10k tokens. Oversized tool results now push OM past its thresholds and trigger compaction before the provider's context window overflows.

--- a/packages/memory/src/processors/observational-memory/__tests__/token-counter-large-tool-result.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/token-counter-large-tool-result.test.ts
@@ -1,0 +1,67 @@
+import type { MastraDBMessage } from '@mastra/core/agent';
+import { describe, expect, it } from 'vitest';
+
+import { TokenCounter } from '../token-counter';
+import { DEFAULT_OBSERVER_TOOL_RESULT_MAX_TOKENS } from '../tool-result-helpers';
+
+function messageWithToolResult(result: unknown): MastraDBMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    createdAt: new Date(),
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+    content: {
+      format: 2,
+      parts: [
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'result',
+            toolCallId: 'tool-1',
+            toolName: 'read_file',
+            args: {},
+            result,
+          },
+        },
+      ],
+    },
+  } as unknown as MastraDBMessage;
+}
+
+describe('TokenCounter with oversized tool results', () => {
+  it('counts the full tool result, not the representation truncated for the Observer', () => {
+    const counter = new TokenCounter();
+    // Comfortably past the Observer's per-tool-result truncation budget.
+    const hugeResult = { contents: 'lorem ipsum dolor sit amet '.repeat(40_000) };
+
+    const tokens = counter.countMessage(messageWithToolResult(hugeResult));
+
+    expect(tokens).toBeGreaterThan(DEFAULT_OBSERVER_TOOL_RESULT_MAX_TOKENS * 5);
+  });
+
+  it('scales with tool result size past the Observer truncation budget', () => {
+    const counter = new TokenCounter();
+    const build = (repeats: number) =>
+      messageWithToolResult({ contents: 'lorem ipsum dolor sit amet '.repeat(repeats) });
+
+    const smaller = counter.countMessage(build(40_000));
+    const larger = counter.countMessage(build(80_000));
+
+    expect(larger).toBeGreaterThan(smaller * 1.8);
+  });
+
+  it('counts oversized entries inside multimodal tool result content', () => {
+    const counter = new TokenCounter();
+    const build = (repeats: number) =>
+      messageWithToolResult({
+        content: [{ type: 'json', value: { contents: 'lorem ipsum dolor sit amet '.repeat(repeats) } }],
+      });
+
+    const smaller = counter.countMessage(build(40_000));
+    const larger = counter.countMessage(build(80_000));
+
+    expect(smaller).toBeGreaterThan(DEFAULT_OBSERVER_TOOL_RESULT_MAX_TOKENS * 5);
+    expect(larger).toBeGreaterThan(smaller * 1.8);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -5,7 +5,7 @@ import type { MastraToolInvocation } from '@mastra/core/agent/message-list';
 import imageSize from 'image-size';
 import { estimateTokenCount } from 'tokenx';
 
-import { formatToolResultForObserver, resolveToolResultValue } from './tool-result-helpers';
+import { resolveToolResultValue, serializeToolResultForTokenCounting } from './tool-result-helpers';
 
 type TokenEstimateCacheEntry = {
   v: number;
@@ -1324,7 +1324,7 @@ export class TokenCounter {
     let tokens = 0;
     const cacheParts: unknown[] = [];
     const countJsonContentPart = (contentPart: Record<string, unknown>) => {
-      const formatted = formatToolResultForObserver(contentPart);
+      const formatted = serializeToolResultForTokenCounting(contentPart);
       tokens += this.countString(formatted);
       cacheParts.push({ type: 'json', valueHash: createHash('sha256').update(formatted).digest('hex') });
     };
@@ -1781,7 +1781,7 @@ export class TokenCounter {
           if (contentTokens !== undefined) {
             tokens += contentTokens;
           } else {
-            const formattedResult = formatToolResultForObserver(resultForCounting);
+            const formattedResult = serializeToolResultForTokenCounting(resultForCounting);
             tokens += this.readOrPersistPartEstimate(
               part,
               usingStoredModelOutput ? 'tool-result-model-output-json' : 'tool-result-json',

--- a/packages/memory/src/processors/observational-memory/tool-result-helpers.ts
+++ b/packages/memory/src/processors/observational-memory/tool-result-helpers.ts
@@ -48,6 +48,17 @@ function sanitizeToolResultValue(value: unknown, seen: WeakMap<object, unknown> 
   return sanitizedObject;
 }
 
+/**
+ * Serializes a tool result without truncating it.
+ *
+ * Token accounting must see the full result: the truncation applied by
+ * {@link formatToolResultForObserver} exists to bound what the Observer LLM reads,
+ * not to describe what the agent's provider context actually holds.
+ */
+export function serializeToolResultForTokenCounting(value: unknown): string {
+  return stringifyToolResult(value);
+}
+
 function stringifyToolResult(value: unknown): string {
   if (typeof value === 'string') {
     return value;


### PR DESCRIPTION
## Summary

Observational Memory watches how many tokens a conversation is carrying and compacts it before the model's context window fills up. When a tool returned a very large result — a big file read, a wide query — that safeguard did not fire, and the run instead failed with a provider context-window error.

The cause is a shared helper used for two different jobs. OM formats tool results for the Observer LLM and truncates them to 10k tokens there, which is correct: the Observer only needs a readable sample. But the token counter reused that same truncated representation when deciding whether the conversation had grown large enough to compact. A 150k token tool result therefore looked like a 10k token one, so the conversation appeared small right up until the provider rejected it.

Token accounting now serializes tool results in full, while the Observer-facing formatting keeps its truncation. Large tool results push OM over its thresholds and compaction happens when it should.

Closes #20671
Closes #20930

## Test plan

- New `token-counter-large-tool-result.test.ts`: an oversized tool result is counted well beyond the Observer truncation budget, counts scale with result size, and the same holds for oversized entries inside multimodal tool result content. All three confirmed failing before the change (capped at ~10k tokens) and passing after.
- `packages/memory` suite: 39 files, 1308 tests passing.
- `pnpm --filter ./packages/memory check` clean.
