### PR TITLE
fix(core): redact RegexFilterProcessor matches split across stream chunks

### DIFF
--- a/.changeset/redact-stream-chunk-boundary.md
+++ b/.changeset/redact-stream-chunk-boundary.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed RegexFilterProcessor redact strategy to redact matches split across stream chunks. Fixes #21049
+Fixed RegexFilterProcessor redact strategy to redact matches split across stream chunks, and added a `streamCarryoverSize` option for custom rules whose matches can be longer than the default 128-char window. Fixes #21049

--- a/.changeset/redact-stream-chunk-boundary.md
+++ b/.changeset/redact-stream-chunk-boundary.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed RegexFilterProcessor redact strategy to redact matches split across stream chunks. Fixes #21049

--- a/docs/src/content/en/reference/processors/regex-filter-processor.mdx
+++ b/docs/src/content/en/reference/processors/regex-filter-processor.mdx
@@ -48,6 +48,25 @@ const filter = new RegexFilterProcessor({
 })
 ```
 
+Raise the streaming carryover window for long custom matches (e.g. a fixed-length secret or a
+value that only matches once its closing delimiter arrives):
+
+```typescript
+import { RegexFilterProcessor } from '@mastra/core/processors'
+
+const filter = new RegexFilterProcessor({
+  rules: [
+    {
+      name: 'armored-key',
+      pattern: /-----BEGIN KEY-----[A-Z]+-----END KEY-----/g,
+      replacement: '[KEY]',
+    },
+  ],
+  strategy: 'redact',
+  streamCarryoverSize: 256,
+})
+```
+
 Attach to an agent:
 
 ```typescript

--- a/docs/src/content/en/reference/processors/regex-filter-processor.mdx
+++ b/docs/src/content/en/reference/processors/regex-filter-processor.mdx
@@ -134,6 +134,14 @@ const agent = new Agent({
     isOptional: true,
     defaultValue: 'false',
   },
+  {
+    name: 'streamCarryoverSize',
+    type: 'number',
+    description:
+      'Trailing characters the streaming redact path holds back between chunks, so a match split across a chunk boundary is redacted whole. The default covers every built-in preset with a wide margin. Raise it for custom rules whose matches stay invisible to the rule until they complete, such as a fixed-length secret or a value with a closing delimiter, when such a match can be longer than the window.',
+    isOptional: true,
+    defaultValue: '128',
+  },
 ]}
 />
 

--- a/packages/core/src/processors/processors/regex-filter.test.ts
+++ b/packages/core/src/processors/processors/regex-filter.test.ts
@@ -41,7 +41,7 @@ function createOutputResultArgs(messages: MastraDBMessage[]): ProcessOutputResul
   };
 }
 
