### PR TITLE
fix(ci): add checkout step timeouts

### DIFF
--- a/.github/workflows/backport-auto.yml
+++ b/.github/workflows/backport-auto.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -38,6 +39,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           token: ${{ steps.app-auth.outputs.token }}
           persist-credentials: true

--- a/.github/workflows/backport-auto.yml
+++ b/.github/workflows/backport-auto.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -39,7 +39,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           token: ${{ steps.app-auth.outputs.token }}
           persist-credentials: true

--- a/.github/workflows/changed-test-gate-labeler.yml
+++ b/.github/workflows/changed-test-gate-labeler.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout automation scripts
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/changed-test-gate-labeler.yml
+++ b/.github/workflows/changed-test-gate-labeler.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - name: Checkout automation scripts
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - name: Checkout base
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Checkout base
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/cron-alpha-publish.yml
+++ b/.github/workflows/cron-alpha-publish.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -35,7 +35,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/cron-alpha-publish.yml
+++ b/.github/workflows/cron-alpha-publish.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -34,6 +35,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Checkout notification script
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false

--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -43,6 +43,7 @@ jobs:
     steps:
       - name: Checkout notification script
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false

--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-experiment-worker.yml
+++ b/.github/workflows/e2e-experiment-worker.yml
@@ -37,6 +37,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
       - name: Setup pnpm and Node.js
@@ -79,6 +80,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-pnpm-node
@@ -127,6 +129,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-pnpm-node
@@ -180,6 +183,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-pnpm-node
@@ -229,6 +233,7 @@ jobs:
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
       - run: node scripts/gated-interface.mjs remote-sandbox
@@ -258,6 +263,7 @@ jobs:
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
       - run: node scripts/gated-interface.mjs object-store
@@ -288,6 +294,7 @@ jobs:
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
       - run: node scripts/gated-interface.mjs real-model
@@ -317,6 +324,7 @@ jobs:
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
       - run: node scripts/gated-interface.mjs hosted-proxy

--- a/.github/workflows/e2e-experiment-worker.yml
+++ b/.github/workflows/e2e-experiment-worker.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
       - name: Setup pnpm and Node.js
@@ -80,7 +80,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-pnpm-node
@@ -129,7 +129,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-pnpm-node
@@ -183,7 +183,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-pnpm-node
@@ -233,7 +233,7 @@ jobs:
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
       - run: node scripts/gated-interface.mjs remote-sandbox
@@ -263,7 +263,7 @@ jobs:
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
       - run: node scripts/gated-interface.mjs object-store
@@ -294,7 +294,7 @@ jobs:
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
       - run: node scripts/gated-interface.mjs real-model
@@ -324,7 +324,7 @@ jobs:
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
       - run: node scripts/gated-interface.mjs hosted-proxy

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,6 +37,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -90,6 +91,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -157,6 +159,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -201,6 +204,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -247,6 +251,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -291,6 +296,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -335,6 +341,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -378,6 +385,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -422,6 +430,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -468,6 +477,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -510,6 +520,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -91,7 +91,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -159,7 +159,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -204,7 +204,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -251,7 +251,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -296,7 +296,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -341,7 +341,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -385,7 +385,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -430,7 +430,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -477,7 +477,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
 
@@ -520,7 +520,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
 

--- a/.github/workflows/issue-pending-release.yml
+++ b/.github/workflows/issue-pending-release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout automation scripts
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/issue-pending-release.yml
+++ b/.github/workflows/issue-pending-release.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - name: Checkout automation scripts
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           persist-credentials: false
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           persist-credentials: false
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 1
           fetch-tags: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 1
           fetch-tags: false

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 0
 
@@ -126,7 +126,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -195,7 +195,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 0
 
@@ -42,6 +43,7 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 0
 
@@ -124,6 +126,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -192,6 +195,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 0
 
@@ -62,6 +63,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -85,6 +87,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -116,6 +119,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -142,6 +146,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -164,6 +169,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           # Fetch entire git history so Changesets can generate changelogs
           # with the correct commits
@@ -214,6 +220,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@04be95cf3511ea51ebf9f224ddfb99cc7ab87cd4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 0
 
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -87,7 +87,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -119,7 +119,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -146,7 +146,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -169,7 +169,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           # Fetch entire git history so Changesets can generate changelogs
           # with the correct commits
