### PR TITLE
fix(factory): seed OM models from the connected provider

### DIFF
--- a/.changeset/free-stamps-march.md
+++ b/.changeset/free-stamps-march.md
@@ -1,0 +1,11 @@
+---
+'@mastra/factory': patch
+'@mastra/code-sdk': patch
+---
+
+Added a helper that resolves a provider's low-cost observational-memory model, returning nothing for providers that have no such model instead of falling back to an unrelated one.
+
+```ts
+resolveBuiltinProviderOMModelId('anthropic'); // 'anthropic/claude-haiku-4-5'
+resolveBuiltinProviderOMModelId('xai'); // undefined
+```

--- a/.changeset/wet-kings-tan.md
+++ b/.changeset/wet-kings-tan.md
@@ -1,0 +1,14 @@
+---
+'@mastra/factory': patch
+'@mastra/code-sdk': patch
+---
+
+Fixed observational memory defaulting to a Google model no matter which provider you connected. Signing in or saving an API key now seeds the observer and reflector models from that provider — Anthropic gives you `anthropic/claude-haiku-4-5`, OpenAI gives you `openai/gpt-5.4-mini` — instead of leaving them on `google/gemini-3.5-flash` and failing at run time. Providers without a low-cost model are left unset rather than pinned to a full-size coding model, and a model you picked yourself is never overwritten.
+
+**Switching one role no longer pins the other**
+
+Changing the observer model used to silently persist whatever the reflector happened to be running, turning an inherited default into a choice you never made. Only the role you change is written now.
+
+**The settings page tells you when a model can't run**
+
+`GET /web/config/om` and `PUT /web/config/om/:role/model` now report whether each role's provider has credentials, and the memory settings section warns per role — naming the provider to connect — instead of letting the run fail with an opaque error. The model change is still accepted: the warning never blocks it.

--- a/mastracode/factory-ui/src/api/keys.ts
+++ b/mastracode/factory-ui/src/api/keys.ts
@@ -59,6 +59,8 @@ export const queryKeys = {
   /** Prefix that matches every `modelPacks(*)` entry — pack CRUD is global, so it invalidates all of them. */
   modelPacksAll: () => ['model-packs'] as const,
   om: (resourceId: string | undefined) => ['om', resourceId ?? null] as const,
+  /** Prefix that matches every `om(*)` entry — OM settings are per user, not per session. */
+  omAll: () => ['om'] as const,
   thinkingConfig: () => ['thinking-config'] as const,
   fsList: (path: string | undefined) => ['fs-list', path ?? null] as const,
   artifactsList: (path: string | undefined) => ['artifacts-list', path ?? null] as const,

--- a/mastracode/factory-ui/src/api/types.ts
+++ b/mastracode/factory-ui/src/api/types.ts
@@ -13,6 +13,8 @@ import type {
   CustomProviderInfo,
   ModelPackInfo,
   OMConfigInfo,
+  OMProviderStatus,
+  OMRoleProviderStatus,
   ProviderInfo,
   ProviderOMDefaultsResponse,
   ThinkingConfigInfo,
@@ -38,6 +40,8 @@ export type {
   CustomProviderInfo,
   ModelPackInfo,
   OMConfigInfo,
+  OMProviderStatus,
+  OMRoleProviderStatus,
   ProviderOMDefaultsResponse,
   ThinkingConfigInfo,
   UpdateThinkingConfigResponse,
@@ -76,6 +80,8 @@ export interface ModelPacksResponse {
 
 export interface OMResponse {
   config: OMConfigInfo;
+  /** Absent on servers predating provider reachability — callers fail open. */
+  providerStatus?: OMProviderStatus;
 }
 
 // ── Mutation request bodies ────────────────────────────────────────────────
@@ -167,4 +173,8 @@ export interface ActivateModelPackResponse {
 export interface UpdateOMResponse {
   ok: true;
   config: OMConfigInfo;
+}
+
+export interface UpdateOMModelResponse extends UpdateOMResponse {
+  providerStatus?: OMProviderStatus;
 }

--- a/mastracode/factory-ui/src/hooks/__tests__/fixtures/om.ts
+++ b/mastracode/factory-ui/src/hooks/__tests__/fixtures/om.ts
@@ -1,4 +1,4 @@
-import type { OMConfigInfo, OMResponse } from '../../../api/types';
+import type { OMConfigInfo, OMProviderStatus, OMResponse } from '../../../api/types';
 
 export const omConfig: OMConfigInfo = {
   observerModelId: 'p/observer',
@@ -8,6 +8,6 @@ export const omConfig: OMConfigInfo = {
   observeAttachments: 'auto',
 };
 
-export function omResponse(overrides: Partial<OMConfigInfo> = {}): OMResponse {
-  return { config: { ...omConfig, ...overrides } };
+export function omResponse(overrides: Partial<OMConfigInfo> = {}, providerStatus?: OMProviderStatus): OMResponse {
+  return { config: { ...omConfig, ...overrides }, ...(providerStatus ? { providerStatus } : {}) };
 }

--- a/mastracode/factory-ui/src/hooks/__tests__/use-om.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/use-om.msw.test.tsx
@@ -87,6 +87,32 @@ describe('useUpdateOMThresholds', () => {
       // single-response UX: no refetch
       expect(onGet.mock.calls.length).toBe(callsBefore);
     });
+
+    it('keeps the provider reachability the GET reported', async () => {
+      const providerStatus = {
+        observer: { providerId: 'p', configured: false },
+        reflector: { providerId: 'p', configured: true },
+      };
+      server.use(
+        http.get(URL, () => HttpResponse.json(omResponse({}, providerStatus))),
+        http.put(`${URL}/thresholds`, () =>
+          HttpResponse.json({ ok: true, config: omResponse({ observationThreshold: 55_000 }).config }),
+        ),
+      );
+
+      const { result, client } = renderHookWithProviders(() => ({
+        query: useOMQuery('res-1'),
+        update: useUpdateOMThresholds('res-1'),
+      }));
+
+      await waitFor(() => expect(result.current.query.isSuccess).toBe(true));
+      await act(async () => {
+        await result.current.update.mutateAsync({ observationThreshold: 55_000 });
+      });
+      await waitForMutationsIdle(client);
+
+      expect(result.current.query.data?.providerStatus).toEqual(providerStatus);
+    });
   });
 });
 

--- a/mastracode/factory-ui/src/hooks/use-om.ts
+++ b/mastracode/factory-ui/src/hooks/use-om.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
-import type { OMResponse, ProviderOMDefaultsResponse, UpdateOMResponse } from '../api/types';
+import type { OMResponse, ProviderOMDefaultsResponse, UpdateOMModelResponse, UpdateOMResponse } from '../api/types';
 
 /**
  * Observational Memory config (mirrors the TUI `/om` command). Settings are
@@ -10,9 +10,9 @@ import type { OMResponse, ProviderOMDefaultsResponse, UpdateOMResponse } from '.
  * session is available, resourceId and scope let the server apply changes to it
  * immediately as well.
  *
- * The update mutations return the full refreshed `{ config }`, so they write it
- * straight into the cache via `setQueryData` instead of triggering a refetch —
- * preserving the single-response UX the section relies on.
+ * The update mutations return the refreshed config, so they merge it straight
+ * into the cache via `setQueryData` instead of triggering a refetch — merging
+ * rather than replacing, so the entry keeps whatever the response omits.
  */
 export function useOMQuery(resourceId: string | undefined, scope?: string) {
   const { client } = useApiConfig();
@@ -37,7 +37,8 @@ export function useApplyProviderOMDefaults() {
         providerId,
         factoryModelId,
       }),
-    onSuccess: response => queryClient.setQueryData<OMResponse>(queryKeys.om(undefined), { config: response.config }),
+    onSuccess: response =>
+      queryClient.setQueryData<OMResponse>(queryKeys.om(undefined), prev => ({ ...prev, config: response.config })),
   });
 }
 
