### PR TITLE
fix(factory): recover repo-backed Slack sessions from stale connections, chat-only remote deploys, and top-level DMs

### DIFF
--- a/.changeset/calm-otters-resolve.md
+++ b/.changeset/calm-otters-resolve.md
@@ -1,0 +1,11 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Slack threads on cloud factory deployments falling back to chat-only sessions or erroring instead of getting a repo-backed workspace.
+
+Three fixes:
+
+- Repository resolution now tries every source-control connection on a factory project and skips connections that no longer resolve. Previously it took the first connection and failed outright when that row was stale (for example after a GitHub App reinstall deleted the old installation but left its connection behind), which silently dropped every Slack thread to a chat-only session even though a healthy connection existed.
+- Chat-only sessions on deployments configured with a remote sandbox now run without a workspace instead of replying with "A Factory session ID is required to create a remote sandbox workspace" on every message. The server host never executes commands for these sessions; workspace tools are simply not registered.
+- Top-level DM and channel conversations (threads with no thread timestamp) now derive their session branch from the channel id instead of producing the invalid git ref `slack/`, which made every top-level DM session fail its clone.

--- a/.changeset/calm-otters-resolve.md
+++ b/.changeset/calm-otters-resolve.md
@@ -4,8 +4,6 @@
 
 Fixed Slack threads on cloud factory deployments falling back to chat-only sessions or erroring instead of getting a repo-backed workspace.
 
-Three fixes:
-
-- Repository resolution now tries every source-control connection on a factory project and skips connections that no longer resolve. Previously it took the first connection and failed outright when that row was stale (for example after a GitHub App reinstall deleted the old installation but left its connection behind), which silently dropped every Slack thread to a chat-only session even though a healthy connection existed.
-- Chat-only sessions on deployments configured with a remote sandbox now run without a workspace instead of replying with "A Factory session ID is required to create a remote sandbox workspace" on every message. The server host never executes commands for these sessions; workspace tools are simply not registered.
-- Top-level DM and channel conversations (threads with no thread timestamp) now derive their session branch from the channel id instead of producing the invalid git ref `slack/`, which made every top-level DM session fail its clone.
+- Fixed repository resolution failing when a factory project carries a stale source-control connection (for example after a GitHub App reinstall deleted the old installation but left its connection behind). Resolution now tries every connection and skips the ones that no longer resolve.
+- Fixed chat-only sessions on deployments configured with a remote sandbox replying with "A Factory session ID is required to create a remote sandbox workspace" on every message. These sessions now run without a workspace, so workspace tools are simply not registered and the server host never executes commands for them.
+- Fixed top-level DM and channel conversations (threads with no thread timestamp) failing their clone with the invalid git ref `slack/`. Their session branch now derives from the channel id.

