### PR TITLE
Allow the Okta auth provider to accept access tokens, not just ID tokens

### DIFF
--- a/.changeset/crisp-baboons-open.md
+++ b/.changeset/crisp-baboons-open.md
@@ -1,0 +1,28 @@
+---
+'@mastra/auth-okta': minor
+---
+
+Added an `audience` option to `MastraAuthOkta` so bearer-token verification is no longer pinned to the OAuth client ID.
+
+Previously the provider always required `aud` to equal the client ID, which is the audience of an Okta **ID token**. Okta **access tokens** carry the authorization server's audience instead, so machine-to-machine callers (MCP clients, CI jobs, service-to-service traffic) always got a 401 on an org authorization server. Those callers have no session cookie, so bearer was their only way in.
+
+Set `audience` (or the `OKTA_AUDIENCE` environment variable) to the audience your tokens actually carry:
+
+```typescript
+// Before: only ID tokens whose aud is the client ID were accepted
+const auth = new MastraAuthOkta({ domain, clientId, clientSecret, redirectUri });
+
+// After: accept access tokens from an org authorization server
+const auth = new MastraAuthOkta({
+  domain,
+  clientId,
+  clientSecret,
+  redirectUri,
+  audience: 'https://your-org.okta.com',
+});
+
+// Or accept both ID tokens from the browser and access tokens from services
+const auth = new MastraAuthOkta({ /* ... */ audience: [clientId, 'api://default'] });
+```
+
+The default is unchanged, so existing setups keep working.

