### PR TITLE
feat(core): add SubscribeOptions.startFrom, and a supportsOffsets capability

### DIFF
--- a/.changeset/subscribe-start-from.md
+++ b/.changeset/subscribe-start-from.md
@@ -1,0 +1,25 @@
+---
+'@mastra/core': minor
+'@mastra/redis-streams': minor
+---
+
+Add `SubscribeOptions.startFrom` so a subscription can begin at the current tail
+
+`subscribe()` replayed the retained backlog and `subscribeWithReplay()` replayed all of it,
+but there was no way to say "deliver only what happens from now on". A consumer that already
+owns the completed history through another store had to first call `getHistory()` to learn the
+current length and pass it as an offset — racy, and only possible on transports that implement
+`getHistory`.
+
+`startFrom: 'latest'` expresses it directly. It defaults to `'earliest'`, so existing behavior
+is unchanged, and it only applies when a consumer group is created — an existing group keeps its
+own checkpoint, so this can never rewind or skip past a position a running cluster has committed.
+On transports that do not retain messages it is a no-op, which is already the correct semantics.
+
+For Redis Streams this maps onto `XGROUP CREATE ... $` instead of `0`.
+
+Also adds a `PubSub.supportsOffsets` capability getter. `subscribeFromOffset()` falls back to
+`subscribeWithReplay()` on transports without indexed history, silently discarding the offset and
+delivering the full backlog — which turns a caller's guard against re-processing into a no-op.
+Callers can now check `supportsOffsets` before relying on offset semantics, and implementations
+with a logger surface the discarded offset instead of dropping it silently.

