### PR TITLE
fix(core): reject empty auth headers

### DIFF
--- a/.changeset/tidy-auth-headers.md
+++ b/.changeset/tidy-auth-headers.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed gateway authentication so empty header objects fall back to API keys and are not reported as valid credentials.

--- a/packages/core/src/llm/model/gateways/gateway-helpers.ts
+++ b/packages/core/src/llm/model/gateways/gateway-helpers.ts
@@ -1,5 +1,5 @@
 import { MastraError } from '../../../error/index.js';
-import type { MastraModelGatewayInterface } from './base.js';
+import type { GatewayAuthResult, MastraModelGatewayInterface } from './base.js';
 
 export function getGatewayId(gateway: MastraModelGatewayInterface): string {
   return gateway.getId?.() ?? gateway.id;
@@ -7,6 +7,10 @@ export function getGatewayId(gateway: MastraModelGatewayInterface): string {
 
 export function shouldEnableGateway(gateway: MastraModelGatewayInterface): boolean {
   return gateway.shouldEnable?.() ?? true;
+}
+
+export function hasAuthCredentials(auth?: GatewayAuthResult): auth is GatewayAuthResult {
+  return Boolean(auth?.apiKey || auth?.bearerToken || (auth?.headers && Object.keys(auth.headers).length > 0));
 }
 
 export function serializeGatewayForSpan(

--- a/packages/core/src/llm/model/gateways/gateway-manager.test.ts
+++ b/packages/core/src/llm/model/gateways/gateway-manager.test.ts
@@ -238,6 +238,34 @@ describe('GatewayManager', () => {
       expect(auth.apiKey).toBe('env-key');
       expect(auth.source).toBe('legacy');
     });
+
+    it('falls back to getApiKey when resolveAuth returns empty headers', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        apiKey: 'env-key',
+        resolveAuth: () => ({ headers: {} }),
+      });
+      const manager = new GatewayManager([gateway]);
+      const auth = await manager.resolveAuth('test-gateway/acme/sonic-fast');
+
+      expect(auth).toEqual({ apiKey: 'env-key', source: 'legacy' });
+      expect(gateway.getApiKey).toHaveBeenCalledWith('test-gateway/acme/sonic-fast');
+    });
+
+    it('accepts non-empty gateway headers without falling back to getApiKey', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        apiKey: 'env-key',
+        resolveAuth: () => ({ headers: { 'x-api-key': 'gateway-key' } }),
+      });
+      const manager = new GatewayManager([gateway]);
+      const auth = await manager.resolveAuth('test-gateway/acme/sonic-fast');
+
+      expect(auth).toEqual({ headers: { 'x-api-key': 'gateway-key' }, source: 'gateway' });
+      expect(gateway.getApiKey).not.toHaveBeenCalled();
+    });
   });
 
   describe('hasAuth', () => {
@@ -258,6 +286,18 @@ describe('GatewayManager', () => {
         apiKey: '',
       });
       const manager = new GatewayManager([gateway]);
+      expect(await manager.hasAuth('test-gateway/acme/sonic-fast')).toBe(false);
+    });
+
+    it('returns false when gateway auth contains empty headers and getApiKey is empty', async () => {
+      const gateway = createFakeGateway({
+        id: 'test-gateway',
+        provider: 'acme',
+        apiKey: '',
+        resolveAuth: () => ({ headers: {} }),
+      });
+      const manager = new GatewayManager([gateway]);
+
       expect(await manager.hasAuth('test-gateway/acme/sonic-fast')).toBe(false);
     });
 

--- a/packages/core/src/llm/model/gateways/gateway-manager.ts
+++ b/packages/core/src/llm/model/gateways/gateway-manager.ts
@@ -1,7 +1,7 @@
 import { MastraError } from '../../../error/index.js';
 import { parseModelRouterId } from '../gateway-resolver.js';
 import type { GatewayAuthRequest, GatewayAuthResult, MastraModelGatewayInterface, ProviderConfig } from './base.js';
