### PR TITLE
feat(factory-ui): humanize tool calls and group tool loops in chat

### DIFF
--- a/.changeset/fine-loops-behave.md
+++ b/.changeset/fine-loops-behave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+The shimmer used by streaming text now ships its own stylesheet with the `Shimmer` component instead of relying on a keyframe declared in the global theme, so it works in any app that imports the component. The sweep also runs at a constant speed whatever the text length, loops without the jump it had at the end of each cycle, and stops under `prefers-reduced-motion`.

--- a/.changeset/fine-loops-behave.md
+++ b/.changeset/fine-loops-behave.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-The shimmer used by streaming text now ships its own stylesheet with the `Shimmer` component instead of relying on a keyframe declared in the global theme, so it works in any app that imports the component. The sweep also runs at a constant speed whatever the text length, loops without the jump it had at the end of each cycle, and stops under `prefers-reduced-motion`.
+The shimmer used by streaming text now ships its own stylesheet with the `Shimmer` component instead of relying on a keyframe declared in the global theme, so it animates in any app that imports the component. The sweep travels a fixed distance rather than a multiple of the text width, so a short label no longer sweeps faster than a long one and two labels side by side stay in step. It also stops under `prefers-reduced-motion`.

--- a/.changeset/fine-loops-behave.md
+++ b/.changeset/fine-loops-behave.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-The shimmer used by streaming text now ships its own stylesheet with the `Shimmer` component instead of relying on a keyframe declared in the global theme, so it animates in any app that imports the component. The sweep travels a fixed distance rather than a multiple of the text width, so a short label no longer sweeps faster than a long one and two labels side by side stay in step. It also stops under `prefers-reduced-motion`.
+Fixed the shimmer that runs under streaming text. It now animates in every app that renders the `Shimmer` component, a short label sweeps at the same speed as a long one so labels side by side stay in step, and the sweep stops under `prefers-reduced-motion`.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -2,22 +2,18 @@ import type { PlanResume } from '@mastra/client-js';
 import { mastraDBMessageToSignal } from '@mastra/core/signals';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
-import { CodeBlock as DsCodeBlock } from '@mastra/playground-ui/components/CodeBlock';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
-import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { MessageScrollerItem } from '@mastra/playground-ui/components/MessageScroller';
 import { Notice } from '@mastra/playground-ui/components/Notice';
-import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { MessageFactory } from '@mastra/react/ui';
 import type { FilePart, MessageRoleRenderers, ReasoningPart, TextPart, ToolInvocationPart } from '@mastra/react/ui';
-import { Bell, ChevronDown, CircleDot, ExternalLink, Info, Layers, Slack, Wrench, X } from 'lucide-react';
+import { Bell, ChevronDown, CircleDot, ExternalLink, Info, Layers, Slack } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
-import { highlightCode, languageForPath } from '../../../ui/highlight';
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 import { useChatSessionContext } from '../context/useChatSessionContext';
 import { useChatTranscript } from '../context/useChatTranscript';
@@ -25,9 +21,10 @@ import {
   useApproveAgentControllerToolMutation,
   useRespondAgentControllerSuspensionMutation,
 } from '../../../../hooks/useAgentControllerRunMutations';
-import { stripSerializedAnsi } from '../services/ansi';
 import { AGENT_CONTROLLER_ID } from '../services/constants';
 import { isTerminalInvocationState } from '../services/transcript';
+import { ToolCard } from './tool/ToolCard';
+import { ToolGroup, TOOL_GROUP_MIN } from './tool/ToolGroup';
 import { isTranscriptToolVisible, ToolFactory } from './ToolFactory';
 import { Markdown } from '../../../ui/Markdown';
 
