### PR TITLE
Fix MCP Streamable HTTP client disconnects crashing the server

### DIFF
--- a/.changeset/brave-moons-repeat.md
+++ b/.changeset/brave-moons-repeat.md
@@ -1,0 +1,14 @@
+---
+'@mastra/hono': patch
+---
+
+Fix MCP Streamable HTTP client disconnects crashing the server with `ERR_INVALID_STATE`
+
+When an MCP Streamable HTTP client dropped its session, nothing informed the simulated Node
+response behind the `fetch-to-node` bridge, so the MCP transport kept its SSE keep-alive timer
+armed. A later keep-alive tick wrote into an already-closed stream controller, and because that
+write originates in a timer callback the resulting `ERR_INVALID_STATE` was unhandled and took
+down the process roughly 15 seconds after the disconnect.
+
+Client disconnects are now propagated to the simulated Node response, which aborts the transport
+and lets it tear the stream down and clear its keep-alive timer.

--- a/server-adapters/hono/src/__tests__/mcp-disconnect.test.ts
+++ b/server-adapters/hono/src/__tests__/mcp-disconnect.test.ts
@@ -1,0 +1,95 @@
+import process from 'node:process';
+import { toReqRes, toFetchResponse } from 'fetch-to-node';
+import { describe, expect, it } from 'vitest';
+import { propagateClientDisconnect } from '../mcp-disconnect';
+
+/**
+ * Reproduces https://github.com/mastra-ai/mastra/issues/20332.
+ *
+ * An MCP Streamable HTTP session is served through the `fetch-to-node` bridge. When the client
+ * disconnects, the returned body stream is cancelled, but nothing informs the simulated Node
+ * response. The MCP transport therefore keeps its SSE keep-alive timer armed and eventually
+ * writes into a closed stream controller from a timer callback, crashing the process with an
+ * uncatchable ERR_INVALID_STATE.
+ */
+function startSseSession() {
+  const { res } = toReqRes(new Request('http://localhost/mcp', { method: 'GET' }));
+  res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+  // Headers are only flushed on the first write, which is what resolves `toFetchResponse`.
+  res.write(':\n\n');
+  return res;
+}
+
+/**
+ * Mirrors the contract in `@modelcontextprotocol/node`'s `toNodeHandler`, which aborts the
+ * request controller on `res` "close". That abort is what tears down the SSE stream and clears
+ * the keep-alive timer.
+ */
+function attachTransportCloseContract(res: { on: (event: string, cb: () => void) => void }) {
+  const abort = new AbortController();
+  res.on('close', () => abort.abort());
+  return abort.signal;
+}
+
+describe('MCP client disconnect (issue #20332)', () => {
+  it('emits close on the simulated Node response when the client disconnects', async () => {
+    const res = startSseSession();
+    let closeEvents = 0;
+    res.on('close', () => closeEvents++);
+
+    const response = propagateClientDisconnect(await toFetchResponse(res), res);
+
+    expect(closeEvents).toBe(0);
+    await response.body!.cancel();
+
+    expect(closeEvents).toBe(1);
+  });
+
+  it('aborts the transport request signal so the keep-alive timer is cleared', async () => {
+    const res = startSseSession();
+    const signal = attachTransportCloseContract(res);
+
+    const response = propagateClientDisconnect(await toFetchResponse(res), res);
+    expect(signal.aborted).toBe(false);
+
+    await response.body!.cancel();
+
+    // Without propagation the transport never learns the client is gone and keeps writing.
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('does not crash when a keep-alive write lands after the client disconnected', async () => {
+    const res = startSseSession();
+    const signal = attachTransportCloseContract(res);
+
+    const response = propagateClientDisconnect(await toFetchResponse(res), res);
+    await response.body!.cancel();
+
+    expect(signal.aborted).toBe(true);
+
+    // The MCP keep-alive tick is a timer callback, and the bridge flushes writes from a cork
+    // timer - so a bad write surfaces as an *uncaught* exception, not a throw at the call site.
+    // Capture process-level failures across the flush to prove the process would survive.
+    const uncaught: unknown[] = [];
+    const onUncaught = (error: unknown) => uncaught.push(error);
+    process.on('uncaughtException', onUncaught);
+    try {
+      res.write(': keepalive\n\n');
+      await new Promise(resolve => setTimeout(resolve, 50));
+    } finally {
+      process.off('uncaughtException', onUncaught);
+    }
+
+    expect(uncaught).toEqual([]);
+  });
+
+  it('streams data through to the client while the session is live', async () => {
+    const res = startSseSession();
+    const response = propagateClientDisconnect(await toFetchResponse(res), res);
+
+    res.write('event: message\ndata: {"jsonrpc":"2.0"}\n\n');
+    res.end();
+
+    expect(await response.text()).toContain('"jsonrpc":"2.0"');
+  });
+});

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -18,6 +18,7 @@ import { toReqRes, toFetchResponse } from 'fetch-to-node';
 import type { Context, ExecutionContext, HonoRequest, MiddlewareHandler } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { stream } from 'hono/streaming';
+import { propagateClientDisconnect } from './mcp-disconnect';
 export { createAuthMiddleware } from './auth-middleware';
 export type { HonoAuthMiddlewareOptions } from './auth-middleware';
 // Browser stream setup (Hono-specific WebSocket implementation)
@@ -401,7 +402,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
           }
         });
 
