### PR TITLE
perf(core): batch Workspace search embedding on the eager path

### DIFF
--- a/.changeset/eager-workspace-batch-embedding.md
+++ b/.changeset/eager-workspace-batch-embedding.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Workspace search indexing sending one embedding request per document.
+
+A batch-capable embedder (one branded with `batch: true`) was only used when the search engine ran in lazy mode, which `Workspace` never enables. Indexing a directory therefore cost one embedding round trip per file no matter what the embedder supported — indexing 500 files made 500 requests.
+
+`indexMany` now groups documents into batched embedder calls whenever the configured embedder is batch-capable, so those 500 files take 2 requests with `maxBatchSize: 256`.
+
+Vector writes are bounded as well: a single `upsert` now carries at most `min(maxBatchSize, 100)` vectors instead of the whole batch, since each document's metadata carries its full text and several vector stores reject oversized write requests. Lazy-mode rebuilds that previously issued one large `upsert` per flush now issue several bounded ones.
+
+An embedder declaring an unusable `maxBatchSize` (`0`, negative, or `NaN`) now falls back to the default batch size instead of hanging or silently indexing nothing.

--- a/packages/core/src/workspace/search/search-engine.test.ts
+++ b/packages/core/src/workspace/search/search-engine.test.ts
@@ -963,6 +963,41 @@ Third line has learning too`;
       expect(ids.sort()).toEqual(['a', 'b']);
     });
 
+    it('creates the index once before running groups in parallel', async () => {
+      const store = makeStore();
+      let indexUnderConstruction = false;
+      let upsertedDuringCreate = 0;
+      store.createIndex = vi.fn(async () => {
+        indexUnderConstruction = true;
+        await new Promise(resolve => setTimeout(resolve, 10));
+        indexUnderConstruction = false;
+      });
+      store.upsert = vi.fn(async () => {
+        if (indexUnderConstruction) upsertedDuringCreate++;
+      });
+      const { embedder } = makeBatchEmbedder(10);
+      const engine = new SearchEngine({
+        vector: { vectorStore: store, embedder, indexName: 'idx' },
+      });
+
+      await engine.indexMany(Array.from({ length: 100 }, (_, i) => ({ id: `d-${i}`, content: `c ${i}` })));
+
+      expect(store.createIndex).toHaveBeenCalledTimes(1);
+      expect(upsertedDuringCreate).toBe(0);
+    });
+
+    it('handles an empty document list', async () => {
+      const store = makeStore();
+      const { embedder, fn } = makeBatchEmbedder(256);
+      const engine = new SearchEngine({
+        vector: { vectorStore: store, embedder, indexName: 'idx' },
+      });
+
+      await expect(engine.indexMany([])).resolves.toBeUndefined();
+      expect(fn).not.toHaveBeenCalled();
+      expect(store.upsert).not.toHaveBeenCalled();
+    });
+
     it('rejects with a flat AggregateError of the individual failures when stopOnError is false', async () => {
       const store = makeStore();
       const fn = vi.fn(async (texts: string[]) => {

--- a/packages/core/src/workspace/search/search-engine.test.ts
+++ b/packages/core/src/workspace/search/search-engine.test.ts
@@ -995,6 +995,7 @@ Third line has learning too`;
 
       await expect(engine.indexMany([])).resolves.toBeUndefined();
       expect(fn).not.toHaveBeenCalled();
+      expect(store.createIndex).not.toHaveBeenCalled();
       expect(store.upsert).not.toHaveBeenCalled();
     });
 

