### PR TITLE
fix(core): normalize instruction-file paths to forward slashes on Windows

### DIFF
--- a/.changeset/wild-reminders-jump.md
+++ b/.changeset/wild-reminders-jump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Normalize instruction-file paths (AGENTS.md/CLAUDE.md/CONTEXT.md) to forward slashes in dynamic `system-reminder` injection. On Windows, `node:path` produced backslash-separated paths that leaked into the prompt reminders and the metadata used to avoid re-injection; paths are now identical across platforms and match the paths tool calls report. Windows filesystem APIs accept forward slashes, so file reads are unaffected.

--- a/packages/core/src/processors/tool-result-reminder.test.ts
+++ b/packages/core/src/processors/tool-result-reminder.test.ts
@@ -748,4 +748,83 @@ describe('AgentsMDInjector', () => {
     expect(reminder).toContain('[truncated — showing first ~');
     expect(reminder.endsWith('</system-reminder>')).toBe(true);
   });
+
+  describe('cross-platform path normalization', () => {
+    it('normalizes backslash separators in direct instruction-file references', async () => {
+      const messageList = new TestMessageList();
+      const toolCallId = 'call-win-sep';
+      messageList.push(createUserMessage('Open the instructions'));
+      messageList.pushResponse(
+        createAssistantMessage({
+          format: 2,
+          parts: [
+            createToolInvocationPart(toolCallId, { path: '\\repo\\src\\agents\\nested\\AGENTS.md' }, 'result', {
+              ok: true,
+            }),
+          ],
+        }),
+      );
+
+      const testProcessor = new AgentsMDInjector({
+        reminderText: REMINDER_TEXT,
+        // The backslash input resolves against cwd on POSIX, so match by suffix
+        // rather than the full resolved path.
+        pathExists: path => String(path).endsWith('/agents/nested/AGENTS.md'),
+        isDirectory: () => false,
+        readFile: path => (String(path).endsWith('/agents/nested/AGENTS.md') ? FILE_CONTENT : ''),
+      });
+
+      await testProcessor.processInputStep(
+        createProcessInputStepArgs(messageList, [
+          createToolCall({ path: '\\repo\\src\\agents\\nested\\AGENTS.md' }, 'view', toolCallId),
+        ]),
+      );
+
+      const injectedReminder = messageList.get.all.db().at(-1);
+      expect(injectedReminder?.role).toBe('signal');
+      const reminderPath = (injectedReminder!.content.metadata?.signal as any)?.metadata?.path as string;
+      expect(reminderPath).toBeDefined();
+      // The reminder path must use forward slashes on every platform and still
+      // point at the instruction file.
+      expect(reminderPath).not.toContain('\\');
+      expect(reminderPath.endsWith('/agents/nested/AGENTS.md')).toBe(true);
+      expect(extractReminderMarkup(messageList)[0]).toContain(`path="${reminderPath}"`);
+    });
+
+    it('walks parent directories with forward-slash paths on every platform', async () => {
+      const messageList = new TestMessageList();
+      const toolCallId = 'call-win-walk';
+      messageList.push(createUserMessage('Read the source file'));
+      messageList.pushResponse(
+        createAssistantMessage({
+          format: 2,
+          parts: [
+            createToolInvocationPart(toolCallId, { path: '\\repo\\src\\components\\Button.tsx' }, 'result', {
+              ok: true,
+            }),
+          ],
+        }),
+      );
+
+      const testProcessor = new AgentsMDInjector({
+        reminderText: REMINDER_TEXT,
+        pathExists: path =>
+          String(path).endsWith('/components/AGENTS.md') || String(path).endsWith('/components/Button.tsx'),
+        isDirectory: path => String(path).endsWith('/components') || String(path).endsWith('/src'),
+        readFile: path => (String(path).endsWith('/components/AGENTS.md') ? FILE_CONTENT : ''),
+      });
+
+      await testProcessor.processInputStep(
+        createProcessInputStepArgs(messageList, [
+          createToolCall({ path: '\\repo\\src\\components\\Button.tsx' }, 'view', toolCallId),
+        ]),
+      );
+
+      const injectedReminder = messageList.get.all.db().at(-1);
+      expect(injectedReminder?.role).toBe('signal');
+      const reminderPath = (injectedReminder!.content.metadata?.signal as any)?.metadata?.path as string;
+      expect(reminderPath.endsWith('/components/AGENTS.md')).toBe(true);
+      expect(reminderPath).not.toContain('\\');
+    });
+  });
 });

