### PR TITLE
Add setup and teardown hooks to experiment runs

### DIFF
--- a/.changeset/experiment-lifecycle-hooks.md
+++ b/.changeset/experiment-lifecycle-hooks.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Add `beforeAll`, `afterAll`, `beforeEach`, and `afterEach` lifecycle hooks to `runExperiment` for setting up and tearing down test data around an experiment run. `beforeAll` failures fail the experiment, `beforeEach` failures mark the item failed and skip execution (with `afterEach` still running), and `afterEach` failures are logged as warnings.

--- a/docs/src/content/en/docs/datasets/running-experiments.mdx
+++ b/docs/src/content/en/docs/datasets/running-experiments.mdx
@@ -218,6 +218,55 @@ The `experiment.run.finished` event is awaited before Mastra persists the final 
 
 The exported event types are `ExperimentEvent`, `ExperimentRunStartedEvent`, `ExperimentItemCompletedEvent`, and `ExperimentRunFinishedEvent`. Use the discriminated `type` field to narrow an event before reading event-specific properties.
 
+## Lifecycle hooks
+
+Use lifecycle hooks to prepare state before a target runs and clean it up afterwards. This is useful when an item can't be evaluated against an empty environment. A run might need a fixture file copied into the agent's workspace, or a sandbox provisioned before the agent can touch it.
+
+Hooks run at two levels. `beforeAll` and `afterAll` run once per experiment, and `beforeEach` and `afterEach` run once per item:
+
+```typescript title="src/mastra/experiments/hooks.ts"
+const summary = await dataset.startExperiment({
+  targetType: 'agent',
+  targetId: 'document-agent',
+  scorers: ['accuracy'],
+  beforeAll: async ({ experimentId }) => {
+    await createWorkspace(experimentId)
+  },
+  beforeEach: async ({ item }) => {
+    await copyFixture(item.metadata?.fixture)
+  },
+  afterEach: async ({ item, result }) => {
+    await clearWorkspaceFiles(item.id)
+  },
+  afterAll: async ({ summary }) => {
+    await deleteWorkspace(summary.experimentId)
+  },
+})
+```
+
+Every hook can be async. Each one receives the `experimentId`, the `mastra` instance, and the run-level `signal`, so long-running setup can be cancelled along with the experiment. The per-item hooks also receive `item`. The teardown hooks receive the result they follow: `afterEach` receives the item's `result` including scores, and `afterAll` receives the `summary` that's about to be returned.
+
+The item passed to hooks exposes `id`, `input`, `groundTruth`, and `metadata`. Fields that control execution, such as tool mocks and scorer selection, aren't exposed, so a hook can't change how the item runs.
+
+### Hook failures
+
+Each hook has a different consequence when it throws, based on how much of the run depends on it:
+
+| Hook | On failure |
+| - | - |
+| `beforeAll` | Fails the experiment. No items run. |
+| `beforeEach` | Fails that item with `EXPERIMENT_ITEM_BEFORE_EACH_FAILED`. Other items continue. |
+| `afterEach` | Logged. The item's recorded outcome doesn't change. |
+| `afterAll` | Logged. The returned summary doesn't change. |
+
+When `beforeAll` fails, the experiment is marked failed and the `experiment.run.finished` event is still emitted before the error propagates.
+
+When `beforeEach` fails, the target and its scorers are skipped for that item, since the item's preconditions were never met. `afterEach` is also skipped for that item, on the basis that setup which didn't finish owns its own cleanup.
+
+Teardown failures are logged rather than propagated. By the time `afterEach` runs, the target has already produced a real result, and discarding it because cleanup was untidy would lose the data the experiment was run to collect.
+
+`afterAll` runs on every exit path, including when the experiment fails, when `beforeAll` fails, and when an [event observer](#observe-experiment-events) fails, so teardown isn't skipped when something goes wrong. It runs at most once per experiment.
+
 ## Tool mocks
 
 When an experiment runs an agent that calls side-effecting tools, attach static tool mocks to individual dataset items to make the run deterministic. During the experiment, a mocked tool returns its declared output instead of executing. Tools without a mock on the item run live by default.

--- a/docs/src/content/en/reference/datasets/startExperiment.mdx
+++ b/docs/src/content/en/reference/datasets/startExperiment.mdx
@@ -138,6 +138,34 @@ console.log(`Status: ${summary2.status}`)
       'Controls undeclared agent tool calls. `allow` executes them live. `deny` fails the item with `TOOL_MOCK_NOT_DECLARED` before execution. An item-level value overrides this experiment default.',
   },
   {
+    name: 'beforeAll',
+    type: '(args: ExperimentHookArgs) => void | Promise<void>',
+    isOptional: true,
+    description:
+      'Runs once before any item executes. Receives `experimentId`, `mastra`, and `signal`. A failure fails the experiment and no items run.',
+  },
+  {
+    name: 'beforeEach',
+    type: '(args: ExperimentItemHookArgs) => void | Promise<void>',
+    isOptional: true,
+    description:
+      'Runs before each item executes. Also receives the `item` (`id`, `input`, `groundTruth`, `metadata`). A failure fails that item with `EXPERIMENT_ITEM_BEFORE_EACH_FAILED` and skips its target, scorers, and `afterEach`.',
+  },
+  {
+    name: 'afterEach',
+    type: '(args: ExperimentItemResultHookArgs) => void | Promise<void>',
+    isOptional: true,
+    description:
+      "Runs after each item completes. Also receives the item's `result` with its scores. Skipped when `beforeEach` failed. A failure is logged and doesn't change the item's outcome.",
+  },
+  {
+    name: 'afterAll',
+    type: '(args: ExperimentRunResultHookArgs) => void | Promise<void>',
+    isOptional: true,
+    description:
+      "Runs once after the experiment finishes, on every exit path including failure. Also receives the `summary`. A failure is logged and doesn't change the summary.",
+  },
+  {
     name: 'persistence',
     type: 'ExperimentPersistencePolicy',
     isOptional: true,

--- a/packages/core/src/datasets/experiment/__tests__/lifecycle-hooks.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/lifecycle-hooks.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Mastra } from '../../../mastra';
+import { EXPERIMENT_ITEM_BEFORE_EACH_FAILED, runExperiment } from '../index';
+
+const logger = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+
+// Storage-free Mastra: hooks are orthogonal to persistence, and running without
+// storage keeps these tests focused on hook ordering and error semantics.
+const createMastra = () =>
+  ({
+    getStorage: vi.fn().mockReturnValue(undefined),
+    getLogger: vi.fn().mockReturnValue(logger),
+  }) as unknown as Mastra;
+
+const items = [
+  { id: 'a', input: 'one' },
+  { id: 'b', input: 'two' },
+];
+
+describe('runExperiment lifecycle hooks', () => {
+  it('runs beforeAll once before any item and afterAll once after the run', async () => {
+    const calls: string[] = [];
+    const mastra = createMastra();
+
+    const summary = await runExperiment(mastra, {
+      data: items,
+      maxConcurrency: 1,
+      beforeAll: () => {
+        calls.push('beforeAll');
+      },
+      afterAll: ({ summary }) => {
+        calls.push(`afterAll:${summary.succeededCount}`);
+      },
+      task: ({ input }) => {
+        calls.push(`task:${input}`);
+        return input;
+      },
+    });
+
+    expect(summary.status).toBe('completed');
+    expect(calls).toEqual(['beforeAll', 'task:one', 'task:two', 'afterAll:2']);
+  });
+
+  it('passes experimentId and mastra to run-level hooks', async () => {
+    const mastra = createMastra();
+    const beforeAll = vi.fn();
+
+    const summary = await runExperiment(mastra, {
+      data: items,
+      beforeAll,
+      task: ({ input }) => input,
+    });
+
+    expect(beforeAll).toHaveBeenCalledWith(expect.objectContaining({ experimentId: summary.experimentId, mastra }));
+  });
+
+  it('fails the run without executing items when beforeAll throws', async () => {
+    const task = vi.fn();
+
+    const summary = await runExperiment(createMastra(), {
+      data: items,
+      beforeAll: () => {
+        throw new Error('seed failed');
+      },
+      task,
+    });
+
+    expect(task).not.toHaveBeenCalled();
+    expect(summary.status).toBe('failed');
+    expect(summary.skippedCount).toBe(2);
+    expect(summary.results).toHaveLength(0);
+  });
+
+  it('runs afterAll even when the run fails', async () => {
+    const afterAll = vi.fn();
+
+    await runExperiment(createMastra(), {
+      data: items,
+      beforeAll: () => {
+        throw new Error('seed failed');
+      },
+      afterAll,
+      task: () => 'unused',
+    });
+
+    expect(afterAll).toHaveBeenCalledTimes(1);
+    expect(afterAll.mock.calls[0]![0].summary.status).toBe('failed');
+  });
+
+  it('logs and swallows afterAll failures so teardown cannot mask the outcome', async () => {
+    logger.error.mockClear();
+
+    const summary = await runExperiment(createMastra(), {
+      data: items,
+      afterAll: () => {
+        throw new Error('cleanup exploded');
+      },
+      task: ({ input }) => input,
+    });
+
+    expect(summary.status).toBe('completed');
+    expect(summary.succeededCount).toBe(2);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('cleanup exploded'), expect.anything());
+  });
+
+  it('wraps each item with beforeEach and afterEach', async () => {
+    const calls: string[] = [];
+
+    await runExperiment(createMastra(), {
+      data: items,
+      maxConcurrency: 1,
+      beforeEach: ({ item }) => {
+        calls.push(`before:${item.id}`);
+      },
+      afterEach: ({ item, result }) => {
+        calls.push(`after:${item.id}:${result.output}`);
+      },
+      task: ({ input }) => {
+        calls.push(`task:${input}`);
+        return input;
+      },
+    });
+
+    expect(calls).toEqual(['before:a', 'task:one', 'after:a:one', 'before:b', 'task:two', 'after:b:two']);
+  });
+
+  it('exposes item input, groundTruth and metadata to item hooks', async () => {
+    const beforeEach = vi.fn();
+
+    await runExperiment(createMastra(), {
+      data: [{ id: 'a', input: 'one', groundTruth: 'ONE', metadata: { tag: 'x' } }],
+      beforeEach,
+      task: ({ input }) => input,
+    });
+
+    expect(beforeEach.mock.calls[0]![0].item).toEqual({
+      id: 'a',
+      input: 'one',
+      groundTruth: 'ONE',
+      metadata: { tag: 'x' },
+    });
+  });
+
+  it('fails only the affected item when beforeEach throws, without running the target', async () => {
+    const task = vi.fn(({ input }: { input: unknown }) => input);
+
+    const summary = await runExperiment(createMastra(), {
+      data: items,
+      maxConcurrency: 1,
+      beforeEach: ({ item }) => {
+        if (item.id === 'a') throw new Error('seed failed');
+      },
+      task,
+    });
+
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(summary.status).toBe('completed');
+    expect(summary.failedCount).toBe(1);
+    expect(summary.succeededCount).toBe(1);
+    expect(summary.results[0]!.error).toMatchObject({
+      code: EXPERIMENT_ITEM_BEFORE_EACH_FAILED,
+      message: expect.stringContaining('seed failed'),
+    });
+    expect(summary.results[1]!.error).toBeNull();
+  });
+
+  it('does not retry an item whose beforeEach failed', async () => {
+    const beforeEach = vi.fn(() => {
+      throw new Error('seed failed');
+    });
+
+    await runExperiment(createMastra(), {
+      data: [{ id: 'a', input: 'one' }],
+      maxRetries: 3,
+      beforeEach,
+      task: ({ input }) => input,
+    });
+
+    expect(beforeEach).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips afterEach for an item whose beforeEach failed', async () => {
+    const afterEach = vi.fn();
+
+    await runExperiment(createMastra(), {
+      data: [{ id: 'a', input: 'one' }],
+      beforeEach: () => {
+        throw new Error('seed failed');
+      },
+      afterEach,
+      task: ({ input }) => input,
+    });
+
+    expect(afterEach).not.toHaveBeenCalled();
+  });
+
+  it('runs afterEach for failed items so cleanup still happens', async () => {
+    const afterEach = vi.fn();
+
+    const summary = await runExperiment(createMastra(), {
+      data: [{ id: 'a', input: 'one' }],
+      afterEach,
+      task: () => {
+        throw new Error('target blew up');
+      },
+    });
+
+    expect(summary.failedCount).toBe(1);
+    expect(afterEach).toHaveBeenCalledTimes(1);
+    expect(afterEach.mock.calls[0]![0].result.error).toMatchObject({ message: 'target blew up' });
+  });
+
+  it('logs and swallows afterEach failures without changing the item outcome', async () => {
+    logger.error.mockClear();
+
+    const summary = await runExperiment(createMastra(), {
+      data: [{ id: 'a', input: 'one' }],
+      afterEach: () => {
+        throw new Error('cleanup exploded');
+      },
+      task: ({ input }) => input,
+    });
+
+    expect(summary.succeededCount).toBe(1);
+    expect(summary.results[0]!.error).toBeNull();
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('cleanup exploded'), expect.anything());
+  });
+
+  it('serializes item hooks within a concurrency slot', async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    await runExperiment(createMastra(), {
+      data: [
+        { id: 'a', input: 'one' },
+        { id: 'b', input: 'two' },
+        { id: 'c', input: 'three' },
+      ],
+      maxConcurrency: 2,
+      beforeEach: async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise(r => setTimeout(r, 5));
+      },
+      afterEach: () => {
+        active--;
+      },
+      task: ({ input }) => input,
+    });
+
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -17,6 +17,11 @@ import { TOOL_MOCK_MISMATCH, TOOL_MOCK_EXHAUSTED, TOOL_MOCK_NOT_DECLARED } from 
 import type { ItemToolMock, UnmockedToolPolicy } from './tool-mocks';
 import type { ExperimentConfig, ExperimentSummary, ItemWithScores, ItemResult } from './types';
 
