### PR TITLE
fix(schema-compat): bundle zod-to-json-schema for CJS

### DIFF
--- a/.changeset/quiet-cats-fix.md
+++ b/.changeset/quiet-cats-fix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed Zod v3 schema conversion for CommonJS consumers.

--- a/packages/schema-compat/package.json
+++ b/packages/schema-compat/package.json
@@ -100,8 +100,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "json-schema-to-zod": "^2.7.0",
-    "zod-from-json-schema": "^0.5.2",
-    "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5"
+    "zod-from-json-schema": "^0.5.2"
   },
   "peerDependencies": {
     "zod": "^3.25.0 || ^4.0.0"
@@ -131,7 +130,8 @@
     "vitest": "catalog:",
     "zod": "catalog:",
     "zod-v3": "npm:zod@^3.25.76",
-    "zod-to-json-schema": "^3.25.2"
+    "zod-to-json-schema": "^3.25.2",
+    "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/packages/schema-compat/package.json
+++ b/packages/schema-compat/package.json
@@ -101,8 +101,7 @@
   "dependencies": {
     "json-schema-to-zod": "^2.7.0",
     "zod-from-json-schema": "^0.5.2",
-    "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5",
-    "zod-to-json-schema": "^3.25.1"
+    "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5"
   },
   "peerDependencies": {
     "zod": "^3.25.0 || ^4.0.0"
@@ -131,7 +130,8 @@
     "typescript": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:",
-    "zod-v3": "npm:zod@^3.25.76"
+    "zod-v3": "npm:zod@^3.25.76",
+    "zod-to-json-schema": "^3.25.2"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/packages/schema-compat/src/zod-to-json-cjs-v3.test.ts
+++ b/packages/schema-compat/src/zod-to-json-cjs-v3.test.ts
@@ -1,0 +1,47 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+const requireFromPackage = createRequire(import.meta.url);
+
+describe('CommonJS build', () => {
+  it('converts Zod v3 schemas through zodToJsonSchema', () => {
+    const { zodToJsonSchema } = requireFromPackage('../dist/zod-to-json.cjs') as {
+      zodToJsonSchema(schema: unknown): {
+        type?: string;
+        properties?: Record<string, { type?: string }>;
+      };
+    };
+
+    const result = zodToJsonSchema(z.object({ url: z.string().url() }));
+
+    expect(result).toMatchObject({
+      type: 'object',
+      properties: { url: { type: 'string' } },
+    });
+  });
+
+  it('converts Zod v3 schemas through the standard schema adapter', () => {
+    const { toStandardSchema } = requireFromPackage('../dist/standard-schema/adapters/zod-v3.cjs') as {
+      toStandardSchema(schema: unknown): {
+        '~standard': {
+          jsonSchema: {
+            output(options: { target: string }): {
+              type?: string;
+              properties?: Record<string, { type?: string }>;
+            };
+          };
+        };
+      };
+    };
+
+    const result = toStandardSchema(z.object({ url: z.string().url() }))['~standard'].jsonSchema.output({
+      target: 'draft-07',
+    });
+
+    expect(result).toMatchObject({
+      type: 'object',
+      properties: { url: { type: 'string' } },
+    });
+  });
+});

--- a/packages/schema-compat/tsdown.config.ts
+++ b/packages/schema-compat/tsdown.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   treeshake: true,
   sourcemap: true,
   deps: {
-    alwaysBundle: ['@internal/ai-sdk-v4', 'ajv'],
+    alwaysBundle: ['@internal/ai-sdk-v4', 'ajv', 'zod-to-json-schema'],
   },
   onSuccess: async () => {
     await generateTypes(

--- a/packages/schema-compat/tsdown.config.ts
+++ b/packages/schema-compat/tsdown.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   treeshake: true,
   sourcemap: true,
   deps: {
-    alwaysBundle: ['@internal/ai-sdk-v4', 'ajv', 'zod-to-json-schema'],
+    alwaysBundle: ['@internal/ai-sdk-v4', 'ajv', 'zod-to-json-schema', 'zod-from-json-schema-v3'],
   },
   onSuccess: async () => {
     await generateTypes(
@@ -31,6 +31,8 @@ export default defineConfig({
         '@standard-schema/spec',
         '@types/json-schema',
         'ajv',
+        'zod-to-json-schema',
+        'zod-from-json-schema-v3',
       ]),
     );
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6000,9 +6000,6 @@ importers:
       zod-from-json-schema-v3:
         specifier: npm:zod-from-json-schema@^0.0.5
         version: zod-from-json-schema@0.0.5
-      zod-to-json-schema:
-        specifier: ^3.25.1
-        version: 3.25.2(zod@4.4.3)
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.103
@@ -6073,6 +6070,9 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@4.4.3)
       zod-v3:
         specifier: npm:zod@^3.25.76
         version: zod@3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5997,9 +5997,6 @@ importers:
       zod-from-json-schema:
         specifier: ^0.5.2
         version: 0.5.2
-      zod-from-json-schema-v3:
-        specifier: npm:zod-from-json-schema@^0.0.5
-        version: zod-from-json-schema@0.0.5
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.103
@@ -6070,6 +6067,9 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
+      zod-from-json-schema-v3:
+        specifier: npm:zod-from-json-schema@^0.0.5
+        version: zod-from-json-schema@0.0.5
       zod-to-json-schema:
         specifier: ^3.25.2
         version: 3.25.2(zod@4.4.3)


### PR DESCRIPTION
## Description

Fix the published CommonJS build of `@mastra/schema-compat` when it converts Zod v3 schemas.

## Related issue(s)

Fixes #21107

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

The CJS build was calling the dependency's default export after rolldown wrapped it with `__toESM(..., 1)`. The wrapper can expose a namespace object instead of the callable converter.

This bundles `zod-to-json-schema` with the package and adds regression coverage for both affected CJS entry points. The ESM output and runtime source logic are unchanged.

Verified locally with 34 test files (893 tests, 9 skipped), the focused CJS regression, and package lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

CommonJS users could not convert some Zod v3 schemas because the converter loaded incorrectly. This PR bundles the converter correctly and adds tests for both affected entry points.

## Changes

- Bundle `zod-to-json-schema` and `zod-from-json-schema-v3`.
- Move both packages to development dependencies.
- Add regression tests for both affected CommonJS entry points.
- Add a patch changeset for `@mastra/schema-compat`.

## Validation

- 34 test files passed.
- 893 tests passed.
- 9 tests were skipped.
- Focused CommonJS regression tests passed.
- Package lint passed.
- ESM output and runtime source logic remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->