### PR TITLE
feat(factory): snapshot workspace sandbox at agent turn-end

### DIFF
--- a/.changeset/busy-roses-agree.md
+++ b/.changeset/busy-roses-agree.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed sandbox checkpoints only being captured at session teardown. Factory sessions now snapshot the workspace sandbox at the end of every agent turn, so sandboxes that are reclaimed while idle can be restored from a checkpoint that includes the last completed turn's changes.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -64,6 +64,7 @@ import { assertFactoryRules } from './rules/validation.js';
 import { SandboxFleet } from './sandbox/fleet.js';
 import { registerSandboxReattach } from './sandbox/reattach.js';
 import { handleServerError } from './server-error.js';
+import { observeSessionCheckpoint } from './session/checkpoint-capture.js';
 import { observeSessionFilesystem } from './session/filesystem-capture.js';
 import { observeSessionFirstExec } from './session/first-exec-capture.js';
 import { observeSessionFirstMessage } from './session/first-message-capture.js';
@@ -817,6 +818,7 @@ export class MastraFactory {
         filesystem: filesystemStorage,
         sourceControl: sourceControlStorage.forIntegration('github'),
       });
+      observeSessionCheckpoint(session);
       observeSessionFirstMessage(session, {
         sourceControl: sourceControlStorage.forIntegration('github'),
       });

