### PR TITLE
fix(gcs,s3): create a real directory with mkdir()

### DIFF
--- a/.changeset/tricky-readers-agree.md
+++ b/.changeset/tricky-readers-agree.md
@@ -1,0 +1,13 @@
+---
+'@mastra/gcs': patch
+'@mastra/s3': patch
+---
+
+Fixed `mkdir()` on Google Cloud Storage and S3 workspaces. An empty directory is now created and stays visible to `readdir()`, `exists()` and `stat()` until you remove it with `rmdir()`.
+
+**Related fixes**
+
+- `readdir()` reports a nested directory as its first path segment. After `mkdir('/a/b')`, `readdir('/')` returns one entry named `a`.
+- A listing with `recursive` and `extension` returns files only. Directories no longer pass the extension filter.
+- A path with a trailing slash always means a directory. `stat('/x/')` and `isFile('/x/')` no longer match a file named `x`, and `readFile('/x/')` throws `FileNotFoundError` instead of returning empty content.
+- `mkdir()` works with a credential that can write but not read.

--- a/workspaces/gcs/src/filesystem/index.test.ts
+++ b/workspaces/gcs/src/filesystem/index.test.ts
@@ -485,6 +485,13 @@ describe('GCSFilesystem SDK Operations', () => {
       await expect(fs.readFile('/test.txt')).rejects.toThrow('Forbidden');
     });
 