@@ -78,72 +75,6 @@ function lastSegment(id: string): string {
 
 import { parseSkillActivation, SkillMessage } from './SkillMessage';
 
-// ---------------------------------------------------------------------------
-// Tool card (collapsible)
-// ---------------------------------------------------------------------------
-
-/** Quiet status indicator: muted spinner while running, red cross on failure, nothing on success. */
-function ToolStatusIcon({ status }: { status: ToolCall['status'] }) {
-  if (status === 'running') return <Spinner size="sm" aria-label="Running" className="text-icon3 size-3.5" />;
-  if (status === 'error') return <X size={14} role="img" aria-label="Failed" className="text-error" />;
-  return null;
-}
-
-/** Label + copy header for a section inside a tool card body. */
-function ToolSection({ label, copyText, children }: { label: string; copyText: string; children: ReactNode }) {
-  return (
-    <div className="flex max-w-full min-w-0 flex-col gap-1">
-      <div className="flex items-center justify-between gap-2">
-        <Txt as="span" variant="ui-xs" className="text-icon3 tracking-wide uppercase">
-          {label}
-        </Txt>
-        <CopyButton content={copyText} size="sm" variant="ghost" />
-      </div>
-      {children}
-    </div>
-  );
-}
-
-/** A unified-diff-style view of an edit's before/after text, syntax-highlighted. */
-function DiffView({ oldText, newText, path }: { oldText: string; newText: string; path?: string }) {
-  const lang = languageForPath(path);
-  const removed = oldText.split('\n');
-  const added = newText.split('\n');
-  return (
-    <div
-      className="border-border1 bg-surface1 max-w-full min-w-0 overflow-x-auto rounded-xl border font-mono text-xs leading-normal"
-      role="group"
-      aria-label="File change"
-    >
-      {removed.map((line, i) => (
-        <div key={`r${i}`} className="bg-error/10 flex whitespace-pre">
-          <span className="text-error w-5 shrink-0 text-center opacity-70 select-none">-</span>
-          <span
-            className="text-icon6 [&_span]:font-inherit [&_span]:leading-inherit flex-1 pr-2.5 [&_span]:text-inherit dark:[&_span]:![background-color:var(--shiki-dark-bg)] dark:[&_span]:![color:var(--shiki-dark)]"
-            dangerouslySetInnerHTML={{ __html: highlightCode(line, lang) || '&nbsp;' }}
-          />
-        </div>
-      ))}
-      {added.map((line, i) => (
-        <div key={`a${i}`} className="bg-accent1/10 flex whitespace-pre">
-          <span className="text-accent1 w-5 shrink-0 text-center opacity-70 select-none">+</span>
-          <span
-            className="text-icon6 [&_span]:font-inherit [&_span]:leading-inherit flex-1 pr-2.5 [&_span]:text-inherit dark:[&_span]:![background-color:var(--shiki-dark-bg)] dark:[&_span]:![color:var(--shiki-dark)]"
-            dangerouslySetInnerHTML={{ __html: highlightCode(line, lang) || '&nbsp;' }}
-          />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-interface EditArgs {
-  path?: string;
-  old_string?: string;
-  new_string?: string;
-  content?: string;
-}
-
 function hasProperty<K extends string>(value: object, key: K): value is object & Record<K, unknown> {
   return key in value;
 }
@@ -151,103 +82,6 @@ function hasProperty<K extends string>(value: object, key: K): value is object &
 function stringProperty(value: unknown, key: string): string | undefined {
   if (!value || typeof value !== 'object' || !hasProperty(value, key)) return undefined;
   return typeof value[key] === 'string' ? value[key] : undefined;
-}
-
-/** Detect edit-style tools whose args are better shown as a diff/code block. */
-function editArgs(toolName: string, args: unknown): EditArgs | undefined {
-  const edit = {
-    path: stringProperty(args, 'path'),
-    old_string: stringProperty(args, 'old_string'),
-    new_string: stringProperty(args, 'new_string'),
-    content: stringProperty(args, 'content'),
-  };
-  const isReplace = /string_replace|str_replace/i.test(toolName) && edit.new_string !== undefined;
-  const isWrite = /write_file|create_file/i.test(toolName) && edit.content !== undefined;
-  return isReplace || isWrite ? edit : undefined;
-}
-
-function ToolCard({ tool }: { tool: ToolCall }) {
-  const [expanded, setExpanded] = useState(false);
-  const argsPreview = tool.args !== undefined ? JSON.stringify(tool.args) : tool.argsText;
-  const argsPretty = tool.args !== undefined ? stringify(tool.args) : tool.argsText;
-  const resultText =
-    tool.status !== 'running' && tool.result !== undefined ? stripSerializedAnsi(stringify(tool.result)) : undefined;
-  const edit = editArgs(tool.toolName, tool.args);
-
-  return (
-    <Collapsible
-      open={expanded}
-      onOpenChange={setExpanded}
-      className="max-w-full min-w-0"
-      role="group"
-      aria-label={`Tool: ${tool.toolName}`}
-    >
-      {/*
-        Wrap the trigger content in a span so the chevron is not a *direct*
-        child of CollapsibleTrigger — the DS trigger rotates direct-child <svg>
-        via `[&>svg]:rotate-90` on open. Nesting keeps the chevron controlled
-        here.
-      */}
-      <CollapsibleTrigger className="hover:bg-surface2 active:bg-surface4 w-full rounded-lg text-left transition-colors">
-        <span className="flex w-full items-center gap-2 px-2 py-1.5">
-          <ChevronDown
-            size={13}
-            className={cn(
-              'shrink-0 text-icon3 transition-transform duration-150',
-              expanded ? 'rotate-0' : '-rotate-90',
-            )}
-          />
-          <span className="flex shrink-0 items-center">
-            <Wrench size={13} className="text-icon3" />
-          </span>
-          <Txt as="span" variant="ui-smd" className="text-icon5">
-            {tool.toolName}
-          </Txt>
-          {edit?.path && (
-            <Txt as="span" variant="ui-xs" font="mono" className="text-icon3 truncate">
-              {edit.path}
-            </Txt>
-          )}
-          {!edit && argsPreview && (
-            <Txt as="span" variant="ui-xs" font="mono" className="text-icon3 truncate">
-              {truncate(argsPreview, 72)}
-            </Txt>
-          )}
-          <span className="ml-auto flex shrink-0 items-center">
-            <ToolStatusIcon status={tool.status} />
-          </span>
-        </span>
-      </CollapsibleTrigger>
-      <CollapsibleContent className="max-w-full min-w-0">
-        <div className="border-border1 bg-surface2 mt-1 flex max-w-full min-w-0 flex-col gap-2 rounded-2xl border p-2">
-          {edit ? (
-            edit.new_string !== undefined ? (
-              <ToolSection label={edit.path ?? 'Change'} copyText={edit.new_string}>
-                <DiffView oldText={edit.old_string ?? ''} newText={edit.new_string} path={edit.path} />
-              </ToolSection>
-            ) : (
-              <DsCodeBlock
-                code={truncate(edit.content ?? '', 2000)}
-                lang={languageForPath(edit.path)}
-                fileName={edit.path ?? 'Change'}
-                overflow="scroll"
-              />
-            )
-          ) : argsPretty ? (
-            <DsCodeBlock code={argsPretty} lang="json" fileName="Arguments" />
-          ) : null}
-          {tool.output && (
-            <ToolSection label="Output" copyText={tool.output}>
-              <pre className="bg-surface1 text-icon3 m-0 max-h-72 max-w-full overflow-auto rounded-xl px-3 py-2 font-mono text-xs leading-normal whitespace-pre">
-                {tool.output}
-              </pre>
-            </ToolSection>
-          )}
-          {resultText !== undefined && <DsCodeBlock code={truncate(resultText, 800)} lang="json" fileName="Result" />}
-        </div>
-      </CollapsibleContent>
-    </Collapsible>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -854,6 +688,7 @@ function MessageBubble({
     return undefined;
   })();
 
+  const toolGroups = collectToolGroups(parts, suspensions, entry.runtimeTools);
   const origin = channelOrigin(entry);
   const roles: MessageRoleRenderers = {
     User: ({ children }) => (
@@ -907,7 +742,12 @@ function MessageBubble({
       </div>
     ),
     ToolInvocation: (part: ToolInvocationPart) => {
-      const runtime = entry.runtimeTools?.[part.toolInvocation.toolCallId];
+      const toolCallId = part.toolInvocation.toolCallId;
+      const group = toolGroups.byFirstId.get(toolCallId);
+      if (group) return <ToolGroup tools={group} />;
+      if (toolGroups.memberIds.has(toolCallId)) return null;
+
+      const runtime = entry.runtimeTools?.[toolCallId];
       const tool = toolFromInvocationPart(part, runtime);
       const suspension = suspensions.get(tool.toolCallId);
       if (tool.toolName === 'ask_user' && tool.status === 'running' && !suspension) return null;
@@ -991,6 +831,46 @@ function terminalInvocationStatus(invocation: ToolInvocationPart['toolInvocation
   if (!isTerminalInvocationState(invocation.state)) return undefined;
   if (invocation.state !== 'result') return 'error';
   return 'isError' in invocation && invocation.isError === true ? 'error' : 'done';
+}
+
+/**
+ * Collapse runs of {@link TOOL_GROUP_MIN}+ consecutive plain tool calls into
+ * groups keyed by their first toolCallId. Interactive tools (ask_user,
+ * submit_plan, suspended calls) break a run — their prompt cards must render
+ * inline, never swallowed by a group.
+ */
+function collectToolGroups(
+  parts: MessageEntry['message']['content']['parts'],
+  suspensions: ReadonlyMap<string, SuspensionPrompt>,
+  runtimeTools: MessageEntry['runtimeTools'],
+): { byFirstId: Map<string, ToolCall[]>; memberIds: Set<string> } {
+  const byFirstId = new Map<string, ToolCall[]>();
+  const memberIds = new Set<string>();
+  let run: ToolCall[] = [];
+
+  const flush = () => {
+    if (run.length >= TOOL_GROUP_MIN) {
+      byFirstId.set(run[0].toolCallId, run);
+      for (const tool of run.slice(1)) memberIds.add(tool.toolCallId);
+    }
+    run = [];
+  };
+
+  for (const part of parts) {
+    const groupable =
+      part.type === 'tool-invocation' &&
+      part.toolInvocation.toolName !== 'ask_user' &&
+      part.toolInvocation.toolName !== 'submit_plan' &&
+      !suspensions.has(part.toolInvocation.toolCallId);
+    if (groupable) {
+      run.push(toolFromInvocationPart(part, runtimeTools?.[part.toolInvocation.toolCallId]));
+    } else {
+      flush();
+    }
+  }
+  flush();
+
+  return { byFirstId, memberIds };
 }
 
 function toolFromInvocationPart(part: ToolInvocationPart, runtime?: ToolCall): ToolCall {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
@@ -36,11 +36,12 @@ type ToolInvocationFixture = Extract<MastraMessagePart, { type: 'tool-invocation
   isError?: boolean;
 };
 
-function doneTool(toolCallId: string, toolName: string): MastraDBMessage['content']['parts'][number] {
-  return {
-    type: 'tool-invocation',
-    toolInvocation: { state: 'result', toolCallId, toolName, args: { path: 'src/index.ts' }, result: 'ok' },
-  };
+function doneTool(
+  toolCallId: string,
+  toolName: string,
+  args: unknown = { path: 'src/index.ts' },
+): MastraDBMessage['content']['parts'][number] {
+  return { type: 'tool-invocation', toolInvocation: { state: 'result', toolCallId, toolName, args, result: 'ok' } };
 }
 
 function runningTool(toolCallId: string, toolName: string, args: unknown): MastraDBMessage['content']['parts'][number] {
@@ -151,6 +152,48 @@ describe('TranscriptEntries tool rows', () => {
 
     expect(screen.queryByRole('group', { name: /Tool group/ })).not.toBeInTheDocument();
     expect(screen.getAllByRole('group', { name: 'Tool: view' })).toHaveLength(3);
+  });
+
+  it.each([
+    ['ask_user', 'Question from the agent', { question: 'Which file should I edit?' }],
+    ['submit_plan', 'Plan approval', { plan: { title: 'Ship the fix', content: 'Step one' } }],
+  ])('breaks a run on %s so its prompt is never swallowed by a group', (toolName, promptLabel, args) => {
+    renderEntries([
+      assistantMessage('msg-1', [
+        doneTool('call-1', 'view'),
+        doneTool('call-2', 'view'),
+        doneTool('call-3', toolName, args),
+        doneTool('call-4', 'view'),
+        doneTool('call-5', 'view'),
+      ]),
+    ]);
+
+    expect(screen.queryByRole('group', { name: /Tool group/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: promptLabel })).toBeInTheDocument();
+  });
+
+  it('breaks a run on a suspended call so the agent question stays answerable', () => {
+    renderEntries([
+      assistantMessage('msg-1', [
+        doneTool('call-1', 'view'),
+        doneTool('call-2', 'view'),
+        runningTool('call-3', 'ask_user', {}),
+        doneTool('call-4', 'view'),
+        doneTool('call-5', 'view'),
+      ]),
+      {
+        kind: 'suspension',
+        id: 'susp-1',
+        toolCallId: 'call-3',
+        toolName: 'ask_user',
+        args: {},
+        suspendPayload: { question: 'Which file should I edit?' },
+      },
+    ]);
+
+    expect(screen.queryByRole('group', { name: /Tool group/ })).not.toBeInTheDocument();
+    const question = screen.getByRole('group', { name: 'Question from the agent' });
+    expect(within(question).getByText('Which file should I edit?')).toBeInTheDocument();
   });
 
   it('trusts the persisted result over a stale running overlay — a lost tool_end must not spin forever', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
@@ -1,5 +1,6 @@
 import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent-controller';
 import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 
 import { renderWithProviders } from '../../../../../../e2e/ui/render';
@@ -42,6 +43,10 @@ function doneTool(toolCallId: string, toolName: string): MastraDBMessage['conten
   };
 }
 
+function runningTool(toolCallId: string, toolName: string, args: unknown): MastraDBMessage['content']['parts'][number] {
+  return { type: 'tool-invocation', toolInvocation: { state: 'call', toolCallId, toolName, args } };
+}
+
 function renderEntries(entries: TimelineEntry[]) {
   return renderWithProviders(<TranscriptEntries entries={entries} onApprove={() => {}} onRespond={() => {}} />);
 }
@@ -49,12 +54,9 @@ function renderEntries(entries: TimelineEntry[]) {
 describe('TranscriptEntries tool rows', () => {
   it('shows no status icon on success — only running and failed carry indicators', () => {
     renderEntries([
-      assistantMessage('msg-1', [
-        doneTool('call-1', 'view'),
-        {
-          type: 'tool-invocation',
-          toolInvocation: { state: 'call', toolCallId: 'call-2', toolName: 'execute_command', args: {} },
-        },
+      assistantMessage('msg-1', [doneTool('call-1', 'view')]),
+      assistantMessage('msg-2', [runningTool('call-2', 'execute_command', {})]),
+      assistantMessage('msg-3', [
         {
           type: 'tool-invocation',
           toolInvocation: {
@@ -80,6 +82,75 @@ describe('TranscriptEntries tool rows', () => {
     // Failure keeps its red cross.
     const failedRow = screen.getByRole('group', { name: 'Tool: write_file' });
     expect(within(failedRow).getByRole('img', { name: 'Failed' })).toBeInTheDocument();
+  });
+
+  it('renders a humanized action and salient argument instead of the raw tool name', () => {
+    renderEntries([
+      assistantMessage('msg-1', [
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'result',
+            toolCallId: 'call-1',
+            toolName: 'execute_command',
+            args: { command: 'pnpm build' },
+            result: 'ok',
+          },
+        },
+      ]),
+    ]);
+
+    const row = screen.getByRole('group', { name: 'Tool: execute_command' });
+    expect(within(row).getByText('Run')).toBeInTheDocument();
+    expect(within(row).getByText('pnpm build')).toBeInTheDocument();
+    expect(within(row).queryByText('execute_command')).not.toBeInTheDocument();
+  });
+
+  it('collapses three or more consecutive tool calls into a single group row', async () => {
+    renderEntries([
+      assistantMessage('msg-1', [
+        doneTool('call-1', 'view'),
+        doneTool('call-2', 'search_content'),
+        doneTool('call-3', 'view'),
+      ]),
+    ]);
+
+    const group = screen.getByRole('group', { name: 'Tool group: 3 steps' });
+    expect(screen.queryByRole('group', { name: 'Tool: view' })).not.toBeInTheDocument();
+
+    await userEvent.click(within(group).getAllByRole('button')[0]);
+    expect(screen.getAllByRole('group', { name: 'Tool: view' })).toHaveLength(2);
+  });
+
+  it('surfaces the running action live on a collapsed group header', () => {
+    renderEntries([
+      assistantMessage('msg-1', [
+        doneTool('call-1', 'view'),
+        doneTool('call-2', 'view'),
+        doneTool('call-3', 'view'),
+        runningTool('call-4', 'execute_command', { command: 'pnpm test' }),
+      ]),
+    ]);
+
+    const group = screen.getByRole('group', { name: 'Tool group: 4 steps' });
+    expect(within(group).getByText('Run')).toBeInTheDocument();
+    expect(within(group).getByText('pnpm test')).toBeInTheDocument();
+    expect(within(group).getByText('3/4')).toBeInTheDocument();
+    expect(within(group).getByLabelText('Running')).toBeInTheDocument();
+  });
+
+  it('does not group runs broken by prose', () => {
+    renderEntries([
+      assistantMessage('msg-1', [
+        doneTool('call-1', 'view'),
+        doneTool('call-2', 'view'),
+        { type: 'text', text: 'Interlude' },
+        doneTool('call-3', 'view'),
+      ]),
+    ]);
+
+    expect(screen.queryByRole('group', { name: /Tool group/ })).not.toBeInTheDocument();
+    expect(screen.getAllByRole('group', { name: 'Tool: view' })).toHaveLength(3);
   });
 
   it('trusts the persisted result over a stale running overlay — a lost tool_end must not spin forever', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolCard.tsx
@@ -1,0 +1,214 @@
+import { CodeBlock as DsCodeBlock } from '@mastra/playground-ui/components/CodeBlock';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+
+import { highlightCode, languageForPath } from '../../../../ui/highlight';
+import { stripSerializedAnsi } from '../../services/ansi';
+import type { ToolCall } from '../../services/transcript';
+import { presentTool } from './tool-presentation';
+import { ToolRow, TOOL_RAIL_OFFSET, TOOL_ROW_TRIGGER } from './ToolRow';
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + '…' : s;
+}
+
+function stringify(v: unknown): string {
+  if (typeof v === 'string') return v;
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}
+
+function MonoBlock({ copyText, className, children }: { copyText: string; className?: string; children: ReactNode }) {
+  return (
+    <div className="group/block relative max-w-full min-w-0">
+      <pre
+        className={cn(
+          'bg-surface1 m-0 max-h-60 max-w-full overflow-auto rounded-md px-3 py-2 font-mono text-xs leading-normal break-words whitespace-pre-wrap',
+          className,
+        )}
+      >
+        {children}
+      </pre>
+      <CopyButton
+        content={copyText}
+        size="sm"
+        variant="ghost"
+        className="absolute top-1 right-1 opacity-0 transition-opacity group-hover/block:opacity-100"
+      />
+    </div>
+  );
+}
+
+/** A unified-diff-style view of an edit's before/after text, syntax-highlighted. */
+function DiffView({ oldText, newText, path }: { oldText: string; newText: string; path?: string }) {
+  const lang = languageForPath(path);
+  const removed = oldText.split('\n');
+  const added = newText.split('\n');
+  return (
+    <div
+      className="border-border1 bg-surface1 max-w-full min-w-0 overflow-x-auto rounded-md border font-mono text-xs leading-normal"
+      role="group"
+      aria-label="File change"
+    >
+      {removed.map((line, i) => (
+        <div key={`r${i}`} className="bg-error/10 flex whitespace-pre">
+          <span className="text-error w-5 shrink-0 text-center opacity-70 select-none">-</span>
+          <span
+            className="text-icon6 [&_span]:font-inherit [&_span]:leading-inherit flex-1 pr-2.5 [&_span]:text-inherit dark:[&_span]:![background-color:var(--shiki-dark-bg)] dark:[&_span]:![color:var(--shiki-dark)]"
+            dangerouslySetInnerHTML={{ __html: highlightCode(line, lang) || '&nbsp;' }}
+          />
+        </div>
+      ))}
+      {added.map((line, i) => (
+        <div key={`a${i}`} className="bg-accent1/10 flex whitespace-pre">
+          <span className="text-accent1 w-5 shrink-0 text-center opacity-70 select-none">+</span>
+          <span
+            className="text-icon6 [&_span]:font-inherit [&_span]:leading-inherit flex-1 pr-2.5 [&_span]:text-inherit dark:[&_span]:![background-color:var(--shiki-dark-bg)] dark:[&_span]:![color:var(--shiki-dark)]"
+            dangerouslySetInnerHTML={{ __html: highlightCode(line, lang) || '&nbsp;' }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface EditArgs {
+  path?: string;
+  old_string?: string;
+  new_string?: string;
+  content?: string;
+}
+
+function hasProperty<K extends string>(value: object, key: K): value is object & Record<K, unknown> {
+  return key in value;
+}
+
+function stringProperty(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== 'object' || !hasProperty(value, key)) return undefined;
+  return typeof value[key] === 'string' ? value[key] : undefined;
+}
+
+/** Detect edit-style tools whose args are better shown as a diff/code block. */
+function editArgs(toolName: string, args: unknown): EditArgs | undefined {
+  const edit = {
+    path: stringProperty(args, 'path'),
+    old_string: stringProperty(args, 'old_string'),
+    new_string: stringProperty(args, 'new_string'),
+    content: stringProperty(args, 'content'),
+  };
+  const isReplace = /string_replace|str_replace|edit_file/i.test(toolName) && edit.new_string !== undefined;
+  const isWrite = /write_file|create_file/i.test(toolName) && edit.content !== undefined;
+  return isReplace || isWrite ? edit : undefined;
+}
+
+function ToolBody({ tool, command }: { tool: ToolCall; command?: string }) {
+  const edit = editArgs(tool.toolName, tool.args);
+  const resultText =
+    tool.status !== 'running' && tool.result !== undefined ? stripSerializedAnsi(stringify(tool.result)) : undefined;
+
+  if (edit) {
+    return (
+      <>
+        {edit.new_string !== undefined ? (
+          <DiffView oldText={edit.old_string ?? ''} newText={edit.new_string} path={edit.path} />
+        ) : (
+          <DsCodeBlock
+            code={truncate(edit.content ?? '', 2000)}
+            lang={languageForPath(edit.path)}
+            fileName={edit.path ?? 'Change'}
+            overflow="scroll"
+          />
+        )}
+        {tool.status === 'error' && resultText !== undefined && (
+          <MonoBlock copyText={resultText} className="text-error/90">
+            {truncate(resultText, 800)}
+          </MonoBlock>
+        )}
+      </>
+    );
+  }
+
+  if (command) {
+    return (
+      <>
+        <MonoBlock copyText={command} className="text-icon5">
+          <span className="text-icon3 select-none">$ </span>
+          {command}
+        </MonoBlock>
+        {tool.output ? (
+          <MonoBlock copyText={tool.output} className="text-icon3">
+            {tool.output}
+          </MonoBlock>
+        ) : (
+          resultText !== undefined && (
+            <MonoBlock copyText={resultText} className="text-icon3">
+              {truncate(resultText, 800)}
+            </MonoBlock>
+          )
+        )}
+      </>
+    );
+  }
+
+  const argsPretty = tool.args !== undefined ? stringify(tool.args) : tool.argsText;
+  return (
+    <>
+      {argsPretty && (
+        <MonoBlock copyText={argsPretty} className="text-icon5">
+          {argsPretty}
+        </MonoBlock>
+      )}
+      {tool.output && (
+        <MonoBlock copyText={tool.output} className="text-icon3">
+          {tool.output}
+        </MonoBlock>
+      )}
+      {resultText !== undefined && (
+        <MonoBlock copyText={resultText} className="text-icon3">
+          {truncate(resultText, 800)}
+        </MonoBlock>
+      )}
+    </>
+  );
+}
+
+export function ToolCard({ tool }: { tool: ToolCall }) {
+  const [expanded, setExpanded] = useState(false);
+  const presentation = presentTool(tool.toolName, tool.args);
+
+  return (
+    <Collapsible
+      open={expanded}
+      onOpenChange={setExpanded}
+      className="max-w-full min-w-0"
+      role="group"
+      aria-label={`Tool: ${tool.toolName}`}
+    >
+      <CollapsibleTrigger className={TOOL_ROW_TRIGGER}>
+        <ToolRow
+          icon={presentation.icon}
+          label={presentation.label}
+          detail={presentation.detail}
+          status={tool.status}
+          expanded={expanded}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="max-w-full min-w-0">
+        <div
+          className={cn(
+            'border-border1 flex max-w-full min-w-0 flex-col gap-1.5 border-l py-1.5 pr-1 pl-4',
+            TOOL_RAIL_OFFSET,
+          )}
+        >
+          <ToolBody tool={tool} command={presentation.command} />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolCard.tsx
@@ -18,7 +18,7 @@ function truncate(s: string, max: number): string {
 function stringify(v: unknown): string {
   if (typeof v === 'string') return v;
   try {
-    return JSON.stringify(v, null, 2);
+    return JSON.stringify(v, null, 2) ?? String(v);
   } catch {
     return String(v);
   }
@@ -45,35 +45,49 @@ function MonoBlock({ copyText, className, children }: { copyText: string; classN
   );
 }
 
-/** A unified-diff-style view of an edit's before/after text, syntax-highlighted. */
+const DIFF_MAX_LINES = 200;
+
+const DIFF_SIDES = {
+  removed: { sign: '-', row: 'bg-error/10', gutter: 'text-error' },
+  added: { sign: '+', row: 'bg-accent1/10', gutter: 'text-accent1' },
+} as const;
+
+function boundedLines(text: string): { lines: string[]; hidden: number } {
+  const lines = text.split('\n');
+  return { lines: lines.slice(0, DIFF_MAX_LINES), hidden: Math.max(0, lines.length - DIFF_MAX_LINES) };
+}
+
+function DiffSide({ lines, side, lang }: { lines: string[]; side: keyof typeof DIFF_SIDES; lang: string | undefined }) {
+  const { sign, row, gutter } = DIFF_SIDES[side];
+  return (
+    <>
+      {lines.map((line, i) => (
+        <div key={i} className={cn('flex whitespace-pre', row)}>
+          <span className={cn('w-5 shrink-0 text-center opacity-70 select-none', gutter)}>{sign}</span>
+          <span
+            className="text-icon6 [&_span]:font-inherit [&_span]:leading-inherit flex-1 pr-2.5 [&_span]:text-inherit dark:[&_span]:![background-color:var(--shiki-dark-bg)] dark:[&_span]:![color:var(--shiki-dark)]"
+            dangerouslySetInnerHTML={{ __html: highlightCode(line, lang) || '&nbsp;' }}
+          />
+        </div>
+      ))}
+    </>
+  );
+}
+
 function DiffView({ oldText, newText, path }: { oldText: string; newText: string; path?: string }) {
   const lang = languageForPath(path);
-  const removed = oldText.split('\n');
-  const added = newText.split('\n');
+  const removed = boundedLines(oldText);
+  const added = boundedLines(newText);
+  const hidden = removed.hidden + added.hidden;
   return (
     <div
       className="border-border1 bg-surface1 max-w-full min-w-0 overflow-x-auto rounded-md border font-mono text-xs leading-normal"
       role="group"
       aria-label="File change"
     >
-      {removed.map((line, i) => (
-        <div key={`r${i}`} className="bg-error/10 flex whitespace-pre">
-          <span className="text-error w-5 shrink-0 text-center opacity-70 select-none">-</span>
-          <span
-            className="text-icon6 [&_span]:font-inherit [&_span]:leading-inherit flex-1 pr-2.5 [&_span]:text-inherit dark:[&_span]:![background-color:var(--shiki-dark-bg)] dark:[&_span]:![color:var(--shiki-dark)]"
-            dangerouslySetInnerHTML={{ __html: highlightCode(line, lang) || '&nbsp;' }}
-          />
-        </div>
-      ))}
-      {added.map((line, i) => (
-        <div key={`a${i}`} className="bg-accent1/10 flex whitespace-pre">
-          <span className="text-accent1 w-5 shrink-0 text-center opacity-70 select-none">+</span>
-          <span
-            className="text-icon6 [&_span]:font-inherit [&_span]:leading-inherit flex-1 pr-2.5 [&_span]:text-inherit dark:[&_span]:![background-color:var(--shiki-dark-bg)] dark:[&_span]:![color:var(--shiki-dark)]"
-            dangerouslySetInnerHTML={{ __html: highlightCode(line, lang) || '&nbsp;' }}
-          />
-        </div>
-      ))}
+      <DiffSide lines={removed.lines} side="removed" lang={lang} />
+      <DiffSide lines={added.lines} side="added" lang={lang} />
+      {hidden > 0 && <div className="text-icon3 px-2.5 py-1 select-none">… {hidden} more lines</div>}
     </div>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolGroup.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolGroup.tsx
@@ -1,0 +1,63 @@
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import { useState } from 'react';
+
+import type { ToolCall } from '../../services/transcript';
+import { ToolCard } from './ToolCard';
+import { presentTool } from './tool-presentation';
+import { ToolRow, TOOL_RAIL_OFFSET, TOOL_ROW_TRIGGER } from './ToolRow';
+
+/** Consecutive tool calls this long collapse into one group row. */
+export const TOOL_GROUP_MIN = 3;
+
+export function ToolGroup({ tools }: { tools: ToolCall[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const running = tools.find(tool => tool.status === 'running');
+  const hasError = tools.some(tool => tool.status === 'error');
+  const doneCount = tools.filter(tool => tool.status !== 'running').length;
+
+  const live = running ? presentTool(running.toolName, running.args) : undefined;
+
+  return (
+    <Collapsible
+      open={expanded}
+      onOpenChange={setExpanded}
+      className="max-w-full min-w-0"
+      role="group"
+      aria-label={`Tool group: ${tools.length} steps`}
+    >
+      <CollapsibleTrigger className={TOOL_ROW_TRIGGER}>
+        <ToolRow
+          label={live?.label ?? `${tools.length} steps`}
+          detail={live?.detail ?? actionSummary(tools)}
+          status={running ? 'running' : hasError ? 'error' : 'done'}
+          expanded={expanded}
+          rule
+          trailing={
+            running && (
+              <Txt as="span" variant="ui-xs" className="text-icon3 shrink-0 tabular-nums">
+                {doneCount}/{tools.length}
+              </Txt>
+            )
+          }
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="max-w-full min-w-0">
+        <div className={cn('border-border1 max-w-full min-w-0 border-l py-0.5 pl-2.5', TOOL_RAIL_OFFSET)}>
+          <ScrollArea maxHeight="18rem" autoScroll={Boolean(running)}>
+            {tools.map(tool => (
+              <ToolCard key={tool.toolCallId} tool={tool} />
+            ))}
+          </ScrollArea>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function actionSummary(tools: ToolCall[]): string {
+  const labels = [...new Set(tools.map(tool => presentTool(tool.toolName, tool.args).label))];
+  return labels.slice(0, 4).join(' · ');
+}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolRow.tsx
@@ -1,3 +1,4 @@
+import { Shimmer } from '@mastra/playground-ui/components/Shimmer';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
@@ -59,12 +60,8 @@ export function ToolRow({ icon: Icon, label, detail, status, expanded, rule, tra
           <Chevron expanded={expanded} className="text-icon3 group-hover/tool:text-icon5" />
         )}
       </span>
-      <Txt
-        as="span"
-        variant="ui-sm"
-        className={cn('max-w-[55%] shrink-0 truncate', status === 'running' ? 'text-shimmer text-icon4' : 'text-icon5')}
-      >
-        {label}
+      <Txt as="span" variant="ui-sm" className="text-icon5 max-w-[55%] shrink-0 truncate">
+        {status === 'running' ? <Shimmer>{label}</Shimmer> : label}
       </Txt>
       {detail && (
         <Txt as="span" variant="ui-xs" font="mono" className="text-icon3 min-w-0 truncate">

--- a/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolRow.tsx
@@ -1,0 +1,80 @@
+import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import { ChevronRight, X } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import type { ToolCall } from '../../services/transcript';
+
+/** Shell of a clickable tool row: hover surface, pointer, and the `group/tool` hover scope. */
+export const TOOL_ROW_TRIGGER =
+  'group/tool hover:bg-neutral6/5 w-full cursor-pointer rounded-md text-left transition-colors';
+
+/** Left offset of the rail under an expanded row: the centre of the leading slot. */
+export const TOOL_RAIL_OFFSET = 'ml-[14px]';
+
+export function ToolStatusIcon({ status }: { status: ToolCall['status'] }) {
+  if (status === 'running') return <Spinner size="sm" aria-label="Running" className="text-icon3 size-3" />;
+  if (status === 'error') return <X size={13} role="img" aria-label="Failed" className="text-error" />;
+  return null;
+}
+
+function Chevron({ expanded, className }: { expanded: boolean; className: string }) {
+  // Nested, not a direct trigger child — the DS trigger rotates direct-child <svg> on open.
+  return (
+    <ChevronRight
+      size={13}
+      aria-hidden
+      className={cn('shrink-0 transition-[transform,color] duration-150', expanded && 'rotate-90', className)}
+    />
+  );
+}
+
+interface ToolRowProps {
+  /** A single call leads with its tool icon; a group leads with the disclosure chevron instead. */
+  icon?: LucideIcon;
+  label: string;
+  detail?: string;
+  status: ToolCall['status'];
+  expanded: boolean;
+  /** Trails the label with a hairline, marking the row as a group of calls. */
+  rule?: boolean;
+  trailing?: ReactNode;
+}
+
+/** The one row shape every tool line uses, so single calls and groups share a rhythm. */
+export function ToolRow({ icon: Icon, label, detail, status, expanded, rule, trailing }: ToolRowProps) {
+  return (
+    <span className="flex w-full min-w-0 items-center gap-2 px-1.5 py-1">
+      <span className="flex size-4 shrink-0 items-center justify-center">
+        {Icon ? (
+          <Icon
+            size={14}
+            strokeWidth={1.75}
+            aria-hidden
+            className={status === 'error' ? 'text-error/80' : 'text-icon3'}
+          />
+        ) : (
+          <Chevron expanded={expanded} className="text-icon3 group-hover/tool:text-icon5" />
+        )}
+      </span>
+      <Txt
+        as="span"
+        variant="ui-sm"
+        className={cn('shrink-0', status === 'running' ? 'text-shimmer text-icon4' : 'text-icon5')}
+      >
+        {label}
+      </Txt>
+      {detail && (
+        <Txt as="span" variant="ui-xs" font="mono" className="text-icon3 min-w-0 truncate">
+          {detail}
+        </Txt>
+      )}
+      {Icon && <Chevron expanded={expanded} className="text-icon2 group-hover/tool:text-icon4" />}
+      {rule ? <span aria-hidden className="bg-border1 h-px min-w-2 flex-1" /> : <span className="flex-1" />}
+      {trailing}
+      <ToolStatusIcon status={status} />
+    </span>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolRow.tsx
@@ -15,8 +15,8 @@ export const TOOL_ROW_TRIGGER =
 export const TOOL_RAIL_OFFSET = 'ml-[14px]';
 
 export function ToolStatusIcon({ status }: { status: ToolCall['status'] }) {
-  if (status === 'running') return <Spinner size="sm" aria-label="Running" className="text-icon3 size-3" />;
-  if (status === 'error') return <X size={13} role="img" aria-label="Failed" className="text-error" />;
+  if (status === 'running') return <Spinner size="sm" aria-label="Running" className="text-icon3 size-3 shrink-0" />;
+  if (status === 'error') return <X size={13} role="img" aria-label="Failed" className="text-error shrink-0" />;
   return null;
 }
 
@@ -62,7 +62,7 @@ export function ToolRow({ icon: Icon, label, detail, status, expanded, rule, tra
       <Txt
         as="span"
         variant="ui-sm"
-        className={cn('shrink-0', status === 'running' ? 'text-shimmer text-icon4' : 'text-icon5')}
+        className={cn('max-w-[55%] shrink-0 truncate', status === 'running' ? 'text-shimmer text-icon4' : 'text-icon5')}
       >
         {label}
       </Txt>

--- a/mastracode/factory-ui/src/ui/domains/chat/components/tool/tool-presentation.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/tool/tool-presentation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { presentTool } from './tool-presentation';
+
+describe('presentTool', () => {
+  it('maps stable workspace aliases to humanized actions with their salient argument', () => {
+    expect(presentTool('view', { path: 'src/a.ts' })).toMatchObject({ label: 'Read', detail: 'src/a.ts' });
+    expect(presentTool('search_content', { pattern: 'useChat' })).toMatchObject({ label: 'Search', detail: 'useChat' });
+    expect(presentTool('string_replace', { path: 'src/a.ts' })).toMatchObject({ label: 'Edit', detail: 'src/a.ts' });
+  });
+
+  it('marks terminal-style tools with their command for the expanded body', () => {
+    expect(presentTool('execute_command', { command: 'pnpm test' })).toMatchObject({
+      label: 'Run',
+      detail: 'pnpm test',
+      command: 'pnpm test',
+    });
+  });
+
+  it('strips the raw workspace prefix before lookup', () => {
+    expect(presentTool('mastra_workspace_read_file', { path: 'a.ts' })).toMatchObject({
+      label: 'Read',
+      detail: 'a.ts',
+    });
+  });
+
+  it('prettifies unknown tool names instead of surfacing raw identifiers', () => {
+    expect(presentTool('fetch_pull_request', undefined).label).toBe('Fetch pull request');
+  });
+
+  it('omits the detail when the salient argument has not streamed yet', () => {
+    expect(presentTool('execute_command', undefined).detail).toBeUndefined();
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/components/tool/tool-presentation.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/tool/tool-presentation.ts
@@ -1,0 +1,95 @@
+import {
+  Braces,
+  CircleStop,
+  Eye,
+  FileSearch,
+  FolderPlus,
+  FolderSearch,
+  Globe,
+  ScrollText,
+  Search,
+  SquarePen,
+  SquareTerminal,
+  Trash2,
+  Wrench,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+export interface ToolPresentation {
+  icon: LucideIcon;
+  label: string;
+  /** Salient argument shown next to the label: command, path, pattern… */
+  detail?: string;
+  /** Shell command, when the tool is terminal-style. Drives the expanded body. */
+  command?: string;
+}
+
+function hasProperty<K extends string>(value: object, key: K): value is object & Record<K, unknown> {
+  return key in value;
+}
+
+function stringArg(args: unknown, key: string): string | undefined {
+  if (!args || typeof args !== 'object' || !hasProperty(args, key)) return undefined;
+  const value = args[key];
+  if (typeof value === 'number') return String(value);
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function firstStringArg(args: unknown, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = stringArg(args, key);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+interface ToolStyle {
+  icon: LucideIcon;
+  label: string;
+  detailKeys?: string[];
+  isCommand?: boolean;
+}
+
+const TOOL_STYLES: Record<string, ToolStyle> = {
+  view: { icon: Eye, label: 'Read', detailKeys: ['path'] },
+  read_file: { icon: Eye, label: 'Read', detailKeys: ['path'] },
+  write_file: { icon: SquarePen, label: 'Write', detailKeys: ['path'] },
+  create_file: { icon: SquarePen, label: 'Write', detailKeys: ['path'] },
+  edit_file: { icon: SquarePen, label: 'Edit', detailKeys: ['path'] },
+  string_replace: { icon: SquarePen, label: 'Edit', detailKeys: ['path'] },
+  str_replace: { icon: SquarePen, label: 'Edit', detailKeys: ['path'] },
+  ast_edit: { icon: SquarePen, label: 'Edit', detailKeys: ['path'] },
+  execute_command: { icon: SquareTerminal, label: 'Run', detailKeys: ['command'], isCommand: true },
+  get_process_output: { icon: ScrollText, label: 'Process output', detailKeys: ['pid'] },
+  kill_process: { icon: CircleStop, label: 'Stop process', detailKeys: ['pid'] },
+  find_files: { icon: FolderSearch, label: 'Find files', detailKeys: ['pattern', 'path'] },
+  list_files: { icon: FolderSearch, label: 'List files', detailKeys: ['pattern', 'path'] },
+  grep: { icon: Search, label: 'Search', detailKeys: ['pattern', 'path'] },
+  search_content: { icon: Search, label: 'Search', detailKeys: ['pattern', 'query'] },
+  search: { icon: Search, label: 'Search', detailKeys: ['query'] },
+  web_search: { icon: Globe, label: 'Search the web', detailKeys: ['query'] },
+  lsp_inspect: { icon: Braces, label: 'Inspect code', detailKeys: ['path'] },
+  file_stat: { icon: FileSearch, label: 'File info', detailKeys: ['path'] },
+  delete: { icon: Trash2, label: 'Delete', detailKeys: ['path'] },
+  delete_file: { icon: Trash2, label: 'Delete', detailKeys: ['path'] },
+  mkdir: { icon: FolderPlus, label: 'New folder', detailKeys: ['path'] },
+};
+
+function prettifyToolName(toolName: string): string {
+  const words = toolName.replace(/[_-]+/g, ' ').trim();
+  return words ? words.charAt(0).toUpperCase() + words.slice(1) : toolName;
+}
+
+export function presentTool(toolName: string, args: unknown): ToolPresentation {
+  const style = TOOL_STYLES[toolName.replace(/^mastra_workspace_/, '')];
+  if (!style) {
+    return { icon: Wrench, label: prettifyToolName(toolName) };
+  }
+  const detail = style.detailKeys ? firstStringArg(args, style.detailKeys) : undefined;
+  return {
+    icon: style.icon,
+    label: style.label,
+    ...(detail ? { detail } : {}),
+    ...(style.isCommand && detail ? { command: detail } : {}),
+  };
+}

--- a/mastracode/factory-ui/src/ui/tailwind.css
+++ b/mastracode/factory-ui/src/ui/tailwind.css
@@ -100,3 +100,25 @@ html.light {
     }
   }
 }
+
+/* Sweeping highlight on the label of a running tool. Falls back to plain
+ * (inherited) text color under reduced motion — never transparent text. */
+@utility text-shimmer {
+  @media (prefers-reduced-motion: no-preference) {
+    background: linear-gradient(90deg, var(--neutral3) 35%, var(--neutral6) 50%, var(--neutral3) 65%);
+    background-size: 200% 100%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    animation: text-shimmer 2s linear infinite;
+  }
+}
+
+@keyframes text-shimmer {
+  from {
+    background-position: 130% 0;
+  }
+  to {
+    background-position: -70% 0;
+  }
+}

--- a/mastracode/factory-ui/src/ui/tailwind.css
+++ b/mastracode/factory-ui/src/ui/tailwind.css
@@ -100,25 +100,3 @@ html.light {
     }
   }
 }
-
-/* Sweeping highlight on the label of a running tool. Falls back to plain
- * (inherited) text color under reduced motion — never transparent text. */
-@utility text-shimmer {
-  @media (prefers-reduced-motion: no-preference) {
-    background: linear-gradient(90deg, var(--neutral3) 35%, var(--neutral6) 50%, var(--neutral3) 65%);
-    background-size: 200% 100%;
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-    animation: text-shimmer 2s linear infinite;
-  }
-}
-
-@keyframes text-shimmer {
-  from {
-    background-position: 130% 0;
-  }
-  to {
-    background-position: -70% 0;
-  }
-}

--- a/packages/playground-ui/src/ds/components/Shimmer/shimmer.css
+++ b/packages/playground-ui/src/ds/components/Shimmer/shimmer.css
@@ -8,6 +8,7 @@
   background-image: linear-gradient(90deg, var(--neutral3) 0%, var(--neutral6) 50%, var(--neutral3) 100%);
   background-size: var(--shimmer-period) 100%;
   background-repeat: repeat;
+  /* stylelint-disable-next-line property-no-vendor-prefix -- Chrome < 120 and Safari < 14 only clip to text prefixed. */
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;

--- a/packages/playground-ui/src/ds/components/Shimmer/shimmer.css
+++ b/packages/playground-ui/src/ds/components/Shimmer/shimmer.css
@@ -1,0 +1,33 @@
+/* Sweeping highlight for text that is still being produced.
+ * The gradient period is a fixed pixel width and the animation travels exactly
+ * one period, so the loop never jumps and a short label sweeps at the same
+ * speed as a long one. */
+.shimmer-text {
+  --shimmer-period: 180px;
+
+  background-image: linear-gradient(90deg, var(--neutral3) 0%, var(--neutral6) 50%, var(--neutral3) 100%);
+  background-size: var(--shimmer-period) 100%;
+  background-repeat: repeat;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: shimmer-text 1.6s linear infinite;
+}
+
+@keyframes shimmer-text {
+  from {
+    background-position: calc(-1 * var(--shimmer-period)) 0;
+  }
+
+  to {
+    background-position: 0 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shimmer-text {
+    background-image: none;
+    color: inherit;
+    animation: none;
+  }
+}

--- a/packages/playground-ui/src/ds/components/Shimmer/shimmer.test.tsx
+++ b/packages/playground-ui/src/ds/components/Shimmer/shimmer.test.tsx
@@ -20,13 +20,6 @@ describe('Shimmer', () => {
 
     const el = screen.getByText('Loading');
     expect(el.className).toContain('custom-class');
-    expect(el.className).toContain('text-transparent');
-  });
-
-  it('drives the shimmer-text keyframe animation', () => {
-    render(<Shimmer>Animate</Shimmer>);
-
-    const el = screen.getByText('Animate');
-    expect(el.style.animation).toContain('shimmer-text');
+    expect(el.className).toContain('shimmer-text');
   });
 });

--- a/packages/playground-ui/src/ds/components/Shimmer/shimmer.tsx
+++ b/packages/playground-ui/src/ds/components/Shimmer/shimmer.tsx
@@ -2,24 +2,13 @@ import type { ReactNode } from 'react';
 
 import { cn } from '@/lib/utils';
 
+import './shimmer.css';
+
 export interface ShimmerProps {
   children: ReactNode;
   className?: string;
 }
 
 export const Shimmer = ({ children, className }: ShimmerProps) => {
-  return (
-    <span
-      className={cn('inline-block text-transparent', className)}
-      style={{
-        backgroundImage: 'linear-gradient(to right, var(--neutral3), var(--neutral6), var(--neutral3))',
-        backgroundSize: '200% 100%',
-        backgroundClip: 'text',
-        WebkitBackgroundClip: 'text',
-        animation: 'shimmer-text 2s linear infinite',
-      }}
-    >
-      {children}
-    </span>
-  );
+  return <span className={cn('shimmer-text inline-block', className)}>{children}</span>;
 };

--- a/packages/playground-ui/theme.css
+++ b/packages/playground-ui/theme.css
@@ -400,16 +400,6 @@ html.light {
       transform: translateX(100%);
     }
   }
-
-  @keyframes shimmer-text {
-    0% {
-      background-position: 200% 0;
-    }
-
-    100% {
-      background-position: -200% 0;
-    }
-  }
 }
 
 @utility duration-normal {

--- a/packages/playground/src/index.css
+++ b/packages/playground/src/index.css
@@ -72,15 +72,6 @@ html::-webkit-scrollbar-thumb:hover {
   }
 }
 
-@keyframes shimmer-text {
-  0% {
-    background-position: 200% 0;
-  }
-  100% {
-    background-position: -200% 0;
-  }
-}
-
 div[class^='language-'],
 pre[class^='language-'],
 code[class^='language-'] {

--- a/packages/playground/src/lib/ai-ui/messages/__tests__/reasoning-streaming-line.test.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/__tests__/reasoning-streaming-line.test.tsx
@@ -8,9 +8,7 @@ describe('ReasoningStreamingLine', () => {
     render(<ReasoningStreamingLine text="Reasoning..." />);
 
     const label = screen.getByText('Reasoning...');
-    expect(label).not.toBeNull();
-    // The shared Shimmer leaf drives the shimmer-text animation.
-    expect(label.style.animation).toContain('shimmer-text');
+    expect(label.className).toContain('shimmer-text');
   });
 
   it('renders a spinner alongside the shimmer label', () => {


### PR DESCRIPTION
Before, every tool call in the factory chat rendered as a raw row carrying its internal id — execute_command, mastra_workspace_view — and a long run of them buried the assistant's actual answer under dozens of near-identical lines. Now each row leads with a per-tool icon and a plain action (Read, Run, Edit, Search…) followed by the argument that matters: the command, the path, the pattern. Tools I don't map fall back to a prettified name rather than snake_case. The running row shimmers its label and keeps a spinner, the chevron stays visible instead of appearing on hover, and expanding a row shows the command and its output indented under a thin rail — no boxed card, no Input/Output labels.

Runs of three or more consecutive calls now collapse into a single group row with a leading chevron, a hairline and a live counter, expanding into a bounded auto-scrolling list. Interactive tools — ask_user, submit_plan, anything suspended — break a run, so their prompt cards keep rendering inline where you can answer them.

This only touches the factory UI, but every row goes through one presentational primitive that takes plain props and imports nothing from the factory services, so the tool/ folder can move to playground-ui when the studio wants the same rendering. I previewed it against live sessions locally; typecheck, the factory unit suite and the chat MSW tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The chat now shows tool actions with clear names, icons, details, and output instead of raw IDs. Related actions can collapse into groups, while interactive and suspended actions remain easy to use.

## Changes

- Added human-readable tool labels, icons, arguments, command details, and fallbacks for unknown tools.
- Added reusable `ToolRow`, `ToolCard`, and `ToolGroup` components.
- Grouped three or more consecutive non-interactive tool calls into expandable, bounded, auto-scrolling groups with live status counters.
- Kept interactive and suspended tools inline and excluded them from groups.
- Added status indicators, shimmer labels, persistent chevrons, indented output, truncation, copy controls, ANSI stripping, and syntax-highlighted file diffs.
- Limited string-replacement diff rendering to 200 lines per side and reported dropped lines.
- Added fallback handling when `JSON.stringify` returns `undefined`.
- Removed legacy tool-card rendering from `Transcript`.
- Removed factory-service imports from the presentational tool components.
- Added presentation and grouping test coverage, including `ask_user`, `submit_plan`, prose, prompt, and suspended tool boundaries.
- Moved `Shimmer` styles into its component stylesheet.
- Added fixed-distance shimmer animation, the required `-webkit-` vendor prefix, and reduced-motion support.
- Removed obsolete global shimmer styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->