### PR TITLE
docs(auth-okta): fix the bearer-token section for Okta org authorization servers

### DIFF
--- a/auth/okta/src/bearer-token.test.ts
+++ b/auth/okta/src/bearer-token.test.ts
@@ -1,0 +1,166 @@
+/**
+ * End-to-end bearer-token verification against a real JWKS endpoint.
+ *
+ * Unlike index.test.ts, this file does NOT mock `jose`. Tokens are really
+ * signed and really verified, so the assertions describe what an Okta
+ * deployment actually observes.
+ */
+
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { exportJWK, generateKeyPair, SignJWT, type JWK } from 'jose';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { MastraAuthOkta } from './auth-provider';
+
+const CLIENT_ID = 'test-client-id';
+const COOKIE_PASSWORD = 'test-cookie-password-must-be-32-chars-long';
+
+let server: Server;
+let orgUrl: string;
+let privateKey: Awaited<ReturnType<typeof generateKeyPair>>['privateKey'];
+let jwksRequests = 0;
+
+/**
+ * Stand-in for an Okta org authorization server: issuer is the org root and
+ * the JWKS lives under `/oauth2/v1/keys`.
+ */
+beforeAll(async () => {
+  const keyPair = await generateKeyPair('RS256', { extractable: true });
+  privateKey = keyPair.privateKey;
+  const publicJwk: JWK = { ...(await exportJWK(keyPair.publicKey)), kid: 'test-key', alg: 'RS256', use: 'sig' };
+
+  server = createServer((req, res) => {
+    if (req.url === '/oauth2/v1/keys' || req.url === '/oauth2/default/v1/keys') {
+      jwksRequests++;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ keys: [publicJwk] }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  orgUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+});
+
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  jwksRequests = 0;
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
+/** The error text the provider logs when verification fails. */
+function loggedVerificationError(): string {
+  const call = consoleError.mock.calls.at(-1);
+  return call ? String((call[1] as Error)?.message ?? call[1]) : '';
+}
+
+async function signToken(claims: { iss: string; aud: string; sub?: string }) {
+  return new SignJWT({ email: 'user@example.com', name: 'Test User', groups: ['Engineering'] })
+    .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+    .setIssuer(claims.iss)
+    .setAudience(claims.aud)
+    .setSubject(claims.sub ?? '00u1234567890')
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(privateKey);
+}
+
+function createProvider(issuer: string) {
+  return new MastraAuthOkta({
+    domain: '127.0.0.1',
+    clientId: CLIENT_ID,
+    clientSecret: 'test-client-secret',
+    issuer,
+    redirectUri: 'http://localhost:4111/api/auth/callback',
+    session: { cookiePassword: COOKIE_PASSWORD },
+  });
+}
+
+describe('bearer token on an Okta org authorization server', () => {
+  test('rejects an access token, whose audience is the org URL', async () => {
+    const auth = createProvider(orgUrl);
+
+    // An org authorization server mints access tokens with `aud` set to the
+    // org URL, not the client ID. There is no way to change that, so the
+    // bearer path can never accept one.
+    const accessToken = await signToken({ iss: orgUrl, aud: orgUrl });
+
+    const user = await auth.authenticateToken(accessToken, new Request('http://localhost:4111/api/agents'));
+
+    // The JWKS was fetched and the signature checked, so the audience is the
+    // only reason this token is rejected.
+    expect(jwksRequests).toBeGreaterThan(0);
+    expect(user).toBeNull();
+  });
+
+  test('accepts an ID token, whose audience is the client ID', async () => {
+    const auth = createProvider(orgUrl);
+    const idToken = await signToken({ iss: orgUrl, aud: CLIENT_ID });
+
+    const user = await auth.authenticateToken(idToken, new Request('http://localhost:4111/api/agents'));
+
+    expect(user).not.toBeNull();
+    expect(user?.oktaId).toBe('00u1234567890');
+    expect(user?.email).toBe('user@example.com');
+  });
+});
+
+describe('bearer token on a custom authorization server', () => {
+  test('rejects an access token that still uses the default `api://default` audience', async () => {
+    const issuer = `${orgUrl}/oauth2/default`;
+    const auth = createProvider(issuer);
+
+    const accessToken = await signToken({ iss: issuer, aud: 'api://default' });
+
+    const user = await auth.authenticateToken(accessToken, new Request('http://localhost:4111/api/agents'));
+
+    expect(user).toBeNull();
+  });
+
+  test('accepts an access token whose audience is reconfigured to the client ID', async () => {
+    const issuer = `${orgUrl}/oauth2/default`;
+    const auth = createProvider(issuer);
+    const accessToken = await signToken({ iss: issuer, aud: CLIENT_ID });
+
+    const user = await auth.authenticateToken(accessToken, new Request('http://localhost:4111/api/agents'));
+
+    expect(user).not.toBeNull();
+    expect(user?.oktaId).toBe('00u1234567890');
+  });
+});
+
+describe('failure signature', () => {
+  // The string asserted here is the one documented under Troubleshooting on
+  // the Okta auth docs page. Keep the two in sync.
+  test('an audience mismatch logs `unexpected "aud" claim value`', async () => {
+    const auth = createProvider(orgUrl);
+    const accessToken = await signToken({ iss: orgUrl, aud: orgUrl });
+
+    await auth.authenticateToken(accessToken, new Request('http://localhost:4111/api/agents'));
+
+    expect(loggedVerificationError()).toContain('unexpected "aud" claim value');
+  });
+
+  test('an issuer mismatch logs `unexpected "iss" claim value`', async () => {
+    // Default issuer, pointed at an org authorization server that stamps the
+    // org root into `iss`.
+    const auth = createProvider(`${orgUrl}/oauth2/default`);
+    const idToken = await signToken({ iss: orgUrl, aud: CLIENT_ID });
+
+    await auth.authenticateToken(idToken, new Request('http://localhost:4111/api/agents'));
+
+    expect(loggedVerificationError()).toContain('unexpected "iss" claim value');
+  });
+});

--- a/docs/src/content/en/docs/server/auth/okta.mdx
+++ b/docs/src/content/en/docs/server/auth/okta.mdx
@@ -175,16 +175,34 @@ export const mastraClient = new MastraClient({
 
 ### Bearer token
 
-You can also pass an Okta access token as a Bearer token. The token is verified against Okta's JWKS endpoint:
+When a request has no valid session cookie, `MastraAuthOkta` falls back to the `Authorization` header. It verifies the token against Okta's JWKS endpoint and requires two claims to match:
+
+- `aud` equals your client ID (`OKTA_CLIENT_ID`).
+- `iss` equals your issuer (`OKTA_ISSUER`, or `https://{domain}/oauth2/default` when unset).
+
+Okta puts the client ID in the `aud` claim of ID tokens, so an ID token passes this check. Access tokens carry a different audience:
+
+| Authorization server | Access token `aud` | Works as a Bearer token |
+| - | - | - |
+| Org (`https://{domain}`) | The org URL | No |
+| Custom (`https://{domain}/oauth2/{name}`) | `api://default`, unless changed | Only after you set the audience to your client ID |
+
+:::warning
+
+The org authorization server is the default when you haven't created a custom one, and it can't mint an access token whose audience is your client ID. Send an ID token instead, or create a custom authorization server and set its audience to `OKTA_CLIENT_ID`.
+
+:::
+
+The following example passes a token that satisfies both claims:
 
 ```typescript title="lib/mastra-client.ts"
 import { MastraClient } from '@mastra/client-js'
 
-export const createMastraClient = (accessToken: string) => {
+export const createMastraClient = (token: string) => {
   return new MastraClient({
     baseUrl: 'http://localhost:4111',
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${token}`,
     },
   })
 }
