### PR TITLE
feat(factory): record when a session's agent ran its first successful sandbox command

### DIFF
--- a/.changeset/cute-hornets-go.md
+++ b/.changeset/cute-hornets-go.md
@@ -1,0 +1,6 @@
+---
+'@mastra/factory': minor
+'@mastra/core': patch
+---
+
+Added a `firstMeaningfulExecAt` timestamp to source-control sessions, recording when the session's agent completed its first successful sandbox command. Together with `firstMessageAt` this measures time-to-first-meaningful-exec: how long a user waits between sending their first message and the agent actually doing work in a live sandbox. The value is written once per session and is available on all session read APIs; setup commands run by the platform itself (skill loading, repo checkout) do not count.

--- a/.changeset/plenty-jobs-fry.md
+++ b/.changeset/plenty-jobs-fry.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': minor
+'@mastra/factory': patch
+---
+
+Added a `command_exit` session event to the agent controller. Subscribers now receive the exit code and success flag of each foreground `execute_command` tool call, alongside the existing `shell_output` stream:
+
+```typescript
+session.subscribe(event => {
+  if (event.type === 'command_exit') {
+    console.log(event.toolCallId, event.exitCode, event.success);
+  }
+});
+```
+
+Previously the exit outcome was only visible inside the tool result text, so observers could stream a command's output but never tell whether it succeeded.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -65,6 +65,7 @@ import { SandboxFleet } from './sandbox/fleet.js';
 import { registerSandboxReattach } from './sandbox/reattach.js';
 import { handleServerError } from './server-error.js';
 import { observeSessionFilesystem } from './session/filesystem-capture.js';
+import { observeSessionFirstExec } from './session/first-exec-capture.js';
 import { observeSessionFirstMessage } from './session/first-message-capture.js';
 import { createSpaStaticMiddleware, resolveUiDistDir } from './spa-static.js';
 import { createStateSigner } from './state-signing.js';
@@ -817,6 +818,9 @@ export class MastraFactory {
         sourceControl: sourceControlStorage.forIntegration('github'),
       });
       observeSessionFirstMessage(session, {
+        sourceControl: sourceControlStorage.forIntegration('github'),
+      });
+      observeSessionFirstExec(session, {
         sourceControl: sourceControlStorage.forIntegration('github'),
       });
     });

