### PR TITLE
Add regression coverage for parallel workflow results returned to the caller

### DIFF
--- a/workflows/_test-utils/src/domains/storage.ts
+++ b/workflows/_test-utils/src/domains/storage.ts
@@ -82,6 +82,44 @@ export function createStorageWorkflows(ctx: WorkflowCreatorContext) {
     };
   }
 
+  // Test: parallel result returned by execute matches the persisted run result
+  {
+    const shoutAction = vi.fn().mockImplementation(async ({ inputData }: any) => {
+      await new Promise(resolve => setTimeout(resolve, 20));
+      return { shouted: String(inputData.text).toUpperCase() };
+    });
+    const countAction = vi.fn().mockImplementation(async ({ inputData }: any) => ({
+      count: String(inputData.text).length,
+    }));
+
+    const shout = createStep({
+      id: 'shout',
+      execute: shoutAction,
+      inputSchema: z.object({ text: z.string() }),
+      outputSchema: z.object({ shouted: z.string() }),
+    });
+
+    const countChars = createStep({
+      id: 'countChars',
+      execute: countAction,
+      inputSchema: z.object({ text: z.string() }),
+      outputSchema: z.object({ count: z.number() }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'storage-parallel-result-workflow',
+      inputSchema: z.object({ text: z.string() }),
+      outputSchema: z.object({}),
+    });
+
+    workflow.parallel([shout, countChars]).commit();
+
+    workflows['storage-parallel-result-workflow'] = {
+      workflow,
+      mocks: { shoutAction, countAction },
+    };
+  }
+
   // Test: should persist resourceId when creating workflow runs
   {
     const stepAction = vi.fn().mockResolvedValue({ result: 'success' });
@@ -349,6 +387,22 @@ export function createStorageTests(ctx: WorkflowTestContext, registry?: Workflow
       const deleted = await (workflow as any).getWorkflowRunById(runId);
       expect(deleted).toBeNull();
     });
+
+    it.skipIf(skipTests.storageGetDelete)(
+      'should return the same parallel result from execute and from storage',
+      async () => {
+        const { workflow } = registry!['storage-parallel-result-workflow']!;
+
+        const runId = `storage-parallel-result-test-${Date.now()}`;
+        const result: any = await execute(workflow, { text: 'hello world' }, { runId });
+
+        const expected = { shout: { shouted: 'HELLO WORLD' }, countChars: { count: 11 } };
+        expect(result.result).toEqual(expected);
+
+        const workflowRun = await (workflow as any).getWorkflowRunById(runId);
+        expect(workflowRun?.result?.output ?? workflowRun?.result).toEqual(expected);
+      },
+    );
 
     it.skipIf(skipTests.storageResourceId)('should persist resourceId when creating workflow runs', async () => {
       const { workflow } = registry!['storage-resourceid-workflow']!;


### PR DESCRIPTION
## Summary

#20164 reports that a workflow ending in a parallel block returns an incomplete `result` to the caller while the stored run record holds the complete one. I could not reproduce that anywhere: the merged branch outputs come back correctly from a plain parallel graph, a parallel graph preceded by a step, and a nested workflow ending in parallel, on both the default and the evented engine, and each matches what the run record holds afterwards. That matches what maintainers found earlier on the reported version.

Rather than change behavior on a hypothesis, this adds the check to the shared workflow test suite so the property is now pinned on every engine that runs that suite. If the reporter comes back with the graph and adapters that reproduce it, this test is the place to extend.

Relates to #20164

## Test plan

- New shared-suite case: a terminal parallel graph must return the merged branch outputs from `execute()`, and the persisted run record must hold the same value.
- Runs green on both engines: `packages/core` workflows suite, 44 files, 1151 tests passing, no type errors.