+    it('throws FileNotFoundError for a trailing-slash directory path', async () => {
+      configureMockFile({ download: [Buffer.alloc(0)] });
+
+      await expect(fs.readFile('/logs/', { encoding: 'utf-8' })).rejects.toThrow(/logs/);
+      expect(mockFile.download).not.toHaveBeenCalled();
+    });
+
     it('applies prefix to key', async () => {
       const prefixMockFile = {
         download: vi.fn().mockResolvedValue([Buffer.from('data')]),
@@ -701,20 +708,105 @@ describe('GCSFilesystem SDK Operations', () => {
   });
 
   describe('mkdir()', () => {
-    it('is a no-op (GCS has no real directories)', async () => {
+    it('writes a zero-byte directory marker so empty directories are visible', async () => {
+      mockFile.exists.mockResolvedValueOnce([false]);
+
       await fs.mkdir('/new-dir');
 
-      // No SDK calls should be made
+      expect(mockBucket.file).toHaveBeenCalledWith('new-dir/');
+      const [body, options] = mockFile.save.mock.calls[0];
+      expect(body.length).toBe(0);
+      expect(options).toEqual({ resumable: false });
+    });
+
+    it('normalizes trailing slashes in the marker key', async () => {
+      mockFile.exists.mockResolvedValueOnce([false]);
+
+      await fs.mkdir('/nested/dir//');
+
+      expect(mockBucket.file).toHaveBeenCalledWith('nested/dir/');
+    });
+
+    it('does nothing for the root path', async () => {
+      await fs.mkdir('/');
+
       expect(mockBucket.file).not.toHaveBeenCalled();
+    });
+
+    it('throws FileExistsError when a file occupies the path', async () => {
+      mockFile.exists.mockResolvedValueOnce([true]);
+
+      await expect(fs.mkdir('/thing')).rejects.toThrow(/thing/);
+      expect(mockFile.save).not.toHaveBeenCalled();
+    });
+
+    it('writes one marker for a nested path', async () => {
+      mockFile.exists.mockResolvedValueOnce([false]);
+
+      await fs.mkdir('/a/b');
+
+      expect(mockBucket.file.mock.calls.map((call: unknown[]) => call[0])).toEqual(['a/b', 'a/b/']);
+      expect(mockFile.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('still writes the marker when the existence probe is denied', async () => {
+      mockFile.exists.mockRejectedValueOnce(Object.assign(new Error('Access denied'), { code: 403 }));
+
+      await fs.mkdir('/write-only');
+
+      expect(mockBucket.file).toHaveBeenCalledWith('write-only/');
+      expect(mockFile.save).toHaveBeenCalledTimes(1);
+      expect(fs.status).toBe('ready');
+    });
+
+    it('does nothing for the root path of a configured prefix', async () => {
+      const prefixFs = new GCSFilesystem({
+        bucket: 'test-bucket',
+        prefix: 'base',
+        credentials: { type: 'service_account', project_id: 'test' },
+      });
+      (prefixFs as any)._storage = {};
+      (prefixFs as any)._bucket = mockBucket;
+      (prefixFs as any).status = 'ready';
+
+      await prefixFs.mkdir('/');
+
+      expect(mockBucket.file).not.toHaveBeenCalled();
+      expect(mockFile.save).not.toHaveBeenCalled();
     });
   });
 
   describe('rmdir()', () => {
     it('throws if non-recursive and directory is not empty', async () => {
-      // getFiles with maxResults:1 returns a file → not empty
+      // getFiles returns a file → not empty
       mockBucket.getFiles.mockResolvedValueOnce([[{ name: 'dir/file.txt' }]]);
 
       await expect(fs.rmdir('/dir')).rejects.toThrow('Directory not empty');
+    });
+
+    it('deletes the directory marker of an empty directory', async () => {
+      mockBucket.getFiles.mockResolvedValueOnce([[{ name: 'dir/' }]]);
+
+      await fs.rmdir('/dir');
+
+      expect(mockBucket.file).toHaveBeenCalledWith('dir/');
+      expect(mockFile.delete).toHaveBeenCalledWith({ ignoreNotFound: true });
+    });
+
+    it('does nothing for the root path of a configured prefix', async () => {
+      const prefixFs = new GCSFilesystem({
+        bucket: 'test-bucket',
+        prefix: 'base',
+        credentials: { type: 'service_account', project_id: 'test' },
+      });
+      (prefixFs as any)._storage = {};
+      (prefixFs as any)._bucket = mockBucket;
+      (prefixFs as any).status = 'ready';
+      mockBucket.getFiles.mockResolvedValueOnce([[{ name: 'base/' }]]);
+
+      await prefixFs.rmdir('/');
+
+      expect(mockFile.delete).not.toHaveBeenCalled();
     });
 
     it('recursive calls bucket.deleteFiles with prefix', async () => {
@@ -771,6 +863,23 @@ describe('GCSFilesystem SDK Operations', () => {
       expect(entries).toContainEqual({ name: 'file.txt', type: 'file', size: 50 });
     });
 
+    it('rolls a nested directory marker up to its first segment', async () => {
+      // mkdir('/a/b') writes the single key 'a/b/'
+      mockBucket.getFiles.mockResolvedValueOnce([[{ name: 'a/b/', metadata: { size: 0 } }]]);
+
+      const entries = await fs.readdir('/');
+
+      expect(entries).toEqual([{ name: 'a', type: 'directory' }]);
+    });
+
+    it('reports the full path of a nested directory marker when recursive', async () => {
+      mockBucket.getFiles.mockResolvedValueOnce([[{ name: 'a/b/', metadata: { size: 0 } }]]);
+
+      const entries = await fs.readdir('/', { recursive: true });
+
+      expect(entries).toEqual([{ name: 'a/b', type: 'directory' }]);
+    });
+
     it('filters by extension', async () => {
       mockBucket.getFiles.mockResolvedValueOnce([
         [
@@ -783,6 +892,19 @@ describe('GCSFilesystem SDK Operations', () => {
 
       expect(entries).toHaveLength(1);
       expect(entries[0]!.name).toBe('b.ts');
+    });
+
+    it('excludes directory markers from a recursive listing filtered by extension', async () => {
+      mockBucket.getFiles.mockResolvedValueOnce([
+        [
+          { name: 'notes/', metadata: { size: 0 } },
+          { name: 'notes/a.md', metadata: { size: 1 } },
+        ],
+      ]);
+
+      const entries = await fs.readdir('/', { recursive: true, extension: '.md' });
+
+      expect(entries).toEqual([{ name: 'notes/a.md', type: 'file', size: 1 }]);
     });
 
     it('deduplicates directory entries', async () => {
@@ -966,6 +1088,20 @@ describe('GCSFilesystem SDK Operations', () => {
       expect(stat.type).toBe('directory');
       expect(stat.name).toBe('mydir');
       expect(stat.size).toBe(0);
+    });
+
+    it('treats a trailing slash as a directory even when a file has the same name', async () => {
+      const mockFile = mockBucket.file();
+      mockFile.exists.mockResolvedValue([true]);
+      // isDirectory: has contents
+      mockBucket.getFiles.mockResolvedValueOnce([[{ name: 'report/file.txt' }]]);
+
+      const stat = await fs.stat('/report/');
+
+      expect(stat.type).toBe('directory');
+      expect(stat.name).toBe('report');
+      expect(mockFile.getMetadata).not.toHaveBeenCalled();
+      expect(await fs.isFile('/report/')).toBe(false);
     });
 
     it('throws FileNotFoundError when nothing exists', async () => {

--- a/workspaces/gcs/src/filesystem/index.ts
+++ b/workspaces/gcs/src/filesystem/index.ts
@@ -368,6 +368,11 @@ export class GCSFilesystem extends MastraFilesystem {
   // ---------------------------------------------------------------------------
 
   async readFile(path: string, options?: ReadOptions): Promise<string | Buffer> {
+    // A trailing slash means a directory: never return the empty body of a directory marker
+    if (path.endsWith('/')) {
+      throw new FileNotFoundError(path);
+    }
+
     const bucket = await this.getReadyBucket();
     const file = bucket.file(this.toKey(path));
 
@@ -444,6 +449,11 @@ export class GCSFilesystem extends MastraFilesystem {
   }
 
   async copyFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
+    // A trailing slash means a directory: never copy a directory marker as a file
+    if (src.endsWith('/')) {
+      throw new FileNotFoundError(src);
+    }
+
     const bucket = await this.getReadyBucket();
     const srcFile = bucket.file(this.toKey(src));
     const destFile = bucket.file(this.toKey(dest));
@@ -471,19 +481,46 @@ export class GCSFilesystem extends MastraFilesystem {
   // Directory Operations
   // ---------------------------------------------------------------------------
 
-  async mkdir(_path: string, _options?: { recursive?: boolean }): Promise<void> {
-    // GCS doesn't have real directories - they're just key prefixes
-    // No-op, directories are created implicitly when files are written
+  async mkdir(path: string, _options?: { recursive?: boolean }): Promise<void> {
+    // GCS doesn't have real directories - they're just key prefixes.
+    // Write a zero-byte marker object at "<key>/" (the convention the GCS console uses)
+    // so an empty directory is visible to readdir(), exists() and stat().
+    // Parent directories need no marker of their own: the marker key already
+    // matches every parent prefix, so nested paths work without `recursive`.
+    const key = trimSlashes(this.toKey(path));
+    if (!key || key + '/' === this.prefix) return; // Root always exists
+
+    const bucket = await this.getReadyBucket();
+
+    // A file already occupies this path. A credential that can write but not read
+    // cannot probe, so treat a failed probe as "no file there" and let the write below
+    // report a real problem.
+    let fileExists = false;
+    try {
+      [fileExists] = await bucket.file(key).exists();
+    } catch {
+      fileExists = false;
+    }
+    if (fileExists) {
+      throw new FileExistsError(path);
+    }
+
+    await bucket.file(key + '/').save(Buffer.alloc(0), { resumable: false });
   }
 
   async rmdir(path: string, options?: RemoveOptions): Promise<void> {
     if (!options?.recursive) {
-      // Quick emptiness check — only fetch one object instead of full readdir
+      // Quick emptiness check — only the directory marker itself may remain
       const bucket = await this.getReadyBucket();
-      const prefix = this.toKey(path).replace(/\/$/, '') + '/';
-      const [files] = await bucket.getFiles({ prefix, maxResults: 1 });
-      if (files.length > 0) {
+      const key = trimSlashes(this.toKey(path));
+      const prefix = key + '/';
+      const [files] = await bucket.getFiles({ prefix, maxResults: 2 });
+      if (files.some(file => file.name !== prefix)) {
         throw new Error(`Directory not empty: ${path}`);
+      }
+      // Remove the directory marker so the empty directory disappears
+      if (key && prefix !== this.prefix) {
+        await bucket.file(prefix).delete({ ignoreNotFound: true });
       }
       return;
     }
@@ -518,7 +555,13 @@ export class GCSFilesystem extends MastraFilesystem {
 
       // Skip if this looks like a directory marker
       if (relativePath.endsWith('/')) {
-        const dirName = relativePath.slice(0, -1);
+        // A directory is not a file, so an extension filter must exclude it. Only a
+        // recursive listing reaches this branch for a nested marker.
+        if (options?.recursive && options.extension) continue;
+        // A nested marker such as "a/b/" belongs to the directory "a" in a
+        // non-recursive listing; only a recursive listing reports the full path.
+        const dirName = options?.recursive ? relativePath.slice(0, -1) : relativePath.split('/')[0]!;
+        if (!dirName) continue;
         if (!seenDirs.has(dirName)) {
           seenDirs.add(dirName);
           entries.push({ name: dirName, type: 'directory' });
@@ -585,7 +628,10 @@ export class GCSFilesystem extends MastraFilesystem {
   }
 
   async stat(path: string): Promise<FileStat> {
-    const key = this.toKey(path);
+    // The key never keeps a trailing slash, so a lookup never matches a directory marker
+    const key = trimSlashes(this.toKey(path));
+    // A trailing slash always means a directory, so never look for a file
+    const directoryOnly = path.endsWith('/');
 
     // Root path is always a directory
     if (!key) {
@@ -601,11 +647,11 @@ export class GCSFilesystem extends MastraFilesystem {
 
     const bucket = await this.getReadyBucket();
     const file = bucket.file(key);
+    const name = key.split('/').pop() ?? '';
 
-    const [exists] = await file.exists();
+    const [exists] = directoryOnly ? [false] : await file.exists();
     if (exists) {
       const [metadata] = await file.getMetadata();
-      const name = path.split('/').pop() ?? '';
 
       return {
         name,
@@ -622,7 +668,6 @@ export class GCSFilesystem extends MastraFilesystem {
     // Check if it's a directory
     const isDir = await this.isDirectory(path);
     if (isDir) {
-      const name = path.split('/').filter(Boolean).pop() ?? '';
       return {
         name,
         path,
@@ -637,7 +682,11 @@ export class GCSFilesystem extends MastraFilesystem {
   }
 
   async isFile(path: string): Promise<boolean> {
-    const key = this.toKey(path);
+    // A trailing slash always means a directory
+    if (path.endsWith('/')) return false;
+
+    // The key never keeps a trailing slash, so a lookup never matches a directory marker
+    const key = trimSlashes(this.toKey(path));
     if (!key) return false; // Root is a directory, not a file
 
     const bucket = await this.getReadyBucket();

--- a/workspaces/s3/src/filesystem/index.test.ts
+++ b/workspaces/s3/src/filesystem/index.test.ts
@@ -847,6 +847,16 @@ describe('S3Filesystem SDK Operations', () => {
       await expect(fs.readFile('/empty.txt')).rejects.toThrow(/empty\.txt/);
     });
 
+    it('throws FileNotFoundError for a trailing-slash directory path', async () => {
+      // The directory marker is a real zero-byte object
+      mockSend.mockResolvedValueOnce({
+        Body: { transformToByteArray: () => Promise.resolve(new Uint8Array(0)) },
+      });
+
+      await expect(fs.readFile('/logs/', { encoding: 'utf-8' })).rejects.toThrow(/logs/);
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
     it('applies prefix to key', async () => {
       const { GetObjectCommand } = await import('@aws-sdk/client-s3');
       const prefixFs = new S3Filesystem({
@@ -1066,15 +1076,124 @@ describe('S3Filesystem SDK Operations', () => {
   });
 
   describe('mkdir()', () => {
-    it('is a no-op (S3 has no real directories)', async () => {
+    it('writes a zero-byte directory marker so empty directories are visible', async () => {
+      const { PutObjectCommand } = await import('@aws-sdk/client-s3');
+      vi.mocked(PutObjectCommand).mockClear();
+
+      mockSend.mockRejectedValueOnce({ name: 'NotFound' }); // HeadObject: no file at this path
+      mockSend.mockResolvedValueOnce({}); // PutObject: marker
+
       await fs.mkdir('/new-dir');
 
-      // No SDK calls should be made
+      const args = vi.mocked(PutObjectCommand).mock.calls[0]![0]!;
+      expect(args.Bucket).toBe('test-bucket');
+      expect(args.Key).toBe('new-dir/');
+      expect((args.Body as Uint8Array).length).toBe(0);
+    });
+
+    it('normalizes trailing slashes in the marker key', async () => {
+      const { PutObjectCommand } = await import('@aws-sdk/client-s3');
+      vi.mocked(PutObjectCommand).mockClear();
+
+      mockSend.mockRejectedValueOnce({ name: 'NotFound' });
+      mockSend.mockResolvedValueOnce({});
+
+      await fs.mkdir('/nested/dir//');
+
+      expect(vi.mocked(PutObjectCommand).mock.calls[0]![0]!.Key).toBe('nested/dir/');
+    });
+
+    it('does nothing for the root path', async () => {
+      await fs.mkdir('/');
+
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('throws FileExistsError when a file occupies the path', async () => {
+      mockSend.mockResolvedValueOnce({ ContentLength: 5 }); // HeadObject: a file is there
+
+      await expect(fs.mkdir('/thing')).rejects.toThrow(/thing/);
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes one marker for a nested path', async () => {
+      const { PutObjectCommand } = await import('@aws-sdk/client-s3');
+      vi.mocked(PutObjectCommand).mockClear();
+
+      mockSend.mockRejectedValueOnce({ name: 'NotFound' });
+      mockSend.mockResolvedValueOnce({});
+
+      await fs.mkdir('/a/b');
+
+      expect(vi.mocked(PutObjectCommand).mock.calls).toHaveLength(1);
+      expect(vi.mocked(PutObjectCommand).mock.calls[0]![0]!.Key).toBe('a/b/');
+    });
+
+    it('still writes the marker when the existence probe is denied', async () => {
+      const { PutObjectCommand } = await import('@aws-sdk/client-s3');
+      vi.mocked(PutObjectCommand).mockClear();
+
+      // HeadObject: write-only credentials answer 403 instead of 404
+      mockSend.mockRejectedValueOnce({ name: 'AccessDenied', $metadata: { httpStatusCode: 403 } });
+      mockSend.mockResolvedValueOnce({}); // PutObject: marker
+
+      await fs.mkdir('/write-only');
+
+      expect(vi.mocked(PutObjectCommand).mock.calls[0]![0]!.Key).toBe('write-only/');
+      expect(fs.status).toBe('ready');
+    });
+
+    it('does nothing for the root path of a configured prefix', async () => {
+      const prefixFs = new S3Filesystem({
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        accessKeyId: 'k',
+        secretAccessKey: 's',
+        prefix: 'base',
+      });
+      (prefixFs as any)._client = { send: mockSend };
+      (prefixFs as any).status = 'ready';
+
+      await prefixFs.mkdir('/');
+
       expect(mockSend).not.toHaveBeenCalled();
     });
   });
 
   describe('rmdir()', () => {
+    it('deletes the directory marker of an empty directory', async () => {
+      const { DeleteObjectCommand } = await import('@aws-sdk/client-s3');
+      vi.mocked(DeleteObjectCommand).mockClear();
+
+      // readdir: only the directory marker itself
+      mockSend.mockResolvedValueOnce({ Contents: [{ Key: 'dir/', Size: 0 }], CommonPrefixes: [] });
+      mockSend.mockResolvedValueOnce({}); // DeleteObject: marker
+
+      await fs.rmdir('/dir');
+
+      expect(DeleteObjectCommand).toHaveBeenCalledWith({ Bucket: 'test-bucket', Key: 'dir/' });
+    });
+
+    it('does nothing for the root path of a configured prefix', async () => {
+      const { DeleteObjectCommand } = await import('@aws-sdk/client-s3');
+      vi.mocked(DeleteObjectCommand).mockClear();
+      const prefixFs = new S3Filesystem({
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        accessKeyId: 'k',
+        secretAccessKey: 's',
+        prefix: 'base',
+      });
+      (prefixFs as any)._client = { send: mockSend };
+      (prefixFs as any).status = 'ready';
+      // readdir: empty mount root
+      mockSend.mockResolvedValueOnce({ Contents: [], CommonPrefixes: [] });
+
+      await prefixFs.rmdir('/');
+
+      expect(DeleteObjectCommand).not.toHaveBeenCalled();
+    });
+
     it('throws if non-recursive and directory is not empty', async () => {
       // readdir: ListObjectsV2 returns files
       mockSend.mockResolvedValueOnce({
@@ -1199,6 +1318,28 @@ describe('S3Filesystem SDK Operations', () => {
 
       expect(entries).toContainEqual({ name: 'mydir', type: 'directory' });
       expect(entries).toContainEqual({ name: 'file.txt', type: 'file', size: 100 });
+    });
+
+    it('rolls a nested directory marker up to its first segment', async () => {
+      // A recursive listing has no delimiter, so a nested marker reaches Contents
+      mockSend.mockResolvedValueOnce({ Contents: [{ Key: 'a/b/', Size: 0 }], CommonPrefixes: [] });
+
+      const entries = await fs.readdir('/');
+
+      expect(entries).toEqual([{ name: 'a', type: 'directory' }]);
+    });
+
+    it('excludes directory markers from a recursive listing filtered by extension', async () => {
+      mockSend.mockResolvedValueOnce({
+        Contents: [
+          { Key: 'notes/', Size: 0 },
+          { Key: 'notes/a.md', Size: 1 },
+        ],
+      });
+
+      const entries = await fs.readdir('/', { recursive: true, extension: '.md' });
+
+      expect(entries).toEqual([{ name: 'notes/a.md', type: 'file', size: 1 }]);
     });
 
     it('skips empty relative paths and searchPrefix itself', async () => {
@@ -1350,6 +1491,18 @@ describe('S3Filesystem SDK Operations', () => {
       mockSend.mockResolvedValueOnce({ Contents: [] });
 
       await expect(fs.stat('/missing')).rejects.toThrow(/missing/);
+    });
+
+    it('treats a trailing slash as a directory even when a file has the same name', async () => {
+      // isDirectory: ListObjectsV2 finds contents. No HeadObject is sent
+      mockSend.mockResolvedValueOnce({ Contents: [{ Key: 'report/file.txt' }] });
+
+      const stat = await fs.stat('/report/');
+
+      expect(stat.type).toBe('directory');
+      expect(stat.name).toBe('report');
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(await fs.isFile('/report/')).toBe(false);
     });
   });
 });

--- a/workspaces/s3/src/filesystem/index.ts
+++ b/workspaces/s3/src/filesystem/index.ts
@@ -515,6 +515,11 @@ export class S3Filesystem extends MastraFilesystem {
   // ---------------------------------------------------------------------------
 
   async readFile(path: string, options?: ReadOptions): Promise<string | Buffer> {
+    // A trailing slash means a directory: never return the empty body of a directory marker
+    if (path.endsWith('/')) {
+      throw new FileNotFoundError(path);
+    }
+
     const client = await this.getReadyClient();
 
     try {
@@ -605,6 +610,11 @@ export class S3Filesystem extends MastraFilesystem {
   }
 
   async copyFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
+    // A trailing slash means a directory: never copy a directory marker as a file
+    if (src.endsWith('/')) {
+      throw new FileNotFoundError(src);
+    }
+
     const client = await this.getReadyClient();
 
     if (options?.overwrite === false && (await this.exists(dest))) {
@@ -636,17 +646,53 @@ export class S3Filesystem extends MastraFilesystem {
   // Directory Operations
   // ---------------------------------------------------------------------------
 
-  async mkdir(_path: string, _options?: { recursive?: boolean }): Promise<void> {
-    // S3 doesn't have real directories - they're just key prefixes
-    // No-op, directories are created implicitly when files are written
+  async mkdir(path: string, _options?: { recursive?: boolean }): Promise<void> {
+    // S3 doesn't have real directories - they're just key prefixes.
+    // Write a zero-byte marker object at "<key>/" (the convention the S3 console uses)
+    // so an empty directory is visible to readdir(), exists() and stat().
+    // Parent directories need no marker of their own: the marker key already
+    // matches every parent prefix, so nested paths work without `recursive`.
+    const key = trimSlashes(this.toKey(path));
+    if (!key || key + '/' === this.prefix) return; // Root always exists
+
+    const client = await this.getReadyClient();
+
+    // A file already occupies this path. A credential that can write but not read
+    // cannot probe, so treat a failed probe as "no file there" and let the write below
+    // report a real problem.
+    try {
+      await client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: key }));
+      throw new FileExistsError(path);
+    } catch (error: unknown) {
+      if (error instanceof FileExistsError) throw error;
+    }
+
+    await client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key + '/',
+        Body: new Uint8Array(0),
+      }),
+    );
   }
 
   async rmdir(path: string, options?: RemoveOptions): Promise<void> {
     if (!options?.recursive) {
-      // Check if directory is empty
+      // Check if directory is empty (the directory marker is not listed as an entry)
       const entries = await this.readdir(path);
       if (entries.length > 0) {
         throw new Error(`Directory not empty: ${path}`);
+      }
+      // Remove the directory marker so the empty directory disappears
+      const key = trimSlashes(this.toKey(path));
+      if (key && key + '/' !== this.prefix) {
+        const client = await this.getReadyClient();
+        await client.send(
+          new DeleteObjectCommand({
+            Bucket: this.bucket,
+            Key: key + '/',
+          }),
+        );
       }
       return;
     }
@@ -717,7 +763,13 @@ export class S3Filesystem extends MastraFilesystem {
 
           // Skip if this looks like a directory marker
           if (relativePath.endsWith('/')) {
-            const dirName = relativePath.slice(0, -1);
+            // A directory is not a file, so an extension filter must exclude it. Only a
+            // recursive listing reaches this branch for a nested marker.
+            if (options?.recursive && options.extension) continue;
+            // A nested marker such as "a/b/" belongs to the directory "a" in a
+            // non-recursive listing; only a recursive listing reports the full path.
+            const dirName = options?.recursive ? relativePath.slice(0, -1) : relativePath.split('/')[0]!;
+            if (!dirName) continue;
             if (!seenDirs.has(dirName)) {
               seenDirs.add(dirName);
               entries.push({ name: dirName, type: 'directory' });
@@ -801,7 +853,10 @@ export class S3Filesystem extends MastraFilesystem {
   }
 
   async stat(path: string): Promise<FileStat> {
-    const key = this.toKey(path);
+    // The key never keeps a trailing slash, so a lookup never matches a directory marker
+    const key = trimSlashes(this.toKey(path));
+    // A trailing slash always means a directory, so never look for a file
+    const directoryOnly = path.endsWith('/');
 
     // Root is always a directory
     if (!key) {
@@ -815,46 +870,53 @@ export class S3Filesystem extends MastraFilesystem {
       };
     }
 
-    const client = await this.getReadyClient();
+    const name = key.split('/').pop() ?? '';
 
-    try {
-      const response: { ContentLength?: number; LastModified?: Date } = await client.send(
-        new HeadObjectCommand({
-          Bucket: this.bucket,
-          Key: key,
-        }),
-      );
+    if (!directoryOnly) {
+      const client = await this.getReadyClient();
 
-      const name = path.split('/').pop() ?? '';
-      return {
-        name,
-        path,
-        type: 'file',
-        size: response.ContentLength ?? 0,
-        createdAt: response.LastModified ?? new Date(),
-        modifiedAt: response.LastModified ?? new Date(),
-      };
-    } catch (error: unknown) {
-      if (!isNotFoundError(error)) throw this.handleError(error);
-      // Check if it's a directory
-      const isDir = await this.isDirectory(path);
-      if (isDir) {
-        const name = path.split('/').filter(Boolean).pop() ?? '';
+      try {
+        const response: { ContentLength?: number; LastModified?: Date } = await client.send(
+          new HeadObjectCommand({
+            Bucket: this.bucket,
+            Key: key,
+          }),
+        );
+
         return {
           name,
           path,
-          type: 'directory',
-          size: 0,
-          createdAt: new Date(),
-          modifiedAt: new Date(),
+          type: 'file',
+          size: response.ContentLength ?? 0,
+          createdAt: response.LastModified ?? new Date(),
+          modifiedAt: response.LastModified ?? new Date(),
         };
+      } catch (error: unknown) {
+        if (!isNotFoundError(error)) throw this.handleError(error);
       }
-      throw new FileNotFoundError(path);
     }
+
+    // Check if it's a directory
+    const isDir = await this.isDirectory(path);
+    if (isDir) {
+      return {
+        name,
+        path,
+        type: 'directory',
+        size: 0,
+        createdAt: new Date(),
+        modifiedAt: new Date(),
+      };
+    }
+    throw new FileNotFoundError(path);
   }
 
   async isFile(path: string): Promise<boolean> {
-    const key = this.toKey(path);
+    // A trailing slash always means a directory
+    if (path.endsWith('/')) return false;
+
+    // The key never keeps a trailing slash, so a lookup never matches a directory marker
+    const key = trimSlashes(this.toKey(path));
     if (!key) return false; // Root is a directory, not a file
 
     const client = await this.getReadyClient();


### PR DESCRIPTION
## Description

`mkdir()` on the GCS and S3 workspace filesystems was an empty stub. An empty directory did not exist after the call, so `readdir()`, `exists()` and `stat()` did not report it.

`mkdir()` now writes a zero-byte marker object at `<key>/`, the convention the GCS and S3 consoles use. A nested path needs no `recursive` flag, because the marker key already matches every parent prefix. `rmdir()` deletes the marker and still rejects a directory that holds other objects.

Handling the marker exposed four related defects, fixed here as well:

- `readdir()` reports a nested directory as its first path segment. After `mkdir('/a/b')`, `readdir('/')` returns one entry named `a`, not `a/b`.
- A listing with `recursive` and `extension` returns files only. A directory no longer passes the extension filter.
- A path with a trailing slash always means a directory. `stat('/x/')` and `isFile('/x/')` no longer match a file named `x`, and `readFile('/x/')` and `copyFile('/x/', ...)` throw `FileNotFoundError` instead of returning or copying the empty marker body.
- `mkdir()` works with a credential that can write but not read. A failed existence probe is treated as "no file there".

## Related issue(s)

Fixes #21167

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- `@mastra/gcs` unit tests: 89 passed (80 before).
- `@mastra/s3` unit tests: 140 passed, 17 skipped (132 before).
- Each new test was confirmed to fail without the source change.
- `tsc --noEmit` and prettier are clean for both packages.
- Integration tests against a real bucket or MinIO were not run.

## Notes

Review order: `workspaces/gcs/src/filesystem/index.ts` first; the S3 file makes the same changes against the AWS SDK.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

`mkdir()` now creates visible empty folders in GCS and S3. The filesystems also correctly list, inspect, and remove these folders.

## Changes

- Create zero-byte directory markers at `<key>/`.
- Support nested directories without `recursive`.
- Remove empty directory markers with `rmdir()`.
- Reject non-empty directories during non-recursive removal.
- Recognize directory markers in `readdir()`, `exists()`, and `stat()`.
- Treat trailing-slash paths as directories.
- List nested directories by their first path segment.
- Exclude directory markers from recursive extension-filtered file listings.
- Allow `mkdir()` when credentials can write but cannot read.
- Add comprehensive GCS and S3 test coverage.

## Validation

- GCS: 89 tests passed.
- S3: 140 tests passed, 17 skipped.
- TypeScript checks and formatting passed.
- Real-bucket and MinIO integration tests were not run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->