### PR TITLE
Fix browser bundling of @mastra/client-js by keeping Node builtins out of core browser entries

### DIFF
--- a/.changeset/shy-pugs-smile.md
+++ b/.changeset/shy-pugs-smile.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Stop the browser-safe `@mastra/core/a2a/client` entry from pulling in the Node `module` builtin, which broke `@mastra/client-js` in browser bundles (`Module not found: Can't resolve 'module'` in Next.js).

--- a/packages/core/src/a2a/browser-entry.test.ts
+++ b/packages/core/src/a2a/browser-entry.test.ts
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { builtinModules } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const distEntry = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../dist/a2a/client.js');
+const builtins = new Set(builtinModules);
+
+function collectBuiltinImports(entry: string): string[] {
+  const visited = new Set<string>();
+  const found: string[] = [];
+
+  const walk = (file: string) => {
+    if (visited.has(file)) return;
+    visited.add(file);
+
+    const code = readFileSync(file, 'utf8');
+    for (const match of code.matchAll(/from "([^"]+)"|^import "([^"]+)"/gm)) {
+      const specifier = match[1] ?? match[2]!;
+      if (specifier.startsWith('.')) {
+        walk(path.resolve(path.dirname(file), specifier));
+      } else if (builtins.has(specifier.replace(/^node:/, ''))) {
+        found.push(`${path.basename(file)} -> ${specifier}`);
+      }
+    }
+  };
+
+  walk(entry);
+  return found;
+}
+
+// `@mastra/client-js` imports this entry, and that gets bundled for the browser by Next and
+// friends, so nothing in its chunk graph may reach for a Node builtin.
+describe('a2a/client build output', () => {
+  it.skipIf(!existsSync(distEntry))('imports no Node builtins', () => {
+    expect(collectBuiltinImports(distEntry)).toEqual([]);
+  });
+});

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -40,6 +40,26 @@ const treeshakeDecorators = {
   },
 };
 
+/**
+ * Rolldown can attribute a side-effect-only import of a Node builtin to a chunk that never
+ * uses it, including the shared runtime chunk that every entry imports. That drags `module`
+ * into browser-safe entries such as `a2a/client`, and bundlers targeting the browser fail to
+ * resolve it. A bare import of a builtin has no side effects worth keeping, so drop it.
+ */
+const dropBareBuiltinImports = {
+  name: 'drop-bare-builtin-imports',
+  generateBundle(_options: unknown, bundle: Record<string, { type: string; code?: string }>) {
+    const bareBuiltinImport =
+      /^import "(?:node:)?(?:assert|async_hooks|buffer|child_process|cluster|console|constants|crypto|dgram|diagnostics_channel|dns|domain|events|fs|http|http2|https|inspector|module|net|os|path|perf_hooks|process|punycode|querystring|readline|repl|stream|string_decoder|timers|tls|trace_events|tty|url|util|v8|vm|wasi|worker_threads|zlib)(?:\/[\w/]+)?";?$/gm;
+
+    for (const chunk of Object.values(bundle)) {
+      if (chunk.type === 'chunk' && chunk.code) {
+        chunk.code = chunk.code.replace(bareBuiltinImport, '');
+      }
+    }
+  },
+};
+
 export default defineConfig({
   entry: [
     'src/index.ts',
@@ -85,7 +105,7 @@ export default defineConfig({
   dts: false,
   treeshake: true,
   inputOptions: {
-    plugins: [treeshakeDecorators],
+    plugins: [treeshakeDecorators, dropBareBuiltinImports],
   },
   define: {
     __MASTRA_VERSION__: JSON.stringify(pkg.version),


### PR DESCRIPTION
## Summary

Bundling an app that uses `@mastra/client-js` for the browser failed:

```
./node_modules/@mastra/core/dist/rolldown-runtime-DP3BCW9_.js
Module not found: Can't resolve 'module'

Import trace for requested module:
./node_modules/@mastra/core/dist/client-D9NcUAi0.js
./node_modules/@mastra/core/dist/a2a/client.js
./node_modules/@mastra/client-js/dist/index.js
```

`@mastra/client-js` imports `MastraA2AError` from `@mastra/core/a2a/client`, which is browser-safe source code. The Node builtin came in purely as a build artifact: the bundler attributed a side-effect-only `import "module"` to the shared runtime chunk, and every entry imports that chunk, so the browser-safe entry inherited a Node-only dependency. The chunk it landed in never uses the import, so nothing depends on it being there.

The build now drops those bare builtin imports from the emitted bundle. The real `createRequire` usage in the Node-only chunks is untouched — those imports have bindings and are left alone.

## Test plan

- New guard test walks the emitted `dist/a2a/client.js` chunk graph and asserts it reaches no Node builtin. Fails before the fix (`rolldown-runtime-*.js -> module`), passes after.
- Bundled both `@mastra/core/a2a/client` and `@mastra/client-js` for the browser with esbuild: previously unresolvable, now clean.
- `dist/index.js` still loads under Node and the provider registry keeps its `createRequire` resolution; a2a and provider-registry suites pass (63 tests, no type errors).