### PR TITLE
fix(core): reconcile client-echoed message history against stored records

### DIFF
--- a/.changeset/calm-echoes-bounce.md
+++ b/.changeset/calm-echoes-bounce.md
@@ -2,6 +2,6 @@
 '@mastra/core': patch
 ---
 
-Reconcile client-echoed messages by stored record ID before persisting.
+Reconcile client-echoed messages by stored record ID before persisting in standard and observational memory flows.
 
 Unchanged echoes are not persisted again. Lossy client copies can no longer replace server content. Output-processor transformations, tool history, and metadata are retained. Only supported client-authored transitions are merged, such as a tool call advancing from `call` to `result`. Fixes [#20836](https://github.com/mastra-ai/mastra/issues/20836).

--- a/.changeset/calm-echoes-bounce.md
+++ b/.changeset/calm-echoes-bounce.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix client-echoed message history silently overwriting canonical stored messages. When a client submits its visible transcript back on a later turn, previously-persisted messages are now reconciled against the stored record by ID (instead of the recall window): unchanged echoes are no longer re-persisted, and only supported client-authored transitions — such as a client-side tool result advancing a stored `call` to `result` — are merged into the stored version, preserving output-processor transformations, tool history, and server-authored metadata. Fixes [#20836](https://github.com/mastra-ai/mastra/issues/20836).

--- a/.changeset/calm-echoes-bounce.md
+++ b/.changeset/calm-echoes-bounce.md
@@ -2,4 +2,6 @@
 '@mastra/core': patch
 ---
 
-Fix client-echoed message history silently overwriting canonical stored messages. When a client submits its visible transcript back on a later turn, previously-persisted messages are now reconciled against the stored record by ID (instead of the recall window): unchanged echoes are no longer re-persisted, and only supported client-authored transitions — such as a client-side tool result advancing a stored `call` to `result` — are merged into the stored version, preserving output-processor transformations, tool history, and server-authored metadata. Fixes [#20836](https://github.com/mastra-ai/mastra/issues/20836).
+Reconcile client-echoed messages by stored record ID before persisting.
+
+Unchanged echoes are not persisted again. Lossy client copies can no longer replace server content. Output-processor transformations, tool history, and metadata are retained. Only supported client-authored transitions are merged, such as a tool call advancing from `call` to `result`. Fixes [#20836](https://github.com/mastra-ai/mastra/issues/20836).

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -26,6 +26,12 @@ Sending the full history is redundant because Mastra loads messages from storage
 For an AI SDK example, see [Using Mastra Memory](/integrations/agentic-ui/ai-sdk-ui#using-mastra-memory).
 :::
 
+:::info
+If your client does echo the full transcript back, Mastra reconciles those messages against the stored records by ID before saving them.
+
+An unchanged echo isn't persisted again, and a lossy client copy can't replace server-authored content such as output-processor transformations or completed tool history. Only supported client-authored transitions are merged into the stored message, for example a client-side tool result that advances a stored tool call from `call` to `result`.
+:::
+
 ## Threads and resources
 
 Mastra organizes conversations using two identifiers:

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -29,7 +29,7 @@ For an AI SDK example, see [Using Mastra Memory](/integrations/agentic-ui/ai-sdk
 :::info
 If your client does echo the full transcript back, Mastra reconciles those messages against the stored records by ID before saving them.
 
-An unchanged echo isn't persisted again, and a lossy client copy can't replace server-authored content such as output-processor transformations or completed tool history. Only supported client-authored transitions are merged into the stored message, for example a client-side tool result that advances a stored tool call from `call` to `result`.
+An unchanged echo isn't persisted again, and a lossy client copy can't replace server-authored content such as output-processor transformations or completed tool history. The only client-authored change that merges into a stored message is a tool result advancing a stored tool call from `call` to `result`; the tool name, call id, and args always come from the stored record, and echo-only metadata keys are dropped. User messages stay client-authored: an edited re-send replaces the stored copy.
 :::
 
 ## Threads and resources

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -27,9 +27,16 @@ For an AI SDK example, see [Using Mastra Memory](/integrations/agentic-ui/ai-sdk
 :::
 
 :::info
-If your client does echo the full transcript back, Mastra reconciles those messages against the stored records by ID before saving them.
+If your client does echo the full transcript back, Mastra attempts to reconcile those messages against stored records with the same ID and thread before saving them. When the request includes a resource, the stored resource must also match. Records from another thread or requested resource never take part in reconciliation.
 
-An unchanged echo isn't persisted again, and a lossy client copy can't replace server-authored content such as output-processor transformations or completed tool history. The only client-authored change that merges into a stored message is a tool result advancing a stored tool call from `call` to `result`; the tool name, call id, and args always come from the stored record, and echo-only metadata keys are dropped. User messages stay client-authored: an edited re-send replaces the stored copy.
+When the lookup succeeds, an unchanged echo isn't persisted again, and a lossy client copy can't replace server-authored content such as output-processor transformations or completed tool history. A stored tool invocation in `call` state accepts only these client-authored terminal transitions:
+
+- `result`: The client contributes `state` and `result`. A v4-style error result can also contribute `isError` and `errorText`.
+- `output-error`: The client contributes `state` and `errorText` for a v6 error.
+
+The tool name, call ID, and args always come from the stored record. Echo-only metadata and other client fields are dropped. User messages stay client-authored, so an edited resend replaces the stored copy.
+
+The stored-record lookup is best effort. If it isn't available, Mastra saves the original input and output instead of aborting persistence. Sending only the new message remains the recommended client behavior.
 :::
 
 ## Threads and resources

--- a/docs/src/content/en/integrations/agentic-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/integrations/agentic-ui/ai-sdk-ui.mdx
@@ -283,7 +283,7 @@ Set `memory.thread` and `memory.resource` from your app's own state, such as URL
 
 ### When a client echoes the full transcript
 
-If a client does echo the full transcript back, Mastra keeps the stored history correct: it reconciles each echoed message against the stored record with the same ID before saving. An unchanged echo isn't persisted again, and a lossy client copy can't replace server-authored content such as output-processor transformations or completed tool history. Only supported client-authored transitions merge into the stored message, for example a client-side tool result that advances a stored tool call from `call` to `result`.
+If a client does echo the full transcript back, Mastra keeps the stored history correct: it reconciles each echoed message against the stored record with the same ID before saving. An unchanged echo isn't persisted again, and a lossy client copy can't replace server-authored content such as output-processor transformations or completed tool history. Only a client-side tool result merging into a stored tool call is accepted, and for user messages an edited re-send replaces the stored copy.
 
 See [Message history](/docs/memory/message-history) for more on how Mastra memory loads and stores messages.
 

--- a/docs/src/content/en/integrations/agentic-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/integrations/agentic-ui/ai-sdk-ui.mdx
@@ -281,6 +281,10 @@ const { messages, sendMessage } = useChat({
 
 Set `memory.thread` and `memory.resource` from your app's own state, such as URL params, auth context, or your database.
 
+### When a client echoes the full transcript
+
+If a client does echo the full transcript back, Mastra keeps the stored history correct: it reconciles each echoed message against the stored record with the same ID before saving. An unchanged echo isn't persisted again, and a lossy client copy can't replace server-authored content such as output-processor transformations or completed tool history. Only supported client-authored transitions merge into the stored message, for example a client-side tool result that advances a stored tool call from `call` to `result`.
+
 See [Message history](/docs/memory/message-history) for more on how Mastra memory loads and stores messages.
 
 [`chatRoute()`](/reference/ai-sdk/chat-route) and [`handleChatStream()`](/reference/ai-sdk/handle-chat-stream) already work with memory. Configure the client to send only the new message and include the thread and resource identifiers.

--- a/docs/src/content/en/integrations/agentic-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/integrations/agentic-ui/ai-sdk-ui.mdx
@@ -283,7 +283,14 @@ Set `memory.thread` and `memory.resource` from your app's own state, such as URL
 
 ### When a client echoes the full transcript
 
-If a client does echo the full transcript back, Mastra keeps the stored history correct: it reconciles each echoed message against the stored record with the same ID before saving. An unchanged echo isn't persisted again, and a lossy client copy can't replace server-authored content such as output-processor transformations or completed tool history. Only a client-side tool result merging into a stored tool call is accepted, and for user messages an edited re-send replaces the stored copy.
+If a client does echo the full transcript back, Mastra attempts to reconcile each message against the stored record with the same ID and thread. When the request includes a resource, the stored resource must also match. If the lookup succeeds, unchanged echoes aren't persisted again, and lossy client copies can't replace server-authored content such as output-processor transformations or completed tool history.
+
+A stored tool invocation in `call` state accepts two client-authored terminal transitions:
+
+- `result`: The client contributes `state` and `result`. A v4-style error result can also contribute `isError` and `errorText`.
+- `output-error`: The client contributes `state` and `errorText` for a v6 error.
+
+The stored tool name, call ID, and args remain unchanged, and other client-supplied fields are dropped. For user messages, an edited resend replaces the stored copy. If the stored-record lookup fails, Mastra saves the original input and output instead of aborting persistence, which is why sending only the new message remains recommended.
 
 See [Message history](/docs/memory/message-history) for more on how Mastra memory loads and stores messages.
 

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -1238,6 +1238,53 @@ describe('MessageHistory', () => {
       saveSpy.mockRestore();
     });
 
+    it('should preserve a deliberately emptied stored content string against an echo', async () => {
+      // The server emptied the content string (e.g. a redaction pass); an empty
+      // string is a stored value, not an absent one. The part list keeps the
+      // stored shape so the record itself still exists.
+      const stored = assistantMessage({
+        content: { format: 2, content: '', parts: [{ type: 'text', text: '' }] },
+      });
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      // The client echoes an older copy that still carries the pre-redaction text.
+      const staleEcho = assistantMessage({
+        content: { format: 2, content: 'Transformed answer', parts: [{ type: 'text', text: 'Transformed answer' }] },
+      });
+      const newUserMessage = assistantMessage({
+        id: 'msg-2',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Next turn' }] },
+        createdAt: new Date(baseTime),
+      });
+
+      const messageList = new MessageList().add([staleEcho, newUserMessage], 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      // The emptied stored string survives: a falsy-but-present stored value must
+      // not be refilled from the client echo.
+      expect(saveSpy).toHaveBeenCalledWith({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'msg-1',
+            content: expect.objectContaining({ content: '', parts: [{ type: 'text', text: '' }] }),
+          }),
+          expect.objectContaining({ id: 'msg-2' }),
+        ]),
+      });
+
+      saveSpy.mockRestore();
+    });
+
     it('should merge a client-side tool result into the stored call message', async () => {
       const stored = assistantMessage({
         content: {

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -1226,6 +1226,15 @@ describe('MessageHistory', () => {
         ]),
       });
 
+      // The client's raw copy is not persisted anywhere: the stored server text
+      // is the only text part, and the tool history survives intact.
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      const savedMsg1 = savedMessages.find(m => m.id === 'msg-1')!;
+      expect(savedMsg1.content.parts.filter((p: any) => p.type === 'text').map((p: any) => p.text)).toEqual([
+        'Transformed answer',
+      ]);
+      expect(savedMsg1.content.parts.filter((p: any) => p.type === 'tool-invocation')).toHaveLength(1);
+
       saveSpy.mockRestore();
     });
 
@@ -1297,6 +1306,311 @@ describe('MessageHistory', () => {
         toolName: 'search',
         result: 'result-from-client',
         args: { query: 'mastra' },
+      });
+
+      saveSpy.mockRestore();
+    });
+
+    it('should never adopt client-supplied toolName or client-injected args keys', async () => {
+      const stored = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Let me look that up',
+          parts: [
+            { type: 'text', text: 'Let me look that up' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'call',
+                toolCallId: 'call-1',
+                toolName: 'search',
+                args: { query: 'mastra' },
+              },
+            },
+          ],
+        },
+      });
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      // The client echo returns the invocation with a different toolName and
+      // extra args keys the server call never had.
+      const echoWithResult = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Let me look that up',
+          parts: [
+            { type: 'text', text: 'Let me look that up' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-1',
+                toolName: 'other-tool',
+                args: { query: 'client-modified', injected: 'key' },
+                result: 'result-from-client',
+              },
+            },
+          ],
+        },
+      });
+
+      const messageList = new MessageList().add([echoWithResult], 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      const savedMsg1 = savedMessages.find(m => m.id === 'msg-1');
+      const toolPart = savedMsg1!.content.parts.find((p: any) => p.type === 'tool-invocation')!;
+
+      // Only `state` and `result` are taken from the client: the server-authored
+      // toolName and args (exactly, without injected keys) survive.
+      expect(toolPart.toolInvocation).toEqual({
+        state: 'result',
+        toolCallId: 'call-1',
+        toolName: 'search',
+        args: { query: 'mastra' },
+        result: 'result-from-client',
+      });
+
+      saveSpy.mockRestore();
+    });
+
+    it('should not adopt client tool history when the stored message has no legacy toolInvocations', async () => {
+      const stored = assistantMessage({
+        content: { format: 2, content: 'Answer', parts: [{ type: 'text', text: 'Answer' }] },
+      });
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      // The client copy carries a legacy toolInvocations array the server never stored.
+      const echo = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Answer',
+          parts: [{ type: 'text', text: 'Answer' }],
+          toolInvocations: [
+            {
+              state: 'result',
+              toolCallId: 'call-1',
+              toolName: 'search',
+              args: { query: 'x' },
+              result: 'found',
+            },
+          ],
+        } as any,
+      });
+
+      const messageList = new MessageList().add([echo], 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      const savedMsg1 = savedMessages.find(m => m.id === 'msg-1');
+      expect(savedMsg1!.content.toolInvocations).toBeUndefined();
+
+      saveSpy.mockRestore();
+    });
+
+    it('should drop echo-only metadata keys', async () => {
+      const stored = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Answer',
+          parts: [{ type: 'text', text: 'Answer' }],
+          metadata: { sealed: true },
+        },
+      });
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      // The echo pre-seeds a metadata key the server never set.
+      const echo = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Answer',
+          parts: [{ type: 'text', text: 'Answer' }],
+          metadata: { sealed: true, clientSeeded: 'x' },
+        },
+      });
+
+      const messageList = new MessageList().add([echo], 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      const savedMsg1 = savedMessages.find(m => m.id === 'msg-1');
+      expect(savedMsg1!.content.metadata).toEqual({ sealed: true });
+
+      saveSpy.mockRestore();
+    });
+
+    it('should not accept incoming-only parts regardless of position', async () => {
+      const stored = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Let me look that up',
+          parts: [
+            { type: 'text', text: 'Let me look that up' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-1',
+                toolName: 'search',
+                args: { query: 'mastra' },
+                result: 'found',
+              },
+            },
+          ],
+        },
+      });
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      // The echo carries two text parts the stored message never had: one at a
+      // position where the stored array has a part, one at a tail index. Under a
+      // positional rule the tail one would survive while the other is dropped —
+      // the rule must be position-independent: incoming-only parts are never
+      // accepted.
+      const echo = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Let me look that up',
+          parts: [
+            { type: 'text', text: 'Let me look that up' },
+            { type: 'text', text: 'New client part 1' },
+            { type: 'text', text: 'New client part 2' },
+          ],
+        },
+      });
+
+      const messageList = new MessageList().add([echo], 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      const savedMsg1 = savedMessages.find(m => m.id === 'msg-1');
+      const savedTexts = savedMsg1!.content.parts.filter((p: any) => p.type === 'text').map((p: any) => p.text);
+      expect(savedTexts).toEqual(['Let me look that up']);
+
+      saveSpy.mockRestore();
+    });
+
+    it('should keep an edited user message and skip an unchanged user echo', async () => {
+      const stored = {
+        id: 'msg-1',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Original question' }] },
+        threadId: 'thread-1',
+        createdAt: new Date(baseTime - 1000),
+      } as MastraDBMessage;
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      const edited = {
+        ...stored,
+        content: { format: 2, parts: [{ type: 'text', text: 'Edited question' }] },
+      } as MastraDBMessage;
+      const messageList = new MessageList().add([edited], 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      // The client is the author of user messages: the edit is persisted as-is
+      // instead of being discarded by the server-wins merge.
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      expect(savedMessages.map(m => m.id)).toEqual(['msg-1']);
+      expect(savedMessages[0]!.content.parts.map((p: any) => ({ type: p.type, text: p.text }))).toEqual([
+        { type: 'text', text: 'Edited question' },
+      ]);
+
+      // An unchanged re-send of the same user message is still recognized as a
+      // stale echo and not re-persisted.
+      const unchanged = { ...stored } as MastraDBMessage;
+      const messageList2 = new MessageList().add([unchanged], 'input');
+      await processor.processOutputResult({
+        messageList: messageList2,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+      expect(saveSpy.mock.calls.length).toBe(1);
+
+      saveSpy.mockRestore();
+    });
+
+    it('should treat an echoed ID from another thread as a fresh message', async () => {
+      const foreign = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Other thread answer',
+          parts: [{ type: 'text', text: 'Other thread answer' }],
+        },
+        threadId: 'thread-2',
+      });
+      mockStorage.setMessages([foreign]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      const echo = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Other thread answer',
+          parts: [{ type: 'text', text: 'Other thread answer' }],
+        },
+        threadId: 'thread-1',
+      });
+
+      const messageList = new MessageList().add([echo], 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      // msg-1 resolves to thread-2's record, which is not canonical for this
+      // thread: the echo is persisted as-is (fresh message), neither suppressed
+      // as an "unchanged echo" nor merged under the foreign thread's IDs.
+      expect(saveSpy).toHaveBeenCalledWith({
+        messages: [expect.objectContaining({ id: 'msg-1', threadId: 'thread-1' })],
       });
 
       saveSpy.mockRestore();

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -1857,6 +1857,37 @@ describe('MessageHistory', () => {
       saveSpy.mockRestore();
     });
 
+    it('should not let a client change the role of a stored user message', async () => {
+      const stored = {
+        id: 'msg-1',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Canonical question' }] },
+        threadId: 'thread-1',
+        createdAt: new Date(baseTime - 1000),
+      } as MastraDBMessage;
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+      const roleChangedEcho = {
+        ...stored,
+        role: 'assistant',
+        content: { format: 2, parts: [{ type: 'text', text: 'Client replacement' }] },
+      } as MastraDBMessage;
+
+      await processor.processOutputResult({
+        messageList: new MessageList().add([roleChangedEcho], 'input'),
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      expect(savedMessages).toEqual([stored]);
+
+      saveSpy.mockRestore();
+    });
+
     it('should treat an echoed ID from another thread as a fresh message', async () => {
       const foreign = assistantMessage({
         content: {

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -1311,10 +1311,16 @@ describe('MessageHistory', () => {
       saveSpy.mockRestore();
     });
 
-    it('should persist the original input and output when the stored-record lookup fails', async () => {
+    it('should record a stored-record lookup failure and persist the original input and output', async () => {
       processor = new MessageHistory({ storage: mockStorage });
-      vi.spyOn(mockStorage, 'listMessagesById').mockRejectedValueOnce(new Error('lookup unavailable'));
+      const lookupError = new Error('lookup unavailable');
+      vi.spyOn(mockStorage, 'listMessagesById').mockRejectedValueOnce(lookupError);
       const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+      const lookupSpan = { end: vi.fn(), error: vi.fn() };
+      const saveSpan = { end: vi.fn(), error: vi.fn() };
+      const currentSpan = {
+        createChildSpan: vi.fn().mockReturnValueOnce(lookupSpan).mockReturnValueOnce(saveSpan),
+      };
 
       const input = assistantMessage({
         id: 'msg-input',
@@ -1332,9 +1338,20 @@ describe('MessageHistory', () => {
         messages: [],
         abort: mockAbort,
         requestContext: createRuntimeContextWithMemory('thread-1'),
+        tracingContext: { currentSpan } as any,
       });
 
+      expect(currentSpan.createChildSpan).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          name: 'memory: recall',
+          input: { messageIds: ['msg-input'] },
+          attributes: { operationType: 'recall', messageCount: 1 },
+        }),
+      );
+      expect(lookupSpan.error).toHaveBeenCalledWith({ error: lookupError, endSpan: true });
       expect(saveSpy).toHaveBeenCalledWith({ messages: [input, output] });
+      expect(saveSpan.end).toHaveBeenCalledWith({ output: { success: true } });
 
       saveSpy.mockRestore();
     });

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -9,6 +9,7 @@ import { MemoryStorage } from '../../storage';
 import type { StorageListThreadsInput, StorageListThreadsOutput } from '../../storage/types';
 
 import { MessageHistory } from './message-history.js';
+import { CLIENT_CONTRIBUTABLE_TERMINAL_FIELDS } from './reconcile-client-echoes.js';
 
 // Helper to create RequestContext with memory context
 function createRuntimeContextWithMemory(threadId: string, resourceId?: string): RequestContext {
@@ -1950,6 +1951,92 @@ describe('MessageHistory', () => {
       });
 
       saveSpy.mockRestore();
+    });
+
+    it('should not adopt tool-invocation fields outside the terminal whitelist', async () => {
+      const stored = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Let me look that up',
+          parts: [
+            { type: 'text', text: 'Let me look that up' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'call',
+                toolCallId: 'call-1',
+                toolName: 'search',
+                args: { query: 'mastra' },
+              },
+            },
+          ],
+        },
+      });
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      // The client echo advances the call to a result but also smuggles a
+      // server-authored-only field (`rawInput`) and an `approval` object the
+      // server never stored. Neither is part of the client-contributable
+      // whitelist, so neither may reach the persisted record.
+      const echoWithResult = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Let me look that up',
+          parts: [
+            { type: 'text', text: 'Let me look that up' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-1',
+                toolName: 'search',
+                args: { query: 'mastra' },
+                result: 'result-from-client',
+                rawInput: { query: 'client-injected-raw-input' },
+                approval: { id: 'client-approval', approved: true },
+              },
+            },
+          ],
+        },
+      });
+
+      const messageList = new MessageList().add([echoWithResult], 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      const savedMsg1 = savedMessages.find(m => m.id === 'msg-1');
+      const toolPart = savedMsg1!.content.parts.find((pp: any) => pp.type === 'tool-invocation')!;
+
+      // Only the whitelisted terminal field (`result`) is taken from the client;
+      // `rawInput` and `approval` are dropped.
+      expect(toolPart.toolInvocation).toEqual({
+        state: 'result',
+        toolCallId: 'call-1',
+        toolName: 'search',
+        args: { query: 'mastra' },
+        result: 'result-from-client',
+      });
+
+      saveSpy.mockRestore();
+    });
+
+    it('codifies the client-contributable terminal-field whitelist as an explicit constant', () => {
+      // This guard fails loudly if the client-contributable surface is ever
+      // widened silently: any new key here is a new field a client echo could
+      // overwrite on a server-authored tool call.
+      expect(CLIENT_CONTRIBUTABLE_TERMINAL_FIELDS).toEqual({
+        result: ['result', 'isError', 'errorText'],
+        'output-error': ['errorText'],
+      });
     });
   });
 });

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -1422,6 +1422,66 @@ describe('MessageHistory', () => {
       saveSpy.mockRestore();
     });
 