@@ -209,7 +227,7 @@ Visit [Mastra Client SDK](/docs/server/mastra-client) for more configuration opt
     ```bash
     curl -X POST http://localhost:4111/api/agents/weatherAgent/generate \
       -H "Content-Type: application/json" \
-      -H "Authorization: Bearer <your-okta-access-token>" \
+      -H "Authorization: Bearer <your-okta-id-token>" \
       -d '{
         "messages": "Weather in London"
       }'
@@ -220,6 +238,8 @@ Visit [Mastra Client SDK](/docs/server/mastra-client) for more configuration opt
 ## Troubleshooting
 
 - **401 on every request**: Verify your Okta domain, client ID, and client secret are correct. Check that the redirect URI in your Okta application matches `OKTA_REDIRECT_URI`.
+- **401 with `unexpected "aud" claim value` in the server logs**: The Bearer token's `aud` claim doesn't match `OKTA_CLIENT_ID`. Access tokens from the org authorization server always fail this check. Send an ID token, or use a custom authorization server whose audience is set to your client ID.
+- **401 with `unexpected "iss" claim value` in the server logs**: The token's issuer doesn't match `OKTA_ISSUER`. The default issuer is `https://{domain}/oauth2/default`, so set `OKTA_ISSUER` to `https://{domain}` when you use the org authorization server.
 - **Cookies not sent cross-origin**: Set `credentials: "include"` in `MastraClient` and configure `server.cors` with your frontend origin and `credentials: true`.
 - **Session lost on restart**: Set `OKTA_COOKIE_PASSWORD` to a stable value (at least 32 characters). Without it, an auto-generated key is used that changes on each restart.
 - **RBAC returns empty permissions**: Verify `OKTA_API_TOKEN` is set and the token has permission to list user groups. Check that group names in `roleMapping` match your Okta group names exactly.

