### PR TITLE
feat(observability): pause telemetry export when org exceeds observability quota

### DIFF
--- a/.changeset/ten-baboons-grow.md
+++ b/.changeset/ten-baboons-grow.md
@@ -2,7 +2,7 @@
 '@mastra/observability': patch
 ---
 
-Added automatic quota pause to MastraPlatformExporter. When the Mastra platform reports that an organization's observability quota is exhausted (via the `x-mastra-observability: disabled` response header), the exporter now stops uploading telemetry, drops events locally instead of retrying, and periodically probes the platform (honoring the `x-mastra-observability-retry-after` hint, defaulting to every 5 minutes). Exports resume automatically once the platform re-enables observability, with warnings logged on pause and resume.
+Added automatic quota pause to MastraPlatformExporter. When the Mastra platform reports that an organization's observability quota is exhausted (by rejecting publish requests with `402 Payment Required` and the `x-mastra-observability: disabled` header), the exporter now stops uploading telemetry, drops events locally instead of retrying, and periodically probes the platform (honoring the `x-mastra-observability-retry-after` hint, defaulting to every 5 minutes). Exports resume automatically once the platform re-enables observability, with warnings logged on pause and resume.
 
 No configuration is needed — any existing exporter setup gets this behavior automatically:
 

--- a/.changeset/ten-baboons-grow.md
+++ b/.changeset/ten-baboons-grow.md
@@ -4,12 +4,12 @@
 
 Added automatic quota pause to MastraPlatformExporter. When the Mastra platform reports that an organization's observability quota is exhausted (by rejecting publish requests with `402 Payment Required` and the `x-mastra-observability: disabled` header), the exporter now stops uploading telemetry, drops events locally instead of retrying, and periodically probes the platform (honoring the `x-mastra-observability-retry-after` hint, defaulting to every 5 minutes). Exports resume automatically once the platform re-enables observability, with warnings logged on pause and resume.
 
-No configuration is needed — any existing exporter setup gets this behavior automatically:
+No quota-specific configuration is needed — any existing exporter setup gets this behavior automatically:
 
 ```typescript
 import { MastraPlatformExporter } from '@mastra/observability';
 
 const exporter = new MastraPlatformExporter({
-  accessToken: process.env.MASTRA_ACCESS_TOKEN,
+  accessToken: process.env.MASTRA_PLATFORM_ACCESS_TOKEN,
 });
 ```

--- a/.changeset/ten-baboons-grow.md
+++ b/.changeset/ten-baboons-grow.md
@@ -3,3 +3,13 @@
 ---
 
 Added automatic quota pause to MastraPlatformExporter. When the Mastra platform reports that an organization's observability quota is exhausted (via the `x-mastra-observability: disabled` response header), the exporter now stops uploading telemetry, drops events locally instead of retrying, and periodically probes the platform (honoring the `x-mastra-observability-retry-after` hint, defaulting to every 5 minutes). Exports resume automatically once the platform re-enables observability, with warnings logged on pause and resume.
+
+No configuration is needed — any existing exporter setup gets this behavior automatically:
+
+```typescript
+import { MastraPlatformExporter } from '@mastra/observability';
+
+const exporter = new MastraPlatformExporter({
+  accessToken: process.env.MASTRA_ACCESS_TOKEN,
+});
+```

--- a/.changeset/ten-baboons-grow.md
+++ b/.changeset/ten-baboons-grow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Added automatic quota pause to MastraPlatformExporter. When the Mastra platform reports that an organization's observability quota is exhausted (via the `x-mastra-observability: disabled` response header), the exporter now stops uploading telemetry, drops events locally instead of retrying, and periodically probes the platform (honoring the `x-mastra-observability-retry-after` hint, defaulting to every 5 minutes). Exports resume automatically once the platform re-enables observability, with warnings logged on pause and resume.

--- a/docs/src/content/en/reference/observability/tracing/exporters/mastra-platform-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/mastra-platform-exporter.mdx
@@ -254,6 +254,17 @@ The exporter batches tracing spans, logs, metrics, scores, and feedback for effi
 
 Errors raised by `MastraPlatformExporter` use the `MASTRA_PLATFORM_EXPORTER_*` `id` prefix. The deprecated `CloudExporter` continues to emit `CLOUD_EXPORTER_*` `id`s.
 
+### Quota pause
+
+When an organization has exhausted its observability quota, the Mastra platform responds to publish requests with `200 OK` plus the `x-mastra-observability: disabled` header. When the exporter sees this header on any publish route, it:
+
+- Pauses all five signal types (traces, logs, metrics, scores, feedback) and drops buffered and new events instead of sending them
+- Logs a warning that telemetry is paused
+- Probes the platform periodically with an empty batch, using the interval from the `x-mastra-observability-retry-after` header (seconds), or every 5 minutes if the header is absent
+- Resumes exporting automatically and logs a warning once the platform stops sending the disabled header
+
+The probe timer doesn't keep the Node.js process alive, so short-lived and serverless processes exit normally while paused.
+
 ### Endpoint routing
 
 - Base origins derive signal endpoints automatically

