### PR TITLE
fix(mastracode): show one "Thinking..." label per run of hidden reasoning

### DIFF
--- a/.changeset/single-thinking-label.md
+++ b/.changeset/single-thinking-label.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed duplicate `Thinking...` lines in the chat transcript. When a model emitted more than one reasoning span in a single step, each span rendered its own label; consecutive hidden reasoning parts now collapse into a single `Thinking...` line.

--- a/mastracode/tui/e2e/tui/hidden-reasoning-single-label.ts
+++ b/mastracode/tui/e2e/tui/hidden-reasoning-single-label.ts
@@ -1,0 +1,217 @@
+import stripAnsi from 'strip-ansi';
+import { createGlobalPatchScope } from './global-patches.js';
+import type { McE2eInProcessApp, McE2eScenario } from './types.js';
+
+const PROMPT = 'Summarize the plan with visible effort.';
+const REPLY_TEXT = 'Two reasoning spans produced this reply.';
+const REASONING_ONE = 'First reasoning span: weighing the options.';
+const REASONING_TWO = 'Second reasoning span: settling on the answer.';
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function requestBodyText(body: BodyInit | null | undefined): string {
+  if (typeof body === 'string') return body;
+  if (body instanceof Uint8Array) return new TextDecoder().decode(body);
+  return '';
+}
+
+type SseEvent = { type: string } & Record<string, unknown>;
+
+function sse(events: SseEvent[]): Response {
+  const body = events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join('');
+  return new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+}
+
+function reasoningItemEvents(id: string, outputIndex: number, text: string): SseEvent[] {
+  return [
+    {
+      type: 'response.output_item.added',
+      output_index: outputIndex,
+      item: { type: 'reasoning', id, summary: [] },
+    },
+    {
+      type: 'response.reasoning_summary_part.added',
+      item_id: id,
+      output_index: outputIndex,
+      summary_index: 0,
+      part: { type: 'summary_text', text: '' },
+    },
+    {
+      type: 'response.reasoning_summary_text.delta',
+      item_id: id,
+      output_index: outputIndex,
+      summary_index: 0,
+      delta: text,
+    },
+    {
+      type: 'response.reasoning_summary_text.done',
+      item_id: id,
+      output_index: outputIndex,
+      summary_index: 0,
+      text,
+    },
+    {
+      type: 'response.reasoning_summary_part.done',
+      item_id: id,
+      output_index: outputIndex,
+      summary_index: 0,
+      part: { type: 'summary_text', text },
+    },
+    {
+      type: 'response.output_item.done',
+      output_index: outputIndex,
+      item: { type: 'reasoning', id, summary: [{ type: 'summary_text', text }] },
+    },
+  ];
+}
+
+function multiSpanReasoningResponse(): Response {
+  const respId = 'resp-hidden-reasoning-single-label';
+  const created = Math.floor(Date.now() / 1000);
+  const model = 'gpt-5.4-mini';
+  const msgId = 'msg-hidden-reasoning-single-label';
+
+  const responseShell = (status: string, output: unknown[]) => ({
+    id: respId,
+    object: 'response',
+    created_at: created,
+    model,
+    status,
+    output,
+  });
+
+  const reasoningItemOne = {
+    type: 'reasoning',
+    id: 'rs-span-one',
+    summary: [{ type: 'summary_text', text: REASONING_ONE }],
+  };
+  const reasoningItemTwo = {
+    type: 'reasoning',
+    id: 'rs-span-two',
+    summary: [{ type: 'summary_text', text: REASONING_TWO }],
+  };
+  const msgItem = {
+    type: 'message',
+    id: msgId,
+    status: 'completed',
+    role: 'assistant',
+    content: [{ type: 'output_text', text: REPLY_TEXT, annotations: [] }],
+  };
+
+  const events: SseEvent[] = [
+    { type: 'response.created', response: responseShell('in_progress', []) },
+    { type: 'response.in_progress', response: responseShell('in_progress', []) },
+    ...reasoningItemEvents('rs-span-one', 0, REASONING_ONE),
+    ...reasoningItemEvents('rs-span-two', 1, REASONING_TWO),
+    {
+      type: 'response.output_item.added',
+      output_index: 2,
+      item: { type: 'message', id: msgId, status: 'in_progress', role: 'assistant', content: [] },
+    },
+    {
+      type: 'response.content_part.added',
+      item_id: msgId,
+      output_index: 2,
+      content_index: 0,
+      part: { type: 'output_text', text: '', annotations: [] },
+    },
+    {
+      type: 'response.output_text.delta',
+      item_id: msgId,
+      output_index: 2,
+      content_index: 0,
+      delta: REPLY_TEXT,
+    },
+    {
+      type: 'response.output_text.done',
+      item_id: msgId,
+      output_index: 2,
+      content_index: 0,
+      text: REPLY_TEXT,
+    },
+    {
+      type: 'response.content_part.done',
+      item_id: msgId,
+      output_index: 2,
+      content_index: 0,
+      part: { type: 'output_text', text: REPLY_TEXT, annotations: [] },
+    },
+    { type: 'response.output_item.done', output_index: 2, item: msgItem },
+    {
+      type: 'response.completed',
+      response: {
+        ...responseShell('completed', [reasoningItemOne, reasoningItemTwo, msgItem]),
+        usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+      },
+    },
+  ];
+
+  return sse(events);
+}
+
+export const hiddenReasoningSingleLabelScenario = {
+  name: 'hidden-reasoning-single-label',
+  description:
+    'Render exactly one hidden Thinking... label for a response with two consecutive reasoning items, not one per span.',
+  testName: 'collapses consecutive hidden reasoning spans into a single Thinking label',
+  useOpenAIModel: true,
+  async inProcessApp({ startMastraCodeApp }): Promise<McE2eInProcessApp> {
+    const patches = createGlobalPatchScope();
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    let servedPrimary = false;
+    patches.setProperty(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestUrl(input);
+      const isPrimary = !servedPrimary && url.includes('/responses') && requestBodyText(init?.body).includes(PROMPT);
+      if (!isPrimary) return originalFetch(input, init);
+      servedPrimary = true;
+      // Tee the request through to AIMock so the harness's fidelity check
+      // (terminal-backend-vitest-shared.ts requestCount === 0 guard) records it,
+      // but serve the hand-built multi-span reasoning stream: AIMock fixtures
+      // cannot emit more than one reasoning item per response.
+      await originalFetch(input, init)
+        .then(response => response.body?.cancel())
+        .catch(() => undefined);
+      return multiSpanReasoningResponse();
+    });
+
+    try {
+      const app = await startMastraCodeApp({
+        config: { disableHooks: true, disableMcp: true, unixSocketPubSub: false },
+      });
+      return { stop: () => patches.stopApp(app.stop) };
+    } catch (error) {
+      patches.restore();
+      throw error;
+    }
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/Resource ID:/i, terminal);
+
+    terminal.submit(PROMPT);
+    await runtime.waitForScreenText(new RegExp(REPLY_TEXT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), terminal, 15_000);
+
+    // Counts labels in the visible viewport; the transcript here is short
+    // enough that the label cannot scroll above the fold. Sample twice so a
+    // late re-render adding a duplicate label is still caught.
+    const countLabels = () => {
+      const view = stripAnsi(terminal.serialize().view);
+      return { view, count: (view.match(/Thinking\.\.\./g) ?? []).length };
+    };
+    const first = countLabels();
+    await new Promise(resolve => setTimeout(resolve, 500));
+    const second = countLabels();
+    for (const sample of [first, second]) {
+      if (sample.count !== 1) {
+        throw new Error(
+          `Expected exactly one Thinking... label for two consecutive reasoning spans, saw ${sample.count}:\n${sample.view}`,
+        );
+      }
+    }
+    terminal.keyCtrlC();
+  },
+} satisfies McE2eScenario;

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -49,6 +49,7 @@ import { goalDurationToolApprovalScenario } from './goal-duration-tool-approval.
 import { goalJudgeOmModelIsolationScenario } from './goal-judge-om-model-isolation.js';
 import { goalJudgeSingleRenderScenario } from './goal-judge-single-render.js';
 import { headlessMcpToolAvailabilityScenario } from './headless-mcp-tool-availability.js';
