### PR TITLE
Remove the vulnerable image-size dependency from agent memory

### DIFF
--- a/.changeset/olive-jars-tan.md
+++ b/.changeset/olive-jars-tan.md
@@ -1,0 +1,9 @@
+---
+'@mastra/memory': patch
+---
+
+Remove the `image-size` dependency from `@mastra/memory` and measure image dimensions with the already-present `probe-image-size` instead.
+
+Every published version of `image-size` carries unfixed denial-of-service advisories (GHSA-w3rx-r6r6-pgpr / CVE-2025-71330 and GHSA-5p2g-fcmc-qvqq): a malformed image could hang its parse loop and exhaust the heap. The repository is archived, so no fixed release is coming, and the previous pin to `1.2.1` moved between two equally affected releases rather than remediating the flaw. Because image bytes reaching agent memory are untrusted, a crafted 32-byte image was enough to crash the process.
+
+Dimension detection still covers the formats models accept (PNG, JPEG, WebP, GIF, AVIF, BMP, ICO, PSD, SVG, TIFF). Unrecognized formats now report unknown dimensions, which token counting already handled.

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -52,7 +52,6 @@
     "@mastra/schema-compat": "workspace:*",
     "async-mutex": "^0.5.0",
     "diff": "^8.0.3",
-    "image-size": "1.2.1",
     "json-schema": "^0.4.0",
     "lru-cache": "^11.2.7",
     "probe-image-size": "^7.2.3",

--- a/packages/memory/src/probe-image-size.d.ts
+++ b/packages/memory/src/probe-image-size.d.ts
@@ -14,3 +14,18 @@ declare module 'probe-image-size' {
 
   export default probeImageSize;
 }
+
+declare module 'probe-image-size/sync' {
+  interface SyncProbeResult {
+    width: number;
+    height: number;
+    type: string;
+    mime: string;
+    wUnits: string;
+    hUnits: string;
+  }
+
+  function probeImageSizeSync(buffer: Uint8Array): SyncProbeResult | null;
+
+  export default probeImageSizeSync;
+}

