### PR TITLE
Cache MCP tool definitions and rebuild tools without reconnecting at startup

### DIFF
--- a/.changeset/serializable-mcp-tool-definitions.md
+++ b/.changeset/serializable-mcp-tool-definitions.md
@@ -1,0 +1,16 @@
+---
+'@mastra/mcp': minor
+---
+
+Add serializable MCP tool definitions and lazy hydration.
+
+`MCPClient` can now export its tool catalog as plain JSON and rebuild executable tools from it later, without reconnecting at startup. This removes the need to connect to every MCP server on every cold start just to discover tools that may never be called.
+
+- `listToolDefinitions()` returns definitions grouped by server and keyed by tool name. The result is JSON-serializable, so it can be cached in Redis, a database, or a build artifact.
+- `listToolDefinitionsWithErrors()` also reports per-server failures, so a partial catalog isn't cached silently.
+- `toolFromDefinition(serverName, definition)` rebuilds a single tool from a cached definition.
+- `toolsFromDefinitions(catalog)` rebuilds a whole namespaced tool map, matching the `serverName_toolName` keys from `listTools()`.
+
+Hydrated tools connect lazily on first execution and behave the same as discovered tools, including strict-mode metadata, approval policies, structured content, tool error handling, progress metadata, abort signals, and reconnect and retry behavior. Definitions capture the server version and instructions recorded at discovery time so that metadata isn't lost.
+
+Existing `listTools()` and `listToolsets()` behavior is unchanged.

--- a/.changeset/serializable-mcp-tool-definitions.md
+++ b/.changeset/serializable-mcp-tool-definitions.md
@@ -8,8 +8,8 @@ Add serializable MCP tool definitions and lazy hydration.
 
 - `listToolDefinitions()` returns definitions grouped by server and keyed by tool name. The result is JSON-serializable, so it can be cached in Redis, a database, or a build artifact.
 - `listToolDefinitionsWithErrors()` also reports per-server failures, so a partial catalog isn't cached silently.
-- `toolFromDefinition(serverName, definition)` rebuilds a single tool from a cached definition.
-- `toolsFromDefinitions(catalog)` rebuilds a whole namespaced tool map, matching the `serverName_toolName` keys from `listTools()`.
+- `toolFromDefinition({ serverName, definition })` rebuilds a single tool from a cached definition.
+- `toolsFromDefinitions({ definitions })` rebuilds a whole namespaced tool map, matching the `serverName_toolName` keys from `listTools()`.
 
 Hydrated tools connect lazily on first execution and behave the same as discovered tools, including strict-mode metadata, approval policies, structured content, tool error handling, progress metadata, abort signals, and reconnect and retry behavior. Definitions capture the server version and instructions recorded at discovery time so that metadata isn't lost.
 

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -392,7 +392,10 @@ The returned tool behaves exactly like one from `listTools()`, with the same str
 ```typescript
 const definitions = JSON.parse(await cache.get('mcp-tools'))
 
-const tool = await mcp.toolFromDefinition('weather', definitions.weather.getForecast)
+const tool = await mcp.toolFromDefinition({
+  serverName: 'weather',
+  definition: definitions.weather.getForecast,
+})
 ```
 
 ### `toolsFromDefinitions()`
