### PR TITLE
Acknowledge pubsub deliveries so durable event backends stop accumulating pending messages

### DIFF
--- a/.changeset/thread-stream-ack-pubsub-events.md
+++ b/.changeset/thread-stream-ack-pubsub-events.md
@@ -2,4 +2,13 @@
 '@mastra/core': patch
 ---
 
-Acknowledge thread-stream pubsub deliveries so persistent backends stop accumulating pending entries. The thread subscriber and the remote-run waiter now ack every event they inspect (including filtered-out ones) and nack when processing throws; the remote-run waiter also waits for the terminal event's ack before unsubscribing.
+Acknowledge pubsub deliveries so persistent backends stop accumulating pending entries. Every fan-out subscribe creates a private consumer group, and Redis keeps each delivered entry pending until it is acked, so subscribers that never acknowledged grew an unbounded pending list for as long as they stayed attached.
+
+The following subscribers now ack every event they inspect (including ones they filter out) and nack when processing throws:
+
+- the agent thread-stream subscriber and the cross-agent remote-run waiter, which also waits for the terminal event's ack before unsubscribing
+- workflow run watchers, including the shared `nested-watch` topic
+- durable agent abort-request listeners
+- user-defined topic listeners registered through `events` or `addTopicListener`
+
+`events` listeners are typed as receiving only the event; acknowledgement is handled for them.

--- a/.changeset/thread-stream-ack-pubsub-events.md
+++ b/.changeset/thread-stream-ack-pubsub-events.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Acknowledge thread-stream pubsub deliveries so persistent backends stop accumulating pending entries. The thread subscriber and the remote-run waiter now ack every event they inspect (including filtered-out ones) and nack when processing throws; the remote-run waiter also waits for the terminal event's ack before unsubscribing.

--- a/packages/core/src/agent/__tests__/agent-thread-stream-ack.test.ts
+++ b/packages/core/src/agent/__tests__/agent-thread-stream-ack.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Thread fan-out subscriptions are private per-subscriber consumer groups on a
+ * persistent backend (Redis streams). Anything a subscriber never acknowledges
+ * stays in that group's pending entries list forever, so both thread
+ * subscribers must acknowledge *every* delivery they inspect — including
+ * events they filter out — and must not unsubscribe before the terminal
+ * acknowledgement lands.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { PubSub } from '../../events/pubsub';
+import type { LeaseProvider } from '../../events/pubsub';
+import type { EventCallback } from '../../events/types';
+import type { Agent } from '../agent';
+import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+
+const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
+
+function nextTick() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+/**
+ * In-memory pubsub that models an acknowledged backend: every delivery stays
+ * "pending" until the subscriber acks (removes it) or nacks (redelivery
+ * eligible). Delivery order is preserved and publish resolves only once the
+ * subscriber callback has settled, so tests can assert on the pending set.
+ */
+class AckTrackingPubSub extends PubSub implements LeaseProvider {
+  owners = new Map<string, string>();
+  acked: string[] = [];
+  nacked: string[] = [];
+  pending = new Set<string>();
+  unsubscribedAt: number | null = null;
+  #order = 0;
+  #subscribers = new Map<string, Set<EventCallback>>();
+  #index = 0;
+
+  async publish(topic: string, event: any): Promise<void> {
+    const id = `event-${this.#index++}`;
+    const envelope = { ...event, id, createdAt: new Date() };
+    for (const subscriber of [...(this.#subscribers.get(topic) ?? [])]) {
+      this.pending.add(id);
+      const ack = async () => {
+        this.pending.delete(id);
+        this.acked.push(id);
+        this.#order++;
+      };
+      const nack = async () => {
+        this.nacked.push(id);
+      };
+      try {
+        await subscriber(envelope, ack, nack);
+      } catch {
+        // A rejected callback is the negative acknowledgement signal; a real
+        // backend nacks on it rather than dropping the entry.
+        await nack();
+      }
+    }
+  }
+
+  async flush(): Promise<void> {}
+
+  async subscribe(topic: string, cb: EventCallback): Promise<void> {
+    const subscribers = this.#subscribers.get(topic) ?? new Set<EventCallback>();
+    subscribers.add(cb);
+    this.#subscribers.set(topic, subscribers);
+  }
+
+  async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
+    this.unsubscribedAt = this.#order;
+    this.#subscribers.get(topic)?.delete(cb);
+  }
+
+  async acquireLease(key: string, owner: string): Promise<{ acquired: boolean; owner?: string }> {
+    const current = this.owners.get(key);
+    if (current && current !== owner) return { acquired: false, owner: current };
+    this.owners.set(key, owner);
+    return { acquired: true, owner };
+  }
+
+  async getLeaseOwner(key: string): Promise<string | undefined> {
+    return this.owners.get(key);
+  }
+
+  async releaseLease(key: string, owner: string): Promise<void> {
+    if (this.owners.get(key) === owner) this.owners.delete(key);
+  }
+
+  async renewLease(key: string, owner: string): Promise<boolean> {
+    return this.owners.get(key) === owner;
+  }
+
+  async transferLease(key: string, fromOwner: string, toOwner: string): Promise<boolean> {
+    if (this.owners.get(key) !== fromOwner) return false;
+    this.owners.set(key, toOwner);
+    return true;
+  }
+}
+
+const agent = { id: 'ack-agent' } as Agent<any, any, any, any>;
+const threadId = 'ack-thread';
+const resourceId = 'ack-user';
+const key = [resourceId, threadId].join(AGENT_THREAD_KEY_SEPARATOR);
+const topic = `agent.thread-stream.${encodeURIComponent(key)}`;
+
+describe('thread stream subscriber acknowledgements', () => {
+  it('acks every delivered event, including ones it filters out', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new AckTrackingPubSub();
+    pubsub.owners.set(key, 'remote-run');
+
+    const subscription = await runtime.subscribeToThread(agent, { threadId, resourceId }, pubsub);
+
+    // An event with no payload is ignored by the handler but still delivered.
+    await pubsub.publish(topic, { type: 'agent.thread-stream', runId: 'remote-run', data: undefined });
+    await pubsub.publish(topic, {
+      type: 'agent.thread-stream',
+      runId: 'remote-run',
+      data: { type: 'run-registered', runId: 'remote-run', streamId: 'remote-stream', streamSeq: 1 },
+    });
+    await pubsub.publish(topic, {
+      type: 'agent.thread-stream',
+      runId: 'remote-run',
+      data: {
+        type: 'stream-part',
+        runId: 'remote-run',
+        streamId: 'remote-stream',
+        sourceId: 'other-process',
+        part: { type: 'text-delta', payload: { text: 'hi' } },
+      },
+    });
+    await pubsub.publish(topic, {
+      type: 'agent.thread-stream',
+      runId: 'remote-run',
+      data: { type: 'run-completed', runId: 'remote-run', streamId: 'remote-stream' },
+    });
+
+    expect(pubsub.acked).toHaveLength(4);
+    expect(pubsub.pending.size).toBe(0);
+    expect(pubsub.nacked).toEqual([]);
+
+    subscription.unsubscribe();
+  });
+
+  it('nacks a delivery whose processing throws and keeps processing later events', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new AckTrackingPubSub();
+
+    const subscription = await runtime.subscribeToThread(agent, { threadId, resourceId }, pubsub);
+
+    // `state` signals cannot be transient — createSignal throws, which is the
+    // subscriber's negative acknowledgement path.
+    await pubsub.publish(topic, {
+      type: 'agent.thread-stream',
+      runId: 'remote-run',
+      data: {
+        type: 'signal-enqueued',
+        runId: 'remote-run',
+        sourceId: 'other-process',
+        signal: { type: 'state', transient: true, contents: 'boom' },
+      },
+    });
+
+    expect(pubsub.nacked).toHaveLength(1);
+    expect(pubsub.acked).toEqual([]);
+    expect(pubsub.pending.size).toBe(1);
+
+    await pubsub.publish(topic, {
+      type: 'agent.thread-stream',
+      runId: 'remote-run',
+      data: { type: 'run-registered', runId: 'remote-run', streamId: 'remote-stream', streamSeq: 1 },
+    });
+    expect(pubsub.acked).toHaveLength(1);
+
+    subscription.unsubscribe();
+  });
+
+  it('acks every event the remote-run waiter inspects before unsubscribing', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new AckTrackingPubSub();
+    pubsub.owners.set(key, 'remote-run');
+
+    // Seed the runtime's view of the thread with a remote run that has no local
+    // record, which is what routes the waiter through #waitForRemoteRunToFinish.
+    const seeder = await runtime.subscribeToThread(agent, { threadId, resourceId }, pubsub);
+    await pubsub.publish(topic, {
+      type: 'agent.thread-stream',
+      runId: 'remote-run',
+      data: { type: 'run-registered', runId: 'remote-run', streamId: 'remote-stream', streamSeq: 1 },
+    });
+    seeder.unsubscribe();
+
+    const ackedBefore = pubsub.acked.length;
+    const waiting = runtime.waitForCrossAgentThreadRun(
+      { id: 'other-agent' } as Agent<any, any, any, any>,
+      { memory: { thread: threadId, resource: resourceId } } as any,
+      pubsub,
+    );
+    await nextTick();
+
+    // A non-terminal event is acked even though the waiter ignores it.
+    await pubsub.publish(topic, {
+      type: 'agent.thread-stream',
+      runId: 'remote-run',
+      data: {
+        type: 'stream-part',
+        runId: 'remote-run',
+        streamId: 'remote-stream',
+        sourceId: 'other-process',
+        part: { type: 'text-delta', payload: { text: 'hi' } },
+      },
+    });
+    pubsub.owners.delete(key);
+    await pubsub.publish(topic, {
+      type: 'agent.thread-stream',
+      runId: 'remote-run',
+      data: { type: 'run-completed', runId: 'remote-run', streamId: 'remote-stream' },
+    });
+
+    await waiting;
+
+    expect(pubsub.acked.length - ackedBefore).toBe(2);
+    expect(pubsub.pending.size).toBe(0);
+    // Unsubscribe must happen after the terminal ack, never racing it.
+    expect(pubsub.unsubscribedAt).toBe(pubsub.acked.length);
+  });
+});

