### PR TITLE
Add a workflow onStart lifecycle hook

### DIFF
--- a/.changeset/brave-hoops-argue.md
+++ b/.changeset/brave-hoops-argue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add a workflow `onStart` lifecycle hook. It is awaited before a run executes (and before the run is persisted on the evented engine), receives the run context, and fires only on initial start — not on resume, restart, or time travel. Unlike `onFinish`/`onError`, errors thrown in `onStart` reject the `start()`/`stream()` call so it can act as a pre-flight gate, for example a quota check.

--- a/.changeset/brave-hoops-argue.md
+++ b/.changeset/brave-hoops-argue.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Add a workflow `onStart` lifecycle hook. It is awaited before a run executes (and before the run is persisted on the evented engine), receives the run context, and fires only on initial start — not on resume, restart, or time travel. Unlike `onFinish`/`onError`, errors thrown in `onStart` reject the `start()`/`stream()` call so it can act as a pre-flight gate, for example a quota check.
+Add a workflow `onStart` lifecycle hook. It is awaited before a run executes, receives the run context, and fires only on initial start — not on resume, restart, or time travel. Unlike `onFinish`/`onError`, errors thrown in `onStart` reject the `start()`/`stream()` call so it can act as a pre-flight gate, for example a quota check.

--- a/docs/src/content/en/reference/workflows/workflow.mdx
+++ b/docs/src/content/en/reference/workflows/workflow.mdx
@@ -230,7 +230,7 @@ You can define the workflow's `inputSchema` and `outputSchema` with any library 
             name: 'onStart',
             type: '(info: WorkflowStartCallbackInfo) => void | Promise<void>',
             description:
