### PR TITLE
fix(factory): preserve review session identity

### DIFF
--- a/.changeset/grumpy-apples-sell.md
+++ b/.changeset/grumpy-apples-sell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory review sessions losing caller identity when an existing request context is empty.

--- a/mastracode/factory/src/rules/start-coordinator.test.ts
+++ b/mastracode/factory/src/rules/start-coordinator.test.ts
@@ -1,3 +1,4 @@
+import { RequestContext } from '@mastra/core/request-context';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
@@ -158,6 +159,22 @@ describe('FactoryStartCoordinator', () => {
       branch: 'factory/issue-1',
       startedBy: 'user-1',
     });
+  });
+
+  it('seeds caller identity into an existing request context', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { controller } = makeController();
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      undefined,
+      makeSourceControl() as never,
+    );
+    const requestContext = new RequestContext();
+
+    await coordinator.prepare({ ...startRequest(), requestContext });
+
+    expect(requestContext.get('user')).toEqual({ workosId: 'user-1', organizationId: 'org-1' });
   });
 
   it('applies the Factory default model before preparing a board run', async () => {

--- a/mastracode/factory/src/rules/start-coordinator.test.ts
+++ b/mastracode/factory/src/rules/start-coordinator.test.ts
@@ -177,6 +177,23 @@ describe('FactoryStartCoordinator', () => {
     expect(requestContext.get('user')).toEqual({ workosId: 'user-1', organizationId: 'org-1' });
   });
 
+  it('leaves an authenticated identity on the request context untouched', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { controller } = makeController();
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      undefined,
+      makeSourceControl() as never,
+    );
+    const requestContext = new RequestContext();
+    requestContext.set('user', { workosId: 'authenticated-user', organizationId: 'org-1' });
+
+    await coordinator.prepare({ ...startRequest(), requestContext });
+
+    expect(requestContext.get('user')).toEqual({ workosId: 'authenticated-user', organizationId: 'org-1' });
+  });
+
   it('applies the Factory default model before preparing a board run', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const { controller, session } = makeController();

--- a/mastracode/factory/src/rules/start-coordinator.ts
+++ b/mastracode/factory/src/rules/start-coordinator.ts
@@ -130,7 +130,7 @@ export class FactoryStartCoordinator {
     if (!this.#sourceControl) throw new Error('Factory source control storage is unavailable');
     const sourceSession = await resolveSourceSession(this.#sourceControl, request);
     const requestContext = request.requestContext ?? new RequestContext();
-    if (!request.requestContext) {
+    if (!requestContext.get('user')) {
       requestContext.set('user', { workosId: request.userId, organizationId: request.orgId });
     }
     // Sessions kicked off against third-party content (a PR under review, or


### PR DESCRIPTION
## Summary

- preserve authenticated tenant identity when a Factory review start receives an existing but empty request context
- ensure workspace resolution can attribute the session caller
- add regression coverage for the existing-context path

## Test plan

- `pnpm exec vitest run src/rules/start-coordinator.test.ts` (from `mastracode/factory`)
- `pnpm build:lib` (from `mastracode/factory`)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a review starts with an empty context, the system now remembers who is signed in. It keeps any user identity already in the context.

## Changes

- Seed the authenticated tenant identity in existing empty `RequestContext` instances.
- Preserve existing user context values.
- Add regression coverage for `FactoryStartCoordinator.prepare`.
- Add a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->