### PR TITLE
Serve same-file LSP diagnostics in arrival order

### DIFF
--- a/.changeset/big-shrimps-open.md
+++ b/.changeset/big-shrimps-open.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed a race condition in the workspace LSP manager where three or more concurrent diagnostics requests for the same file could acquire the per-file lock at the same time. Requests for a file are now strictly serialized in FIFO order, preventing interleaved open/change/close notifications that produced wrong or missing diagnostics.
+Made the workspace LSP manager's per-file lock hand out access in arrival order. Diagnostics requests for the same file were already serialized; a request that arrived at the moment the previous one finished could jump ahead of requests that had been waiting longer. Requests for different files still run in parallel.

--- a/.changeset/big-shrimps-open.md
+++ b/.changeset/big-shrimps-open.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a race condition in the workspace LSP manager where three or more concurrent diagnostics requests for the same file could acquire the per-file lock at the same time. Requests for a file are now strictly serialized in FIFO order, preventing interleaved open/change/close notifications that produced wrong or missing diagnostics.

--- a/packages/core/src/workspace/lsp/manager.test.ts
+++ b/packages/core/src/workspace/lsp/manager.test.ts
@@ -707,6 +707,62 @@ describe('LSPManager', () => {
       expect(callOrder).toEqual(['open', 'wait', 'close', 'open', 'wait', 'close']);
     });
 
