### PR TITLE
fix(core): export RunEvalsResult so the runEvals type tests compile

### DIFF
--- a/.changeset/true-plants-taste.md
+++ b/.changeset/true-plants-taste.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Exported the `RunEvalsResult` type so the return type of `runEvals` can be imported from `@mastra/core/evals/run`. This also fixes a type error introduced in #21143 where the type-level tests imported a type that was not exported.

--- a/.changeset/true-plants-taste.md
+++ b/.changeset/true-plants-taste.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Exported the `RunEvalsResult` type so the return type of `runEvals` can be imported from `@mastra/core/evals/run`. This also fixes a type error introduced in #21143 where the type-level tests imported a type that was not exported.
+Exported the `RunEvalsResult` type so the return type of `runEvals` can be imported from `@mastra/core/evals`. This also fixes a type error introduced in #21143 where the type-level tests imported a type that was not exported.

--- a/packages/core/src/evals/run/index.ts
+++ b/packages/core/src/evals/run/index.ts
@@ -138,7 +138,7 @@ type ScoredTurn = {
 };
 type ItemTurnResults = ScoredTurn[];
 
-type RunEvalsResult = {
+export type RunEvalsResult = {
   scores: Record<string, any>;
   summary: {
     totalItems: number;


### PR DESCRIPTION
Since #21143 merged, typecheck on main fails: its regression test imports RunEvalsResult from the evals run module, but the type was declared without export, so every PR touching core now goes red on "Module '\".\"' declares 'RunEvalsResult' locally, but it is not exported." This adds the missing export keyword, which also makes the return type of runEvals importable by consumers via @mastra/core/evals.

I verified the previously failing gates-scorer-config-types.test-d.ts passes with the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the `RunEvalsResult` type available to package users. This fixes a type-checking error in the `runEvals` tests.

## Changes

- Export `RunEvalsResult` from `@mastra/core/evals/run`.
- Add a patch changeset for the export.
- Fix the related type-test import error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->