@@ -404,7 +407,7 @@ Servers present in the catalog but no longer configured on the client are skippe
 ```typescript
 const definitions = JSON.parse(await cache.get('mcp-tools'))
 
-new Agent({ id: 'agent', tools: await mcp.toolsFromDefinitions(definitions) })
+new Agent({ id: 'agent', tools: await mcp.toolsFromDefinitions({ definitions }) })
 ```
 
 ### `getServerInstructions()`

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -359,6 +359,54 @@ const res = await agent.stream(prompt, {
 })
 ```
 
+### `listToolDefinitions()`
+
+Returns every server's tools as plain, serializable definitions, grouped by server name and keyed by the server's own tool name (without the `serverName_toolName` namespacing that `listTools()` applies).
+
+Unlike `listTools()`, the result contains no functions or references to a live client, so it can be passed through `JSON.stringify` and cached in Redis, a database, or a build artifact. Each definition holds the data from the MCP `tools/list` response (name, description, input schema, output schema, annotations, and `_meta`), plus the server name, version, and instructions captured at discovery time.
+
+```typescript
+const definitions = await mcp.listToolDefinitions()
+
+await cache.set('mcp-tools', JSON.stringify(definitions))
+```
+
+### `listToolDefinitionsWithErrors()`
+
+Like `listToolDefinitions()`, but also returns per-server errors for servers that failed to connect. Use this when caching a catalog, so you don't persist a partial manifest that omits a server that was down at discovery time.
+
+```typescript
+const { definitions, errors } = await mcp.listToolDefinitionsWithErrors()
+
+if (Object.keys(errors).length === 0) {
+  await cache.set('mcp-tools', JSON.stringify(definitions))
+}
+```
+
+### `toolFromDefinition()`
+
+Rebuilds a single executable tool from a cached definition. No connection is opened here. The client connects lazily, the first time the tool is executed.
+
+The returned tool behaves exactly like one from `listTools()`, with the same strict-mode metadata, approval policy, structured content handling, tool error handling, and reconnect behavior.
+
+```typescript
+const definitions = JSON.parse(await cache.get('mcp-tools'))
+
+const tool = await mcp.toolFromDefinition('weather', definitions.weather.getForecast)
+```
+
+### `toolsFromDefinitions()`
+
+Rebuilds an entire cached catalog into a namespaced tool map, without connecting. This is the cached counterpart to `listTools()`. It produces the same `serverName_toolName` keys, so you can reconstruct an agent's tool map on a cold start, and connections only open for the servers whose tools are actually called.
+
+Servers present in the catalog but no longer configured on the client are skipped, so a stale cached manifest degrades gracefully.
+
+```typescript
+const definitions = JSON.parse(await cache.get('mcp-tools'))
+
+new Agent({ id: 'agent', tools: await mcp.toolsFromDefinitions(definitions) })
+```
+
 ### `getServerInstructions()`
 
 Returns the instructions currently known for each configured MCP server. Servers that haven't connected yet, or don't advertise instructions, return `undefined`.

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -44,6 +44,7 @@ import type {
   InternalMastraMCPClientOptions,
   Root,
   RequireToolApproval,
+  SerializableMCPToolDefinition,
 } from './types';
 import {
   assertHostAllowed,
@@ -66,7 +67,11 @@ export type {
   RequireToolApproval,
   RequireToolApprovalFn,
   RequireToolApprovalContext,
+  SerializableMCPToolDefinition,
 } from './types';
+
+/** A single entry from the MCP `tools/list` response. */
+type MCPToolListEntry = Awaited<ReturnType<Client['listTools']>>['tools'][0];
 
 const DEFAULT_SERVER_CONNECT_TIMEOUT_MSEC = 3000;
 const DEFAULT_INSTRUCTIONS_MAX_LENGTH = 512;
@@ -1225,9 +1230,9 @@ export class InternalMastraMCPClient extends MastraBase {
     });
   }
 
-  private async convertInputSchema(
+  private convertInputSchema(
     inputSchema: Awaited<ReturnType<Client['listTools']>>['tools'][0]['inputSchema'],
-  ): Promise<JSONSchema7> {
+  ): JSONSchema7 {
     return ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
   }
 
@@ -1249,12 +1254,115 @@ export class InternalMastraMCPClient extends MastraBase {
     };
   }
 
+  /**
+   * Returns the server's tool catalog as plain, serializable definitions.
+   *
+   * Unlike {@link tools}, this performs no schema conversion and creates no executable
+   * wrappers, so the result can be cached and reused by other processes. Pass a definition
+   * back to {@link toolFromDefinition} to rebuild the executable tool without rediscovery.
+   */
+  async toolDefinitions(): Promise<Record<string, SerializableMCPToolDefinition>> {
+    this.log('debug', `Requesting tool definitions from MCP server`);
+    const { tools } = await this.client.listTools({}, { timeout: this.timeout });
+
+    const definitions: Record<string, SerializableMCPToolDefinition> = {};
+    for (const tool of tools) {
+      if (!tool.name) continue;
+      definitions[tool.name] = this.toSerializableDefinition(tool);
+    }
+    return definitions;
+  }
+
+  /**
+   * Captures a `tools/list` entry plus the server metadata that is only reachable from a live
+   * connection, so a hydrated tool is indistinguishable from a freshly discovered one.
+   */
+  private toSerializableDefinition(tool: MCPToolListEntry): SerializableMCPToolDefinition {
+    const annotations = tool.annotations;
+    const rawMeta = (tool as { _meta?: Record<string, unknown> })._meta;
+
+    return {
+      name: tool.name,
+      ...(tool.description ? { description: tool.description } : {}),
+      inputSchema: tool.inputSchema,
+      ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+      ...(annotations ? { annotations } : {}),
+      ...(rawMeta ? { _meta: rawMeta } : {}),
+      server: {
+        name: this.name,
+        ...(this.client.getServerVersion()?.version ? { version: this.client.getServerVersion()!.version } : {}),
+        ...(this.serverInstructions ? { instructions: this.serverInstructions } : {}),
+      },
+    };
+  }
+
+  /**
+   * Rebuilds an executable Mastra tool from a cached {@link SerializableMCPToolDefinition}.
+   *
+   * No connection is opened here. The client connects lazily, the first time the returned tool
+   * is actually executed, which is what makes a cached catalog useful for cold starts.
+   */
+  toolFromDefinition(definition: SerializableMCPToolDefinition): Tool<any, any, any, any> {
+    const tool = {
+      name: definition.name,
+      description: definition.description,
+      inputSchema: definition.inputSchema,
+      outputSchema: definition.outputSchema,
+      annotations: definition.annotations,
+      _meta: definition._meta,
+    } as MCPToolListEntry;
+
+    const built = this.buildToolFromListEntry(tool, {
+      version: definition.server.version,
+      instructions: definition.server.instructions,
+      connectFirst: true,
+    });
+
+    if (!built) {
+      throw new MastraError({
+        id: 'MCP_CLIENT_TOOL_HYDRATION_FAILED',
+        domain: ErrorDomain.MCP,
+        category: ErrorCategory.USER,
+        text: `Failed to rebuild MCP tool "${definition.name}" from its cached definition`,
+        details: { toolName: definition.name, serverName: this.name },
+      });
+    }
+
+    return built;
+  }
+
   async tools(): Promise<Record<string, Tool<any, any, any, any>>> {
     this.log('debug', `Requesting tools from MCP server`);
     const { tools } = await this.client.listTools({}, { timeout: this.timeout });
     const toolsRes: Record<string, Tool<any, any, any, any>> = {};
     for (const tool of tools) {
       this.log('debug', `Processing tool: ${tool.name}`);
+      const mastraTool = this.buildToolFromListEntry(tool, {
+        version: this.client.getServerVersion()?.version,
+        instructions: this.serverInstructions,
+      });
+
+      if (mastraTool && tool.name) {
+        toolsRes[tool.name] = mastraTool;
+      }
+    }
+
+    return toolsRes;
+  }
+
+  /**
+   * Single conversion path shared by live discovery and cached hydration.
+   *
+   * Keeping both callers on this one method is what guarantees the issue's requirement that
+   * hydrated tools behave identically to discovered ones: strict-mode metadata, approval
+   * policies, structured content, in-band tool errors, progress metadata, abort signals and
+   * reconnect/retry all come from here rather than being reimplemented per call site.
+   */
+  private buildToolFromListEntry(
+    tool: MCPToolListEntry,
+    serverMeta: { version?: string; instructions?: string; connectFirst?: boolean },
+  ): Tool<any, any, any, any> | undefined {
+    {
       try {
         // Resolve requireToolApproval for this tool
         let requireApproval: boolean | undefined;
@@ -1303,7 +1411,7 @@ export class InternalMastraMCPClient extends MastraBase {
         const mastraTool = createTool({
           id: `${this.name}_${tool.name}`,
           description: tool.description || '',
-          inputSchema: await this.convertInputSchema(tool.inputSchema),
+          inputSchema: this.convertInputSchema(tool.inputSchema),
           outputSchema: this.convertOutputSchema(tool.outputSchema),
           strict: getMastraToolStrictMeta(toolMeta),
           // Preserve the full _meta from the remote MCP server (including ui.resourceUri
@@ -1314,8 +1422,8 @@ export class InternalMastraMCPClient extends MastraBase {
           requireApproval,
           mcpMetadata: {
             serverName: this.name,
-            serverVersion: this.client.getServerVersion()?.version,
-            serverInstructions: this.serverInstructions,
+            serverVersion: serverMeta.version,
+            serverInstructions: serverMeta.instructions,
             forwardInstructions: this.forwardInstructions,
             instructionsMaxLength: this.instructionsMaxLength,
           },
@@ -1329,6 +1437,13 @@ export class InternalMastraMCPClient extends MastraBase {
               _meta?: Record<string, unknown>;
             },
           ) => {
+            // A hydrated tool was rebuilt from cache without ever opening a connection, so the
+            // first execution is what establishes it. `connect()` is memoised, making this a
+            // no-op for tools that came from live discovery.
+            if (serverMeta.connectFirst) {
+              await this.connect();
+            }
+
             const operationContext = context?.requestContext ?? null;
             const scalarMcpContentReservation = tool.outputSchema
               ? reserveScalarMcpContent(scalarMcpContentQueue)
@@ -1441,19 +1556,16 @@ export class InternalMastraMCPClient extends MastraBase {
           mastraTool.needsApprovalFn = needsApprovalFn;
         }
 
-        if (tool.name) {
-          toolsRes[tool.name] = mastraTool;
-        }
+        return mastraTool;
       } catch (toolCreationError: unknown) {
         // Catch errors during tool creation itself (e.g., if createTool has issues)
         this.log('error', `Failed to create Mastra tool wrapper for MCP tool: ${tool.name}`, {
           error: toolCreationError instanceof Error ? toolCreationError.stack : String(toolCreationError),
           mcpToolDefinition: tool,
         });
+        return undefined;
       }
     }
-
-    return toolsRes;
   }
 
   private stampServerIdInMeta(meta: Record<string, unknown>): Record<string, unknown> {

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -1302,7 +1302,7 @@ export class InternalMastraMCPClient extends MastraBase {
    * No connection is opened here. The client connects lazily, the first time the returned tool
    * is actually executed, which is what makes a cached catalog useful for cold starts.
    */
-  toolFromDefinition(definition: SerializableMCPToolDefinition): Tool<any, any, any, any> {
+  toolFromDefinition({ definition }: { definition: SerializableMCPToolDefinition }): Tool<any, any, any, any> {
     const tool = {
       name: definition.name,
       description: definition.description,

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -1236,15 +1236,18 @@ To fix this you have three different options:
    * @param serverName Name of the server the definition came from, as configured on this client.
    * @param definition A definition previously obtained from {@link listToolDefinitions}.
    */
-  public async toolFromDefinition(
-    serverName: string,
-    definition: SerializableMCPToolDefinition,
-  ): Promise<Tool<any, any, any, any>> {
+  public async toolFromDefinition({
+    serverName,
+    definition,
+  }: {
+    serverName: string;
+    definition: SerializableMCPToolDefinition;
+  }): Promise<Tool<any, any, any, any>> {
     this.addToInstanceCache();
     // getOrCreateClient constructs the client without connecting; connection is deferred to
     // the tool's first execution.
     const client = await this.getOrCreateClient(serverName, this.getServerConfig(serverName));
-    return client.toolFromDefinition(definition);
+    return client.toolFromDefinition({ definition });
   }
 
   /**
@@ -1260,12 +1263,14 @@ To fix this you have three different options:
    * @example
    * ```typescript
    * const definitions = JSON.parse(await cache.get('mcp-tools'));