--- a/packages/core/src/processors/tool-result-reminder.ts
+++ b/packages/core/src/processors/tool-result-reminder.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import { basename, dirname, isAbsolute, join, normalize, resolve } from 'node:path';
+import { isAbsolute, normalize, posix, resolve } from 'node:path';
 import { estimateTokenCount } from 'tokenx';
 import type { MessageList, MastraDBMessage } from '../agent/message-list';
 import { signalToXmlMarkup } from '../agent/signals';
@@ -73,8 +73,22 @@ function isInstructionFileName(name: string): boolean {
   return INSTRUCTION_FILE_NAMES.some(instructionFileName => instructionFileName.toLowerCase() === name.toLowerCase());
 }
 
+/**
+ * Normalize path separators to forward slashes.
+ *
+ * Instruction paths are embedded in prompt reminders and used as the dedup
+ * identity in metadata, so they must be stable across platforms. `node:path`
+ * produces `\` separators on Windows; converting to `/` keeps the reminder
+ * path (and the metadata used to avoid re-injection) identical on every OS.
+ * Windows filesystem APIs accept forward slashes, so real reads still work.
+ */
+function toPosixPath(candidatePath: string): string {
+  return candidatePath.replaceAll('\\', '/');
+}
+
 function toAbsolutePath(candidatePath: string): string {
-  return normalize(isAbsolute(candidatePath) ? candidatePath : resolve(process.cwd(), candidatePath));
+  const absolutePath = normalize(isAbsolute(candidatePath) ? candidatePath : resolve(process.cwd(), candidatePath));
+  return toPosixPath(absolutePath);
 }
 
 function findInstructionFileForPath(
@@ -83,28 +97,31 @@ function findInstructionFileForPath(
   isDirectory: (path: string) => boolean,
 ): string | undefined {
   const absoluteCandidatePath = toAbsolutePath(candidatePath);
-  const candidateName = basename(absoluteCandidatePath);
+  const candidateName = posix.basename(absoluteCandidatePath);
 
   if (isInstructionFileName(candidateName)) {
     return absoluteCandidatePath;
   }
 
+  // Walk the directory ancestry with POSIX operations. `toAbsolutePath` already
+  // returned a forward-slash path, and `path.posix` keeps it that way on every
+  // platform, so the walk (and the reminder path it produces) is deterministic.
   let currentDir = absoluteCandidatePath;
   if (!pathExists(currentDir) || !isDirectory(currentDir)) {
-    currentDir = dirname(currentDir);
+    currentDir = posix.dirname(currentDir);
   }
 
   let previousDir: string | undefined;
   while (currentDir && currentDir !== previousDir) {
     for (const instructionFileName of INSTRUCTION_FILE_NAMES) {
-      const instructionFilePath = join(currentDir, instructionFileName);
+      const instructionFilePath = posix.join(currentDir, instructionFileName);
       if (pathExists(instructionFilePath)) {
         return instructionFilePath;
       }
     }
 
     previousDir = currentDir;
-    currentDir = dirname(currentDir);
+    currentDir = posix.dirname(currentDir);
   }
 
   return undefined;


### PR DESCRIPTION
Fixes #21070

## What

On Windows, `node:path` produced backslash-separated paths that leaked into dynamic `system-reminder` injection (prompt text, signal metadata, and the dedup keys) whenever an `AGENTS.md`/`CLAUDE.md`/`CONTEXT.md` instruction file was referenced. The same platform operators broke the directory walk, so `pathExists`/`isDirectory` checks against POSIX-style paths never matched on Windows (e.g. the `agents-md-autoload` injector silently did nothing).

## Changes

- `toPosixPath()`: normalizes separators to `/`
- `toAbsolutePath()` now returns the POSIX form (`C:/...` on Windows, `/repo/...` unchanged elsewhere)
- the parent-directory walk uses `path.posix` over the normalized path
- neutral on Linux by construction (`path.posix` === native module; `toPosixPath` is a no-op for POSIX paths), and Windows filesystem APIs accept forward slashes, so real file reads are unaffected

## Tests

- Cross-platform regression tests: backslash inputs must produce POSIX reminders on every platform — verified to fail without the fix and pass with it
- Windows: the 16 pre-existing failures in `tool-result-reminder.test.ts` + `agents-md-autoload-integration.test.ts` → **25/25 pass**; full `packages/core/src/processors` suite: 1084 pass / 1 skip
- Linux: these tests already pass on POSIX (the failures were Windows-only); a WSL cross-check is queued as follow-up (scripts ready)

## Changeset

`wild-reminders-jump.md` (`@mastra/core` patch)
