### PR TITLE
fix(core): make partial thread updates backward compatible with older storage adapters

### DIFF
--- a/.changeset/frank-pumas-double.md
+++ b/.changeset/frank-pumas-double.md
@@ -11,7 +11,6 @@
 '@mastra/core': patch
 '@mastra/convex': patch
 '@mastra/libsql': patch
-'@mastra/lance': patch
 '@mastra/mssql': patch
 '@mastra/mysql': patch
 '@mastra/redis': patch

--- a/.changeset/frank-pumas-double.md
+++ b/.changeset/frank-pumas-double.md
@@ -1,0 +1,22 @@
+---
+'@mastra/cloudflare-d1': patch
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+'@mastra/memory': patch
+'@mastra/dynamodb': patch
+'@mastra/oracledb': patch
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+'@mastra/upstash': patch
+'@mastra/core': patch
+'@mastra/convex': patch
+'@mastra/libsql': patch
+'@mastra/lance': patch
+'@mastra/mssql': patch
+'@mastra/mysql': patch
+'@mastra/redis': patch
+'@mastra/dsql': patch
+'@mastra/pg': patch
+---
+
+Fixed a crash where updating a thread without a title (for example during observational memory buffering) could write a null title and violate the database's not-null constraint when running a newer @mastra/memory against an older storage package. Memory now checks whether the connected storage adapter supports partial thread updates and backfills the existing title for older adapters, so mixed-version deployments keep working. See #21041 for the original title-clobbering fix this makes backward compatible.

--- a/.changeset/fresh-tigers-go.md
+++ b/.changeset/fresh-tigers-go.md
@@ -1,0 +1,22 @@
+---
+'@mastra/cloudflare-d1': patch
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+'@mastra/memory': patch
+'@mastra/dynamodb': patch
+'@mastra/oracledb': patch
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+'@mastra/upstash': patch
+'@mastra/core': patch
+'@mastra/convex': patch
+'@mastra/libsql': patch
+'@mastra/lance': patch
+'@mastra/mssql': patch
+'@mastra/mysql': patch
+'@mastra/redis': patch
+'@mastra/dsql': patch
+'@mastra/pg': patch
+---
+
+Storage adapters now declare support for partial thread updates, letting newer @mastra/memory preserve existing thread titles instead of overwriting them, while remaining safe against older versions.

--- a/.changeset/fresh-tigers-go.md
+++ b/.changeset/fresh-tigers-go.md
@@ -11,7 +11,6 @@
 '@mastra/core': patch
 '@mastra/convex': patch
 '@mastra/libsql': patch
-'@mastra/lance': patch
 '@mastra/mssql': patch
 '@mastra/mysql': patch
 '@mastra/redis': patch