-   * const agent = new Agent({ tools: await mcp.toolsFromDefinitions(definitions), ... });
+   * const agent = new Agent({ tools: await mcp.toolsFromDefinitions({ definitions }), ... });
    * ```
    */
-  public async toolsFromDefinitions(
-    catalog: SerializableMCPToolCatalog,
-  ): Promise<Record<string, Tool<any, any, any, any>>> {
+  public async toolsFromDefinitions({
+    definitions: catalog,
+  }: {
+    definitions: SerializableMCPToolCatalog;
+  }): Promise<Record<string, Tool<any, any, any, any>>> {
     const configuredServers = new Set(Object.keys(this.serverConfigs));
     const tools: Record<string, Tool<any, any, any, any>> = {};
 
@@ -1278,7 +1283,7 @@ To fix this you have three different options:
       }
 
       for (const [toolName, definition] of Object.entries(definitions)) {
-        tools[`${serverName}_${toolName}`] = await this.toolFromDefinition(serverName, definition);
+        tools[`${serverName}_${toolName}`] = await this.toolFromDefinition({ serverName, definition });
       }
     }
 

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -23,6 +23,7 @@ import { createOAuthCallbackServer, getCallbackUrlCandidates } from './oauth-cal
 import type { OAuthCallbackServer } from './oauth-callback-server';
 import { MCPOAuthClientProvider } from './oauth-provider';
 import { MCPClientServerProxy } from './server-proxy';
+import type { SerializableMCPToolCatalog, SerializableMCPToolDefinition } from './types';
 
 const mcpClientInstances = new Map<string, InstanceType<typeof MCPClient>>();
 const TOOL_DISCOVERY_MAX_ATTEMPTS = 2;
@@ -1154,6 +1155,134 @@ To fix this you have three different options:
     }
 
     return { toolsets: connectedToolsets, errors };
+  }
+
+  /**
+   * Discovers every configured server's tools as plain, serializable definitions.
+   *
+   * Unlike `listTools()`/`listToolsets()`, the result contains no functions or references to a
+   * live client, so it can be JSON-serialized and cached (Redis, a database, a build artifact)
+   * and reused by other processes. Rebuild an executable tool from a cached definition with
+   * {@link toolFromDefinition}, which does not reconnect.
+   *
+   * Definitions are grouped by server and keyed by the server's own tool name, without the
+   * `serverName_toolName` namespacing that `listTools()` applies.
+   *
+   * @example
+   * ```typescript
+   * // Once, at build time or on the first worker:
+   * const definitions = await mcp.listToolDefinitions();
+   * await cache.set('mcp-tools', JSON.stringify(definitions));
+   *
+   * // In every other worker, with no MCP connections opened:
+   * const definitions = JSON.parse(await cache.get('mcp-tools'));
+   * const tool = mcp.toolFromDefinition('weather', definitions.weather.getForecast);
+   * ```
+   */
+  public async listToolDefinitions(): Promise<SerializableMCPToolCatalog> {
+    const result = await this.listToolDefinitionsWithErrors();
+    return result.definitions;
+  }
+
+  /**
+   * Like {@link listToolDefinitions}, but also returns errors for servers that failed to
+   * connect instead of surfacing only the servers that succeeded.
+   *
+   * Useful when caching a catalog, since it lets you avoid persisting a partial manifest that
+   * silently omits a server which happened to be down at discovery time.
+   */
+  public async listToolDefinitionsWithErrors(): Promise<{
+    definitions: SerializableMCPToolCatalog;
+    errors: Record<string, string>;
+  }> {
+    this.addToInstanceCache();
+    const definitions: SerializableMCPToolCatalog = {};
+    const errors: Record<string, string> = {};
+
+    const settled = await this.discoverAcrossServers(
+      async serverName => {
+        const client = await this.getConnectedClientForServer(serverName);
+        return client.toolDefinitions();
+      },
+      {
+        errorId: 'MCP_CLIENT_GET_TOOL_DEFINITIONS_FAILED',
+        logMessage: 'Failed to list tool definitions from server:',
+      },
+    );
+
+    for (const { serverName, value, error } of settled) {
+      if (error !== undefined) {
+        errors[serverName] = error;
+        continue;
+      }
+      definitions[serverName] = value;
+    }
+
+    return { definitions, errors };
+  }
+
+  /**
+   * Rebuilds an executable Mastra tool from a cached {@link SerializableMCPToolDefinition}.
+   *
+   * No MCP connection is opened here — that is the point of the method. The underlying client
+   * connects lazily, the first time the returned tool is actually executed, so a worker can
+   * reconstruct an entire tool map at startup and only pay for connections to the servers whose
+   * tools the model really calls.
+   *
+   * The returned tool behaves exactly like one from `listTools()`: same strict-mode metadata,
+   * approval policy, structured content handling, in-band tool errors, progress metadata, abort
+   * signal support, and reconnect/retry behavior.
+   *
+   * @param serverName Name of the server the definition came from, as configured on this client.
+   * @param definition A definition previously obtained from {@link listToolDefinitions}.
+   */
+  public async toolFromDefinition(
+    serverName: string,
+    definition: SerializableMCPToolDefinition,
+  ): Promise<Tool<any, any, any, any>> {
+    this.addToInstanceCache();
+    // getOrCreateClient constructs the client without connecting; connection is deferred to
+    // the tool's first execution.
+    const client = await this.getOrCreateClient(serverName, this.getServerConfig(serverName));
+    return client.toolFromDefinition(definition);
+  }
+
+  /**
+   * Rebuilds an entire cached catalog into a namespaced tool map, without connecting.
+   *
+   * This is the cached counterpart to `listTools()`: it produces the same `serverName_toolName`
+   * keys, so an agent's tool map can be reconstructed on a cold start from a catalog in Redis
+   * and dropped straight into the agent, with connections opened lazily per tool call.
+   *
+   * Servers present in the catalog but no longer configured on this client are skipped, so a
+   * stale cached manifest degrades gracefully instead of throwing.
+   *
+   * @example
+   * ```typescript
+   * const definitions = JSON.parse(await cache.get('mcp-tools'));
+   * const agent = new Agent({ tools: await mcp.toolsFromDefinitions(definitions), ... });
+   * ```
+   */
+  public async toolsFromDefinitions(
+    catalog: SerializableMCPToolCatalog,
+  ): Promise<Record<string, Tool<any, any, any, any>>> {
+    const configuredServers = new Set(Object.keys(this.serverConfigs));
+    const tools: Record<string, Tool<any, any, any, any>> = {};
+
+    for (const [serverName, definitions] of Object.entries(catalog)) {
+      if (!configuredServers.has(serverName)) {
+        this.logger.warn('Skipping cached MCP tool definitions for a server that is no longer configured', {
+          serverName,
+        });
+        continue;
+      }
+
+      for (const [toolName, definition] of Object.entries(definitions)) {
+        tools[`${serverName}_${toolName}`] = await this.toolFromDefinition(serverName, definition);
+      }
+    }
+
+    return tools;
   }
 
   /**

--- a/packages/mcp/src/client/index.ts
+++ b/packages/mcp/src/client/index.ts
@@ -10,6 +10,8 @@ export type {
   RequireToolApprovalFn,
   RequireToolApprovalContext,
   ToolAnnotations,
+  SerializableMCPToolDefinition,
+  SerializableMCPToolCatalog,
 } from './types';
 export * from './client';
 export * from './configuration';

--- a/packages/mcp/src/client/serializable-tool-definitions.test.ts
+++ b/packages/mcp/src/client/serializable-tool-definitions.test.ts
@@ -1,0 +1,227 @@
+import { randomUUID } from 'node:crypto';
+import { createServer } from 'node:http';
+import type { Server as HttpServer } from 'node:http';
+import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
+import { McpServer } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { InternalMastraMCPClient } from './client.js';
+import { MCPClient } from './configuration.js';
+
+/**
+ * Covers https://github.com/mastra-ai/mastra/issues/20527.
+ *
+ * The contract under test has two halves that are easy to get wrong independently:
+ *   1. definitions must survive a JSON round trip with no loss of `tools/list` data, and
+ *   2. a tool rebuilt from a definition must behave exactly like a discovered one, while
+ *      opening no connection until it is first executed.
+ *
+ * These run against a real MCP server rather than mocks, so schema conversion, execution,
+ * structured content and annotations are all exercised through the genuine code path.
+ */
+
+let port = 0;
+
+async function setupTestServer() {
+  const httpServer: HttpServer = createServer();
+  const mcpServer = new McpServer(
+    { name: 'test-definitions-server', version: '3.1.4' },
+    { capabilities: { tools: {} }, instructions: 'Server level instructions.' },
+  );
+
+  mcpServer.registerTool(
+    'greet',
+    {
+      description: 'A simple greeting tool',
+      inputSchema: z.object({ name: z.string().describe('Name to greet').default('World') }),
+      annotations: { title: 'Greeter', readOnlyHint: true },
+    },
+    async ({ name }): Promise<CallToolResult> => ({
+      content: [{ type: 'text', text: `Hello, ${name}!` }],
+    }),
+  );
+
+  // A tool with an output schema exercises the structured-content path, which is wired up
+  // separately from the plain-text path and is easy to drop during hydration.
+  mcpServer.registerTool(
+    'measure',
+    {
+      description: 'Returns a structured measurement',
+      inputSchema: z.object({ city: z.string() }),
+      outputSchema: z.object({ celsius: z.number() }),
+    },
+    async ({ city }): Promise<CallToolResult> => ({
+      content: [{ type: 'text', text: `measured ${city}` }],
+      structuredContent: { celsius: 21 },
+    }),
+  );
+
+  // Stateless mode: SDK 1.27+ requires a new transport per request, and it lets several
+  // clients talk to this server, which the cold-worker hydration test depends on.
+  httpServer.on('request', async (req: any, res: any) => {
+    await mcpServer.close().catch(() => {});
+    const transport = new NodeStreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    await mcpServer.connect(transport);
+    await transport.handleRequest(req, res);
+  });
+
+  const baseUrl = await new Promise<URL>(resolve => {
+    httpServer.listen(0, '127.0.0.1', () => {
+      const addr = httpServer.address();
+      port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve(new URL(`http://127.0.0.1:${port}/mcp`));
+    });
+  });
+
+  return { httpServer, mcpServer, baseUrl };
+}
+
+describe('serializable MCP tool definitions (issue #20527)', () => {
+  let testServer: Awaited<ReturnType<typeof setupTestServer>>;
+
+  beforeEach(async () => {
+    testServer = await setupTestServer();
+  });
+
+  afterEach(async () => {
+    await testServer?.mcpServer.close().catch(() => {});
+    testServer?.httpServer.close();
+  });
+
+  describe('InternalMastraMCPClient', () => {
+    let client: InternalMastraMCPClient;
+
+    beforeEach(async () => {
+      client = new InternalMastraMCPClient({ name: 'defs', server: { url: testServer.baseUrl } });
+      await client.connect();
+    });
+
+    afterEach(async () => {
+      await client?.disconnect().catch(() => {});
+    });
+
+    it('exposes tools/list data as definitions that survive a JSON round trip', async () => {
+      const definitions = await client.toolDefinitions();
+
+      expect(Object.keys(definitions).sort()).toEqual(['greet', 'measure']);
+      expect(definitions.greet.description).toBe('A simple greeting tool');
+      expect(definitions.greet.annotations).toMatchObject({ title: 'Greeter', readOnlyHint: true });
+      expect(definitions.measure.outputSchema).toBeDefined();
+
+      // The whole point is cacheability: no functions, no client references.
+      expect(JSON.parse(JSON.stringify(definitions))).toEqual(definitions);
+    });
+
+    it('captures server metadata that is otherwise only reachable from a live connection', async () => {
+      const definitions = await client.toolDefinitions();
+
+      // Without this, a hydrated tool would silently lose the server version and instructions
+      // that a normally discovered tool carries.
+      expect(definitions.greet.server).toEqual({
+        name: 'defs',
+        version: '3.1.4',
+        instructions: 'Server level instructions.',
+      });
+    });
+
+    it('rebuilds a tool that matches the discovered one and executes identically', async () => {
+      const definitions = await client.toolDefinitions();
+      const cached = JSON.parse(JSON.stringify(definitions));
+
+      const discovered = (await client.tools()).greet;
+      const hydrated = client.toolFromDefinition(cached.greet);
+
+      expect(hydrated.id).toBe(discovered.id);
+      expect(hydrated.description).toBe(discovered.description);
+      // Schema wrappers compare by identity, so compare the schema they carry.
+      expect(JSON.stringify(hydrated.inputSchema)).toEqual(JSON.stringify(discovered.inputSchema));
+      expect((hydrated as any).mcp).toEqual((discovered as any).mcp);
+
+      const fromDiscovered = await discovered.execute!({ name: 'Ada' } as any, {});
+      const fromHydrated = await hydrated.execute!({ name: 'Ada' } as any, {});
+      expect(fromHydrated).toEqual(fromDiscovered);
+      expect(JSON.stringify(fromHydrated)).toContain('Hello, Ada!');
+    });
+
+    it('preserves structured content behavior for tools with an output schema', async () => {
+      const definitions = await client.toolDefinitions();
+      const hydrated = client.toolFromDefinition(JSON.parse(JSON.stringify(definitions.measure)));
+
+      expect(hydrated.outputSchema).toBeDefined();
+      // `toModelOutput` is only attached for output-schema tools; losing it would silently
+      // change how results are presented to the model.
+      expect((hydrated as any).toModelOutput).toBeTypeOf('function');
+
+      const result = await hydrated.execute!({ city: 'Berlin' } as any, {});
+      expect(result).toMatchObject({ celsius: 21 });
+    });
+  });
+
+  describe('MCPClient', () => {
+    let mcp: MCPClient;
+    const clients: MCPClient[] = [];
+
+    afterEach(async () => {
+      await Promise.all(clients.map(client => client.disconnect().catch(() => {})));
+      clients.length = 0;
+    });
+
+    function createClient(servers?: Record<string, any>) {
+      mcp = new MCPClient({
+        id: `defs-test-${randomUUID()}`,
+        servers: servers ?? { weather: { url: testServer.baseUrl } },
+      });
+      clients.push(mcp);
+      return mcp;
+    }
+
+    it('returns a catalog grouped by server and keyed by unnamespaced tool name', async () => {
+      const definitions = await createClient().listToolDefinitions();
+
+      expect(Object.keys(definitions)).toEqual(['weather']);
+      expect(Object.keys(definitions.weather).sort()).toEqual(['greet', 'measure']);
+      expect(JSON.parse(JSON.stringify(definitions))).toEqual(definitions);
+    });
+
+    it('reports per-server failures instead of silently caching a partial catalog', async () => {
+      const client = createClient({
+        weather: { url: testServer.baseUrl },
+        broken: { url: new URL('http://127.0.0.1:1/mcp'), timeout: 500 },
+      });
+
+      const { definitions, errors } = await client.listToolDefinitionsWithErrors();
+
+      expect(Object.keys(definitions)).toEqual(['weather']);
+      expect(errors.broken).toBeDefined();
+    });
+
+    it('hydrates a whole catalog into a namespaced tool map without connecting', async () => {
+      const definitions = await createClient().listToolDefinitions();
+      const cached = JSON.parse(JSON.stringify(definitions));
+
+      // A fresh client stands in for a cold worker process that has never talked to the server.
+      const worker = createClient();
+      const tools = await worker.toolsFromDefinitions(cached);
+
+      expect(Object.keys(tools).sort()).toEqual(['weather_greet', 'weather_measure']);
+      // The whole tool map was rebuilt without opening a single connection.
+      expect((worker as any).mcpClientsById.get('weather')?.isConnected).toBeFalsy();
+
+      // Connection is deferred until the tool is actually used.
+      const result = await tools.weather_greet.execute!({ name: 'Grace' } as any, {});
+      expect(JSON.stringify(result)).toContain('Hello, Grace!');
+      expect((worker as any).mcpClientsById.get('weather')?.isConnected).toBeTruthy();
+    });
+
+    it('skips cached definitions for servers that are no longer configured', async () => {
+      const definitions = await createClient().listToolDefinitions();
+      const cached = JSON.parse(JSON.stringify(definitions));
+      cached.retired = { ghost: { ...cached.weather.greet, name: 'ghost' } };
+
+      const tools = await mcp.toolsFromDefinitions(cached);
+
+      expect(Object.keys(tools).sort()).toEqual(['weather_greet', 'weather_measure']);
+    });
+  });
+});

