### PR TITLE
fix(nestjs): pass Web Request to auth providers

### DIFF
--- a/.changeset/big-windows-speak.md
+++ b/.changeset/big-windows-speak.md
@@ -1,0 +1,7 @@
+---
+'@mastra/nestjs': patch
+---
+
+Fixed NestJS auth passing a Web Request to authenticateToken and authorize hooks so cookie-based providers (such as Better Auth) no longer fail with 401 on valid credentials.
+
+Resolves https://github.com/mastra-ai/mastra/issues/21253

--- a/server-adapters/nestjs/src/__tests__/auth-rate-limit.test.ts
+++ b/server-adapters/nestjs/src/__tests__/auth-rate-limit.test.ts
@@ -120,6 +120,104 @@ describe('NestJS Adapter - Auth and Rate Limiting', () => {
     expect(response.status).toBe(200);
   });
 
+  it('passes a Web Request with readable headers to authorizeUser', async () => {
+    let receivedRequest: unknown;
+
+    vi.spyOn(context.mastra, 'getServer').mockReturnValue({
+      auth: {
+        protected: ['/*'],
+        public: [],
+        authenticateToken: async (token: string) => {
+          if (token === 'valid') {
+            return { id: 'user-1' };
+          }
+          return null;
+        },
+        authorizeUser: async (_user: unknown, request: unknown) => {
+          receivedRequest = request;
+          if (!(request instanceof Request)) {
+            return false;
+          }
+          return request.headers.get('cookie')?.includes('session=abc') === true;
+        },
+      },
+    } as any);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        MastraModule.register({
+          mastra: context.mastra,
+        }),
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    expressApp = app.getHttpAdapter().getInstance() as Application;
+    await app.init();
+
+    const response = await executeExpressRequest(expressApp, {
+      method: 'GET',
+      path: '/api/agents',
+      headers: {
+        authorization: 'Bearer valid',
+        cookie: 'session=abc',
+      },
+    });
+
+    expect(receivedRequest).toBeInstanceOf(Request);
+    expect((receivedRequest as Request).headers.get('cookie')).toBe('session=abc');
+    expect(response.status).toBe(200);
+  });
+
+  it('passes a Web Request with readable headers to authorize context.req', async () => {
+    let receivedRequest: unknown;
+
+    vi.spyOn(context.mastra, 'getServer').mockReturnValue({
+      auth: {
+        protected: ['/*'],
+        public: [],
+        authenticateToken: async (token: string) => {
+          if (token === 'valid') {
+            return { id: 'user-1' };
+          }
+          return null;
+        },
+        authorize: async (_path: string, _method: string, _user: unknown, authContext: { req?: unknown }) => {
+          receivedRequest = authContext.req;
+          if (!(authContext.req instanceof Request)) {
+            return false;
+          }
+          return authContext.req.headers.get('cookie')?.includes('session=abc') === true;
+        },
+      },
+    } as any);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        MastraModule.register({
+          mastra: context.mastra,
+        }),
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    expressApp = app.getHttpAdapter().getInstance() as Application;
+    await app.init();
+
+    const response = await executeExpressRequest(expressApp, {
+      method: 'GET',
+      path: '/api/agents',
+      headers: {
+        authorization: 'Bearer valid',
+        cookie: 'session=abc',
+      },
+    });
+
+    expect(receivedRequest).toBeInstanceOf(Request);
+    expect((receivedRequest as Request).headers.get('cookie')).toBe('session=abc');
+    expect(response.status).toBe(200);
+  });
+
   it('should only allow query apiKey auth when explicitly enabled', async () => {
     vi.spyOn(context.mastra, 'getServer').mockReturnValue({
       auth: {

--- a/server-adapters/nestjs/src/__tests__/auth-rate-limit.test.ts
+++ b/server-adapters/nestjs/src/__tests__/auth-rate-limit.test.ts
@@ -71,6 +71,55 @@ describe('NestJS Adapter - Auth and Rate Limiting', () => {
     expect(validToken.status).toBe(200);
   });
 
+  it('passes a Web Request with readable headers to authenticateToken', async () => {
+    let receivedRequest: unknown;
+
+    vi.spyOn(context.mastra, 'getServer').mockReturnValue({
+      auth: {
+        protected: ['/*'],
+        public: [],
+        authenticateToken: async (token: string, request: unknown) => {
+          receivedRequest = request;
+          if (!(request instanceof Request)) {
+            return null;
+          }
+          // Cookie-based providers (e.g. better-auth) call headers.get — this
+          // must not throw on the Nest/Express request shape.
+          const cookie = request.headers.get('cookie');
+          if (token === 'valid' && cookie?.includes('session=abc')) {
+            return { id: 'user-1', isAdmin: true };
+          }
+          return null;
+        },
+      },
+    } as any);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        MastraModule.register({
+          mastra: context.mastra,
+        }),
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    expressApp = app.getHttpAdapter().getInstance() as Application;
+    await app.init();
+
+    const response = await executeExpressRequest(expressApp, {
+      method: 'GET',
+      path: '/api/agents',
+      headers: {
+        authorization: 'Bearer valid',
+        cookie: 'session=abc',
+      },
+    });
+
+    expect(receivedRequest).toBeInstanceOf(Request);
+    expect((receivedRequest as Request).headers.get('cookie')).toBe('session=abc');
+    expect(response.status).toBe(200);
+  });
+
   it('should only allow query apiKey auth when explicitly enabled', async () => {
     vi.spyOn(context.mastra, 'getServer').mockReturnValue({
       auth: {

--- a/server-adapters/nestjs/src/controllers/mastra.controller.ts
+++ b/server-adapters/nestjs/src/controllers/mastra.controller.ts
@@ -13,32 +13,6 @@ import {
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 
-/**
- * Convert Express request to Web API Request for accessing headers, cookies, etc.
- */
-function toWebRequest(req: Request): globalThis.Request {
-  const protocol = req.protocol || 'http';
-  const host = req.get('host') || 'localhost';
-  const url = `${protocol}://${host}${req.originalUrl || req.url}`;
-
-  const headers = new Headers();
-  for (const [key, value] of Object.entries(req.headers)) {
-    if (value) {
-      if (Array.isArray(value)) {
-        value.forEach(v => headers.append(key, v));
-      } else {
-        headers.set(key, value);
-      }
-    }
-  }
-
-  return new globalThis.Request(url, {
-    method: req.method,
-    headers,
-    // Note: body is not needed as it's already parsed
-  });
-}
-
 import { MASTRA_OPTIONS } from '../constants';
 import { MastraExceptionFilter } from '../filters/mastra-exception.filter';
 import { MastraRouteGuard } from '../guards/mastra-route.guard';
@@ -50,6 +24,7 @@ import { RequestContextService } from '../services/request-context.service';
 import { RouteHandlerService } from '../services/route-handler.service';
 import { parseMultipartFormData } from '../utils/parse-multipart';
 import { getMastraRoutePath } from '../utils/route-path';
+import { toWebRequest } from '../utils/to-web-request';
 
 /**
  * Main Mastra controller that handles all routes dynamically.

--- a/server-adapters/nestjs/src/services/auth.service.ts
+++ b/server-adapters/nestjs/src/services/auth.service.ts
@@ -12,6 +12,7 @@ import type { Request } from 'express';
 
 import { MASTRA, MASTRA_OPTIONS } from '../constants';
 import type { MastraModuleOptions } from '../mastra.module';
+import { toWebRequest } from '../utils/to-web-request';
 
 type AuthConfigBridge = {
   authenticateToken?: (token: string, request: unknown) => Promise<unknown> | unknown;
@@ -90,9 +91,9 @@ export class AuthService {
       let user: unknown;
 
       if (typeof authConfig?.authenticateToken === 'function') {
-        // Mastra auth hooks are adapter-agnostic at runtime; Nest passes the
-        // underlying Express request object for parity with the Express adapter.
-        user = await authConfig.authenticateToken(token, request);
+        // Match other adapters: pass a Web Request so providers can read
+        // headers/cookies via the fetch Headers API (not Express IncomingMessage).
+        user = await authConfig.authenticateToken(token, toWebRequest(request));
       } else {
         throw new Error('No token verification method configured');
       }
@@ -131,7 +132,7 @@ export class AuthService {
   ): Promise<void> {
     // Client-provided authorizeUser function
     if (typeof authConfig.authorizeUser === 'function') {
-      const isAuthorized = await authConfig.authorizeUser(user, request);
+      const isAuthorized = await authConfig.authorizeUser(user, toWebRequest(request));
       if (!isAuthorized) {
         throw new ForbiddenException('Access denied');
       }
@@ -147,7 +148,7 @@ export class AuthService {
           if (key === 'customRouteAuthConfig') return this.options.customRouteAuthConfig;
           return undefined;
         },
-        req: request,
+        req: toWebRequest(request),
       };
 
       const isAuthorized = await authConfig.authorize(path, method, user, context);

--- a/server-adapters/nestjs/src/utils/to-web-request.ts
+++ b/server-adapters/nestjs/src/utils/to-web-request.ts
@@ -1,0 +1,28 @@
+import type { Request } from 'express';
+
+/**
+ * Convert an Express request to a Web API Request.
+ * Auth providers and route handlers expect this canonical header/cookie shape.
+ */
+export function toWebRequest(req: Request): globalThis.Request {
+  const protocol = req.protocol || 'http';
+  const host = req.get('host') || 'localhost';
+  const url = `${protocol}://${host}${req.originalUrl || req.url}`;
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value) {
+      if (Array.isArray(value)) {
+        value.forEach(v => headers.append(key, v));
+      } else {
+        headers.set(key, value);
+      }
+    }
+  }
+
+  return new globalThis.Request(url, {
+    method: req.method,
+    headers,
+    // Note: body is not needed as it's already parsed
+  });
+}


### PR DESCRIPTION
Before, NestJS auth passed the raw Express request into `authenticateToken` / `authorizeUser`. Cookie-based providers (e.g. Better Auth) call `headers.get()`, which throws on Express's plain header object, gets swallowed, and surfaces as a misleading 401.

After, Nest matches the Express adapter and passes a Web `Request` from `toWebRequest`.

```ts
// before
user = await authConfig.authenticateToken(token, request);

// after
user = await authConfig.authenticateToken(token, toWebRequest(request));
```

Closes #21253


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The NestJS adapter now gives authentication code the type of request it expects. Valid cookie-based sessions can now authenticate instead of returning `401 Invalid or expired token`.

## Changes

- Added the shared `toWebRequest` utility for NestJS.
- Converted Express requests before calling `authenticateToken` and `authorizeUser`.
- Reused the utility in `MastraController`.
- Preserved request methods and headers, including array-valued headers.
- Added tests for Web `Request` objects, readable cookie headers, and successful authentication and authorization.
- Added a patch changeset for `@mastra/nestjs`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->