### PR TITLE
feat(playground-ui): fade the transcript into the composer instead of covering it

### DIFF
--- a/.changeset/chubby-ravens-peel.md
+++ b/.changeset/chubby-ravens-peel.md
@@ -1,0 +1,13 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved how the chat transcript meets the composer in `ChatShell`. The dock used to sit on a flat translucent panel with a visible hard edge where it started. It now carries a masked veil that ramps in across the air above the composer and tops out behind the card, so messages dim progressively as they scroll under instead of hitting an edge. The veil never reaches full strength, so the transcript stays visible below the composer while you scroll.
+
+Two new custom properties tune it, alongside the existing `--chat-column` and `--chat-surface`:
+
+```tsx
+<ChatShell className="[--chat-fade:1.5rem] [--chat-veil:30%]">
+```
+
+`--chat-fade` is the band of air above the composer the veil ramps in across, and `--chat-veil` is the strongest it ever gets. `--chat-gutter` now means the room below the composer only — the room above belongs to the fade band, so `ChatShell.Content` no longer carries its own bottom padding.

--- a/.changeset/chubby-ravens-peel.md
+++ b/.changeset/chubby-ravens-peel.md
@@ -7,7 +7,7 @@ Improved how the chat transcript meets the composer in `ChatShell`. The dock use
 Two new custom properties tune it, alongside the existing `--chat-column` and `--chat-surface`:
 
 ```tsx
-<ChatShell className="[--chat-fade:1.5rem] [--chat-veil:30%]">
+<ChatShell className="[--chat-fade:1.5rem] [--chat-veil:70%]">
 ```
 
 `--chat-fade` is the band of air above the composer the veil ramps in across, and `--chat-veil` is the strongest it ever gets. `--chat-gutter` now means the room below the composer only — the room above belongs to the fade band, so `ChatShell.Content` no longer carries its own bottom padding.

--- a/.changeset/chubby-ravens-peel.md
+++ b/.changeset/chubby-ravens-peel.md
@@ -2,12 +2,24 @@
 '@mastra/playground-ui': patch
 ---
 
-Improved how the chat transcript meets the composer in `ChatShell`. The dock used to sit on a flat translucent panel with a visible hard edge where it started. It now carries a masked veil that ramps in across the air above the composer and tops out behind the card, so messages dim progressively as they scroll under instead of hitting an edge. The veil never reaches full strength, so the transcript stays visible below the composer while you scroll.
+Improved how the chat transcript meets the composer in `ChatShell`. The dock used to sit on a flat translucent panel with a visible hard edge where it started. It now carries a masked veil that ramps in across the air above the composer and tops out behind the card, so messages dim progressively as they scroll under instead of hitting an edge. The veil never fully hides them, so you can still tell the conversation continues below the composer while you scroll.
 
-Two new custom properties tune it, alongside the existing `--chat-column` and `--chat-surface`:
+**Migrating a `--chat-veil` override**
+
+`--chat-veil` is now an alpha percentage, not a colour: it feeds the veil's mask instead of painting a background. A colour override lands inside `rgb(0 0 0 / …)`, produces invalid CSS and silently drops the fade, so it has to be migrated.
 
 ```tsx
-<ChatShell className="[--chat-fade:1.5rem] [--chat-veil:70%]">
+// before
+<ChatShell className="[--chat-veil:color-mix(in_oklab,var(--chat-surface)_70%,transparent)]" />
+
+// after — how strong the veil ever gets
+<ChatShell className="[--chat-veil:70%]" />
 ```
 
-`--chat-fade` is the band of air above the composer the veil ramps in across, and `--chat-veil` is the strongest it ever gets. `--chat-gutter` now means the room below the composer only — the room above belongs to the fade band, so `ChatShell.Content` no longer carries its own bottom padding.
+**The room above the composer moved to the dock**
+
+`--chat-fade` is new: the band of air above the composer the veil ramps in across, `1.5rem` by default. It takes over the top half of `--chat-gutter`, which now means the room below the composer only, and `ChatShell.Content` no longer carries bottom padding of its own. Anything rendering `Content` without a `ChatShell.Dock` under it has to supply that room itself.
+
+```tsx
+<ChatShell.Content className="pb-3" />
+```

--- a/.changeset/moody-candies-bet.md
+++ b/.changeset/moody-candies-bet.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+---
+
+Softened the chat composer in the Factory UI. Messages now fade out gradually as they scroll behind the composer instead of meeting a hard translucent edge, and they stay faintly visible below it so you can tell the conversation continues.