--- a/mastracode/factory/src/session/first-exec-capture.test.ts
+++ b/mastracode/factory/src/session/first-exec-capture.test.ts
@@ -1,0 +1,91 @@
+import type { AgentControllerEvent } from '@mastra/core/agent-controller';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  observeSessionFirstExec,
+  type FirstExecCaptureDependencies,
+  type FirstExecCaptureSession,
+} from './first-exec-capture.js';
+
+function createSession() {
+  const listeners: Array<(event: AgentControllerEvent) => void> = [];
+  const session: FirstExecCaptureSession = {
+    identity: { getResourceId: () => 'resource-1' },
+    subscribe: listener => {
+      listeners.push(listener);
+      return () => {
+        const index = listeners.indexOf(listener);
+        if (index !== -1) listeners.splice(index, 1);
+      };
+    },
+  };
+  const emit = (event: AgentControllerEvent) => {
+    for (const listener of [...listeners]) listener(event);
+  };
+  return { session, listeners, emit };
+}
+
+function createDependencies(): FirstExecCaptureDependencies {
+  return {
+    sourceControl: { sessions: { markFirstMeaningfulExec: vi.fn().mockResolvedValue(undefined) } },
+  };
+}
+
+describe('observeSessionFirstExec', () => {
+  it('marks the first exec on the first successful command_exit and unsubscribes', () => {
+    const { session, listeners, emit } = createSession();
+    const dependencies = createDependencies();
+    observeSessionFirstExec(session, dependencies);
+
+    emit({ type: 'command_exit', toolCallId: 'call-1', exitCode: 0, success: true });
+
+    expect(dependencies.sourceControl.sessions.markFirstMeaningfulExec).toHaveBeenCalledExactlyOnceWith({
+      sessionId: 'resource-1',
+    });
+    expect(listeners).toHaveLength(0);
+  });
+
+  it('stays subscribed past failed commands and marks on the first success only', () => {
+    const { session, emit } = createSession();
+    const dependencies = createDependencies();
+    observeSessionFirstExec(session, dependencies);
+
+    emit({ type: 'agent_start' });
+    emit({ type: 'command_exit', toolCallId: 'call-1', exitCode: 1, success: false });
+    emit({ type: 'command_exit', toolCallId: 'call-2', exitCode: 127, success: false });
+    expect(dependencies.sourceControl.sessions.markFirstMeaningfulExec).not.toHaveBeenCalled();
+
+    emit({ type: 'command_exit', toolCallId: 'call-3', exitCode: 0, success: true });
+    emit({ type: 'command_exit', toolCallId: 'call-4', exitCode: 0, success: true });
+    expect(dependencies.sourceControl.sessions.markFirstMeaningfulExec).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns instead of throwing when the storage write fails', async () => {
+    const { session, emit } = createSession();
+    const dependencies = createDependencies();
+    dependencies.sourceControl.sessions.markFirstMeaningfulExec = vi.fn().mockRejectedValue(new Error('db down'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    observeSessionFirstExec(session, dependencies);
+
+    emit({ type: 'command_exit', toolCallId: 'call-1', exitCode: 0, success: true });
+    await vi.waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        '[Factory first-exec capture] Unable to persist first exec time.',
+        expect.any(Error),
+      ),
+    );
+    warn.mockRestore();
+  });
+
+  it('stops observing when the returned unsubscribe is called before any exec', () => {
+    const { session, listeners, emit } = createSession();
+    const dependencies = createDependencies();
+    const unsubscribe = observeSessionFirstExec(session, dependencies);
+
+    unsubscribe();
+    expect(listeners).toHaveLength(0);
+
+    emit({ type: 'command_exit', toolCallId: 'call-1', exitCode: 0, success: true });
+    expect(dependencies.sourceControl.sessions.markFirstMeaningfulExec).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/factory/src/session/first-exec-capture.ts
+++ b/mastracode/factory/src/session/first-exec-capture.ts
@@ -1,0 +1,46 @@
+import type { AgentControllerEvent } from '@mastra/core/agent-controller';
+
+import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
+
+export interface FirstExecCaptureSession {
+  readonly identity: { getResourceId(): string };
+  subscribe(listener: (event: AgentControllerEvent) => void): () => void;
+}
+
+export interface FirstExecCaptureDependencies {
+  sourceControl: {
+    sessions: Pick<SourceControlStorageHandle['sessions'], 'markFirstMeaningfulExec'>;
+  };
+}
+
+/**
+ * Record when a session's agent completed its first successful sandbox exec
+ * (the TTFME anchor — "time to first meaningful exec").
+ *
+ * `command_exit` is emitted only for the agent's own foreground
+ * `execute_command` tool calls: direct `sandbox.executeCommand()` calls from
+ * the skill loader / preflight / materializer never flow through the tool, so
+ * the first successful exit event is definitionally the agent's first
+ * meaningful exec — no command classifier needed. Background spawns emit no
+ * exit event at spawn time and are intentionally excluded.
+ *
+ * Failed commands (nonzero exit) don't count; the listener stays subscribed
+ * until a successful exit, then unsubscribes. The storage write is guarded
+ * (`first_meaningful_exec_at IS NULL`), so restarts, re-materialized
+ * sessions, and sessions without a source-control row are no-ops.
+ */
+export function observeSessionFirstExec(
+  session: FirstExecCaptureSession,
+  { sourceControl }: FirstExecCaptureDependencies,
+): () => void {
+  let seen = false;
+  const unsubscribe = session.subscribe(event => {
+    if (seen || event.type !== 'command_exit' || !event.success) return;
+    seen = true;
+    unsubscribe();
+    void sourceControl.sessions
+      .markFirstMeaningfulExec({ sessionId: session.identity.getResourceId() })
+      .catch(error => console.warn('[Factory first-exec capture] Unable to persist first exec time.', error));
+  });
+  return unsubscribe;
+}

--- a/mastracode/factory/src/storage/domains/source-control/base.test.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.test.ts
@@ -466,6 +466,34 @@ describe('SourceControlStorage', () => {
     await expect(github.sessions.markFirstMessage({ sessionId: 'missing-session' })).resolves.toBeUndefined();
   });
 
+  it('records first_meaningful_exec_at write-once via markFirstMeaningfulExec', async () => {
+    const project = await createProject();
+    const link = await linkRepository({ factoryProjectId: project.id });
+    const session = await github.sessions.create({
+      sessionId: '00000000-0000-4000-8000-000000000004',
+      projectRepositoryId: link.id,
+      orgId: 'org-1',
+      userId: 'user-1',
+      branch: 'user/session-00000000-0000-4000-8000-000000000004',
+      baseBranch: 'main',
+    });
+    expect(session.firstMeaningfulExecAt).toBeNull();
+
+    await github.sessions.markFirstMeaningfulExec({ sessionId: session.sessionId });
+    const marked = await github.sessions.getBySessionId(session.sessionId);
+    expect(marked?.firstMeaningfulExecAt).toBeInstanceOf(Date);
+
+    // A later call must not move the timestamp: the guarded update only
+    // matches rows where the column is still NULL.
+    await new Promise(resolve => setTimeout(resolve, 5));
+    await github.sessions.markFirstMeaningfulExec({ sessionId: session.sessionId });
+    const again = await github.sessions.getBySessionId(session.sessionId);
+    expect(again?.firstMeaningfulExecAt?.getTime()).toBe(marked!.firstMeaningfulExecAt!.getTime());
+
+    // Sessions without a source-control row are a zero-row no-op.
+    await expect(github.sessions.markFirstMeaningfulExec({ sessionId: 'missing-session' })).resolves.toBeUndefined();
+  });
+
   it('clears every owned source-control collection', async () => {
     const project = await createProject();
     const link = await linkRepository({ factoryProjectId: project.id });

--- a/mastracode/factory/src/storage/domains/source-control/base.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.ts
@@ -182,6 +182,7 @@ export const SOURCE_CONTROL_SCHEMAS: CollectionSchema[] = [
       sandbox_workdir: { type: 'text', nullable: true },
       materialized_at: { type: 'timestamp', nullable: true },
       first_message_at: { type: 'timestamp', nullable: true },
+      first_meaningful_exec_at: { type: 'timestamp', nullable: true },
       created_at: { type: 'timestamp' },
       updated_at: { type: 'timestamp' },
     },
@@ -365,6 +366,8 @@ export interface SourceControlSession {
   materializedAt: Date | null;
   /** When the first user message reached the session's agent. Write-once. */
   firstMessageAt: Date | null;
+  /** When the agent's first successful sandbox exec finished. Write-once. */
+  firstMeaningfulExecAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -485,6 +488,13 @@ export interface SourceControlStorageHandle {
      * the session observer — only knows the controller resourceId.
      */
     markFirstMessage(args: { sessionId: string }): Promise<void>;
+    /**
+     * Record when the session's agent completed its first successful sandbox
+     * exec (TTFME anchor). Same write-once contract as `markFirstMessage`:
+     * guarded on the column being NULL, keyed by the controller-facing
+     * `sessionId`.
+     */
+    markFirstMeaningfulExec(args: { sessionId: string }): Promise<void>;
     delete(id: string): Promise<void>;
   };
 }
@@ -577,6 +587,7 @@ interface SessionDbRow extends Record<string, unknown> {
   sandbox_workdir: string | null;
   materialized_at: Date | null;
   first_message_at: Date | null;
+  first_meaningful_exec_at: Date | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -684,6 +695,7 @@ function toSession(row: SessionDbRow): SourceControlSession {
     sandboxWorkdir: row.sandbox_workdir,
     materializedAt: row.materialized_at,
     firstMessageAt: row.first_message_at,
+    firstMeaningfulExecAt: row.first_meaningful_exec_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -1275,6 +1287,15 @@ export class SourceControlStorage extends FactoryStorageDomain {
             SESSIONS,
             { session_id: sessionId, first_message_at: null },
             { first_message_at: new Date(), updated_at: new Date() },
+          );
+        },
+        markFirstMeaningfulExec: async ({ sessionId }) => {
+          // Same atomic one-shot shape as markFirstMessage: the NULL filter
+          // makes concurrent callers and later execs zero-row no-ops.
+          await db().updateMany(
+            SESSIONS,
+            { session_id: sessionId, first_meaningful_exec_at: null },
+            { first_meaningful_exec_at: new Date(), updated_at: new Date() },
           );
         },
         delete: async id => {

--- a/mastracode/factory/src/storage/domains/source-control/inmemory.ts
+++ b/mastracode/factory/src/storage/domains/source-control/inmemory.ts
@@ -494,6 +494,7 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
         sandboxWorkdir: null,
         materializedAt: null,
         firstMessageAt: null,
+        firstMeaningfulExecAt: null,
         createdAt: now,
         updatedAt: now,
       };
@@ -519,6 +520,12 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
     markFirstMessage: async ({ sessionId }: { sessionId: string }) => {
       const row = this.sessionsRows.find(candidate => candidate.sessionId === sessionId);
       if (row && row.firstMessageAt === null) Object.assign(row, { firstMessageAt: new Date(), updatedAt: new Date() });
+    },
+    markFirstMeaningfulExec: async ({ sessionId }: { sessionId: string }) => {
+      const row = this.sessionsRows.find(candidate => candidate.sessionId === sessionId);
+      if (row && row.firstMeaningfulExecAt === null) {
+        Object.assign(row, { firstMeaningfulExecAt: new Date(), updatedAt: new Date() });
+      }
     },
     delete: async (id: string) => {
       this.sessionsRows.splice(0, this.sessionsRows.length, ...this.sessionsRows.filter(row => row.id !== id));

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -96,7 +96,8 @@ type StreamChunk =
   | StreamDataChunk<'data-om-thread-update'>
   | StreamDataChunk<'data-mastracode-tool-progress'>
   | StreamDataChunk<'data-sandbox-stdout'>
-  | StreamDataChunk<'data-sandbox-stderr'>;
+  | StreamDataChunk<'data-sandbox-stderr'>
+  | StreamDataChunk<'data-sandbox-exit'>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -1132,6 +1133,20 @@ export class SessionRunEngine {
         const toolCallId = getString(d?.toolCallId);
         if (output && toolCallId) {
           this.#session.emit({ type: 'shell_output', toolCallId, output, stream: 'stderr' });
+        }
+        break;
+      }
+      case 'data-sandbox-exit': {
+        const d = getDataRecord(chunk);
+        const toolCallId = getString(d?.toolCallId);
+        const exitCode = getOptionalNumber(d?.exitCode);
+        if (toolCallId && exitCode !== undefined) {
+          this.#session.emit({
+            type: 'command_exit',
+            toolCallId,
+            exitCode,
+            success: getBoolean(d?.success, exitCode === 0),
+          });
         }
         break;
       }

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -785,6 +785,7 @@ export type AgentControllerEvent =
   | { type: 'tool_input_delta'; toolCallId: string; argsTextDelta: unknown; toolName?: string }
   | { type: 'tool_input_end'; toolCallId: string }
   | { type: 'shell_output'; toolCallId: string; output: string; stream: 'stdout' | 'stderr' }
+  | { type: 'command_exit'; toolCallId: string; exitCode: number; success: boolean }
   | { type: 'usage_update'; usage: TokenUsage }
   | { type: 'info'; message: string }
   | {


### PR DESCRIPTION
## Summary

Implements the TTFME (time-to-first-meaningful-exec) anchor from the TTFI/TTFME instrumentation design: a `first_meaningful_exec_at` column on `source_control_sessions`, recording when the session's agent completed its **first successful sandbox command**.

`first_message_at` (#21206) measures TTFI — when the agent started reasoning. That under-reports cold-start cost whenever the LLM thinks while the sandbox is still materializing. TTFME is the strict superset: it includes think time before the first tool call plus any materialize cost that didn't finish before the run started.

### What counts as "meaningful exec"

The first successful `WORKSPACE_ACTION` exec — i.e. the agent's own foreground `execute_command` tool call exiting with code 0. This is structural, no command classifier needed:

- Skill loader / preflight / materializer call `sandbox.executeCommand()` directly and never go through the tool, so platform setup commands can't count.
- Failed commands (nonzero exit) don't count — the observer stays subscribed until the first success.
- Background spawns (`spawnProcess`) are excluded.

### How it works

- **Core: new `command_exit` session event.** The `execute_command` tool already emits a `data-sandbox-exit` chunk carrying the exit code and success flag (the same value the `WORKSPACE_ACTION` span records), but the run engine consumed it without surfacing anything — and `tool_end.isError` can't stand in, because the tool returns normally on nonzero exit. The run engine now emits `command_exit { toolCallId, exitCode, success }`, symmetric with the existing `shell_output` event. This is a generally useful addition: session subscribers could previously stream a command's output but never tell whether it succeeded.
- **Factory: schema + write-once storage method.** `first_meaningful_exec_at timestamptz NULL` on `source_control_sessions` (auto-added on boot via the same `ADD COLUMN IF NOT EXISTS` path as `first_message_at`, no manual migration) and `sessions.markFirstMeaningfulExec({ sessionId })` with the same guarded atomic `UPDATE … WHERE first_meaningful_exec_at IS NULL` contract — concurrent callers, later execs, restarts, and sessions without a row are zero-row no-ops.
- **Factory: observer.** `observeSessionFirstExec` is wired in the same `onSessionCreated` hook as the first-message observer, covering all session kinds (user, work, review, channel). It marks on the first successful `command_exit`, then unsubscribes.
- **Read.** The value flows through all existing session read APIs; the TTFME KPI query is the TTFI query with the column substituted.

**Deviation from the design memo, called out explicitly:** the memo places the writer in `packages/core/.../execute-command.ts` doing the SQL UPDATE directly. Core cannot depend on factory storage (the dependency points the other way), so the write happens in a factory session observer at the same seam as #21206, fed by the new `command_exit` event. Semantics are identical to the memo's span-based definition — same source value, same structural setup-exec exclusion.

## Test plan

- New observer tests: marks on first successful `command_exit` and unsubscribes, skips failed commands and marks the first success only, warns instead of throwing on storage failure, respects early unsubscribe (`first-exec-capture.test.ts`, 4 tests).
- New storage test: `markFirstMeaningfulExec` is write-once, later calls don't move the timestamp, unknown session ids are no-ops (`base.test.ts`).
- Core: all 50 agent-controller test files pass (446 tests); the single remaining vitest error and the `tsc --noEmit` failure are the pre-existing `RunEvalsResult` evals type issue (verified identical with changes stashed).
- Factory: focused suites pass (27 tests across the three touched areas); `lint` clean; `oxfmt --check` clean on all touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This change records when an agent first runs a successful command in its workspace. It helps measure how long the agent takes to reach its first useful action.

## What changed

- Added the `command_exit` session event with:
  - `toolCallId`
  - `exitCode`
  - `success`
- Added the nullable `first_meaningful_exec_at` field to source-control sessions.
- Added write-once storage support through `sessions.markFirstMeaningfulExec`.
- Added a factory observer that:
  - Watches for successful `WORKSPACE_ACTION` commands.
  - Records the first successful command timestamp.
  - Unsubscribes after the first capture.
- Exposed the timestamp through existing session APIs and TTFME KPI queries.
- Added in-memory storage support and tests for write-once behavior.
- Added tests for successful capture, ignored commands, persistence errors, and unsubscribe behavior.
- Excluded failed commands, background processes, and direct platform setup commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->