--- a/packages/memory/src/processors/observational-memory/measure-image-buffer.test.ts
+++ b/packages/memory/src/processors/observational-memory/measure-image-buffer.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { measureImageBuffer } from './measure-image-buffer';
+
+const PNG_1X1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+const GIF_1X1 = Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64');
+
+/**
+ * 32-byte ICNS whose second entry declares a length of 0. The `image-size` parser this
+ * module replaced never advanced past it, looping forever while pushing to an array until
+ * the heap was exhausted (GHSA-w3rx-r6r6-pgpr / CVE-2025-71330).
+ */
+function craftedIcns(): Buffer {
+  const buffer = Buffer.alloc(32);
+  buffer.write('icns', 0, 'ascii');
+  buffer.writeUInt32BE(32, 4); // declared file length
+  buffer.write('ic09', 8, 'ascii');
+  buffer.writeUInt32BE(8, 12); // entry 1 length, advances the offset
+  buffer.write('ic09', 16, 'ascii');
+  buffer.writeUInt32BE(0, 20); // entry 2 length of 0, never advances the offset
+  return buffer;
+}
+
+describe('measureImageBuffer', () => {
+  it('reads dimensions from a PNG', () => {
+    expect(measureImageBuffer(PNG_1X1)).toEqual({ width: 1, height: 1 });
+  });
+
+  it('reads dimensions from a GIF', () => {
+    expect(measureImageBuffer(GIF_1X1)).toEqual({ width: 1, height: 1 });
+  });
+
+  it('returns undefined for a buffer that is not an image', () => {
+    expect(measureImageBuffer(Buffer.from([1, 2, 3, 4]))).toBeUndefined();
+  });
+
+  it('returns undefined for an empty buffer', () => {
+    expect(measureImageBuffer(Buffer.alloc(0))).toBeUndefined();
+  });
+
+  it('returns promptly on the malformed ICNS that hung the previous parser', () => {
+    const startedAt = Date.now();
+    expect(measureImageBuffer(craftedIcns())).toBeUndefined();
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/measure-image-buffer.ts
+++ b/packages/memory/src/processors/observational-memory/measure-image-buffer.ts
@@ -1,0 +1,48 @@
+/**
+ * Synchronous image dimension lookup for in-memory image buffers.
+ *
+ * Uses `probe-image-size`'s sync parsers rather than `image-size`, which has unfixed
+ * denial-of-service advisories (GHSA-w3rx-r6r6-pgpr / CVE-2025-71330 and
+ * GHSA-5p2g-fcmc-qvqq) affecting every published version, on an archived repository
+ * with no fixed release coming. A malformed 32-byte ICNS buffer was enough to hang the
+ * parse loop and exhaust the heap, and image bytes reaching agent memory are untrusted.
+ *
+ * `probe-image-size` covers the formats models actually accept (PNG, JPEG, WebP, GIF,
+ * AVIF, BMP, ICO, PSD, SVG, TIFF). Anything else returns `undefined`, which callers
+ * already handle as "dimensions unknown".
+ */
+
+// Imported for its value only; `probe-image-size` ships no types, and declaring it here
+// keeps the untyped import from breaking consumers that compile these source files
+// without this package's ambient declarations.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore TS7016/TS2307 -- probe-image-size ships no types
+import probeImageSizeSync from 'probe-image-size/sync';
+
+const probeBuffer = probeImageSizeSync as (buffer: Uint8Array) => { width?: number; height?: number } | null;
+
+/**
+ * Read the pixel dimensions of an image buffer.
+ *
+ * @returns The dimensions, or `undefined` if the buffer isn't a recognized image.
+ */
+export function measureImageBuffer(buffer: Uint8Array): { width: number; height: number } | undefined {
+  let probed: { width?: number; height?: number } | null;
+
+  try {
+    probed = probeBuffer(buffer);
+  } catch {
+    return undefined;
+  }
+
+  if (!probed) {
+    return undefined;
+  }
+
+  const { width, height } = probed;
+  if (typeof width !== 'number' || !Number.isFinite(width) || typeof height !== 'number' || !Number.isFinite(height)) {
+    return undefined;
+  }
+
+  return { width, height };
+}

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -2,9 +2,9 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash } from 'node:crypto';
 import type { MastraDBMessage } from '@mastra/core/agent';
 import type { MastraToolInvocation } from '@mastra/core/agent/message-list';
-import imageSize from 'image-size';
 import { estimateTokenCount } from 'tokenx';
 
+import { measureImageBuffer } from './measure-image-buffer';
 import { resolveToolResultValue, serializeToolResultForTokenCounting } from './tool-result-helpers';
 
 type TokenEstimateCacheEntry = {
@@ -562,25 +562,25 @@ function resolveImageDimensions(part: CacheablePart): { width?: number; height?:
     return { width, height };
   }
 
-  try {
-    const measured = imageSize(buffer);
-    const measuredWidth = getFiniteNumber(measured.width);
-    const measuredHeight = getFiniteNumber(measured.height);
-
-    if (!measuredWidth || !measuredHeight) {
-      return { width, height };
-    }
-
-    const resolved = {
-      width: width ?? measuredWidth,
-      height: height ?? measuredHeight,
-    };
-
-    persistImageDimensions(part, resolved as { width: number; height: number });
-    return resolved;
-  } catch {
+  const measured = measureImageBuffer(buffer);
+  if (!measured) {
     return { width, height };
   }
+
+  const measuredWidth = getFiniteNumber(measured.width);
+  const measuredHeight = getFiniteNumber(measured.height);
+
+  if (!measuredWidth || !measuredHeight) {
+    return { width, height };
+  }
+
+  const resolved = {
+    width: width ?? measuredWidth,
+    height: height ?? measuredHeight,
+  };
+
+  persistImageDimensions(part, resolved as { width: number; height: number });
+  return resolved;
 }
 
 function getBase64Size(base64: string): number {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,6 @@ overrides:
   better-auth: ^1.6.23
   js-yaml: ^5.2.2
   glob@<=10.5.0: 10.5.0
-  '@mastra/memory>image-size': 1.2.1
   body-parser@<=2.2.1: 2.3.0
   inngest: ^4.2.2
   fast-xml-parser@<5.5.7: ^5.10.1
@@ -5397,9 +5396,6 @@ importers:
       diff:
         specifier: ^8.0.3
         version: 8.0.4
-      image-size:
-        specifier: 1.2.1
-        version: 1.2.1
       json-schema:
         specifier: ^0.4.0
         version: 0.4.0
@@ -12344,6 +12340,7 @@ packages:
   '@copilotkit/aimock@1.29.0':
     resolution: {integrity: sha512-xNMHMUDX7zPSc56dm2ZXbttoLk6x72oEBHwWCAakVWNO85zZepLkB8Poc/x1cJrY69FI9frN0gavI/zVuZq/9A==}
     engines: {node: '>=20.15.0'}
+    hasBin: true
     peerDependencies:
       jest: '>=29'
       vitest: '>=3'
@@ -12899,6 +12896,7 @@ packages:
   '@docusaurus/core@3.10.1':
     resolution: {integrity: sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==}
     engines: {node: '>=20.0'}
+    hasBin: true
     peerDependencies:
       '@docusaurus/faster': '*'
       '@mdx-js/react': ^3.0.0
@@ -15244,6 +15242,7 @@ packages:
 
   '@livekit/agents@1.5.0':
     resolution: {integrity: sha512-vZ0Wx+mmUSh0wEkgnJM734SIx/crpu7ZYiu1Vrsd4I/wD/7U1n1HDc7gxNRGIAtmfRqAq13Vle7mZRP0HkVw3w==}
+    hasBin: true
     peerDependencies:
       '@livekit/rtc-node': ^0.13.30
       zod: ^3.25.76 || ^4.1.8
@@ -15328,6 +15327,7 @@ packages:
 
   '@livekit/throws-transformer@0.1.8':
     resolution: {integrity: sha512-AaSwQfIaG6YArKOCO+5/DgI8HfL19oHdrkyI0LJJVCqGeZXzPsZIO/Nm/SKUHbT1ERGhF5c34X8CcVWeOePpIQ==}
+    hasBin: true
     peerDependencies:
       typescript: ^6.0.3
 
@@ -15389,6 +15389,7 @@ packages:
   '@mastra/lint-docs@1.1.1':
     resolution: {integrity: sha512-47Y2OKf4aBOG7jekl5M5iKxLy1N4trHqV/t/i+Ib1//hZ6DwKWxFzvWVB56wKJ0ChmABKHowuTM3xQAXJvr45w==}
     engines: {node: '>=22.13.0'}
+    hasBin: true
     peerDependencies:
       oxfmt: ^0.59.0
       prettier: ^3.8.3
@@ -22267,6 +22268,7 @@ packages:
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
     engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
     peerDependencies:
       postcss: ^8.1.0
 
@@ -22574,6 +22576,7 @@ packages:
 
   braintrust@3.27.0:
     resolution: {integrity: sha512-xtWgk4o8OACq6qPhIQSIBeJErj9POUUDcpTWIIjbPNSgpBPMktNLb1cMbk06YsF3goNnOlKaMcOBgwNhy1OSxQ==}
+    hasBin: true
     peerDependencies:
       zod: ^3.25.34 || ^4.0
 
@@ -23231,6 +23234,7 @@ packages:
   convex@1.42.3:
     resolution: {integrity: sha512-7Tz/lH6UlZdiqzLPF/zrlH6Rlo/DOp836dL+GZkUMEQ2jaGGNnBIiIDcOOiEqtfSehuQ65r/rdNMnb4LupowaA==}
     engines: {node: '>=18.0.0', npm: '>=7.0.0'}
+    hasBin: true
     peerDependencies:
       '@auth0/auth0-react': ^2.0.1
       '@clerk/clerk-react': ^4.12.8 || ^5.0.0
@@ -23787,6 +23791,7 @@ packages:
 
   deepeval@0.1.32:
     resolution: {integrity: sha512-NO4tn3QaPIH1UM5+gefDzzS5pGG8sbmxJ42sqzEu7fZbVY4zR7m7nKufcpz/S/xm2TbcLKrgxg35PIEcYzmhbQ==}
+    hasBin: true
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.30.0'
       '@aws-sdk/client-bedrock-runtime': '>=3.0.0'
@@ -24508,6 +24513,7 @@ packages:
   eslint@10.7.0:
     resolution: {integrity: sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
     peerDependencies:
       jiti: '*'
     peerDependenciesMeta:
@@ -24845,6 +24851,7 @@ packages:
 
   files-sdk@1.9.0:
     resolution: {integrity: sha512-GbWQsE2xPmUcCCTmxCl3OaWxS5Brmu2AwVaAUlnpufFzxynTUrbeYYLY5rYJyUTUuSMcm+XPtVLiL2J3vTzEJQ==}
+    hasBin: true
     peerDependencies:
       '@anthropic-ai/claude-agent-sdk': ^0.3.0
       '@aws-sdk/client-s3': ^3.700.0
@@ -25756,10 +25763,6 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  image-size@1.2.1:
-    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
-    engines: {node: '>=16.x'}
-
   image-size@2.0.2:
     resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
     engines: {node: '>=16.x'}
@@ -26242,6 +26245,7 @@ packages:
   jscodeshift@17.3.0:
     resolution: {integrity: sha512-LjFrGOIORqXBU+jwfC9nbkjmQfFldtMIoS6d9z2LG/lkmyNXsJAySPT+2SWXJEoE68/bCWcxKpXH37npftgmow==}
     engines: {node: '>=16'}
+    hasBin: true
     peerDependencies:
       '@babel/preset-env': ^7.1.6
     peerDependenciesMeta:
@@ -26835,6 +26839,7 @@ packages:
   madge@8.0.0:
     resolution: {integrity: sha512-9sSsi3TBPhmkTCIpVQF0SPiChj1L7Rq9kU2KDG1o6v2XH9cCw086MopjVCD+vuoL5v8S77DTbVopTO8OUiQpIw==}
     engines: {node: '>=18'}
+    hasBin: true
     peerDependencies:
       typescript: ^6.0.3
     peerDependenciesMeta:
@@ -27444,6 +27449,7 @@ packages:
   msw@2.14.6:
     resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
     engines: {node: '>=18'}
+    hasBin: true
     peerDependencies:
       typescript: ^6.0.3
     peerDependenciesMeta:
@@ -27737,6 +27743,7 @@ packages:
   nunjucks@3.2.4:
     resolution: {integrity: sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==}
     engines: {node: '>= 6.9.0'}
+    hasBin: true
     peerDependencies:
       chokidar: ^3.3.0
     peerDependenciesMeta:
@@ -27863,6 +27870,7 @@ packages:
 
   openai@4.104.0:
     resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+    hasBin: true
     peerDependencies:
       ws: 8.21.0
       zod: ^3.23.8
@@ -27877,6 +27885,7 @@ packages:
 
   openai@5.23.2:
     resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
+    hasBin: true
     peerDependencies:
       ws: 8.21.0
       zod: ^3.23.8
@@ -27979,6 +27988,7 @@ packages:
   oxfmt@0.59.0:
     resolution: {integrity: sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
     peerDependencies:
       svelte: ^5.0.0
       vite-plus: '*'
@@ -27991,6 +28001,7 @@ packages:
   oxlint@1.75.0:
     resolution: {integrity: sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
     peerDependencies:
       oxlint-tsgolint: '>=7.0.2001'
       vite-plus: '*'
@@ -29153,9 +29164,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  queue@6.0.2:
-    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
-
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
@@ -29252,6 +29260,7 @@ packages:
 
   react-grab@0.1.37:
     resolution: {integrity: sha512-XVAc/qPyxsDT8Putu9UnP7iVHmAORMzvaN/3GDTOfbuLIRXWdOt7vebPOzM9RVTVUjucXv0135JI++kSVPSfYg==}
+    hasBin: true
     peerDependencies:
       react: '>=17.0.0'
     peerDependenciesMeta:
@@ -30395,6 +30404,7 @@ packages:
 
   storybook@10.4.2:
     resolution: {integrity: sha512-5Ax5vbHxFgMBGGhQDm75Rrumm/HZC4ICFhMcJaM0UlqnC/4FKj/IaZtImZFupknyiiyUEcWHPQFA2kX3/VSv1A==}
+    hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       prettier: ^2 || ^3
@@ -30409,6 +30419,7 @@ packages:
 
   storybook@9.1.20:
     resolution: {integrity: sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==}
+    hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
     peerDependenciesMeta:
@@ -30989,6 +31000,7 @@ packages:
 
   tsc-files@1.1.4:
     resolution: {integrity: sha512-RePsRsOLru3BPpnf237y1Xe1oCGta8rmSYzM76kYo5tLGsv5R2r3s64yapYorGTPuuLyfS9NVbh9ydzmvNie2w==}
+    hasBin: true
     peerDependencies:
       typescript: ^6.0.3
 
@@ -30999,6 +31011,7 @@ packages:
   tsdown@0.22.9:
     resolution: {integrity: sha512-/0QEjQEhOU1t1YxOIAGzFN7bIssd8P0pBpkOmNLCQi3c5UtrcMF5bvq3f30xHJNW9QCA9aUNcNAorMr2CTd6Lg==}
     engines: {node: ^22.18.0 || >=24.11.0}
+    hasBin: true
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
       '@tsdown/css': 0.22.9
@@ -31347,6 +31360,7 @@ packages:
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
 
@@ -31546,6 +31560,7 @@ packages:
   vite@6.4.3:
     resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
     peerDependencies:
       '@types/node': 22.19.15
       jiti: '>=1.21.0'
@@ -31585,6 +31600,7 @@ packages:
   vite@7.3.6:
     resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
     peerDependencies:
       '@types/node': 22.19.15
       jiti: '>=1.21.0'
@@ -31624,6 +31640,7 @@ packages:
   vitest@4.1.10:
     resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
@@ -31664,6 +31681,7 @@ packages:
   vitest@4.1.8:
     resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
@@ -31853,6 +31871,7 @@ packages:
   webpack-dev-server@5.2.6:
     resolution: {integrity: sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==}
     engines: {node: '>= 18.12.0'}
+    hasBin: true
     peerDependencies:
       webpack: ^5.0.0
       webpack-cli: '*'
@@ -31880,6 +31899,7 @@ packages:
   webpack@5.108.4:
     resolution: {integrity: sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
     peerDependencies:
       webpack-cli: '*'
     peerDependenciesMeta:
@@ -31996,6 +32016,7 @@ packages:
   wrangler@4.110.0:
     resolution: {integrity: sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg==}
     engines: {node: '>=22.0.0'}
+    hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^5.20260708.1
     peerDependenciesMeta:
@@ -51318,10 +51339,6 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  image-size@1.2.1:
-    dependencies:
-      queue: 6.0.2
-
   image-size@2.0.2: {}
 
   immediate@3.0.6: {}
@@ -55366,10 +55383,6 @@ snapshots:
   query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
-
-  queue@6.0.2:
-    dependencies:
-      inherits: 2.0.4
 
   quick-format-unescaped@4.0.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -186,13 +186,6 @@ overrides:
   better-auth: ^1.6.23
   js-yaml: ^5.2.2
   glob@<=10.5.0: 10.5.0
-  # image-size 2.x (incl. 2.0.2 latest) has unpatched DoS infinite-loop flaws
-  # (CVE-2025-71330 / GHSA-w3rx-r6r6-pgpr). No fixed 2.x exists, so pin to the
-  # maintained legacy 1.2.1 release, which predates the vulnerable code paths
-  # and is API-compatible (default imageSize(buffer) usage). See issue #17975.
-  # Scoped to @mastra/memory only — a global override breaks the docs build,
-  # which relies on the `image-size/fromFile` subpath export added in 2.x.
-  '@mastra/memory>image-size': 1.2.1
   body-parser@<=2.2.1: 2.3.0
   inngest: ^4.2.2
   fast-xml-parser@<5.5.7: ^5.10.1


### PR DESCRIPTION
Fixes #21112

## What this changes

`@mastra/memory` measures image dimensions when counting tokens for messages that contain images. It did that with the `image-size` package, which is no longer safe to depend on.

Every published version of `image-size` has denial-of-service flaws (GHSA-w3rx-r6r6-pgpr / CVE-2025-71330 and GHSA-5p2g-fcmc-qvqq) where a malformed image makes the parser loop forever while allocating memory, until the process runs out of heap and dies. The project's repository has been archived, so there will never be a fixed release. An earlier attempt to address this pinned the version to `1.2.1`, but that release is affected too — the pin swapped one vulnerable version for another.

This matters because the images being measured come from whatever a user or tool feeds the agent. A 32-byte file crafted by an attacker is enough to kill the agent process.

This PR removes `image-size` entirely and measures dimensions with `probe-image-size`, which was already a dependency of this package for remote images, is actively maintained, and is not affected.

## Behavior

Dimension detection still works for the image formats models accept: PNG, JPEG, WebP, GIF, AVIF, BMP, ICO, PSD, SVG, and TIFF. A few exotic formats the old parser recognized (ICNS, JXL, HEIF) now report unknown dimensions — a case token counting already handled, and the same formats whose parsers were the source of the vulnerability.

The now-obsolete `image-size` version pin was removed from the workspace config.

## Test plan

- New unit tests cover PNG and GIF measurement, non-image and empty buffers, and a regression test using the crafted ICNS file that hung the old parser.
- Reproduced the crash first: the crafted file exhausts a 256 MB heap against `image-size@1.2.1` in under a second. The replacement returns "not an image" immediately.
- `packages/memory` unit tests pass (1313 tests), plus typecheck, lint, and build.
- Verified the built CJS and ESM bundles load and reference only `probe-image-size`.
