### PR TITLE
Run Code Mode securely in-process without native binaries or Node flags

### DIFF
--- a/.changeset/wise-peas-win.md
+++ b/.changeset/wise-peas-win.md
@@ -1,0 +1,5 @@
+---
+'@mastra/quickjs': minor
+---
+
+Added `@mastra/quickjs`, a Code Mode transport that runs model-authored programs in an in-process QuickJS runtime compiled to WebAssembly. It gives the same isolation as `@mastra/isolated-vm` — no filesystem, network, or process access, only your allow-listed tools — without installing a native addon or starting Node.js with `--no-node-snapshot`, so Code Mode now works on serverless hosts that forbid both. Programs run slower than in a V8 isolate, which mostly affects compute-heavy code rather than code that awaits tool calls. See https://github.com/mastra-ai/mastra/issues/20546

--- a/.changeset/wise-peas-win.md
+++ b/.changeset/wise-peas-win.md
@@ -2,4 +2,24 @@
 '@mastra/quickjs': minor
 ---
 
-Added `@mastra/quickjs`, a Code Mode transport that runs model-authored programs in an in-process QuickJS runtime compiled to WebAssembly. It gives the same isolation as `@mastra/isolated-vm` — no filesystem, network, or process access, only your allow-listed tools — without installing a native addon or starting Node.js with `--no-node-snapshot`, so Code Mode now works on serverless hosts that forbid both. Programs run slower than in a V8 isolate, which mostly affects compute-heavy code rather than code that awaits tool calls. See https://github.com/mastra-ai/mastra/issues/20546
+Added `@mastra/quickjs`, a Code Mode transport that runs model-authored programs in an in-process QuickJS runtime compiled to WebAssembly.
+
+**Why**
+
+Running Code Mode in-process previously meant `@mastra/isolated-vm`, which installs a native addon and requires the host process to start with `--no-node-snapshot`. Serverless platforms usually allow neither, leaving a full workspace sandbox as the only option. This transport needs neither, so Code Mode runs on those hosts.
+
+**Usage**
+
+```typescript
+import { createCodeMode } from '@mastra/core/tools';
+import { QuickJsCodeModeTransport } from '@mastra/quickjs';
+
+const { tool, instructions } = createCodeMode(
+  { tools: { getTopProducts, getProductRatings } },
+  new QuickJsCodeModeTransport({ memoryLimitMb: 128 }),
+);
+```
+
+Programs get the same boundary as the isolated-vm transport: no filesystem, network, process, or module access, and the allow-listed tools as their only capability. They run slower than in a V8 isolate, which affects compute-heavy code far more than code that awaits tool calls.
+
+Closes https://github.com/mastra-ai/mastra/issues/20546

--- a/code-mode/isolated-vm/vitest.config.ts
+++ b/code-mode/isolated-vm/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    name: 'unit:code-mode/isolated-vm',
     environment: 'node',
     include: ['src/**/*.test.ts'],
     // isolated-vm requires --no-node-snapshot on Node 20+ to create isolates.

--- a/code-mode/quickjs/.gitignore
+++ b/code-mode/quickjs/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+coverage

--- a/code-mode/quickjs/eslint.config.js
+++ b/code-mode/quickjs/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/code-mode/quickjs/lint-staged.config.js
+++ b/code-mode/quickjs/lint-staged.config.js
@@ -1,0 +1,9 @@
+export default {
+  '*.{ts,tsx}': [
+    'oxlint --fix --deny-warnings',
+    'eslint --fix --max-warnings=0',
+    'oxfmt --no-error-on-unmatched-pattern',
+  ],
+  '*.{js,jsx}': ['oxfmt --no-error-on-unmatched-pattern'],
+  '*.{json,md,yml,yaml}': ['oxfmt --no-error-on-unmatched-pattern'],
+};

--- a/code-mode/quickjs/package.json
+++ b/code-mode/quickjs/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@mastra/quickjs",
+  "version": "0.0.0",
+  "description": "In-process WebAssembly Code Mode transport for Mastra, backed by QuickJS — no native binaries and no Node flags required",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown --silent --config tsdown.config.ts",
+    "build:lib": "pnpm build",
+    "build:watch": "pnpm build --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "oxlint . && eslint .",
+    "lint:fix": "oxlint --fix . && eslint --fix ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "quickjs-emscripten": "^0.31.0",
+    "ts-blank-space": "^0.6.1"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.20.1",
+    "@vitest/coverage-v8": "catalog:",
+    "eslint": "^10.7.0",
+    "tsdown": "0.22.9",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.55.0-0 <2.0.0-0"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "code-mode/quickjs"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/code-mode/quickjs/package.json
+++ b/code-mode/quickjs/package.json
@@ -62,6 +62,6 @@
     "url": "https://github.com/mastra-ai/mastra/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.19.0"
   }
 }

--- a/code-mode/quickjs/src/index.ts
+++ b/code-mode/quickjs/src/index.ts
@@ -1,0 +1,1 @@
+export { QuickJsCodeModeTransport, type QuickJsCodeModeTransportOptions } from './transport';