--- a/packages/core/src/workspace/search/search-engine.test.ts
+++ b/packages/core/src/workspace/search/search-engine.test.ts
@@ -816,9 +816,231 @@ Third line has learning too`;
         .sort();
       expect(docCallSizes).toEqual([1, 2, 2]);
 
-      // Single upsert with all 5 vectors.
-      expect(store.upsert).toHaveBeenCalledTimes(1);
-      expect(store.upsert.mock.calls[0]![0].vectors).toHaveLength(5);
+      // Writes follow the same grouping as the embedder calls, so no single upsert carries
+      // the whole queue.
+      expect(store.upsert).toHaveBeenCalledTimes(3);
+      const upsertedIds = store.upsert.mock.calls.flatMap((call: unknown[]) => (call[0] as { ids: string[] }).ids);
+      expect(upsertedIds.sort()).toEqual(['1', '2', '3', '4', '5']);
+      const upsertSizes = store.upsert.mock.calls.map(
+        (call: unknown[]) => (call[0] as { vectors: number[][] }).vectors.length,
+      );
+      expect(upsertSizes.reduce((a: number, b: number) => a + b, 0)).toBe(5);
+    });
+
+    it('batches embedder calls on the eager path (default Workspace configuration)', async () => {
+      const store = makeStore();
+      const { embedder, fn } = makeBatchEmbedder(256);
+      // No lazyVectorIndex — exactly how Workspace builds its SearchEngine.
+      const engine = new SearchEngine({
+        vector: { vectorStore: store, embedder, indexName: 'idx' },
+      });
+
+      const docs = Array.from({ length: 500 }, (_, i) => ({ id: `doc-${i}`, content: `contents ${i}` }));
+      await engine.indexMany(docs);
+
+      // 500 docs / 256 per call = 2 embedder calls, not one per document.
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn.mock.calls.map((call: unknown[]) => (call[0] as string[]).length)).toEqual([256, 244]);
+
+      // Every document is embedded exactly once, in input order.
+      const embeddedTexts = fn.mock.calls.flatMap((call: unknown[]) => call[0] as string[]);
+      expect(embeddedTexts).toEqual(docs.map(d => d.content));
+    });
+
+    it('keeps each vector aligned with its own document when batching', async () => {
+      const store = makeStore();
+      // Order-sensitive polynomial hash so no two fixture contents share a vector: a plain
+      // character sum collides on anagrams like "contents 12" and "contents 21", which would
+      // hide a transposition instead of exposing it.
+      const vectorFor = (content: string) => {
+        const hash = content.split('').reduce((acc, c) => (acc * 131 + c.charCodeAt(0)) % 2147483647, 7);
+        return [hash, hash * 2, hash * 3];
+      };
+      const embedder: BatchEmbedder = Object.assign(async (texts: string[]) => texts.map(vectorFor), {
+        batch: true as const,
+        maxBatchSize: 256,
+      });
+      const engine = new SearchEngine({
+        vector: { vectorStore: store, embedder, indexName: 'idx' },
+      });
+
+      const docs = Array.from({ length: 250 }, (_, i) => ({ id: `doc-${i}`, content: `contents ${i}` }));
+      // Guard the guard: if the fixture ever collides, this test stops proving alignment.
+      expect(new Set(docs.map(d => vectorFor(d.content)[0])).size).toBe(docs.length);
+
+      await engine.indexMany(docs);
+
+      // Rebuild what actually reached the store, in upsert order.
+      const upserted = store.upsert.mock.calls.flatMap((call: unknown[]) => {
+        const arg = call[0] as { ids: string[]; vectors: number[][]; metadata: Record<string, unknown>[] };
+        return arg.ids.map((id, i) => ({ id, vector: arg.vectors[i]!, text: arg.metadata[i]!.text }));
+      });
+
+      expect(upserted).toHaveLength(docs.length);
+      for (const doc of docs) {
+        const row = upserted.find(r => r.id === doc.id);
+        expect(row, `missing ${doc.id}`).toBeDefined();
+        expect(row!.text).toBe(doc.content);
+        expect(row!.vector).toEqual(vectorFor(doc.content));
+      }
+    });
+
+    it('bounds how many vectors a single upsert carries', async () => {
+      const store = makeStore();
+      const { embedder } = makeBatchEmbedder(1000);
+      const engine = new SearchEngine({
+        vector: { vectorStore: store, embedder, indexName: 'idx' },
+      });
+
+      await engine.indexMany(Array.from({ length: 450 }, (_, i) => ({ id: `d-${i}`, content: `c ${i}` })));
+
+      const sizes = store.upsert.mock.calls.map(
+        (call: unknown[]) => (call[0] as { vectors: number[][] }).vectors.length,
+      );
+      expect(Math.max(...sizes)).toBeLessThanOrEqual(100);
+      expect(sizes.reduce((a: number, b: number) => a + b, 0)).toBe(450);
+    });
+
+    it('leaves documents searchable as soon as indexMany resolves on the eager path', async () => {
+      const store = makeStore();
+      store.query.mockResolvedValue([{ id: 'doc-7', score: 0.9, metadata: { id: 'doc-7', text: 'contents 7' } }]);
+      const { embedder } = makeBatchEmbedder(4);
+      const engine = new SearchEngine({
+        vector: { vectorStore: store, embedder, indexName: 'idx' },
+      });
+
+      await engine.indexMany(Array.from({ length: 10 }, (_, i) => ({ id: `doc-${i}`, content: `contents ${i}` })));
+
+      // Eager contract: no flush-on-search needed, the writes already happened.
+      const upsertsBeforeSearch = store.upsert.mock.calls.length;
+      const results = await engine.search('contents 7', { mode: 'vector' });
+      expect(store.upsert).toHaveBeenCalledTimes(upsertsBeforeSearch);
+      expect(results.map(r => r.id)).toContain('doc-7');
+    });
+
+    it('collapses duplicate ids within one indexMany call', async () => {
+      const store = makeStore();
+      const { embedder } = makeBatchEmbedder(256);
+      const engine = new SearchEngine({
+        vector: { vectorStore: store, embedder, indexName: 'idx' },
+      });
+
+      await engine.indexMany([
+        { id: 'x', content: 'first' },
+        { id: 'y', content: 'other' },
+        { id: 'x', content: 'second' },
+      ]);
+
+      const ids = store.upsert.mock.calls.flatMap((call: unknown[]) => (call[0] as { ids: string[] }).ids);
+      expect(ids.sort()).toEqual(['x', 'y']);
+      const texts = store.upsert.mock.calls.flatMap((call: unknown[]) =>
+        (call[0] as { metadata: Record<string, unknown>[] }).metadata.map(m => m.text),
+      );
+      // Last entry wins, matching the lazy flush path.
+      expect(texts).toContain('second');
+      expect(texts).not.toContain('first');
+    });
+
+    it.each([
+      ['zero', 0],
+      ['negative', -5],
+      ['NaN', Number('oops')],
+    ])('still indexes every document when maxBatchSize is unusable (%s)', async (_label, maxBatchSize) => {
+      const store = makeStore();
+      const { embedder, fn } = makeBatchEmbedder(maxBatchSize);
+      const engine = new SearchEngine({
+        vector: { vectorStore: store, embedder, indexName: 'idx' },
+      });
+
+      await engine.indexMany([
+        { id: 'a', content: 'alpha' },
+        { id: 'b', content: 'beta' },
+      ]);
+
+      // An unusable limit must fall back to the default, not stall and not silently index nothing.
+      expect(fn).toHaveBeenCalledTimes(1);
+      const ids = store.upsert.mock.calls.flatMap((call: unknown[]) => (call[0] as { ids: string[] }).ids);
+      expect(ids.sort()).toEqual(['a', 'b']);
+    });
+
+    it('rejects with a flat AggregateError of the individual failures when stopOnError is false', async () => {
+      const store = makeStore();
+      const fn = vi.fn(async (texts: string[]) => {
+        if (texts.some(t => t === 'BOOM')) throw new Error(`embed failed: ${texts.length}`);
+        return texts.map(t => [t.length, 0, 0]);
+      });
+      const embedder: BatchEmbedder = Object.assign(fn, { batch: true as const, maxBatchSize: 256 });
+      const engine = new SearchEngine({
+        vector: { vectorStore: store, embedder, indexName: 'idx' },
+      });
+
+      const error = await engine
+        .indexMany(
+          [
+            { id: 'a', content: 'alpha' },
+            { id: 'b', content: 'BOOM' },
+            { id: 'c', content: 'gamma' },
+          ],
+          { stopOnError: false },
+        )
+        .catch((e: unknown) => e);
+
+      // The documented contract is one AggregateError holding the per-document failures —
+      // not an AggregateError wrapping another AggregateError.
+      expect(error).toBeInstanceOf(AggregateError);
+      const errors = (error as AggregateError).errors;
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(Error);
+      expect(errors[0]).not.toBeInstanceOf(AggregateError);
+      expect((errors[0] as Error).message).toBe('embed failed: 1');
+    });
+
+    it('does not leave BM25 populated with documents the vector half never indexed', async () => {
+      const store = makeStore();
+      const fn = vi.fn(async () => {
+        throw new Error('embedder down');
+      });
+      const embedder: BatchEmbedder = Object.assign(fn, { batch: true as const, maxBatchSize: 4 });
+      const engine = new SearchEngine({
+        bm25: {},
+        vector: { vectorStore: store, embedder, indexName: 'idx' },
+      });
+
+      const docs = Array.from({ length: 20 }, (_, i) => ({ id: `doc-${i}`, content: `zebra ${i}` }));
+      await expect(engine.indexMany(docs, { concurrency: 1 })).rejects.toThrow('embedder down');
+
+      // Only the group that was actually attempted may appear in the keyword index; a rejected
+      // indexMany must not leave all 20 documents searchable.
+      const results = await engine.search('zebra', { mode: 'bm25', topK: 100 });
+      expect(results.length).toBeLessThanOrEqual(4);
+    });
+
+    it('still processes every document when a grouped embed fails with stopOnError false', async () => {
+      const store = makeStore();
+      const fn = vi.fn(async (texts: string[]) => {
+        if (texts.length > 1 && texts.includes('BOOM')) throw new Error('batch embed failed');
+        if (texts[0] === 'BOOM') throw new Error('single embed failed');
+        return texts.map(t => [t.length, 0, 0]);
+      });
+      const embedder: BatchEmbedder = Object.assign(fn, { batch: true as const, maxBatchSize: 256 });
+      const engine = new SearchEngine({
+        vector: { vectorStore: store, embedder, indexName: 'idx' },
+      });
+
+      await expect(
+        engine.indexMany(
+          [
+            { id: 'a', content: 'alpha' },
+            { id: 'b', content: 'BOOM' },
+            { id: 'c', content: 'gamma' },
+          ],
+          { stopOnError: false },
+        ),
+      ).rejects.toThrow();
+
+      // The healthy documents are still written despite sharing a group with the bad one.
+      const ids = store.upsert.mock.calls.flatMap((call: unknown[]) => (call[0] as { ids: string[] }).ids);
+      expect(ids.sort()).toEqual(['a', 'c']);
     });
 
     it('uses batched call for single search query', async () => {

--- a/packages/core/src/workspace/search/search-engine.ts
+++ b/packages/core/src/workspace/search/search-engine.ts
@@ -159,8 +159,11 @@ export interface SearchOptions {
 /** Options for batch indexing */
 export interface IndexManyOptions {
   /**
-   * Maximum number of documents to index concurrently (embedder + vector upsert).
+   * Maximum number of indexing units to run concurrently (embedder + vector upsert).
    * Must be a safe integer ≥ 1 (same rule as `p-map`).
+   *
+   * A unit is one document, or — when the embedder is batch-capable — one group of up to
+   * `maxBatchSize` documents sharing a single embedder call.
    * @default 8
    */
   concurrency?: number;
@@ -173,6 +176,42 @@ export interface IndexManyOptions {
 
 /** Default `indexMany` / lazy-vector flush concurrency (embedder + upsert). */
 const DEFAULT_INDEX_MANY_CONCURRENCY = 8;
+
+/** Documents per embedder call when the embedder does not declare its own `maxBatchSize`. */
+const DEFAULT_EMBED_GROUP_SIZE = 256;
+
+/**
+ * Upper bound on vectors handed to a single `upsert`.
+ *
+ * Vector stores cap how much one write request may carry — `PineconeVector` already slices at
+ * this exact size — and each document's metadata carries its full text, so an unbounded batch
+ * turns into an unbounded request. Kept separate from the embedder's `maxBatchSize`, which
+ * limits the embedding API rather than the store.
+ */
+const MAX_VECTORS_PER_UPSERT = 100;
+
+/**
+ * Documents to group per embedder call, honouring the embedder's own limit.
+ *
+ * A `maxBatchSize` of `0`, a negative number or `NaN` (easy to produce with
+ * `Number(process.env.EMBED_BATCH_SIZE)`) would otherwise mean "never make progress", so those
+ * fall back to the default rather than stalling or silently indexing nothing.
+ */
+function resolveEmbedGroupSize(embedder: BatchEmbedder): number {
+  const declared = embedder.maxBatchSize;
+  if (declared === undefined || !Number.isFinite(declared) || declared < 1) {
+    return DEFAULT_EMBED_GROUP_SIZE;
+  }
+  return Math.floor(declared);
+}
+
+function chunkItems<T>(items: readonly T[], size: number): T[][] {
+  const groups: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    groups.push(items.slice(i, i + size));
+  }
+  return groups;
+}
 
 /**
  * Configuration for SearchEngine
@@ -327,6 +366,29 @@ export class SearchEngine {
    * Index a document for search
    */
   async index(doc: IndexDocument): Promise<void> {
+    const docWithMergedMetadata = this.#indexNonVectorParts(doc);
+
+    // Vector indexing
+    if (this.#vectorConfig) {
+      if (this.#lazyVectorIndex) {
+        // Store for later indexing
+        this.#pendingVectorDocs.push(docWithMergedMetadata);
+        this.#vectorIndexBuilt = false;
+      } else {
+        // Index immediately
+        await this.#indexVector(docWithMergedMetadata);
+      }
+    }
+  }
+
+  /**
+   * Run the synchronous, per-document half of indexing: metadata merge, id tracking and BM25.
+   *
+   * Returns the document with merged metadata so the caller can hand it to the vector path.
+   * Split out of {@link SearchEngine.index} so `indexMany` can keep BM25 per-document while
+   * batching the vector work.
+   */
+  #indexNonVectorParts(doc: IndexDocument): IndexDocument {
     // Merge startLineOffset into metadata for retrieval at search time
     const metadata: Record<string, unknown> = {
       ...doc.metadata,
@@ -342,18 +404,7 @@ export class SearchEngine {
       this.#bm25Index.add(doc.id, doc.content, metadata);
     }
 
-    // Vector indexing
-    if (this.#vectorConfig) {
-      const docWithMergedMetadata = { ...doc, metadata };
-      if (this.#lazyVectorIndex) {
-        // Store for later indexing
-        this.#pendingVectorDocs.push(docWithMergedMetadata);
-        this.#vectorIndexBuilt = false;
-      } else {
-        // Index immediately
-        await this.#indexVector(docWithMergedMetadata);
-      }
-    }
+    return { ...doc, metadata };
   }
 
   /**
@@ -365,7 +416,76 @@ export class SearchEngine {
   async indexMany(docs: IndexDocument[], options?: IndexManyOptions): Promise<void> {
     const stopOnError = options?.stopOnError;
     const concurrency = options?.concurrency ?? DEFAULT_INDEX_MANY_CONCURRENCY;
-    await pMap(docs, doc => this.index(doc), { stopOnError, concurrency });
+
+    // A batch-capable embedder is only worth grouping for on the eager vector path. Lazy mode
+    // already batches at flush time, and a single-text embedder gains nothing from grouping.
+    const embedder = this.#vectorConfig?.embedder;
+    if (!embedder || this.#lazyVectorIndex || !isBatchEmbedder(embedder)) {
+      await pMap(docs, doc => this.index(doc), { stopOnError, concurrency });
+      return;
+    }
+
+    // Match the lazy path: a repeated id must not appear twice in one upsert payload.
+    const unique = this.#dedupeDocsLastWins(docs);
+
+    const groups = chunkItems(unique, resolveEmbedGroupSize(embedder));
+
+    if (stopOnError === false) {
+      // Contract: every document is processed and the call rejects with a flat `AggregateError`
+      // of the individual failures. Collect them here rather than letting a failed group reject,
+      // so the caller never sees an `AggregateError` nested inside another one.
+      const failures: unknown[] = [];
+      await pMap(
+        groups,
+        async group => {
+          const merged = this.#indexNonVectorPartsOf(group);
+          try {
+            await this.#embedAndUpsertGroup(merged);
+          } catch {
+            // One unusable document must not drop the rest of its group.
+            for (const doc of merged) {
+              try {
+                await this.#indexVector(doc);
+              } catch (error) {
+                failures.push(error);
+              }
+            }
+          }
+        },
+        { stopOnError: false, concurrency },
+      );
+      if (failures.length > 0) {
+        throw new AggregateError(failures);
+      }
+      return;
+    }
+
+    await pMap(groups, group => this.#embedAndUpsertGroup(this.#indexNonVectorPartsOf(group)), {
+      stopOnError,
+      concurrency,
+    });
+  }
+
+  /**
+   * BM25-index a group of documents as it is attempted.
+   *
+   * Keeping this inside the group task means a rejected `indexMany` leaves the keyword index in
+   * the same shape the per-document path would have: populated only for documents that indexing
+   * actually reached, rather than for every document handed in.
+   */
+  #indexNonVectorPartsOf(group: IndexDocument[]): IndexDocument[] {
+    return group.map(doc => this.#indexNonVectorParts(doc));
+  }
+
+  /**
+   * Collapse duplicate document ids so a single upsert runs per id (last entry wins).
+   */
+  #dedupeDocsLastWins(docs: readonly IndexDocument[]): IndexDocument[] {
+    const byId = new Map<string, IndexDocument>();
+    for (const doc of docs) {
+      byId.set(doc.id, doc);
+    }
+    return [...byId.values()];
   }
 
   /**
@@ -583,16 +703,14 @@ export class SearchEngine {
     const { embedder } = this.#vectorConfig;
 
     if (isBatchEmbedder(embedder)) {
-      const max = embedder.maxBatchSize;
-      if (max === undefined || texts.length <= max) {
+      // Same sanitized size the callers group by, so an unusable `maxBatchSize` can never turn
+      // this loop into a non-advancing one.
+      const max = resolveEmbedGroupSize(embedder);
+      if (texts.length <= max) {
         return embedder(texts);
       }
       // Chunk by maxBatchSize and run chunks in parallel up to DEFAULT_INDEX_MANY_CONCURRENCY.
-      const chunks: string[][] = [];
-      for (let i = 0; i < texts.length; i += max) {
-        chunks.push(texts.slice(i, i + max));
-      }
-      const results = await pMap(chunks, chunk => embedder(chunk), {
+      const results = await pMap(chunkItems(texts, max), chunk => embedder(chunk), {
         concurrency: DEFAULT_INDEX_MANY_CONCURRENCY,
       });
       return results.flat();
@@ -649,14 +767,14 @@ export class SearchEngine {
   /**
    * Embed and upsert a batch of documents in as few provider calls as possible.
    *
-   * - If the embedder is batch-capable, all texts go through a single embedder
-   *   call (chunked by `maxBatchSize`), then a single `upsert` with all vectors.
+   * - If the embedder is batch-capable, texts are grouped into `maxBatchSize` embedder calls
+   *   and written with upserts bounded by {@link MAX_VECTORS_PER_UPSERT}.
    * - Otherwise falls back to per-doc embedding via {@link SearchEngine.#indexVector}.
    */
   async #flushVectorBatch(docs: IndexDocument[]): Promise<void> {
     if (!this.#vectorConfig || docs.length === 0) return;
 
-    const { vectorStore, embedder, indexName } = this.#vectorConfig;
+    const { embedder } = this.#vectorConfig;
 
     if (!isBatchEmbedder(embedder)) {
       // Single-text embedder: parallelize per-doc work, preserving prior semantics.
@@ -665,6 +783,29 @@ export class SearchEngine {
       });
       return;
     }
+
+    const groups = chunkItems(docs, resolveEmbedGroupSize(embedder));
+
+    // The first group runs alone so `createIndex` happens once, before any parallel writes.
+    await this.#embedAndUpsertGroup(groups[0]!);
+    if (groups.length > 1) {
+      await pMap(groups.slice(1), group => this.#embedAndUpsertGroup(group), {
+        concurrency: DEFAULT_INDEX_MANY_CONCURRENCY,
+      });
+    }
+  }
+
+  /**
+   * Embed one group of documents with a single embedder call, then write the vectors using
+   * upserts no larger than {@link MAX_VECTORS_PER_UPSERT}.
+   *
+   * Vectors are paired with their documents positionally, so the embedder must return exactly
+   * one embedding per input in input order.
+   */
+  async #embedAndUpsertGroup(docs: IndexDocument[]): Promise<void> {
+    if (!this.#vectorConfig || docs.length === 0) return;
+
+    const { vectorStore, indexName } = this.#vectorConfig;
 
     const embeddings = await this.#embedAll(docs.map(d => d.content));
     if (embeddings.length !== docs.length) {
@@ -680,29 +821,23 @@ export class SearchEngine {
       }
     }
 
-    await vectorStore.upsert({
-      indexName,
-      vectors: embeddings,
-      metadata: docs.map(doc => ({
-        id: doc.id,
-        text: doc.content,
-        ...doc.metadata,
-      })),
-      ids: docs.map(d => d.id),
-    });
+    for (let start = 0; start < docs.length; start += MAX_VECTORS_PER_UPSERT) {
+      const slice = docs.slice(start, start + MAX_VECTORS_PER_UPSERT);
+      await vectorStore.upsert({
+        indexName,
+        vectors: embeddings.slice(start, start + MAX_VECTORS_PER_UPSERT),
+        metadata: slice.map(doc => ({
+          id: doc.id,
+          text: doc.content,
+          ...doc.metadata,
+        })),
+        ids: slice.map(d => d.id),
+      });
 
-    this.#vectorIndexReady = true;
-  }
-
-  /**
-   * Collapse duplicate document ids so a single deterministic upsert runs per id (last queue entry wins).
-   */
-  #dedupePendingVectorDocsLastWins(docs: readonly IndexDocument[]): IndexDocument[] {
-    const byId = new Map<string, IndexDocument>();
-    for (const doc of docs) {
-      byId.set(doc.id, doc);
+      // Mark index as ready only after a successful upsert so createIndex is retried
+      // on subsequent writes if the previous attempt did not produce a usable index.
+      this.#vectorIndexReady = true;
     }
-    return [...byId.values()];
   }
 
   /**
@@ -726,7 +861,7 @@ export class SearchEngine {
       const batch = this.#pendingVectorDocs;
       this.#pendingVectorDocs = [];
 
-      const uniqueDocs = this.#dedupePendingVectorDocsLastWins(batch);
+      const uniqueDocs = this.#dedupeDocsLastWins(batch);
 
       try {
         await this.#flushVectorBatch(uniqueDocs);

--- a/packages/core/src/workspace/search/search-engine.ts
+++ b/packages/core/src/workspace/search/search-engine.ts
@@ -429,41 +429,43 @@ export class SearchEngine {
     const unique = this.#dedupeDocsLastWins(docs);
 
     const groups = chunkItems(unique, resolveEmbedGroupSize(embedder));
+    if (groups.length === 0) return;
 
-    if (stopOnError === false) {
-      // Contract: every document is processed and the call rejects with a flat `AggregateError`
-      // of the individual failures. Collect them here rather than letting a failed group reject,
-      // so the caller never sees an `AggregateError` nested inside another one.
-      const failures: unknown[] = [];
-      await pMap(
-        groups,
-        async group => {
-          const merged = this.#indexNonVectorPartsOf(group);
-          try {
-            await this.#embedAndUpsertGroup(merged);
-          } catch {
-            // One unusable document must not drop the rest of its group.
-            for (const doc of merged) {
-              try {
-                await this.#indexVector(doc);
-              } catch (error) {
-                failures.push(error);
-              }
-            }
-          }
-        },
-        { stopOnError: false, concurrency },
-      );
-      if (failures.length > 0) {
-        throw new AggregateError(failures);
+    // Contract for `stopOnError: false`: every document is processed and the call rejects with a
+    // flat `AggregateError` of the individual failures. Collect them here rather than letting a
+    // failed group reject, so the caller never sees an `AggregateError` nested inside another one.
+    const failures: unknown[] = [];
+    const runGroup = async (group: IndexDocument[]) => {
+      const merged = this.#indexNonVectorPartsOf(group);
+      if (stopOnError !== false) {
+        await this.#embedAndUpsertGroup(merged);
+        return;
       }
-      return;
+      try {
+        await this.#embedAndUpsertGroup(merged);
+      } catch {
+        // One unusable document must not drop the rest of its group.
+        for (const doc of merged) {
+          try {
+            await this.#indexVector(doc);
+          } catch (error) {
+            failures.push(error);
+          }
+        }
+      }
+    };
+
+    // The first group runs alone so `createIndex` completes before any parallel writes, matching
+    // what the lazy flush does. Otherwise every concurrent group sees `#vectorIndexReady === false`
+    // and upserts against an index that may still be under construction.
+    await runGroup(groups[0]!);
+    if (groups.length > 1) {
+      await pMap(groups.slice(1), runGroup, { stopOnError, concurrency });
     }
 
