### PR TITLE
chore(docs): scope staged MDX formatting

### DIFF
--- a/docs/lint-staged.config.mjs
+++ b/docs/lint-staged.config.mjs
@@ -1,4 +1,4 @@
 export default {
   '*.{ts,tsx,js,jsx,json,md,yml,yaml,css}': ['oxfmt --no-error-on-unmatched-pattern'],
-  '*.mdx': ['oxfmt-mdx --write'],
+  'src/content/en/{docs,guides,reference}/**/*.mdx': ['oxfmt-mdx --write'],
 }


### PR DESCRIPTION
Generated model pages are outside the normal MDX formatting scope, but the basename-only lint-staged glob matched every staged `.mdx` file. This could rewrite generated model docs during commits that stage a large set of files.

This scopes the formatter through lint-staged's path matching instead:

```js
'src/content/en/{docs,guides,reference}/**/*.mdx': ['oxfmt-mdx --write']
```

The matcher follows the same authored-doc directories as `format:mdx`, excludes generated model pages, and lets lint-staged pass file paths to the task without manually constructing a shell command. Verified with docs, guides, reference, generated-model, and space-containing paths using a real lint-staged run with an isolated Git index.

This supersedes https://github.com/mastra-ai/mastra/pull/20968.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The formatter now changes only authored English documentation files. It skips generated pages, which prevents unwanted file changes.

## Changes

- Scoped the lint-staged MDX pattern to:
  - `src/content/en/docs/**/*.mdx`
  - `src/content/en/guides/**/*.mdx`
  - `src/content/en/reference/**/*.mdx`
- Passed matched file paths directly to `oxfmt-mdx --write`.
- Verified paths for documentation, guides, reference, generated-model, and space-containing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->