--- a/packages/core/src/agent/durable/abort-transport.ts
+++ b/packages/core/src/agent/durable/abort-transport.ts
@@ -44,10 +44,14 @@ export async function subscribeToAbortRequests(
   onAbortRequested: () => void,
 ): Promise<() => Promise<void>> {
   const topic = AGENT_CONTROL_TOPIC(runId);
-  const handler = (event: { type?: string }) => {
+  // Every delivery is acknowledged, including control events this listener
+  // ignores. An ignored delivery is still a delivery, and a durable transport
+  // keeps unacknowledged entries pending for the life of the subscription.
+  const handler = async (event: { type?: string }, ack?: () => Promise<void>) => {
     if (event?.type === AgentControlEventTypes.ABORT_REQUEST) {
       onAbortRequested();
     }
+    await ack?.();
   };
 
   await pubsub.subscribe(topic, handler as Parameters<PubSub['subscribe']>[1]);

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -1462,12 +1462,21 @@ export class AgentThreadStreamRuntime {
       }
       timer = setTimeout(() => void checkLease(), AGENT_THREAD_LEASE_TTL_MS);
     };
-    const onEvent: EventCallback = event => {
+    const onEvent: EventCallback = async (event, ack) => {
       const data = event.data as AgentThreadStreamRuntimeEvent | undefined;
-      if (
+      const isTerminal =
         (data?.type === 'run-completed' || data?.type === 'run-aborted' || data?.type === 'run-failed') &&
-        data.runId === runId
-      ) {
+        data.runId === runId;
+      // Acknowledge every delivered event, not just the terminal one — this is a
+      // private fan-out subscription, so anything left unacked stays pending on
+      // the backend. The terminal ack completes before the waiter resolves so
+      // the subsequent unsubscribe cannot race it.
+      // A failing ack must never strand the waiter: the backend's ack deadline
+      // will redeliver or expire the entry, but this run is still finished.
+      try {
+        await ack?.();
+      } catch {}
+      if (isTerminal) {
         clearRemoteActive(data.streamId);
         finish();
       }
@@ -1735,8 +1744,20 @@ export class AgentThreadStreamRuntime {
     };
 
     let eventTail = Promise.resolve();
-    const onEvent: EventCallback = event => {
-      eventTail = eventTail.then(() => handleEvent(event)).catch(() => {});
+    const onEvent: EventCallback = (event, ack) => {
+      // Events are processed strictly in publish order, but each delivery is
+      // acknowledged on its own outcome. Every delivered event is acked once it
+      // has been inspected — including events this subscriber filters out —
+      // because a persistent backend (Redis consumer groups) keeps unacked
+      // deliveries pending for the lifetime of the subscription.
+      const processed = eventTail.then(() => handleEvent(event));
+      // The tail must survive a failed event so later events still run.
+      eventTail = processed.then(
+        () => {},
+        () => {},
+      );
+      // Returned rejection lets the backend nack and redeliver.
+      return processed.then(() => ack?.());
     };
 
     await resolvedPubSub.subscribe(topic, onEvent);

--- a/packages/core/src/events/caching-pubsub.ts
+++ b/packages/core/src/events/caching-pubsub.ts
@@ -223,8 +223,10 @@ export class CachingPubSub extends PubSub {
 
     const wrappedCb: EventCallback = (event, ack, nack) => {
       // Drop events strictly before the requested offset on the live path.
+      // Dropped deliveries are still acknowledged: the consumer will never see
+      // them, so leaving them unacknowledged would strand them on the backend.
       if (typeof event.index === 'number' && event.index < offset) {
-        return;
+        return ack?.();
       }
 
       if (bootstrapping) {
@@ -237,13 +239,16 @@ export class CachingPubSub extends PubSub {
       // deliveryAttempt > 1, and the consumer must see them to retry processing.
       const isRetry = typeof event.deliveryAttempt === 'number' && event.deliveryAttempt > 1;
       if (typeof event.index === 'number' && event.index <= lastDelivered && !isRetry) {
-        return;
+        // Already delivered via history or the buffer drain. Acknowledge the
+        // duplicate so it doesn't stay pending on the backend.
+        return ack?.();
       }
 
       if (typeof event.index === 'number' && event.index > lastDelivered) {
         lastDelivered = event.index;
       }
-      cb(event, ack, nack);
+      // Hand the consumer's outcome back to the backend so it can ack or nack.
+      return cb(event, ack, nack);
     };
 
     this.callbackMap.set(cb, wrappedCb);
@@ -259,7 +264,10 @@ export class CachingPubSub extends PubSub {
         if (typeof event.index === 'number') {
           lastDelivered = event.index;
         }
-        cb(event);
+        // Awaited so history is delivered in order before the buffer drain.
+        // History comes from storage, not the transport, so there is nothing
+        // to acknowledge.
+        await cb(event);
       }
 
       // --- Phase 3: drain buffer, suppressing duplicates history already covered ---
@@ -272,7 +280,14 @@ export class CachingPubSub extends PubSub {
         if (typeof event.index === 'number') {
           lastDelivered = event.index;
         }
-        cb(event, ack, nack);
+        // The consumer settles these itself through the ack/nack it was handed
+        // on the live path. Awaited so a rejection can still reach nack, which
+        // the backend would otherwise have routed.
+        try {
+          await cb(event, ack, nack);
+        } catch {
+          await nack?.();
+        }
       }
 
       // --- Phase 4: flip to passthrough ---

--- a/packages/core/src/events/event-emitter/index.ts
+++ b/packages/core/src/events/event-emitter/index.ts
@@ -76,6 +76,20 @@ export class EventEmitterPubSub extends PubSub implements LeaseProvider {
    * Debug-hostile silent failures are the default for emitter listeners.
    * Surface buffer-side errors on a single channel so they're at least visible.
    */
+  /**
+   * Subscribers may return a promise now that they can acknowledge deliveries.
+   * This transport is push-only and has nothing to redeliver, so a rejection is
+   * logged rather than becoming an unhandled rejection.
+   */
+  private logSubscriberError(topic: string, err: unknown): void {
+    const message = `[EventEmitterPubSub] subscriber failed for ${topic}`;
+    if (this.logger) {
+      this.logger.error(message, err);
+    } else {
+      console.error(message, err);
+    }
+  }
+
   private logBufferError(topic: string, err: unknown, ctx: { phase: 'cb' | 'ack-dropped' }): void {
     const message = `[EventEmitterPubSub] batched ${ctx.phase} failed for ${topic}`;
     if (this.logger) {
@@ -145,7 +159,9 @@ export class EventEmitterPubSub extends PubSub implements LeaseProvider {
       this.subscribeWithGroup(topic, cb, options.group);
     } else {
       const wrapper = (event: Event) => {
-        cb(event, NOOP_ACK, NOOP_ACK);
+        void Promise.resolve(cb(event, NOOP_ACK, NOOP_ACK)).catch(err => {
+          this.logSubscriberError(topic, err);
+        });
       };
       let byCb = this.fanoutWrappers.get(topic);
       if (!byCb) {
@@ -351,7 +367,9 @@ export class EventEmitterPubSub extends PubSub implements LeaseProvider {
         this.logBufferError(topic, err, { phase: 'cb' });
       });
     } else {
-      member(eventWithAttempt, ack, nack);
+      void Promise.resolve(member(eventWithAttempt, ack, nack)).catch(err => {
+        this.logSubscriberError(topic, err);
+      });
     }
   }
 

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -94,5 +94,17 @@ export interface SubscribeOptions {
  * @param nack - Negative acknowledge. Message is requeued for redelivery after a delay.
  *               Not calling either ack or nack leaves the message in-flight until the
  *               backend's ack deadline expires (typically 10s for GCP).
+ *
+ * Subscribers on persistent backends must call `ack` for every delivered event —
+ * including events they filter out — otherwise the message stays in the backend's
+ * pending set for the lifetime of the subscription and the topic grows unbounded.
+ *
+ * A returned promise is honored by backends that support redelivery: a rejection
+ * is treated as a `nack`. The promise is not awaited before the next delivery, so
+ * subscribers that need ordering must serialize internally.
  */
-export type EventCallback = (event: Event, ack?: () => Promise<void>, nack?: () => Promise<void>) => void;
+export type EventCallback = (
+  event: Event,
+  ack?: () => Promise<void>,
+  nack?: () => Promise<void>,
+) => void | Promise<void>;

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -445,10 +445,9 @@ export interface Config<
    * Maps event topics to handler functions for event-driven architectures.
    */
   events?: {
-    [topic: string]: (
-      event: Event,
-      cb?: () => Promise<void>,
-    ) => Promise<void> | ((event: Event, cb?: () => Promise<void>) => Promise<void>)[];
+    // Listeners receive only the event. Acknowledgement is handled for them:
+    // the delivery is acked once the listener resolves and nacked if it throws.
+    [topic: string]: ((event: Event) => Promise<void> | void) | ((event: Event) => Promise<void> | void)[];
   };
 
   /**
@@ -798,7 +797,7 @@ export class Mastra<
   }> = [];
 
   #events: {
-    [topic: string]: ((event: Event, cb?: () => Promise<void>) => Promise<void>)[];
+    [topic: string]: ((event: Event) => Promise<void> | void)[];
   } = {};
   #internalMastraWorkflows: Record<string, AnyWorkflow> = {};
   // Tracks registration timestamps for run-scoped internal workflows so a lazy
@@ -5822,7 +5821,7 @@ export class Mastra<
         await listener(event);
       } catch (err) {
         this.#logger?.error?.('Error in topic listener; nacking event', {
-          topic: event.type,
+          eventType: event.type,
           err: err instanceof Error ? err.message : err,
         });
         await nack?.();

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -794,7 +794,7 @@ export class Mastra<
   // must not double-subscribe the same listener.
   #userEventSubscriptions: Array<{
     topic: string;
-    cb: (event: Event, ack?: () => Promise<void>) => Promise<void>;
+    cb: EventCallback;
   }> = [];
 
   #events: {
@@ -5801,12 +5801,45 @@ export class Mastra<
     }
   }
 
+  /**
+   * Wrap a user-provided topic listener so the delivery is acknowledged once
+   * the listener resolves. User listeners take only the event, so nothing
+   * would ever call `ack` for them — and on a durable transport (Redis
+   * consumer groups) an unacknowledged delivery stays pending for the life of
+   * the subscription. A throwing listener nacks instead so the transport can
+   * redeliver rather than assume success.
+   *
+   * The wrapper is memoized per listener so `removeTopicListener` can
+   * unsubscribe the exact callback `addTopicListener` registered.
+   */
+  #ackingTopicListeners = new WeakMap<(event: any) => Promise<void> | void, EventCallback>();
+
+  #ackingTopicListener(listener: (event: any) => Promise<void> | void): EventCallback {
+    const existing = this.#ackingTopicListeners.get(listener);
+    if (existing) return existing;
+    const wrapped: EventCallback = async (event, ack, nack) => {
+      try {
+        await listener(event);
+      } catch (err) {
+        this.#logger?.error?.('Error in topic listener; nacking event', {
+          topic: event.type,
+          err: err instanceof Error ? err.message : err,
+        });
+        await nack?.();
+        return;
+      }
+      await ack?.();
+    };
+    this.#ackingTopicListeners.set(listener, wrapped);
+    return wrapped;
+  }
+
   public async addTopicListener(topic: string, listener: (event: any) => Promise<void>) {
-    await this.#pubsub.subscribe(topic, listener);
+    await this.#pubsub.subscribe(topic, this.#ackingTopicListener(listener));
   }
 
   public async removeTopicListener(topic: string, listener: (event: any) => Promise<void>) {
-    await this.#pubsub.unsubscribe(topic, listener);
+    await this.#pubsub.unsubscribe(topic, this.#ackingTopicListener(listener));
   }
 
   /**
@@ -5943,12 +5976,11 @@ export class Mastra<
 
         const listeners = Array.isArray(this.#events[topic]) ? this.#events[topic] : [this.#events[topic]];
         for (const listener of listeners) {
-          const alreadySubscribed = this.#userEventSubscriptions.some(
-            sub => sub.topic === topic && sub.cb === listener,
-          );
+          const cb = this.#ackingTopicListener(listener);
+          const alreadySubscribed = this.#userEventSubscriptions.some(sub => sub.topic === topic && sub.cb === cb);
           if (alreadySubscribed) continue;
-          await this.#pubsub.subscribe(topic, listener);
-          this.#userEventSubscriptions.push({ topic, cb: listener });
+          await this.#pubsub.subscribe(topic, cb);
+          this.#userEventSubscriptions.push({ topic, cb });
         }
       }
     }

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -2441,13 +2441,13 @@ export class EventedRun<
     return executionResultPromise;
   }
 
-  watch(cb: (event: WorkflowStreamEvent) => void): () => void {
+  watch(cb: (event: WorkflowStreamEvent) => void | Promise<void>): () => void {
     const watchCb = async (event: Event, ack?: () => Promise<void>) => {
       if (event.runId !== this.runId) {
         return;
       }
 
-      cb(event.data);
+      await cb(event.data);
       await ack?.();
     };
 
@@ -2458,13 +2458,13 @@ export class EventedRun<
     };
   }
 
-  async watchAsync(cb: (event: WorkflowStreamEvent) => void): Promise<() => void> {
+  async watchAsync(cb: (event: WorkflowStreamEvent) => void | Promise<void>): Promise<() => void> {
     const watchCb = async (event: Event, ack?: () => Promise<void>) => {
       if (event.runId !== this.runId) {
         return;
       }
 
-      cb(event.data);
+      await cb(event.data);
       await ack?.();
     };
 

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -4034,13 +4034,19 @@ export class Run<
    * @internal
    */
   watch(cb: (event: WorkflowStreamEvent) => void): () => void {
-    const wrappedCb = (event: Event) => {
+    // Both callbacks acknowledge every delivery, including events for other
+    // runs. `nested-watch` is a shared topic, so a watcher sees every nested
+    // workflow's events; leaving the ones it filters out unacknowledged grows
+    // the subscription's pending list on a durable transport for as long as
+    // the watcher is attached.
+    const wrappedCb = async (event: Event, ack?: () => Promise<void>) => {
       if (event.runId === this.runId) {
         cb(event.data as WorkflowStreamEvent);
       }
+      await ack?.();
     };
 
-    const nestedWatchCb = (event: Event) => {
+    const nestedWatchCb = async (event: Event, ack?: () => Promise<void>) => {
       if (event.runId === this.runId) {
         const { event: nestedEvent, workflowId } = event.data as {
           event: { type: string; payload?: { id: string } & Record<string, unknown>; data?: any };
@@ -4070,6 +4076,7 @@ export class Run<
           });
         }
       }
+      await ack?.();
     };
 
     void this.pubsub.subscribe(`workflow.events.v2.${this.runId}`, wrappedCb);

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -4033,15 +4033,17 @@ export class Run<
   /**
    * @internal
    */
-  watch(cb: (event: WorkflowStreamEvent) => void): () => void {
+  watch(cb: (event: WorkflowStreamEvent) => void | Promise<void>): () => void {
     // Both callbacks acknowledge every delivery, including events for other
     // runs. `nested-watch` is a shared topic, so a watcher sees every nested
     // workflow's events; leaving the ones it filters out unacknowledged grows
     // the subscription's pending list on a durable transport for as long as
-    // the watcher is attached.
+    // the watcher is attached. The ack is the last thing each callback does so
+    // a failure in the consumer or in the nested republish leaves the delivery
+    // unacknowledged and redeliverable.
     const wrappedCb = async (event: Event, ack?: () => Promise<void>) => {
       if (event.runId === this.runId) {
-        cb(event.data as WorkflowStreamEvent);
+        await cb(event.data as WorkflowStreamEvent);
       }
       await ack?.();
     };
@@ -4057,14 +4059,14 @@ export class Run<
         // These are events with type starting with 'data-' and have a 'data' property
         if (nestedEvent.type.startsWith('data-') && nestedEvent.data !== undefined) {
           // Bubble up custom data events directly to preserve their structure
-          void this.pubsub.publish(`workflow.events.v2.${this.runId}`, {
+          await this.pubsub.publish(`workflow.events.v2.${this.runId}`, {
             type: 'watch',
             runId: this.runId,
             data: nestedEvent,
           });
         } else {
           // Regular workflow events get prefixed with nested workflow ID
-          void this.pubsub.publish(`workflow.events.v2.${this.runId}`, {
+          await this.pubsub.publish(`workflow.events.v2.${this.runId}`, {
             type: 'watch',
             runId: this.runId,
             data: {
@@ -4091,7 +4093,7 @@ export class Run<
   /**
    * @internal
    */
-  async watchAsync(cb: (event: WorkflowStreamEvent) => void): Promise<() => void> {
+  async watchAsync(cb: (event: WorkflowStreamEvent) => void | Promise<void>): Promise<() => void> {
     return this.watch(cb);
   }
 

--- a/pubsub/redis-streams/src/agent-thread-ack.test.ts
+++ b/pubsub/redis-streams/src/agent-thread-ack.test.ts
@@ -13,6 +13,8 @@ import { createClient } from 'redis';
 import type { RedisClientType } from 'redis';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
+// AgentThreadStreamRuntime is internal to @mastra/core with no public export,
+// and these tests have to drive its real subscribers to observe the PEL.
 import { AgentThreadStreamRuntime } from '../../../packages/core/src/agent/thread-stream-runtime';
 import { flushRedis, REDIS_URL, waitFor } from '../test-fixtures/harness';
 import { RedisStreamsPubSub } from './index';
@@ -36,6 +38,14 @@ async function pendingCount(streamKey: string): Promise<number> {
   if (!exists) return 0;
   const groups = (await inspector.xInfoGroups(streamKey)) as Array<{ name: string; pending: number }>;
   return groups.reduce((total, group) => total + Number(group.pending ?? 0), 0);
+}
+
+/** Names of every consumer group currently attached to the stream. */
+async function groupNames(streamKey: string): Promise<string[]> {
+  const exists = await inspector.exists(streamKey);
+  if (!exists) return [];
+  const groups = (await inspector.xInfoGroups(streamKey)) as Array<{ name: string }>;
+  return groups.map(group => group.name);
 }
 
 async function entryCount(streamKey: string): Promise<number> {
@@ -162,6 +172,7 @@ describe('agent thread-stream Redis acknowledgements', () => {
       data: { type: 'run-registered', runId, streamId, streamSeq: 1 },
     } as any);
     await waitFor(async () => (await pendingCount(streamKey)) === 0);
+    const seedingGroups = await groupNames(streamKey);
     seeding.unsubscribe();
 
     const waiting = waiterRuntime.waitForCrossAgentThreadRun(
@@ -169,6 +180,16 @@ describe('agent thread-stream Redis acknowledgements', () => {
       { memory: { thread: threadId, resource: resourceId } } as any,
       waiterPubSub,
     );
+
+    // Both sides are asynchronous: the seeder unsubscribes fire-and-forget and
+    // the waiter subscribes inside the promise above. Publishing before the
+    // waiter's group exists would read from the tail and hang the waiter;
+    // publishing while the seeder's group still exists would leave entries
+    // pending behind a group nobody drains.
+    await waitFor(async () => {
+      const groups = await groupNames(streamKey);
+      return groups.length === 1 && !seedingGroups.includes(groups[0]!);
+    });
 
     await producer.publish(topic, {
       type: 'agent.thread-stream',
@@ -192,6 +213,7 @@ describe('agent thread-stream Redis acknowledgements', () => {
 
     // The waiter unsubscribes as it resolves; nothing it consumed may be left
     // pending behind the removed consumer group.
+    await waitFor(async () => (await pendingCount(streamKey)) === 0);
     expect(await pendingCount(streamKey)).toBe(0);
   });
 });

--- a/pubsub/redis-streams/src/agent-thread-ack.test.ts
+++ b/pubsub/redis-streams/src/agent-thread-ack.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Proves against a real Redis that agent thread-stream subscribers do not leak
+ * pending entries.
+ *
+ * Each fan-out subscriber gets a private consumer group (`__fanout-<uuid>`).
+ * Redis keeps every delivered entry in that group's PEL until the consumer
+ * XACKs it, so a subscriber that never acknowledges leaves the PEL growing for
+ * the lifetime of the subscription. These tests drive the real
+ * AgentThreadStreamRuntime subscribers over RedisStreamsPubSub and assert the
+ * PEL drains to zero.
+ */
+import { createClient } from 'redis';
+import type { RedisClientType } from 'redis';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { AgentThreadStreamRuntime } from '../../../packages/core/src/agent/thread-stream-runtime';
+import { flushRedis, REDIS_URL, waitFor } from '../test-fixtures/harness';
+import { RedisStreamsPubSub } from './index';
+
+const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
+
+function threadStreamKeyFor(resourceId: string, threadId: string): string {
+  const key = `${resourceId}${AGENT_THREAD_KEY_SEPARATOR}${threadId}`;
+  return `mastra:topic:agent.thread-stream.${encodeURIComponent(key)}`;
+}
+
+function threadTopicFor(resourceId: string, threadId: string): string {
+  return `agent.thread-stream.${encodeURIComponent(`${resourceId}${AGENT_THREAD_KEY_SEPARATOR}${threadId}`)}`;
+}
+
+let inspector: RedisClientType;
+
+/** Total entries still pending across every consumer group on the stream. */
+async function pendingCount(streamKey: string): Promise<number> {
+  const exists = await inspector.exists(streamKey);
+  if (!exists) return 0;
+  const groups = (await inspector.xInfoGroups(streamKey)) as Array<{ name: string; pending: number }>;
+  return groups.reduce((total, group) => total + Number(group.pending ?? 0), 0);
+}
+
+async function entryCount(streamKey: string): Promise<number> {
+  const exists = await inspector.exists(streamKey);
+  if (!exists) return 0;
+  return await inspector.xLen(streamKey);
+}
+
+const agent = { id: 'redis-ack-agent' } as any;
+
+describe('agent thread-stream Redis acknowledgements', () => {
+  const created: RedisStreamsPubSub[] = [];
+
+  const makePubSub = () => {
+    const pubsub = new RedisStreamsPubSub({ url: REDIS_URL });
+    created.push(pubsub);
+    return pubsub;
+  };
+
+  beforeAll(async () => {
+    inspector = createClient({ url: REDIS_URL }) as RedisClientType;
+    await inspector.connect();
+  });
+
+  afterAll(async () => {
+    await inspector.quit();
+  });
+
+  afterEach(async () => {
+    while (created.length) {
+      await created.pop()?.close?.();
+    }
+    await flushRedis();
+  });
+
+  it('drains the PEL for a thread subscriber that consumed a full remote run', async () => {
+    const threadId = `ack-thread-${Date.now()}`;
+    const resourceId = 'ack-user';
+    const streamKey = threadStreamKeyFor(resourceId, threadId);
+    const topic = threadTopicFor(resourceId, threadId);
+
+    // Subscriber process.
+    const subscriberPubSub = makePubSub();
+    const subscriberRuntime = new AgentThreadStreamRuntime();
+    const subscription = await subscriberRuntime.subscribeToThread(agent, { threadId, resourceId }, subscriberPubSub);
+
+    // Producer process — a separate pubsub instance so every event crosses
+    // Redis instead of being short-circuited by local delivery.
+    const producer = makePubSub();
+    const runId = 'remote-run-1';
+    const streamId = 'remote-stream-1';
+    const publish = (data: Record<string, unknown>) =>
+      producer.publish(topic, { type: 'agent.thread-stream', runId, data } as any);
+
+    await publish({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    for (let i = 0; i < 5; i++) {
+      await publish({
+        type: 'stream-part',
+        runId,
+        streamId,
+        sourceId: 'producer-process',
+        part: { type: 'text-delta', payload: { text: `chunk-${i}` } },
+      });
+    }
+    await publish({ type: 'run-completed', runId, streamId });
+
+    // All seven events must land on the stream and then be acknowledged.
+    await waitFor(async () => (await entryCount(streamKey)) === 7);
+    await waitFor(async () => (await pendingCount(streamKey)) === 0);
+
+    expect(await pendingCount(streamKey)).toBe(0);
+
+    subscription.unsubscribe();
+  });
+
+  it('drains the PEL for events the subscriber filters out', async () => {
+    const threadId = `ack-thread-filtered-${Date.now()}`;
+    const resourceId = 'ack-user';
+    const streamKey = threadStreamKeyFor(resourceId, threadId);
+    const topic = threadTopicFor(resourceId, threadId);
+
+    const subscriberPubSub = makePubSub();
+    const subscriberRuntime = new AgentThreadStreamRuntime();
+    const subscription = await subscriberRuntime.subscribeToThread(agent, { threadId, resourceId }, subscriberPubSub);
+
+    const producer = makePubSub();
+    // Events with no runtime payload, and an abort request for a run this
+    // process knows nothing about, are both ignored by the handler. Ignored
+    // still means delivered, so they must still be acknowledged.
+    await producer.publish(topic, { type: 'agent.thread-stream', runId: 'noop-run' } as any);
+    await producer.publish(topic, {
+      type: 'agent.thread-stream',
+      runId: 'unknown-run',
+      data: { type: 'run-abort-requested', runId: 'unknown-run', streamId: 'unknown-stream' },
+    } as any);
+
+    await waitFor(async () => (await entryCount(streamKey)) === 2);
+    await waitFor(async () => (await pendingCount(streamKey)) === 0);
+
+    expect(await pendingCount(streamKey)).toBe(0);
+
+    subscription.unsubscribe();
+  });
+
+  it('drains the PEL for the cross-agent waiter once the remote run finishes', async () => {
+    const threadId = `ack-thread-waiter-${Date.now()}`;
+    const resourceId = 'ack-user';
+    const streamKey = threadStreamKeyFor(resourceId, threadId);
+    const topic = threadTopicFor(resourceId, threadId);
+
+    const waiterPubSub = makePubSub();
+    const waiterRuntime = new AgentThreadStreamRuntime();
+    const runId = 'remote-run-2';
+    const streamId = 'remote-stream-2';
+
+    // Seed this process's view of the thread with a remote run holding the
+    // lease, so waitForCrossAgentThreadRun routes through the remote waiter.
+    const seeding = await waiterRuntime.subscribeToThread(agent, { threadId, resourceId }, waiterPubSub);
+    const producer = makePubSub();
+    await producer.acquireLease(`${resourceId}${AGENT_THREAD_KEY_SEPARATOR}${threadId}`, runId, 60_000);
+    await producer.publish(topic, {
+      type: 'agent.thread-stream',
+      runId,
+      data: { type: 'run-registered', runId, streamId, streamSeq: 1 },
+    } as any);
+    await waitFor(async () => (await pendingCount(streamKey)) === 0);
+    seeding.unsubscribe();
+
+    const waiting = waiterRuntime.waitForCrossAgentThreadRun(
+      { id: 'other-agent' } as any,
+      { memory: { thread: threadId, resource: resourceId } } as any,
+      waiterPubSub,
+    );
+
+    await producer.publish(topic, {
+      type: 'agent.thread-stream',
+      runId,
+      data: {
+        type: 'stream-part',
+        runId,
+        streamId,
+        sourceId: 'producer-process',
+        part: { type: 'text-delta', payload: { text: 'hi' } },
+      },
+    } as any);
+    await producer.releaseLease(`${resourceId}${AGENT_THREAD_KEY_SEPARATOR}${threadId}`, runId);
+    await producer.publish(topic, {
+      type: 'agent.thread-stream',
+      runId,
+      data: { type: 'run-completed', runId, streamId },
+    } as any);
+
+    await waiting;
+
+    // The waiter unsubscribes as it resolves; nothing it consumed may be left
+    // pending behind the removed consumer group.
+    expect(await pendingCount(streamKey)).toBe(0);
+  });
+});

--- a/pubsub/redis-streams/src/pubsub-ack-audit.test.ts
+++ b/pubsub/redis-streams/src/pubsub-ack-audit.test.ts
@@ -7,14 +7,13 @@
  * long as it stays attached. These tests drive the production subscription
  * helpers directly and assert the PEL drains.
  */
+import { AGENT_CONTROL_TOPIC, AgentControlEventTypes, subscribeToAbortRequests } from '@mastra/core/agent/durable';
+import { Mastra } from '@mastra/core/mastra';
+import { createStep, createWorkflow } from '@mastra/core/workflows';
 import { createClient } from 'redis';
 import type { RedisClientType } from 'redis';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
-import { subscribeToAbortRequests } from '../../../packages/core/src/agent/durable/abort-transport';
-import { AGENT_CONTROL_TOPIC, AgentControlEventTypes } from '../../../packages/core/src/agent/durable/constants';
-import { Mastra } from '../../../packages/core/src/mastra';
-import { createStep, createWorkflow } from '../../../packages/core/src/workflows';
 import { flushRedis, REDIS_URL, waitFor } from '../test-fixtures/harness';
 import { RedisStreamsPubSub } from './index';
 

--- a/pubsub/redis-streams/src/pubsub-ack-audit.test.ts
+++ b/pubsub/redis-streams/src/pubsub-ack-audit.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Audit of the remaining fan-out pubsub subscribers, proven against real Redis.
+ *
+ * Every ungrouped `subscribe()` creates a private consumer group. Redis holds
+ * each delivered entry in that group's PEL until the consumer XACKs it, so any
+ * subscriber that never acknowledges grows an unbounded pending list for as
+ * long as it stays attached. These tests drive the production subscription
+ * helpers directly and assert the PEL drains.
+ */
+import { createClient } from 'redis';
+import type { RedisClientType } from 'redis';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { subscribeToAbortRequests } from '../../../packages/core/src/agent/durable/abort-transport';
+import { AGENT_CONTROL_TOPIC, AgentControlEventTypes } from '../../../packages/core/src/agent/durable/constants';
+import { Mastra } from '../../../packages/core/src/mastra';
+import { createStep, createWorkflow } from '../../../packages/core/src/workflows';
+import { flushRedis, REDIS_URL, waitFor } from '../test-fixtures/harness';
+import { RedisStreamsPubSub } from './index';
+
+let inspector: RedisClientType;
+
+function streamKeyFor(topic: string): string {
+  return `mastra:topic:${topic}`;
+}
+
+async function pendingCount(topic: string): Promise<number> {
+  const streamKey = streamKeyFor(topic);
+  if (!(await inspector.exists(streamKey))) return 0;
+  const groups = (await inspector.xInfoGroups(streamKey)) as Array<{ name: string; pending: number }>;
+  return groups.reduce((total, group) => total + Number(group.pending ?? 0), 0);
+}
+
+async function entryCount(topic: string): Promise<number> {
+  const streamKey = streamKeyFor(topic);
+  if (!(await inspector.exists(streamKey))) return 0;
+  return await inspector.xLen(streamKey);
+}
+
+describe('pubsub subscriber acknowledgement audit', () => {
+  const created: RedisStreamsPubSub[] = [];
+
+  const makePubSub = () => {
+    const pubsub = new RedisStreamsPubSub({ url: REDIS_URL });
+    created.push(pubsub);
+    return pubsub;
+  };
+
+  beforeAll(async () => {
+    inspector = createClient({ url: REDIS_URL }) as RedisClientType;
+    await inspector.connect();
+  });
+
+  afterAll(async () => {
+    await inspector.quit();
+  });
+
+  afterEach(async () => {
+    while (created.length) {
+      await created.pop()?.close?.();
+    }
+    await flushRedis();
+  });
+
+  it('drains the PEL for durable-agent abort listeners', async () => {
+    const runId = `abort-run-${Date.now()}`;
+    const topic = AGENT_CONTROL_TOPIC(runId);
+
+    const listenerPubSub = makePubSub();
+    let aborts = 0;
+    const unsubscribe = await subscribeToAbortRequests(listenerPubSub, runId, () => {
+      aborts++;
+    });
+
+    const producer = makePubSub();
+    // An unrelated control event is filtered out by the handler but is still a
+    // delivery, then a real abort request the handler acts on.
+    await producer.publish(topic, { type: 'agent.control.other', runId, data: {} } as any);
+    await producer.publish(topic, { type: AgentControlEventTypes.ABORT_REQUEST, runId, data: {} } as any);
+
+    await waitFor(async () => aborts === 1);
+    await waitFor(async () => (await entryCount(topic)) === 2);
+    await waitFor(async () => (await pendingCount(topic)) === 0);
+
+    expect(await pendingCount(topic)).toBe(0);
+    await unsubscribe();
+  });
+
+  it('drains the PEL for user event listeners registered on Mastra', async () => {
+    const topic = `user-topic-${Date.now()}`;
+    const mastra = new Mastra({ pubsub: makePubSub() });
+    const received: unknown[] = [];
+    const listener = async (event: any) => {
+      received.push(event);
+    };
+    await mastra.addTopicListener(topic, listener);
+
+    const producer = makePubSub();
+    await producer.publish(topic, { type: 'custom', runId: 'n/a', data: { i: 1 } } as any);
+    await producer.publish(topic, { type: 'custom', runId: 'n/a', data: { i: 2 } } as any);
+
+    await waitFor(async () => received.length === 2);
+    await waitFor(async () => (await pendingCount(topic)) === 0);
+
+    expect(await pendingCount(topic)).toBe(0);
+    await mastra.removeTopicListener(topic, listener);
+  });
+
+  it('drains the PEL for workflow run watchers', async () => {
+    const step = createStep({
+      id: 'noop',
+      inputSchema: undefined as any,
+      outputSchema: undefined as any,
+      execute: async () => ({}),
+    });
+    const workflow = createWorkflow({
+      id: 'ack-audit-workflow',
+      inputSchema: undefined as any,
+      outputSchema: undefined as any,
+    })
+      .then(step)
+      .commit();
+    const mastra = new Mastra({ pubsub: makePubSub(), workflows: { 'ack-audit-workflow': workflow } });
+
+    // Run.watch() subscribes on the run's own pubsub, which defaults to an
+    // in-process EventEmitter, so hand it the Redis-backed one under test.
+    const run = await mastra.getWorkflow('ack-audit-workflow').createRun({ pubsub: makePubSub() });
+    const seen: unknown[] = [];
+    const unwatch = run.watch(event => {
+      seen.push(event);
+    });
+
+    const runTopic = `workflow.events.v2.${run.runId}`;
+    const producer = makePubSub();
+    // `run.watch()` subscribes in the background, so republish until the
+    // watcher is actually attached instead of racing the first delivery.
+    // `nested-watch` is a global topic: every watcher on the process receives
+    // every nested workflow's events, including ones for other runs.
+    await waitFor(async () => {
+      await producer.publish(runTopic, { type: 'watch', runId: run.runId, data: { type: 'step-start' } } as any);
+      await producer.publish('nested-watch', {
+        type: 'watch',
+        runId: 'some-other-run',
+        data: { event: { type: 'step-start' }, workflowId: 'other' },
+      } as any);
+      return seen.length > 0;
+    });
+    await waitFor(async () => (await pendingCount(runTopic)) === 0);
+    await waitFor(async () => (await pendingCount('nested-watch')) === 0);
+
+    expect(await pendingCount(runTopic)).toBe(0);
+    expect(await pendingCount('nested-watch')).toBe(0);
+    unwatch();
+  });
+});


### PR DESCRIPTION
Fixes #20154

## What's going on

Mastra's event layer lets a subscriber report the outcome of each delivery. A subscriber receives `ack` (this delivery was handled, drop it) and `nack` (this delivery failed, redeliver it). Calling neither is a third, silent outcome: the backend keeps holding the message, waiting to hear back.

In-process transports don't care — there's nothing to hold. Durable transports do. On Redis Streams every subscription gets its own consumer group, and an unacknowledged delivery sits in that group's pending entries list (PEL) for the entire life of the subscription. A long-lived subscription that never acks accumulates one pending entry per message it was ever handed, forever.

Several core subscribers were doing exactly that: reading the event, acting on it, and never reporting back.

## Why it grows faster than it looks

The most expensive part is the deliveries a handler *ignores*. A subscriber is handed everything published to its topic and filters down to what it cares about — parts from other agents, events for other runs, control messages it doesn't handle. Those discarded deliveries were never acked either, so the pending list grew with traffic the subscription had no interest in.

Workflow watchers show this clearly. Every watcher subscribes to one shared `nested-watch` topic that carries the events of every nested workflow in the process, then keeps only the events matching its own run. The other 99% were silently retained.

## What changed

Every affected subscriber now acknowledges each delivery once it has finished inspecting it, whether or not the event turned out to be relevant:

- **Thread stream runtime** — the cross-agent run waiter and the thread subscriber. The thread subscriber processes events strictly in publish order and acks each one on its own outcome; a handler that throws now propagates so the backend can redeliver, and the ordering chain survives a failed event so later events still run. The waiter finishes acknowledging the terminal event before it resolves, so unsubscribing can't race the ack.
- **Workflow watchers** — `watch()` and `watchAsync()`, including the shared nested-watch topic described above.
- **Agent abort transport** — acks all control events, not just abort requests.
- **User topic listeners** — listeners registered via `addTopicListener` take only an event, so they're wrapped: ack after the listener resolves, nack if it throws. The wrapper is memoized per listener so `removeTopicListener` and `stopWorkers()` still unsubscribe the exact callback that was registered.
- **Background task, schedule worker, and evented workflow subscribers** — same treatment.

The supporting type change: an event callback may now return a promise, so the transport can wait for a handler before deciding the delivery's fate.

## Test plan

The interesting assertion is about a backend's internal bookkeeping, so the real coverage runs against actual Redis (`pubsub/redis-streams`, `docker compose up`):

- `agent-thread-ack.test.ts` — runs a thread stream to completion across two runtimes on separate connections and asserts XPENDING drains to zero.
- `pubsub-ack-audit.test.ts` — same assertion for abort transport subscriptions, user topic listeners, and workflow run watchers.

Both suites were verified to actually catch the bug: with the source fixes reverted, every test fails by timing out on a pending list that never drains. Unit-level ack/nack behavior is also covered in `packages/core` (`agent-thread-stream-ack.test.ts`), including the negative-acknowledgement path.

`pnpm --filter ./packages/core check` is clean and the core suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR confirms that event subscribers finished handling each message. This prevents processed messages from staying stuck in durable queues and allows failed messages to be delivered again.

## Changes

- Added acknowledgements for:
  - Thread stream subscribers.
  - Remote-run terminal waiters.
  - Workflow watchers.
  - Agent abort listeners.
  - User topic listeners.
- Acknowledged filtered and ignored events.
- Added negative acknowledgements when event processing fails.
- Updated `EventCallback` to support `Promise<void>`.
- Preserved listener unsubscribe and duplicate-subscription behavior.
- Added a patch changeset for `@mastra/core`.

## Tests

- Added Core tests for:
  - Thread event acknowledgements.
  - Filtered event handling.
  - Processing failures and redelivery.
  - Remote-run waiter cleanup.
- Added Redis Streams integration tests.
- Verified that consumer-group pending entries drain to zero for thread, abort, topic, and workflow subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->