@@ -52,8 +53,13 @@ export function useUpdateOMModel(resourceId: string | undefined, role: OMRole, s
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ modelId }: UpdateOMModelArgs) =>
-      client.put<UpdateOMResponse>(`/web/config/om/${role}/model`, { resourceId, modelId, scope }),
-    onSuccess: res => queryClient.setQueryData<OMResponse>(queryKeys.om(resourceId), { config: res.config }),
+      client.put<UpdateOMModelResponse>(`/web/config/om/${role}/model`, { resourceId, modelId, scope }),
+    onSuccess: res =>
+      queryClient.setQueryData<OMResponse>(queryKeys.om(resourceId), prev => ({
+        ...prev,
+        config: res.config,
+        providerStatus: res.providerStatus,
+      })),
   });
 }
 
@@ -68,7 +74,8 @@ export function useUpdateOMThresholds(resourceId: string | undefined, scope?: st
   return useMutation({
     mutationFn: (args: UpdateOMThresholdsArgs) =>
       client.put<UpdateOMResponse>('/web/config/om/thresholds', { resourceId, scope, ...args }),
-    onSuccess: res => queryClient.setQueryData<OMResponse>(queryKeys.om(resourceId), { config: res.config }),
+    onSuccess: res =>
+      queryClient.setQueryData<OMResponse>(queryKeys.om(resourceId), prev => ({ ...prev, config: res.config })),
   });
 }
 
@@ -82,6 +89,7 @@ export function useUpdateOMObserveAttachments(resourceId: string | undefined, sc
   return useMutation({
     mutationFn: ({ value }: UpdateOMObserveAttachmentsArgs) =>
       client.put<UpdateOMResponse>('/web/config/om/observe-attachments', { resourceId, value, scope }),
-    onSuccess: res => queryClient.setQueryData<OMResponse>(queryKeys.om(resourceId), { config: res.config }),
+    onSuccess: res =>
+      queryClient.setQueryData<OMResponse>(queryKeys.om(resourceId), prev => ({ ...prev, config: res.config })),
   });
 }

--- a/mastracode/factory-ui/src/hooks/use-providers.ts
+++ b/mastracode/factory-ui/src/hooks/use-providers.ts
@@ -21,14 +21,16 @@ import type {
  */
 /**
  * A credential change (key saved/removed, OAuth completed, signed out) alters
- * which models are runnable, so the model catalog and the credential-gated
- * model packs must refetch along with the provider list.
+ * which models are runnable, so the model catalog, the credential-gated model
+ * packs and the OM config — seeded on connect, and reported against provider
+ * reachability — must refetch along with the provider list.
  */
 function invalidateCredentialDependentQueries(queryClient: QueryClient) {
   return Promise.all([
     queryClient.invalidateQueries({ queryKey: queryKeys.providers() }),
     queryClient.invalidateQueries({ queryKey: queryKeys.availableModels() }),
     queryClient.invalidateQueries({ queryKey: queryKeys.modelPacksAll() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.omAll() }),
   ]);
 }
 

--- a/mastracode/factory-ui/src/ui/domains/settings/components/OMSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/OMSection.tsx
@@ -5,6 +5,7 @@ import { Input } from '@mastra/playground-ui/components/Input';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useState } from 'react';
 