+/** Error code recorded on an item whose `beforeEach` hook threw. */
+export const EXPERIMENT_ITEM_BEFORE_EACH_FAILED = 'EXPERIMENT_ITEM_BEFORE_EACH_FAILED';
+
+const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
 /** Unified item shape used within experiment execution (bridges inline + versioned data) */
 type ExperimentItem = {
   id: string; // item id (or generated for inline)
@@ -41,6 +46,11 @@ type ExperimentItem = {
 export type {
   DataItem,
   ExperimentConfig,
+  ExperimentHookArgs,
+  ExperimentHookItem,
+  ExperimentItemHookArgs,
+  ExperimentItemResultHookArgs,
+  ExperimentRunResultHookArgs,
   ExperimentSummary,
   ItemWithScores,
   ItemResult,
@@ -118,6 +128,10 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
     agentVersion,
     versions,
     persistence,
+    beforeAll,
+    afterAll,
+    beforeEach,
+    afterEach,
   } = config;
 
   const persistExperiments = persistence?.experiments !== 'none';
@@ -134,6 +148,26 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
   const eventTarget = {
     type: targetType ?? ('task' as const),
     id: targetId ?? 'inline',
+  };
+
+  const hookArgs = { experimentId, mastra, signal: executionSignal };
+  let afterAllRan = false;
+  /**
+   * Teardown counterpart to `beforeAll`. Idempotent so it can be invoked from
+   * every exit path (normal return, failed return, observer-error rethrow)
+   * without double-running. Errors are logged, never propagated — teardown must
+   * not mask the run's real outcome.
+   */
+  const runAfterAll = async (summary: ExperimentSummary) => {
+    if (!afterAll || afterAllRan) return;
+    afterAllRan = true;
+    try {
+      await afterAll({ ...hookArgs, summary });
+    } catch (hookError) {
+      mastra.getLogger()?.error(`Experiment ${experimentId} afterAll hook failed: ${errorMessage(hookError)}`, {
+        error: hookError,
+      });
+    }
   };
 
   // 1. Get storage and resolve components
@@ -429,6 +463,13 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
   let lastProgressUpdate = 0;
 
   try {
+    if (beforeAll) {
+      // Runs inside the execution try/catch so a failing setup produces the
+      // same `failed` summary shape as any other run-level failure, with every
+      // item counted as skipped.
+      await beforeAll(hookArgs);
+    }
+
     const pMap = (await import('p-map')).default;
 
     await pMap(
@@ -470,14 +511,39 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
             itemSignal = executionSignal ? AbortSignal.any([executionSignal, timeoutSignal]) : timeoutSignal;
           }
 
+          // Per-item setup runs once (not per retry attempt) inside this
+          // concurrency slot. A failing setup is deterministic from the
+          // runner's perspective, so it skips the target and retries entirely.
+          let beforeEachError: ExecutionResult['error'] = null;
+          if (beforeEach && !scorerConfigError) {
+            try {
+              await beforeEach({
+                ...hookArgs,
+                item: {
+                  id: item.id,
+                  input: item.input,
+                  groundTruth: item.groundTruth,
+                  metadata: item.metadata,
+                },
+              });
+            } catch (hookError) {
+              beforeEachError = {
+                code: EXPERIMENT_ITEM_BEFORE_EACH_FAILED,
+                message: `beforeEach hook failed: ${errorMessage(hookError)}`,
+                stack: hookError instanceof Error ? hookError.stack : undefined,
+              };
+            }
+          }
+
           // Resolve item scorer configuration before executing the target. Invalid item
           // references are deterministic and therefore skip both target execution and retries.
           let retryCount = 0;
-          let execResult: ExecutionResult = scorerConfigError
-            ? { output: null, error: scorerConfigError, traceId: null }
+          const preflightError = scorerConfigError ?? beforeEachError;
+          let execResult: ExecutionResult = preflightError
+            ? { output: null, error: preflightError, traceId: null }
             : await execFn(item, itemSignal);
 
-          while (execResult.error && !scorerConfigError && retryCount < maxRetries) {
+          while (execResult.error && !preflightError && retryCount < maxRetries) {
             // Don't retry abort errors
             if (execResult.error.message.toLowerCase().includes('abort')) break;
 
@@ -523,10 +589,11 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
             ...(execResult.toolMockReport ? { toolMockReport: execResult.toolMockReport } : {}),
           };
 
-          // Run scorers (inline, after target completes). A scorer-configuration
-          // failure skips scoring because the selected source could not be resolved fully.
+          // Run scorers (inline, after target completes). A preflight failure
+          // (unresolvable scorer configuration, or a failed `beforeEach`) skips
+          // scoring because the target never ran under valid conditions.
           let itemScores: Awaited<ReturnType<typeof runScorersForItem>> = [];
-          if (!scorerConfigError) {
+          if (!preflightError) {
             const workflowData =
               execResult.stepResults || execResult.stepExecutionPath
                 ? {
@@ -621,6 +688,31 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
             succeededCount++;
           }
 
+          // Per-item teardown. Skipped when `beforeEach` failed — a failed setup
+          // owns its own cleanup. Errors are logged, never propagated, so
+          // teardown cannot change the item's already-recorded outcome.
+          if (afterEach && !beforeEachError) {
+            try {
+              await afterEach({
+                ...hookArgs,
+                item: {
+                  id: item.id,
+                  input: item.input,
+                  groundTruth: item.groundTruth,
+                  metadata: item.metadata,
+                },
+                result: results[idx]!,
+              });
+            } catch (hookError) {
+              mastra
+                .getLogger()
+                ?.error(
+                  `Experiment ${experimentId} afterEach hook failed for item ${item.id}: ${errorMessage(hookError)}`,
+                  { error: hookError },
+                );
+            }
+          }
+
           if (experimentsStore) {
             // Throttled progress update
             const now = Date.now();
@@ -662,12 +754,6 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
     const skippedCount = items.length - succeededCount - failedCount;
     const observerError = eventDispatcher?.failure;
 
-    if (observerError) {
-      await markFailedForObserverError({ succeededCount, failedCount, skippedCount, completedAt });
-      throw observerError;
-    }
-
-    const terminalError = error instanceof AggregateError ? (error.errors[0] ?? error) : error;
     const summary: ExperimentSummary = {
       experimentId,
       status: 'failed' as const,
@@ -681,6 +767,14 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
       completedAt,
       results: results.filter(Boolean),
     };
+
+    if (observerError) {
+      await runAfterAll(summary);
+      await markFailedForObserverError({ succeededCount, failedCount, skippedCount, completedAt });
+      throw observerError;
+    }
+
+    const terminalError = error instanceof AggregateError ? (error.errors[0] ?? error) : error;
 
     if (eventDispatcher) {
       try {
@@ -701,6 +795,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
           completedAt: completedAt.toISOString(),
         });
       } catch (observerError) {
+        await runAfterAll(summary);
         await markFailedForObserverError({ succeededCount, failedCount, skippedCount, completedAt });
         throw observerError;
       }
@@ -717,6 +812,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
       });
     }
 
+    await runAfterAll(summary);
     return summary;
   }
 
@@ -763,6 +859,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
         completedAt: completedAt.toISOString(),
       });
     } catch (observerError) {
+      await runAfterAll(summary);
       await markFailedForObserverError({ succeededCount, failedCount, skippedCount, completedAt });
       throw observerError;
     }
