### PR TITLE
fix(factory): reconcile memory settings on every run

### DIFF
--- a/.changeset/ripe-tires-behave.md
+++ b/.changeset/ripe-tires-behave.md
@@ -1,0 +1,9 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed observational-memory settings not reaching sessions that were already running. Changing the observer or reflector model only applied to sessions created afterwards, so a review session that started on a model you can't run kept failing on every message even after you fixed the setting. Each message now reconciles the session against your stored settings, so the next message uses the model you picked.
+
+The chat also stops reporting an observational-memory failure as an anonymous run error: the notice names the role that failed and links straight to the memory settings.
+
+Only the models reconcile mid-session. Thresholds still take effect on the following run, because memory is built before the message is processed.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -16,8 +16,10 @@ import type { FilePart, MessageRoleRenderers, ReasoningPart, TextPart, ToolInvoc
 import { Bell, ChevronDown, CircleDot, ExternalLink, Info, Layers, Slack, Wrench, X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
 
 import { highlightCode, languageForPath } from '../../../ui/highlight';
+import { settingsSectionPath } from '../../settings/settingsSections';
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 import { useChatSessionContext } from '../context/useChatSessionContext';
 import { useChatTranscript } from '../context/useChatTranscript';
@@ -1220,11 +1222,18 @@ function StatusMetadataCard({ status }: { status: StatusMetadata }) {
 }
 
 function NoticeCard({ entry }: { entry: NoticeEntry }) {
+  const { factoryId } = useParams();
+  const navigate = useNavigate();
   return (
     <Notice className="my-2" variant={entry.level === 'error' ? 'destructive' : 'info'}>
       <div className="prose">
         <Markdown>{entry.text}</Markdown>
       </div>
+      {entry.action === 'om-settings' && factoryId && (
+        <Notice.Button onClick={() => void navigate(settingsSectionPath(factoryId, 'models'))}>
+          Memory settings
+        </Notice.Button>
+      )}
     </Notice>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -832,6 +832,31 @@ describe('transcript reducer error notices', () => {
   it('falls back to a generic hint when the payload is empty', () => {
     expect(errorNoticeText({ error: {} })).toBe('Run failed with an unknown error. Check the server logs for details.');
   });
+
+  function errorNotice(event: Record<string, unknown>) {
+    const state = transcriptReducer(initialTranscript, { type: 'event', event: { type: 'error', ...event } });
+    const notice = state.entries.find(entry => entry.kind === 'notice');
+    if (!notice || notice.kind !== 'notice') throw new Error('expected a notice entry');
+    return notice;
+  }
+
+  it('points an observation failure at the setting that caused it', () => {
+    const notice = errorNotice({ error: 'Observational memory observation run failed: 401 no credentials' });
+
+    expect(notice.text).toContain('401 no credentials');
+    expect(notice.text).toContain("The observer model can't run.");
+    expect(notice.action).toBe('om-settings');
+  });
+
+  it('names the reflector when reflection is what failed', () => {
+    const notice = errorNotice({ error: 'Observational memory reflection run failed: 401 no credentials' });
+
+    expect(notice.text).toContain("The reflector model can't run.");
+  });
+
+  it('leaves an unrelated failure without a settings shortcut', () => {
+    expect(errorNotice({ error: 'model quota exhausted' }).action).toBeUndefined();
+  });
 });
 
 describe('live user-signal events render the same as their persisted copy', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -52,6 +52,8 @@ export interface NoticeEntry {
   id: string;
   level: 'info' | 'error';
   text: string;
+  /** Where the user can fix what caused this notice, when there is such a place. */
+  action?: 'om-settings';
 }
 
 /** A pending tool approval (`tool_approval_required`). */
@@ -514,12 +516,28 @@ function applyEvent(state: TranscriptState, event: AgentControllerEvent): Transc
     // Notices.
     case 'info':
       return pushNotice(state, 'info', event.message);
-    case 'error':
-      return pushNotice(state, 'error', describeErrorEvent(event));
+    case 'error': {
+      const message = describeErrorEvent(event);
+      const omRole = omFailureRole(message);
+      return omRole
+        ? pushNotice(state, 'error', `${message}\n\nThe ${omRole} model can't run. Pick another one.`, 'om-settings')
+        : pushNotice(state, 'error', message);
+    }
 
     default:
       return state;
   }
+}
+
+/**
+ * The observational-memory role named by an abort error, if it is one. OM
+ * failures abort the whole turn, so the notice has to point at the setting
+ * that caused it rather than read as a generic run failure.
+ */
+function omFailureRole(message: string): 'observer' | 'reflector' | undefined {
+  const match = /^Observational memory (observation|reflection) /.exec(message);
+  if (!match) return undefined;
+  return match[1] === 'reflection' ? 'reflector' : 'observer';
 }
 
 /**
@@ -1061,9 +1079,17 @@ function pushPrompt(state: TranscriptState, prompt: PromptEntry): TranscriptStat
   return { ...state, entries: [...state.entries, prompt] };
 }
 
-function pushNotice(state: TranscriptState, level: 'info' | 'error', text: string): TranscriptState {
+function pushNotice(
+  state: TranscriptState,
+  level: 'info' | 'error',
+  text: string,
+  action?: NoticeEntry['action'],
+): TranscriptState {
   return {
     ...state,
-    entries: [...state.entries, { kind: 'notice', id: `notice-${Date.now()}-${noticeSeq++}`, level, text }],
+    entries: [
+      ...state.entries,
+      { kind: 'notice', id: `notice-${Date.now()}-${noticeSeq++}`, level, text, ...(action ? { action } : {}) },
+    ],
   };
 }

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -68,6 +68,7 @@ import { observeSessionCheckpoint } from './session/checkpoint-capture.js';
 import { observeSessionFilesystem } from './session/filesystem-capture.js';
 import { observeSessionFirstExec } from './session/first-exec-capture.js';
 import { observeSessionFirstMessage } from './session/first-message-capture.js';
+import { FactoryMemorySettingsProcessor } from './session/memory-settings-processor.js';
 import { createSpaStaticMiddleware, resolveUiDistDir } from './spa-static.js';
 import { createStateSigner } from './state-signing.js';
 import { observeAgentGitAction } from './storage/domains/audit/agent-audit.js';
@@ -586,6 +587,16 @@ export class MastraFactory {
           },
         })
       : undefined;
+    // Every run reconciles the caller's stored memory settings onto their live
+    // session, so a setting changed mid-session takes effect on the next
+    // message instead of only on sessions created afterwards. Unconditional:
+    // plain chat sessions never run the start path that seeds them.
+    const memorySettingsProcessor = new FactoryMemorySettingsProcessor({
+      memorySettings: memorySettingsStorage,
+      getController: () => this.#prepared?.base.controller,
+      authEnabled: Boolean(auth),
+    });
+    const inputProcessors = [...(factoryProcessor ? [factoryProcessor] : []), memorySettingsProcessor];
 
     // Boot assertion: an active integration that signs OAuth `state` needs a
     // replica-stable signer — a per-process random secret silently breaks the
@@ -642,7 +653,7 @@ export class MastraFactory {
         initialState: { skipGlobalInstructions: true },
         storage: storage.getMastraStorage(),
         ...(mastraStorageBackend ? { storageBackend: mastraStorageBackend } : {}),
-        ...(factoryProcessor ? { inputProcessors: [factoryProcessor] } : {}),
+        inputProcessors,
         ...(vector ? { vector } : {}),
         ...(toolIntegrations.length > 0 || (workItemsStorage && transitionService)
           ? {

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -15,6 +15,13 @@ import type { ApiRoute } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 
 import type { Context } from 'hono';
+import {
+  applyMemorySettingsToSession,
+  DEFAULT_OBSERVATION_THRESHOLD,
+  DEFAULT_REFLECTION_THRESHOLD,
+  resolveMemorySettingsIdentity,
+} from '../session/memory-settings.js';
+import type { MemorySettingsSession } from '../session/memory-settings.js';
 import type {
   CredentialRecord,
   LoginSessionKind,
@@ -104,25 +111,8 @@ interface OMRole {
   switchModel: (args: { modelId: string }) => Promise<void>;
 }
 
-/**
- * Session-state fields the OM config routes write. The index signatures mirror
- * `MastraCodeState` so the concrete `Session.state.set(Partial<MastraCodeState>)`
- * stays assignable to this minimal surface (contravariant parameter check).
- */
-interface OMStateWrites {
-  [key: string]: unknown;
-  [key: `subagentModelId_${string}`]: string | undefined;
-  observationThreshold?: number;
-  reflectionThreshold?: number;
-  observeAttachments?: 'auto' | boolean;
-}
-
 /** Minimal session surface the OM config routes touch. */
-export interface OMSession extends PackSession {
-  state: {
-    get: () => Record<string, unknown> | undefined;
-    set: (updates: OMStateWrites) => Promise<void> | void;
-  };
+export interface OMSession extends PackSession, MemorySettingsSession {
   om: { observer: OMRole; reflector: OMRole };
 }
 
@@ -488,10 +478,6 @@ async function applyPackToSession({
 // user in the Factory app database. Requests with an active session also apply
 // changes immediately to that session's state and thread settings.
 
-/** Default thresholds mirror the TUI `/om` fallbacks. */
-const DEFAULT_OBSERVATION_THRESHOLD = 30_000;
-const DEFAULT_REFLECTION_THRESHOLD = 40_000;
-
 /** Read the current OM config from a session. */
 export interface OMConfigInfo {
   observerModelId: string;
@@ -570,14 +556,12 @@ async function resolveMemorySettingsContext({
   memorySettings?: MemorySettingsStorage;
 }): Promise<MemorySettingsContext | { response: Response }> {
   await auth.ensureUser(c);
-  const tenant = auth.tenant(c);
-  if (!tenant && auth.enabled()) return { response: c.json({ error: 'unauthorized' }, 401) };
+  const identity = resolveMemorySettingsIdentity({ tenant: auth.tenant(c), authEnabled: auth.enabled() });
+  if (!identity) return { response: c.json({ error: 'unauthorized' }, 401) };
   if (memorySettings) {
     try {
       await memorySettings.ensureReady();
-      return tenant
-        ? { storage: memorySettings, orgId: tenantOrgId(tenant), userId: tenant.userId }
-        : { storage: memorySettings, orgId: 'local', userId: 'local' };
+      return { storage: memorySettings, ...identity };
     } catch {
       // fall through to the unavailable response
     }
@@ -600,38 +584,6 @@ async function persistMemorySettings(
   fillIfUnset?: MemorySettingsFillIfUnset,
 ): Promise<void> {
   await context.storage.patch({ orgId: context.orgId, userId: context.userId, patch, fillIfUnset });
-}
-
-/**
- * Apply the stored memory-settings row onto the session, so the DB — not
- * whatever happens to sit in persisted session state (e.g. a stale boot-time
- * seed from before memory settings moved to the DB) — is what the web surface
- * reads and what the session's OM actually runs with. The row is authoritative:
- * knobs without a stored value reset to the built-in defaults.
- */
-async function hydrateSessionMemorySettings(session: OMSession, record: MemorySettingsRecord | null): Promise<void> {
-  for (const role of ['observer', 'reflector'] as const) {
-    const stored = role === 'observer' ? record?.observerModelId : record?.reflectorModelId;
-    const target = stored ?? DEFAULT_OM_MODEL_ID;
-    if (session.om[role].modelId() !== target) {
-      await session.om[role].switchModel({ modelId: target });
-    }
-  }
-  const state = session.state.get() ?? {};
-  const updates: OMStateWrites = {};
-  const observationThreshold = record?.observationThreshold ?? DEFAULT_OBSERVATION_THRESHOLD;
-  if (state.observationThreshold !== observationThreshold) {
-    updates.observationThreshold = observationThreshold;
-  }
-  const reflectionThreshold = record?.reflectionThreshold ?? DEFAULT_REFLECTION_THRESHOLD;
-  if (state.reflectionThreshold !== reflectionThreshold) {
-    updates.reflectionThreshold = reflectionThreshold;
-  }
-  const observeAttachments = record?.observeAttachments ?? 'auto';
-  if ((state.observeAttachments ?? 'auto') !== observeAttachments) {
-    updates.observeAttachments = observeAttachments;
-  }
-  if (Object.keys(updates).length > 0) await session.state.set(updates);
 }
 
 /** Dependencies injected into {@link ConfigRoutes}. */
@@ -1240,7 +1192,7 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
             // stored config instead of failing.
             const session = await controller.getSessionByResource?.(resourceId, scope);
             if (!session) return c.json({ config: readStoredOMConfig(record) });
-            await hydrateSessionMemorySettings(session, record);
+            await applyMemorySettingsToSession(session, record);
             return c.json({ config: readOMConfig(session) });
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);

--- a/mastracode/factory/src/session/factory-session.test.ts
+++ b/mastracode/factory/src/session/factory-session.test.ts
@@ -44,12 +44,25 @@ async function seedLinkedRepository(options?: { pinnedBranch?: string }) {
 
 function createSessionDouble() {
   const calls: string[] = [];
+  const models = { observer: 'google/gemini-3.5-flash', reflector: 'google/gemini-3.5-flash' };
   const session = {
     om: {
-      observer: { switchModel: vi.fn(async () => void calls.push('observer')) },
-      reflector: { switchModel: vi.fn(async () => void calls.push('reflector')) },
+      observer: {
+        modelId: () => models.observer,
+        switchModel: vi.fn(async ({ modelId }: { modelId: string }) => {
+          models.observer = modelId;
+          calls.push('observer');
+        }),
+      },
+      reflector: {
+        modelId: () => models.reflector,
+        switchModel: vi.fn(async ({ modelId }: { modelId: string }) => {
+          models.reflector = modelId;
+          calls.push('reflector');
+        }),
+      },
     },
-    state: { set: vi.fn(async () => void calls.push('state')) },
+    state: { get: () => ({}), set: vi.fn(async () => void calls.push('state')) },
     model: { switch: vi.fn(async () => void calls.push('model')) },
   };
   return { session: session as unknown as FactorySessionHandle, double: session, calls };

--- a/mastracode/factory/src/session/factory-session.ts
+++ b/mastracode/factory/src/session/factory-session.ts
@@ -3,9 +3,10 @@ import { randomUUID } from 'node:crypto';
 import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentController } from '@mastra/core/agent-controller';
 
-import type { MemorySettingsRecord, MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
+import { applyMemorySettingsToSession } from './memory-settings.js';
 
 type FactorySession = Awaited<ReturnType<AgentController<MastraCodeState>['createSession']>>;
 
@@ -195,18 +196,6 @@ export async function ensureFactorySourceSession(
   };
 }
 
-async function applyMemorySettings(session: FactorySession, record: MemorySettingsRecord | null): Promise<void> {
-  if (record?.observerModelId) await session.om.observer.switchModel({ modelId: record.observerModelId });
-  if (record?.reflectorModelId) await session.om.reflector.switchModel({ modelId: record.reflectorModelId });
-
-  const state = {
-    ...(record?.observationThreshold != null ? { observationThreshold: record.observationThreshold } : {}),
-    ...(record?.reflectionThreshold != null ? { reflectionThreshold: record.reflectionThreshold } : {}),
-    ...(record?.observeAttachments != null ? { observeAttachments: record.observeAttachments } : {}),
-  };
-  if (Object.keys(state).length > 0) await session.state.set(state);
-}
-
 export interface HydrateFactorySessionArgs {
   orgId: string;
   userId: string;
@@ -228,7 +217,7 @@ export async function hydrateFactorySession(session: FactorySession, args: Hydra
   if (args.memorySettings) {
     try {
       const record = await args.memorySettings.get({ orgId: args.orgId, userId: args.userId });
-      await applyMemorySettings(session, record);
+      await applyMemorySettingsToSession(session, record);
     } catch (error) {
       console.warn('[Factory Start] Failed to apply observational-memory settings', {
         error: error instanceof Error ? error.message : String(error),

--- a/mastracode/factory/src/session/memory-settings-processor.test.ts
+++ b/mastracode/factory/src/session/memory-settings-processor.test.ts
@@ -1,0 +1,128 @@
+import { MessageList } from '@mastra/core/agent/message-list';
+import { RequestContext } from '@mastra/core/request-context';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
+import { FactoryMemorySettingsProcessor } from './memory-settings-processor.js';
+
+const TENANT = { orgId: 'org-1', userId: 'user-1' };
+
+let seed: FactoryStorageTestSeed;
+
+function requestContext(options: { authenticated?: boolean; scope?: string } = {}) {
+  const context = new RequestContext();
+  if (options.authenticated !== false) {
+    context.set('user', { workosId: 'user-1', organizationId: 'org-1' });
+  }
+  context.set('controller', { resourceId: 'resource-1', threadId: 'thread-1', scope: options.scope });
+  return context;
+}
+
+function sessionDouble(models: { observer: string; reflector: string }) {
+  const current = { ...models };
+  return {
+    om: {
+      observer: {
+        modelId: () => current.observer,
+        switchModel: vi.fn(async ({ modelId }: { modelId: string }) => void (current.observer = modelId)),
+      },
+      reflector: {
+        modelId: () => current.reflector,
+        switchModel: vi.fn(async ({ modelId }: { modelId: string }) => void (current.reflector = modelId)),
+      },
+    },
+    state: { get: () => ({ observationThreshold: 30_000, reflectionThreshold: 40_000 }), set: vi.fn(async () => {}) },
+  };
+}
+
+function buildProcessor(
+  session: ReturnType<typeof sessionDouble> | undefined,
+  options: { authEnabled?: boolean } = {},
+) {
+  const getSessionByResource = vi.fn(async () => session);
+  const processor = new FactoryMemorySettingsProcessor({
+    memorySettings: seed.memorySettings,
+    getController: () => ({ getSessionByResource }),
+    authEnabled: options.authEnabled ?? true,
+  });
+  return { processor, getSessionByResource };
+}
+
+const run = (processor: FactoryMemorySettingsProcessor, context: RequestContext) =>
+  processor.processInput({ messageList: new MessageList(), requestContext: context });
+
+beforeEach(async () => {
+  seed = await createFactoryStorageForTests();
+});
+
+describe('FactoryMemorySettingsProcessor', () => {
+  it('moves a live session onto the model the user picked after it started', async () => {
+    await seed.memorySettings.patch({ ...TENANT, patch: { observerModelId: 'anthropic/claude-haiku-4-5' } });
+    const session = sessionDouble({ observer: 'google/gemini-3.5-flash', reflector: 'google/gemini-3.5-flash' });
+    const { processor } = buildProcessor(session);
+
+    await run(processor, requestContext());
+
+    expect(session.om.observer.switchModel).toHaveBeenCalledWith({ modelId: 'anthropic/claude-haiku-4-5' });
+  });
+
+  it('stops writing once the session already matches the stored row', async () => {
+    await seed.memorySettings.patch({ ...TENANT, patch: { observerModelId: 'anthropic/claude-haiku-4-5' } });
+    const session = sessionDouble({ observer: 'google/gemini-3.5-flash', reflector: 'google/gemini-3.5-flash' });
+    const { processor } = buildProcessor(session);
+
+    await run(processor, requestContext());
+    await run(processor, requestContext());
+
+    expect(session.om.observer.switchModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets a session restored with a stale model when the row holds no choice', async () => {
+    const session = sessionDouble({ observer: 'openai/gpt-5.6', reflector: 'openai/gpt-5.6' });
+    const { processor } = buildProcessor(session);
+
+    await run(processor, requestContext());
+
+    expect(session.om.observer.switchModel).toHaveBeenCalledWith({ modelId: 'google/gemini-3.5-flash' });
+  });
+
+  it('reads the sentinel local row when auth is disabled', async () => {
+    await seed.memorySettings.patch({
+      orgId: 'local',
+      userId: 'local',
+      patch: { observerModelId: 'anthropic/claude-haiku-4-5', reflectorModelId: 'anthropic/claude-haiku-4-5' },
+    });
+    const session = sessionDouble({ observer: 'google/gemini-3.5-flash', reflector: 'google/gemini-3.5-flash' });
+    const { processor } = buildProcessor(session, { authEnabled: false });
+
+    await run(processor, requestContext({ authenticated: false }));
+
+    expect(session.om.observer.switchModel).toHaveBeenCalledWith({ modelId: 'anthropic/claude-haiku-4-5' });
+  });
+
+  it('leaves the session alone when auth is on but the caller is unidentified', async () => {
+    const session = sessionDouble({ observer: 'openai/gpt-5.6', reflector: 'openai/gpt-5.6' });
+    const { processor, getSessionByResource } = buildProcessor(session);
+
+    await run(processor, requestContext({ authenticated: false }));
+
+    expect(getSessionByResource).not.toHaveBeenCalled();
+    expect(session.om.observer.switchModel).not.toHaveBeenCalled();
+  });
+
+  it('passes the isolation scope through so the right session is found', async () => {
+    const session = sessionDouble({ observer: 'google/gemini-3.5-flash', reflector: 'google/gemini-3.5-flash' });
+    const { processor, getSessionByResource } = buildProcessor(session);
+
+    await run(processor, requestContext({ scope: '/worktree' }));
+
+    expect(getSessionByResource).toHaveBeenCalledWith('resource-1', '/worktree');
+  });
+
+  it('returns cleanly when no session is live for the resource', async () => {
+    const { processor } = buildProcessor(undefined);
+
+    await expect(run(processor, requestContext())).resolves.toBeDefined();
+  });
+});

--- a/mastracode/factory/src/session/memory-settings-processor.ts
+++ b/mastracode/factory/src/session/memory-settings-processor.ts
@@ -1,0 +1,71 @@
+import type { MastraCodeState } from '@mastra/code-sdk/schema';
+import type { AgentController } from '@mastra/core/agent-controller';
+import type { ProcessInputArgs, ProcessInputResult, Processor } from '@mastra/core/processors';
+import type { RequestContext } from '@mastra/core/request-context';
+
+import { getFactoryAuthOrgId, getFactoryAuthUserFromContext, getFactoryAuthUserId } from '../auth.js';
+import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+import { applyMemorySettingsToSession, resolveMemorySettingsIdentity } from './memory-settings.js';
+
+type FactoryController = Pick<AgentController<MastraCodeState>, 'getSessionByResource'>;
+
+interface SessionTarget {
+  resourceId: string;
+  scope?: string;
+}
+
+/** The session this run addresses, from the controller entry on the request context. */
+function getSessionTarget(requestContext: RequestContext | undefined): SessionTarget | undefined {
+  if (!requestContext || typeof requestContext.get !== 'function') return undefined;
+  const context = requestContext.get('controller');
+  if (typeof context !== 'object' || context === null) return undefined;
+  const resourceId = 'resourceId' in context ? context.resourceId : undefined;
+  const scope = 'scope' in context ? context.scope : undefined;
+  if (typeof resourceId !== 'string' || !resourceId) return undefined;
+  return { resourceId, ...(typeof scope === 'string' && scope ? { scope } : {}) };
+}
+
+/**
+ * Re-apply the caller's stored memory settings to their live session at the
+ * start of every run.
+ *
+ * Sessions are seeded once at creation, but a long-lived one — an autonomous
+ * review, a chat left open — outlives that snapshot: change the OM model in
+ * settings and the running session keeps calling the old one, failing forever
+ * when that was the point of the change. The stored row is authoritative, so
+ * reconcile against it rather than hoping a write reached every session.
+ */
+export class FactoryMemorySettingsProcessor implements Processor<'factory-memory-settings'> {
+  readonly id = 'factory-memory-settings';
+
+  constructor(
+    private readonly options: {
+      memorySettings: MemorySettingsStorage;
+      getController: () => FactoryController | undefined;
+      authEnabled: boolean;
+    },
+  ) {}
+
+  async processInput(args: ProcessInputArgs): Promise<ProcessInputResult> {
+    const target = getSessionTarget(args.requestContext);
+    const user = getFactoryAuthUserFromContext(args.requestContext);
+    const userId = getFactoryAuthUserId(user);
+    const identity = resolveMemorySettingsIdentity({
+      tenant: userId ? { orgId: getFactoryAuthOrgId(user), userId } : undefined,
+      authEnabled: this.options.authEnabled,
+    });
+    if (!target || !identity) return args.messageList;
+
+    try {
+      await this.options.memorySettings.ensureReady();
+    } catch {
+      // A settings row we cannot read must not block the user's message.
+      return args.messageList;
+    }
+    const session = await this.options.getController()?.getSessionByResource(target.resourceId, target.scope);
+    if (session) {
+      await applyMemorySettingsToSession(session, await this.options.memorySettings.get(identity));
+    }
+    return args.messageList;
+  }
+}

--- a/mastracode/factory/src/session/memory-settings.ts
+++ b/mastracode/factory/src/session/memory-settings.ts
@@ -1,0 +1,88 @@
+import { DEFAULT_OM_MODEL_ID } from '@mastra/code-sdk/constants';
+
+import { tenantOrgId } from '../routes/provider-credentials.js';
+import type { MemorySettingsRecord } from '../storage/domains/memory-settings/base.js';
+
+/** Default thresholds mirror the TUI `/om` fallbacks. */
+export const DEFAULT_OBSERVATION_THRESHOLD = 30_000;
+export const DEFAULT_REFLECTION_THRESHOLD = 40_000;
+
+/**
+ * Session-state fields the OM settings write. The index signatures mirror
+ * `MastraCodeState` so the concrete `Session.state.set(Partial<MastraCodeState>)`
+ * stays assignable to this minimal surface (contravariant parameter check).
+ */
+export interface OMStateWrites {
+  [key: string]: unknown;
+  [key: `subagentModelId_${string}`]: string | undefined;
+  observationThreshold?: number;
+  reflectionThreshold?: number;
+  observeAttachments?: 'auto' | boolean;
+}
+
+interface MemorySettingsOMRole {
+  modelId: () => string | undefined;
+  switchModel: (args: { modelId: string }) => Promise<void>;
+}
+
+/** Minimal session surface the memory settings are applied to. */
+export interface MemorySettingsSession {
+  state: {
+    get: () => Record<string, unknown> | undefined;
+    set: (updates: OMStateWrites) => Promise<void> | void;
+  };
+  om: { observer: MemorySettingsOMRole; reflector: MemorySettingsOMRole };
+}
+
+/**
+ * The `(org, user)` key of a caller's memory-settings row: one row per user,
+ * or a sentinel `(local, local)` row when no auth provider is active.
+ * `undefined` when auth is on but the caller could not be identified — the
+ * only case where settings must not be read or written.
+ */
+export function resolveMemorySettingsIdentity({
+  tenant,
+  authEnabled,
+}: {
+  tenant: { orgId?: string; userId: string } | undefined;
+  authEnabled: boolean;
+}): { orgId: string; userId: string } | undefined {
+  if (tenant) return { orgId: tenantOrgId(tenant), userId: tenant.userId };
+  return authEnabled ? undefined : { orgId: 'local', userId: 'local' };
+}
+
+/**
+ * Apply the stored memory-settings row onto a session, so the DB — not whatever
+ * happens to sit in persisted session state (e.g. a stale boot-time seed, or a
+ * long-lived session created before the user changed the setting) — is what the
+ * session's OM actually runs with. The row is authoritative: knobs without a
+ * stored value reset to the built-in defaults. Writes only on a real difference,
+ * so re-applying every run costs nothing.
+ */
+export async function applyMemorySettingsToSession(
+  session: MemorySettingsSession,
+  record: MemorySettingsRecord | null,
+): Promise<void> {
+  for (const role of ['observer', 'reflector'] as const) {
+    const stored = role === 'observer' ? record?.observerModelId : record?.reflectorModelId;
+    const target = stored ?? DEFAULT_OM_MODEL_ID;
+    if (session.om[role].modelId() !== target) {
+      await session.om[role].switchModel({ modelId: target });
+    }
+  }
+  const state = session.state.get() ?? {};
+  const updates: OMStateWrites = {};
+  const observationThreshold = record?.observationThreshold ?? DEFAULT_OBSERVATION_THRESHOLD;
+  if (state.observationThreshold !== observationThreshold) {
+    updates.observationThreshold = observationThreshold;
+  }
+  const reflectionThreshold = record?.reflectionThreshold ?? DEFAULT_REFLECTION_THRESHOLD;
+  if (state.reflectionThreshold !== reflectionThreshold) {
+    updates.reflectionThreshold = reflectionThreshold;
+  }
+  const observeAttachments = record?.observeAttachments ?? 'auto';
+  if ((state.observeAttachments ?? 'auto') !== observeAttachments) {
+    updates.observeAttachments = observeAttachments;
+  }
+  if (Object.keys(updates).length > 0) await session.state.set(updates);
+}


### PR DESCRIPTION
Changing the observational memory model used to apply only to sessions created afterwards. Follow-up messages don't go through any factory route — they hit the generic agent-controller handler, which returns the cached session and never re-runs the start path that seeds its memory settings. So a review session that began on a model the user can't run kept aborting on every single message, even after they went and fixed the setting. The only way out was starting a new session.

The stored row is already documented as the authority; this makes the code honor it. A small factory input processor re-applies the caller's memory settings at run start, so the next message uses whatever they picked. The apply already compared before writing, so a session that's in sync writes nothing — the cost is one indexed row read per user message. It also picks up plain chat sessions, which never ran the seeding path at all. Note that only the models reconcile mid-session: memory is constructed before input processors run and thresholds are baked into its cache key, so those still land on the following run.

While wiring this I found three places deriving the memory-settings row key differently — the config route, the auth helper, and the start coordinator. They agree for org accounts but diverge for personal ones and in auth-disabled local dev, which is exactly where this would have silently done nothing. They now share one derivation and one apply function.

Last piece: an OM failure aborts the user's whole turn, and the chat was showing it as an anonymous run error. The notice now names the role that failed and links to the memory settings. One caveat worth a reviewer's eye — the row is keyed on whoever sends the message, so an autonomous run and a human follow-up on the same session can resolve to different rows. That's the behaviour this asks for (the person who changed the setting is the person messaging), but it is a choice, not an accident.

Companion to #21247, which fixes where the bad default came from in the first place.