### PR TITLE
fix(voice): clear Gemini readiness timers

### DIFF
--- a/.changeset/clean-gemini-readiness-timers.md
+++ b/.changeset/clean-gemini-readiness-timers.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-google-gemini-live': patch
+---
+
+Fixed Gemini Live session readiness waits to release timeout resources after settling.

--- a/voice/google-gemini-live-api/src/managers/SessionManager.test.ts
+++ b/voice/google-gemini-live-api/src/managers/SessionManager.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SessionManager } from './SessionManager';
+
+describe('SessionManager', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('waitForSessionCreated', () => {
+    it('clears the readiness timeout after setup completes', async () => {
+      vi.useFakeTimers();
+      const manager = new SessionManager({ debug: false, timeoutMs: 30_000 });
+
+      const sessionCreated = manager.waitForSessionCreated();
+      manager.getEventEmitter().emit('setupComplete');
+
+      await expect(sessionCreated).resolves.toBeUndefined();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('clears the readiness timeout after setup fails', async () => {
+      vi.useFakeTimers();
+      const manager = new SessionManager({ debug: false, timeoutMs: 30_000 });
+
+      const sessionCreated = manager.waitForSessionCreated();
+      manager.getEventEmitter().emit('error', { message: 'connection failed' });
+
+      await expect(sessionCreated).rejects.toThrow('Session creation failed: connection failed');
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('clears the readiness timeout when the session ends during setup', async () => {
+      vi.useFakeTimers();
+      const manager = new SessionManager({ debug: false, timeoutMs: 30_000 });
+
+      const sessionCreated = manager.waitForSessionCreated();
+      manager.getEventEmitter().emit('sessionEnd');
+
+      await expect(sessionCreated).rejects.toThrow('Session ended before setup completed');
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('clears the readiness timeout after timing out', async () => {
+      vi.useFakeTimers();
+      const manager = new SessionManager({ debug: false, timeoutMs: 30_000 });
+
+      const sessionCreated = manager.waitForSessionCreated();
+      const expectation = expect(sessionCreated).rejects.toThrow('Session creation timeout');
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await expectation;
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+});

--- a/voice/google-gemini-live-api/src/managers/SessionManager.ts
+++ b/voice/google-gemini-live-api/src/managers/SessionManager.ts
@@ -92,6 +92,7 @@ export class SessionManager {
   async waitForSessionCreated(): Promise<void> {
     return new Promise((resolve, reject) => {
       let isResolved = false;
+      let readinessTimeout: NodeJS.Timeout | undefined;
 
       const onSetupComplete = () => {
         if (!isResolved) {
@@ -121,6 +122,10 @@ export class SessionManager {
         this.eventEmitter.removeListener('setupComplete', onSetupComplete);
         this.eventEmitter.removeListener('error', onError);
         this.eventEmitter.removeListener('sessionEnd', onSessionEnd);
+        if (readinessTimeout) {
+          clearTimeout(readinessTimeout);
+          readinessTimeout = undefined;
+        }
       };
 
       // Listen for setup completion
@@ -129,7 +134,7 @@ export class SessionManager {
       this.eventEmitter.once('sessionEnd', onSessionEnd);
 
       // Add timeout to prevent hanging indefinitely
-      setTimeout(() => {
+      readinessTimeout = setTimeout(() => {
         if (!isResolved) {
           isResolved = true;
           cleanup();


### PR DESCRIPTION
Fixes #21077.

SessionManager now retains the readiness timeout handle and clears it through the shared cleanup path whenever setup completes, fails, the session ends, or the timeout itself fires. Previously, an early settlement left the timer and its captured state alive until the full timeout elapsed. With this change, no readiness timer remains pending once the wait settles.

Added focused fake-timer coverage for all four settlement paths. The SessionManager tests pass (4 tests), and formatting passes.

The package build could not be run in this environment because tsdown cannot import an existing, unbuilt dependency. The installed Node.js 22.14 is also below the repository's tooling requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Gemini sessions use a timer while they start. This PR makes sure the timer is always stopped when setup finishes, fails, ends, or times out, so unused timers do not remain active.

## Changes

- Store the Gemini readiness timeout handle in `SessionManager`.
- Clear the timeout through the shared cleanup path for all settlement outcomes.
- Add fake-timer tests for successful setup, setup failure, session termination, and timeout rejection.
- Add a patch changeset for `@mastra/voice-google-gemini-live`.

## Validation

- `SessionManager` tests and formatting pass.
- The package build was not run because a dependency was not built and the installed Node.js version did not meet the repository requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->