### PR TITLE
fix(core): allow gates with AgentScorerConfig/WorkflowScorerConfig in runEvals

### DIFF
--- a/.changeset/runevals-gates-with-scorer-config.md
+++ b/.changeset/runevals-gates-with-scorer-config.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `runEvals` type overloads so `gates` can be combined with a categorized scorer config (`AgentScorerConfig` / `WorkflowScorerConfig`). The runtime already ran gates independently of the scorer shape, but the TypeScript overloads only declared `gates` alongside a flat `ScorerEntry[]`, so calls like `runEvals({ target, data, gates, scorers: { trajectory: [...] } })` failed to compile with TS2769. Added the optional `gates` property to both the agent and workflow categorized-config overloads.

--- a/.changeset/runevals-gates-with-scorer-config.md
+++ b/.changeset/runevals-gates-with-scorer-config.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix `runEvals` type overloads so `gates` can be combined with a categorized scorer config (`AgentScorerConfig` / `WorkflowScorerConfig`). The runtime already ran gates independently of the scorer shape, but the TypeScript overloads only declared `gates` alongside a flat `ScorerEntry[]`, so calls like `runEvals({ target, data, gates, scorers: { trajectory: [...] } })` failed to compile with TS2769. Added the optional `gates` property to both the agent and workflow categorized-config overloads.
+`runEvals` now accepts `gates` together with a categorized scorer config (`AgentScorerConfig` / `WorkflowScorerConfig`) without a TypeScript error. Previously a call like `runEvals({ target, data, gates, scorers: { trajectory: [...] } })` failed to compile with TS2769 because the categorized-config overloads didn't declare `gates`, even though the runtime already ran gates independently of the scorer shape. The optional `gates` property was added to both the agent and workflow categorized-config overloads.

--- a/packages/core/src/evals/run/gates-scorer-config-types.test-d.ts
+++ b/packages/core/src/evals/run/gates-scorer-config-types.test-d.ts
@@ -1,0 +1,74 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { Agent } from '../../agent';
+import type { AnyWorkflow } from '../../workflows/workflow';
+import type { MastraScorer } from '../base';
+import { runEvals } from '.';
+import type { AgentScorerConfig, RunEvalsResult, WorkflowScorerConfig } from '.';
+
+/**
+ * Regression tests for issue #21136: `runEvals` accepts `gates` together with a
+ * categorized scorer config (`AgentScorerConfig` / `WorkflowScorerConfig`) at
+ * runtime, but the TypeScript overloads only declared `gates` alongside a flat
+ * `ScorerEntry[]`. Combining `gates` with `scorers: { trajectory: [...] }`
+ * therefore failed to compile with TS2769 even though the call works. These are
+ * type-level assertions only — no runtime behavior is exercised.
+ */
+describe('runEvals gates + categorized scorer config overloads (issue #21136)', () => {
+  it('accepts gates together with an AgentScorerConfig (trajectory scorers)', () => {
+    const agent = {} as Agent;
+    const gates = [] as MastraScorer<any, any, any, any>[];
+    const scorers = {} as AgentScorerConfig;
+
+    const result = runEvals({
+      target: agent,
+      data: [{ input: 'Where is my order 1002?' }],
+      gates,
+      scorers,
+    });
+
+    expectTypeOf(result).resolves.toEqualTypeOf<RunEvalsResult>();
+  });
+
+  it('accepts gates together with a WorkflowScorerConfig', () => {
+    const workflow = {} as AnyWorkflow;
+    const gates = [] as MastraScorer<any, any, any, any>[];
+    const scorers = {} as WorkflowScorerConfig;
+
+    const result = runEvals({
+      target: workflow,
+      data: [{ input: 'run it' }],
+      gates,
+      scorers,
+    });
+
+    expectTypeOf(result).resolves.toEqualTypeOf<RunEvalsResult>();
+  });
+
+  it('still accepts an AgentScorerConfig without gates', () => {
+    const agent = {} as Agent;
+    const scorers = {} as AgentScorerConfig;
+
+    const result = runEvals({
+      target: agent,
+      data: [{ input: 'hi' }],
+      scorers,
+    });
+
+    expectTypeOf(result).resolves.toEqualTypeOf<RunEvalsResult>();
+  });
+
+  it('rejects unknown properties on the categorized-config overload', () => {
+    const agent = {} as Agent;
+    const gates = [] as MastraScorer<any, any, any, any>[];
+    const scorers = {} as AgentScorerConfig;
+
+    void runEvals({
+      target: agent,
+      data: [{ input: 'hi' }],
+      gates,
+      scorers,
+      // @ts-expect-error - `notARealOption` is not a valid runEvals config property
+      notARealOption: true,
+    });
+  });
+});

