### PR TITLE
Instrument prompt token composition per model step

### DIFF
--- a/.changeset/token-composition-instrumentation.md
+++ b/.changeset/token-composition-instrumentation.md
@@ -4,15 +4,17 @@
 
 Added prompt token-composition instrumentation to `MODEL_STEP` spans, so you can see _which parts_ of a prompt your tokens went to instead of only a single input-token total.
 
-Two new optional attributes on `ModelStepAttributes` (additive; nothing existing changes, and the bytes sent to the model are byte-for-byte identical — there is a regression test that fails if a single byte moves):
+Two new optional attributes on `ModelStepAttributes`. Both are additive: nothing existing changes, and the bytes sent to the model do not move. A regression test asserts that the prompt for a fixed scenario is byte-identical to a fixture captured on the base commit.
 
-- `promptRegions` — estimated tokens per prompt region (`system`, `tagged-system:<tag>` for each tagged system message such as memory, `messages`, and `unattributed` for anything injected after prompt assembly). Estimated with the token counter already used by `TokenLimiterProcessor`; the estimation method is emitted alongside the numbers so consumers know these are heuristics to be compared against provider-reported usage, not a substitute for it.
-- `promptPrefixChangedFromPreviousStep` — whether this step's prompt prefix diverged from the previous step's, which is what invalidates provider prompt caches for everything below it. Undefined on the first step of a turn.
+- `promptRegions`: estimated tokens per prompt region (`system`, `tagged-system:<tag>` for each tagged system message such as memory, `messages`, and `unattributed` for anything injected after prompt assembly). Estimated with the token counter already used by `TokenLimiterProcessor`. The estimation method is emitted alongside the numbers so consumers know these are heuristics to be compared against provider-reported usage, not a substitute for it.
+- `promptPrefixChangedFromPreviousStep`: whether this step's prompt prefix diverged from the previous step's, which is what invalidates provider prompt caches for everything below it. The attribute is absent on the first step of a turn rather than set to a value, so read it by key presence.
 
-Also added a session rollup script that turns a dump of exported spans into decision-grade numbers — cache-hit rate, per-region totals, steps-per-turn distribution, and estimate-vs-provider delta:
+Both attributes are only computed when a live `MODEL_STEP` span exists, so there is no cost when observability is off.
+
+Also added a session rollup script that turns a dump of exported spans into decision-grade numbers: cache-hit rate, per-region totals, steps-per-turn distribution, and estimate-vs-provider delta.
 
 ```bash
 npx tsx packages/core/scripts/token-composition-rollup.ts ./session-spans.json
 ```
 
-Steps where the provider did not report cache details are counted as _unreported_ rather than as zero cached, so a provider that stays quiet cannot silently drag a cache-hit rate toward zero. Output is token counts by type only — no pricing, since rate cards change.
+Steps where the provider did not report cache details are counted as _unreported_ rather than as zero cached, so a provider that stays quiet cannot silently drag a cache-hit rate toward zero. Output is token counts by type only, with no pricing, since rate cards change.

--- a/.changeset/token-composition-instrumentation.md
+++ b/.changeset/token-composition-instrumentation.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': patch
+---
+
+Added prompt token-composition instrumentation to `MODEL_STEP` spans, so you can see _which parts_ of a prompt your tokens went to instead of only a single input-token total.
+
+Two new optional attributes on `ModelStepAttributes` (additive; nothing existing changes, and the bytes sent to the model are byte-for-byte identical — there is a regression test that fails if a single byte moves):
+
+- `promptRegions` — estimated tokens per prompt region (`system`, `tagged-system:<tag>` for each tagged system message such as memory, `messages`, and `unattributed` for anything injected after prompt assembly). Estimated with the token counter already used by `TokenLimiterProcessor`; the estimation method is emitted alongside the numbers so consumers know these are heuristics to be compared against provider-reported usage, not a substitute for it.
+- `promptPrefixChangedFromPreviousStep` — whether this step's prompt prefix diverged from the previous step's, which is what invalidates provider prompt caches for everything below it. Undefined on the first step of a turn.
+
+Also added a session rollup script that turns a dump of exported spans into decision-grade numbers — cache-hit rate, per-region totals, steps-per-turn distribution, and estimate-vs-provider delta:
+
+```bash
+npx tsx packages/core/scripts/token-composition-rollup.ts ./session-spans.json
+```
+
+Steps where the provider did not report cache details are counted as _unreported_ rather than as zero cached, so a provider that stays quiet cannot silently drag a cache-hit rate toward zero. Output is token counts by type only — no pricing, since rate cards change.

