### PR TITLE
Allow agent controller sessions to run without a workspace

### DIFF
--- a/.changeset/purple-heads-share.md
+++ b/.changeset/purple-heads-share.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': minor
+---
+
+Made the workspace optional when creating an agent controller session. Previously `createSession()` threw `A session requires a valid workspace instance` unless a workspace was configured, which blocked chat-style sessions that only need threads, state, and agent runs.
+
+```ts
+// Now works — no workspace configured anywhere
+const controller = new AgentController({ id: 'chat', storage, modes });
+const session = await controller.createSession({ resourceId: 'user-1' });
+
+session.getWorkspace(); // undefined
+```
+
+`Session.getWorkspace()` now returns `Workspace | undefined`, so check the result before using it. Passing a value that is not a `Workspace` instance is still rejected. Sessions that do configure a workspace are unchanged, including workspace initialization and the `workspace_ready` / `workspace_error` events.
+
+Closes #20594

--- a/docs/src/content/en/reference/agent-controller/session.mdx
+++ b/docs/src/content/en/reference/agent-controller/session.mdx
@@ -205,7 +205,7 @@ session.abort()
 
 Return the workspace resolved for this session. This preserves session-level overrides and workspaces selected from the session scope.
 
-A workspace is optional. When neither the session nor the `AgentController` configures one, the session still runs — it just has no filesystem or sandbox access — and this returns `undefined`. Check the result before using it.
+A workspace is optional. When neither the session nor the `AgentController` configures one, the session still runs without filesystem or sandbox access, and this returns `undefined`. Check the result before using it.
 
 ```typescript
 const workspace = session.getWorkspace()

--- a/docs/src/content/en/reference/agent-controller/session.mdx
+++ b/docs/src/content/en/reference/agent-controller/session.mdx
@@ -205,12 +205,14 @@ session.abort()
 
 Return the workspace resolved for this session. This preserves session-level overrides and workspaces selected from the session scope.
 
+A workspace is optional. When neither the session nor the `AgentController` configures one, the session still runs — it just has no filesystem or sandbox access — and this returns `undefined`. Check the result before using it.
+
 ```typescript
 const workspace = session.getWorkspace()
