### PR TITLE
chore(core,factory-ui): fix stale comments about stream message identity

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -613,10 +613,10 @@ function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]):
 
   const reconciled = reconcileToolResults(adoptCoveringWindowCopies(state, messages), messages);
 
-  // A streamed turn and its persisted copy carry different message ids (the
-  // engine mints display ids independently of what MessageList persists), so
-  // identity falls back to shared toolCallIds — inserting such a window message
-  // would duplicate a turn that reconcileToolResults already heals in place.
+  // Streamed turns adopt the loop's persisted message id (#21185), so window
+  // copies normally match by id; the shared-toolCallId fallback covers paths
+  // that can still diverge (retries, resume, older servers) — inserting such a
+  // window message would duplicate a turn reconcileToolResults heals in place.
   const entryToolCallIds = reconciled.entries.map(entry =>
     entry.kind === 'message' && entry.message.role === 'assistant'
       ? new Set(toolCallIdsOf(entry.message.content.parts))

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -415,7 +415,8 @@ export class SessionRunEngine {
   }
 
   /**
-   * Process a stream response (shared between sendMessage and tool approval).
+   * Process a stream response. Production runs stream through
+   * `processSubscribedThreadStream`; only tests call this entry directly.
    */
   async processStream(
     response: { fullStream: AsyncIterable<StreamChunk> },

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3014,7 +3014,8 @@ export class Session<TState = unknown> {
   /**
    * Consume an agent stream response, folding chunks into this session's display
    * messages and usage and driving tool approval. Delegates to the per-session
-   * run engine. Used by the initial run path and tool resume.
+   * run engine. Production runs go through `processSubscribedThreadStream`;
+   * only tests call this directly.
    */
   processStream(
     response: { fullStream: AsyncIterable<any> },


### PR DESCRIPTION
Comment-only follow-up to #21185. Two docs were still claiming the opposite of what the code does: the merge fallback in factory-ui's transcript service said streamed and persisted turns always carry different message ids, when they now share the loop's response message id and the toolCallId fallback only covers paths that can still diverge (retries, resume, older servers). The comment now says that.

Session.processStream and the engine's processStream also claimed to serve the initial run path, sendMessage and tool resume. Nothing in production calls them — runs go through processSubscribedThreadStream — so their docs now say they're test-only entries. I left the methods in place since they're public API and the test suites drive the engine through them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates comments so developers can understand how message IDs and stream-processing methods work. It also explains which stream-processing methods production and tests should use.

## Changes

- Clarified message ID handling in `mergeServerWindow`.
  - Persisted turns generally use the streamed response message ID.
  - The `toolCallId` fallback supports retries, resumed runs, and older servers.
- Documented that `Session.processStream` and the engine’s `processStream` are test-only entry points.
- Documented that production uses `processSubscribedThreadStream`.
- Kept the public methods unchanged because test suites use them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->