### PR TITLE
fix(core): guard null model configurations

### DIFF
--- a/.changeset/safe-model-config-guards.md
+++ b/.changeset/safe-model-config-guards.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed model configuration validation to safely reject null values.

--- a/packages/core/src/llm/model/resolve-model.test.ts
+++ b/packages/core/src/llm/model/resolve-model.test.ts
@@ -4,7 +4,7 @@ import { RequestContext } from '../../request-context';
 import { AISDKV4LegacyLanguageModel } from './aisdk/v4/model';
 import { AISDKV5LanguageModel } from './aisdk/v5/model';
 import { AISDKV7LanguageModel } from './aisdk/v7/model';
-import { resolveModelConfig } from './resolve-model';
+import { isOpenAICompatibleObjectConfig, resolveModelConfig } from './resolve-model';
 import { ModelRouterLanguageModel } from './router';
 
 describe('resolveModelConfig', () => {
@@ -72,6 +72,14 @@ describe('resolveModelConfig', () => {
 
   it('should throw error for invalid config', async () => {
     await expect(resolveModelConfig({} as any)).rejects.toThrow('Invalid model configuration');
+  });
+
+  it('should return false when checking a null OpenAI-compatible config', () => {
+    expect(isOpenAICompatibleObjectConfig(null as any)).toBe(false);
+  });
+
+  it('should throw an invalid configuration error for null', async () => {
+    await expect(resolveModelConfig(null as any)).rejects.toThrow('Invalid model configuration provided');
   });
 
   describe('v4 (LanguageModelV4 / AI SDK v7) handling', () => {

--- a/packages/core/src/llm/model/resolve-model.ts
+++ b/packages/core/src/llm/model/resolve-model.ts
@@ -31,11 +31,12 @@ export function isOpenAICompatibleObjectConfig(
         mastra?: Mastra;
       }) => MastraModelConfig | Promise<MastraModelConfig>),
 ): modelConfig is OpenAICompatibleConfig {
-  if (typeof modelConfig === 'object' && 'specificationVersion' in modelConfig) return false;
+  if (modelConfig === null || typeof modelConfig !== 'object') return false;
+  if ('specificationVersion' in modelConfig) return false;
   // Check for OpenAICompatibleConfig - it should have either:
   // 1. 'id' field (but NOT 'model' - that's ModelWithRetries)
   // 2. Both 'providerId' and 'modelId' fields
-  if (typeof modelConfig === 'object' && !('model' in modelConfig)) {
+  if (!('model' in modelConfig)) {
     if ('id' in modelConfig) return true;
     if ('providerId' in modelConfig && 'modelId' in modelConfig) return true;
   }
@@ -103,7 +104,7 @@ export async function resolveModelConfig(
   }
 
   // If it's already a LanguageModel, wrap it with the appropriate wrapper
-  if (typeof modelConfig === 'object' && 'specificationVersion' in modelConfig) {
+  if (modelConfig !== null && typeof modelConfig === 'object' && 'specificationVersion' in modelConfig) {
     if (modelConfig.specificationVersion === 'v2') {
       return new AISDKV5LanguageModel(modelConfig as LanguageModelV2);
     }


### PR DESCRIPTION
## Description

`resolveModelConfig()` currently crashes with a raw JavaScript `TypeError` when it receives `null`.

JavaScript reports:

```ts
typeof null === 'object';
```

This allows `null` to reach property checks using the `in` operator:

```ts
'specificationVersion' in modelConfig
```

Using `in` with `null` throws before Mastra reaches its existing invalid-configuration handling.

This PR adds explicit null guards so:

- `isOpenAICompatibleObjectConfig(null)` returns `false`.
- `resolveModelConfig(null)` rejects with `Invalid model configuration provided`.
- Valid model configurations continue to behave unchanged.

## Related issue(s)

Fixes #21191 

## Changes

- Reject null and non-object values before property checks in `isOpenAICompatibleObjectConfig()`.
- Add a non-null condition to the language-model check in `resolveModelConfig()`.
- Add regression tests for both the type guard and public resolver.
- Add an `@mastra/core` patch changeset.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test update

## Testing

The following checks passed:

- `resolve-model.test.ts`: 23 tests
- Focused Vitest type checking: no errors
- Targeted ESLint
- `git diff --check`

The full `@mastra/core` typecheck currently reaches an unrelated error already present on `upstream/main`:

```text
src/evals/run/gates-scorer-config-types.test-d.ts(6,34):
error TS2459: Module '"."' declares 'RunEvalsResult' locally,
but it is not exported.
```

This PR does not modify the affected eval files.

## Checklist

- [x] I have linked the related issue.
- [x] I have added tests that prove the fix is effective.
- [x] I have added the required changeset.
- [x] I have run the relevant focused tests and lint checks.
- [ ] I have addressed all review comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes `resolveModelConfig()` handle `null` safely. It returns the expected validation error instead of causing a JavaScript `TypeError`.

## Changes

- Added null and object checks in `isOpenAICompatibleObjectConfig()` and `resolveModelConfig()`.
- Added regression tests for:
  - `isOpenAICompatibleObjectConfig(null)` returning `false`.
  - `resolveModelConfig(null)` rejecting with `Invalid model configuration provided`.
- Added an `@mastra/core` patch changeset.
- Valid model configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->