### PR TITLE
docs: use discord.gg/mastra-ai vanity invite in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/@mastra%2Fcore.svg)](https://www.npmjs.com/package/@mastra/core)
 [![CodeQl](https://github.com/mastra-ai/mastra/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/mastra-ai/mastra/actions/workflows/github-code-scanning/codeql)
 [![GitHub Repo stars](https://img.shields.io/github/stars/mastra-ai/mastra)](https://github.com/mastra-ai/mastra/stargazers)
-[![Discord](https://img.shields.io/discord/1309558646228779139?logo=discord&label=Discord&labelColor=white&color=7289DA)](https://discord.gg/BTYqqHKUrf)
+[![Discord](https://img.shields.io/discord/1309558646228779139?logo=discord&label=Discord&labelColor=white&color=7289DA)](https://discord.gg/mastra-ai)
 [![Twitter Follow](https://img.shields.io/twitter/follow/mastra?style=social)](https://x.com/mastra)
 [![NPM Downloads](https://img.shields.io/npm/dm/%40mastra%252Fcore)](https://www.npmjs.com/package/@mastra/core)
 [![Static Badge](https://img.shields.io/badge/Y%20Combinator-W25-orange)](https://www.ycombinator.com/companies?batch=W25)
@@ -89,7 +89,7 @@ Information about the project setup can be found in the [development documentati
 
 ## Support
 
-We have an [open community Discord](https://discord.gg/BTYqqHKUrf). Come and say hello and let us know if you have any questions or need any help getting things running.
+We have an [open community Discord](https://discord.gg/mastra-ai). Come and say hello and let us know if you have any questions or need any help getting things running.
 
 It's also super helpful if you leave the project a star here, at the [top of the page](https://github.com/mastra-ai/mastra)
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -59,3 +59,4 @@ npm install @mastra/core
 - [API Reference](https://mastra.ai/reference)
 - [Examples](https://mastra.ai/docs/examples)
 - [Deployment Guide](https://mastra.ai/docs/deployment/overview)
+- [Community Discord](https://discord.gg/mastra-ai)


### PR DESCRIPTION
## Description

Swaps the Discord invite links to the vanity URL `https://discord.gg/mastra-ai`.

- `README.md`: Discord badge link and the Support section link (were `discord.gg/BTYqqHKUrf`)
- `packages/core/README.md`: adds a Community Discord entry under Additional Resources, so the npm README links to Discord too

## Related issue(s)

No issue. Trivial docs link change.

## Type of change

- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a, docs only)
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates the project’s Discord links. It points readers to the new community invite and adds the link to the core package documentation.

## Changes

- Updated the Discord badge and Support links in `README.md` to `https://discord.gg/mastra-ai`.
- Added a Community Discord entry under Additional Resources in `packages/core/README.md`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->