+    it('should preserve v4 error fields in the legacy toolInvocations result path', async () => {
+      const stored = assistantMessage({
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Searching' }],
+          toolInvocations: [
+            {
+              state: 'call',
+              toolCallId: 'call-1',
+              toolName: 'search',
+              args: { query: 'mastra' },
+            },
+          ],
+        },
+      });
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+      const echoWithError = assistantMessage({
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Searching' }],
+          toolInvocations: [
+            {
+              state: 'result',
+              toolCallId: 'call-1',
+              toolName: 'client-tool-name',
+              args: { query: 'client-modified', injected: true },
+              result: 'Search failed',
+              isError: true,
+              errorText: 'Search failed',
+            },
+          ],
+        },
+      });
+
+      await processor.processOutputResult({
+        messageList: new MessageList().add([echoWithError], 'input'),
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      expect(savedMessages[0]!.content.toolInvocations).toEqual([
+        {
+          state: 'result',
+          toolCallId: 'call-1',
+          toolName: 'search',
+          args: { query: 'mastra' },
+          result: 'Search failed',
+          isError: true,
+          errorText: 'Search failed',
+        },
+      ]);
+
+      saveSpy.mockRestore();
+    });
+
     it('should preserve a v6 client-authored output error without accepting other client fields', async () => {
       const stored = assistantMessage({
         content: {

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -1109,4 +1109,197 @@ describe('MessageHistory', () => {
       expect(savedParts.map((p: any) => p.text)).toEqual(['Saved.', ' untouched ']);
     });
   });
+
+  describe('client echo reconciliation', () => {
+    const baseTime = Date.now();
+
+    function assistantMessage(overrides: Partial<MastraDBMessage> = {}): MastraDBMessage {
+      return {
+        id: 'msg-1',
+        role: 'assistant',
+        content: {
+          format: 2,
+          content: 'Transformed answer',
+          parts: [{ type: 'text', text: 'Transformed answer' }],
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(baseTime - 1000),
+        ...overrides,
+      };
+    }
+
+    it('should not re-persist an unchanged echo of a stored message', async () => {
+      const stored = assistantMessage();
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      const echo = assistantMessage();
+      const newUserMessage = assistantMessage({
+        id: 'msg-2',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Next turn' }] },
+        createdAt: new Date(baseTime),
+      });
+
+      const messageList = new MessageList().add([echo, newUserMessage], 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      // Only the genuinely new message is persisted — the echo of msg-1 is skipped
+      // so the upsert cannot overwrite the stored canonical record.
+      expect(saveSpy).toHaveBeenCalledWith({
+        messages: [expect.objectContaining({ id: 'msg-2' })],
+      });
+
+      saveSpy.mockRestore();
+    });
+
+    it('should preserve stored server-authored content when a lossy echo is submitted', async () => {
+      const stored = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Transformed answer',
+          parts: [
+            { type: 'text', text: 'Transformed answer' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-1',
+                toolName: 'search',
+                args: { q: 'x' },
+                result: 'found',
+              },
+            },
+          ],
+        },
+      });
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      // Client echoes the raw (un-transformed) text and drops the tool history.
+      const lossyEcho = assistantMessage({
+        content: { format: 2, content: 'Raw answer', parts: [{ type: 'text', text: 'Raw answer' }] },
+      });
+      const newUserMessage = assistantMessage({
+        id: 'msg-2',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Next turn' }] },
+        createdAt: new Date(baseTime),
+      });
+
+      const messageList = new MessageList().add([lossyEcho, newUserMessage], 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      // The stored (transformed) text and the completed tool history survive the echo.
+      expect(saveSpy).toHaveBeenCalledWith({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'msg-1',
+            content: expect.objectContaining({
+              content: 'Transformed answer',
+              parts: expect.arrayContaining([
+                expect.objectContaining({ type: 'text', text: 'Transformed answer' }),
+                expect.objectContaining({
+                  type: 'tool-invocation',
+                  toolInvocation: expect.objectContaining({ toolCallId: 'call-1', state: 'result', result: 'found' }),
+                }),
+              ]),
+            }),
+          }),
+          expect.objectContaining({ id: 'msg-2' }),
+        ]),
+      });
+
+      saveSpy.mockRestore();
+    });
+
+    it('should merge a client-side tool result into the stored call message', async () => {
+      const stored = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Let me look that up',
+          parts: [
+            { type: 'text', text: 'Let me look that up' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'call',
+                toolCallId: 'call-1',
+                toolName: 'search',
+                args: { query: 'mastra' },
+              },
+            },
+          ],
+        },
+      });
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      // Client executed the tool and returns the same assistant message ID with the
+      // invocation advanced to `result`, carrying client-side args that differ
+      // from the stored call's args (the client copy must not replace them).
+      const echoWithResult = assistantMessage({
+        content: {
+          format: 2,
+          content: 'Let me look that up',
+          parts: [
+            { type: 'text', text: 'Let me look that up' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-1',
+                toolName: 'search',
+                args: { query: 'client-modified' },
+                result: 'result-from-client',
+              },
+            },
+          ],
+        },
+      });
+
+      const messageList = new MessageList().add([echoWithResult], 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      const savedMsg1 = savedMessages.find(m => m.id === 'msg-1');
+      const toolPart = savedMsg1!.content.parts.find((p: any) => p.type === 'tool-invocation')!;
+
+      // The client-authored result is stored, but the server-authored args, name,
+      // and text are not discarded.
+      expect(toolPart.toolInvocation).toMatchObject({
+        state: 'result',
+        toolCallId: 'call-1',
+        toolName: 'search',
+        result: 'result-from-client',
+        args: { query: 'mastra' },
+      });
+
+      saveSpy.mockRestore();
+    });
+  });
 });

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -1311,6 +1311,164 @@ describe('MessageHistory', () => {
       saveSpy.mockRestore();
     });
 