--- a/packages/core/src/channels/state-adapter.ts
+++ b/packages/core/src/channels/state-adapter.ts
@@ -58,7 +58,7 @@ export class MastraStateAdapter implements StateAdapter {
     // Find the Mastra thread mapped to this external thread ID and mark it
     const thread = await this.findThreadByExternalId(threadId);
     if (!thread) return; // Thread not yet mapped — subscribe will be a no-op
-    await this.memoryStore.updateThread({
+    await this.memoryStore.patchThread({
       id: thread.id,
       metadata: { ...thread.metadata, channel_subscribed: 'true' },
     });
@@ -67,7 +67,7 @@ export class MastraStateAdapter implements StateAdapter {
   async unsubscribe(threadId: string): Promise<void> {
     const thread = await this.findThreadByExternalId(threadId);
     if (!thread) return;
-    await this.memoryStore.updateThread({
+    await this.memoryStore.patchThread({
       id: thread.id,
       metadata: { ...((thread.metadata ?? {}) as Record<string, unknown>), channel_subscribed: 'false' },
     });

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -191,7 +191,7 @@ export class MockMemory extends MastraMemory {
     memoryConfig?: MemoryConfigInternal;
   }): Promise<StorageThreadType> {
     const memoryStorage = await this.getMemoryStore();
-    return memoryStorage.updateThread({ id, title, metadata });
+    return memoryStorage.patchThread({ id, title, metadata });
   }
 
   async deleteThread(threadId: string) {

--- a/packages/core/src/storage/domains/memory/base.ts
+++ b/packages/core/src/storage/domains/memory/base.ts
@@ -43,6 +43,17 @@ export abstract class MemoryStorage extends StorageDomain {
    */
   readonly supportsObservationalMemory?: boolean = false;
 
+  /**
+   * Whether this adapter's `updateThread` treats an omitted `title`/`metadata`
+   * as "leave that column untouched" (partial update).
+   *
+   * Adapters compiled before partial updates existed require both fields and
+   * may write `NULL` into the title column when it is omitted. They won't set
+   * this flag, so `patchThread` backfills the current title for them.
+   * Adapters that implement partial updates must set this to true.
+   */
+  readonly supportsPartialThreadUpdate?: boolean = false;
+
   constructor() {
     super({
       component: 'STORAGE',
@@ -78,6 +89,43 @@ export abstract class MemoryStorage extends StorageDomain {
     title?: string;
     metadata?: Record<string, unknown>;
   }): Promise<StorageThreadType>;
+
+  /**
+   * Partial-update a thread's title and/or metadata, tolerating adapters that
+   * predate partial `updateThread` support.
+   *
+   * Adapters that declare `supportsPartialThreadUpdate` receive the arguments
+   * as-is (omitted fields are left untouched). For legacy adapters — whose
+   * `updateThread` writes both columns unconditionally and would blank or
+   * `NULL` an omitted title — the current values are read and backfilled
+   * first. That restores the legacy adapter's previous behavior (including
+   * its title-clobbering race) instead of crashing on a NOT NULL constraint.
+   *
+   * Callers that only change metadata should use this instead of calling
+   * `updateThread` directly.
+   */
+  async patchThread({
+    id,
+    title,
+    metadata,
+  }: {
+    id: string;
+    title?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<StorageThreadType> {
+    if (!this.supportsPartialThreadUpdate && (title === undefined || metadata === undefined)) {
+      const existing = await this.getThreadById({ threadId: id });
+      if (existing) {
+        title = title ?? existing.title ?? '';
+        metadata = metadata ?? existing.metadata ?? {};
+      }
+    }
+    return this.updateThread({
+      id,
+      ...(title !== undefined ? { title } : {}),
+      ...(metadata !== undefined ? { metadata } : {}),
+    });
+  }
 
   abstract deleteThread({ threadId }: { threadId: string }): Promise<void>;
 

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -38,6 +38,7 @@ import type { InMemoryDB } from '../inmemory-db';
 import { MemoryStorage } from './base';
 
 export class InMemoryMemory extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate: boolean = true;
   readonly supportsObservationalMemory = true;
   private db: InMemoryDB;
 

--- a/packages/core/src/storage/domains/memory/patch-thread.test.ts
+++ b/packages/core/src/storage/domains/memory/patch-thread.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import type { StorageThreadType } from '../../../memory/types';
+import { InMemoryDB } from '../inmemory-db';
+import { InMemoryMemory } from './inmemory';
+
+function createThread(overrides: Partial<StorageThreadType> = {}): StorageThreadType {
+  return {
+    id: 'thread-1',
+    resourceId: 'resource-1',
+    title: 'Generated title',
+    metadata: { a: 1 },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+/**
+ * Models a storage adapter compiled before `updateThread` supported partial
+ * updates: it does not declare `supportsPartialThreadUpdate` and its
+ * `updateThread` writes both columns unconditionally — an omitted title would
+ * be persisted as NULL (a NOT NULL violation on SQL adapters).
+ */
+class LegacyMemoryStorage extends InMemoryMemory {
+  updateThreadCalls: Array<{ id: string; title?: string; metadata?: Record<string, unknown> }> = [];
+
+  // Models an adapter that never declared support for partial updates.
+  override readonly supportsPartialThreadUpdate: boolean = false;
+
+  override async updateThread(args: {
+    id: string;
+    title?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<StorageThreadType> {
+    this.updateThreadCalls.push(args);
+    if (args.title === undefined) {
+      throw new Error('null value in column "title" of relation "mastra_threads" violates not-null constraint');
+    }
+    return super.updateThread(args);
+  }
+}
+
+class ModernMemoryStorage extends InMemoryMemory {
+  updateThreadCalls: Array<{ id: string; title?: string; metadata?: Record<string, unknown> }> = [];
+
+  override async updateThread(args: {
+    id: string;
+    title?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<StorageThreadType> {
+    this.updateThreadCalls.push(args);
+    return super.updateThread(args);
+  }
+}
+
+describe('MemoryStorage.patchThread legacy-adapter compatibility', () => {
+  it('backfills the current title for adapters without supportsPartialThreadUpdate', async () => {
+    const storage = new LegacyMemoryStorage({ db: new InMemoryDB() });
+    await storage.saveThread({ thread: createThread() });
+
+    const updated = await storage.patchThread({ id: 'thread-1', metadata: { b: 2 } });
+
+    expect(storage.updateThreadCalls).toHaveLength(1);
+    expect(storage.updateThreadCalls[0]!.title).toBe('Generated title');
+    expect(updated.title).toBe('Generated title');
+    expect(updated.metadata).toMatchObject({ b: 2 });
+  });
+
+  it('backfills an empty title when the legacy adapter thread has no title', async () => {
+    const storage = new LegacyMemoryStorage({ db: new InMemoryDB() });
+    await storage.saveThread({ thread: createThread({ title: undefined as unknown as string }) });
+
+    await storage.patchThread({ id: 'thread-1', metadata: { b: 2 } });
+
+    expect(storage.updateThreadCalls[0]!.title).toBe('');
+  });
+
+  it('omits the title for adapters that declare supportsPartialThreadUpdate', async () => {
+    const storage = new ModernMemoryStorage({ db: new InMemoryDB() });
+    await storage.saveThread({ thread: createThread() });
+
+    const updated = await storage.patchThread({ id: 'thread-1', metadata: { b: 2 } });
+
+    expect(storage.updateThreadCalls).toHaveLength(1);
+    expect('title' in storage.updateThreadCalls[0]!).toBe(false);
+    expect(updated.title).toBe('Generated title');
+  });
+
+  it('passes an explicit title through unchanged without extra reads', async () => {
+    const storage = new LegacyMemoryStorage({ db: new InMemoryDB() });
+    await storage.saveThread({ thread: createThread() });
+
+    const updated = await storage.patchThread({ id: 'thread-1', title: 'New title', metadata: { b: 2 } });
+
+    expect(storage.updateThreadCalls[0]!.title).toBe('New title');
+    expect(updated.title).toBe('New title');
+  });
+});

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -725,7 +725,7 @@ export class Memory extends MastraMemory {
     memoryConfig?: MemoryConfigInternal;
   }): Promise<StorageThreadType> {
     const memoryStore = await this.getMemoryStore();
-    const updatedThread = await memoryStore.updateThread({
+    const updatedThread = await memoryStore.patchThread({
       id,
       title,
       metadata,
@@ -871,7 +871,7 @@ export class Memory extends MastraMemory {
             throw new Error(`Thread ${threadId} not found`);
           }
 
-          await memoryStore.updateThread({
+          await memoryStore.patchThread({
             id: threadId,
             metadata: {
               ...thread.metadata,
@@ -1022,7 +1022,7 @@ ${workingMemory}`;
           throw new Error(`Thread ${threadId} not found`);
         }
 
-        await memoryStore.updateThread({
+        await memoryStore.patchThread({
           id: threadId,
           metadata: {
             ...thread.metadata,

--- a/packages/memory/src/processors/observational-memory/observation-strategies/async-buffer.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/async-buffer.ts
@@ -178,7 +178,7 @@ export class AsyncBufferObservationStrategy extends ObservationStrategy {
             ...(metadataUpdate.extracted ?? {}),
           },
         });
-        await this.storage.updateThread({
+        await this.storage.patchThread({
           id: threadId,
           ...(shouldUpdateThreadTitle ? { title: newTitle } : {}),
           metadata: newMetadata,

--- a/packages/memory/src/processors/observational-memory/observation-strategies/resource-scoped.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/resource-scoped.ts
@@ -418,7 +418,7 @@ export class ResourceScopedObservationStrategy extends ObservationStrategy {
             },
             lastObservedMessageCursor: update.lastObservedMessageCursor,
           });
-          await this.storage.updateThread({
+          await this.storage.patchThread({
             id: update.threadId,
             ...(shouldUpdateThreadTitle ? { title: newTitle } : {}),
             metadata: newMetadata,

--- a/packages/memory/src/processors/observational-memory/observation-strategies/sync.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/sync.ts
@@ -212,7 +212,7 @@ export class SyncObservationStrategy extends ObservationStrategy {
         },
         lastObservedMessageCursor: getLastObservedMessageCursor(messages),
       });
-      await this.storage.updateThread({
+      await this.storage.patchThread({
         id: threadId,
         ...(shouldUpdateThreadTitle ? { title: newTitle } : {}),
         metadata: newMetadata,

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -3445,7 +3445,7 @@ ${formattedMessages}
         const oldTitle = thread.title?.trim();
         const newTitle = chunkThreadTitle?.trim();
         const shouldUpdateThreadTitle = !!newTitle && newTitle.length >= 3 && newTitle !== oldTitle;
-        await this.storage.updateThread({
+        await this.storage.patchThread({
           id: threadId,
           ...(shouldUpdateThreadTitle ? { title: newTitle } : {}),
           metadata: newMetadata,
@@ -3722,7 +3722,7 @@ ${formattedMessages}
           threadTitle: metadataUpdate.threadTitle ?? previousOmMetadata?.threadTitle,
           extracted: { ...(previousOmMetadata?.extracted ?? {}), ...(metadataUpdate.extracted ?? {}) },
         });
-        await this.storage.updateThread({
+        await this.storage.patchThread({
           id: threadId,
           metadata: newMetadata,
         });

--- a/packages/memory/src/processors/observational-memory/reflector-runner.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-runner.ts
@@ -98,7 +98,7 @@ async function persistThreadExtractedValues(
     threadTitle: metadataUpdate.threadTitle ?? previousOmMetadata?.threadTitle,
     extracted: { ...(previousOmMetadata?.extracted ?? {}), ...(metadataUpdate.extracted ?? {}) },
   });
-  await storage.updateThread({
+  await storage.patchThread({
     id: threadId,
     metadata: newMetadata,
   });

--- a/stores/clickhouse/src/storage/domains/memory/index.ts
+++ b/stores/clickhouse/src/storage/domains/memory/index.ts
@@ -83,6 +83,7 @@ function appendClickhouseMessageMetadataFilter(
 }
 
 export class MemoryStorageClickhouse extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   protected client: ClickHouseClient;
   #db: ClickhouseDB;
   constructor(config: ClickhouseDomainConfig) {

--- a/stores/cloudflare-d1/src/storage/domains/memory/index.ts
+++ b/stores/cloudflare-d1/src/storage/domains/memory/index.ts
@@ -79,6 +79,7 @@ function addSqliteMetadataValuePredicate(
 }
 
 export class MemoryStorageD1 extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   #db: D1DB;
 
   constructor(config: D1DomainConfig) {

--- a/stores/cloudflare/src/do/storage/domains/memory/index.ts
+++ b/stores/cloudflare/src/do/storage/domains/memory/index.ts
@@ -80,6 +80,7 @@ function addSqliteMetadataValuePredicate(
 }
 
 export class MemoryStorageDO extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   #db: DODB;
 
   constructor(config: DODomainConfig) {

--- a/stores/cloudflare/src/kv/storage/domains/memory/index.ts
+++ b/stores/cloudflare/src/kv/storage/domains/memory/index.ts
@@ -27,6 +27,7 @@ import { CloudflareKVDB, resolveCloudflareConfig } from '../../db';
 import type { CloudflareDomainConfig } from '../../types';
 
 export class MemoryStorageCloudflare extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   #db: CloudflareKVDB;
 
   constructor(config: CloudflareDomainConfig) {

--- a/stores/convex/src/storage/domains/memory/index.ts
+++ b/stores/convex/src/storage/domains/memory/index.ts
@@ -195,6 +195,7 @@ function parseStoredOMRecord(doc: StoredOMRecord): ObservationalMemoryRecord {
 }
 
 export class MemoryConvex extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   readonly supportsObservationalMemory = true;
 
   #db: ConvexDB;

--- a/stores/dsql/src/storage/domains/memory/index.ts
+++ b/stores/dsql/src/storage/domains/memory/index.ts
@@ -49,6 +49,7 @@ function inPlaceholders(count: number, startIndex = 1): string {
   return Array.from({ length: count }, (_, i) => `$${i + startIndex}`).join(', ');
 }
 export class MemoryDSQL extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   #db: DsqlDB;
   #schema: string;
   #skipDefaultIndexes?: boolean;

--- a/stores/dynamodb/src/storage/domains/memory/index.ts
+++ b/stores/dynamodb/src/storage/domains/memory/index.ts
@@ -29,6 +29,7 @@ import { getTtlProps } from '../../ttl';
 import { deleteTableData } from '../utils';
 
 export class MemoryStorageDynamoDB extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   private service: Service<Record<string, any>>;
   private ttlConfig?: DynamoDBTtlConfig;
 

--- a/stores/lance/src/storage/domains/memory/index.ts
+++ b/stores/lance/src/storage/domains/memory/index.ts
@@ -27,6 +27,7 @@ import type { LanceDomainConfig } from '../../db';
 import { getTableSchema, processResultWithTypeConversion } from '../../db/utils';
 
 export class StoreMemoryLance extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   private client: Connection;
   #db: LanceDB;
 

--- a/stores/lance/src/storage/domains/memory/index.ts
+++ b/stores/lance/src/storage/domains/memory/index.ts
@@ -27,7 +27,9 @@ import type { LanceDomainConfig } from '../../db';
 import { getTableSchema, processResultWithTypeConversion } from '../../db/utils';
 
 export class StoreMemoryLance extends MemoryStorage {
-  override readonly supportsPartialThreadUpdate = true;
+  // Note: not declaring supportsPartialThreadUpdate — Lance's updateThread uses a
+  // read-modify-write mergeInsert that rewrites the full row, so an omitted title
+  // is not atomically preserved. patchThread's legacy backfill path matches that.
   private client: Connection;
   #db: LanceDB;
 

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -109,6 +109,7 @@ function addSqliteMetadataValuePredicate(
 }
 
 export class MemoryLibSQL extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   readonly supportsObservationalMemory = true;
 
   /**

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -57,6 +57,7 @@ import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';
 import { formatDateForMongoDB } from '../utils';
 
 export class MemoryStorageMongoDB extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   readonly supportsObservationalMemory = true;
 
   #connector: MongoDBConnector;

--- a/stores/mssql/src/storage/domains/memory/index.ts
+++ b/stores/mssql/src/storage/domains/memory/index.ts
@@ -64,6 +64,7 @@ function buildMssqlMessageMetadataFilter(metadataFilter: StorageMetadataFilter |
 }
 
 export class MemoryMSSQL extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   private pool: sql.ConnectionPool;
   private schema?: string;
   private db: MssqlDB;

--- a/stores/mysql/src/storage/domains/memory/index.ts
+++ b/stores/mysql/src/storage/domains/memory/index.ts
@@ -170,6 +170,7 @@ function addMySQLMessageMetadataFilter(
 }
 
 export class MemoryMySQL extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   readonly supportsObservationalMemory = true;
 
   private pool: Pool;

--- a/stores/oracledb/src/storage/domains/memory/index.ts
+++ b/stores/oracledb/src/storage/domains/memory/index.ts
@@ -83,6 +83,7 @@ const DEFAULT_MESSAGE_SAVE_BATCH_SIZE = 200;
 const DEFAULT_VECTOR_REGISTRY_TABLE = 'MASTRA_VECTOR_INDEXES';
 
 export class MemoryOracle extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   readonly supportsObservationalMemory = true;
   // Memory owns all tables needed for normal message history plus observational memory state.
   static readonly MANAGED_TABLES = [

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -164,6 +164,7 @@ function dedupeMessagesForSave(messages: MastraDBMessage[]): MastraDBMessage[] {
 }
 
 export class MemoryPG extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   readonly supportsObservationalMemory = true;
 
   /**

--- a/stores/redis/src/storage/domains/memory/index.ts
+++ b/stores/redis/src/storage/domains/memory/index.ts
@@ -35,6 +35,7 @@ import type { RedisClient } from '../../types';
 import { getKey, processRecord } from '../utils';
 
 export class StoreMemoryRedis extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   private client: RedisClient;
   private db: RedisDB;
 

--- a/stores/spanner/src/storage/domains/memory/index.ts
+++ b/stores/spanner/src/storage/domains/memory/index.ts
@@ -73,6 +73,7 @@ function buildSpannerMessageMetadataFilter(metadataFilter: StorageMetadataFilter
  * (the durable state surface used by `@mastra/memory`).
  */
 export class MemorySpanner extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   private database: Database;
   private db: SpannerDB;
   private readonly skipDefaultIndexes?: boolean;

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -47,6 +47,7 @@ function getMessageIndexKey(messageId: string): string {
 }
 
 export class StoreMemoryUpstash extends MemoryStorage {
+  override readonly supportsPartialThreadUpdate = true;
   private client: Redis;
   #db: UpstashDB;
   constructor(config: UpstashDomainConfig) {


### PR DESCRIPTION
## Summary

Mixed-version deployments running a newer `@mastra/memory` against an older storage package (e.g. `@mastra/pg` 1.20.0-alpha.0) crash with:

```
Observational memory observation buffering failed: null value in column "title" of relation "mastra_threads" violates not-null constraint
```

#21041 made `title` optional in `updateThread` so metadata-only updates stop clobbering concurrently generated thread titles. That relies on the storage adapter preserving the existing title when omitted (`COALESCE($1, title)`), which older published store versions don't do — they write NULL and violate the NOT NULL constraint.

## Fix

- Add a `supportsPartialThreadUpdate` capability flag to the `MemoryStorage` base class (defaults to `false`, so legacy adapters compiled against older base classes are treated as legacy).
- Add a concrete `patchThread()` helper on the base class: for legacy adapters it reads the thread and backfills the existing title (empty string if missing) before calling `updateThread`; for adapters that declare support it omits the title, keeping the no-clobber race fix from #21041.
- All 17 in-tree stores (+ in-memory) declare `supportsPartialThreadUpdate = true`.
- All title-omitting callers (observational-memory strategies, reflector runner, channel state adapter, `Memory.updateThread`, finalize-run, mock memory) route through `patchThread()`.

Result: new memory + old store = old (working) behavior; new + new = race fix preserved.

## Test plan

- New `patch-thread.test.ts`: legacy adapter gets title backfilled (its `updateThread` throws the exact NOT NULL error if it ever sees an omitted title), NULL-title threads backfill `''`, modern adapters get a genuinely partial update, explicit titles pass through untouched.
- Core typecheck + memory package typecheck clean; all 16 store packages typecheck clean.
- Core processor/channel suites (371 tests) and observational-memory suite (471 tests) pass through the updated callers.
- Changesets added for `@mastra/core`/`@mastra/memory` and all store packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

New memory code can work safely with both newer and older storage adapters. It preserves thread titles during metadata-only updates and prevents missing titles from causing database errors.

## Changes

- Added `MemoryStorage.supportsPartialThreadUpdate`, which defaults to `false`.
- Added `MemoryStorage.patchThread()` for partial thread updates.
- Preserved existing titles for legacy adapters.
- Passed an empty title to legacy adapters when no title exists.
- Preserved omitted fields for adapters that support partial updates.
- Updated memory, channel, mock, and observational-memory callers to use `patchThread()`.
- Enabled partial-update support for compatible in-tree storage adapters.
- Kept Lance on the legacy compatibility path because its read-modify-write implementation cannot safely preserve omitted titles.
- Added compatibility tests for legacy and modern adapters.
- Added changesets for the affected core, memory, and storage packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->