-import { findGatewayForModel, getGatewayId, shouldEnableGateway } from './gateway-helpers.js';
+import { findGatewayForModel, getGatewayId, hasAuthCredentials, shouldEnableGateway } from './gateway-helpers.js';
 
 /**
  * MastraError IDs that represent expected "auth not available" states —
@@ -155,7 +155,7 @@ export class GatewayManager {
         }
       : rawGatewayAuth;
 
-    if (gatewayAuth?.apiKey || gatewayAuth?.headers || gatewayAuth?.bearerToken) {
+    if (hasAuthCredentials(gatewayAuth)) {
       return {
         ...gatewayAuth,
         source: gatewayAuth.source ?? 'gateway',
@@ -178,7 +178,7 @@ export class GatewayManager {
   async hasAuth(routerId: string): Promise<boolean> {
     try {
       const auth = await this.resolveAuth(routerId);
-      return Boolean(auth.apiKey || auth.bearerToken || auth.headers);
+      return hasAuthCredentials(auth);
     } catch (error) {
       if (isExpectedMissingAuthError(error)) {
         return false;

--- a/packages/core/src/llm/model/model-auth-resolver.test.ts
+++ b/packages/core/src/llm/model/model-auth-resolver.test.ts
@@ -63,4 +63,27 @@ describe('resolveModelAuth', () => {
     expect(auth).toMatchObject({ apiKey: 'legacy-key', source: 'legacy' });
     expect(getApiKey).toHaveBeenCalledWith('test-gateway/test-provider/test-model');
   });
+
+  it('falls back to legacy getApiKey when gateway auth contains empty headers', async () => {
+    const getApiKey = vi.fn(async () => 'legacy-key');
+    const gateway = createGateway({ resolveAuth: vi.fn(() => ({ headers: {} })), getApiKey });
+
+    const auth = await resolveModelAuth({ gateway, request });
+
+    expect(auth).toEqual({ apiKey: 'legacy-key', source: 'legacy' });
+    expect(getApiKey).toHaveBeenCalledWith('test-gateway/test-provider/test-model');
+  });
+
+  it('ignores empty explicit headers and continues to gateway auth', async () => {
+    const gateway = createGateway({
+      resolveAuth: vi.fn(() => ({ apiKey: 'gateway-key' })),
+      getApiKey: vi.fn(async () => 'legacy-key'),
+    });
+
+    const auth = await resolveModelAuth({ gateway, request, explicit: { headers: {} } });
+
+    expect(auth).toEqual({ apiKey: 'gateway-key', source: 'gateway' });
+    expect(gateway.resolveAuth).toHaveBeenCalledWith(request);
+    expect(gateway.getApiKey).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/llm/model/model-auth-resolver.ts
+++ b/packages/core/src/llm/model/model-auth-resolver.ts
@@ -1,4 +1,5 @@
 import type { GatewayAuthRequest, GatewayAuthResult, MastraModelGatewayInterface } from './gateways/base.js';
+import { hasAuthCredentials } from './gateways/gateway-helpers.js';
 
 export type ResolveModelAuthArgs = {
   gateway: MastraModelGatewayInterface;
@@ -17,12 +18,6 @@ function mergeAuthHeaders(auth: GatewayAuthResult | undefined): GatewayAuthResul
   };
 }
 
-function hasExplicitAuth(explicit?: Pick<GatewayAuthResult, 'apiKey' | 'headers' | 'bearerToken'>): boolean {
-  return Boolean(
-    explicit?.apiKey || explicit?.bearerToken || (explicit?.headers && Object.keys(explicit.headers).length > 0),
-  );
-}
-
 /**
  * @deprecated This function is deprecated and will be removed in a future release.
  * Auth resolution is now handled internally by {@link ModelRouterLanguageModel}.
@@ -33,12 +28,12 @@ export async function resolveModelAuth({
   request,
   explicit,
 }: ResolveModelAuthArgs): Promise<GatewayAuthResult> {
-  if (hasExplicitAuth(explicit)) {
+  if (hasAuthCredentials(explicit)) {
     return mergeAuthHeaders({ ...explicit, source: 'explicit' }) ?? { source: 'explicit' };
   }
 
   const gatewayAuth = mergeAuthHeaders(await gateway.resolveAuth?.(request));
-  if (gatewayAuth?.apiKey || gatewayAuth?.headers || gatewayAuth?.bearerToken) {
+  if (hasAuthCredentials(gatewayAuth)) {
     return { ...gatewayAuth, source: gatewayAuth.source ?? 'gateway' };
   }
 


### PR DESCRIPTION
## Description

Gateway authentication currently treats an empty headers object as valid credentials because objects are truthy in JavaScript:

```ts
{ headers: {} }
```

This causes `GatewayManager.resolveAuth()` to accept an unusable authentication result instead of continuing to the existing `getApiKey()` fallback. It can also cause `GatewayManager.hasAuth()` to report that authentication is available when no usable credentials exist.

This PR treats empty header objects as missing authentication. Header-based authentication is now considered present only when the object contains at least one enumerable key.

Bearer-token promotion to the `Authorization` header remains unchanged, and no public APIs are modified.

## Changes

- Added a shared internal `hasAuthCredentials()` helper.
- Authentication is considered available only when it contains:
  - A non-empty API key
  - A non-empty bearer token
  - A headers object containing at least one key
- Updated `GatewayManager.resolveAuth()` so `{ headers: {} }` continues to the legacy `getApiKey()` fallback.
- Updated `GatewayManager.hasAuth()` so empty headers do not report authentication as available.
- Updated the deprecated `resolveModelAuth()` path to use the same credential-presence rules.
- Preserved the existing behavior for non-empty custom headers and bearer tokens.
- Added regression coverage for:
  - Empty gateway headers with an available fallback API key
  - Empty gateway headers without a fallback API key
  - Valid non-empty gateway headers
  - Empty gateway headers in the deprecated resolver
  - Empty explicit headers continuing to gateway authentication
- Added an `@mastra/core` patch changeset.

## Test plan

The following focused tests pass:

```bash
cd packages/core

./node_modules/.bin/vitest run \
  src/llm/model/gateways/gateway-manager.test.ts \
  src/llm/model/model-auth-resolver.test.ts
```

Result:

```text
Test Files  2 passed (2)
Tests       42 passed (42)
Type Errors no errors
```

The core TypeScript check passes:

```bash
cd packages/core
./node_modules/.bin/tsc --noEmit --pretty false
```

Targeted Oxlint, ESLint, and formatting checks pass for the modified source and test files.

The final diff also passes:

```bash
git diff --check
```

## Related issue(s)

Fixes #21264 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The gateway now treats empty authentication headers as missing credentials. It then uses the API key fallback when available and avoids reporting authentication when no usable credentials exist.

## Changes

- Added shared `hasAuthCredentials()` logic for API keys, bearer tokens, and non-empty headers.
- Updated `GatewayManager.resolveAuth()`, `GatewayManager.hasAuth()`, and `resolveModelAuth()` to use the shared logic.
- Preserved support for non-empty custom headers and bearer-token promotion.
- Added regression tests for empty and non-empty header behavior.
- Added an `@mastra/core` patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->