### PR TITLE
fix(core): sanitize thread-stream broadcasts and stop unpersisted-run phantom replay

### DIFF
--- a/.changeset/olive-durable-guards.md
+++ b/.changeset/olive-durable-guards.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix DurableAgent inference crashes with "Cannot read properties of undefined (reading 'type')" (#21138). Prompt conversion now skips undefined holes in message content arrays and backfills a valid `{ type: 'json', value: null }` output for tool-result parts missing an output, so malformed messages produced by upstream rewrites can no longer crash provider converters. Error chunks emitted by durable LLM execution now serialize the message, name, and stack explicitly, and consumers preserve the producer's stack and cause when re-throwing, keeping crashes attributable to their real throw site.

--- a/.changeset/olive-durable-guards.md
+++ b/.changeset/olive-durable-guards.md
@@ -2,4 +2,7 @@
 '@mastra/core': patch
 ---
 
-Fix DurableAgent inference crashes with "Cannot read properties of undefined (reading 'type')" (#21138). Prompt conversion now skips undefined holes in message content arrays and backfills a valid `{ type: 'json', value: null }` output for tool-result parts missing an output, so malformed messages produced by upstream rewrites can no longer crash provider converters. Error chunks emitted by durable LLM execution now serialize the message, name, and stack explicitly, and consumers preserve the producer's stack and cause when re-throwing, keeping crashes attributable to their real throw site.
+Fix DurableAgent inference crashes and error reporting (#21138):
+
+- DurableAgent inference no longer crashes with "Cannot read properties of undefined (reading 'type')" on malformed message content.
+- Durable LLM errors now keep their original message, name, stack, and cause when reported to callers and `onError`.

--- a/.changeset/sharp-brooms-fall.md
+++ b/.changeset/sharp-brooms-fall.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed two thread-stream broadcast issues when subscribing to agent threads. Broadcast copies of step-start, step-finish, and finish parts no longer embed the raw model request body or duplicated step history, preventing multi-gigabyte pubsub streams and out-of-memory crashes when threads contain large media (#21219). Runs that failed before persisting any messages no longer replay as phantom partial messages to new thread subscribers on retained backends like Redis Streams (#21223).

--- a/.changeset/sharp-brooms-fall.md
+++ b/.changeset/sharp-brooms-fall.md
@@ -2,4 +2,7 @@
 '@mastra/core': patch
 ---
 
-Fixed two thread-stream broadcast issues when subscribing to agent threads. Broadcast copies of step-start, step-finish, and finish parts no longer embed the raw model request body or duplicated step history, preventing multi-gigabyte pubsub streams and out-of-memory crashes when threads contain large media (#21219). Runs that failed before persisting any messages no longer replay as phantom partial messages to new thread subscribers on retained backends like Redis Streams (#21223).
+Fixed two thread-stream broadcast issues when subscribing to agent threads:
+
+- **Broadcast payload sanitization (#21219):** broadcast copies of `step-start`, `step-finish`, and `finish` parts no longer embed the raw model request body or duplicated step history, preventing multi-gigabyte pubsub streams and out-of-memory crashes when threads contain large media.
+- **Phantom replay prevention (#21223):** runs that failed before persisting any messages no longer replay as phantom partial messages to new thread subscribers on retained backends like Redis Streams.

--- a/.changeset/spicy-scheduler-role.md
+++ b/.changeset/spicy-scheduler-role.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix dedicated scheduler deployments never starting the scheduler. When `MASTRA_WORKERS=scheduler` (or any worker filter naming the `scheduler` role) is set, `startWorkers()` now always injects the SchedulerWorker instead of relying on boot-time heuristics (declarative workflow schedules or persisted agent-schedule rows) that a standalone scheduler process cannot see — it exists to fire schedule rows created by other processes. `workers: false` and `scheduler: { enabled: false }` still take precedence.

--- a/packages/core/src/agent/__tests__/thread-stream-broadcast-sanitization.test.ts
+++ b/packages/core/src/agent/__tests__/thread-stream-broadcast-sanitization.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/21219
+ *
+ * Every thread-bound run broadcasts its chunk stream to the thread-stream
+ * pubsub topic. `step-start` embeds the full serialized model request (which
+ * can include base64 media from context), and `step-finish`/`finish` repeat it
+ * via `metadata.request`, `output.steps[]` and `messages` — amplifying the
+ * largest object in the system ≥5× per step, persisting it in durable pubsub
+ * backends, and exposing prompt contents to every subscriber. The broadcast
+ * copy must be sanitized; the caller's local output must stay untouched.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { PubSub } from '../../events/pubsub';
+import type { Event } from '../../events/types';
+import type { MastraModelOutput } from '../../stream/base/output';
+import type { Agent } from '../agent';
+import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+
+class CapturePubSub extends PubSub {
+  events: Array<{ topic: string; event: Event }> = [];
+
+  async publish(topic: string, event: Event): Promise<void> {
+    this.events.push({ topic, event });
+  }
+  async flush(): Promise<void> {}
+  async subscribe(): Promise<void> {}
+  async unsubscribe(): Promise<void> {}
+}
+
+function fakeOutput(runId: string, parts: unknown[]): MastraModelOutput<any> {
+  let finish!: () => void;
+  const finished = new Promise<void>(resolve => (finish = resolve));
+  return {
+    runId,
+    status: 'success',
+    fullStream: new ReadableStream({
+      start(controller) {
+        for (const part of parts) controller.enqueue(part);
+        controller.close();
+        finish();
+      },
+    }),
+    _waitUntilFinished: () => finished,
+  } as unknown as MastraModelOutput<any>;
+}
+
+const MARKER = 'RAW_MODEL_REQUEST_BODY_'.repeat(64);
+const agent = { id: 'sanitize-agent' } as Agent<any, any, any, any>;
+
+describe('thread-stream broadcast sanitization', () => {
+  it('drops raw model request bookkeeping from broadcast parts without mutating the originals', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new CapturePubSub();
+
+    const stepStart = {
+      type: 'step-start',
+      payload: {
+        messageId: 'msg-1',
+        request: { body: MARKER },
+        inputMessages: [{ role: 'user', content: MARKER }],
+        warnings: [],
+      },
+    };
+    const textDelta = { type: 'text-delta', payload: { text: 'hi' } };
+    const stepFinish = {
+      type: 'step-finish',
+      payload: {
+        stepResult: { reason: 'stop' },
+        output: { usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 }, steps: [{ request: { body: MARKER } }] },
+        metadata: { request: { body: MARKER }, providerMetadata: { test: { keep: true } } },
+        messages: { all: [{ role: 'user', content: MARKER }], user: [], nonUser: [] },
+      },
+    };
+    const finishPart = {
+      type: 'finish',
+      payload: {
+        stepResult: { reason: 'stop' },
+        output: { usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 }, steps: [{ request: { body: MARKER } }] },
+        metadata: { request: { body: MARKER }, providerMetadata: { test: { keep: true } } },
+        messages: { all: [{ role: 'user', content: MARKER }], user: [], nonUser: [] },
+      },
+    };
+
+    const output = fakeOutput('sanitize-run', [stepStart, textDelta, stepFinish, finishPart]);
+    await runtime.registerRun(
+      agent,
+      output,
+      { memory: { thread: 'sanitize-thread', resource: 'sanitize-user' } },
+      pubsub,
+    );
+
+    // The broadcast pump runs asynchronously after registration.
+    const streamParts = async () =>
+      pubsub.events
+        .map(({ event }) => event.data as { type?: string; part?: unknown })
+        .filter(data => data?.type === 'stream-part')
+        .map(data => data.part as { type: string; payload: Record<string, any> });
+    const deadline = Date.now() + 2000;
+    while ((await streamParts()).length < 4 && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    const parts = await streamParts();
+    expect(parts.map(p => p.type)).toEqual(['step-start', 'text-delta', 'step-finish', 'finish']);
+
+    // No broadcast part carries the raw request body.
+    expect(JSON.stringify(parts)).not.toContain(MARKER);
+
+    const [broadcastStepStart, , broadcastStepFinish, broadcastFinish] = parts;
+    expect(broadcastStepStart!.payload).toEqual({ messageId: 'msg-1', warnings: [] });
+    for (const part of [broadcastStepFinish!, broadcastFinish!]) {
+      expect(part.payload.metadata).toEqual({ providerMetadata: { test: { keep: true } } });
+      expect(part.payload.output).toEqual({ usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } });
+      expect('messages' in part.payload).toBe(false);
+      expect(part.payload.stepResult).toEqual({ reason: 'stop' });
+    }
+
+    // The caller's chunks are untouched — only the broadcast copies are rewritten.
+    expect(stepStart.payload.request.body).toBe(MARKER);
+    expect(stepFinish.payload.metadata.request.body).toBe(MARKER);
+    expect(finishPart.payload.output.steps[0]!.request.body).toBe(MARKER);
+    expect(finishPart.payload.messages.all[0]!.content).toBe(MARKER);
+  });
+
+  it('keeps multi-step broadcast size bounded (no compounding steps[] duplication)', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new CapturePubSub();
+
+    // Three model steps. Each step-finish re-embeds every prior step's full
+    // request via output.steps[], so unsanitized broadcast traffic grows
+    // quadratically with step count.
+    const chunks: unknown[] = [];
+    const steps: Array<{ request: { body: string } }> = [];
+    for (let index = 0; index < 3; index++) {
+      steps.push({ request: { body: MARKER } });
+      chunks.push(
+        { type: 'step-start', payload: { messageId: `msg-${index}`, request: { body: MARKER }, warnings: [] } },
+        { type: 'text-delta', payload: { text: `step ${index}` } },
+        {
+          type: 'step-finish',
+          payload: {
+            stepResult: { reason: 'stop' },
+            output: { usage: { totalTokens: 2 }, steps: structuredClone(steps) },
+            metadata: { request: { body: MARKER } },
+            messages: { all: [], user: [], nonUser: [] },
+          },
+        },
+      );
+    }
+    chunks.push({
+      type: 'finish',
+      payload: {
+        stepResult: { reason: 'stop' },
+        output: { usage: { totalTokens: 6 }, steps: structuredClone(steps) },
+        metadata: { request: { body: MARKER } },
+        messages: { all: [], user: [], nonUser: [] },
+      },
+    });
+
+    const rawSize = JSON.stringify(chunks).length;
+    const output = fakeOutput('multi-step-run', chunks);
+    await runtime.registerRun(
+      agent,
+      output,
+      { memory: { thread: 'multi-step-thread', resource: 'sanitize-user' } },
+      pubsub,
+    );
+
+    const streamParts = () =>
+      pubsub.events
+        .map(({ event }) => event.data as { type?: string; part?: unknown })
+        .filter(data => data?.type === 'stream-part')
+        .map(data => data.part);
+    const deadline = Date.now() + 2000;
+    while (streamParts().length < chunks.length && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    const parts = streamParts();
+    expect(parts.length).toBe(chunks.length);
+
+    const broadcastJson = JSON.stringify(parts);
+    expect(broadcastJson).not.toContain(MARKER);
+    // The raw chunks embed the marker 14 times (~21 KB); the sanitized
+    // broadcast retains only control metadata and text.
+    expect(broadcastJson.length).toBeLessThan(rawSize / 10);
+  });
+});

--- a/packages/core/src/agent/__tests__/thread-stream-phantom-replay.test.ts
+++ b/packages/core/src/agent/__tests__/thread-stream-phantom-replay.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/21223
+ *
+ * On a retained pubsub backend (Redis Streams), a fresh `subscribeToThread`
+ * replays the topic backlog. A run that failed mid-stream (or whose process
+ * died) published its partial chunks but never persisted a message, so
+ * replaying it surfaces a phantom partial assistant message that hydrated
+ * history can never reconcile. Replayed runs whose origin no longer holds the
+ * thread lease must be buffered and only released to the subscriber when
+ * their backlog proves they finished cleanly.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { PubSub } from '../../events/pubsub';
+import type { LeaseProvider } from '../../events/pubsub';
+import type { EventCallback } from '../../events/types';
+import type { Agent } from '../agent';
+import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+
+const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
+
+function nextTicks(count = 5) {
+  return Array.from({ length: count }).reduce<Promise<void>>(
+    acc => acc.then(() => new Promise(resolve => setTimeout(resolve, 0))),
+    Promise.resolve(),
+  );
+}
+
+/** In-memory pubsub with a real lease provider, standing in for Redis Streams. */
+class LeasePubSub extends PubSub implements LeaseProvider {
+  owners = new Map<string, string>();
+  #subscribers = new Map<string, Set<EventCallback>>();
+
+  async publish(topic: string, event: any): Promise<void> {
+    for (const subscriber of [...(this.#subscribers.get(topic) ?? [])]) {
+      await subscriber({ ...event, id: 'evt', createdAt: new Date() }, async () => {});
+    }
+  }
+  async flush(): Promise<void> {}
+  async subscribe(topic: string, cb: EventCallback): Promise<void> {
+    const subscribers = this.#subscribers.get(topic) ?? new Set<EventCallback>();
+    subscribers.add(cb);
+    this.#subscribers.set(topic, subscribers);
+  }
+  async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
+    this.#subscribers.get(topic)?.delete(cb);
+  }
+  async acquireLease(key: string, owner: string): Promise<{ acquired: boolean; owner?: string }> {
+    const current = this.owners.get(key);
+    if (current && current !== owner) return { acquired: false, owner: current };
+    this.owners.set(key, owner);
+    return { acquired: true, owner };
+  }
+  async getLeaseOwner(key: string): Promise<string | undefined> {
+    return this.owners.get(key);
+  }
+  async releaseLease(key: string, owner: string): Promise<void> {
+    if (this.owners.get(key) === owner) this.owners.delete(key);
+  }
+  async renewLease(key: string, owner: string): Promise<boolean> {
+    return this.owners.get(key) === owner;
+  }
+  async transferLease(key: string, fromOwner: string, toOwner: string): Promise<boolean> {
+    if (this.owners.get(key) !== fromOwner) return false;
+    this.owners.set(key, toOwner);
+    return true;
+  }
+}
+
+const agent = { id: 'phantom-agent' } as Agent<any, any, any, any>;
+const threadId = 'phantom-thread';
+const resourceId = 'phantom-user';
+const key = [resourceId, threadId].join(AGENT_THREAD_KEY_SEPARATOR);
+const topic = `agent.thread-stream.${encodeURIComponent(key)}`;
+const runId = 'replayed-run';
+const streamId = 'replayed-stream';
+
+function setup() {
+  const runtime = new AgentThreadStreamRuntime();
+  const pubsub = new LeasePubSub();
+  const emit = (data: Record<string, unknown>) =>
+    pubsub.publish(topic, { type: 'agent.thread-stream', runId: data.runId, data });
+  const streamPart = (part: unknown) => emit({ type: 'stream-part', runId, streamId, sourceId: 'origin', part });
+  return { runtime, pubsub, emit, streamPart };
+}
+
+async function collect(runtime: AgentThreadStreamRuntime, pubsub: LeasePubSub) {
+  const subscription = await runtime.subscribeToThread(agent, { threadId, resourceId }, pubsub);
+  const collected: Array<{ type: string }> = [];
+  const consumed = (async () => {
+    for await (const part of subscription.stream) collected.push(part as { type: string });
+  })();
+  return { subscription, collected, consumed };
+}
+
+describe('phantom replay of unpersisted runs', () => {
+  it('does not replay a run that failed mid-stream and terminated with run-completed', async () => {
+    const { runtime, pubsub, emit, streamPart } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    // Replayed backlog of a dead run (no lease owner): partial content, an
+    // in-band error, then the plain-stream() error path's `run-completed`.
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    await streamPart({ type: 'start', payload: {} });
+    await streamPart({ type: 'text-delta', payload: { text: 'Your refund has been approved.' } });
+    await streamPart({ type: 'error', payload: { error: 'connection dropped' } });
+    await emit({ type: 'run-completed', runId, streamId });
+    await nextTicks();
+
+    expect(collected).toEqual([]);
+
+    subscription.unsubscribe();
+    await consumed;
+    expect(collected).toEqual([]);
+  });
+
+  it('does not replay a run whose process crashed mid-stream (no terminal event)', async () => {
+    const { runtime, pubsub, emit, streamPart } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    await streamPart({ type: 'start', payload: {} });
+    await streamPart({ type: 'text-delta', payload: { text: 'partial' } });
+    await nextTicks();
+
+    expect(collected).toEqual([]);
+
+    subscription.unsubscribe();
+    await consumed;
+    expect(collected).toEqual([]);
+  });
+
+  it('does not replay a run whose backlog terminates with run-failed', async () => {
+    const { runtime, pubsub, emit, streamPart } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    await streamPart({ type: 'start', payload: {} });
+    await streamPart({ type: 'text-delta', payload: { text: 'partial' } });
+    await emit({ type: 'run-failed', runId, streamId, error: 'boom' });
+    await nextTicks();
+
+    expect(collected).toEqual([]);
+
+    subscription.unsubscribe();
+    await consumed;
+  });
+
+  it('still replays a run that completed cleanly', async () => {
+    const { runtime, pubsub, emit, streamPart } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    await streamPart({ type: 'start', payload: {} });
+    await streamPart({ type: 'text-delta', payload: { text: 'hello' } });
+    await streamPart({
+      type: 'finish',
+      payload: { stepResult: { reason: 'stop' }, output: { usage: {} }, metadata: {} },
+    });
+    await emit({ type: 'run-completed', runId, streamId });
+    await nextTicks();
+
+    expect(collected.map(part => part.type)).toEqual(['start', 'text-delta', 'finish']);
+
+    subscription.unsubscribe();
+    await consumed;
+  });
+
+  it('trusts persisted: false over a clean-finish backlog', async () => {
+    const { runtime, pubsub, emit, streamPart } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    // Backlog looks clean, but the origin knows the storage flush failed.
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    await streamPart({ type: 'start', payload: {} });
+    await streamPart({ type: 'text-delta', payload: { text: 'never stored' } });
+    await streamPart({
+      type: 'finish',
+      payload: { stepResult: { reason: 'stop' }, output: { usage: {} }, metadata: {} },
+    });
+    await emit({ type: 'run-completed', runId, streamId, persisted: false });
+    await nextTicks();
+
+    expect(collected).toEqual([]);
+
+    subscription.unsubscribe();
+    await consumed;
+  });
+
+  it('trusts persisted: true even when the backlog is missing its finish chunk', async () => {
+    const { runtime, pubsub, emit, streamPart } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    // A subscriber can attach mid-topic-retention and miss trailing chunks;
+    // the origin's verdict still marks the run as backed by storage.
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    await streamPart({ type: 'start', payload: {} });
+    await streamPart({ type: 'text-delta', payload: { text: 'stored' } });
+    await emit({ type: 'run-completed', runId, streamId, persisted: true });
+    await nextTicks();
+
+    expect(collected.map(part => part.type)).toEqual(['start', 'text-delta']);
+
+    subscription.unsubscribe();
+    await consumed;
+  });
+
+  it('defers a dead run discovered via stream-part without run-registered', async () => {
+    const { runtime, pubsub, streamPart, emit } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    // No run-registered in the retained window — first evidence of the run is
+    // a replayed chunk. Dead origin (no lease), no terminal event: phantom.
+    await streamPart({ type: 'start', payload: {} });
+    await streamPart({ type: 'text-delta', payload: { text: 'partial' } });
+    await nextTicks();
+
+    expect(collected).toEqual([]);
+
+    // A later clean terminal event still releases it.
+    await streamPart({
+      type: 'finish',
+      payload: { stepResult: { reason: 'stop' }, output: { usage: {} }, metadata: {} },
+    });
+    await emit({ type: 'run-completed', runId, streamId, persisted: true });
+    await nextTicks();
+
+    expect(collected.map(part => part.type)).toEqual(['start', 'text-delta', 'finish']);
+
+    subscription.unsubscribe();
+    await consumed;
+  });
+
+  it('flushes a deferred run when it suspends (suspends persist a snapshot)', async () => {
+    const { runtime, pubsub, emit, streamPart } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    await streamPart({ type: 'start', payload: {} });
+    await streamPart({ type: 'text-delta', payload: { text: 'thinking' } });
+    await emit({ type: 'run-suspended', runId, streamId });
+    await nextTicks();
+
+    expect(collected.map(part => part.type)).toEqual(['start', 'text-delta']);
+
+    subscription.unsubscribe();
+    await consumed;
+  });
+
+  it('still streams a live run whose origin holds the thread lease', async () => {
+    const { runtime, pubsub, emit, streamPart } = setup();
+    pubsub.owners.set(key, runId);
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    await streamPart({ type: 'start', payload: {} });
+    await streamPart({ type: 'text-delta', payload: { text: 'live' } });
+    await nextTicks();
+
+    // Live parts stream through immediately, before any terminal event.
+    expect(collected.map(part => part.type)).toEqual(['start', 'text-delta']);
+
+    await streamPart({
+      type: 'finish',
+      payload: { stepResult: { reason: 'stop' }, output: { usage: {} }, metadata: {} },
+    });
+    await emit({ type: 'run-completed', runId, streamId });
+    await nextTicks();
+
+    expect(collected.map(part => part.type)).toEqual(['start', 'text-delta', 'finish']);
+
+    subscription.unsubscribe();
+    await consumed;
+  });
+});

--- a/packages/core/src/agent/__tests__/thread-stream-phantom-replay.test.ts
+++ b/packages/core/src/agent/__tests__/thread-stream-phantom-replay.test.ts
@@ -11,87 +11,22 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { PubSub } from '../../events/pubsub';
-import type { LeaseProvider } from '../../events/pubsub';
-import type { EventCallback } from '../../events/types';
-import type { Agent } from '../agent';
-import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+import type { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+import type { LeasePubSub } from './thread-stream-test-utils';
+import {
+  AGENT_THREAD_KEY_SEPARATOR,
+  collectThread,
+  createHarness,
+  nextTicks,
+  setupRuntime,
+} from './thread-stream-test-utils';
 
-const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
-
-function nextTicks(count = 5) {
-  return Array.from({ length: count }).reduce<Promise<void>>(
-    acc => acc.then(() => new Promise(resolve => setTimeout(resolve, 0))),
-    Promise.resolve(),
-  );
-}
-
-/** In-memory pubsub with a real lease provider, standing in for Redis Streams. */
-class LeasePubSub extends PubSub implements LeaseProvider {
-  owners = new Map<string, string>();
-  #subscribers = new Map<string, Set<EventCallback>>();
-
-  async publish(topic: string, event: any): Promise<void> {
-    for (const subscriber of [...(this.#subscribers.get(topic) ?? [])]) {
-      await subscriber({ ...event, id: 'evt', createdAt: new Date() }, async () => {});
-    }
-  }
-  async flush(): Promise<void> {}
-  async subscribe(topic: string, cb: EventCallback): Promise<void> {
-    const subscribers = this.#subscribers.get(topic) ?? new Set<EventCallback>();
-    subscribers.add(cb);
-    this.#subscribers.set(topic, subscribers);
-  }
-  async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
-    this.#subscribers.get(topic)?.delete(cb);
-  }
-  async acquireLease(key: string, owner: string): Promise<{ acquired: boolean; owner?: string }> {
-    const current = this.owners.get(key);
-    if (current && current !== owner) return { acquired: false, owner: current };
-    this.owners.set(key, owner);
-    return { acquired: true, owner };
-  }
-  async getLeaseOwner(key: string): Promise<string | undefined> {
-    return this.owners.get(key);
-  }
-  async releaseLease(key: string, owner: string): Promise<void> {
-    if (this.owners.get(key) === owner) this.owners.delete(key);
-  }
-  async renewLease(key: string, owner: string): Promise<boolean> {
-    return this.owners.get(key) === owner;
-  }
-  async transferLease(key: string, fromOwner: string, toOwner: string): Promise<boolean> {
-    if (this.owners.get(key) !== fromOwner) return false;
-    this.owners.set(key, toOwner);
-    return true;
-  }
-}
-
-const agent = { id: 'phantom-agent' } as Agent<any, any, any, any>;
-const threadId = 'phantom-thread';
-const resourceId = 'phantom-user';
+const harness = createHarness('phantom');
+const { runId, streamId, resourceId, threadId } = harness;
 const key = [resourceId, threadId].join(AGENT_THREAD_KEY_SEPARATOR);
-const topic = `agent.thread-stream.${encodeURIComponent(key)}`;
-const runId = 'replayed-run';
-const streamId = 'replayed-stream';
 
-function setup() {
-  const runtime = new AgentThreadStreamRuntime();
-  const pubsub = new LeasePubSub();
-  const emit = (data: Record<string, unknown>) =>
-    pubsub.publish(topic, { type: 'agent.thread-stream', runId: data.runId, data });
-  const streamPart = (part: unknown) => emit({ type: 'stream-part', runId, streamId, sourceId: 'origin', part });
-  return { runtime, pubsub, emit, streamPart };
-}
-
-async function collect(runtime: AgentThreadStreamRuntime, pubsub: LeasePubSub) {
-  const subscription = await runtime.subscribeToThread(agent, { threadId, resourceId }, pubsub);
-  const collected: Array<{ type: string }> = [];
-  const consumed = (async () => {
-    for await (const part of subscription.stream) collected.push(part as { type: string });
-  })();
-  return { subscription, collected, consumed };
-}
+const setup = () => setupRuntime(harness);
+const collect = (runtime: AgentThreadStreamRuntime, pubsub: LeasePubSub) => collectThread(harness, runtime, pubsub);
 
 describe('phantom replay of unpersisted runs', () => {
   it('does not replay a run that failed mid-stream and terminated with run-completed', async () => {
@@ -229,6 +164,29 @@ describe('phantom replay of unpersisted runs', () => {
 
     subscription.unsubscribe();
     await consumed;
+  });
+
+  it('does not replay a deferred run terminated by run-aborted, even with a clean-finish backlog', async () => {
+    const { runtime, pubsub, emit, streamPart } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    // Aborted runs never persist their messages: the backlog must be dropped
+    // even if a finish chunk made it onto the wire before the abort.
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    await streamPart({ type: 'start', payload: {} });
+    await streamPart({ type: 'text-delta', payload: { text: 'about to abort' } });
+    await streamPart({
+      type: 'finish',
+      payload: { stepResult: { reason: 'stop' }, output: { usage: {} }, metadata: {} },
+    });
+    await emit({ type: 'run-aborted', runId, streamId });
+    await nextTicks();
+
+    expect(collected).toEqual([]);
+
+    subscription.unsubscribe();
+    await consumed;
+    expect(collected).toEqual([]);
   });
 
   it('flushes a deferred run when it suspends (suspends persist a snapshot)', async () => {

--- a/packages/core/src/agent/__tests__/thread-stream-replay-ordering.test.ts
+++ b/packages/core/src/agent/__tests__/thread-stream-replay-ordering.test.ts
@@ -13,85 +13,15 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { PubSub } from '../../events/pubsub';
-import type { LeaseProvider } from '../../events/pubsub';
-import type { EventCallback } from '../../events/types';
-import type { Agent } from '../agent';
-import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+import type { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+import type { LeasePubSub } from './thread-stream-test-utils';
+import { collectThread, createHarness, nextTicks, setupRuntime } from './thread-stream-test-utils';
 
-const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
+const harness = createHarness('ordering');
+const { runId, streamId } = harness;
 
-function nextTicks(count = 5) {
-  return Array.from({ length: count }).reduce<Promise<void>>(
-    acc => acc.then(() => new Promise(resolve => setTimeout(resolve, 0))),
-    Promise.resolve(),
-  );
-}
-
-class LeasePubSub extends PubSub implements LeaseProvider {
-  owners = new Map<string, string>();
-  #subscribers = new Map<string, Set<EventCallback>>();
-
-  async publish(topic: string, event: any): Promise<void> {
-    for (const subscriber of [...(this.#subscribers.get(topic) ?? [])]) {
-      await subscriber({ ...event, id: 'evt', createdAt: new Date() }, async () => {});
-    }
-  }
-  async flush(): Promise<void> {}
-  async subscribe(topic: string, cb: EventCallback): Promise<void> {
-    const subscribers = this.#subscribers.get(topic) ?? new Set<EventCallback>();
-    subscribers.add(cb);
-    this.#subscribers.set(topic, subscribers);
-  }
-  async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
-    this.#subscribers.get(topic)?.delete(cb);
-  }
-  async acquireLease(key: string, owner: string): Promise<{ acquired: boolean; owner?: string }> {
-    const current = this.owners.get(key);
-    if (current && current !== owner) return { acquired: false, owner: current };
-    this.owners.set(key, owner);
-    return { acquired: true, owner };
-  }
-  async getLeaseOwner(key: string): Promise<string | undefined> {
-    return this.owners.get(key);
-  }
-  async releaseLease(key: string, owner: string): Promise<void> {
-    if (this.owners.get(key) === owner) this.owners.delete(key);
-  }
-  async renewLease(key: string, owner: string): Promise<boolean> {
-    return this.owners.get(key) === owner;
-  }
-  async transferLease(key: string, fromOwner: string, toOwner: string): Promise<boolean> {
-    if (this.owners.get(key) !== fromOwner) return false;
-    this.owners.set(key, toOwner);
-    return true;
-  }
-}
-
-const agent = { id: 'ordering-agent' } as Agent<any, any, any, any>;
-const threadId = 'ordering-thread';
-const resourceId = 'ordering-user';
-const key = [resourceId, threadId].join(AGENT_THREAD_KEY_SEPARATOR);
-const topic = `agent.thread-stream.${encodeURIComponent(key)}`;
-const runId = 'ordered-run';
-const streamId = 'ordered-stream';
-
-function setup() {
-  const runtime = new AgentThreadStreamRuntime();
-  const pubsub = new LeasePubSub();
-  const emit = (data: Record<string, unknown>) =>
-    pubsub.publish(topic, { type: 'agent.thread-stream', runId: data.runId, data });
-  return { runtime, pubsub, emit };
-}
-
-async function collect(runtime: AgentThreadStreamRuntime, pubsub: LeasePubSub) {
-  const subscription = await runtime.subscribeToThread(agent, { threadId, resourceId }, pubsub);
-  const collected: Array<{ type: string }> = [];
-  const consumed = (async () => {
-    for await (const part of subscription.stream) collected.push(part as { type: string });
-  })();
-  return { subscription, collected, consumed };
-}
+const setup = () => setupRuntime(harness);
+const collect = (runtime: AgentThreadStreamRuntime, pubsub: LeasePubSub) => collectThread(harness, runtime, pubsub);
 
 const finishPart = {
   type: 'finish',

--- a/packages/core/src/agent/__tests__/thread-stream-replay-ordering.test.ts
+++ b/packages/core/src/agent/__tests__/thread-stream-replay-ordering.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Adversarial ordering + mixed-version coverage for the deferred replay
+ * system (issue #21223 fix).
+ *
+ * - Mixed-version: an origin running an older @mastra/core publishes
+ *   `run-registered` without `sourceId` and `run-completed` without
+ *   `persisted`. The subscriber must fall back to the clean-finish heuristic
+ *   without dropping clean runs or replaying phantoms.
+ * - Ordering permutations: the origin gates terminal publishes on
+ *   `broadcastFinished`, but a subscriber must stay correct (no phantom, no
+ *   hang, in-order delivery) for every interleaving of registration and
+ *   terminal events among the stream parts, since older origins do not gate.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { PubSub } from '../../events/pubsub';
+import type { LeaseProvider } from '../../events/pubsub';
+import type { EventCallback } from '../../events/types';
+import type { Agent } from '../agent';
+import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+
+const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
+
+function nextTicks(count = 5) {
+  return Array.from({ length: count }).reduce<Promise<void>>(
+    acc => acc.then(() => new Promise(resolve => setTimeout(resolve, 0))),
+    Promise.resolve(),
+  );
+}
+
+class LeasePubSub extends PubSub implements LeaseProvider {
+  owners = new Map<string, string>();
+  #subscribers = new Map<string, Set<EventCallback>>();
+
+  async publish(topic: string, event: any): Promise<void> {
+    for (const subscriber of [...(this.#subscribers.get(topic) ?? [])]) {
+      await subscriber({ ...event, id: 'evt', createdAt: new Date() }, async () => {});
+    }
+  }
+  async flush(): Promise<void> {}
+  async subscribe(topic: string, cb: EventCallback): Promise<void> {
+    const subscribers = this.#subscribers.get(topic) ?? new Set<EventCallback>();
+    subscribers.add(cb);
+    this.#subscribers.set(topic, subscribers);
+  }
+  async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
+    this.#subscribers.get(topic)?.delete(cb);
+  }
+  async acquireLease(key: string, owner: string): Promise<{ acquired: boolean; owner?: string }> {
+    const current = this.owners.get(key);
+    if (current && current !== owner) return { acquired: false, owner: current };
+    this.owners.set(key, owner);
+    return { acquired: true, owner };
+  }
+  async getLeaseOwner(key: string): Promise<string | undefined> {
+    return this.owners.get(key);
+  }
+  async releaseLease(key: string, owner: string): Promise<void> {
+    if (this.owners.get(key) === owner) this.owners.delete(key);
+  }
+  async renewLease(key: string, owner: string): Promise<boolean> {
+    return this.owners.get(key) === owner;
+  }
+  async transferLease(key: string, fromOwner: string, toOwner: string): Promise<boolean> {
+    if (this.owners.get(key) !== fromOwner) return false;
+    this.owners.set(key, toOwner);
+    return true;
+  }
+}
+
+const agent = { id: 'ordering-agent' } as Agent<any, any, any, any>;
+const threadId = 'ordering-thread';
+const resourceId = 'ordering-user';
+const key = [resourceId, threadId].join(AGENT_THREAD_KEY_SEPARATOR);
+const topic = `agent.thread-stream.${encodeURIComponent(key)}`;
+const runId = 'ordered-run';
+const streamId = 'ordered-stream';
+
+function setup() {
+  const runtime = new AgentThreadStreamRuntime();
+  const pubsub = new LeasePubSub();
+  const emit = (data: Record<string, unknown>) =>
+    pubsub.publish(topic, { type: 'agent.thread-stream', runId: data.runId, data });
+  return { runtime, pubsub, emit };
+}
+
+async function collect(runtime: AgentThreadStreamRuntime, pubsub: LeasePubSub) {
+  const subscription = await runtime.subscribeToThread(agent, { threadId, resourceId }, pubsub);
+  const collected: Array<{ type: string }> = [];
+  const consumed = (async () => {
+    for await (const part of subscription.stream) collected.push(part as { type: string });
+  })();
+  return { subscription, collected, consumed };
+}
+
+const finishPart = {
+  type: 'finish',
+  payload: { stepResult: { reason: 'stop' }, output: { usage: {} }, metadata: {} },
+};
+
+describe('mixed-version compat: events from an older origin', () => {
+  // Older origins publish run-registered without sourceId and run-completed
+  // without persisted. Subscriber must use the clean-finish heuristic.
+  it('replays a clean legacy run (no sourceId, no persisted flag)', async () => {
+    const { runtime, pubsub, emit } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    await emit({
+      type: 'stream-part',
+      runId,
+      streamId,
+      sourceId: 'legacy-origin',
+      part: { type: 'start', payload: {} },
+    });
+    await emit({
+      type: 'stream-part',
+      runId,
+      streamId,
+      sourceId: 'legacy-origin',
+      part: { type: 'text-delta', payload: { text: 'hello' } },
+    });
+    await emit({ type: 'stream-part', runId, streamId, sourceId: 'legacy-origin', part: finishPart });
+    await emit({ type: 'run-completed', runId, streamId });
+    await nextTicks();
+
+    expect(collected.map(part => part.type)).toEqual(['start', 'text-delta', 'finish']);
+
+    subscription.unsubscribe();
+    await consumed;
+  });
+
+  it('drops a legacy phantom (error backlog, terminal without persisted flag)', async () => {
+    const { runtime, pubsub, emit } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1 });
+    await emit({
+      type: 'stream-part',
+      runId,
+      streamId,
+      sourceId: 'legacy-origin',
+      part: { type: 'start', payload: {} },
+    });
+    await emit({
+      type: 'stream-part',
+      runId,
+      streamId,
+      sourceId: 'legacy-origin',
+      part: { type: 'error', payload: { error: 'boom' } },
+    });
+    await emit({ type: 'run-completed', runId, streamId });
+    await nextTicks();
+
+    expect(collected).toEqual([]);
+
+    subscription.unsubscribe();
+    await consumed;
+  });
+
+  it('defers a foreign run even when its registration carries a sourceId', async () => {
+    // New-origin event observed by a different (new) process: sourceId is
+    // present but does not match the subscriber, so it must still defer.
+    const { runtime, pubsub, emit } = setup();
+    const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+    await emit({ type: 'run-registered', runId, streamId, streamSeq: 1, sourceId: 'some-other-process' });
+    await emit({
+      type: 'stream-part',
+      runId,
+      streamId,
+      sourceId: 'some-other-process',
+      part: { type: 'start', payload: {} },
+    });
+    await nextTicks();
+
+    expect(collected).toEqual([]);
+
+    subscription.unsubscribe();
+    await consumed;
+  });
+});
+
+describe('adversarial orderings of registration/terminal among stream parts', () => {
+  const parts = [{ type: 'start', payload: {} }, { type: 'text-delta', payload: { text: 'hello' } }, finishPart];
+
+  /** All interleavings of markers R (register) and C (complete) among the
+   *  ordered parts P0..P2. R always precedes C (origin invariant even on old
+   *  versions), but either may land anywhere relative to the parts. */
+  function orderings(): string[][] {
+    const results: string[][] = [];
+    const base = ['P0', 'P1', 'P2'];
+    for (let r = 0; r <= base.length; r++) {
+      for (let c = r; c <= base.length; c++) {
+        const seq = [...base];
+        seq.splice(c, 0, 'C');
+        seq.splice(r, 0, 'R');
+        results.push(seq);
+      }
+    }
+    return results;
+  }
+
+  for (const seq of orderings()) {
+    it(`dead-run replay stays phantom-free and hang-free for order ${seq.join(' ')}`, async () => {
+      const { runtime, pubsub, emit } = setup();
+      const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+      const partsBeforeTerminal = seq.slice(0, seq.indexOf('C')).filter(tok => tok.startsWith('P')).length;
+
+      for (const token of seq) {
+        if (token === 'R') {
+          await emit({ type: 'run-registered', runId, streamId, streamSeq: 1, sourceId: 'origin' });
+        } else if (token === 'C') {
+          await emit({ type: 'run-completed', runId, streamId, persisted: true });
+        } else {
+          const part = parts[Number(token.slice(1))];
+          await emit({ type: 'stream-part', runId, streamId, sourceId: 'origin', part });
+        }
+      }
+      await nextTicks();
+
+      // Invariants:
+      // 1. In-order subsequence of the published parts (no reordering, no
+      //    duplication, no fabricated parts).
+      const publishedOrder = parts.map(part => part.type);
+      let cursor = 0;
+      for (const part of collected) {
+        const idx = publishedOrder.indexOf(part.type, cursor);
+        expect(idx, `part ${part.type} out of order in ${collected.map(p => p.type).join(',')}`).toBeGreaterThanOrEqual(
+          0,
+        );
+        cursor = idx + 1;
+      }
+      // 2. persisted: true terminal means everything buffered before the
+      //    terminal must be delivered — a clean run is never silently dropped.
+      expect(collected.length).toBeGreaterThanOrEqual(partsBeforeTerminal);
+
+      // 3. No hang: unsubscribe ends the consumer loop promptly.
+      subscription.unsubscribe();
+      await consumed;
+    });
+
+    it(`unpersisted-run replay yields nothing for order ${seq.join(' ')}`, async () => {
+      const { runtime, pubsub, emit } = setup();
+      const { subscription, collected, consumed } = await collect(runtime, pubsub);
+
+      for (const token of seq) {
+        if (token === 'R') {
+          await emit({ type: 'run-registered', runId, streamId, streamSeq: 1, sourceId: 'origin' });
+        } else if (token === 'C') {
+          await emit({ type: 'run-completed', runId, streamId, persisted: false });
+        } else {
+          const part = parts[Number(token.slice(1))];
+          await emit({ type: 'stream-part', runId, streamId, sourceId: 'origin', part });
+        }
+      }
+      await nextTicks();
+
+      // Parts published before the terminal must never surface. Parts that
+      // arrive after the run was discarded are tolerated only if the run is
+      // re-buffered and never released (still nothing delivered).
+      expect(collected).toEqual([]);
+
+      subscription.unsubscribe();
+      await consumed;
+    });
+  }
+});

--- a/packages/core/src/agent/__tests__/thread-stream-test-utils.ts
+++ b/packages/core/src/agent/__tests__/thread-stream-test-utils.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared fixtures for thread-stream deferred-replay tests
+ * (thread-stream-phantom-replay.test.ts, thread-stream-replay-ordering.test.ts).
+ */
+import { PubSub } from '../../events/pubsub';
+import type { LeaseProvider } from '../../events/pubsub';
+import type { EventCallback } from '../../events/types';
+import type { Agent } from '../agent';
+import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+
+export const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
+
+export function nextTicks(count = 5) {
+  return Array.from({ length: count }).reduce<Promise<void>>(
+    acc => acc.then(() => new Promise(resolve => setTimeout(resolve, 0))),
+    Promise.resolve(),
+  );
+}
+
+/** In-memory pubsub with a real lease provider, standing in for Redis Streams. */
+export class LeasePubSub extends PubSub implements LeaseProvider {
+  owners = new Map<string, string>();
+  #subscribers = new Map<string, Set<EventCallback>>();
+
+  async publish(topic: string, event: any): Promise<void> {
+    for (const subscriber of [...(this.#subscribers.get(topic) ?? [])]) {
+      await subscriber({ ...event, id: 'evt', createdAt: new Date() }, async () => {});
+    }
+  }
+  async flush(): Promise<void> {}
+  async subscribe(topic: string, cb: EventCallback): Promise<void> {
+    const subscribers = this.#subscribers.get(topic) ?? new Set<EventCallback>();
+    subscribers.add(cb);
+    this.#subscribers.set(topic, subscribers);
+  }
+  async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
+    this.#subscribers.get(topic)?.delete(cb);
+  }
+  async acquireLease(key: string, owner: string): Promise<{ acquired: boolean; owner?: string }> {
+    const current = this.owners.get(key);
+    if (current && current !== owner) return { acquired: false, owner: current };
+    this.owners.set(key, owner);
+    return { acquired: true, owner };
+  }
+  async getLeaseOwner(key: string): Promise<string | undefined> {
+    return this.owners.get(key);
+  }
+  async releaseLease(key: string, owner: string): Promise<void> {
+    if (this.owners.get(key) === owner) this.owners.delete(key);
+  }
+  async renewLease(key: string, owner: string): Promise<boolean> {
+    return this.owners.get(key) === owner;
+  }
+  async transferLease(key: string, fromOwner: string, toOwner: string): Promise<boolean> {
+    if (this.owners.get(key) !== fromOwner) return false;
+    this.owners.set(key, toOwner);
+    return true;
+  }
+}
+
+export interface ThreadStreamHarness {
+  agent: Agent<any, any, any, any>;
+  threadId: string;
+  resourceId: string;
+  topic: string;
+  runId: string;
+  streamId: string;
+}
+
+export function createHarness(prefix: string): ThreadStreamHarness {
+  const threadId = `${prefix}-thread`;
+  const resourceId = `${prefix}-user`;
+  const key = [resourceId, threadId].join(AGENT_THREAD_KEY_SEPARATOR);
+  return {
+    agent: { id: `${prefix}-agent` } as Agent<any, any, any, any>,
+    threadId,
+    resourceId,
+    topic: `agent.thread-stream.${encodeURIComponent(key)}`,
+    runId: `${prefix}-run`,
+    streamId: `${prefix}-stream`,
+  };
+}
+
+export function setupRuntime(harness: ThreadStreamHarness) {
+  const runtime = new AgentThreadStreamRuntime();
+  const pubsub = new LeasePubSub();
+  const emit = (data: Record<string, unknown>) =>
+    pubsub.publish(harness.topic, { type: 'agent.thread-stream', runId: data.runId, data });
+  const streamPart = (part: unknown) =>
+    emit({ type: 'stream-part', runId: harness.runId, streamId: harness.streamId, sourceId: 'origin', part });
+  return { runtime, pubsub, emit, streamPart };
+}
+
+export async function collectThread(
+  harness: ThreadStreamHarness,
+  runtime: AgentThreadStreamRuntime,
+  pubsub: LeasePubSub,
+) {
+  const subscription = await runtime.subscribeToThread(
+    harness.agent,
+    { threadId: harness.threadId, resourceId: harness.resourceId },
+    pubsub,
+  );
+  const collected: Array<{ type: string }> = [];
+  const consumed = (async () => {
+    for await (const part of subscription.stream) collected.push(part as { type: string });
+  })();
+  return { subscription, collected, consumed };
+}

--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -230,6 +230,7 @@ export function createDurableAgentStream<OUTPUT = undefined>(
   // surface it in onError when the FINISH event arrives with reason 'error'.
   let lastErrorMessage: string | undefined;
   let lastErrorStack: string | undefined;
+  let lastErrorName: string | undefined;
   let lastErrorCause: unknown;
 
   // Idle/liveness watchdog. A durable run whose driving process crashed stops
@@ -336,6 +337,7 @@ export function createDurableAgentStream<OUTPUT = undefined>(
             const errPayload = (chunk as any).payload;
             lastErrorMessage = errPayload?.error?.message || errPayload?.message || 'LLM execution error';
             lastErrorStack = typeof errPayload?.error?.stack === 'string' ? errPayload.error.stack : undefined;
+            lastErrorName = typeof errPayload?.error?.name === 'string' ? errPayload.error.name : undefined;
             lastErrorCause = errPayload?.error ?? errPayload;
           }
           safeEnqueue(controller, chunk as ChunkType<OUTPUT>);
@@ -427,8 +429,9 @@ export function createDurableAgentStream<OUTPUT = undefined>(
           if (onError && data.stepResult?.reason === 'error') {
             try {
               const error = new Error(lastErrorMessage || 'LLM execution error', { cause: lastErrorCause });
-              // Preserve the producer's stack so the failure stays attributable to its real throw site.
+              // Preserve the producer's stack and name so the failure stays attributable and classifiable.
               if (lastErrorStack) error.stack = lastErrorStack;
+              if (lastErrorName) error.name = lastErrorName;
               await onError({ error });
             } catch (callbackError) {
               logError(`[DurableAgentStream] onError (from FINISH) callback error:`, callbackError);

--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -229,6 +229,8 @@ export function createDurableAgentStream<OUTPUT = undefined>(
   // Track the last error message seen in an 'error' chunk, so we can
   // surface it in onError when the FINISH event arrives with reason 'error'.
   let lastErrorMessage: string | undefined;
+  let lastErrorStack: string | undefined;
+  let lastErrorCause: unknown;
 
   // Idle/liveness watchdog. A durable run whose driving process crashed stops
   // emitting chunks but never publishes a terminal FINISH/ERROR/ABORT event, so
@@ -333,6 +335,8 @@ export function createDurableAgentStream<OUTPUT = undefined>(
           if ((chunk as any).type === 'error') {
             const errPayload = (chunk as any).payload;
             lastErrorMessage = errPayload?.error?.message || errPayload?.message || 'LLM execution error';
+            lastErrorStack = typeof errPayload?.error?.stack === 'string' ? errPayload.error.stack : undefined;
+            lastErrorCause = errPayload?.error ?? errPayload;
           }
           safeEnqueue(controller, chunk as ChunkType<OUTPUT>);
           await onChunk?.(chunk as ChunkType<OUTPUT>);
@@ -422,7 +426,10 @@ export function createDurableAgentStream<OUTPUT = undefined>(
           // event never fires.
           if (onError && data.stepResult?.reason === 'error') {
             try {
-              await onError({ error: new Error(lastErrorMessage || 'LLM execution error') });
+              const error = new Error(lastErrorMessage || 'LLM execution error', { cause: lastErrorCause });
+              // Preserve the producer's stack so the failure stays attributable to its real throw site.
+              if (lastErrorStack) error.stack = lastErrorStack;
+              await onError({ error });
             } catch (callbackError) {
               logError(`[DurableAgentStream] onError (from FINISH) callback error:`, callbackError);
             }

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -1328,7 +1328,11 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                   case 'error': {
                     const payload = rawChunk.payload as any;
                     const errorMessage = payload?.error?.message || payload?.message || 'LLM execution error';
-                    const errorObj = new Error(errorMessage);
+                    const errorObj = new Error(errorMessage, { cause: payload?.error ?? payload });
+                    // Keep the producer's stack so crashes stay attributable to their real throw site.
+                    if (typeof payload?.error?.stack === 'string') {
+                      errorObj.stack = payload.error.stack;
+                    }
                     // DON'T emit error event here - we might have fallback models to try
                     // Error event will be emitted after all models are exhausted
                     throw errorObj;
@@ -1853,7 +1857,16 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
           type: 'error',
           runId,
           from: ChunkFrom.AGENT,
-          payload: { error: fatalError },
+          // Serialize explicitly: a raw Error JSON-stringifies to `{}` on plain
+          // transports, which destroys the producer stack and makes crashes
+          // unattributable on the consumer side.
+          payload: {
+            error: {
+              message: fatalError.message,
+              stack: fatalError.stack,
+              name: fatalError.name,
+            },
+          },
         });
 
         // Emit step-finish so MastraModelOutput resolves finishReason to 'error'

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -1333,6 +1333,10 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                     if (typeof payload?.error?.stack === 'string') {
                       errorObj.stack = payload.error.stack;
                     }
+                    // Retain the producer's error name so classification (e.g. AbortError) survives transport.
+                    if (typeof payload?.error?.name === 'string' && payload.error.name) {
+                      errorObj.name = payload.error.name;
+                    }
                     // DON'T emit error event here - we might have fallback models to try
                     // Error event will be emitted after all models are exhausted
                     throw errorObj;

--- a/packages/core/src/agent/message-list/conversion/to-prompt-malformed-parts.test.ts
+++ b/packages/core/src/agent/message-list/conversion/to-prompt-malformed-parts.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { aiV5ModelMessageToV2PromptMessage } from './to-prompt';
+
+// Regression tests for #21138 — DurableAgent inference crashed with
+// "Cannot read properties of undefined (reading 'type')" when malformed
+// messages (undefined content entries or output-less tool results) reached
+// the provider converter.
+describe('aiV5ModelMessageToV2PromptMessage malformed message hardening', () => {
+  it('skips undefined/null holes in content arrays instead of crashing', () => {
+    const result = aiV5ModelMessageToV2PromptMessage({
+      role: 'assistant',
+      content: [undefined, { type: 'text', text: 'hello' }, null] as any,
+    });
+
+    expect(result.role).toBe('assistant');
+    expect(result.content).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+
+  it('treats undefined content as empty instead of crashing', () => {
+    const result = aiV5ModelMessageToV2PromptMessage({
+      role: 'assistant',
+      content: undefined as any,
+    });
+
+    expect(result.content).toEqual([]);
+  });
+
+  it('backfills a valid output for tool-result parts missing output', () => {
+    const result = aiV5ModelMessageToV2PromptMessage({
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'myTool',
+          output: undefined,
+        } as any,
+      ],
+    });
+
+    expect(result.role).toBe('tool');
+    // Providers (e.g. @ai-sdk/openai-compatible) read output.type unguarded.
+    expect((result.content[0] as any).output).toEqual({ type: 'json', value: null });
+  });
+
+  it('leaves valid tool-result outputs untouched', () => {
+    const output = { type: 'json', value: { ok: true } };
+    const result = aiV5ModelMessageToV2PromptMessage({
+      role: 'tool',
+      content: [{ type: 'tool-result', toolCallId: 'call-1', toolName: 'myTool', output } as any],
+    });
+
+    expect((result.content[0] as any).output).toEqual(output);
+  });
+});

--- a/packages/core/src/agent/message-list/conversion/to-prompt.ts
+++ b/packages/core/src/agent/message-list/conversion/to-prompt.ts
@@ -207,7 +207,12 @@ export function aiV5ModelMessageToV2PromptMessage(modelMessage: AIV5Type.ModelMe
 
   const role = modelMessage.role;
 
-  for (const part of modelMessage.content) {
+  for (const part of modelMessage.content ?? []) {
+    // Defensive: upstream rewrites (e.g. observational memory) have produced sparse
+    // content arrays in production. A hole here would crash the provider converter
+    // with an unattributable "Cannot read properties of undefined (reading 'type')".
+    if (!part || typeof part !== 'object') continue;
+
     const incompatibleMessage = `Saw incompatible message content part type ${part.type} for message role ${role}`;
 
     switch (part.type) {
@@ -245,6 +250,10 @@ export function aiV5ModelMessageToV2PromptMessage(modelMessage: AIV5Type.ModelMe
         roleContent[role].push({
           ...part,
           toolName: sanitizeToolName(part.toolName),
+          // Providers read `output.type` unguarded (e.g. @ai-sdk/openai-compatible).
+          // An output-less tool result (lost result chunk, OM rewrite) must still
+          // present a valid LanguageModelV2ToolResultOutput shape.
+          output: part.output ?? { type: 'json', value: null },
         });
         break;
       }

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -692,6 +692,7 @@ export class MessageList {
         messages = ensureGeminiCompatibleMessages(messages, this.logger);
 
         return messages
+          .filter(message => message != null)
           .map(aiV5ModelMessageToV2PromptMessage)
           .filter(
             message => message.role === 'system' || typeof message.content === 'string' || message.content.length > 0,

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -62,6 +62,56 @@ const AGENT_SUSPENDED_RUN_TTL_MS = readPositiveIntEnv('MASTRA_SUSPENDED_RUN_TTL_
 
 export let defaultAgentThreadPubSub: PubSub = new EventEmitterPubSub();
 
+/**
+ * Strip raw model-request bookkeeping from a chunk before it is broadcast to
+ * the thread-stream topic (and retained for subscriber replay). `step-start`
+ * embeds the full serialized provider request (including any base64 media in
+ * context), and `step-finish`/`finish` repeat it via `metadata.request`,
+ * `output.steps[]` (each step re-embeds its cumulative request/response) and
+ * `messages`. No thread subscriber needs those — they are available to the
+ * local caller via `output.request`/`output.steps` — and broadcasting them
+ * multiplies the largest object in the system ≥5× per step, persists it in
+ * durable pubsub backends, and exposes prompt contents to every subscriber.
+ * Only the broadcast copy is rewritten; the caller's MastraModelOutput is
+ * untouched.
+ */
+function sanitizeBroadcastPart(part: unknown): unknown {
+  if (!part || typeof part !== 'object' || !('type' in part)) return part;
+  const typed = part as { type?: string; payload?: Record<string, unknown> };
+  const payload = typed.payload;
+  if (!payload || typeof payload !== 'object') return part;
+
+  if (typed.type === 'step-start') {
+    if (!('request' in payload) && !('inputMessages' in payload)) return part;
+    const { request: _request, inputMessages: _inputMessages, ...rest } = payload;
+    return { ...typed, payload: rest };
+  }
+
+  if (typed.type === 'step-finish' || typed.type === 'finish') {
+    let changed = false;
+    const next: Record<string, unknown> = { ...payload };
+    const metadata = payload.metadata;
+    if (metadata && typeof metadata === 'object' && 'request' in metadata) {
+      const { request: _request, ...restMetadata } = metadata as Record<string, unknown>;
+      next.metadata = restMetadata;
+      changed = true;
+    }
+    const output = payload.output;
+    if (output && typeof output === 'object' && 'steps' in output) {
+      const { steps: _steps, ...restOutput } = output as Record<string, unknown>;
+      next.output = restOutput;
+      changed = true;
+    }
+    if ('messages' in payload) {
+      delete next.messages;
+      changed = true;
+    }
+    return changed ? { ...typed, payload: next } : part;
+  }
+
+  return part;
+}
+
 function withThreadMemory(memory: unknown, resourceId: string, threadId: string) {
   return {
     ...((memory && typeof memory === 'object' ? memory : {}) as Record<string, unknown>),
@@ -92,6 +142,8 @@ type AgentThreadRunRecord<OUTPUT = unknown> = {
   resourceId?: string;
   streamOptions: AgentExecutionOptions<OUTPUT>;
   createSubscriberStream?: () => ReadableStream<unknown>;
+  /** Settles once every stream-part broadcast publish for this run completed. */
+  broadcastFinished?: Promise<void>;
 };
 
 type PreparedThreadRun = {
@@ -153,9 +205,9 @@ export type AgentThreadState = 'active' | 'idle';
 type SerializableAgentSignal = AgentSignal & Pick<CreatedAgentSignal, 'id' | 'createdAt'>;
 
 type AgentThreadStreamRuntimeEvent =
-  | { type: 'run-registered'; runId: string; streamId: string; streamSeq: number }
+  | { type: 'run-registered'; runId: string; streamId: string; streamSeq: number; sourceId?: string }
   | { type: 'stream-part'; runId: string; streamId: string; part: unknown; sourceId: string }
-  | { type: 'run-completed'; runId: string; streamId?: string }
+  | { type: 'run-completed'; runId: string; streamId?: string; persisted?: boolean }
   | { type: 'run-suspended'; runId: string; streamId?: string }
   | { type: 'run-abort-requested'; runId: string; streamId: string }
   | { type: 'run-aborted'; runId: string; streamId?: string }
@@ -533,6 +585,16 @@ export class AgentThreadStreamRuntime {
     let started = false;
     let done = false;
     let error: unknown;
+    // Resolves once the broadcast pump has drained the source stream AND every
+    // stream-part publish has completed. Terminal events (`run-completed` /
+    // `run-suspended`) must wait on this: publishing the terminal event while
+    // part publishes are still in flight lets it overtake them on the wire,
+    // and a subscriber that deferred the run would flush an empty buffer and
+    // then drop the late-arriving parts.
+    let resolveBroadcastFinished!: () => void;
+    const broadcastFinished = new Promise<void>(resolve => {
+      resolveBroadcastFinished = resolve;
+    });
 
     const wake = () => {
       const pending = [...waiters];
@@ -540,9 +602,9 @@ export class AgentThreadStreamRuntime {
       for (const waiter of pending) waiter();
     };
 
-    const emitPart = async (part: unknown) => {
-      if (part && typeof part === 'object' && 'type' in part) {
-        const typedPart = part as { type?: string; payload?: { toolCallId?: string; toolName?: string } };
+    const emitPart = async (rawPart: unknown) => {
+      if (rawPart && typeof rawPart === 'object' && 'type' in rawPart) {
+        const typedPart = rawPart as { type?: string; payload?: { toolCallId?: string; toolName?: string } };
         if (typedPart.type === 'tool-call-approval' || typedPart.type === 'tool-call-suspended') {
           runtime.#markRunSuspending(runtime.#getState(pubsub), output.runId, streamId, {
             toolCallId: typedPart.payload?.toolCallId,
@@ -551,6 +613,7 @@ export class AgentThreadStreamRuntime {
           });
         }
       }
+      const part = sanitizeBroadcastPart(rawPart);
       parts.push(part);
       await runtime.#publishAndWait(pubsub, key, {
         type: 'stream-part',
@@ -590,6 +653,7 @@ export class AgentThreadStreamRuntime {
           error = caught;
         } finally {
           done = true;
+          resolveBroadcastFinished();
           wake();
         }
       })();
@@ -636,7 +700,7 @@ export class AgentThreadStreamRuntime {
       });
     };
 
-    return { output, createSubscriberStream: createStream, startBroadcast: start };
+    return { output, createSubscriberStream: createStream, startBroadcast: start, broadcastFinished };
   }
 
   #getThreadTarget(options?: { memory?: AgentExecutionOptions<any>['memory']; requestContext?: RequestContext }) {
@@ -910,6 +974,7 @@ export class AgentThreadStreamRuntime {
       output: outputForSubscribers,
       createSubscriberStream,
       startBroadcast,
+      broadcastFinished,
     } = this.#withBroadcastStream(output, pubsub, key, streamId);
     const record: AgentThreadRunRecord<any> = {
       agent: { id: `persisted-signal:${signal.id}` } as Agent<any, any, any, any>,
@@ -928,9 +993,19 @@ export class AgentThreadStreamRuntime {
     state.threadRunsByStreamId.set(streamId, record);
     state.threadKeysByRunId.set(runId, key);
     state.activeThreadStreamIds.set(key, streamId);
-    const registered = this.#publishAndWait(pubsub, key, { type: 'run-registered', runId, streamId, streamSeq });
+    const registered = this.#publishAndWait(pubsub, key, {
+      type: 'run-registered',
+      runId,
+      streamId,
+      streamSeq,
+      sourceId: this.#getSourceId(),
+    });
     void registered.then(startBroadcast, startBroadcast);
-    void outputForSubscribers._waitUntilFinished().finally(() => {
+    // Wait for the local stream to finish AND for every stream-part publish to
+    // land before publishing `run-completed`: the terminal event must not
+    // overtake the parts on the wire, or a deferred subscriber flushes an
+    // empty buffer and drops the late parts.
+    void Promise.allSettled([outputForSubscribers._waitUntilFinished(), broadcastFinished]).then(() => {
       setTimeout(() => {
         state.threadRunsByStreamId.delete(streamId);
         if (state.threadRunsById.get(runId) === record) {
@@ -942,7 +1017,8 @@ export class AgentThreadStreamRuntime {
           state.activeThreadStreamIds.delete(key);
         }
         this.#releaseThreadLease(pubsub, key, runId);
-        this.#publish(pubsub, key, { type: 'run-completed', runId, streamId });
+        // The signal this run rebroadcasts is persisted by definition.
+        this.#publish(pubsub, key, { type: 'run-completed', runId, streamId, persisted: true });
       }, 0);
     });
   }
@@ -1005,7 +1081,8 @@ export class AgentThreadStreamRuntime {
         state.activeThreadRunIds.delete(staleKey);
         state.activeThreadStreamIds.delete(staleKey);
       }
-      this.#publish(pubsub, staleKey, { type: 'run-completed', runId: record.runId, streamId });
+      // An abandoned suspend persisted its snapshot before parking.
+      this.#publish(pubsub, staleKey, { type: 'run-completed', runId: record.runId, streamId, persisted: true });
     }
   }
 
@@ -1026,6 +1103,7 @@ export class AgentThreadStreamRuntime {
       output: outputForSubscribers,
       createSubscriberStream,
       startBroadcast,
+      broadcastFinished,
     } = this.#withBroadcastStream(output, pubsub, key, streamId);
     const resumedToolCallId = (streamOptions as AgentExecutionOptions<OUTPUT> & { toolCallId?: string }).toolCallId;
     if (resumedToolCallId) {
@@ -1046,6 +1124,7 @@ export class AgentThreadStreamRuntime {
       streamOptions: streamOptions as AgentThreadRunRecord<OUTPUT>['streamOptions'],
       createSubscriberStream,
       suspensions: state.suspensionMetadataByRunId.get(output.runId),
+      broadcastFinished,
     };
 
     state.threadRunsById.set(output.runId, record);
@@ -1079,6 +1158,7 @@ export class AgentThreadStreamRuntime {
         runId: output.runId,
         streamId,
         streamSeq,
+        sourceId: this.#getSourceId(),
       });
     })();
     // Always drive the run's stream to completion, even when no caller consumes
@@ -1088,7 +1168,7 @@ export class AgentThreadStreamRuntime {
     // its active-run record + thread lease would never release, permanently
     // wedging the thread.
     void registered.then(startBroadcast, startBroadcast);
-    this.#watchThreadRunCompletion(state, pubsub, key, record);
+    this.#watchThreadRunCompletion(state, pubsub, key, record, registered);
     return registered;
   }
 
@@ -1097,11 +1177,19 @@ export class AgentThreadStreamRuntime {
     pubsub: PubSub | undefined,
     key: string,
     record: AgentThreadRunRecord<any>,
+    registered?: Promise<unknown>,
   ) {
     if (state.watchedThreadStreamIds.has(record.streamId)) return;
     state.watchedThreadStreamIds.add(record.streamId);
 
-    void record.output._waitUntilFinished().finally(() => {
+    // Wait for BOTH the run to finish AND `run-registered` to be on the wire
+    // before publishing the terminal event. A run that finishes faster than
+    // the async lease-acquire that precedes the registration publish would
+    // otherwise put `run-completed` on the wire before `run-registered`,
+    // which subscribers cannot reconcile (and would release a lease that is
+    // still being acquired).
+    const finished = record.output._waitUntilFinished();
+    void Promise.allSettled(registered ? [finished, registered] : [finished]).then(() => {
       state.watchedThreadStreamIds.delete(record.streamId);
       this.#cleanupPreparedRun(state, record.runId);
 
@@ -1140,12 +1228,28 @@ export class AgentThreadStreamRuntime {
       // transferred lease and releases it only once every queue is empty. If
       // there's no pending work, release as usual so other processes can wake
       // the thread.
-      this.#publish(pubsub, key, { type: 'run-completed', runId: record.runId, streamId: record.streamId });
-      if (this.#hasPendingThreadWork(state, key)) {
-        void this.#drainPendingSignals(state, pubsub, key, record);
-      } else {
-        this.#releaseThreadLease(pubsub, key, record.runId);
-      }
+      // Wait for every stream-part broadcast publish to land before putting the
+      // terminal event on the wire: `run-completed` overtaking in-flight parts
+      // makes a deferred subscriber flush an empty buffer and drop the late
+      // parts. The stream has already ended here (the run is terminal, not
+      // suspended), so the broadcast pump is guaranteed to settle. Local state
+      // cleanup above stays immediate.
+      void Promise.resolve(record.broadcastFinished).then(() => {
+        this.#publish(pubsub, key, {
+          type: 'run-completed',
+          runId: record.runId,
+          streamId: record.streamId,
+          // Origin-side truth for replay filtering: only a successful run flushed
+          // its messages to storage, so only its retained chunks are backed by a
+          // persisted message and safe to replay to fresh subscribers.
+          persisted: record.output.status === 'success',
+        });
+        if (this.#hasPendingThreadWork(state, key)) {
+          void this.#drainPendingSignals(state, pubsub, key, record);
+        } else {
+          this.#releaseThreadLease(pubsub, key, record.runId);
+        }
+      });
     });
   }
 
@@ -1725,6 +1829,15 @@ export class AgentThreadStreamRuntime {
 
     const localStreamIds = new Set<string>();
     const replayedStreamIds = new Set<string>();
+    // Replayed runs whose origin no longer holds the thread lease (the run is
+    // terminal or its process died). Their parts are buffered instead of being
+    // yielded live: a retained backend replays every run's chunks to a fresh
+    // subscriber, but a run that failed mid-stream never persisted a message,
+    // so replaying it would surface a phantom partial message that hydrated
+    // history can never reconcile. The run is only released to the subscriber
+    // once its terminal control event proves it finished cleanly; failed,
+    // aborted, or never-terminated (process crash) runs are dropped.
+    const deferredRunsByStreamId = new Map<string, AgentThreadRunRecord<any>>();
     let currentReader: ReadableStreamDefaultReader<any> | null = null;
     let activeReaderRunId: string | null = null;
     let cancelledByAbort = false;
@@ -1734,6 +1847,36 @@ export class AgentThreadStreamRuntime {
       state.activeThreadRunIds.set(key, runId);
       state.activeThreadStreamIds.set(key, streamId);
       if (!local) state.remoteThreadKeysByRunId.set(runId, key);
+    };
+
+    // A deferred run may be flushed only when its replayed chunks ended with a
+    // clean `finish` — the origin publishes `run-completed` after the run's
+    // messages were flushed to storage, so a clean finish implies a persisted
+    // message backs the replay. An in-band `error` chunk, a finish with
+    // `stepResult.reason: 'error'`, or a missing finish all mean nothing was
+    // persisted for the run.
+    const deferredRunEndedCleanly = (parts: unknown[]) => {
+      let sawFinish = false;
+      for (const part of parts) {
+        const typed = part as { type?: string; payload?: { stepResult?: { reason?: string } } } | undefined;
+        if (typed?.type === 'error' || typed?.type === 'abort') return false;
+        if (typed?.type === 'finish') {
+          if (typed.payload?.stepResult?.reason === 'error') return false;
+          sawFinish = true;
+        }
+      }
+      return sawFinish;
+    };
+
+    const discardDeferredRun = (streamId: string) => {
+      deferredRunsByStreamId.delete(streamId);
+      const remoteRun = remoteRuns.get(streamId);
+      if (!remoteRun) return;
+      remoteRun.parts.length = 0;
+      remoteRun.done = true;
+      while (remoteRun.waiters.length) remoteRun.waiters.shift()?.();
+      while (remoteRun.finishWaiters.length) remoteRun.finishWaiters.shift()?.();
+      remoteRuns.delete(streamId);
     };
 
     const clearActiveIfCurrent = (runId: string, streamId?: string) => {
@@ -1759,9 +1902,37 @@ export class AgentThreadStreamRuntime {
         } else {
           replayedStreamIds.add(data.streamId);
         }
-        await markActiveIfLive(data.runId, data.streamId, Boolean(localRecord));
-        const record = localRecord ?? createRemoteRun(data.runId, data.streamId, data.streamSeq);
-        enqueueRun(record);
+        const local = Boolean(localRecord);
+        // A registration published by this very runtime instance is always a
+        // live delivery — a restarted process gets a fresh source id, so a
+        // matching id can never be a stale replay of a dead run. This also
+        // covers runs that complete before the event is delivered in-process
+        // (record cleaned up, lease released) where deferral would strand the
+        // run because its terminal event was already processed.
+        const live =
+          local ||
+          (data.sourceId !== undefined && data.sourceId === this.#getSourceId()) ||
+          (await this.#hasLiveThreadLease(resolvedPubSub, key, data.runId));
+        if (live) {
+          state.activeThreadRunIds.set(key, data.runId);
+          state.activeThreadStreamIds.set(key, data.streamId);
+          if (!local) state.remoteThreadKeysByRunId.set(data.runId, key);
+        }
+        // Reuse a proxy that a stream-part-first delivery already created for
+        // this stream — creating a fresh record here would orphan its
+        // buffered parts.
+        const record =
+          localRecord ??
+          deferredRunsByStreamId.get(data.streamId) ??
+          createRemoteRun(data.runId, data.streamId, data.streamSeq);
+        if (live) {
+          deferredRunsByStreamId.delete(data.streamId);
+          enqueueRun(record);
+        } else {
+          // Replayed run from a retained backend with no live owner: buffer it
+          // until its terminal event proves it completed cleanly.
+          deferredRunsByStreamId.set(data.streamId, record);
+        }
         wake();
         return;
       }
@@ -1783,7 +1954,12 @@ export class AgentThreadStreamRuntime {
           // A subscriber can attach after another runtime already broadcast run-registered.
           // Treat the first stream-part on this thread topic as proof of the remote run and
           // create the local proxy stream from that point forward.
-          enqueueRun(createRemoteRun(data.runId, data.streamId, state.streamSeqByRunId.get(data.runId) ?? 1));
+          const record = createRemoteRun(data.runId, data.streamId, state.streamSeqByRunId.get(data.runId) ?? 1);
+          if (await this.#hasLiveThreadLease(resolvedPubSub, key, data.runId)) {
+            enqueueRun(record);
+          } else {
+            deferredRunsByStreamId.set(data.streamId, record);
+          }
           remoteRun = remoteRuns.get(data.streamId);
           if (!remoteRun) return;
         }
@@ -1814,6 +1990,14 @@ export class AgentThreadStreamRuntime {
       if (data.type === 'run-failed') {
         const eventStreamId = data.streamId ?? data.runId;
         clearActiveIfCurrent(data.runId, data.streamId);
+        if (deferredRunsByStreamId.has(eventStreamId)) {
+          // Replayed failure of a run that never persisted anything — drop it.
+          discardDeferredRun(eventStreamId);
+          seenStreamIds.delete(eventStreamId);
+          await this.#drainPendingIdleSignals(state, resolvedPubSub, key, data.runId);
+          wake();
+          return;
+        }
         let errorRun: AgentThreadRunRecord<any> | undefined;
         let remoteRun = remoteRuns.get(eventStreamId);
         if (!remoteRun) {
@@ -1835,6 +2019,25 @@ export class AgentThreadStreamRuntime {
       }
       if (data.type === 'run-completed' || data.type === 'run-aborted' || data.type === 'run-suspended') {
         const eventStreamId = data.streamId ?? data.runId;
+        const deferredRecord = deferredRunsByStreamId.get(eventStreamId);
+        if (deferredRecord) {
+          deferredRunsByStreamId.delete(eventStreamId);
+          const bufferedRun = remoteRuns.get(eventStreamId);
+          // Prefer the origin's explicit `persisted` verdict; fall back to the
+          // clean-finish heuristic for events published by older origins.
+          const flush =
+            data.type === 'run-suspended' ||
+            (data.type === 'run-completed' &&
+              (data.persisted ?? (bufferedRun !== undefined && deferredRunEndedCleanly(bufferedRun.parts))));
+          if (flush) {
+            enqueueRun(deferredRecord);
+          } else {
+            // Unpersisted terminal run (mid-stream failure surfaces as
+            // `run-completed` on the wire, aborts as `run-aborted`): no stored
+            // message backs its partial content, so it must not replay.
+            discardDeferredRun(eventStreamId);
+          }
+        }
         if (data.type === 'run-suspended') {
           state.suspendedRunIds.add(data.runId);
           const record = state.threadRunsByStreamId.get(eventStreamId) ?? state.threadRunsById.get(data.runId);

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -623,6 +623,15 @@ export class AgentThreadStreamRuntime {
         sourceId: runtime.#getSourceId(),
       });
       wake();
+      // An error chunk settles `_waitUntilFinished()` without closing
+      // `fullStream` (durable error-recovery keeps consuming), so the pump can
+      // stay blocked on `read()` forever. The error chunk is the last part
+      // this run broadcasts, and it has now been published — settle
+      // `broadcastFinished` here so the terminal publish gate (and the lease
+      // release/drain behind it) is never stranded on the error path.
+      if ((part as { type?: string } | null | undefined)?.type === 'error') {
+        resolveBroadcastFinished();
+      }
     };
 
     const start = () => {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -5893,7 +5893,15 @@ export class Mastra<
     // This runs after all workflows have been registered (unlike the
     // constructor's default-workers block), so #hasScheduledWorkflow is
     // accurate.
-    if (!name && this.#shouldEnableScheduler() && this.#storage) {
+    //
+    // An explicit worker filter naming the scheduler role (e.g.
+    // `MASTRA_WORKERS=scheduler` on a dedicated scheduler deployment) always
+    // injects it: a standalone scheduler process polls storage for rows
+    // created by *other* processes, so boot-time heuristics like
+    // #hasScheduledWorkflow or persisted-row probes can't see the work it
+    // exists to serve. Only `#schedulerDisabled()` overrides the request.
+    const schedulerExplicitlyRequested = (this.#workerFilter?.has('scheduler') ?? false) && !this.#schedulerDisabled();
+    if (!name && (this.#shouldEnableScheduler() || schedulerExplicitlyRequested) && this.#storage) {
       if (!this.#findSchedulerWorker()) {
         const sw = new SchedulerWorker(this.#schedulerConfig);
         sw.__registerMastra(this);

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -5881,10 +5881,12 @@ export class Mastra<
     // must run after storage.init() above.
     //
     // Skip the read when the flag cannot change the outcome: it is already
-    // set, or the app opted out of the scheduler and nothing may start it.
-    // Reading the store anyway is a useless boot-time query, and storage
-    // adapters that need request/tenant context warn on it (see #20550).
-    if (!name && !this.#schedulerRequested && !this.#schedulerDisabled()) {
+    // set, the app opted out of the scheduler and nothing may start it, or an
+    // explicit worker filter already forces injection (see below). Reading the
+    // store anyway is a useless boot-time query, and storage adapters that
+    // need request/tenant context warn on it (see #20550).
+    const schedulerExplicitlyRequested = (this.#workerFilter?.has('scheduler') ?? false) && !this.#schedulerDisabled();
+    if (!name && !this.#schedulerRequested && !schedulerExplicitlyRequested && !this.#schedulerDisabled()) {
       await this.#detectPersistedSchedulerWork();
     }
 
@@ -5900,7 +5902,6 @@ export class Mastra<
     // created by *other* processes, so boot-time heuristics like
     // #hasScheduledWorkflow or persisted-row probes can't see the work it
     // exists to serve. Only `#schedulerDisabled()` overrides the request.
-    const schedulerExplicitlyRequested = (this.#workerFilter?.has('scheduler') ?? false) && !this.#schedulerDisabled();
     if (!name && (this.#shouldEnableScheduler() || schedulerExplicitlyRequested) && this.#storage) {
       if (!this.#findSchedulerWorker()) {
         const sw = new SchedulerWorker(this.#schedulerConfig);

--- a/pubsub/redis-streams/src/auth-e2e.test.ts
+++ b/pubsub/redis-streams/src/auth-e2e.test.ts
@@ -90,14 +90,19 @@ async function teardown(pair: Pair | undefined): Promise<void> {
   await pair.storage?.cleanup();
 }
 
-/** POST start-async with a hard client-side abort. start-async waits for the
- *  run to finish, so when the worker can't authenticate the request would
- *  otherwise hang forever. The signal-driven abort lets the test continue. */
+interface StartAsyncBody {
+  status: string;
+  error?: { name?: string; status?: number; message?: string };
+  result?: { greeting?: string };
+}
+
+/** POST start-async with a hard client-side abort as a safety net so a
+ *  regression back to the old hang-forever behavior can't wedge the test. */
 async function fireStartAsync(
   serverUrl: string,
   token: string | undefined,
   abortMs: number,
-): Promise<{ aborted: boolean; status?: number }> {
+): Promise<{ aborted: boolean; status?: number; body?: StartAsyncBody }> {
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), abortMs);
   try {
@@ -111,7 +116,7 @@ async function fireStartAsync(
       signal: ac.signal,
     });
     clearTimeout(timer);
-    return { aborted: false, status: res.status };
+    return { aborted: false, status: res.status, body: (await res.json()) as StartAsyncBody };
   } catch (err) {
     clearTimeout(timer);
     if ((err as Error).name === 'AbortError') return { aborted: true };
@@ -154,30 +159,36 @@ describe.sequential('step-execution endpoint auth (end-to-end)', () => {
     expect(countMarker(pair.server, 'step-execute-hit')).toBeGreaterThan(before);
   }, 60_000);
 
-  it('B: workflow stalls when worker presents the wrong token', async () => {
+  it('B: workflow fails with a 401 step error when worker presents the wrong token', async () => {
     pair = await spawnServer({ TEST_AUTH_TOKEN: 'secret-abc' });
     await spawnWorker(pair, { MASTRA_WORKER_AUTH_TOKEN: 'wrong-token' });
 
-    // start-async waits for the run to finish; the worker will fail auth
-    // forever, so abort the client after 6s.
-    const result = await fireStartAsync(pair.serverUrl, 'secret-abc', 6000);
-    expect(result.aborted).toBe(true);
+    // The orchestrator retries the step-execute call up to the event delivery
+    // budget, then surfaces a terminal failure — the run fails, it never
+    // silently advances past auth.
+    const result = await fireStartAsync(pair.serverUrl, 'secret-abc', 25_000);
+    expect(result.aborted).toBe(false);
+    expect(result.body?.status).toBe('failed');
+    expect(result.body?.error?.status).toBe(401);
+    expect(result.body?.result?.greeting).toBeUndefined();
 
-    // The middleware ran — proves the worker actually called the endpoint.
-    // start-async never returned (request aborted), so the run did not
-    // complete. Together this means the worker hit auth and was rejected.
+    // The middleware ran — proves the worker actually called the endpoint
+    // and was rejected by auth (rather than never attempting the call).
     expect(countMarker(pair.server, 'step-execute-hit')).toBeGreaterThan(0);
-  }, 30_000);
+  }, 60_000);
 
-  it('C: workflow stalls when worker omits the token entirely', async () => {
+  it('C: workflow fails with a 401 step error when worker omits the token entirely', async () => {
     pair = await spawnServer({ TEST_AUTH_TOKEN: 'secret-abc' });
     await spawnWorker(pair, { MASTRA_WORKER_AUTH_TOKEN: '' });
 
-    const result = await fireStartAsync(pair.serverUrl, 'secret-abc', 6000);
-    expect(result.aborted).toBe(true);
+    const result = await fireStartAsync(pair.serverUrl, 'secret-abc', 25_000);
+    expect(result.aborted).toBe(false);
+    expect(result.body?.status).toBe('failed');
+    expect(result.body?.error?.status).toBe(401);
+    expect(result.body?.result?.greeting).toBeUndefined();
 
     expect(countMarker(pair.server, 'step-execute-hit')).toBeGreaterThan(0);
-  }, 30_000);
+  }, 60_000);
 
   it('D: anonymous direct request rejected with 401 when auth provider is configured', async () => {
     pair = await spawnServer({ TEST_AUTH_TOKEN: 'secret-abc' });

--- a/pubsub/redis-streams/src/auth-e2e.test.ts
+++ b/pubsub/redis-streams/src/auth-e2e.test.ts
@@ -115,8 +115,11 @@ async function fireStartAsync(
       body: JSON.stringify({ inputData: { name: 'world' } }),
       signal: ac.signal,
     });
+    // Keep the abort timer armed while the body is read: fetch resolves on
+    // headers, and a stalled body would otherwise bypass the safety net.
+    const body = (await res.json()) as StartAsyncBody;
     clearTimeout(timer);
-    return { aborted: false, status: res.status, body: (await res.json()) as StartAsyncBody };
+    return { aborted: false, status: res.status, body };
   } catch (err) {
     clearTimeout(timer);
     if ((err as Error).name === 'AbortError') return { aborted: true };


### PR DESCRIPTION
Fixes #21219
Fixes #21223
Fixes #21138

## Summary

Fixes two production-impacting bugs in the agent thread-stream broadcast system, plus a scheduler worker startup bug found while validating against real Redis.

### #21219 — Broadcast parts embed the entire raw model request

Every model call broadcast its full provider request body (including base64 media) in `step-start`, `step-finish`, and `finish` parts — ~5× amplification per call, all retained for replay. A production thread with attached documents accumulated a 1 GB Redis stream for a single thread topic; subscribing OOM-killed the server in a restart loop.

**Fix:** broadcast copies are sanitized (`payload.request`, `payload.metadata.request`, `payload.output.steps`, `payload.messages` stripped) before entering the replay buffer and the wire. The local caller's `MastraModelOutput` is untouched. No consumer read these fields from broadcasts — the server adapter already redacted them before they reached clients.

### #21223 — Unpersisted runs replay as phantom messages

On retained backends (Redis Streams), a run that failed mid-stream published its partial chunks but never persisted a message. Every fresh `subscribeToThread()` replayed the phantom partial assistant message, which hydrated history can never reconcile — it reappeared on every reconnect until the topic entries aged out.

**Fix:** replayed runs whose origin no longer holds the thread lease are buffered instead of streamed, and only released once their terminal event proves persistence. Origins now publish a truthful `persisted` flag on `run-completed` (computed from run status: success/suspended ⇒ persisted). Events from older origins without the flag fall back to a clean-finish heuristic. Live runs, self-originated deliveries (via a new `sourceId` on `run-registered`), and in-process pubsub keep their existing behavior.

### Ordering hardening

Validating against real `RedisStreamsPubSub` and exhaustive event-ordering permutations surfaced three wire-ordering bugs, all fixed:

- terminal publishes now gate on registration **and** broadcast completion, so `run-completed` can't race ahead of `run-registered` or the stream-parts (local cleanup stays immediate; suspends don't gate on the still-open pump)
- deferred runs are tracked in the remote-runs map so their terminal events resolve them
- the `run-registered` handler reuses a proxy created by a stream-part-first delivery instead of clobbering its buffered parts

### Scheduler worker startup

`MASTRA_WORKERS=scheduler` silently never started the SchedulerWorker: enablement relied on boot-time heuristics (declarative schedules, persisted agent-schedule rows) that a standalone scheduler process — which exists to fire schedules created by *other* processes — cannot satisfy. An explicit scheduler role in the worker filter now injects the worker directly. `workers: false` and `scheduler.enabled: false` still take precedence.

Auth e2e tests were also updated to pin current behavior: a worker that fails step-execution auth now fails the run terminally with the 401 (post-retry-budget), rather than stalling forever.

## Test plan

- New regression suites: broadcast sanitization (incl. multi-step accumulation), phantom replay (9 scenarios: dead/crashed/failed runs drop; clean/persisted/suspended/lease-live runs replay), mixed-version compat (old origins without `persisted`/`sourceId`), and all 10 registration/terminal orderings among stream parts × persisted/unpersisted
- Soak: timing-sensitive unit suites ×50, Redis cross-process integration ×10 — all clean
- Full runs: core agent suite (3610 passed), full redis-streams integration suite (82 passed), `tsc --noEmit` clean
- Changesets included for both fixes



## Durable agent crash hardening (#21138)

- Guard prompt conversion against tool-result parts with undefined `output` and text parts with undefined content, so malformed entries can no longer crash the OpenAI-compatible converter (`Cannot read properties of undefined (reading 'type')`).
- Filter undefined-output tool results in the `llmPrompt` builder before conversion.
- Preserve the producer's original stack (and cause) when error chunks are serialized and re-thrown, so crashes are attributable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR keeps private and incomplete stream data from reaching other clients. It also stops failed runs from appearing during replay and ensures scheduler workers and durable-agent errors behave correctly.

## Changes

- Remove raw model requests, metadata requests, output steps, and duplicate messages from broadcast copies.
- Preserve local `MastraModelOutput` data.
- Defer replay for runs without an active thread lease until persistence is confirmed.
- Add a `persisted` flag to `run-completed` events.
- Preserve ordering across registration, streaming, broadcasting, replay, and completion.
- Reuse proxies created when stream parts arrive before registration.
- Start scheduler workers when `MASTRA_WORKERS=scheduler`.
- Keep `workers: false` and `scheduler.enabled: false` authoritative.
- Preserve error names, stacks, and causes in durable stream and LLM errors.
- Handle malformed prompt content and missing tool-result output safely.
- Update authorization tests to expect terminal workflow failure with status `401`.

## Tests

- Add broadcast sanitization regression tests.
- Add phantom replay and replay-ordering tests.
- Add compatibility coverage for older event formats.
- Add malformed prompt conversion tests.
- Include Redis integration, core agent, and TypeScript checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
