### PR TITLE
fix(factory-ui): give sidebar session rows one trailing slot

### DIFF
--- a/.changeset/factory-session-row-slot.md
+++ b/.changeset/factory-session-row-slot.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Improved the Mastra Code session sidebar. A session's status dot, merged pull request icon, loading spinner and actions menu now share one slot at the end of the row instead of sitting at different spots with the menu floating over the name, so the session name gets the full row width until you hover it. The actions menu no longer flashes in the top-left corner of the screen while it closes, and the session preview card stays in place instead of sliding sideways when the actions button appears.

--- a/.changeset/factory-session-row-slot.md
+++ b/.changeset/factory-session-row-slot.md
@@ -2,4 +2,4 @@
 'mastra': patch
 ---
 
-Improved the Mastra Code session sidebar. A session's status dot, merged pull request icon, loading spinner and actions menu now share one slot at the end of the row instead of sitting at different spots with the menu floating over the name, so the session name gets the full row width until you hover it. The actions menu no longer flashes in the top-left corner of the screen while it closes, and the session preview card stays in place instead of sliding sideways when the actions button appears.
+Improved the Mastra Code session sidebar. Status indicators and the actions menu now share one slot at the end of the row, so the session name uses the full row width until you hover it. Fixed the actions menu flashing in the top-left corner of the screen while it closes. Fixed the session preview card sliding sideways when the actions button appears.

--- a/.changeset/jolly-wombats-kiss.md
+++ b/.changeset/jolly-wombats-kiss.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Sidebar nav rows now place their trailing action in the layout flow instead of overlaying the row. A row with an `action` renders as a flex pair — label then action — so the action can never sit on top of the label, and hover/active backgrounds paint the whole row including the action.

