### PR TITLE
fix(auth): harden getRequestHeader for Express requests

### DIFF
--- a/.changeset/empty-ducks-fold.md
+++ b/.changeset/empty-ducks-fold.md
@@ -1,0 +1,12 @@
+---
+'@mastra/auth-better-auth': patch
+'@mastra/auth-google': patch
+'@mastra/auth-studio': patch
+'@mastra/auth-cloud': patch
+'@mastra/auth-neon': patch
+'@mastra/auth-okta': patch
+---
+
+Fixed reading request headers from Express-style plain header objects so cookie-based auth providers no longer throw and fail with a misleading 401.
+
+Related to https://github.com/mastra-ai/mastra/issues/21253

--- a/auth/better-auth/src/index.ts
+++ b/auth/better-auth/src/index.ts
@@ -6,7 +6,9 @@ import type {
   IOrganizationsProvider,
   IUserProvider,
   CredentialsResult,
+  MastraAuthRequest,
 } from '@internal/auth';
+import { getRequestHeader } from '@internal/auth';
 import type { EEUser } from '@internal/auth/ee';
 import type { MastraAuthProviderOptions } from '@internal/auth/provider';
 import { MastraAuthProvider } from '@internal/auth/provider';
@@ -18,14 +20,6 @@ import { makeSignature } from 'better-auth/crypto';
 import { getMigrations } from 'better-auth/db/migration';
 import { organization } from 'better-auth/plugins';
 
-type HonoRequestLike = {
-  raw?: Request;
-  headers?: Headers;
-  header(name: string): string | undefined;
-};
-
-type MastraAuthRequest = Request | HonoRequestLike;
-
 type BetterAuthContext = Awaited<Auth['$context']>;
 
 function tryDecode(value: string): string {
@@ -34,14 +28,6 @@ function tryDecode(value: string): string {
   } catch {
     return value;
   }
-}
-
-function getRequestHeader(request: MastraAuthRequest, name: string): string | null {
-  if (request instanceof Request) {
-    return request.headers.get(name);
-  }
-
-  return request.raw?.headers.get(name) ?? request.headers?.get(name) ?? request.header(name) ?? null;
 }
 
 /**

--- a/auth/cloud/src/auth-provider.ts
+++ b/auth/cloud/src/auth-provider.ts
@@ -11,10 +11,12 @@ import type {
   IUserProvider,
   ISSOProvider,
   ISessionProvider,
+  MastraAuthRequest,
   Session,
   SSOCallbackResult,
   SSOLoginConfig,
 } from '@internal/auth';
+import { getRequestHeader } from '@internal/auth';
 import type { EEUser } from '@internal/auth/ee';
 import type { MastraAuthProviderOptions } from '@internal/auth/provider';
 import { MastraAuthProvider } from '@internal/auth/provider';
@@ -22,22 +24,6 @@ import { MastraAuthProvider } from '@internal/auth/provider';
 import { MastraCloudAuth } from './client';
 import { parseSessionCookie } from './session/cookie';
 import type { CloudUser } from './types';
-
-type HonoRequestLike = {
-  raw?: Request;
-  headers?: Headers;
-  header(name: string): string | undefined;
-};
-
-type MastraAuthRequest = Request | HonoRequestLike;
-
-function getRequestHeader(request: MastraAuthRequest, name: string): string | null {
-  if (request instanceof Request) {
-    return request.headers.get(name);
-  }
-
-  return request.raw?.headers.get(name) ?? request.headers?.get(name) ?? request.header(name) ?? null;
-}
 
 /**
  * Configuration options for MastraCloudAuthProvider.

--- a/auth/google/src/auth-provider.ts
+++ b/auth/google/src/auth-provider.ts
@@ -9,24 +9,18 @@ import type {
   ISSOProvider,
   ISessionProvider,
   IUserProvider,
+  MastraAuthRequest,
   Session,
   SSOCallbackResult,
   SSOLoginConfig,
 } from '@internal/auth';
+import { getRequestHeader } from '@internal/auth';
 import { MastraAuthProvider } from '@internal/auth/provider';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import type { JWTPayload } from 'jose';
 
 import type { GoogleUser, MastraAuthGoogleOptions } from './types';
 import { mapGoogleClaimsToUser } from './types';
-
-type HonoRequestLike = {
-  raw?: Request;
-  headers?: Headers;
-  header(name: string): string | undefined;
-};
-
-type MastraAuthRequest = Request | HonoRequestLike;
 
 const GOOGLE_AUTHORIZATION_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
@@ -49,14 +43,6 @@ interface StatePayload {
   e: number;
   /** OIDC nonce tied to the ID token. */
   n: string;