-const skill = await workspace.skills?.get('code-review')
+const skill = await workspace?.skills?.get('code-review')
 ```
 
-Returns: `Workspace`
+Returns: `Workspace | undefined`
 
 ### Session grants
 

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -551,7 +551,7 @@ export class AgentController<TState = {}> {
           initialState,
           stateSchema: this.config.stateSchema,
         },
-        workspace: workspaceToConnect as Workspace,
+        workspace: workspaceToConnect,
         browser: browserToConnect,
       }),
     );

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -2749,7 +2749,7 @@ export class Session<TState = unknown> {
    * filtered back to the session's scope. Empty when the session is unscoped.
    */
   readonly #tags: Record<string, string>;
-  readonly #workspace: Workspace;
+  readonly #workspace: Workspace | undefined;
   browser?: MastraBrowser;
 
   constructor({
@@ -2766,7 +2766,7 @@ export class Session<TState = unknown> {
     id: string;
     ownerId: string;
     tags?: Record<string, string>;
-    workspace: Workspace;
+    workspace?: Workspace;
     browser?: MastraBrowser;
   }) {
     this.#tags = tags && Object.keys(tags).length > 0 ? { ...tags } : {};
@@ -2788,8 +2788,8 @@ export class Session<TState = unknown> {
       return args => this.thread.setSettingOn({ threadId, ...args });
     });
 
-    if (!workspace || !(workspace instanceof Workspace)) {
-      throw new Error(`A session requires a valid workspace instance.`);
+    if (workspace !== undefined && !(workspace instanceof Workspace)) {
+      throw new Error(`A session workspace must be a valid Workspace instance.`);
     }
 
     this.#workspace = workspace;
@@ -2818,13 +2818,16 @@ export class Session<TState = unknown> {
   }
 
   /**
-   * The workspace resolved for this session.
+   * The workspace resolved for this session, or `undefined` when the session
+   * runs without one. A workspace is optional: sessions that only need threads,
+   * state, and agent runs (chat-style usage) do not have to configure
+   * filesystem or sandbox access.
    *
    * Dynamic workspace factories are evaluated independently when each session
    * is created. Use this accessor for operations that must stay bound to the
    * session's workspace rather than resolving through controller-global state.
    */
-  getWorkspace(): Workspace {
+  getWorkspace(): Workspace | undefined {
     return this.#workspace;
   }
 

--- a/packages/core/src/agent-controller/workspace-resolution.test.ts
+++ b/packages/core/src/agent-controller/workspace-resolution.test.ts
@@ -114,21 +114,6 @@ describe('AgentController workspace — dynamic factory', () => {
     expect(factory).toHaveBeenCalledTimes(2);
   });
 
-  it('createSession throws when factory returns undefined', async () => {
-    const nullFactory = vi.fn().mockResolvedValue(undefined);
-    const controller = new AgentController({
-      id: 'test',
-      storage: new InMemoryStore(),
-      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
-      workspace: nullFactory,
-    });
-    await controller.init();
-
-    await expect(controller.createSession({ id: 'test-session', ownerId: 'test-owner' })).rejects.toThrow(
-      'A session requires a valid workspace instance.',
-    );
-  });
-
   it('resolveWorkspace provides session state to the factory', async () => {
     const ws = createMockWorkspace('dynamic-ws');
     // Simulates a dynamic workspace factory that reads session state via
@@ -157,25 +142,6 @@ describe('AgentController workspace — dynamic factory', () => {
     // this.workspace, so this re-invokes the factory with a fresh context.
     const resolved = await controller.resolveWorkspace({ session });
     expect(resolved).toBe(ws);
-  });
-});
-
-// ===========================================================================
-// No workspace configured
-// ===========================================================================
-
-describe('AgentController workspace — none configured', () => {
-  it('createSession throws when no workspace is configured', async () => {
-    const controller = new AgentController({
-      id: 'test',
-      storage: new InMemoryStore(),
-      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
-    });
-    await controller.init();
-
-    await expect(controller.createSession({ id: 'test-session', ownerId: 'test-owner' })).rejects.toThrow(
-      'A session requires a valid workspace instance.',
-    );
   });
 });
 
@@ -309,17 +275,19 @@ describe('AgentController createSession — workspace isolation', () => {
       workspace: wsA,
     });
 
-    // Session B has no workspace override — should throw because no workspace is available
-    await expect(
-      controller.createSession({
-        id: 'session-b',
-        ownerId: 'test-owner',
-        resourceId: 'resource-b',
-      }),
-    ).rejects.toThrow('A session requires a valid workspace instance.');
+    // Session B has no workspace override and the controller has none either —
+    // it runs without a workspace rather than inheriting session A's.
+    const sessionB = await controller.createSession({
+      id: 'session-b',
+      ownerId: 'test-owner',
+      resourceId: 'resource-b',
+    });
+
+    expect(sessionB.getWorkspace()).toBeUndefined();
+    expect(sessionB.getWorkspace()).not.toBe(wsA);
 
     // Session A still has its own workspace (init was called)
-    expect(sessionA).toBeDefined();
+    expect(sessionA.getWorkspace()).toBe(wsA);
     expect(initSpyA).toHaveBeenCalled();
   });
 });
@@ -423,5 +391,87 @@ describe('AgentController createSession — browser overrides', () => {
 
     // Session A still has its own browser
     expect(sessionA.browser).toBe(browserA);
+  });
+});
+
+// ===========================================================================
+// Sessions without a workspace (#20594)
+// ===========================================================================
+
+describe('AgentController createSession — no workspace', () => {
+  it('creates a usable session when no workspace is configured anywhere', async () => {
+    const controller = new AgentController({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+    });
+    await controller.init();
+
+    const session = await controller.createSession({
+      id: 'test-session',
+      ownerId: 'test-owner',
+      resourceId: 'resource-1',
+    });
+
+    expect(session.getWorkspace()).toBeUndefined();
+    expect(controller.hasWorkspace()).toBe(false);
+    // The rest of the session is fully wired: it still has an identity and a thread.
+    expect(session.identity.getResourceId()).toBe('resource-1');
+    expect(session.thread.requireId()).toBeDefined();
+  });
+
+  it('emits no workspace lifecycle events for a workspace-less session', async () => {
+    const controller = new AgentController({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+    });
+    await controller.init();
+
+    const events: string[] = [];
+    controller.onSessionCreated(session => {
+      session.subscribe(event => {
+        if (event.type.startsWith('workspace')) events.push(event.type);
+      });
+    });
+
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    // Late subscribers get replayed workspace events; there must be none to replay.
+    session.subscribe(event => {
+      if (event.type.startsWith('workspace')) events.push(event.type);
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it('a dynamic workspace factory resolving to undefined yields a workspace-less session', async () => {
+    const controller = new AgentController({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      workspace: async () => undefined,
+    });
+    await controller.init();
+
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+
+    expect(session.getWorkspace()).toBeUndefined();
+  });
+
+  it('still rejects a workspace that is not a Workspace instance', async () => {
+    const controller = new AgentController({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+    });
+    await controller.init();
+
+    await expect(
+      controller.createSession({
+        id: 'test-session',
+        ownerId: 'test-owner',
+        workspace: { name: 'not-a-workspace' } as unknown as Workspace,
+      }),
+    ).rejects.toThrow(/must be a valid Workspace instance/);
   });
 });


### PR DESCRIPTION
## Summary

An `AgentController` session could not be created unless a workspace was configured — `createSession()` threw `A session requires a valid workspace instance.` This blocked a whole class of use: chat-style sessions that only need threads, state, mode/model selection, and agent runs, with no filesystem or sandbox access at all.

A workspace is now optional. `Session.getWorkspace()` returns `Workspace | undefined`, and sessions that do configure a workspace behave exactly as before.

## Why this was a small change

`AgentController` already handled an absent workspace everywhere — it resolves the workspace (which may be `undefined`, including from a dynamic factory) and guards initialization and the `workspace_ready` / `workspace_error` events behind an `instanceof Workspace` check. The only thing forcing a workspace to exist was `Session`'s constructor, which is why the call site had to cast the resolved value with `as Workspace`.

So the fix is to relax `Session` and drop the cast. The validation is kept, just narrowed: a missing workspace is valid, a value that is not a `Workspace` instance still throws.

## Testing

`packages/core/src/agent-controller/workspace-resolution.test.ts` — three existing tests asserted the old throwing behavior and were rewritten. Two of them were the reported bug itself. The third asserted that a session without an override "should throw because no workspace is available", which was really testing for workspace leakage between sessions; it now asserts the actual property — session B gets `undefined` rather than inheriting session A's workspace — which the throw had been masking.

New coverage:
- a workspace-less session is otherwise fully wired (identity and thread intact)
- no `workspace_*` events are emitted, including to late subscribers that receive replayed events
- a dynamic workspace factory resolving to `undefined` produces a workspace-less session
- a non-`Workspace` value is still rejected

Full `src/agent-controller` suite passes: 441 tests, no type errors. `packages/core` typechecks and docs validation passes.

Closes #20594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Sessions can now work without a workspace. Sessions with a workspace keep the same behavior, and invalid workspace values still cause errors.

## Changes

- Made `Session` workspaces optional.
- Updated `Session.getWorkspace()` to return `Workspace | undefined`.
- Preserved workspace initialization and `workspace_*` events only for sessions with a workspace.
- Updated workspace resolution and isolation behavior.
- Added tests for workspace-less sessions, dynamic factories, event behavior, workspace isolation, and invalid values.
- Updated documentation and added a `@mastra/core` changeset.

## Validation

- Agent-controller tests pass.
- Typechecks pass.
- Documentation validation passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->