### PR TITLE
docs: rename Neon storage to Neon Postgres

### DIFF
--- a/docs/src/content/en/docs/storage/overview.mdx
+++ b/docs/src/content/en/docs/storage/overview.mdx
@@ -211,7 +211,7 @@ Each provider page includes installation instructions, configuration parameters,
 
 - [libSQL](/reference/storage/libsql)
 - [PostgreSQL](/reference/storage/postgresql)
-- [Neon (PostgreSQL)](/reference/storage/neon)
+- [Neon Postgres](/reference/storage/neon)
 - [MongoDB](/reference/storage/mongodb)
 - [OracleDB](/reference/storage/oracledb)
 - [Upstash](/reference/storage/upstash)

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -780,7 +780,7 @@ const sidebars = {
         { type: 'doc', id: 'storage/libsql', label: 'libSQL Storage' },
         { type: 'doc', id: 'storage/mongodb', label: 'MongoDB Storage' },
         { type: 'doc', id: 'storage/mssql', label: 'MSSQL Storage' },
-        { type: 'doc', id: 'storage/neon', label: 'Neon Storage' },
+        { type: 'doc', id: 'storage/neon', label: 'Neon Postgres' },
         { type: 'doc', id: 'storage/oracledb', label: 'OracleDB Storage' },
         { type: 'doc', id: 'storage/postgresql', label: 'PostgreSQL Storage' },
         { type: 'doc', id: 'storage/redis', label: 'Redis Storage' },

--- a/docs/src/content/en/reference/storage/neon.mdx
+++ b/docs/src/content/en/reference/storage/neon.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Reference: Neon storage | Storage"
+title: "Reference: Neon Postgres | Storage"
 description: "Use Neon Postgres as a Mastra storage and vector backend."
 packages:
   - "@mastra/core"
   - "@mastra/pg"
 ---
 
-# Neon storage
+# Neon Postgres
 
 [Neon](https://neon.com) is a managed PostgreSQL service. Mastra connects to Neon through [`PostgresStore`](/reference/storage/postgresql), which uses the Node.js `pg` driver. Neon doesn't require a separate Mastra storage package.
 


### PR DESCRIPTION
Renames the visible provider name from Neon Storage and Neon (PostgreSQL) to Neon Postgres across the reference page, sidebar, and supported provider list. The existing `/reference/storage/neon` URL remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR gives Neon the same name everywhere in the storage documentation. It uses “Neon Postgres” while keeping the existing page URL unchanged.

## Changes

- Renamed “Neon (PostgreSQL)” to “Neon Postgres” in the supported provider list.
- Renamed “Neon Storage” to “Neon Postgres” in the reference sidebar.
- Updated the Neon reference page title and heading to “Neon Postgres”.
- Preserved `/reference/storage/neon`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->