### PR TITLE
fix(observability): preserve response model on inference spans

### DIFF
--- a/.changeset/preserve-response-model.md
+++ b/.changeset/preserve-response-model.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Preserved the provider response model on completed model inference spans.

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -1774,6 +1774,38 @@ describe('ModelSpanTracker', () => {
       expect(inferenceSpan!.attributes.usage).toBeDefined();
     });
 
+    it('preserves the provider response model on MODEL_INFERENCE', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+        attributes: { model: 'requested-model', provider: 'test', streaming: true },
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+      tracker.setDeferStepClose(true);
+
+      const chunks = [
+        { type: 'step-start', payload: { messageId: 'msg-1' } },
+        { type: 'text-delta', payload: { text: 'hi' } },
+        {
+          type: 'step-finish',
+          payload: {
+            output: { usage: { totalTokens: 5 } },
+            stepResult: { reason: 'tool-calls', warnings: [], isContinued: true },
+            metadata: { modelId: 'provider/selected-model' },
+          },
+        },
+      ];
+
+      await consumeStream(tracker.wrapStream(createMockStream(chunks)));
+
+      const [inferenceSpan] = testExporter.getSpansByType(SpanType.MODEL_INFERENCE);
+      expect(inferenceSpan).toBeDefined();
+      expect(inferenceSpan!.attributes.responseModel).toBe('provider/selected-model');
+
+      modelSpan.end();
+    });
+
     it('applies inference context (parameters / providerOptions / availableTools / toolChoice / responseFormat) set via setInferenceContext', async () => {
       const modelSpan = tracing.startSpan({
         type: SpanType.MODEL_GENERATION,

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -1801,6 +1801,7 @@ describe('ModelSpanTracker', () => {
 
       const [inferenceSpan] = testExporter.getSpansByType(SpanType.MODEL_INFERENCE);
       expect(inferenceSpan).toBeDefined();
+      expect(inferenceSpan!.attributes.model).toBe('requested-model');
       expect(inferenceSpan!.attributes.responseModel).toBe('provider/selected-model');
 
       modelSpan.end();

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -503,6 +503,7 @@ export class ModelSpanTracker {
 
     const { usage: rawUsage, ...otherOutput } = payload.output;
     const usage = extractUsageMetrics(rawUsage, payload.metadata?.providerMetadata);
+    const responseModel = typeof payload.metadata?.modelId === 'string' ? payload.metadata.modelId : undefined;
 
     this.#currentInferenceSpan.end({
       output: otherOutput,
@@ -511,6 +512,7 @@ export class ModelSpanTracker {
         finishReason: payload.stepResult.reason,
         warnings: payload.stepResult.warnings,
         completionStartTime: this.#completionStartTime,
+        ...(responseModel?.trim() ? { responseModel } : {}),
       },
     });
     this.#currentInferenceSpan = undefined;


### PR DESCRIPTION
## Summary
- preserve the provider-selected model ID as responseModel on completed MODEL_INFERENCE spans
- ignore missing, non-string, or blank model IDs
- add a deferred-step regression test and patch changeset

## Testing
- pnpm turbo build --filter=@mastra/observability^...
- pnpm --filter @mastra/observability exec vitest run src/model-tracing.test.ts (52 passed)
- pnpm --filter @mastra/observability lint

Fixes #21149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The tracing system now records which model actually answered a request. This helps users identify the provider-selected model when a tool call delays completion.

## Changes

- Store a non-blank `payload.metadata.modelId` value as `responseModel` on completed `MODEL_INFERENCE` spans.
- Keep the requested model in `model`.
- Ignore missing, non-string, and blank model IDs.
- Preserve existing inference attributes.
- Add a regression test for deferred durable steps.
- Add a patch changeset for `@mastra/observability`.

## Testing

- Observability build
- 52 model-tracing tests
- Linting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->