-    await pMap(groups, group => this.#embedAndUpsertGroup(this.#indexNonVectorPartsOf(group)), {
-      stopOnError,
-      concurrency,
-    });
+    if (failures.length > 0) {
+      throw new AggregateError(failures);
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

`SearchEngine` only reaches its batch embedding path when it runs in lazy mode, and `Workspace` builds its engine without `lazyVectorIndex`:

```ts
// packages/core/src/workspace/workspace.ts
this._searchEngine = new SearchEngine({
  bm25: config.bm25 ? parseBM25Config(config.bm25) : undefined,
  vector: config.vectorStore && config.embedder ? { ... } : undefined,
});   // no lazyVectorIndex -> defaults to false
```

So `indexFilesForSearch` -> `indexMany` -> `index` -> `#indexVector` -> `#embedOne`, which calls `embedder([text])` once per document. `#embedAll` / `#flushVectorBatch` / `maxBatchSize` are never reached, even though `docs/.../workspace/search.mdx` tells users that "Mastra checks for that property at runtime and switches to the batched path".

Measured against a `SearchEngine` built the way `Workspace` builds it, with `maxBatchSize: 256`:

| documents | embedder calls before | after |
| --- | --- | --- |
| 500 | 500 (all of size 1) | 2 |

Before:

```ts
async indexMany(docs: IndexDocument[], options?: IndexManyOptions): Promise<void> {
  const stopOnError = options?.stopOnError;
  const concurrency = options?.concurrency ?? DEFAULT_INDEX_MANY_CONCURRENCY;
  await pMap(docs, doc => this.index(doc), { stopOnError, concurrency });
}
```

After: when the configured embedder is batch-capable and the engine is eager, documents are grouped into batched embedder calls. Lazy mode, single-text embedders and single-document `index()` keep their existing paths.

### Vector writes are bounded

Routing the default path into code that previously only ran in lazy mode would have replaced per-document upserts with one unbounded write request. Each document's metadata carries its full text (`DEFAULT_MAX_CHUNK_CHARS` is 4000), so a large rebuild would build a very large payload, and several stores cap request size — `PineconeVector` already slices at 100 for exactly this reason, while `upstash`, `vectorize` and `s3vectors` do not slice at all.

An `upsert` now carries at most `min(maxBatchSize, 100)` vectors. This also bounds lazy-mode flushes, which previously issued a single `upsert` for the whole queue.

### Behaviour notes

- **`concurrency`** now counts indexing units rather than documents: a unit is one document, or one group of up to `maxBatchSize` documents sharing an embedder call. The JSDoc was updated to say so rather than leaving it inaccurate.
- **`stopOnError: false`** keeps its documented contract — every document is processed, and the call rejects with a single flat `AggregateError` of the individual failures. A failed group is retried document by document so one unusable document does not drop the rest of its group.
- **BM25** stays per document and in input order, and runs as each group is attempted, so a rejected `indexMany` does not leave the keyword index holding documents the vector half never reached.
- **Unusable `maxBatchSize`** (`0`, negative, `NaN` — easy to produce with `Number(process.env.…)`) now falls back to the default group size. Previously `0` made the chunk loop stop advancing and `NaN` produced an empty group set, so indexing either hung or reported success while writing nothing.
- **`createIndex` concurrency on the eager path is unchanged** — it could already run once per in-flight unit before this change, and still can. Only the lazy path serialises its first group, as it did before.

### Test change

`chunks pending docs by maxBatchSize when configured` asserted "Single upsert with all 5 vectors". Since upserts are now bounded, it asserts the new count exactly and additionally checks that every id reaches the store.

## Related issue(s)

Fixes #21066

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Verified with

```
pnpm --filter ./packages/core exec vitest run src/workspace/search/   # 148 passed
pnpm --filter ./packages/core check                                   # clean
npx oxlint packages/core/src/workspace/search/                        # clean
```

The gate test fails without the source change (`expected 2 embedder calls, got 500`), and the alignment test was checked against an injected transposition of two embeddings to confirm it detects misordering.

`packages/core/src/workspace/workspace.test.ts` and `workspace-skills.test.ts` do not run on my machine — `gray-matter@4` resolves to `js-yaml@5` through the repo-wide `js-yaml: ^5.2.2` override in `pnpm-workspace.yaml`, and fails at import. That is pre-existing and unrelated to this change, but it means the `Workspace`-level assertions here rest on reading the code rather than running it, and CI is the judge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Workspace search now sends documents to the embedder in groups instead of one at a time. This reduces embedding requests while preserving BM25 order and reliable indexing.

## Changes

- Adds eager-path batching to `SearchEngine.indexMany`.
- Groups documents by `maxBatchSize`.
- Limits vector upserts to `min(maxBatchSize, 100)`.
- Preserves per-document BM25 indexing and input order.
- Serializes the first eager indexing group before parallel vector writes.
- Deduplicates document IDs with last-write-wins behavior.
- Continues processing after group failures when `stopOnError` is `false`.
- Reports individual failures in a flat `AggregateError`.
- Uses the default batch size for invalid values such as `0`, negative numbers, and `NaN`.
- Updates `concurrency` documentation to describe indexing units.
- Updates lazy batching to use the same grouped embedding and upsert behavior.
- Adds tests for batching, ordering, duplicate IDs, failures, partial indexing, invalid batch sizes, empty input, index creation ordering, and bounded writes.
- Adds release notes for the Workspace indexing improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->