### PR TITLE
fix(core): stop resolveWorkspace pinning a session workspace on the controller

### DIFF
--- a/.changeset/agent-controller-resolve-workspace.md
+++ b/.changeset/agent-controller-resolve-workspace.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/core': patch
-'@mastra/code-sdk': patch
 ---
 
 Stop `AgentController.resolveWorkspace` from pinning one session's workspace onto the controller. It cached the resolved instance on `this.workspace`, which replaced the dynamic workspace factory: every session created afterwards skipped resolution and inherited that instance, so on a multi-session controller one user's workspace became everyone's. It also made `isWorkspaceReady()` flip from `true` to `false` for factory configs. `resolveWorkspace` now returns the workspace the session already resolved at creation, and only falls back to the factory for a session created without one — which also means slash commands read the same instance the session's runs use, instead of a second one materialized from a fresh context.

--- a/.changeset/agent-controller-resolve-workspace.md
+++ b/.changeset/agent-controller-resolve-workspace.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/code-sdk': patch
+---
+
+Stop `AgentController.resolveWorkspace` from pinning one session's workspace onto the controller. It cached the resolved instance on `this.workspace`, which replaced the dynamic workspace factory: every session created afterwards skipped resolution and inherited that instance, so on a multi-session controller one user's workspace became everyone's. It also made `isWorkspaceReady()` flip from `true` to `false` for factory configs. `resolveWorkspace` now returns the workspace the session already resolved at creation, and only falls back to the factory for a session created without one — which also means slash commands read the same instance the session's runs use, instead of a second one materialized from a fresh context.

--- a/.changeset/agent-controller-resolve-workspace.md
+++ b/.changeset/agent-controller-resolve-workspace.md
@@ -2,4 +2,6 @@
 '@mastra/core': patch
 ---
 
-Stop `AgentController.resolveWorkspace` from pinning one session's workspace onto the controller. It cached the resolved instance on `this.workspace`, which replaced the dynamic workspace factory: every session created afterwards skipped resolution and inherited that instance, so on a multi-session controller one user's workspace became everyone's. It also made `isWorkspaceReady()` flip from `true` to `false` for factory configs. `resolveWorkspace` now returns the workspace the session already resolved at creation, and only falls back to the factory for a session created without one — which also means slash commands read the same instance the session's runs use, instead of a second one materialized from a fresh context.
+Fixed `AgentController.resolveWorkspace` handing one session's workspace to every session created after it. On a controller configured with a dynamic workspace factory, the first call cached its result over the factory itself, so later sessions skipped resolution and ran against the first session's workspace instead of their own.
+
+`resolveWorkspace` now returns the workspace a session already resolved at creation, and caches nothing on the controller. Two smaller fixes come with it: `isWorkspaceReady()` no longer flips to `false` for factory configs, and slash commands read the same workspace instance the session's runs use.

--- a/.changeset/code-sdk-notification-workspace.md
+++ b/.changeset/code-sdk-notification-workspace.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed woken notifications running against the controller-level workspace, which is `undefined` for dynamic workspace factories. They now use the workspace of the session that owns the target thread.

--- a/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
+++ b/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
@@ -488,7 +488,7 @@ Returns: `boolean`
 
 #### `getWorkspace()`
 
-Return a static controller workspace. Dynamic workspace factories return `undefined` until resolved.
+Return a static controller workspace. Dynamic workspace factories return `undefined` — they resolve per session, so use `resolveWorkspace` instead.
 
 ```typescript
 const workspace = controller.getWorkspace()
@@ -498,7 +498,7 @@ Returns: `Workspace | undefined`
 
 #### `resolveWorkspace({ session, requestContext? })`
 
-Resolve a dynamic workspace for a session and cache the result on the controller.
+Return the workspace a session runs against. Sessions resolve theirs at creation, dynamic factories included, so this returns that instance and only falls back to the factory for a session created without one.
 
 ```typescript
 const workspace = await controller.resolveWorkspace({ session, requestContext })

--- a/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
+++ b/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
@@ -488,7 +488,7 @@ Returns: `boolean`
 
 #### `getWorkspace()`
 