--- a/mastracode/factory/src/integrations/slack/slack.test.ts
+++ b/mastracode/factory/src/integrations/slack/slack.test.ts
@@ -448,15 +448,16 @@ describe('repo-backed thread sessions (resolveResourceId)', () => {
   // Top-level DM and channel conversations use the empty-threadTs thread form
   // (`slack:D-1:`), which previously derived the invalid git ref `slack/` and
   // made every top-level DM session fail its clone.
-  it('a top-level conversation thread (empty threadTs) derives its branch from the channel id', async () => {
+  it.each([
+    { id: 'slack:D-1:', branch: 'slack/D-1' },
+    { id: 'slack:C-1:', branch: 'slack/C-1' },
+  ])('a top-level conversation thread (empty threadTs) derives its branch from the channel id ($id)', async ({ id, branch }) => {
     const deps = makeResolverDeps();
     const resolve = createChannelResourceIdResolver(deps as any);
 
-    await expect(resolve(resolveArgs({ id: 'slack:D-1:' }))).resolves.toBe('us-new');
+    await expect(resolve(resolveArgs({ id }))).resolves.toBe('us-new');
 
-    expect(deps.sourceControl.sessions.create).toHaveBeenCalledWith(
-      expect.objectContaining({ branch: 'slack/D-1' }),
-    );
+    expect(deps.sourceControl.sessions.create).toHaveBeenCalledWith(expect.objectContaining({ branch }));
   });
 
   it('a repeat message on the same thread reuses the existing session, no second row', async () => {

--- a/mastracode/factory/src/integrations/slack/slack.test.ts
+++ b/mastracode/factory/src/integrations/slack/slack.test.ts
@@ -445,6 +445,20 @@ describe('repo-backed thread sessions (resolveResourceId)', () => {
     });
   });
 
+  // Top-level DM and channel conversations use the empty-threadTs thread form
+  // (`slack:D-1:`), which previously derived the invalid git ref `slack/` and
+  // made every top-level DM session fail its clone.
+  it('a top-level conversation thread (empty threadTs) derives its branch from the channel id', async () => {
+    const deps = makeResolverDeps();
+    const resolve = createChannelResourceIdResolver(deps as any);
+
+    await expect(resolve(resolveArgs({ id: 'slack:D-1:' }))).resolves.toBe('us-new');
+
+    expect(deps.sourceControl.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({ branch: 'slack/D-1' }),
+    );
+  });
+
   it('a repeat message on the same thread reuses the existing session, no second row', async () => {
     const sourceControl = makeSourceControl({ existingSession: { sessionId: 'us-existing' } });
     const deps = makeResolverDeps({ sourceControl });

--- a/mastracode/factory/src/integrations/slack/slack.ts
+++ b/mastracode/factory/src/integrations/slack/slack.ts
@@ -272,10 +272,16 @@ export async function resolveFactoryForLink({
  * outside the sandbox git-ref allow-list (`[A-Za-z0-9_./-]`, and `.` for
  * readability) mapped to `-`. `thread.id` is `{channelId}:{threadTs}`
  * (platform-prefixed on handler threads) — the trailing segment is the ts.
+ *
+ * Top-level DM and channel conversations use the empty-threadTs thread form,
+ * so the trailing segment can be empty; a bare `slack/` is not a valid git
+ * ref. Fall back to the last non-empty segment (the channel id): one
+ * deterministic branch per top-level conversation.
  */
 function threadBranch(threadId: string): string {
-  const ts = threadId.split(':').at(-1) ?? threadId;
-  return `slack/${ts.replace(/[^A-Za-z0-9_/-]/g, '-')}`;
+  const segments = threadId.split(':');
+  const tail = segments.findLast(segment => segment.length > 0) ?? threadId;
+  return `slack/${tail.replace(/[^A-Za-z0-9_/-]/g, '-')}`;
 }
 
 /**

--- a/mastracode/factory/src/rules/start-coordinator.ts
+++ b/mastracode/factory/src/rules/start-coordinator.ts
@@ -65,7 +65,7 @@ async function resolveKickoffMessage(
   if (!invocation) return null;
   if (invocation.type === 'prompt') return invocation.prompt;
 
-  const skills = session.getWorkspace().skills;
+  const skills = session.getWorkspace()?.skills;
   await skills?.maybeRefresh();
   const skill = await skills?.get(invocation.skillName);
   if (!skill || skill['user-invocable'] === false) {

--- a/mastracode/factory/src/session/factory-session.test.ts
+++ b/mastracode/factory/src/session/factory-session.test.ts
@@ -313,6 +313,106 @@ describe('resolveFactorySourceRepository', () => {
       resolveFactorySourceRepository({ sourceControl, orgId: 'org-1', factoryProjectId: project.id }),
     ).resolves.toMatchObject({ found: true });
   });
+
+  // A provider-app reinstall deletes the installation but leaves the old
+  // connection row behind. That stale connection must not shadow the healthy
+  // one created for the new installation.
+  it('skips a stale connection whose installation was deleted and resolves through the healthy one', async () => {
+    const seeded = await createFactoryStorageForTests();
+    const sourceControl = seeded.sourceControl.forIntegration('github');
+    const project = await seeded.projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Mastra' } });
+
+    const staleInstallation = await sourceControl.installations.upsert({
+      orgId: 'org-1',
+      connectedByUserId: 'user-1',
+      externalId: 'old-install',
+    });
+    const staleRepository = await sourceControl.repositories.upsert({
+      orgId: 'org-1',
+      input: {
+        installationId: staleInstallation.id,
+        externalId: '456',
+        slug: 'mastra-ai/mastra',
+        defaultBranch: 'main',
+      },
+    });
+    const staleConnection = await sourceControl.connections.create({
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      installationId: staleInstallation.id,
+      createdByUserId: 'user-1',
+    });
+    await sourceControl.projectRepositories.link({
+      orgId: 'org-1',
+      connectionId: staleConnection.id,
+      repositoryId: staleRepository.id,
+      createdByUserId: 'user-1',
+      sandboxProvider: 'local',
+      sandboxWorkdir: '/sandbox/mastra',
+    });
+    // The reinstall: the installation row goes away, the connection stays.
+    await sourceControl.installations.delete({ orgId: 'org-1', id: staleInstallation.id });
+
+    const freshInstallation = await sourceControl.installations.upsert({
+      orgId: 'org-1',
+      connectedByUserId: 'user-2',
+      externalId: 'new-install',
+    });
+    const freshRepository = await sourceControl.repositories.upsert({
+      orgId: 'org-1',
+      input: {
+        installationId: freshInstallation.id,
+        externalId: '456',
+        slug: 'mastra-ai/mastra',
+        defaultBranch: 'main',
+      },
+    });
+    const freshConnection = await sourceControl.connections.create({
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      installationId: freshInstallation.id,
+      createdByUserId: 'user-2',
+    });
+    const freshProjectRepository = await sourceControl.projectRepositories.link({
+      orgId: 'org-1',
+      connectionId: freshConnection.id,
+      repositoryId: freshRepository.id,
+      createdByUserId: 'user-2',
+      sandboxProvider: 'local',
+      sandboxWorkdir: '/sandbox/mastra',
+    });
+
+    await expect(
+      resolveFactorySourceRepository({ sourceControl, orgId: 'org-1', factoryProjectId: project.id }),
+    ).resolves.toEqual({
+      found: true,
+      projectRepositoryId: freshProjectRepository.id,
+      baseBranch: 'main',
+      connectedByUserId: 'user-2',
+    });
+  });
+
+  it('reports a repository miss instead of throwing when every connection is stale', async () => {
+    const seeded = await createFactoryStorageForTests();
+    const sourceControl = seeded.sourceControl.forIntegration('github');
+    const project = await seeded.projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Mastra' } });
+    const installation = await sourceControl.installations.upsert({
+      orgId: 'org-1',
+      connectedByUserId: 'user-1',
+      externalId: 'old-install',
+    });
+    await sourceControl.connections.create({
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      installationId: installation.id,
+      createdByUserId: 'user-1',
+    });
+    await sourceControl.installations.delete({ orgId: 'org-1', id: installation.id });
+
+    await expect(
+      resolveFactorySourceRepository({ sourceControl, orgId: 'org-1', factoryProjectId: project.id }),
+    ).resolves.toEqual({ found: false, reason: 'repository' });
+  });
 });
 
 /**

--- a/mastracode/factory/src/session/factory-session.ts
+++ b/mastracode/factory/src/session/factory-session.ts
@@ -84,27 +84,41 @@ export async function resolveFactorySourceRepository(args: {
   const { sourceControl, orgId, factoryProjectId, repositorySlug } = args;
 
   const connections = await sourceControl.connections.list({ orgId, factoryProjectId });
-  const connection = connections.find(candidate => candidate.integrationId === sourceControl.integrationId);
-  if (!connection) return { found: false, reason: 'connection' };
+  const candidates = connections.filter(candidate => candidate.integrationId === sourceControl.integrationId);
+  if (candidates.length === 0) return { found: false, reason: 'connection' };
 
-  const projectRepositories = await sourceControl.projectRepositories.list({ orgId, connectionId: connection.id });
-  const resolvedRepositories = await Promise.all(
-    projectRepositories.map(async projectRepository => ({
-      projectRepository,
-      repository: await sourceControl.repositories.get({ orgId, id: projectRepository.repositoryId }),
-    })),
-  );
-  const resolved = resolvedRepositories.find(
-    candidate => candidate.repository && (!repositorySlug || candidate.repository.slug === repositorySlug),
-  );
-  if (!resolved?.repository) return { found: false, reason: 'repository' };
+  // A project can carry stale connections: a provider-app reinstall leaves the
+  // old connection pointing at an installation that no longer exists, and that
+  // row can sit ahead of the healthy one. Try every candidate and skip the ones
+  // that no longer resolve rather than failing on the first.
+  for (const connection of candidates) {
+    let projectRepositories;
+    try {
+      projectRepositories = await sourceControl.projectRepositories.list({ orgId, connectionId: connection.id });
+    } catch {
+      // The connection no longer resolves (e.g. its installation was deleted).
+      continue;
+    }
+    const resolvedRepositories = await Promise.all(
+      projectRepositories.map(async projectRepository => ({
+        projectRepository,
+        repository: await sourceControl.repositories.get({ orgId, id: projectRepository.repositoryId }),
+      })),
+    );
+    const resolved = resolvedRepositories.find(
+      candidate => candidate.repository && (!repositorySlug || candidate.repository.slug === repositorySlug),
+    );
+    if (!resolved?.repository) continue;
 
-  return {
-    found: true,
-    projectRepositoryId: resolved.projectRepository.id,
-    baseBranch: resolved.projectRepository.branch ?? resolved.repository.defaultBranch,
-    connectedByUserId: connection.createdByUserId,
-  };
+    return {
+      found: true,
+      projectRepositoryId: resolved.projectRepository.id,
+      baseBranch: resolved.projectRepository.branch ?? resolved.repository.defaultBranch,
+      connectedByUserId: connection.createdByUserId,
+    };
+  }
+
+  return { found: false, reason: 'repository' };
 }
 
 /**

--- a/mastracode/factory/src/session/factory-session.ts
+++ b/mastracode/factory/src/session/factory-session.ts
@@ -92,22 +92,22 @@ export async function resolveFactorySourceRepository(args: {
   // row can sit ahead of the healthy one. Try every candidate and skip the ones
   // that no longer resolve rather than failing on the first.
   for (const connection of candidates) {
-    let projectRepositories;
+    let resolved;
     try {
-      projectRepositories = await sourceControl.projectRepositories.list({ orgId, connectionId: connection.id });
+      const projectRepositories = await sourceControl.projectRepositories.list({ orgId, connectionId: connection.id });
+      const resolvedRepositories = await Promise.all(
+        projectRepositories.map(async projectRepository => ({
+          projectRepository,
+          repository: await sourceControl.repositories.get({ orgId, id: projectRepository.repositoryId }),
+        })),
+      );
+      resolved = resolvedRepositories.find(
+        candidate => candidate.repository && (!repositorySlug || candidate.repository.slug === repositorySlug),
+      );
     } catch {
       // The connection no longer resolves (e.g. its installation was deleted).
       continue;
     }
-    const resolvedRepositories = await Promise.all(
-      projectRepositories.map(async projectRepository => ({
-        projectRepository,
-        repository: await sourceControl.repositories.get({ orgId, id: projectRepository.repositoryId }),
-      })),
-    );
-    const resolved = resolvedRepositories.find(
-      candidate => candidate.repository && (!repositorySlug || candidate.repository.slug === repositorySlug),
-    );
     if (!resolved?.repository) continue;
 
     return {

--- a/mastracode/factory/src/session/filesystem-capture.ts
+++ b/mastracode/factory/src/session/filesystem-capture.ts
@@ -10,7 +10,7 @@ const ARTIFACTS_LIST_COMMAND = 'cd "$1" && test -d .artifacts && find .artifacts
 export interface FilesystemCaptureSession {
   readonly identity: { getResourceId(): string };
   readonly thread: { requireId(): string };
-  getWorkspace(): { sandbox?: Pick<WorkspaceSandbox, 'executeCommand'> };
+  getWorkspace(): { sandbox?: Pick<WorkspaceSandbox, 'executeCommand'> } | undefined;
   onBeforeAgentEnd(listener: SessionBeforeAgentEndListener): () => void;
 }
 
@@ -50,7 +50,8 @@ export async function captureSessionFilesystem(
     const resourceId = session.identity.getResourceId();
     const threadId = session.thread.requireId();
     const sourceSession = await sourceControl.sessions.getBySessionId(resourceId);
-    const sandbox = session.getWorkspace().sandbox;
+    // Chat-only sessions run without a workspace; there is nothing to capture.
+    const sandbox = session.getWorkspace()?.sandbox;
     if (!sourceSession?.sandboxWorkdir || !sandbox?.executeCommand) return;
 
     const result = await sandbox.executeCommand('git', ['-C', sourceSession.sandboxWorkdir, ...GIT_STATUS_ARGS], {

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -726,6 +726,23 @@ describe('GitHub session workspace preparation', () => {
     });
   }
 
+  // A chat-only resourceId (e.g. `channel:slack:C1:170042` from an unrouted
+  // Slack sender) resolves no Factory session. On a remote-sandbox deploy that
+  // used to throw on every message; the session must instead run without a
+  // workspace — never a host-backed one, and never a provisioned sandbox.
+  it('a chat-only session on a remote-sandbox deploy gets no workspace instead of an error', async () => {
+    const workspace = createRemoteFactory();
+    addProject({ sandboxProvider: 'railway' });
+    // No session row: `sessions.getBySessionId` misses for the chat-only id.
+
+    await expect(
+      workspace({ requestContext: createGithubRequestContext('project-1', 'channel:slack:C-1:1700.42') }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.ensureSandbox).not.toHaveBeenCalled();
+    expect(mocks.materializeRepo).not.toHaveBeenCalled();
+  });
+
   it('claims a pooled sandbox for a new remote session instead of provisioning fresh', async () => {
     const workspace = createRemoteFactory();
     addProject({ sandboxProvider: 'railway' });

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -151,7 +151,12 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
 
     if (!session) {
       if (sandboxConfig && !isLocalSandbox) {
-        throw new Error('A Factory session ID is required to create a remote sandbox workspace');
+        // Chat-only session on a remote-sandbox deploy: there is no repository
+        // to materialize, and the server host must never execute commands on a
+        // shared deployment. Run the session without a workspace (chat works,
+        // workspace tools are simply not registered) instead of erroring on
+        // every message.
+        return undefined;
       }
       return getDynamicWorkspace({ requestContext, mastra, skillExtension: effectiveSkillExtension });
     }


### PR DESCRIPTION
## Summary

Slack threads on cloud factory deployments were falling back to chat-only sessions (or erroring on every message) instead of getting a repo-backed session with a remote sandbox. Three fixes, each with red-verified regression tests:

1. **Stale connections no longer shadow healthy ones.** `resolveFactorySourceRepository` took the first source-control connection on the factory project and failed outright when that row was stale. It now tries every candidate connection and skips the ones that no longer resolve, so a healthy connection later in the list still backs the session.
2. **Chat-only sessions on remote-sandbox deploys run without a workspace instead of erroring.** The workspace factory threw `A Factory session ID is required to create a remote sandbox workspace` for every message on a chat-only thread. It now returns `undefined` (supported since #21084): chat works, workspace tools are simply not registered, and the server host never executes commands for these sessions. Two call sites that assumed every session has a workspace now handle the workspace-less case.
3. **Top-level DM branches are valid git refs.** Top-level DM and channel conversations use the empty-threadTs thread form, which derived the invalid branch name `slack/` and failed every clone with `fatal: 'slack/' is not a valid branch name`. The branch now falls back to the channel id segment, giving one deterministic branch per top-level conversation.

## How this was found (stale / zombie connection)

Debugged live on the Shipyard deployment: every Slack mention answered with the remote-sandbox error even though the sender was linked with a default factory set. The factory project has two `github` connections in its database. The older one points at an installation row that no longer exists (a GitHub App reinstall deleted the installation but left the connection and its orphaned repository rows behind), and it sits ahead of the healthy connection created for the new installation. The resolver picked the stale row, threw, and the catch dropped the thread to chat-only, which then hit fix 2's error path on every message.

Fix 1 makes deployments resilient to that data shape. Deleting the zombie connection row (via `connections.delete`, which cascades safely) is still worth doing on affected deployments, and a follow-up could clean up stale connections automatically when an app reinstall is detected.

## Test plan

- New regression tests, each verified to fail against the previous code:
  - `factory-session.test.ts`: stale connection skipped in favor of the healthy one; all-stale project reports a repository miss instead of throwing
  - `workspace.test.ts`: chat-only resourceId on a remote-sandbox deploy resolves to no workspace, provisions nothing
  - `slack.test.ts`: empty-threadTs thread derives `slack/{channelId}`
- `pnpm --filter ./mastracode/factory exec vitest run`: suites touching this change all pass (the only failures are pre-existing on main in unrelated files: reconcile-worker and work-items locking)
- `pnpm --filter ./mastracode/factory check`: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Slack sessions can now recover when a repository connection is stale or broken. Chat-only sessions can run without a workspace, and top-level Slack conversations now use valid branch names.

## Changes

- Try all matching source-control connections.
- Skip stale or failing connections.
- Return the first suitable repository.
- Support chat-only remote-sandbox sessions without a workspace or sandbox.
- Safely handle sessions without a workspace during kickoff and filesystem capture.
- Derive top-level Slack branches from the channel ID, such as `slack/D-1`.
- Add regression tests for stale connections, workspace-free sessions, and top-level DM and channel branches.
- Add a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->