### PR TITLE
Document that the Okta bearer-token audience is configurable

### DIFF
--- a/docs/src/content/en/docs/server/auth/okta.mdx
+++ b/docs/src/content/en/docs/server/auth/okta.mdx
@@ -175,12 +175,30 @@ export const mastraClient = new MastraClient({
 
 ### Bearer token
 
-You can also pass an Okta token as a Bearer token. The token is verified against Okta's JWKS endpoint, and its `aud` claim must equal `OKTA_CLIENT_ID`.
+You can also pass an Okta token as a Bearer token. The token is verified against Okta's JWKS endpoint, and its `aud` claim must match the configured audience. The audience defaults to your client ID, and you can override it with the `audience` option or `OKTA_AUDIENCE`.
 
-Okta puts the client ID in the `aud` claim of **ID tokens**. **Access tokens** carry the audience of the authorization server that issued them, so they're only accepted when that audience is the client ID:
+Okta puts the client ID in the `aud` claim of **ID tokens**, so ID tokens work with the default. **Access tokens** carry the audience of the authorization server that issued them, so set the audience to match:
 
-- **Org authorization server** (the default, issuer `https://{domain}`): access tokens use `https://{domain}` as the audience, so they're rejected. Send an ID token instead.
-- **Custom authorization server** (issuer `https://{domain}/oauth2/{name}`): access tokens are accepted if you set the server's audience to your client ID in the Okta Admin Console.
+- **Org authorization server** (the default, issuer `https://{domain}`): set the audience to `https://{domain}`.
+- **Custom authorization server** (issuer `https://{domain}/oauth2/{name}`): set the audience to the server's audience value from the Okta Admin Console, for example `api://default`.
+
+```env title=".env"
+OKTA_AUDIENCE=https://dev-123456.okta.com
+```
+
+Pass an array to accept more than one audience, for example ID tokens from browsers and access tokens from service callers against the same provider:
+
+```typescript title="src/mastra/index.ts"
+new MastraAuthOkta({
+  audience: ['your-client-id', 'https://dev-123456.okta.com'],
+})
+```
+
+:::note
+
+`audience` applies only to Bearer tokens. The ID token exchanged during the SSO login flow is always verified against your client ID.
+
+:::
 
 ```typescript title="lib/mastra-client.ts"
 import { MastraClient } from '@mastra/client-js'
@@ -225,7 +243,7 @@ Visit [Mastra Client SDK](/docs/server/mastra-client) for more configuration opt
 ## Troubleshooting
 
 - **401 on every request**: Verify your Okta domain, client ID, and client secret are correct. Check that the redirect URI in your Okta application matches `OKTA_REDIRECT_URI`.
-- **401 with `unexpected "aud" claim value` in the server logs**: The Bearer token's audience isn't your client ID. This usually means you sent an access token from an org authorization server. Send an ID token, or use a custom authorization server whose audience is set to your client ID. See [Bearer token](#bearer-token).
+- **401 with `unexpected "aud" claim value` in the server logs**: The Bearer token's audience doesn't match the configured audience. This usually means you sent an access token while the audience is still the default client ID. Set `OKTA_AUDIENCE` to the audience of the authorization server that issued the token. See [Bearer token](#bearer-token).
 - **Cookies not sent cross-origin**: Set `credentials: "include"` in `MastraClient` and configure `server.cors` with your frontend origin and `credentials: true`.
 - **Session lost on restart**: Set `OKTA_COOKIE_PASSWORD` to a stable value (at least 32 characters). Without it, an auto-generated key is used that changes on each restart.
 - **RBAC returns empty permissions**: Verify `OKTA_API_TOKEN` is set and the token has permission to list user groups. Check that group names in `roleMapping` match your Okta group names exactly.

--- a/docs/src/content/en/reference/auth/okta.mdx
+++ b/docs/src/content/en/reference/auth/okta.mdx
@@ -77,6 +77,14 @@ You can omit the constructor parameters if the required environment variables ar
     defaultValue: 'process.env.OKTA_REDIRECT_URI',
   },
   {
+    name: 'audience',
+    type: 'string | string[]',
+    description:
+      "Expected `aud` claim for Bearer tokens. Defaults to the client ID, which matches Okta ID tokens. Set it to the authorization server's audience to accept access tokens, or pass an array to accept several. Does not affect the ID token verified during the SSO login flow, which always uses the client ID.",
+    isOptional: true,
+    defaultValue: 'process.env.OKTA_AUDIENCE ?? clientId',
+  },
+  {
     name: 'scopes',
     type: 'string[]',
     description: 'OAuth scopes to request during the login flow.',
@@ -171,6 +179,12 @@ The following environment variables are automatically used when constructor opti
     isOptional: true,
   },
   {
+    name: 'OKTA_AUDIENCE',
+    type: 'string',
+    description: 'Expected `aud` claim for Bearer tokens. Defaults to the client ID if not set.',
+    isOptional: true,
+  },
+  {
     name: 'OKTA_REDIRECT_URI',
     type: 'string',
     description: 'OAuth redirect URI for the SSO callback.',
@@ -195,7 +209,7 @@ The following environment variables are automatically used when constructor opti
 `MastraAuthOkta` authenticates requests in the following order:
 
 1. **Session cookie**: Reads the encrypted session cookie and decrypts it. If the session is valid and not expired, the user is authenticated.
-1. **JWT fallback**: If no session cookie is present, verifies the `Authorization` header token against Okta's JWKS endpoint.
+1. **JWT fallback**: If no session cookie is present, verifies the `Authorization` header token against Okta's JWKS endpoint. The token's `iss` claim is checked against `issuer` and its `aud` claim against `audience`.
 
 After authentication, `authorizeUser` checks that the user has a valid `oktaId`. Provide a custom `authorizeUser` function to implement additional logic.
 


### PR DESCRIPTION
## What this is

`@mastra/auth-okta` verifies incoming Bearer tokens against an expected `aud` claim. That expected value used to be hardcoded to your Okta client ID; it is now a configurable `audience` option that falls back to `OKTA_AUDIENCE` and then to the client ID.

The documentation never caught up. Two PRs landed the same day in an unlucky order: one rewrote the Bearer token section to explain the client-ID-only restriction, and the next removed the restriction. The result was docs that actively told readers a supported path did not exist.

This matters most for machine-to-machine callers (MCP clients, CI jobs, service-to-service requests). They authenticate with access tokens, whose `aud` is the authorization server rather than the client ID. The docs said those tokens are rejected and to send an ID token instead, which is not something a non-browser caller can easily do. Setting `OKTA_AUDIENCE` makes them work.

## What changed

Documentation only, no source changes.

Guide (`docs/server/auth/okta.mdx`):
- The Bearer token section now explains that the audience defaults to the client ID and is overridable, with the value to set for org and custom authorization servers.
- Added an example of passing an array to accept ID tokens from browsers and access tokens from services on one provider.
- The troubleshooting entry for `unexpected "aud" claim value` now points at `OKTA_AUDIENCE` instead of telling the reader to switch token types.
- Added a note that the override applies to Bearer tokens only.

Reference (`reference/auth/okta.mdx`):
- Added `audience` to the constructor parameters table and `OKTA_AUDIENCE` to the environment variables table. Both were missing entirely.
- The JWT fallback step now states that `iss` is checked against `issuer` and `aud` against `audience`.

## Test plan

- Verified each claim against the source: the audience resolution chain, the Bearer path verification, and that the SSO ID token exchange is still pinned to the client ID.
- `pnpm validate` passes (frontmatter, sidebar links, sort order).
- `pnpm lint:prose` reports no Vale or remark findings in either file; remaining output is pre-existing in unrelated docs.

Closes #21122