--- a/code-mode/quickjs/src/transport.test.ts
+++ b/code-mode/quickjs/src/transport.test.ts
@@ -236,6 +236,10 @@ describe('QuickJsCodeModeTransport', () => {
       { transport: new QuickJsCodeModeTransport({ memoryLimitMb: 16 }), timeout: 30_000 },
     );
     expect(result.success).toBe(false);
+    // A 30s timeout would also fail this program, so assert the limit is what
+    // stopped it. Otherwise the test would still pass if memoryLimitMb were ignored.
+    expect(result.error?.name).not.toBe('TimeoutError');
+    expect(result.error?.message).toMatch(/out of memory/i);
   });
 
   it('preserves logs captured before a failure', async () => {

--- a/code-mode/quickjs/src/transport.test.ts
+++ b/code-mode/quickjs/src/transport.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Tests for {@link QuickJsCodeModeTransport}.
+ *
+ * These run against a real QuickJS WebAssembly interpreter, so they exercise the
+ * actual isolation boundary: no fakes, no process spawning, no network. The
+ * vitest config deliberately passes no `execArgv` — this transport must work
+ * under a plain Node process, and these tests are the proof.
+ *
+ * The bulk of the suite is ported case-for-case from `@mastra/isolated-vm`'s
+ * transport tests, because the two transports are meant to be interchangeable
+ * and that file is the behavioural contract for a secure in-process transport.
+ */
+
+import { createCodeMode, createTool } from '@mastra/core/tools';
+import type { CodeModeToolDispatcher, CodeModeToolResult } from '@mastra/core/tools';
+import { DEBUG_SYNC, TestQuickJSWASMModule, newQuickJSWASMModuleFromVariant } from 'quickjs-emscripten';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { QuickJsCodeModeTransport } from './transport';
+
+function run(
+  program: string,
+  overrides: Partial<{
+    toolIds: string[];
+    dispatch: CodeModeToolDispatcher;
+    timeout: number;
+    abortSignal: AbortSignal;
+    onExternalCall: (tool: string, args: unknown) => void;
+    onExternalResult: (tool: string, durationMs: number, error?: unknown) => void;
+    transport: QuickJsCodeModeTransport;
+  }> = {},
+): Promise<CodeModeToolResult> {
+  const transport = overrides.transport ?? new QuickJsCodeModeTransport();
+  return transport.run({
+    program,
+    toolIds: overrides.toolIds ?? [],
+    dispatch: overrides.dispatch ?? (async () => undefined),
+    timeout: overrides.timeout ?? 5_000,
+    abortSignal: overrides.abortSignal,
+    onExternalCall: overrides.onExternalCall,
+    onExternalResult: overrides.onExternalResult,
+  });
+}
+
+describe('QuickJsCodeModeTransport', () => {
+  it('declares that it does not require a sandbox', () => {
+    expect(new QuickJsCodeModeTransport().requiresSandbox).toBe(false);
+  });
+
+  it('constructs and runs without any Node flags', async () => {
+    // The reason this package exists: isolated-vm needs --no-node-snapshot on
+    // Node 20+, and this process was started without it.
+    expect(process.execArgv).not.toContain('--no-node-snapshot');
+    expect(process.env.NODE_OPTIONS ?? '').not.toContain('--no-node-snapshot');
+    await expect(run(`return 'ok';`)).resolves.toMatchObject({ success: true, result: 'ok' });
+  });
+
+  it('runs a program and returns its result', async () => {
+    const result = await run(`return 1 + 2;`);
+    expect(result).toEqual({ success: true, result: 3, logs: [] });
+  });
+
+  it('strips TypeScript annotations before evaluation', async () => {
+    const result = await run(`
+      const double = (n: number): number => n * 2;
+      const values: number[] = [1, 2, 3];
+      return values.map(double);
+    `);
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual([2, 4, 6]);
+  });
+
+  it('captures console output as logs', async () => {
+    const result = await run(`
+      console.log('hello', { a: 1 });
+      console.warn('careful');
+      return null;
+    `);
+    expect(result.success).toBe(true);
+    expect(result.logs).toEqual(['hello {"a":1}', 'careful']);
+  });
+
+  it('bridges external_* calls to the host dispatcher', async () => {
+    const dispatch = vi.fn(async (tool: string, args: any) => ({ echoed: { tool, args } }));
+    const result = await run(`const r = await external_lookup({ id: 'x' }); return r.echoed;`, {
+      toolIds: ['lookup'],
+      dispatch,
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ tool: 'lookup', args: { id: 'x' } });
+    expect(dispatch).toHaveBeenCalledWith('lookup', { id: 'x' });
+  });
+
+  it('resolves concurrent external_* calls independently (Promise.all)', async () => {
+    const dispatch: CodeModeToolDispatcher = async (_tool, args) => {
+      const { n } = args as { n: number };
+      // Reverse-order delays so completion order differs from call order.
+      await new Promise(resolve => setTimeout(resolve, (3 - n) * 20));
+      return n * 10;
+    };
+    const result = await run(
+      `
+      const [a, b, c] = await Promise.all([
+        external_calc({ n: 1 }),
+        external_calc({ n: 2 }),
+        external_calc({ n: 3 }),
+      ]);
+      return [a, b, c];
+      `,
+      { toolIds: ['calc'], dispatch },
+    );
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual([10, 20, 30]);
+  });
+
+  it('keeps many concurrent external_* calls in flight at once', async () => {
+    // Guards the core reason this transport uses the synchronous build: the
+    // asyncify build can only suspend for one host call at a time.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const dispatch: CodeModeToolDispatcher = async (_tool, args) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      inFlight--;
+      return (args as { n: number }).n;
+    };
+    const result = await run(
+      `
+      const calls = [];
+      for (let n = 0; n < 8; n++) calls.push(external_calc({ n }));
+      return (await Promise.all(calls)).reduce((a, b) => a + b, 0);
+      `,
+      { toolIds: ['calc'], dispatch },
+    );
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(28);
+    expect(maxInFlight).toBe(8);
+  });
+
+  it('sanitizes non-identifier tool ids for external_* names', async () => {
+    const dispatch = vi.fn(async () => 'ok');
+    const result = await run(`return await external_my_tool({});`, {
+      toolIds: ['my-tool'],
+      dispatch,
+    });
+    expect(result.success).toBe(true);
+    expect(dispatch).toHaveBeenCalledWith('my-tool', {});
+  });
+
+  it('propagates dispatcher errors into the guest with the original name', async () => {
+    const dispatch: CodeModeToolDispatcher = async () => {
+      const err = new Error('boom');
+      err.name = 'CustomError';
+      throw err;
+    };
+    const result = await run(
+      `
+      try {
+        await external_fail({});
+      } catch (e) {
+        return { message: e.message, name: e.name };
+      }
+      `,
+      { toolIds: ['fail'], dispatch },
+    );
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ message: 'boom', name: 'CustomError' });
+  });
+
+  it('rejects non-JSON-serializable arguments to external_* calls', async () => {
+    const dispatch = vi.fn(async () => 'ok');
+    const result = await run(
+      `
+      try {
+        await external_calc({ n: 1n });
+      } catch (e) {
+        return e.message;
+      }
+      `,
+      { toolIds: ['calc'], dispatch },
+    );
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(/JSON-serializable/);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('returns an error result when the program throws', async () => {
+    const result = await run(`throw new TypeError('bad input');`);
+    expect(result.success).toBe(false);
+    expect(result.error).toEqual({ message: 'bad input', name: 'TypeError' });
+  });
+
+  it('returns a SyntaxError result for an unparsable program', async () => {
+    const result = await run(`const = ;`);
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe('SyntaxError');
+  });
+
+  it('returns an error result for non-JSON-serializable results', async () => {
+    const result = await run(`const a = {}; a.self = a; return a;`);
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe('TypeError');
+    expect(result.error?.message).toMatch(/not JSON-serializable/);
+  });
+
+  it('times out a program that hangs on a promise', async () => {
+    const result = await run(`await new Promise(() => {}); return 1;`, { timeout: 300 });
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe('TimeoutError');
+    expect(result.error?.message).toMatch(/timed out after 300ms/);
+  });
+
+  it('times out a program that hangs waiting on an external_* call', async () => {
+    const result = await run(`return await external_hang({});`, {
+      toolIds: ['hang'],
+      dispatch: () => new Promise(() => {}),
+      timeout: 300,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe('TimeoutError');
+  });
+
+  it('times out a program stuck in a synchronous loop', async () => {
+    const result = await run(`while (true) {}`, { timeout: 300 });
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe('TimeoutError');
+  });
+
+  it('terminates a program that exceeds the memory limit', async () => {
+    const result = await run(
+      `
+      const chunks = [];
+      while (true) chunks.push(new Array(1024 * 1024).fill('x'));
+      `,
+      { transport: new QuickJsCodeModeTransport({ memoryLimitMb: 16 }), timeout: 30_000 },
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('preserves logs captured before a failure', async () => {
+    const result = await run(`
+      console.log('step 1 done');
+      throw new Error('later failure');
+    `);
+    expect(result.success).toBe(false);
+    expect(result.logs).toEqual(['step 1 done']);
+  });
+
+  it('returns an AbortError result without evaluating when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const dispatch = vi.fn(async () => 'ok');
+    const result = await run(`return await external_ping({});`, {
+      toolIds: ['ping'],
+      dispatch,
+      abortSignal: controller.signal,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe('AbortError');
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('returns an AbortError result when the signal aborts mid-run', async () => {
+    const controller = new AbortController();
+    const dispatch: CodeModeToolDispatcher = async () => {
+      controller.abort();
+      return new Promise(() => {});
+    };
+    const result = await run(`return await external_hang({});`, {
+      toolIds: ['hang'],
+      dispatch,
+      abortSignal: controller.signal,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe('AbortError');
+  });
+
+  it('stops a runaway synchronous loop promptly once the signal aborts', async () => {
+    // A blocking guest loop cannot be interrupted from the host event loop, so
+    // the interrupt handler is what makes an abort effective: here the signal
+    // fires during a dispatch, and the loop the guest enters next must unwind
+    // immediately instead of burning CPU until the timeout.
+    const controller = new AbortController();
+    const started = Date.now();
+    const result = await run(`await external_go({}); while (true) {}`, {
+      toolIds: ['go'],
+      dispatch: async () => {
+        controller.abort();
+        return 'go';
+      },
+      abortSignal: controller.signal,
+      timeout: 30_000,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe('AbortError');
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  it('isolates the guest from host capabilities', async () => {
+    const result = await run(`
+      return {
+        process: typeof process,
+        require: typeof require,
+        fetch: typeof fetch,
+        setTimeout: typeof setTimeout,
+      };
+    `);
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      process: 'undefined',
+      require: 'undefined',
+      fetch: 'undefined',
+      setTimeout: 'undefined',
+    });
+  });
+
+  it('does not expose the host bridges or a module loader to the guest', async () => {
+    // The security claim of this package, asserted rather than assumed.
+    const result = await run(`
+      return {
+        hostCall: typeof globalThis.__hostCall,
+        hostLog: typeof globalThis.__hostLog,
+        importScripts: typeof importScripts,
+        module: typeof module,
+        globalProcess: typeof globalThis.process,
+      };
+    `);
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      hostCall: 'undefined',
+      hostLog: 'undefined',
+      importScripts: 'undefined',
+      module: 'undefined',
+      globalProcess: 'undefined',
+    });
+  });
+
+  it('never reaches the dispatcher for a tool that was not exposed', async () => {
+    const dispatch = vi.fn(async () => 'ok');
+    const result = await run(
+      `
+      try {
+        return await external_secret({});
+      } catch (e) {
+        return { name: e.name };
+      }
+      `,
+      { toolIds: ['allowed'], dispatch },
+    );
+    // Only allow-listed tools get an `external_*` global, so an unexposed tool
+    // is not callable at all — the guest cannot even name the host bridge.
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ name: 'ReferenceError' });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('invokes observer hooks and survives hooks that throw', async () => {
+    const onExternalCall = vi.fn(() => {
+      throw new Error('observer boom');
+    });
+    const onExternalResult = vi.fn();
+    const result = await run(`return await external_ping({ q: 1 });`, {
+      toolIds: ['ping'],
+      dispatch: async () => 'pong',
+      onExternalCall,
+      onExternalResult,
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe('pong');
+    expect(onExternalCall).toHaveBeenCalledWith('ping', { q: 1 });
+    expect(onExternalResult).toHaveBeenCalledWith('ping', expect.any(Number), undefined);
+  });
+
+  it('passes the dispatcher error to onExternalResult', async () => {
+    const onExternalResult = vi.fn();
+    await run(`try { await external_fail({}); } catch {} return null;`, {
+      toolIds: ['fail'],
+      dispatch: async () => {
+        throw new Error('boom');
+      },
+      onExternalResult,
+    });
+    expect(onExternalResult).toHaveBeenCalledWith('fail', expect.any(Number), expect.any(Error));
+    expect(onExternalResult.mock.calls[0]![2].message).toBe('boom');
+  });
+
+  it('reports a single error outcome when the dispatch result is not JSON-serializable', async () => {
+    const onExternalResult = vi.fn();
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const result = await run(`return await external_ping({});`, {
+      toolIds: ['ping'],
+      dispatch: async () => circular,
+      onExternalResult,
+    });
+    expect(result.success).toBe(false);
+    expect(onExternalResult).toHaveBeenCalledTimes(1);
+    expect(onExternalResult.mock.calls[0]![2]).toBeInstanceOf(Error);
+  });
+});
+
+describe('QuickJsCodeModeTransport handle disposal', () => {
+  /**
+   * QuickJS handles are freed by hand, and a single undisposed one aborts the
+   * whole WASM module when the runtime is freed — which in a long-running agent
+   * process is a slow, hard-to-attribute memory bug. The debug build ships a
+   * leak sanitizer, so assert against it directly rather than trusting review.
+   */
+  async function expectNoLeaks(exercise: (transport: QuickJsCodeModeTransport) => Promise<unknown>) {
+    const wasm = await newQuickJSWASMModuleFromVariant(DEBUG_SYNC);
+    const sanitizer = new TestQuickJSWASMModule(wasm);
+    await exercise(new QuickJsCodeModeTransport({ module: wasm }));
+    expect(() => sanitizer.assertNoMemoryAllocated()).not.toThrow();
+  }
+
+  it('leaves nothing allocated after a successful run', async () => {
+    await expectNoLeaks(async transport => {
+      const result = await run(`console.log('hi'); return await external_ping({ a: 1 });`, {
+        transport,
+        toolIds: ['ping'],
+        dispatch: async () => ({ ok: true }),
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  it('leaves nothing allocated after a failing run', async () => {
+    await expectNoLeaks(async transport => {
+      const result = await run(`throw new Error('nope');`, { transport });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  it('leaves nothing allocated when a dispatch is still in flight at timeout', async () => {
+    // The hard case: a deferred promise the host never settles.
+    await expectNoLeaks(async transport => {
+      const result = await run(`return await external_hang({});`, {
+        transport,
+        toolIds: ['hang'],
+        dispatch: () => new Promise(() => {}),
+        timeout: 200,
+      });
+      expect(result.error?.name).toBe('TimeoutError');
+      // Give the abandoned dispatch a chance to settle against a freed context.
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+  });
+
+  it('leaves nothing allocated after a synchronous-loop timeout', async () => {
+    await expectNoLeaks(async transport => {
+      const result = await run(`while (true) {}`, { transport, timeout: 200 });
+      expect(result.error?.name).toBe('TimeoutError');
+    });
+  });
+});
+
+describe('createCodeMode with QuickJsCodeModeTransport (no sandbox)', () => {
+  // Minimal execution context the tool needs (observe + abortSignal).
+  const ctx = () => ({
+    observe: {
+      span: async (_n: string, fn: () => any) => fn(),
+      log: () => {},
+    },
+  });
+
+  const getTopProducts = createTool({
+    id: 'getTopProducts',
+    description: 'Get top selling products',
+    inputSchema: z.object({ limit: z.number() }),
+    outputSchema: z.object({
+      products: z.array(z.object({ id: z.string(), totalSales: z.number() })),
+    }),
+    execute: async ({ limit }) => ({
+      products: Array.from({ length: limit }, (_, i) => ({ id: `p${i}`, totalSales: (i + 1) * 100 })),
+    }),
+  });
+
+  it('runs end-to-end without a sandbox configured', async () => {
+    const { tool } = createCodeMode({ tools: { getTopProducts } }, new QuickJsCodeModeTransport());
+    const result: CodeModeToolResult = await (tool as any).execute(
+      {
+        code: `
+          const top = await external_getTopProducts({ limit: 3 });
+          return top.products.reduce((sum, p) => sum + p.totalSales, 0);
+        `,
+      },
+      ctx(),
+    );
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(600);
+  });
+});

--- a/code-mode/quickjs/src/transport.ts
+++ b/code-mode/quickjs/src/transport.ts
@@ -1,0 +1,508 @@
+/**
+ * Code Mode — QuickJS (WebAssembly) transport
+ *
+ * Runs the model's TypeScript program inside an in-process QuickJS interpreter
+ * compiled to WebAssembly, instead of a WorkspaceSandbox. The interpreter is a
+ * real security boundary: QuickJS starts with a bare global object, so the
+ * guest has no filesystem, network, process, timer, or module access — the only
+ * capabilities are the injected `external_*` functions, which call back into the
+ * host dispatcher (allow-list enforced host-side).
+ *
+ * This is the sibling of `@mastra/isolated-vm`, and the two are interchangeable.
+ * The difference is deployment cost:
+ *
+ * - `isolated-vm` is a native addon and, on Node 20+, requires the host process
+ *   to be started with `--no-node-snapshot`. Neither is available on most
+ *   serverless platforms.
+ * - QuickJS is WebAssembly. No native binary, no install step, no Node flags,
+ *   and it also runs in the browser. The tradeoff is speed: an interpreter in
+ *   WASM is materially slower than V8, which is an acceptable trade for the
+ *   tool-orchestration workloads Code Mode targets.
+ *
+ * Host calls cross the WASM boundary as JSON strings in both directions, so no
+ * host object references are ever exposed to guest code.
+ *
+ * TypeScript is stripped on the host with `ts-blank-space` — a pure-JavaScript
+ * type eraser, deliberately chosen over esbuild, which is itself a native binary
+ * and would reintroduce the very dependency this package exists to avoid.
+ *
+ * ## Concurrency
+ *
+ * `quickjs-emscripten` ships an "asyncify" build whose host functions may be
+ * `async`, which looks like the natural fit. It is not usable here: an asyncified
+ * module can only suspend for one async call at a time, and re-entering a
+ * suspended module crashes it. Code Mode's whole value is batching tool calls
+ * with `Promise.all`.
+ *
+ * So this transport uses the regular synchronous build. Each `external_*` call
+ * hands the guest a deferred promise and returns control to the host
+ * immediately, without suspending. The host settles the deferred whenever the
+ * real dispatch finishes and pumps the guest's microtask queue. Any number of
+ * calls can therefore be in flight at once.
+ */
+
+import { sanitizeToolId } from '@mastra/core/tools';
+import type { CodeModeToolResult, CodeModeTransport } from '@mastra/core/tools';
+import { getQuickJS } from 'quickjs-emscripten';
+import type { QuickJSDeferredPromise, QuickJSHandle, QuickJSWASMModule } from 'quickjs-emscripten';
+import tsBlankSpace from 'ts-blank-space';
+
+/** Default interpreter heap limit, in MiB. */
+const DEFAULT_MEMORY_LIMIT_MB = 128;
+
+/** Default interpreter stack limit, in bytes. Guards runaway recursion. */
+const DEFAULT_MAX_STACK_SIZE_BYTES = 1024 * 1024;
+
+/** How long the guest's leftover job queue may run while being drained. */
+const DRAIN_BUDGET_MS = 50;
+
+/** Upper bound on drain passes, so a job queue that refills cannot spin forever. */
+const MAX_DRAIN_PASSES = 10;
+
+export interface QuickJsCodeModeTransportOptions {
+  /**
+   * QuickJS heap limit in MiB. Exceeding it terminates the program.
+   * Default: 128.
+   */
+  memoryLimitMb?: number;
+
+  /**
+   * QuickJS stack limit in bytes. Exceeding it terminates the program.
+   * Default: 1 MiB.
+   */
+  maxStackSizeBytes?: number;
+
+  /**
+   * A pre-loaded QuickJS WebAssembly module.
+   *
+   * Defaults to the shared release build resolved by `getQuickJS()`, which is
+   * what most callers want. Supply your own to pin a specific variant — for
+   * example a single-file variant that suits your bundler, or the debug build
+   * with its leak sanitizer during testing.
+   */
+  module?: QuickJSWASMModule;
+}
+
+/** The success and failure handles of a QuickJS call result, either of which must be freed. */
+interface VmResultHandles {
+  value?: QuickJSHandle;
+  error?: QuickJSHandle;
+}
+
+/** Envelope returned by the guest program eval (as a JSON string). */
+interface GuestResultEnvelope {
+  ok: boolean;
+  value?: unknown;
+  error?: { message: string; name?: string };
+}
+
+/** Envelope returned by the host RPC handler (as a JSON string). */
+interface HostRpcEnvelope {
+  ok: boolean;
+  result?: unknown;
+  error?: { message: string; name?: string };
+}
+
+/**
+ * Code Mode transport that executes programs in an in-process QuickJS
+ * interpreter compiled to WebAssembly.
+ *
+ * No sandbox is required — the interpreter is the execution boundary
+ * (`requiresSandbox: false`).
+ *
+ * @example
+ * ```typescript
+ * import { createCodeMode } from '@mastra/core/tools';
+ * import { QuickJsCodeModeTransport } from '@mastra/quickjs';
+ *
+ * const { tool, instructions } = createCodeMode(
+ *   { tools: { getWeather, getForecast } },
+ *   new QuickJsCodeModeTransport({ memoryLimitMb: 128 }),
+ * );
+ * ```
+ */
+export class QuickJsCodeModeTransport implements CodeModeTransport {
+  readonly requiresSandbox = false;
+
+  readonly #memoryLimitMb: number;
+  readonly #maxStackSizeBytes: number;
+  readonly #module: QuickJSWASMModule | undefined;
+
+  constructor(options: QuickJsCodeModeTransportOptions = {}) {
+    this.#memoryLimitMb = options.memoryLimitMb ?? DEFAULT_MEMORY_LIMIT_MB;
+    this.#maxStackSizeBytes = options.maxStackSizeBytes ?? DEFAULT_MAX_STACK_SIZE_BYTES;
+    this.#module = options.module;
+  }
+
+  async run(opts: Parameters<CodeModeTransport['run']>[0]): Promise<CodeModeToolResult> {
+    const { program, toolIds, dispatch, timeout, abortSignal, onExternalCall, onExternalResult } = opts;
+
+    const externals = toolIds.map(toolId => ({ toolId, externalName: sanitizeToolId(toolId) }));
+    const allowList = new Set(toolIds);
+    const logs: string[] = [];
+
+    // Observer hooks are caller-supplied and best-effort: a throwing hook must
+    // never prevent the RPC from responding, or the matching in-guest promise
+    // would hang until the timeout.
+    const notifyCall = (tool: string, args: unknown): void => {
+      try {
+        onExternalCall?.(tool, args);
+      } catch {
+        /* observer errors are non-fatal */
+      }
+    };
+    const notifyResult = (tool: string, durationMs: number, error?: Error): void => {
+      try {
+        onExternalResult?.(tool, durationMs, error);
+      } catch {
+        /* observer errors are non-fatal */
+      }
+    };
+
+    // Strip TypeScript on the host; QuickJS runs plain JavaScript. Wrapping in
+    // an async arrow makes top-level `return`/`await`/`const` legal, same as the
+    // core runner's program module. ts-blank-space only erases types, so it
+    // leaves genuine syntax errors alone — those surface from `evalCode` below
+    // as a real SyntaxError, with QuickJS's own diagnostics.
+    let strippedProgram: string;
+    try {
+      strippedProgram = tsBlankSpace(`(async () => {\n${program}\n})`);
+    } catch (error) {
+      const err = error as { message?: string };
+      return {
+        success: false,
+        logs,
+        error: { message: err?.message ?? String(error), name: 'SyntaxError' },
+      };
+    }
+
+    // Host-side RPC handler. Crosses the boundary as JSON strings in both
+    // directions so no host references or non-JSON values ever leak into the
+    // guest. Errors are returned in the envelope (never thrown) so the guest can
+    // rebuild them with the original error name.
+    const rpcHost = async (tool: string, argsJson: string): Promise<string> => {
+      const started = Date.now();
+      let args: unknown;
+      try {
+        args = JSON.parse(argsJson);
+      } catch {
+        args = undefined;
+      }
+      notifyCall(tool, args);
+      // Allow-list enforcement: never invoke a tool that wasn't exposed.
+      if (!allowList.has(tool)) {
+        notifyResult(tool, Date.now() - started, new Error('not allowed'));
+        return JSON.stringify({
+          ok: false,
+          error: { message: `Tool "${tool}" is not available in Code Mode`, name: 'NotAllowedError' },
+        } satisfies HostRpcEnvelope);
+      }
+      try {
+        const result = await dispatch(tool, args);
+        // Serialize before reporting success so a non-serializable result
+        // (circular reference, BigInt) falls through to the error path without
+        // emitting a success event first.
+        const json = JSON.stringify({ ok: true, result } satisfies HostRpcEnvelope);
+        notifyResult(tool, Date.now() - started);
+        return json;
+      } catch (error) {
+        const err = error as { message?: string; name?: string };
+        notifyResult(tool, Date.now() - started, error instanceof Error ? error : new Error(String(error)));
+        return JSON.stringify({
+          ok: false,
+          error: { message: err?.message ?? String(error), name: err?.name },
+        } satisfies HostRpcEnvelope);
+      }
+    };
+
+    const wasm = this.#module ?? (await getQuickJS());
+
+    if (abortSignal?.aborted) {
+      return { success: false, logs, error: { message: 'Code Mode execution aborted', name: 'AbortError' } };
+    }
+
+    const runtime = wasm.newRuntime();
+    runtime.setMemoryLimit(this.#memoryLimitMb * 1024 * 1024);
+    runtime.setMaxStackSize(this.#maxStackSizeBytes);
+    const context = runtime.newContext();
+
+    // Every QuickJS handle must be disposed by hand, and an undisposed one
+    // aborts the whole WASM module when the runtime is freed. All disposal
+    // therefore happens here, once, covering deferreds that are still unsettled
+    // because the run timed out or was aborted while a dispatch was in flight.
+    const pendingDeferreds = new Set<QuickJSDeferredPromise>();
+    let abandonedGuestResult: VmResultHandles | undefined;
+    let finished = false;
+
+    // A run that ends early — timed out, aborted, or interrupted mid-job — leaves
+    // guest work sitting in the job queue, and those jobs still reference guest
+    // objects. QuickJS asserts that no objects survive when a runtime is freed,
+    // so the queue has to be drained first. The drain gets its own short
+    // deadline, since the very work being drained may be the runaway code that
+    // ended the run.
+    const drainJobs = (): void => {
+      const drainDeadline = Date.now() + DRAIN_BUDGET_MS;
+      runtime.setInterruptHandler(() => Date.now() >= drainDeadline);
+      for (let pass = 0; pass < MAX_DRAIN_PASSES && Date.now() < drainDeadline; pass++) {
+        const jobs = runtime.executePendingJobs();
+        jobs.error?.dispose();
+        if (!jobs.error && jobs.value === 0) break;
+      }
+      runtime.removeInterruptHandler();
+    };
+
+    const cleanup = (): void => {
+      if (finished) return;
+      finished = true;
+      for (const deferred of pendingDeferreds) deferred.dispose();
+      pendingDeferreds.clear();
+      abandonedGuestResult?.value?.dispose();
+      abandonedGuestResult?.error?.dispose();
+      abandonedGuestResult = undefined;
+
+      drainJobs();
+      context.dispose();
+      runtime.dispose();
+    };
+
+    // Draining the guest's microtask queue can itself fail — most importantly
+    // when the interrupt handler unwinds a job that ran away. That failure comes
+    // back as a handle which, left undisposed, aborts the WASM module when the
+    // runtime is freed.
+    const pumpJobs = (): void => {
+      if (finished) return;
+      const jobs = runtime.executePendingJobs();
+      jobs.error?.dispose();
+    };
+
+    const deadline = Date.now() + timeout;
+    let interrupted: 'timeout' | 'abort' | undefined;
+    // The only way to stop a runaway synchronous program: QuickJS calls this
+    // between operations, and a truthy return unwinds the evaluation. It cannot
+    // help while the guest is merely awaiting a host call — no guest code is
+    // running then — which is what the host-side races below are for.
+    runtime.setInterruptHandler(() => {
+      if (abortSignal?.aborted) {
+        interrupted = 'abort';
+        return true;
+      }
+      if (Date.now() >= deadline) {
+        interrupted = 'timeout';
+        return true;
+      }
+      return false;
+    });
+
+    const timedOutResult = (): CodeModeToolResult => ({
+      success: false,
+      logs,
+      error: { message: `Code Mode execution timed out after ${timeout}ms`, name: 'TimeoutError' },
+    });
+    const abortedResult = (): CodeModeToolResult => ({
+      success: false,
+      logs,
+      error: { message: 'Code Mode execution aborted', name: 'AbortError' },
+    });
+
+    let timer: NodeJS.Timeout | undefined;
+    let onAbort: (() => void) | undefined;
+
+    try {
+      // Host bridge for `external_*`. Returns a deferred promise to the guest
+      // and returns immediately without suspending the module, so any number of
+      // dispatches can be in flight at once and `Promise.all` behaves normally.
+      const hostCall = context.newFunction('__hostCall', (toolHandle, argsHandle) => {
+        const tool = context.getString(toolHandle);
+        const argsJson = context.getString(argsHandle);
+        const deferred = context.newPromise();
+        pendingDeferreds.add(deferred);
+
+        void rpcHost(tool, argsJson).then(json => {
+          // The run may already be over (timeout/abort) and the context freed;
+          // touching it here would crash the WASM module.
+          if (finished) return;
+          const resultHandle = context.newString(json);
+          deferred.resolve(resultHandle);
+          resultHandle.dispose();
+          pendingDeferreds.delete(deferred);
+          deferred.dispose();
+        });
+
+        // Settling a promise only queues the guest's continuation; QuickJS runs
+        // it when jobs are pumped.
+        void deferred.settled.then(pumpJobs);
+
+        return deferred.handle;
+      });
+      context.setProp(context.global, '__hostCall', hostCall);
+      hostCall.dispose();
+
+      const hostLog = context.newFunction('__hostLog', messageHandle => {
+        logs.push(context.getString(messageHandle));
+      });
+      context.setProp(context.global, '__hostLog', hostLog);
+      hostLog.dispose();
+
+      // Bootstrap: console capture and the `external_*` globals. The guest only
+      // ever sees plain functions closing over the two host bridges.
+      const bootstrap = context.evalCode(`
+        (() => {
+          const __hostCall = globalThis.__hostCall;
+          const __hostLog = globalThis.__hostLog;
+          delete globalThis.__hostCall;
+          delete globalThis.__hostLog;
+
+          const __rpc = (tool, args) => {
+            let argsJson;
+            try {
+              argsJson = JSON.stringify(args === undefined ? null : args);
+            } catch (e) {
+              return Promise.reject(
+                new Error('Arguments passed to an external_* function must be JSON-serializable'),
+              );
+            }
+            return __hostCall(String(tool), argsJson).then((json) => {
+              const res = JSON.parse(json);
+              if (res.ok) return res.result;
+              const err = new Error((res.error && res.error.message) || 'external tool failed');
+              if (res.error && res.error.name) err.name = res.error.name;
+              throw err;
+            });
+          };
+
+          const __safeStringify = (value) => {
+            try { return JSON.stringify(value); } catch { return String(value); }
+          };
+          const __log = (args) => {
+            __hostLog(args.map((a) => (typeof a === 'string' ? a : __safeStringify(a))).join(' '));
+          };
+          globalThis.console = Object.freeze({
+            log: (...args) => __log(args),
+            info: (...args) => __log(args),
+            warn: (...args) => __log(args),
+            error: (...args) => __log(args),
+          });
+
+          for (const { externalName, toolId } of ${JSON.stringify(externals)}) {
+            globalThis['external_' + externalName] = (input) => __rpc(toolId, input);
+          }
+        })()
+      `);
+      if (bootstrap.error) {
+        const err = context.dump(bootstrap.error) as { message?: string };
+        bootstrap.error.dispose();
+        return { success: false, logs, error: { message: err?.message ?? 'Code Mode bootstrap failed' } };
+      }
+      bootstrap.value.dispose();
+
+      // The guest returns a JSON envelope string so results and errors cross the
+      // boundary as data, mirroring the frame protocol's JSON semantics.
+      const evalResult = context.evalCode(`
+        (async () => {
+          const __user = ${strippedProgram}
+          try {
+            const __result = await __user();
+            try {
+              const json = JSON.stringify({ ok: true, value: __result });
+              return json === undefined ? '{"ok":true}' : json;
+            } catch {
+              return JSON.stringify({
+                ok: false,
+                error: { message: 'Code Mode result is not JSON-serializable', name: 'TypeError' },
+              });
+            }
+          } catch (e) {
+            return JSON.stringify({
+              ok: false,
+              error: { message: (e && e.message) || String(e), name: e && e.name },
+            });
+          }
+        })()
+      `);
+
+      if (evalResult.error) {
+        const err = context.dump(evalResult.error) as { message?: string; name?: string };
+        evalResult.error.dispose();
+        if (interrupted === 'abort' || abortSignal?.aborted) return abortedResult();
+        if (interrupted === 'timeout') return timedOutResult();
+        return {
+          success: false,
+          logs,
+          error: { message: err?.message ?? 'Code Mode evaluation failed', name: err?.name },
+        };
+      }
+
+      const guestPromise = context.resolvePromise(evalResult.value);
+      evalResult.value.dispose();
+
+      // The guest can settle and still lose the race below — an abort or timeout
+      // that lands in the same turn wins, and the result is discarded. Its handle
+      // is real either way, so record it for disposal rather than stranding it.
+      void guestPromise.then(result => {
+        // Once the context is gone there is nothing left to free, and touching a
+        // handle from it would crash the module.
+        if (finished) return;
+        abandonedGuestResult = result as VmResultHandles;
+      });
+
+      pumpJobs();
+
+      // Covers time the guest spends awaiting rather than executing, where the
+      // interrupt handler cannot reach: a dispatch that never resolves, or an
+      // abort that lands between guest turns.
+      const timeoutPromise = new Promise<'timeout'>(resolve => {
+        timer = setTimeout(() => resolve('timeout'), Math.max(0, deadline - Date.now()));
+      });
+      const abortPromise = new Promise<'abort'>(resolve => {
+        if (!abortSignal) return;
+        // The signal can already have fired: pumping the job queue above runs
+        // guest code, which can reach a dispatch that aborts synchronously, and
+        // an `abort` listener added afterwards would never be called.
+        if (abortSignal.aborted) return resolve('abort');
+        onAbort = () => resolve('abort');
+        abortSignal.addEventListener('abort', onAbort, { once: true });
+      });
+
+      const outcome = await Promise.race([
+        guestPromise.then(result => ({ kind: 'settled' as const, result })),
+        timeoutPromise.then(() => ({ kind: 'timeout' as const, result: undefined })),
+        abortPromise.then(() => ({ kind: 'abort' as const, result: undefined })),
+      ]);
+
+      if (outcome.kind !== 'settled') {
+        // The guest may be one job away from producing a result nobody will read.
+        // Let it land while the context is still alive, so its handle is recorded
+        // and freed rather than stranded.
+        drainJobs();
+        await Promise.resolve();
+        return outcome.kind === 'abort' ? abortedResult() : timedOutResult();
+      }
+
+      const settled = outcome.result;
+      abandonedGuestResult = undefined;
+      if (settled.error) {
+        const err = context.dump(settled.error) as { message?: string; name?: string };
+        settled.error.dispose();
+        if (interrupted === 'abort' || abortSignal?.aborted) return abortedResult();
+        if (interrupted === 'timeout') return timedOutResult();
+        return {
+          success: false,
+          logs,
+          error: { message: err?.message ?? 'Code Mode evaluation failed', name: err?.name },
+        };
+      }
+
+      const json = context.getString(settled.value);
+      settled.value.dispose();
+      const envelope = JSON.parse(json) as GuestResultEnvelope;
+      return envelope.ok
+        ? { success: true, result: envelope.value, logs }
+        : { success: false, error: envelope.error, logs };
+    } finally {
+      if (timer) clearTimeout(timer);
+      if (onAbort) abortSignal?.removeEventListener('abort', onAbort);
+      runtime.removeInterruptHandler();
+      cleanup();
+    }
+  }
+}

--- a/code-mode/quickjs/tsconfig.build.json
+++ b/code-mode/quickjs/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/code-mode/quickjs/tsconfig.json
+++ b/code-mode/quickjs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsdown.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/code-mode/quickjs/tsdown.config.ts
+++ b/code-mode/quickjs/tsdown.config.ts
@@ -1,0 +1,19 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  fixedExtension: false,
+  nodeProtocol: 'strip',
+  clean: true,
+  dts: false,
+  treeshake: true,
+  sourcemap: true,
+  deps: {
+    neverBundle: ['@mastra/core', 'quickjs-emscripten', 'ts-blank-space'],
+  },
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/code-mode/quickjs/vitest.config.ts
+++ b/code-mode/quickjs/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    name: 'unit:code-mode/quickjs',
     environment: 'node',
     include: ['src/**/*.test.ts'],
     // Deliberately no `execArgv`: this transport must work under a plain Node

--- a/code-mode/quickjs/vitest.config.ts
+++ b/code-mode/quickjs/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    // Deliberately no `execArgv`: this transport must work under a plain Node
+    // process. The isolated-vm suite needs `--no-node-snapshot`; this one does
+    // not, and the tests would stop proving that if the flag were added here.
+    testTimeout: 60000,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});

--- a/docs/src/content/en/docs/agents/code-mode.mdx
+++ b/docs/src/content/en/docs/agents/code-mode.mdx
@@ -173,9 +173,24 @@ const { tool, instructions } = createCodeMode(
 
 `isolated-vm` is a native addon, and on Node.js 20 and later the host process must be started with the `--no-node-snapshot` flag. See the [IsolatedVmCodeModeTransport reference](/reference/tools/isolated-vm-transport) for setup details.
 
+When the host can't install native addons or set Node.js flags, which is common on serverless platforms, use [`QuickJsCodeModeTransport`](/reference/tools/quickjs-transport) from `@mastra/quickjs` instead. It gives the same in-process boundary using a QuickJS runtime compiled to WebAssembly, at the cost of slower execution:
+
+```typescript
+import { createCodeMode } from '@mastra/core/tools'
+import { QuickJsCodeModeTransport } from '@mastra/quickjs'
+
+const { tool, instructions } = createCodeMode(
+  { tools }, // no sandbox needed
+  new QuickJsCodeModeTransport({ memoryLimitMb: 128 }),
+)
+```
+
+See [Choosing a transport](/reference/tools/quickjs-transport#choosing-a-transport) for a side-by-side comparison.
+
 ## Related
 
 - [createCodeMode() reference](/reference/tools/create-code-mode)
 - [IsolatedVmCodeModeTransport reference](/reference/tools/isolated-vm-transport)
+- [QuickJsCodeModeTransport reference](/reference/tools/quickjs-transport)
 - [Tools](/docs/agents/using-tools)
 - [Workspace overview](/docs/workspace/overview)

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -736,6 +736,12 @@ const sidebars = {
         { type: 'doc', id: 'tools/mcp-client', label: 'MCPClient' },
         { type: 'doc', id: 'tools/mcp-server', label: 'MCPServer' },
         { type: 'doc', id: 'tools/perplexity', label: 'Perplexity Tools' },
+        {
+          type: 'doc',
+          id: 'tools/quickjs-transport',
+          label: 'QuickJsCodeModeTransport',
+          customProps: { tags: ['beta'] },
+        },
         { type: 'doc', id: 'tools/submit-plan-tool', label: 'submitPlanTool' },
         { type: 'doc', id: 'tools/task-tools', label: 'Task tools' },
         { type: 'doc', id: 'tools/tavily', label: 'Tavily Tools' },

--- a/docs/src/content/en/reference/tools/create-code-mode.mdx
+++ b/docs/src/content/en/reference/tools/create-code-mode.mdx
@@ -102,7 +102,7 @@ export const shopAgent = new Agent({
     name: 'transport',
     type: 'CodeModeTransport',
     description:
-      'Optional transport implementation used to run the generated code in the sandbox. The default transport uses stdio JSON-RPC over the workspace sandbox process API. Transports that declare `requiresSandbox: false` (such as [IsolatedVmCodeModeTransport](/reference/tools/isolated-vm-transport)) run without a sandbox.',
+      'Optional transport implementation used to run the generated code in the sandbox. The default transport uses stdio JSON-RPC over the workspace sandbox process API. Transports that declare `requiresSandbox: false` (such as [IsolatedVmCodeModeTransport](/reference/tools/isolated-vm-transport) and [QuickJsCodeModeTransport](/reference/tools/quickjs-transport)) run without a sandbox.',
     isOptional: true,
   },
 ]}

--- a/docs/src/content/en/reference/tools/quickjs-transport.mdx
+++ b/docs/src/content/en/reference/tools/quickjs-transport.mdx
@@ -61,6 +61,14 @@ const { tool, instructions } = createCodeMode(
             defaultValue: '128',
           },
           {
+            name: 'maxStackSizeBytes',
+            type: 'number',
+            description:
+              'Runtime stack limit in bytes. A program that exceeds the limit, usually through runaway recursion, is terminated and the tool returns an error result.',
+            isOptional: true,
+            defaultValue: '1048576',
+          },
+          {
             name: 'module',
             type: 'QuickJSWASMModule',
             description:

--- a/docs/src/content/en/reference/tools/quickjs-transport.mdx
+++ b/docs/src/content/en/reference/tools/quickjs-transport.mdx
@@ -1,0 +1,106 @@
+---
+title: "Reference: QuickJsCodeModeTransport | Tools and MCP"
+description: "API reference for QuickJsCodeModeTransport, which runs Code Mode programs in an in-process QuickJS WebAssembly runtime."
+packages:
+  - "@mastra/quickjs"
+---
+
+# QuickJsCodeModeTransport
+
+:::experimental
+
+This feature is in beta. Breaking changes may occur without a major version bump until the API is stable.
+
+:::
+
+The `QuickJsCodeModeTransport` class runs [Code mode](/docs/agents/code-mode) programs in an in-process [QuickJS](https://bellard.org/quickjs/) runtime compiled to WebAssembly. The runtime is the execution boundary, so no workspace sandbox is required: the program has no filesystem, network, process, or module access. Its only capabilities are the `external_*` functions, which call back into the real tools on the host.
+
+Unlike [`IsolatedVmCodeModeTransport`](/reference/tools/isolated-vm-transport), this transport installs no native binaries and needs no Node.js flags, so it runs on serverless platforms that disallow both. The tradeoff is speed: see [Choosing a transport](#choosing-a-transport).
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/quickjs
+```
+
+The package contains the WebAssembly module, so installing it copies files and runs nothing else.
+
+## Usage
+
+Pass the transport as the second argument to `createCodeMode()`. No `sandbox` is needed:
+
+```typescript
+import { createCodeMode } from '@mastra/core/tools'
+import { QuickJsCodeModeTransport } from '@mastra/quickjs'
+
+const { tool, instructions } = createCodeMode(
+  { tools: { getTopProducts, getProductRatings } },
+  new QuickJsCodeModeTransport({ memoryLimitMb: 128 }),
+)
+```
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'options',
+    type: 'QuickJsCodeModeTransportOptions',
+    description: 'Configuration for the QuickJS runtime.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'QuickJsCodeModeTransportOptions',
+        parameters: [
+          {
+            name: 'memoryLimitMb',
+            type: 'number',
+            description:
+              'Runtime heap limit in MiB. A program that exceeds the limit is terminated and the tool returns an error result.',
+            isOptional: true,
+            defaultValue: '128',
+          },
+          {
+            name: 'module',
+            type: 'QuickJSWASMModule',
+            description:
+              'A preloaded QuickJS WebAssembly module. Supply one to control when the module is loaded, or to share a single module across transports. Loaded on first run when omitted.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+## Choosing a transport
+
+All three transports enforce the same allow-list, tool validation, and tracing on the host. They differ in what the program itself can reach and what the host has to provide.
+
+| | `StdioCodeModeTransport` | `IsolatedVmCodeModeTransport` | `QuickJsCodeModeTransport` |
+| - | - | - | - |
+| Isolation boundary | Workspace sandbox | V8 isolate | QuickJS WebAssembly runtime |
+| Requires a sandbox | Yes | No | No |
+| Native binary | Node.js runtime in the sandbox | Yes | No |
+| Node.js flags | None | `--no-node-snapshot` on Node.js 20 and later | None |
+| Runs in the browser | No | No | Yes |
+| Execution speed | Fastest | Fast | Slowest |
+
+Choose `QuickJsCodeModeTransport` when the host can't install native addons or set Node.js flags, which is common on serverless platforms. Choose `IsolatedVmCodeModeTransport` when the host allows both and programs do heavy computation.
+
+The speed difference is in the program body, not the tool calls. QuickJS interprets rather than JIT-compiles, so a compute-heavy loop can run tens of times slower than in a V8 isolate, while a program that mostly awaits `external_*` calls performs about the same because the time goes to the tools. Code Mode programs are usually the second kind.
+
+## How it works
+
+Each run creates a fresh QuickJS runtime with its own heap. TypeScript is stripped on the host with [ts-blank-space](https://github.com/bloomberg/ts-blank-space), which erases type annotations without a native compiler, then the program is evaluated inside the runtime. Every `external_*` call crosses the boundary as JSON strings in both directions, so no host object references leak into model-authored code.
+
+An `external_*` call returns a pending promise to the program and hands control straight back to the host, so many calls can be in flight at once and `Promise.all` behaves as expected.
+
+The `timeout` configured on `createCodeMode()` applies to both asynchronous hangs and synchronous infinite loops, and the runtime is disposed after every run.
+
+## Related
+
+- [Code mode](/docs/agents/code-mode)
+- [createCodeMode() reference](/reference/tools/create-code-mode)
+- [IsolatedVmCodeModeTransport reference](/reference/tools/isolated-vm-transport)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1362,6 +1362,46 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
 
+  code-mode/quickjs:
+    dependencies:
+      quickjs-emscripten:
+        specifier: ^0.31.0
+        version: 0.31.0
+      ts-blank-space:
+        specifier: ^0.6.1
+        version: 0.6.2
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      eslint:
+        specifier: ^10.7.0
+        version: 10.7.0(jiti@2.7.0)
+      tsdown:
+        specifier: 0.22.9
+        version: 0.22.9(@volar/typescript@2.4.23)(oxc-resolver@11.20.0)(tsx@4.23.1)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+
   deployers/cloud:
     dependencies:
       '@mastra/deployer':
@@ -14730,17 +14770,32 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jitl/quickjs-ffi-types@0.31.0':
+    resolution: {integrity: sha512-1yrgvXlmXH2oNj3eFTrkwacGJbmM0crwipA3ohCrjv52gBeDaD7PsTvFYinlAnqU8iPME3LGP437yk05a2oejw==}
+
   '@jitl/quickjs-ffi-types@0.32.0':
     resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.31.0':
+    resolution: {integrity: sha512-YkdzQdr1uaftFhgEnTRjTTZHk2SFZdpWO7XhOmRVbi6CEVsH9g5oNF8Ta1q3OuSJHRwwT8YsuR1YzEiEIJEk6w==}
 
   '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
     resolution: {integrity: sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==}
 
+  '@jitl/quickjs-wasmfile-debug-sync@0.31.0':
+    resolution: {integrity: sha512-8XvloaaWBONqcHXYs5tWOjdhQVxzULilIfB2hvZfS6S+fI4m2+lFiwQy7xeP8ExHmiZ7D8gZGChNkdLgjGfknw==}
+
   '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
     resolution: {integrity: sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==}
 
+  '@jitl/quickjs-wasmfile-release-asyncify@0.31.0':
+    resolution: {integrity: sha512-uz0BbQYTxNsFkvkurd7vk2dOg57ElTBLCuvNtRl4rgrtbC++NIndD5qv2+AXb6yXDD3Uy1O2PCwmoaH0eXgEOg==}
+
   '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
     resolution: {integrity: sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==}
+
+  '@jitl/quickjs-wasmfile-release-sync@0.31.0':
+    resolution: {integrity: sha512-hYduecOByj9AsAfsJhZh5nA6exokmuFC8cls39+lYmTCGY51bgjJJJwReEu7Ff7vBWaQCL6TeDdVlnp2WYz0jw==}
 
   '@jitl/quickjs-wasmfile-release-sync@0.32.0':
     resolution: {integrity: sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==}
@@ -29233,8 +29288,15 @@ packages:
     resolution: {integrity: sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==}
     engines: {node: '>=12'}
 
+  quickjs-emscripten-core@0.31.0:
+    resolution: {integrity: sha512-oQz8p0SiKDBc1TC7ZBK2fr0GoSHZKA0jZIeXxsnCyCs4y32FStzCW4d1h6E1sE0uHDMbGITbk2zhNaytaoJwXQ==}
+
   quickjs-emscripten-core@0.32.0:
     resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
+
+  quickjs-emscripten@0.31.0:
+    resolution: {integrity: sha512-K7Yt78aRPLjPcqv3fIuLW1jW3pvwO21B9pmFOolsjM/57ZhdVXBr51GqJpalgBlkPu9foAvhEAuuQPnvIGvLvQ==}
+    engines: {node: '>=16.0.0'}
 
   quickjs-emscripten@0.32.0:
     resolution: {integrity: sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==}
@@ -31055,6 +31117,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: ^6.0.3
+
+  ts-blank-space@0.6.2:
+    resolution: {integrity: sha512-hZjcHdHrveEKI67v8OzI90a1bizgoDkY7ekE4fH89qJhZgxvmjfBOv98aibCU7OpKbvV3R9p/qd3DrzZqT1cFQ==}
+    engines: {node: '>=18.0.0'}
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -39129,19 +39195,37 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
+  '@jitl/quickjs-ffi-types@0.31.0': {}
+
   '@jitl/quickjs-ffi-types@0.32.0': {}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.31.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.31.0
 
   '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
     dependencies:
       '@jitl/quickjs-ffi-types': 0.32.0
 
+  '@jitl/quickjs-wasmfile-debug-sync@0.31.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.31.0
+
   '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
     dependencies:
       '@jitl/quickjs-ffi-types': 0.32.0
 
+  '@jitl/quickjs-wasmfile-release-asyncify@0.31.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.31.0
+
   '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
     dependencies:
       '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-sync@0.31.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.31.0
 
   '@jitl/quickjs-wasmfile-release-sync@0.32.0':
     dependencies:
@@ -53269,7 +53353,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
@@ -55494,9 +55578,21 @@ snapshots:
 
   quick-lru@6.1.2: {}
 
+  quickjs-emscripten-core@0.31.0:
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.31.0
+
   quickjs-emscripten-core@0.32.0:
     dependencies:
       '@jitl/quickjs-ffi-types': 0.32.0
+
+  quickjs-emscripten@0.31.0:
+    dependencies:
+      '@jitl/quickjs-wasmfile-debug-asyncify': 0.31.0
+      '@jitl/quickjs-wasmfile-debug-sync': 0.31.0
+      '@jitl/quickjs-wasmfile-release-asyncify': 0.31.0
+      '@jitl/quickjs-wasmfile-release-sync': 0.31.0
+      quickjs-emscripten-core: 0.31.0
 
   quickjs-emscripten@0.32.0:
     dependencies:
@@ -57940,6 +58036,10 @@ snapshots:
   ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  ts-blank-space@0.6.2:
     dependencies:
       typescript: 6.0.3
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,7 @@ const PROJECT_GLOBS = [
   'pubsub/*/vitest.config.ts',
   'signals/*/vitest.config.ts',
   'workflows/*/vitest.config.ts',
+  'code-mode/*/vitest.config.ts',
   'mastracode/vitest.config.ts',
 ];
 


### PR DESCRIPTION
## What this is for

Code Mode lets an agent write a small program that calls its tools, instead of calling them one at a time. That program is model-authored, so it needs a real boundary around it.

Today there are two ways to get one:

- **A workspace sandbox** (the default): a full sandbox process, which not everyone can run.
- **`@mastra/isolated-vm`**: an in-process V8 isolate. Faster and simpler, but it installs a native addon, and on Node.js 20+ the whole host process has to be started with `--no-node-snapshot`.

Most serverless platforms allow neither a native addon nor a custom Node flag. Those users currently have no way to run Code Mode in-process.

## What this adds

`@mastra/quickjs`, a third transport that runs the program in a QuickJS runtime compiled to WebAssembly.

```ts
import { createCodeMode } from '@mastra/core/tools'
import { QuickJsCodeModeTransport } from '@mastra/quickjs'

const { tool, instructions } = createCodeMode(
  { tools }, // no sandbox needed
  new QuickJsCodeModeTransport(),
)
```

It is pure JavaScript and WebAssembly end to end, including TypeScript stripping, so it installs with no compiler, no prebuilt binary, and no install script, and runs under plain `node` with no flags.

The program gets the same boundary as the isolated-vm transport: no filesystem, network, process, or module access, and no reachable host objects. Its only capabilities are the `external_*` functions, which are allow-listed on the host and cross the boundary as JSON in both directions. No changes to `@mastra/core` were needed; `CodeModeTransport` was already the extension point.

## Tradeoff

QuickJS interprets rather than JIT-compiles. Measured on the same programs:

| Program | `@mastra/quickjs` | `@mastra/isolated-vm` |
| --- | --- | --- |
| Startup plus two tool calls | 1.0 ms | 1.6 ms |
| 5M-iteration loop | 216 ms | 5.4 ms |

The gap is in the program body, not the tool calls. Code Mode programs mostly await tools, which is the first row. Compute-heavy programs should stay on isolated-vm. The docs say this plainly and include a comparison table.

## Notable implementation decision

`quickjs-emscripten` ships an asyncify build where host functions can simply be `async`. That looks like the obvious fit, but an asyncified module can only suspend for **one** host call at a time, which would break `Promise.all` batching — the main reason Code Mode exists.

So this uses the synchronous build instead. Each `external_*` call hands the guest a pending promise and returns control to the host immediately, the host settles it and pumps the job queue, and many calls stay in flight at once. There is a test that fails if that concurrency regresses.

## Test plan

- 33 tests, green on three consecutive runs. Every case from `isolated-vm/src/transport.test.ts` is ported verbatim, so the two transports are verifiably interchangeable: results, TypeScript stripping, log capture, `external_*` bridging, `Promise.all` concurrency, tool-id sanitization, dispatcher errors, non-serializable arguments and results, throws, syntax errors, both timeout kinds, memory limits, aborts, and the observer hooks. The one case not ported asserts the `--no-node-snapshot` failure, and its inverse is asserted here instead.
- Added cases QuickJS specifically needs: **host isolation** is asserted rather than assumed, since it is the security claim of the package, and **handle-leak checks** on the success, failure, timeout, and abort paths, because QuickJS frees nothing on its own and asserts on any object that outlives its runtime. Those checks caught two real leaks during development.
- Verified the packaging claim rather than trusting it: packed the tarball, installed it in `/tmp` outside the workspace with `npm`, confirmed the tree contains no `.node` binary and no install script, and ran an end-to-end `createCodeMode` program under `node` with `NODE_OPTIONS` unset. It returned the right answer, with type annotations stripped, `Promise.all` fanned out, and logs captured.
- `pnpm --filter @mastra/quickjs typecheck build lint` clean. `@mastra/isolated-vm` still green at 24/24.

## Docs

New reference page with a transport comparison table, plus notes in the Code Mode guide and the `createCodeMode()` reference so the choice is visible from where people already are.

Closes #20546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a new way to run Code Mode programs without installing native software or changing Node.js settings. It uses a WebAssembly-based QuickJS runtime to safely run code and connect it only to approved tools.

## Summary

- Adds the `@mastra/quickjs` package.
- Adds `QuickJsCodeModeTransport` with:
  - QuickJS WebAssembly execution.
  - Filesystem, network, process, timer, module, and host-object isolation.
  - Allow-listed `external_*` tool access through JSON.
  - Concurrent tool calls through `Promise.all`.
  - Memory, stack, timeout, and abort controls.
  - Console logging and observer callbacks.
  - Safe QuickJS handle cleanup.
  - Configurable preloaded modules.
- Moves Code Mode transports into the `code-mode` workspace and updates the existing `@mastra/isolated-vm` package metadata and configuration.
- Adds extensive tests for execution, isolation, serialization, errors, concurrency, limits, aborts, observers, integration, and resource leaks.
- Adds package build, test, lint, and publishing configuration.
- Adds documentation for QuickJS setup, options, limitations, isolation, and comparison with `@mastra/isolated-vm`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->