@@ -220,7 +220,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@04be95cf3511ea51ebf9f224ddfb99cc7ab87cd4

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Checkout for local action
         if: steps.check_major.outputs.has_major_changeset == 'true'
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           # Always check out the local action from the trusted default branch.
           # Never use PR-derived refs here: this privileged workflow (issue_comment)

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout for local action
         if: steps.check_major.outputs.has_major_changeset == 'true'
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           # Always check out the local action from the trusted default branch.
           # Never use PR-derived refs here: this privileged workflow (issue_comment)

--- a/.github/workflows/mastracode-e2e.yml
+++ b/.github/workflows/mastracode-e2e.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
 

--- a/.github/workflows/mastracode-e2e.yml
+++ b/.github/workflows/mastracode-e2e.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -189,7 +189,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -206,7 +206,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0
@@ -375,7 +375,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -391,7 +391,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0
@@ -453,7 +453,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -469,7 +469,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,6 +51,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -188,6 +189,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -204,6 +206,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0
@@ -372,6 +375,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -387,6 +391,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0
@@ -448,6 +453,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -463,6 +469,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           token: ${{ steps.app-auth.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
@@ -99,7 +99,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 0
 
@@ -385,7 +385,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 0
 
@@ -53,6 +54,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
@@ -97,6 +99,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 0
 
@@ -382,6 +385,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -44,6 +45,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: main
           token: ${{ steps.app-auth.outputs.token }}

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -45,7 +45,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: main
           token: ${{ steps.app-auth.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -41,6 +41,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -24,7 +24,7 @@ jobs:
       # Checkout the default branch so local actions are loaded from a trusted
       # ref, not the workflow_run head SHA which may come from an untrusted PR.
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -133,7 +133,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
       - name: Set success status for unchanged workspaces
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:
@@ -154,7 +154,7 @@ jobs:
       packages: ${{ steps.set-packages.outputs.packages }}
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - id: set-packages
@@ -183,7 +183,7 @@ jobs:
       TURBO_CACHE: remote:r
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
@@ -221,7 +221,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
       - name: Set success status for completed tests
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:
@@ -241,7 +241,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
       - name: Set failure status for failed tests
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:
@@ -261,7 +261,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
       - name: Set status for skipped tests
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -24,6 +24,7 @@ jobs:
       # Checkout the default branch so local actions are loaded from a trusted
       # ref, not the workflow_run head SHA which may come from an untrusted PR.
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -132,6 +133,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
       - name: Set success status for unchanged workspaces
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:
@@ -152,6 +154,7 @@ jobs:
       packages: ${{ steps.set-packages.outputs.packages }}
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - id: set-packages
@@ -180,6 +183,7 @@ jobs:
       TURBO_CACHE: remote:r
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
@@ -217,6 +221,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
       - name: Set success status for completed tests
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:
@@ -236,6 +241,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
       - name: Set failure status for failed tests
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:
@@ -255,6 +261,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
       - name: Set status for skipped tests
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:

--- a/.github/workflows/sync-softwarefactory-template.yml
+++ b/.github/workflows/sync-softwarefactory-template.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -77,7 +77,7 @@ jobs:
 
       - name: Checkout template repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           repository: mastra-ai/softwarefactory-template
           token: ${{ steps.app-auth.outputs.token }}

--- a/.github/workflows/sync-softwarefactory-template.yml
+++ b/.github/workflows/sync-softwarefactory-template.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -76,6 +77,7 @@ jobs:
 
       - name: Checkout template repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           repository: mastra-ai/softwarefactory-template
           token: ${{ steps.app-auth.outputs.token }}

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -38,7 +38,7 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -37,6 +38,7 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node

--- a/.github/workflows/sync_renovate-changesets.yml
+++ b/.github/workflows/sync_renovate-changesets.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 0
           token: ${{ secrets.RENOVATE_PAT  }}

--- a/.github/workflows/sync_renovate-changesets.yml
+++ b/.github/workflows/sync_renovate-changesets.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 0
           token: ${{ secrets.RENOVATE_PAT  }}

--- a/.github/workflows/test-combined-stores.yml
+++ b/.github/workflows/test-combined-stores.yml
@@ -35,7 +35,7 @@ jobs:
       stores: ${{ steps.set-stores.outputs.stores }}
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false

--- a/.github/workflows/test-combined-stores.yml
+++ b/.github/workflows/test-combined-stores.yml
@@ -35,6 +35,7 @@ jobs:
       stores: ${{ steps.set-stores.outputs.stores }}
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -86,6 +87,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
           fetch-depth: 2
@@ -108,7 +108,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
           fetch-depth: 2
@@ -170,7 +170,7 @@ jobs:
     steps:
       - name: Checkout PR code
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 2
           ref: ${{ inputs.head_sha }}
@@ -243,7 +243,7 @@ jobs:
       - name: Checkout repo
         if: inputs.has_code == 'true' && (inputs.run_full != 'false' || inputs.unit_test_files != '' || inputs.e2e_test_files != '')
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 1
           ref: ${{ inputs.head_sha }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -53,6 +53,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
           fetch-depth: 2
@@ -107,6 +108,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
           fetch-depth: 2
@@ -168,6 +170,7 @@ jobs:
     steps:
       - name: Checkout PR code
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 2
           ref: ${{ inputs.head_sha }}
@@ -240,6 +243,7 @@ jobs:
       - name: Checkout repo
         if: inputs.has_code == 'true' && (inputs.run_full != 'false' || inputs.unit_test_files != '' || inputs.e2e_test_files != '')
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 1
           ref: ${{ inputs.head_sha }}

--- a/.github/workflows/test-workspaces.yml
+++ b/.github/workflows/test-workspaces.yml
@@ -23,6 +23,7 @@ jobs:
       packages: ${{ steps.set-packages.outputs.packages }}
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -49,6 +50,7 @@ jobs:
         package: ${{ fromJson(needs.setup.outputs.packages) }}
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -78,6 +80,7 @@ jobs:
         package: [s3, gcs, azure]
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false

--- a/.github/workflows/test-workspaces.yml
+++ b/.github/workflows/test-workspaces.yml
@@ -23,7 +23,7 @@ jobs:
       packages: ${{ steps.set-packages.outputs.packages }}
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -50,7 +50,7 @@ jobs:
         package: ${{ fromJson(needs.setup.outputs.packages) }}
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false
@@ -80,7 +80,7 @@ jobs:
         package: [s3, gcs, azure]
     steps:
       - uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           ref: ${{ inputs.head_sha }}
           persist-credentials: false

--- a/.github/workflows/upload-studio-r2.yml
+++ b/.github/workflows/upload-studio-r2.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 1
           ref: mastra@${{ inputs.version }}

--- a/.github/workflows/upload-studio-r2.yml
+++ b/.github/workflows/upload-studio-r2.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 1
           ref: mastra@${{ inputs.version }}

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -34,6 +35,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           token: ${{ steps.app-auth.outputs.token }}
           # Fetch entire git history so Changesets can generate changelogs

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Initial checkout
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           # Use default GITHUB_TOKEN for initial checkout
           # This is needed to access the .github/actions/app-auth action
@@ -35,7 +35,7 @@ jobs:
 
       - name: Re-checkout with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           token: ${{ steps.app-auth.outputs.token }}
           # Fetch entire git history so Changesets can generate changelogs

--- a/.github/workflows/vitest-all.yml
+++ b/.github/workflows/vitest-all.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 0
 
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           fetch-depth: 0
 
@@ -159,7 +159,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
-        timeout-minutes: 3
+        timeout-minutes: 5
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node

--- a/.github/workflows/vitest-all.yml
+++ b/.github/workflows/vitest-all.yml
@@ -31,6 +31,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 0
 
@@ -94,6 +95,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
         with:
           fetch-depth: 0
 
@@ -157,6 +159,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        timeout-minutes: 3
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node


### PR DESCRIPTION
Adds a three-minute timeout to every actions/checkout step so CI jobs fail promptly when repository checkout stalls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If a repository checkout gets stuck, CI now stops waiting after five minutes. This helps workflows fail quickly instead of hanging.

## Changes

- Added `timeout-minutes: 5` to `actions/checkout` steps across the GitHub Actions workflows.
- Applied the timeout to workflows with one or multiple checkout steps.
- No public entities or application code changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->