--- a/packages/mcp/src/client/serializable-tool-definitions.test.ts
+++ b/packages/mcp/src/client/serializable-tool-definitions.test.ts
@@ -130,7 +130,7 @@ describe('serializable MCP tool definitions (issue #20527)', () => {
       const cached = JSON.parse(JSON.stringify(definitions));
 
       const discovered = (await client.tools()).greet;
-      const hydrated = client.toolFromDefinition(cached.greet);
+      const hydrated = client.toolFromDefinition({ definition: cached.greet });
 
       expect(hydrated.id).toBe(discovered.id);
       expect(hydrated.description).toBe(discovered.description);
@@ -146,7 +146,7 @@ describe('serializable MCP tool definitions (issue #20527)', () => {
 
     it('preserves structured content behavior for tools with an output schema', async () => {
       const definitions = await client.toolDefinitions();
-      const hydrated = client.toolFromDefinition(JSON.parse(JSON.stringify(definitions.measure)));
+      const hydrated = client.toolFromDefinition({ definition: JSON.parse(JSON.stringify(definitions.measure)) });
 
       expect(hydrated.outputSchema).toBeDefined();
       // `toModelOutput` is only attached for output-schema tools; losing it would silently
@@ -202,7 +202,7 @@ describe('serializable MCP tool definitions (issue #20527)', () => {
 
       // A fresh client stands in for a cold worker process that has never talked to the server.
       const worker = createClient();
-      const tools = await worker.toolsFromDefinitions(cached);
+      const tools = await worker.toolsFromDefinitions({ definitions: cached });
 
       expect(Object.keys(tools).sort()).toEqual(['weather_greet', 'weather_measure']);
       // The whole tool map was rebuilt without opening a single connection.
@@ -219,7 +219,7 @@ describe('serializable MCP tool definitions (issue #20527)', () => {
       const cached = JSON.parse(JSON.stringify(definitions));
       cached.retired = { ghost: { ...cached.weather.greet, name: 'ghost' } };
 
-      const tools = await mcp.toolsFromDefinitions(cached);
+      const tools = await mcp.toolsFromDefinitions({ definitions: cached });
 
       expect(Object.keys(tools).sort()).toEqual(['weather_greet', 'weather_measure']);
     });

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -513,3 +513,51 @@ export type InternalMastraMCPClientOptions = {
   /** Optional timeout in milliseconds */
   timeout?: number;
 };
+
+/**
+ * A fully serializable description of a single tool advertised by an MCP server.
+ *
+ * This is the data returned by the MCP `tools/list` response, plus the server metadata needed
+ * to reconstruct the tool faithfully. It contains no functions, class instances or references
+ * to a live client, so it survives `JSON.stringify` and can be cached in Redis, a database, or
+ * a build artifact and reused by other processes.
+ *
+ * Obtain these via {@link MCPClient.listToolDefinitions} and turn them back into executable
+ * tools with {@link MCPClient.toolFromDefinition}.
+ */
+export type SerializableMCPToolDefinition = {
+  /** Tool name as advertised by the server, without any server namespace prefix. */
+  name: string;
+  /** Human readable description from the server, if it supplied one. */
+  description?: string;
+  /** Raw JSON Schema for the tool's arguments, exactly as sent by the server. */
+  inputSchema: unknown;
+  /** Raw JSON Schema for the tool's structured output, if the server declared one. */
+  outputSchema?: unknown;
+  /** Server-advertised annotations (title, readOnlyHint, destructiveHint, ...). */
+  annotations?: ToolAnnotations;
+  /** Server-supplied `_meta`, including `ui.resourceUri` for MCP Apps. */
+  _meta?: Record<string, unknown>;
+  /**
+   * Metadata about the server that advertised this tool.
+   *
+   * Captured at discovery time because it is otherwise only available from a live connection.
+   * Without it, hydrating a tool would silently drop the server version and instructions that
+   * a normally discovered tool carries.
+   */
+  server: {
+    /** The name this server is configured under. */
+    name: string;
+    /** Server version reported during the MCP handshake, if any. */
+    version?: string;
+    /** Instructions the server returned during initialization, if any. */
+    instructions?: string;
+  };
+};
+
+/**
+ * A serializable catalog of MCP tool definitions, keyed by server name and then tool name.
+ *
+ * This is the shape returned by {@link MCPClient.listToolDefinitions}.
+ */
+export type SerializableMCPToolCatalog = Record<string, Record<string, SerializableMCPToolDefinition>>;


### PR DESCRIPTION
Closes #20527

## Problem

`MCPClient` only exposes tools as fully-constructed objects whose `execute` closures hold a live client. Getting them requires connecting to every configured MCP server and calling `tools/list`.

That means every process pays full MCP discovery on startup. In serverless and multi-worker deployments, that cost is repeated on each cold start, for every server, including servers whose tools the model never calls.

## What changed

Tool *definitions* are now separated from tool *execution*. The `tools/list` data can be exported as plain JSON, cached anywhere, and turned back into working tools later, with connections deferred until a tool actually runs.

New methods on `MCPClient`:

- `listToolDefinitions()` returns definitions grouped by server, keyed by tool name.
- `listToolDefinitionsWithErrors()` also reports per-server failures, so a partial catalog isn't cached silently.
- `toolFromDefinition(serverName, definition)` rebuilds one tool.
- `toolsFromDefinitions(catalog)` rebuilds a whole namespaced tool map, matching the `serverName_toolName` keys `listTools()` produces.

```ts
// Once, at build time or on the first worker
await cache.set('mcp-tools', JSON.stringify(await mcp.listToolDefinitions()));

// Every cold start after that, with no MCP connections opened
const definitions = JSON.parse(await cache.get('mcp-tools'));
new Agent({ id: 'agent', tools: await mcp.toolsFromDefinitions(definitions) });
```

## Design notes

**One conversion path.** The obvious risk is that hydrated tools quietly drift from discovered ones. Rather than writing a second construction path, the existing per-tool loop body in `InternalMastraMCPClient.tools()` is extracted into a single builder that both live discovery and hydration call. Strict-mode metadata, approval policies, structured content, in-band tool errors, progress metadata, abort signals, and reconnect/retry all keep working because there is only one implementation of them.

**Server metadata is captured, not recomputed.** Conversion reads `getServerVersion()` and the server instructions, which are only available from a live connection. Hydrating without them would silently produce tools missing their server version and instructions, so they are recorded in the definition at discovery time.

**Lazy, not eager.** Hydration opens no connection. The client connects on the tool's first execution, and `connect()` is already memoized, so this is a no-op for tools that came from live discovery.

**Backward compatible.** `listTools()` and `listToolsets()` are unchanged.

## Test plan

New `packages/mcp/src/client/serializable-tool-definitions.test.ts` runs against a real MCP server rather than mocks, covering:

- definitions survive a JSON round trip with no loss of `tools/list` data
- server version and instructions are captured
- a hydrated tool matches the discovered tool and returns identical execution results
- structured-content tools keep their output schema and `toModelOutput`
- a whole catalog hydrates with zero connections open, and connects only on first execution
- per-server errors are reported instead of caching a partial catalog
- definitions for servers no longer configured are skipped

Verified: 368 tests pass across the 17 `@mastra/mcp` suites, `tsc --noEmit` clean, lint clean, `build:lib` clean, docs `pnpm validate` clean.