+import type { OMRoleProviderStatus } from '../../../../api/types';
 import {
   useOMQuery,
   useUpdateOMModel,
@@ -14,6 +15,7 @@ import {
 import type { AvailableModelOption } from '../../../../hooks/useAvailableModels';
 import { SkeletonRows } from '../../../ui/SkeletonRows';
 import { ModelCombobox } from './ModelCombobox';
+import { providerDisplayName } from './provider-display-name';
 
 type AttachmentChoice = 'auto' | 'on' | 'off';
 
@@ -27,6 +29,44 @@ function choiceToAttachment(choice: AttachmentChoice): 'auto' | boolean {
   if (choice === 'on') return true;
   if (choice === 'off') return false;
   return 'auto';
+}
+
+/** Why a role's model may not run — an unconnected provider outranks a model the catalog dropped. */
+function modelIssue({
+  role,
+  status,
+  inCatalog,
+}: {
+  role: 'Observer' | 'Reflector';
+  status: OMRoleProviderStatus | undefined;
+  inCatalog: boolean;
+}): { badge: string; message: string } | undefined {
+  if (status && !status.configured) {
+    return {
+      badge: 'Provider not connected',
+      message: `${role} model runs on ${providerDisplayName(status.providerId)}, which has no credentials. Connect it under Providers, or pick another model.`,
+    };
+  }
+  if (!inCatalog) {
+    return {
+      badge: 'Model credentials required',
+      message: `${role} model calls may fail until credentials are configured.`,
+    };
+  }
+  return undefined;
+}
+
+function ModelIssueNotice({ badge, message }: { badge: string; message: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <Badge size="md" variant="warning">
+        {badge}
+      </Badge>
+      <Txt as="p" variant="ui-xs" className="text-icon3">
+        {message}
+      </Txt>
+    </div>
+  );
 }
 
 function Field({ label, hint, children }: { label: string; hint: string; children: React.ReactNode }) {
@@ -98,10 +138,22 @@ export function OMSection({
   const attachmentsMutation = useUpdateOMObserveAttachments(resourceId, scope);
 
   const config = omQuery.data?.config;
-  const configuredModelIds = new Set(models.map(model => model.id));
-  const observerAvailable = config !== undefined && configuredModelIds.has(config.observerModelId);
-  const reflectorAvailable = config !== undefined && configuredModelIds.has(config.reflectorModelId);
-  const modelsAvailable = observerAvailable && reflectorAvailable;
+  const providerStatus = omQuery.data?.providerStatus;
+  const catalogModelIds = new Set(models.map(model => model.id));
+  const observerIssue =
+    config &&
+    modelIssue({
+      role: 'Observer',
+      status: providerStatus?.observer,
+      inCatalog: catalogModelIds.has(config.observerModelId),
+    });
+  const reflectorIssue =
+    config &&
+    modelIssue({
+      role: 'Reflector',
+      status: providerStatus?.reflector,
+      inCatalog: catalogModelIds.has(config.reflectorModelId),
+    });
   const loading = omQuery.isPending;
   const busy =
     observerMutation.isPending ||
@@ -141,17 +193,6 @@ export function OMSection({
         </Txt>
       )}
 
-      {config && !modelsAvailable && (
-        <div className="flex items-center gap-2">
-          <Badge size="md" variant="warning">
-            Model credentials required
-          </Badge>
-          <Txt as="p" variant="ui-xs" className="text-icon3">
-            Observational-memory model calls may fail until credentials are configured.
-          </Txt>
-        </div>
-      )}
-
       <Field label="Observer model" hint="Summarizes the conversation into observations">
         <ModelCombobox
           models={models}
@@ -160,6 +201,7 @@ export function OMSection({
           disabled={busy}
           onValueChange={modelId => switchModel('observer', modelId)}
         />
+        {observerIssue && <ModelIssueNotice badge={observerIssue.badge} message={observerIssue.message} />}
       </Field>
 
       <Field label="Reflector model" hint="Distills observations into longer-term memory">
@@ -170,6 +212,7 @@ export function OMSection({
           disabled={busy}
           onValueChange={modelId => switchModel('reflector', modelId)}
         />
+        {reflectorIssue && <ModelIssueNotice badge={reflectorIssue.badge} message={reflectorIssue.message} />}
       </Field>
 
       <Field label="Messages before observation" hint="Message tokens processed before the observer runs.">

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/OMSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/OMSection.msw.test.tsx
@@ -69,6 +69,46 @@ describe('OMSection', () => {
     expect(reflectorModel).toHaveTextContent('google/gemini-3.5-flash');
   });
 
+  it('names the provider a role needs when that provider has no credentials', async () => {
+    server.use(
+      http.get(OM_URL, () =>
+        HttpResponse.json({
+          config: { ...baseConfig, observerModelId: 'google/gemini-3.5-flash' },
+          providerStatus: {
+            observer: { providerId: 'google', configured: false },
+            reflector: { providerId: 'openai', configured: true },
+          },
+        }),
+      ),
+    );
+
+    renderWithProviders(<OMSection models={models} />);
+
+    expect(await screen.findByText('Provider not connected')).toBeInTheDocument();
+    expect(screen.getByText(/Observer model runs on Google, which has no credentials/)).toBeInTheDocument();
+    expect(screen.queryByText(/Reflector model runs on/)).not.toBeInTheDocument();
+  });
+
+  it('stays quiet when both roles run on connected providers', async () => {
+    server.use(
+      http.get(OM_URL, () =>
+        HttpResponse.json({
+          config: baseConfig,
+          providerStatus: {
+            observer: { providerId: 'openai', configured: true },
+            reflector: { providerId: 'openai', configured: true },
+          },
+        }),
+      ),
+    );
+
+    renderWithProviders(<OMSection models={models} />);
+
+    expect(await screen.findByDisplayValue('1000')).toBeInTheDocument();
+    expect(screen.queryByText('Provider not connected')).not.toBeInTheDocument();
+    expect(screen.queryByText('Model credentials required')).not.toBeInTheDocument();
+  });
+
   it('loads the observer, reflector, thresholds, and attachment setting', async () => {
     server.use(
       http.get(OM_URL, async () => {

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -238,7 +238,11 @@ describe('provider key routes with a tenant', () => {
     { provider: 'anthropic', hasApiKey: false, apiKeyEnvVar: 'ANTHROPIC_API_KEY' },
   ]);
 
-  function buildApp(user: { workosId: string; organizationId?: string } | null, authStorage?: AuthStorage) {
+  function buildApp(
+    user: { workosId: string; organizationId?: string } | null,
+    authStorage?: AuthStorage,
+    opts: { authEnabled?: boolean } = {},
+  ) {
     const app = new Hono();
     app.use('*', async (c, next) => {
       if (user) c.set('factoryAuthUser' as never, user as never);
@@ -247,10 +251,11 @@ describe('provider key routes with a tenant', () => {
     mountApiRoutes(
       app as any,
       new ConfigRoutes({
-        auth: fakeRouteAuth({ isOrganizationAdmin }),
+        auth: fakeRouteAuth({ isOrganizationAdmin, enabled: opts.authEnabled }),
         controller,
         authStorage,
         modelCredentials: seed.credentials,
+        memorySettings: seed.memorySettings,
       }).routes(),
     );
     return app;
@@ -367,6 +372,65 @@ describe('provider key routes with a tenant', () => {
     const authStorage = { setStoredApiKey } as unknown as AuthStorage;
     await putKey(buildApp(userA, authStorage), { key: 'sk-mine' });
     expect(setStoredApiKey).not.toHaveBeenCalled();
+  });
+
+  // ── OM defaults seeded on connect ──────────────────────────────────────
+
+  const putProviderKey = (app: Hono, provider: string, body: unknown) =>
+    app.request(`/web/config/providers/${provider}/key`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+  it('seeds both OM roles from the provider the key belongs to', async () => {
+    await putKey(buildApp(userA), { key: 'sk-mine' });
+
+    await expect(seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).resolves.toMatchObject({
+      observerModelId: 'anthropic/claude-haiku-4-5',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+    });
+  });
+
+  it('leaves OM unset for a provider with no low-cost model', async () => {
+    await putProviderKey(buildApp(userA), 'xai', { key: 'sk-xai' });
+
+    await expect(seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).resolves.toBeNull();
+  });
+
+  it('does not overwrite an OM model the user already chose', async () => {
+    await seed.memorySettings.patch({
+      orgId: 'org1',
+      userId: 'user-a',
+      patch: { observerModelId: 'openai/gpt-5.6' },
+    });
+
+    await putKey(buildApp(userA), { key: 'sk-mine' });
+
+    await expect(seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).resolves.toMatchObject({
+      observerModelId: 'openai/gpt-5.6',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+    });
+  });
+
+  it('seeds the caller row, not the org, for an org-scoped key', async () => {
+    await putKey(buildApp(userA), { key: 'sk-shared', scope: 'org' });
+
+    await expect(seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).resolves.toMatchObject({
+      observerModelId: 'anthropic/claude-haiku-4-5',
+    });
+    await expect(seed.memorySettings.get({ orgId: 'org1', userId: 'user-b' })).resolves.toBeNull();
+  });
+
+  it('seeds the sentinel local row in local mode', async () => {
+    const authStorage = Object.assign(makeAuthStorage({}), { setStoredApiKey: vi.fn() });
+
+    const res = await putKey(buildApp(null, authStorage, { authEnabled: false }), { key: 'sk-local' });
+
+    expect(res.status).toBe(200);
+    await expect(seed.memorySettings.get({ orgId: 'local', userId: 'local' })).resolves.toMatchObject({
+      observerModelId: 'anthropic/claude-haiku-4-5',
+    });
   });
 });
 
@@ -674,6 +738,7 @@ describe('OM routes with a tenant', () => {
         auth: fakeRouteAuth({ enabled: opts.authEnabled !== false }),
         controller,
         modelCredentials: seed.credentials,
+        customProviders: seed.customProviders,
         ...(opts.withStorage === false ? {} : { memorySettings: seed.memorySettings }),
       }).routes(),
     );
@@ -792,7 +857,56 @@ describe('OM routes with a tenant', () => {
     });
   });
 
-  it('persists a role model switch to the memory-settings domain, snapshotting the other role', async () => {
+  it('reports the fallback OM model as unreachable when its provider has no credential', async () => {
+    const res = await buildApp(null).request('/web/config/om');
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).providerStatus).toEqual({
+      observer: { providerId: 'google', configured: false },
+      reflector: { providerId: 'google', configured: false },
+    });
+  });
+
+  it('reports a stored OM model as reachable once its provider is credentialed', async () => {
+    await seed.memorySettings.patch({
+      orgId: 'org1',
+      userId: 'user-a',
+      patch: { observerModelId: 'anthropic/claude-haiku-4-5', reflectorModelId: 'anthropic/claude-haiku-4-5' },
+    });
+
+    const res = await buildApp(null).request('/web/config/om');
+
+    expect((await res.json()).providerStatus.observer).toEqual({ providerId: 'anthropic', configured: true });
+  });
+
+  it('counts DB-backed custom providers as reachable', async () => {
+    await seed.customProviders.upsert({
+      orgId: 'org1',
+      userId: 'user-a',
+      input: { providerId: 'acme', name: 'Acme', url: 'https://acme.test/v1', models: ['small'] },
+    });
+    await seed.memorySettings.patch({
+      orgId: 'org1',
+      userId: 'user-a',
+      patch: { observerModelId: 'acme/small' },
+    });
+
+    const res = await buildApp(null).request('/web/config/om');
+
+    expect((await res.json()).providerStatus.observer).toEqual({ providerId: 'acme', configured: true });
+  });
+
+  it('accepts a model whose provider is unconfigured and reports it back', async () => {
+    const res = await putJson(buildApp(makeOmSession()), '/web/config/om/observer/model', {
+      resourceId: 'r1',
+      modelId: 'google/gemini-3.5-flash',
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).providerStatus.observer).toEqual({ providerId: 'google', configured: false });
+  });
+
+  it('persists a role model switch without inventing a choice for the other role', async () => {
     const session = makeOmSession();
     const res = await putJson(buildApp(session), '/web/config/om/observer/model', {
       resourceId: 'r1',
@@ -804,8 +918,7 @@ describe('OM routes with a tenant', () => {
     const stored = await seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' });
     expect(stored).toMatchObject({
       observerModelId: 'anthropic/claude-fable-5',
-      // The reflector's current model is pinned so a restart doesn't drift it.
-      reflectorModelId: 'anthropic/claude-haiku-4-5',
+      reflectorModelId: null,
     });
   });
 

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -28,6 +28,7 @@ import type {
   MemorySettingsStorage,
 } from '../storage/domains/memory-settings/base.js';
 import type { ModelPackRecord, ModelPacksStorage } from '../storage/domains/model-packs/base.js';
+import { fillProviderOMDefaults } from './om-defaults.js';
 import {
   getAuthProviderId,
   listTenantCredentialsForRequest,
@@ -506,6 +507,17 @@ export interface ProviderOMDefaultsResponse {
   config: OMConfigInfo;
 }
 
+/** Whether an OM role's model belongs to a provider the caller can reach. */
+export interface OMRoleProviderStatus {
+  providerId: string;
+  configured: boolean;
+}
+
+export interface OMProviderStatus {
+  observer: OMRoleProviderStatus;
+  reflector: OMRoleProviderStatus;
+}
+
 /** `GET /web/config/thinking` — deployment-scoped reasoning-effort defaults. */
 export interface ThinkingConfigInfo {
   /** All selectable levels, in escalation order. */
@@ -680,6 +692,41 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
     const onCredentialsChanged = options.onCredentialsChanged ?? (() => {});
     const onCustomProvidersChanged = options.onCustomProvidersChanged ?? (() => {});
 
+    /** Custom providers live only in the DB, so the model catalog alone would miss them. */
+    const reachableProviderIds = async (c: Context): Promise<Set<string>> => {
+      const tenantCredentials = await listTenantCredentialsForRequest({
+        c,
+        auth,
+        credentials: options.modelCredentials,
+      });
+      const access = await buildProviderAccess({
+        controller,
+        authStorage: tenantCredentials ? undefined : authStorage,
+        tenantCredentials,
+      });
+      const reachable = new Set(Object.keys(access).filter(provider => access[provider]));
+      if (options.customProviders) {
+        try {
+          const ctx = await resolveCustomProvidersContext({ c, auth, customProviders: options.customProviders });
+          if (!('response' in ctx)) {
+            for (const record of await ctx.storage.list({ orgId: ctx.orgId })) reachable.add(record.providerId);
+          }
+        } catch {
+          // Fail soft: built-in provider access still answers.
+        }
+      }
+      return reachable;
+    };
+
+    const omProviderStatus = async (c: Context, config: OMConfigInfo): Promise<OMProviderStatus> => {
+      const reachable = await reachableProviderIds(c);
+      const roleStatus = (modelId: string): OMRoleProviderStatus => {
+        const providerId = modelId.split('/')[0] ?? '';
+        return { providerId, configured: reachable.has(providerId) };
+      };
+      return { observer: roleStatus(config.observerModelId), reflector: roleStatus(config.reflectorModelId) };
+    };
+
     return [
       registerApiRoute('/web/config/providers', {
         method: 'GET',
@@ -739,6 +786,13 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
               // per-request, never written into process.env.
               await ctx.storage.setCredential(tenant, getAuthProviderId(provider), { type: 'api_key', key });
               onCredentialsChanged(tenant);
+              // Rows are per (org, user): an org-scoped key seeds only the caller.
+              await fillProviderOMDefaults({
+                memorySettings: options.memorySettings,
+                orgId: ctx.orgId,
+                userId: ctx.userId,
+                providerId: provider,
+              });
               const records = await ctx.storage.listCredentials(ctx.orgId, ctx.userId);
               const providers = await listProviders({ controller, tenantCredentials: records });
               return c.json({ ok: true, provider: providers.find(p => p.provider === provider) });
@@ -746,6 +800,12 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
             if (!authStorage) return c.json({ error: 'Credential storage is not available' }, 503);
             // Local mode is single-user: scope is meaningless and ignored.
             authStorage.setStoredApiKey(provider, key, envVar);
+            await fillProviderOMDefaults({
+              memorySettings: options.memorySettings,
+              orgId: 'local',
+              userId: 'local',
+              providerId: provider,
+            });
             const providers = await listProviders({ controller, authStorage });
             return c.json({ ok: true, provider: providers.find(p => p.provider === provider) });
           } catch (error) {
@@ -1232,16 +1292,18 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           if ('response' in context) return context.response;
           try {
             const record = await context.storage.get({ orgId: context.orgId, userId: context.userId });
-            if (!resourceId) return c.json({ config: readStoredOMConfig(record) });
+            const respond = async (config: OMConfigInfo) =>
+              c.json({ config, providerStatus: await omProviderStatus(loose(c), config) });
+            if (!resourceId) return respond(readStoredOMConfig(record));
 
             // Session sync is best-effort: the stored row is authoritative and
             // new sessions hydrate from it, so a resourceId without a live
             // session (e.g. settings page after a restart) still reads the
             // stored config instead of failing.
             const session = await controller.getSessionByResource?.(resourceId, scope);
-            if (!session) return c.json({ config: readStoredOMConfig(record) });
+            if (!session) return respond(readStoredOMConfig(record));
             await hydrateSessionMemorySettings(session, record);
-            return c.json({ config: readOMConfig(session) });
+            return respond(readOMConfig(session));
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);
           }
@@ -1276,24 +1338,14 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
             // Best-effort session sync: persist regardless, apply to the live
             // session only when one exists for the resourceId.
             const session = resourceId ? await controller.getSessionByResource?.(resourceId, scope) : undefined;
-            const otherRole = session ? (role === 'observer' ? session.om.reflector : session.om.observer) : undefined;
-            const otherRoleCurrentModelId = otherRole?.modelId() ?? null;
             await session?.om[role].switchModel({ modelId });
-            // Pin the other role's current model too, so a later restart
-            // doesn't drift it once this role is explicitly overridden. The
-            // "only if still unset" check runs inside the storage layer's
-            // atomic update, so a concurrent explicit switch of the other
-            // role is never clobbered by this fill.
-            const otherKey = role === 'observer' ? 'reflectorModelId' : 'observerModelId';
-            await persistMemorySettings(
-              context,
-              { [role === 'observer' ? 'observerModelId' : 'reflectorModelId']: modelId },
-              otherRoleCurrentModelId ? { [otherKey]: otherRoleCurrentModelId } : undefined,
-            );
+            await persistMemorySettings(context, {
+              [role === 'observer' ? 'observerModelId' : 'reflectorModelId']: modelId,
+            });
             const config = session
               ? readOMConfig(session)
               : readStoredOMConfig(await context.storage.get({ orgId: context.orgId, userId: context.userId }));
-            return c.json({ ok: true, config });
+            return c.json({ ok: true, config, providerStatus: await omProviderStatus(loose(c), config) });
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);
           }

--- a/mastracode/factory/src/routes/oauth.test.ts
+++ b/mastracode/factory/src/routes/oauth.test.ts
@@ -69,6 +69,7 @@ function buildApp(
       auth: fakeRouteAuth({ enabled: opts?.enabled }),
       authStorage,
       modelCredentials: opts?.noCredentials ? undefined : seed.credentials,
+      memorySettings: seed.memorySettings,
     }).routes(),
   );
   return app;
@@ -295,6 +296,71 @@ describe('device-code flow (github-copilot)', () => {
     const res = await post(app, '/web/config/providers/github-copilot/oauth/poll', { sessionId });
     expect(await res.json()).toMatchObject({ status: 'failed', error: 'Unsupported GitHub host' });
     expect(pollGitHubCopilotDeviceLogin).not.toHaveBeenCalled();
+  });
+});
+
+// ── OM defaults seeded on sign-in ────────────────────────────────────────
+
+describe('observational-memory defaults on sign-in', () => {
+  it('seeds both roles from the provider a paste-code sign-in connected', async () => {
+    const app = buildApp(userA);
+    const { sessionId } = await (await post(app, '/web/config/providers/anthropic/oauth/start')).json();
+
+    await post(app, '/web/config/providers/anthropic/oauth/complete', { sessionId, code: 'c' });
+
+    await expect(seed.memorySettings.get(TENANT_A)).resolves.toMatchObject({
+      observerModelId: 'anthropic/claude-haiku-4-5',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+    });
+  });
+
+  it('seeds both roles when a device-code sign-in completes', async () => {
+    pollCodexDeviceLogin.mockResolvedValue({ status: 'complete', credentials: CODEX_CREDS });
+    const app = buildApp(userA);
+    const { sessionId } = await (await post(app, '/web/config/providers/openai/oauth/start')).json();
+    await makePollable(sessionId);
+
+    await post(app, '/web/config/providers/openai/oauth/poll', { sessionId });
+
+    await expect(seed.memorySettings.get(TENANT_A)).resolves.toMatchObject({
+      observerModelId: 'openai/gpt-5.4-mini',
+      reflectorModelId: 'openai/gpt-5.4-mini',
+    });
+  });
+
+  it('leaves OM unset for a provider with no low-cost model', async () => {
+    pollGitHubCopilotDeviceLogin.mockResolvedValue({ status: 'complete', credentials: CODEX_CREDS });
+    const app = buildApp(userA);
+    const { sessionId } = await (await post(app, '/web/config/providers/github-copilot/oauth/start')).json();
+    await makePollable(sessionId);
+
+    await post(app, '/web/config/providers/github-copilot/oauth/poll', { sessionId });
+
+    await expect(seed.memorySettings.get(TENANT_A)).resolves.toBeNull();
+  });
+
+  it('does not overwrite a model the user already chose', async () => {
+    await seed.memorySettings.patch({ ...TENANT_A, patch: { observerModelId: 'openai/gpt-5.6' } });
+    const app = buildApp(userA);
+    const { sessionId } = await (await post(app, '/web/config/providers/anthropic/oauth/start')).json();
+
+    await post(app, '/web/config/providers/anthropic/oauth/complete', { sessionId, code: 'c' });
+
+    await expect(seed.memorySettings.get(TENANT_A)).resolves.toMatchObject({
+      observerModelId: 'openai/gpt-5.6',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+    });
+  });
+
+  it('seeds the sentinel local row when auth is disabled', async () => {
+    const app = buildApp(null, { enabled: false });
+    const { sessionId } = await (await post(app, '/web/config/providers/anthropic/oauth/start')).json();
+
+    await post(app, '/web/config/providers/anthropic/oauth/complete', { sessionId, code: 'c' });
+
+    await expect(seed.memorySettings.get({ orgId: 'local', userId: 'local' })).resolves.toMatchObject({
+      observerModelId: 'anthropic/claude-haiku-4-5',
+    });
   });
 });
 

--- a/mastracode/factory/src/routes/oauth.ts
+++ b/mastracode/factory/src/routes/oauth.ts
@@ -36,6 +36,8 @@ import type { Context } from 'hono';
 
 import { ModelCredentialsStorage } from '../storage/domains/credentials/base.js';
 import type { LoginSessionKind, LoginSessionRow } from '../storage/domains/credentials/base.js';
+import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+import { fillProviderOMDefaults } from './om-defaults.js';
 import { getAuthProviderId, resolveCredentialContext } from './provider-credentials.js';
 import type { CredentialContext } from './provider-credentials.js';
 import { Route } from './route.js';
@@ -245,6 +247,8 @@ export interface OAuthRoutesDeps extends RouteDependencies {
   modelCredentials?: ModelCredentialsStorage;
   /** Notifies the host after tenant credentials change so caches can be dropped. */
   onCredentialsChanged?: (tenant: { orgId: string; userId?: string }) => void;
+  /** Memory-settings domain handle; seeds the caller's OM models on sign-in. */
+  memorySettings?: MemorySettingsStorage;
 }
 
 /**
@@ -257,7 +261,7 @@ export interface OAuthRoutesDeps extends RouteDependencies {
  */
 export class OAuthRoutes extends Route<OAuthRoutesDeps> {
   routes(): ApiRoute[] {
-    const { auth, authStorage, modelCredentials } = this.deps;
+    const { auth, authStorage, modelCredentials, memorySettings } = this.deps;
     const onCredentialsChanged = this.deps.onCredentialsChanged ?? (() => {});
 
     return [
@@ -353,6 +357,7 @@ export class OAuthRoutes extends Route<OAuthRoutesDeps> {
           }
 
           await persistOAuthCredential({ ctx, provider, credentials, authStorage, onCredentialsChanged });
+          await fillProviderOMDefaults({ memorySettings, ...sessionTenant(ctx), providerId: provider });
           await (await sessionStore(ctx)).deleteLoginSession(sessionId);
           return c.json({ status: 'complete', ok: true });
         },
@@ -411,6 +416,7 @@ export class OAuthRoutes extends Route<OAuthRoutesDeps> {
               authStorage,
               onCredentialsChanged,
             });
+            await fillProviderOMDefaults({ memorySettings, ...sessionTenant(ctx), providerId: provider });
             await (await sessionStore(ctx)).deleteLoginSession(sessionId);
             return c.json({ status: 'complete', ok: true });
           }

--- a/mastracode/factory/src/routes/om-defaults.ts
+++ b/mastracode/factory/src/routes/om-defaults.ts
@@ -1,0 +1,36 @@
+import { resolveBuiltinProviderOMModelId } from '@mastra/code-sdk/onboarding/packs';
+
+import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+
+/**
+ * Seed a caller's observational-memory models from the provider they just
+ * connected, filling only knobs still unset. Providers with no low-cost
+ * built-in OM pack are skipped: leaving OM unset beats pinning observation and
+ * reflection to a full-size coding model.
+ */
+export async function fillProviderOMDefaults({
+  memorySettings,
+  orgId,
+  userId,
+  providerId,
+}: {
+  memorySettings: MemorySettingsStorage | undefined;
+  orgId: string;
+  userId: string;
+  providerId: string;
+}): Promise<void> {
+  if (!memorySettings) return;
+  const modelId = resolveBuiltinProviderOMModelId(providerId);
+  if (!modelId) return;
+  try {
+    await memorySettings.ensureReady();
+    await memorySettings.patch({
+      orgId,
+      userId,
+      patch: {},
+      fillIfUnset: { observerModelId: modelId, reflectorModelId: modelId },
+    });
+  } catch {
+    // The credential is already persisted; an unreachable settings row must not fail the connect.
+  }
+}

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -419,6 +419,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
       auth: deps.auth,
       authStorage: deps.authStorage,
       modelCredentials: deps.domains.modelCredentials,
+      memorySettings: deps.domains.memorySettings,
       onCredentialsChanged: invalidateTenantCredentialSnapshots,
     }).routes(),
     ...new SkillRoutes({

--- a/mastracode/sdk/src/onboarding/__tests__/packs.test.ts
+++ b/mastracode/sdk/src/onboarding/__tests__/packs.test.ts
@@ -4,6 +4,7 @@ import { PROVIDER_DEFAULT_MODELS } from '../../auth/storage.js';
 import {
   getAvailableModePacks,
   getAvailableOmPacks,
+  resolveBuiltinProviderOMModelId,
   resolveProviderOMDefault,
   selectPreferredOMPack,
   type ProviderAccess,
@@ -115,6 +116,18 @@ describe('OM packs', () => {
       id: 'custom',
       modelId: 'xai/grok-4.5',
     });
+  });
+
+  it.each([
+    ['anthropic', 'anthropic/claude-haiku-4-5'],
+    ['openai-codex', 'openai/gpt-5.4-mini'],
+    ['deepseek', 'deepseek/deepseek-v4-flash'],
+  ])('resolves %s to its low-cost OM model', (providerId, modelId) => {
+    expect(resolveBuiltinProviderOMModelId(providerId)).toBe(modelId);
+  });
+
+  it.each(['xai', 'github-copilot', 'cerebras'])('resolves nothing for %s, which has no low-cost pack', providerId => {
+    expect(resolveBuiltinProviderOMModelId(providerId)).toBeUndefined();
   });
 
   it('lists only reachable packs, labelled by how each provider is reached', () => {

--- a/mastracode/sdk/src/onboarding/packs.ts
+++ b/mastracode/sdk/src/onboarding/packs.ts
@@ -177,10 +177,22 @@ function normalizeOMProviderId(providerId: string): string {
   return providerId === 'openai-codex' ? 'openai' : providerId;
 }
 
+function findBuiltinOMPack(providerId: string): BuiltinOMPack | undefined {
+  const normalizedProviderId = normalizeOMProviderId(providerId);
+  return BUILTIN_OM_PACKS.find(pack => pack.providerId === normalizedProviderId);
+}
+
+/**
+ * A provider's low-cost OM model, or `undefined` when it has none. Callers
+ * seeding a default leave OM unset rather than pinning it to a full-size model.
+ */
+export function resolveBuiltinProviderOMModelId(providerId: string): string | undefined {
+  return findBuiltinOMPack(providerId)?.modelId;
+}
+
 /** A provider's low-cost OM pack, or a custom pack on `fallbackModelId` when it has none. */
 export function resolveProviderOMDefault(providerId: string, fallbackModelId = DEFAULT_OM_MODEL_ID): OMPack {
-  const normalizedProviderId = normalizeOMProviderId(providerId);
-  const builtin = BUILTIN_OM_PACKS.find(pack => pack.providerId === normalizedProviderId);
+  const builtin = findBuiltinOMPack(providerId);
   if (builtin) {
     return {
       id: builtin.id,


### PR DESCRIPTION
Observational memory has been defaulting to `google/gemini-3.5-flash` no matter which provider you connected, so anyone signed in with only Anthropic or OpenAI hits an OM failure that aborts the whole turn with an opaque error. Only one flow ever fixed this — the factory creation onboarding step — so connecting a provider from Settings left the bad default in place. Now every connect path seeds it: completing an OAuth sign-in or saving an API key fills the observer and reflector models from that provider, server-side, so it holds for any client. Providers with no low-cost model (xAI, Copilot) are left unset rather than pinned to a full-size coding model, and a model you picked yourself is never overwritten.

I also removed a smaller trap: switching one OM role used to persist whatever the other role happened to be running, which turned an inherited Google default into an explicit choice you never made and made it stick. Only the role you change is written now. Existing installs are not backfilled — that was deliberate, per the discussion with Ward, since silently rewriting a stored choice can hide a real problem like an expired key.

So instead of automatic repair the settings page now tells you: the OM routes report whether each role's provider has credentials, and the memory settings section shows a per-role warning naming the provider to connect. The warning never blocks anything — you can still select a model whose provider isn't set up. Custom DB-backed providers count as reachable, otherwise everyone on a custom endpoint would see a permanent false warning.

A follow-up PR handles the other half of this: an OM model change still doesn't reach already-running factory sessions, so a review session that started on the failing model keeps failing even after you fix the setting.