--- a/docs/src/content/en/reference/observability/tracing/exporters/mastra-platform-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/mastra-platform-exporter.mdx
@@ -256,12 +256,13 @@ Errors raised by `MastraPlatformExporter` use the `MASTRA_PLATFORM_EXPORTER_*` `
 
 ### Quota pause
 
-When an organization has exhausted its observability quota, the Mastra platform responds to publish requests with `200 OK` plus the `x-mastra-observability: disabled` header. When the exporter sees this header on any publish route, it:
+When an organization has exhausted its observability quota, the Mastra platform rejects publish requests with `402 Payment Required` plus the `x-mastra-observability: disabled` header. When the exporter sees a `402` (or the header) on any publish route, it:
 
+- Drops the rejected batch without retrying it
 - Pauses all five signal types (traces, logs, metrics, scores, feedback) and drops buffered and new events instead of sending them
 - Logs a warning that telemetry is paused
 - Probes the platform periodically with an empty batch, using the interval from the `x-mastra-observability-retry-after` header (seconds), or every 5 minutes if the header is absent
-- Resumes exporting automatically and logs a warning once the platform stops sending the disabled header
+- Resumes exporting automatically and logs a warning once the platform stops rejecting with `402`
 
 The probe timer doesn't keep the Node.js process alive, so short-lived and serverless processes exit normally while paused.
 

--- a/observability/mastra/src/exporters/auth-failure-cooldown.ts
+++ b/observability/mastra/src/exporters/auth-failure-cooldown.ts
@@ -29,6 +29,7 @@ export async function fetchWithAuthFailureHandling(
   url: string,
   options: RequestInit,
   maxRetries: number,
+  shouldRetryResponse?: (response: Response) => boolean,
 ): Promise<Response> {
   let authFailureStatus: number | undefined;
 
@@ -40,7 +41,7 @@ export async function fetchWithAuthFailureHandling(
           return false;
         }
 
-        return true;
+        return shouldRetryResponse?.(response) ?? true;
       },
     });
   } catch (error) {

--- a/observability/mastra/src/exporters/auth-failure-cooldown.ts
+++ b/observability/mastra/src/exporters/auth-failure-cooldown.ts
@@ -29,7 +29,7 @@ export async function fetchWithAuthFailureHandling(
   url: string,
   options: RequestInit,
   maxRetries: number,
-  shouldRetryResponse?: (response: Response) => boolean,
+  callerShouldRetry?: (response: Response) => boolean,
 ): Promise<Response> {
   let authFailureStatus: number | undefined;
 
@@ -41,7 +41,7 @@ export async function fetchWithAuthFailureHandling(
           return false;
         }
 
-        return shouldRetryResponse?.(response) ?? true;
+        return callerShouldRetry?.(response) ?? true;
       },
     });
   } catch (error) {

--- a/observability/mastra/src/exporters/auth-failure-cooldown.ts
+++ b/observability/mastra/src/exporters/auth-failure-cooldown.ts
@@ -29,11 +29,11 @@ export async function fetchWithAuthFailureHandling(
   url: string,
   options: RequestInit,
   maxRetries: number,
-): Promise<void> {
+): Promise<Response> {
   let authFailureStatus: number | undefined;
 
   try {
-    await fetchWithRetry(url, options, maxRetries, {
+    return await fetchWithRetry(url, options, maxRetries, {
       shouldRetryResponse: response => {
         if (isAuthFailureStatus(response.status)) {
           authFailureStatus = response.status;

--- a/observability/mastra/src/exporters/mastra-platform.test.ts
+++ b/observability/mastra/src/exporters/mastra-platform.test.ts
@@ -2102,6 +2102,46 @@ describe('MastraPlatformExporter', () => {
         await vi.advanceTimersByTimeAsync(300_000);
         expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
         expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(300);
+
+        // Trailing characters are rejected, not silently truncated to 60
+        mockFetchWithRetry.mockResolvedValue(disabledResponse('60seconds'));
+        await vi.advanceTimersByTimeAsync(300_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(3);
+        expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(300);
+
+        // Negative and zero values fall back to the default
+        mockFetchWithRetry.mockResolvedValue(disabledResponse('-60'));
+        await vi.advanceTimersByTimeAsync(300_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(4);
+        expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(300);
+
+        mockFetchWithRetry.mockResolvedValue(disabledResponse('0'));
+        await vi.advanceTimersByTimeAsync(300_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(5);
+        expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(300);
+      } finally {
+        await quotaExporter.shutdown();
+      }
+    });
+
+    it('should clamp oversized retry-after values to the Node timer limit', async () => {
+      const quotaExporter = createQuotaExporter();
+      // 10_000_000s * 1000 exceeds 2^31 - 1 ms; unclamped it would wrap to ~1ms
+      mockFetchWithRetry.mockResolvedValue(disabledResponse('10000000'));
+
+      try {
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.flush();
+        expect((quotaExporter as any).quotaPaused).toBe(true);
+        expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(Math.floor(0x7fffffff / 1000));
+
+        // No rapid probe loop: nothing fires shortly after pausing
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+
+        // Probe fires once the clamped interval elapses
+        await vi.advanceTimersByTimeAsync(Math.floor(0x7fffffff / 1000) * 1000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
       } finally {
         await quotaExporter.shutdown();
       }

--- a/observability/mastra/src/exporters/mastra-platform.test.ts
+++ b/observability/mastra/src/exporters/mastra-platform.test.ts
@@ -2167,6 +2167,33 @@ describe('MastraPlatformExporter', () => {
       await vi.advanceTimersByTimeAsync(600_000);
       expect(mockFetchWithRetry.mock.calls.length).toBe(callsAfterShutdown);
     });
+
+    it('should not rearm the probe timer when a probe is in flight during shutdown', async () => {
+      const quotaExporter = createQuotaExporter();
+      mockFetchWithRetry.mockResolvedValue(disabledResponse('60'));
+
+      await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+      await quotaExporter.flush();
+      expect((quotaExporter as any).quotaPaused).toBe(true);
+
+      // Next probe hangs on a deferred response so it is in flight when shutdown runs
+      let resolveProbe!: (response: Response) => void;
+      mockFetchWithRetry.mockImplementation(() => new Promise<Response>(resolve => (resolveProbe = resolve)));
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(mockFetchWithRetry).toHaveBeenCalledTimes(2); // probe fired, still pending
+
+      await quotaExporter.shutdown();
+      expect((quotaExporter as any).quotaProbeTimer).toBeNull();
+
+      // Probe completes after shutdown with a still-disabled response
+      resolveProbe(disabledResponse('60'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      // No new timer was scheduled and no further probes fire
+      expect((quotaExporter as any).quotaProbeTimer).toBeNull();
+      await vi.advanceTimersByTimeAsync(600_000);
+      expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('Shutdown Functionality', () => {

--- a/observability/mastra/src/exporters/mastra-platform.test.ts
+++ b/observability/mastra/src/exporters/mastra-platform.test.ts
@@ -1949,6 +1949,226 @@ describe('MastraPlatformExporter', () => {
     });
   });
 
+  describe('Quota Stop Signal', () => {
+    const mockSpan = getMockSpan({
+      id: 'span-quota',
+      name: 'quota-span',
+      type: SpanType.MODEL_GENERATION,
+      isEvent: false,
+      traceId: 'trace-quota',
+      input: { prompt: 'test' },
+      output: { response: 'result' },
+    });
+
+    function disabledResponse(retryAfter?: string): Response {
+      const headers: Record<string, string> = { 'x-mastra-observability': 'disabled' };
+      if (retryAfter !== undefined) {
+        headers['x-mastra-observability-retry-after'] = retryAfter;
+      }
+      return new Response(JSON.stringify({ ok: true, data: { spanCount: 0 }, observability: 'disabled' }), {
+        status: 200,
+        headers,
+      });
+    }
+
+    function createQuotaExporter(): MastraPlatformExporter {
+      return new MastraPlatformExporter({
+        accessToken: createTestJWT({ teamId: 'quota-team', projectId: 'quota-project' }),
+        endpoint: 'http://localhost:3000',
+      });
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should pause all signals, drop buffered events, and stop POSTs on disabled header', async () => {
+      const quotaExporter = createQuotaExporter();
+      const warnSpy = vi.spyOn((quotaExporter as any).logger, 'warn');
+      mockFetchWithRetry.mockImplementation(async () => disabledResponse('300'));
+
+      try {
+        // Buffer two signal types so both uploads see the header
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.onLogEvent(getMockLogEvent());
+        await quotaExporter.flush();
+
+        expect((quotaExporter as any).quotaPaused).toBe(true);
+        expect((quotaExporter as any).buffer.totalSize).toBe(0);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2); // traces + logs uploads only
+        // Exactly one warn despite both signal responses carrying the header
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Mastra observability paused: quota exhausted, dropping telemetry and probing every 300s',
+        );
+
+        // All five signal types are dropped while paused, memory stays bounded
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.onLogEvent(getMockLogEvent());
+        await quotaExporter.onMetricEvent(getMockMetricEvent());
+        await quotaExporter.onScoreEvent(getMockScoreEvent());
+        await quotaExporter.onFeedbackEvent(getMockFeedbackEvent());
+
+        expect((quotaExporter as any).buffer.totalSize).toBe(0);
+        await quotaExporter.flush();
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2); // no further POSTs
+        expect(warnSpy).toHaveBeenCalledTimes(1); // no per-dropped-batch logging
+      } finally {
+        await quotaExporter.shutdown();
+      }
+    });
+
+    it('should probe after retry-after seconds and resume when header is absent', async () => {
+      const quotaExporter = createQuotaExporter();
+      const warnSpy = vi.spyOn((quotaExporter as any).logger, 'warn');
+      mockFetchWithRetry.mockResolvedValue(disabledResponse('60'));
+
+      try {
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.flush();
+        expect((quotaExporter as any).quotaPaused).toBe(true);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+
+        // Recovery: collector stops sending the header
+        mockFetchWithRetry.mockResolvedValue(new Response('{}', { status: 200 }));
+
+        await vi.advanceTimersByTimeAsync(59_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1); // header value respected, not default 300
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+
+        // Probe is an empty spans batch against the traces publish route
+        const [probeUrl, probeOptions] = mockFetchWithRetry.mock.calls[1] as [string, RequestInit];
+        expect(probeUrl).toBe('http://localhost:3000/ai/spans/publish');
+        expect(JSON.parse(probeOptions.body as string)).toEqual({ spans: [] });
+
+        expect((quotaExporter as any).quotaPaused).toBe(false);
+        expect(warnSpy).toHaveBeenCalledTimes(2); // one pause, one resume
+        expect(warnSpy).toHaveBeenLastCalledWith('Mastra observability resumed: quota restored, exports re-enabled');
+
+        // Full resume: new events are exported again
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.flush();
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(3);
+      } finally {
+        await quotaExporter.shutdown();
+      }
+    });
+
+    it('should stay paused and reschedule when probe response still has the header', async () => {
+      const quotaExporter = createQuotaExporter();
+      const warnSpy = vi.spyOn((quotaExporter as any).logger, 'warn');
+      mockFetchWithRetry.mockResolvedValue(disabledResponse('60'));
+
+      try {
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.flush();
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+
+        // Probe still gets the header, with an updated retry-after hint
+        mockFetchWithRetry.mockResolvedValue(disabledResponse('120'));
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+        expect((quotaExporter as any).quotaPaused).toBe(true);
+        expect(warnSpy).toHaveBeenCalledTimes(1); // still just the single pause warn
+
+        // Next probe honors the updated 120s hint
+        await vi.advanceTimersByTimeAsync(119_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(3);
+      } finally {
+        await quotaExporter.shutdown();
+      }
+    });
+
+    it('should default to 300s when retry-after header is missing or unparseable', async () => {
+      const quotaExporter = createQuotaExporter();
+      mockFetchWithRetry.mockResolvedValue(disabledResponse());
+
+      try {
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.flush();
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+        expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(300);
+
+        // Probe still disabled, now with an unparseable retry-after
+        mockFetchWithRetry.mockResolvedValue(disabledResponse('not-a-number'));
+        await vi.advanceTimersByTimeAsync(300_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+        expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(300);
+      } finally {
+        await quotaExporter.shutdown();
+      }
+    });
+
+    it('should stay paused and reschedule when the probe request fails', async () => {
+      const quotaExporter = createQuotaExporter();
+      mockFetchWithRetry.mockResolvedValue(disabledResponse('60'));
+
+      try {
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.flush();
+
+        mockFetchWithRetry.mockRejectedValue(new Error('network down'));
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+        expect((quotaExporter as any).quotaPaused).toBe(true);
+
+        // Rescheduled probe succeeds -> resume
+        mockFetchWithRetry.mockResolvedValue(new Response('{}', { status: 200 }));
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(3);
+        expect((quotaExporter as any).quotaPaused).toBe(false);
+      } finally {
+        await quotaExporter.shutdown();
+      }
+    });
+
+    it('should not change behavior for 200 responses without the header', async () => {
+      const quotaExporter = createQuotaExporter();
+      const warnSpy = vi.spyOn((quotaExporter as any).logger, 'warn');
+      mockFetchWithRetry.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      try {
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.flush();
+
+        expect((quotaExporter as any).quotaPaused).toBe(false);
+        expect((quotaExporter as any).quotaProbeTimer).toBeNull();
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.flush();
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+      } finally {
+        await quotaExporter.shutdown();
+      }
+    });
+
+    it('should clear the probe timer on shutdown', async () => {
+      const quotaExporter = createQuotaExporter();
+      mockFetchWithRetry.mockResolvedValue(disabledResponse('300'));
+
+      await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+      await quotaExporter.flush();
+      expect((quotaExporter as any).quotaProbeTimer).not.toBeNull();
+
+      await quotaExporter.shutdown();
+      expect((quotaExporter as any).quotaProbeTimer).toBeNull();
+
+      // No probe fires after shutdown
+      const callsAfterShutdown = mockFetchWithRetry.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(600_000);
+      expect(mockFetchWithRetry.mock.calls.length).toBe(callsAfterShutdown);
+    });
+  });
+
   describe('Shutdown Functionality', () => {
     const mockSpan = getMockSpan({
       id: 'span-123',

--- a/observability/mastra/src/exporters/mastra-platform.test.ts
+++ b/observability/mastra/src/exporters/mastra-platform.test.ts
@@ -2277,8 +2277,8 @@ describe('MastraPlatformExporter', () => {
       expect((quotaExporter as any).quotaPaused).toBe(true);
 
       // Next probe hangs on a deferred response so it is in flight when shutdown runs
-      let resolveProbe!: (response: Response) => void;
-      mockFetchWithRetry.mockImplementation(() => new Promise<Response>(resolve => (resolveProbe = resolve)));
+      const deferredProbe = createDeferred<Response>();
+      mockFetchWithRetry.mockImplementation(() => deferredProbe.promise);
       await vi.advanceTimersByTimeAsync(60_000);
       expect(mockFetchWithRetry).toHaveBeenCalledTimes(2); // probe fired, still pending
 
@@ -2286,7 +2286,34 @@ describe('MastraPlatformExporter', () => {
       expect((quotaExporter as any).quotaProbeTimer).toBeNull();
 
       // Probe completes after shutdown while the org is still exhausted
-      resolveProbe(quota402Response('60'));
+      deferredProbe.resolve(quota402Response('60'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      // No new timer was scheduled and no further probes fire
+      expect((quotaExporter as any).quotaProbeTimer).toBeNull();
+      await vi.advanceTimersByTimeAsync(600_000);
+      expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not rearm the probe timer when an in-flight probe rejects after shutdown', async () => {
+      const quotaExporter = createQuotaExporter();
+      mockQuota402('60');
+
+      await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+      await quotaExporter.flush();
+      expect((quotaExporter as any).quotaPaused).toBe(true);
+
+      // Next probe hangs on a deferred response so it is in flight when shutdown runs
+      const deferredProbe = createDeferred<Response>();
+      mockFetchWithRetry.mockImplementation(() => deferredProbe.promise);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(mockFetchWithRetry).toHaveBeenCalledTimes(2); // probe fired, still pending
+
+      await quotaExporter.shutdown();
+      expect((quotaExporter as any).quotaProbeTimer).toBeNull();
+
+      // Probe fails after shutdown; the rejection path reaches scheduleQuotaProbe()
+      deferredProbe.reject(new Error('network error'));
       await vi.advanceTimersByTimeAsync(0);
 
       // No new timer was scheduled and no further probes fire

--- a/observability/mastra/src/exporters/mastra-platform.test.ts
+++ b/observability/mastra/src/exporters/mastra-platform.test.ts
@@ -1960,15 +1960,33 @@ describe('MastraPlatformExporter', () => {
       output: { response: 'result' },
     });
 
-    function disabledResponse(retryAfter?: string): Response {
+    function quotaHeaders(retryAfter?: string): Record<string, string> {
       const headers: Record<string, string> = { 'x-mastra-observability': 'disabled' };
       if (retryAfter !== undefined) {
         headers['x-mastra-observability-retry-after'] = retryAfter;
       }
-      return new Response(JSON.stringify({ ok: true, data: { spanCount: 0 }, observability: 'disabled' }), {
-        status: 200,
-        headers,
+      return headers;
+    }
+
+    function quota402Response(retryAfter?: string): Response {
+      return new Response(JSON.stringify({ ok: false, code: 'OBSERVABILITY_QUOTA_EXCEEDED' }), {
+        status: 402,
+        statusText: 'Payment Required',
+        headers: quotaHeaders(retryAfter),
       });
+    }
+
+    // Emulates the real fetchWithRetry contract for a 402: the retry predicate
+    // is consulted, then the request throws without the Response. Records each
+    // predicate decision so tests can assert the 402'd batch was never retried.
+    function mockQuota402(retryAfter?: string): { retryDecisions: boolean[] } {
+      const retryDecisions: boolean[] = [];
+      mockFetchWithRetry.mockImplementation(async (_url, _options, _maxRetries, retryOptions) => {
+        const decision = retryOptions?.shouldRetryResponse?.(quota402Response(retryAfter)) ?? true;
+        retryDecisions.push(decision);
+        throw new Error('Request failed with status: 402 Payment Required');
+      });
+      return { retryDecisions };
     }
 
     function createQuotaExporter(): MastraPlatformExporter {
@@ -1986,13 +2004,14 @@ describe('MastraPlatformExporter', () => {
       vi.useRealTimers();
     });
 
-    it('should pause all signals, drop buffered events, and stop POSTs on disabled header', async () => {
+    it('should pause all signals, drop the batch without retrying, and stop POSTs on 402', async () => {
       const quotaExporter = createQuotaExporter();
       const warnSpy = vi.spyOn((quotaExporter as any).logger, 'warn');
-      mockFetchWithRetry.mockImplementation(async () => disabledResponse('300'));
+      const errorSpy = vi.spyOn((quotaExporter as any).logger, 'error');
+      const { retryDecisions } = mockQuota402('300');
 
       try {
-        // Buffer two signal types so both uploads see the header
+        // Buffer two signal types so both uploads see the 402
         await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
         await quotaExporter.onLogEvent(getMockLogEvent());
         await quotaExporter.flush();
@@ -2000,7 +2019,11 @@ describe('MastraPlatformExporter', () => {
         expect((quotaExporter as any).quotaPaused).toBe(true);
         expect((quotaExporter as any).buffer.totalSize).toBe(0);
         expect(mockFetchWithRetry).toHaveBeenCalledTimes(2); // traces + logs uploads only
-        // Exactly one warn despite both signal responses carrying the header
+        // The 402'd batches are never auto-retried
+        expect(retryDecisions).toEqual([false, false]);
+        // Quota-dropped batches are not logged as upload failures
+        expect(errorSpy).not.toHaveBeenCalled();
+        // Exactly one warn despite both signal responses being 402s
         expect(warnSpy).toHaveBeenCalledTimes(1);
         expect(warnSpy).toHaveBeenCalledWith(
           'Mastra observability paused: quota exhausted, dropping telemetry and probing every 300s',
@@ -2022,10 +2045,10 @@ describe('MastraPlatformExporter', () => {
       }
     });
 
-    it('should probe after retry-after seconds and resume when header is absent', async () => {
+    it('should probe after retry-after seconds and resume when the probe gets a 2xx without the header', async () => {
       const quotaExporter = createQuotaExporter();
       const warnSpy = vi.spyOn((quotaExporter as any).logger, 'warn');
-      mockFetchWithRetry.mockResolvedValue(disabledResponse('60'));
+      mockQuota402('60');
 
       try {
         await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
@@ -2033,7 +2056,7 @@ describe('MastraPlatformExporter', () => {
         expect((quotaExporter as any).quotaPaused).toBe(true);
         expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
 
-        // Recovery: collector stops sending the header
+        // Recovery: collector stops rejecting with 402
         mockFetchWithRetry.mockResolvedValue(new Response('{}', { status: 200 }));
 
         await vi.advanceTimersByTimeAsync(59_000);
@@ -2060,18 +2083,18 @@ describe('MastraPlatformExporter', () => {
       }
     });
 
-    it('should stay paused and reschedule when probe response still has the header', async () => {
+    it('should stay paused and reschedule when the probe still gets a 402', async () => {
       const quotaExporter = createQuotaExporter();
       const warnSpy = vi.spyOn((quotaExporter as any).logger, 'warn');
-      mockFetchWithRetry.mockResolvedValue(disabledResponse('60'));
+      mockQuota402('60');
 
       try {
         await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
         await quotaExporter.flush();
         expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
 
-        // Probe still gets the header, with an updated retry-after hint
-        mockFetchWithRetry.mockResolvedValue(disabledResponse('120'));
+        // Probe still gets a 402, with an updated retry-after hint
+        mockQuota402('120');
         await vi.advanceTimersByTimeAsync(60_000);
         expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
         expect((quotaExporter as any).quotaPaused).toBe(true);
@@ -2089,7 +2112,7 @@ describe('MastraPlatformExporter', () => {
 
     it('should default to 300s when retry-after header is missing or unparseable', async () => {
       const quotaExporter = createQuotaExporter();
-      mockFetchWithRetry.mockResolvedValue(disabledResponse());
+      mockQuota402();
 
       try {
         await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
@@ -2097,25 +2120,25 @@ describe('MastraPlatformExporter', () => {
         expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
         expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(300);
 
-        // Probe still disabled, now with an unparseable retry-after
-        mockFetchWithRetry.mockResolvedValue(disabledResponse('not-a-number'));
+        // Probe still 402, now with an unparseable retry-after
+        mockQuota402('not-a-number');
         await vi.advanceTimersByTimeAsync(300_000);
         expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
         expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(300);
 
         // Trailing characters are rejected, not silently truncated to 60
-        mockFetchWithRetry.mockResolvedValue(disabledResponse('60seconds'));
+        mockQuota402('60seconds');
         await vi.advanceTimersByTimeAsync(300_000);
         expect(mockFetchWithRetry).toHaveBeenCalledTimes(3);
         expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(300);
 
         // Negative and zero values fall back to the default
-        mockFetchWithRetry.mockResolvedValue(disabledResponse('-60'));
+        mockQuota402('-60');
         await vi.advanceTimersByTimeAsync(300_000);
         expect(mockFetchWithRetry).toHaveBeenCalledTimes(4);
         expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(300);
 
-        mockFetchWithRetry.mockResolvedValue(disabledResponse('0'));
+        mockQuota402('0');
         await vi.advanceTimersByTimeAsync(300_000);
         expect(mockFetchWithRetry).toHaveBeenCalledTimes(5);
         expect((quotaExporter as any).quotaProbeIntervalSeconds).toBe(300);
@@ -2127,7 +2150,7 @@ describe('MastraPlatformExporter', () => {
     it('should clamp oversized retry-after values to the Node timer limit', async () => {
       const quotaExporter = createQuotaExporter();
       // 10_000_000s * 1000 exceeds 2^31 - 1 ms; unclamped it would wrap to ~1ms
-      mockFetchWithRetry.mockResolvedValue(disabledResponse('10000000'));
+      mockQuota402('10000000');
 
       try {
         await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
@@ -2149,7 +2172,7 @@ describe('MastraPlatformExporter', () => {
 
     it('should stay paused and reschedule when the probe request fails', async () => {
       const quotaExporter = createQuotaExporter();
-      mockFetchWithRetry.mockResolvedValue(disabledResponse('60'));
+      mockQuota402('60');
 
       try {
         await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
@@ -2191,9 +2214,46 @@ describe('MastraPlatformExporter', () => {
       }
     });
 
+    it('should pause when a 2xx response carries the disabled header (robustness)', async () => {
+      const quotaExporter = createQuotaExporter();
+      mockFetchWithRetry.mockResolvedValue(new Response('{}', { status: 200, headers: quotaHeaders('300') }));
+
+      try {
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.flush();
+
+        expect((quotaExporter as any).quotaPaused).toBe(true);
+      } finally {
+        await quotaExporter.shutdown();
+      }
+    });
+
+    it('should not pause on non-402 error statuses', async () => {
+      const quotaExporter = createQuotaExporter();
+      const retryDecisions: boolean[] = [];
+      mockFetchWithRetry.mockImplementation(async (_url, _options, _maxRetries, retryOptions) => {
+        const response = new Response('oops', { status: 500, statusText: 'Internal Server Error' });
+        retryDecisions.push(retryOptions?.shouldRetryResponse?.(response) ?? true);
+        throw new Error('Request failed with status: 500 Internal Server Error');
+      });
+
+      try {
+        await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
+        await quotaExporter.flush();
+
+        // Existing behavior: batch dropped after retries, but no quota pause
+        expect((quotaExporter as any).quotaPaused).toBe(false);
+        expect((quotaExporter as any).quotaProbeTimer).toBeNull();
+        // 5xx responses remain retryable
+        expect(retryDecisions).toEqual([true]);
+      } finally {
+        await quotaExporter.shutdown();
+      }
+    });
+
     it('should clear the probe timer on shutdown', async () => {
       const quotaExporter = createQuotaExporter();
-      mockFetchWithRetry.mockResolvedValue(disabledResponse('300'));
+      mockQuota402('300');
 
       await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
       await quotaExporter.flush();
@@ -2210,7 +2270,7 @@ describe('MastraPlatformExporter', () => {
 
     it('should not rearm the probe timer when a probe is in flight during shutdown', async () => {
       const quotaExporter = createQuotaExporter();
-      mockFetchWithRetry.mockResolvedValue(disabledResponse('60'));
+      mockQuota402('60');
 
       await quotaExporter.exportTracingEvent({ type: TracingEventType.SPAN_ENDED, exportedSpan: mockSpan });
       await quotaExporter.flush();
@@ -2225,8 +2285,8 @@ describe('MastraPlatformExporter', () => {
       await quotaExporter.shutdown();
       expect((quotaExporter as any).quotaProbeTimer).toBeNull();
 
-      // Probe completes after shutdown with a still-disabled response
-      resolveProbe(disabledResponse('60'));
+      // Probe completes after shutdown while the org is still exhausted
+      resolveProbe(quota402Response('60'));
       await vi.advanceTimersByTimeAsync(0);
 
       // No new timer was scheduled and no further probes fire

--- a/observability/mastra/src/exporters/mastra-platform.ts
+++ b/observability/mastra/src/exporters/mastra-platform.ts
@@ -616,12 +616,18 @@ export class MastraPlatformExporter extends BaseExporter {
   /**
    * Uploads a signal batch to the configured Mastra Observability API using fetchWithRetry.
    */
-  private async batchUpload<T>(signal: PlatformSignal, records: T[]): Promise<void> {
-    const headers = {
+  private buildPublishHeaders(): Record<string, string> {
+    return {
       Authorization: `Bearer ${this.platformConfig.accessToken}`,
       'Content-Type': 'application/json',
     };
+  }
 
+  private buildPublishBody<T>(signal: PlatformSignal, records: T[]): string {
+    return JSON.stringify({ [SIGNAL_PUBLISH_SEGMENTS[signal]]: records });
+  }
+
+  private async batchUpload<T>(signal: PlatformSignal, records: T[]): Promise<void> {
     const endpointMap: Record<PlatformSignal, string> = {
       traces: this.platformConfig.tracesEndpoint,
       logs: this.platformConfig.logsEndpoint,
@@ -632,8 +638,8 @@ export class MastraPlatformExporter extends BaseExporter {
 
     const options: RequestInit = {
       method: 'POST',
-      headers,
-      body: JSON.stringify({ [SIGNAL_PUBLISH_SEGMENTS[signal]]: records }),
+      headers: this.buildPublishHeaders(),
+      body: this.buildPublishBody(signal, records),
     };
 
     // Capture a quota-exceeded response in the retry predicate: returning
@@ -737,11 +743,8 @@ export class MastraPlatformExporter extends BaseExporter {
         this.platformConfig.tracesEndpoint,
         {
           method: 'POST',
-          headers: {
-            Authorization: `Bearer ${this.platformConfig.accessToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ spans: [] }),
+          headers: this.buildPublishHeaders(),
+          body: this.buildPublishBody('traces', []),
         },
         1,
         {

--- a/observability/mastra/src/exporters/mastra-platform.ts
+++ b/observability/mastra/src/exporters/mastra-platform.ts
@@ -9,6 +9,7 @@ import type {
   ScoreEvent,
   FeedbackEvent,
 } from '@mastra/core/observability';
+import { fetchWithRetry } from '@mastra/core/utils';
 import { AuthFailureCooldown, fetchWithAuthFailureHandling, isAuthFailureError } from './auth-failure-cooldown';
 import { BaseExporter } from './base';
 import type { BaseExporterConfig } from './base';
@@ -39,6 +40,28 @@ const SIGNAL_PUBLISH_SUFFIXES: Record<PlatformSignal, string> = {
 };
 
 const DEFAULT_PLATFORM_SPAN_FILTER = (span: AnyExportedSpan): boolean => span.type !== SpanType.MODEL_CHUNK;
+
+// Stop-signal contract: when the org's observability quota is exhausted, the
+// collector returns 200 with this header on every publish route. The exporter
+// must pause (dropping events) and probe until the header disappears.
+const OBSERVABILITY_STATUS_HEADER = 'x-mastra-observability';
+const OBSERVABILITY_DISABLED_VALUE = 'disabled';
+const OBSERVABILITY_RETRY_AFTER_HEADER = 'x-mastra-observability-retry-after';
+const DEFAULT_QUOTA_PROBE_INTERVAL_SECONDS = 300;
+
+function isObservabilityDisabled(response: Response): boolean {
+  return response.headers.get(OBSERVABILITY_STATUS_HEADER) === OBSERVABILITY_DISABLED_VALUE;
+}
+
+function parseQuotaRetryAfterSeconds(response: Response): number {
+  const raw = response.headers.get(OBSERVABILITY_RETRY_AFTER_HEADER);
+  if (!raw) {
+    return DEFAULT_QUOTA_PROBE_INTERVAL_SECONDS;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_QUOTA_PROBE_INTERVAL_SECONDS;
+}
 
 const SIGNAL_PUBLISH_SEGMENTS: Record<PlatformSignal, string> = {
   traces: 'spans',
@@ -225,6 +248,9 @@ export class MastraPlatformExporter extends BaseExporter {
   private buffer: MastraPlatformBuffer;
   private flushTimer: NodeJS.Timeout | null = null;
   private inFlightFlushes = new Set<Promise<void>>();
+  private quotaPaused = false;
+  private quotaProbeTimer: NodeJS.Timeout | null = null;
+  private quotaProbeIntervalSeconds = DEFAULT_QUOTA_PROBE_INTERVAL_SECONDS;
 
   constructor(config: MastraPlatformExporterConfig = {}) {
     super(config);
@@ -308,7 +334,7 @@ export class MastraPlatformExporter extends BaseExporter {
       return;
     }
 
-    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+    if (this.quotaPaused || this.authFailureCooldown.dropEventIfCoolingDown()) {
       return;
     }
 
@@ -322,7 +348,7 @@ export class MastraPlatformExporter extends BaseExporter {
       return;
     }
 
-    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+    if (this.quotaPaused || this.authFailureCooldown.dropEventIfCoolingDown()) {
       return;
     }
 
@@ -335,7 +361,7 @@ export class MastraPlatformExporter extends BaseExporter {
       return;
     }
 
-    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+    if (this.quotaPaused || this.authFailureCooldown.dropEventIfCoolingDown()) {
       return;
     }
 
@@ -348,7 +374,7 @@ export class MastraPlatformExporter extends BaseExporter {
       return;
     }
 
-    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+    if (this.quotaPaused || this.authFailureCooldown.dropEventIfCoolingDown()) {
       return;
     }
 
@@ -361,7 +387,7 @@ export class MastraPlatformExporter extends BaseExporter {
       return;
     }
 
-    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+    if (this.quotaPaused || this.authFailureCooldown.dropEventIfCoolingDown()) {
       return;
     }
 
@@ -507,6 +533,11 @@ export class MastraPlatformExporter extends BaseExporter {
       return;
     }
 
+    if (this.quotaPaused) {
+      this.resetBuffer();
+      return;
+    }
+
     if (this.authFailureCooldown.dropEventsIfCoolingDown(this.buffer.totalSize)) {
       this.resetBuffer();
       return;
@@ -591,7 +622,91 @@ export class MastraPlatformExporter extends BaseExporter {
       body: JSON.stringify({ [SIGNAL_PUBLISH_SEGMENTS[signal]]: records }),
     };
 
-    await fetchWithAuthFailureHandling(endpointMap[signal], options, this.platformConfig.maxRetries);
+    const response = await fetchWithAuthFailureHandling(endpointMap[signal], options, this.platformConfig.maxRetries);
+
+    if (isObservabilityDisabled(response)) {
+      this.enterQuotaPause(parseQuotaRetryAfterSeconds(response));
+    }
+  }
+
+  /**
+   * Enter the quota-exhausted paused state: drop buffered events, stop the
+   * flush timer, and start probing until the collector stops sending the
+   * disabled header. The gate is per-org, so a signal on any publish route
+   * pauses all five signal types.
+   */
+  private enterQuotaPause(retryAfterSeconds: number): void {
+    this.quotaProbeIntervalSeconds = retryAfterSeconds;
+
+    if (this.quotaPaused) {
+      return;
+    }
+
+    this.quotaPaused = true;
+
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    this.resetBuffer();
+
+    this.logger.warn(
+      `Mastra observability paused: quota exhausted, dropping telemetry and probing every ${retryAfterSeconds}s`,
+    );
+
+    this.scheduleQuotaProbe();
+  }
+
+  private scheduleQuotaProbe(): void {
+    if (this.quotaProbeTimer) {
+      clearTimeout(this.quotaProbeTimer);
+    }
+
+    this.quotaProbeTimer = setTimeout(() => {
+      this.quotaProbeTimer = null;
+      void this.probeQuotaStatus();
+    }, this.quotaProbeIntervalSeconds * 1000);
+
+    // Don't keep the process alive just to probe; no activity means no egress burn either.
+    this.quotaProbeTimer.unref?.();
+  }
+
+  /**
+   * Send an empty spans batch as a free probe. The collector treats an empty
+   * batch as a no-op, and an exhausted org still gets the disabled header on it.
+   */
+  private async probeQuotaStatus(): Promise<void> {
+    if (!this.quotaPaused) {
+      return;
+    }
+
+    try {
+      const response = await fetchWithRetry(
+        this.platformConfig.tracesEndpoint,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${this.platformConfig.accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ spans: [] }),
+        },
+        1,
+      );
+
+      if (!isObservabilityDisabled(response)) {
+        this.quotaPaused = false;
+        this.quotaProbeIntervalSeconds = DEFAULT_QUOTA_PROBE_INTERVAL_SECONDS;
+        this.logger.warn('Mastra observability resumed: quota restored, exports re-enabled');
+        return;
+      }
+
+      this.quotaProbeIntervalSeconds = parseQuotaRetryAfterSeconds(response);
+    } catch {
+      // Probe failed (network error or non-2xx); stay paused and try again later.
+    }
+
+    this.scheduleQuotaProbe();
   }
 
   private async flushSignalBatch<T>(
@@ -679,6 +794,11 @@ export class MastraPlatformExporter extends BaseExporter {
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
       this.flushTimer = null;
+    }
+
+    if (this.quotaProbeTimer) {
+      clearTimeout(this.quotaProbeTimer);
+      this.quotaProbeTimer = null;
     }
 
     try {

--- a/observability/mastra/src/exporters/mastra-platform.ts
+++ b/observability/mastra/src/exporters/mastra-platform.ts
@@ -251,6 +251,7 @@ export class MastraPlatformExporter extends BaseExporter {
   private quotaPaused = false;
   private quotaProbeTimer: NodeJS.Timeout | null = null;
   private quotaProbeIntervalSeconds = DEFAULT_QUOTA_PROBE_INTERVAL_SECONDS;
+  private shuttingDown = false;
 
   constructor(config: MastraPlatformExporterConfig = {}) {
     super(config);
@@ -658,6 +659,10 @@ export class MastraPlatformExporter extends BaseExporter {
   }
 
   private scheduleQuotaProbe(): void {
+    if (this.shuttingDown) {
+      return;
+    }
+
     if (this.quotaProbeTimer) {
       clearTimeout(this.quotaProbeTimer);
     }
@@ -676,7 +681,7 @@ export class MastraPlatformExporter extends BaseExporter {
    * batch as a no-op, and an exhausted org still gets the disabled header on it.
    */
   private async probeQuotaStatus(): Promise<void> {
-    if (!this.quotaPaused) {
+    if (this.shuttingDown || !this.quotaPaused) {
       return;
     }
 
@@ -693,6 +698,10 @@ export class MastraPlatformExporter extends BaseExporter {
         },
         1,
       );
+
+      if (this.shuttingDown) {
+        return;
+      }
 
       if (!isObservabilityDisabled(response)) {
         this.quotaPaused = false;
@@ -787,6 +796,8 @@ export class MastraPlatformExporter extends BaseExporter {
   }
 
   async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+
     if (this.isDisabled) {
       return;
     }

--- a/observability/mastra/src/exporters/mastra-platform.ts
+++ b/observability/mastra/src/exporters/mastra-platform.ts
@@ -42,8 +42,10 @@ const SIGNAL_PUBLISH_SUFFIXES: Record<PlatformSignal, string> = {
 const DEFAULT_PLATFORM_SPAN_FILTER = (span: AnyExportedSpan): boolean => span.type !== SpanType.MODEL_CHUNK;
 
 // Stop-signal contract: when the org's observability quota is exhausted, the
-// collector returns 200 with this header on every publish route. The exporter
-// must pause (dropping events) and probe until the header disappears.
+// collector rejects every publish route with 402 Payment Required plus the
+// headers below. 402 is deliberately non-retryable: the exporter must drop the
+// batch (no auto-retry), pause, and probe until the collector stops sending it.
+const QUOTA_EXCEEDED_STATUS = 402;
 const OBSERVABILITY_STATUS_HEADER = 'x-mastra-observability';
 const OBSERVABILITY_DISABLED_VALUE = 'disabled';
 const OBSERVABILITY_RETRY_AFTER_HEADER = 'x-mastra-observability-retry-after';
@@ -53,6 +55,11 @@ const MAX_QUOTA_PROBE_INTERVAL_SECONDS = Math.floor(0x7fffffff / 1000);
 
 function isObservabilityDisabled(response: Response): boolean {
   return response.headers.get(OBSERVABILITY_STATUS_HEADER) === OBSERVABILITY_DISABLED_VALUE;
+}
+
+// The contract says either signal means pause; check both for robustness.
+function isQuotaExceededResponse(response: Response): boolean {
+  return response.status === QUOTA_EXCEEDED_STATUS || isObservabilityDisabled(response);
 }
 
 function parseQuotaRetryAfterSeconds(response: Response): number {
@@ -629,7 +636,37 @@ export class MastraPlatformExporter extends BaseExporter {
       body: JSON.stringify({ [SIGNAL_PUBLISH_SEGMENTS[signal]]: records }),
     };
 
-    const response = await fetchWithAuthFailureHandling(endpointMap[signal], options, this.platformConfig.maxRetries);
+    // Capture a quota-exceeded response in the retry predicate: returning
+    // false makes fetchWithRetry throw without retrying (the 402'd batch must
+    // never be re-sent), but the thrown error loses the Response and its
+    // retry-after header, so we keep a reference here.
+    let quotaResponse: Response | undefined;
+    let response: Response;
+
+    try {
+      response = await fetchWithAuthFailureHandling(
+        endpointMap[signal],
+        options,
+        this.platformConfig.maxRetries,
+        res => {
+          if (isQuotaExceededResponse(res)) {
+            quotaResponse = res;
+            return false;
+          }
+
+          return true;
+        },
+      );
+    } catch (error) {
+      if (quotaResponse) {
+        // Quota exhaustion is the pause signal, not an upload failure: drop
+        // the batch silently (the pause transition logs once) and pause.
+        this.enterQuotaPause(parseQuotaRetryAfterSeconds(quotaResponse));
+        return;
+      }
+
+      throw error;
+    }
 
     if (isObservabilityDisabled(response)) {
       this.enterQuotaPause(parseQuotaRetryAfterSeconds(response));
@@ -638,9 +675,9 @@ export class MastraPlatformExporter extends BaseExporter {
 
   /**
    * Enter the quota-exhausted paused state: drop buffered events, stop the
-   * flush timer, and start probing until the collector stops sending the
-   * disabled header. The gate is per-org, so a signal on any publish route
-   * pauses all five signal types.
+   * flush timer, and start probing until the collector stops rejecting with
+   * 402. The gate is per-org, so a signal on any publish route pauses all
+   * five signal types.
    */
   private enterQuotaPause(retryAfterSeconds: number): void {
     this.quotaProbeIntervalSeconds = retryAfterSeconds;
@@ -684,12 +721,16 @@ export class MastraPlatformExporter extends BaseExporter {
 
   /**
    * Send an empty spans batch as a free probe. The collector treats an empty
-   * batch as a no-op, and an exhausted org still gets the disabled header on it.
+   * batch as a no-op, and an exhausted org still gets the 402 on it. A 402
+   * throws out of fetchWithRetry without the Response, so the retry predicate
+   * captures it to keep the retry-after hint.
    */
   private async probeQuotaStatus(): Promise<void> {
     if (this.shuttingDown || !this.quotaPaused) {
       return;
     }
+
+    let quotaResponse: Response | undefined;
 
     try {
       const response = await fetchWithRetry(
@@ -703,6 +744,16 @@ export class MastraPlatformExporter extends BaseExporter {
           body: JSON.stringify({ spans: [] }),
         },
         1,
+        {
+          shouldRetryResponse: res => {
+            if (isQuotaExceededResponse(res)) {
+              quotaResponse = res;
+            }
+
+            // Probes are best-effort; never retry them.
+            return false;
+          },
+        },
       );
 
       if (this.shuttingDown) {
@@ -718,7 +769,12 @@ export class MastraPlatformExporter extends BaseExporter {
 
       this.quotaProbeIntervalSeconds = parseQuotaRetryAfterSeconds(response);
     } catch {
-      // Probe failed (network error or non-2xx); stay paused and try again later.
+      if (quotaResponse) {
+        // Still exhausted (402); honor the collector's updated probe hint.
+        this.quotaProbeIntervalSeconds = parseQuotaRetryAfterSeconds(quotaResponse);
+      }
+      // Otherwise the probe failed (network error or non-402 failure); stay
+      // paused and try again later.
     }
 
     this.scheduleQuotaProbe();

--- a/observability/mastra/src/exporters/mastra-platform.ts
+++ b/observability/mastra/src/exporters/mastra-platform.ts
@@ -48,6 +48,8 @@ const OBSERVABILITY_STATUS_HEADER = 'x-mastra-observability';
 const OBSERVABILITY_DISABLED_VALUE = 'disabled';
 const OBSERVABILITY_RETRY_AFTER_HEADER = 'x-mastra-observability-retry-after';
 const DEFAULT_QUOTA_PROBE_INTERVAL_SECONDS = 300;
+// Node.js timers overflow above 2^31 - 1 ms and fire after ~1ms instead.
+const MAX_QUOTA_PROBE_INTERVAL_SECONDS = Math.floor(0x7fffffff / 1000);
 
 function isObservabilityDisabled(response: Response): boolean {
   return response.headers.get(OBSERVABILITY_STATUS_HEADER) === OBSERVABILITY_DISABLED_VALUE;
@@ -55,12 +57,16 @@ function isObservabilityDisabled(response: Response): boolean {
 
 function parseQuotaRetryAfterSeconds(response: Response): number {
   const raw = response.headers.get(OBSERVABILITY_RETRY_AFTER_HEADER);
-  if (!raw) {
+  if (!raw || !/^\d+$/.test(raw.trim())) {
     return DEFAULT_QUOTA_PROBE_INTERVAL_SECONDS;
   }
 
   const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_QUOTA_PROBE_INTERVAL_SECONDS;
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_QUOTA_PROBE_INTERVAL_SECONDS;
+  }
+
+  return Math.min(parsed, MAX_QUOTA_PROBE_INTERVAL_SECONDS);
 }
 
 const SIGNAL_PUBLISH_SEGMENTS: Record<PlatformSignal, string> = {


### PR DESCRIPTION
The platform now drops telemetry at ingest for orgs past their observability grace period (mastra-ai/platform#1934), responding with 200 OK plus an `x-mastra-observability: disabled` header instead of a 429. Before this change the exporter would keep buffering and uploading payloads that were silently discarded server-side.

`MastraPlatformExporter` now detects that header on any publish response and pauses: it drops buffered and incoming events, cancels the flush timer, and logs a warning. While paused it probes with an empty spans batch on the interval advertised by `x-mastra-observability-retry-after` (default 300s, timer unref'd), and automatically resumes exporting once the header is no longer returned. Probe timers are cleaned up on `shutdown()`.

Covered by new unit tests for the pause/probe/resume cycle (all 1001 package tests pass), plus a docs update on the exporter reference page and a patch changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If observability quota is exhausted, the exporter stops sending telemetry and drops new events. It checks periodically and resumes automatically when the quota is available again.

## Changes

- Detects `402` responses with `x-mastra-observability: disabled`.
- Drops buffered and incoming events while paused.
- Cancels the normal flush timer.
- Logs pause and resume warnings.
- Probes periodically using `x-mastra-observability-retry-after`, with a 300-second default.
- Validates and clamps retry intervals.
- Resumes exporting when the disabled header is absent.
- Keeps failed or disabled probes paused.
- Prevents probes from rearming timers after shutdown.
- Clears probe timers during shutdown.
- Returns the `Response` from `fetchWithAuthFailureHandling`.
- Adds unit tests for pause, event dropping, probing, resume, failures, retry intervals, and shutdown.
- Updates exporter documentation.
- Adds a patch changeset for `@mastra/observability`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->