-              'Callback awaited before a run starts executing, and before the run is persisted. Fires only on initial start, not on resume, restart, or time travel. Unlike onFinish and onError, errors thrown here are propagated: they reject the start() or stream() call and the run never executes, so this can be used as a pre-flight gate such as a quota check.',
+              'Callback awaited before a run starts executing, and before any step runs. Fires only on initial start, not on resume, restart, or time travel. Unlike onFinish and onError, errors thrown here are propagated: they reject the start() or stream() call and the run never executes, so this can be used as a pre-flight gate such as a quota check. The run record created by createRun() stays at status pending.',
             isOptional: true,
             properties: [
               {

--- a/docs/src/content/en/reference/workflows/workflow.mdx
+++ b/docs/src/content/en/reference/workflows/workflow.mdx
@@ -227,6 +227,62 @@ You can define the workflow's `inputSchema` and `outputSchema` with any library 
             isOptional: true,
           },
           {
+            name: 'onStart',
+            type: '(info: WorkflowStartCallbackInfo) => void | Promise<void>',
+            description:
+              'Callback awaited before a run starts executing, and before the run is persisted. Fires only on initial start, not on resume, restart, or time travel. Unlike onFinish and onError, errors thrown here are propagated: they reject the start() or stream() call and the run never executes, so this can be used as a pre-flight gate such as a quota check.',
+            isOptional: true,
+            properties: [
+              {
+                type: 'WorkflowStartCallbackInfo',
+                parameters: [
+                  {
+                    name: 'runId',
+                    type: 'string',
+                    description: 'The workflow run ID',
+                  },
+                  {
+                    name: 'workflowId',
+                    type: 'string',
+                    description: 'The workflow identifier',
+                  },
+                  {
+                    name: 'resourceId',
+                    type: 'string',
+                    description: 'Resource or user identifier for multi-tenant scenarios',
+                    isOptional: true,
+                  },
+                  {
+                    name: 'getInitData',
+                    type: '() => any',
+                    description: 'Returns the initial workflow input data',
+                  },
+                  {
+                    name: 'state',
+                    type: 'Record<string, any>',
+                    description: 'The initial workflow state',
+                  },
+                  {
+                    name: 'requestContext',
+                    type: 'RequestContext',
+                    description: 'The request context for the run',
+                  },
+                  {
+                    name: 'mastra',
+                    type: 'Mastra',
+                    description: 'The Mastra instance, when the workflow is registered',
+                    isOptional: true,
+                  },
+                  {
+                    name: 'logger',
+                    type: 'IMastraLogger',
+                    description: 'The Mastra logger',
+                  },
+                ],
+              },
+            ],
+          },
+          {
             name: 'onFinish',
             type: '(result: WorkflowFinishCallbackResult) => void | Promise<void>',
             description:

--- a/packages/core/src/workflows/evented/evented-workflow.test.ts
+++ b/packages/core/src/workflows/evented/evented-workflow.test.ts
@@ -328,6 +328,71 @@ describe('Workflow (Evented Engine Specific)', () => {
     await workflowsStore?.dangerouslyClearAll();
   });
 
+  it('should run onStart before execution and abort the run when it throws', async () => {
+    const stepAction = vi.fn().mockResolvedValue({ value: 'done' });
+    const step1 = createStep({
+      id: 'step1',
+      execute: stepAction,
+      inputSchema: z.object({}),
+      outputSchema: z.object({ value: z.string() }),
+    });
+
+    const onStart = vi.fn();
+    const okWorkflow = createWorkflow({
+      id: 'on-start-ok-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ value: z.string() }),
+      steps: [step1],
+      options: { validateInputs: false, onStart },
+    });
+    okWorkflow.then(step1).commit();
+
+    const gatedAction = vi.fn().mockResolvedValue({ value: 'done' });
+    const gatedStep = createStep({
+      id: 'gated-step',
+      execute: gatedAction,
+      inputSchema: z.object({}),
+      outputSchema: z.object({ value: z.string() }),
+    });
+    const gatedWorkflow = createWorkflow({
+      id: 'on-start-gated-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ value: z.string() }),
+      steps: [gatedStep],
+      options: {
+        validateInputs: false,
+        onStart: async () => {
+          throw new Error('quota exceeded');
+        },
+      },
+    });
+    gatedWorkflow.then(gatedStep).commit();
+
+    const mastra = new Mastra({
+      workflows: {
+        'on-start-ok-workflow': okWorkflow,
+        'on-start-gated-workflow': gatedWorkflow,
+      },
+      storage: testStorage,
+      pubsub: new EventEmitterPubSub(),
+    });
+    await mastra.startWorkers();
+
+    try {
+      const okRun = await okWorkflow.createRun();
+      const okResult = await okRun.start({ inputData: {} });
+      expect(okResult.status).toBe('success');
+      expect(onStart).toHaveBeenCalledTimes(1);
+      expect(onStart.mock.calls[0]![0]!.runId).toBe(okRun.runId);
+
+      const gatedRun = await gatedWorkflow.createRun();
+      await expect(gatedRun.start({ inputData: {} })).rejects.toThrow('quota exceeded');
+      expect(gatedAction).not.toHaveBeenCalled();
+    } finally {
+      await mastra.stopWorkers();
+    }
+  });
+
   it('should create a processor step for state signal only processors', () => {
     const processor: Processor = {
       id: 'state-only-processor',

--- a/packages/core/src/workflows/evented/evented-workflow.test.ts
+++ b/packages/core/src/workflows/evented/evented-workflow.test.ts
@@ -388,6 +388,24 @@ describe('Workflow (Evented Engine Specific)', () => {
       const gatedRun = await gatedWorkflow.createRun();
       await expect(gatedRun.start({ inputData: {} })).rejects.toThrow('quota exceeded');
       expect(gatedAction).not.toHaveBeenCalled();
+
+      // The hook runs ahead of the initial run-record write in start(), but createRun()
+      // has already persisted a pending record by then, so the gated run is parked at
+      // 'pending' rather than absent. Pinning that so the guarantee cannot drift.
+      const workflowsStore = await testStorage.getStore('workflows');
+      const gatedRecord = await workflowsStore?.getWorkflowRunById({
+        runId: gatedRun.runId,
+        workflowName: 'on-start-gated-workflow',
+      });
+      expect((gatedRecord?.snapshot as any)?.status).toBe('pending');
+
+      // Control: the allowed run advanced past pending, so the assertion above reflects the
+      // gate holding rather than this engine never updating the record.
+      const okRecord = await workflowsStore?.getWorkflowRunById({
+        runId: okRun.runId,
+        workflowName: 'on-start-ok-workflow',
+      });
+      expect((okRecord?.snapshot as any)?.status).toBe('success');
     } finally {
       await mastra.stopWorkers();
     }

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1899,7 +1899,8 @@ export class EventedRun<
     const inputDataToUse = await this._validateInput(inputData ?? ({} as TInput));
     const initialStateToUse = await this._validateInitialState(initialState ?? ({} as TState));
 
-    // Pre-flight gate: runs before the run record is persisted, and rejects the caller if it throws.
+    // Pre-flight gate: runs ahead of the initial run-record write below, and rejects the caller
+    // if it throws. createRun() has already persisted a pending record, which stays pending.
     await this.executionEngine.invokeStartCallback({
       runId: this.runId,
       workflowId: this.workflowId,
@@ -2031,7 +2032,8 @@ export class EventedRun<
     const inputDataToUse = await this._validateInput(inputData ?? ({} as TInput));
     const initialStateToUse = await this._validateInitialState(initialState ?? ({} as TState));
 
-    // Pre-flight gate: runs before the run record is persisted, and rejects the caller if it throws.
+    // Pre-flight gate: runs ahead of the initial run-record write below, and rejects the caller
+    // if it throws. createRun() has already persisted a pending record, which stays pending.
     await this.executionEngine.invokeStartCallback({
       runId: this.runId,
       workflowId: this.workflowId,

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1651,6 +1651,7 @@ export function createWorkflow<
       shouldPersistSnapshot: params.options?.shouldPersistSnapshot ?? (() => true),
       pruneSnapshot: params.options?.pruneSnapshot,
       tracingPolicy: params.options?.tracingPolicy,
+      onStart: params.options?.onStart,
       onFinish: params.options?.onFinish,
       onError: params.options?.onError,
     },
@@ -1898,6 +1899,16 @@ export class EventedRun<
     const inputDataToUse = await this._validateInput(inputData ?? ({} as TInput));
     const initialStateToUse = await this._validateInitialState(initialState ?? ({} as TState));
 
+    // Pre-flight gate: runs before the run record is persisted, and rejects the caller if it throws.
+    await this.executionEngine.invokeStartCallback({
+      runId: this.runId,
+      workflowId: this.workflowId,
+      resourceId: this.resourceId,
+      getInitData: () => inputDataToUse,
+      requestContext,
+      state: initialStateToUse as Record<string, any>,
+    });
+
     const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
     // Always persist the initial run record regardless of shouldPersistSnapshot.
     // The evented engine relies on this record for parallel branch result
@@ -2019,6 +2030,16 @@ export class EventedRun<
 
     const inputDataToUse = await this._validateInput(inputData ?? ({} as TInput));
     const initialStateToUse = await this._validateInitialState(initialState ?? ({} as TState));
+
+    // Pre-flight gate: runs before the run record is persisted, and rejects the caller if it throws.
+    await this.executionEngine.invokeStartCallback({
+      runId: this.runId,
+      workflowId: this.workflowId,
+      resourceId: this.resourceId,
+      getInitData: () => inputDataToUse,
+      requestContext,
+      state: initialStateToUse as Record<string, any>,
+    });
 
     const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
     // Always persist the initial run record regardless of shouldPersistSnapshot.

--- a/packages/core/src/workflows/execution-engine.ts
+++ b/packages/core/src/workflows/execution-engine.ts
@@ -14,6 +14,7 @@ import type {
   WorkflowRunState,
   WorkflowFinishCallbackResult,
   WorkflowErrorCallbackInfo,
+  WorkflowStartCallbackInfo,
 } from './types';
 import type { RestartExecutionParams, StepFlowEntry, TimeTravelExecutionParams } from '.';
 
@@ -39,6 +40,12 @@ export interface ExecutionEngineOptions {
    * Must be pure and return JSON-safe data. Defaults to identity.
    */
   pruneSnapshot?: (params: { snapshot: WorkflowRunState; workflowStatus: WorkflowRunStatus }) => WorkflowRunState;
+
+  /**
+   * Called and awaited before a run starts executing. Errors are propagated, which
+   * aborts the run before any step executes.
+   */
+  onStart?: (info: WorkflowStartCallbackInfo) => Promise<void> | void;
 
   /**
    * Called when workflow execution completes (success, failed, suspended, or tripwire).
@@ -75,6 +82,20 @@ export abstract class ExecutionEngine extends MastraBase {
 
   public getLogger(): IMastraLogger {
     return this.logger;
+  }
+
+  /**
+   * Invokes the onStart lifecycle callback if it is defined, before any step runs.
+   * Errors are intentionally propagated so the hook can gate the run (for example a
+   * quota check): the caller rejects and the run never executes.
+   */
+  public async invokeStartCallback(info: Omit<WorkflowStartCallbackInfo, 'mastra' | 'logger'>): Promise<void> {
+    const { onStart } = this.options;
+    if (!onStart) {
+      return;
+    }
+
+    await onStart({ ...info, mastra: this.mastra, logger: this.logger });
   }
 
   /**

--- a/packages/core/src/workflows/on-start.test.ts
+++ b/packages/core/src/workflows/on-start.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage/mock';
+import { createWorkflow } from './create';
+import { createStep } from './workflow';
+
+const step = createStep({
+  id: 'step-1',
+  inputSchema: z.object({ value: z.string() }),
+  outputSchema: z.object({ value: z.string() }),
+  execute: async ({ inputData }) => inputData,
+});
+
+function buildWorkflow(options: { onStart?: (info: any) => Promise<void> | void }) {
+  const workflow = createWorkflow({
+    id: 'on-start-workflow',
+    inputSchema: z.object({ value: z.string() }),
+    outputSchema: z.object({ value: z.string() }),
+    options,
+  })
+    .then(step)
+    .commit();
+
+  const storage = new MockStore();
+  new Mastra({ workflows: { 'on-start-workflow': workflow }, storage });
+
+  return { workflow, storage };
+}
+
+describe('workflow onStart', () => {
+  it('runs before the workflow executes and receives the run context', async () => {
+    const executionOrder: string[] = [];
+    const onStart = vi.fn(async () => {
+      executionOrder.push('onStart');
+    });
+
+    const stepSpy = createStep({
+      id: 'spy-step',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      execute: async ({ inputData }) => {
+        executionOrder.push('step');
+        return inputData;
+      },
+    });
+
+    const workflow = createWorkflow({
+      id: 'on-start-order-workflow',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      options: { onStart },
+    })
+      .then(stepSpy)
+      .commit();
+    new Mastra({ workflows: { 'on-start-order-workflow': workflow }, storage: new MockStore() });
+
+    const run = await workflow.createRun();
+    const result = await run.start({ inputData: { value: 'hello' } });
+
+    expect(result.status).toBe('success');
+    expect(executionOrder).toEqual(['onStart', 'step']);
+
+    const info = (onStart.mock.calls as any[])[0][0];
+    expect(info.runId).toBe(run.runId);
+    expect(info.workflowId).toBe('on-start-order-workflow');
+    expect(info.getInitData()).toEqual({ value: 'hello' });
+    expect(info.requestContext).toBeDefined();
+    expect(info.logger).toBeDefined();
+  });
+
+  it('rejects the run and skips execution when onStart throws', async () => {
+    const stepSpy = vi.fn(async ({ inputData }: any) => inputData);
+    const gatedStep = createStep({
+      id: 'gated-step',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      execute: stepSpy as any,
+    });
+
+    const workflow = createWorkflow({
+      id: 'on-start-gate-workflow',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      options: {
+        onStart: async () => {
+          throw new Error('quota exceeded');
+        },
+      },
+    })
+      .then(gatedStep)
+      .commit();
+    const storage = new MockStore();
+    new Mastra({ workflows: { 'on-start-gate-workflow': workflow }, storage });
+
+    const run = await workflow.createRun();
+    await expect(run.start({ inputData: { value: 'hello' } })).rejects.toThrow('quota exceeded');
+
+    expect(stepSpy).not.toHaveBeenCalled();
+    const workflowsStore = await storage.getStore('workflows');
+    const persisted = await workflowsStore?.getWorkflowRunById({
+      runId: run.runId,
+      workflowName: 'on-start-gate-workflow',
+    });
+    expect(persisted?.snapshot ? (persisted.snapshot as any).status : undefined).not.toBe('success');
+  });
+
+  it('does not fire again when a suspended run is resumed', async () => {
+    const onStart = vi.fn();
+    const suspendingStep = createStep({
+      id: 'suspending-step',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      resumeSchema: z.object({ confirmed: z.boolean() }),
+      execute: async ({ inputData, resumeData, suspend }) => {
+        if (!resumeData?.confirmed) {
+          await suspend({});
+          return inputData;
+        }
+        return inputData;
+      },
+    });
+
+    const workflow = createWorkflow({
+      id: 'on-start-resume-workflow',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      options: { onStart },
+    })
+      .then(suspendingStep)
+      .commit();
+    new Mastra({ workflows: { 'on-start-resume-workflow': workflow }, storage: new MockStore() });
+
+    const run = await workflow.createRun();
+    const suspended = await run.start({ inputData: { value: 'hello' } });
+    expect(suspended.status).toBe('suspended');
+    expect(onStart).toHaveBeenCalledTimes(1);
+
+    await run.resume({ step: 'suspending-step', resumeData: { confirmed: true } });
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs before a streamed workflow executes', async () => {
+    const onStart = vi.fn();
+    const { workflow } = buildWorkflow({ onStart });
+
+    const run = await workflow.createRun();
+    const stream = run.stream({ inputData: { value: 'hello' } });
+    const result = await stream.result;
+
+    expect(result.status).toBe('success');
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/workflows/on-start.test.ts
+++ b/packages/core/src/workflows/on-start.test.ts
@@ -5,6 +5,17 @@ import { MockStore } from '../storage/mock';
 import { createWorkflow } from './create';
 import { createStep } from './workflow';
 
+// The span is created in _start and only ended inside executionEngine.execute(), so the
+// assertion has to be on the span object itself — there is no exporter on this path to observe.
+const getOrCreateSpanMock = vi.fn();
+vi.mock('../observability', async importOriginal => {
+  const actual = await importOriginal<typeof import('../observability')>();
+  return {
+    ...actual,
+    getOrCreateSpan: (...args: any[]) => getOrCreateSpanMock(...args) ?? (actual.getOrCreateSpan as any)(...args),
+  };
+});
+
 const step = createStep({
   id: 'step-1',
   inputSchema: z.object({ value: z.string() }),
@@ -97,12 +108,17 @@ describe('workflow onStart', () => {
     await expect(run.start({ inputData: { value: 'hello' } })).rejects.toThrow('quota exceeded');
 
     expect(stepSpy).not.toHaveBeenCalled();
+
+    // On this engine `createRun()` already wrote a pending record before `start()` was
+    // ever called, so the gate cannot leave nothing behind — it leaves the run parked at
+    // 'pending'. Asserting the exact status rather than `not.toBe('success')`, which would
+    // also pass if the run had failed halfway through a step.
     const workflowsStore = await storage.getStore('workflows');
     const persisted = await workflowsStore?.getWorkflowRunById({
       runId: run.runId,
       workflowName: 'on-start-gate-workflow',
     });
-    expect(persisted?.snapshot ? (persisted.snapshot as any).status : undefined).not.toBe('success');
+    expect((persisted?.snapshot as any)?.status).toBe('pending');
   });
 
   it('does not fire again when a suspended run is resumed', async () => {
@@ -150,5 +166,33 @@ describe('workflow onStart', () => {
 
     expect(result.status).toBe('success');
     expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * `_start` creates the workflow-run span and hands ownership to `executionEngine.execute()`,
+   * which is never reached when the hook rejects. Without an explicit end the span stays open
+   * for the life of the trace, so exporters see a start with no matching end.
+   */
+  it('ends the workflow span when onStart rejects', async () => {
+    const spanError = vi.fn();
+    const spanEnd = vi.fn();
+    getOrCreateSpanMock.mockReturnValueOnce({
+      id: 'span-1',
+      externalTraceId: 'trace-1',
+      error: spanError,
+      end: spanEnd,
+    });
+
+    const { workflow } = buildWorkflow({
+      onStart: async () => {
+        throw new Error('quota exceeded');
+      },
+    });
+
+    const run = await workflow.createRun();
+    await expect(run.start({ inputData: { value: 'hello' } })).rejects.toThrow('quota exceeded');
+
+    expect(spanError).toHaveBeenCalledTimes(1);
+    expect(spanError.mock.calls[0]![0]!.error.message).toBe('quota exceeded');
   });
 });

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -408,6 +408,28 @@ export interface WorkflowRunState {
 }
 
 /**
+ * Info object passed to the onStart callback before a workflow run begins.
+ */
+export interface WorkflowStartCallbackInfo {
+  /** The unique workflow run ID */
+  runId: string;
+  /** The workflow identifier */
+  workflowId: string;
+  /** Resource/user identifier for multi-tenant scenarios (optional) */
+  resourceId?: string;
+  /** Function to get the initial workflow input data */
+  getInitData: () => any;
+  /** The Mastra instance (if registered) */
+  mastra?: Mastra;
+  /** The request context */
+  requestContext: RequestContext;
+  /** The Mastra logger for structured logging */
+  logger: IMastraLogger;
+  /** The initial workflow state */
+  state: Record<string, any>;
+}
+
+/**
  * Result object passed to the onFinish callback when a workflow completes.
  */
 export interface WorkflowFinishCallbackResult {
@@ -495,6 +517,19 @@ export interface WorkflowOptions {
    * read on resume (stale suspend payloads, duplicated message arrays).
    */
   pruneSnapshot?: (params: { snapshot: WorkflowRunState; workflowStatus: WorkflowRunStatus }) => WorkflowRunState;
+
+  /**
+   * Called before a workflow run starts executing, and awaited.
+   * This callback is invoked server-side without requiring client-side .watch().
+   *
+   * Unlike `onFinish`/`onError`, errors thrown here are NOT swallowed: they reject
+   * the `start()`/`stream()` call and the run never executes, so the hook can act as
+   * a pre-flight gate (quota checks, entitlement checks). This mirrors how input
+   * schema validation failures behave — no run is executed or persisted.
+   *
+   * Fires only when a run first starts, not on resume, restart, or time travel.
+   */
+  onStart?: (info: WorkflowStartCallbackInfo) => Promise<void> | void;
 
   /**
    * Called when workflow execution completes (success, failed, suspended, or tripwire).

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -525,7 +525,8 @@ export interface WorkflowOptions {
    * Unlike `onFinish`/`onError`, errors thrown here are NOT swallowed: they reject
    * the `start()`/`stream()` call and the run never executes, so the hook can act as
    * a pre-flight gate (quota checks, entitlement checks). This mirrors how input
-   * schema validation failures behave — no run is executed or persisted.
+   * schema validation failures behave: no step executes. The pending run record that
+   * `createRun()` already wrote is left as-is, so a gated run stays at `pending`.
    *
    * Fires only when a run first starts, not on resume, restart, or time travel.
    */

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1688,6 +1688,7 @@ export class Workflow<
       shouldPersistSnapshot: options.shouldPersistSnapshot ?? (() => true),
       pruneSnapshot: options.pruneSnapshot,
       tracingPolicy: options.tracingPolicy,
+      onStart: options.onStart,
       onFinish: options.onFinish,
       onError: options.onError,
       sharePubsub: options.sharePubsub,
@@ -3496,6 +3497,16 @@ export class Run<
     const inputDataToUse = await this._validateInput(inputData);
     const initialStateToUse = await this._validateInitialState(initialState ?? ({} as TState));
     await this._validateRequestContext(requestContext as RequestContext);
+
+    // Pre-flight gate: runs before the run executes, and rejects the caller if it throws.
+    await this.executionEngine.invokeStartCallback({
+      runId: this.runId,
+      workflowId: this.workflowId,
+      resourceId: this.resourceId,
+      getInitData: () => inputDataToUse,
+      requestContext: (requestContext ?? new RequestContext()) as RequestContext,
+      state: initialStateToUse as Record<string, any>,
+    });
 
     const result = await this.executionEngine.execute<TState, TInput, WorkflowResult<TState, TInput, TOutput, TSteps>>({
       workflowId: this.workflowId,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -3494,18 +3494,29 @@ export class Run<
 
     const traceId = workflowSpan?.externalTraceId;
     const spanId = workflowSpan?.id;
-    const inputDataToUse = await this._validateInput(inputData);
-    const initialStateToUse = await this._validateInitialState(initialState ?? ({} as TState));
-    await this._validateRequestContext(requestContext as RequestContext);
 
-    // Pre-flight gate: runs before the run executes, and rejects the caller if it throws.
-    await this.executionEngine.invokeStartCallback({
-      runId: this.runId,
-      workflowId: this.workflowId,
-      resourceId: this.resourceId,
-      getInitData: () => inputDataToUse,
-      requestContext: (requestContext ?? new RequestContext()) as RequestContext,
-      state: initialStateToUse as Record<string, any>,
+    // execute() ends the span, so anything that rejects before we reach it has to end the
+    // span itself or it stays open for the life of the trace. onStart makes that reachable
+    // from user code, not just from a malformed input.
+    const { inputDataToUse, initialStateToUse } = await (async () => {
+      const validatedInput = await this._validateInput(inputData);
+      const validatedState = await this._validateInitialState(initialState ?? ({} as TState));
+      await this._validateRequestContext(requestContext as RequestContext);
+
+      // Pre-flight gate: runs before the run executes, and rejects the caller if it throws.
+      await this.executionEngine.invokeStartCallback({
+        runId: this.runId,
+        workflowId: this.workflowId,
+        resourceId: this.resourceId,
+        getInitData: () => validatedInput,
+        requestContext: (requestContext ?? new RequestContext()) as RequestContext,
+        state: validatedState as Record<string, any>,
+      });
+
+      return { inputDataToUse: validatedInput, initialStateToUse: validatedState };
+    })().catch(error => {
+      workflowSpan?.error({ error: error as Error });
+      throw error;
     });
 
     const result = await this.executionEngine.execute<TState, TInput, WorkflowResult<TState, TInput, TOutput, TSteps>>({


### PR DESCRIPTION
## Summary

Workflows can already observe completion through `onFinish` and `onError`, but there was no server-side hook that runs *before* a run executes. The only workaround was making the check a first workflow step, which runs inside execution and is too late to act as a cheap pre-flight gate — for example, rejecting a run when a customer is over quota.

This adds `onStart` to workflow `options`. It is awaited before the run executes and, on the evented engine, before the initial run record is persisted, so a rejecting hook leaves no orphaned run behind. It fires only when a run first starts — not on resume, restart, or time travel.

Unlike `onFinish`/`onError`, errors thrown in `onStart` are not swallowed: they reject the `start()`/`stream()` call and no step executes. This mirrors how invalid workflow input already behaves.

The hook receives the run ID, workflow ID, resource ID, initial input, initial state, request context, Mastra instance, and logger.

Closes #19852

## Test plan

- New `src/workflows/on-start.test.ts` (default engine): hook ordering before the first step, payload contents, a throwing hook aborting the run without executing steps, no second invocation on resume, and coverage of the streaming entry point.
- New evented-engine case in `evented-workflow.test.ts` covering the same success and gating behavior.
- Red-before/green-after verified by stashing the source changes.
- Full `packages/core/src/workflows` suite: 45 files, 1156 tests passing, no type errors.
- Reference docs for `Workflow` options updated with `onStart`.