### PR TITLE
fix(channels): render approval cards even when toolDisplay is 'hidden…

### DIFF
--- a/.changeset/fix-approval-card-hidden-display.md
+++ b/.changeset/fix-approval-card-hidden-display.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed approval cards being silently suppressed when `toolDisplay` is set to `'hidden'` in the static channel driver. The Approve/Deny card is now always rendered regardless of `toolDisplay` or `toolDisplayFn` settings, matching the streaming driver behavior. Previously, using `toolDisplay: 'hidden'` with `requireApproval` would cause the agent run to park forever with no visible approval buttons.

--- a/.changeset/fix-approval-card-hidden-display.md
+++ b/.changeset/fix-approval-card-hidden-display.md
@@ -2,4 +2,4 @@
 "@mastra/core": patch
 ---
 
-Fixed approval cards being silently suppressed when `toolDisplay` is set to `'hidden'` in the static channel driver. The Approve/Deny card is now always rendered regardless of `toolDisplay` or `toolDisplayFn` settings, matching the streaming driver behavior. Previously, using `toolDisplay: 'hidden'` with `requireApproval` would cause the agent run to park forever with no visible approval buttons.
+Fixed approval cards being silently suppressed when `toolDisplay` is set to `'hidden'` in the static channel driver. The Approve/Deny card is now always rendered regardless of `toolDisplay` or `toolDisplayFn` settings, matching the streaming driver behavior. Previously, using `toolDisplay: 'hidden'` with `requireApproval` would cause the agent run to wait indefinitely with no visible approval buttons.

--- a/packages/core/src/channels/__tests__/output-processor.test.ts
+++ b/packages/core/src/channels/__tests__/output-processor.test.ts
@@ -1384,6 +1384,36 @@ describe('ChatChannelOutputProcessor', () => {
       // Tool call itself is hidden (no post for running card), but approval MUST post
       const posts = calls.filter(c => c.kind === 'post');
       expect(posts).toHaveLength(1);
+      const payloadStr = JSON.stringify((posts[0] as any).arg);
+      expect(payloadStr).toContain('tool_approve:t1');
+      expect(payloadStr).toContain('tool_deny:t1');
+      expect((channels as any).pendingApprovalCards.has('t1')).toBe(true);
+    });
+
+    it('posts approval card even when toolDisplayFn returns undefined (static mode)', async () => {
+      const { channels, calls, chatThread } = makeChannels({
+        streaming: false,
+        toolDisplay: () => undefined,
+      });
+      await drive(
+        channels,
+        [
+          {
+            type: 'tool-call',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } },
+          },
+          {
+            type: 'tool-call-approval',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } },
+          },
+        ],
+        chatThread,
+      );
+      const posts = calls.filter(c => c.kind === 'post');
+      expect(posts).toHaveLength(1);
+      const payloadStr = JSON.stringify((posts[0] as any).arg);
+      expect(payloadStr).toContain('tool_approve:t1');
+      expect(payloadStr).toContain('tool_deny:t1');
       expect((channels as any).pendingApprovalCards.has('t1')).toBe(true);
     });
 

--- a/packages/core/src/channels/__tests__/output-processor.test.ts
+++ b/packages/core/src/channels/__tests__/output-processor.test.ts
@@ -1365,6 +1365,28 @@ describe('ChatChannelOutputProcessor', () => {
       expect((edits[0] as Extract<Call, { kind: 'editMessage' }>).messageId).toBe('m1');
     });
 
