### PR TITLE
feat(core): preserve optional filename on FilePayload through Channel…

### DIFF
--- a/.changeset/file-payload-preserve-filename.md
+++ b/.changeset/file-payload-preserve-filename.md
@@ -3,3 +3,11 @@
 ---
 
 Added optional `filename` property to `FilePayload`. When an agent emits a file chunk with a filename, the Channel layer now preserves it through to the Chat SDK adapter instead of generating a name from the MIME type. Existing file chunks without a filename continue using the `generated.<ext>` fallback.
+
+```ts
+const chunk: FilePayload = {
+  data: fileBuffer,
+  mimeType: 'text/plain',
+  filename: 'report.txt', // preserved through to the channel adapter
+};
+```

--- a/.changeset/file-payload-preserve-filename.md
+++ b/.changeset/file-payload-preserve-filename.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": minor
+---
+
+Added optional `filename` property to `FilePayload`. When an agent emits a file chunk with a filename, the Channel layer now preserves it through to the Chat SDK adapter instead of generating a name from the MIME type. Existing file chunks without a filename continue using the `generated.<ext>` fallback.

--- a/packages/core/src/channels/__tests__/stream-helpers.test.ts
+++ b/packages/core/src/channels/__tests__/stream-helpers.test.ts
@@ -168,6 +168,81 @@ describe('postFileAttachment', () => {
     expect(arg.files[0].filename).toBe('generated.png');
     expect(arg.files[0].mimeType).toBe('image/png');
   });
+
+  it('preserves an explicit filename from the payload (text file)', async () => {
+    const post = vi.fn().mockResolvedValue({});
+
+    await postFileAttachment({
+      chunk: {
+        type: 'file',
+        payload: { data: Buffer.from('hello').toString('base64'), mimeType: 'text/plain', filename: 'report.txt' },
+      } as any,
+      chatThread: { post },
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const arg = post.mock.calls[0]![0];
+    expect(arg.files[0].filename).toBe('report.txt');
+    expect(arg.files[0].mimeType).toBe('text/plain');
+  });
+
+  it('preserves an explicit filename from the payload (PDF)', async () => {
+    const post = vi.fn().mockResolvedValue({});
+
+    await postFileAttachment({
+      chunk: {
+        type: 'file',
+        payload: {
+          data: Buffer.from('pdf-bytes').toString('base64'),
+          mimeType: 'application/pdf',
+          filename: 'contract.pdf',
+        },
+      } as any,
+      chatThread: { post },
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const arg = post.mock.calls[0]![0];
+    expect(arg.files[0].filename).toBe('contract.pdf');
+    expect(arg.files[0].mimeType).toBe('application/pdf');
+  });
+
+  it('preserves an explicit filename from the payload (image)', async () => {
+    const post = vi.fn().mockResolvedValue({});
+
+    await postFileAttachment({
+      chunk: {
+        type: 'file',
+        payload: {
+          data: Buffer.from('img-bytes').toString('base64'),
+          mimeType: 'image/png',
+          filename: 'screenshot.png',
+        },
+      } as any,
+      chatThread: { post },
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const arg = post.mock.calls[0]![0];
+    expect(arg.files[0].filename).toBe('screenshot.png');
+    expect(arg.files[0].mimeType).toBe('image/png');
+  });
+
+  it('falls back to generated.<ext> when no filename is provided', async () => {
+    const post = vi.fn().mockResolvedValue({});
+
+    await postFileAttachment({
+      chunk: {
+        type: 'file',
+        payload: { data: Buffer.from('data').toString('base64'), mimeType: 'application/pdf' },
+      } as any,
+      chatThread: { post },
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const arg = post.mock.calls[0]![0];
+    expect(arg.files[0].filename).toBe('generated.pdf');
+  });
 });
 
 describe('extractErrorMessage', () => {

--- a/packages/core/src/channels/stream-helpers.ts
+++ b/packages/core/src/channels/stream-helpers.ts
@@ -274,14 +274,22 @@ export async function postFileAttachment(args: {
   logger?: IMastraLogger;
 }): Promise<void> {
   const { chunk, chatThread, logger } = args;
-  const { data, mimeType } = chunk.payload as { data: string | Uint8Array; mimeType: string };
+  const {
+    data,
+    mimeType,
+    filename: payloadFilename,
+  } = chunk.payload as {
+    data: string | Uint8Array;
+    mimeType: string;
+    filename?: string;
+  };
   logger?.debug?.('[CHANNEL] Received file chunk', {
     mimeType,
     dataType: typeof data,
     size: typeof data === 'string' ? data.length : (data as Uint8Array)?.byteLength,
   });
   const ext = mimeType.split('/')[1]?.split(';')[0] || 'bin';
-  const filename = `generated.${ext}`;
+  const filename = payloadFilename ?? `generated.${ext}`;
   const binary =
     typeof data === 'string' ? Buffer.from(data, 'base64') : data instanceof Uint8Array ? Buffer.from(data) : data;
   try {

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -144,6 +144,7 @@ export interface FilePayload {
   data: string | Uint8Array;
   base64?: string;
   mimeType: string;
+  filename?: string;
   providerMetadata?: ProviderMetadata;
 }
 


### PR DESCRIPTION
## Description

Adds an optional `filename?: string` field to `FilePayload` in `@mastra/core` and updates the channel file handler `postFileAttachment` to preserve any supplied filename when posting attachments via Chat SDK. 

- If `filename` is provided on the file chunk payload, it is preserved and forwarded to the downstream channel adapter.
- If `filename` is omitted, it seamlessly falls back to the existing `generated.<ext>` behavior derived from the MIME type.

## Related issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/20731

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

File attachments now keep the filename provided by the sender. If no filename is provided, the system continues to create a name from the file type.

## Changes

- Added optional `filename?: string` support to `FilePayload`.
- Preserved filenames when `postFileAttachment` forwards attachments through Chat SDK channels.
- Kept the `generated.<ext>` fallback for attachments without filenames.
- Added tests for text, PDF, image, and fallback filenames.
- Added a minor changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->