### PR TITLE
docs: refine Develop / Deploy navigation

### DIFF
--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -443,37 +443,9 @@ const sidebars = {
       className: 'sidebar-group-name',
       items: [
         {
-          type: 'category',
-          label: 'Studio',
-          link: {
-            type: 'doc',
-            id: 'studio/overview',
-          },
-          customProps: {
-            contextualSidebar: true,
-          },
-          items: [
-            {
-              type: 'doc',
-              id: 'studio/deployment',
-              label: 'Deployment',
-            },
-            {
-              type: 'doc',
-              id: 'studio/auth',
-              label: 'Auth',
-            },
-            {
-              type: 'doc',
-              id: 'studio/observability',
-              label: 'Observability',
-            },
-            {
-              type: 'doc',
-              id: 'editor/overview',
-              label: 'Editor',
-            },
-          ],
+          type: 'doc',
+          id: 'storage/overview',
+          label: 'Storage',
         },
         {
           type: 'category',
@@ -524,9 +496,37 @@ const sidebars = {
           ],
         },
         {
-          type: 'doc',
-          id: 'storage/overview',
-          label: 'Storage',
+          type: 'category',
+          label: 'Studio',
+          link: {
+            type: 'doc',
+            id: 'studio/overview',
+          },
+          customProps: {
+            contextualSidebar: true,
+          },
+          items: [
+            {
+              type: 'doc',
+              id: 'studio/deployment',
+              label: 'Deployment',
+            },
+            {
+              type: 'doc',
+              id: 'studio/auth',
+              label: 'Auth',
+            },
+            {
+              type: 'doc',
+              id: 'studio/observability',
+              label: 'Observability',
+            },
+            {
+              type: 'doc',
+              id: 'editor/overview',
+              label: 'Editor',
+            },
+          ],
         },
         {
           type: 'category',

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -443,11 +443,6 @@ const sidebars = {
       className: 'sidebar-group-name',
       items: [
         {
-          type: 'doc',
-          id: 'storage/overview',
-          label: 'Storage',
-        },
-        {
           type: 'category',
           label: 'Studio',
           link: {
@@ -527,6 +522,11 @@ const sidebars = {
               label: 'Mastra Client',
             },
           ],
+        },
+        {
+          type: 'doc',
+          id: 'storage/overview',
+          label: 'Storage',
         },
         {
           type: 'category',
@@ -616,7 +616,7 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'Deployment',
+          label: 'Deploy',
           link: {
             type: 'doc',
             id: 'deployment/overview',

--- a/docs/tests/navigation.spec.ts
+++ b/docs/tests/navigation.spec.ts
@@ -496,7 +496,7 @@ test.describe('Contextual sidebar', () => {
 
     const deploymentPane = visibleSidebarPane(page, 'contextual')
     await expect(deploymentPane).toBeVisible()
-    await expect(deploymentPane.getByRole('button', { name: 'Back to global sidebar' })).toHaveText('Deployment')
+    await expect(deploymentPane.getByRole('button', { name: 'Back to global sidebar' })).toHaveText('Deploy')
     await expect(deploymentPane.locator('a.menu__link[href="/docs/deployment/workflow-runners"]')).toHaveAttribute(
       'aria-current',
       'page',


### PR DESCRIPTION
## Summary

- reorder the Develop / Deploy section to Storage, Server, Studio, Auth, and Deploy
- rename the Deployment sidebar item to Deploy
- update the contextual sidebar navigation assertion

## Testing

- `pnpm validate:sidebar-docs`
- `pnpm exec oxfmt --check src/content/en/docs/sidebars.js tests/navigation.spec.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The documentation menu now shows Develop and Deploy pages in a clearer order. It also uses the shorter name “Deploy” consistently.

## Changes

- Reordered sidebar items to: Studio, Server, Storage, Auth, and Deploy.
- Renamed the `Deployment` sidebar item to `Deploy`.
- Updated the navigation test to expect `Deploy`.
- Validated sidebar checks, formatting, and `git diff --check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->