### PR TITLE
feat(factory): timing phases for the sandbox session-open path

### DIFF
--- a/.changeset/little-turkeys-invite.md
+++ b/.changeset/little-turkeys-invite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Slow workspace opens can now be diagnosed directly from server logs. Added `[factory:timing]` log lines for each phase of the sandbox session-open path — `sandbox.reattach`, `sandbox.provision`, `workspace.materialize`, and `workspace.checkout` — so you can see exactly which phase is slow instead of reconstructing timings by hand.

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -30,6 +30,7 @@ import type {
   ProjectRepositorySandbox,
   SourceControlStorageHandle,
 } from '../../storage/domains/source-control/base.js';
+import { timedPhase } from '../../timing.js';
 
 type SourceControlSandboxStorage = SourceControlStorageHandle['sandboxes'];
 type MaterializationStore = Pick<SourceControlSandboxStorage, 'markMaterialized'>;
@@ -269,13 +270,8 @@ export interface RepoMaterializeInfo {
   defaultBranch: string;
 }
 
-/**
- * Materialize the repo inside the user's sandbox. Clones on first open, pulls on
- * re-open. Always scrubs the install token from the remote afterwards and sets
- * `materialized_at` on the per-user sandbox binding row.
- *
- */
-export async function materializeRepo(options: {
+/** Options for {@link materializeRepo}. */
+export interface MaterializeRepoOptions {
   /** The per-(project,user) sandbox binding (provisioned via `ensureProjectSandbox`). */
   row: RepoMaterializationBinding;
   /** Repo metadata from the org-owned project row. */
@@ -286,7 +282,19 @@ export async function materializeRepo(options: {
   token: string;
   storage: MaterializationStore;
   onProgress?: ProgressFn;
-}): Promise<void> {
+}
+
+/**
+ * Materialize the repo inside the user's sandbox. Clones on first open, pulls on
+ * re-open. Always scrubs the install token from the remote afterwards and sets
+ * `materialized_at` on the per-user sandbox binding row.
+ *
+ */
+export async function materializeRepo(options: MaterializeRepoOptions): Promise<void> {
+  return timedPhase('workspace.materialize', () => materializeRepoImpl(options));
+}
+
+async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<void> {
   const { row: sandboxRow, repoInfo, sandbox, token, storage, onProgress } = options;
   const workdir = sandboxRow.sandboxWorkdir;
   const repo = repoInfo.repoFullName;
@@ -438,6 +446,14 @@ export async function recycleClaimedWorkdir(
 
 /** Check out a session's branch inside its isolated repository clone. */
 export async function checkoutSessionBranch(
+  sandbox: MaterializationSandbox,
+  workdir: string,
+  options: { branch: string; baseBranch: string; token: string; repoFullName: string },
+): Promise<void> {
+  return timedPhase('workspace.checkout', () => checkoutSessionBranchImpl(sandbox, workdir, options));
+}
+
+async function checkoutSessionBranchImpl(
   sandbox: MaterializationSandbox,
   workdir: string,
   {

--- a/mastracode/factory/src/sandbox/fleet.ts
+++ b/mastracode/factory/src/sandbox/fleet.ts
@@ -21,6 +21,8 @@ import path from 'node:path';
 
 import type { WorkspaceSandbox } from '@mastra/core/workspace';
 
+import { timedPhase } from '../timing.js';
+
 /** Minimal command result shape sandbox consumers depend on. */
 export interface SandboxCommandResult {
   exitCode: number;
@@ -447,7 +449,7 @@ export class SandboxFleet {
         ...(options.workingDirectory ? { workingDirectory: options.workingDirectory } : {}),
       });
       try {
-        await reattached.start();
+        await timedPhase('sandbox.reattach', () => reattached.start());
         return reattached;
       } catch {
         await store.setSandboxId(null);
@@ -468,7 +470,7 @@ export class SandboxFleet {
       ...(env ? { env } : {}),
       ...(options.workingDirectory ? { workingDirectory: options.workingDirectory } : {}),
     });
-    await sandbox.start();
+    await timedPhase('sandbox.provision', () => sandbox.start());
     this.#liveCount += 1;
 
     const providerSandboxId = await readProviderSandboxId(sandbox);


### PR DESCRIPTION
## Summary

Opening a factory workspace involves several server-side phases — reattaching to (or provisioning) the project's sandbox VM, cloning or pulling the repo inside it, and checking out the session branch. When an open is slow today, none of these phases report how long they took, so diagnosing the slowness means manually reconstructing timings from provider logs.

This PR instruments the sandbox session-open path in `@mastra/factory` with the existing `timedPhase` helper, so each phase emits a greppable `[factory:timing] <phase> <N>ms` line:

- `sandbox.reattach` — reconnecting to a stored sandbox VM (`SandboxFleet`)
- `sandbox.provision` — provisioning a fresh sandbox VM (`SandboxFleet`)
- `workspace.materialize` — `git clone` / `git pull` of the repo inside the sandbox (`materializeRepo`)
- `workspace.checkout` — session branch checkout (`checkoutSessionBranch`)

A failed reattach still logs its duration before falling through to provisioning, so the reattach→re-provision recovery path produces both numbers.

Wrapping happens inside the functions (not at call sites) so every production caller is covered.

## Test plan

- `fleet.test.ts` + `sandbox.test.ts`: 110/110 pass; timing lines are visible in test output (`[factory:timing] workspace.materialize 2000ms`, `[factory:timing] workspace.checkout 0ms`)
- `eslint` clean on both changed files; `oxfmt --check` clean on files in its scope
- Pre-existing `tsc --noEmit` errors and 3 unrelated test failures verified identical on the clean branch (stashed diff)
