### PR TITLE
Stop dropping input typed while the mastracode TUI is busy

### DIFF
--- a/.changeset/tui-input-dropped-while-busy.md
+++ b/.changeset/tui-input-dropped-while-busy.md
@@ -1,0 +1,12 @@
+---
+'mastracode': patch
+---
+
+Keep input typed while the TUI is handling a slash command or a `!` shell command. Submitting during that window used to be swallowed — the editor cleared, nothing ran, and the text was gone — because the input loop had already moved on and no longer had a read pending. Submissions made while the loop is busy are now held and delivered in order on its next read, so a quick sequence like:
+
+```
+!echo hi
+/browser clear viewport
+```
+
+runs both commands instead of only the first.

--- a/mastracode/tui/src/tui/__tests__/mastra-tui-input-handoff.test.ts
+++ b/mastracode/tui/src/tui/__tests__/mastra-tui-input-handoff.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { MastraTUI } from '../mastra-tui.js';
+
+function createTui() {
+  const editor = {
+    onSubmit: undefined as ((text: string) => void) | undefined,
+    addToHistory: vi.fn(),
+    setText: vi.fn(),
+  };
+  const tui = Object.create(MastraTUI.prototype) as any;
+  tui.queuedUserInput = [];
+  tui.pendingUserInputResolve = undefined;
+  tui.state = {
+    editor,
+    session: { run: { isRunning: () => false } },
+  };
+  return { tui, editor };
+}
+
+describe('MastraTUI user input handoff', () => {
+  it('resolves the pending read with the submitted text', async () => {
+    const { tui, editor } = createTui();
+
+    const input = tui.getUserInput() as Promise<string>;
+    editor.onSubmit!('hello');
+
+    await expect(input).resolves.toBe('hello');
+  });
+
+  it('delivers text submitted while the loop was busy on the next read', async () => {
+    const { tui, editor } = createTui();
+
+    // First read completes, mirroring a command the loop is now off handling.
+    const first = tui.getUserInput() as Promise<string>;
+    editor.onSubmit!('!echo hi');
+    await expect(first).resolves.toBe('!echo hi');
+
+    // Submitted before the loop comes back around to read again.
+    editor.onSubmit!('/browser clear viewport');
+
+    await expect(tui.getUserInput()).resolves.toBe('/browser clear viewport');
+  });
+
+  it('preserves the order of several submissions made while busy', async () => {
+    const { tui, editor } = createTui();
+
+    const first = tui.getUserInput() as Promise<string>;
+    editor.onSubmit!('one');
+    await first;
+
+    editor.onSubmit!('two');
+    editor.onSubmit!('three');
+
+    await expect(tui.getUserInput()).resolves.toBe('two');
+    await expect(tui.getUserInput()).resolves.toBe('three');
+  });
+});

--- a/mastracode/tui/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/tui/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -163,6 +163,10 @@ describe('MastraTUI queueing', () => {
     tui.queueFollowUpMessage = vi.fn();
     tui.signalMessage = vi.fn();
 
+    // Object.create bypasses field initializers; getUserInput reads the queue.
+
+    (tui as any).queuedUserInput = [];
+
     const pendingInput = tui.getUserInput();
     editor.onSubmit?.('queued follow-up');
 
@@ -208,6 +212,10 @@ describe('MastraTUI queueing', () => {
     tui.signalMessage = vi.fn();
     tui.handleSlashCommand = vi.fn().mockResolvedValue(true);
 
+    // Object.create bypasses field initializers; getUserInput reads the queue.
+
+    (tui as any).queuedUserInput = [];
+
     tui.getUserInput();
     editor.onSubmit?.('/help');
 
@@ -244,6 +252,10 @@ describe('MastraTUI queueing', () => {
     };
     tui.state = state;
     tui.queueFollowUpMessage = vi.fn();
+
+    // Object.create bypasses field initializers; getUserInput reads the queue.
+
+    (tui as any).queuedUserInput = [];
 
     const pendingInput = tui.getUserInput();
     editor.onSubmit?.('wait for judge');

--- a/mastracode/tui/src/tui/mastra-tui.ts
+++ b/mastracode/tui/src/tui/mastra-tui.ts
@@ -164,6 +164,14 @@ export class MastraTUI {
   private cleanupPluginReloadListener?: () => void;
   private cleanupPluginUpdateListener?: () => void;
   private lastStreamError: string | null = null;
+  /**
+   * Text submitted while the main loop was busy (running a slash command or a
+   * shell passthrough) and so was not waiting on `getUserInput`. The editor's
+   * submit handler stays installed across loop iterations, so without this the
+   * submission would resolve an already-settled promise and be silently lost.
+   */
+  private queuedUserInput: string[] = [];
+  private pendingUserInputResolve: ((text: string) => void) | undefined;
 
   private static readonly DOUBLE_CTRL_C_MS = 500;
 
@@ -1122,7 +1130,12 @@ export class MastraTUI {
   // ===========================================================================
 
   private getUserInput(): Promise<string> {
+    const queued = this.queuedUserInput.shift();
+    if (queued !== undefined) {
+      return Promise.resolve(queued);
+    }
     return new Promise(resolve => {
+      this.pendingUserInputResolve = resolve;
       this.state.editor.onSubmit = (text: string) => {
         if (isGoalJudgeInputLocked(this.state)) {
           this.state.editor.setText(text);
@@ -1168,7 +1181,14 @@ export class MastraTUI {
           return;
         }
 
-        resolve(text);
+        const pending = this.pendingUserInputResolve;
+        if (!pending) {
+          // The loop is busy elsewhere; hand the text over on its next turn.
+          this.queuedUserInput.push(text);
+          return;
+        }
+        this.pendingUserInputResolve = undefined;
+        pending(text);
       };
     });
   }


### PR DESCRIPTION
## What

Typing into the mastracode TUI while it is handling a slash command or a `!` shell command could silently lose the input: the editor cleared, nothing ran, and the text was gone.

## Why

`getUserInput()` installs `editor.onSubmit` and returns a promise. The handler stays installed across turns of the input loop, but the `resolve` it closes over belongs to the read that installed it. A submission that arrives while the loop is busy elsewhere — running a slash command, running a shell passthrough — therefore resolves an already-settled promise, which is a no-op, after the handler has already cleared the editor.

The window is normally tiny, which is why this surfaces as flake rather than a steady complaint. The `browser-viewport` e2e scenario submits a command immediately after a bang command's output appears, and intermittently fails in CI because that submission lands inside the window.

## How

Submissions that arrive with no pending read are held in order and handed to the next read.

## Test plan

- New `mastra-tui-input-handoff.test.ts` covers the normal path, the busy-loop handoff, and ordering of several queued submissions. Two of its three cases fail without the fix.
- `pnpm --filter ./mastracode/tui exec vitest run src/tui/__tests__` — 400 passed.
- `browser-viewport` e2e scenario passes.
- Typecheck and lint clean.
