### PR TITLE
feat(platform-workspace): boot observability for session-start latency (TTFMB)

### DIFF
--- a/.changeset/clever-moons-hang.md
+++ b/.changeset/clever-moons-hang.md
@@ -1,0 +1,5 @@
+---
+'@mastra/platform-workspace': minor
+---
+
+Added boot observability to PlatformSandbox for tracing slow session starts. New optional sessionId and threadId options are sent to the workspace proxy as advisory x-mastra-session-id / x-mastra-thread-id headers so proxy-side logs can be joined back to the calling session. The sidecar health probe now logs its outcome (duration and attempt count on success, a warning on timeout), and start() logs one timing summary line with the total boot time and proxy round-trip time.

--- a/.changeset/clever-moons-hang.md
+++ b/.changeset/clever-moons-hang.md
@@ -2,4 +2,15 @@
 '@mastra/platform-workspace': minor
 ---
 
-Added boot observability to PlatformSandbox for tracing slow session starts. New optional sessionId and threadId options are sent to the workspace proxy as advisory x-mastra-session-id / x-mastra-thread-id headers so proxy-side logs can be joined back to the calling session. The sidecar health probe now logs its outcome (duration and attempt count on success, a warning on timeout), and start() logs one timing summary line with the total boot time and proxy round-trip time.
+Added startup observability to `PlatformSandbox`. New optional `sessionId` and `threadId` options let you correlate all sandbox startup activity with the session that triggered it, and the sandbox now logs how long startup took and whether it became reachable.
+
+```ts
+import { PlatformSandbox } from '@mastra/platform-workspace';
+
+const sandbox = new PlatformSandbox({
+  projectId: 'proj_123',
+  environmentId: 'env_123',
+  sessionId: 'session_abc', // correlate startup logs with your session
+  threadId: 'thread_xyz', // optional finer-grained correlation
+});
+```

--- a/workspaces/platform-workspace/src/client.test.ts
+++ b/workspaces/platform-workspace/src/client.test.ts
@@ -29,6 +29,36 @@ describe('PlatformClient', () => {
     expect(init.method).toBe('POST');
   });
 
