### PR TITLE
ci: require monorepo E2E coverage for deployer changes

### DIFF
--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -47,7 +47,8 @@ jobs:
           # before the no-test exemptions below so it applies to all contributors.
           if grep -q '^packages/deployer/' /tmp/changed-files \
             && ! grep -q '^e2e-tests/monorepo/' /tmp/changed-files; then
-            echo "::error::Changes under packages/deployer/ must include corresponding coverage under e2e-tests/monorepo/. The deployer build pipeline is not validated by package unit tests alone; add or update a monorepo E2E test."
+            first_deployer_file="$(grep -m1 '^packages/deployer/' /tmp/changed-files || true)"
+            echo "::error file=${first_deployer_file},title=Monorepo E2E coverage required::This PR changes packages/deployer/ but has no corresponding changes under e2e-tests/monorepo/. Deployer unit tests alone do not validate generated monorepo applications — add or update a monorepo E2E test. See packages/deployer/AGENTS.md for commands."
             exit 1
           fi
 

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -51,7 +51,8 @@ jobs:
           # not restored from FETCH_HEAD. The package instructions are exempt.
           if grep -q '^packages/deployer/' /tmp/changed-coverage-files \
             && ! grep -q '^e2e-tests/monorepo/' /tmp/changed-coverage-files \
-            && grep '^packages/deployer/' /tmp/changed-coverage-files | grep -qv '^packages/deployer/AGENTS\.md$'; then
+            && awk '$0 ~ /^packages\/deployer\// && $0 != "packages/deployer/AGENTS.md" { found=1; exit } END { exit(found ? 0 : 1) }' \
+              /tmp/changed-coverage-files; then
             first_deployer_file="$(grep -m1 '^packages/deployer/' /tmp/changed-files || true)"
             escaped_deployer_file="${first_deployer_file//%/%25}"
             escaped_deployer_file="${escaped_deployer_file//$'\r'/%0D}"

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -41,8 +41,18 @@ jobs:
 
           git fetch "${HEAD_REPO}" "${HEAD_SHA}" --depth=1
           git diff --name-only --diff-filter=ACMRT "${BASE_SHA}" FETCH_HEAD \
-            | grep -E '(^|/)(test|tests|__tests__)/|\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$|\.test-d\.ts$' \
-            | sort > /tmp/changed-test-files || true
+            | sort > /tmp/changed-files || true
+
+          # Deployer changes must include monorepo E2E coverage. This rule runs
+          # before the no-test exemptions below so it applies to all contributors.
+          if grep -q '^packages/deployer/' /tmp/changed-files \
+            && ! grep -q '^e2e-tests/monorepo/' /tmp/changed-files; then
+            echo "::error::Changes under packages/deployer/ must include corresponding coverage under e2e-tests/monorepo/. The deployer build pipeline is not validated by package unit tests alone; add or update a monorepo E2E test."
+            exit 1
+          fi
+
+          grep -E '(^|/)(test|tests|__tests__)/|\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$|\.test-d\.ts$' \
+            /tmp/changed-files | sort > /tmp/changed-test-files || true
 
           if [ ! -s /tmp/changed-test-files ]; then
             echo "has_tests=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -53,7 +53,12 @@ jobs:
             && ! grep -q '^e2e-tests/monorepo/' /tmp/changed-coverage-files \
             && grep '^packages/deployer/' /tmp/changed-coverage-files | grep -qv '^packages/deployer/AGENTS\.md$'; then
             first_deployer_file="$(grep -m1 '^packages/deployer/' /tmp/changed-files || true)"
-            echo "::error file=${first_deployer_file},title=Monorepo E2E coverage required::This PR changes packages/deployer/ but has no corresponding changes under e2e-tests/monorepo/. Deployer unit tests alone do not validate generated monorepo applications — add or update a monorepo E2E test. See packages/deployer/AGENTS.md for commands."
+            escaped_deployer_file="${first_deployer_file//%/%25}"
+            escaped_deployer_file="${escaped_deployer_file//$'\r'/%0D}"
+            escaped_deployer_file="${escaped_deployer_file//$'\n'/%0A}"
+            escaped_deployer_file="${escaped_deployer_file//:/%3A}"
+            escaped_deployer_file="${escaped_deployer_file//,/%2C}"
+            echo "::error file=${escaped_deployer_file},title=Monorepo E2E coverage required::This PR changes packages/deployer/ but has no corresponding changes under e2e-tests/monorepo/. Deployer unit tests alone do not validate generated monorepo applications — add or update a monorepo E2E test. See packages/deployer/AGENTS.md for commands."
             exit 1
           fi
 

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -41,12 +41,16 @@ jobs:
 
           git fetch "${HEAD_REPO}" "${HEAD_SHA}" --depth=1
           git diff --name-only --diff-filter=ACMRT "${BASE_SHA}" FETCH_HEAD \
-            | sort > /tmp/changed-files || true
+            | sort > /tmp/changed-files
+          git diff --no-renames --name-only --diff-filter=ACMRTD "${BASE_SHA}" FETCH_HEAD \
+            | sort > /tmp/changed-coverage-files
 
           # Deployer changes must include monorepo E2E coverage. This rule runs
           # before the no-test exemptions below so it applies to all contributors.