--- a/docs/src/content/en/reference/auth/okta.mdx
+++ b/docs/src/content/en/reference/auth/okta.mdx
@@ -195,7 +195,13 @@ The following environment variables are automatically used when constructor opti
 `MastraAuthOkta` authenticates requests in the following order:
 
 1. **Session cookie**: Reads the encrypted session cookie and decrypts it. If the session is valid and not expired, the user is authenticated.
-1. **JWT fallback**: If no session cookie is present, verifies the `Authorization` header token against Okta's JWKS endpoint.
+1. **JWT fallback**: If no session cookie is present, verifies the `Authorization` header token against Okta's JWKS endpoint. The token's `iss` claim must equal `issuer` and its `aud` claim must equal `clientId`.
+
+:::note
+
+Okta sets `aud` to the client ID on ID tokens, not access tokens. Visit [Okta](/docs/server/auth/okta#bearer-token) for which token to send.
+
+:::
 
 After authentication, `authorizeUser` checks that the user has a valid `oktaId`. Provide a custom `authorizeUser` function to implement additional logic.
 


### PR DESCRIPTION
Fixes #21110.

The Okta auth docs told you to pass an Okta access token as a bearer token, but the provider pins the JWT audience to the client ID, which is the ID-token shape. On the org authorization server that combination can never match, so anyone following the docs got an unexplained 401 with only a `JWTClaimValidationFailed` in the server logs. On a custom authorization server it works, but only once you've set that server's audience to the client ID, which the docs never mentioned.

So the docs now say what the code actually checks, with a table of what each authorization server mints and a warning about the org server. The cURL example asks for an ID token instead of an access token:

```
-H "Authorization: Bearer <your-okta-id-token>"
```

I also added the `unexpected "aud" claim value` and `unexpected "iss" claim value` signatures to troubleshooting, since a 401 is otherwise indistinguishable from a bad token, and noted the claim requirements on the reference page.

The existing tests mock `jose` wholesale, so nothing ever exercised real verification and this was invisible to them. `bearer-token.test.ts` signs real RS256 tokens and verifies them against a local JWKS server, covering both authorization server types with both token kinds. It asserts the JWKS actually got fetched, so the audience is provably the only reason a token is rejected, and it pins the two error strings the docs now quote. Written first as the docs' claim, it failed on both access-token cases.

Docs and tests only, no runtime change, so no changeset. The configurable audience that would let the docs describe the access-token flow properly is #21111.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR corrects the Okta documentation so users send tokens that the provider can validate. It also adds tests to confirm which token types and claims work.

## Changes

- Explain that bearer authentication requires:
  - `aud` to match `OKTA_CLIENT_ID`.
  - `iss` to match the configured issuer.
- Clarify token behavior:
  - Org authorization server access tokens fail the audience check.
  - Custom authorization server access tokens work only when their audience is the client ID.
  - ID tokens include the client ID audience and are used in the cURL example.
- Add `aud` and `iss` validation errors to troubleshooting guidance.
- Add claim requirements to the Okta reference documentation.
- Add integration-style tests with real RS256 tokens and a local JWKS server.
- Test org and custom authorization servers, valid and invalid claims, JWKS retrieval, user mapping, and verification errors.
- Make no runtime changes and add no changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->