### PR TITLE
feat(factory): record when a session's first message reached the agent

### DIFF
--- a/.changeset/social-hounds-bathe.md
+++ b/.changeset/social-hounds-bathe.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Added a `firstMessageAt` timestamp to Factory source-control sessions. The session's first agent run now records when the first message reached the agent, so session listings and latency reporting can measure time-to-first-response from the real conversation start instead of the session's creation time (which can be long before the user sends anything). The value is returned on session objects from the source-control sessions API and is write-once: later messages never move it.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -65,6 +65,7 @@ import { SandboxFleet } from './sandbox/fleet.js';
 import { registerSandboxReattach } from './sandbox/reattach.js';
 import { handleServerError } from './server-error.js';
 import { observeSessionFilesystem } from './session/filesystem-capture.js';
+import { observeSessionFirstMessage } from './session/first-message-capture.js';
 import { createSpaStaticMiddleware, resolveUiDistDir } from './spa-static.js';
 import { createStateSigner } from './state-signing.js';
 import { observeAgentGitAction } from './storage/domains/audit/agent-audit.js';
@@ -813,6 +814,9 @@ export class MastraFactory {
     prepared.base.controller.onSessionCreated(session => {
       observeSessionFilesystem(session, {
         filesystem: filesystemStorage,
+        sourceControl: sourceControlStorage.forIntegration('github'),
+      });
+      observeSessionFirstMessage(session, {
         sourceControl: sourceControlStorage.forIntegration('github'),
       });
     });

--- a/mastracode/factory/src/session/first-message-capture.test.ts
+++ b/mastracode/factory/src/session/first-message-capture.test.ts
@@ -1,0 +1,90 @@
+import type { AgentControllerEvent } from '@mastra/core/agent-controller';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  observeSessionFirstMessage,
+  type FirstMessageCaptureDependencies,
+  type FirstMessageCaptureSession,
+} from './first-message-capture.js';
+
+function createSession() {
+  const listeners: Array<(event: AgentControllerEvent) => void> = [];
+  const session: FirstMessageCaptureSession = {
+    identity: { getResourceId: () => 'resource-1' },
+    subscribe: listener => {
+      listeners.push(listener);
+      return () => {
+        const index = listeners.indexOf(listener);
+        if (index !== -1) listeners.splice(index, 1);
+      };
+    },
+  };
+  const emit = (event: AgentControllerEvent) => {
+    for (const listener of [...listeners]) listener(event);
+  };
+  return { session, listeners, emit };
+}
+
+function createDependencies(): FirstMessageCaptureDependencies {
+  return {
+    sourceControl: { sessions: { markFirstMessage: vi.fn().mockResolvedValue(undefined) } },
+  };
+}
+
+describe('observeSessionFirstMessage', () => {
+  it('marks the first message on the first agent_start and unsubscribes', () => {
+    const { session, listeners, emit } = createSession();
+    const dependencies = createDependencies();
+    observeSessionFirstMessage(session, dependencies);
+
+    emit({ type: 'agent_start' });
+
+    expect(dependencies.sourceControl.sessions.markFirstMessage).toHaveBeenCalledExactlyOnceWith({
+      sessionId: 'resource-1',
+    });
+    expect(listeners).toHaveLength(0);
+  });
+
+  it('ignores non-start events and later runs', () => {
+    const { session, emit } = createSession();
+    const dependencies = createDependencies();
+    observeSessionFirstMessage(session, dependencies);
+
+    emit({ type: 'thread_changed', threadId: 'thread-2', previousThreadId: 'thread-1' });
+    emit({ type: 'agent_end', reason: 'complete' });
+    expect(dependencies.sourceControl.sessions.markFirstMessage).not.toHaveBeenCalled();
+
+    emit({ type: 'agent_start' });
+    emit({ type: 'agent_start' });
+    expect(dependencies.sourceControl.sessions.markFirstMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns instead of throwing when the storage write fails', async () => {
+    const { session, emit } = createSession();
+    const dependencies = createDependencies();
+    dependencies.sourceControl.sessions.markFirstMessage = vi.fn().mockRejectedValue(new Error('db down'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    observeSessionFirstMessage(session, dependencies);
+
+    emit({ type: 'agent_start' });
+    await vi.waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        '[Factory first-message capture] Unable to persist first message time.',
+        expect.any(Error),
+      ),
+    );
+    warn.mockRestore();
+  });
+
+  it('stops observing when the returned unsubscribe is called before any run', () => {
+    const { session, listeners, emit } = createSession();
+    const dependencies = createDependencies();
+    const unsubscribe = observeSessionFirstMessage(session, dependencies);
+
+    unsubscribe();
+    expect(listeners).toHaveLength(0);
+
+    emit({ type: 'agent_start' });
+    expect(dependencies.sourceControl.sessions.markFirstMessage).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/factory/src/session/first-message-capture.ts
+++ b/mastracode/factory/src/session/first-message-capture.ts
@@ -1,0 +1,44 @@
+import type { AgentControllerEvent } from '@mastra/core/agent-controller';
+
+import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
+
+export interface FirstMessageCaptureSession {
+  readonly identity: { getResourceId(): string };
+  subscribe(listener: (event: AgentControllerEvent) => void): () => void;
+}
+
+export interface FirstMessageCaptureDependencies {
+  sourceControl: {
+    sessions: Pick<SourceControlStorageHandle['sessions'], 'markFirstMessage'>;
+  };
+}
+
+/**
+ * Record when a session's agent first started working on a message.
+ *
+ * `agent_start` is the earliest reliable session event for "a message reached
+ * the agent": it fires when the run engine begins processing an accepted
+ * message — a user's chat message, a factory run's kickoff prompt, or a
+ * channel message — for every session kind (user, work, review). The plain
+ * user message itself is never emitted as a `message_start` event, so the run
+ * start is the observable proxy, milliseconds after arrival.
+ *
+ * The listener unsubscribes after the first event; the storage write is
+ * guarded (`first_message_at IS NULL`), so restarts, re-materialized sessions,
+ * and sessions without a source-control row (chat-only channels) are no-ops.
+ */
+export function observeSessionFirstMessage(
+  session: FirstMessageCaptureSession,
+  { sourceControl }: FirstMessageCaptureDependencies,
+): () => void {
+  let seen = false;
+  const unsubscribe = session.subscribe(event => {
+    if (seen || event.type !== 'agent_start') return;
+    seen = true;
+    unsubscribe();
+    void sourceControl.sessions
+      .markFirstMessage({ sessionId: session.identity.getResourceId() })
+      .catch(error => console.warn('[Factory first-message capture] Unable to persist first message time.', error));
+  });
+  return unsubscribe;
+}

--- a/mastracode/factory/src/storage/domains/source-control/base.test.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.test.ts
@@ -438,6 +438,34 @@ describe('SourceControlStorage', () => {
     );
   });
 
+  it('records first_message_at write-once via markFirstMessage', async () => {
+    const project = await createProject();
+    const link = await linkRepository({ factoryProjectId: project.id });
+    const session = await github.sessions.create({
+      sessionId: '00000000-0000-4000-8000-000000000003',
+      projectRepositoryId: link.id,
+      orgId: 'org-1',
+      userId: 'user-1',
+      branch: 'user/session-00000000-0000-4000-8000-000000000003',
+      baseBranch: 'main',
+    });
+    expect(session.firstMessageAt).toBeNull();
+
+    await github.sessions.markFirstMessage({ sessionId: session.sessionId });
+    const marked = await github.sessions.getBySessionId(session.sessionId);
+    expect(marked?.firstMessageAt).toBeInstanceOf(Date);
+
+    // A later call must not move the timestamp: the guarded update only
+    // matches rows where the column is still NULL.
+    await new Promise(resolve => setTimeout(resolve, 5));
+    await github.sessions.markFirstMessage({ sessionId: session.sessionId });
+    const again = await github.sessions.getBySessionId(session.sessionId);
+    expect(again?.firstMessageAt?.getTime()).toBe(marked!.firstMessageAt!.getTime());
+
+    // Sessions without a source-control row are a zero-row no-op.
+    await expect(github.sessions.markFirstMessage({ sessionId: 'missing-session' })).resolves.toBeUndefined();
+  });
+
   it('clears every owned source-control collection', async () => {
     const project = await createProject();
     const link = await linkRepository({ factoryProjectId: project.id });

--- a/mastracode/factory/src/storage/domains/source-control/base.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.ts
@@ -181,6 +181,7 @@ export const SOURCE_CONTROL_SCHEMAS: CollectionSchema[] = [
       sandbox_id: { type: 'text', nullable: true },
       sandbox_workdir: { type: 'text', nullable: true },
       materialized_at: { type: 'timestamp', nullable: true },
+      first_message_at: { type: 'timestamp', nullable: true },
       created_at: { type: 'timestamp' },
       updated_at: { type: 'timestamp' },
     },
@@ -362,6 +363,8 @@ export interface SourceControlSession {
   sandboxId: string | null;
   sandboxWorkdir: string | null;
   materializedAt: Date | null;
+  /** When the first user message reached the session's agent. Write-once. */
+  firstMessageAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -474,6 +477,14 @@ export interface SourceControlStorageHandle {
     create(input: CreateSourceControlSessionInput): Promise<SourceControlSession>;
     setSandbox(args: { id: string; sandboxId: string | null; sandboxWorkdir: string }): Promise<void>;
     markMaterialized(args: { id: string }): Promise<void>;
+    /**
+     * Record when the session's agent received its first user message.
+     * Write-once: the guarded update only lands while the column is still
+     * NULL, so retries and process restarts are no-ops. Keyed by the
+     * controller-facing `sessionId` (not the row id) because the caller —
+     * the session observer — only knows the controller resourceId.
+     */
+    markFirstMessage(args: { sessionId: string }): Promise<void>;
     delete(id: string): Promise<void>;
   };
 }
@@ -565,6 +576,7 @@ interface SessionDbRow extends Record<string, unknown> {
   sandbox_id: string | null;
   sandbox_workdir: string | null;
   materialized_at: Date | null;
+  first_message_at: Date | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -671,6 +683,7 @@ function toSession(row: SessionDbRow): SourceControlSession {
     sandboxId: row.sandbox_id,
     sandboxWorkdir: row.sandbox_workdir,
     materializedAt: row.materialized_at,
+    firstMessageAt: row.first_message_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -1227,6 +1240,7 @@ export class SourceControlStorage extends FactoryStorageDomain {
               sandbox_id: null,
               sandbox_workdir: null,
               materialized_at: null,
+              first_message_at: null,
               created_at: now,
               updated_at: now,
             });
@@ -1251,6 +1265,17 @@ export class SourceControlStorage extends FactoryStorageDomain {
         },
         markMaterialized: async ({ id }) => {
           await db().updateMany(SESSIONS, { id }, { materialized_at: new Date(), updated_at: new Date() });
+        },
+        markFirstMessage: async ({ sessionId }) => {
+          // `first_message_at: null` in the filter compiles to `IS NULL`, making
+          // this an atomic one-shot: concurrent callers and later messages
+          // match zero rows. Sessions without a source-control row (chat-only
+          // channels) are a zero-row no-op too.
+          await db().updateMany(
+            SESSIONS,
+            { session_id: sessionId, first_message_at: null },
+            { first_message_at: new Date(), updated_at: new Date() },
+          );
         },
         delete: async id => {
           await db().deleteMany(SESSIONS, { id });

--- a/mastracode/factory/src/storage/domains/source-control/inmemory.ts
+++ b/mastracode/factory/src/storage/domains/source-control/inmemory.ts
@@ -493,6 +493,7 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
         sandboxId: null,
         sandboxWorkdir: null,
         materializedAt: null,
+        firstMessageAt: null,
         createdAt: now,
         updatedAt: now,
       };
@@ -514,6 +515,10 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
     markMaterialized: async ({ id }: { id: string }) => {
       const row = this.sessionsRows.find(candidate => candidate.id === id);
       if (row) Object.assign(row, { materializedAt: new Date(), updatedAt: new Date() });
+    },
+    markFirstMessage: async ({ sessionId }: { sessionId: string }) => {
+      const row = this.sessionsRows.find(candidate => candidate.sessionId === sessionId);
+      if (row && row.firstMessageAt === null) Object.assign(row, { firstMessageAt: new Date(), updatedAt: new Date() });
     },
     delete: async (id: string) => {
       this.sessionsRows.splice(0, this.sessionsRows.length, ...this.sessionsRows.filter(row => row.id !== id));


### PR DESCRIPTION
## Summary

Factory sessions now record when their first message actually reached the agent, via a new nullable `first_message_at` column on `source_control_sessions`.

Today the only conversation-start signal on a session is `created_at`, which is misleading: a user can create a workspace and send their first message minutes or hours later, and autonomous work/review runs create the session row before the kickoff prompt is dispatched. Any latency metric anchored on `created_at` (e.g. time-to-first-meaningful-bytes) inherits that skew.

### How it works

- **Schema** — `first_message_at timestamptz NULL` added to the `source_control_sessions` collection schema. `PgFactoryStorage`/`LibSQLFactoryStorage` auto-add missing columns on boot (`ADD COLUMN IF NOT EXISTS`), so no manual migration is needed.
- **Write** — a new `sessions.markFirstMessage({ sessionId })` storage method performs a guarded atomic update (`WHERE session_id = $1 AND first_message_at IS NULL`), making it write-once: concurrent callers, later messages, retries, and process restarts are zero-row no-ops. Sessions with no source-control row (chat-only channel sessions) are no-ops too.
- **Observer** — `observeSessionFirstMessage` is wired via the controller's `onSessionCreated` hook (next to the existing filesystem observer) and marks the session on its first `agent_start` event, then unsubscribes. This covers every session kind — user (web), work, review, and channel sessions — because they all materialize through the same controller, and work/review kickoff prompts trigger `agent_start` like any user message. `agent_start` is used because the plain user message is never emitted as a session event; the run start is the earliest observable proxy, milliseconds after arrival.
- **Read** — the sessions list API returns full session objects, so `firstMessageAt` is included in the payload with no route changes. Direct SQL (`SELECT first_message_at FROM source_control_sessions`) works for reporting/CLI tooling.

Existing rows stay `NULL` and can be backfilled from the earliest user message per session resource if historical data is wanted.

## Test plan

- New storage test: `markFirstMessage` sets the timestamp once, later calls don't move it, unknown session ids are no-ops (`base.test.ts`).
- New observer tests: marks on first `agent_start` and unsubscribes, ignores other events and later runs, warns instead of throwing on storage failure, respects early unsubscribe (`first-message-capture.test.ts`).
- `pnpm --filter ./mastracode/factory test` — only pre-existing failures remain (verified identical on clean `main`).
- `pnpm --filter ./mastracode/factory lint` and `build:lib` pass; the two `tsc --noEmit` errors are pre-existing on `main`.
