### PR TITLE
fix(core): stop deepEqual matching a Date/array against a plain object

### DIFF
--- a/.changeset/deep-equal-cross-type-false-positives.md
+++ b/.changeset/deep-equal-cross-type-false-positives.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `deepEqual` returning `true` for values of mismatched shapes. A `Date` compared against a plain object (e.g. `deepEqual(new Date(), {})`) fell through to the generic object-key comparison — and since a `Date` has no own enumerable keys, it matched `{}`. Likewise an array compared against an object with matching index keys (e.g. `deepEqual([1, 2], { '0': 1, '1': 2 })`) returned `true`. Added guards so an array only equals an array and a `Date` only equals a `Date`; the checks apply recursively to nested values.

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1103,6 +1103,32 @@ describe('deepEqual', () => {
   it('returns false for values of different types', () => {
     expect(deepEqual(1, '1')).toBe(false);
   });
+
+  it('returns false when comparing a Date to a plain object', () => {
+    // A Date has no own enumerable keys, so without a type guard it would
+    // compare equal to an empty object via the generic object branch.
+    expect(deepEqual(new Date('2024-01-01'), {})).toBe(false);
+    expect(deepEqual({}, new Date('2024-01-01'))).toBe(false);
+    expect(deepEqual(new Date('2024-01-01'), { getTime: 1 })).toBe(false);
+  });
+
+  it('returns false when comparing an array to a plain object with matching index keys', () => {
+    expect(deepEqual([1, 2], { '0': 1, '1': 2 })).toBe(false);
+    expect(deepEqual({ '0': 1, '1': 2 }, [1, 2])).toBe(false);
+  });
+
+  it('returns false when comparing a Date to an array', () => {
+    expect(deepEqual(new Date('2024-01-01'), [])).toBe(false);
+    expect(deepEqual([], new Date('2024-01-01'))).toBe(false);
+  });
+
+  it('applies the type guards recursively for nested values', () => {
+    expect(deepEqual({ when: new Date('2024-01-01') }, { when: {} })).toBe(false);
+    expect(deepEqual({ items: [1, 2] }, { items: { '0': 1, '1': 2 } })).toBe(false);
+    // Sanity: genuinely equal nested Dates/arrays still match.
+    expect(deepEqual({ when: new Date('2024-01-01') }, { when: new Date('2024-01-01') })).toBe(true);
+    expect(deepEqual({ items: [1, 2] }, { items: [1, 2] })).toBe(true);
+  });
 });
 
 describe('omitKeys', () => {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -9,7 +9,6 @@ import { toStandardSchema } from './schema';
 import { createTool, isVercelTool } from './tools';
 import {
   boundedStringify,
-  deepEqual,
   deepMerge,
   ensureSerializable,
   isBoundedSerializable,
@@ -1031,103 +1030,6 @@ describe('deepMerge', () => {
   it('source undefined values do not overwrite target keys', () => {
     const result = deepMerge({ a: 1 }, { a: undefined });
     expect(result.a).toBe(1);
-  });
-});
-
-describe('deepEqual', () => {
-  it('returns true for identical primitives', () => {
-    expect(deepEqual(1, 1)).toBe(true);
-    expect(deepEqual('hello', 'hello')).toBe(true);
-    expect(deepEqual(true, true)).toBe(true);
-  });
-
-  it('returns false for different primitives', () => {
-    expect(deepEqual(1, 2)).toBe(false);
-    expect(deepEqual('a', 'b')).toBe(false);
-  });
-
-  it('returns true for the same object reference', () => {
-    const obj = { a: 1 };
-    expect(deepEqual(obj, obj)).toBe(true);
-  });
-
-  it('returns true for deeply equal plain objects', () => {
-    expect(deepEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe(true);
-  });
-
-  it('returns false when object keys differ', () => {
-    expect(deepEqual({ a: 1 }, { b: 1 })).toBe(false);
-  });
-
-  it('returns false when object values differ', () => {
-    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
-  });
-
-  it('returns false when objects have different key counts', () => {
-    expect(deepEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
-  });
-
-  it('returns true for equal arrays', () => {
-    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
-  });
-
-  it('returns false for arrays of different length', () => {
-    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
-  });
-
-  it('returns false for arrays with different elements', () => {
-    expect(deepEqual([1, 2, 3], [1, 2, 4])).toBe(false);
-  });
-
-  it('returns true for equal Date instances', () => {
-    const d1 = new Date('2024-01-01');
-    const d2 = new Date('2024-01-01');
-    expect(deepEqual(d1, d2)).toBe(true);
-  });
-
-  it('returns false for different Date instances', () => {
-    const d1 = new Date('2024-01-01');
-    const d2 = new Date('2025-06-01');
-    expect(deepEqual(d1, d2)).toBe(false);
-  });
-
-  it('returns true for both null values', () => {
-    expect(deepEqual(null, null)).toBe(true);
-  });
-
-  it('returns false when only one side is null', () => {
-    expect(deepEqual(null, {})).toBe(false);
-    expect(deepEqual({}, null)).toBe(false);
-  });
-
-  it('returns false for values of different types', () => {
-    expect(deepEqual(1, '1')).toBe(false);
-  });
-
-  it('returns false when comparing a Date to a plain object', () => {
-    // A Date has no own enumerable keys, so without a type guard it would
-    // compare equal to an empty object via the generic object branch.
-    expect(deepEqual(new Date('2024-01-01'), {})).toBe(false);
-    expect(deepEqual({}, new Date('2024-01-01'))).toBe(false);
-    expect(deepEqual(new Date('2024-01-01'), { getTime: 1 })).toBe(false);
-  });
-
-  it('returns false when comparing an array to a plain object with matching index keys', () => {
-    expect(deepEqual([1, 2], { '0': 1, '1': 2 })).toBe(false);
-    expect(deepEqual({ '0': 1, '1': 2 }, [1, 2])).toBe(false);
-  });
-
-  it('returns false when comparing a Date to an array', () => {
-    expect(deepEqual(new Date('2024-01-01'), [])).toBe(false);
-    expect(deepEqual([], new Date('2024-01-01'))).toBe(false);
-  });
-
-  it('applies the type guards recursively for nested values', () => {
-    expect(deepEqual({ when: new Date('2024-01-01') }, { when: {} })).toBe(false);
-    expect(deepEqual({ items: [1, 2] }, { items: { '0': 1, '1': 2 } })).toBe(false);
-    // Sanity: genuinely equal nested Dates/arrays still match.
-    expect(deepEqual({ when: new Date('2024-01-01') }, { when: new Date('2024-01-01') })).toBe(true);
-    expect(deepEqual({ items: [1, 2] }, { items: [1, 2] })).toBe(true);
   });
 });
 

--- a/packages/core/src/utils/deep-equal.test.ts
+++ b/packages/core/src/utils/deep-equal.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { deepEqual } from './deep-equal';
+
+describe('deepEqual', () => {
+  it('returns true for identical primitives', () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual('hello', 'hello')).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+  });
+
+  it('returns false for different primitives', () => {
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual('a', 'b')).toBe(false);
+  });
+
+  it('returns true for the same object reference', () => {
+    const obj = { a: 1 };
+    expect(deepEqual(obj, obj)).toBe(true);
+  });
+
+  it('returns true for deeply equal plain objects', () => {
+    expect(deepEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe(true);
+  });
+
+  it('returns false when object keys differ', () => {
+    expect(deepEqual({ a: 1 }, { b: 1 })).toBe(false);
+  });
+
+  it('returns false when object values differ', () => {
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it('returns false when objects have different key counts', () => {
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+  });
+
+  it('returns true for equal arrays', () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+  });
+
+  it('returns false for arrays of different length', () => {
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+  });
+
+  it('returns false for arrays with different elements', () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+  });
+
+  it('returns true for equal Date instances', () => {
+    const d1 = new Date('2024-01-01');
+    const d2 = new Date('2024-01-01');
+    expect(deepEqual(d1, d2)).toBe(true);
+  });
+
+  it('returns false for different Date instances', () => {
+    const d1 = new Date('2024-01-01');
+    const d2 = new Date('2025-06-01');
+    expect(deepEqual(d1, d2)).toBe(false);
+  });
+
+  it('returns true for both null values', () => {
+    expect(deepEqual(null, null)).toBe(true);
+  });
+
+  it('returns false when only one side is null', () => {
+    expect(deepEqual(null, {})).toBe(false);
+    expect(deepEqual({}, null)).toBe(false);
+  });
+
+  it('returns false for values of different types', () => {
+    expect(deepEqual(1, '1')).toBe(false);
+  });
+
+  it('returns false when comparing a Date to a plain object', () => {
+    // A Date has no own enumerable keys, so without a type guard it would
+    // compare equal to an empty object via the generic object branch.
+    expect(deepEqual(new Date('2024-01-01'), {})).toBe(false);
+    expect(deepEqual({}, new Date('2024-01-01'))).toBe(false);
+    expect(deepEqual(new Date('2024-01-01'), { getTime: 1 })).toBe(false);
+  });
+
+  it('returns false when comparing an array to a plain object with matching index keys', () => {
+    expect(deepEqual([1, 2], { '0': 1, '1': 2 })).toBe(false);
+    expect(deepEqual({ '0': 1, '1': 2 }, [1, 2])).toBe(false);
+  });
+
+  it('returns false when comparing a Date to an array', () => {
+    expect(deepEqual(new Date('2024-01-01'), [])).toBe(false);
+    expect(deepEqual([], new Date('2024-01-01'))).toBe(false);
+  });
+
+  it('applies the type guards recursively for nested values', () => {
+    expect(deepEqual({ when: new Date('2024-01-01') }, { when: {} })).toBe(false);
+    expect(deepEqual({ items: [1, 2] }, { items: { '0': 1, '1': 2 } })).toBe(false);
+    // Sanity: genuinely equal nested Dates/arrays still match.
+    expect(deepEqual({ when: new Date('2024-01-01') }, { when: new Date('2024-01-01') })).toBe(true);
+    expect(deepEqual({ items: [1, 2] }, { items: [1, 2] })).toBe(true);
+  });
+});

--- a/packages/core/src/utils/deep-equal.ts
+++ b/packages/core/src/utils/deep-equal.ts
@@ -12,6 +12,13 @@ export function deepEqual(a: unknown, b: unknown): boolean {
   // Handle different types
   if (typeof a !== typeof b) return false;
 
+  // An array is only ever equal to another array, and a Date only to another
+  // Date. Without these guards the generic object branch below compares
+  // `Object.keys`, so a Date (no own enumerable keys) would equal `{}` and
+  // `[1, 2]` would equal `{ '0': 1, '1': 2 }`.
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (a instanceof Date !== b instanceof Date) return false;
+
   // Handle arrays
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) return false;


### PR DESCRIPTION
## Description

`deepEqual` (`packages/core/src/utils/deep-equal.ts`, re-exported from `@mastra/core/utils`) returned `true` for values of mismatched shapes:

```ts
deepEqual(new Date('2024-01-01'), {});   // was true → now false
deepEqual([1, 2], { '0': 1, '1': 2 });   // was true → now false
```

The type-specific branches (`Array.isArray(a) && Array.isArray(b)`, `a instanceof Date && b instanceof Date`) only run when **both** operands are of that type. When only one is, execution fell through to the generic object branch, which compares `Object.keys(a)` vs `Object.keys(b)` — and a `Date` has no own enumerable keys, so it matched `{}`; an array matched an object with the same index keys.

### Fix

Before the object branch, guard that an array is only equal to another array and a `Date` only to another `Date`:

```ts
if (Array.isArray(a) !== Array.isArray(b)) return false;
if (a instanceof Date !== (b instanceof Date)) return false;
```

Because `deepEqual` recurses, the guards also apply to nested values (`{ when: new Date() }` vs `{ when: {} }`). Genuinely-equal Dates/arrays are unaffected. The change is behavior-narrowing (some previously-`true` comparisons become `false`); no comparison that was `false` becomes `true`.

### Why it matters

`deepEqual` is used to short-circuit work based on equality — e.g. `workflows/default.ts` compares a step's `payload` to the previous output to decide whether to reuse it, and `datasets/experiment/tool-mocks.ts` matches recorded tool-call args. A false-positive there can reuse a stale value or match the wrong mock when a `Date`- or array-valued field is involved.

### Tests

Added cases to the existing `deepEqual` suite in `packages/core/src/utils.test.ts` covering Date-vs-object, array-vs-object, Date-vs-array, and the nested variants, plus sanity assertions that equal Dates/arrays (including nested) still compare equal.

Verified against the compiled source: all previously-buggy cases now return `false` and all genuinely-equal cases still return `true`.

Hey @YujohnNattrass @wardpeet — small, self-contained correctness fix for `deepEqual` (behavior-narrowing, type-only guard). Would appreciate a review when you have a moment.

## Related issue(s)

Fixes #21145

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have added tests that prove my fix is effective
- [x] I have added a changeset (`@mastra/core` patch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

`deepEqual` now treats different kinds of values as different. Arrays only match arrays, and `Date` values only match other `Date` values, including when nested.

## Changes

- Fixed cross-type comparisons in `deepEqual`.
- Added regression tests for arrays, objects, and `Date` mismatches.
- Confirmed equal arrays and dates still match.
- Moved tests to `utils/deep-equal.test.ts`.
- Added an `@mastra/core` patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->