-}
-
-function getRequestHeader(request: MastraAuthRequest, name: string): string | null {
-  if (request instanceof Request) {
-    return request.headers.get(name);
-  }
-
-  return request.raw?.headers.get(name) ?? request.headers?.get(name) ?? request.header(name) ?? null;
 }
 
 function normalizeDomain(domain: string | undefined | null): string | undefined {

--- a/auth/neon/src/index.ts
+++ b/auth/neon/src/index.ts
@@ -2,9 +2,11 @@ import type {
   IUserProvider,
   ICredentialsProvider,
   ISessionProvider,
+  MastraAuthRequest,
   Session,
   CredentialsResult,
 } from '@mastra/core/auth';
+import { getRequestHeader } from '@mastra/core/auth';
 import type { EEUser } from '@mastra/core/auth/ee';
 import type { MastraAuthProviderOptions } from '@mastra/core/server';
 import { MastraAuthProvider } from '@mastra/core/server';
@@ -14,21 +16,6 @@ import type { JWTPayload } from 'jose';
 
 export { MastraRBACNeon } from './rbac-provider';
 export type { MastraRBACNeonOptions, NeonRoleMappingOptions } from './rbac-provider';
-
-type HonoRequestLike = {
-  raw?: Request;
-  headers?: Headers;
-  header(name: string): string | undefined;
-};
-
-type MastraAuthRequest = Request | HonoRequestLike;
-
-function getRequestHeader(request: MastraAuthRequest, name: string): string | null {
-  if (request instanceof Request) {
-    return request.headers.get(name);
-  }
-  return request.raw?.headers.get(name) ?? request.headers?.get(name) ?? request.header(name) ?? null;
-}
 
 function stripTrailingSlashes(url: string): string {
   let end = url.length;

--- a/auth/okta/src/auth-provider.ts
+++ b/auth/okta/src/auth-provider.ts
@@ -8,21 +8,18 @@ import type {
   ISSOProvider,
   ISessionProvider,
   IUserProvider,
+  MastraAuthRequest,
   Session,
   SSOCallbackResult,
   SSOLoginConfig,
 } from '@internal/auth';
+import { getRequestHeader } from '@internal/auth';
 import type { MastraAuthProviderOptions } from '@internal/auth/provider';
 import { MastraAuthProvider } from '@internal/auth/provider';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 
-type HonoRequestLike = {
-  raw?: Request;
-  headers?: Headers;
-  header(name: string): string | undefined;
-};
-
-type MastraAuthRequest = Request | HonoRequestLike;
+import type { OktaUser, MastraAuthOktaOptions } from './types.js';
+import { mapOktaClaimsToUser } from './types.js';
 
 /**
  * Trim trailing slashes. Index scan instead of regex to avoid backtracking
@@ -33,17 +30,6 @@ function trimTrailingSlashes(value: string): string {
   while (end > 0 && value[end - 1] === '/') end--;
   return value.slice(0, end);
 }
-
-function getRequestHeader(request: MastraAuthRequest, name: string): string | null {
-  if (request instanceof Request) {
-    return request.headers.get(name);
-  }
-
-  return request.raw?.headers.get(name) ?? request.headers?.get(name) ?? request.header(name) ?? null;
-}
-
-import type { OktaUser, MastraAuthOktaOptions } from './types.js';
-import { mapOktaClaimsToUser } from './types.js';
 
 /** Default cookie name for Okta sessions */
 const DEFAULT_COOKIE_NAME = 'okta_session';

--- a/auth/studio/src/index.ts
+++ b/auth/studio/src/index.ts
@@ -5,30 +5,16 @@ import type {
   ISSOProvider,
   ISessionProvider,
   IUserProvider,
+  MastraAuthRequest,
   Session,
   SSOCallbackResult,
   SSOLoginConfig,
 } from '@internal/auth';
+import { getRequestHeader } from '@internal/auth';
 import type { EEUser, IRBACProvider, RoleMapping } from '@internal/auth/ee';
 import { resolvePermissionsFromMapping, matchesPermission } from '@internal/auth/ee';
 import { MastraAuthProvider } from '@internal/auth/provider';
 import type { MastraAuthProviderOptions } from '@internal/auth/provider';
-
-type HonoRequestLike = {
-  raw?: Request;
-  headers?: Headers;
-  header(name: string): string | undefined;
-};
-
-type MastraAuthRequest = Request | HonoRequestLike;
-
-function getRequestHeader(request: MastraAuthRequest, name: string): string | null {
-  if (request instanceof Request) {
-    return request.headers.get(name);
-  }
-
-  return request.raw?.headers.get(name) ?? request.headers?.get(name) ?? request.header(name) ?? null;
-}
 
 export interface StudioUser extends EEUser {
   id: string;

--- a/packages/_internals/auth/src/types/get-request-header.test.ts
+++ b/packages/_internals/auth/src/types/get-request-header.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { getRequestHeader } from './index';
+
+describe('getRequestHeader', () => {
+  it('reads from a fetch Request', () => {
+    const request = new Request('http://localhost/', {
+      headers: { Cookie: 'session=abc', Authorization: 'Bearer tok' },
+    });
+
+    expect(getRequestHeader(request, 'cookie')).toBe('session=abc');
+    expect(getRequestHeader(request, 'authorization')).toBe('Bearer tok');
+  });
+
+  it('reads from Hono-like request.raw', () => {
+    const raw = new Request('http://localhost/', {
+      headers: { Cookie: 'session=raw' },
+    });
+
+    expect(getRequestHeader({ raw, header: () => undefined }, 'cookie')).toBe('session=raw');
+  });
+
+  it('reads from Headers without throwing', () => {
+    const headers = new Headers({ Cookie: 'session=headers' });
+    expect(getRequestHeader({ headers, header: () => undefined }, 'cookie')).toBe('session=headers');
+  });
+
+  it('uses header() for Express-like requests (plain headers object)', () => {
+    const request = {
+      headers: { cookie: 'session=express', authorization: 'Bearer tok' } as Record<
+        string,
+        string | string[] | undefined
+      >,
+      header(name: string) {
+        const value = this.headers[name.toLowerCase()];
+        return Array.isArray(value) ? value[0] : value;
+      },
+    };
+
+    // Previously threw: TypeError: request.headers.get is not a function
+    expect(getRequestHeader(request, 'cookie')).toBe('session=express');
+    expect(getRequestHeader(request, 'authorization')).toBe('Bearer tok');
+  });
+
+  it('reads plain header objects when header() is absent', () => {
+    const request = {
+      headers: { cookie: 'session=plain', 'x-api-key': ['first', 'second'] },
+    };
+
+    expect(getRequestHeader(request, 'Cookie')).toBe('session=plain');
+    expect(getRequestHeader(request, 'x-api-key')).toBe('first');
+  });
+
+  it('returns null when the header is missing', () => {
+    expect(getRequestHeader(new Request('http://localhost/'), 'cookie')).toBeNull();
+    expect(getRequestHeader({ headers: {} }, 'cookie')).toBeNull();
+  });
+});

--- a/packages/_internals/auth/src/types/index.ts
+++ b/packages/_internals/auth/src/types/index.ts
@@ -1,7 +1,7 @@
 export interface HonoRequestLike {
   raw?: Request;
-  headers?: Headers;
-  header(name: string): string | undefined;
+  headers?: Headers | Record<string, string | string[] | undefined>;
+  header?(name: string): string | undefined;
 }
 
 export type MastraAuthRequest = Request | HonoRequestLike;
@@ -14,12 +14,41 @@ export type AuthorizeUserFn<TUser, TResult = Promise<boolean> | boolean> = {
   bivarianceHack(user: TUser, request: MastraAuthRequest): TResult;
 }['bivarianceHack'];
 
+function headerFromPlainObject(
+  headers: Record<string, string | string[] | undefined>,
+  name: string,
+): string | null {
+  const value = headers[name.toLowerCase()] ?? headers[name];
+  return Array.isArray(value) ? (value[0] ?? null) : (value ?? null);
+}
+
+/**
+ * Read a request header across fetch, Hono, and Express-style request shapes.
+ * Must not throw when `headers` is a plain object (Express `IncomingHttpHeaders`).
+ */
 export function getRequestHeader(request: MastraAuthRequest, name: string): string | null {
   if (request instanceof Request) {
     return request.headers.get(name);
   }
 
-  return request.raw?.headers.get(name) ?? request.headers?.get(name) ?? request.header(name) ?? null;
+  if (request.raw instanceof Request) {
+    return request.raw.headers.get(name);
+  }
+
+  const headers = request.headers;
+  if (headers instanceof Headers) {
+    return headers.get(name);
+  }
+
+  if (typeof request.header === 'function') {
+    return request.header(name) ?? null;
+  }
+
+  if (headers && typeof headers === 'object') {
+    return headerFromPlainObject(headers, name);
+  }
+
+  return null;
 }
 
 export function getWebRequest(request: MastraAuthRequest): Request | undefined {


### PR DESCRIPTION
Defense-in-depth for #21253. Auth providers used to assume `headers.get()` always exists, so an Express plain header object threw before the `header()` fallback ran. That TypeError was swallowed and became a misleading 401.

```ts
// before — throws on Express req.headers
return request.headers?.get(name) ?? request.header(name) ?? null;

// after — feature-detects Headers, header(), and plain objects
```

Also routes the six local copies through the shared `@internal/auth` helper.

Pairs with #21258 (NestJS adapter normalization).

Fixes #21253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Express requests can store headers in a different format than other web requests. This change makes authentication read those headers correctly instead of failing and returning a misleading 401 error.

## Changes

- Updated `getRequestHeader` to support:
  - Fetch `Request`
  - `Headers`
  - Hono-style `request.raw`
  - Express-style `header()`
  - Plain header objects
  - Array-valued headers
  - Case-insensitive lookup
- Returns `null` when a header is unavailable.
- Added tests for all supported request formats and missing headers.
- Replaced six local authentication helpers with the shared `@internal/auth` implementation.
- Updated `HonoRequestLike` to support optional `header()` methods and plain-object headers.
- Added patch changesets for six `@mastra/auth-*` packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->