### PR TITLE
feat(core): add SKILL_RESOLUTION span type for dynamic skills resolvers

### DIFF
--- a/.changeset/skill-resolution-span-client.md
+++ b/.changeset/skill-resolution-span-client.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Added the `skill_resolution` span type to the generated route types.

--- a/.changeset/skill-resolution-span-studio.md
+++ b/.changeset/skill-resolution-span-studio.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Skill resolution spans now show with their own icon and label in the trace view instead of falling back to "Other".

--- a/.changeset/skill-resolution-span-studio.md
+++ b/.changeset/skill-resolution-span-studio.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Skill resolution spans now show with their own icon and label in the trace view instead of falling back to "Other".
+Added a dedicated icon and label for skill resolution spans in the trace view. They now show as "Skill" instead of falling back to "Other".

--- a/.changeset/skill-resolution-span-type.md
+++ b/.changeset/skill-resolution-span-type.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Dynamic agent skills resolvers now run inside a dedicated `SKILL_RESOLUTION` span type instead of `GENERIC`, and the `resolve-skills` span reports `agentId` and `skillCount` as typed span attributes. If you filter or query traces by span type, the resolver span's type value changed from `generic` to `skill_resolution`.
+Added a dedicated `SKILL_RESOLUTION` span type for dynamic agent skills resolvers, replacing the `GENERIC` type the `resolve-skills` span used before. The span now reports `agentId` and `skillCount` as typed span attributes. If you filter or query traces by span type, the resolver span's type value changed from `generic` to `skill_resolution`.

--- a/.changeset/skill-resolution-span-type.md
+++ b/.changeset/skill-resolution-span-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Dynamic agent skills resolvers now run inside a dedicated `SKILL_RESOLUTION` span type instead of `GENERIC`, and the `resolve-skills` span reports `agentId` and `skillCount` as typed span attributes. If you filter or query traces by span type, the resolver span's type value changed from `generic` to `skill_resolution`.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -1474,7 +1474,8 @@ type Shared_Type_70 =
   | 'rag_vector_operation'
   | 'rag_action'
   | 'graph_action'
-  | 'mapping';
+  | 'mapping'
+  | 'skill_resolution';
 
 type Shared_Type_71 =
   | 'agent'
@@ -8818,6 +8819,7 @@ export type GetObservabilityTracesTraceIdSpanIdScores_Response = {
           | 'rag_action'
           | 'graph_action'
           | 'mapping'
+          | 'skill_resolution'
         )
       | undefined;
     structuredOutput?: boolean | undefined;

--- a/packages/core/src/agent/__tests__/agent-skills-wiring.test.ts
+++ b/packages/core/src/agent/__tests__/agent-skills-wiring.test.ts
@@ -400,10 +400,14 @@ describe('Agent-level skills wiring', () => {
       });
 
       expect(parent.createChildSpan).toHaveBeenCalledTimes(1);
-      expect(children[0]!.options).toMatchObject({ name: 'resolve-skills', metadata: { agentId: 'skills-span' } });
+      expect(children[0]!.options).toMatchObject({
+        type: 'skill_resolution',
+        name: 'resolve-skills',
+        attributes: { agentId: 'skills-span' },
+      });
       expect(seenSpans).toEqual([children[0]!.span]);
       expect(children[0]!.ended).toBe(true);
