### PR TITLE
Fix the Okta docs claim that access tokens work as bearer tokens

### DIFF
--- a/docs/src/content/en/docs/server/auth/okta.mdx
+++ b/docs/src/content/en/docs/server/auth/okta.mdx
@@ -175,16 +175,21 @@ export const mastraClient = new MastraClient({
 
 ### Bearer token
 
-You can also pass an Okta access token as a Bearer token. The token is verified against Okta's JWKS endpoint:
+You can also pass an Okta token as a Bearer token. The token is verified against Okta's JWKS endpoint, and its `aud` claim must equal `OKTA_CLIENT_ID`.
+
+Okta puts the client ID in the `aud` claim of **ID tokens**. **Access tokens** carry the audience of the authorization server that issued them, so they're only accepted when that audience is the client ID:
+
+- **Org authorization server** (the default, issuer `https://{domain}`): access tokens use `https://{domain}` as the audience, so they're rejected. Send an ID token instead.
+- **Custom authorization server** (issuer `https://{domain}/oauth2/{name}`): access tokens are accepted if you set the server's audience to your client ID in the Okta Admin Console.
 
 ```typescript title="lib/mastra-client.ts"
 import { MastraClient } from '@mastra/client-js'
 
-export const createMastraClient = (accessToken: string) => {
+export const createMastraClient = (token: string) => {
   return new MastraClient({
     baseUrl: 'http://localhost:4111',
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${token}`,
     },
   })
 }
@@ -209,7 +214,7 @@ Visit [Mastra Client SDK](/docs/server/mastra-client) for more configuration opt
     ```bash
     curl -X POST http://localhost:4111/api/agents/weatherAgent/generate \
       -H "Content-Type: application/json" \
-      -H "Authorization: Bearer <your-okta-access-token>" \
+      -H "Authorization: Bearer <your-okta-token>" \
       -d '{
         "messages": "Weather in London"
       }'
@@ -220,6 +225,7 @@ Visit [Mastra Client SDK](/docs/server/mastra-client) for more configuration opt
 ## Troubleshooting
 
 - **401 on every request**: Verify your Okta domain, client ID, and client secret are correct. Check that the redirect URI in your Okta application matches `OKTA_REDIRECT_URI`.
+- **401 with `unexpected "aud" claim value` in the server logs**: The Bearer token's audience isn't your client ID. This usually means you sent an access token from an org authorization server. Send an ID token, or use a custom authorization server whose audience is set to your client ID. See [Bearer token](#bearer-token).
 - **Cookies not sent cross-origin**: Set `credentials: "include"` in `MastraClient` and configure `server.cors` with your frontend origin and `credentials: true`.
 - **Session lost on restart**: Set `OKTA_COOKIE_PASSWORD` to a stable value (at least 32 characters). Without it, an auto-generated key is used that changes on each restart.
 - **RBAC returns empty permissions**: Verify `OKTA_API_TOKEN` is set and the token has permission to list user groups. Check that group names in `roleMapping` match your Okta group names exactly.


### PR DESCRIPTION
## Summary

The Okta authentication guide told readers they could send an Okta **access token** as a Bearer token. On Okta's default setup that never works, and the docs gave no hint why.

When the Mastra Okta provider verifies a Bearer token, it requires the token's `aud` (audience) claim to equal your OAuth client ID. Okta puts the client ID in the audience of an **ID token** — the token a browser receives after a user logs in. An **access token** carries the audience of the authorization server that issued it, which on Okta's default (org) authorization server is your Okta domain. So the request 401s, and the symptom looks identical to simply having a bad token.

This PR makes the guide describe what the code actually does:

- The Bearer token section now states the audience rule up front and spells out when an access token is and isn't accepted, split by authorization server type.
- The examples no longer imply the token must be an access token.
- A new troubleshooting entry maps the real failure signature — `unexpected "aud" claim value` in the server logs — to its cause and fix, so readers can tell it apart from a genuinely invalid token.

Closes #21110

## Test plan

Docs-only change. Verified in `docs/`:

- `pnpm run format` — applied, no further diff
- `pnpm run lint:remark` — clean
- `pnpm run validate` — all 569 files pass, sidebars valid
- The new troubleshooting bullet links to the `#bearer-token` anchor, which is the existing `### Bearer token` heading on the same page.

Vale was not run; its binary isn't installed in this environment.

## Note

A follow-up (#21117, closing #21111) makes the audience configurable so access tokens can be accepted directly. Once that ships, this section can be rewritten to describe the `audience` option instead of working around the limitation.