+    it('hands the lock to waiters in arrival order when a late caller races the release', async () => {
+      // The lock is a FIFO queue, so a caller that shows up while others are
+      // already queued goes to the back of that queue.
+      //
+      // The interesting moment is the instant the holder releases. A caller
+      // that asks for the lock in that same synchronous turn sees a free lock
+      // and can take it before the already-queued waiters get to resume. Under
+      // a FIFO queue it waits its turn instead.
+      const filePath = '/project/src/app.ts';
+      const acquire = (): Promise<() => void> =>
+        (manager as unknown as { acquireFileLock(p: string): Promise<() => void> }).acquireFileLock(filePath);
+
+      const order: string[] = [];
+      let held = 0;
+      let maxHeld = 0;
+      const enter = (name: string) => {
+        order.push(name);
+        held++;
+        maxHeld = Math.max(maxHeld, held);
+      };
+
+      const releaseFirst = await acquire();
+      enter('first');
+
+      const second = (async () => {
+        const release = await acquire();
+        enter('second');
+        held--;
+        release();
+      })();
+      await Promise.resolve();
+
+      const third = (async () => {
+        const release = await acquire();
+        enter('third');
+        held--;
+        release();
+      })();
+      await Promise.resolve();
+
+      // `late` asks for the lock in the same turn that the first holder frees it.
+      const late = (async () => {
+        held--;
+        releaseFirst();
+        const release = await acquire();
+        enter('late');
+        held--;
+        release();
+      })();
+
+      await Promise.all([second, third, late]);
+
+      expect(order).toEqual(['first', 'second', 'third', 'late']);
+      expect(maxHeld).toBe(1);
+    });
+
     it('serializes three or more concurrent getDiagnostics for same file', async () => {
       const callOrder: string[] = [];
       let concurrentWaits = 0;

--- a/packages/core/src/workspace/lsp/manager.test.ts
+++ b/packages/core/src/workspace/lsp/manager.test.ts
@@ -707,6 +707,37 @@ describe('LSPManager', () => {
       expect(callOrder).toEqual(['open', 'wait', 'close', 'open', 'wait', 'close']);
     });
 
+    it('serializes three or more concurrent getDiagnostics for same file', async () => {
+      const callOrder: string[] = [];
+      let concurrentWaits = 0;
+      let maxConcurrentWaits = 0;
+
+      mockNotifyOpen.mockImplementation((_file: string) => {
+        callOrder.push('open');
+      });
+      mockNotifyClose.mockImplementation((_file: string) => {
+        callOrder.push('close');
+      });
+      mockWaitForDiagnostics.mockImplementation(async () => {
+        concurrentWaits++;
+        maxConcurrentWaits = Math.max(maxConcurrentWaits, concurrentWaits);
+        callOrder.push('wait');
+        await new Promise(resolve => setTimeout(resolve, 10));
+        concurrentWaits--;
+        return [{ severity: 1, message: 'err', range: { start: { line: 0, character: 0 } } }];
+      });
+
+      await Promise.all([
+        manager.getDiagnostics('/project/src/app.ts', 'content1'),
+        manager.getDiagnostics('/project/src/app.ts', 'content2'),
+        manager.getDiagnostics('/project/src/app.ts', 'content3'),
+      ]);
+
+      // Never more than one caller inside the critical section at a time.
+      expect(maxConcurrentWaits).toBe(1);
+      expect(callOrder).toEqual(['open', 'wait', 'close', 'open', 'wait', 'close', 'open', 'wait', 'close']);
+    });
+
     it('allows parallel getDiagnostics for different files', async () => {
       let concurrentCount = 0;
       let maxConcurrent = 0;

--- a/packages/core/src/workspace/lsp/manager.ts
+++ b/packages/core/src/workspace/lsp/manager.ts
@@ -87,20 +87,30 @@ export class LSPManager {
    * Different files can run in parallel.
    */
   private async acquireFileLock(filePath: string): Promise<() => void> {
-    // Wait for any existing lock on this file
-    while (this.fileLocks.has(filePath)) {
-      await this.fileLocks.get(filePath);
-    }
+    // Chain onto the tail of any existing lock for this file to form a FIFO
+    // queue. Each caller awaits its own distinct predecessor, so two waiters
+    // can never resume together and interleave their open/change/close.
+    const previous = this.fileLocks.get(filePath) ?? Promise.resolve();
 
     let release!: () => void;
-    const lockPromise = new Promise<void>(resolve => {
+    const current = new Promise<void>(resolve => {
       release = resolve;
     });
-    this.fileLocks.set(filePath, lockPromise);
+
+    // The new tail resolves only after the whole chain up to and including this
+    // holder has released.
+    const tail = previous.then(() => current);
+    this.fileLocks.set(filePath, tail);
+
+    // Wait for all predecessors to finish before this caller holds the lock.
+    await previous;
 
     return () => {
-      this.fileLocks.delete(filePath);
       release();
+      // Drop the map entry only if nobody chained after us, to avoid leaks.
+      if (this.fileLocks.get(filePath) === tail) {
+        this.fileLocks.delete(filePath);
+      }
     };
   }
 

--- a/packages/core/src/workspace/lsp/manager.ts
+++ b/packages/core/src/workspace/lsp/manager.ts
@@ -83,13 +83,15 @@ export class LSPManager {
 
   /**
    * Acquire a per-file lock so that concurrent getDiagnostics calls for the
-   * same file are serialized (preventing interleaved open/change/close).
-   * Different files can run in parallel.
+   * same file are serialized (preventing interleaved open/change/close) and
+   * are served in the order they arrived. Different files run in parallel.
    */
   private async acquireFileLock(filePath: string): Promise<() => void> {
     // Chain onto the tail of any existing lock for this file to form a FIFO
-    // queue. Each caller awaits its own distinct predecessor, so two waiters
-    // can never resume together and interleave their open/change/close.
+    // queue. Waiting on a single shared promise instead would still serialize
+    // callers, but a caller arriving in the same turn as a release could take
+    // the lock ahead of longer-waiting ones, and every release would wake all
+    // waiters rather than just the next.
     const previous = this.fileLocks.get(filePath) ?? Promise.resolve();
 
     let release!: () => void;


### PR DESCRIPTION
## Summary

**The bug reported in #21076 does not exist.** The original version of this PR accepted the issue's premise; review pushed back, and on verification the reviewer was right. This PR now describes what the change actually does.

The claim was that when three or more diagnostics calls queue for the same file, releasing the first lets multiple waiters install their own locks and run concurrently. That does not happen. In the old `while (this.fileLocks.has(...)) await ...` loop there is no `await` between the check and the `set`, so the first waiter to resume installs its lock atomically; every later waiter then observes that entry and waits. Mutual exclusion held.

What the old lock did get wrong is **ordering**. Callers were serialized but not queued fairly:

- A caller that asked for the lock in the same turn as a release found the map empty and took the lock ahead of callers that had been waiting longer.
- Each release woke *every* waiter, not just the next one.

This replaces the shared-promise loop with a FIFO chain: each caller awaits its own predecessor and publishes a new tail, so callers are served in arrival order and a release wakes exactly one. Different files still run in parallel.

Because mutual exclusion was never broken, there is **no fix to a correctness bug here** — diagnostics were not interleaved, wrong, or prematurely closed. The changeset has been rewritten to say so.

## Evidence

- Extracted the pre-PR algorithm into a standalone harness: 200 rounds × 8 same-file contenders, each holding across a macrotask and a microtask. Max concurrent holders: **1**.
- The test shipped in the first commit **passed against base** (`manager.ts` reverted to `HEAD~1`), so it pinned nothing. This is what the `changed-tests` gate was reporting.
- Barging is *not* reachable through the public API — `release()` runs in a `finally` with nothing synchronous after it — so the ordering guarantee is verified against the lock primitive directly.

## Test plan

- Replaced the non-regression test with `hands the lock to waiters in arrival order when a late caller races the release`, which queues two waiters and has a third request the lock in the same turn the holder releases.
  - Against base: **fails** — `['first', 'late', 'second', 'third']`.
  - Against this branch: **passes** — `['first', 'second', 'third', 'late']`.
- Kept the three-caller serialization test as plain coverage (it passes either way; it is not a regression test).
- `packages/core` LSP suite: 170 tests pass. `tsc --noEmit` clean, oxlint and prettier clean.

Refs #21076 (retitled expectations: the issue should be closed as invalid, or re-scoped to lock fairness).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When several requests check the same file, they now run in the order they arrived. Requests for different files can still run at the same time. Tests confirm this behavior.

## Changes

- Replaced the per-file shared-promise lock loop with a FIFO promise chain.
- Preserved one active diagnostics request per file.
- Preserved parallel diagnostics requests for different files.
- Added tests for late callers and three concurrent `getDiagnostics` calls.
- Added a patch changeset for `@mastra/core`.

## Tests

- Verified strict `open → wait → close` ordering.
- Verified maximum concurrency of one per file.
- `packages/core` LSP manager suite passes 52 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->