--- a/packages/core/src/evals/run/index.ts
+++ b/packages/core/src/evals/run/index.ts
@@ -218,6 +218,8 @@ export function runEvals<TWorkflow extends AnyWorkflow>(config: {
   data: RunEvalsDataItem<TWorkflow>[];
   scorers: WorkflowScorerConfig;
   target: TWorkflow;
+  /** Gates: scorers that must score 1.0 for the run to pass. */
+  gates?: MastraScorer<any, any, any, any>[];
   targetOptions?: WorkflowRunOptions;
   onItemComplete?: (params: {
     item: RunEvalsDataItem<TWorkflow>;
@@ -236,6 +238,8 @@ export function runEvals<TAgent extends Agent>(config: {
   data: RunEvalsDataItem<TAgent>[];
   scorers: AgentScorerConfig;
   target: TAgent;
+  /** Gates: scorers that must score 1.0 for the run to pass. */
+  gates?: MastraScorer<any, any, any, any>[];
   targetOptions?: RunEvalsAgentOptions;
   onItemComplete?: (params: {
     item: RunEvalsDataItem<TAgent>;


### PR DESCRIPTION
## Description

`runEvals` supports running `gates` (hard pass/fail scorers) independently of the scorer configuration, and this works correctly at runtime for both agent and workflow targets — the gates loop runs before scorer dispatch, and `validateEvalsInputs` accepts `gates` regardless of the scorer shape.

However, the public TypeScript overloads only declared `gates` alongside a flat `ScorerEntry[]`. The categorized-config overloads (`AgentScorerConfig` / `WorkflowScorerConfig`) had no `gates` property, so a call like:

```ts
runEvals({
  target: agent,
  data: [{ input: 'Where is my order 1002?' }],
  gates: [checks.calledTool('lookup_order'), checks.noToolErrors()],
  scorers: { trajectory: [trajectoryScorer] }, // AgentScorerConfig
})
```

failed to compile with `TS2769: No overload matches this call` even though the exact call runs correctly. This blocks the documented CI pattern of combining hard gates (invariants like "must call this tool", "no tool errors") with trajectory guardrails in a single run — splitting them into two `runEvals` calls would execute the agent twice and score a different run than the gated one.

### Fix

Add the optional `gates` property to the `AgentScorerConfig` and `WorkflowScorerConfig` overloads. This follows the same approach as #19348, which added the missing gate overload for gate-only agent runs. The workflow overload is included for symmetry because the implementation runs gates for workflow targets too.

The change is type-only; runtime behavior is unchanged.

### Tests

Added `packages/core/src/evals/run/gates-scorer-config-types.test-d.ts` — type-level (vitest `typecheck`) regression tests covering:

- `gates` + `AgentScorerConfig` compiles
- `gates` + `WorkflowScorerConfig` compiles
- `AgentScorerConfig` without `gates` still compiles
- unknown properties are still rejected on the categorized-config overload

Verified locally with the `typecheck:packages/core` project: all four pass with the fix, and reverting the source change makes the two combined-call tests fail with the original `TS2769` (`'gates' does not exist in type ...`), confirming the tests exercise the bug.

## Related issue(s)

Fixes #21136

Hi @YujohnNattrass @intojhanurag — this one's a small, type-only overload fix for the evals runner (no runtime change). Would appreciate a look when you get a chance. Happy to adjust if you'd rather scope it to just the agent overload.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have added tests that prove my fix is effective
- [x] I have added a changeset (`@mastra/core` patch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

`runEvals` already supported gates with agent and workflow scorers at runtime. This change updates the TypeScript definitions so these valid combinations compile correctly.

## Changes

- Added optional `gates` support to agent and workflow scorer configuration overloads.
- Added type-level tests for:
  - Configurations with gates.
  - Configurations without gates.
  - `RunEvalsResult` inference.
  - Rejection of unknown properties.
- Added a changeset for the fix.
- No runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->