--- a/auth/okta/README.md
+++ b/auth/okta/README.md
@@ -81,6 +81,7 @@ const mastra = new Mastra({
 | `OKTA_CLIENT_SECRET`   | OAuth client secret                       | For auth only                                      |
 | `OKTA_REDIRECT_URI`    | OAuth redirect URI for SSO callback       | For auth only                                      |
 | `OKTA_ISSUER`          | Token issuer URL                          | No (defaults to `https://{domain}/oauth2/default`) |
+| `OKTA_AUDIENCE`        | Expected `aud` claim on bearer tokens     | No (defaults to `OKTA_CLIENT_ID`)                  |
 | `OKTA_COOKIE_PASSWORD` | Session encryption key (min 32 chars)     | No (auto-generated if omitted; set for production) |
 | `OKTA_API_TOKEN`       | API token for management SDK              | For RBAC only                                      |
 
@@ -93,6 +94,7 @@ interface MastraAuthOktaOptions {
   clientSecret?: string; // OAuth client secret (or OKTA_CLIENT_SECRET)
   redirectUri?: string; // SSO callback URI (or OKTA_REDIRECT_URI)
   issuer?: string; // Token issuer URL (or OKTA_ISSUER)
+  audience?: string | string[]; // Expected bearer-token `aud` (or OKTA_AUDIENCE; defaults to clientId)
   scopes?: string[]; // OAuth scopes (default: ['openid', 'profile', 'email', 'groups'])
   name?: string; // Provider name (default: 'okta')
   session?: {

--- a/auth/okta/src/auth-provider.ts
+++ b/auth/okta/src/auth-provider.ts
@@ -143,6 +143,7 @@ export class MastraAuthOkta
   protected issuer: string;
   protected endpointBase: string;
   protected redirectUri: string;
+  protected audience: string | string[];
   protected scopes: string[];
   protected cookieName: string;
   protected cookieMaxAge: number;
@@ -199,6 +200,9 @@ export class MastraAuthOkta
     this.endpointBase =
       this.issuer.includes('/oauth2/') || this.issuer.endsWith('/oauth2') ? this.issuer : `${this.issuer}/oauth2`;
     this.redirectUri = redirectUri;
+    // Defaults to the client ID, which is the `aud` of an Okta ID token. Deployments that
+    // send access tokens need the authorization server's audience instead.
+    this.audience = options?.audience ?? process.env.OKTA_AUDIENCE ?? clientId;
     this.scopes = options?.scopes ?? DEFAULT_SCOPES;
     this.cookieName = options?.session?.cookieName ?? DEFAULT_COOKIE_NAME;
     this.cookieMaxAge = options?.session?.cookieMaxAge ?? DEFAULT_COOKIE_MAX_AGE;
@@ -246,7 +250,7 @@ export class MastraAuthOkta
     try {
       const { payload } = await jwtVerify(token, this.jwks, {
         issuer: this.issuer,
-        audience: this.clientId,
+        audience: this.audience,
       });
 
       return mapOktaClaimsToUser(payload);

--- a/auth/okta/src/index.test.ts
+++ b/auth/okta/src/index.test.ts
@@ -40,6 +40,7 @@ describe('MastraAuthOkta', () => {
     delete process.env.OKTA_REDIRECT_URI;
     delete process.env.OKTA_COOKIE_PASSWORD;
     delete process.env.OKTA_ISSUER;
+    delete process.env.OKTA_AUDIENCE;
   });
 
   describe('constructor', () => {
@@ -166,6 +167,68 @@ describe('MastraAuthOkta', () => {
           updatedAt: undefined,
         },
       });
+    });
+
+    test('verifies against the configured audience option', async () => {
+      const mockJWKS = vi.fn();
+      (createRemoteJWKSet as any).mockReturnValue(mockJWKS);
+      (jwtVerify as any).mockResolvedValue({ payload: { sub: 'u1' } });
+
+      const auth = new MastraAuthOkta({ audience: 'api://default' });
+      await auth.authenticateToken('test-token', {} as any);
+
+      expect(jwtVerify).toHaveBeenCalledWith(
+        'test-token',
+        mockJWKS,
+        expect.objectContaining({ audience: 'api://default' }),
+      );
+    });
+
+    test('verifies against OKTA_AUDIENCE when no option is given', async () => {
+      const mockJWKS = vi.fn();
+      (createRemoteJWKSet as any).mockReturnValue(mockJWKS);
+      (jwtVerify as any).mockResolvedValue({ payload: { sub: 'u1' } });
+      process.env.OKTA_AUDIENCE = 'https://dev-123456.okta.com';
+
+      const auth = new MastraAuthOkta();
+      await auth.authenticateToken('test-token', {} as any);
+
+      expect(jwtVerify).toHaveBeenCalledWith(
+        'test-token',
+        mockJWKS,
+        expect.objectContaining({ audience: 'https://dev-123456.okta.com' }),
+      );
+    });
+
+    test('accepts an array of audiences', async () => {
+      const mockJWKS = vi.fn();
+      (createRemoteJWKSet as any).mockReturnValue(mockJWKS);
+      (jwtVerify as any).mockResolvedValue({ payload: { sub: 'u1' } });
+
+      const auth = new MastraAuthOkta({ audience: ['test-client-id', 'api://default'] });
+      await auth.authenticateToken('test-token', {} as any);
+
+      expect(jwtVerify).toHaveBeenCalledWith(
+        'test-token',
+        mockJWKS,
+        expect.objectContaining({ audience: ['test-client-id', 'api://default'] }),
+      );
+    });
+
+    test('the option wins over OKTA_AUDIENCE', async () => {
+      const mockJWKS = vi.fn();
+      (createRemoteJWKSet as any).mockReturnValue(mockJWKS);
+      (jwtVerify as any).mockResolvedValue({ payload: { sub: 'u1' } });
+      process.env.OKTA_AUDIENCE = 'from-env';
+
+      const auth = new MastraAuthOkta({ audience: 'from-option' });
+      await auth.authenticateToken('test-token', {} as any);
+
+      expect(jwtVerify).toHaveBeenCalledWith(
+        'test-token',
+        mockJWKS,
+        expect.objectContaining({ audience: 'from-option' }),
+      );
     });
 
     test('returns null for invalid token', async () => {

--- a/auth/okta/src/types.ts
+++ b/auth/okta/src/types.ts
@@ -91,6 +91,18 @@ export interface MastraAuthOktaOptions {
    */
   redirectUri?: string;
   /**
+   * Expected `aud` claim when verifying bearer tokens.
+   * Defaults to OKTA_AUDIENCE env var, then to the client ID (the ID-token audience).
+   *
+   * Set this to accept Okta access tokens:
+   * - org authorization server: `https://{domain}`
+   * - custom authorization server: the configured audience, e.g. `api://default`
+   *
+   * Pass an array to accept more than one, e.g. ID tokens from the browser and
+   * access tokens from service callers against the same provider.
+   */
+  audience?: string | string[];
+  /**
    * OAuth scopes to request.
    * Default: ['openid', 'profile', 'email', 'groups']
    */


### PR DESCRIPTION
## Summary

`MastraAuthOkta` lets you sign in through Okta, and also accepts an Okta token passed directly as an `Authorization: Bearer` header. That bearer path only ever worked for one kind of Okta token.

When verifying a bearer token, the provider checked that the token's `aud` (audience) claim equalled the OAuth client ID. That value is the audience Okta puts on an **ID token** — the token a browser gets after a user logs in. An Okta **access token**, which is what a program gets when it authenticates as itself, carries the authorization server's audience instead. So any access token was rejected with a 401 on Okta's default (org) authorization server.

That matters because programs — MCP clients, CI jobs, other services — have no browser and therefore no session cookie. A bearer token was their only way into a Mastra server behind Okta, and it was closed unless they wrote their own auth provider.

This PR makes the expected audience configurable, so you can tell the provider what your tokens actually carry.

```typescript
// Accept access tokens from an org authorization server
new MastraAuthOkta({ domain, clientId, clientSecret, redirectUri, audience: 'https://your-org.okta.com' });

// Or accept both: ID tokens from the browser, access tokens from services
new MastraAuthOkta({ /* ... */ audience: [clientId, 'api://default'] });
```

It can also be set with the `OKTA_AUDIENCE` environment variable, matching how every other option on the provider works. The default is the previous value, so existing deployments are unaffected.

Closes #21111

## Test plan

- Four new unit tests in `auth/okta/src/index.test.ts` cover the option, the environment variable, an array of audiences, and the option taking precedence over the environment variable.
- The existing test asserting the client ID is used by default is unchanged and still passes, which is the backwards-compatibility check.
- `pnpm vitest run` in `auth/okta`: 39/39 passing.
- `tsc --noEmit` and `pnpm lint` clean.
