### PR TITLE
fix(mastracode): stop a plan approval from stealing focus from an open command panel and leaving it stuck

### DIFF
--- a/.changeset/approval-overlay-focus.md
+++ b/.changeset/approval-overlay-focus.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+A plan approval arriving while a command overlay (such as the /models pack selector) is open no longer steals focus from the overlay or deadlocks it. The approval defers its focus until the overlay closes, then takes focus so it must still be answered.

--- a/mastracode/tui/e2e/tui/approval-overlay-focus.ts
+++ b/mastracode/tui/e2e/tui/approval-overlay-focus.ts
@@ -1,0 +1,146 @@
+import stripAnsi from 'strip-ansi';
+import { createGlobalPatchScope } from './global-patches.js';
+import type { McE2eInProcessApp, McE2eScenario } from './types.js';
+
+// Regression scenario for #21139: a plan approval arriving while the /models
+// overlay is open must not steal focus from the overlay (symptom 1) and must
+// not deadlock it (symptom 2). The overlay stays operable, Escape closes it,
+// and the pending approval then receives focus so Enter approves the plan.
+//
+// Determinism: the second model turn (the one whose tool result belongs to the
+// plan write_file call, i.e. the turn that emits submit_plan) is held behind a
+// gate until run() has opened the /models overlay. That pins the approval's
+// arrival inside the overlay-open window without racing AIMock's near-instant
+// responses.
+
+let releaseSubmitPlanTurn: () => void;
+let submitPlanTurnGate: Promise<void>;
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function requestBodyText(body: BodyInit | null | undefined): string {
+  if (typeof body === 'string') return body;
+  if (body instanceof Uint8Array) return new TextDecoder().decode(body);
+  return '';
+}
+
+async function waitForScreenGone(terminal: any, pattern: RegExp, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const view = stripAnsi(terminal.serialize().view);
+    if (!pattern.test(view)) return;
+    if (Date.now() > deadline) {
+      throw new Error(`Expected ${pattern} to leave the screen (overlay deadlocked?):\n${view}`);
+    }
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+export const approvalOverlayFocusScenario = {
+  name: 'approval-overlay-focus',
+  description:
+    'Plan approval arriving while the /models overlay is open defers focus: the overlay stays operable and the approval takes focus after it closes.',
+  testName: 'keeps the /models overlay operable when a plan approval arrives and hands focus off on close',
+  useOpenAIModel: true,
+  aimockFixture: 'plan-approval-handoff.json',
+  async inProcessApp({ startMastraCodeApp }): Promise<McE2eInProcessApp> {
+    submitPlanTurnGate = new Promise<void>(resolve => {
+      releaseSubmitPlanTurn = resolve;
+    });
+
+    const patches = createGlobalPatchScope();
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    patches.setProperty(globalThis, 'fetch', async (input, init) => {
+      const url = requestUrl(input);
+      if (!url.includes('/chat/completions') && !url.includes('/responses')) return originalFetch(input, init);
+
+      // The submit_plan turn carries the tool result of the plan write_file
+      // call. Hold it until the /models overlay is open on screen.
+      const rawBody = requestBodyText(init?.body);
+      if (rawBody.includes('call_plan_approval_e2e_write')) {
+        await submitPlanTurnGate;
+      }
+      return originalFetch(input, init);
+    });
+
+    try {
+      const app = await startMastraCodeApp({
+        config: { disableHooks: true, disableMcp: true, unixSocketPubSub: false },
+      });
+      return {
+        stop: () => {
+          // Never leave a fetch parked on the gate if run() failed before
+          // releasing it; a held promise would hang teardown.
+          releaseSubmitPlanTurn();
+          return patches.stopApp(app.stop);
+        },
+      };
+    } catch (error) {
+      patches.restore();
+      throw error;
+    }
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/Resource ID:/i, terminal);
+
+    terminal.submit('/mode plan');
+    await runtime.waitForScreenText(/▐plan▌/i, terminal, 8_000);
+
+    terminal.submit('Create a concise implementation plan for the plan approval e2e test.');
+
+    // Open the model pack selector while the plan run is in flight; the
+    // submit_plan turn is gated until this overlay is visible.
+    terminal.submit('/models');
+    await runtime.waitForScreenText(/Switch model pack/i, terminal, 10_000);
+
+    releaseSubmitPlanTurn();
+
+    // Let the approval arrive behind the overlay, then confirm the overlay is
+    // still on screen (it must not be dismissed or repainted away).
+    await runtime.sleep(3_000);
+    const withApproval = stripAnsi(terminal.serialize().view);
+    if (!/Switch model pack/i.test(withApproval)) {
+      throw new Error(`Expected the /models overlay to remain open when the approval arrived:\n${withApproval}`);
+    }
+
+    // Symptom 1: arrow keys must still drive the overlay's selection, not the
+    // hidden approval underneath it. Pre-fix, focus was stolen by the approval
+    // so the selector highlight never moved.
+    // First pin the starting highlight so the "gone" check below cannot pass
+    // vacuously. Note this makes the scenario row-sensitive: in the harness
+    // environment no provider pack precedes Custom, so Custom is row one; a
+    // local run with provider keys detected would fail loudly here rather
+    // than pass vacuously below.
+    await runtime.waitForScreenText(/→\s+Custom\s/i, terminal, 5_000);
+    terminal.write('\u001b[B');
+    // Assert the highlight left the first row rather than naming the landing
+    // row.
+    await waitForScreenGone(terminal, /→\s+Custom\s/i, 5_000);
+
+    // Escape must close the overlay. Pre-fix, focus was stolen by the hidden
+    // approval, so Escape never reaches the overlay and it stays up (deadlock).
+    terminal.write('\u001b');
+    await waitForScreenGone(terminal, /Switch model pack/i, 5_000);
+
+    // With the overlay gone the pending approval takes focus; Enter approves.
+    await runtime.waitForScreenText(/Use as \/goal/i, terminal, 10_000);
+    terminal.write('\r');
+    await runtime.waitForScreenText(/✓\s+Approved/i, terminal, 10_000);
+
+    await runtime.sleep(500);
+    terminal.keyCtrlC();
+  },
+  verifyAimockRequests(requests) {
+    if (requests.length < 2) {
+      throw new Error(`Expected the plan flow to make at least 2 AIMock requests, received ${requests.length}`);
+    }
+    if (!JSON.stringify(requests).includes('call_plan_approval_e2e_submit')) {
+      throw new Error('Expected AIMock requests to include the submit_plan tool call id');
+    }
+  },
+} satisfies McE2eScenario;

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -4,6 +4,7 @@ import { apiKeyDeleteEnvScenario } from './api-key-delete-env.js';
 import { apiKeyMultiProviderDeleteScenario } from './api-key-multi-provider-delete.js';
 import { apiKeyPromptScenario } from './api-key-prompt.js';
 import { apiKeyReopenStoredScenario } from './api-key-reopen-stored.js';
