### PR TITLE
fix(core): close each workflow stream through its own close action

### DIFF
--- a/.changeset/hip-papers-wash.md
+++ b/.changeset/hip-papers-wash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a hang when two streams were started for the same workflow run at once. Resuming or time-traveling a suspended run twice concurrently (a double-clicked approval, a client retry, or two open tabs) left one of the two streams open forever, so the matching resume-stream or time-travel-stream HTTP request never ended. Each stream now closes itself independently.

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1330,3 +1330,124 @@ describe('createRun storage existence read (issue #19015)', () => {
     expect(readSpy).toHaveBeenCalled();
   });
 });
+
+describe('concurrent stream close', () => {
+  // An abandoned stream can only be observed by bounding the read — a plain drain
+  // would hang the suite rather than fail it.
+  async function drainWithin(stream: ReadableStream<any>, boundMs = 2000) {
+    const reader = stream.getReader();
+    const types: string[] = [];
+    try {
+      for (;;) {
+        const res = await Promise.race([
+          reader.read(),
+          new Promise<'timed-out'>(resolve => setTimeout(() => resolve('timed-out'), boundMs)),
+        ]);
+        if (res === 'timed-out') return { closed: false, types };
+        if (res.done) return { closed: true, types };
+        if (res.value?.type) types.push(res.value.type);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  it('closes both outputs when two resumeStream calls race for the same run', async () => {
+    const suspending = createStep({
+      id: 'suspending-step',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+      execute: async ({ suspend }) => {
+        await suspend({ waiting: true });
+        return { result: 'resumed' };
+      },
+    });
+    const final = createStep({
+      id: 'final-step',
+      inputSchema: z.object({ result: z.string() }),
+      outputSchema: z.object({ result: z.string() }),
+      execute: async () => ({ result: 'done' }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'concurrent-resume-close-wf',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+      steps: [suspending, final],
+    })
+      .then(suspending)
+      .then(final)
+      .commit();
+
+    new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: { 'concurrent-resume-close-wf': workflow },
+    });
+
+    const run = await workflow.createRun({ runId: 'concurrent-resume-close-run' });
+    await run.start({ inputData: {} });
+
+    // Two concurrent resumes of the same cached run: each must close its own stream.
+    const first = run.resumeStream({ step: 'suspending-step', resumeData: {} });
+    const second = run.resumeStream({ step: 'suspending-step', resumeData: {} });
+
+    const [firstDrain, secondDrain] = await Promise.all([
+      drainWithin(first.fullStream),
+      drainWithin(second.fullStream),
+    ]);
+
+    expect(firstDrain.closed).toBe(true);
+    expect(secondDrain.closed).toBe(true);
+    expect(firstDrain.types).toContain('workflow-finish');
+    expect(secondDrain.types).toContain('workflow-finish');
+  });
+
+  it('closes both outputs when two timeTravelStream calls race for the same run', async () => {
+    const first = createStep({
+      id: 'first-step',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+      execute: async () => ({ result: 'first' }),
+    });
+    const second = createStep({
+      id: 'second-step',
+      inputSchema: z.object({ result: z.string() }),
+      outputSchema: z.object({ result: z.string() }),
+      execute: async () => ({ result: 'second' }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'concurrent-time-travel-close-wf',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+      steps: [first, second],
+    })
+      .then(first)
+      .then(second)
+      .commit();
+
+    new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: { 'concurrent-time-travel-close-wf': workflow },
+    });
+
+    const run = await workflow.createRun({ runId: 'concurrent-time-travel-close-run' });
+    await run.start({ inputData: {} });
+
+    // Two concurrent time travels of the same cached run: each must close its own stream.
+    const firstTravel = run.timeTravelStream({ step: 'second-step', inputData: { result: 'first' } });
+    const secondTravel = run.timeTravelStream({ step: 'second-step', inputData: { result: 'first' } });
+
+    const [firstDrain, secondDrain] = await Promise.all([
+      drainWithin(firstTravel.fullStream),
+      drainWithin(secondTravel.fullStream),
+    ]);
+
+    expect(firstDrain.closed).toBe(true);
+    expect(secondDrain.closed).toBe(true);
+    expect(firstDrain.types).toContain('workflow-finish');
+    expect(secondDrain.types).toContain('workflow-finish');
+  });
+});

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -3676,7 +3676,7 @@ export class Run<
       } catch {}
     });
 
