### PR TITLE
fix: keep pnpm worktree builds isolated

### DIFF
--- a/.changeset/thick-streets-begin.md
+++ b/.changeset/thick-streets-begin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed memory timeline event markers failing to build with current Recharts types.

--- a/.changeset/thick-streets-begin.md
+++ b/.changeset/thick-streets-begin.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed memory timeline event markers failing to build with current Recharts types.
+Fixed memory timeline event markers not rendering correctly in the Playground UI.

--- a/packages/playground-ui/src/domains/memory/components/flame-graph.tsx
+++ b/packages/playground-ui/src/domains/memory/components/flame-graph.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
   XAxis,
   YAxis,
+  type ScatterShapeProps,
 } from 'recharts';
 
 import { Button } from '../../../ds/components/Button';
@@ -268,12 +269,12 @@ function EventRow({ label, data, color, height = 32, domain, zoomDomain }: Event
               data={data}
               fill={color}
               isAnimationActive={false}
-              shape={(props: Record<string, unknown>) => {
-                const cx = props.cx as number;
+              shape={(props: ScatterShapeProps) => {
+                if (props.cx === undefined) return null;
                 return (
                   <g>
-                    <rect x={cx - 6} y={0} width={12} height={height} fill="transparent" />
-                    <rect x={cx - 1.5} y={0} width={3} height={height} fill={color} />
+                    <rect x={props.cx - 6} y={0} width={12} height={height} fill="transparent" />
+                    <rect x={props.cx - 1.5} y={0} width={3} height={height} fill={color} />
                   </g>
                 );
               }}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,8 +32,9 @@ packages:
   - e2e-tests/client-js/zod-v4
   - e2e-tests/workspace-compat
 
-# Share pnpm's virtual store across git worktrees: https://pnpm.io/git-worktrees
-enableGlobalVirtualStore: true
+# Keep workspace dependency links isolated per worktree. The global virtual store
+# reuses peer dependency snapshots whose workspace links can point at another worktree.
+enableGlobalVirtualStore: false
 
 catalog:
   '@microsoft/api-extractor': ^7.57.7


### PR DESCRIPTION
pnpm’s global virtual store can reuse workspace dependency snapshots that still point to another git worktree. That causes clean builds to combine incompatible package instances and fail TypeScript checks.

This keeps the virtual store local to each worktree and updates the memory flame graph to use Recharts’ declared scatter shape props, which was exposed once the clean build reached playground-ui.

Before, `pnpm install && pnpm build` could resolve workspace packages from a sibling worktree and then fail declaration generation. After this change, workspace links stay in the active worktree and the full build completes successfully.

Tested with `pnpm --filter @mastra/playground-ui typecheck`, `pnpm --filter @mastra/playground-ui build`, and root `pnpm build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR keeps each git worktree’s packages separate. It also fixes memory flame graph markers so the project builds correctly with current Recharts types.

## Changes

- Disabled pnpm’s global virtual store in `pnpm-workspace.yaml`.
- Updated the flame graph event marker callback to use Recharts’ `ScatterShapeProps`.
- Returned no shape when `cx` is unavailable.
- Added a patch changeset for `@mastra/playground-ui`.

## Testing

- `pnpm --filter `@mastra/playground-ui` typecheck`
- `pnpm --filter `@mastra/playground-ui` build`
- `pnpm build`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->