+  it('sends advisory session/thread correlation headers when configured', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response('{}', { status: 200 }));
+    const client = new PlatformClient({
+      accessToken: 'sk_test',
+      projectId: 'proj_123',
+      sessionId: 'sess_42',
+      threadId: 'thread_7',
+      fetch: fetchMock,
+    });
+
+    await client.request('/sandbox');
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init.headers as Headers).get('x-mastra-session-id')).toBe('sess_42');
+    expect((init.headers as Headers).get('x-mastra-thread-id')).toBe('thread_7');
+    // Auth is unchanged — the correlation headers ride alongside, never replace.
+    expect((init.headers as Headers).get('authorization')).toBe('Bearer sk_test');
+  });
+
+  it('omits correlation headers when session/thread ids are not configured', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response('{}', { status: 200 }));
+    const client = new PlatformClient({ accessToken: 'sk_test', projectId: 'proj_123', fetch: fetchMock });
+
+    await client.request('/sandbox');
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init.headers as Headers).get('x-mastra-session-id')).toBeNull();
+    expect((init.headers as Headers).get('x-mastra-thread-id')).toBeNull();
+  });
+
   it('reads the access token from MASTRA_PLATFORM_ACCESS_TOKEN', () => {
     vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform_access_token');
     vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');

--- a/workspaces/platform-workspace/src/client.ts
+++ b/workspaces/platform-workspace/src/client.ts
@@ -1,6 +1,19 @@
 export interface PlatformClientOptions {
   accessToken?: string;
   projectId?: string;
+  /**
+   * Advisory correlation id for the factory session driving this client.
+   * Sent as `x-mastra-session-id` on every proxy request so proxy-side logs
+   * can be joined back to the calling session without a multi-store hand-join
+   * (`threadId → sessionId → sandboxId → providerResourceId`). Never used for
+   * authorization — the Bearer token remains the only credential.
+   */
+  sessionId?: string;
+  /**
+   * Advisory correlation id for the factory thread, sent as
+   * `x-mastra-thread-id` when present. See {@link PlatformClientOptions.sessionId}.
+   */
+  threadId?: string;
   fetch?: typeof fetch;
 }
 
@@ -27,6 +40,8 @@ export function resolvePlatformOptions(options: PlatformClientOptions) {
     accessToken: requireOption(options.accessToken ?? process.env.MASTRA_PLATFORM_ACCESS_TOKEN, 'accessToken'),
     projectId: requireOption(options.projectId ?? process.env.MASTRA_PROJECT_ID, 'projectId'),
     proxyUrl: (process.env.MASTRA_WORKSPACE_PROXY_URL ?? DEFAULT_PROXY_URL).replace(/\/$/, ''),
+    sessionId: options.sessionId,
+    threadId: options.threadId,
     fetch: options.fetch ?? fetch,
   };
 }
@@ -83,6 +98,10 @@ export class PlatformClient {
   readonly accessToken: string;
   readonly projectId: string;
   readonly proxyUrl: string;
+  /** Advisory session correlation id — see {@link PlatformClientOptions.sessionId}. */
+  readonly sessionId: string | undefined;
+  /** Advisory thread correlation id — see {@link PlatformClientOptions.threadId}. */
+  readonly threadId: string | undefined;
   readonly fetch: typeof fetch;
 
   constructor(options: PlatformClientOptions) {
@@ -90,6 +109,8 @@ export class PlatformClient {
     this.accessToken = resolved.accessToken;
     this.projectId = resolved.projectId;
     this.proxyUrl = resolved.proxyUrl;
+    this.sessionId = resolved.sessionId;
+    this.threadId = resolved.threadId;
     this.fetch = resolved.fetch;
   }
 
@@ -101,6 +122,12 @@ export class PlatformClient {
 
     const headers = new Headers(options.headers);
     headers.set('authorization', `Bearer ${this.accessToken}`);
+    // Advisory correlation headers — the proxy folds them into its log lines
+    // so proxy-side events can be joined back to the calling factory session
+    // without a cross-store hand-join. Unknown headers are passthrough for
+    // older proxies; these are never used for authorization.
+    if (this.sessionId) headers.set('x-mastra-session-id', this.sessionId);
+    if (this.threadId) headers.set('x-mastra-thread-id', this.threadId);
 
     // Strip our helper-only field so the underlying fetch sees a valid RequestInit.
     const { query: _query, ...fetchOptions } = options;

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -2247,7 +2247,9 @@ describe('PlatformSandbox', () => {
   describe('boot timing log', () => {
     it('logs one start-complete summary on fresh provision', async () => {
       vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
-      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_timing', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_timing', createdAt: '2026-06-26T00:00:00.000Z' }));
       const sandbox = new PlatformSandbox({
         accessToken: 'sk_test',
         projectId: 'proj_123',

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1712,6 +1712,45 @@ describe('PlatformSandbox', () => {
         expect(privateNetFetch).toHaveBeenCalledTimes(3);
       });
 
+      it('logs one probe-ok line with duration and attempt count on first 200', async () => {
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi.fn().mockResolvedValueOnce(
+          json({
+            id: 'sbx_probe_log',
+            createdAt: '2026-06-26T00:00:00.000Z',
+            instanceUrl: 'http://[fd12::1]:47000',
+          }),
+        );
+        const privateNetFetch = vi
+          .fn()
+          .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+          .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+        const { registry, sets } = fakeAddressRegistry();
+
+        const sandbox = new PlatformSandbox({
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          sessionId: 'sess_42',
+          fetch: fetchMock,
+          privateNetFetch,
+          addressRegistry: registry,
+        });
+        const loggerInfoSpy = vi.spyOn((sandbox as any).logger, 'info');
+        await sandbox._start();
+        await vi.waitFor(() => expect(sets.length).toBeGreaterThan(0));
+
+        expect(loggerInfoSpy).toHaveBeenCalledWith(
+          'platform-workspace probe ok',
+          expect.objectContaining({
+            sandboxId: 'sbx_probe_log',
+            sessionId: 'sess_42',
+            probeDurationMs: expect.any(Number),
+            attempts: 2,
+          }),
+        );
+      });
+
       it('leaves the registry empty when the probe times out', async () => {
         vi.useFakeTimers();
         vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
@@ -1730,10 +1769,12 @@ describe('PlatformSandbox', () => {
           accessToken: 'sk_test',
           projectId: 'proj_123',
           environmentId: 'env_123',
+          sessionId: 'sess_42',
           fetch: fetchMock,
           privateNetFetch,
           addressRegistry: registry,
         });
+        const loggerWarnSpy = vi.spyOn((sandbox as any).logger, 'warn');
         await sandbox._start();
 
         // Advance past the probe timeout (30s).
@@ -1742,6 +1783,16 @@ describe('PlatformSandbox', () => {
         // Registry was never populated.
         expect(sets).toEqual([]);
         expect(entries.size).toBe(0);
+        // Timeout is logged once, with enough context to join back to the session.
+        expect(loggerWarnSpy).toHaveBeenCalledWith(
+          'platform-workspace probe timed out',
+          expect.objectContaining({
+            sandboxId: 'sbx_timeout',
+            sessionId: 'sess_42',
+            timeoutMs: 30_000,
+            attempts: expect.any(Number),
+          }),
+        );
         vi.useRealTimers();
       });
 
@@ -2081,6 +2132,26 @@ describe('PlatformSandbox', () => {
       });
     });
 
+    it('inherits session/thread correlation ids so clone requests carry the headers', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_child', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const template = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        sessionId: 'sess_42',
+        threadId: 'thread_7',
+        fetch: fetchMock,
+      });
+
+      const child = template.clone({ id: 'mc-project-1' });
+      await child._start();
+
+      const headers = fetchMock.mock.calls[0]![1].headers as Headers;
+      expect(headers.get('x-mastra-session-id')).toBe('sess_42');
+      expect(headers.get('x-mastra-thread-id')).toBe('thread_7');
+    });
+
     it('reattaches to a provider sandbox when sandboxId is passed', async () => {
       vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
       const fetchMock = vi
@@ -2170,6 +2241,61 @@ describe('PlatformSandbox', () => {
 
       const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
       expect(body.id).toBe('explicit-id');
+    });
+  });
+
+  describe('boot timing log', () => {
+    it('logs one start-complete summary on fresh provision', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_timing', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        sessionId: 'sess_42',
+        fetch: fetchMock,
+      });
+      const loggerInfoSpy = vi.spyOn((sandbox as any).logger, 'info');
+
+      await sandbox._start();
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        'platform-workspace start complete',
+        expect.objectContaining({
+          sandboxId: 'sbx_timing',
+          sessionId: 'sess_42',
+          mode: 'provision',
+          totalMs: expect.any(Number),
+          requestMs: expect.any(Number),
+        }),
+      );
+    });
+
+    it('logs one start-complete summary on reattach', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_reattach', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        sandboxId: 'sbx_reattach',
+        fetch: fetchMock,
+      });
+      const loggerInfoSpy = vi.spyOn((sandbox as any).logger, 'info');
+
+      await sandbox._start();
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        'platform-workspace start complete',
+        expect.objectContaining({
+          sandboxId: 'sbx_reattach',
+          mode: 'reattach',
+          totalMs: expect.any(Number),
+          requestMs: expect.any(Number),
+        }),
+      );
     });
   });
 

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -458,6 +458,8 @@ export class PlatformSandbox extends MastraSandbox {
       ...(id !== undefined && { id }),
       accessToken: this._client.accessToken,
       projectId: this._client.projectId,
+      ...(this._client.sessionId !== undefined && { sessionId: this._client.sessionId }),
+      ...(this._client.threadId !== undefined && { threadId: this._client.threadId }),
       fetch: this._client.fetch,
       environmentId: this._environmentId,
       ...(options.sandboxId !== undefined && { sandboxId: options.sandboxId }),
@@ -501,9 +503,12 @@ export class PlatformSandbox extends MastraSandbox {
    * awaiter.
    */
   private async _doStart(): Promise<void> {
+    const startedAt = Date.now();
     if (this._sandboxId) {
       try {
+        const requestStartedAt = Date.now();
         const response = await this._client.request(`/sandbox/${encodeURIComponent(this._sandboxId)}`);
+        const requestMs = Date.now() - requestStartedAt;
         const json = (await response.json()) as CreateSandboxResponse;
         // A destroyed record (idle GC, manual delete) is not reattachable —
         // treat it like a missing sandbox so we fall through to a fresh
@@ -511,6 +516,7 @@ export class PlatformSandbox extends MastraSandbox {
         if (!json.destroyedAt) {
           this._createdAt = json.createdAt ? new Date(json.createdAt) : new Date();
           this._populateAddressFromResponse(json);
+          this._logStartComplete(json.id, startedAt, requestMs, 'reattach');
           return;
         }
         this._sandboxId = undefined;
@@ -539,6 +545,7 @@ export class PlatformSandbox extends MastraSandbox {
     // 5xx responses with a short backoff is safe and keeps a single flaky
     // window from killing the caller's whole workflow.
     let response: Response | undefined;
+    const requestStartedAt = Date.now();
     for (let attempt = 1; ; attempt++) {
       try {
         response = await this._client.request('/sandbox', {
@@ -553,10 +560,33 @@ export class PlatformSandbox extends MastraSandbox {
         await new Promise(resolve => setTimeout(resolve, CREATE_RETRY_BASE_DELAY_MS * attempt));
       }
     }
+    const requestMs = Date.now() - requestStartedAt;
     const json = (await response.json()) as CreateSandboxResponse;
     this._sandboxId = json.id;
     this._createdAt = json.createdAt ? new Date(json.createdAt) : new Date();
     this._populateAddressFromResponse(json);
+    this._logStartComplete(json.id, startedAt, requestMs, 'provision');
+  }
+
+  /**
+   * One timing summary per completed `start()` — the whole
+   * `PlatformSandbox`-visible boot in a single greppable line.
+   *
+   * `requestMs` is the proxy round-trip (`GET /sandbox/:id` on reattach,
+   * `POST /sandbox` including transient-5xx retries on provision) — a black
+   * box from this side that rolls up Railway RPC, sidecar launch, and the
+   * proxy's discovery exec. Sidecar probe cost is intentionally NOT here: the
+   * probe is fire-and-forget and outlives `start()` by design, so its
+   * duration lands on the `platform-workspace probe ok` line instead.
+   */
+  private _logStartComplete(sandboxId: string, startedAt: number, requestMs: number, mode: string): void {
+    this.logger.info('platform-workspace start complete', {
+      sandboxId,
+      sessionId: this._client.sessionId,
+      mode,
+      totalMs: Date.now() - startedAt,
+      requestMs,
+    });
   }
 
   /**
@@ -604,11 +634,14 @@ export class PlatformSandbox extends MastraSandbox {
    *   was superseded by a teardown or a new `start()`, so we skip the `set()`.
    */
   private async _probeSidecarThenRegister(sandboxId: string, instanceUrl: string, generation: number): Promise<void> {
-    const deadline = Date.now() + SIDECAR_PROBE_TIMEOUT_MS;
+    const probeStartedAt = Date.now();
+    const deadline = probeStartedAt + SIDECAR_PROBE_TIMEOUT_MS;
     const fetchFn = this._privateNetFetch ?? fetch;
+    let attempts = 0;
     while (Date.now() < deadline) {
       // Teardown or new start() superseded this probe — bail out early.
       if (generation !== this._probeGeneration) return;
+      attempts++;
       try {
         const res = await fetchFn(`${instanceUrl}/health`, {
           method: 'GET',
@@ -618,6 +651,15 @@ export class PlatformSandbox extends MastraSandbox {
         // Release the response body so the connection returns to the pool.
         await res.body?.cancel().catch(() => {});
         if (ok) {
+          // A ~1-attempt probe means the sidecar was ready when the proxy
+          // returned; hundreds of ms means it was still booting — the exact
+          // window that used to silently fall back to the lease path.
+          this.logger.info('platform-workspace probe ok', {
+            sandboxId,
+            sessionId: this._client.sessionId,
+            probeDurationMs: Date.now() - probeStartedAt,
+            attempts,
+          });
           // Sidecar is listening. Only populate if this probe is still current.
           if (generation === this._probeGeneration && this._sandboxId === sandboxId) {
             this._addressRegistry?.set(sandboxId, instanceUrl);
@@ -630,7 +672,12 @@ export class PlatformSandbox extends MastraSandbox {
       await new Promise(r => setTimeout(r, SIDECAR_PROBE_INTERVAL_MS));
     }
     // Sidecar never came up. Leave registry entry unset — every exec goes lease.
-    this.logger.warn('Sidecar never answered /health within probe window', { sandboxId });
+    this.logger.warn('platform-workspace probe timed out', {
+      sandboxId,
+      sessionId: this._client.sessionId,
+      timeoutMs: SIDECAR_PROBE_TIMEOUT_MS,
+      attempts,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Debugging slow factory session starts currently requires a five-query hand-join across Neon, Aiven, and gcloud logs, because `PlatformSandbox` (the factory-runtime side of the sandbox transport) emits almost no boot telemetry and the workspace proxy never learns which session a request belongs to. This PR makes the `PlatformSandbox`-visible boot path fully observable in three surgical changes (PR A of the TTFMB design memo, `.scratch/factory-deploy/design-ttfmb-instrumentation.md` in the platform repo):

1. **Session/thread correlation headers.** `PlatformClientOptions` gains optional `sessionId` / `threadId`. When set, every workspace-proxy request carries advisory `x-mastra-session-id` / `x-mastra-thread-id` headers alongside the existing Bearer auth. Headers are correlation-only (never authorization) and passthrough on older proxies — zero server-side change required. `PlatformSandbox.clone()` inherits them like other credentials.

2. **Sidecar probe outcome logging.** The fire-and-forget `/health` probe (added in #21028) now logs exactly one outcome line per sandbox:
   - `platform-workspace probe ok` (info) with `probeDurationMs` + `attempts` — ~1 attempt means the sidecar was ready when the proxy returned; hundreds of ms means it was still booting, the window that used to silently fall back to the lease path.
   - `platform-workspace probe timed out` (warn) with `timeoutMs` + `attempts`, replacing the previous context-poor warning.

3. **`start()` timing summary.** One `platform-workspace start complete` info line with `totalMs`, the proxy round-trip `requestMs` (the black box that rolls up Railway RPC + sidecar launch + discovery), and `mode: provision | reattach`.

One deviation from the memo: the start-complete line does not include `probeMs`, because the probe intentionally outlives `start()` (fire-and-forget by design since #21028). Probe duration lands on the `probe ok` line instead; both lines share `sandboxId`/`sessionId` and the `platform-workspace` grep prefix.

Wiring `session.id` into these options at the factory call sites, plus proxy-side header capture, are follow-ups (PR B/C in the memo).

## Test plan

- [x] New unit tests: correlation headers sent when configured / omitted otherwise, clone inherits them, probe-ok log fields (attempts, duration), probe-timeout warn fields, start-complete summary for both provision and reattach
- [x] `pnpm --filter @mastra/platform-workspace test` — 133 tests pass
- [x] `pnpm --filter @mastra/platform-workspace build` and `lint` pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes PlatformSandbox easier to debug. It adds request identifiers and startup timing logs so teams can trace activity and find slow startup steps.

## Changes

- Add optional `sessionId` and `threadId` values to `PlatformClientOptions`.
- Forward these values as advisory proxy headers.
- Preserve bearer authentication. Correlation headers do not authorize requests.
- Propagate session and thread identifiers when cloning a `PlatformSandbox`.
- Log sidecar health-probe results with duration and attempt count.
- Add timeout diagnostics for failed health probes.
- Log total startup duration for both new sandboxes and reattached sandboxes.
- Add tests for correlation headers, health-probe logging, clone behavior, and startup timing.
- Add a changeset for `@mastra/platform-workspace`.

## Testing

- Expanded coverage for client and sandbox observability behavior.
- Typecheck and format checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->