### PR TITLE
fix(factory): stop deep decision queues from starving new session starts

### DIFF
--- a/.changeset/sunny-rooms-invent.md
+++ b/.changeset/sunny-rooms-invent.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed new Factory sessions stalling for minutes when the background decision queue was deep. The dispatcher now claims pending session starts before deferred decisions, so a new session always starts on the next tick.

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -668,7 +668,7 @@ describe('FactoryDecisionDispatcher', () => {
       skillName: 'understand-issue',
       idempotencyKey: 'wake-holds-capacity',
     });
-    await storage.prepareRunStart({
+    const prepared = await storage.prepareRunStart({
       orgId: 'org-1',
       userId: 'user-1',
       factoryProjectId: PROJECT_ID,
@@ -688,6 +688,10 @@ describe('FactoryDecisionDispatcher', () => {
       kickoffKey: 'kickoff-null',
       kickoffMessage: null,
     });
+    // The coordinator marks null-kickoff starts sent at prepare time; leaving
+    // the row pending would let it win the single in-flight slot under
+    // starts-first claiming and stall the wake decision this test exercises.
+    await storage.markPendingStart(prepared.binding.id, 'sent');
     const { controller, session, emitAgentEnd, getAgentEndListenerCount } = createSession(undefined, {
       signalAccepted: Promise.resolve({ accepted: true, action: 'wake' }),
     });
@@ -1624,6 +1628,75 @@ describe('FactoryDecisionDispatcher', () => {
     expect(primeCredentials).toHaveBeenCalledWith({ orgId: 'org-1', userId: 'user-1' });
     const kickoffOptions = sendNotificationSignal.mock.calls[0]![1];
     expect(kickoffOptions?.requestContext?.get('user')).toEqual({ workosId: 'user-1', organizationId: 'org-1' });
+    expect((await storage.listPendingStarts('org-1', PROJECT_ID))[0]?.status).toBe('sent');
+  });
+
+  it('dispatches a pending start on the first tick even when the deferred-decision queue exceeds the batch size', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    // Deeper than one tick's claim limit: without starts-first claiming these
+    // would consume the whole batch and starve the pending start.
+    const queueDepth = FACTORY_DISPATCH_CONSTANTS.batchSize + 2;
+    for (let index = 0; index < queueDepth; index += 1) {
+      await queueDecision(
+        storage,
+        { type: 'sendMessage', role: 'work', message: 'Continue.', idempotencyKey: `message-${index}` },
+        { sourceKey: `github-issue:${100 + index}`, ingress: `move-${index}` },
+      );
+    }
+    const { controller, delivered } = createSession();
+    const rules = defaultFactoryRules({ version: 'rules-v1' });
+    const transitionService = new FactoryTransitionService({ storage, rules });
+    const sourceControl = {
+      sessions: {
+        getBySessionId: async () => ({
+          id: 'source-session-1',
+          sessionId: 'session-1',
+          projectRepositoryId: 'project-repository-1',
+          orgId: 'org-1',
+          userId: 'user-1',
+          branch: 'factory/issue-1',
+          baseBranch: 'main',
+        }),
+      },
+      projectRepositories: { get: async ({ id }: { id: string }) => ({ id, connectionId: 'connection-1' }) },
+      connections: { get: async () => ({ factoryProjectId: PROJECT_ID }) },
+    };
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      transitionService,
+      sourceControl as never,
+    );
+    await coordinator.prepare({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: PROJECT_ID,
+      sessionId: 'session-1',
+      threadTitle: 'Fix issue',
+      kickoffKey: 'kickoff-1',
+      invocation: { type: 'prompt', prompt: 'Investigate the issue.' },
+      destinationStage: 'triage',
+      workItem: {
+        role: 'work',
+        input: {
+          externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:1' },
+          title: 'Fix issue',
+          stages: ['intake'],
+          sessions: {},
+          metadata: {},
+        },
+      },
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+
+    expect(delivered).toContain('factory-kickoff:kickoff-1');
     expect((await storage.listPendingStarts('org-1', PROJECT_ID))[0]?.status).toBe('sent');
   });
 

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -196,25 +196,29 @@ export class FactoryDecisionDispatcher {
     if (capacity <= 0) return [];
     const limit = Math.min(BATCH_SIZE, capacity);
     const leaseExpiresAt = new Date(now.getTime() + LEASE_MS);
-    const decisions = await this.#storage.claimDeferredDecisions({
+    // Starts are claimed before deferred decisions: a pending start is a user
+    // waiting on a brand-new session, while a deferred decision is a background
+    // continuation of one that is already running. A deep decision queue must
+    // never starve new sessions out of the tick.
+    const starts = await this.#storage.claimPendingStarts({
       ownerId: this.#ownerId,
       now,
       leaseExpiresAt,
       limit,
     });
-    const startsLimit = limit - decisions.length;
-    const starts =
-      startsLimit > 0
-        ? await this.#storage.claimPendingStarts({
+    const decisionsLimit = limit - starts.length;
+    const decisions =
+      decisionsLimit > 0
+        ? await this.#storage.claimDeferredDecisions({
             ownerId: this.#ownerId,
             now,
             leaseExpiresAt,
-            limit: startsLimit,
+            limit: decisionsLimit,
           })
         : [];
     return [
-      ...decisions.map(decision => this.#track(this.#dispatchDecision(decision, now))),
       ...starts.map(start => this.#track(this.#dispatchPendingStart(start, now))),
+      ...decisions.map(decision => this.#track(this.#dispatchDecision(decision, now))),
     ];
   }
 


### PR DESCRIPTION
## Summary

New Factory sessions could stall for minutes before their kickoff fired. `FactoryDecisionDispatcher.#claimAndStart` claimed deferred decisions first, up to the entire per-tick batch limit, and gave pending starts only the leftover capacity. Whenever the deferred-decision queue was deeper than the batch size (10), pending starts got zero capacity per tick and sat until the decision queue drained — production data showed a 372s time-to-first-message with 78 queued decisions vs 24s with a short queue, on identical code paths.

The two record classes have different latency sensitivity:

- **Pending starts** are brand-new sessions — a user is staring at an empty page waiting for the first message.
- **Deferred decisions** are background continuations of sessions that are already running.

The dispatcher now claims pending starts first, up to the full tick limit, and deferred decisions take the remaining capacity. Starts dispatch quickly (they hand off to the agent loop), so decisions only ever wait a tick behind them rather than holding new sessions hostage for minutes.

## Changes

- `mastracode/factory/src/rules/dispatcher.ts` — swap claim order in `#claimAndStart`: starts get the full limit first, decisions get the remainder.
- `mastracode/factory/src/rules/dispatcher.test.ts` — new regression test: with `batchSize + 2` deferred decisions queued and one prepared pending start, a single tick delivers the kickoff and marks the start `sent`. One existing test's setup now marks its null-kickoff seed row `sent`, matching what the start coordinator does in production, so the incidental row doesn't occupy the test's single in-flight slot.

## Test plan

- New regression test fails on the previous claim ordering (kickoff never delivered) and passes with this change.
- All 30 dispatcher tests pass; `@mastra/factory` typecheck and lint clean.
- Full package suite: only pre-existing failures remain (github reconcile-worker, work-items locking) — identical on the base commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

New sessions now start before background work is processed. This prevents a long queue of deferred decisions from delaying session startup.

## Changes

- Updated `FactoryDecisionDispatcher.#claimAndStart` to claim pending starts first.
- Allocated remaining batch capacity to deferred decisions.
- Added regression coverage for deferred-decision queues larger than the batch size.
- Adjusted an existing test setup to mark a null-kickoff seed row as sent.
- Added a patch changeset for `@mastra/factory`.

## Validation

- All 30 dispatcher tests pass.
- Factory typecheck and lint pass.
- Remaining full-suite failures are pre-existing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->