### PR TITLE
fix(core): preserve client-tool call args in stored messages

### DIFF
--- a/.changeset/recover-empty-tool-call-args.md
+++ b/.changeset/recover-empty-tool-call-args.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Preserve client-tool call arguments in stored messages. When a tool result was persisted without its originating tool call, its arguments were saved as an empty object; on later turns the model saw an argument-less call in its own history and began emitting empty-argument tool calls. `MessageList` now backfills the arguments from the originating call as messages are added, so the stored conversation stays correct for every reader rather than only being repaired while building the prompt.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -42,7 +42,7 @@ import type {
   SerializedMessageListState,
 } from './state';
 import type { AIV5Type, AIV5ResponseMessage, AIV6Type, MessageInput, MessageListInput } from './types';
-import { ensureGeminiCompatibleMessages } from './utils/provider-compat';
+import { ensureGeminiCompatibleMessages, findToolCallArgs } from './utils/provider-compat';
 import { stampPart } from './utils/stamp-part';
 
 function isSignalDataMessage<T extends { role: string; parts: Array<{ type: string }> }>(message: T): boolean {
@@ -1796,12 +1796,33 @@ export class MessageList {
 
     for (const storedMessage of this.messages) {
       this.updateLastCreatedAt(storedMessage);
+      this.recoverEmptyToolCallArgs(storedMessage);
     }
 
     // make sure messages are always stored in order of when they were created!
     this.messages.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
     return this;
+  }
+
+  // Backfill a tool-result's args from its originating call; an empty `{}` left
+  // here is replayed to the model as an argument-less call and imitated.
+  private recoverEmptyToolCallArgs(message: MastraDBMessage): void {
+    if (message.role !== 'assistant') return;
+
+    const fill = (invocation: { toolCallId: string; args?: unknown }) => {
+      const args = invocation.args;
+      if (args && typeof args === 'object' && Object.keys(args).length > 0) return;
+      const recovered = findToolCallArgs(this.messages, invocation.toolCallId);
+      if (Object.keys(recovered).length > 0) invocation.args = recovered;
+    };
+
+    for (const part of message.content.parts ?? []) {
+      if (part.type === 'tool-invocation') fill(part.toolInvocation);
+    }
+    for (const invocation of message.content.toolInvocations ?? []) {
+      fill(invocation);
+    }
   }
 
   private pushMessageToSource(messageV2: MastraDBMessage, messageSource: MessageSource) {

--- a/packages/core/src/agent/message-list/tests/recover-empty-tool-call-args.test.ts
+++ b/packages/core/src/agent/message-list/tests/recover-empty-tool-call-args.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { MessageList } from '../index';
+import type { MastraDBMessage } from '../types';
+
+/**
+ * A client tool-result persisted without its originating tool-call is stored with
+ * `args: {}`. Left empty in storage, that `{}` is replayed to the model as an
+ * argument-less tool call and imitated on later turns (regression of #16017).
+ *
+ * findToolCallArgs already recovers the args when building the prompt, but the
+ * stored message itself stays empty. MessageList should backfill the args from
+ * the originating call at store time so the persisted message is correct for
+ * every reader, not just the prompt path.
+ */
+describe('MessageList - backfill empty tool-call args at store time', () => {
+  const argsFor = (stored: MastraDBMessage[], toolCallId: string): Array<unknown> => {
+    const out: Array<unknown> = [];
+    for (const message of stored) {
+      for (const part of message.content.parts ?? []) {
+        if (part.type === 'tool-invocation' && part.toolInvocation.toolCallId === toolCallId) {
+          out.push(part.toolInvocation.args);
+        }
+      }
+      for (const invocation of message.content.toolInvocations ?? []) {
+        if (invocation.toolCallId === toolCallId) out.push(invocation.args);
+      }
+    }
+    return out;
+  };
+
+  it('stores the original args on a tool-result that arrived without its call', () => {
+    const messageList = new MessageList();
+
+    messageList.add({ role: 'user', content: 'Get the weather for San Francisco' }, 'input');
+    messageList.add(
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool-call', toolCallId: 'call-1', toolName: 'getWeather', args: { city: 'San Francisco' } },
+        ],
+      },
+      'response',
+    );
+    // Client tool result comes back without its args (the split-message case).
+    messageList.add(
+      {
+        role: 'tool',
+        content: [{ type: 'tool-result', toolCallId: 'call-1', toolName: 'getWeather', result: { temperature: 18 } }],
+      },
+      'response',
+    );
+
+    // The stored message — not just the prompt output — must carry the args.
+    const stored = messageList.get.all.db();
+    const seen = argsFor(stored, 'call-1');
+
+    expect(seen.length).toBeGreaterThan(0);
+    for (const args of seen) {
+      expect(args).toEqual({ city: 'San Francisco' });
+    }
+  });
+
+  it('leaves a genuinely argument-less call untouched (nothing to recover)', () => {
+    const messageList = new MessageList();
+
+    messageList.add({ role: 'user', content: 'List every connection' }, 'input');
+    messageList.add(
+      {
+        role: 'assistant',
+        content: [{ type: 'tool-call', toolCallId: 'call-2', toolName: 'getConnections', args: {} }],
+      },
+      'response',
+    );
+    messageList.add(
+      {
+        role: 'tool',
+        content: [{ type: 'tool-result', toolCallId: 'call-2', toolName: 'getConnections', result: { count: 3 } }],
+      },
+      'response',
+    );
+
+    const stored = messageList.get.all.db();
+    for (const args of argsFor(stored, 'call-2')) {
+      expect(args).toEqual({});
+    }
+  });
+});


### PR DESCRIPTION
Fixes #21131

## What's happening

When a client tool's result is persisted without its originating tool-call in the same message, the stored tool-invocation keeps `args: {}`. `findToolCallArgs` already recovers the args while building the prompt, but the stored message itself stays empty. On later turns the model sees an argument-less call in its own history and starts imitating it — emitting empty-argument tool calls (#16017).

## What changed

`MessageList` backfills empty tool-call args from the originating call as messages are added (`recoverEmptyToolCallArgs`), reusing the existing `findToolCallArgs` helper. The stored conversation is then correct for every reader, not only the prompt path. Genuinely argument-less calls are left untouched (nothing to recover).

## Tests

`recover-empty-tool-call-args.test.ts` covers both cases: the stored message carries the original args after a split call/result, and a genuinely empty call is left as-is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a tool result is saved separately from its original request, this change restores the missing request details. It keeps truly empty tool calls empty.

## Changes

- Added tool-call argument recovery during `MessageList` deserialization.
- Updated current message parts and legacy `toolInvocations` entries when matching arguments exist.
- Added regression tests for split tool call/result persistence.
- Added coverage for genuinely argument-less tool calls.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->