### PR TITLE
fix(playground-ui): fade button icons on hover and make duration tokens generate utilities

### DIFF
--- a/.changeset/all-areas-buy.md
+++ b/.changeset/all-areas-buy.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Button icons now fade with the rest of the button on hover instead of snapping to full opacity.
+
+The `duration-normal` and `duration-slow` classes now apply the durations they name. Tailwind generates no utility for a `--duration-*` token, so both classes matched nothing and every transition using them silently ran at the 150ms default. They now run at 200ms and 300ms.

--- a/packages/playground-ui/src/ds/components/Button/Button.tsx
+++ b/packages/playground-ui/src/ds/components/Button/Button.tsx
@@ -14,6 +14,7 @@ const TEXT_MODE_ADORNMENTS = cn(
   'gap-[.75em] rounded-full',
   '[&>svg]:mx-[-.3em] [&>svg]:size-[1.1em]',
   '[&:hover>svg]:opacity-100 [&>svg]:opacity-50',
+  '[&>svg]:transition-opacity [&>svg]:duration-normal [&>svg]:ease-out-custom',
 );
 
 // eslint-disable-next-line react-refresh/only-export-components -- exported variant helper is part of Button's public API

--- a/packages/playground-ui/theme.css
+++ b/packages/playground-ui/theme.css
@@ -411,3 +411,11 @@ html.light {
     }
   }
 }
+
+@utility duration-normal {
+  transition-duration: var(--duration-normal);
+}
+
+@utility duration-slow {
+  transition-duration: var(--duration-slow);
+}


### PR DESCRIPTION
Fixes #21209

Two fixes in the design system, both about transitions that were not doing what the code said.

## Button icons snapped on hover

`Button` puts `transition-all` on the button element, but the icon rule targets a child:

```
'[&:hover>svg]:opacity-100 [&>svg]:opacity-50'
```

Transitions do not reach a child, so the background eased from `bg-neutral6` to `bg-neutral6/90` while the icon jumped 50% → 100% in the same instant. Every text-mode size carries `TEXT_MODE_ADORNMENTS`, so this affected every button with an inline `<svg>`, in all four variants.

The icon now transitions its own opacity on the same curve and duration as the button.

## `duration-normal` and `duration-slow` generated no CSS

`theme.css` defines both tokens, but Tailwind has no `--duration-*` theme namespace, so neither produced a utility. The classes matched nothing and every transition using them silently fell back to `--default-transition-duration`, 150ms. `--ease-out-custom` worked all along because `--ease-*` is a real namespace, which is why this went unnoticed.

Two `@utility` rules make the tokens resolve. Verified by building the package against `main` and against this branch:

```
                                   main    this branch
.duration-normal { ... }              0          1
[&>svg]:transition-opacity > svg      0          1
```

```css
.\[\&\>svg\]\:duration-normal > svg { transition-duration: var(--duration-normal); }
```

**Worth knowing:** `duration-normal` is already written in 33 places across 19 files in this package. Those transitions were running at 150ms and now run at the 200ms the token always specified. That is the token behaving correctly, but it is a timing change across the design system, not only on Button.

## Testing

Storybook on `Elements/Button`, hovering `WithIcon` and `Variants` in both themes. `vitest run src/ds/components/Button` (6 pass), `tsc --noEmit`, `oxlint`, and `prettier --check` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Buttons now fade their icons smoothly when you hover over them. Transition timing options also use their intended durations instead of the default timing.

## Changes

- Added opacity transitions to inline SVG icons in text-mode `Button` components.
- Added `duration-normal` and `duration-slow` utilities with 200ms and 300ms values.
- Added a patch changeset for `@mastra/playground-ui`.

## Validation

- Storybook checks passed.
- Button component tests passed.
- TypeScript, Oxlint, and Prettier checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->