--- a/mastracode/factory/src/session/checkpoint-capture.test.ts
+++ b/mastracode/factory/src/session/checkpoint-capture.test.ts
@@ -1,0 +1,96 @@
+import type { SessionBeforeAgentEndListener } from '@mastra/core/agent-controller';
+import { describe, expect, it, vi } from 'vitest';
+
+import { observeSessionCheckpoint, type CheckpointCaptureSession } from './checkpoint-capture.js';
+
+function createSession(snapshot = vi.fn<() => Promise<void>>(async () => {})) {
+  const listeners: SessionBeforeAgentEndListener[] = [];
+  const session: CheckpointCaptureSession = {
+    getWorkspace: () => ({ sandbox: { snapshot } }),
+    onBeforeAgentEnd: listener => {
+      listeners.push(listener);
+      return () => {
+        const index = listeners.indexOf(listener);
+        if (index !== -1) listeners.splice(index, 1);
+      };
+    },
+  };
+
+  return { session, snapshot, listeners };
+}
+
+describe('observeSessionCheckpoint', () => {
+  it.each(['complete', 'aborted', 'error', 'suspended'] as const)(
+    'snapshots before %s agent-end events',
+    async reason => {
+      const { session, snapshot, listeners } = createSession();
+      observeSessionCheckpoint(session);
+
+      await listeners[0]!({ type: 'agent_end', reason });
+
+      expect(snapshot).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('skips snapshotting when the session has no workspace sandbox', async () => {
+    const { listeners } = createSession();
+    const session: CheckpointCaptureSession = {
+      getWorkspace: () => undefined,
+      onBeforeAgentEnd: listener => {
+        listeners.push(listener);
+        return () => {};
+      },
+    };
+    observeSessionCheckpoint(session);
+
+    await expect(listeners[0]!({ type: 'agent_end', reason: 'complete' })).resolves.toBeUndefined();
+  });
+
+  it('logs and swallows snapshot failures', async () => {
+    const failure = new Error('snapshot unavailable');
+    const { session, listeners } = createSession(vi.fn().mockRejectedValue(failure));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    observeSessionCheckpoint(session);
+
+    await expect(listeners[0]!({ type: 'agent_end', reason: 'complete' })).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith('[Factory checkpoint capture] Unable to snapshot sandbox.', failure);
+    warn.mockRestore();
+  });
+
+  it('serializes snapshots when terminal events arrive before the prior snapshot finishes', async () => {
+    let completeFirstSnapshot: (() => void) | undefined;
+    const snapshot = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>(resolve => {
+            completeFirstSnapshot = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    const { session, listeners } = createSession(snapshot);
+    observeSessionCheckpoint(session);
+
+    const first = listeners[0]!({ type: 'agent_end', reason: 'complete' });
+    await vi.waitFor(() => expect(snapshot).toHaveBeenCalledTimes(1));
+
+    const second = listeners[0]!({ type: 'agent_end', reason: 'complete' });
+    await Promise.resolve();
+    expect(snapshot).toHaveBeenCalledTimes(1);
+
+    completeFirstSnapshot?.();
+    await first;
+    await second;
+    expect(snapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops snapshotting after unsubscribe', async () => {
+    const { session, snapshot, listeners } = createSession();
+    const unsubscribe = observeSessionCheckpoint(session);
+
+    unsubscribe();
+    expect(listeners).toHaveLength(0);
+    expect(snapshot).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/factory/src/session/checkpoint-capture.ts
+++ b/mastracode/factory/src/session/checkpoint-capture.ts
@@ -1,0 +1,31 @@
+import type { SessionBeforeAgentEndListener } from '@mastra/core/agent-controller';
+import type { WorkspaceSandbox } from '@mastra/core/workspace';
+
+export interface CheckpointCaptureSession {
+  getWorkspace(): { sandbox?: Pick<WorkspaceSandbox, 'snapshot'> } | undefined;
+  onBeforeAgentEnd(listener: SessionBeforeAgentEndListener): () => void;
+}
+
+/**
+ * Snapshot the session's sandbox before every agent-end event so providers
+ * with checkpoint support (for example Railway-backed sandboxes) persist the
+ * last completed turn's writes. Captures are chained sequentially so a slow
+ * snapshot never overlaps the next one, and failures are logged rather than
+ * thrown so they never break the agent turn.
+ */
+export function observeSessionCheckpoint(session: CheckpointCaptureSession): () => void {
+  let capture = Promise.resolve();
+  return session.onBeforeAgentEnd(() => {
+    capture = capture.then(async () => {
+      // Chat-only sessions run without a workspace; there is nothing to snapshot.
+      const sandbox = session.getWorkspace()?.sandbox;
+      if (!sandbox) return;
+      try {
+        await sandbox.snapshot();
+      } catch (error) {
+        console.warn('[Factory checkpoint capture] Unable to snapshot sandbox.', error);
+      }
+    });
+    return capture;
+  });
+}


### PR DESCRIPTION
Factory sessions now snapshot their workspace sandbox at the end of every agent turn. The provider-agnostic `sandbox.snapshot()` primitive (#21221) shipped without any callers, so checkpoints were only captured at explicit factory teardown — sandboxes reclaimed while idle left nothing recent to restore from, and the next session start fell back to a template build.

This wires a checkpoint observer into the same `onBeforeAgentEnd` seam already used for filesystem capture:

```ts
prepared.base.controller.onSessionCreated(session => {
  observeSessionFilesystem(session, { ... });
  observeSessionCheckpoint(session); // new
});
```

Snapshots chain sequentially per session so two are never in flight at once, chat-only sessions without a workspace are skipped, and failures are logged instead of thrown so a bad snapshot never breaks the agent turn. Works uniformly for any sandbox provider via the shared `WorkspaceSandbox.snapshot()` interface; providers without snapshot support no-op.

Tested with a unit suite mirroring the filesystem-capture tests: fires on all agent-end reasons, skips missing workspaces, swallows errors, serializes overlapping captures, and unsubscribes cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The factory now saves workspace changes after each agent turn. This lets the system restore changes if an idle sandbox is reclaimed.

## Changes

- Register workspace checkpoint observation when a factory session starts.
- Snapshot workspaces after every agent-end reason.
- Run snapshots sequentially for each session.
- Skip sessions without a workspace.
- Log snapshot failures without interrupting agent execution.
- Treat unsupported workspace providers as no-ops.
- Remove observers during cleanup.
- Add a patch changeset for `@mastra/factory`.

## Tests

- Cover all agent-end reasons.
- Cover missing workspaces.
- Cover snapshot failures.
- Cover overlapping snapshots.
- Cover observer cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->