### PR TITLE
feat(workspace): add sandbox snapshots

### DIFF
--- a/.changeset/curly-suits-taste.md
+++ b/.changeset/curly-suits-taste.md
@@ -1,0 +1,9 @@
+---
+'@mastra/railway': minor
+---
+
+Added `RailwaySandbox.snapshot()` to capture the configured recovery checkpoint.
+
+```ts
+await sandbox.snapshot()
+```

--- a/.changeset/happy-eels-press.md
+++ b/.changeset/happy-eels-press.md
@@ -1,0 +1,9 @@
+---
+'@mastra/platform-workspace': minor
+---
+
+Added `PlatformSandbox.snapshot()` to capture the configured recovery checkpoint.
+
+```ts
+await sandbox.snapshot()
+```

--- a/.changeset/violet-donuts-occur.md
+++ b/.changeset/violet-donuts-occur.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': minor
+---
+
+Added `WorkspaceSandbox.snapshot()` for persisting sandbox state when supported.
+
+```ts
+await sandbox.snapshot()
+```

--- a/deployers/sandbox/src/fake-sandbox.mock.ts
+++ b/deployers/sandbox/src/fake-sandbox.mock.ts
@@ -85,6 +85,7 @@ export class FakeSandbox implements WorkspaceSandbox {
   async start(): Promise<void> {
     this.started++;
   }
+  async snapshot(): Promise<void> {}
   async stop(): Promise<void> {
     this.stopped++;
   }

--- a/docs/src/content/en/reference/workspace/platform-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/platform-sandbox.mdx
@@ -130,6 +130,12 @@ await sandbox.start() // Boots from the most recent checkpoint for this id, or f
 
 Checkpoint recovery is coarser than `sandboxId` reattachment. Reattaching (via `sandboxId`) rejoins the exact live sandbox and its running processes. Checkpoint recovery constructs a brand new sandbox and restores its filesystem from the latest checkpoint the platform captured for the previous sandbox with that `id`. Running processes and any filesystem writes made after the last checkpoint aren't restored.
 
+Call `snapshot()` after a filesystem update to capture the configured recovery checkpoint immediately. It resolves without capturing when the sandbox has no caller-provided `id` or isn't running.
+
+```typescript
+await sandbox.snapshot()
+```
+
 Each `id` maps to one independent filesystem. Reusing the same `id` across unrelated sandboxes causes the platform to boot them from each other's checkpoint.
 
 ### Cloning for a fleet of sandboxes
@@ -316,6 +322,12 @@ The `command` argument is a shell string and is concatenated verbatim into the r
     type: '(options?: SandboxCloneOptions) => PlatformSandbox',
     description:
       'Construct an unstarted sibling PlatformSandbox that inherits credentials and defaults with per-instance overrides (id, sandboxId, env, idleTimeoutMinutes). Performs no I/O. Use to build a fleet of independent sandboxes from one configured template.',
+  },
+  {
+    name: 'snapshot',
+    type: '() => Promise<void>',
+    description:
+      'Capture the configured recovery checkpoint immediately. Resolves without work when no caller-provided id exists or the sandbox is not running.',
   },
   {
     name: 'getInfo',

--- a/docs/src/content/en/reference/workspace/railway-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/railway-sandbox.mdx
@@ -131,6 +131,12 @@ const sandbox = new RailwaySandbox({
 
 `RailwaySandbox` refreshes the checkpoint shortly before the idle timeout. Recovery restores the latest successful checkpoint. It doesn't restore running processes or filesystem writes made after the last checkpoint.
 
+Call `snapshot()` after a filesystem update to capture the configured checkpoint immediately. It resolves without capturing when `checkpointName` isn't configured or the sandbox isn't running.
+
+```typescript
+await sandbox.snapshot()
+```
+
 Use one stable checkpoint name for each independent filesystem. Don't share a checkpoint name across unrelated sessions or projects.
 
 ### Cloned sandbox checkpoints
@@ -311,6 +317,12 @@ const result = await sandbox.executeCommand('cat', ['/tmp/state.txt'])
     type: '(options?) => RailwaySandbox',
     description:
       'Construct an unstarted sibling sandbox that inherits credentials and defaults. Accepts optional id, sandboxId, env, idleTimeoutMinutes, and checkpointName overrides. The cloned sandbox uses options.checkpointName when set, otherwise it inherits the template checkpointName.',
+  },
+  {
+    name: 'snapshot',
+    type: '() => Promise<void>',
+    description:
+      'Capture the configured recovery checkpoint immediately. Resolves without work when checkpointName is not configured or the sandbox is not running.',
   },
 ]}
 />

