### PR TITLE
fix(ci): include exported server subpaths in affected tests

### DIFF
--- a/scripts/affected-tests.mjs
+++ b/scripts/affected-tests.mjs
@@ -16,13 +16,16 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve, relative, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
+const require = createRequire(import.meta.url);
+const { buildWorkspaceSourceAliases } = require('./workspace-source-aliases.cjs');
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -330,19 +333,6 @@ for (const [node, deps] of Object.entries(graph)) {
 
 const ALL = '*';
 const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
-const SKIP_DIRS = new Set([
-  'node_modules',
-  'dist',
-  'build',
-  '.pnpm',
-  '.turbo',
-  '.git',
-  '.next',
-  '.mastra',
-  '.claude',
-  '.mastracode',
-  '.agents',
-]);
 
 function toRel(root, path) {
   return path.replace(`${root}/`, '').replaceAll('\\', '/');
@@ -350,47 +340,6 @@ function toRel(root, path) {
 
 function normalizeRel(path) {
   return path.replaceAll('\\', '/').replace(/^\.\//, '');
-}
-
-function findPackageJsonFiles(dir) {
-  const results = [];
-  let entries;
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return results;
-  }
-
-  for (const entry of entries) {
-    if (entry.isFile() && entry.name === 'package.json') {
-      results.push(join(dir, entry.name));
-      continue;
-    }
-    if (!entry.isDirectory()) continue;
-    if (SKIP_DIRS.has(entry.name)) continue;
-    if (entry.name === '__fixtures__' || entry.name === 'fixtures' || entry.name === 'test-fixtures') continue;
-    results.push(...findPackageJsonFiles(join(dir, entry.name)));
-  }
-
-  return results;
-}
-
-function buildAliasMap(root) {
-  const alias = new Map();
-  for (const pkgJsonPath of findPackageJsonFiles(root)) {
-    const pkgDir = dirname(pkgJsonPath);
-    const srcDir = join(pkgDir, 'src');
-    if (!existsSync(srcDir)) continue;
-    if (pkgDir.includes('__fixtures__') || pkgDir.includes('/fixtures/')) continue;
-
-    try {
-      const json = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
-      if (json.name) alias.set(json.name, srcDir);
-    } catch {
-      // ignore malformed package.json files in fixture-like directories
-    }
-  }
-  return alias;
 }
 
 function scriptKindFor(file) {
@@ -542,13 +491,13 @@ function resolveModuleToGraphDep(root, fromFile, moduleName, deps, aliasMap) {
   if (moduleName.startsWith('.')) {
     basePath = resolve(root, dirname(fromFile), moduleName);
   } else {
-    const matchingAlias = [...aliasMap.keys()]
-      .filter(name => moduleName === name || moduleName.startsWith(`${name}/`))
-      .sort((a, b) => b.length - a.length)[0];
+    const matchingAlias = aliasMap
+      .filter(alias => moduleName === alias.name || (!alias.exact && moduleName.startsWith(`${alias.name}/`)))
+      .sort((a, b) => b.name.length - a.name.length)[0];
 
     if (matchingAlias) {
-      const suffix = moduleName === matchingAlias ? '' : moduleName.slice(matchingAlias.length + 1);
-      basePath = join(aliasMap.get(matchingAlias), suffix);
+      const suffix = moduleName === matchingAlias.name ? '' : moduleName.slice(matchingAlias.name.length + 1);
+      basePath = join(matchingAlias.target, suffix);
     }
   }
 
@@ -567,7 +516,7 @@ function edgeKey(from, to) {
 }
 
 function buildSymbolIndex({ graph, root }) {
-  const aliasMap = buildAliasMap(root);
+  const aliasMap = buildWorkspaceSourceAliases(root);
   const fileSymbols = new Map();
   const edges = new Map();
 

--- a/scripts/madge.webpack.config.cjs
+++ b/scripts/madge.webpack.config.cjs
@@ -2,99 +2,26 @@
  * Webpack config consumed by madge (via enhanced-resolve) for the
  * affected-tests analyzer.
  *
- * Dynamically discovers every workspace package that has a `src/` directory
- * and aliases its package name to that source directory. This, combined with
- * emptying `exportsFields` / `mainFields` / `aliasFields`, forces resolution
- * onto TypeScript source files instead of bundled `dist/` output — which is
- * what lets madge trace through the workspace at the source level.
+ * Workspace package names and exported subpaths are aliased to TypeScript
+ * sources. This, combined with emptying `exportsFields` / `mainFields` /
+ * `aliasFields`, forces resolution onto source files instead of bundled `dist/`
+ * output — which lets madge trace through the workspace at the source level.
  */
 
-const { readFileSync, readdirSync, existsSync } = require('node:fs');
-const { join, dirname } = require('node:path');
+const { join } = require('node:path');
+const { buildWorkspaceSourceAliases } = require('./workspace-source-aliases.cjs');
 
 const ROOT = join(__dirname, '..');
 
-const SKIP_DIRS = new Set([
-  'node_modules',
-  'dist',
-  'build',
-  '.pnpm',
-  '.turbo',
-  '.git',
-  '.next',
-  '.mastra',
-  '.claude',
-  '.mastracode',
-  '.agents',
-]);
-
-/**
- * Recursively find all package.json files under `dir`, skipping build
- * artifacts and node_modules.
- */
-function findPackageJsonFiles(dir) {
-  const results = [];
-  let entries;
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return results;
-  }
-
-  for (const entry of entries) {
-    if (!entry.isDirectory() && !entry.isFile()) continue;
-    if (entry.name === 'package.json' && entry.isFile()) {
-      results.push(join(dir, entry.name));
-      continue;
-    }
-    if (!entry.isDirectory()) continue;
-    if (SKIP_DIRS.has(entry.name)) continue;
-
-    const fullPath = join(dir, entry.name);
-    // Exclude fixture/scaffold directories anywhere in the tree
-    if (entry.name === '__fixtures__' || entry.name === 'fixtures' || entry.name === 'test-fixtures') continue;
-
-    results.push(...findPackageJsonFiles(fullPath));
-  }
-  return results;
-}
-
-/**
- * Build the alias map: package name → absolute path to src/ dir.
- */
-function buildAliasMap() {
-  const alias = {};
-  const packageJsons = findPackageJsonFiles(ROOT);
-
-  for (const pkgJsonPath of packageJsons) {
-    const pkgDir = dirname(pkgJsonPath);
-    const srcDir = join(pkgDir, 'src');
-
-    if (!existsSync(srcDir)) continue;
-
-    // Skip fixture packages
-    if (pkgDir.includes('__fixtures__') || pkgDir.includes('/fixtures/')) continue;
-
-    let json;
-    try {
-      json = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
-    } catch {
-      continue;
-    }
-
-    if (!json.name) continue;
-
-    alias[json.name] = srcDir;
-  }
-
-  return alias;
-}
-
-const aliasMap = buildAliasMap();
+const alias = buildWorkspaceSourceAliases(ROOT).map(({ name, target, exact }) => ({
+  name,
+  alias: target,
+  onlyModule: exact,
+}));
 
 module.exports = {
   resolve: {
-    alias: aliasMap,
+    alias,
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json'],
     exportsFields: [],
     mainFields: [],

--- a/scripts/workspace-source-aliases.cjs
+++ b/scripts/workspace-source-aliases.cjs
@@ -92,15 +92,11 @@ function buildWorkspaceSourceAliases(root) {
     if (!existsSync(srcDir)) continue;
     if (packageDir.includes('__fixtures__') || packageDir.includes('/fixtures/')) continue;
 
-    try {
-      const json = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
-      if (!json.name) continue;
+    const json = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    if (!json.name) continue;
 
-      addExportAliases(aliases, json.name, packageDir, json.exports);
-      aliases.push({ name: json.name, target: srcDir, exact: false });
-    } catch {
-      // Ignore malformed package.json files in fixture-like directories.
-    }
+    addExportAliases(aliases, json.name, packageDir, json.exports);
+    aliases.push({ name: json.name, target: srcDir, exact: false });
   }
 
   return aliases;

--- a/scripts/workspace-source-aliases.cjs
+++ b/scripts/workspace-source-aliases.cjs
@@ -1,0 +1,109 @@
+const { existsSync, readFileSync, readdirSync } = require('node:fs');
+const { dirname, join } = require('node:path');
+
+const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.pnpm',
+  '.turbo',
+  '.git',
+  '.next',
+  '.mastra',
+  '.claude',
+  '.mastracode',
+  '.agents',
+]);
+
+function findPackageJsonFiles(dir) {
+  const results = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name === 'package.json') {
+      results.push(join(dir, entry.name));
+      continue;
+    }
+    if (!entry.isDirectory()) continue;
+    if (SKIP_DIRS.has(entry.name)) continue;
+    if (entry.name === '__fixtures__' || entry.name === 'fixtures' || entry.name === 'test-fixtures') continue;
+    results.push(...findPackageJsonFiles(join(dir, entry.name)));
+  }
+
+  return results;
+}
+
+function getRuntimeExportPath(exportEntry) {
+  if (typeof exportEntry === 'string') return exportEntry;
+  if (!exportEntry || typeof exportEntry !== 'object') return null;
+
+  for (const condition of ['import', 'default', 'require']) {
+    const path = getRuntimeExportPath(exportEntry[condition]);
+    if (path) return path;
+  }
+
+  return null;
+}
+
+function sourceTargetExists(sourcePath) {
+  return (
+    existsSync(sourcePath) ||
+    EXTENSIONS.some(extension => existsSync(`${sourcePath}${extension}`)) ||
+    EXTENSIONS.some(extension => existsSync(join(sourcePath, `index${extension}`)))
+  );
+}
+
+function addExportAliases(aliases, packageName, packageDir, exports) {
+  if (!exports || typeof exports !== 'object') return;
+
+  for (const [exportName, exportEntry] of Object.entries(exports)) {
+    if (exportName === '.' || !exportName.startsWith('./')) continue;
+
+    const runtimeExportPath = getRuntimeExportPath(exportEntry);
+    if (!runtimeExportPath?.startsWith('./dist/') || !/\.[cm]?js$/.test(runtimeExportPath)) continue;
+
+    const isPattern = exportName.endsWith('/*');
+    const subpath = exportName.slice(2).replace(/\/\*$/, '');
+    if (!subpath || subpath === '*') continue;
+
+    const sourcePath = runtimeExportPath
+      .replace(/^\.\/dist\//, 'src/')
+      .replace(/\/\*/, '')
+      .replace(/\.[cm]?js$/, '');
+    const target = join(packageDir, sourcePath);
+    if (!sourceTargetExists(target)) continue;
+
+    aliases.push({ name: `${packageName}/${subpath}`, target, exact: !isPattern });
+  }
+}
+
+function buildWorkspaceSourceAliases(root) {
+  const aliases = [];
+
+  for (const packageJsonPath of findPackageJsonFiles(root)) {
+    const packageDir = dirname(packageJsonPath);
+    const srcDir = join(packageDir, 'src');
+    if (!existsSync(srcDir)) continue;
+    if (packageDir.includes('__fixtures__') || packageDir.includes('/fixtures/')) continue;
+
+    try {
+      const json = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+      if (!json.name) continue;
+
+      addExportAliases(aliases, json.name, packageDir, json.exports);
+      aliases.push({ name: json.name, target: srcDir, exact: false });
+    } catch {
+      // Ignore malformed package.json files in fixture-like directories.
+    }
+  }
+
+  return aliases;
+}
+
+module.exports = { buildWorkspaceSourceAliases };


### PR DESCRIPTION
Before, `@mastra/server/server-adapter` was resolved as if it lived directly under `packages/server/src`, so affected-test selection skipped adapter coverage.

This now follows workspace export paths back to source modules, so server handler changes select dependent adapter tests. For the workflow change from #20184, the analyzer now includes 9 Express and 11 Fastify tests.

I checked formatting and graph resolution, then ran the affected-test analyzer. Running the Express suite now reaches the existing 409 expectation failures that this CI gap had hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The test tool now follows workspace package links to the real source files. It selects tests that depend on changed server handlers, including 9 Express tests and 11 Fastify tests.

## Changes

- Added `buildWorkspaceSourceAliases` in `scripts/workspace-source-aliases.cjs`.
- Reused shared workspace alias logic in affected-test analysis and Madge Webpack configuration.
- Added support for workspace export subpaths and exact aliases.
- Removed duplicated package discovery and alias construction logic.
- The Express suite now exposes existing 409 expectation failures that CI previously missed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->