### PR TITLE
Fix durable agents losing the caller's request context after the first iteration

### DIFF
--- a/.changeset/wild-owls-listen.md
+++ b/.changeset/wild-owls-listen.md
@@ -1,0 +1,10 @@
+---
+'@mastra/core': patch
+'@mastra/inngest': patch
+---
+
+Fix durable agents losing the caller's request context after the first iteration.
+
+`prepareForDurableExecution` snapshots the caller's `RequestContext` onto the workflow input as `requestContextEntries`, and steps that rebuild the model and tools from the Mastra instance restore the context from that snapshot. The snapshot was dropped when iteration state was rebuilt and was never forwarded to the LLM step, so from the second iteration on, dynamic `model`, `tools`, `memory` and `workspace` resolvers ran against an empty context and silently fell back to defaults. This affected every path that cannot use the in-process run registry: Inngest workers, recovered runs, and evicted registry entries.
+
+The snapshot is now declared on the iteration state and LLM step input schemas, carried forward by `createBaseIterationStateUpdate`, and forwarded by the `map-to-llm-input` step in both the core and Inngest durable agentic workflows.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-request-context-iterations.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-request-context-iterations.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression coverage for #20673.
+ *
+ * `prepareForDurableExecution` snapshots the caller's RequestContext onto the
+ * workflow input as `requestContextEntries`. Any step that cannot use the
+ * in-process run registry — an Inngest worker, a recovered run, an evicted
+ * registry entry — rebuilds the model and tools from the Mastra instance and
+ * restores the caller's context from that snapshot
+ * (`resolveRuntimeDependencies` -> `restoreRequestContext`).
+ *
+ * The snapshot only reached iteration 1. `createBaseIterationStateUpdate`
+ * dropped the field when it rebuilt iteration state, and `map-to-llm-input`
+ * never forwarded it to the LLM step, so from iteration 2 on the LLM step
+ * input carried no snapshot. On a cross-isolate engine there is no run-level
+ * context to fall back to either — @mastra/inngest derives the run-level
+ * context from `inputData.requestContextEntries` — so dynamic `model`,
+ * `tools`, `memory` and `workspace` resolvers silently fell back to defaults
+ * with no error raised.
+ */
+
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { Mastra } from '../../../mastra';
+import { RequestContext } from '../../../request-context';
+import { InMemoryStore } from '../../../storage/mock';
+import { createTool } from '../../../tools';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../create-durable-agent';
+import * as resolveRuntime from '../utils/resolve-runtime';
+import { createBaseIterationStateUpdate } from '../workflows/shared/iteration-state';
+
+/**
+ * Calls a tool on the first turn and finishes on the second, so the agentic
+ * loop runs more than one iteration.
+ */
+function createTwoIterationModel() {
+  let turn = 0;
+
+  return new MockLanguageModelV2({
+    doStream: async () => {
+      turn += 1;
+
+      if (turn === 1) {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'echoTool',
+              input: JSON.stringify({ data: 'hello' }),
+            },
+            { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      }
+
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Done' },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      };
+    },
+  });
+}
+
+describe('durable agent requestContextEntries across iterations', () => {
+  describe('createBaseIterationStateUpdate', () => {
+    function buildUpdate(requestContextEntries?: Record<string, unknown>) {
+      return createBaseIterationStateUpdate({
+        currentState: {
+          runId: 'run-1',
+          agentId: 'agent-1',
+          agentName: 'Agent',
+          requestContextEntries,
+          iterationCount: 1,
+          accumulatedSteps: [],
+          accumulatedUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        } as any,
+        executionOutput: {
+          output: { usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          stepResult: { reason: 'stop' },
+          messageListState: {},
+          state: {},
+        } as any,
+      });
+    }
+
+    it('carries the request context snapshot into the next iteration state', () => {
+      // Without this the snapshot is gone from iteration 2 onwards and every
+      // downstream step that reads `getInitData().requestContextEntries`
+      // (tool-call, goal, is-task-complete, finalize-run) sees undefined.
+      expect(buildUpdate({ tenantId: 'tenant-1' }).requestContextEntries).toEqual({ tenantId: 'tenant-1' });
+    });
+
+    it('leaves the snapshot undefined when the run had no request context', () => {
+      expect(buildUpdate().requestContextEntries).toBeUndefined();
+    });
+  });
+
+  describe('LLM step input', () => {
+    let pubsub: EventEmitterPubSub;
+
+    beforeEach(() => {
+      pubsub = new EventEmitterPubSub();
+    });
+
+    afterEach(async () => {
+      vi.restoreAllMocks();
+      await pubsub.close();
+    });
+
+    it('carries the request context snapshot on every iteration', async () => {
+      // `resolveRuntimeDependencies` is the seam every durable step goes
+      // through to rebuild the model/tools when the registry cannot serve
+      // them, and `options.input` is verbatim the step input. Recording what
+      // it receives shows exactly what a cross-isolate worker would have to
+      // work with.
+      const snapshotsSeenBySteps: (Record<string, unknown> | undefined)[] = [];
+      const actual = resolveRuntime.resolveRuntimeDependencies;
+      vi.spyOn(resolveRuntime, 'resolveRuntimeDependencies').mockImplementation(async options => {
+        snapshotsSeenBySteps.push(options.input?.requestContextEntries);
+        return actual(options);
+      });
+
+      const echoTool = createTool({
+        id: 'echoTool',
+        description: 'Echoes its input',
+        inputSchema: z.object({ data: z.string() }),
+        execute: async input => ({ data: input.data }),
+      });
+
+      const baseAgent = new Agent({
+        id: 'request-context-iterations-agent',
+        name: 'Request Context Iterations Agent',
+        instructions: 'Use the tool, then answer.',
+        model: createTwoIterationModel() as LanguageModelV2,
+        tools: { echoTool },
+      });
+
+      const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+      new Mastra({
+        agents: { 'request-context-iterations-agent': durableAgent as any },
+        storage: new InMemoryStore(),
+        logger: false,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('tenantId', 'tenant-1');
+
+      const { cleanup } = await durableAgent.stream('Use the tool', { requestContext });
+      await new Promise(resolve => setTimeout(resolve, 800));
+      cleanup();
+
+      // Two model turns means the loop ran at least twice; every one of those
+      // step inputs must carry the caller's snapshot, not just the first.
+      expect(snapshotsSeenBySteps.length).toBeGreaterThanOrEqual(2);
+      expect(snapshotsSeenBySteps).not.toContain(undefined);
+      for (const snapshot of snapshotsSeenBySteps) {
+        expect(snapshot).toMatchObject({ tenantId: 'tenant-1' });
+      }
+    });
+  });
+});

--- a/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
+++ b/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
@@ -184,6 +184,7 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
           options: state.options,
           state: state.state,
           messageId: state.messageId,
+          requestContextEntries: state.requestContextEntries,
           stepIndex: state.iterationCount,
           agentSpanData: state.agentSpanData,
           modelSpanData: state.modelSpanData,

--- a/packages/core/src/agent/durable/workflows/shared/iteration-state.ts
+++ b/packages/core/src/agent/durable/workflows/shared/iteration-state.ts
@@ -90,6 +90,9 @@ export function createBaseIterationStateUpdate(input: IterationStateUpdateInput)
     options: currentState.options,
     state: executionOutput.state,
     messageId: executionOutput.messageId,
+    // Carried, not recomputed: the request context is fixed for the run, and
+    // the steps that rebuild from Mastra have no other source for it.
+    requestContextEntries: currentState.requestContextEntries,
     iterationCount: currentState.iterationCount + 1,
     accumulatedSteps: [...currentState.accumulatedSteps, stepRecord],
     accumulatedUsage: newUsage,

--- a/packages/core/src/agent/durable/workflows/shared/schemas.ts
+++ b/packages/core/src/agent/durable/workflows/shared/schemas.ts
@@ -91,6 +91,11 @@ export const baseIterationStateSchema = z.object({
   options: z.any(),
   state: z.any(),
   messageId: z.string(),
+  // JSON-safe snapshot of the caller's requestContext.entries(), carried
+  // across every iteration so steps that rebuild runtime state from the Mastra
+  // instance resolve with the same request context on iteration N as on
+  // iteration 1. Dropping it here silently falls back to an empty context.
+  requestContextEntries: z.record(z.string(), z.any()).optional(),
   // Iteration tracking
   iterationCount: z.number(),
   accumulatedSteps: z.array(z.any()),

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -86,6 +86,10 @@ const durableLLMInputSchema = z.object({
   options: z.any(),
   state: z.any(),
   messageId: z.string(),
+  // JSON-safe request context snapshot, forwarded from iteration state so the
+  // rebuild-from-Mastra path resolves the model and tools with the caller's
+  // context rather than an empty one.
+  requestContextEntries: z.record(z.string(), z.any()).optional(),
   // Agent span data for model span parenting
   agentSpanData: z.any().optional(),
   // Model span data (ONE span for entire agent run, created before workflow)

--- a/workflows/inngest/src/durable-agent/create-inngest-agentic-workflow.ts
+++ b/workflows/inngest/src/durable-agent/create-inngest-agentic-workflow.ts
@@ -44,6 +44,10 @@ const durableAgenticInputSchema = z.object({
   options: z.any(),
   state: z.any(),
   messageId: z.string(),
+  // JSON-safe snapshot of the caller's request context. Inngest runs durable
+  // steps on a separate worker process, so this snapshot is the only way the
+  // rebuild path can recover request-scoped configuration.
+  requestContextEntries: z.record(z.string(), z.any()).optional(),
   // Observability fields (Inngest-specific)
   agentSpanData: z.any().optional(),
   modelSpanData: z.any().optional(),
@@ -151,6 +155,9 @@ export function createInngestDurableAgenticWorkflow(options: InngestDurableAgent
           options: state.options,
           state: state.state,
           messageId: state.messageId,
+          // Pass the request context snapshot so dynamic model/tool resolvers
+          // see the caller's context on every iteration, not just the first.
+          requestContextEntries: state.requestContextEntries,
           // Pass agent span data so model spans can use it as parent
           agentSpanData: state.agentSpanData,
           // Pass model span data (ONE span for entire agent run)


### PR DESCRIPTION
Fixes #20673.

## What this is about

When you call a durable agent, Mastra takes a JSON-safe snapshot of the caller's `RequestContext` — things like `tenantId` or `userId` — and stores it on the workflow input as `requestContextEntries`.

That snapshot exists because durable agents don't necessarily run in the process that started them. An Inngest worker, a recovered run, or a run whose in-memory registry entry was evicted all have to rebuild the agent's model, tools, memory and processors from the Mastra instance. When they do, they replay the caller's context from that snapshot so a dynamic `model: ({ requestContext }) => ...` resolver picks the same model it would have picked at the original call site.

## The bug

The snapshot only survived the first iteration of the agentic loop.

Two places dropped it:

- `createBaseIterationStateUpdate` rebuilds the iteration state after each iteration from an explicit field list, and `requestContextEntries` wasn't in that list.
- The `map-to-llm-input` step, which maps iteration state onto the LLM step's input, never forwarded it either.

So from the second iteration onward, the rebuild path saw no snapshot. Nothing threw — dynamic `model`, `tools`, `memory` and `workspace` resolvers just received an empty context and returned their defaults. In a multi-tenant deployment that means the run silently continues under the wrong per-request configuration, which is the failure mode reported in the issue.

## The fix

- Declare `requestContextEntries` on `baseIterationStateSchema` and on the core + Inngest LLM step input schemas, so the field is part of the contract rather than an incidental passenger of an object spread.
- Carry it forward in `createBaseIterationStateUpdate`, which both the core and Inngest workflows share.
- Forward it from `map-to-llm-input` in both the core and Inngest durable agentic workflows.

## Test plan

New `packages/core/src/agent/durable/__tests__/durable-agent-request-context-iterations.test.ts`:

- Unit coverage that `createBaseIterationStateUpdate` carries the snapshot into the next iteration state, and leaves it undefined when the run had no request context.
- An integration test that runs a real durable agent through a tool call and a second model turn, spying on `resolveRuntimeDependencies` — the seam every step goes through to rebuild from Mastra — and asserting the step input carries the caller's snapshot on *every* iteration.

Both tests were confirmed to fail against the unpatched code (the integration test reports `[undefined, undefined]`, i.e. the LLM step never received the snapshot at all) and to pass with the fix.

- `packages/core`: 707 durable agent tests pass, no type errors.
- `@mastra/inngest`: builds clean, lint clean, 20 unit tests pass.

## Note on #21092

This supersedes #21092, which identified the same root cause. This version additionally declares the field on the step input schemas so it can't be stripped by input validation, and adds coverage that exercises the real workflow rather than only the state-update helper.