### PR TITLE
fix(core): serialize queued LSP diagnostics

### DIFF
--- a/.changeset/tidy-lsp-file-locks.md
+++ b/.changeset/tidy-lsp-file-locks.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed same-file LSP diagnostics to remain serialized when multiple requests are queued.

--- a/packages/core/src/workspace/lsp/manager.test.ts
+++ b/packages/core/src/workspace/lsp/manager.test.ts
@@ -681,6 +681,57 @@ describe('LSPManager', () => {
   // ==========================================================================
 
   describe('per-file mutex serialization', () => {
+    it('serializes three concurrent getDiagnostics calls for the same file', async () => {
+      const callOrder: string[] = [];
+      let releaseFirst!: () => void;
+      const firstDiagnostics = new Promise<void>(resolve => {
+        releaseFirst = resolve;
+      });
+
+      mockNotifyOpen.mockImplementation((_file: string, content: string) => {
+        callOrder.push(`open-${content}`);
+      });
+      mockNotifyClose.mockImplementation(() => {
+        callOrder.push('close');
+      });
+      mockWaitForDiagnostics
+        .mockImplementationOnce(async () => {
+          callOrder.push('wait-1');
+          await firstDiagnostics;
+          return [];
+        })
+        .mockImplementationOnce(async () => {
+          callOrder.push('wait-2');
+          return [];
+        })
+        .mockImplementationOnce(async () => {
+          callOrder.push('wait-3');
+          return [];
+        });
+
+      const diagnostics = [
+        manager.getDiagnostics('/project/src/app.ts', '1'),
+        manager.getDiagnostics('/project/src/app.ts', '2'),
+        manager.getDiagnostics('/project/src/app.ts', '3'),
+      ];
+
+      await vi.waitFor(() => expect(callOrder).toEqual(['open-1', 'wait-1']));
+      releaseFirst();
+      await Promise.all(diagnostics);
+
+      expect(callOrder).toEqual([
+        'open-1',
+        'wait-1',
+        'close',
+        'open-2',
+        'wait-2',
+        'close',
+        'open-3',
+        'wait-3',
+        'close',
+      ]);
+    });
+
     it('serializes concurrent getDiagnostics for same file', async () => {
       const callOrder: string[] = [];
 

--- a/packages/core/src/workspace/lsp/manager.ts
+++ b/packages/core/src/workspace/lsp/manager.ts
@@ -87,10 +87,7 @@ export class LSPManager {
    * Different files can run in parallel.
    */
   private async acquireFileLock(filePath: string): Promise<() => void> {
-    // Wait for any existing lock on this file
-    while (this.fileLocks.has(filePath)) {
-      await this.fileLocks.get(filePath);
-    }
+    const previousLock = this.fileLocks.get(filePath);
 
     let release!: () => void;
     const lockPromise = new Promise<void>(resolve => {
@@ -98,8 +95,12 @@ export class LSPManager {
     });
     this.fileLocks.set(filePath, lockPromise);
 
+    await previousLock;
+
     return () => {
-      this.fileLocks.delete(filePath);
+      if (this.fileLocks.get(filePath) === lockPromise) {
+        this.fileLocks.delete(filePath);
+      }
       release();
     };
   }


### PR DESCRIPTION
Fixes #21076 by appending each same-file diagnostics request to a promise chain before waiting for its predecessor. This keeps the LSP open/change/close sequence serialized when three or more requests are queued for the same path.

Previously, multiple waiters could resume from the same stored lock. With this change, each waiter captures and waits for its immediate predecessor, while requests for different files continue to run in parallel.

Added a deterministic three-request regression test. The focused LSP suite passes with all 52 tests.

The full core build/typecheck could not be run in this environment because internal dependencies are unbuilt, and the installed Node.js 22.14 is below the repository's tooling requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When several requests check the same file, they now take turns instead of running over each other. Requests for different files can still run at the same time.

## Changes

- Chain each same-file LSP request to its immediate predecessor.
- Preserve FIFO order for `didOpen`, `didChange`, and `didClose` operations.
- Prevent stale lock releases from removing a newer lock.
- Add a deterministic regression test for three queued same-file requests.
- Add a patch changeset for `@mastra/core`.

## Validation

- Focused LSP suite passes all 52 tests.
- Full core build and typecheck were not run because internal dependencies were unbuilt and Node.js 22.14 does not meet the repository tooling requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->