### PR TITLE
Unbreak the telegram package build on main

### DIFF
--- a/channels/telegram/tsconfig.json
+++ b/channels/telegram/tsconfig.json
@@ -6,7 +6,11 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2023"]
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
+    // tsup's dts step injects `baseUrl`, which TypeScript 6 reports as deprecated
+    // (TS5101) and refuses to compile. Remove this once the dts build stops
+    // setting `baseUrl`, or when this package moves to tsdown like channels/slack.
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]


### PR DESCRIPTION
## What

`@mastra/telegram#build` currently fails on `main`. Because turbo builds the workspace as one graph, that single package takes down `Build`, `Validate build outputs`, and `changed-tests` for every open PR.

## Why it broke

The package builds with `tsup`, and tsup's declaration step injects a `baseUrl` compiler option. TypeScript 6 reports `baseUrl` as deprecated and fails the compile outright:

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

The JS output is produced fine; the build only dies when generating types. `channels/slack` is unaffected because it builds with `tsdown` rather than `tsup`.

This was invisible until now: installs were failing earlier in the pipeline, so no job ever reached the build step.

## The fix

Silence the deprecation for this package, with a comment recording the condition for removing it (the dts build no longer setting `baseUrl`, or the package moving to `tsdown` like slack).

One file changed, no source or dependency changes, no changeset — this restores the build rather than altering published behaviour.

## Test plan

- `pnpm build` in `channels/telegram` fails on `main` with TS5101 and succeeds on this branch, emitting `dist/index.d.ts`.
- `pnpm typecheck` passes.

## Noted separately

`src/telegram-provider.test.ts` has one failing test on `main` ("routes a message update through handleWebhookEvent to the agent and sends the reply"): the agent's model is invoked but no reply is posted, so `sends.length` stays at 0. That is a product bug in this package, independent of the build, and is left for its owner rather than patched here.