### PR TITLE
fix(mastracode): store Factory plans as artifacts

### DIFF
--- a/.changeset/slimy-guests-repair.md
+++ b/.changeset/slimy-guests-repair.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed Factory interactive plans so they are stored as browsable artifacts.

--- a/mastracode/sdk/src/agents/__tests__/mode-available-tools.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/mode-available-tools.test.ts
@@ -44,6 +44,12 @@ describe('mode availableTools configuration', () => {
       expect(tools).toContain(MC_TOOLS.STRING_REPLACE_LSP);
     });
 
+    it('leaves the plan directory to the session-specific system prompt', () => {
+      expect(planMode.instructions).toContain('session-specific plan directory identified in your system prompt');
+      expect(planMode.instructions).not.toContain('.mastracode/plans/');
+      expect(planMode.instructions).not.toContain('.artifacts/plans/');
+    });
+
     it('allows plan-mode writes to any .md file inside .mastracode/plans/', () => {
       const projectPath = '/tmp/mastracode-plan-guard';
       // Mirror the real HarnessRequestContext shape: session.modeId is a string
@@ -91,6 +97,58 @@ describe('mode availableTools configuration', () => {
         proceed: false,
         output: 'Plan mode can only write plan files inside .mastracode/plans/. Refusing to edit src/index.ts.',
       });
+    });
+
+    it('allows Factory plan files only inside .artifacts/plans/', () => {
+      const projectPath = '/tmp/mastracode-factory-plan-guard';
+      const context = {
+        requestContext: {
+          harness: {
+            session: {
+              modeId: 'plan',
+              state: { get: () => ({ projectPath, factoryProjectId: 'factory-123' }) },
+            },
+          },
+        },
+      };
+
+      expect(
+        guardPlanModePlanFileWrites({
+          toolName: MC_TOOLS.WRITE_FILE,
+          workspaceToolName: WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE,
+          input: { path: '.artifacts/plans/add-dark-mode.md' },
+          context,
+        }),
+      ).toBeUndefined();
+
+      expect(
+        guardPlanModePlanFileWrites({
+          toolName: MC_TOOLS.STRING_REPLACE_LSP,
+          workspaceToolName: WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE,
+          input: { path: `${projectPath}/.artifacts/plans/another-plan.md` },
+          context,
+        }),
+      ).toBeUndefined();
+
+      for (const inputPath of [
+        '.mastracode/plans/legacy.md',
+        'src/index.ts',
+        '.artifacts/plans/notes.txt',
+        '.artifacts/plans/sub/plan.md',
+        '.artifacts/plans/../../evil.md',
+      ]) {
+        expect(
+          guardPlanModePlanFileWrites({
+            toolName: MC_TOOLS.WRITE_FILE,
+            workspaceToolName: WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE,
+            input: { path: inputPath },
+            context,
+          }),
+        ).toMatchObject({
+          proceed: false,
+          output: `Plan mode can only write plan files inside .artifacts/plans/. Refusing to edit ${inputPath}.`,
+        });
+      }
     });
 
     it('rejects plan-mode writes to non-markdown or nested paths inside the plans dir', () => {

--- a/mastracode/sdk/src/agents/__tests__/prompts.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/prompts.test.ts
@@ -162,6 +162,29 @@ describe('buildFullPrompt', () => {
     expect(prompt).toContain('goal judge can tell when the work is done');
   });
 
+  it('uses Factory artifact paths consistently throughout the plan prompt', () => {
+    const prompt = buildFullPrompt({
+      projectPath: '/tmp/project',
+      projectName: 'test-project',
+      gitBranch: 'main',
+      platform: 'darwin',
+      date: '2026-03-23',
+      mode: 'plan',
+      activePlan: null,
+      modeId: 'plan',
+      currentDate: '2026-03-23',
+      workingDir: '/tmp/project',
+      state: {
+        factoryProjectId: 'factory-123',
+        permissionRules: { tools: {} },
+      },
+    });
+
+    expect(prompt).toContain('.artifacts/plans/');
+    expect(prompt).toContain('.artifacts/plans/add-dark-mode.md');
+    expect(prompt).not.toContain('.mastracode/plans/');
+  });
+
   it('includes the selected model id in commit co-author guidance', () => {
     const prompt = buildFullPrompt({
       projectPath: '/tmp/project',

--- a/mastracode/sdk/src/agents/modes/plan.ts
+++ b/mastracode/sdk/src/agents/modes/plan.ts
@@ -15,7 +15,7 @@ export const planMode: AgentControllerMode = {
 
 ## Rules
 - You have READ-ONLY access to the project. You cannot modify project files or run commands.
-- The one exception is plan files: you can create and edit markdown files inside \`.mastracode/plans/\` using \`write_file\`, \`view\`, and \`string_replace_lsp\`. You may not write anywhere else.
+- The one exception is plan files: you can create and edit markdown files inside the session-specific plan directory identified in your system prompt using \`write_file\`, \`view\`, and \`string_replace_lsp\`. You may not write anywhere else.
 - First, explore the codebase to understand existing patterns, architecture, and conventions.
 - Produce a concrete, actionable plan — not vague suggestions.
 
@@ -26,7 +26,7 @@ export const planMode: AgentControllerMode = {
 - **Parallelize**: Make multiple independent tool calls when exploring different areas
 
 ## Plan Delivery
-- Write your plan to a markdown file under \`.mastracode/plans/\` (e.g. \`.mastracode/plans/add-dark-mode.md\`) using \`write_file\`, then call \`submit_plan({ path })\` with the path to that file (never the plan body).
+- Write your plan to a markdown file in the session-specific plan directory identified in your system prompt using \`write_file\`, then call \`submit_plan({ path })\` with the path to that file (never the plan body).
 - Start the file with a \`# Title\` heading describing the plan.
 - Reuse the same file while iterating on the same plan; only create a new file for a genuinely different plan so each plan stays available to review.
 - Do NOT output the plan as text — it MUST live in the plan file.

--- a/mastracode/sdk/src/agents/prompts/index.ts
+++ b/mastracode/sdk/src/agents/prompts/index.ts
@@ -9,6 +9,7 @@ export { fastModePrompt } from './fast.js';
 import { buildBasePrompt } from '@mastra/core/coding-agent';
 import type { PromptContext as BasePromptContext } from '@mastra/core/coding-agent';
 import { hasTavilyKey } from '../../tools/index.js';
+import { getLocalPlansRelativeDir } from '../../utils/plans.js';
 import { loadAgentInstructions, formatAgentInstructions, createGitRefInstructionReader } from './agent-instructions.js';
 import { buildModePromptFn } from './build.js';
 import { fastModePrompt } from './fast.js';
@@ -49,7 +50,12 @@ export function buildFullPrompt(ctx: PromptContext): string {
   }
 
   // Build mode-aware tool guidance
-  const toolGuidance = buildToolGuidance(ctx.modeId, { hasWebSearch, deniedTools });
+  const factoryProjectId = typeof ctx.state?.factoryProjectId === 'string' ? ctx.state.factoryProjectId : undefined;
+  const toolGuidance = buildToolGuidance(ctx.modeId, {
+    hasWebSearch,
+    deniedTools,
+    plansDir: getLocalPlansRelativeDir({ factoryProjectId }),
+  });
 
   // Map new context to base context
   const baseCtx: BasePromptContext = {

--- a/mastracode/sdk/src/agents/prompts/plan.test.ts
+++ b/mastracode/sdk/src/agents/prompts/plan.test.ts
@@ -2,11 +2,20 @@ import { describe, expect, it } from 'vitest';
 import { planModePrompt } from './plan.js';
 
 describe('planModePrompt', () => {
-  it('instructs writing named plan files into .mastracode/plans/', () => {
+  it('instructs ordinary sessions to write named plan files into .mastracode/plans/', () => {
     const prompt = planModePrompt({ state: {} });
 
     expect(prompt).toContain('.mastracode/plans/');
     expect(prompt).toContain('.mastracode/plans/add-dark-mode.md');
+    expect(prompt).not.toContain('.artifacts/plans/');
+  });
+
+  it('instructs Factory sessions to write named plan files into .artifacts/plans/', () => {
+    const prompt = planModePrompt({ state: { factoryProjectId: 'factory-123' } });
+
+    expect(prompt).toContain('.artifacts/plans/');
+    expect(prompt).toContain('.artifacts/plans/add-dark-mode.md');
+    expect(prompt).not.toContain('.mastracode/plans/');
   });
 
   it('tells the agent to submit_plan with a path, not the plan body', () => {

--- a/mastracode/sdk/src/agents/prompts/plan.ts
+++ b/mastracode/sdk/src/agents/prompts/plan.ts
@@ -7,8 +7,9 @@ interface PlanPromptContext {
   state?: Record<string, unknown>;
 }
 
-export function planModePrompt(_ctx: PlanPromptContext): string {
-  const plansDir = getLocalPlansRelativeDir();
+export function planModePrompt(ctx: PlanPromptContext): string {
+  const factoryProjectId = typeof ctx.state?.factoryProjectId === 'string' ? ctx.state.factoryProjectId : undefined;
+  const plansDir = getLocalPlansRelativeDir({ factoryProjectId });
   const examplePath = `${plansDir}/add-dark-mode.md`;
 
   return `

--- a/mastracode/sdk/src/agents/prompts/tool-guidance.test.ts
+++ b/mastracode/sdk/src/agents/prompts/tool-guidance.test.ts
@@ -23,4 +23,18 @@ describe('buildToolGuidance task tools', () => {
     expect(guidance).toContain('task_complete');
     expect(guidance).not.toContain('task_write');
   });
+
+  it('uses the supplied plan directory in plan-mode guidance', () => {
+    const guidance = buildToolGuidance('plan', { plansDir: '.artifacts/plans' });
+
+    expect(guidance).toContain('.artifacts/plans/');
+    expect(guidance).not.toContain('.mastracode/plans/');
+  });
+
+  it('uses .mastracode/plans/ by default in plan-mode guidance', () => {
+    const guidance = buildToolGuidance('plan');
+
+    expect(guidance).toContain('.mastracode/plans/');
+    expect(guidance).not.toContain('.artifacts/plans/');
+  });
 });

--- a/mastracode/sdk/src/agents/prompts/tool-guidance.ts
+++ b/mastracode/sdk/src/agents/prompts/tool-guidance.ts
@@ -10,10 +10,13 @@ interface ToolGuidanceOptions {
   hasWebSearch?: boolean;
   /** Tool names that have been denied — omit their guidance sections. */
   deniedTools?: Set<string>;
+  /** Workspace-relative directory where plan mode can write plans. */
+  plansDir?: string;
 }
 
 export function buildToolGuidance(modeId: string, options: ToolGuidanceOptions = {}): string {
   const denied = options.deniedTools ?? new Set<string>();
+  const plansDir = options.plansDir ?? '.mastracode/plans';
   const sections: string[] = [];
 
   sections.push(`# Tool Usage Rules
@@ -213,12 +216,12 @@ ${patchToolGuidance}
 - Call this tool when your plan is complete. Do NOT just describe your plan in text — you MUST call this tool.
 - The plan will be rendered as markdown and the user can approve, reject, or request changes.
 - On approval, the system automatically switches to the default mode so you can implement.
-- Takes one argument: \`path\` (the plan markdown file you wrote under \`.mastracode/plans/\`). Do NOT pass the plan body — it lives in the file.`);
+- Takes one argument: \`path\` (the plan markdown file you wrote under \`${plansDir}/\`). Do NOT pass the plan body — it lives in the file.`);
   }
 
   if (modeId === 'plan') {
     sections.push(`
-**Plan file access** — Your plan lives in a markdown file under \`.mastracode/plans/\` (e.g. \`add-dark-mode-toggle.md\`)
+**Plan file access** — Your plan lives in a markdown file under \`${plansDir}/\` (e.g. \`add-dark-mode-toggle.md\`)
 - Use \`write_file\` to create the plan file, \`view\` to read it, and \`string_replace_lsp\` for targeted edits.
 - On first submission: write the plan to the file, then call \`submit_plan\` with its \`path\`.
 - On revision: read the existing file, edit specific sections, re-read, then call \`submit_plan\` with the same \`path\`.

--- a/mastracode/sdk/src/agents/tool-availability.ts
+++ b/mastracode/sdk/src/agents/tool-availability.ts
@@ -49,12 +49,15 @@ function getHarnessProjectPath(harness: PlanModeGuardHarness | undefined): strin
   return typeof projectPath === 'string' ? projectPath : undefined;
 }
 
+function getHarnessFactoryProjectId(harness: PlanModeGuardHarness | undefined): string | undefined {
+  const factoryProjectId = getHarnessState(harness)?.factoryProjectId;
+  return typeof factoryProjectId === 'string' ? factoryProjectId : undefined;
+}
+
 function getToolInputPath(input: unknown): string | undefined {
   const toolPath = (input as { path?: unknown } | undefined)?.path;
   return typeof toolPath === 'string' ? toolPath : undefined;
 }
-
-const PLAN_DIR_HINT = `${getLocalPlansRelativeDir()}/`;
 
 export function guardPlanModePlanFileWrites({ workspaceToolName, input, context }: WorkspaceToolHookContext) {
   if (!PLAN_MODE_WRITE_TOOL_NAMES.has(workspaceToolName)) return;
@@ -62,22 +65,25 @@ export function guardPlanModePlanFileWrites({ workspaceToolName, input, context 
   const harness = getHarnessContext(context);
   if (getHarnessModeId(harness) !== 'plan') return;
 
+  const factoryProjectId = getHarnessFactoryProjectId(harness);
+  const planOptions = { factoryProjectId };
+  const planDirHint = `${getLocalPlansRelativeDir(planOptions)}/`;
   const projectPath = getHarnessProjectPath(harness);
   const inputPath = getToolInputPath(input);
   if (!projectPath || !inputPath) {
     return {
       proceed: false as const,
-      output: `Plan mode can only write plan files inside ${PLAN_DIR_HINT}.`,
+      output: `Plan mode can only write plan files inside ${planDirHint}.`,
     };
   }
 
-  // Plan mode may write any `.md` file directly inside `.mastracode/plans/`, but
-  // nothing else in the project.
-  if (isPlanFilePath(projectPath, inputPath)) return;
+  // Plan mode may write any `.md` file directly inside the configured plan directory,
+  // but nothing else in the project.
+  if (isPlanFilePath(projectPath, inputPath, planOptions)) return;
 
   return {
     proceed: false as const,
-    output: `Plan mode can only write plan files inside ${PLAN_DIR_HINT}. Refusing to edit ${inputPath}.`,
+    output: `Plan mode can only write plan files inside ${planDirHint}. Refusing to edit ${inputPath}.`,
   };
 }
 
@@ -96,7 +102,7 @@ export const PLAN_MODE_AVAILABLE_TOOLS: readonly string[] = [
   MC_TOOLS.FILE_STAT,
   MC_TOOLS.LSP_INSPECT,
   // Plan file writing. Tool hooks enforce that these can only write `.md`
-  // files inside `.mastracode/plans/` while the session is in plan mode.
+  // files inside the session's configured plan directory while in plan mode.
   MC_TOOLS.WRITE_FILE,
   MC_TOOLS.STRING_REPLACE_LSP,
   // Plan delivery tools

--- a/mastracode/sdk/src/utils/__tests__/save-plan.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/save-plan.test.ts
@@ -5,6 +5,8 @@ import {
   savePlanToDisk,
   getPlanFilename,
   getLocalPlansDir,
+  getLocalPlansRelativeDir,
+  getSuggestedPlanRelativePath,
   isPlanFilePath,
   readPlanFile,
   approvePlanFile,
@@ -162,6 +164,22 @@ function writePlanFile(filename: string, content: string): string {
   return filePath;
 }
 
+describe('local plan directories', () => {
+  it('uses .mastracode/plans/ outside Factory sessions', () => {
+    expect(getLocalPlansRelativeDir()).toBe('.mastracode/plans');
+    expect(getSuggestedPlanRelativePath('Add dark mode')).toBe('.mastracode/plans/add-dark-mode.md');
+    expect(getLocalPlansDir(tmpProjectPath)).toBe(path.join(tmpProjectPath, '.mastracode', 'plans'));
+  });
+
+  it('uses .artifacts/plans/ for Factory sessions', () => {
+    const options = { factoryProjectId: 'factory-123' };
+
+    expect(getLocalPlansRelativeDir(options)).toBe('.artifacts/plans');
+    expect(getSuggestedPlanRelativePath('Add dark mode', options)).toBe('.artifacts/plans/add-dark-mode.md');
+    expect(getLocalPlansDir(tmpProjectPath, options)).toBe(path.join(tmpProjectPath, '.artifacts', 'plans'));
+  });
+});
+
 describe('isPlanFilePath', () => {
   it('accepts a .md file directly inside .mastracode/plans/', () => {
     expect(isPlanFilePath(tmpProjectPath, '.mastracode/plans/add-dark-mode.md')).toBe(true);
@@ -172,18 +190,33 @@ describe('isPlanFilePath', () => {
     expect(isPlanFilePath(tmpProjectPath, abs)).toBe(true);
   });
 
-  it('rejects files outside .mastracode/plans/', () => {
+  it('accepts relative and absolute .md files directly inside .artifacts/plans/ for Factory sessions', () => {
+    const options = { factoryProjectId: 'factory-123' };
+    const abs = path.join(getLocalPlansDir(tmpProjectPath, options), 'feature.md');
+
+    expect(isPlanFilePath(tmpProjectPath, '.artifacts/plans/add-dark-mode.md', options)).toBe(true);
+    expect(isPlanFilePath(tmpProjectPath, abs, options)).toBe(true);
+  });
+
+  it('rejects files outside the configured plan directory', () => {
     expect(isPlanFilePath(tmpProjectPath, 'src/index.ts')).toBe(false);
     expect(isPlanFilePath(tmpProjectPath, '.mastracode/other.md')).toBe(false);
+    expect(isPlanFilePath(tmpProjectPath, '.mastracode/plans/legacy.md', { factoryProjectId: 'factory-123' })).toBe(
+      false,
+    );
   });
 
   it('rejects non-markdown files and nested subdirectories', () => {
-    expect(isPlanFilePath(tmpProjectPath, '.mastracode/plans/notes.txt')).toBe(false);
-    expect(isPlanFilePath(tmpProjectPath, '.mastracode/plans/sub/plan.md')).toBe(false);
+    const options = { factoryProjectId: 'factory-123' };
+
+    expect(isPlanFilePath(tmpProjectPath, '.artifacts/plans/notes.txt', options)).toBe(false);
+    expect(isPlanFilePath(tmpProjectPath, '.artifacts/plans/sub/plan.md', options)).toBe(false);
   });
 
-  it('rejects path traversal out of the plans directory', () => {
-    expect(isPlanFilePath(tmpProjectPath, '.mastracode/plans/../../evil.md')).toBe(false);
+  it('rejects path traversal out of the configured plan directory', () => {
+    expect(isPlanFilePath(tmpProjectPath, '.artifacts/plans/../../evil.md', { factoryProjectId: 'factory-123' })).toBe(
+      false,
+    );
   });
 });
 

--- a/mastracode/sdk/src/utils/plans.ts
+++ b/mastracode/sdk/src/utils/plans.ts
@@ -8,14 +8,18 @@ export function getPlansDir(): string {
   return process.env.MASTRA_PLANS_DIR ?? path.join(getAppDataDir(), 'plans');
 }
 
-/** Local (project-scoped) plans directory where the agent writes named plan files. */
-export function getLocalPlansDir(projectPath: string): string {
-  return path.join(projectPath, DEFAULT_CONFIG_DIR, 'plans');
+export interface LocalPlansOptions {
+  factoryProjectId?: string | null;
 }
 
 /** Workspace-relative directory the agent writes plan files into. */
-export function getLocalPlansRelativeDir(): string {
-  return path.join(DEFAULT_CONFIG_DIR, 'plans');
+export function getLocalPlansRelativeDir(options: LocalPlansOptions = {}): string {
+  return options.factoryProjectId ? path.join('.artifacts', 'plans') : path.join(DEFAULT_CONFIG_DIR, 'plans');
+}
+
+/** Local (project-scoped) plans directory where the agent writes named plan files. */
+export function getLocalPlansDir(projectPath: string, options: LocalPlansOptions = {}): string {
+  return path.join(projectPath, getLocalPlansRelativeDir(options));
 }
 
 function slugify(str: string): string {
@@ -35,9 +39,9 @@ export function getPlanFilename(title: string): string {
  * Suggested workspace-relative path for a new plan file, shown in plan-mode prompts.
  * Without a title we fall back to a generic name the agent can rename later.
  */
-export function getSuggestedPlanRelativePath(title?: string): string {
+export function getSuggestedPlanRelativePath(title?: string, options: LocalPlansOptions = {}): string {
   const filename = title ? getPlanFilename(title) : 'plan.md';
-  return path.join(getLocalPlansRelativeDir(), filename);
+  return path.join(getLocalPlansRelativeDir(options), filename);
 }
 
 /**
@@ -51,16 +55,16 @@ export function resolvePlanPath(projectPath: string, submittedPath: string): str
 
 /**
  * Whether `targetPath` (absolute or project-relative) is a valid plan file: a `.md`
- * file located directly inside the project's `.mastracode/plans/` directory. Used by the
+ * file located directly inside the project's configured plan directory. Used by the
  * plan-mode write guard so the agent can write any named plan file there, but nothing
  * outside that directory.
  */
-export function isPlanFilePath(projectPath: string, targetPath: string): boolean {
+export function isPlanFilePath(projectPath: string, targetPath: string, options: LocalPlansOptions = {}): boolean {
   const abs = resolvePlanPath(projectPath, targetPath);
   if (!abs) return false;
   if (path.extname(abs).toLowerCase() !== '.md') return false;
 
-  const plansDir = path.resolve(getLocalPlansDir(projectPath));
+  const plansDir = path.resolve(getLocalPlansDir(projectPath, options));
   const rel = path.relative(plansDir, abs);
   // Must be directly inside the plans dir (no nested subdirectories, no escaping it).
   if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) return false;


### PR DESCRIPTION
Factory interactive plan sessions now save plans under `.artifacts/plans/` instead of `.mastracode/plans/`, so plans appear in Factory's artifact browser while normal sessions keep the existing location.

Factory sessions also validate plan-mode writes against the artifact directory, and the plan prompt and tool guidance use the same session-specific path.

Before: `.mastracode/plans/add-dark-mode.md`
After: `.artifacts/plans/add-dark-mode.md`

Tests: focused SDK plan-mode tests; `pnpm --filter @mastra/code-sdk build:lib`.

<img width="3182" height="2034" alt="CleanShot 2026-08-10 at 17 53 38@2x" src="https://github.com/user-attachments/assets/74c71a97-bd42-4227-95c8-7fe337444a02" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory sessions now save plan files in the artifact browser. Other sessions keep using the existing plan location. The SDK also checks that plan files use the correct session-specific directory.

## Changes

- Added Factory-specific plan storage under `.artifacts/plans/`.
- Preserved `.mastracode/plans/` for normal sessions.
- Updated plan prompts and tool guidance to use the configured plan directory.
- Updated plan-file validation and error messages for Factory sessions.
- Added SDK tests for path selection, validation, prompt content, and tool guidance.
- Added a patch changeset for `@mastra/code-sdk`.
- Built the `@mastra/code-sdk` library successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->