+import { hiddenReasoningSingleLabelScenario } from './hidden-reasoning-single-label.js';
 import { integrationCommandsScenario } from './integration-commands.js';
 import { lifecycleHooksConfiguredScenario } from './lifecycle-hooks-configured.js';
 import { lifecycleHooksEventsScenario } from './lifecycle-hooks-events.js';
@@ -222,6 +223,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'goal-judge-single-render': goalJudgeSingleRenderScenario,
   'controller-api-config': controllerApiConfigScenario,
   'headless-mcp-tool-availability': headlessMcpToolAvailabilityScenario,
+  'hidden-reasoning-single-label': hiddenReasoningSingleLabelScenario,
   'visible-commands': visibleCommandsScenario,
   'integration-commands': integrationCommandsScenario,
   'lifecycle-hooks-configured': lifecycleHooksConfiguredScenario,

--- a/mastracode/tui/src/tui/components/__tests__/assistant-message.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/assistant-message.test.ts
@@ -1,3 +1,4 @@
+import { Spacer } from '@earendil-works/pi-tui';
 import type { MastraDBMessage } from '@mastra/core/agent-controller';
 import { describe, expect, it } from 'vitest';
 import { AssistantMessageComponent } from '../assistant-message.js';
@@ -19,6 +20,16 @@ function collectText(component: AssistantMessageComponent): string {
   };
   walk(component);
   return lines.join('\n');