+    it("posts approval card even when toolDisplay is 'hidden' (static mode)", async () => {
+      const { channels, calls, chatThread } = makeChannels({ streaming: false, toolDisplay: 'hidden' });
+      await drive(
+        channels,
+        [
+          {
+            type: 'tool-call',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } },
+          },
+          {
+            type: 'tool-call-approval',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } },
+          },
+        ],
+        chatThread,
+      );
+      // Tool call itself is hidden (no post for running card), but approval MUST post
+      const posts = calls.filter(c => c.kind === 'post');
+      expect(posts).toHaveLength(1);
+      expect((channels as any).pendingApprovalCards.has('t1')).toBe(true);
+    });
+
     it('uses the pendingApprovalCards entry when tool-result arrives without a matching tool-call (resumed run)', async () => {
       const { channels, calls, chatThread } = makeChannels({ streaming: false });
       // Pre-seed a pending card as if the click handler posted the "Approved ⋯" card.

--- a/packages/core/src/channels/chat-driver-static.ts
+++ b/packages/core/src/channels/chat-driver-static.ts
@@ -2,6 +2,7 @@ import type { Adapter, Thread } from 'chat';
 
 import type { IMastraLogger } from '../logger/logger';
 import type { AgentChunkType } from '../stream/types';
+import { formatToolApproval } from './formatting';
 import type { PendingApprovalRecord } from './stream-helpers';
 import {
   ToolTracker,
@@ -300,17 +301,15 @@ export async function runStaticDriver({
         toolName: chunk.payload.toolName,
         args: chunk.payload.args,
       });
-      const approvalMessage = renderToolEvent({
-        kind: 'approval',
-        toolName: enr.toolName,
-        displayName: enr.displayName,
-        argsSummary: enr.argsSummary,
-        args: enr.args,
-        toolCallId: enr.toolCallId,
-      });
+      // Approval cards are always rendered regardless of toolDisplay or
+      // toolDisplayFn — an approval is not tool chatter, it is the one
+      // message the flow cannot proceed without. This matches the streaming
+      // driver which always calls formatToolApproval directly (line 734).
+      // Approval cards always use Block Kit (`useCards: true`) so the
+      // Approve/Deny buttons render.
+      const approvalMessage = formatToolApproval(enr.displayName, enr.argsSummary, enr.toolCallId, true);
       const existingMessageId = toolMessageIds.get(enr.toolCallId) ?? getPendingApproval(enr.toolCallId)?.messageId;
-      const finalMessageId =
-        approvalMessage != null ? await editOrPost(existingMessageId, approvalMessage) : existingMessageId;
+      const finalMessageId = await editOrPost(existingMessageId, approvalMessage);
       // Stash by toolCallId so the click handler can resume the correct
       // run directly. The persisted-metadata path keys by toolName and
       // collides on parallel same-tool approvals.


### PR DESCRIPTION
## Description

Fixes an issue where setting `toolDisplay: 'hidden'` (or using a `toolDisplayFn` returning `undefined` for approvals) silently suppressed approval cards in the static channel driver (`chat-driver-static.ts`), causing runs with `requireApproval` to hang indefinitely without posting interactive Approve/Deny buttons.

### Root Cause
The static driver was routing `tool-call-approval` chunks through `renderToolEvent`, which early-exits when `toolDisplay === 'hidden'` or when `toolDisplayFn` returns `undefined`. Approval is human-in-the-loop control flow rather than tool execution chatter, and should not be suppressed by display filters.

### Solution
- Bypassed `renderToolEvent` in the `tool-call-approval` chunk handler inside `packages/core/src/channels/chat-driver-static.ts`.
- Called `formatToolApproval(enr.displayName, enr.argsSummary, enr.toolCallId, true)` directly to ensure approval cards are always posted, aligning behavior with the streaming channel driver (`chat-driver-streaming.ts`).
- Added unit test in `packages/core/src/channels/__tests__/output-processor.test.ts` verifying that `toolDisplay: 'hidden'` still posts the approval card in static mode.
- Added a patch changeset for `@mastra/core`.

## Related issue(s)

Fixes #21162

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a run needs approval, it now always shows the Approve/Deny card. Hiding other tool messages no longer hides the approval controls.

## Changes

- Render `tool-call-approval` chunks directly with `formatToolApproval`.
- Preserve approval cards when `toolDisplay` is `'hidden'`.
- Preserve approval cards when `toolDisplayFn` returns `undefined`.
- Store the posted or edited message ID for approval resumption.
- Add regression tests for both hidden display modes.
- Add a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->