### PR TITLE
fix(core): reject empty azure deployment names

### DIFF
--- a/.changeset/clean-azure-deployments.md
+++ b/.changeset/clean-azure-deployments.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed Azure OpenAI routing to reject empty deployment names.

--- a/packages/core/src/llm/model/gateway-resolver.test.ts
+++ b/packages/core/src/llm/model/gateway-resolver.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseModelRouterId } from './gateway-resolver';
+
+describe('parseModelRouterId', () => {
+  it('parses an Azure OpenAI deployment name', () => {
+    expect(parseModelRouterId('azure-openai/my-deployment', 'azure-openai')).toEqual({
+      providerId: 'azure-openai',
+      modelId: 'my-deployment',
+    });
+  });
+
+  it('rejects an empty Azure OpenAI deployment name', () => {
+    expect(() => parseModelRouterId('azure-openai/', 'azure-openai')).toThrow(
+      'Expected format azure-openai/deployment-name, but got azure-openai/',
+    );
+  });
+});

--- a/packages/core/src/llm/model/gateway-resolver.ts
+++ b/packages/core/src/llm/model/gateway-resolver.ts
@@ -14,12 +14,13 @@ export function parseModelRouterId(routerId: string, gatewayPrefix?: string): { 
 
   // Azure OpenAI uses 2-part format (azure-openai/deployment), others use 3-part (gateway/provider/model)
   if (gatewayPrefix === 'azure-openai') {
-    if (idParts.length < 2) {
+    const modelId = idParts.slice(1).join('/');
+    if (!modelId) {
       throw new Error(`Expected format azure-openai/deployment-name, but got ${routerId}`);
     }
     return {
       providerId: 'azure-openai',
-      modelId: idParts.slice(1).join('/'), // Deployment name
+      modelId, // Deployment name
     };
   }
 


### PR DESCRIPTION
## Description

Azure OpenAI model routing previously accepted `azure-openai/` even though it did not contain a deployment name.

Splitting this router ID produces `['azure-openai', '']`. The existing validation only checked the array length, so the parser returned:

```ts
{
  providerId: 'azure-openai',
  modelId: '',
}
```

This PR validates the computed deployment name and throws a clear error when it is empty.

## Related issue(s)

Fixes #21104 

## Changes

- Validate the Azure OpenAI deployment name after parsing the router ID.
- Reject `azure-openai/` with a clear format error.
- Preserve the existing behavior for valid deployment IDs.
- Add focused parser regression tests.
- Add an `@mastra/core` patch changeset.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test update

## Testing

The following checks passed:

- Related model gateway tests: 3 files, 80 tests
- `@mastra/core` TypeScript check
- Targeted ESLint
- `git diff --check`

Test cases cover:

- Parsing `azure-openai/my-deployment`
- Rejecting `azure-openai/`

## Checklist

- [x] I have linked the related issue.
- [x] I have added tests that prove the fix is effective.
- [x] I have added the required changeset.
- [x] I have run the relevant tests and type checks.
- [ ] I have addressed all review comments.