### PR TITLE
chore: upgrade pnpm to 11.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "pnpm": ">=11.0.0"
   },
   "license": "Apache-2.0",
-  "packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25",
+  "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "dependencies": {
     "node-forge": "1.4.0",
     "resolve-from": "^5.0.0",

--- a/packages/playground/e2e/kitchen-sink/package.json
+++ b/packages/playground/e2e/kitchen-sink/package.json
@@ -23,5 +23,5 @@
     "@types/node": "22.19.20",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@11.13.1"
+  "packageManager": "pnpm@11.21.0"
 }


### PR DESCRIPTION
Upgrades the repository pnpm pin from 11.13.1 to 11.21.0, including the standalone Studio kitchen-sink project.

pnpm 11.21.0 includes https://github.com/pnpm/pnpm/pull/13658, which incorporates resolved `link:` targets into global virtual store slot hashes. This keeps `enableGlobalVirtualStore` enabled for fast worktree installs while preventing workspace dependency links from being reused across different worktrees.

Verified with a frozen lockfile install, formatting checks, and `pnpm --filter @mastra/deepeval build`. The regenerated deepeval slot resolves both `@mastra/core` and `@mastra/observability` to the current checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates pnpm to a newer version in the repository and the Studio kitchen-sink project. The update prevents dependencies from different worktrees from being mixed while keeping the global virtual store enabled.

## Changes

- Upgrade pnpm from `11.13.1` to `11.21.0`.
- Update the pnpm integrity hash in the root `package.json`.
- Update the pnpm version in `packages/playground/e2e/kitchen-sink/package.json`.
- Resolve `link:` targets in global virtual store slot hashes.

## Verification

- Frozen lockfile install.
- Formatting checks.
- `pnpm --filter `@mastra/deepeval` build`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->