--- a/packages/playground-ui/src/ds/components/ChatShell/chat-shell.test.tsx
+++ b/packages/playground-ui/src/ds/components/ChatShell/chat-shell.test.tsx
@@ -106,19 +106,21 @@ describe('ChatShell', () => {
     expect(track?.className).toContain('min-h-full');
   });
 
-  it('veils the dock and leaves the air above it clear', () => {
+  it('ramps the veil in over its own band of air, never past full strength', () => {
     renderShell();
 
     const dock = screen.getByTestId('dock');
-    // A background, not an overlay: it passes behind the composer card, dimming
-    // the transcript in its rounded corners too.
-    expect(dock.className).toContain('bg-(--chat-veil)');
-    expect(dock.className).toContain('pb-(--chat-gutter)');
-    // The matching room above belongs to the content, which paints nothing.
-    expect(screen.getByTestId('content').className).toContain('pb-(--chat-gutter)');
-    expect(screen.getByTestId('shell').className).toContain(
-      '[--chat-veil:color-mix(in_oklab,var(--chat-surface)_70%,transparent)]',
+    // Rise and margin match, so the ramp starts exactly where resting content
+    // ends; anything shorter dims the last row on a still transcript.
+    expect(dock.className).toContain('mt-(--chat-fade)');
+    expect(dock.className).toContain('before:-top-(--chat-fade)');
+    expect(dock.className).toContain(
+      'before:[mask-image:linear-gradient(to_bottom,transparent,rgb(0_0_0/var(--chat-veil))_calc(var(--chat-fade)*3))]',
     );
+    expect(dock.className).toContain('pb-(--chat-gutter)');
+    expect(screen.getByTestId('content').className).not.toContain('pb-');
+    expect(screen.getByTestId('shell').className).toContain('[--chat-fade:1.5rem]');
+    expect(screen.getByTestId('shell').className).toContain('[--chat-veil:30%]');
   });
 
   it('anchors the scroll button on the dock, not the page', () => {

--- a/packages/playground-ui/src/ds/components/ChatShell/chat-shell.test.tsx
+++ b/packages/playground-ui/src/ds/components/ChatShell/chat-shell.test.tsx
@@ -120,7 +120,7 @@ describe('ChatShell', () => {
     expect(dock.className).toContain('pb-(--chat-gutter)');
     expect(screen.getByTestId('content').className).not.toContain('pb-');
     expect(screen.getByTestId('shell').className).toContain('[--chat-fade:1.5rem]');
-    expect(screen.getByTestId('shell').className).toContain('[--chat-veil:30%]');
+    expect(screen.getByTestId('shell').className).toContain('[--chat-veil:70%]');
   });
 
   it('anchors the scroll button on the dock, not the page', () => {

--- a/packages/playground-ui/src/ds/components/ChatShell/chat-shell.tsx
+++ b/packages/playground-ui/src/ds/components/ChatShell/chat-shell.tsx
@@ -25,9 +25,10 @@ export type ChatShellProps = ComponentPropsWithoutRef<'div'> & {
  * composer docks inside it, every region shares one column.
  *
  * Tuned through custom properties, all defaulted here: `--chat-column` (column
- * width), `--chat-surface` (page colour), `--chat-gutter` (room above and below
- * the composer), `--chat-veil` (what the dock paints with), `--chat-inset-end`
- * (room an overlay panel claims on the end edge).
+ * width), `--chat-surface` (page colour), `--chat-fade` (the band the veil ramps
+ * in across, above the composer), `--chat-veil` (strongest it ever gets — the
+ * transcript keeps showing through), `--chat-gutter` (room below the composer),
+ * `--chat-inset-end` (room an overlay panel claims on the end edge).
  */
 export function ChatShellRoot({ className, scroller, ...props }: ChatShellProps) {
   return (
@@ -36,9 +37,8 @@ export function ChatShellRoot({ className, scroller, ...props }: ChatShellProps)
         data-slot="chat-shell"
         className={cn(
           '@container relative isolate flex min-h-0 min-w-0 flex-col bg-(--chat-surface)',
-          '[--chat-column:48rem] [--chat-gutter:0.75rem] [--chat-inset-end:0px]',
-          '[--chat-surface:var(--color-surface2)]',
-          '[--chat-veil:color-mix(in_oklab,var(--chat-surface)_70%,transparent)]',
+          '[--chat-column:48rem] [--chat-fade:1.5rem] [--chat-gutter:0.75rem] [--chat-inset-end:0px]',
+          '[--chat-surface:var(--color-surface2)] [--chat-veil:30%]',
           className,
         )}
         {...props}
@@ -83,9 +83,9 @@ export function ChatShellViewport({ className, children, ...props }: MessageScro
   );
 }
 
-/** Scrolling content. Its bottom padding is the unveiled air above the composer. */
+/** Scrolling content. The air above the composer belongs to the dock's fade band. */
 export function ChatShellContent({ className, ...props }: MessageScrollerContentProps) {
-  return <MessageScrollerContent className={cn('flex-1 pb-(--chat-gutter)', className)} {...props} />;
+  return <MessageScrollerContent className={cn('flex-1', className)} {...props} />;
 }
 
 /** The shared reading column. Every chat region must go through it. */
@@ -104,14 +104,21 @@ export function ChatShellColumn({ className, ...props }: ComponentPropsWithoutRe
  * transcript scrolls behind, so nothing measures it and a composer growing under
  * the cursor resizes no box the scroller watches.
  *
- * The veil is a background, not an overlay, so it passes behind the composer card
- * and dims the transcript in its rounded corners too.
+ * Behind it, one sheet of the page masked in over `--chat-fade` of air and never
+ * past `--chat-veil`, so the transcript dims as it slides under but stays
+ * readable through the card's surroundings. The ramp runs three times the air, so
+ * it tops out behind the card and its end never shows.
  */
 export function ChatShellDock({ className, ...props }: ComponentPropsWithoutRef<'div'>) {
   return (
     <div
       data-slot="chat-shell-dock"
-      className={cn('sticky bottom-0 z-10 shrink-0 bg-(--chat-veil) pb-(--chat-gutter)', className)}
+      className={cn(
+        'sticky bottom-0 z-10 mt-(--chat-fade) shrink-0 pb-(--chat-gutter)',
+        'before:pointer-events-none before:absolute before:inset-x-0 before:-top-(--chat-fade) before:bottom-0 before:-z-10',
+        'before:bg-(--chat-surface) before:[mask-image:linear-gradient(to_bottom,transparent,rgb(0_0_0/var(--chat-veil))_calc(var(--chat-fade)*3))]',
+        className,
+      )}
       {...props}
     />
   );

--- a/packages/playground-ui/src/ds/components/ChatShell/chat-shell.tsx
+++ b/packages/playground-ui/src/ds/components/ChatShell/chat-shell.tsx
@@ -38,7 +38,7 @@ export function ChatShellRoot({ className, scroller, ...props }: ChatShellProps)
         className={cn(
           '@container relative isolate flex min-h-0 min-w-0 flex-col bg-(--chat-surface)',
           '[--chat-column:48rem] [--chat-fade:1.5rem] [--chat-gutter:0.75rem] [--chat-inset-end:0px]',
-          '[--chat-surface:var(--color-surface2)] [--chat-veil:30%]',
+          '[--chat-surface:var(--color-surface2)] [--chat-veil:70%]',
           className,
         )}
         {...props}


### PR DESCRIPTION
The chat dock used to paint a flat translucent panel behind the composer. It met the transcript on a hard edge where the panel started, and because it was translucent all the way down, text kept ghosting through around the composer card and in its rounded corners. Now the dock carries one sheet of the page colour masked in over the air above the composer, so messages dim progressively as they slide under.

Two things I tuned by eye and would like a second opinion on, ideally on the preview rather than the diff. The ramp runs three times the band of air, which puts its end behind the composer card so you never see it arrive. And it tops out at 70% rather than fully hiding anything, so a hint of the transcript stays visible below the composer and you can tell the conversation continues while you scroll. Both are custom properties on ChatShell now, `--chat-fade` and `--chat-veil`.

Two contract changes worth flagging, both written up in the changeset. `--chat-veil` was a colour and is now an alpha percentage feeding the mask, so a colour override would silently drop the fade. And the air above the composer moved from `ChatShell.Content`'s bottom padding to the dock's margin, because the ramp has to start exactly where resting content ends or the last row of a still transcript dims for no reason; `--chat-gutter` now means the room below the composer only. `ChatShell.Dock` has no consumer besides the Factory UI today, so that is the only surface affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The chat transcript now fades smoothly behind the composer instead of stopping at a flat overlay. This reduces visible text around the composer while keeping some transcript content visible.

## Changes

- Added configurable `--chat-fade` and alpha-based `--chat-veil` properties to `ChatShell`.
- Capped the veil at 70%.
- Made the fade band span three times the space above the composer.
- Moved the space above the composer from `ChatShell.Content` padding to the dock margin.
- Updated `--chat-gutter` to represent only the space below the composer.
- Removed built-in `ChatShell.Content` bottom padding.
- Updated tests for the fade band, gradient mask, gutter padding, removed bottom padding, and configured properties.
- Documented the updated `ChatShell` contract and standalone content migration.
- Added changesets for `@mastra/playground-ui` and `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->