-          if grep -q '^packages/deployer/' /tmp/changed-files \
-            && ! grep -q '^e2e-tests/monorepo/' /tmp/changed-files; then
+          # Keep this list separate from /tmp/changed-files so deleted tests are
+          # not restored from FETCH_HEAD.
+          if grep -q '^packages/deployer/' /tmp/changed-coverage-files \
+            && ! grep -q '^e2e-tests/monorepo/' /tmp/changed-coverage-files; then
             first_deployer_file="$(grep -m1 '^packages/deployer/' /tmp/changed-files || true)"
             echo "::error file=${first_deployer_file},title=Monorepo E2E coverage required::This PR changes packages/deployer/ but has no corresponding changes under e2e-tests/monorepo/. Deployer unit tests alone do not validate generated monorepo applications — add or update a monorepo E2E test. See packages/deployer/AGENTS.md for commands."
             exit 1

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -48,9 +48,10 @@ jobs:
           # Deployer changes must include monorepo E2E coverage. This rule runs
           # before the no-test exemptions below so it applies to all contributors.
           # Keep this list separate from /tmp/changed-files so deleted tests are
-          # not restored from FETCH_HEAD.
+          # not restored from FETCH_HEAD. The package instructions are exempt.
           if grep -q '^packages/deployer/' /tmp/changed-coverage-files \
-            && ! grep -q '^e2e-tests/monorepo/' /tmp/changed-coverage-files; then
+            && ! grep -q '^e2e-tests/monorepo/' /tmp/changed-coverage-files \
+            && grep '^packages/deployer/' /tmp/changed-coverage-files | grep -qv '^packages/deployer/AGENTS\.md$'; then
             first_deployer_file="$(grep -m1 '^packages/deployer/' /tmp/changed-files || true)"
             echo "::error file=${first_deployer_file},title=Monorepo E2E coverage required::This PR changes packages/deployer/ but has no corresponding changes under e2e-tests/monorepo/. Deployer unit tests alone do not validate generated monorepo applications — add or update a monorepo E2E test. See packages/deployer/AGENTS.md for commands."
             exit 1

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -53,7 +53,10 @@ jobs:
             && ! grep -q '^e2e-tests/monorepo/' /tmp/changed-coverage-files \
             && awk '$0 ~ /^packages\/deployer\// && $0 != "packages/deployer/AGENTS.md" { found=1; exit } END { exit(found ? 0 : 1) }' \
               /tmp/changed-coverage-files; then
-            first_deployer_file="$(grep -m1 '^packages/deployer/' /tmp/changed-files || true)"
+            first_deployer_file="$(
+              awk '$0 ~ /^packages\/deployer\// && $0 != "packages/deployer/AGENTS.md" { print; exit }' \
+                /tmp/changed-coverage-files
+            )"
             escaped_deployer_file="${first_deployer_file//%/%25}"
             escaped_deployer_file="${escaped_deployer_file//$'\r'/%0D}"
             escaped_deployer_file="${escaped_deployer_file//$'\n'/%0A}"

--- a/packages/deployer/AGENTS.md
+++ b/packages/deployer/AGENTS.md
@@ -1,0 +1,6 @@
+Build from root: pnpm build:deployer
+Test from root: pnpm test:deployer
+
+Every change under packages/deployer/ must include corresponding coverage under e2e-tests/monorepo/. The deployer build pipeline generates monorepo applications and package unit tests alone do not validate that output. The changed-test-gate workflow enforces this: a PR touching packages/deployer/ without also touching e2e-tests/monorepo/ will fail.
+
+Run the monorepo E2E suite from root: pnpm --filter ./e2e-tests/monorepo test

--- a/packages/deployer/AGENTS.md
+++ b/packages/deployer/AGENTS.md
@@ -1,3 +1,5 @@
+# Deployer validation
+
 Build from root: pnpm build:deployer
 Test from root: pnpm test:deployer
 


### PR DESCRIPTION
Deployer changes are hard to validate with unit tests alone — the real signal comes from the monorepo E2E suite under `e2e-tests/monorepo/`. This extends the existing Changed Test Gate workflow so any non-draft PR touching `packages/deployer/**` must also change at least one file under `e2e-tests/monorepo/**`. The check runs before the contributor exemptions, so it applies to everyone.

Also adds `packages/deployer/AGENTS.md` so AI agents know about the rule during implementation rather than finding out from CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If a non-draft pull request changes deployer files, it must also update the related monorepo end-to-end tests. This ensures deployer changes include test coverage for all contributors.

## Changes

- Updated the Changed Test Gate workflow to enforce this requirement for all non-draft pull requests.
- Run the deployer coverage check before contributor exemptions.
- Exempt documentation-only changes to `packages/deployer/AGENTS.md`.
- Use separate changed-file lists for file restoration and coverage validation.
- Report the first non-exempt path with an escaped file-specific error when coverage is missing.
- Added `packages/deployer/AGENTS.md` with the requirement, build and test commands, and the monorepo E2E test command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->