--- a/docs/src/content/en/reference/workspace/sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/sandbox.mdx
@@ -53,6 +53,16 @@ Clean up sandbox resources. Called by `workspace.destroy()`.
 await sandbox.destroy()
 ```
 
+### `snapshot()`
+
+Persists the sandbox's current state when the provider supports snapshots. Other providers resolve without doing work.
+
+```typescript
+await sandbox.snapshot()
+```
+
+**Returns:** `Promise<void>`
+
 ### `executeCommand(command, args?, options?)`
 
 Execute a shell command.

--- a/packages/core/src/workspace/sandbox/mastra-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/mastra-sandbox.test.ts
@@ -232,6 +232,14 @@ describe('MastraSandbox Base Class', () => {
     });
   });
 
+  describe('Snapshot', () => {
+    it('resolves as a no-op by default', async () => {
+      const sandbox = new MountableSandbox();
+
+      await expect(sandbox.snapshot()).resolves.toBeUndefined();
+    });
+  });
+
   describe('Lifecycle Methods', () => {
     it('_start() sets status to running', async () => {
       const sandbox = new MountableSandbox();

--- a/packages/core/src/workspace/sandbox/mastra-sandbox.ts
+++ b/packages/core/src/workspace/sandbox/mastra-sandbox.ts
@@ -166,6 +166,13 @@ export abstract class MastraSandbox extends MastraBase implements WorkspaceSandb
   /** Get sandbox status and metadata */
   getInfo?(): SandboxInfo | Promise<SandboxInfo>;
 
+  /**
+   * Persist the sandbox's current state when supported.
+   *
+   * The default implementation is a no-op for providers without snapshot support.
+   */
+  async snapshot(): Promise<void> {}
+
   // ---------------------------------------------------------------------------
   // Lifecycle Promise Tracking (prevents race conditions)
   // ---------------------------------------------------------------------------

--- a/packages/core/src/workspace/sandbox/sandbox.ts
+++ b/packages/core/src/workspace/sandbox/sandbox.ts
@@ -139,6 +139,12 @@ export interface WorkspaceSandbox extends SandboxLifecycle<SandboxInfo> {
   readonly provider: string;
 
   /**
+   * Persist the sandbox's current state when the provider supports snapshots.
+   * Providers without snapshot support resolve without performing work.
+   */
+  snapshot(): Promise<void>;
+
+  /**
    * Get instructions describing how this sandbox works.
    * Used in tool descriptions to help agents understand execution context.
    *

--- a/workspaces/_test-utils/src/sandbox/mock-sandbox.ts
+++ b/workspaces/_test-utils/src/sandbox/mock-sandbox.ts
@@ -81,6 +81,8 @@ export class MockSandbox implements WorkspaceSandbox {
     this.status = 'running';
   }
 
+  async snapshot(): Promise<void> {}
+
   async stop(): Promise<void> {
     this.status = 'stopping';
     this.status = 'stopped';

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -2571,6 +2571,27 @@ describe('PlatformSandbox', () => {
   });
 
   describe('captureCheckpoint (public, on-demand)', () => {
+    it('delegates snapshot to captureCheckpoint', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const sandbox = new PlatformSandbox({
+        id: 'mc-session-42',
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+      await sandbox._start();
+      const captureCheckpoint = vi.spyOn(sandbox, 'captureCheckpoint').mockResolvedValue({
+        status: 'captured',
+        checkpointName: 'mastra-checkpoint-abc123',
+      });
+
+      await expect(sandbox.snapshot()).resolves.toBeUndefined();
+
+      expect(captureCheckpoint).toHaveBeenCalledOnce();
+    });
+
     it('POSTs to /checkpoint with the recovery key and returns the captured name', async () => {
       vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
       const fetchMock = vi

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -816,6 +816,11 @@ export class PlatformSandbox extends MastraSandbox {
     this._addressRegistry?.delete(destroyedSandboxId);
   }
 
+  /** Persist the configured recovery checkpoint when available. */
+  async snapshot(): Promise<void> {
+    await this.captureCheckpoint();
+  }
+
   /**
    * Capture the sandbox's checkpoint on demand, outside any refresh timer the
    * workspace-proxy owns internally.

--- a/workspaces/railway/src/sandbox/index.test.ts
+++ b/workspaces/railway/src/sandbox/index.test.ts
@@ -261,6 +261,16 @@ describe('RailwaySandbox', () => {
     });
 
     describe('captureCheckpoint (public, on-demand)', () => {
+      it('delegates snapshot to captureCheckpoint', async () => {
+        const sandbox = new RailwaySandbox({ token: 'tok', checkpointName: 'mastracode-repo-abc123' });
+        await sandbox._start();
+        const captureCheckpoint = vi.spyOn(sandbox, 'captureCheckpoint');
+
+        await expect(sandbox.snapshot()).resolves.toBeUndefined();
+
+        expect(captureCheckpoint).toHaveBeenCalledOnce();
+      });
+
       it('captures the checkpoint synchronously and returns the captured name', async () => {
         mockCheckpoints.mockResolvedValueOnce([
           { id: 'checkpoint-id', key: 'mastracode-repo-abc123', environmentId: 'env-1' },

--- a/workspaces/railway/src/sandbox/index.ts
+++ b/workspaces/railway/src/sandbox/index.ts
@@ -336,6 +336,11 @@ export class RailwaySandbox extends MastraSandbox {
     };
   }
 
+  /** Persist the configured recovery checkpoint when available. */
+  async snapshot(): Promise<void> {
+    await this.captureCheckpoint();
+  }
+
   /**
    * Capture the sandbox's checkpoint on demand, outside the idle-timer schedule.
    *


### PR DESCRIPTION
Adds a provider-agnostic `snapshot()` method to workspace sandboxes.

```ts
await sandbox.snapshot()
```

Railway and Platform snapshots capture their configured recovery checkpoint. Other providers safely no-op. Tests cover the default behavior and both checkpoint delegates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Sandboxes can now save a recovery point with one common `snapshot()` method. Providers that support recovery checkpoints use it, while other providers safely do nothing.

## Changes

- Added `snapshot(): Promise<void>` to `WorkspaceSandbox` and `MastraSandbox`.
- Added no-op implementations to the fake and mock sandboxes.
- Added `PlatformSandbox.snapshot()` and `RailwaySandbox.snapshot()`.
- Delegated supported snapshots to `captureCheckpoint()`.
- Added tests for default no-op behavior and both provider delegates.
- Added documentation and changesets for the new API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->