+import { approvalOverlayFocusScenario } from './approval-overlay-focus.js';
 import { askUserAdvancedPromptsScenario } from './ask-user-advanced-prompts.js';
 import { autocompleteWrappingNavigationScenario } from './autocomplete-wrapping-navigation.js';
 import { automatedChatScenario } from './automated-chat.js';
@@ -177,6 +178,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'autocomplete-wrapping-navigation': autocompleteWrappingNavigationScenario,
   'api-key-delete-env': apiKeyDeleteEnvScenario,
   'api-key-multi-provider-delete': apiKeyMultiProviderDeleteScenario,
+  'approval-overlay-focus': approvalOverlayFocusScenario,
   'api-key-prompt': apiKeyPromptScenario,
   'api-key-reopen-stored': apiKeyReopenStoredScenario,
   'ask-user-advanced-prompts': askUserAdvancedPromptsScenario,

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -13,6 +13,7 @@ export type ScenarioName =
   | 'api-key-multi-provider-delete'
   | 'api-key-prompt'
   | 'api-key-reopen-stored'
+  | 'approval-overlay-focus'
   | 'ask-user-advanced-prompts'
   | 'automated-chat'
   | 'browser-active-pending-status'

--- a/mastracode/tui/src/tui/__tests__/overlay-focus-handoff.test.ts
+++ b/mastracode/tui/src/tui/__tests__/overlay-focus-handoff.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { installOverlayFocusHandoff } from '../setup.js';
+
+// Regression tests for #21139: when a plan approval defers its focus because a
+// command overlay (e.g. the model pack selector) is open, closing the overlay
+// must hand focus to the pending approval. The seam is a transparent wrapper
+// around `state.ui.hideOverlay` installed at setup time
+// (installOverlayFocusHandoff in setup.ts).
+
+function createUi() {
+  const overlays: string[] = [];
+  const ui = {
+    overlays,
+    setFocus: vi.fn(),
+    hasOverlay: vi.fn(() => overlays.length > 0),
+    hideOverlay: vi.fn(() => {
+      overlays.pop();
+    }),
+  };
+  return ui;
+}
+
+function createState(ui: ReturnType<typeof createUi>) {
+  const approval = { kind: 'plan-approval' };
+  return {
+    ui,
+    editor: {},
+    activeInlinePlanApproval: approval as any,
+    pendingFocus: approval as any,
+  };
+}
+
+const install: (ui: any, state: any) => void = installOverlayFocusHandoff;
+
+describe('installOverlayFocusHandoff (#21139)', () => {
+  it('hands focus to the pending approval when the overlay stack empties', async () => {
+    const ui = createUi();
+    ui.overlays.push('model-pack');
+    const state = createState(ui);
+    install(ui, state);
+
+    state.ui.hideOverlay();
+
+    expect(ui.overlays).toHaveLength(0);
+    expect(ui.setFocus).toHaveBeenCalledWith(state.activeInlinePlanApproval);
+    expect(state.pendingFocus).toBeUndefined();
+  });
+
+  it('does not hand off while deeper overlays remain (stacked overlays)', async () => {
+    const ui = createUi();
+    ui.overlays.push('model-pack', 'permission-modal');
+    const state = createState(ui);
+    install(ui, state);
+
+    state.ui.hideOverlay();
+    expect(ui.setFocus).not.toHaveBeenCalled();
+    expect(state.pendingFocus).toBe(state.activeInlinePlanApproval);
+
+    state.ui.hideOverlay();
+    expect(ui.setFocus).toHaveBeenCalledWith(state.activeInlinePlanApproval);
+    expect(state.pendingFocus).toBeUndefined();
+  });
+
+  it('ignores a stale pendingFocus after the approval was dismissed (Ctrl+C paths)', async () => {
+    const ui = createUi();
+    ui.overlays.push('model-pack');
+    const state = createState(ui);
+    install(ui, state);
+
+    // setup.ts Ctrl+C / abort paths clear activeInlinePlanApproval outside the
+    // three resolution handlers; the hand-off must be guarded by
+    // pendingFocus === activeInlinePlanApproval, not a bare null check.
+    state.activeInlinePlanApproval = undefined;
+
+    state.ui.hideOverlay();
+
+    expect(ui.setFocus).not.toHaveBeenCalled();
+    expect(state.pendingFocus).toBeUndefined();
+  });
+
+  it('stays transparent: the original hideOverlay still runs and pops the stack', async () => {
+    const ui = createUi();
+    ui.overlays.push('model-pack');
+    const state = createState(ui);
+    state.pendingFocus = undefined;
+    install(ui, state);
+
+    state.ui.hideOverlay();
+
+    expect(ui.overlays).toHaveLength(0);
+    expect(ui.setFocus).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/tui/src/tui/__tests__/setup-layout.test.ts
+++ b/mastracode/tui/src/tui/__tests__/setup-layout.test.ts
@@ -102,6 +102,8 @@ function createState(modeCount = 2) {
       ui: {
         addChild: vi.fn(child => uiChildren.push(child)),
         setFocus: vi.fn(),
+        hasOverlay: vi.fn(() => false),
+        hideOverlay: vi.fn(),
       },
       chatContainer: { type: 'chat' },
       editorContainer: { type: 'editor-container', addChild: vi.fn(child => editorChildren.push(child)) },

--- a/mastracode/tui/src/tui/handlers/__tests__/prompts.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/prompts.test.ts
@@ -161,7 +161,7 @@ function createPlanApprovalCtx(projectPath?: string) {
       }),
       invalidate: vi.fn(),
     },
-    ui: { requestRender: vi.fn(), setFocus: vi.fn() },
+    ui: { requestRender: vi.fn(), setFocus: vi.fn(), hasOverlay: vi.fn(() => false) },
     editor: {},
     pendingSubmitPlanComponents: new Map(),
     planStartedGoalId: undefined,
@@ -397,5 +397,55 @@ describe('handlePlanApproval regular approval', () => {
       path: samePlanPath,
       plan: 'Build the feature\nAdd focused tests\nUpdate docs',
     });
+  });
+});
+
+describe('handlePlanApproval with a command overlay open (#21139)', () => {
+  // Regression tests for the overlay focus-steal deadlock: a plan approval
+  // arriving while an overlay (e.g. the model pack selector) is focused must
+  // not steal focus, and resolving it must not force editor focus while an
+  // overlay is still up (pi-tui transfers its blocked overlay-restore state
+  // onto the editor, permanently deadlocking the overlay).
+
+  it('does not steal focus on arrival while an overlay is open; defers via pendingFocus', async () => {
+    const projectPath = createTmpProjectWithPlan(PLAN_TITLE, 'Build the feature');
+    const { state, ctx } = createPlanApprovalCtx(projectPath);
+    state.ui.hasOverlay.mockReturnValue(true);
+
+    const { component } = await renderPlanApproval(ctx, state, PLAN_PATH);
+
+    expect(state.ui.setFocus).not.toHaveBeenCalledWith(component);
+    expect(state.pendingFocus).toBe(component);
+  });
+
+  it.each([['onApprove'], ['onGoal'], ['onReject']])(
+    'does not force editor focus on %s while an overlay is open',
+    async method => {
+      const projectPath = createTmpProjectWithPlan(PLAN_TITLE, 'Build the feature');
+      const { state, ctx } = createPlanApprovalCtx(projectPath);
+      state.ui.hasOverlay.mockReturnValue(true);
+
+      const { promise, component } = await renderPlanApproval(ctx, state, PLAN_PATH);
+      state.ui.setFocus.mockClear();
+
+      await (component as any)[method]();
+      await promise;
+
+      expect(state.ui.setFocus).not.toHaveBeenCalled();
+      expect(state.pendingFocus).toBeUndefined();
+    },
+  );
+
+  it('keeps the no-overlay behavior: arrival focuses the approval, approve focuses the editor', async () => {
+    const projectPath = createTmpProjectWithPlan(PLAN_TITLE, 'Build the feature');
+    const { state, ctx } = createPlanApprovalCtx(projectPath);
+
+    const { promise, component } = await renderPlanApproval(ctx, state, PLAN_PATH);
+    expect(state.ui.setFocus).toHaveBeenCalledWith(component);
+    expect(state.pendingFocus).toBeUndefined();
+
+    await (component as any).onApprove();
+    await promise;
+    expect(state.ui.setFocus).toHaveBeenLastCalledWith(state.editor);
   });
 });