+}
+
+function countSpacers(component: AssistantMessageComponent): number {
+  let count = 0;
+  const walk = (node: unknown): void => {
+    if (node instanceof Spacer) count++;
+    for (const child of (node as { children?: unknown[] }).children ?? []) walk(child);
+  };
+  walk(component);
+  return count;
 }
 
 function assistantMessage(
@@ -49,6 +60,65 @@ describe('AssistantMessageComponent (DB-native)', () => {
       false,
     );
     expect(collectText(component)).toContain('let me think');
+  });
+
+  it('renders a single Thinking label for consecutive reasoning parts when thinking is hidden', () => {
+    const component = new AssistantMessageComponent(
+      assistantMessage([
+        { type: 'reasoning', reasoning: 'first span' } as never,
+        { type: 'reasoning', reasoning: 'second span' } as never,
+      ]),
+      true,
+    );
+    const labels = collectText(component)
+      .split('\n')
+      .filter(line => line.includes('Thinking...'));
+    expect(labels).toHaveLength(1);
+  });
+
+  it('renders separate Thinking labels when text interrupts hidden reasoning runs', () => {
+    const component = new AssistantMessageComponent(
+      assistantMessage([
+        { type: 'reasoning', reasoning: 'before' } as never,
+        { type: 'text', text: 'visible answer' },
+        { type: 'reasoning', reasoning: 'after' } as never,
+      ]),
+      true,
+    );
+    const rendered = collectText(component)
+      .split('\n')
+      .filter(line => line.includes('Thinking...') || line.includes('visible answer'));
+    expect(rendered.map(line => (line.includes('Thinking...') ? 'thinking' : 'text'))).toEqual([
+      'thinking',
+      'text',
+      'thinking',
+    ]);
+  });
+
+  it('adds one spacer after a collapsed hidden thinking run, not one per part', () => {
+    const component = new AssistantMessageComponent(
+      assistantMessage([
+        { type: 'reasoning', reasoning: 'first span' } as never,
+        { type: 'reasoning', reasoning: 'second span' } as never,
+        { type: 'text', text: 'visible answer' },
+      ]),
+      true,
+    );
+    expect(countSpacers(component)).toBe(1);
+  });
+
+  it('renders every reasoning span as its own block when thinking is visible', () => {
+    const component = new AssistantMessageComponent(
+      assistantMessage([
+        { type: 'reasoning', reasoning: 'first span' } as never,
+        { type: 'reasoning', reasoning: 'second span' } as never,
+      ]),
+      false,
+    );
+    const text = collectText(component);
+    expect(text).toContain('first span');
+    expect(text).toContain('second span');
+    expect(text).not.toContain('Thinking...');
   });
 
   it('reads abort status from content.metadata.stopReason', () => {

--- a/mastracode/tui/src/tui/components/assistant-message.ts
+++ b/mastracode/tui/src/tui/components/assistant-message.ts
@@ -89,10 +89,18 @@ export class AssistantMessageComponent extends Container {
         part.kind === 'text' || part.kind === 'thinking',
     );
 
+    // Tracks whether a "Thinking..." label was already emitted for the current
+    // run of consecutive thinking parts (models can emit several reasoning
+    // spans back to back; hidden mode should show one label per run, not one
+    // per span). A run never spans a tool call: callers slice an assistant
+    // message at tool boundaries and render each slice with its own component.
+    let inHiddenThinkingRun = false;
+
     for (let i = 0; i < renderParts.length; i++) {
       const part = renderParts[i]!;
 
       if (part.kind === 'text' && part.text.trim()) {
+        inHiddenThinkingRun = false;
         // Assistant text messages - trim and sanitize escape codes
         this.contentContainer.addChild(
           new Markdown(sanitizeAnsiForRendering(part.text.trim()), CHAT_INDENT, 0, this.markdownTheme, {
@@ -100,15 +108,20 @@ export class AssistantMessageComponent extends Container {
           }),
         );
       } else if (part.kind === 'thinking' && part.text.trim()) {
-        // Check if there's text content after this thinking block
-        const hasTextAfter = renderParts.slice(i + 1).some(p => p.kind === 'text' && p.text.trim());
-
         if (this.hideThinkingBlock) {
-          // Show static "Thinking..." label when hidden
-          this.contentContainer.addChild(
-            new Text(theme.italic(theme.fg('thinkingText', 'Thinking...')), CHAT_INDENT, 0),
-          );
-          if (hasTextAfter) {
+          // The next part that actually renders something; used to keep the
+          // spacer attached to the end of a run rather than to every part in it.
+          const nextRenderedPart = renderParts.slice(i + 1).find(p => p.text.trim());
+
+          // Show a single static "Thinking..." label per run of consecutive
+          // thinking parts when hidden
+          if (!inHiddenThinkingRun) {
+            this.contentContainer.addChild(
+              new Text(theme.italic(theme.fg('thinkingText', 'Thinking...')), CHAT_INDENT, 0),
+            );
+            inHiddenThinkingRun = true;
+          }
+          if (nextRenderedPart?.kind === 'text') {
             this.contentContainer.addChild(new Spacer(1));
           }
         } else {


### PR DESCRIPTION
# fix(mastracode): show one "Thinking..." label per run of hidden reasoning

Closes #21133

## What was wrong

In the mastracode TUI, an assistant turn could render two identical `Thinking...`
lines stacked on top of each other. The rest of the message was fine: the answer
appeared once, and the expanded thinking content was not duplicated.

The cause is a mismatch between what the label means and how often it is drawn.
`Thinking...` describes a state ("the model is reasoning and you have it
collapsed"), but `AssistantMessageComponent.updateContent()` drew it once per
reasoning render part. Reasoning parts are one to one with reasoning spans from
the model, and a single step can contain several spans. Anthropic adaptive
thinking splits reasoning on signatures, and OpenAI reasoning models emit
reasoning before and after text. Two spans, two parts, two labels.

## The change

When the thinking block is hidden, a `Thinking...` label is emitted for the first
part of a run of consecutive thinking parts and suppressed for the rest of that
run. Assistant text ends the run, so reasoning that resumes after text still gets
its own label: the transcript keeps showing where thinking happened, without
repeating itself.

The spacer that separates hidden thinking from following content is now added
once at the end of a run, instead of once per part in it, so collapsing a run
does not leave a stray blank line behind.

A run never spans a tool call, and this PR does not change that. Callers slice an
assistant message at tool boundaries and render each slice with its own
component, so reasoning before and after a tool call still shows one label each.
That is the intended behavior: the tool output visually separates the two runs.

Visible-thinking mode is untouched. Each reasoning span still renders its own
block, so no reasoning content is merged or hidden.

## Alternative considered

Merging adjacent `reasoning` parts in the projection layer
(`db-message-parts.ts`) would also fix the symptom, but it changes the visible
thinking view as well (two distinct spans would be fused into one block) and
affects every consumer of the projection. The label is the thing that was wrong,
so the fix stays in the component that draws it.

## Test plan

Four new tests in `mastracode/tui/src/tui/components/__tests__/assistant-message.test.ts`:

- Two consecutive reasoning parts with thinking hidden render exactly one
  `Thinking...` line. Fails on the previous code with two lines.
- One spacer, not two, is emitted after a collapsed run followed by text. Also
  fails on the previous code.
- Reasoning, text, reasoning renders two labels in that order, so the coalescing
  does not swallow a genuinely separate thinking run.
- Visible mode with two spans still renders both spans and no label.

Gates run on this branch:

- `pnpm --filter ./mastracode/tui exec vitest run`: 1159 passed. Four failures in
  `goal.test.ts` and `shell-output.test.ts` reproduce with this branch's changes
  stashed and are unrelated to this fix.
- `pnpm --filter ./mastracode/tui check` (tsc --noEmit): clean.
- `pnpm --filter ./mastracode/tui lint`: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The TUI now shows one `Thinking...` label for consecutive hidden reasoning steps. It starts a new label after assistant text or a tool call, while visible reasoning stays unchanged.

## Changes

- Group consecutive hidden reasoning parts into one `Thinking...` label.
- Preserve separate rendering across tool-call boundaries.
- Add component tests for grouping, separation, spacer placement, and visible reasoning.
- Add a TUI E2E scenario with a hand-built OpenAI Responses SSE stream containing two consecutive reasoning items.
- Register the new E2E scenario.
- Add a patch changeset.

## Validation

- Type checking and linting pass.
- Unrelated existing failures remain in `goal.test.ts` and `shell-output.test.ts`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->