### PR TITLE
fix: mark patches/*.patch as no-text to prevent CRLF corruption on Wi…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+patches/*.patch -text


### PR DESCRIPTION
## Description

Adds a `.gitattributes` entry marking `patches/*.patch` as `-text`, so Git never converts their line endings during checkout.

Without this, Windows users with `core.autocrlf=true` (the default/recommended Git-for-Windows setting) get their patch files silently converted from LF to CRLF on checkout. pnpm's patch engine can't apply a CRLF-corrupted patch, but fails silently — `pnpm install` reports "Already up to date" with no error, so all 7 patched dependencies (`@changesets/get-dependents-graph`, `@earendil-works/pi-tui`, `@manypkg/tools`, `fetch-to-node`, `gray-matter`, `read-yaml-file`, `tsup`) end up installed **unpatched**. This surfaces later as unrelated, confusing runtime errors (e.g. a `TypeError` in `gray-matter`'s `js-yaml` fallback that the patch was supposed to add).

## Related issue(s)

Fixes #21141

## Type of change

- [x] Bug fix (non-breaking change that fixes an issu
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the descr
- [x] I have made corresponding changes to the documentation (if applicable) — not applicable, no docs reference patch line-ending handling
- [ ] I have added tests that prove my fix is effecti this is a Git checkout-behavior fix(`.gitattributes`), not something the test suite can exercise; verified manually by reproducing the CRLF corruption and confirming it no longer occurs with this file in place
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This change keeps patch files unchanged when Git checks out the project. This helps pnpm apply patches correctly on Windows.

## Changes

- Added `.gitattributes` rule: `patches/*.patch -text`
- Prevented CRLF conversion for patch files when `core.autocrlf=true`.
- Ensured patched dependencies remain patched across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->