@@ -779,6 +876,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
     });
   }
 
+  await runAfterAll(summary);
   return summary;
 }
 

--- a/packages/core/src/datasets/experiment/types.ts
+++ b/packages/core/src/datasets/experiment/types.ts
@@ -66,6 +66,50 @@ export interface DataItem<I = unknown, E = unknown> {
 }
 
 /**
+ * The subset of a dataset item exposed to experiment lifecycle hooks.
+ * Mirrors the fields a hook can meaningfully act on without letting hooks
+ * mutate execution-control fields (tool mocks, resume data, scorer selection).
+ */
+export interface ExperimentHookItem<I = unknown, E = unknown> {
+  /** ID of the dataset item */
+  id: string;
+  /** Input data that will be passed to the target */
+  input: I;
+  /** Ground truth for scoring, when the item declares one */
+  groundTruth?: E;
+  /** Item metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/** Arguments passed to run-level and item-level experiment hooks. */
+export interface ExperimentHookArgs {
+  /** ID of the experiment being run */
+  experimentId: string;
+  /** The Mastra instance the experiment is running against */
+  mastra: Mastra;
+  /** Run-level abort signal, when the run is cancellable */
+  signal?: AbortSignal;
+}
+
+/** Arguments passed to `beforeEach`. */
+export interface ExperimentItemHookArgs<I = unknown, E = unknown> extends ExperimentHookArgs {
+  /** The item about to be executed */
+  item: ExperimentHookItem<I, E>;
+}
+
+/** Arguments passed to `afterEach`. */
+export interface ExperimentItemResultHookArgs<I = unknown, E = unknown> extends ExperimentItemHookArgs<I, E> {
+  /** The completed item result, including scores */
+  result: ItemWithScores;
+}
+
+/** Arguments passed to `afterAll`. */
+export interface ExperimentRunResultHookArgs extends ExperimentHookArgs {
+  /** The summary that is about to be returned from `runExperiment` */
+  summary: ExperimentSummary;
+}
+
+/**
  * Per-domain persistence selection for a single experiment run.
  *
  * - `default` — write through the `Mastra` instance's configured storage (current behavior).
@@ -122,6 +166,54 @@ export interface ExperimentConfig<I = unknown, O = unknown, E = unknown> {
   scorers?: (MastraScorer<any, any, any, any> | string)[] | AgentScorerConfig | WorkflowScorerConfig;
 
   // === Options ===
+
+  // === Lifecycle hooks ===
+
+  /**
+   * Runs once before any item executes — use it to seed fixtures the target
+   * depends on (files, database rows, sandbox state).
+   *
+   * A throw or rejection aborts the run before any item executes: the
+   * experiment finishes with status `failed`, every item counted as skipped.
+   *
+   * @example
+   * ```ts
+   * await runExperiment(mastra, {
+   *   data: items,
+   *   targetType: 'agent',
+   *   targetId: 'my-agent',
+   *   beforeAll: async () => { await seedWorkspace(); },
+   *   afterAll: async () => { await clearWorkspace(); },
+   * });
+   * ```
+   */
+  beforeAll?: (args: ExperimentHookArgs) => void | Promise<void>;
+  /**
+   * Runs once after every item has settled, immediately before `runExperiment`
+   * returns — including when the run failed or was cancelled. Receives the
+   * summary that is about to be returned.
+   *
+   * Errors are logged and swallowed so teardown cannot mask the run outcome.
+   */
+  afterAll?: (args: ExperimentRunResultHookArgs) => void | Promise<void>;
+  /**
+   * Runs before each item executes, inside the item's concurrency slot, so it
+   * respects `maxConcurrency`. Runs once per item, not once per retry attempt.
+   *
+   * A throw or rejection fails that item without executing the target and
+   * without retrying; the error is recorded on the item result. Other items
+   * are unaffected. `afterEach` is skipped for the item, on the assumption
+   * that a failed setup owns its own cleanup.
+   */
+  beforeEach?: (args: ExperimentItemHookArgs<I, E>) => void | Promise<void>;
+  /**
+   * Runs after each item completes (including failed items), once its result
+   * and scores are final. Use it to tear down whatever `beforeEach` set up.
+   *
+   * Errors are logged and swallowed so teardown cannot change an item's
+   * recorded outcome.
+   */
+  afterEach?: (args: ExperimentItemResultHookArgs<I, E>) => void | Promise<void>;
 
   /** Pin to specific dataset version (default: latest). Only applies when datasetId is used. */
   version?: number;


### PR DESCRIPTION
Fixes #19889

## The problem

An experiment often needs the world put into a particular state before the target can be evaluated, and cleaned up afterwards. Copying a fixture PDF into the agent's workspace, seeding a database, provisioning a sandbox, deleting whatever the run left behind.

`runExperiment` had nowhere to put that work. The only extension point was the task function itself, which runs once per item and can't express run-level setup. People were working around it by inspecting the request context during workspace startup and conditionally running setup — the setup logic ends up living far away from the experiment that needs it.

## What this adds

Four optional hooks on `ExperimentConfig`, named after the pattern people already know from test runners:

- `beforeAll` / `afterAll` — run once around the whole experiment
- `beforeEach` / `afterEach` — run around each item

Every hook is async and receives the experiment id, the Mastra instance, and an abort signal so long-running setup can be cancelled with the run. The per-item hooks additionally receive the item. The teardown hooks receive the result they follow: `afterEach` gets the item result including scores, `afterAll` gets the summary about to be returned.

The item exposed to hooks is a reduced view — `id`, `input`, `groundTruth`, `metadata`. Execution-control fields like tool mocks and scorer selection are deliberately not exposed, so a hook can't change how the item runs.

## How failures behave

Each hook fails differently, according to how much of the run depends on it:

| Hook | On failure |
| --- | --- |
| `beforeAll` | Fails the experiment. No items run. |
| `beforeEach` | Fails that item with `EXPERIMENT_ITEM_BEFORE_EACH_FAILED`. Other items continue. |
| `afterEach` | Logged. The item's recorded outcome is unchanged. |
| `afterAll` | Logged. The returned summary is unchanged. |

When `beforeAll` fails the experiment record is marked failed and the finish event is still emitted before the error propagates.

When `beforeEach` fails, the target and its scorers are skipped for that item, and `afterEach` is skipped too — setup that didn't complete owns its own cleanup, so teardown isn't handed a half-built state it never created.

Teardown failures are logged rather than propagated. By the time `afterEach` runs the target has already produced a real result, and discarding it because cleanup was untidy would throw away the data the experiment was run to collect.

`afterAll` runs on every exit path — success, experiment failure, `beforeAll` failure, and observer failure — and runs at most once.

## Test plan

13 new tests in `packages/core` cover hook ordering, argument shape, cancellation via signal, and each failure mode above, including that `afterAll` still runs when `beforeAll` throws and that `afterEach` is skipped when `beforeEach` fails. The existing experiment tests pass unchanged and `pnpm --filter ./packages/core check` is clean.

## Docs

`running-experiments.mdx` gets a Lifecycle hooks section and `startExperiment.mdx` documents the four parameters. Docs formatting, remark, vale, and sidebar validation all pass.