-    this.closeStreamAction = async () => {
+    const closeStreamAction = async () => {
       await this.pubsub.publish(`workflow.events.v2.${this.runId}`, {
         type: 'watch',
         runId: this.runId,
@@ -3694,6 +3694,7 @@ export class Run<
         writer.releaseLock();
       }
     };
+    this.closeStreamAction = closeStreamAction;
 
     void this.pubsub.publish(`workflow.events.v2.${this.runId}`, {
       type: 'watch',
@@ -3710,7 +3711,7 @@ export class Run<
       tracingOptions,
     } as any).then(result => {
       if (result.status !== 'suspended') {
-        this.closeStreamAction?.().catch(() => {});
+        closeStreamAction().catch(() => {});
       }
 
       return result;
@@ -3850,7 +3851,11 @@ export class Run<
           }
         });
 
-        self.closeStreamAction = async () => {
+        // Captured per invocation: `closeStreamAction` is a field on the run, and
+        // `createRun({ runId })` returns the cached run, so concurrent calls would
+        // otherwise each close the most recently created stream and strand the rest.
+        // The field is still assigned for external consumers (observeStreamLegacy).
+        const closeStreamAction = async () => {
           unwatch();
 
           try {
@@ -3862,6 +3867,7 @@ export class Run<
             self.mastra?.getLogger()?.error('Error closing stream:', err);
           }
         };
+        self.closeStreamAction = closeStreamAction;
 
         const executionResultsPromise = self._start({
           inputData,
@@ -3893,13 +3899,13 @@ export class Run<
           if (closeOnSuspend) {
             // always close stream, even if the workflow is suspended
             // this will trigger a finish event with workflow status set to suspended
-            self.closeStreamAction?.().catch(() => {});
+            closeStreamAction().catch(() => {});
           } else if (executionResults.status !== 'suspended') {
-            self.closeStreamAction?.().catch(() => {});
+            closeStreamAction().catch(() => {});
           }
         } catch (err) {
           self.streamOutput?.rejectResults(err as unknown as Error);
-          self.closeStreamAction?.().catch(() => {});
+          closeStreamAction().catch(() => {});
         }
       },
     });
@@ -3980,7 +3986,10 @@ export class Run<
           }
         });
 
-        self.closeStreamAction = async () => {
+        // Captured per invocation — see the note in the stream() path. Two concurrent
+        // resumes of one suspended run are reachable in normal use (double-clicked
+        // approval, client retry, two tabs) and each returned stream must terminate.
+        const closeStreamAction = async () => {
           unwatch();
 
           try {
@@ -3992,6 +4001,8 @@ export class Run<
             self.mastra?.getLogger()?.error('Error closing stream:', err);
           }
         };
+        self.closeStreamAction = closeStreamAction;
+
         const executionResultsPromise = self._resume({
           resumeData,
           step,
@@ -4017,10 +4028,10 @@ export class Run<
             self.streamOutput.updateResults(executionResults);
           }
 
-          self.closeStreamAction?.().catch(() => {});
+          closeStreamAction().catch(() => {});
         } catch (err) {
           self.streamOutput?.rejectResults(err as unknown as Error);
-          self.closeStreamAction?.().catch(() => {});
+          closeStreamAction().catch(() => {});
         }
       },
     });
@@ -4771,7 +4782,8 @@ export class Run<
           } as WorkflowStreamEvent);
         });
 