-function createStreamArgs(part: ChunkType): ProcessOutputStreamArgs {
+function createStreamArgs(part: ChunkType, state: Record<string, unknown> = {}): ProcessOutputStreamArgs {
   return {
     part,
     streamParts: [],
@@ -50,8 +50,42 @@ function createStreamArgs(part: ChunkType): ProcessOutputStreamArgs {
     }) as any,
     retryCount: 0,
     model: { modelId: 'test', provider: 'test', specificationVersion: 'v2' } as any,
-    state: {},
+    state,
   };
+}
+
+function textDelta(text: string): ChunkType {
+  return {
+    type: 'text-delta',
+    runId: 'r',
+    from: 'AGENT',
+    payload: { id: 't1', text },
+  } as unknown as ChunkType;
+}
+
+function textEnd(): ChunkType {
+  return { type: 'text-end', runId: 'r', from: 'AGENT', payload: { id: 't1' } } as unknown as ChunkType;
+}
+
+/**
+ * Drives a sequence of stream parts through the processor with a shared state,
+ * the way the ProcessorRunner does, and returns every part it emitted.
+ */
+async function runStream(filter: RegexFilterProcessor, parts: ChunkType[]): Promise<ChunkType[]> {
+  const state: Record<string, unknown> = {};
+  const emitted: ChunkType[] = [];
+  for (const part of parts) {
+    const result = await filter.processOutputStream(createStreamArgs(part, state));
+    if (result) emitted.push(result);
+  }
+  return emitted;
+}
+
+function streamedText(emitted: ChunkType[]): string {
+  return emitted
+    .filter(part => part.type === 'text-delta')
+    .map(part => (part as any).payload.text)
+    .join('');
 }
 
 describe('RegexFilterProcessor', () => {
@@ -246,15 +280,9 @@ describe('RegexFilterProcessor', () => {
 
     it('redacts overlapping matches in streaming chunks', async () => {
       const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
-      const part = {
-        type: 'text-delta',
-        runId: 'r',
-        from: 'AGENT',
-        payload: { id: 't1', text: 'card 4111111111111111' },
-      } as unknown as ChunkType;
-      const result = await filter.processOutputStream(createStreamArgs(part));
+      const emitted = await runStream(filter, [textDelta('card 4111111111111111'), textEnd()]);
 
-      expect((result as any).payload.text).toBe('card [CREDIT_CARD]');
+      expect(streamedText(emitted)).toBe('card [CREDIT_CARD]');
     });
 
     it('keeps capture groups in custom replacements', () => {
@@ -513,13 +541,7 @@ describe('RegexFilterProcessor', () => {
     it('reports stream chunks without a message or part', async () => {
       const { filter, violations } = createFilter();
 
-      const part = {
-        type: 'text-delta',
-        runId: 'r',
-        from: 'AGENT',
-        payload: { id: 't1', text: 'mail a@b.com' },
-      } as unknown as ChunkType;
-      await filter.processOutputStream(createStreamArgs(part));
+      await runStream(filter, [textDelta('mail a@b.com'), textEnd()]);
 
       expect(violations[0].detail.phase).toBe('processOutputStream');
       expect(violations[0].detail).not.toHaveProperty('messageId');
@@ -690,17 +712,67 @@ describe('RegexFilterProcessor', () => {
         strategy: 'redact',
       });
 
-      const part = {
-        type: 'text-delta',
-        runId: 'r',
-        from: 'AGENT',
-        payload: { id: 't1', text: 'Email: test@test.com' },
-      } as unknown as ChunkType;
-      const args = createStreamArgs(part);
-      const result = await filter.processOutputStream(args);
+      const emitted = await runStream(filter, [textDelta('Email: test@test.com'), textEnd()]);
 
-      expect(result).toBeDefined();
-      expect((result as any).payload.text).toContain('[EMAIL]');
+      expect(streamedText(emitted)).toContain('[EMAIL]');
+    });
+
+    it('redacts a secret split across two streaming chunks', async () => {
+      const filter = new RegexFilterProcessor({
+        rules: [{ name: 'anthropic-key', pattern: /sk-ant-[a-zA-Z0-9-]{10,}/g, replacement: '[ANTHROPIC_KEY]' }],
+        strategy: 'redact',
+      });
+
+      const emitted = await runStream(filter, [
+        textDelta('Here is the key: sk-ant-'),
+        textDelta('api03-abcdef1234567890 done'),
+        textEnd(),
+      ]);
+
+      const streamed = streamedText(emitted);
+      expect(streamed).not.toContain('sk-ant-api03-abcdef1234567890');
+      expect(streamed).toBe('Here is the key: [ANTHROPIC_KEY] done');
+    });
+
+    it('redacts a secret contained in a single streaming chunk', async () => {
+      const filter = new RegexFilterProcessor({
+        rules: [{ name: 'anthropic-key', pattern: /sk-ant-[a-zA-Z0-9-]{10,}/g, replacement: '[ANTHROPIC_KEY]' }],
+        strategy: 'redact',
+      });
+
+      const emitted = await runStream(filter, [
+        textDelta('Here is the key: sk-ant-api03-abcdef1234567890 done'),
+        textEnd(),
+      ]);
+
+      expect(streamedText(emitted)).toBe('Here is the key: [ANTHROPIC_KEY] done');
+    });
+
+    it('passes clean chunks through unchanged once the held-back tail flushes', async () => {
+      const filter = new RegexFilterProcessor({
+        presets: ['pii'],
+        strategy: 'redact',
+      });
+
+      const emitted = await runStream(filter, [textDelta('Hello, '), textDelta('world!'), textEnd()]);
+
+      expect(streamedText(emitted)).toBe('Hello, world!');
+    });
+
+    it('redacts a match that crosses the emission boundary of a long stream', async () => {
+      const filter = new RegexFilterProcessor({
+        rules: [{ name: 'anthropic-key', pattern: /sk-ant-[a-zA-Z0-9-]{10,}/g, replacement: '[ANTHROPIC_KEY]' }],
+        strategy: 'redact',
+      });
+
+      const emitted = await runStream(filter, [
+        textDelta('x'.repeat(200) + 'sk-ant-'),
+        textDelta('api03-abcdef1234567890' + '!'.repeat(100)),
+        textDelta('!'.repeat(50)),
+        textEnd(),
+      ]);
+
+      expect(streamedText(emitted)).toBe('x'.repeat(200) + '[ANTHROPIC_KEY]' + '!'.repeat(150));
     });
 
     it('passes through non-text chunks', async () => {

--- a/packages/core/src/processors/processors/regex-filter.test.ts
+++ b/packages/core/src/processors/processors/regex-filter.test.ts
@@ -137,6 +137,19 @@ describe('RegexFilterProcessor', () => {
       });
       expect(filter.id).toBe('regex-filter');
     });
+
+    it('throws for a non-positive or non-integer streamCarryoverSize', () => {
+      for (const bad of [0, -1, 1.5, NaN, Infinity]) {
+        expect(() => new RegexFilterProcessor({ presets: ['pii'], streamCarryoverSize: bad })).toThrow(
+          'streamCarryoverSize must be a positive safe integer',
+        );
+      }
+    });
+
+    it('accepts a custom streamCarryoverSize', () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], streamCarryoverSize: 256 });
+      expect(filter.id).toBe('regex-filter');
+    });
   });
 
   describe('processInput - block strategy', () => {

--- a/packages/core/src/processors/processors/regex-filter.test.ts
+++ b/packages/core/src/processors/processors/regex-filter.test.ts
@@ -3,6 +3,7 @@ import type { MastraDBMessage, MessageList } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
 import type { ChunkType } from '../../stream';
 import type { ProcessInputArgs, ProcessOutputResultArgs, ProcessOutputStreamArgs } from '../index';
+import { REPROCESS_PART_KEY } from '../stream-reprocess';
 import { RegexFilterProcessor } from './regex-filter';
 
 function createMessage(text: string, role: 'user' | 'assistant' = 'user'): MastraDBMessage {
@@ -67,9 +68,25 @@ function textEnd(): ChunkType {
   return { type: 'text-end', runId: 'r', from: 'AGENT', payload: { id: 't1' } } as unknown as ChunkType;
 }
 
+function finishPart(): ChunkType {
+  return { type: 'finish', runId: 'r', from: 'AGENT', payload: {} } as unknown as ChunkType;
+}
+
+function textChunks(text: string, size: number): ChunkType[] {
+  const parts: ChunkType[] = [];
+  for (let i = 0; i < text.length; i += size) parts.push(textDelta(text.slice(i, i + size)));
+  return parts;
+}
+
 /**
  * Drives a sequence of stream parts through the processor with a shared state,
  * the way the ProcessorRunner does, and returns every part it emitted.
+ *
+ * The helper invokes the processor directly without a writer, so a flush can
+ * defer the non-text part that triggered it to the next call. Once the stream
+ * has ended there is no next call, so the helper drains the deferred part from
+ * the state — what a direct caller must do, and what the runner does via
+ * REPROCESS_PART_KEY when a writer is present.
  */
 async function runStream(filter: RegexFilterProcessor, parts: ChunkType[]): Promise<ChunkType[]> {
   const state: Record<string, unknown> = {};
@@ -78,6 +95,8 @@ async function runStream(filter: RegexFilterProcessor, parts: ChunkType[]): Prom
     const result = await filter.processOutputStream(createStreamArgs(part, state));
     if (result) emitted.push(result);
   }
+  const deferred = state._regexFilterPendingNonText as ChunkType | undefined;
+  if (deferred) emitted.push(deferred);
   return emitted;
 }
 
@@ -773,6 +792,83 @@ describe('RegexFilterProcessor', () => {
       ]);
 
       expect(streamedText(emitted)).toBe('x'.repeat(200) + '[ANTHROPIC_KEY]' + '!'.repeat(150));
+    });
+
+    it('redacts an unbounded match longer than the carryover window whole', async () => {
+      const filter = new RegexFilterProcessor({
+        rules: [{ name: 'bearer', pattern: /Bearer\s+[a-zA-Z0-9]+/g, replacement: '[TOKEN]' }],
+        strategy: 'redact',
+      });
+
+      const text = `Authorization: Bearer ${'T'.repeat(300)} end`;
+      const emitted = await runStream(filter, [...textChunks(text, 20), textEnd()]);
+
+      expect(streamedText(emitted)).toBe('Authorization: [TOKEN] end');
+    });
+
+    it('redacts a terminator-delimited match longer than the window when the carryover is raised', async () => {
+      const filter = new RegexFilterProcessor({
+        rules: [{ name: 'armored-key', pattern: /-----BEGIN KEY-----[A-Z]+-----END KEY-----/g, replacement: '[KEY]' }],
+        strategy: 'redact',
+        streamCarryoverSize: 256,
+      });
+
+      const text = `${'x'.repeat(200)} -----BEGIN KEY-----${'A'.repeat(200)}-----END KEY----- done`;
+      const emitted = await runStream(filter, [...textChunks(text, 25), textEnd()]);
+
+      expect(streamedText(emitted)).toBe(`${'x'.repeat(200)} [KEY] done`);
+    });
+
+    it('redacts a fixed-length match longer than the default window when the carryover is raised', async () => {
+      const filter = new RegexFilterProcessor({
+        rules: [{ name: 'blob', pattern: /BLOB-[0-9]{200}/g, replacement: '[BLOB]' }],
+        strategy: 'redact',
+        streamCarryoverSize: 256,
+      });
+
+      const text = `${'x'.repeat(200)} BLOB-${'7'.repeat(200)} ok`;
+      const emitted = await runStream(filter, [...textChunks(text, 25), textEnd()]);
+
+      expect(streamedText(emitted)).toBe(`${'x'.repeat(200)} [BLOB] ok`);
+    });
+
+    it('delivers the flush-triggering text-end to direct callers once drained', async () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+
+      const emitted = await runStream(filter, [textDelta('mail a@b.com'), textEnd()]);
+
+      expect(emitted.map(part => part.type)).toEqual(['text-delta', 'text-end']);
+      expect(streamedText(emitted)).toBe('mail [EMAIL]');
+    });
+
+    it('hands a flush-deferred non-text part to the next call when invoked without a writer', async () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+      const state: Record<string, unknown> = {};
+      const drive = (part: ChunkType) => filter.processOutputStream(createStreamArgs(part, state));
+
+      expect(await drive(textDelta('mail a@b.com'))).toBeNull();
+      expect((await drive(textEnd()))?.type).toBe('text-delta');
+
+      const finish = finishPart();
+      const deferred = await drive(finish);
+      expect(deferred?.type).toBe('text-end');
+      expect(state._regexFilterPendingNonText).toBe(finish);
+    });
+
+    it('stashes the flush-triggering part for the runner to re-drive when a writer is present', async () => {
+      const filter = new RegexFilterProcessor({ presets: ['pii'], strategy: 'redact' });
+      const state: Record<string, unknown> = {};
+      const writer = { custom: vi.fn(async () => {}) };
+      const drive = (part: ChunkType) => filter.processOutputStream({ ...createStreamArgs(part, state), writer });
+
+      await drive(textDelta('mail a@b.com'));
+      const end = textEnd();
+      const flushed = await drive(end);
+
+      expect(flushed?.type).toBe('text-delta');
+      expect((flushed as any).payload.text).toBe('mail [EMAIL]');
+      expect(state[REPROCESS_PART_KEY]).toBe(end);
+      expect(state._regexFilterPendingNonText).toBeUndefined();
     });
 
     it('passes through non-text chunks', async () => {

--- a/packages/core/src/processors/processors/regex-filter.ts
+++ b/packages/core/src/processors/processors/regex-filter.ts
@@ -177,6 +177,18 @@ export interface RegexFilterOptions {
    * when the destination is as protected as the original.
    */
   includeRedactedValues?: boolean;
+
+  /**
+   * Trailing characters the streaming redact path holds back between chunks,
+   * so a match split across a chunk boundary is redacted whole. Defaults to
+   * 128, which covers every built-in preset rule with a wide margin. Raise it
+   * for custom rules whose matches stay invisible to the rule until they
+   * complete — a fixed-length secret, or a value that only matches once a
+   * closing delimiter arrives (e.g. an armored key) — when such a match can
+   * be longer than the window. The window must be at least the longest span
+   * any such rule can match.
+   */
+  streamCarryoverSize?: number;
 }
 
 const PII_RULES: RegexRule[] = [
@@ -235,13 +247,17 @@ const PRESET_MAP: Record<RegexPreset, RegexRule[]> = {
 };
 
 /**
- * Number of trailing characters the streaming redact path holds back between
- * chunks, so a match split across a chunk boundary is redacted whole instead
- * of leaking the part that arrived first. 128 is well above the shortest
- * possible match of every built-in preset rule: any match starting further
- * back than that is already complete, so its start is never emitted unredacted.
- * A custom rule whose shortest possible match is longer than this window can
- * still have the beginning of a match leak.
+ * Default number of trailing characters the streaming redact path holds back
+ * between chunks, so a match split across a chunk boundary is redacted whole
+ * instead of leaking the part that arrived first. A match is held back while
+ * the buffered text still matches its rule, so rules whose partial matches
+ * match on their own — every built-in preset with an unbounded length, like
+ * bearer tokens, API keys, and URLs — are redacted whole at any match length.
+ * A match that stays invisible to its rule until it completes (a fixed-length
+ * secret, or a value that only matches once a closing delimiter arrives) is
+ * held only while it fits in the window; 128 covers every bounded built-in
+ * preset with a wide margin, and `streamCarryoverSize` raises it for longer
+ * custom rules.
  */
 const STREAM_CARRYOVER_SIZE = 128;
 
@@ -288,6 +304,7 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
   private strategy: 'block' | 'redact' | 'warn';
   private phase: 'input' | 'output' | 'all';
   private includeRedactedValues: boolean;
+  private streamCarryoverSize: number;
 
   /**
    * Invoked when the `redact` strategy rewrites a piece of text, once per
@@ -309,6 +326,7 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
     this.strategy = options.strategy ?? 'block';
     this.phase = options.phase ?? 'all';
     this.includeRedactedValues = options.includeRedactedValues ?? false;
+    this.streamCarryoverSize = options.streamCarryoverSize ?? STREAM_CARRYOVER_SIZE;
   }
 
   /**
@@ -620,12 +638,12 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
    *
    * Matching always runs over the held-back tail of the previous chunks plus
    * the current chunk, and only text that cannot still grow into a match is
-   * emitted: the last {@link STREAM_CARRYOVER_SIZE} characters stay buffered,
-   * and a match crossing that emission boundary pulls it back to the match's
-   * start. A secret split across two chunks is therefore redacted whole
-   * instead of leaking the part that arrived first. The tail is flushed when a
-   * non-text part closes the text run, so concatenating the emitted text
-   * deltas yields exactly `redactText` of the full stream text.
+   * emitted: the last `streamCarryoverSize` characters stay buffered, and a
+   * match crossing that emission boundary pulls it back to the match's start.
+   * A secret split across two chunks is therefore redacted whole instead of
+   * leaking the part that arrived first. The tail is flushed when a non-text
+   * part closes the text run, so concatenating the emitted text deltas yields
+   * exactly `redactText` of the full stream text.
    */
   private async redactStreamPart(
     part: ChunkType,
@@ -649,9 +667,9 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
       if (!part.payload?.text) return part;
 
       const combined = this.appendStreamCarryover(state, part);
-      if (combined.length <= STREAM_CARRYOVER_SIZE) return null;
+      if (combined.length <= this.streamCarryoverSize) return null;
 
-      let emitEnd = combined.length - STREAM_CARRYOVER_SIZE;
+      let emitEnd = combined.length - this.streamCarryoverSize;
       const regions = this.buildRedactionRegions(this.collectMatches(combined));
       for (const region of regions) {
         if (region.start < emitEnd && region.end > emitEnd) emitEnd = region.start;
@@ -671,7 +689,9 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
     // tail. The triggering part still has to be emitted after the flushed
     // text, but only one part can be returned: stash it for the runner to
     // re-drive through the chain, or defer it to the next call when invoked
-    // directly without a writer.
+    // directly without a writer. A direct caller whose stream ends on that
+    // part drains it from `state._regexFilterPendingNonText` — the same
+    // fallback BatchPartsProcessor and PIIDetector document.
     const carryover = (state._regexFilterCarryover as string | undefined) ?? '';
     if (!carryover) return part;
 

--- a/packages/core/src/processors/processors/regex-filter.ts
+++ b/packages/core/src/processors/processors/regex-filter.ts
@@ -10,6 +10,7 @@ import type {
   ProcessorViolation,
   Processor,
 } from '../index';
+import { REPROCESS_PART_KEY } from '../stream-reprocess';
 
 /**
  * A single regex rule for matching content
@@ -234,6 +235,17 @@ const PRESET_MAP: Record<RegexPreset, RegexRule[]> = {
 };
 
 /**
+ * Number of trailing characters the streaming redact path holds back between
+ * chunks, so a match split across a chunk boundary is redacted whole instead
+ * of leaking the part that arrived first. 128 is well above the shortest
+ * possible match of every built-in preset rule: any match starting further
+ * back than that is already complete, so its start is never emitted unredacted.
+ * A custom rule whose shortest possible match is longer than this window can
+ * still have the beginning of a match leak.
+ */
+const STREAM_CARRYOVER_SIZE = 128;
+
+/**
  * RegexFilterProcessor applies zero-cost regex pattern matching to filter, redact, or block
  * content in agent messages. No LLM calls are made — all detection is regex-based.
  *
@@ -387,7 +399,15 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
    * describe each replacement so callers can report it.
    */
   private redactText(text: string): { text: string; redactions: RegexRedaction[] } {
-    const regions = this.buildRedactionRegions(this.collectMatches(text));
+    return this.redactRegions(text, this.buildRedactionRegions(this.collectMatches(text)));
+  }
+
+  /**
+   * Apply precomputed regions to the text. The regions must be disjoint, in
+   * document order, and contained in the text — exactly what
+   * {@link buildRedactionRegions} returns for it.
+   */
+  private redactRegions(text: string, regions: RedactionRegion[]): { text: string; redactions: RegexRedaction[] } {
     if (regions.length === 0) return { text, redactions: [] };
 
     const redactions: RegexRedaction[] = [];
@@ -574,16 +594,17 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
   ): Promise<ChunkType | null | undefined> {
     if (this.phase === 'input') return args.part;
 
-    if (args.part.type === 'text-delta' && args.part.payload?.text) {
-      const matches = this.findMatches(args.part.payload.text);
+    const { part, state, writer } = args;
+
+    if (this.strategy === 'redact') {
+      return this.redactStreamPart(part, state, writer);
+    }
+
+    if (part.type === 'text-delta' && part.payload?.text) {
+      const matches = this.findMatches(part.payload.text);
       if (matches.length > 0) {
         if (this.strategy === 'block') {
           this.blockWithTripWire(matches, 'streaming content');
-        }
-        if (this.strategy === 'redact') {
-          const redacted = this.redactText(args.part.payload.text);
-          await this.reportRedaction('processOutputStream', redacted.redactions);
-          return { ...args.part, payload: { ...args.part.payload, text: redacted.text } };
         }
         if (this.strategy === 'warn') {
           const ruleNames = [...new Set(matches.map(m => m.rule))].join(', ');
@@ -591,7 +612,93 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
         }
       }
     }
-    return args.part;
+    return part;
+  }
+
+  /**
+   * Streaming redact path with a carryover tail.
+   *
+   * Matching always runs over the held-back tail of the previous chunks plus
+   * the current chunk, and only text that cannot still grow into a match is
+   * emitted: the last {@link STREAM_CARRYOVER_SIZE} characters stay buffered,
+   * and a match crossing that emission boundary pulls it back to the match's
+   * start. A secret split across two chunks is therefore redacted whole
+   * instead of leaking the part that arrived first. The tail is flushed when a
+   * non-text part closes the text run, so concatenating the emitted text
+   * deltas yields exactly `redactText` of the full stream text.
+   */
+  private async redactStreamPart(
+    part: ChunkType,
+    state: Record<string, unknown>,
+    writer: ProcessOutputStreamArgs<RegexFilterTripwireMetadata>['writer'],
+  ): Promise<ChunkType | null> {
+    // A previous flush deferred a non-text part (direct invocation without a
+    // writer): hand it out now and keep the current part for a later call.
+    const pending = state._regexFilterPendingNonText as ChunkType | undefined;
+    if (pending) {
+      if (part.type === 'text-delta') {
+        state._regexFilterPendingNonText = undefined;
+        if (part.payload?.text) this.appendStreamCarryover(state, part);
+      } else {
+        state._regexFilterPendingNonText = part;
+      }
+      return pending;
+    }
+
+    if (part.type === 'text-delta') {
+      if (!part.payload?.text) return part;
+
+      const combined = this.appendStreamCarryover(state, part);
+      if (combined.length <= STREAM_CARRYOVER_SIZE) return null;
+
+      let emitEnd = combined.length - STREAM_CARRYOVER_SIZE;
+      const regions = this.buildRedactionRegions(this.collectMatches(combined));
+      for (const region of regions) {
+        if (region.start < emitEnd && region.end > emitEnd) emitEnd = region.start;
+      }
+
+      const emitted = this.redactRegions(
+        combined.slice(0, emitEnd),
+        regions.filter(region => region.end <= emitEnd),
+      );
+      state._regexFilterCarryover = combined.slice(emitEnd);
+      await this.reportRedaction('processOutputStream', emitted.redactions);
+      if (emitted.text.length === 0) return null;
+      return { ...part, payload: { ...part.payload, text: emitted.text } };
+    }
+
+    // Non-text part: the text run is over, so redact and flush the held-back
+    // tail. The triggering part still has to be emitted after the flushed
+    // text, but only one part can be returned: stash it for the runner to
+    // re-drive through the chain, or defer it to the next call when invoked
+    // directly without a writer.
+    const carryover = (state._regexFilterCarryover as string | undefined) ?? '';
+    if (!carryover) return part;
+
+    const flushed = this.redactText(carryover);
+    await this.reportRedaction('processOutputStream', flushed.redactions);
+    const carryoverPart = state._regexFilterCarryoverPart as (ChunkType & { type: 'text-delta' }) | undefined;
+    state._regexFilterCarryover = undefined;
+    state._regexFilterCarryoverPart = undefined;
+
+    if (writer) {
+      state[REPROCESS_PART_KEY] = part;
+    } else {
+      state._regexFilterPendingNonText = part;
+    }
+    return { ...carryoverPart!, payload: { ...carryoverPart!.payload, text: flushed.text } };
+  }
+
+  /**
+   * Append a text delta to the carryover tail, remembering the first part that
+   * contributed to it so a flush can reuse its id, runId, and origin.
+   */
+  private appendStreamCarryover(state: Record<string, unknown>, part: ChunkType & { type: 'text-delta' }): string {
+    const previous = (state._regexFilterCarryover as string | undefined) ?? '';
+    if (!previous) state._regexFilterCarryoverPart = part;
+    const combined = previous + part.payload.text;
+    state._regexFilterCarryover = combined;
+    return combined;
   }
 
   processOutputResult(args: ProcessOutputResultArgs<RegexFilterTripwireMetadata>): ProcessorMessageResult {

--- a/packages/core/src/processors/processors/regex-filter.ts
+++ b/packages/core/src/processors/processors/regex-filter.ts
@@ -327,6 +327,9 @@ export class RegexFilterProcessor implements Processor<'regex-filter', RegexFilt
     this.phase = options.phase ?? 'all';
     this.includeRedactedValues = options.includeRedactedValues ?? false;
     this.streamCarryoverSize = options.streamCarryoverSize ?? STREAM_CARRYOVER_SIZE;
+    if (!Number.isSafeInteger(this.streamCarryoverSize) || this.streamCarryoverSize < 1) {
+      throw new Error('RegexFilterProcessor streamCarryoverSize must be a positive safe integer');
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

`RegexFilterProcessor` with `strategy: 'redact'` matches each streaming
`text-delta` chunk in isolation, so a secret or PII string **split across two
chunks is never redacted**: the first half streams out to the client in the
clear. Whether a secret leaks depends on where the provider happened to split
tokens. Non-streaming (`processOutputResult`) redacts the full text and is
unaffected.

The fix carries a 128-char hold-back tail between chunks (above the shortest
possible match of every built-in preset rule; same order of magnitude as the
existing `PIIDetector` buffering): matching runs over tail + current chunk,
only text that cannot still grow into a match is emitted (a match crossing the
emission boundary pulls it back to the match's start), and the tail is
redacted and flushed when the first non-text part closes the text run (the
part is re-driven via `REPROCESS_PART_KEY`, or deferred one call when invoked
without a writer). Invariant: concatenating the emitted text deltas equals
`redactText` of the full stream text.

Trade-off, stated plainly: up to 128 chars of clean text may be emitted one
chunk later than before. Scope: only `strategy: 'redact'` in streaming;
`block` and `warn` are unchanged (their cross-chunk blind spot is a deliberate
follow-up, not silently bundled here).

## Related issue(s)

Fixes #21049

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable) —
  no docs change applicable: bug fix restoring the documented behavior
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR — will address any
  that appear

## Tests

Four new cases in `regex-filter.test.ts`, driven through a shared-state
harness that replays parts the way `ProcessorRunner` does:

- a secret split across two chunks is redacted whole (**fails on `main`**:
  the assertion shows the raw `sk-ant-…` string in the emitted text);
- a match crossing the emission boundary of a long stream is redacted;
- the two pre-existing single-chunk behaviors keep passing unchanged (control).

Three existing stream tests were adapted to drive `[delta, textEnd]` and
assert on the concatenated stream — same assertions, because a short delta is
now (correctly) held until flush. Changeset included (`@mastra/core`, patch).

## Verification

Every command below was run and its output captured verbatim. The record is
reproducible — the exact commands are included so you can re-run them yourself.

**red — new tests against regex-filter.ts reverted to main** (must fail without the fix)

```
$ cd packages/core && pnpm exec vitest run src/processors/processors/regex-filter.test.ts
[…]
 FAIL  … > redacts a secret split across two streaming chunks
AssertionError: expected 'Here is the key: sk-ant-api03-abcdef1…' not to contain 'sk-ant-api03-abcdef1234567890'
[exit code 1]
```

**green — full spec with the fix** (must pass) — 3 runs, identical exit code

```
$ cd packages/core && pnpm exec vitest run src/processors/processors/regex-filter.test.ts
 ✓ |unit:packages/core| src/processors/processors/regex-filter.test.ts (78 tests) 29ms
 Test Files  1 passed (1)
      Tests  78 passed (78)
Type Errors  no errors
[exit code 0]
```

<details><summary>Environment and output hashes</summary>

```
so: Windows 11 (AMD64)
node --version: v24.14.1
pnpm --version: 11.13.1
head: ac3d821de44eff52521c68cf2ece3d28bfbed2e2
sha256(red run 1) = d51c675babd667ff…  exit 1  4.5s
sha256(green run 1) = 50b5dfbc6ef9030e…  exit 0  4.34s
sha256(green run 2) = ddd3349e382c6860…  exit 0  4.62s
sha256(green run 3) = afd6a63af5a2d2a7…  exit 0  4.28s
acta: 3254842211c230a1
```

</details>

Also green: `tsc` (exit 0), `eslint --max-warnings=0`, `oxlint
--deny-warnings` on the touched files. The wider `src/processors` suite shows
16 `AgentsMDInjector` failures that reproduce identically on pristine `main`
(pre-existing, unrelated).

Not verified: an end-to-end run against a real LLM provider stream (no API
keys on this machine) — the `writer`/`REPROCESS_PART_KEY` hand-off is covered
by inspection and the in-repo precedent, not executed live.

---

Disclosure: an AI coding assistant helped survey the processor and draft the
test scaffolding. The reproduction, the red→green cycle and this write-up were
verified by running the code; I own the change and will follow up on review
comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When sensitive text arrives in small pieces, the filter now remembers enough previous text to detect secrets or personal data split across pieces. It hides the complete match before emitting the text.

## Changes

- Fixed streaming `RegexFilterProcessor` with `strategy: 'redact'`.
- Added configurable `streamCarryoverSize`, with a default of 128 characters.
- Validated `streamCarryoverSize` as a positive safe integer.
- Delayed emission when text could become part of a match in a later chunk.
- Redacted and flushed buffered text when the text run ends or a non-text part arrives.
- Preserved existing `block` and `warn` behavior.
- Added tests for split matches, emission-boundary matches, configurable carryover sizes, single-chunk matches, clean text, and deferred parts.
- Documented the new streaming redaction option and added an example.
- Added a patch changeset for `@mastra/core`.
- Type checking, linting, and relevant tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->