--- a/.changeset/popup-anchor-stability.md
+++ b/.changeset/popup-anchor-stability.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Dropdown menus and hover cards no longer jump to the top-left corner or drift across the screen when their trigger is hidden or resized while the popup is open. Positioners now honour Floating UI's hidden-anchor state, and `MainSidebar.NavLink` accepts a `ref` so callers can anchor popups to the stable row box instead of a control that comes and goes on hover.

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -67,43 +67,16 @@ export function SessionNavRow({
   );
   const indicator = indicatorKind({ loading, status, merged });
   const action = (
-    <span
-      className={cn(
-        'size-form-sm shrink-0 place-items-center *:col-start-1 *:row-start-1',
-        // Empty slot claims no width, so the label runs full width until there is something to show.
-        indicator
-          ? 'grid'
-          : 'hidden group-focus-within/session:grid group-hover/session:grid group-has-[[data-popup-open]]/session:grid',
-      )}
-    >
+    <span className={cn(trailingSlot, indicator ? 'grid' : revealedSlot)}>
       {indicator ? <SessionRowIndicator kind={indicator} name={name} /> : null}
-      {loading ? null : (
-        <DropdownMenu>
-          <DropdownMenu.Trigger
-            render={
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                aria-label={`Session actions for ${name}`}
-                disabled={disabled}
-                className="hidden group-focus-within/session:flex group-hover/session:flex data-[popup-open]:flex"
-              >
-                <MoreHorizontal />
-              </Button>
-            }
-          />
-          <DropdownMenu.Content align="end" className="min-w-28">
-            <DropdownMenu.Item onClick={() => onPinChange(!pinned)}>
-              {pinned ? <PinOff /> : <Pin />}
-              {pinned ? 'Unpin' : 'Pin session'}
-            </DropdownMenu.Item>
-            <DropdownMenu.Item variant="destructive" onClick={onDelete}>
-              <Trash2 />
-              Delete
-            </DropdownMenu.Item>
-          </DropdownMenu.Content>
-        </DropdownMenu>
+      {indicator === 'loading' ? null : (
+        <SessionActionsMenu
+          name={name}
+          disabled={disabled}
+          pinned={pinned}
+          onPinChange={onPinChange}
+          onDelete={onDelete}
+        />
       )}
     </span>
   );
@@ -128,6 +101,12 @@ export function SessionNavRow({
   );
 }
 
+const trailingSlot = 'size-form-sm shrink-0 place-items-center *:col-start-1 *:row-start-1';
+
+// An empty slot claims no width, so the label runs the full row until there is something to show.
+const revealedSlot =
+  'hidden group-focus-within/session:grid group-hover/session:grid group-has-[[data-popup-open]]/session:grid';
+
 type IndicatorKind = 'loading' | 'running' | 'attention' | 'merged';
 
 function indicatorKind({
@@ -142,6 +121,49 @@ function indicatorKind({
   if (loading) return 'loading';
   if (status) return status;
   return merged ? 'merged' : undefined;
+}
+
+function SessionActionsMenu({
+  name,
+  disabled,
+  pinned,
+  onPinChange,
+  onDelete,
+}: {
+  name: string;
+  disabled: boolean;
+  pinned: boolean;
+  onPinChange: (pinned: boolean) => void;
+  onDelete: () => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Trigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Session actions for ${name}`}
+            disabled={disabled}
+            className="hidden group-focus-within/session:flex group-hover/session:flex data-[popup-open]:flex"
+          >
+            <MoreHorizontal />
+          </Button>
+        }
+      />
+      <DropdownMenu.Content align="end" className="min-w-28">
+        <DropdownMenu.Item onClick={() => onPinChange(!pinned)}>
+          {pinned ? <PinOff /> : <Pin />}
+          {pinned ? 'Unpin' : 'Pin session'}
+        </DropdownMenu.Item>
+        <DropdownMenu.Item variant="destructive" onClick={onDelete}>
+          <Trash2 />
+          Delete
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
 }
 
 // The actions menu owns the slot as soon as the row is hovered, focused, or its menu is open.

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -3,6 +3,7 @@ import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { HoverCard, HoverCardTrigger } from '@mastra/playground-ui/components/HoverCard';
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { GitBranch, MoreHorizontal, Pin, PinOff, Trash2 } from 'lucide-react';
 
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
@@ -12,8 +13,9 @@ import type { SessionPreviewDetails } from './SessionPreviewCard';
 /**
  * Shared sidebar row for workspace/user sessions. Built on `MainSidebar.NavLink`
  * so every session list (work, review, user) renders with identical density,
- * hover, and active states. The optional status dot (agent running/finished)
- * hides on hover so the actions menu can take its place.
+ * hover, and active states. Spinner, status dot and actions menu share one
+ * trailing slot beside the label: they swap in place, and the slot collapses
+ * when there is nothing to show so the label gets the full row.
  */
 export function SessionNavRow({
   name,
@@ -61,61 +63,49 @@ export function SessionNavRow({
       {pinned && !loading ? (
         <Pin aria-label={`${name} pinned`} className="text-icon3/70 size-2 shrink-0 rotate-45" />
       ) : null}
-      {loading ? (
-        <Spinner size="sm" aria-label={`Opening ${name}`} className="text-icon3 ml-auto shrink-0" />
-      ) : status === 'running' ? (
-        <span
-          role="status"
-          aria-label={`Agent working in ${name}`}
-          title="Agent working"
-          className="bg-accent1 ml-auto size-2 shrink-0 animate-pulse rounded-full group-hover/session:opacity-0"
-        />
-      ) : status === 'attention' ? (
-        <span
-          role="status"
-          aria-label={`Agent finished in ${name}`}
-          title="Agent finished — open to dismiss"
-          className="bg-accent1 ml-auto size-2 shrink-0 rounded-full group-hover/session:opacity-0"
-        />
-      ) : merged ? (
-        <span
-          role="img"
-          aria-label={`Pull request merged for ${name}`}
-          title="Pull request merged"
-          className="ml-auto flex shrink-0 group-hover/session:opacity-0"
-        >
-          <PullRequestStatusIcon status="merged" className="size-3!" decorative />
-        </span>
-      ) : null}
     </button>
   );
-  const action = loading ? undefined : (
-    <DropdownMenu>
-      <DropdownMenu.Trigger
-        render={
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label={`Session actions for ${name}`}
-            disabled={disabled}
-            className="opacity-0 group-focus-within/session:opacity-100 group-hover/session:opacity-100 data-[popup-open]:opacity-100"
-          >
-            <MoreHorizontal />
-          </Button>
-        }
-      />
-      <DropdownMenu.Content align="end" className="min-w-28">
-        <DropdownMenu.Item onClick={() => onPinChange(!pinned)}>
-          {pinned ? <PinOff /> : <Pin />}
-          {pinned ? 'Unpin' : 'Pin session'}
-        </DropdownMenu.Item>
-        <DropdownMenu.Item variant="destructive" onClick={onDelete}>
-          <Trash2 />
-          Delete
-        </DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu>
+  const indicator = indicatorKind({ loading, status, merged });
+  const action = (
+    <span
+      className={cn(
+        'size-form-sm shrink-0 place-items-center *:col-start-1 *:row-start-1',
+        // Empty slot claims no width, so the label runs full width until there is something to show.
+        indicator
+          ? 'grid'
+          : 'hidden group-focus-within/session:grid group-hover/session:grid group-has-[[data-popup-open]]/session:grid',
+      )}
+    >
+      {indicator ? <SessionRowIndicator kind={indicator} name={name} /> : null}
+      {loading ? null : (
+        <DropdownMenu>
+          <DropdownMenu.Trigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`Session actions for ${name}`}
+                disabled={disabled}
+                className="hidden group-focus-within/session:flex group-hover/session:flex data-[popup-open]:flex"
+              >
+                <MoreHorizontal />
+              </Button>
+            }
+          />
+          <DropdownMenu.Content align="end" className="min-w-28">
+            <DropdownMenu.Item onClick={() => onPinChange(!pinned)}>
+              {pinned ? <PinOff /> : <Pin />}
+              {pinned ? 'Unpin' : 'Pin session'}
+            </DropdownMenu.Item>
+            <DropdownMenu.Item variant="destructive" onClick={onDelete}>
+              <Trash2 />
+              Delete
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      )}
+    </span>
   );
   const row = (
     <MainSidebar.NavLink
@@ -135,5 +125,60 @@ export function SessionNavRow({
       {row}
       <SessionPreviewCard name={name} status={status} merged={merged} details={preview} />
     </HoverCard>
+  );
+}
+
+type IndicatorKind = 'loading' | 'running' | 'attention' | 'merged';
+
+function indicatorKind({
+  loading,
+  status,
+  merged,
+}: {
+  loading?: boolean;
+  status?: 'running' | 'attention';
+  merged?: boolean;
+}): IndicatorKind | undefined {
+  if (loading) return 'loading';
+  if (status) return status;
+  return merged ? 'merged' : undefined;
+}
+
+// The actions menu owns the slot as soon as the row is hovered, focused, or its menu is open.
+const yieldsToActions =
+  'group-hover/session:hidden group-focus-within/session:hidden group-has-[[data-popup-open]]/session:hidden';
+
+function SessionRowIndicator({ kind, name }: { kind: IndicatorKind; name: string }) {
+  if (kind === 'loading') return <Spinner size="sm" aria-label={`Opening ${name}`} className="text-icon3" />;
+
+  if (kind === 'running')
+    return (
+      <span
+        role="status"
+        aria-label={`Agent working in ${name}`}
+        title="Agent working"
+        className={cn('bg-accent1 size-2 animate-pulse rounded-full', yieldsToActions)}
+      />
+    );
+
+  if (kind === 'attention')
+    return (
+      <span
+        role="status"
+        aria-label={`Agent finished in ${name}`}
+        title="Agent finished — open to dismiss"
+        className={cn('bg-accent1 size-2 rounded-full', yieldsToActions)}
+      />
+    );
+
+  return (
+    <span
+      role="img"
+      aria-label={`Pull request merged for ${name}`}
+      title="Pull request merged"
+      className={cn('flex', yieldsToActions)}
+    >
+      <PullRequestStatusIcon status="merged" className="size-3!" decorative />
+    </span>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -5,6 +5,8 @@ import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { GitBranch, MoreHorizontal, Pin, PinOff, Trash2 } from 'lucide-react';
+import { useRef } from 'react';
+import type { RefObject } from 'react';
 
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 import { SessionPreviewCard } from './SessionPreviewCard';
@@ -15,7 +17,9 @@ import type { SessionPreviewDetails } from './SessionPreviewCard';
  * so every session list (work, review, user) renders with identical density,
  * hover, and active states. Spinner, status dot and actions menu share one
  * trailing slot beside the label: they swap in place, and the slot collapses
- * when there is nothing to show so the label gets the full row.
+ * when there is nothing to show so the label gets the full row. Because that
+ * slot comes and goes, the menu and the preview card anchor to the row box
+ * instead — a resized or hidden anchor would drag them across the screen.
  */
 export function SessionNavRow({
   name,
@@ -49,6 +53,7 @@ export function SessionNavRow({
   onPinChange: (pinned: boolean) => void;
   onDelete: () => void;
 }) {
+  const anchor = useRef<HTMLLIElement>(null);
   const button = (
     <button
       type="button"
@@ -72,6 +77,7 @@ export function SessionNavRow({
       {indicator === 'loading' ? null : (
         <SessionActionsMenu
           name={name}
+          anchor={anchor}
           disabled={disabled}
           pinned={pinned}
           onPinChange={onPinChange}
@@ -82,6 +88,7 @@ export function SessionNavRow({
   );
   const row = (
     <MainSidebar.NavLink
+      ref={anchor}
       link={{ name, url }}
       isActive={active}
       className="group/session"
@@ -96,7 +103,7 @@ export function SessionNavRow({
   return (
     <HoverCard>
       {row}
-      <SessionPreviewCard name={name} status={status} merged={merged} details={preview} />
+      <SessionPreviewCard name={name} anchor={anchor} status={status} merged={merged} details={preview} />
     </HoverCard>
   );
 }
@@ -125,12 +132,14 @@ function indicatorKind({
 
 function SessionActionsMenu({
   name,
+  anchor,
   disabled,
   pinned,
   onPinChange,
   onDelete,
 }: {
   name: string;
+  anchor: RefObject<HTMLElement | null>;
   disabled: boolean;
   pinned: boolean;
   onPinChange: (pinned: boolean) => void;
@@ -152,7 +161,7 @@ function SessionActionsMenu({
           </Button>
         }
       />
-      <DropdownMenu.Content align="end" className="min-w-28">
+      <DropdownMenu.Content anchor={anchor} align="end" className="min-w-28">
         <DropdownMenu.Item onClick={() => onPinChange(!pinned)}>
           {pinned ? <PinOff /> : <Pin />}
           {pinned ? 'Unpin' : 'Pin session'}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionPreviewCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionPreviewCard.tsx
@@ -1,7 +1,7 @@
 import { HoverCardContent } from '@mastra/playground-ui/components/HoverCard';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { CircleDot, GitBranch, GitMerge } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { ReactNode, RefObject } from 'react';
 
 import { relativeTime } from '../../../../lib/date/relativeTime';
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
@@ -36,11 +36,14 @@ function DetailRow({ icon, label, children }: { icon: ReactNode; label: string; 
 
 export function SessionPreviewCard({
   name,
+  anchor,
   status,
   merged,
   details,
 }: {
   name: string;
+  /** The sidebar row box — a stable anchor, unlike the label whose width follows the hover-revealed actions. */
+  anchor: RefObject<HTMLElement | null>;
   status?: 'running' | 'attention';
   merged?: boolean;
   details: SessionPreviewDetails;
@@ -59,6 +62,7 @@ export function SessionPreviewCard({
   return (
     <HoverCardContent
       aria-label={`${name} session details`}
+      anchor={anchor}
       side="right"
       align="start"
       sideOffset={8}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceActivityIndicators.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceActivityIndicators.msw.test.tsx
@@ -12,6 +12,8 @@
  * actually carry, and the legacy `projectPath` shape personal worktree sessions
  * still use.
  */
+import assert from 'node:assert';
+
 import { screen, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter, Route, Routes } from 'react-router';
@@ -95,7 +97,10 @@ describe('Workspace activity indicators', () => {
 
     renderSection();
 
-    expect(await screen.findByRole('status', { name: `Agent working in ${workName}` })).toBeInTheDocument();
+    const dot = await screen.findByRole('status', { name: `Agent working in ${workName}` });
+    const actions = screen.getByRole('button', { name: `Session actions for ${workName}` });
+    // Same trailing slot: the menu takes the dot's place on hover instead of covering the label.
+    expect(dot.parentElement).toBe(actions.parentElement);
   });
 
   it('leaves an idle factory thread without a running dot', async () => {
@@ -107,7 +112,8 @@ describe('Workspace activity indicators', () => {
     renderSection();
 
     // The row must exist before the absence of its dot means anything.
-    const row = await screen.findByRole('button', { name: workName });
+    const row = (await screen.findByRole('button', { name: workName })).closest('li');
+    assert(row);
     expect(within(row).queryByRole('status', { name: `Agent working in ${workName}` })).not.toBeInTheDocument();
   });
 

--- a/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.tsx
+++ b/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.tsx
@@ -21,6 +21,9 @@ const itemClass = cn(
   '[&:hover>svg]:opacity-100 [&>svg]:size-[1.1em] [&>svg]:opacity-60',
 );
 
+// A hidden anchor makes Floating UI fall back to the top-left corner, so the popup goes with it.
+const positionerClass = 'z-50 outline-none data-[anchor-hidden]:hidden';
+
 const popupClass = cn(
   'z-50 max-h-[min(20rem,var(--available-height))] min-w-44 origin-[var(--transform-origin)] overflow-x-hidden overflow-y-auto rounded-xl border border-border1 bg-surface3 p-1 text-neutral4 shadow-dialog outline-none',
   'data-[closed]:animate-out data-[closed]:fade-out-0 data-[closed]:zoom-out-95 data-[open]:animate-in data-[open]:fade-in-0 data-[open]:zoom-in-95',
@@ -117,7 +120,7 @@ const DropdownMenuSubContent = React.forwardRef<HTMLDivElement, DropdownMenuSubC
 
     return (
       <MenuPrimitive.Portal container={resolvedContainer}>
-        <MenuPrimitive.Positioner className="z-50 outline-none" {...positionerProps}>
+        <MenuPrimitive.Positioner className={positionerClass} {...positionerProps}>
           <MenuPrimitive.Popup
             ref={ref}
             data-slot="dropdown-menu-sub-content"
@@ -177,7 +180,7 @@ const DropdownMenuContent = React.forwardRef<HTMLDivElement, DropdownMenuContent
 
     return (
       <MenuPrimitive.Portal container={resolvedContainer}>
-        <MenuPrimitive.Positioner className="z-50 outline-none" {...positionerProps}>
+        <MenuPrimitive.Positioner className={positionerClass} {...positionerProps}>
           <MenuPrimitive.Popup
             ref={ref}
             data-slot="dropdown-menu-content"

--- a/packages/playground-ui/src/ds/components/HoverCard/hover-card.tsx
+++ b/packages/playground-ui/src/ds/components/HoverCard/hover-card.tsx
@@ -87,7 +87,7 @@ const HoverCardContent = React.forwardRef<HTMLDivElement, HoverCardContentProps>
 
     return (
       <PreviewCardPrimitive.Portal container={container ?? undefined}>
-        <PreviewCardPrimitive.Positioner className="z-50" {...positionerProps}>
+        <PreviewCardPrimitive.Positioner className="z-50 data-[anchor-hidden]:hidden" {...positionerProps}>
           <PreviewCardPrimitive.Popup
             ref={ref}
             className={cn(

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-item-classes.ts
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-item-classes.ts
@@ -2,7 +2,7 @@ import { cva } from 'class-variance-authority';
 import type { VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
-const navItemVariants = cva('flex min-w-0 cursor-pointer items-center rounded-lg whitespace-nowrap text-neutral3', {
+const navItemVariants = cva('flex min-w-0 cursor-pointer items-center rounded-lg whitespace-nowrap', {
   variants: {
     size: {
       default: 'h-8 text-ui-md',
@@ -18,12 +18,17 @@ type NavItemVariantProps = VariantProps<typeof navItemVariants>;
 
 export type MainSidebarNavItemSize = NonNullable<NavItemVariantProps['size']>;
 
-type ItemStyleOptions = {
+type SurfaceOptions = {
   isActive?: boolean;
-  isCollapsed?: boolean;
   isFeatured?: boolean;
+};
+
+type ItemStyleOptions = SurfaceOptions & {
+  isCollapsed?: boolean;
   level?: number;
   size?: MainSidebarNavItemSize;
+  /** Set false when a wrapper owns the row surface, e.g. a row with a trailing action. */
+  withSurface?: boolean;
 };
 
 const nestedExpandedItemClasses = (level: number) => {
@@ -34,25 +39,44 @@ const nestedExpandedItemClasses = (level: number) => {
 };
 
 /**
- * Shared classes for any sidebar nav row element (anchor, button, custom).
- * Apply directly to the interactive element so `asChild` and custom slotted
- * elements all receive the same styling.
+ * Color chrome of a nav row: background, text, and icon states. Applied to
+ * whatever element spans the full row box — the interactive element itself, or
+ * the flex wrapper holding it next to a trailing action.
  */
-export const navItemClasses = ({ isActive, isCollapsed, isFeatured, level = 0, size }: ItemStyleOptions = {}) =>
+export const navRowSurfaceClasses = ({ isActive, isFeatured }: SurfaceOptions = {}) =>
   cn(
-    navItemVariants({ size }),
-    'duration-normal transition-all ease-out-custom motion-reduce:transition-none',
-    '[&_svg]:duration-normal [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:text-neutral3/70 [&_svg]:transition-colors motion-reduce:[&_svg]:transition-none',
+    'rounded-lg text-neutral3',
+    '[&_svg]:text-neutral3/70',
     'hover:bg-sidebar-nav-hover hover:text-neutral6 [&:hover_svg]:text-neutral5',
-    'focus-visible:shadow-focus-ring focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:outline-hidden',
-    !isCollapsed && nestedExpandedItemClasses(level),
-    isCollapsed && 'w-full justify-center p-0',
     isActive &&
       'bg-sidebar-nav-active text-neutral6 hover:bg-sidebar-nav-active hover:text-neutral6 [&_svg]:text-neutral6 [&:hover_svg]:text-neutral6',
-    isCollapsed && !isActive && '[&_svg]:text-neutral3',
     isFeatured && 'my-2 border border-accent1/30 bg-accent1Dark text-accent1 hover:bg-accent1Darker hover:text-accent1',
     isFeatured &&
       'dark:border-transparent dark:bg-accent1 dark:text-black dark:hover:bg-accent1/90 dark:hover:text-black',
     isFeatured &&
       '[&_svg]:text-accent1 dark:[&_svg]:text-black/75 [&:hover_svg]:text-accent1 dark:[&:hover_svg]:text-black',
+  );
+
+/**
+ * Shared classes for any sidebar nav row element (anchor, button, custom).
+ * Apply directly to the interactive element so `asChild` and custom slotted
+ * elements all receive the same styling.
+ */
+export const navItemClasses = ({
+  isActive,
+  isCollapsed,
+  isFeatured,
+  level = 0,
+  size,
+  withSurface = true,
+}: ItemStyleOptions = {}) =>
+  cn(
+    navItemVariants({ size }),
+    'duration-normal transition-all ease-out-custom motion-reduce:transition-none',
+    '[&_svg]:duration-normal [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:transition-colors motion-reduce:[&_svg]:transition-none',
+    'focus-visible:shadow-focus-ring focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:outline-hidden',
+    !isCollapsed && nestedExpandedItemClasses(level),
+    isCollapsed && 'w-full justify-center p-0',
+    withSurface && navRowSurfaceClasses({ isActive, isFeatured }),
+    isCollapsed && !isActive && '[&_svg]:text-neutral3',
   );

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-item-classes.ts
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-item-classes.ts
@@ -18,18 +18,18 @@ type NavItemVariantProps = VariantProps<typeof navItemVariants>;
 
 export type MainSidebarNavItemSize = NonNullable<NavItemVariantProps['size']>;
 
-type SurfaceOptions = {
+type NavRowSurfaceOptions = {
   isActive?: boolean;
   isFeatured?: boolean;
 };
 
-type ItemStyleOptions = SurfaceOptions & {
+type NavItemLayoutOptions = {
   isCollapsed?: boolean;
   level?: number;
   size?: MainSidebarNavItemSize;
-  /** Set false when a wrapper owns the row surface, e.g. a row with a trailing action. */
-  withSurface?: boolean;
 };
+
+type ItemStyleOptions = NavRowSurfaceOptions & NavItemLayoutOptions;
 
 const nestedExpandedItemClasses = (level: number) => {
   if (level <= 0) return 'w-full gap-2 py-1 px-3 justify-start';
@@ -38,38 +38,30 @@ const nestedExpandedItemClasses = (level: number) => {
   return 'w-full gap-2 py-1 pr-3 pl-12 justify-start text-ui-sm h-8';
 };
 
-/**
- * Color chrome of a nav row: background, text, and icon states. Applied to
- * whatever element spans the full row box — the interactive element itself, or
- * the flex wrapper holding it next to a trailing action.
- */
-export const navRowSurfaceClasses = ({ isActive, isFeatured }: SurfaceOptions = {}) =>
-  cn(
-    'rounded-lg text-neutral3',
-    '[&_svg]:text-neutral3/70',
-    'hover:bg-sidebar-nav-hover hover:text-neutral6 [&:hover_svg]:text-neutral5',
-    isActive &&
-      'bg-sidebar-nav-active text-neutral6 hover:bg-sidebar-nav-active hover:text-neutral6 [&_svg]:text-neutral6 [&:hover_svg]:text-neutral6',
-    isFeatured && 'my-2 border border-accent1/30 bg-accent1Dark text-accent1 hover:bg-accent1Darker hover:text-accent1',
-    isFeatured &&
-      'dark:border-transparent dark:bg-accent1 dark:text-black dark:hover:bg-accent1/90 dark:hover:text-black',
-    isFeatured &&
-      '[&_svg]:text-accent1 dark:[&_svg]:text-black/75 [&:hover_svg]:text-accent1 dark:[&:hover_svg]:text-black',
-  );
+const idleSurface = cn(
+  'rounded-lg text-neutral3 [&_svg]:text-neutral3/70',
+  'hover:bg-sidebar-nav-hover hover:text-neutral6 [&:hover_svg]:text-neutral5',
+);
+
+const activeSurface =
+  'bg-sidebar-nav-active text-neutral6 hover:bg-sidebar-nav-active hover:text-neutral6 [&_svg]:text-neutral6 [&:hover_svg]:text-neutral6';
+
+const featuredSurface = cn(
+  'my-2 border border-accent1/30 bg-accent1Dark text-accent1 hover:bg-accent1Darker hover:text-accent1',
+  'dark:border-transparent dark:bg-accent1 dark:text-black dark:hover:bg-accent1/90 dark:hover:text-black',
+  '[&_svg]:text-accent1 dark:[&_svg]:text-black/75 [&:hover_svg]:text-accent1 dark:[&:hover_svg]:text-black',
+);
 
 /**
- * Shared classes for any sidebar nav row element (anchor, button, custom).
- * Apply directly to the interactive element so `asChild` and custom slotted
- * elements all receive the same styling.
+ * Color chrome of a nav row: background, text, and icon states. Belongs on
+ * whatever element spans the whole row box — the interactive element itself, or
+ * the flex wrapper holding it next to a trailing action.
  */
-export const navItemClasses = ({
-  isActive,
-  isCollapsed,
-  isFeatured,
-  level = 0,
-  size,
-  withSurface = true,
-}: ItemStyleOptions = {}) =>
+export const navRowSurfaceClasses = ({ isActive, isFeatured }: NavRowSurfaceOptions) =>
+  cn(idleSurface, isActive && activeSurface, isFeatured && featuredSurface);
+
+/** Box and typography of a nav row, without the colour chrome. */
+export const navItemLayoutClasses = ({ isCollapsed, level = 0, size }: NavItemLayoutOptions) =>
   cn(
     navItemVariants({ size }),
     'duration-normal transition-all ease-out-custom motion-reduce:transition-none',
@@ -77,6 +69,16 @@ export const navItemClasses = ({
     'focus-visible:shadow-focus-ring focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:outline-hidden',
     !isCollapsed && nestedExpandedItemClasses(level),
     isCollapsed && 'w-full justify-center p-0',
-    withSurface && navRowSurfaceClasses({ isActive, isFeatured }),
+  );
+
+/**
+ * Shared classes for any sidebar nav row element (anchor, button, custom).
+ * Apply directly to the interactive element so `asChild` and custom slotted
+ * elements all receive the same styling.
+ */
+export const navItemClasses = ({ isActive, isCollapsed, isFeatured, level, size }: ItemStyleOptions = {}) =>
+  cn(
+    navItemLayoutClasses({ isCollapsed, level, size }),
+    navRowSurfaceClasses({ isActive, isFeatured }),
     isCollapsed && !isActive && '[&_svg]:text-neutral3',
   );

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
 import type { SidebarState } from './main-sidebar-context';
 import { useMaybeSidebarState } from './main-sidebar-context';
-import { navItemClasses } from './main-sidebar-nav-item-classes';
+import { navItemClasses, navRowSurfaceClasses } from './main-sidebar-nav-item-classes';
 import type { MainSidebarNavItemSize } from './main-sidebar-nav-item-classes';
 import { MainSidebarNavLabel } from './main-sidebar-nav-label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
@@ -80,6 +80,10 @@ export function MainSidebarNavLink({
   const linkParams = isExternal ? { target: '_blank', rel: 'noreferrer' } : {};
   const needsTooltip = link ? isCollapsed || Boolean(link.tooltipMsg) : false;
 
+  // With a trailing action the row becomes a flex pair: the wrapper owns the row
+  // surface so hover/active paint the whole box, the action sits after the label.
+  const hasRowAction = Boolean(action) && !isCollapsed;
+
   const itemClassName = cn(
     navItemClasses({
       isActive,
@@ -87,8 +91,9 @@ export function MainSidebarNavLink({
       isFeatured,
       level,
       size,
+      withSurface: !hasRowAction,
     }),
-    action && !isCollapsed && 'pr-10',
+    hasRowAction && 'flex-1 pr-1',
   );
 
   let interactiveEl: React.ReactNode = null;
@@ -121,19 +126,28 @@ export function MainSidebarNavLink({
     );
   }
 
+  const rowEl =
+    link && needsTooltip && React.isValidElement(interactiveEl) ? (
+      <Tooltip>
+        <TooltipTrigger render={interactiveEl} />
+        <TooltipContent side="right" align="center" sideOffset={16}>
+          {link.tooltipMsg ? (isCollapsed ? `${link.name} | ${link.tooltipMsg}` : link.tooltipMsg) : link.name}
+        </TooltipContent>
+      </Tooltip>
+    ) : (
+      (interactiveEl ?? children)
+    );
+
   return (
     <li {...props} className={cn('relative flex min-w-0 flex-col', className)}>
-      {link && needsTooltip && React.isValidElement(interactiveEl) ? (
-        <Tooltip>
-          <TooltipTrigger render={interactiveEl} />
-          <TooltipContent side="right" align="center" sideOffset={16}>
-            {link.tooltipMsg ? (isCollapsed ? `${link.name} | ${link.tooltipMsg}` : link.tooltipMsg) : link.name}
-          </TooltipContent>
-        </Tooltip>
+      {hasRowAction ? (
+        <div className={cn('flex min-w-0 items-center pr-1', navRowSurfaceClasses({ isActive, isFeatured }))}>
+          {rowEl}
+          {action}
+        </div>
       ) : (
-        (interactiveEl ?? children)
+        rowEl
       )}
-      {!isCollapsed && action && <div className="absolute top-1/2 right-1 -translate-y-1/2">{action}</div>}
       {!isCollapsed && subItems}
     </li>
   );

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -69,6 +69,10 @@ export function MainSidebarNavLink({
   asChild = false,
   ...props
 }: MainSidebarNavLinkProps) {
+  if (render && asChild) {
+    throw new Error('MainSidebarNavLink accepts either `render` or `asChild`, not both.');
+  }
+
   // Auto-inherit state + LinkComponent from context; explicit props still win.
   const ctx = useMaybeSidebarState();
   const state: SidebarState = stateProp ?? ctx?.state ?? 'default';
@@ -78,7 +82,7 @@ export function MainSidebarNavLink({
   const level = levelProp ?? (link?.indent ? 1 : 0);
   const isExternal = Boolean(link?.url && /^(https?:)?\/\//.test(link.url));
   const linkParams = isExternal ? { target: '_blank', rel: 'noreferrer' } : {};
-  const needsTooltip = link ? isCollapsed || Boolean(link.tooltipMsg) : false;
+  const tooltip = navTooltipLabel(link, isCollapsed);
 
   // A collapsed rail has no room for a trailing control, so the action is dropped there.
   const rowAction = isCollapsed ? undefined : action;
@@ -87,11 +91,7 @@ export function MainSidebarNavLink({
     ? cn(navItemLayoutClasses({ level, size }), 'flex-1 pr-1')
     : navItemClasses({ isActive, isCollapsed, isFeatured, level, size });
 
-  let interactiveEl: React.ReactNode = null;
-
-  if (render && asChild) {
-    throw new Error('MainSidebarNavLink accepts either `render` or `asChild`, not both.');
-  }
+  let interactiveEl: React.ReactNode = undefined;
 
   if (render) {
     interactiveEl = React.cloneElement(render, {
@@ -117,25 +117,33 @@ export function MainSidebarNavLink({
     );
   }
 
-  const rowEl =
-    link && needsTooltip && React.isValidElement(interactiveEl) ? (
-      <Tooltip>
-        <TooltipTrigger render={interactiveEl} />
-        <TooltipContent side="right" align="center" sideOffset={16}>
-          {link.tooltipMsg ? (isCollapsed ? `${link.name} | ${link.tooltipMsg}` : link.tooltipMsg) : link.name}
-        </TooltipContent>
-      </Tooltip>
-    ) : (
-      (interactiveEl ?? children)
-    );
-
   return (
     <li {...props} className={cn('relative flex min-w-0 flex-col', className)}>
       <NavRowBody action={rowAction} surfaceClassName={navRowSurfaceClasses({ isActive, isFeatured })}>
-        {rowEl}
+        <NavRowTooltip label={tooltip}>{interactiveEl ?? children}</NavRowTooltip>
       </NavRowBody>
       {!isCollapsed && subItems}
     </li>
+  );
+}
+
+/** A collapsed rail hides the label, so the row names itself through a tooltip. */
+function navTooltipLabel(link: NavLink | undefined, isCollapsed: boolean) {
+  if (!link) return undefined;
+  if (link.tooltipMsg) return isCollapsed ? `${link.name} | ${link.tooltipMsg}` : link.tooltipMsg;
+  return isCollapsed ? link.name : undefined;
+}
+
+function NavRowTooltip({ label, children }: { label?: string; children: React.ReactNode }) {
+  if (!label || !React.isValidElement(children)) return children;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={children} />
+      <TooltipContent side="right" align="center" sideOffset={16}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
 import type { SidebarState } from './main-sidebar-context';
 import { useMaybeSidebarState } from './main-sidebar-context';
-import { navItemClasses, navRowSurfaceClasses } from './main-sidebar-nav-item-classes';
+import { navItemClasses, navItemLayoutClasses, navRowSurfaceClasses } from './main-sidebar-nav-item-classes';
 import type { MainSidebarNavItemSize } from './main-sidebar-nav-item-classes';
 import { MainSidebarNavLabel } from './main-sidebar-nav-label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
@@ -80,21 +80,12 @@ export function MainSidebarNavLink({
   const linkParams = isExternal ? { target: '_blank', rel: 'noreferrer' } : {};
   const needsTooltip = link ? isCollapsed || Boolean(link.tooltipMsg) : false;
 
-  // With a trailing action the row becomes a flex pair: the wrapper owns the row
-  // surface so hover/active paint the whole box, the action sits after the label.
-  const hasRowAction = Boolean(action) && !isCollapsed;
+  // A collapsed rail has no room for a trailing control, so the action is dropped there.
+  const rowAction = isCollapsed ? undefined : action;
 
-  const itemClassName = cn(
-    navItemClasses({
-      isActive,
-      isCollapsed,
-      isFeatured,
-      level,
-      size,
-      withSurface: !hasRowAction,
-    }),
-    hasRowAction && 'flex-1 pr-1',
-  );
+  const itemClassName = rowAction
+    ? cn(navItemLayoutClasses({ level, size }), 'flex-1 pr-1')
+    : navItemClasses({ isActive, isCollapsed, isFeatured, level, size });
 
   let interactiveEl: React.ReactNode = null;
 
@@ -140,15 +131,34 @@ export function MainSidebarNavLink({
 
   return (
     <li {...props} className={cn('relative flex min-w-0 flex-col', className)}>
-      {hasRowAction ? (
-        <div className={cn('flex min-w-0 items-center pr-1', navRowSurfaceClasses({ isActive, isFeatured }))}>
-          {rowEl}
-          {action}
-        </div>
-      ) : (
-        rowEl
-      )}
+      <NavRowBody action={rowAction} surfaceClassName={navRowSurfaceClasses({ isActive, isFeatured })}>
+        {rowEl}
+      </NavRowBody>
       {!isCollapsed && subItems}
     </li>
+  );
+}
+
+/**
+ * Pairs the interactive row with its trailing action. The pair carries the row
+ * surface so hover and active paint the whole box, action included, and the
+ * action stays in flow instead of floating over the label.
+ */
+function NavRowBody({
+  action,
+  surfaceClassName,
+  children,
+}: {
+  action?: React.ReactNode;
+  surfaceClassName: string;
+  children: React.ReactNode;
+}) {
+  if (!action) return children;
+
+  return (
+    <div className={cn('flex min-w-0 items-center pr-1', surfaceClassName)}>
+      {children}
+      {action}
+    </div>
   );
 }

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -80,10 +80,6 @@ export function MainSidebarNavLink({
   const isCollapsed = state === 'collapsed';
   const isFeatured = link?.variant === 'featured';
   const level = levelProp ?? (link?.indent ? 1 : 0);
-  const isExternal = Boolean(link?.url && /^(https?:)?\/\//.test(link.url));
-  const linkParams = isExternal ? { target: '_blank', rel: 'noreferrer' } : {};
-  const tooltip = navTooltipLabel(link, isCollapsed);
-
   // A collapsed rail has no room for a trailing control, so the action is dropped there.
   const rowAction = isCollapsed ? undefined : action;
 
@@ -91,39 +87,61 @@ export function MainSidebarNavLink({
     ? cn(navItemLayoutClasses({ level, size }), 'flex-1 pr-1')
     : navItemClasses({ isActive, isCollapsed, isFeatured, level, size });
 
-  let interactiveEl: React.ReactNode = undefined;
+  return (
+    <li {...props} className={cn('relative flex min-w-0 flex-col', className)}>
+      <NavRowBody action={rowAction} surfaceClassName={navRowSurfaceClasses({ isActive, isFeatured })}>
+        <NavRowTooltip label={navTooltipLabel(link, isCollapsed)}>
+          {navInteractiveRow({ render, asChild, children, link, state, Link, className: itemClassName })}
+        </NavRowTooltip>
+      </NavRowBody>
+      {!isCollapsed && subItems}
+    </li>
+  );
+}
 
-  if (render) {
-    interactiveEl = React.cloneElement(render, {
-      className: cn(itemClassName, render.props.className),
-    });
-  } else if (asChild) {
+/**
+ * Builds the element the row is interactive through. It is slotted into
+ * `Tooltip`'s `render`, so it must be an element value, not a component.
+ */
+function navInteractiveRow({
+  render,
+  asChild,
+  children,
+  link,
+  state,
+  Link,
+  className,
+}: {
+  render?: React.ReactElement<SlottedNavChildProps>;
+  asChild: boolean;
+  children?: React.ReactNode;
+  link?: NavLink;
+  state: SidebarState;
+  Link: LinkComponent;
+  className: string;
+}) {
+  if (render) return React.cloneElement(render, { className: cn(className, render.props.className) });
+
+  if (asChild) {
     if (!React.isValidElement<SlottedNavChildProps>(children)) {
       throw new Error(
         'MainSidebarNavLink requires a valid React element child when `asChild` is true so it can apply `SlottedNavChildProps` and merge `itemClassName`.',
       );
     }
 
-    interactiveEl = React.cloneElement(children, {
-      className: cn(itemClassName, children.props.className),
-    });
-  } else if (link) {
-    interactiveEl = (
-      <Link href={link.url} {...linkParams} className={itemClassName}>
-        {link.icon}
-        <MainSidebarNavLabel state={state}>{link.name}</MainSidebarNavLabel>
-        {children}
-      </Link>
-    );
+    return React.cloneElement(children, { className: cn(className, children.props.className) });
   }
 
+  if (!link) return children;
+
+  const externalParams = /^(https?:)?\/\//.test(link.url) ? { target: '_blank', rel: 'noreferrer' } : {};
+
   return (
-    <li {...props} className={cn('relative flex min-w-0 flex-col', className)}>
-      <NavRowBody action={rowAction} surfaceClassName={navRowSurfaceClasses({ isActive, isFeatured })}>
-        <NavRowTooltip label={tooltip}>{interactiveEl ?? children}</NavRowTooltip>
-      </NavRowBody>
-      {!isCollapsed && subItems}
-    </li>
+    <Link href={link.url} {...externalParams} className={className}>
+      {link.icon}
+      <MainSidebarNavLabel state={state}>{link.name}</MainSidebarNavLabel>
+      {children}
+    </Link>
   );
 }
 

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ComponentPropsWithoutRef } from 'react';
+import type { ComponentProps } from 'react';
 import type { SidebarState } from './main-sidebar-context';
 import { useMaybeSidebarState } from './main-sidebar-context';
 import { navItemClasses, navItemLayoutClasses, navRowSurfaceClasses } from './main-sidebar-nav-item-classes';
@@ -21,7 +21,7 @@ export type NavLink = {
   indent?: boolean;
 };
 
-export type MainSidebarNavLinkProps = Omit<ComponentPropsWithoutRef<'li'>, 'children'> & {
+export type MainSidebarNavLinkProps = Omit<ComponentProps<'li'>, 'children'> & {
   link?: NavLink;
   isActive?: boolean;
   state?: SidebarState;


### PR DESCRIPTION
Before, a sidebar session row had its status dot in the row flow and its three-dot menu absolutely positioned on top of the row, at a different spot, fading in on hover. So the dot and the menu never lined up, and the row had to reserve 40px of right padding forever to keep the overlay off the label.

Now the dot, the merged-PR icon, the spinner and the menu share one slot at the end of the row. They swap in place with no transition, and the slot collapses to nothing when the row has no status, so the label runs the full width until you hover. To make that possible without an overlay, `MainSidebar.NavLink` now lays out a row with an `action` as a flex pair instead of absolutely positioning the action; the row's colour chrome moved to the wrapper (`navRowSurfaceClasses`) so hover and active still paint the whole box, menu included. `SessionNavRow` is the only caller passing `action`, so nothing else changes shape.

A slot that appears on hover also moves whatever is anchored to it: the preview card slid sideways the moment the dots showed up, and the actions menu snapped to the top-left corner of the viewport for a frame while closing, because its trigger was already `display: none` by then. Both popups now anchor to the row `<li>`, the one box that keeps its geometry for as long as they live, so `MainSidebar.NavLink` forwards a ref. As a safety net for other callers, the DropdownMenu and HoverCard positioners now hide themselves when Floating UI reports a hidden anchor instead of drifting to 0,0.

I checked it in the local factory UI across review sessions and user sessions, and added an assertion that the running dot and the actions button really share the same parent slot — the neighbouring "idle" test was scoped to the row button, which had quietly become vacuous once the dot moved out of it, so it now scopes to the list item.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Sidebar session rows now use one fixed space for status indicators and actions. This keeps rows stable during session updates and hover actions. Session menus and preview cards stay attached to the correct row.

## Changes

- Added a shared trailing slot for status dots, merged-PR icons, spinners, and action menus.
- Anchored session menus and preview cards to the row `<li>` element.
- Hid dropdown and hover-card positioners when Floating UI hides their anchors.
- Moved row surface styling to the wrapper while keeping action content in the row layout.
- Split sidebar styling into surface and layout helpers.
- Refactored `MainSidebar.NavLink` action, tooltip, and nested-item rendering.
- Added `navRowSurfaceClasses` and `navItemLayoutClasses`.
- Added tests that verify status indicators and action buttons share one slot.
- Adjusted the idle-session test scope.
- Added patch changesets for the sidebar layout, session-row behavior, and popup positioning fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->