-Return a static controller workspace. Dynamic workspace factories return `undefined` — they resolve per session, so use `resolveWorkspace` instead.
+Return a static controller workspace. Dynamic workspace factories resolve per session and return `undefined` here, so use `resolveWorkspace` instead.
 
 ```typescript
 const workspace = controller.getWorkspace()

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -715,7 +715,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
           update: updater => session.state.update(updater),
         },
       },
-      workspace: controller.getWorkspace(),
+      workspace: session.getWorkspace(),
       getSubagentModelId: params => session.subagents.model.get(params ?? {}),
     };
     requestContext.set('controller', agentControllerContext);

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -670,10 +670,11 @@ export class AgentController<TState = {}> {
   }
 
   /**
-   * Eagerly resolve the workspace. For dynamic workspaces (factory function),
-   * this triggers resolution against the given session's request context and
-   * caches the result so {@link getWorkspace} returns it. Useful for code paths
-   * outside the request flow (e.g. slash commands).
+   * The workspace this session runs against, for code paths outside the request
+   * flow (e.g. slash commands). Sessions resolve their workspace once at
+   * creation — dynamic factories included — so this returns that instance
+   * rather than re-resolving, and only falls back to the factory for a session
+   * created without one.
    */
   async resolveWorkspace({
     session,
@@ -682,11 +683,11 @@ export class AgentController<TState = {}> {
     session: Session<TState>;
     requestContext?: RequestContext;
   }): Promise<Workspace | undefined> {
+    const sessionWorkspace = session.getWorkspace();
+    if (sessionWorkspace) return sessionWorkspace;
     if (typeof this.workspace !== 'function') return this.workspace ?? undefined;
     const ctx = await this.buildRequestContext(session, requestContext);
-    const resolved = await this.workspace({ requestContext: ctx, mastra: this.getMastra() });
-    this.workspace = resolved;
-    return resolved ?? undefined;
+    return (await this.workspace({ requestContext: ctx, mastra: this.getMastra() })) ?? undefined;
   }
 
   /**

--- a/packages/core/src/agent-controller/workspace-resolution.test.ts
+++ b/packages/core/src/agent-controller/workspace-resolution.test.ts
@@ -114,7 +114,7 @@ describe('AgentController workspace — dynamic factory', () => {
     expect(factory).toHaveBeenCalledTimes(2);
   });
 
-  it('resolveWorkspace provides session state to the factory', async () => {
+  it('the factory reads session state through the request context', async () => {
     const ws = createMockWorkspace('dynamic-ws');
     // Simulates a dynamic workspace factory that reads session state via
     // getState() — the recommended accessor on AgentControllerRequestContext.
@@ -137,11 +137,46 @@ describe('AgentController workspace — dynamic factory', () => {
 
     const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
 
-    // resolveWorkspace is called outside the request flow (e.g. from slash
-    // commands). createSession does not cache the resolved workspace on
-    // this.workspace, so this re-invokes the factory with a fresh context.
-    const resolved = await controller.resolveWorkspace({ session });
-    expect(resolved).toBe(ws);
+    // Callers outside the request flow (e.g. slash commands) get the instance
+    // the session already runs against, so the factory is not asked twice.
+    expect(await controller.resolveWorkspace({ session })).toBe(ws);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolveWorkspace does not pin one session workspace onto the controller', async () => {
+    const wsA = createMockWorkspace('ws-a');
+    const wsB = createMockWorkspace('ws-b');
+    const factory = vi.fn(async ({ requestContext }) => {
+      const projectPath = requestContext.get('controller').getState().projectPath;
+      return projectPath === '/repo-a' ? wsA : wsB;
+    });
+    const controller = new AgentController({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      workspace: factory,
+    });
+    await controller.init();
+
+    const sessionA = await controller.createSession({
+      id: 'session-a',
+      ownerId: 'test-owner',
+      resourceId: 'resource-a',
+      tags: { projectPath: '/repo-a' },
+    });
+    await controller.resolveWorkspace({ session: sessionA });
+
+    const sessionB = await controller.createSession({
+      id: 'session-b',
+      ownerId: 'test-owner',
+      resourceId: 'resource-b',
+      tags: { projectPath: '/repo-b' },
+    });
+
+    expect(sessionB.getWorkspace()).toBe(wsB);
+    expect(await controller.resolveWorkspace({ session: sessionB })).toBe(wsB);
+    expect(controller.getWorkspace()).toBeUndefined();
+    expect(controller.isWorkspaceReady()).toBe(true);
   });
 });
 

--- a/packages/core/src/agent-controller/workspace-resolution.test.ts
+++ b/packages/core/src/agent-controller/workspace-resolution.test.ts
@@ -173,8 +173,11 @@ describe('AgentController workspace — dynamic factory', () => {
       tags: { projectPath: '/repo-b' },
     });
 
+    expect(sessionA.getWorkspace()).toBe(wsA);
     expect(sessionB.getWorkspace()).toBe(wsB);
+    expect(await controller.resolveWorkspace({ session: sessionA })).toBe(wsA);
     expect(await controller.resolveWorkspace({ session: sessionB })).toBe(wsB);
+    expect(factory).toHaveBeenCalledTimes(2);
     expect(controller.getWorkspace()).toBeUndefined();
     expect(controller.isWorkspaceReady()).toBe(true);
   });


### PR DESCRIPTION
`AgentController.resolveWorkspace` cached whatever it resolved onto `this.workspace`. That field is also where the dynamic workspace factory lives, so the cache overwrote the factory: the next `createSession` saw a plain instance instead of a function, skipped resolution entirely, and handed the new session the workspace belonging to whoever called first. A single-session TUI never notices, but a controller serving several sessions gives one user's workspace to all of them. Two smaller things fell out of the same line — `isWorkspaceReady()` flipped from `true` to `false` for factory configs, and `/skills` read a second instance materialized from a fresh context rather than the one the session actually runs on.

Sessions already resolve their workspace once, at creation, factories included, and keep it. So `resolveWorkspace` now returns `session.getWorkspace()` and only falls back to the factory for a session created without one; nothing is cached on the controller anymore, which is what `getWorkspace()`'s own doc comment already claimed. I also pointed the code SDK's notification path at the target session's workspace instead of the controller's, since it has the session in hand and that field only ever held a value because of the caching.

The new test resolves session A's workspace, then creates session B with a different `projectPath` and checks B gets its own. On main it fails on both counts: B inherits A's instance, and the factory is invoked twice instead of once. The rest of `packages/core/src/agent-controller` passes unchanged (446 tests), along with the three TUI suites that go through `resolveWorkspace`. Draft because I have not exercised it against a live multi-session Factory server, only the unit suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Each session now gets its own workspace. One session no longer replaces the workspace used by later sessions.

## Changes

- Updated `AgentController.resolveWorkspace` to reuse the session workspace and avoid controller-level caching.
- Updated code SDK notifications to use the target session’s workspace.
- Clarified dynamic workspace resolution in the `AgentController` documentation.
- Added regression tests for per-session workspaces and factory calls.
- Added patch changesets for `@mastra/core` and `@mastra/code-sdk`.

## Validation

- Agent-controller tests pass.
- TUI tests pass.
- Live multi-session Factory server testing is still pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->