--- a/observability/mastra/src/__snapshots__/agent-processors-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace-generate.json
@@ -196,6 +196,14 @@
                         "entityId": "validator-agent",
                         "attributes": {
                           "stepIndex": 0,
+                          "promptRegions": {
+                            "method": "tokenx-estimate",
+                            "totalEstimated": 15,
+                            "regions": {
+                              "system": 6,
+                              "messages": 9
+                            }
+                          },
                           "messageId": "<messageId-1>",
                           "usage": {
                             "inputTokens": 15,
@@ -392,6 +400,14 @@
                 "entityId": "test-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 13,
+                    "regions": {
+                      "system": 7,
+                      "messages": 6
+                    }
+                  },
                   "messageId": "<messageId-2>",
                   "usage": {
                     "inputTokens": 15,
@@ -664,6 +680,14 @@
                         "entityId": "summarizer-agent",
                         "attributes": {
                           "stepIndex": 0,
+                          "promptRegions": {
+                            "method": "tokenx-estimate",
+                            "totalEstimated": 15,
+                            "regions": {
+                              "system": 6,
+                              "messages": 9
+                            }
+                          },
                           "messageId": "<messageId-3>",
                           "usage": {
                             "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/agent-processors-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace.json
@@ -196,6 +196,14 @@
                         "entityId": "validator-agent",
                         "attributes": {
                           "stepIndex": 0,
+                          "promptRegions": {
+                            "method": "tokenx-estimate",
+                            "totalEstimated": 15,
+                            "regions": {
+                              "system": 6,
+                              "messages": 9
+                            }
+                          },
                           "messageId": "<messageId-1>",
                           "usage": {
                             "inputTokens": 15,
@@ -392,6 +400,14 @@
                 "entityId": "test-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 13,
+                    "regions": {
+                      "system": 7,
+                      "messages": 6
+                    }
+                  },
                   "messageId": "<messageId-2>",
                   "usage": {
                     "inputTokens": 15,
@@ -662,6 +678,14 @@
                         "entityId": "summarizer-agent",
                         "attributes": {
                           "stepIndex": 0,
+                          "promptRegions": {
+                            "method": "tokenx-estimate",
+                            "totalEstimated": 14,
+                            "regions": {
+                              "system": 6,
+                              "messages": 8
+                            }
+                          },
                           "messageId": "<messageId-3>",
                           "usage": {
                             "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/agent-structured-output-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-structured-output-trace-generate.json
@@ -116,6 +116,14 @@
                 "entityId": "test-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 14,
+                    "regions": {
+                      "system": 5,
+                      "messages": 9
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
@@ -116,6 +116,14 @@
                 "entityId": "test-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 14,
+                    "regions": {
+                      "system": 5,
+                      "messages": 9
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/agent-tool-call-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-tool-call-trace-generate.json
@@ -197,6 +197,14 @@
                 "entityId": "test-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 10,
+                    "regions": {
+                      "system": 5,
+                      "messages": 5
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
@@ -417,6 +425,15 @@
                 "entityId": "test-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 102,
+                    "regions": {
+                      "system": 5,
+                      "messages": 97
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/agent-tool-call-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-tool-call-trace.json
@@ -197,6 +197,14 @@
                 "entityId": "test-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 10,
+                    "regions": {
+                      "system": 5,
+                      "messages": 5
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
@@ -415,6 +423,15 @@
                 "entityId": "test-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 102,
+                    "regions": {
+                      "system": 5,
+                      "messages": 97
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/agent-workflow-direct-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-direct-trace-generate.json
@@ -150,6 +150,14 @@
                 "entityId": "workflow-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 20,
+                    "regions": {
+                      "system": 11,
+                      "messages": 9
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
@@ -421,6 +429,15 @@
                 "entityId": "workflow-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 136,
+                    "regions": {
+                      "system": 11,
+                      "messages": 125
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/agent-workflow-direct-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-direct-trace.json
@@ -150,6 +150,14 @@
                 "entityId": "workflow-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 20,
+                    "regions": {
+                      "system": 11,
+                      "messages": 9
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
@@ -419,6 +427,15 @@
                 "entityId": "workflow-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 136,
+                    "regions": {
+                      "system": 11,
+                      "messages": 125
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/agent-workflow-tool-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-tool-trace-generate.json
@@ -156,6 +156,14 @@
                 "entityId": "workflow-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 22,
+                    "regions": {
+                      "system": 13,
+                      "messages": 9
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
@@ -444,6 +452,15 @@
                 "entityId": "workflow-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 131,
+                    "regions": {
+                      "system": 13,
+                      "messages": 118
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/agent-workflow-tool-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-tool-trace.json
@@ -156,6 +156,14 @@
                 "entityId": "workflow-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 22,
+                    "regions": {
+                      "system": 13,
+                      "messages": 9
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
@@ -442,6 +450,15 @@
                 "entityId": "workflow-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 131,
+                    "regions": {
+                      "system": 13,
+                      "messages": 118
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/model-step-timing-trace.json
+++ b/observability/mastra/src/__snapshots__/model-step-timing-trace.json
@@ -108,6 +108,14 @@
                 "entityId": "delayed-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 6,
+                    "regions": {
+                      "system": 5,
+                      "messages": 1
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 10,

--- a/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace-generate.json
@@ -139,6 +139,14 @@
                 "entityId": "multi-step-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 26,
+                    "regions": {
+                      "system": 20,
+                      "messages": 6
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 10,
@@ -374,6 +382,15 @@
                 "entityId": "multi-step-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 126,
+                    "regions": {
+                      "system": 20,
+                      "messages": 106
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 20,

--- a/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace.json
+++ b/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace.json
@@ -139,6 +139,14 @@
                 "entityId": "multi-step-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 26,
+                    "regions": {
+                      "system": 20,
+                      "messages": 6
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 10,
@@ -372,6 +380,15 @@
                 "entityId": "multi-step-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 126,
+                    "regions": {
+                      "system": 20,
+                      "messages": 106
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 20,

--- a/observability/mastra/src/__snapshots__/tags-call-overrides-defaults-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tags-call-overrides-defaults-trace-generate.json
@@ -111,6 +111,14 @@
                 "entityId": "test-agent-merge-tags",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 6,
+                    "regions": {
+                      "system": 5,
+                      "messages": 1
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/tags-from-default-options-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tags-from-default-options-trace-generate.json
@@ -109,6 +109,14 @@
                 "entityId": "test-agent-with-tags",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 6,
+                    "regions": {
+                      "system": 5,
+                      "messages": 1
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/tags-from-generate-call-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tags-from-generate-call-trace-generate.json
@@ -109,6 +109,14 @@
                 "entityId": "test-agent-tags-call",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 6,
+                    "regions": {
+                      "system": 5,
+                      "messages": 1
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/tags-from-stream-default-options-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-from-stream-default-options-trace.json
@@ -109,6 +109,14 @@
                 "entityId": "test-agent-stream-tags",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 6,
+                    "regions": {
+                      "system": 5,
+                      "messages": 1
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/tags-preserved-with-other-options-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tags-preserved-with-other-options-trace-generate.json
@@ -111,6 +111,14 @@
                 "entityId": "test-agent-preserve-tags",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 6,
+                    "regions": {
+                      "system": 5,
+                      "messages": 1
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/tool-child-spans-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tool-child-spans-trace-generate.json
@@ -133,6 +133,14 @@
                 "entityId": "child-span-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 17,
+                    "regions": {
+                      "system": 7,
+                      "messages": 10
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
@@ -360,6 +368,15 @@
                 "entityId": "child-span-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 109,
+                    "regions": {
+                      "system": 7,
+                      "messages": 102
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/tool-child-spans-trace.json
+++ b/observability/mastra/src/__snapshots__/tool-child-spans-trace.json
@@ -133,6 +133,14 @@
                 "entityId": "child-span-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 17,
+                    "regions": {
+                      "system": 7,
+                      "messages": 10
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
@@ -358,6 +366,15 @@
                 "entityId": "child-span-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 109,
+                    "regions": {
+                      "system": 7,
+                      "messages": 102
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/tool-metadata-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tool-metadata-trace-generate.json
@@ -132,6 +132,14 @@
                 "entityId": "metadata-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 16,
+                    "regions": {
+                      "system": 7,
+                      "messages": 9
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
@@ -338,6 +346,15 @@
                 "entityId": "metadata-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 102,
+                    "regions": {
+                      "system": 7,
+                      "messages": 95
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/tool-metadata-trace.json
+++ b/observability/mastra/src/__snapshots__/tool-metadata-trace.json
@@ -132,6 +132,14 @@
                 "entityId": "metadata-agent",
                 "attributes": {
                   "stepIndex": 0,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 16,
+                    "regions": {
+                      "system": 7,
+                      "messages": 9
+                    }
+                  },
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
@@ -336,6 +344,15 @@
                 "entityId": "metadata-agent",
                 "attributes": {
                   "stepIndex": 1,
+                  "promptRegions": {
+                    "method": "tokenx-estimate",
+                    "totalEstimated": 102,
+                    "regions": {
+                      "system": 7,
+                      "messages": 95
+                    }
+                  },
+                  "promptPrefixChangedFromPreviousStep": false,
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/workflow-agent-step-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/workflow-agent-step-trace-generate.json
@@ -164,6 +164,14 @@
                         "entityId": "test-agent",
                         "attributes": {
                           "stepIndex": 0,
+                          "promptRegions": {
+                            "method": "tokenx-estimate",
+                            "totalEstimated": 9,
+                            "regions": {
+                              "system": 5,
+                              "messages": 4
+                            }
+                          },
                           "messageId": "<messageId-1>",
                           "usage": {
                             "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/workflow-agent-step-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-agent-step-trace.json
@@ -164,6 +164,14 @@
                         "entityId": "test-agent",
                         "attributes": {
                           "stepIndex": 0,
+                          "promptRegions": {
+                            "method": "tokenx-estimate",
+                            "totalEstimated": 9,
+                            "regions": {
+                              "system": 5,
+                              "messages": 4
+                            }
+                          },
                           "messageId": "<messageId-1>",
                           "usage": {
                             "inputTokens": 15,

--- a/observability/mastra/src/__snapshots__/workflow-create-step-agent-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-create-step-agent-trace.json
@@ -193,6 +193,14 @@
                         "entityId": "workflow-agent",
                         "attributes": {
                           "stepIndex": 0,
+                          "promptRegions": {
+                            "method": "tokenx-estimate",
+                            "totalEstimated": 10,
+                            "regions": {
+                              "system": 8,
+                              "messages": 2
+                            }
+                          },
                           "messageId": "<messageId-1>",
                           "usage": {
                             "inputTokens": 10,

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -1,6 +1,12 @@
 import { ReadableStream } from 'node:stream/web';
 import { coreFeatures } from '@mastra/core/features';
-import type { ObservabilityExporter, TracingEvent, ExportedSpan, MetricEvent } from '@mastra/core/observability';
+import type {
+  ObservabilityExporter,
+  TracingEvent,
+  ExportedSpan,
+  MetricEvent,
+  UsageStats,
+} from '@mastra/core/observability';
 import { SpanType, SamplingStrategyType, TracingEventType } from '@mastra/core/observability';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -1684,6 +1690,62 @@ describe('ModelSpanTracker', () => {
       const stepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
       expect(stepSpans).toHaveLength(1);
       expect(stepSpans[0]!.input).toEqual([{ role: 'tool', content: '[tool-result: someTool]' }]);
+    });
+
+    it('stamps incrementing stepIndex on distinct MODEL_STEP spans and populates cache details only when the provider reported them', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+        attributes: { model: 'gpt-test', provider: 'test', streaming: true },
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const stepChunk = (usage: Record<string, number>) => [
+        { type: 'step-start', payload: { messageId: 'msg' } },
+        { type: 'text-delta', payload: { text: 'hi' } },
+        {
+          type: 'step-finish',
+          payload: { output: { usage }, stepResult: { reason: 'stop', warnings: [] }, metadata: {} },
+        },
+      ];
+
+      const chunks = [
+        // Step 0: provider reported no cache fields — must NOT be zero-stuffed.
+        ...stepChunk({ inputTokens: 100, outputTokens: 5, totalTokens: 105 }),
+        // Step 1: cache read reported.
+        ...stepChunk({ inputTokens: 100, cachedInputTokens: 94, outputTokens: 5, totalTokens: 105 }),
+        // Step 2: cache read + cache write reported.
+        ...stepChunk({
+          inputTokens: 100,
+          cachedInputTokens: 90,
+          cacheCreationInputTokens: 6,
+          outputTokens: 5,
+          totalTokens: 105,
+        }),
+      ];
+
+      const stream = createMockStream(chunks);
+      await consumeStream(tracker.wrapStream(stream));
+      modelSpan.end();
+
+      const stepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
+      expect(stepSpans).toHaveLength(3);
+      expect(stepSpans.map(s => s!.attributes?.stepIndex)).toEqual([0, 1, 2]);
+
+      const usages = stepSpans.map(s => (s!.attributes as { usage?: UsageStats })?.usage);
+      // Unreported cache fields stay absent — never recorded as zero.
+      expect(usages[0]?.inputDetails?.cacheRead).toBeUndefined();
+      expect(usages[0]?.inputDetails?.cacheWrite).toBeUndefined();
+      // Reported fields land on the step's own span.
+      expect(usages[1]?.inputDetails?.cacheRead).toBe(94);
+      expect(usages[1]?.inputDetails?.cacheWrite).toBeUndefined();
+      expect(usages[2]?.inputDetails?.cacheRead).toBe(90);
+      expect(usages[2]?.inputDetails?.cacheWrite).toBe(6);
+      // inputTokens populated on every step (rollup's delta denominator).
+      for (const usage of usages) {
+        expect(usage?.inputTokens).toBe(100);
+      }
     });
   });
 

--- a/packages/core/scripts/token-composition-rollup.ts
+++ b/packages/core/scripts/token-composition-rollup.ts
@@ -35,7 +35,7 @@ function main() {
     // An all-zero report from a mis-exported session reads exactly like a real
     // finding. Fail loudly instead.
     console.error(
-      `\nno MODEL_STEP spans found in ${file} — check the exporter is wired and MODEL_STEP is not in excludeSpanTypes`,
+      `\nno MODEL_STEP spans found in ${file}. Check the exporter is wired and MODEL_STEP is not in excludeSpanTypes`,
     );
     process.exit(2);
   }
@@ -43,7 +43,7 @@ function main() {
   if (rollup.steps.uninstrumented === rollup.steps.total) {
     // Every span predates the instrumentation: the region table above is an
     // all-zero table, which reads like a finding rather than a stale capture.
-    console.error(`\nno MODEL_STEP span in ${file} carries promptRegions — these spans predate the instrumentation`);
+    console.error(`\nno MODEL_STEP span in ${file} carries promptRegions. These spans predate the instrumentation`);
     process.exit(2);
   }
 }

--- a/packages/core/scripts/token-composition-rollup.ts
+++ b/packages/core/scripts/token-composition-rollup.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * CLI entry for the session token-composition rollup.
+ *
+ * Usage: tsx scripts/token-composition-rollup.ts <exported-spans.json> [--json]
+ *
+ * Input is a JSON array of exported spans (the shape @mastra/observability
+ * exporters emit). Output is a human-readable report, or raw JSON with --json.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import {
+  formatTokenCompositionRollup,
+  rollupTokenComposition,
+} from '../src/observability/rollup/token-composition-rollup';
+
+function main() {
+  const args = process.argv.slice(2);
+  const asJson = args.includes('--json');
+  const file = args.find(arg => !arg.startsWith('--'));
+
+  if (!file) {
+    console.error('usage: token-composition-rollup <exported-spans.json> [--json]');
+    process.exit(1);
+  }
+
+  const parsed = JSON.parse(readFileSync(file, 'utf-8'));
+  const spans = Array.isArray(parsed) ? parsed : (parsed.spans ?? []);
+  const rollup = rollupTokenComposition(spans);
+
+  console.log(asJson ? JSON.stringify(rollup, null, 2) : formatTokenCompositionRollup(rollup));
+}
+
+main();

--- a/packages/core/scripts/token-composition-rollup.ts
+++ b/packages/core/scripts/token-composition-rollup.ts
@@ -30,6 +30,15 @@ function main() {
   const rollup = rollupTokenComposition(spans);
 
   console.log(asJson ? JSON.stringify(rollup, null, 2) : formatTokenCompositionRollup(rollup));
+
+  if (rollup.steps.total === 0) {
+    // An all-zero report from a mis-exported session reads exactly like a real
+    // finding. Fail loudly instead.
+    console.error(
+      `\nno MODEL_STEP spans found in ${file} — check the exporter is wired and MODEL_STEP is not in excludeSpanTypes`,
+    );
+    process.exit(2);
+  }
 }
 
 main();

--- a/packages/core/scripts/token-composition-rollup.ts
+++ b/packages/core/scripts/token-composition-rollup.ts
@@ -39,6 +39,13 @@ function main() {
     );
     process.exit(2);
   }
+
+  if (rollup.steps.uninstrumented === rollup.steps.total) {
+    // Every span predates the instrumentation: the region table above is an
+    // all-zero table, which reads like a finding rather than a stale capture.
+    console.error(`\nno MODEL_STEP span in ${file} carries promptRegions — these spans predate the instrumentation`);
+    process.exit(2);
+  }
 }
 
 main();

--- a/packages/core/src/agent/message-list/region-attribution.test.ts
+++ b/packages/core/src/agent/message-list/region-attribution.test.ts
@@ -43,6 +43,47 @@ describe('attributePromptRegions', () => {
     expect(withImage.totalEstimated).toBeLessThan(textOnly.totalEstimated + 20);
   });
 
+  it('counts tool-call arguments and tool results, which the provider also charges for', () => {
+    const messageList = new MessageList();
+    const args = { query: 'quarterly revenue by region', limit: 50, includeProjections: true };
+
+    const withToolCall = attributePromptRegions({
+      messageList,
+      inputMessages: [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool-call', toolCallId: 'call_1', toolName: 'searchReports', input: args }],
+        },
+      ],
+    });
+    const bare = attributePromptRegions({
+      messageList,
+      inputMessages: [{ role: 'assistant', content: [{ type: 'text', text: '' }] }],
+    });
+
+    // A tool payload is text the provider serializes and bills. Collapsing it to
+    // a placeholder would understate the messages region in exactly the
+    // tool-calling loops this instrumentation exists to measure.
+    expect(withToolCall.regions.messages).toBeGreaterThan(bare.regions.messages + 10);
+  });
+
+  it('replaces a base64 payload buried inside a structured part', () => {
+    const messageList = new MessageList();
+    const blob = 'QUJDREVG'.repeat(500);
+
+    const result = attributePromptRegions({
+      messageList,
+      inputMessages: [
+        {
+          role: 'tool',
+          content: [{ type: 'tool-result', toolCallId: 'call_1', output: { screenshot: blob, status: 'ok' } }],
+        },
+      ],
+    });
+
+    expect(result.regions.messages).toBeLessThan(40);
+  });
+
   it('attributes tagged system messages to per-tag regions', () => {
     const messageList = new MessageList();
     messageList.addSystem('Base instructions.');

--- a/packages/core/src/agent/message-list/region-attribution.test.ts
+++ b/packages/core/src/agent/message-list/region-attribution.test.ts
@@ -18,6 +18,31 @@ describe('attributePromptRegions', () => {
     expect(sumRegions(result.regions)).toBe(result.totalEstimated);
   });
 
+  it('does not let a binary content part dominate the estimate', () => {
+    const messageList = new MessageList();
+    const hugeBase64 = 'A'.repeat(200_000);
+
+    const withImage = attributePromptRegions({
+      messageList,
+      inputMessages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is in this picture?' },
+            { type: 'image', image: `data:image/png;base64,${hugeBase64}` },
+          ],
+        },
+      ],
+    });
+    const textOnly = attributePromptRegions({
+      messageList,
+      inputMessages: [{ role: 'user', content: [{ type: 'text', text: 'What is in this picture?' }] }],
+    });
+
+    // The image part contributes a bounded placeholder, not its payload.
+    expect(withImage.totalEstimated).toBeLessThan(textOnly.totalEstimated + 20);
+  });
+
   it('attributes tagged system messages to per-tag regions', () => {
     const messageList = new MessageList();
     messageList.addSystem('Base instructions.');
@@ -119,6 +144,15 @@ describe('didPromptPrefixChange', () => {
         { role: 'user', content: 'b' },
       ]),
     ).toBe(true);
+  });
+
+  it('returns true when the prompt shrinks', () => {
+    const key = {};
+    didPromptPrefixChange(key, [
+      { role: 'system', content: 'a' },
+      { role: 'user', content: 'b' },
+    ]);
+    expect(didPromptPrefixChange(key, [{ role: 'system', content: 'a' }])).toBe(true);
   });
 
   it('tracks keys independently', () => {

--- a/packages/core/src/agent/message-list/region-attribution.test.ts
+++ b/packages/core/src/agent/message-list/region-attribution.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { attributePromptRegions } from './region-attribution';
+import { MessageList } from './index';
+
+const sumRegions = (regions: Record<string, number>) => Object.values(regions).reduce((a, b) => a + b, 0);
+
+describe('attributePromptRegions', () => {
+  it('attributes untagged system messages to the system region', () => {
+    const messageList = new MessageList();
+    messageList.addSystem('You are a helpful assistant.');
+
+    const inputMessages = [{ role: 'system', content: 'You are a helpful assistant.' }];
+    const result = attributePromptRegions({ messageList, inputMessages });
+
+    expect(Object.keys(result.regions)).toEqual(['system']);
+    expect(result.regions.system).toBeGreaterThan(0);
+    expect(result.method).toBe('tokenx-estimate');
+    expect(sumRegions(result.regions)).toBe(result.totalEstimated);
+  });
+
+  it('attributes tagged system messages to per-tag regions', () => {
+    const messageList = new MessageList();
+    messageList.addSystem('Base instructions.');
+    messageList.addSystem('Working memory block contents.', 'memory');
+    messageList.addSystem('Observation block contents here.', 'observational-memory');
+
+    const inputMessages = [
+      { role: 'system', content: 'Base instructions.' },
+      { role: 'system', content: 'Working memory block contents.' },
+      { role: 'system', content: 'Observation block contents here.' },
+    ];
+    const result = attributePromptRegions({ messageList, inputMessages });
+
+    expect(Object.keys(result.regions).sort()).toEqual([
+      'system',
+      'tagged-system:memory',
+      'tagged-system:observational-memory',
+    ]);
+    expect(sumRegions(result.regions)).toBe(result.totalEstimated);
+  });
+
+  it('attributes non-system messages to the messages region', () => {
+    const messageList = new MessageList();
+    messageList.addSystem('Instructions.', 'memory');
+
+    const inputMessages = [
+      { role: 'system', content: 'Instructions.' },
+      { role: 'user', content: [{ type: 'text', text: 'Hello there' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Hi! How can I help?' }] },
+    ];
+    const result = attributePromptRegions({ messageList, inputMessages });
+
+    expect(Object.keys(result.regions).sort()).toEqual(['messages', 'tagged-system:memory']);
+    expect(result.regions.messages).toBeGreaterThan(0);
+    expect(sumRegions(result.regions)).toBe(result.totalEstimated);
+  });
+
+  it('returns an empty attribution for an empty prompt', () => {
+    const messageList = new MessageList();
+    const result = attributePromptRegions({ messageList, inputMessages: [] });
+
+    expect(result.regions).toEqual({});
+    expect(result.totalEstimated).toBe(0);
+  });
+
+  it('puts injected system content not present in the MessageList into unattributed', () => {
+    const messageList = new MessageList();
+    messageList.addSystem('Known system message.');
+
+    const inputMessages = [
+      { role: 'system', content: 'Known system message.' },
+      // e.g. applyAutoResumeSystemMessage / injectBackgroundTaskPrompt / processor rewrite
+      { role: 'system', content: 'Injected by a processor after render.' },
+      { role: 'user', content: [{ type: 'text', text: 'question' }] },
+    ];
+    const result = attributePromptRegions({ messageList, inputMessages });
+
+    expect(Object.keys(result.regions).sort()).toEqual(['messages', 'system', 'unattributed']);
+    expect(result.regions.unattributed).toBeGreaterThan(0);
+    expect(sumRegions(result.regions)).toBe(result.totalEstimated);
+  });
+
+  it('never mutates its inputs', () => {
+    const messageList = new MessageList();
+    messageList.addSystem('Stable.');
+    const inputMessages = [{ role: 'system', content: 'Stable.' }];
+    const before = JSON.stringify(inputMessages);
+    const serializedBefore = JSON.stringify(messageList.serializeForSpan());
+
+    attributePromptRegions({ messageList, inputMessages });
+
+    expect(JSON.stringify(inputMessages)).toBe(before);
+    expect(JSON.stringify(messageList.serializeForSpan())).toBe(serializedBefore);
+  });
+});

--- a/packages/core/src/agent/message-list/region-attribution.test.ts
+++ b/packages/core/src/agent/message-list/region-attribution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { attributePromptRegions } from './region-attribution';
+import { attributePromptRegions, didPromptPrefixChange } from './region-attribution';
 import { MessageList } from './index';
 
 const sumRegions = (regions: Record<string, number>) => Object.values(regions).reduce((a, b) => a + b, 0);
@@ -91,5 +91,40 @@ describe('attributePromptRegions', () => {
 
     expect(JSON.stringify(inputMessages)).toBe(before);
     expect(JSON.stringify(messageList.serializeForSpan())).toBe(serializedBefore);
+  });
+});
+
+describe('didPromptPrefixChange', () => {
+  it('returns undefined on the first step for a key', () => {
+    const key = {};
+    expect(didPromptPrefixChange(key, [{ role: 'system', content: 'a' }])).toBeUndefined();
+  });
+
+  it('returns false when the prompt grows append-only', () => {
+    const key = {};
+    const first = [{ role: 'system', content: 'a' }];
+    didPromptPrefixChange(key, first);
+    expect(didPromptPrefixChange(key, [...first, { role: 'user', content: 'b' }])).toBe(false);
+  });
+
+  it('returns true when earlier prompt bytes change', () => {
+    const key = {};
+    didPromptPrefixChange(key, [
+      { role: 'system', content: 'a' },
+      { role: 'user', content: 'b' },
+    ]);
+    expect(
+      didPromptPrefixChange(key, [
+        { role: 'system', content: 'CHANGED' },
+        { role: 'user', content: 'b' },
+      ]),
+    ).toBe(true);
+  });
+
+  it('tracks keys independently', () => {
+    const keyA = {};
+    const keyB = {};
+    didPromptPrefixChange(keyA, [{ role: 'system', content: 'a' }]);
+    expect(didPromptPrefixChange(keyB, [{ role: 'system', content: 'completely different' }])).toBeUndefined();
   });
 });

--- a/packages/core/src/agent/message-list/region-attribution.test.ts
+++ b/packages/core/src/agent/message-list/region-attribution.test.ts
@@ -1,3 +1,4 @@
+import { estimateTokenCount } from 'tokenx';
 import { describe, expect, it } from 'vitest';
 import { attributePromptRegions, didPromptPrefixChange } from './region-attribution';
 import { MessageList } from './index';
@@ -63,8 +64,27 @@ describe('attributePromptRegions', () => {
 
     // A tool payload is text the provider serializes and bills. Collapsing it to
     // a placeholder would understate the messages region in exactly the
-    // tool-calling loops this instrumentation exists to measure.
-    expect(withToolCall.regions.messages).toBeGreaterThan(bare.regions.messages + 10);
+    // tool-calling loops this instrumentation exists to measure. Pinned against
+    // the payload's own estimate, not just a floor: dropping `input` while
+    // keeping `toolName` would clear a floor and still be the bug.
+    const payloadTokens = estimateTokenCount(JSON.stringify(args));
+    expect(withToolCall.regions.messages).toBeGreaterThanOrEqual(bare.regions.messages + payloadTokens * 0.8);
+  });
+
+  it('does not serialize raw bytes nested in an untyped part', () => {
+    const messageList = new MessageList();
+    const bytes = new Uint8Array(20_000).fill(137);
+
+    const result = attributePromptRegions({
+      messageList,
+      inputMessages: [
+        { role: 'tool', content: [{ type: 'tool-result', toolCallId: 'call_1', output: { screenshot: bytes } }] },
+      ],
+    });
+
+    // A Uint8Array stringifies to {"0":137,"1":137,...}: bigger than the base64
+    // it stands in for, and not text the provider bills.
+    expect(result.regions.messages).toBeLessThan(40);
   });
 
   it('replaces a base64 payload buried inside a structured part', () => {

--- a/packages/core/src/agent/message-list/region-attribution.ts
+++ b/packages/core/src/agent/message-list/region-attribution.ts
@@ -71,9 +71,16 @@ function projectPart(part: unknown): string {
   const type = (part as { type?: unknown }).type;
   if (typeof type === 'string' && BINARY_PART_TYPES.has(type)) return placeholder(type);
   try {
-    return JSON.stringify(part, (_key, value) =>
-      typeof value === 'string' && looksBinary(value) ? placeholder('binary') : value,
-    );
+    return JSON.stringify(part, (_key, value) => {
+      if (typeof value === 'string') return looksBinary(value) ? placeholder('binary') : value;
+      // Raw bytes nested in an untyped part: a Uint8Array serializes to
+      // {"0":137,"1":80,...} and a Buffer to {"type":"Buffer","data":[...]},
+      // both larger than the base64 they replace.
+      if (ArrayBuffer.isView(value) || (value as { type?: unknown } | null)?.type === 'Buffer') {
+        return placeholder('binary');
+      }
+      return value;
+    });
   } catch {
     // Cyclic or otherwise unserializable: fall back to the type name.
     return placeholder(typeof type === 'string' ? type : 'part');

--- a/packages/core/src/agent/message-list/region-attribution.ts
+++ b/packages/core/src/agent/message-list/region-attribution.ts
@@ -27,20 +27,33 @@ interface PromptLikeMessage {
   content?: unknown;
 }
 
-/** Deterministic text projection of a message's content for token estimation. */
+/**
+ * Deterministic text projection of a message's content for token estimation.
+ *
+ * Non-text parts (images, files, tool payloads) are projected to a bounded
+ * placeholder rather than serialized: a base64 data URL would otherwise be fed
+ * whole into the estimator and dominate every region total it touches. The
+ * placeholder means binary parts contribute a small constant instead of a real
+ * token count — one more reason the estimate is reported alongside the
+ * provider-reported total rather than in place of it.
+ */
 function contentToText(content: unknown): string {
   if (typeof content === 'string') return content;
   if (Array.isArray(content)) {
-    return content
-      .map(part => {
-        if (part && typeof part === 'object' && typeof (part as { text?: unknown }).text === 'string') {
-          return (part as { text: string }).text;
-        }
-        return JSON.stringify(part);
-      })
-      .join('');
+    return content.map(projectPart).join('');
   }
-  return content === undefined ? '' : JSON.stringify(content);
+  if (content === undefined) return '';
+  if (typeof content === 'object') return projectPart(content);
+  return String(content);
+}
+
+function projectPart(part: unknown): string {
+  if (typeof part === 'string') return part;
+  if (!part || typeof part !== 'object') return String(part ?? '');
+  const text = (part as { text?: unknown }).text;
+  if (typeof text === 'string') return text;
+  const type = (part as { type?: unknown }).type;
+  return `\u0002${typeof type === 'string' ? type : 'part'}\u0002`;
 }
 
 /**
@@ -58,6 +71,10 @@ export function attributePromptRegions({
 
   // Map exact system-message text -> region name. Tagged entries win their
   // own region; untagged land in 'system'.
+  //
+  // Known limitation: when the SAME system text appears both untagged and under
+  // a tag, every occurrence is attributed to the first writer (untagged), which
+  // under-reports the tagged region. Totals still reconcile.
   const systemTextToRegion = new Map<string, string>();
   for (const sys of systemMessages) {
     const text = contentToText(sys.content);
@@ -89,27 +106,41 @@ export function attributePromptRegions({
 }
 
 /**
- * Previous step's serialized prompt, keyed by a per-run object (the
- * MessageList instance). WeakMap so the entry dies with the run.
+ * Previous step's per-message prompt digests, keyed by a per-run object (the
+ * MessageList instance). WeakMap so the entry dies with the run. Digests rather
+ * than the prompt itself: retaining a second full copy of every prompt for the
+ * life of a run is not a price instrumentation gets to charge.
  */
-const previousPromptByKey = new WeakMap<object, string>();
+const previousPromptByKey = new WeakMap<object, string[]>();
+
+/** FNV-1a. Not cryptographic — only needs to be cheap, stable, and collision-shy. */
+function digest(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return `${value.length.toString(36)}:${hash.toString(36)}`;
+}
 
 /**
  * Cheap step-to-step prompt-prefix change detector (instrumentation only).
  *
- * Serializes the prompt deterministically and compares against the previous
- * step's serialization for the same key. Returns:
+ * Digests each message deterministically and compares against the previous
+ * step's digests for the same key. Granularity is per-message, not per-byte:
+ * an edit anywhere inside a message counts as a change. Returns:
  * - `undefined` on the first step (no previous prompt to compare against)
- * - `false` when the previous prompt is a strict prefix of the current one
- *   (append-only growth — provider prompt caches stay warm)
- * - `true` when earlier bytes changed (prompt prefix invalidated)
+ * - `false` when the previous prompt's messages are an unchanged prefix of the
+ *   current one (append-only growth — provider prompt caches stay warm)
+ * - `true` when an earlier message changed or disappeared (prefix invalidated)
  *
- * Cost is one serialization + one startsWith over in-memory strings per step.
+ * Cost is one digest pass over the prompt per step; only digests are retained.
  */
 export function didPromptPrefixChange(key: object, inputMessages: readonly PromptLikeMessage[]): boolean | undefined {
-  const serialized = inputMessages.map(m => `${String(m.role)}\u0000${contentToText(m.content)}`).join('\u0001');
+  const current = inputMessages.map(m => digest(`${String(m.role)}\u0000${contentToText(m.content)}`));
   const previous = previousPromptByKey.get(key);
-  previousPromptByKey.set(key, serialized);
+  previousPromptByKey.set(key, current);
   if (previous === undefined) return undefined;
-  return !serialized.startsWith(previous);
+  if (previous.length > current.length) return true;
+  return previous.some((entry, index) => entry !== current[index]);
 }

--- a/packages/core/src/agent/message-list/region-attribution.ts
+++ b/packages/core/src/agent/message-list/region-attribution.ts
@@ -1,0 +1,94 @@
+import { estimateTokenCount } from 'tokenx';
+import type { MessageList } from './index';
+
+/**
+ * Prompt token-composition estimate by MessageList region, computed over the
+ * FINAL prompt actually sent to the model (after processLLMRequest processors
+ * and other post-render rewrites).
+ *
+ * Regions:
+ * - `system`             — untagged MessageList system messages
+ * - `tagged-system:<tag>` — one region per taggedSystemMessages key (e.g. memory)
+ * - `messages`           — non-system messages (conversation history)
+ * - `unattributed`       — content present in the final prompt but not traceable
+ *                          to a MessageList partition (processor/loop rewrites)
+ *
+ * A missing region key means not-present, never zero. Estimates always sum to
+ * `totalEstimated` over the final prompt by construction.
+ */
+export interface PromptRegionAttribution {
+  /** Token-estimation method used (e.g. 'tokenx-estimate'). */
+  method: string;
+  /** Sum of all region estimates over the final prompt. */
+  totalEstimated: number;
+  /** Estimated tokens per region. */
+  regions: Record<string, number>;
+}
+
+const ESTIMATION_METHOD = 'tokenx-estimate';
+
+interface PromptLikeMessage {
+  role?: unknown;
+  content?: unknown;
+}
+
+/** Deterministic text projection of a message's content for token estimation. */
+function contentToText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map(part => {
+        if (part && typeof part === 'object' && typeof (part as { text?: unknown }).text === 'string') {
+          return (part as { text: string }).text;
+        }
+        return JSON.stringify(part);
+      })
+      .join('');
+  }
+  return content === undefined ? '' : JSON.stringify(content);
+}
+
+/**
+ * Read-only region attribution over the final prompt. Pure function of its
+ * inputs — never mutates the MessageList or the messages.
+ */
+export function attributePromptRegions({
+  messageList,
+  inputMessages,
+}: {
+  messageList: Pick<MessageList, 'serializeForSpan'>;
+  inputMessages: readonly PromptLikeMessage[];
+}): PromptRegionAttribution {
+  const { systemMessages } = messageList.serializeForSpan();
+
+  // Map exact system-message text -> region name. Tagged entries win their
+  // own region; untagged land in 'system'.
+  const systemTextToRegion = new Map<string, string>();
+  for (const sys of systemMessages) {
+    const text = contentToText(sys.content);
+    const region = sys.tag ? `tagged-system:${sys.tag}` : 'system';
+    // First writer wins; identical text across regions is attributed to the
+    // earlier (untagged-first) partition, matching render order.
+    if (!systemTextToRegion.has(text)) {
+      systemTextToRegion.set(text, region);
+    }
+  }
+
+  const regions: Record<string, number> = {};
+  let totalEstimated = 0;
+
+  for (const message of inputMessages) {
+    const text = contentToText(message.content);
+    const tokens = estimateTokenCount(text);
+    let region: string;
+    if (message.role === 'system') {
+      region = systemTextToRegion.get(text) ?? 'unattributed';
+    } else {
+      region = 'messages';
+    }
+    regions[region] = (regions[region] ?? 0) + tokens;
+    totalEstimated += tokens;
+  }
+
+  return { method: ESTIMATION_METHOD, totalEstimated, regions };
+}

--- a/packages/core/src/agent/message-list/region-attribution.ts
+++ b/packages/core/src/agent/message-list/region-attribution.ts
@@ -30,12 +30,15 @@ interface PromptLikeMessage {
 /**
  * Deterministic text projection of a message's content for token estimation.
  *
- * Non-text parts (images, files, tool payloads) are projected to a bounded
- * placeholder rather than serialized: a base64 data URL would otherwise be fed
- * whole into the estimator and dominate every region total it touches. The
- * placeholder means binary parts contribute a small constant instead of a real
- * token count — one more reason the estimate is reported alongside the
- * provider-reported total rather than in place of it.
+ * Structured text payloads (tool-call arguments, tool results) ARE serialized,
+ * because the provider serializes them too and charges tokens for them. In a
+ * tool-calling loop they are most of the `messages` region, so collapsing them
+ * would understate exactly the region a caller is usually trying to measure.
+ *
+ * Binary payloads are the exception: an image or file part, or any long
+ * base64/data-URL string inside a part, projects to a bounded placeholder. Fed
+ * whole to the estimator it would dominate every region total it touches, and
+ * its real token cost is not a function of its serialized length anyway.
  */
 function contentToText(content: unknown): string {
   if (typeof content === 'string') return content;
@@ -47,13 +50,34 @@ function contentToText(content: unknown): string {
   return String(content);
 }
 
+/** Part types whose payload is bytes, not tokens-worth-of-text. */
+const BINARY_PART_TYPES = new Set(['image', 'file']);
+
+/** A data URL, or a long unbroken base64-ish run: too big to estimate, not text anyway. */
+function looksBinary(value: string): boolean {
+  if (value.startsWith('data:')) return true;
+  return value.length > 512 && /^[A-Za-z0-9+/=_-]+$/.test(value);
+}
+
+function placeholder(label: string): string {
+  return `\u0002${label}\u0002`;
+}
+
 function projectPart(part: unknown): string {
-  if (typeof part === 'string') return part;
+  if (typeof part === 'string') return looksBinary(part) ? placeholder('binary') : part;
   if (!part || typeof part !== 'object') return String(part ?? '');
   const text = (part as { text?: unknown }).text;
   if (typeof text === 'string') return text;
   const type = (part as { type?: unknown }).type;
-  return `\u0002${typeof type === 'string' ? type : 'part'}\u0002`;
+  if (typeof type === 'string' && BINARY_PART_TYPES.has(type)) return placeholder(type);
+  try {
+    return JSON.stringify(part, (_key, value) =>
+      typeof value === 'string' && looksBinary(value) ? placeholder('binary') : value,
+    );
+  } catch {
+    // Cyclic or otherwise unserializable: fall back to the type name.
+    return placeholder(typeof type === 'string' ? type : 'part');
+  }
 }
 
 /**

--- a/packages/core/src/agent/message-list/region-attribution.ts
+++ b/packages/core/src/agent/message-list/region-attribution.ts
@@ -1,10 +1,10 @@
 import { estimateTokenCount } from 'tokenx';
+import type { PromptRegionAttribution } from '../../observability/types/tracing';
 import type { MessageList } from './index';
 
 /**
- * Prompt token-composition estimate by MessageList region, computed over the
- * FINAL prompt actually sent to the model (after processLLMRequest processors
- * and other post-render rewrites).
+ * Region attribution over the FINAL prompt actually sent to the model (after
+ * processLLMRequest processors and other post-render rewrites).
  *
  * Regions:
  * - `system`             — untagged MessageList system messages
@@ -15,15 +15,10 @@ import type { MessageList } from './index';
  *
  * A missing region key means not-present, never zero. Estimates always sum to
  * `totalEstimated` over the final prompt by construction.
+ *
+ * The emitted shape is the span-attribute contract `PromptRegionAttribution`,
+ * which lives with the other span attributes in `observability/types/tracing`.
  */
-export interface PromptRegionAttribution {
-  /** Token-estimation method used (e.g. 'tokenx-estimate'). */
-  method: string;
-  /** Sum of all region estimates over the final prompt. */
-  totalEstimated: number;
-  /** Estimated tokens per region. */
-  regions: Record<string, number>;
-}
 
 const ESTIMATION_METHOD = 'tokenx-estimate';
 

--- a/packages/core/src/agent/message-list/region-attribution.ts
+++ b/packages/core/src/agent/message-list/region-attribution.ts
@@ -92,3 +92,29 @@ export function attributePromptRegions({
 
   return { method: ESTIMATION_METHOD, totalEstimated, regions };
 }
+
+/**
+ * Previous step's serialized prompt, keyed by a per-run object (the
+ * MessageList instance). WeakMap so the entry dies with the run.
+ */
+const previousPromptByKey = new WeakMap<object, string>();
+
+/**
+ * Cheap step-to-step prompt-prefix change detector (instrumentation only).
+ *
+ * Serializes the prompt deterministically and compares against the previous
+ * step's serialization for the same key. Returns:
+ * - `undefined` on the first step (no previous prompt to compare against)
+ * - `false` when the previous prompt is a strict prefix of the current one
+ *   (append-only growth — provider prompt caches stay warm)
+ * - `true` when earlier bytes changed (prompt prefix invalidated)
+ *
+ * Cost is one serialization + one startsWith over in-memory strings per step.
+ */
+export function didPromptPrefixChange(key: object, inputMessages: readonly PromptLikeMessage[]): boolean | undefined {
+  const serialized = inputMessages.map(m => `${String(m.role)}\u0000${contentToText(m.content)}`).join('\u0001');
+  const previous = previousPromptByKey.get(key);
+  previousPromptByKey.set(key, serialized);
+  if (previous === undefined) return undefined;
+  return !serialized.startsWith(previous);
+}

--- a/packages/core/src/loop/__fixtures__/prompt-identity-baseline.json
+++ b/packages/core/src/loop/__fixtures__/prompt-identity-baseline.json
@@ -1,0 +1,24 @@
+[
+  {
+    "role": "system",
+    "content": "You are a test agent. Answer briefly."
+  },
+  {
+    "role": "system",
+    "content": "Remembered fact: the sky is blue."
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "What color is the sky?",
+        "providerOptions": {
+          "mastra": {
+            "createdAt": 1704067200000
+          }
+        }
+      }
+    ]
+  }
+]

--- a/packages/core/src/loop/prompt-identity.test.ts
+++ b/packages/core/src/loop/prompt-identity.test.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessageList } from '../agent/message-list';
+import type { Mastra } from '../mastra';
+import { testUsage } from '../stream/aisdk/v5/test-utils';
+import { loop } from './loop';
+import { MastraLanguageModelV2Mock as MockLanguageModelV2 } from './test-utils/MastraLanguageModelV2Mock';
+import { createTestMastra, mockDate } from './test-utils/utils';
+
+/**
+ * Prompt-identity regression test (instrumentation must never change prompt bytes).
+ *
+ * The fixture at __fixtures__/prompt-identity-baseline.json was captured by
+ * running this file on the pristine base commit (upstream/main, before any
+ * instrumentation changes) with CAPTURE_PROMPT_IDENTITY_BASELINE=1. The test
+ * asserts the serialized prompt sent to the model is byte-identical to that
+ * baseline. Regenerating the fixture is permitted ONLY when an upstream commit
+ * changed prompt assembly; name that commit in the plan's progress file.
+ */
+
+const FIXTURE_PATH = join(__dirname, '__fixtures__', 'prompt-identity-baseline.json');
+const CAPTURE = process.env.CAPTURE_PROMPT_IDENTITY_BASELINE === '1';
+
+describe('prompt identity (loop-level)', () => {
+  let mastraRef: { current?: Mastra } = {};
+  let dispose: (() => Promise<void>) | undefined;
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(mockDate);
+    const created = await createTestMastra();
+    mastraRef.current = created.mastra;
+    dispose = created.dispose;
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await dispose?.();
+    mastraRef.current = undefined;
+    dispose = undefined;
+  });
+
+  it('sends a prompt byte-identical to the committed baseline', async () => {
+    const messageList = new MessageList();
+    messageList.addSystem('You are a test agent. Answer briefly.');
+    messageList.addSystem('Remembered fact: the sky is blue.', 'memory');
+    messageList.add(
+      {
+        id: 'msg-1',
+        role: 'user',
+        content: [{ type: 'text', text: 'What color is the sky?' }],
+      },
+      'input',
+    );
+
+    let capturedPrompt: unknown;
+    const result = loop({
+      methodType: 'stream',
+      runId: 'prompt-identity-run',
+      mastra: mastraRef.current as any,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: new MockLanguageModelV2({
+            doStream: async ({ prompt }) => {
+              capturedPrompt = prompt;
+              return {
+                stream: convertArrayToReadableStream([
+                  { type: 'text-start', id: 'text-1' },
+                  { type: 'text-delta', id: 'text-1', delta: 'Blue.' },
+                  { type: 'text-end', id: 'text-1' },
+                  { type: 'finish', finishReason: 'stop', usage: testUsage },
+                ]),
+              };
+            },
+          }),
+        },
+      ],
+      messageList,
+      agentId: 'agent-id',
+    });
+
+    expect(await result.text).toBe('Blue.');
+    expect(capturedPrompt).toBeDefined();
+
+    const serialized = JSON.stringify(capturedPrompt, null, 2) + '\n';
+
+    if (CAPTURE) {
+      mkdirSync(dirname(FIXTURE_PATH), { recursive: true });
+      writeFileSync(FIXTURE_PATH, serialized);
+      // Capture mode only writes the baseline; identity is asserted on normal runs.
+      return;
+    }
+
+    expect(existsSync(FIXTURE_PATH), `missing baseline fixture at ${FIXTURE_PATH}`).toBe(true);
+    const baseline = readFileSync(FIXTURE_PATH, 'utf8');
+    expect(serialized).toBe(baseline);
+  });
+});

--- a/packages/core/src/loop/prompt-identity.test.ts
+++ b/packages/core/src/loop/prompt-identity.test.ts
@@ -16,8 +16,16 @@ import { createTestMastra, mockDate } from './test-utils/utils';
  * running this file on the pristine base commit (upstream/main, before any
  * instrumentation changes) with CAPTURE_PROMPT_IDENTITY_BASELINE=1. The test
  * asserts the serialized prompt sent to the model is byte-identical to that
- * baseline. Regenerating the fixture is permitted ONLY when an upstream commit
- * changed prompt assembly; name that commit in the plan's progress file.
+ * baseline.
+ *
+ * If this test fails, the default conclusion is that a change altered the bytes
+ * sent to models — investigate before touching the fixture. Regenerating it is
+ * legitimate ONLY when an upstream change intentionally altered prompt
+ * assembly, in which case regenerate with:
+ *
+ *   CAPTURE_PROMPT_IDENTITY_BASELINE=1 vitest run src/loop/prompt-identity.test.ts
+ *
+ * and state the intentional prompt-assembly change in the commit message.
  */
 
 const FIXTURE_PATH = join(__dirname, '__fixtures__', 'prompt-identity-baseline.json');

--- a/packages/core/src/loop/prompt-identity.test.ts
+++ b/packages/core/src/loop/prompt-identity.test.ts
@@ -26,6 +26,11 @@ import { createTestMastra, mockDate } from './test-utils/utils';
  *   CAPTURE_PROMPT_IDENTITY_BASELINE=1 vitest run src/loop/prompt-identity.test.ts
  *
  * and state the intentional prompt-assembly change in the commit message.
+ *
+ * Scope: this guards prompt BYTES, not the instrumentation. It passes whether
+ * or not the region-attribution seam fires — that is covered by
+ * agent/message-list/region-attribution.test.ts and by the span snapshots in
+ * observability/mastra.
  */
 
 const FIXTURE_PATH = join(__dirname, '__fixtures__', 'prompt-identity-baseline.json');

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1566,10 +1566,14 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
         const stepSpanForRegions = modelSpanTracker?.getTracingContext()?.currentSpan;
         if (stepSpanForRegions?.type === SpanType.MODEL_STEP) {
           try {
+            // Prefix baseline first: it is stateful, and skipping it because
+            // attribution threw would silently compare the NEXT step against a
+            // stale prompt.
+            const prefixChanged = didPromptPrefixChange(messageList, inputMessages);
             stepSpanForRegions.update({
               attributes: {
                 promptRegions: attributePromptRegions({ messageList, inputMessages }),
-                promptPrefixChangedFromPreviousStep: didPromptPrefixChange(messageList, inputMessages),
+                promptPrefixChangedFromPreviousStep: prefixChanged,
               },
             });
           } catch (error) {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1573,7 +1573,9 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             stepSpanForRegions.update({
               attributes: {
                 promptRegions: attributePromptRegions({ messageList, inputMessages }),
-                promptPrefixChangedFromPreviousStep: prefixChanged,
+                // Omitted rather than set undefined on the first step: consumers
+                // distinguish "first step" from "instrumented" by absence.
+                ...(prefixChanged === undefined ? {} : { promptPrefixChangedFromPreviousStep: prefixChanged }),
               },
             });
           } catch (error) {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1564,12 +1564,18 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
         // composition by MessageList region onto the current MODEL_STEP span.
         // Attribute-only — never alters inputMessages, ordering, or control flow.
         const stepSpanForRegions = modelSpanTracker?.getTracingContext()?.currentSpan;
+        // The prefix baseline is stateful and must advance on EVERY step, even
+        // steps with no MODEL_STEP span to report on. Skipping it would leave
+        // the next step comparing against a prompt two steps old and reporting
+        // the result as if it were a step-to-step comparison.
+        let prefixChanged: boolean | undefined;
+        try {
+          prefixChanged = didPromptPrefixChange(messageList, inputMessages);
+        } catch (error) {
+          logger?.debug('Failed to update prompt prefix baseline', { error });
+        }
         if (stepSpanForRegions?.type === SpanType.MODEL_STEP) {
           try {
-            // Prefix baseline first: it is stateful, and skipping it because
-            // attribution threw would silently compare the NEXT step against a
-            // stale prompt.
-            const prefixChanged = didPromptPrefixChange(messageList, inputMessages);
             stepSpanForRegions.update({
               attributes: {
                 promptRegions: attributePromptRegions({ messageList, inputMessages }),

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -5,6 +5,7 @@ import { APICallError, generateId } from '@internal/ai-sdk-v5';
 import type { CallSettings, StepResult, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
 import type { StructuredOutputOptions } from '../../../agent';
 import type { MessageList } from '../../../agent/message-list';
+import { attributePromptRegions } from '../../../agent/message-list/region-attribution';
 import { TripWire } from '../../../agent/trip-wire';
 import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../../../agent/utils';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../../error';
@@ -1557,6 +1558,22 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           }
           logger?.error('Error in processLLMRequest processors:', error);
           throw error;
+        }
+
+        // Instrumentation only: attribute the FINAL prompt's estimated token
+        // composition by MessageList region onto the current MODEL_STEP span.
+        // Attribute-only — never alters inputMessages, ordering, or control flow.
+        const stepSpanForRegions = modelSpanTracker?.getTracingContext()?.currentSpan;
+        if (stepSpanForRegions?.type === SpanType.MODEL_STEP) {
+          try {
+            stepSpanForRegions.update({
+              attributes: {
+                promptRegions: attributePromptRegions({ messageList, inputMessages }),
+              },
+            });
+          } catch (error) {
+            logger?.debug('Failed to attach prompt region attribution', { error });
+          }
         }
 
         if (cachedResponse) {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -5,7 +5,7 @@ import { APICallError, generateId } from '@internal/ai-sdk-v5';
 import type { CallSettings, StepResult, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
 import type { StructuredOutputOptions } from '../../../agent';
 import type { MessageList } from '../../../agent/message-list';
-import { attributePromptRegions } from '../../../agent/message-list/region-attribution';
+import { attributePromptRegions, didPromptPrefixChange } from '../../../agent/message-list/region-attribution';
 import { TripWire } from '../../../agent/trip-wire';
 import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../../../agent/utils';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../../error';
@@ -1569,6 +1569,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             stepSpanForRegions.update({
               attributes: {
                 promptRegions: attributePromptRegions({ messageList, inputMessages }),
+                promptPrefixChangedFromPreviousStep: didPromptPrefixChange(messageList, inputMessages),
               },
             });
           } catch (error) {

--- a/packages/core/src/observability/rollup/__fixtures__/token-composition-spans.json
+++ b/packages/core/src/observability/rollup/__fixtures__/token-composition-spans.json
@@ -1,0 +1,123 @@
+[
+  {
+    "id": "gen-1",
+    "traceId": "trace-1",
+    "name": "model generation",
+    "type": "model_generation",
+    "parentSpanId": "agent-run-1",
+    "attributes": { "model": "test-model" }
+  },
+  {
+    "id": "step-1",
+    "traceId": "trace-1",
+    "name": "model step",
+    "type": "model_step",
+    "parentSpanId": "gen-1",
+    "attributes": {
+      "stepIndex": 0,
+      "usage": {
+        "inputTokens": 106,
+        "outputTokens": 20,
+        "inputDetails": { "text": 6, "cacheRead": 94, "cacheWrite": 6 }
+      },
+      "promptRegions": {
+        "method": "tokenx-estimate",
+        "totalEstimated": 100,
+        "regions": { "system": 40, "tagged-system:memory": 30, "messages": 30 }
+      }
+    }
+  },
+  {
+    "id": "step-2",
+    "traceId": "trace-1",
+    "name": "model step",
+    "type": "model_step",
+    "parentSpanId": "gen-1",
+    "attributes": {
+      "stepIndex": 1,
+      "usage": {
+        "inputTokens": 110,
+        "outputTokens": 15,
+        "inputDetails": { "text": 10, "cacheRead": 100, "cacheWrite": 0 }
+      },
+      "promptRegions": {
+        "method": "tokenx-estimate",
+        "totalEstimated": 105,
+        "regions": { "system": 40, "tagged-system:memory": 30, "messages": 35 }
+      },
+      "promptPrefixChangedFromPreviousStep": false
+    }
+  },
+  {
+    "id": "step-3",
+    "traceId": "trace-1",
+    "name": "model step",
+    "type": "model_step",
+    "parentSpanId": "gen-1",
+    "attributes": {
+      "stepIndex": 2,
+      "usage": { "inputTokens": 120, "outputTokens": 30 },
+      "promptRegions": {
+        "method": "tokenx-estimate",
+        "totalEstimated": 118,
+        "regions": { "system": 40, "messages": 78 }
+      },
+      "promptPrefixChangedFromPreviousStep": true
+    }
+  },
+  {
+    "id": "step-4",
+    "traceId": "trace-1",
+    "name": "model step",
+    "type": "model_step",
+    "parentSpanId": "gen-2",
+    "attributes": {
+      "stepIndex": 0,
+      "usage": {
+        "inputTokens": 90,
+        "outputTokens": 12,
+        "inputDetails": { "text": 10, "cacheRead": 50, "cacheWrite": 0, "image": 30 }
+      },
+      "promptRegions": {
+        "method": "tokenx-estimate",
+        "totalEstimated": 88,
+        "regions": { "system": 40, "messages": 48 }
+      }
+    }
+  },
+  {
+    "id": "step-5",
+    "traceId": "trace-2",
+    "name": "model step",
+    "type": "model_step",
+    "parentSpanId": "gen-3",
+    "attributes": {
+      "stepIndex": 0,
+      "usage": {
+        "inputTokens": 10,
+        "outputTokens": 4,
+        "inputDetails": { "text": 4, "cacheRead": 6, "cacheWrite": 0 }
+      }
+    }
+  },
+  {
+    "id": "step-6",
+    "traceId": "trace-2",
+    "name": "model step",
+    "type": "model_step",
+    "parentSpanId": "gen-3",
+    "attributes": {
+      "stepIndex": 1,
+      "usage": {
+        "inputTokens": 20,
+        "outputTokens": 6,
+        "inputDetails": { "text": 6, "cacheRead": 10, "cacheWrite": 4 }
+      },
+      "promptRegions": {
+        "method": "tokenx-estimate",
+        "totalEstimated": 22,
+        "regions": { "system": 12, "messages": 10 }
+      }
+    }
+  }
+]

--- a/packages/core/src/observability/rollup/token-composition-rollup.test.ts
+++ b/packages/core/src/observability/rollup/token-composition-rollup.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import { SpanType } from '../types';
 import {
   CACHE_HIT_RATE_FORMULA,
   formatTokenCompositionRollup,
@@ -55,6 +56,32 @@ describe('rollupTokenComposition', () => {
     expect(rollup.estimateDelta.samples).toBe(5);
     expect(rollup.estimateDelta.meanSigned).toBeCloseTo(-13 / 5, 10);
     expect(rollup.estimateDelta.meanAbsolute).toBeCloseTo(17 / 5, 10);
+  });
+
+  it('computes estimator bias only over steps carrying both an estimate and a provider total', () => {
+    const withEstimate = (id: string, totalEstimated: number, inputTokens?: number) => ({
+      id,
+      traceId: 't',
+      spanId: id,
+      parentSpanId: 'gen-bias',
+      type: SpanType.MODEL_STEP,
+      attributes: {
+        promptRegions: { method: 'tokenx-estimate', totalEstimated, regions: { system: totalEstimated } },
+        ...(inputTokens === undefined ? {} : { usage: { inputTokens } }),
+      },
+    });
+
+    // 110 estimated against 100 reported is a 10% bias. The second span carries
+    // a large estimate but no provider total, so it must not enter the ratio.
+    const rollup = rollupTokenComposition([withEstimate('a', 110, 100), withEstimate('b', 9000)] as any);
+
+    expect(rollup.estimateDelta.samples).toBe(1);
+    expect(rollup.estimateDelta.biasFraction).toBeCloseTo(0.1, 10);
+    expect(rollup.regions.totalEstimated).toBe(9110);
+  });
+
+  it('reports no bias when no step carries a provider total', () => {
+    expect(rollupTokenComposition([]).estimateDelta.biasFraction).toBeUndefined();
   });
 
   it('counts prefix-change observations without inventing a value for the first step', () => {

--- a/packages/core/src/observability/rollup/token-composition-rollup.test.ts
+++ b/packages/core/src/observability/rollup/token-composition-rollup.test.ts
@@ -121,4 +121,31 @@ describe('formatTokenCompositionRollup', () => {
     expect(output).toContain('uninstrumented (no promptRegions) 1');
     expect(output).toContain('unreported 1');
   });
+
+  it('refuses to let a heavily unattributed session pass as gate input', () => {
+    const withUnattributed = (unattributed: number, system: number) =>
+      [
+        {
+          id: 'u',
+          traceId: 't',
+          spanId: 'u',
+          parentSpanId: 'gen-u',
+          type: SpanType.MODEL_STEP,
+          attributes: {
+            promptRegions: {
+              method: 'tokenx-estimate',
+              totalEstimated: unattributed + system,
+              regions: { system, unattributed },
+            },
+          },
+        },
+      ] as any;
+
+    // Text rewritten after render falls through to `unattributed`; a large
+    // bucket there means the named regions are quietly missing mass.
+    expect(formatTokenCompositionRollup(rollupTokenComposition(withUnattributed(300, 700)))).toContain(
+      'WARNING: 30.0% of estimated prompt tokens are unattributed',
+    );
+    expect(formatTokenCompositionRollup(rollupTokenComposition(withUnattributed(1, 999)))).not.toContain('WARNING');
+  });
 });

--- a/packages/core/src/observability/rollup/token-composition-rollup.test.ts
+++ b/packages/core/src/observability/rollup/token-composition-rollup.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CACHE_HIT_RATE_FORMULA,
+  formatTokenCompositionRollup,
+  rollupTokenComposition,
+} from './token-composition-rollup';
+
+const spans = JSON.parse(
+  readFileSync(join(__dirname, '__fixtures__', 'token-composition-spans.json'), 'utf-8'),
+) as any[];
+
+describe('rollupTokenComposition', () => {
+  const rollup = rollupTokenComposition(spans);
+
+  it('counts only MODEL_STEP spans, classifying reported/unreported/multimodal/uninstrumented', () => {
+    expect(rollup.steps).toEqual({
+      total: 6,
+      reported: 5,
+      unreported: 1,
+      multimodalExcluded: 1,
+      uninstrumented: 1,
+    });
+  });
+
+  it('computes the cache-hit rate over reported, text-only steps only', () => {
+    // cacheRead 210 / (210 cacheRead + 26 text + 10 cacheWrite) — the multimodal
+    // step's 50 cacheRead is excluded, not folded into the denominator.
+    expect(rollup.cache.cacheReadTokens).toBe(210);
+    expect(rollup.cache.cacheWriteTokens).toBe(10);
+    expect(rollup.cache.textTokens).toBe(26);
+    expect(rollup.cache.hitRate).toBeCloseTo(210 / 246, 10);
+    expect(rollup.cache.unreportedFraction).toBeCloseTo(1 / 6, 10);
+  });
+
+  it('sums region totals across instrumented steps without conflating uninstrumented spans', () => {
+    expect(rollup.regions.methods).toEqual(['tokenx-estimate']);
+    expect(rollup.regions.totals).toEqual({
+      system: 172,
+      'tagged-system:memory': 60,
+      messages: 201,
+    });
+    expect(rollup.regions.totalEstimated).toBe(433);
+    // The uninstrumented step contributed nothing but is reported separately.
+    expect(rollup.steps.uninstrumented).toBe(1);
+  });
+
+  it('derives the steps-per-turn distribution by parent generation span', () => {
+    expect(rollup.stepsPerTurn).toEqual({ turns: 3, min: 1, median: 2, p95: 3, max: 3 });
+  });
+
+  it('measures estimate-vs-provider-total delta only where a provider total exists', () => {
+    expect(rollup.estimateDelta.samples).toBe(5);
+    expect(rollup.estimateDelta.meanSigned).toBeCloseTo(-13 / 5, 10);
+    expect(rollup.estimateDelta.meanAbsolute).toBeCloseTo(17 / 5, 10);
+  });
+
+  it('counts prefix-change observations without inventing a value for the first step', () => {
+    expect(rollup.prefixChanges).toEqual({ observed: 2, changed: 1 });
+  });
+
+  it('never reports a hit rate when no step qualifies', () => {
+    const empty = rollupTokenComposition([]);
+    expect(empty.cache.hitRate).toBeUndefined();
+    expect(empty.cache.unreportedFraction).toBe(0);
+    expect(empty.estimateDelta.samples).toBe(0);
+  });
+
+  it('does not read a missing cache field as zero', () => {
+    const unreportedOnly = rollupTokenComposition([spans[3]]);
+    expect(unreportedOnly.steps.unreported).toBe(1);
+    expect(unreportedOnly.steps.reported).toBe(0);
+    expect(unreportedOnly.cache.hitRate).toBeUndefined();
+  });
+});
+
+describe('formatTokenCompositionRollup', () => {
+  const output = formatTokenCompositionRollup(rollupTokenComposition(spans));
+
+  it('prints the cache-hit formula in the header', () => {
+    expect(output).toContain(CACHE_HIT_RATE_FORMULA);
+    expect(output.split('\n').slice(0, 3).join('\n')).toContain(CACHE_HIT_RATE_FORMULA);
+  });
+
+  it('reports tokens by type only — no prices anywhere', () => {
+    expect(output).not.toMatch(/[$€£¥]/);
+    expect(output).not.toMatch(/\b(cost|price|usd|dollar)/i);
+  });
+
+  it('surfaces the excluded populations so the rate cannot be read as the whole session', () => {
+    expect(output).toContain('multimodal excluded 1');
+    expect(output).toContain('uninstrumented (no promptRegions) 1');
+    expect(output).toContain('unreported 1');
+  });
+});

--- a/packages/core/src/observability/rollup/token-composition-rollup.ts
+++ b/packages/core/src/observability/rollup/token-composition-rollup.ts
@@ -25,11 +25,20 @@ export interface TokenCompositionRollup {
   steps: {
     /** MODEL_STEP spans seen. */
     total: number;
-    /** Steps whose provider reported cache fields — the hit-rate population. */
+    /** Steps whose provider reported cache fields. The hit-rate population is `reported - multimodalExcluded`. */
     reported: number;
     /** Steps with no provider-reported cache fields. Excluded from the hit rate. */
     unreported: number;
-    /** Reported steps carrying audio/image input tokens. Excluded from the hit rate. */
+    /**
+     * Reported steps carrying broken-out audio/image input tokens. Excluded from
+     * the hit rate because `text` would then exclude them and under-count the
+     * denominator. Forward-compatibility guard: no provider path populates
+     * `inputDetails.audio`/`image` today (they are derived-but-never-assigned in
+     * observability/mastra's usage extractor), so this is expected to be 0 —
+     * today's `text` is `inputTokens - cacheRead - cacheWrite`, which means
+     * image tokens land inside `text` and the denominator is the full provider
+     * input total.
+     */
     multimodalExcluded: number;
     /** MODEL_STEP spans with no `promptRegions` attribute (pre-instrumentation spans). */
     uninstrumented: number;
@@ -191,7 +200,8 @@ export function formatTokenCompositionRollup(rollup: TokenCompositionRollup): st
 
   lines.push('Token composition rollup (tokens by type; no pricing by design)');
   lines.push(`cache-hit rate formula: ${rollup.formula}`);
-  lines.push(`  computed over reported, text-only steps`);
+  lines.push(`  computed over steps whose provider reported cache fields`);
+  lines.push(`  (\`text\` is the provider's non-cached input total; no provider breaks out audio/image today)`);
   lines.push('');
   lines.push(`steps: ${rollup.steps.total} total`);
   lines.push(`  reported ${rollup.steps.reported} | unreported ${rollup.steps.unreported}`);
@@ -211,6 +221,14 @@ export function formatTokenCompositionRollup(rollup: TokenCompositionRollup): st
     lines.push(`  ${region.padEnd(32)} ${tokens}`);
   }
   lines.push(`  ${'TOTAL'.padEnd(32)} ${rollup.regions.totalEstimated}`);
+  // Region shares are estimates. The bias belongs in the same glance as the
+  // table it distorts, not eight lines below it.
+  if (rollup.estimateDelta.meanSigned !== undefined && rollup.regions.totalEstimated > 0) {
+    const estimatedPerSample = rollup.regions.totalEstimated / Math.max(1, rollup.estimateDelta.samples);
+    const providerPerSample = estimatedPerSample - rollup.estimateDelta.meanSigned;
+    const bias = providerPerSample > 0 ? rollup.estimateDelta.meanSigned / providerPerSample : undefined;
+    lines.push(`  (estimate bias vs provider-reported input: ${bias === undefined ? 'n/a' : pct(bias)})`);
+  }
   lines.push('');
   const spt = rollup.stepsPerTurn;
   lines.push(

--- a/packages/core/src/observability/rollup/token-composition-rollup.ts
+++ b/packages/core/src/observability/rollup/token-composition-rollup.ts
@@ -64,6 +64,13 @@ export interface TokenCompositionRollup {
     samples: number;
     meanAbsolute?: number;
     meanSigned?: number;
+    /**
+     * Signed relative bias of the estimator, computed ONLY over the steps that
+     * carried both an estimate and a provider total. Undefined when no step
+     * qualifies — never inferred from population totals, which include
+     * instrumented steps whose usage never landed.
+     */
+    biasFraction?: number;
   };
   /** Steps whose prompt prefix changed from the previous step (cache-invalidating). */
   prefixChanges: {
@@ -107,6 +114,8 @@ export function rollupTokenComposition(spans: AnyExportedSpan[]): TokenCompositi
   let totalEstimated = 0;
 
   const deltas: number[] = [];
+  let estimatedOverSampled = 0;
+  let providerOverSampled = 0;
   let prefixObserved = 0;
   let prefixChanged = 0;
 
@@ -152,6 +161,12 @@ export function rollupTokenComposition(spans: AnyExportedSpan[]): TokenCompositi
       const providerTotal = attributes.usage?.inputTokens;
       if (providerTotal !== undefined) {
         deltas.push(regions.totalEstimated - providerTotal);
+        // Bias is a ratio, so it may only be computed over the spans that
+        // contributed BOTH an estimate and a provider total. Summing the
+        // estimate over a larger population than the delta samples silently
+        // understates the bias.
+        estimatedOverSampled += regions.totalEstimated;
+        providerOverSampled += providerTotal;
       }
     }
 
@@ -188,6 +203,8 @@ export function rollupTokenComposition(spans: AnyExportedSpan[]): TokenCompositi
       samples: deltas.length,
       meanAbsolute: deltas.length ? deltas.reduce((sum, d) => sum + Math.abs(d), 0) / deltas.length : undefined,
       meanSigned: deltas.length ? deltas.reduce((sum, d) => sum + d, 0) / deltas.length : undefined,
+      biasFraction:
+        providerOverSampled > 0 ? (estimatedOverSampled - providerOverSampled) / providerOverSampled : undefined,
     },
     prefixChanges: { observed: prefixObserved, changed: prefixChanged },
   };
@@ -201,7 +218,9 @@ export function formatTokenCompositionRollup(rollup: TokenCompositionRollup): st
   lines.push('Token composition rollup (tokens by type; no pricing by design)');
   lines.push(`cache-hit rate formula: ${rollup.formula}`);
   lines.push(`  computed over steps whose provider reported cache fields`);
-  lines.push(`  (\`text\` is the provider's non-cached input total; no provider breaks out audio/image today)`);
+  lines.push(`  (\`text\` is the provider's non-cached input total; the Mastra usage`);
+  lines.push(`   extractor does not populate inputDetails.audio/image, so both land in \`text\`)`);
+  lines.push(`  replayed steps from the LLM response cache are counted as steps and are not distinguishable here`);
   lines.push('');
   lines.push(`steps: ${rollup.steps.total} total`);
   lines.push(`  reported ${rollup.steps.reported} | unreported ${rollup.steps.unreported}`);
@@ -223,12 +242,10 @@ export function formatTokenCompositionRollup(rollup: TokenCompositionRollup): st
   lines.push(`  ${'TOTAL'.padEnd(32)} ${rollup.regions.totalEstimated}`);
   // Region shares are estimates. The bias belongs in the same glance as the
   // table it distorts, not eight lines below it.
-  if (rollup.estimateDelta.meanSigned !== undefined && rollup.regions.totalEstimated > 0) {
-    const estimatedPerSample = rollup.regions.totalEstimated / Math.max(1, rollup.estimateDelta.samples);
-    const providerPerSample = estimatedPerSample - rollup.estimateDelta.meanSigned;
-    const bias = providerPerSample > 0 ? rollup.estimateDelta.meanSigned / providerPerSample : undefined;
-    lines.push(`  (estimate bias vs provider-reported input: ${bias === undefined ? 'n/a' : pct(bias)})`);
-  }
+  lines.push(
+    `  (estimate bias vs provider-reported input: ${pct(rollup.estimateDelta.biasFraction)}` +
+      `, over ${rollup.estimateDelta.samples}/${rollup.steps.total - rollup.steps.uninstrumented} instrumented steps)`,
+  );
   lines.push('');
   const spt = rollup.stepsPerTurn;
   lines.push(

--- a/packages/core/src/observability/rollup/token-composition-rollup.ts
+++ b/packages/core/src/observability/rollup/token-composition-rollup.ts
@@ -249,6 +249,20 @@ export function formatTokenCompositionRollup(rollup: TokenCompositionRollup): st
     `  (token-weighted estimate bias vs provider-reported input: ${pct(rollup.estimateDelta.biasFraction)}` +
       `, over ${rollup.estimateDelta.samples}/${rollup.steps.total - rollup.steps.uninstrumented} instrumented steps)`,
   );
+  // A region total is only trustworthy if the prompt was mostly attributable.
+  // System text rewritten after render (or roles synthesized at the adapter
+  // boundary) falls through to `unattributed`, and a large bucket there means
+  // the named regions are quietly missing mass.
+  const unattributed = rollup.regions.totals.unattributed ?? 0;
+  if (rollup.regions.totalEstimated > 0) {
+    const unattributedShare = unattributed / rollup.regions.totalEstimated;
+    if (unattributedShare > 0.02) {
+      lines.push(
+        `  WARNING: ${pct(unattributedShare)} of estimated prompt tokens are unattributed — ` +
+          `named region totals are missing mass and should not be used as gate inputs.`,
+      );
+    }
+  }
   lines.push('');
   const spt = rollup.stepsPerTurn;
   lines.push(

--- a/packages/core/src/observability/rollup/token-composition-rollup.ts
+++ b/packages/core/src/observability/rollup/token-composition-rollup.ts
@@ -258,8 +258,8 @@ export function formatTokenCompositionRollup(rollup: TokenCompositionRollup): st
     const unattributedShare = unattributed / rollup.regions.totalEstimated;
     if (unattributedShare > 0.02) {
       lines.push(
-        `  WARNING: ${pct(unattributedShare)} of estimated prompt tokens are unattributed — ` +
-          `named region totals are missing mass and should not be used as gate inputs.`,
+        `  WARNING: ${pct(unattributedShare)} of estimated prompt tokens are unattributed. ` +
+          `Named region totals are missing mass and should not be used as gate inputs.`,
       );
     }
   }

--- a/packages/core/src/observability/rollup/token-composition-rollup.ts
+++ b/packages/core/src/observability/rollup/token-composition-rollup.ts
@@ -1,0 +1,225 @@
+/**
+ * Session-level rollup over exported MODEL_STEP spans.
+ *
+ * Turns a session's exported spans into the numbers the Resolvable State
+ * cost gate needs: cache-hit rate, prompt token composition by region, and
+ * the steps-per-turn distribution. Tokens by type only — never prices.
+ */
+
+import { SpanType } from '../types';
+import type { ExportedSpan, ModelStepAttributes } from '../types';
+
+/** The cache-hit formula, printed in the output header so consumers cannot misread the number. */
+export const CACHE_HIT_RATE_FORMULA = 'cacheRead / (cacheRead + text + cacheWrite)';
+
+export interface StepsPerTurnDistribution {
+  turns: number;
+  min: number;
+  median: number;
+  p95: number;
+  max: number;
+}
+
+export interface TokenCompositionRollup {
+  formula: typeof CACHE_HIT_RATE_FORMULA;
+  steps: {
+    /** MODEL_STEP spans seen. */
+    total: number;
+    /** Steps whose provider reported cache fields — the hit-rate population. */
+    reported: number;
+    /** Steps with no provider-reported cache fields. Excluded from the hit rate. */
+    unreported: number;
+    /** Reported steps carrying audio/image input tokens. Excluded from the hit rate. */
+    multimodalExcluded: number;
+    /** MODEL_STEP spans with no `promptRegions` attribute (pre-instrumentation spans). */
+    uninstrumented: number;
+  };
+  cache: {
+    /** Undefined when no step qualifies — never fabricate a rate from an empty population. */
+    hitRate?: number;
+    unreportedFraction: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    textTokens: number;
+  };
+  regions: {
+    /** Estimation methods seen across spans (should normally be one). */
+    methods: string[];
+    /** Estimated tokens per region, summed across instrumented steps. */
+    totals: Record<string, number>;
+    totalEstimated: number;
+  };
+  stepsPerTurn: StepsPerTurnDistribution;
+  /** Per-step (estimated − provider-reported) input tokens. Empty when providers reported no totals. */
+  estimateDelta: {
+    samples: number;
+    meanAbsolute?: number;
+    meanSigned?: number;
+  };
+  /** Steps whose prompt prefix changed from the previous step (cache-invalidating). */
+  prefixChanges: {
+    observed: number;
+    changed: number;
+  };
+}
+
+type AnyExportedSpan = ExportedSpan<SpanType> & { attributes?: Record<string, any> };
+
+function isModelStep(span: AnyExportedSpan): boolean {
+  return span.type === SpanType.MODEL_STEP;
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[index]!;
+}
+
+function median(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+
+export function rollupTokenComposition(spans: AnyExportedSpan[]): TokenCompositionRollup {
+  const steps = spans.filter(isModelStep);
+
+  let reported = 0;
+  let unreported = 0;
+  let multimodalExcluded = 0;
+  let uninstrumented = 0;
+
+  let cacheReadTokens = 0;
+  let cacheWriteTokens = 0;
+  let textTokens = 0;
+
+  const regionTotals: Record<string, number> = {};
+  const methods = new Set<string>();
+  let totalEstimated = 0;
+
+  const deltas: number[] = [];
+  let prefixObserved = 0;
+  let prefixChanged = 0;
+
+  const stepsByTurn = new Map<string, number>();
+
+  for (const span of steps) {
+    const attributes = (span.attributes ?? {}) as ModelStepAttributes;
+    const turnKey = span.parentSpanId ?? `${span.traceId}:orphan`;
+    stepsByTurn.set(turnKey, (stepsByTurn.get(turnKey) ?? 0) + 1);
+
+    const details = attributes.usage?.inputDetails;
+    // "Unreported" is inferred from absence: providers that do not report cache
+    // fields leave them undefined, and undefined is never read as zero.
+    const hasCacheFields = details?.cacheRead !== undefined || details?.cacheWrite !== undefined;
+    const isMultimodal = (details?.audio ?? 0) > 0 || (details?.image ?? 0) > 0;
+
+    if (!hasCacheFields) {
+      unreported++;
+    } else if (isMultimodal) {
+      // Excluded rather than folded in: `text` deliberately excludes audio/image
+      // tokens, so a multimodal step's denominator would silently under-count.
+      reported++;
+      multimodalExcluded++;
+    } else {
+      reported++;
+      cacheReadTokens += details?.cacheRead ?? 0;
+      cacheWriteTokens += details?.cacheWrite ?? 0;
+      textTokens += details?.text ?? 0;
+    }
+
+    const regions = attributes.promptRegions;
+    if (!regions) {
+      // Distinct from "region total is 0" — a span from before instrumentation
+      // landed must never be conflated with an empty region.
+      uninstrumented++;
+    } else {
+      methods.add(regions.method);
+      totalEstimated += regions.totalEstimated;
+      for (const [region, tokens] of Object.entries(regions.regions)) {
+        regionTotals[region] = (regionTotals[region] ?? 0) + tokens;
+      }
+
+      const providerTotal = attributes.usage?.inputTokens;
+      if (providerTotal !== undefined) {
+        deltas.push(regions.totalEstimated - providerTotal);
+      }
+    }
+
+    if (attributes.promptPrefixChangedFromPreviousStep !== undefined) {
+      prefixObserved++;
+      if (attributes.promptPrefixChangedFromPreviousStep) prefixChanged++;
+    }
+  }
+
+  const hitRateDenominator = cacheReadTokens + textTokens + cacheWriteTokens;
+  const countedForHitRate = reported - multimodalExcluded;
+
+  const perTurn = [...stepsByTurn.values()].sort((a, b) => a - b);
+
+  return {
+    formula: CACHE_HIT_RATE_FORMULA,
+    steps: { total: steps.length, reported, unreported, multimodalExcluded, uninstrumented },
+    cache: {
+      hitRate: countedForHitRate > 0 && hitRateDenominator > 0 ? cacheReadTokens / hitRateDenominator : undefined,
+      unreportedFraction: steps.length > 0 ? unreported / steps.length : 0,
+      cacheReadTokens,
+      cacheWriteTokens,
+      textTokens,
+    },
+    regions: { methods: [...methods].sort(), totals: regionTotals, totalEstimated },
+    stepsPerTurn: {
+      turns: perTurn.length,
+      min: perTurn.length ? perTurn[0]! : 0,
+      median: median(perTurn),
+      p95: percentile(perTurn, 95),
+      max: perTurn.length ? perTurn[perTurn.length - 1]! : 0,
+    },
+    estimateDelta: {
+      samples: deltas.length,
+      meanAbsolute: deltas.length ? deltas.reduce((sum, d) => sum + Math.abs(d), 0) / deltas.length : undefined,
+      meanSigned: deltas.length ? deltas.reduce((sum, d) => sum + d, 0) / deltas.length : undefined,
+    },
+    prefixChanges: { observed: prefixObserved, changed: prefixChanged },
+  };
+}
+
+/** Human-readable report. Token counts by type only — no prices, by design. */
+export function formatTokenCompositionRollup(rollup: TokenCompositionRollup): string {
+  const lines: string[] = [];
+  const pct = (value?: number) => (value === undefined ? 'n/a' : `${(value * 100).toFixed(1)}%`);
+
+  lines.push('Token composition rollup (tokens by type; no pricing by design)');
+  lines.push(`cache-hit rate formula: ${rollup.formula}`);
+  lines.push(`  computed over reported, text-only steps`);
+  lines.push('');
+  lines.push(`steps: ${rollup.steps.total} total`);
+  lines.push(`  reported ${rollup.steps.reported} | unreported ${rollup.steps.unreported}`);
+  lines.push(
+    `  multimodal excluded ${rollup.steps.multimodalExcluded} | uninstrumented (no promptRegions) ${rollup.steps.uninstrumented}`,
+  );
+  lines.push('');
+  lines.push(
+    `cache-hit rate: ${pct(rollup.cache.hitRate)} (unreported fraction ${pct(rollup.cache.unreportedFraction)})`,
+  );
+  lines.push(
+    `  cacheRead ${rollup.cache.cacheReadTokens} | cacheWrite ${rollup.cache.cacheWriteTokens} | text ${rollup.cache.textTokens}`,
+  );
+  lines.push('');
+  lines.push(`prompt regions (estimated, method: ${rollup.regions.methods.join(', ') || 'n/a'})`);
+  for (const [region, tokens] of Object.entries(rollup.regions.totals).sort((a, b) => b[1] - a[1])) {
+    lines.push(`  ${region.padEnd(32)} ${tokens}`);
+  }
+  lines.push(`  ${'TOTAL'.padEnd(32)} ${rollup.regions.totalEstimated}`);
+  lines.push('');
+  const spt = rollup.stepsPerTurn;
+  lines.push(
+    `steps per turn: turns ${spt.turns} | min ${spt.min} | median ${spt.median} | p95 ${spt.p95} | max ${spt.max}`,
+  );
+  lines.push(
+    `estimate vs provider total: samples ${rollup.estimateDelta.samples} | mean signed ${rollup.estimateDelta.meanSigned?.toFixed(1) ?? 'n/a'} | mean absolute ${rollup.estimateDelta.meanAbsolute?.toFixed(1) ?? 'n/a'}`,
+  );
+  lines.push(`prompt prefix changed: ${rollup.prefixChanges.changed}/${rollup.prefixChanges.observed} observed steps`);
+
+  return lines.join('\n');
+}

--- a/packages/core/src/observability/rollup/token-composition-rollup.ts
+++ b/packages/core/src/observability/rollup/token-composition-rollup.ts
@@ -236,14 +236,17 @@ export function formatTokenCompositionRollup(rollup: TokenCompositionRollup): st
   );
   lines.push('');
   lines.push(`prompt regions (estimated, method: ${rollup.regions.methods.join(', ') || 'n/a'})`);
-  for (const [region, tokens] of Object.entries(rollup.regions.totals).sort((a, b) => b[1] - a[1])) {
-    lines.push(`  ${region.padEnd(32)} ${tokens}`);
+  const regionEntries = Object.entries(rollup.regions.totals).sort((a, b) => b[1] - a[1]);
+  // Width from the longest key: dynamic `tagged-system:<tag>` names overflow any fixed pad.
+  const width = Math.max(5, ...regionEntries.map(([region]) => region.length)) + 2;
+  for (const [region, tokens] of regionEntries) {
+    lines.push(`  ${region.padEnd(width)} ${tokens}`);
   }
-  lines.push(`  ${'TOTAL'.padEnd(32)} ${rollup.regions.totalEstimated}`);
+  lines.push(`  ${'TOTAL'.padEnd(width)} ${rollup.regions.totalEstimated}`);
   // Region shares are estimates. The bias belongs in the same glance as the
   // table it distorts, not eight lines below it.
   lines.push(
-    `  (estimate bias vs provider-reported input: ${pct(rollup.estimateDelta.biasFraction)}` +
+    `  (token-weighted estimate bias vs provider-reported input: ${pct(rollup.estimateDelta.biasFraction)}` +
       `, over ${rollup.estimateDelta.samples}/${rollup.steps.total - rollup.steps.uninstrumented} instrumented steps)`,
   );
   lines.push('');

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -336,6 +336,9 @@ export interface ModelStepAttributes extends AIBaseAttributes {
    * Whether this step's prompt prefix changed relative to the previous step in
    * the same run (a changed prefix invalidates provider prompt caches).
    * Undefined on the first step. Emitted on MODEL_STEP only.
+   *
+   * Comparison granularity is per-message, so an append INSIDE the trailing
+   * message reads as a change. The bias is toward over-reporting invalidation.
    */
   promptPrefixChangedFromPreviousStep?: boolean;
   /** Reason this step finished (stop, tool-calls, length, etc.) */

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -304,6 +304,22 @@ export interface ModelGenerationAttributes extends AIBaseAttributes {
 }
 
 /**
+ * Prompt token-composition estimate by MessageList region, computed over the
+ * final prompt actually sent to the model on a step. Region keys are dynamic
+ * (`system`, `tagged-system:<tag>`, `messages`, `unattributed`); a missing key
+ * means not-present, never zero. Estimates are local heuristics — compare
+ * against provider-reported usage for accuracy, using `method` to interpret.
+ */
+export interface PromptRegionAttribution {
+  /** Token-estimation method used (e.g. 'tokenx-estimate'). */
+  method: string;
+  /** Sum of all region estimates over the final prompt. */
+  totalEstimated: number;
+  /** Estimated tokens per region. */
+  regions: Record<string, number>;
+}
+
+/**
  * Model Step attributes - for a single model execution within a generation
  */
 export interface ModelStepAttributes extends AIBaseAttributes {
@@ -311,6 +327,11 @@ export interface ModelStepAttributes extends AIBaseAttributes {
   stepIndex?: number;
   /** Token usage statistics */
   usage?: UsageStats;
+  /**
+   * Estimated prompt token composition by MessageList region for this step's
+   * final prompt. Emitted on MODEL_STEP only (not mirrored to MODEL_INFERENCE).
+   */
+  promptRegions?: PromptRegionAttribution;
   /** Reason this step finished (stop, tool-calls, length, etc.) */
   finishReason?: string;
   /** Should execution continue */

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -332,6 +332,12 @@ export interface ModelStepAttributes extends AIBaseAttributes {
    * final prompt. Emitted on MODEL_STEP only (not mirrored to MODEL_INFERENCE).
    */
   promptRegions?: PromptRegionAttribution;
+  /**
+   * Whether this step's prompt prefix changed relative to the previous step in
+   * the same run (a changed prefix invalidates provider prompt caches).
+   * Undefined on the first step. Emitted on MODEL_STEP only.
+   */
+  promptPrefixChangedFromPreviousStep?: boolean;
   /** Reason this step finished (stop, tool-calls, length, etc.) */
   finishReason?: string;
   /** Should execution continue */


### PR DESCRIPTION
# Instrument prompt token composition per model step

Today a model call reports one input-token number. That number can't answer the
question anyone asks when a prompt gets expensive: **what is the prompt actually
made of, and how much of it is the provider re-reading from its own cache?**

This adds that breakdown as additive span attributes, plus a script that rolls a
whole session up into readable numbers. No prompt-assembly, ordering, or
control-flow change of any kind.

Cost when tracing is off is zero: the whole block is gated on a live
`MODEL_STEP` span. When tracing is on, each step runs the token estimator over a
text projection of the prompt and one digest per message. That projection is
prompt-sized, not bounded: it runs on the final post-processor prompt, so any
truncation processor has already run, and the work scales with what is about to
be sent to the provider anyway.

## What lands

- **`promptRegions` on `MODEL_STEP` spans.** Estimated tokens per prompt region
  over the *final* prompt (after `processLLMRequest` processors, so it reflects
  the bytes actually sent). Regions are dynamic: `system`,
  `tagged-system:<tag>` (one per `MessageList` tag, e.g. memory), `messages`,
  and `unattributed` for content injected after render. A missing key means
  not-present, never zero.
- **`promptPrefixChangedFromPreviousStep` on `MODEL_STEP`.** Whether an earlier
  part of the prompt changed since the previous step, i.e. whether the provider's
  prompt cache was invalidated. Absent on the first step.
- **`packages/core/src/observability/rollup/`** plus a thin CLI at
  `scripts/token-composition-rollup.ts`, turning exported spans into cache-hit
  rate, per-region totals, steps-per-turn distribution, and the estimator's
  measured bias against provider-reported usage.

Both attributes are emitted on `MODEL_STEP` only, deliberately not mirrored onto
`MODEL_INFERENCE`. There is one `MODEL_GENERATION` span per generation, so
per-step data placed there would be overwritten on every step after the first.

No new dependencies: `tokenx` was already a core dependency via
`TokenLimiterProcessor`.

## Why this exists

It's the measurement stage of a research question. Is carrying operational state
in a prompt actually expensive, or is it already cache-priced and close to free?
A negative answer kills a planned feature cheaply. The
instrument is generally useful either way, and nothing in it is specific to that
question.

## Verification

- Byte-identity: `src/loop/prompt-identity.test.ts` asserts the exact prompt
  handed to the model matches a fixture captured on the pristine base commit,
  through the real loop. It guards prompt bytes. It is not a test of the
  instrumentation.
- 25 observability span snapshots regenerated: **340 insertions, 0 deletions**.
  That proves no existing snapshot line changed, not that untested paths are
  unaffected.
- Real session: a 3-turn tool-calling Gemini session, recorded on this branch as
  it now stands, produced `promptRegions` on all 6 `model_step` spans, and the
  rollup ran on it. The estimator ran 9.0% high against provider-reported input,
  which is why the rollup prints that bias next to the region table instead of
  presenting the estimate as truth. Cache-hit rate came back 30.3% on a workload
  Google's implicit cache happened to engage for. Both figures describe one short
  synthetic session and are here to show the pipeline produces numbers, not to
  characterize any real workload.
- Full core suite, `observability/mastra` suite, `tsc --noEmit`, oxlint, and
  prettier are clean apart from four pre-existing
  `src/workspace/sandbox/local-sandbox.test.ts` bwrap failures, verified by
  stashing this entire diff and re-running that file, which still fails.

## Known limitations

- **Estimates are estimates.** Region shares come from a local token estimator.
  The rollup reports its token-weighted bias against provider totals so the
  error is visible in the same glance as the table it distorts.
- **Binary payloads are detected heuristically, and the error is one-way.**
  Tool arguments and tool results are serialized and counted, because the
  provider serializes and bills them. Binary content projects to a bounded
  placeholder instead: typed image and file parts, raw bytes nested anywhere in
  a part, and long base64-looking strings. That last test is a heuristic, so a
  long hex string, or base64 sitting in a nested value, is under-counted in the
  `messages` region. Misfires of that heuristic only ever run low. Separately,
  the serialization being counted is ours and not the provider's wire format, so
  its JSON envelope pushes tool-heavy steps somewhat high. Both are reasons the
  rollup reports estimator bias rather than presenting the estimate as truth.
- **Attribution can leak into `unattributed`.** Region matching keys on exact
  system-message text, so a processor that rewrites a system message after
  injection moves that block out of its tagged region. Roles synthesized at the
  adapter boundary land there too, by construction. The rollup warns when
  more than 2% of estimated prompt tokens land in `unattributed`, because named
  region totals are missing mass in that case.
- **Identical system texts collapse.** Matching is first-writer-wins, so the
  same string appearing both untagged and under a tag is attributed entirely to
  the untagged region. Totals still reconcile. The error under-reports the
  tagged region.
- **Cache-replayed steps are counted as steps** and are not distinguishable in
  the report. The rollup header says so.
- **Prefix-change granularity is per-message**, so an append inside the trailing
  message reads as a change. The bias is toward over-reporting invalidation.
  Processor retries within one step can also contribute an extra sample.
- **A provider that always zero-fills `cachedInputTokens`** is classified as
  reporting a genuine zero. Visible as a 0% hit-rate step rather than as silence.
- **The durable-agent execution path is not instrumented** in this PR, since it
  builds its own step spans. Follow-up.