+    it('should persist the original input and output when the stored-record lookup fails', async () => {
+      processor = new MessageHistory({ storage: mockStorage });
+      vi.spyOn(mockStorage, 'listMessagesById').mockRejectedValueOnce(new Error('lookup unavailable'));
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      const input = assistantMessage({
+        id: 'msg-input',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Next turn' }] },
+      });
+      const output = assistantMessage({
+        id: 'msg-output',
+        content: { format: 2, parts: [{ type: 'text', text: 'Next answer' }] },
+      });
+      const messageList = new MessageList().add([input], 'input').add([output], 'response');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      expect(saveSpy).toHaveBeenCalledWith({ messages: [input, output] });
+
+      saveSpy.mockRestore();
+    });
+
+    it('should preserve a v4 client-authored error result without accepting other client fields', async () => {
+      const stored = assistantMessage({
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'call',
+                toolCallId: 'call-1',
+                toolName: 'search',
+                args: { query: 'mastra' },
+              },
+            },
+          ],
+        },
+      });
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+      const echoWithError = assistantMessage({
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-1',
+                toolName: 'client-tool-name',
+                args: { query: 'client-modified', injected: true },
+                result: 'Search failed',
+                isError: true,
+                errorText: 'Search failed',
+                rawInput: { injected: true },
+              },
+            },
+          ],
+        },
+      });
+
+      await processor.processOutputResult({
+        messageList: new MessageList().add([echoWithError], 'input'),
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      const toolPart = savedMessages[0]!.content.parts.find(part => part.type === 'tool-invocation');
+      expect(toolPart?.type).toBe('tool-invocation');
+      if (toolPart?.type !== 'tool-invocation') throw new Error('Expected a tool-invocation part');
+      expect(toolPart.toolInvocation).toEqual({
+        state: 'result',
+        toolCallId: 'call-1',
+        toolName: 'search',
+        args: { query: 'mastra' },
+        result: 'Search failed',
+        isError: true,
+        errorText: 'Search failed',
+      });
+
+      saveSpy.mockRestore();
+    });
+
+    it('should preserve a v6 client-authored output error without accepting other client fields', async () => {
+      const stored = assistantMessage({
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'call',
+                toolCallId: 'call-1',
+                toolName: 'search',
+                args: { query: 'mastra' },
+              },
+            },
+          ],
+        },
+      });
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+      const echoWithError = assistantMessage({
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'output-error',
+                toolCallId: 'call-1',
+                toolName: 'client-tool-name',
+                args: { query: 'client-modified', injected: true },
+                errorText: 'Search failed',
+                result: 'client-result',
+                isError: false,
+                rawInput: { injected: true },
+              },
+            },
+          ],
+        },
+      });
+
+      await processor.processOutputResult({
+        messageList: new MessageList().add([echoWithError], 'input'),
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      const toolPart = savedMessages[0]!.content.parts.find(part => part.type === 'tool-invocation');
+      expect(toolPart?.type).toBe('tool-invocation');
+      if (toolPart?.type !== 'tool-invocation') throw new Error('Expected a tool-invocation part');
+      expect(toolPart.toolInvocation).toEqual({
+        state: 'output-error',
+        toolCallId: 'call-1',
+        toolName: 'search',
+        args: { query: 'mastra' },
+        errorText: 'Search failed',
+      });
+
+      saveSpy.mockRestore();
+    });
+
     it('should never adopt client-supplied toolName or client-injected args keys', async () => {
       const stored = assistantMessage({
         content: {
@@ -1370,8 +1528,9 @@ describe('MessageHistory', () => {
       const savedMsg1 = savedMessages.find(m => m.id === 'msg-1');
       const toolPart = savedMsg1!.content.parts.find((p: any) => p.type === 'tool-invocation')!;
 
-      // Only `state` and `result` are taken from the client: the server-authored
-      // toolName and args (exactly, without injected keys) survive.
+      // Only fields from a supported terminal transition are taken from the
+      // client. The server-authored toolName and args (exactly, without injected
+      // keys) survive.
       expect(toolPart.toolInvocation).toEqual({
         state: 'result',
         toolCallId: 'call-1',
@@ -1611,6 +1770,28 @@ describe('MessageHistory', () => {
       // as an "unchanged echo" nor merged under the foreign thread's IDs.
       expect(saveSpy).toHaveBeenCalledWith({
         messages: [expect.objectContaining({ id: 'msg-1', threadId: 'thread-1' })],
+      });
+
+      saveSpy.mockRestore();
+    });
+
+    it('should treat an echoed ID from another resource in the same thread as a fresh message', async () => {
+      const foreign = assistantMessage({ resourceId: 'resource-2' });
+      mockStorage.setMessages([foreign]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+      const echo = assistantMessage({ resourceId: 'resource-1' });
+
+      await processor.processOutputResult({
+        messageList: new MessageList().add([echo], 'input'),
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1', 'resource-1'),
+      });
+
+      expect(saveSpy).toHaveBeenCalledWith({
+        messages: [expect.objectContaining({ id: 'msg-1', threadId: 'thread-1', resourceId: 'resource-1' })],
       });
 
       saveSpy.mockRestore();

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -516,6 +516,7 @@ describe('MessageHistory', () => {
           metadata: {},
         }),
         listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        listMessagesById: vi.fn().mockResolvedValue({ messages: [] }),
         updateThread: vi.fn().mockResolvedValue(undefined),
       } as unknown as MemoryStorage;
 
@@ -614,6 +615,7 @@ describe('MessageHistory', () => {
           metadata: {},
         }),
         listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        listMessagesById: vi.fn().mockResolvedValue({ messages: [] }),
         updateThread: vi.fn().mockResolvedValue(undefined),
       } as unknown as MemoryStorage;
 
@@ -660,6 +662,7 @@ describe('MessageHistory', () => {
           metadata: {},
         }),
         listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        listMessagesById: vi.fn().mockResolvedValue({ messages: [] }),
         updateThread: vi.fn().mockResolvedValue(undefined),
       } as unknown as MemoryStorage;
 
@@ -708,6 +711,7 @@ describe('MessageHistory', () => {
           metadata: {},
         }),
         listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        listMessagesById: vi.fn().mockResolvedValue({ messages: [] }),
         updateThread: vi.fn().mockResolvedValue(undefined),
       } as unknown as MemoryStorage;
 
@@ -838,6 +842,7 @@ describe('MessageHistory', () => {
           metadata: {},
         }),
         listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        listMessagesById: vi.fn().mockResolvedValue({ messages: [] }),
         updateThread: vi.fn().mockResolvedValue(undefined),
       } as unknown as MemoryStorage;
 
@@ -888,6 +893,7 @@ describe('MessageHistory', () => {
           metadata: { createdAt: new Date('2024-01-01') },
         }),
         updateThread: vi.fn().mockResolvedValue(undefined),
+        listMessagesById: vi.fn().mockResolvedValue({ messages: [] }),
       } as unknown as MemoryStorage;
 
       const processor = new MessageHistory({
@@ -983,6 +989,7 @@ describe('MessageHistory', () => {
           metadata: {},
         }),
         listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        listMessagesById: vi.fn().mockResolvedValue({ messages: [] }),
         updateThread: vi.fn().mockResolvedValue(undefined),
       } as unknown as MemoryStorage;
 
@@ -1022,6 +1029,7 @@ describe('MessageHistory', () => {
           metadata: {},
         }),
         listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        listMessagesById: vi.fn().mockResolvedValue({ messages: [] }),
         updateThread: vi.fn().mockResolvedValue(undefined),
       } as unknown as MemoryStorage;
 
@@ -1072,6 +1080,7 @@ describe('MessageHistory', () => {
           metadata: {},
         }),
         listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        listMessagesById: vi.fn().mockResolvedValue({ messages: [] }),
         updateThread: vi.fn().mockResolvedValue(undefined),
       } as unknown as MemoryStorage;
 
@@ -1359,7 +1368,7 @@ describe('MessageHistory', () => {
       saveSpy.mockRestore();
     });
 
-    it('should record a stored-record lookup failure and persist the original input and output', async () => {
+    it('should fail closed when the stored-record lookup throws instead of persisting an unreconciled upsert', async () => {
       processor = new MessageHistory({ storage: mockStorage });
       const lookupError = new Error('lookup unavailable');
       vi.spyOn(mockStorage, 'listMessagesById').mockRejectedValueOnce(lookupError);
@@ -1381,13 +1390,17 @@ describe('MessageHistory', () => {
       });
       const messageList = new MessageList().add([input], 'input').add([output], 'response');
 
-      await processor.processOutputResult({
-        messageList,
-        messages: [],
-        abort: mockAbort,
-        requestContext: createRuntimeContextWithMemory('thread-1'),
-        tracingContext: { currentSpan } as any,
-      });
+      // A transient read failure must not fall back to an unreconciled upsert that
+      // could clobber the canonical stored records: the whole save fails closed.
+      await expect(
+        processor.processOutputResult({
+          messageList,
+          messages: [],
+          abort: mockAbort,
+          requestContext: createRuntimeContextWithMemory('thread-1'),
+          tracingContext: { currentSpan } as any,
+        }),
+      ).rejects.toThrow('lookup unavailable');
 
       expect(currentSpan.createChildSpan).toHaveBeenNthCalledWith(
         1,
@@ -1398,8 +1411,39 @@ describe('MessageHistory', () => {
         }),
       );
       expect(lookupSpan.error).toHaveBeenCalledWith({ error: lookupError, endSpan: true });
-      expect(saveSpy).toHaveBeenCalledWith({ messages: [input, output] });
-      expect(saveSpan.end).toHaveBeenCalledWith({ output: { success: true } });
+      // No unreconciled write happened, and the save span was never opened.
+      expect(saveSpy).not.toHaveBeenCalled();
+      expect(saveSpan.end).not.toHaveBeenCalled();
+
+      saveSpy.mockRestore();
+    });
+
+    it('should fail closed when the storage cannot look up stored records by ID', async () => {
+      // A storage adapter that does not support the ID-scoped lookup cannot be
+      // reconciled against, so persisting its client input would be an
+      // unreconciled upsert. The processor must refuse rather than reopen the
+      // clobber vector.
+      const storageWithoutLookup = new MockStorage();
+      (storageWithoutLookup as any).listMessagesById = undefined;
+      processor = new MessageHistory({ storage: storageWithoutLookup });
+      const saveSpy = vi.spyOn(storageWithoutLookup, 'saveMessages');
+
+      const input = assistantMessage({
+        id: 'msg-input',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Next turn' }] },
+      });
+
+      await expect(
+        processor.processOutputResult({
+          messageList: new MessageList().add([input], 'input'),
+          messages: [],
+          abort: mockAbort,
+          requestContext: createRuntimeContextWithMemory('thread-1'),
+        }),
+      ).rejects.toThrow('listMessagesById is required');
+
+      expect(saveSpy).not.toHaveBeenCalled();
 
       saveSpy.mockRestore();
     });
@@ -1858,6 +1902,109 @@ describe('MessageHistory', () => {
       saveSpy.mockRestore();
     });
 
+    it('should keep a user text edit while retaining server observation markers and sealed metadata', async () => {
+      // Observational memory appends a `data-om-*` marker part and stamps
+      // `content.metadata.mastra.sealed` onto the user message.
+      const observationMarker = {
+        type: 'data-om-observation-end',
+        data: { cycleId: 'cycle-1', operationType: 'observation', recordId: 'rec-1', threadId: 'thread-1' },
+      };
+      const stored = {
+        id: 'msg-1',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Original question' }, observationMarker],
+          metadata: { mastra: { sealed: true } },
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(baseTime - 1000),
+      } as unknown as MastraDBMessage;
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      // The client edits the text and — as a lossy echo — drops the observation
+      // marker and the sealed metadata.
+      const edited = {
+        id: 'msg-1',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Edited question' }],
+          metadata: {},
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(baseTime - 1000),
+      } as unknown as MastraDBMessage;
+
+      await processor.processOutputResult({
+        messageList: new MessageList().add([edited], 'input'),
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      const savedMsg1 = savedMessages.find(m => m.id === 'msg-1')!;
+
+      // The client edit survives...
+      const textParts = savedMsg1.content.parts.filter((p: any) => p.type === 'text').map((p: any) => p.text);
+      expect(textParts).toEqual(['Edited question']);
+      // ...but the server-authored observation marker is retained despite the echo
+      // dropping it...
+      expect(savedMsg1.content.parts.some((p: any) => p.type === 'data-om-observation-end')).toBe(true);
+      // ...and the sealed metadata cannot be erased by the lossy echo.
+      expect((savedMsg1.content.metadata as any)?.mastra?.sealed).toBe(true);
+
+      saveSpy.mockRestore();
+    });
+
+    it('should not let a user echo inject server-owned observation marker parts', async () => {
+      const stored = {
+        id: 'msg-1',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Original question' }] },
+        threadId: 'thread-1',
+        createdAt: new Date(baseTime - 1000),
+      } as unknown as MastraDBMessage;
+      mockStorage.setMessages([stored]);
+
+      processor = new MessageHistory({ storage: mockStorage });
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      // The client tries to forge an observation marker the server never wrote.
+      const echo = {
+        id: 'msg-1',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [
+            { type: 'text', text: 'Edited question' },
+            { type: 'data-om-observation-end', data: { cycleId: 'forged', operationType: 'observation' } },
+          ],
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(baseTime - 1000),
+      } as unknown as MastraDBMessage;
+
+      await processor.processOutputResult({
+        messageList: new MessageList().add([echo], 'input'),
+        messages: [],
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      const savedMsg1 = savedMessages.find(m => m.id === 'msg-1')!;
+      // The edit is kept, but the forged marker is stripped from the client surface.
+      expect(savedMsg1.content.parts.map((p: any) => p.type)).toEqual(['text']);
+      expect(savedMsg1.content.parts.some((p: any) => p.type === 'data-om-observation-end')).toBe(false);
+
+      saveSpy.mockRestore();
+    });
+
     it('should not let a client change the role of a stored user message', async () => {
       const stored = {
         id: 'msg-1',
@@ -1889,7 +2036,7 @@ describe('MessageHistory', () => {
       saveSpy.mockRestore();
     });
 
-    it('should treat an echoed ID from another thread as a fresh message', async () => {
+    it('should drop an echoed ID that belongs to another thread instead of clobbering it', async () => {
       const foreign = assistantMessage({
         content: {
           format: 2,
@@ -1903,7 +2050,9 @@ describe('MessageHistory', () => {
       processor = new MessageHistory({ storage: mockStorage });
       const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
 
-      const echo = assistantMessage({
+      // msg-1 canonically belongs to thread-2. The client echoes it into thread-1
+      // alongside a genuinely new message.
+      const foreignEcho = assistantMessage({
         content: {
           format: 2,
           content: 'Other thread answer',
@@ -1911,8 +2060,15 @@ describe('MessageHistory', () => {
         },
         threadId: 'thread-1',
       });
+      const genuinelyNew = assistantMessage({
+        id: 'msg-2',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Next turn' }] },
+        threadId: 'thread-1',
+        createdAt: new Date(baseTime),
+      });
 
-      const messageList = new MessageList().add([echo], 'input');
+      const messageList = new MessageList().add([foreignEcho, genuinelyNew], 'input');
 
       await processor.processOutputResult({
         messageList,
@@ -1921,34 +2077,39 @@ describe('MessageHistory', () => {
         requestContext: createRuntimeContextWithMemory('thread-1'),
       });
 
-      // msg-1 resolves to thread-2's record, which is not canonical for this
-      // thread: the echo is persisted as-is (fresh message), neither suppressed
-      // as an "unchanged echo" nor merged under the foreign thread's IDs.
-      expect(saveSpy).toHaveBeenCalledWith({
-        messages: [expect.objectContaining({ id: 'msg-1', threadId: 'thread-1' })],
-      });
+      // Persistence upserts on ID, so writing the foreign-thread ID under thread-1
+      // would clobber thread-2's canonical record. The echo is dropped; only the
+      // genuinely new message is persisted.
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      expect(savedMessages.map(m => m.id)).toEqual(['msg-2']);
 
       saveSpy.mockRestore();
     });
 
-    it('should treat an echoed ID from another resource in the same thread as a fresh message', async () => {
+    it('should drop an echoed ID from another resource in the same thread instead of clobbering it', async () => {
       const foreign = assistantMessage({ resourceId: 'resource-2' });
       mockStorage.setMessages([foreign]);
 
       processor = new MessageHistory({ storage: mockStorage });
       const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
-      const echo = assistantMessage({ resourceId: 'resource-1' });
+      const foreignEcho = assistantMessage({ resourceId: 'resource-1' });
+      const genuinelyNew = assistantMessage({
+        id: 'msg-2',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Next turn' }] },
+        resourceId: 'resource-1',
+        createdAt: new Date(baseTime),
+      });
 
       await processor.processOutputResult({
-        messageList: new MessageList().add([echo], 'input'),
+        messageList: new MessageList().add([foreignEcho, genuinelyNew], 'input'),
         messages: [],
         abort: mockAbort,
         requestContext: createRuntimeContextWithMemory('thread-1', 'resource-1'),
       });
 
-      expect(saveSpy).toHaveBeenCalledWith({
-        messages: [expect.objectContaining({ id: 'msg-1', threadId: 'thread-1', resourceId: 'resource-1' })],
-      });
+      const savedMessages = (saveSpy.mock.calls[0]![0] as any).messages as MastraDBMessage[];
+      expect(savedMessages.map(m => m.id)).toEqual(['msg-2']);
 
       saveSpy.mockRestore();
     });

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -279,44 +279,13 @@ export class MessageHistory implements Processor {
     // `lastMessages` recall window): identical echoes are skipped, and only
     // supported client-authored transitions (e.g. a client-side tool result
     // advancing a stored `call` to `result`) are merged into the stored version.
-    if (newInput.length > 0 && typeof this.storage.listMessagesById === 'function') {
-      const inputIds = newInput.map(m => m.id).filter((id): id is string => Boolean(id));
-      if (inputIds.length > 0) {
-        const lookupSpan = this.createMemorySpan(
-          'recall',
-          observabilityContext,
-          { messageIds: inputIds },
-          {
-            messageCount: inputIds.length,
-          },
-        );
-        let storedInput: MastraDBMessage[] | undefined;
-        try {
-          ({ messages: storedInput } = await this.storage.listMessagesById({ messageIds: inputIds }));
-          lookupSpan?.end({ output: { success: true } });
-        } catch (error) {
-          lookupSpan?.error({ error: error as Error, endSpan: true });
-          // Reconciliation is best effort. If the optional lookup fails, preserve
-          // the pre-existing persistence behavior and save the original input and
-          // output instead of aborting the whole turn.
-        }
-
-        if (storedInput) {
-          // Only records that actually belong to this thread (and resource) may act
-          // as the canonical version of an echoed ID. An ID that resolves to a
-          // foreign thread — or to another resource's thread — is treated as having
-          // no stored record, so the echo can neither suppress this thread's write
-          // nor drag a foreign threadId/resourceId into it.
-          const storedById = new Map(
-            storedInput
-              .filter(m => m.threadId === threadId && (!resourceId || m.resourceId === resourceId))
-              .map(m => [m.id, m]),
-          );
-          const reconciledInput = reconcileClientEchoes(newInput, storedById);
-          messagesToSave = [...reconciledInput, ...newOutput];
-        }
-      }
-    }
+    const reconciledInput = await this.reconcileClientInputMessages({
+      messages: newInput,
+      threadId,
+      resourceId,
+      observabilityContext,
+    });
+    messagesToSave = [...reconciledInput, ...newOutput];
 
     const span = this.createMemorySpan('save', observabilityContext, undefined, {
       messageCount: messagesToSave.length,
@@ -335,6 +304,45 @@ export class MessageHistory implements Processor {
     } catch (error) {
       span?.error({ error: error as Error, endSpan: true });
       throw error;
+    }
+  }
+
+  /**
+   * Reconcile only messages classified as client input before persistence.
+   * Server-authored output and marker updates must bypass this lookup.
+   */
+  async reconcileClientInputMessages(args: {
+    messages: MastraDBMessage[];
+    threadId: string;
+    resourceId?: string;
+    observabilityContext?: Partial<ObservabilityContext>;
+  }): Promise<MastraDBMessage[]> {
+    const { messages, threadId, resourceId, observabilityContext } = args;
+    if (messages.length === 0 || typeof this.storage.listMessagesById !== 'function') return messages;
+
+    const messageIds = messages.map(message => message.id).filter((id): id is string => Boolean(id));
+    if (messageIds.length === 0) return messages;
+
+    const lookupSpan = this.createMemorySpan(
+      'recall',
+      observabilityContext,
+      { messageIds },
+      {
+        messageCount: messageIds.length,
+      },
+    );
+    try {
+      const { messages: storedInput } = await this.storage.listMessagesById({ messageIds });
+      lookupSpan?.end({ output: { success: true } });
+      const storedById = new Map(
+        storedInput
+          .filter(message => message.threadId === threadId && (!resourceId || message.resourceId === resourceId))
+          .map(message => [message.id, message]),
+      );
+      return reconcileClientEchoes(messages, storedById);
+    } catch (error) {
+      lookupSpan?.error({ error: error as Error, endSpan: true });
+      return messages;
     }
   }
 

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -282,19 +282,29 @@ export class MessageHistory implements Processor {
     if (newInput.length > 0 && typeof this.storage.listMessagesById === 'function') {
       const inputIds = newInput.map(m => m.id).filter((id): id is string => Boolean(id));
       if (inputIds.length > 0) {
-        const { messages: storedInput } = await this.storage.listMessagesById({ messageIds: inputIds });
-        // Only records that actually belong to this thread (and resource) may act
-        // as the canonical version of an echoed ID. An ID that resolves to a
-        // foreign thread — or to another resource's thread — is treated as having
-        // no stored record, so the echo can neither suppress this thread's write
-        // nor drag a foreign threadId/resourceId into it.
-        const storedById = new Map(
-          storedInput
-            .filter(m => m.threadId === threadId && (!resourceId || m.resourceId === resourceId))
-            .map(m => [m.id, m]),
-        );
-        const reconciledInput = reconcileClientEchoes(newInput, storedById);
-        messagesToSave = [...reconciledInput, ...newOutput];
+        let storedInput: MastraDBMessage[] | undefined;
+        try {
+          ({ messages: storedInput } = await this.storage.listMessagesById({ messageIds: inputIds }));
+        } catch {
+          // Reconciliation is best effort. If the optional lookup fails, preserve
+          // the pre-existing persistence behavior and save the original input and
+          // output instead of aborting the whole turn.
+        }
+
+        if (storedInput) {
+          // Only records that actually belong to this thread (and resource) may act
+          // as the canonical version of an echoed ID. An ID that resolves to a
+          // foreign thread — or to another resource's thread — is treated as having
+          // no stored record, so the echo can neither suppress this thread's write
+          // nor drag a foreign threadId/resourceId into it.
+          const storedById = new Map(
+            storedInput
+              .filter(m => m.threadId === threadId && (!resourceId || m.resourceId === resourceId))
+              .map(m => [m.id, m]),
+          );
+          const reconciledInput = reconcileClientEchoes(newInput, storedById);
+          messagesToSave = [...reconciledInput, ...newOutput];
+        }
       }
     }
 

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -7,6 +7,7 @@ import { SpanType, EntityType } from '../../observability';
 import type { ObservabilityContext, MemoryOperationAttributes } from '../../observability';
 import type { RequestContext } from '../../request-context';
 import type { MemoryStorage } from '../../storage';
+import { reconcileClientEchoes } from './reconcile-client-echoes';
 
 /**
  * Options for the MessageHistory processor
@@ -258,7 +259,7 @@ export class MessageHistory implements Processor {
 
     const newInput = messageList.get.input.db();
     const newOutput = messageList.get.response.db();
-    const messagesToSave = [...newInput, ...newOutput];
+    let messagesToSave = [...newInput, ...newOutput];
 
     if (messagesToSave.length === 0) {
       return messageList;
@@ -268,6 +269,24 @@ export class MessageHistory implements Processor {
     // producing any output, saving the user message would orphan it in history.
     if (result?.finishReason === 'error' && newOutput.length === 0) {
       return messageList;
+    }
+
+    // Client-submitted transcripts can echo already-persisted messages back with
+    // the same IDs. Persisting them as-is is a whole-record upsert, so a stale or
+    // lossy echo would silently replace the canonical stored message (dropping
+    // output-processor transformations, tool history, and server-authored
+    // metadata). Reconcile input echoes against the stored records by ID (not the
+    // `lastMessages` recall window): identical echoes are skipped, and only
+    // supported client-authored transitions (e.g. a client-side tool result
+    // advancing a stored `call` to `result`) are merged into the stored version.
+    if (newInput.length > 0 && typeof this.storage.listMessagesById === 'function') {
+      const inputIds = newInput.map(m => m.id).filter((id): id is string => Boolean(id));
+      if (inputIds.length > 0) {
+        const { messages: storedInput } = await this.storage.listMessagesById({ messageIds: inputIds });
+        const storedById = new Map(storedInput.map(m => [m.id, m]));
+        const reconciledInput = reconcileClientEchoes(newInput, storedById);
+        messagesToSave = [...reconciledInput, ...newOutput];
+      }
     }
 
     const span = this.createMemorySpan('save', observabilityContext, undefined, {

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -282,10 +282,20 @@ export class MessageHistory implements Processor {
     if (newInput.length > 0 && typeof this.storage.listMessagesById === 'function') {
       const inputIds = newInput.map(m => m.id).filter((id): id is string => Boolean(id));
       if (inputIds.length > 0) {
+        const lookupSpan = this.createMemorySpan(
+          'recall',
+          observabilityContext,
+          { messageIds: inputIds },
+          {
+            messageCount: inputIds.length,
+          },
+        );
         let storedInput: MastraDBMessage[] | undefined;
         try {
           ({ messages: storedInput } = await this.storage.listMessagesById({ messageIds: inputIds }));
-        } catch {
+          lookupSpan?.end({ output: { success: true } });
+        } catch (error) {
+          lookupSpan?.error({ error: error as Error, endSpan: true });
           // Reconciliation is best effort. If the optional lookup fails, preserve
           // the pre-existing persistence behavior and save the original input and
           // output instead of aborting the whole turn.

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -283,7 +283,16 @@ export class MessageHistory implements Processor {
       const inputIds = newInput.map(m => m.id).filter((id): id is string => Boolean(id));
       if (inputIds.length > 0) {
         const { messages: storedInput } = await this.storage.listMessagesById({ messageIds: inputIds });
-        const storedById = new Map(storedInput.map(m => [m.id, m]));
+        // Only records that actually belong to this thread (and resource) may act
+        // as the canonical version of an echoed ID. An ID that resolves to a
+        // foreign thread — or to another resource's thread — is treated as having
+        // no stored record, so the echo can neither suppress this thread's write
+        // nor drag a foreign threadId/resourceId into it.
+        const storedById = new Map(
+          storedInput
+            .filter(m => m.threadId === threadId && (!resourceId || m.resourceId === resourceId))
+            .map(m => [m.id, m]),
+        );
         const reconciledInput = reconcileClientEchoes(newInput, storedById);
         messagesToSave = [...reconciledInput, ...newOutput];
       }

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -318,10 +318,20 @@ export class MessageHistory implements Processor {
     observabilityContext?: Partial<ObservabilityContext>;
   }): Promise<MastraDBMessage[]> {
     const { messages, threadId, resourceId, observabilityContext } = args;
-    if (messages.length === 0 || typeof this.storage.listMessagesById !== 'function') return messages;
+    if (messages.length === 0) return messages;
 
     const messageIds = messages.map(message => message.id).filter((id): id is string => Boolean(id));
     if (messageIds.length === 0) return messages;
+
+    // Fail closed. Reconciliation is the guard that stops a client echo from
+    // whole-record upserting over canonical server state. Without an ID-scoped
+    // lookup we cannot tell a genuinely new message from a lossy echo or a
+    // foreign-thread ID, so we must not fall through to an unreconciled upsert.
+    if (typeof this.storage.listMessagesById !== 'function') {
+      throw new Error(
+        'MessageHistory: storage.listMessagesById is required to reconcile client echoes before persistence',
+      );
+    }
 
     const lookupSpan = this.createMemorySpan(
       'recall',
@@ -334,15 +344,24 @@ export class MessageHistory implements Processor {
     try {
       const { messages: storedInput } = await this.storage.listMessagesById({ messageIds });
       lookupSpan?.end({ output: { success: true } });
-      const storedById = new Map(
-        storedInput
-          .filter(message => message.threadId === threadId && (!resourceId || message.resourceId === resourceId))
-          .map(message => [message.id, message]),
+      // Only records that actually belong to this thread (and resource) may act as
+      // the canonical version of an echoed ID.
+      const belongsHere = (message: MastraDBMessage) =>
+        message.threadId === threadId && (!resourceId || message.resourceId === resourceId);
+      const storedById = new Map(storedInput.filter(belongsHere).map(message => [message.id, message]));
+      // IDs that resolve to a canonical record on a foreign thread/resource. These
+      // must not be persisted under their echoed ID — an ID-keyed upsert would
+      // clobber the foreign record — so the reconciler drops them instead of
+      // treating them as genuinely new.
+      const foreignIds = new Set(
+        storedInput.filter(message => message.id && !belongsHere(message)).map(message => message.id as string),
       );
-      return reconcileClientEchoes(messages, storedById);
+      return reconcileClientEchoes(messages, storedById, foreignIds);
     } catch (error) {
       lookupSpan?.error({ error: error as Error, endSpan: true });
-      return messages;
+      // Fail closed: a transient read failure must not fall back to an
+      // unreconciled upsert that could clobber canonical stored records.
+      throw error;
     }
   }
 

--- a/packages/core/src/processors/memory/reconcile-client-echoes.ts
+++ b/packages/core/src/processors/memory/reconcile-client-echoes.ts
@@ -2,6 +2,9 @@ import type { MastraDBMessage, MastraMessageContentV2, MastraToolInvocation } fr
 
 type V2Part = MastraMessageContentV2['parts'][number];
 type ToolInvocationPart = Extract<V2Part, { type: 'tool-invocation' }>;
+type ClientTerminalTransition =
+  | { state: 'result'; result: unknown; isError?: boolean; errorText?: string }
+  | { state: 'output-error'; errorText: string };
 
 /**
  * Pick the fields for a supported client-authored terminal transition.
@@ -17,13 +20,13 @@ type ToolInvocationPart = Extract<V2Part, { type: 'tool-invocation' }>;
 function pickClientTerminalTransition(
   stored: MastraToolInvocation,
   incoming: MastraToolInvocation,
-): Partial<MastraToolInvocation> | undefined {
+): ClientTerminalTransition | undefined {
   if (stored.state !== 'call') return undefined;
 
   if (incoming.state === 'result') {
     return {
       state: 'result',
-      ...(incoming.result !== undefined ? { result: incoming.result } : {}),
+      result: incoming.result,
       ...(incoming.isError !== undefined ? { isError: incoming.isError } : {}),
       ...(incoming.errorText !== undefined ? { errorText: incoming.errorText } : {}),
     };
@@ -170,9 +173,9 @@ function mergeEchoParts(storedParts: V2Part[], incomingParts: V2Part[]): V2Part[
  * - The stored array is canonical; a client copy can never introduce tool
  *   history (names, args, results) the server never stored, so when the stored
  *   message has no array the incoming one is dropped entirely.
- * - For matched entries the client may only advance `call` → `result`,
- *   contributing `state`/`result` while the stored `args` (and everything else)
- *   survive.
+ * - For matched entries the client may only advance `call` → `result`, using
+ *   the shared result-transition fields while the stored `args` (and everything
+ *   else) survive. Legacy invocations cannot represent `output-error`.
  */
 function mergeLegacyToolInvocations(
   stored: MastraMessageContentV2,
@@ -184,14 +187,13 @@ function mergeLegacyToolInvocations(
   const incomingById = new Map(incoming.toolInvocations.map(t => [t.toolCallId, t]));
   return stored.toolInvocations.map(t => {
     const incomingEntry = incomingById.get(t.toolCallId);
-    if (incomingEntry && incomingEntry.state === 'result' && t.state === 'call') {
-      // The client may only advance the invocation: take its `state`/`result`
-      // (narrowed to `result` by the guard) while keeping the server-authored
-      // args — and everything else — from the stored entry.
+    const transition = incomingEntry ? pickClientTerminalTransition(t, incomingEntry) : undefined;
+    if (transition?.state === 'result') {
+      // Reuse the same result-field policy as content.parts while keeping the
+      // server-authored args — and everything else — from the stored entry.
       return {
         ...t,
-        state: incomingEntry.state,
-        result: incomingEntry.result,
+        ...transition,
         args: t.args,
       };
     }

--- a/packages/core/src/processors/memory/reconcile-client-echoes.ts
+++ b/packages/core/src/processors/memory/reconcile-client-echoes.ts
@@ -1,0 +1,232 @@
+import type { MastraDBMessage, MastraMessageContentV2 } from '../../agent/message-list';
+
+type V2Part = MastraMessageContentV2['parts'][number];
+type ToolInvocationPart = Extract<V2Part, { type: 'tool-invocation' }>;
+
+/**
+ * Canonicalize a value for deep comparison: sorts object keys and normalizes
+ * Dates so two structurally-identical messages compare equal regardless of
+ * serialization order (DB rows vs client-converted transcripts).
+ */
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map(canonicalize);
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    out[key] = canonicalize((value as Record<string, unknown>)[key]);
+  }
+  return out;
+}
+
+function isDeepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(canonicalize(a)) === JSON.stringify(canonicalize(b));
+}
+
+function isToolInvocationPart(part: V2Part): part is ToolInvocationPart {
+  return part.type === 'tool-invocation';
+}
+
+function getToolCallId(part: ToolInvocationPart): string | undefined {
+  return part.toolInvocation?.toolCallId;
+}
+
+/**
+ * Merge a client-echoed message against the canonical stored record.
+ *
+ * Client transcripts echo previously-persisted messages back with the same IDs.
+ * Message persistence is a whole-record upsert, so blindly re-saving an echo
+ * would let a stale or lossy client copy silently replace server-authored
+ * content (output-processor transformations, tool history, metadata).
+ *
+ * Rules (stored = canonical server state, incoming = client echo):
+ * - Tool-invocation parts are matched by `toolCallId`. A client-authored
+ *   transition (stored `call` → incoming `result`, e.g. a client-side tool
+ *   result) is applied to the stored part, preserving the stored args/name.
+ * - Any other same-position conflict is resolved in favor of the stored part
+ *   (server-authored text wins over a raw client copy).
+ * - Parts that only exist on the echo and extend the stored message (e.g.
+ *   observation markers) are appended.
+ * - The stored `content` string and `metadata` win on conflicts; the `sealed`
+ *   flag therefore survives an echo.
+ */
+export function mergeEchoWithStored(incoming: MastraDBMessage, stored: MastraDBMessage): MastraDBMessage {
+  return {
+    ...stored,
+    content: mergeEchoContent(stored.content, incoming.content),
+  };
+}
+
+function mergeEchoContent(stored: MastraMessageContentV2, incoming: MastraMessageContentV2): MastraMessageContentV2 {
+  const merged: MastraMessageContentV2 = {
+    ...stored,
+    format: 2,
+    parts: mergeEchoParts(stored.parts ?? [], incoming.parts ?? []),
+    toolInvocations: mergeLegacyToolInvocations(stored, incoming),
+  };
+
+  // Content string: the stored (server-authored) version is canonical; only adopt
+  // the incoming string when the stored message never had one.
+  if (!merged.content && incoming.content) {
+    merged.content = incoming.content;
+  }
+
+  // Metadata: stored wins on conflicts (e.g. keeps the `sealed` flag); keys only
+  // present on the echo are carried over.
+  if (incoming.metadata) {
+    merged.metadata = { ...incoming.metadata, ...(stored.metadata ?? {}) };
+  }
+
+  return merged;
+}
+
+function mergeEchoParts(storedParts: V2Part[], incomingParts: V2Part[]): V2Part[] {
+  const merged: V2Part[] = [];
+
+  // Pass 1: match tool-invocation parts by toolCallId (order-independent) and
+  // apply client-authored transitions.
+  const incomingToolById = new Map<string, number>();
+  incomingParts.forEach((part, index) => {
+    if (isToolInvocationPart(part)) {
+      const toolCallId = getToolCallId(part);
+      if (toolCallId) incomingToolById.set(toolCallId, index);
+    }
+  });
+
+  const incomingUsed = new Set<number>();
+
+  for (let i = 0; i < storedParts.length; i++) {
+    const storedPart = storedParts[i]!;
+    if (!isToolInvocationPart(storedPart)) {
+      merged.push(storedPart);
+      continue;
+    }
+
+    const toolCallId = getToolCallId(storedPart);
+    const incomingIndex = toolCallId ? incomingToolById.get(toolCallId) : undefined;
+    if (incomingIndex === undefined) {
+      merged.push(storedPart);
+      continue;
+    }
+
+    incomingUsed.add(incomingIndex);
+    const incomingPart = incomingParts[incomingIndex]!;
+    if (
+      isToolInvocationPart(incomingPart) &&
+      incomingPart.toolInvocation.state === 'result' &&
+      storedPart.toolInvocation.state !== 'result'
+    ) {
+      // Legitimate client-authored transition: advance the stored call with the
+      // client's result while preserving the stored args/name.
+      const transitioned: ToolInvocationPart = {
+        ...storedPart,
+        toolInvocation: {
+          ...storedPart.toolInvocation,
+          ...incomingPart.toolInvocation,
+          // The tool call's identity (name + args) is server-authored: the
+          // stored args win over the client copy, which only adds the result.
+          args: { ...incomingPart.toolInvocation.args, ...storedPart.toolInvocation.args },
+        },
+      };
+      merged.push(transitioned);
+    } else {
+      merged.push(storedPart); // canonical server state
+    }
+  }
+
+  // Pass 2: append incoming-only parts that extend the stored message (e.g.
+  // observation markers). Same-position conflicts were already resolved in favor
+  // of the stored part; unmatched incoming tool parts are dropped as stale echoes
+  // of parts the server never stored.
+  for (let i = 0; i < incomingParts.length; i++) {
+    if (incomingUsed.has(i)) continue;
+    const incomingPart = incomingParts[i]!;
+    if (isToolInvocationPart(incomingPart)) continue;
+    const storedAtPosition = storedParts[i];
+    if (storedAtPosition === undefined) {
+      merged.push(incomingPart);
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Reconcile the legacy parallel `toolInvocations` array for client-authored
+ * transitions, mirroring the part-level merge.
+ */
+function mergeLegacyToolInvocations(
+  stored: MastraMessageContentV2,
+  incoming: MastraMessageContentV2,
+): MastraMessageContentV2['toolInvocations'] | undefined {
+  if (!stored.toolInvocations) return incoming.toolInvocations;
+  if (!incoming.toolInvocations) return stored.toolInvocations;
+
+  const incomingById = new Map(incoming.toolInvocations.map(t => [t.toolCallId, t]));
+  return stored.toolInvocations.map(t => {
+    const incomingEntry = incomingById.get(t.toolCallId);
+    if (incomingEntry && incomingEntry.state === 'result' && t.state !== 'result') {
+      return {
+        ...t,
+        ...incomingEntry,
+        // Keep the server-authored args of the stored call.
+        args: { ...(incomingEntry.args ?? {}), ...(t.args ?? {}) },
+      };
+    }
+    return t;
+  });
+}
+
+/**
+ * Strip presentation-level `createdAt` stamps from message parts.
+ *
+ * `MessageList.add` stamps a `createdAt` onto every part (and re-stamps the
+ * message `createdAt`) when the client transcript is loaded, so an unchanged
+ * echo differs from its stored record only in these timestamps. They are not
+ * content, so they must not defeat the equality check.
+ */
+function stripPartTimestamps(content: MastraMessageContentV2): unknown {
+  const parts = (content.parts ?? []).map(part => {
+    if (!part || typeof part !== 'object' || !('createdAt' in part)) return part;
+    const { createdAt: _createdAt, ...rest } = part as { createdAt?: unknown } & Record<string, unknown>;
+    return rest;
+  });
+  return { ...content, parts };
+}
+
+/**
+ * Whether an incoming message is content-identical to its stored record (an
+ * unchanged echo that never needs to be persisted again).
+ */
+export function messagesContentEqual(a: MastraDBMessage, b: MastraDBMessage): boolean {
+  return a.role === b.role && isDeepEqual(stripPartTimestamps(a.content), stripPartTimestamps(b.content));
+}
+
+/**
+ * Reconcile a batch of client-submitted input messages against their stored
+ * records (looked up by ID, independent of the recall window):
+ *
+ * - Messages with no stored record are returned untouched (genuinely new).
+ * - Identical echoes of stored messages are dropped — re-persisting them would
+ *   overwrite the canonical record with a copy.
+ * - Lossy or transitional echoes are merged into the stored canonical version
+ *   so only supported client-authored changes (e.g. tool results) survive.
+ */
+export function reconcileClientEchoes(
+  messages: MastraDBMessage[],
+  storedById: ReadonlyMap<string, MastraDBMessage>,
+): MastraDBMessage[] {
+  const reconciled: MastraDBMessage[] = [];
+  for (const message of messages) {
+    const stored = message.id ? storedById.get(message.id) : undefined;
+    if (!stored) {
+      reconciled.push(message);
+      continue;
+    }
+    if (messagesContentEqual(message, stored)) {
+      continue; // stale echo — already persisted, nothing to write
+    }
+    reconciled.push(mergeEchoWithStored(message, stored));
+  }
+  return reconciled;
+}

--- a/packages/core/src/processors/memory/reconcile-client-echoes.ts
+++ b/packages/core/src/processors/memory/reconcile-client-echoes.ts
@@ -1,7 +1,33 @@
-import type { MastraDBMessage, MastraMessageContentV2 } from '../../agent/message-list';
+import type { MastraDBMessage, MastraMessageContentV2, MastraToolInvocation } from '../../agent/message-list';
 
 type V2Part = MastraMessageContentV2['parts'][number];
 type ToolInvocationPart = Extract<V2Part, { type: 'tool-invocation' }>;
+
+/**
+ * The only fields a client echo may contribute to a stored tool invocation.
+ * Everything else (`toolName`, `toolCallId`, `args`, ...) is server-authored
+ * and must never be taken from the client copy: letting the client spread its
+ * invocation over the stored one would reopen the clobber vector this module
+ * exists to close. Kept as a single constant so the doc comments and the merge
+ * behavior cannot drift apart.
+ */
+const CLIENT_CONTRIBUTABLE_TOOL_INVOCATION_FIELDS = ['state', 'result'] as const;
+
+/**
+ * Pick only the whitelisted fields from a tool invocation. Used to apply a
+ * client-authored transition (e.g. `call` → `result`) without adopting any
+ * other client-supplied value.
+ */
+function pickClientContributable(invocation: MastraToolInvocation): Partial<MastraToolInvocation> {
+  const picked: Partial<MastraToolInvocation> = {};
+  for (const field of CLIENT_CONTRIBUTABLE_TOOL_INVOCATION_FIELDS) {
+    const value = (invocation as Record<string, unknown>)[field];
+    if (value !== undefined) {
+      (picked as Record<string, unknown>)[field] = value;
+    }
+  }
+  return picked;
+}
 
 /**
  * Canonicalize a value for deep comparison: sorts object keys and normalizes
@@ -42,13 +68,18 @@ function getToolCallId(part: ToolInvocationPart): string | undefined {
  * Rules (stored = canonical server state, incoming = client echo):
  * - Tool-invocation parts are matched by `toolCallId`. A client-authored
  *   transition (stored `call` → incoming `result`, e.g. a client-side tool
- *   result) is applied to the stored part, preserving the stored args/name.
+ *   result) is applied to the stored part, but the client may only contribute
+ *   `state` and `result`; `toolName`, `toolCallId` and `args` always come from
+ *   the stored (server-authored) invocation.
  * - Any other same-position conflict is resolved in favor of the stored part
  *   (server-authored text wins over a raw client copy).
- * - Parts that only exist on the echo and extend the stored message (e.g.
- *   observation markers) are appended.
- * - The stored `content` string and `metadata` win on conflicts; the `sealed`
- *   flag therefore survives an echo.
+ * - Incoming-only parts are never accepted: a client echo cannot introduce
+ *   tool history, text, or other parts the server never stored. Client-side
+ *   presentation parts (e.g. observation markers) are re-created by the client
+ *   on each render and do not belong in the persisted record.
+ * - The stored `content` string and `metadata` win in full; echo-only keys are
+ *   never carried over, so a client cannot pre-seed keys the server hasn't set
+ *   yet (e.g. `sealed`).
  */
 export function mergeEchoWithStored(incoming: MastraDBMessage, stored: MastraDBMessage): MastraDBMessage {
   return {
@@ -71,12 +102,6 @@ function mergeEchoContent(stored: MastraMessageContentV2, incoming: MastraMessag
     merged.content = incoming.content;
   }
 
-  // Metadata: stored wins on conflicts (e.g. keeps the `sealed` flag); keys only
-  // present on the echo are carried over.
-  if (incoming.metadata) {
-    merged.metadata = { ...incoming.metadata, ...(stored.metadata ?? {}) };
-  }
-
   return merged;
 }
 
@@ -93,10 +118,7 @@ function mergeEchoParts(storedParts: V2Part[], incomingParts: V2Part[]): V2Part[
     }
   });
 
-  const incomingUsed = new Set<number>();
-
-  for (let i = 0; i < storedParts.length; i++) {
-    const storedPart = storedParts[i]!;
+  for (const storedPart of storedParts) {
     if (!isToolInvocationPart(storedPart)) {
       merged.push(storedPart);
       continue;
@@ -109,7 +131,6 @@ function mergeEchoParts(storedParts: V2Part[], incomingParts: V2Part[]): V2Part[
       continue;
     }
 
-    incomingUsed.add(incomingIndex);
     const incomingPart = incomingParts[incomingIndex]!;
     if (
       isToolInvocationPart(incomingPart) &&
@@ -117,15 +138,15 @@ function mergeEchoParts(storedParts: V2Part[], incomingParts: V2Part[]): V2Part[
       storedPart.toolInvocation.state !== 'result'
     ) {
       // Legitimate client-authored transition: advance the stored call with the
-      // client's result while preserving the stored args/name.
+      // client's result. Only `state` + `result` are taken from the client — the
+      // tool call's identity (name, call id, args) is server-authored and stays
+      // as stored.
       const transitioned: ToolInvocationPart = {
         ...storedPart,
         toolInvocation: {
           ...storedPart.toolInvocation,
-          ...incomingPart.toolInvocation,
-          // The tool call's identity (name + args) is server-authored: the
-          // stored args win over the client copy, which only adds the result.
-          args: { ...incomingPart.toolInvocation.args, ...storedPart.toolInvocation.args },
+          ...pickClientContributable(incomingPart.toolInvocation),
+          args: storedPart.toolInvocation.args,
         },
       };
       merged.push(transitioned);
@@ -134,43 +155,39 @@ function mergeEchoParts(storedParts: V2Part[], incomingParts: V2Part[]): V2Part[
     }
   }
 
-  // Pass 2: append incoming-only parts that extend the stored message (e.g.
-  // observation markers). Same-position conflicts were already resolved in favor
-  // of the stored part; unmatched incoming tool parts are dropped as stale echoes
-  // of parts the server never stored.
-  for (let i = 0; i < incomingParts.length; i++) {
-    if (incomingUsed.has(i)) continue;
-    const incomingPart = incomingParts[i]!;
-    if (isToolInvocationPart(incomingPart)) continue;
-    const storedAtPosition = storedParts[i];
-    if (storedAtPosition === undefined) {
-      merged.push(incomingPart);
-    }
-  }
-
   return merged;
 }
 
 /**
  * Reconcile the legacy parallel `toolInvocations` array for client-authored
- * transitions, mirroring the part-level merge.
+ * transitions, mirroring the part-level merge:
+ *
+ * - The stored array is canonical; a client copy can never introduce tool
+ *   history (names, args, results) the server never stored, so when the stored
+ *   message has no array the incoming one is dropped entirely.
+ * - For matched entries the client may only advance `call` → `result`,
+ *   contributing `state`/`result` while the stored `args` (and everything else)
+ *   survive.
  */
 function mergeLegacyToolInvocations(
   stored: MastraMessageContentV2,
   incoming: MastraMessageContentV2,
 ): MastraMessageContentV2['toolInvocations'] | undefined {
-  if (!stored.toolInvocations) return incoming.toolInvocations;
+  if (!stored.toolInvocations) return undefined;
   if (!incoming.toolInvocations) return stored.toolInvocations;
 
   const incomingById = new Map(incoming.toolInvocations.map(t => [t.toolCallId, t]));
   return stored.toolInvocations.map(t => {
     const incomingEntry = incomingById.get(t.toolCallId);
     if (incomingEntry && incomingEntry.state === 'result' && t.state !== 'result') {
+      // The client may only advance the invocation: take its `state`/`result`
+      // (narrowed to `result` by the guard) while keeping the server-authored
+      // args — and everything else — from the stored entry.
       return {
         ...t,
-        ...incomingEntry,
-        // Keep the server-authored args of the stored call.
-        args: { ...(incomingEntry.args ?? {}), ...(t.args ?? {}) },
+        state: incomingEntry.state,
+        result: incomingEntry.result,
+        args: t.args,
       };
     }
     return t;
@@ -209,8 +226,13 @@ export function messagesContentEqual(a: MastraDBMessage, b: MastraDBMessage): bo
  * - Messages with no stored record are returned untouched (genuinely new).
  * - Identical echoes of stored messages are dropped — re-persisting them would
  *   overwrite the canonical record with a copy.
- * - Lossy or transitional echoes are merged into the stored canonical version
- *   so only supported client-authored changes (e.g. tool results) survive.
+ * - For assistant (and system) messages, lossy or transitional echoes are
+ *   merged into the stored canonical version so only supported client-authored
+ *   changes (e.g. tool results) survive.
+ * - For user messages the client IS the author, so reconciliation is restricted
+ *   to skipping unchanged echoes: an edit-and-resend that reuses the message ID
+ *   is kept as-is (last-write-wins), never silently discarded by a
+ *   server-wins merge.
  */
 export function reconcileClientEchoes(
   messages: MastraDBMessage[],
@@ -225,6 +247,10 @@ export function reconcileClientEchoes(
     }
     if (messagesContentEqual(message, stored)) {
       continue; // stale echo — already persisted, nothing to write
+    }
+    if (stored.role === 'user') {
+      reconciled.push(message); // client-authored edit, last-write-wins
+      continue;
     }
     reconciled.push(mergeEchoWithStored(message, stored));
   }

--- a/packages/core/src/processors/memory/reconcile-client-echoes.ts
+++ b/packages/core/src/processors/memory/reconcile-client-echoes.ts
@@ -4,29 +4,36 @@ type V2Part = MastraMessageContentV2['parts'][number];
 type ToolInvocationPart = Extract<V2Part, { type: 'tool-invocation' }>;
 
 /**
- * The only fields a client echo may contribute to a stored tool invocation.
- * Everything else (`toolName`, `toolCallId`, `args`, ...) is server-authored
- * and must never be taken from the client copy: letting the client spread its
- * invocation over the stored one would reopen the clobber vector this module
- * exists to close. Kept as a single constant so the doc comments and the merge
- * behavior cannot drift apart.
+ * Pick the fields for a supported client-authored terminal transition.
+ *
+ * A stored `call` may become either:
+ * - `result`, including the v4-compatible `isError` and `errorText` markers.
+ * - `output-error`, including only the v6 error text.
+ *
+ * Everything else (`toolName`, `toolCallId`, `args`, `rawInput`, ...) remains
+ * server-authored. In particular, fields for one terminal state are not
+ * accepted on the other terminal state.
  */
-const CLIENT_CONTRIBUTABLE_TOOL_INVOCATION_FIELDS = ['state', 'result'] as const;
+function pickClientTerminalTransition(
+  stored: MastraToolInvocation,
+  incoming: MastraToolInvocation,
+): Partial<MastraToolInvocation> | undefined {
+  if (stored.state !== 'call') return undefined;
 
-/**
- * Pick only the whitelisted fields from a tool invocation. Used to apply a
- * client-authored transition (e.g. `call` → `result`) without adopting any
- * other client-supplied value.
- */
-function pickClientContributable(invocation: MastraToolInvocation): Partial<MastraToolInvocation> {
-  const picked: Partial<MastraToolInvocation> = {};
-  for (const field of CLIENT_CONTRIBUTABLE_TOOL_INVOCATION_FIELDS) {
-    const value = (invocation as Record<string, unknown>)[field];
-    if (value !== undefined) {
-      (picked as Record<string, unknown>)[field] = value;
-    }
+  if (incoming.state === 'result') {
+    return {
+      state: 'result',
+      ...(incoming.result !== undefined ? { result: incoming.result } : {}),
+      ...(incoming.isError !== undefined ? { isError: incoming.isError } : {}),
+      ...(incoming.errorText !== undefined ? { errorText: incoming.errorText } : {}),
+    };
   }
-  return picked;
+
+  if (incoming.state === 'output-error' && incoming.errorText !== undefined) {
+    return { state: 'output-error', errorText: incoming.errorText };
+  }
+
+  return undefined;
 }
 
 /**
@@ -67,10 +74,10 @@ function getToolCallId(part: ToolInvocationPart): string | undefined {
  *
  * Rules (stored = canonical server state, incoming = client echo):
  * - Tool-invocation parts are matched by `toolCallId`. A client-authored
- *   transition (stored `call` → incoming `result`, e.g. a client-side tool
- *   result) is applied to the stored part, but the client may only contribute
- *   `state` and `result`; `toolName`, `toolCallId` and `args` always come from
- *   the stored (server-authored) invocation.
+ *   transition from a stored `call` to an incoming `result` or `output-error`
+ *   is applied to the stored part. The client may contribute the result/error
+ *   fields for that terminal state; `toolName`, `toolCallId` and `args` always
+ *   come from the stored (server-authored) invocation.
  * - Any other same-position conflict is resolved in favor of the stored part
  *   (server-authored text wins over a raw client copy).
  * - Incoming-only parts are never accepted: a client echo cannot introduce
@@ -132,20 +139,18 @@ function mergeEchoParts(storedParts: V2Part[], incomingParts: V2Part[]): V2Part[
     }
 
     const incomingPart = incomingParts[incomingIndex]!;
-    if (
-      isToolInvocationPart(incomingPart) &&
-      incomingPart.toolInvocation.state === 'result' &&
-      storedPart.toolInvocation.state !== 'result'
-    ) {
+    const transition = isToolInvocationPart(incomingPart)
+      ? pickClientTerminalTransition(storedPart.toolInvocation, incomingPart.toolInvocation)
+      : undefined;
+    if (transition) {
       // Legitimate client-authored transition: advance the stored call with the
-      // client's result. Only `state` + `result` are taken from the client — the
-      // tool call's identity (name, call id, args) is server-authored and stays
-      // as stored.
+      // matching terminal fields. The tool call's identity (name, call id,
+      // args) is server-authored and stays as stored.
       const transitioned: ToolInvocationPart = {
         ...storedPart,
         toolInvocation: {
           ...storedPart.toolInvocation,
-          ...pickClientContributable(incomingPart.toolInvocation),
+          ...transition,
           args: storedPart.toolInvocation.args,
         },
       };
@@ -160,7 +165,7 @@ function mergeEchoParts(storedParts: V2Part[], incomingParts: V2Part[]): V2Part[
 
 /**
  * Reconcile the legacy parallel `toolInvocations` array for client-authored
- * transitions, mirroring the part-level merge:
+ * successful-result transitions:
  *
  * - The stored array is canonical; a client copy can never introduce tool
  *   history (names, args, results) the server never stored, so when the stored
@@ -179,7 +184,7 @@ function mergeLegacyToolInvocations(
   const incomingById = new Map(incoming.toolInvocations.map(t => [t.toolCallId, t]));
   return stored.toolInvocations.map(t => {
     const incomingEntry = incomingById.get(t.toolCallId);
-    if (incomingEntry && incomingEntry.state === 'result' && t.state !== 'result') {
+    if (incomingEntry && incomingEntry.state === 'result' && t.state === 'call') {
       // The client may only advance the invocation: take its `state`/`result`
       // (narrowed to `result` by the guard) while keeping the server-authored
       // args — and everything else — from the stored entry.

--- a/packages/core/src/processors/memory/reconcile-client-echoes.ts
+++ b/packages/core/src/processors/memory/reconcile-client-echoes.ts
@@ -7,6 +7,20 @@ type ClientTerminalTransition =
   | { state: 'output-error'; errorText: string };
 
 /**
+ * The exhaustive set of fields a client echo may contribute when it advances a
+ * stored tool `call` to a terminal state, keyed by that terminal state. This is
+ * the single source of truth for the client-contributable surface: every other
+ * field on a tool invocation (`toolName`, `toolCallId`, `args`, `rawInput`,
+ * `approval`, ...) is server-authored and is always taken from the stored
+ * record. `pickClientTerminalTransition` copies only these keys, so a client
+ * cannot smuggle server-authored fields through a terminal transition.
+ */
+export const CLIENT_CONTRIBUTABLE_TERMINAL_FIELDS = {
+  result: ['result', 'isError', 'errorText'],
+  'output-error': ['errorText'],
+} as const satisfies Record<ClientTerminalTransition['state'], readonly (keyof MastraToolInvocation)[]>;
+
+/**
  * Pick the fields for a supported client-authored terminal transition.
  *
  * A stored `call` may become either:
@@ -24,12 +38,19 @@ function pickClientTerminalTransition(
   if (stored.state !== 'call') return undefined;
 
   if (incoming.state === 'result') {
-    return {
-      state: 'result',
-      result: incoming.result,
-      ...(incoming.isError !== undefined ? { isError: incoming.isError } : {}),
-      ...(incoming.errorText !== undefined ? { errorText: incoming.errorText } : {}),
-    };
+    // `result` is the defining payload of the transition and is always carried
+    // (even when explicitly undefined); the remaining whitelisted markers are
+    // only carried when the client actually set them. No field outside
+    // CLIENT_CONTRIBUTABLE_TERMINAL_FIELDS can ever be copied from the client.
+    const transition: ClientTerminalTransition = { state: 'result', result: incoming.result };
+    for (const field of CLIENT_CONTRIBUTABLE_TERMINAL_FIELDS.result) {
+      if (field === 'result') continue;
+      const value = incoming[field];
+      if (value !== undefined) {
+        (transition as Record<string, unknown>)[field] = value;
+      }
+    }
+    return transition;
   }
 
   if (incoming.state === 'output-error' && incoming.errorText !== undefined) {

--- a/packages/core/src/processors/memory/reconcile-client-echoes.ts
+++ b/packages/core/src/processors/memory/reconcile-client-echoes.ts
@@ -256,7 +256,7 @@ export function reconcileClientEchoes(
     if (messagesContentEqual(message, stored)) {
       continue; // stale echo — already persisted, nothing to write
     }
-    if (stored.role === 'user') {
+    if (stored.role === 'user' && message.role === 'user') {
       reconciled.push(message); // client-authored edit, last-write-wins
       continue;
     }

--- a/packages/core/src/processors/memory/reconcile-client-echoes.ts
+++ b/packages/core/src/processors/memory/reconcile-client-echoes.ts
@@ -107,8 +107,9 @@ function mergeEchoContent(stored: MastraMessageContentV2, incoming: MastraMessag
   };
 
   // Content string: the stored (server-authored) version is canonical; only adopt
-  // the incoming string when the stored message never had one.
-  if (!merged.content && incoming.content) {
+  // the incoming string when the stored message never had one. An empty stored
+  // string is a stored value (e.g. a redaction pass), not an absent one.
+  if (merged.content === undefined && incoming.content !== undefined) {
     merged.content = incoming.content;
   }
 

--- a/packages/core/src/processors/memory/reconcile-client-echoes.ts
+++ b/packages/core/src/processors/memory/reconcile-client-echoes.ts
@@ -84,6 +84,22 @@ function isToolInvocationPart(part: V2Part): part is ToolInvocationPart {
   return part.type === 'tool-invocation';
 }
 
+/**
+ * Whether a part is server-authored state that observational memory writes onto
+ * a message and a client echo must never be able to erase or forge.
+ *
+ * Observational memory appends `data-om-*` observation marker parts
+ * (`data-om-observation-start`/`-end`/`-failed`, `data-om-buffering-*`,
+ * `data-om-activation`, `data-om-thread-update`) to messages — including user
+ * messages — to record observation boundaries. They are server-owned: a client
+ * echo may neither drop them (they are re-added from the stored record) nor
+ * inject them (they are stripped from the incoming editable surface).
+ */
+function isServerOwnedEchoPart(part: V2Part): boolean {
+  const type = (part as { type?: unknown }).type;
+  return typeof type === 'string' && type.startsWith('data-om-');
+}
+
 function getToolCallId(part: ToolInvocationPart): string | undefined {
   return part.toolInvocation?.toolCallId;
 }
@@ -117,6 +133,47 @@ export function mergeEchoWithStored(incoming: MastraDBMessage, stored: MastraDBM
     ...stored,
     content: mergeEchoContent(stored.content, incoming.content),
   };
+}
+
+/**
+ * Merge a client echo of a *user* message.
+ *
+ * The client is the author of the user-visible content, so a genuine
+ * edit-and-resend (same ID, changed text) must survive rather than be discarded
+ * by a server-wins merge. But observational memory writes server-authored state
+ * onto user messages — `data-om-*` observation marker parts and
+ * `content.metadata` (which carries `mastra.sealed`) — and a lossy echo that
+ * dropped them must not be able to erase them.
+ *
+ * So the client may replace only the editable content surface: its own non-marker
+ * parts and the `content` string. Server-owned metadata and observation marker
+ * parts are always taken from the stored record. The client can neither drop the
+ * markers (they are re-added from stored) nor inject new ones (they are stripped
+ * from the incoming parts), and it cannot pre-seed metadata keys the server never
+ * set (the whole metadata object comes from stored).
+ */
+function mergeUserEcho(incoming: MastraDBMessage, stored: MastraDBMessage): MastraDBMessage {
+  const storedContent = stored.content;
+  const incomingContent = incoming.content;
+
+  const clientEditableParts = (incomingContent.parts ?? []).filter(part => !isServerOwnedEchoPart(part));
+  const serverMarkerParts = (storedContent.parts ?? []).filter(isServerOwnedEchoPart);
+
+  const mergedContent: MastraMessageContentV2 = {
+    ...storedContent, // retain server-owned metadata (e.g. mastra.sealed)
+    format: 2,
+    // Client-editable content first, then the server-owned markers. Observational
+    // memory appends its markers after the user content, so this preserves both
+    // their presence and their trailing position regardless of what the echo sent.
+    parts: [...clientEditableParts, ...serverMarkerParts],
+  };
+
+  // The content string is user-editable; adopt the client's when present.
+  if (incomingContent.content !== undefined) {
+    mergedContent.content = incomingContent.content;
+  }
+
+  return { ...stored, content: mergedContent };
 }
 
 function mergeEchoContent(stored: MastraMessageContentV2, incoming: MastraMessageContentV2): MastraMessageContentV2 {
@@ -252,25 +309,38 @@ export function messagesContentEqual(a: MastraDBMessage, b: MastraDBMessage): bo
  * Reconcile a batch of client-submitted input messages against their stored
  * records (looked up by ID, independent of the recall window):
  *
- * - Messages with no stored record are returned untouched (genuinely new).
+ * - Messages with a genuinely-new ID (no stored record anywhere) are returned
+ *   untouched.
+ * - Messages whose ID resolves to a canonical record on a *different*
+ *   thread/resource (`foreignIds`) are dropped: persistence upserts on ID, so
+ *   saving such an echo "as new" would clobber the foreign canonical record (and
+ *   drag foreign content into this thread). A genuinely new message carries a
+ *   fresh client ID, never one already owned by another thread.
  * - Identical echoes of stored messages are dropped — re-persisting them would
  *   overwrite the canonical record with a copy.
  * - For assistant (and system) messages, lossy or transitional echoes are
  *   merged into the stored canonical version so only supported client-authored
  *   changes (e.g. tool results) survive.
- * - For user messages the client IS the author, so reconciliation is restricted
- *   to skipping unchanged echoes: an edit-and-resend that reuses the message ID
- *   is kept as-is (last-write-wins), never silently discarded by a
- *   server-wins merge.
+ * - For user messages the client IS the author of the content, so an
+ *   edit-and-resend that reuses the message ID is kept — but only the editable
+ *   surface (text/content and the client's own parts). Server-authored
+ *   observation markers and metadata (e.g. `mastra.sealed`) are retained from
+ *   the stored record, so a lossy echo cannot erase them.
  */
 export function reconcileClientEchoes(
   messages: MastraDBMessage[],
   storedById: ReadonlyMap<string, MastraDBMessage>,
+  foreignIds: ReadonlySet<string> = new Set(),
 ): MastraDBMessage[] {
   const reconciled: MastraDBMessage[] = [];
   for (const message of messages) {
     const stored = message.id ? storedById.get(message.id) : undefined;
     if (!stored) {
+      // Known-foreign ID: dropping it protects the foreign canonical record from
+      // an ID-keyed upsert clobber. Genuinely-new IDs fall through and are kept.
+      if (message.id && foreignIds.has(message.id)) {
+        continue;
+      }
       reconciled.push(message);
       continue;
     }
@@ -278,7 +348,9 @@ export function reconcileClientEchoes(
       continue; // stale echo — already persisted, nothing to write
     }
     if (stored.role === 'user' && message.role === 'user') {
-      reconciled.push(message); // client-authored edit, last-write-wins
+      // Client-authored user content: keep the edit, but never let a lossy echo
+      // erase server-authored observation markers or sealed metadata.
+      reconciled.push(mergeUserEcho(message, stored));
       continue;
     }
     reconciled.push(mergeEchoWithStored(message, stored));

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1,5 +1,5 @@
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
-import type { MastraDBMessage, MastraMessageContentV2 } from '@mastra/core/agent';
+import { MessageList, type MastraDBMessage, type MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { coreFeatures } from '@mastra/core/features';
 import { MASTRA_THREAD_ID_KEY, RequestContext } from '@mastra/core/request-context';
@@ -361,6 +361,123 @@ describe('ObservationalMemoryProcessor read-only mode', () => {
     expect(messageList.get.all.db().map(m => m.id)).not.toContain('om-continuation');
     expect(messageList.getSystemMessages('observational-memory')).toEqual([]);
     expect(memoryProvider.persistMessages).not.toHaveBeenCalled();
+  });
+});
+
+describe('ObservationalMemoryProcessor client echo reconciliation', () => {
+  it('reconciles client input on a resumed output without a live turn', async () => {
+    const storage = createInMemoryStorage();
+    const threadId = 'resume-echo-thread';
+    const resourceId = 'resume-echo-resource';
+    const stored = {
+      id: 'assistant-echo',
+      role: 'assistant',
+      content: {
+        format: 2,
+        content: 'Server transformed text',
+        parts: [
+          { type: 'text', text: 'Server transformed text' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'call',
+              toolCallId: 'call-1',
+              toolName: 'search',
+              args: { query: 'canonical' },
+            },
+          },
+        ],
+        metadata: { serverOwned: true },
+      },
+      threadId,
+      resourceId,
+      createdAt: new Date('2025-01-01T09:00:00Z'),
+    } as MastraDBMessage;
+    await storage.saveThread({
+      thread: {
+        id: threadId,
+        resourceId,
+        title: 'Resume echo',
+        metadata: {},
+        createdAt: new Date('2025-01-01T08:00:00Z'),
+        updatedAt: new Date('2025-01-01T08:00:00Z'),
+      },
+    });
+    await storage.saveMessages({ messages: [stored] });
+
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        content: [{ type: 'text' as const, text: 'ok' }],
+        warnings: [],
+      }),
+    });
+    const om = new ObservationalMemory({
+      storage,
+      scope: 'thread',
+      model: mockModel as any,
+      observation: { messageTokens: 100000 },
+      reflection: { observationTokens: 200000 },
+    });
+    const processor = new ObservationalMemoryProcessor(om, createMemoryProvider(om));
+    const lookupSpy = vi.spyOn(storage, 'listMessagesById');
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+    const echoWithResult = {
+      ...stored,
+      content: {
+        format: 2,
+        content: 'Lossy client text',
+        parts: [
+          { type: 'text', text: 'Lossy client text' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'call-1',
+              toolName: 'client-name',
+              args: { query: 'changed', injected: true },
+              result: 'client result',
+            },
+          },
+        ],
+        metadata: { clientOwned: true },
+      },
+    } as MastraDBMessage;
+    const messageList = new MessageList({ threadId, resourceId }).add([echoWithResult], 'input');
+
+    await processor.processOutputResult({
+      messageList,
+      messages: [],
+      requestContext,
+      state: {},
+      abort: (() => {
+        throw new Error('aborted');
+      }) as any,
+      result: {} as any,
+      retryCount: 0,
+    });
+
+    const { messages } = await storage.listMessages({ threadId, resourceId, perPage: false });
+    const saved = messages.find(message => message.id === stored.id)!;
+    expect(lookupSpy).toHaveBeenCalledTimes(1);
+    expect(saved.content.content).toBe('Server transformed text');
+    expect(saved.content.metadata).toEqual({ serverOwned: true });
+    expect(saved.content.parts).toEqual([
+      { type: 'text', text: 'Server transformed text' },
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'call-1',
+          toolName: 'search',
+          args: { query: 'canonical' },
+          result: 'client result',
+        },
+      },
+    ]);
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -229,7 +229,7 @@ export class ObservationStep {
         const newOutput = messageList.clear.response.db();
         const messagesToSave = [...newInput, ...newOutput];
         if (messagesToSave.length > 0) {
-          await om.persistMessages(messagesToSave, threadId, resourceId);
+          await om.persistClientInputMessages(newInput, newOutput, threadId, resourceId);
           for (const msg of messagesToSave) {
             messageList.add(msg, 'memory');
           }
@@ -242,9 +242,11 @@ export class ObservationStep {
         // starve them. Persisting alone is enough for post-observation cleanup to operate
         // on stored state; persistMessages is an upsert, so the step > 0 drain re-saving
         // these messages later is harmless.
-        const pending = [...messageList.get.input.db(), ...messageList.get.response.db()];
+        const pendingInput = messageList.get.input.db();
+        const pendingOutput = messageList.get.response.db();
+        const pending = [...pendingInput, ...pendingOutput];
         if (pending.length > 0) {
-          await om.persistMessages(pending, threadId, resourceId);
+          await om.persistClientInputMessages(pendingInput, pendingOutput, threadId, resourceId);
         }
         // The in-flight prompt was just observed, but the model still needs it to answer —
         // protect it (and everything else pending) from cleanup by identity rather than

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -215,9 +215,8 @@ export class ObservationTurn {
     // Save any unsaved messages from the last step
     const unsavedInput = this.messageList.get.input.db();
     const unsavedOutput = this.messageList.get.response.db();
-    const unsavedMessages = [...unsavedInput, ...unsavedOutput];
-    if (unsavedMessages.length > 0) {
-      await this.om.persistMessages(unsavedMessages, this.threadId, this.resourceId);
+    if (unsavedInput.length > 0 || unsavedOutput.length > 0) {
+      await this.om.persistClientInputMessages(unsavedInput, unsavedOutput, this.threadId, this.resourceId);
     }
 
     // When the agent goes idle, start buffering any unobserved messages in the background.

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -1840,6 +1840,21 @@ export class ObservationalMemory {
     }
   }
 
+  /** Persist client input after reconciliation, while leaving server-authored messages untouched. */
+  async persistClientInputMessages(
+    clientInput: MastraDBMessage[],
+    serverAuthored: MastraDBMessage[],
+    threadId: string,
+    resourceId: string | undefined,
+  ): Promise<void> {
+    const reconciledInput = await this.messageHistory.reconcileClientInputMessages({
+      messages: clientInput,
+      threadId,
+      resourceId,
+    });
+    await this.persistMessages([...reconciledInput, ...serverAuthored], threadId, resourceId);
+  }
+
   /**
    * Load messages from storage that haven't been observed yet.
    * Uses cursor-based query with lastObservedAt timestamp for efficiency.

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -394,9 +394,8 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
           // from the resumed turn is not lost.
           const newOutput = messageList.get.response.db();
           const newInput = messageList.get.input.db();
-          const messagesToSave = [...newInput, ...newOutput];
-          if (messagesToSave.length > 0 && context.threadId) {
-            await this.engine.persistMessages(messagesToSave, context.threadId, context.resourceId);
+          if ((newInput.length > 0 || newOutput.length > 0) && context.threadId) {
+            await this.engine.persistClientInputMessages(newInput, newOutput, context.threadId, context.resourceId);
           }
         }
 


### PR DESCRIPTION
Fixes #20836

## What

When a client submits its visible transcript back on a later turn (reusing the same message IDs), the whole-record upsert silently overwrote canonical persisted messages. Server-authored content was clobbered by the raw client copy: output-processor transformations, completed tool history, and metadata.

## Changes

- **`reconcile-client-echoes.ts`** (new, `@mastra/core`): reconciles client-submitted input messages against their stored records by ID (lookup via `listMessagesById`, independent of the `lastMessages` recall window):
  - unchanged echoes are dropped (no re-persist)
  - lossy client copies are merged into the stored canonical version
  - only supported client-authored transitions are applied, e.g. a client-side tool result advancing a stored `call` to `result` — the server's args/name/text/metadata are preserved (including when the client copy carries different args)
- **`message-history.ts`**: `processOutputResult` reconciles `input.db()` against storage before persisting, guarded so storage mocks without `listMessagesById` keep working
- **Tests** (`message-history.test.ts`, 22/22 passing): unchanged echo not re-persisted · lossy echo cannot clobber transformed text or tool history · client tool result merges into the stored `call` preserving server args (incl. overlapping-args case)
- **Docs**: `message-history.mdx` info block on echo reconciliation + `ai-sdk-ui.mdx` "When a client echoes the full transcript" section
- **Changeset**: `calm-echoes-bounce.md` (`@mastra/core` patch)

## Repro

Standalone deterministic repro (mock LLM, no API keys) kept at `mastra-echo-repro/` next to this checkout — not part of this repo. Three scenarios via `node scripts/generate-repro.mjs <echo|tool|om>`:

| Scenario | published `@mastra/core` | this branch |
| --- | --- | --- |
| `echo` — lossy echo clobbers transformed text | ❌ fails (bug) | ✅ passes |
| `tool` — client tool `result` echo with modified args | ❌ fails (bug) | ✅ passes |
| `om` — same invariant under Observational Memory | ✅ passes | ✅ passes (regression guard) |

```bash
cd mastra-echo-repro
npm install
node scripts/generate-repro.mjs echo && npm test      # fails on published (bug)
node scripts/use-local-core.mjs <mastra> && npm install --legacy-peer-deps
npm test                                              # passes on this branch
```

The `tool` scenario caught a real bug in the first version of this fix (client args overriding stored args in the merge) — covered by the strengthened unit test.

## OM follow-up

Observational Memory shares the persistence path but re-saves server-authored content after the input pass (its multistep drain), so a lossy echo cannot clobber it in the current shape — the `om` scenario is kept as a regression guard. If OM evolves to persist before that re-save, the same reconciliation should be applied to its input path; the `om` repro will start failing when that happens. Tracked as a follow-up, not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a client sends an old copy of a conversation, the server keeps the correct saved version instead of overwriting it. It also accepts valid updates, such as tool results or edited user messages.

## Changes

- Added client-echo reconciliation by message ID, thread, and resource.
- Skipped unchanged echoed messages.
- Preserved server-authored content, tool identity, arguments, metadata, legacy `toolInvocations`, and non-tool parts.
- Allowed valid client-authored tool transitions and edited user messages.
- Discarded client-only metadata and parts.
- Added lookup failure tracing with fallback persistence.
- Preserved compatibility with storage implementations without `listMessagesById`.
- Added regression tests, documentation, and a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->