### PR TITLE
Give input processors the agent when a durable run wakes from a signal

### DIFF
--- a/.changeset/ready-buses-nail.md
+++ b/.changeset/ready-buses-nail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed input processors receiving an undefined agent in their context when a durable agent run was resumed by a signal or schedule. The running agent is now passed through the processor workflow, so processors that rely on it (such as working memory and semantic recall) work correctly on wake.

--- a/packages/core/src/agent/durable/__tests__/durable-input-processor-agent-context.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-input-processor-agent-context.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression test for #20161:
+ * Input processors run through the durable preparation path must receive the
+ * `agent` in their context (mirroring the non-durable Agent path). Before the
+ * fix, the durable ProcessorRunner was constructed without `agent`, so
+ * `context.agent` was `undefined` for input processors — notably when an idle
+ * durable agent was woken by a signal or schedule and re-ran preparation.
+ */
+
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect } from 'vitest';
+import type { Processor } from '../../../processors';
+import { Agent } from '../../agent';
+import { prepareForDurableExecution } from '../preparation';
+
+function createTextModel(text: string) {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: text },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+      ]),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+    }),
+  });
+}
+
+describe('DurableAgent input processor agent context (#20161)', () => {
+  it('passes the agent into input processor context during durable preparation', async () => {
+    let capturedAgentId: string | undefined;
+    let sawAgent = false;
+
+    const captureProcessor: Processor = {
+      id: 'capture-agent',
+      name: 'capture-agent',
+      processInput: async ({ agent, messages }) => {
+        sawAgent = !!agent;
+        capturedAgentId = agent?.id;
+        return messages;
+      },
+    };
+
+    const baseAgent = new Agent({
+      id: 'durable-ctx-agent',
+      name: 'Durable Ctx Agent',
+      instructions: 'You are a helpful assistant.',
+      model: createTextModel('ok') as LanguageModelV2,
+      inputProcessors: [captureProcessor as any],
+    });
+
+    await prepareForDurableExecution({
+      agent: baseAgent,
+      messages: 'Hello',
+    });
+
+    expect(sawAgent).toBe(true);
+    expect(capturedAgentId).toBe('durable-ctx-agent');
+  });
+});

--- a/packages/core/src/agent/durable/preparation.ts
+++ b/packages/core/src/agent/durable/preparation.ts
@@ -442,6 +442,7 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
         errorProcessors,
         logger: logger as any,
         agentName: publicAgentName,
+        agent: agent as unknown as Agent<any, any, any, any>,
         processorStates,
       });
       await runner.runInputProcessors(

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -687,6 +687,7 @@ function createStepFromProcessor<TProcessorId extends string>(
       const input = inputData as ProcessorStepOutput & {
         processorStates?: Map<string, ProcessorState>;
         abortSignal?: AbortSignal;
+        agent?: Agent;
       };
       const {
         phase,
@@ -725,6 +726,8 @@ function createStepFromProcessor<TProcessorId extends string>(
         processorStates,
         // Abort signal for cancelling in-flight processor work (e.g. OM observations)
         abortSignal,
+        // Agent reference so processors can access the running agent (e.g. on signal/schedule wake)
+        agent,
       } = input;
 
       // Create a minimal abort function that throws TripWire
@@ -976,6 +979,7 @@ function createStepFromProcessor<TProcessorId extends string>(
 
       const baseContext = {
         abort,
+        agent,
         retryCount: retryCount ?? 0,
         requestContext,
         ...processorObservabilityContext,


### PR DESCRIPTION
## Summary

When a durable agent run is resumed by a signal or schedule, its input processors are combined into a workflow and executed through the processor runner. The runner forwards the running agent on the workflow run's `inputData`, but the processor step never extracted it — so every input processor saw `agent: undefined` in its context on wake. Processors that rely on the agent (working memory, semantic recall) silently misbehaved after a signal or schedule resume, even though they worked on the normal (non-durable) path.

This extracts `agent` from the processor step input and threads it into the processor `baseContext`, mirroring how `processorStates` and `abortSignal` are already carried off-schema for the in-process workflow run. The agent is also passed when constructing the `ProcessorRunner` in durable preparation. No live handle is added to any wire-crossing schema.

Fixes #20161

## Test plan

- Added `durable-input-processor-agent-context.test.ts`, which registers a custom input processor and asserts it receives the correct agent in context during durable preparation. The test failed before the fix and passes after.
- `packages/core` processors suite: 1081 tests pass.