--- a/mastracode/tui/src/tui/handlers/prompts.ts
+++ b/mastracode/tui/src/tui/handlers/prompts.ts
@@ -384,6 +384,18 @@ export async function handlePlanApproval(
         ?.runPermissionResult('plan_approval', toolCallId, 'submit_plan', decision, { path: snapshotKey })
         .catch(() => {});
     };
+    // #21139: never force editor focus while an overlay is still up (it would
+    // deadlock the overlay via pi-tui's blocked-restore transfer), and drop any
+    // deferred focus that pointed at this approval.
+    const releaseApprovalFocus = () => {
+      state.activeInlinePlanApproval = undefined;
+      if (state.pendingFocus === approvalComponent) {
+        state.pendingFocus = undefined;
+      }
+      if (!state.ui.hasOverlay()) {
+        state.ui.setFocus(state.editor);
+      }
+    };
     const approvalOptions = {
       toolCallId,
       title: resolvedTitle,
@@ -391,15 +403,13 @@ export async function handlePlanApproval(
       planFilename,
       previousPlan,
       onApprove: async () => {
-        state.activeInlinePlanApproval = undefined;
-        state.ui.setFocus(state.editor);
+        releaseApprovalFocus();
         firePermissionResult('approved');
         await approvePlan(ctx, toolCallId, resolvedTitle, plan, planPath, snapshotKey);
         resolve();
       },
       onGoal: async () => {
-        state.activeInlinePlanApproval = undefined;
-        state.ui.setFocus(state.editor);
+        releaseApprovalFocus();
         firePermissionResult('approved');
         await approvePlan(ctx, toolCallId, resolvedTitle, plan, planPath, snapshotKey);
 
@@ -416,8 +426,7 @@ export async function handlePlanApproval(
         resolve();
       },
       onReject: () => {
-        state.activeInlinePlanApproval = undefined;
-        state.ui.setFocus(state.editor);
+        releaseApprovalFocus();
         firePermissionResult('declined');
         // Resume the tool with a rejection so the rejection result is persisted
         // in thread history (the next run sees it for context). For submit_plan,
@@ -477,6 +486,16 @@ export async function handlePlanApproval(
     }
     state.ui.requestRender();
     state.chatContainer.invalidate();
-    state.ui.setFocus(approvalComponent);
+    // #21139: focusing the approval while a command overlay (e.g. the /models
+    // pack selector) is focused makes pi-tui record a blocked overlay-restore
+    // state; the unconditional editor refocus on resolve then transfers that
+    // block onto the editor and permanently deadlocks the overlay. Defer focus
+    // until the overlay stack empties (see installOverlayFocusHandoff in
+    // setup.ts).
+    if (state.ui.hasOverlay()) {
+      state.pendingFocus = approvalComponent;
+    } else {
+      state.ui.setFocus(approvalComponent);
+    }
   });
 }

--- a/mastracode/tui/src/tui/setup.ts
+++ b/mastracode/tui/src/tui/setup.ts
@@ -294,6 +294,43 @@ export function buildLayout(state: TUIState, refreshModelAuthStatus: () => Promi
 
   // Set focus to editor
   state.ui.setFocus(state.editor);
+
+  installOverlayFocusHandoff(state.ui, state);
+}
+
+/**
+ * #21139: hand deferred focus to a pending plan approval when the overlay
+ * stack empties. A plan approval arriving while a command overlay (e.g. the
+ * /models pack selector) is focused defers its focus into `state.pendingFocus`
+ * instead of stealing it (see handlePlanApproval); this transparent wrapper
+ * around `ui.hideOverlay` performs the hand-off on the close that empties the
+ * stack. Guarded by `pendingFocus === activeInlinePlanApproval` (not a bare
+ * null check) so a value left behind by the Ctrl+C/abort dismiss paths above,
+ * which clear activeInlinePlanApproval outside the approval's own resolution
+ * handlers, never steals focus later.
+ */
+const installedHandoffUis = new WeakSet<object>();
+
+export function installOverlayFocusHandoff(
+  ui: Pick<TUIState['ui'], 'hideOverlay' | 'hasOverlay' | 'setFocus'>,
+  state: Pick<TUIState, 'pendingFocus' | 'activeInlinePlanApproval'>,
+): void {
+  if (installedHandoffUis.has(ui)) return;
+  installedHandoffUis.add(ui);
+  const originalHideOverlay = ui.hideOverlay.bind(ui);
+  ui.hideOverlay = (...args: Parameters<typeof originalHideOverlay>) => {
+    const result = originalHideOverlay(...args);
+    if (state.pendingFocus !== undefined) {
+      if (state.pendingFocus !== state.activeInlinePlanApproval) {
+        // Stale: the approval was dismissed/aborted before the overlay closed.
+        state.pendingFocus = undefined;
+      } else if (!ui.hasOverlay()) {
+        ui.setFocus(state.pendingFocus);
+        state.pendingFocus = undefined;
+      }
+    }
+    return result;
+  };
 }
 
 // =============================================================================

--- a/mastracode/tui/src/tui/state.ts
+++ b/mastracode/tui/src/tui/state.ts
@@ -234,6 +234,13 @@ export interface TUIState {
   /** Queue of pending inline questions waiting to be shown (when one is already active) */
   pendingInlineQuestions: Array<() => void>;
   activeInlinePlanApproval?: PlanApprovalInlineComponent;
+  /**
+   * Focus deferred because a command overlay was open when a plan approval
+   * arrived. Handed off (setFocus) when the overlay stack empties, guarded by
+   * `pendingFocus === activeInlinePlanApproval` so a stale value never steals
+   * focus. See installOverlayFocusHandoff in setup.ts.
+   */
+  pendingFocus?: Component;
   activeOnboarding?: OnboardingInlineComponent;
   lastSubmitPlanComponent?: Component;
   pendingSubmitPlanComponents: Map<string, PlanApprovalInlineComponent>;


### PR DESCRIPTION
# fix(mastracode): stop a plan approval from stealing focus from an open command panel and leaving it stuck

Closes #21139

## What happens today

When a plan approval arrives while a command overlay (for example the `/models` pack selector) is focused, the approval steals focus:

1. Arrow keys drive the hidden approval options underneath the panel while the visible panel does not respond (the panel covers the approval, so all the user sees is a selection arrow peeking out and moving).
2. Answering the approval then deadlocks the panel permanently: the resolution handlers force focus back to the editor while the approval is still mounted, which transfers pi-tui's blocked overlay focus restore state onto the editor. pi-tui only restores the overlay when focus moves off the blocking component, which now never happens. The panel stays on screen, non-interactive and inescapable; the only way out is killing the TUI.

Root cause: `handlers/prompts.ts` called `setFocus(approvalComponent)` unconditionally on arrival, and `setFocus(state.editor)` unconditionally in `onApprove`/`onGoal`/`onReject`.

## The fix

- **Arrival** (`prompts.ts`): if an overlay is up (`ui.hasOverlay()`), do not steal focus. Record the approval in `state.pendingFocus` instead.
- **Resolution** (`prompts.ts`): a shared `releaseApprovalFocus()` clears `pendingFocus` when it points at this approval and only refocuses the editor when no overlay is up.
- **Hand-off** (`setup.ts`): `installOverlayFocusHandoff()` wraps `ui.hideOverlay` transparently (args and return value forwarded, install-once). When a close empties the overlay stack and `pendingFocus` still points at the live approval, the approval receives focus, so the user is still forced to answer after leaving the panel. Staleness is guarded by `pendingFocus === activeInlinePlanApproval`, not a bare null check, because the Ctrl+C/abort paths in `setup.ts` clear the approval outside its own resolution handlers.

Why the wrapper seam: every overlay close path but one (see scope notes) goes through `state.ui.hideOverlay()` (72 call sites across 20 production files, all discarding the `OverlayHandle`), so `hideOverlay` is the funnel closes pass through. Fixing inside pi-tui was rejected: its focus restore machinery behaves as designed; the defect is the call sites jumping focus around it, and guarding there keeps the blast radius small.

## Scope notes

- Only the plan approval path uses `setFocus` and exhibits this bug. `ask_user` and tool permission dialogs set `component.focused` directly or are themselves overlays; they were probed and left untouched.
- The init-time `setFocus(state.editor)` in `buildLayout` runs before any overlay can exist and is deliberately untouched.
- Reverse ordering (approval focused first, then an overlay opened and closed) is unexercised by the new tests: pi-tui records `preFocus` at `showOverlay` time and restores the approval natively, so it already behaves correctly.
- One in-repo caller closes via the handle instead of `ui.hideOverlay`: the gitcrawl setup progress overlay in `commands/settings.ts` (`overlay.hide()`). It bypasses the wrapper, but that overlay belongs to a synchronous settings flow, not something a plan run streams under, so no plan approval can be pending behind it; the E2E Escape path exercises the real close route the bug lives on.

## Tests

- `handlers/__tests__/prompts.test.ts`: 5 new regression cases (3 tests, one parameterized over the three resolution paths). Arrival with an overlay up must not focus the approval; each resolution path with an overlay up must not call `setFocus` at all; a no-overlay case locks the unchanged existing behavior.
- `__tests__/overlay-focus-handoff.test.ts` (new, 4 tests): hand-off when the stack empties, stacked-overlay depth (no hand-off while another overlay remains), the stale `pendingFocus` guard after a Ctrl+C style dismissal, and wrapper transparency (the original `hideOverlay` still runs and its return value is forwarded).
- `__tests__/setup-layout.test.ts`: its `ui` mock gained `hasOverlay`/`hideOverlay` so `buildLayout` can install the wrapper.
- `e2e/tui/approval-overlay-focus.ts` (new scenario): boots the real TUI in-process, starts a plan run, opens `/models` mid-run, gates the `submit_plan` model turn until the panel is confirmed open, then releases the approval behind it. It pins the panel highlight on the first row, presses ArrowDown, and asserts the highlight moves (symptom 1: pre-fix, arrows drive the hidden approval and the panel highlight stays put); then Escape closes the panel and the approval takes focus and Enter approves (symptom 2).

8 of the 9 new unit cases fail on unfixed code (8 failed, 14 passed across the two files); the ninth locks the unchanged no-overlay path. The E2E scenario fails on unfixed code at the arrow step (the panel highlight never moves because arrows drive the hidden approval), and an earlier capture without that assertion reproduced the full deadlock verbatim: the pack selector stuck on screen after Escape with the approval card trapped behind it. With the fix: 25/25 units, E2E passing, tsc and lint clean; the full TUI suite shows only the 4 pre-existing failures also present on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a command panel is open, plan approval no longer takes control of the keyboard. After the panel closes, the approval receives focus so you can answer it.

## Changes

- Deferred plan approval focus while command overlays are active.
- Prevented approval actions from refocusing the editor while an overlay remains open.
- Restored focus to pending approvals after the final overlay closes.
- Preserved `hideOverlay` arguments, return values, and behavior.
- Guarded against stale pending approvals and repeated handoff installation.
- Added unit tests for focus deferral, stacked overlays, stale approvals, resolution paths, and wrapper transparency.
- Added an end-to-end test for the `/models` panel and approval flow.
- Added a changeset for the `mastracode` patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->