### PR TITLE
fix(code-sdk): keep gateway keys out of direct provider requests

### DIFF
--- a/.changeset/proud-words-hear.md
+++ b/.changeset/proud-words-hear.md
@@ -2,4 +2,4 @@
 '@mastra/code-sdk': patch
 ---
 
-Fixed direct provider models using stored Mastra Gateway credentials instead of provider credentials.
+Fixed authentication failures for unprefixed direct-provider models by using provider environment credentials when no provider-specific stored credential exists.

--- a/.changeset/proud-words-hear.md
+++ b/.changeset/proud-words-hear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed direct provider models using stored Mastra Gateway credentials instead of provider credentials.

--- a/mastracode/sdk/src/agents/__tests__/model.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/model.test.ts
@@ -234,6 +234,7 @@ describe('resolveModel', () => {
     delete process.env.OPENAI_BASE_URL;
     delete process.env.MOONSHOT_API_KEY;
     delete process.env.MOONSHOT_AI_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
     delete process.env.MASTRA_GATEWAY_API_KEY;
     delete process.env.MASTRA_GATEWAY_URL;
   });
@@ -737,6 +738,33 @@ describe('resolveModel', () => {
       mockAuthStorageInstance.getStoredApiKey.mockImplementation((providerId: string) =>
         providerId === 'mastra-gateway' ? 'msk_gateway_key_123' : undefined,
       );
+    });
+
+    it('does not pass the Mastra Gateway key to an unprefixed DeepSeek model', () => {
+      process.env.DEEPSEEK_API_KEY = 'sk-deepseek-env-fixture';
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+
+      const result = resolveModel('deepseek/deepseek-v4-flash') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('model-router');
+      expect(result.modelId).toBe('deepseek/deepseek-v4-flash');
+      expect(result.apiKey).toBe('');
+    });
+
+    it('prefers a stored DeepSeek key over the stored Mastra Gateway key', () => {
+      process.env.DEEPSEEK_API_KEY = 'sk-deepseek-env-fixture';
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+      mockAuthStorageInstance.getStoredApiKey.mockImplementation((providerId: string) => {
+        if (providerId === 'deepseek') return 'sk-deepseek-stored-fixture';
+        if (providerId === 'mastra-gateway') return 'msk_gateway_key_123';
+        return undefined;
+      });
+
+      const result = resolveModel('deepseek/deepseek-v4-flash') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('model-router');
+      expect(result.modelId).toBe('deepseek/deepseek-v4-flash');
+      expect(result.apiKey).toBe('sk-deepseek-stored-fixture');
     });
 
     it('routes explicit mastra-prefixed anthropic model through gateway', () => {

--- a/mastracode/sdk/src/agents/model.ts
+++ b/mastracode/sdk/src/agents/model.ts
@@ -161,7 +161,7 @@ export function resolveModel(
   return gateway.resolveLanguageModel({
     providerId,
     modelId: bareModelId,
-    apiKey: auth?.apiKey ?? mgApiKey ?? '',
+    apiKey: auth?.apiKey ?? '',
     headers,
   });
 }


### PR DESCRIPTION
Unprefixed direct-provider models could receive a stored Mastra Gateway key when no provider-specific stored credential existed. This showed up as intermittent DeepSeek 401s during observational-memory buffering.

Before:
```ts
apiKey: auth?.apiKey ?? mgApiKey ?? ''
```

After:
```ts
apiKey: auth?.apiKey ?? ''
```

This keeps provider-specific stored credentials and explicit `mastra/...` Gateway routing intact while allowing the core router to resolve provider environment keys normally. The focused model suite, SDK typecheck, lint, build, and a manual linked OM flow all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a model uses a provider directly, it must use that provider’s key. This change stops it from incorrectly using a Mastra Gateway key, which prevents intermittent authentication errors.

## Changes

- Updated `resolveModel` to return an empty API key when no provider-specific credential exists.
- Added tests for:
  - Unprefixed DeepSeek models without provider credentials.
  - Stored DeepSeek credentials taking priority.
  - Preventing the Mastra Gateway key from reaching direct-provider requests.
- Added a patch changeset for `@mastra/code-sdk`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->