### PR TITLE
fix(mastracode): surface IdP access denial on the web sign-in page

### DIFF
--- a/.changeset/factory-signin-denied-loop.md
+++ b/.changeset/factory-signin-denied-loop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the sign-in callback redirecting straight back to the identity provider in a loop when it denies access (for example access_denied for an account that is not part of the organization). The denial now lands on the sign-in page with the error shown.

--- a/.changeset/mastracode-signin-denied.md
+++ b/.changeset/mastracode-signin-denied.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+The web sign-in page now explains when the identity provider denies access — showing the reason and a hint to ask an organization admin to add the account — instead of silently returning to the sign-in button.

--- a/mastracode/factory-ui/src/ui/domains/auth/components/__tests__/SignInPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/auth/components/__tests__/SignInPage.msw.test.tsx
@@ -162,12 +162,10 @@ describe('SignInPage', () => {
   });
 
   describe('given an IdP access_denied redirect', () => {
-    it('shows the denied banner and collapses the dead /login returnTo', async () => {
+    it('shows the denial with the IdP description and still allows a retry', async () => {
       stubAuthMe({ provider: 'mastra-studio' });
-      const deadLogin = `/login?error=access_denied&error_description=${encodeURIComponent(
-        'You do not have access to this application.',
-      )}`;
-      renderSignIn(`/signin?returnTo=${encodeURIComponent(deadLogin)}`);
+      const description = encodeURIComponent('You do not have access to this application.');
+      renderSignIn(`/signin?error=access_denied&error_description=${description}`);
 
       const alert = await screen.findByRole('alert');
       expect(alert).toHaveTextContent('Access denied');
@@ -178,7 +176,7 @@ describe('SignInPage', () => {
       expect(redirectToLogin).toHaveBeenCalledWith(TEST_BASE_URL, '/');
     });
 
-    it('shows the banner for error params sent directly to /signin', async () => {
+    it('falls back to the admin hint when the IdP sends no description', async () => {
       stubAuthMe({ provider: 'workos' });
       renderSignIn('/signin?error=access_denied');
 

--- a/mastracode/factory-ui/src/ui/domains/auth/components/__tests__/SignInPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/auth/components/__tests__/SignInPage.msw.test.tsx
@@ -161,6 +161,33 @@ describe('SignInPage', () => {
     });
   });
 
+  describe('given an IdP access_denied redirect', () => {
+    it('shows the denied banner and collapses the dead /login returnTo', async () => {
+      stubAuthMe({ provider: 'mastra-studio' });
+      const deadLogin = `/login?error=access_denied&error_description=${encodeURIComponent(
+        'You do not have access to this application.',
+      )}`;
+      renderSignIn(`/signin?returnTo=${encodeURIComponent(deadLogin)}`);
+
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent('Access denied');
+      expect(alert).toHaveTextContent('You do not have access to this application.');
+      expect(alert).toHaveTextContent('Ask an organization admin to add your account');
+
+      await userEvent.click(await screen.findByRole('button', { name: 'Sign in with Mastra Platform' }));
+      expect(redirectToLogin).toHaveBeenCalledWith(TEST_BASE_URL, '/');
+    });
+
+    it('shows the banner for error params sent directly to /signin', async () => {
+      stubAuthMe({ provider: 'workos' });
+      renderSignIn('/signin?error=access_denied');
+
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent('Access denied');
+      expect(alert).toHaveTextContent('Ask an organization admin to add your account');
+    });
+  });
+
   describe('returnTo sanitization', () => {
     it.each([
       ['/factory/board?x=1#frag', '/factory/board?x=1#frag'],

--- a/mastracode/factory-ui/src/ui/pages/SignInPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/SignInPage.tsx
@@ -36,29 +36,6 @@ export function safeReturnTo(raw?: string): string {
   }
 }
 
-export type AuthRedirectError = { code: string; description: string | null };
-
-/**
- * OAuth error params reach `/signin` two ways: directly (the server callback
- * redirects IdP denials here) or buried in a `returnTo` targeting the
- * IdP-facing `/login` path that the auth guards forwarded verbatim. That
- * returnTo is a dead end, so it collapses to `/`.
- */
-export function readAuthRedirect(params: URLSearchParams): { error: AuthRedirectError | null; returnTo: string } {
-  const returnTo = safeReturnTo(params.get('returnTo') ?? undefined);
-  const direct = params.get('error');
-  if (direct) return { error: { code: direct, description: params.get('error_description') }, returnTo };
-  const nested = new URL(returnTo, window.location.origin);
-  const nestedError = nested.searchParams.get('error');
-  if (nested.pathname === '/login' && nestedError) {
-    return {
-      error: { code: nestedError, description: nested.searchParams.get('error_description') },
-      returnTo: '/',
-    };
-  }
-  return { error: null, returnTo };
-}
-
 /**
  * Email/password credential form for the self-hosted better-auth provider.
  * Posts to the better-auth endpoints (which set the session cookie), then does
@@ -171,8 +148,10 @@ export function SignInPage() {
   const auth = useFactoryAuth();
   const [searchParams] = useSearchParams();
   const [redirecting, setRedirecting] = useState(false);
-  const { error: authError, returnTo } = readAuthRedirect(searchParams);
-  const accessDenied = authError?.code === 'access_denied';
+  const returnTo = safeReturnTo(searchParams.get('returnTo') ?? undefined);
+  const authError = searchParams.get('error');
+  const authErrorDescription = searchParams.get('error_description');
+  const accessDenied = authError === 'access_denied';
   const credentialForm = auth.data?.provider === 'better-auth';
   const studioAuth = auth.data?.provider === 'mastra-studio';
   const hostedLoginLabel = studioAuth ? 'Sign in with Mastra Platform' : 'Continue with GitHub';
@@ -207,9 +186,9 @@ export function SignInPage() {
                 <Txt as="p" variant="ui-md" className="text-accent2 font-medium">
                   {accessDenied ? 'Access denied' : 'Sign-in failed'}
                 </Txt>
-                {authError.description ? (
+                {authErrorDescription ? (
                   <Txt as="p" variant="ui-sm" className="text-neutral4 mt-1 leading-5">
-                    {authError.description}
+                    {authErrorDescription}
                   </Txt>
                 ) : null}
                 {accessDenied ? (

--- a/mastracode/factory-ui/src/ui/pages/SignInPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/SignInPage.tsx
@@ -36,6 +36,29 @@ export function safeReturnTo(raw?: string): string {
   }
 }
 
+export type AuthRedirectError = { code: string; description: string | null };
+
+/**
+ * OAuth error params reach `/signin` two ways: directly (the server callback
+ * redirects IdP denials here) or buried in a `returnTo` targeting the
+ * IdP-facing `/login` path that the auth guards forwarded verbatim. That
+ * returnTo is a dead end, so it collapses to `/`.
+ */
+export function readAuthRedirect(params: URLSearchParams): { error: AuthRedirectError | null; returnTo: string } {
+  const returnTo = safeReturnTo(params.get('returnTo') ?? undefined);
+  const direct = params.get('error');
+  if (direct) return { error: { code: direct, description: params.get('error_description') }, returnTo };
+  const nested = new URL(returnTo, window.location.origin);
+  const nestedError = nested.searchParams.get('error');
+  if (nested.pathname === '/login' && nestedError) {
+    return {
+      error: { code: nestedError, description: nested.searchParams.get('error_description') },
+      returnTo: '/',
+    };
+  }
+  return { error: null, returnTo };
+}
+
 /**
  * Email/password credential form for the self-hosted better-auth provider.
  * Posts to the better-auth endpoints (which set the session cookie), then does
@@ -148,7 +171,8 @@ export function SignInPage() {
   const auth = useFactoryAuth();
   const [searchParams] = useSearchParams();
   const [redirecting, setRedirecting] = useState(false);
-  const returnTo = safeReturnTo(searchParams.get('returnTo')?.toString());
+  const { error: authError, returnTo } = readAuthRedirect(searchParams);
+  const accessDenied = authError?.code === 'access_denied';
   const credentialForm = auth.data?.provider === 'better-auth';
   const studioAuth = auth.data?.provider === 'mastra-studio';
   const hostedLoginLabel = studioAuth ? 'Sign in with Mastra Platform' : 'Continue with GitHub';
@@ -178,6 +202,23 @@ export function SignInPage() {
           </Txt>
 
           <section aria-label="Authentication" className="mt-10 w-full max-w-md lg:mt-12">
+            {authError ? (
+              <div role="alert" className="border-accent2/30 bg-surface3 mb-6 rounded-lg border px-4 py-3">
+                <Txt as="p" variant="ui-md" className="text-accent2 font-medium">
+                  {accessDenied ? 'Access denied' : 'Sign-in failed'}
+                </Txt>
+                {authError.description ? (
+                  <Txt as="p" variant="ui-sm" className="text-neutral4 mt-1 leading-5">
+                    {authError.description}
+                  </Txt>
+                ) : null}
+                {accessDenied ? (
+                  <Txt as="p" variant="ui-sm" className="text-neutral3 mt-1 leading-5">
+                    Ask an organization admin to add your account, then sign in again.
+                  </Txt>
+                ) : null}
+              </div>
+            ) : null}
             {credentialForm ? (
               <>
                 <div className="mb-6">

--- a/mastracode/factory/src/auth.test.ts
+++ b/mastracode/factory/src/auth.test.ts
@@ -405,13 +405,16 @@ describe('mountFactoryAuth /auth routes (enabled)', () => {
     expect(mockHandleCallback).not.toHaveBeenCalled();
   });
 
-  it('surfaces an IdP denial on /signin instead of looping back through login', async () => {
+  it('surfaces an IdP denial on /signin, keeping the intended destination for a retry', async () => {
     const { app } = buildApp();
+    const state = `uuid-1|${encodeURIComponent('/dashboard')}`;
     const res = await app.request(
-      '/auth/callback?error=access_denied&error_description=You%20do%20not%20have%20access',
+      `/auth/callback?error=access_denied&error_description=You%20do%20not%20have%20access&state=${state}`,
     );
     expect(res.status).toBe(302);
-    expect(res.headers.get('location')).toBe('/signin?error=access_denied&error_description=You+do+not+have+access');
+    expect(res.headers.get('location')).toBe(
+      '/signin?error=access_denied&error_description=You+do+not+have+access&returnTo=%2Fdashboard',
+    );
     expect(mockHandleCallback).not.toHaveBeenCalled();
   });
 

--- a/mastracode/factory/src/auth.test.ts
+++ b/mastracode/factory/src/auth.test.ts
@@ -392,6 +392,16 @@ describe('mountFactoryAuth /auth routes (enabled)', () => {
     expect(mockHandleCallback).not.toHaveBeenCalled();
   });
 
+  it('surfaces an IdP denial on /signin instead of looping back through login', async () => {
+    const { app } = buildApp();
+    const res = await app.request(
+      '/auth/callback?error=access_denied&error_description=You%20do%20not%20have%20access',
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('/signin?error=access_denied&error_description=You+do+not+have+access');
+    expect(mockHandleCallback).not.toHaveBeenCalled();
+  });
+
   it('redirects callback back to login when the code exchange fails', async () => {
     mockHandleCallback.mockRejectedValue(new Error('expired code'));
     const { app } = buildApp();

--- a/mastracode/factory/src/auth.test.ts
+++ b/mastracode/factory/src/auth.test.ts
@@ -124,6 +124,19 @@ describe('mountFactoryAuth gate (enabled)', () => {
     expect(await res.text()).toBe('ok');
   });
 
+  it('forwards the platform deploy-auth /login landing to /signin with its query intact', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const { app } = buildApp();
+
+    const res = await app.request('/login?error=access_denied&error_description=You%20do%20not%20have%20access', {
+      headers: { Accept: 'text/html' },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(
+      '/signin?error=access_denied&error_description=You%20do%20not%20have%20access',
+    );
+  });
+
   it('lets unauthenticated requests fetch static assets and metadata needed by the sign-in page', async () => {
     mockAuthenticate.mockResolvedValue(null);
     const { app } = buildApp();

--- a/mastracode/factory/src/auth.ts
+++ b/mastracode/factory/src/auth.ts
@@ -559,6 +559,7 @@ function providerAuthRoutes(provider: IMastraAuthProvider, publicUrl?: string): 
             const query = new URLSearchParams({ error: idpError.slice(0, 64) });
             const description = c.req.query('error_description');
             if (description) query.set('error_description', description.slice(0, 256));
+            if (returnTo !== '/') query.set('returnTo', returnTo);
             return c.redirect(`/signin?${query.toString()}`);
           }
           if (!code) {

--- a/mastracode/factory/src/auth.ts
+++ b/mastracode/factory/src/auth.ts
@@ -752,6 +752,12 @@ export function createFactoryAuthGate(provider: IMastraAuthProvider) {
     if (c.req.method === 'GET' && (path === '/connect/slack' || path.startsWith('/connect/slack/'))) {
       return next();
     }
+    // The platform's deploy-auth flow lands IdP denials on `/login`
+    // (`error=access_denied&error_description=...`); the SPA serves sign-in at
+    // `/signin`, so forward the query there instead of burying it in returnTo.
+    if (c.req.method === 'GET' && path === '/login') {
+      return c.redirect(`/signin${new URL(c.req.url).search}`);
+    }
     // The SPA sign-in page, its static bundle, and browser-fetched metadata
     // must be reachable while signed out; no user is stashed, so `/api/*`
     // stays protected.

--- a/mastracode/factory/src/auth.ts
+++ b/mastracode/factory/src/auth.ts
@@ -552,6 +552,15 @@ function providerAuthRoutes(provider: IMastraAuthProvider, publicUrl?: string): 
           const cookieReturnTo = sanitizeReturnTo(readReturnToCookie(c));
           const returnTo = cookieReturnTo !== '/' ? cookieReturnTo : stateReturnTo;
           c.header('Set-Cookie', clearReturnToCookieHeader(), { append: true });
+          const idpError = c.req.query('error');
+          if (idpError) {
+            // IdP denial (e.g. access_denied for a non-org-member): bouncing to
+            // /auth/login would re-enter the IdP in a redirect loop.
+            const query = new URLSearchParams({ error: idpError.slice(0, 64) });
+            const description = c.req.query('error_description');
+            if (description) query.set('error_description', description.slice(0, 256));
+            return c.redirect(`/signin?${query.toString()}`);
+          }
           if (!code) {
             return c.redirect('/auth/login');
           }


### PR DESCRIPTION
When the identity provider refused an account (shipyard's access_denied for someone outside the org), the platform redirected the browser to /login?error=access_denied... on the deployment — a path nothing served. The auth gate bounced it to /signin with the error buried inside returnTo, so the page just showed the sign-in button again and retrying looped through the IdP with no explanation. The gate now forwards /login to /signin with its query intact, and the sign-in page shows the denial with the IdP's description plus a hint to ask an organization admin.

On the server, /auth/callback also ignored the OAuth error param and redirected straight back to /auth/login, re-entering the IdP in a redirect loop; it now forwards the error to /signin the same way, with the values capped so a hostile response can't inflate the redirect URL.

Covered by gate and callback unit tests plus MSW tests on the sign-in page. Verified in tests only, not against a live WorkOS denial.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an identity provider blocks sign-in, users now see the reason and guidance instead of repeating the sign-in process. The fix also preserves the original destination and limits error data size.

## Changes

- Redirect `/login` requests to `/signin` while preserving query parameters.
- Redirect OAuth callback errors to `/signin` instead of `/auth/login`.
- Display the identity provider’s denial description and administrator guidance.
- Preserve a sanitized `returnTo` value so users can resume the original deep link.
- Limit redirect error parameters to prevent oversized URLs.
- Add unit and MSW tests for gate, callback, and sign-in behavior.
- Add patch changesets for `@mastra/factory` and `mastracode`.

## Verification

- Tests cover access-denied redirects, error display, fallback guidance, retry actions, deep-link preservation, and skipped token exchange.
- Verification did not include a live WorkOS denial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->