--- a/packages/core/src/events/caching-pubsub.ts
+++ b/packages/core/src/events/caching-pubsub.ts
@@ -74,6 +74,14 @@ export class CachingPubSub extends PubSub {
   }
 
   /**
+   * Offsets are indices into this class's own cached history, so they are
+   * honored regardless of what the inner transport supports.
+   */
+  get supportsOffsets(): boolean {
+    return true;
+  }
+
+  /**
    * Log an error message using the configured logger or console.error.
    */
   private logError(message: string, error: unknown): void {

--- a/packages/core/src/events/pubsub.ts
+++ b/packages/core/src/events/pubsub.ts
@@ -83,6 +83,32 @@ export abstract class PubSub {
   }
 
   /**
+   * Whether this implementation honors the `offset` argument to
+   * {@link subscribeFromOffset}. Defaults to `false`.
+   *
+   * The base `subscribeFromOffset` falls back to `subscribeWithReplay`, which
+   * discards the offset and delivers the full retained backlog. That is safe
+   * but not what the caller asked for, and callers guarding against
+   * re-processing need to be able to tell the difference — a resumed run that
+   * silently re-receives every prior event is a correctness problem, not a
+   * performance one.
+   *
+   * Implementations backed by an indexed cache (e.g. `CachingPubSub`) override
+   * this and return `true`. Check it before relying on offset semantics:
+   *
+   * ```ts
+   * if (pubsub.supportsOffsets) {
+   *   await pubsub.subscribeFromOffset(topic, offset, cb);
+   * } else {
+   *   await pubsub.subscribe(topic, cb, { startFrom: 'latest' });
+   * }
+   * ```
+   */
+  get supportsOffsets(): boolean {
+    return false;
+  }
+
+  /**
    * Get historical events for a topic.
    * Default implementation returns empty array (no history support).
    * Override in implementations that support event caching.
@@ -114,13 +140,33 @@ export abstract class PubSub {
    * Default implementation falls back to subscribeWithReplay (full replay).
    * Override in implementations that support indexed event caching.
    *
+   * Implementations that do not override this leave {@link supportsOffsets}
+   * `false`, and the offset is discarded — the subscriber receives the whole
+   * retained backlog. Callers that must not re-process should branch on
+   * `supportsOffsets` rather than assume the offset was honored.
+   *
    * @param topic - The topic to subscribe to
    * @param offset - Start replaying from this index (0-based)
    * @param cb - Callback invoked for each event
    */
-  subscribeFromOffset(topic: string, _offset: number, cb: EventCallback): Promise<void> {
+  subscribeFromOffset(topic: string, offset: number, cb: EventCallback): Promise<void> {
+    if (offset > 0 && !this.supportsOffsets) {
+      // Not an error: full replay is a safe superset of what was asked for.
+      // Surfaced because the caller passed a non-zero offset specifically to
+      // avoid re-processing, and silence makes that failure invisible.
+      this.onUnsupportedOffset(topic, offset);
+    }
     return this.subscribeWithReplay(topic, cb);
   }
+
+  /**
+   * Called when {@link subscribeFromOffset} discards a non-zero offset because
+   * the implementation does not support offsets.
+   *
+   * A no-op by default so this stays a diagnostic rather than a behavior
+   * change. Implementations with a configured logger override it to warn.
+   */
+  protected onUnsupportedOffset(_topic: string, _offset: number): void {}
 }
 
 /**

--- a/packages/core/src/events/subscribe-start-position.test.ts
+++ b/packages/core/src/events/subscribe-start-position.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { InMemoryServerCache } from '../cache/inmemory';
+import { CachingPubSub } from './caching-pubsub';
+import { EventEmitterPubSub } from './event-emitter';
+import { PubSub } from './pubsub';
+import type { Event, EventCallback, SubscribeOptions } from './types';
+
+/**
+ * Minimal transport that records what it was handed and implements nothing
+ * beyond `subscribe`, so it exercises the base-class defaults.
+ */
+class RecordingPubSub extends PubSub {
+  lastOptions: SubscribeOptions | undefined;
+  replayCalls = 0;
+
+  async publish(): Promise<void> {}
+
+  async subscribe(_topic: string, _cb: EventCallback, options?: SubscribeOptions): Promise<void> {
+    this.lastOptions = options;
+  }
+
+  async unsubscribe(): Promise<void> {}
+
+  async flush(): Promise<void> {}
+
+  override subscribeWithReplay(topic: string, cb: EventCallback): Promise<void> {
+    this.replayCalls += 1;
+    return this.subscribe(topic, cb);
+  }
+}
+
+describe('SubscribeOptions.startFrom', () => {
+  it('is passed through to the transport untouched', async () => {
+    const pubsub = new RecordingPubSub();
+    await pubsub.subscribe('topic', () => {}, { startFrom: 'latest' });
+    expect(pubsub.lastOptions?.startFrom).toBe('latest');
+  });
+
+  it('is absent when not requested, so existing behaviour is unchanged', async () => {
+    const pubsub = new RecordingPubSub();
+    await pubsub.subscribe('topic', () => {});
+    expect(pubsub.lastOptions?.startFrom).toBeUndefined();
+  });
+});
+
+describe('PubSub.supportsOffsets', () => {
+  it('defaults to false, because the base subscribeFromOffset discards the offset', () => {
+    expect(new RecordingPubSub().supportsOffsets).toBe(false);
+  });
+
+  it('is true for CachingPubSub, which indexes its own history', () => {
+    const pubsub = new CachingPubSub(new EventEmitterPubSub(), new InMemoryServerCache());
+    expect(pubsub.supportsOffsets).toBe(true);
+  });
+
+  it('CachingPubSub actually honours the offset it advertises', async () => {
+    const cache = new InMemoryServerCache();
+    const pubsub = new CachingPubSub(new EventEmitterPubSub(), cache);
+    const topic = 'offsets';
+
+    for (const n of [1, 2, 3]) {
+      await pubsub.publish(topic, { type: 'tick', runId: 'run-1', data: { n } });
+    }
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    const seen: number[] = [];
+    await pubsub.subscribeFromOffset(topic, 2, (event: Event) => {
+      seen.push((event.data as { n: number }).n);
+      return Promise.resolve();
+    });
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // Offset 2 skips the first two events rather than replaying everything.
+    expect(seen).toEqual([3]);
+  });
+});
+
+describe('PubSub.subscribeFromOffset on a transport without offset support', () => {
+  let pubsub: RecordingPubSub;
+  let onUnsupported: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    pubsub = new RecordingPubSub();
+    onUnsupported = vi.fn();
+    // `onUnsupportedOffset` is protected; implementations override it. Patching
+    // the instance is how a subclass would surface it through its own logger.
+    (pubsub as unknown as { onUnsupportedOffset: unknown }).onUnsupportedOffset = onUnsupported;
+  });
+
+  it('still delivers, falling back to full replay', async () => {
+    await pubsub.subscribeFromOffset('topic', 42, () => {});
+    expect(pubsub.replayCalls).toBe(1);
+  });
+
+  it('reports the discarded offset instead of dropping it silently', async () => {
+    await pubsub.subscribeFromOffset('topic', 42, () => {});
+    expect(onUnsupported).toHaveBeenCalledWith('topic', 42);
+  });
+
+  it('stays quiet for offset 0, which full replay satisfies exactly', async () => {
+    await pubsub.subscribeFromOffset('topic', 0, () => {});
+    expect(onUnsupported).not.toHaveBeenCalled();
+    expect(pubsub.replayCalls).toBe(1);
+  });
+
+  it('stays quiet when the implementation does support offsets', async () => {
+    Object.defineProperty(pubsub, 'supportsOffsets', { get: () => true });
+    await pubsub.subscribeFromOffset('topic', 42, () => {});
+    expect(onUnsupported).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -73,6 +73,14 @@ export interface SubscribeBatchOptions {
   overflow?: 'drop-oldest' | 'drop-newest' | 'coalesce-or-drop-oldest';
 }
 
+/**
+ * Where a brand-new subscription begins on transports that retain messages.
+ *
+ * - `'earliest'`: deliver the retained backlog before live events.
+ * - `'latest'`: deliver only events published after the subscription is established.
+ */
+export type SubscribeStartPosition = 'earliest' | 'latest';
+
 export interface SubscribeOptions {
   /**
    * When set, subscribers with the same group compete for messages.
@@ -84,6 +92,24 @@ export interface SubscribeOptions {
    * Opt-in batching policy. When omitted, behavior is unchanged.
    */
   batch?: SubscribeBatchOptions;
+  /**
+   * Where a **new** subscription begins on transports that retain messages.
+   * Defaults to `'earliest'`, which preserves today's behavior.
+   *
+   * Use `'latest'` for a consumer that already owns the completed history
+   * through another store and only wants to observe what happens from the
+   * moment it attaches. Replaying the backlog into such a consumer is not
+   * merely wasteful — it re-applies side effects for events already accounted
+   * for.
+   *
+   * Only applies when the subscription's consumer group is created. An
+   * existing group keeps its own checkpoint, so this never rewinds or skips
+   * past a position an already-running cluster has committed.
+   *
+   * No-op on transports that do not retain messages, which is already the
+   * correct semantics there.
+   */
+  startFrom?: SubscribeStartPosition;
 }
 
 /**

--- a/pubsub/redis-streams/src/index.ts
+++ b/pubsub/redis-streams/src/index.ts
@@ -92,6 +92,25 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     return ['pull'];
   }
 
+  /**
+   * Redis Streams positions a consumer group by stream ID, not by an index into
+   * a cached array, so it cannot honor `subscribeFromOffset`'s numeric offset.
+   * Declaring that here lets callers branch on it instead of discovering the
+   * full replay at runtime. Use `subscribe(topic, cb, { startFrom: 'latest' })`
+   * to skip the backlog.
+   */
+  override get supportsOffsets(): boolean {
+    return false;
+  }
+
+  protected override onUnsupportedOffset(topic: string, offset: number): void {
+    this.#logger?.warn?.(
+      'redis-streams: subscribeFromOffset ignored a non-zero offset and fell back to full replay; ' +
+        'use subscribe(topic, cb, { startFrom: "latest" }) to skip the backlog',
+      { topic, offset },
+    );
+  }
+
   #writeClient: RedisClientType;
   #connectOptions: RedisClientOptions;
   #keyPrefix: string;
@@ -301,8 +320,16 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     // Existing groups (BUSYGROUP path) keep their own checkpoint, so this
     // doesn't change semantics for already-running clusters. Stream growth is
     // bounded by the MAXLEN ~ trim applied on every publish.
+    //
+    // `startFrom: 'latest'` opts out of that late-join replay by anchoring at
+    // '$' instead, for a consumer that already has the history elsewhere and
+    // would otherwise re-apply side effects for events it has accounted for.
+    // It only affects group *creation* — an existing group keeps its own
+    // checkpoint either way, so this can never rewind or skip past a position
+    // a running cluster has already committed.
+    const groupAnchor: '0' | '$' = options?.startFrom === 'latest' ? '$' : '0';
     try {
-      await this.#writeClient.xGroupCreate(streamKey, group, '0', { MKSTREAM: true });
+      await this.#writeClient.xGroupCreate(streamKey, group, groupAnchor, { MKSTREAM: true });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (!msg.includes('BUSYGROUP')) throw err;
@@ -322,6 +349,7 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
       group,
       consumer,
       isGrouped,
+      groupAnchor,
       readClient,
       stopped: false,
       loop: undefined,
@@ -620,8 +648,9 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
           // returns NOGROUP immediately, ignoring BLOCK, so without recovery
           // this loop busy-retries forever and the subscriber goes permanently
           // deaf — a later publish recreates the stream but not the group.
-          // Recreate the group (anchored at '0', matching subscribe()) so
-          // delivery resumes.
+          // Recreate the group at the anchor this subscription was created
+          // with, matching subscribe(), so delivery resumes without rewinding
+          // a `startFrom: 'latest'` subscriber into the backlog it opted out of.
           try {
             if (this.#streamIdleTtlMs > 0) {
               // MKSTREAM recreates an (empty) stream key, so the TTL must be
@@ -635,11 +664,11 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
               // even on that path.
               await this.#writeClient
                 .multi()
-                .xGroupCreate(sub.streamKey, sub.group, '0', { MKSTREAM: true })
+                .xGroupCreate(sub.streamKey, sub.group, sub.groupAnchor, { MKSTREAM: true })
                 .pExpire(sub.streamKey, this.#streamIdleTtlMs)
                 .exec();
             } else {
-              await this.#writeClient.xGroupCreate(sub.streamKey, sub.group, '0', { MKSTREAM: true });
+              await this.#writeClient.xGroupCreate(sub.streamKey, sub.group, sub.groupAnchor, { MKSTREAM: true });
             }
             this.#logger?.debug?.('redis-streams: recreated consumer group after NOGROUP', {
               topic: sub.topic,
@@ -849,6 +878,13 @@ interface Subscription {
   group: string;
   consumer: string;
   isGrouped: boolean;
+  /**
+   * Stream ID this subscription's consumer group was anchored at: '0' for
+   * `startFrom: 'earliest'`, '$' for `'latest'`. Retained so the NOGROUP
+   * recovery path recreates the group at the same position — re-anchoring a
+   * 'latest' subscriber at '0' would replay the very backlog it opted out of.
+   */
+  groupAnchor: '0' | '$';
   readClient: RedisClientType;
   stopped: boolean;
   loop: Promise<void> | undefined;


### PR DESCRIPTION
## Description

Addresses both halves of #21027.

**1. `SubscribeOptions.startFrom`**

`subscribe()` replays the retained backlog and `subscribeWithReplay()` replays all of it, but nothing expressed "deliver only what happens from now on". A consumer that already owns the completed history through another store had to call `getHistory()` first to learn the current length and pass that as an offset — racy, and only possible on transports that implement `getHistory`.

```ts
export interface SubscribeOptions {
  group?: string;
  batch?: SubscribeBatchOptions;
  startFrom?: 'earliest' | 'latest';
}
```

Defaults to `'earliest'`, so existing behaviour is unchanged. It applies **only when a consumer group is created** — an existing group keeps its own checkpoint, so this can never rewind or skip past a position a running cluster has already committed. On transports that don't retain messages it is a no-op, which is already the correct semantics there.

For Redis Streams it maps onto `XGROUP CREATE ... '$'` instead of `'0'`, as suggested in the issue.

**2. `PubSub.supportsOffsets`**

`subscribeFromOffset()` falls back to `subscribeWithReplay()` on transports without indexed history, discarding the offset and delivering the full backlog. Since callers pass an offset specifically to avoid re-processing, silence turns their guard into a no-op — the correctness point raised in the issue.

Adds a `supportsOffsets` capability getter alongside the existing `supportedModes` / `supportsNativeBatching`, so callers can branch before relying on offset semantics:

```ts
if (pubsub.supportsOffsets) {
  await pubsub.subscribeFromOffset(topic, offset, cb);
} else {
  await pubsub.subscribe(topic, cb, { startFrom: 'latest' });
}
```

Plus a `protected onUnsupportedOffset()` hook — a no-op by default so this stays a diagnostic rather than a behaviour change. `CachingPubSub` reports `true`; `RedisStreamsPubSub` reports `false` and warns through its configured logger.

### One thing not in the issue

The `NOGROUP` recovery path in `RedisStreamsPubSub` recreates a consumer group after Redis has dropped it, and it re-anchored at a hard-coded `'0'`. Left alone, a `startFrom: 'latest'` subscriber would be silently rewound into the exact backlog it opted out of the first time that path ran. The anchor is now stored on the subscription (`groupAnchor`) and reused on recovery.

### Scope

Deliberately left out so this stays reviewable: `createDurableAgentStream`'s resume path still computes `offset` from `getHistory().length`. It can now branch on `supportsOffsets`, but that's a behavioural change to durable agents and belongs in its own PR — happy to follow up.

## Related issue(s)

Fixes #21027

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Testing

New: `packages/core/src/events/subscribe-start-position.test.ts` — 9 cases covering pass-through of the option, the unchanged default, `supportsOffsets` on both the base class and `CachingPubSub`, that `CachingPubSub` actually honours the offset it advertises, and that the diagnostic fires on a non-zero offset but stays quiet at `0` and on transports that do support offsets.

```
$ pnpm vitest run src/events/
Test Files  15 passed (15)
     Tests  225 passed (225)
Type Errors  no errors
```

`@mastra/redis-streams` builds clean; `oxlint` and `prettier --check` pass on all changed files.

A changeset is included (`minor` for `@mastra/core` and `@mastra/redis-streams`).

---

@mrwnh — you mentioned in the issue you were happy to send a PR for either half. I said in the thread I'd pick it up; if you'd already started, say so and I'll close this in favour of yours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Subscriptions can now start with new messages only or include the existing backlog. The API also reports when a message system cannot safely resume from a specific offset.

## Changes

- Added `SubscribeOptions.startFrom`:
  - Defaults to `'earliest'`.
  - Supports `'latest'` for live-only delivery.
  - Preserves existing consumer group checkpoints.
  - Has no effect on non-retaining transports.
- Added `PubSub.supportsOffsets`.
  - `CachingPubSub` supports indexed offsets.
  - `RedisStreamsPubSub` reports unsupported offsets.
  - Unsupported non-zero offsets trigger a diagnostic hook and warning.
- Updated Redis Streams group creation and `NOGROUP` recovery to preserve the selected start position.
- Added tests, documentation, and changesets.

## Validation

- 225 tests passed.
- No type errors found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->