-        self.closeStreamAction = async () => {
+        // Captured per invocation — see the note in the stream() path.
+        const closeStreamAction = async () => {
           unwatch();
 
           try {
@@ -4783,6 +4795,8 @@ export class Run<
             self.mastra?.getLogger()?.error('Error closing stream:', err);
           }
         };
+        self.closeStreamAction = closeStreamAction;
+
         const executionResultsPromise = self._timeTravel({
           inputData,
           step,
@@ -4810,10 +4824,10 @@ export class Run<
             self.streamOutput.updateResults(executionResults);
           }
 
-          self.closeStreamAction?.().catch(() => {});
+          closeStreamAction().catch(() => {});
         } catch (err) {
           self.streamOutput?.rejectResults(err as unknown as Error);
-          self.closeStreamAction?.().catch(() => {});
+          closeStreamAction().catch(() => {});
         }
       },
     });


### PR DESCRIPTION
Fixes #20429.

## What was broken

Starting two streams for the same workflow run at the same time left one of them open forever. The run itself completed normally, but one caller never received `workflow-finish` and never saw end-of-stream.

Over HTTP this meant a `POST /workflows/:workflowId/resume-stream` (or `/time-travel-stream`) response that never ended — the request hung until the client or the proxy timed out. It is reachable by ordinary means: a double-clicked approval button, a client retry, or two browser tabs resuming the same suspended run.

## Why

`closeStreamAction` is a field on the `Run` instance. Each of `stream()`, `resumeStream()` and `timeTravelStream()` assigned to it from inside its own `ReadableStream.start(controller)` — capturing that call's `controller` and `unwatch` — and the completion paths then closed through the *field* rather than through the action they had just created.

Since `createRun({ runId })` returns the run cached under that runId, two concurrent calls share the field. The second assignment replaces the first's action, so when the run finishes, both completion paths close the **second** controller. The first output is stranded and its `unwatch` never runs.

`stream()` doesn't reproduce the concurrent shape today — its memoization guard returns the existing output instead of building a second one — but it is the same aliasing, so it gets the same treatment rather than relying on that guard to stay in place.

## The fix

Each invocation captures its close action in a local `const` and closes through that. The instance field is still assigned, so `observeStreamLegacy()` keeps seeing the most recent stream's close action. That makes this behavior-neutral for everything except the stream that used to be left open.

## Test

`concurrent stream close > closes both outputs when two resumeStream calls race for the same run`, in `packages/core/src/workflows/workflow.test.ts`.

A stranded stream can only be detected by bounding the read — a plain drain would hang the suite instead of failing it — so the test races each read against a 2s bound and asserts both outputs close **and** both observe `workflow-finish`.

Red/green verified by reverting the `workflow.ts` change: without it the test fails on `firstDrain.closed` (`expected false to be true`) after burning the full 2s bound; with it, both streams close and the test finishes in 11ms.

## Verification

- `src/workflows/` — 45 files, 1158 passed, 9 skipped, no type errors
- `src/stream/` — 15 files, 237 passed
- `pnpm --filter ./packages/core check` — clean

## Deliberately out of scope

The same aliasing applies to `streamOutput` and `executionResults`: the first caller's `updateResults` lands on the second call's output, so its result promise never settles. Closing the streams correctly stops the hang, but deciding what two concurrent resumes of a single run *should* return is a semantics question worth answering on its own. Tracking that as a follow-up.

## Credit

The bug report in #20429 included a core-only reproduction and a correct root-cause analysis pointing at the shared field, which is what made this quick to land. Thanks to @machester4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When two workflow streams run at the same time, each stream now closes itself correctly. This prevents requests from hanging without a final response.

## Changes

- Captured a separate close action for each `stream()`, `resumeStream()`, and `timeTravelStream()` call.
- Preserved the instance close action for `observeStreamLegacy()`.
- Added regression tests for concurrent `resumeStream()` and `timeTravelStream()` calls.
- Added a patch changeset for `@mastra/core`.

## Verification

- `src/workflows/`: 1,159 passed, 9 skipped
- `src/stream/`: 238 passed
- Core type checking passed

Aliasing between `streamOutput` and `executionResults` remains out of scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->