-      expect(children[0]!.endOptions).toMatchObject({ metadata: { skillCount: 1 } });
+      expect(children[0]!.endOptions).toMatchObject({ attributes: { skillCount: 1 } });
     });
 
     it('records a resolver failure on the span and opens a fresh one on retry', async () => {
@@ -431,7 +435,7 @@ describe('Agent-level skills wiring', () => {
       expect(children[0]!.errored).toBe(true);
       expect(children[0]!.errorOptions).toMatchObject({ endSpan: true });
       expect(children[1]!.ended).toBe(true);
-      expect(children[1]!.endOptions).toMatchObject({ metadata: { skillCount: 0 } });
+      expect(children[1]!.endOptions).toMatchObject({ attributes: { skillCount: 0 } });
     });
 
     it('passes an empty tracingContext on metadata reads like listSkills', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1355,9 +1355,9 @@ export class Agent<
 
     const parentSpan = tracingContext?.currentSpan ?? resolveCurrentSpan();
     const skillsSpan = parentSpan?.createChildSpan({
-      type: SpanType.GENERIC,
+      type: SpanType.SKILL_RESOLUTION,
       name: 'resolve-skills',
-      metadata: { agentId: this.id },
+      attributes: { agentId: this.id },
     });
 
     const resolution = executeWithContext({
@@ -1365,7 +1365,7 @@ export class Agent<
       fn: async () => resolver({ requestContext, tracingContext: { currentSpan: skillsSpan } }),
     })
       .then(skills => {
-        skillsSpan?.end({ metadata: { skillCount: skills.length } });
+        skillsSpan?.end({ attributes: { skillCount: skills.length } });
         return skills;
       })
       .catch(error => {

--- a/packages/core/src/evals/types.ts
+++ b/packages/core/src/evals/types.ts
@@ -768,6 +768,7 @@ const SKIPPED_SPAN_TYPES = new Set([
   SpanType.SCORER_RUN,
   SpanType.SCORER_STEP,
   SpanType.GENERIC,
+  SpanType.SKILL_RESOLUTION,
   SpanType.MODEL_STEP,
   SpanType.MODEL_INFERENCE,
   SpanType.MODEL_CHUNK,

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -106,6 +106,8 @@ export enum SpanType {
   GRAPH_ACTION = 'graph_action',
   /** Inline data mapping between pipeline stages (e.g. a tool's `toModelOutput` transform) */
   MAPPING = 'mapping',
+  /** Dynamic agent skills resolver run */
+  SKILL_RESOLUTION = 'skill_resolution',
 }
 
 export { EntityType };
@@ -454,6 +456,16 @@ export interface MappingAttributes extends AIBaseAttributes {
 }
 
 /**
+ * Skill resolution attributes — for a dynamic agent skills resolver run.
+ */
+export interface SkillResolutionAttributes extends AIBaseAttributes {
+  /** Agent whose skills resolver ran */
+  agentId?: string;
+  /** Number of skills the resolver returned */
+  skillCount?: number;
+}
+
+/**
  * Processor attributes
  */
 export interface ProcessorRunAttributes extends AIBaseAttributes {
@@ -761,6 +773,7 @@ export interface SpanTypeMap {
   [SpanType.RAG_ACTION]: RagActionAttributes;
   [SpanType.GRAPH_ACTION]: GraphActionAttributes;
   [SpanType.MAPPING]: MappingAttributes;
+  [SpanType.SKILL_RESOLUTION]: SkillResolutionAttributes;
 }
 
 /**

--- a/packages/playground-ui/src/domains/traces/components/shared.tsx
+++ b/packages/playground-ui/src/domains/traces/components/shared.tsx
@@ -4,6 +4,7 @@ import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { FolderIcon } from '@/ds/icons/FolderIcon';
 import { McpServerIcon } from '@/ds/icons/McpServerIcon';
 import { MemoryIcon } from '@/ds/icons/MemoryIcon';
+import { SkillIcon } from '@/ds/icons/SkillIcon';
 import { ToolsIcon } from '@/ds/icons/ToolsIcon';
 import { WorkflowIcon } from '@/ds/icons/WorkflowIcon';
 
@@ -16,6 +17,7 @@ export const spanTypePrefixes = [
   'provider',
   'memory',
   'workspace',
+  'skill',
   'scorer',
   'other',
 ];
@@ -68,6 +70,12 @@ const spanTypeToUiElements: Record<string, UISpanStyle> = {
     color: 'oklch(0.75 0.15 40)',
     label: 'Workspace',
     typePrefix: 'workspace',
+  },
+  skill: {
+    icon: <SkillIcon />,
+    color: 'oklch(0.75 0.15 130)',
+    label: 'Skill',
+    typePrefix: 'skill',
   },
   scorer: {
     icon: <GaugeIcon />,


### PR DESCRIPTION
## Description

Follow-up to #20949: the `resolve-skills` span was typed `GENERIC`, but spans created by Mastra itself should have a dedicated span type ([review comment](https://github.com/mastra-ai/mastra/pull/20949#discussion_r3747171533)). Dynamic skills resolvers now run inside a `SKILL_RESOLUTION` span with typed attributes, and Studio classifies them as "Skill" instead of "Other".

<img width="1365" height="608" alt="image" src="https://github.com/user-attachments/assets/0e644fcb-4907-45d4-9fce-979d4ca289ce" />

## Related Issue(s)

Follow-up to #20949 (fixes no standalone issue)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Dynamic skill lookups now have their own trace type. This makes them easier to identify in Studio and keeps their details out of evaluation results.

## Changes

- Added `SpanType.SKILL_RESOLUTION` with typed `agentId` and `skillCount` attributes.
- Updated `Agent.#resolveDynamicSkills` to use the new span type.
- Preserved eval trace-skipping behavior for skill-resolution spans.
- Updated Studio to display these spans as “Skill” with a dedicated icon.
- Regenerated client route types for `skill_resolution`.
- Kept user-created resolver child spans as `generic`.
- Updated tracing tests and added package changesets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->