-      return await toFetchResponse(res);
+      return propagateClientDisconnect(await toFetchResponse(res), res);
     } else if (route.responseType === 'mcp-sse') {
       // MCP SSE transport
       const { server, ssePath, messagePath } = result as MCPSseTransportResult;

--- a/server-adapters/hono/src/mcp-disconnect.ts
+++ b/server-adapters/hono/src/mcp-disconnect.ts
@@ -1,0 +1,65 @@
+/**
+ * Propagates a client disconnect to the simulated Node response produced by `toReqRes`.
+ *
+ * `fetch-to-node` builds the outgoing body from `res` events but never observes cancellation
+ * of the stream it hands back. When an MCP Streamable HTTP client drops its session, nothing
+ * tells `res` that the socket is gone, so the MCP transport keeps its SSE keep-alive timer
+ * armed. The next keep-alive tick writes into an already-closed stream controller, and because
+ * that write originates in a timer callback the resulting `ERR_INVALID_STATE` is unhandled and
+ * takes down the process.
+ *
+ * Emitting `close` on `res` is the signal the MCP Node transport listens for: it aborts the
+ * request's AbortController, which breaks the write loop and tears down the SSE stream,
+ * clearing the keep-alive timer. No post-disconnect write is ever attempted.
+ */
+export function propagateClientDisconnect(
+  fetchResponse: Response,
+  res: { emit: (event: string) => void; destroy?: () => void },
+): Response {
+  const upstream = fetchResponse.body;
+  if (!upstream) return fetchResponse;
+
+  let disconnected = false;
+  const disconnect = () => {
+    if (disconnected) return;
+    disconnected = true;
+    try {
+      res.emit('close');
+    } catch {
+      // Already torn down - the transport has nothing left to clean up.
+    }
+    // Deliberately *not* cancelling or destroying the bridge stream here. `fetch-to-node`
+    // buffers writes and flushes them from a cork timer; tearing its controller down leaves
+    // that pending flush to enqueue into a closed controller, which throws an unhandled
+    // ERR_INVALID_STATE from a timer callback - the very crash this guards against.
+    // Emitting `close` aborts the transport, which ends the response, so the bridge closes
+    // its own controller in the right order once buffered data has drained.
+    void reader.read().then(
+      function drain({ done }): unknown {
+        return done ? undefined : reader.read().then(drain);
+      },
+      () => {},
+    );
+  };
+
+  const reader = upstream.getReader();
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(value);
+    },
+    cancel() {
+      disconnect();
+    },
+  });
+
+  return new Response(body, {
+    status: fetchResponse.status,
+    statusText: fetchResponse.statusText,
+    headers: fetchResponse.headers,
+  });
+}


### PR DESCRIPTION
Fixes #20332

## What was happening

A Mastra server exposing MCP over Streamable HTTP would crash roughly 15 seconds after MCP clients disconnected, with an uncaught `ERR_INVALID_STATE` ("Invalid state: Controller is already closed"). Because the failure came from a timer callback rather than a request handler, it could not be caught by normal error handling and took the whole process down.

## Why

MCP over HTTP is served through the `fetch-to-node` bridge, which hands Hono a web `Response` whose body is produced from events on a *simulated* Node response object.

That bridge never observes cancellation of the stream it returns. So when a client dropped its connection, nothing informed the simulated response that the socket was gone. The MCP transport, still believing the session was live, kept its SSE keep-alive timer armed and ticked every 15 seconds. That tick wrote into a stream controller that had already been closed, and the resulting error surfaced as an unhandled exception.

## The fix

Client disconnects are now propagated to the simulated Node response by emitting `close` on it. That is the exact signal the MCP Node transport already listens for: it aborts the request's `AbortController`, which breaks the write loop, tears down the SSE stream, and clears the keep-alive timer. No write is ever attempted after the client is gone, and abandoned sessions no longer leak a live timer.

One subtlety is worth calling out for reviewers, because the obvious implementation is wrong: the cancellation must **not** be forwarded upstream into the bridge. `fetch-to-node` buffers writes and flushes them from a cork timer, so cancelling its reader or destroying the response closes its controller while a flush is still pending — which then enqueues into a closed controller and reproduces the very crash being fixed. The remaining data is drained instead, letting the transport end the response so the bridge closes its own controller in the right order.

The change is scoped to the MCP HTTP route and does not alter behaviour for any other response type.

## Test plan

Added `server-adapters/hono/src/__tests__/mcp-disconnect.test.ts`, which drives the real `fetch-to-node` bridge and reproduces the real MCP teardown contract rather than mocking it:

- a disconnect emits `close` on the simulated Node response
- a disconnect aborts the transport's request signal, which is what clears the keep-alive timer
- a keep-alive write landing after a disconnect produces no uncaught exception (asserted by capturing `uncaughtException` across the buffered flush, since the crash is asynchronous and would otherwise slip past a `toThrow` assertion)
- a live session still streams data through to the client, as a control

Verified the tests genuinely reproduce the bug: with the fix reverted to a passthrough, three of them fail with exactly the three `ERR_INVALID_STATE` unhandled errors from the issue, while the streaming control keeps passing.

Full `@mastra/hono` suite passes: 2597 tests across 13 files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an MCP client disconnects, the server now stops sending messages to that client. This prevents delayed stream errors from crashing the server.

## Changes

- Propagate MCP client disconnects to the simulated Node response.
- Emit `close` on disconnect to trigger transport cleanup.
- Abort the request and clear the SSE keep-alive timer.
- Drain buffered bridge data without forwarding cancellation upstream.
- Preserve response status, status text, and headers.
- Add regression tests for disconnects, request abortion, delayed writes, and active streaming.
- Add a patch changeset for `@mastra/hono`.

## Tests

- `@mastra/hono` suite passes.
- 2,597 tests pass across 13 files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->