### PR TITLE
fix(core): normalize run-command-tool path containment for cross-platform security

### DIFF
--- a/.changeset/normalize-run-command-paths.md
+++ b/.changeset/normalize-run-command-paths.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+fix(run-command-tool): normalize path containment to POSIX separators for cross-platform security
+
+`isPathAllowed` used `startsWith(base + '/')` which on Windows produced `C:\projects/` — comparisons against backslash-normalized paths like `C:\projects\sub` always failed, silently rejecting all legitimate working directories. `extractBaseCommand` only split on `/`, letting Windows paths like `C:\tools\git.exe` escape the allowlist and blocklist (the full path was treated as the base command name instead of extracting `git.exe`).
+
+Both sides of `isPathAllowed` now normalize to POSIX forward slashes before comparison. `extractBaseCommand` splits on both `/` and `\`. Added explicit `..` traversal rejection. Added unit tests for cross-platform path containment, command extraction, and traversal guarding.

--- a/packages/core/src/loop/network/run-command-tool.test.ts
+++ b/packages/core/src/loop/network/run-command-tool.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import { createRunCommandTool } from './run-command-tool';
+
+/**
+ * Tests for run-command-tool path containment.
+ *
+ * The tool functions that need testing are private (`isPathAllowed`,
+ * `extractBaseCommand`), so we test them indirectly through the
+ * `execute` method of the public tool API. We craft inputs that
+ * exercise the private functions and check the rejection messages.
+ */
+
+describe('createRunCommandTool - basic security', () => {
+  it('rejects unsafe characters in command', async () => {
+    const tool = createRunCommandTool();
+    const result = await tool.execute?.({ command: 'echo test | cat', timeout: 5000 });
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('unsafe');
+  });
+
+  it('rejects blocked commands', async () => {
+    const tool = createRunCommandTool();
+    const result = await tool.execute?.({ command: 'rm -rf /', timeout: 5000 });
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('is not permitted');
+  });
+
+  it('rejects commands not in allowlist when configured', async () => {
+    const tool = createRunCommandTool({ allowedCommands: ['git', 'npm'] });
+    const result = await tool.execute?.({ command: 'ls -la', timeout: 5000 });
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('not in the allowed commands');
+  });
+});
+
+// ── extractBaseCommand ───────────────────────────────────────────
+// The function is private; we test it by crafting commands where the
+// extracted base command hits the blocklist (if extraction works
+// correctly) or escapes it (if extraction is broken on Windows).
+
+describe('extractBaseCommand — cross-platform command extraction', () => {
+  it('extracts base command from POSIX path', async () => {
+    // `mkdir` is blocked by BLOCKED_COMMANDS but only if extraction works.
+    // If /usr/bin/mkdir is treated as the whole string, it won't match 'mkdir'.
+    const tool = createRunCommandTool({
+      additionalBlockedCommands: ['mkdir'],
+    });
+    const result = await tool.execute?.({ command: '/usr/bin/mkdir testdir', timeout: 5000 });
+    // After fix: extracts 'mkdir' → rejected by blocklist.
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('is not permitted');
+  });
+
+  it('extracts base command from Windows path', async () => {
+    // On Windows, extractBaseCommand must split on both \ and /.
+    // Before the fix: `lastIndexOf('/')` returns -1 for a pure Windows path,
+    // so `C:\\Windows\\System32\\ftp help` would be treated as the base command
+    // instead of extracting `ftp`.
+    const tool = createRunCommandTool({
+      additionalBlockedCommands: ['ftp'],
+    });
+    const result = await tool.execute?.({ command: 'C:\\Windows\\System32\\ftp help', timeout: 5000 });
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('is not permitted');
+  });
+
+  it('extracts base command from path with mixed separators', async () => {
+    // Mixed-forward-slash Windows path (what `path.posix.normalize` might produce)
+    const tool = createRunCommandTool({
+      additionalBlockedCommands: ['ftp'],
+    });
+    const result = await tool.execute?.({ command: 'C:/Windows/System32/ftp help', timeout: 5000 });
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('is not permitted');
+  });
+
+  it('extracts base command from relative Windows path', async () => {
+    const tool = createRunCommandTool({
+      additionalBlockedCommands: ['node'],
+    });
+    const result = await tool.execute?.({ command: '.\\bin\\node server.js', timeout: 5000 });
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('is not permitted');
+  });
+
+  it('extracts simple command with no slashes', async () => {
+    const tool = createRunCommandTool({
+      additionalBlockedCommands: ['rmdir'],
+    });
+    const result = await tool.execute?.({ command: 'rmdir /s /q temp', timeout: 5000 });
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('is not permitted');
+  });
+});
+
+// ── isPathAllowed ─────────────────────────────────────────────────
+// Tested indirectly by providing a cwd and allowedBasePaths. Before the
+// fix, Windows base paths would reject ALL cwds because `startsWith(base + '/')`
+// used forward slashes while `normalize()` produced backslash paths.
+
+describe('isPathAllowed — cross-platform path containment', () => {
+  const basePath = process.platform === 'win32' ? 'C:\\projects' : '/tmp/projects';
+
+  it('allows cwd that is the base path itself', async () => {
+    const tool = createRunCommandTool({
+      allowedBasePaths: [basePath],
+      allowedCommands: ['echo'],
+    });
+    const result = await tool.execute?.({ command: 'echo hello', cwd: basePath, timeout: 5000 });
+    expect(result?.success).toBe(true);
+  });
+
+  it('rejects cwd outside base path', async () => {
+    const tool = createRunCommandTool({
+      allowedBasePaths: [basePath],
+    });
+    const outside = process.platform === 'win32' ? 'C:\\outside' : '/outside';
+    const result = await tool.execute?.({ command: 'echo hello', cwd: outside, timeout: 5000 });
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('not within allowed paths');
+  });
+
+  it('allows cwd as subdirectory of base (POSIX path)', async () => {
+    // This test MUST pass on all platforms — before the fix, it would
+    // fail on Windows because `startsWith(base + '/')` produces `C:\projects/`
+    // which doesn't match `C:\projects\sub`.
+    const tool = createRunCommandTool({
+      allowedBasePaths: [basePath],
+      allowedCommands: ['echo'],
+    });
+    const subdir = process.platform === 'win32' ? 'C:\\projects\\sub' : '/tmp/projects/sub';
+    const result = await tool.execute?.({ command: 'echo ok', cwd: subdir, timeout: 5000 });
+    expect(result?.success).toBe(true);
+  });
+
+  it('allows any cwd when no base paths are configured', async () => {
+    const tool = createRunCommandTool({
+      allowedBasePaths: [],
+      allowedCommands: ['echo'],
+    });
+    const result = await tool.execute?.({ command: 'echo anywhere', cwd: '/anywhere', timeout: 5000 });
+    expect(result?.success).toBe(true);
+  });
+});
+
+// ── traversal guard ───────────────────────────────────────────────
+
+describe('createRunCommandTool — traversal rejection', () => {
+  const basePath = process.platform === 'win32' ? 'C:\\projects' : '/tmp/projects';
+
+  it('rejects path with .. traversal', async () => {
+    const tool = createRunCommandTool({
+      allowedBasePaths: [basePath],
+    });
+    const result = await tool.execute?.({
+      command: 'echo pwn',
+      cwd: process.platform === 'win32' ? 'C:\\projects\\..\\ssh' : '/tmp/projects/../ssh',
+      timeout: 5000,
+    });
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('traversal');
+  });
+
+  it('does NOT reject path containing ... (not real traversal)', async () => {
+    // `...` is not `..` — should pass through to isPathAllowed
+    const tool = createRunCommandTool({
+      allowedBasePaths: [basePath],
+      allowedCommands: ['echo'],
+    });
+    const pathWithDots = process.platform === 'win32' ? 'C:\\projects\\my...app' : '/tmp/projects/my...app';
+    const result = await tool.execute?.({ command: 'echo ok', cwd: pathWithDots, timeout: 5000 });
+    expect(result?.success).toBe(true);
+  });
+});

--- a/packages/core/src/loop/network/run-command-tool.ts
+++ b/packages/core/src/loop/network/run-command-tool.ts
@@ -118,27 +118,42 @@ export interface RunCommandToolOptions {
 }
 
 /**
+ * Normalizes a path to POSIX forward-slash separators.
+ * This ensures cross-platform consistency: on Windows, `node:path` produces
+ * `\` separators, which break `startsWith` comparisons and command extraction.
+ * Windows APIs accept forward slashes, so real filesystem operations still work.
+ */
+function toPosixPath(candidatePath: string): string {
+  return candidatePath.replaceAll('\\', '/');
+}
+
+/**
  * Validates that a path is under one of the allowed base paths.
  */
 function isPathAllowed(targetPath: string, allowedBasePaths: string[]): boolean {
   if (allowedBasePaths.length === 0) return true;
 
-  const normalizedTarget = normalize(resolve(targetPath));
+  // Normalize to POSIX separators so comparisons work on all platforms.
+  // On Windows, `normalize(resolve(...))` produces backslash paths, and
+  // `startsWith(base + '/')` would never match `base\sub`.
+  const normalizedTarget = toPosixPath(normalize(resolve(targetPath)));
   return allowedBasePaths.some(basePath => {
-    const normalizedBase = normalize(resolve(basePath));
+    const normalizedBase = toPosixPath(normalize(resolve(basePath)));
     return normalizedTarget === normalizedBase || normalizedTarget.startsWith(normalizedBase + '/');
   });
 }
 
 /**
  * Extracts the base command from a command string.
+ * Splits on both `/` and `\` to handle Windows paths correctly.
  */
 function extractBaseCommand(command: string): string {
   const trimmed = command.trim();
   const firstSpace = trimmed.indexOf(' ');
   const baseCmd = firstSpace === -1 ? trimmed : trimmed.substring(0, firstSpace);
-  // Handle paths like /usr/bin/git -> git
-  const lastSlash = baseCmd.lastIndexOf('/');
+  // Handle paths like /usr/bin/git → git or C:\tools\git.exe → git.exe
+  // Split on both forward and backward slashes for cross-platform support.
+  const lastSlash = Math.max(baseCmd.lastIndexOf('/'), baseCmd.lastIndexOf('\\'));
   return lastSlash === -1 ? baseCmd : baseCmd.substring(lastSlash + 1);
 }
 
@@ -229,6 +244,17 @@ export function createRunCommandTool(options: RunCommandToolOptions = {}) {
             message: `Command rejected: '${baseCommand}' is not in the allowed commands list`,
           };
         }
+      }
+
+      // Validate: reject path traversal patterns
+      if (cwd && (cwd.includes('..') && cwd.split(/[/\\]/).some(seg => seg === '..'))) {
+        return {
+          success: false,
+          exitCode: 1,
+          stdout: '',
+          stderr: '',
+          message: `Command rejected: working directory '${cwd}' contains path traversal`,
+        };
       }
 
       // Validate: check cwd against allowed base paths


### PR DESCRIPTION
## Summary

Fixes #21074 — the `run-command-tool` (`packages/core/src/loop/network/run-command-tool.ts`) had two path-handling bugs that broke security containment on Windows. The tool had **zero tests** despite executing arbitrary shell commands.

### What changed

**`isPathAllowed` — Windows cwds silently rejected**

Used `startsWith(base + '/')`. On Windows, `normalize()` produces backslash paths like `C:\projects\sub`, but the comparison string became `C:\projects/` — **never matched**, silently rejecting all legitimate working directories when `allowedBasePaths` was configured.

→ Fix: normalize both sides to POSIX forward slashes via `toPosixPath()` before comparison (same pattern as the existing `toPosixPath` in `tool-result-reminder.ts`).

**`extractBaseCommand` — Windows paths escape allowlist/blocklist**

Only split on `/`. A command like `C:\tools\git.exe` has no forward slashes → `lastIndexOf('/')` returns -1 → the **entire path** was treated as the base command name, escaping both `allowedCommands` and `BLOCKED_COMMANDS`.

→ Fix: split on both `/` and `\\` via `Math.max(lastIndexOf('/'), lastIndexOf('\\'))`.

**Additional hardening: `..` traversal rejection**

→ Fix: reject cwd paths containing `..` as a path segment before the containment check.

### Tests added

- **`extractBaseCommand`**: POSIX path extraction, Windows path extraction (the broken case), mixed separators, relative Windows paths, simple commands
- **`isPathAllowed`**: base path match, subdirectory under base (the broken Windows case), outside base rejection, no base paths configured
- **Traversal guard**: `..` rejection, `...` is NOT rejected (not real traversal)
- **Basic security**: unsafe chars, blocked commands, allowlist enforcement

### Testing

CI will run these tests on Linux. For Windows coverage, the test assertions are platform-agnostic (they exercise the `execute` path which calls the private functions under test). The key assertions that would have failed before the fix:
- `extracts base command from Windows path` — would extract `C:\Windows\System32\ftp help` instead of `ftp` (test expects blocklist rejection)
- `allows cwd as subdirectory of base` — on Windows CI, this would fail without the fix
