### PR TITLE
fix(factory): scrub stale branches off reused sandboxes and recover from branch-ref collisions

### DIFF
--- a/.changeset/itchy-dogs-cry.md
+++ b/.changeset/itchy-dogs-cry.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed restarting a review after deleting its thread failing with "git clone failed: a branch named ... already exists". Reused Platform sandboxes now delete the previous session's local branches when they are recycled, so a new session for the same branch starts fresh from the base branch, and branch checkout recovers from leftover or broken branch refs instead of failing the workspace.
+Fixed restarting a review after deleting its thread. It no longer fails with "git clone failed: a branch named ... already exists". Reused Platform sandboxes now delete the previous session's local branches when they are recycled. A new session for the same branch starts fresh from the base branch. Branch checkout also recovers from leftover or broken branch refs instead of failing the workspace.

--- a/.changeset/itchy-dogs-cry.md
+++ b/.changeset/itchy-dogs-cry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed restarting a review after deleting its thread failing with "git clone failed: a branch named ... already exists". Reused Platform sandboxes now delete the previous session's local branches when they are recycled, so a new session for the same branch starts fresh from the base branch, and branch checkout recovers from leftover or broken branch refs instead of failing the workspace.

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -698,6 +698,71 @@ describe('checkoutSessionBranch', () => {
     expect(err).toBeInstanceOf(MaterializeError);
     expect(err.code).toBe('clone-failed');
   });
+
+  it('adopts a branch created concurrently between the show-ref probe and checkout -b', async () => {
+    // Two materializations of the same session raced: the other one created
+    // the branch after this one's probe missed it. Adopt it instead of 500ing.
+    const sandbox = new FakeSandbox(script => {
+      if (script.includes('branch --show-current')) return { exitCode: 0, stdout: 'main\n', stderr: '' };
+      if (script.includes('show-ref')) return { exitCode: 1, stdout: '', stderr: '' };
+      if (script.includes('checkout -b') && script.includes('fetch origin')) {
+        return { exitCode: 1, stdout: '', stderr: "fatal: a branch named 'factory/pr-1' already exists\n" };
+      }
+      return OK;
+    });
+
+    await expect(checkoutSessionBranch(sandbox, '/workspace/repo', opts)).resolves.toBeUndefined();
+
+    const joined = sandbox.calls.join('\n');
+    expect(joined).toContain("checkout 'factory/pr-1'");
+    // The healthy branch is adopted as-is — no ref surgery.
+    expect(joined).not.toContain('update-ref -d');
+  });
+
+  it('replaces a broken loose ref and retries the branch create', async () => {
+    // A reused pooled sandbox carries a corrupt loose ref: show-ref cannot
+    // resolve it, checkout -b refuses "already exists", and plain checkout
+    // fails too. Drop the wedged ref and recreate the branch from FETCH_HEAD.
+    const sandbox = new FakeSandbox(script => {
+      if (script.includes('branch --show-current')) return { exitCode: 0, stdout: 'main\n', stderr: '' };
+      if (script.includes('show-ref')) return { exitCode: 1, stdout: '', stderr: '' };
+      if (script.includes('fetch origin')) {
+        return { exitCode: 1, stdout: '', stderr: "fatal: a branch named 'factory/pr-1' already exists\n" };
+      }
+      if (script.includes("checkout 'factory/pr-1'")) {
+        return { exitCode: 1, stdout: '', stderr: "fatal: unable to resolve reference 'refs/heads/factory/pr-1'\n" };
+      }
+      return OK;
+    });
+
+    await expect(checkoutSessionBranch(sandbox, '/workspace/repo', opts)).resolves.toBeUndefined();
+
+    const joined = sandbox.calls.join('\n');
+    expect(joined).toContain("update-ref -d refs/heads/'factory/pr-1'");
+    expect(sandbox.calls).toContain("git -C '/workspace/repo' checkout -b 'factory/pr-1' FETCH_HEAD");
+    // Token still scrubbed back to the clean URL in the finally.
+    const scrub = sandbox.calls.filter(c => c.includes('remote set-url origin')).at(-1);
+    expect(scrub).toContain('https://github.com/octocat/hello.git');
+    expect(scrub).not.toContain('tok-secret');
+  });
+
+  it('surfaces the collision when the wedged ref cannot be dropped', async () => {
+    const sandbox = new FakeSandbox(script => {
+      if (script.includes('branch --show-current')) return { exitCode: 0, stdout: 'main\n', stderr: '' };
+      if (script.includes('show-ref')) return { exitCode: 1, stdout: '', stderr: '' };
+      if (script.includes('fetch origin')) {
+        return { exitCode: 1, stdout: '', stderr: "fatal: a branch named 'factory/pr-1' already exists\n" };
+      }
+      if (script.includes("checkout 'factory/pr-1'") || script.includes('update-ref -d')) {
+        return { exitCode: 1, stdout: '', stderr: 'fatal: cannot lock ref\n' };
+      }
+      return OK;
+    });
+
+    const err = await checkoutSessionBranch(sandbox, '/workspace/repo', opts).catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('clone-failed');
+  });
 });
 
 describe('recycleClaimedWorkdir', () => {
@@ -723,6 +788,28 @@ describe('recycleClaimedWorkdir', () => {
     // `-x` included: gitignored files (.env, caches) must not leak between sessions.
     expect(recycle).toContain('clean -fdx');
     expect(sandbox.calls.some(call => call.startsWith('rm -rf'))).toBe(false);
+  });
+
+  it('deletes every non-default local branch left by the previous session', async () => {
+    const sandbox = new FakeSandbox();
+
+    await recycleClaimedWorkdir(sandbox, '/workspace/hello', 'main');
+
+    const sweep = sandbox.calls[2]!;
+    expect(sweep).toContain('for-each-ref');
+    expect(sweep).toContain('update-ref -d');
+    // The default branch itself survives the sweep.
+    expect(sweep).toContain("'refs/heads/main'");
+  });
+
+  it('wipes the workdir when the branch sweep fails', async () => {
+    const sandbox = new FakeSandbox(script =>
+      script.includes('for-each-ref') ? { exitCode: 1, stdout: '', stderr: 'cannot lock ref' } : OK,
+    );
+
+    await recycleClaimedWorkdir(sandbox, '/workspace/hello', 'main');
+
+    expect(sandbox.calls.at(-1)).toBe("rm -rf '/workspace/hello'");
   });
 
   it('wipes a wedged checkout so materialization re-clones inside the same VM', async () => {

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -738,7 +738,10 @@ describe('checkoutSessionBranch', () => {
     await expect(checkoutSessionBranch(sandbox, '/workspace/repo', opts)).resolves.toBeUndefined();
 
     const joined = sandbox.calls.join('\n');
-    expect(joined).toContain("update-ref -d refs/heads/'factory/pr-1'");
+    // `--no-deref` so a broken symref cannot redirect the delete onto another
+    // branch, and the loose-ref-file fallback survives an `update-ref` refusal.
+    expect(joined).toContain("update-ref --no-deref -d refs/heads/'factory/pr-1'");
+    expect(joined).toMatch(/update-ref [^\n]* \|\| rm -f -- "[^\n]*\/refs\/heads\/factory\/pr-1"/);
     expect(sandbox.calls).toContain("git -C '/workspace/repo' checkout -b 'factory/pr-1' FETCH_HEAD");
     // Token still scrubbed back to the clean URL in the finally.
     const scrub = sandbox.calls.filter(c => c.includes('remote set-url origin')).at(-1);
@@ -753,7 +756,7 @@ describe('checkoutSessionBranch', () => {
       if (script.includes('fetch origin')) {
         return { exitCode: 1, stdout: '', stderr: "fatal: a branch named 'factory/pr-1' already exists\n" };
       }
-      if (script.includes("checkout 'factory/pr-1'") || script.includes('update-ref -d')) {
+      if (script.includes("checkout 'factory/pr-1'") || script.includes('update-ref --no-deref -d')) {
         return { exitCode: 1, stdout: '', stderr: 'fatal: cannot lock ref\n' };
       }
       return OK;
@@ -797,7 +800,9 @@ describe('recycleClaimedWorkdir', () => {
 
     const sweep = sandbox.calls[2]!;
     expect(sweep).toContain('for-each-ref');
-    expect(sweep).toContain('update-ref -d');
+    // `--no-deref`: a stale symbolic ref pointing at the default branch must
+    // delete the symref itself, never follow it onto the default branch.
+    expect(sweep).toContain('update-ref --no-deref -d');
     // The default branch itself survives the sweep.
     expect(sweep).toContain("'refs/heads/main'");
   });

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -445,11 +445,13 @@ export async function recycleClaimedWorkdir(
     // Ref names cannot contain spaces or shell metacharacters (git rejects
     // them), so word-splitting the for-each-ref output is safe. `update-ref -d`
     // instead of `branch -D` so deletion never trips over "not fully merged"
-    // checks; broken loose refs are skipped by for-each-ref and handled by the
-    // collision fallback in `checkoutSessionBranch`.
+    // checks; `--no-deref` so a symbolic ref pointing at the default branch
+    // deletes the symref itself rather than following it and deleting the
+    // default branch. Broken loose refs are skipped by for-each-ref and
+    // handled by the collision fallback in `checkoutSessionBranch`.
     const sweep = await sh(
       sandbox,
-      `set -e; for ref in $(git -C ${w} for-each-ref --format='%(refname)' refs/heads); do [ "$ref" = ${shellQuote(`refs/heads/${defaultBranch}`)} ] || git -C ${w} update-ref -d "$ref"; done`,
+      `set -e; for ref in $(git -C ${w} for-each-ref --format='%(refname)' refs/heads); do [ "$ref" = ${shellQuote(`refs/heads/${defaultBranch}`)} ] || git -C ${w} update-ref --no-deref -d "$ref"; done`,
       { phase: 'claimed workdir branch sweep' },
     );
     if (sweep.exitCode === 0) return;
@@ -530,10 +532,12 @@ async function checkoutSessionBranchImpl(
       if (adopt.exitCode === 0 || isBlockedByLocalWork(adopt)) return;
       const drop = await sh(
         sandbox,
-        // `update-ref -d` can itself refuse a broken ref; fall back to
-        // removing the loose ref file (branch passed isValidGitRef, so the
-        // interpolation inside the double quotes is inert).
-        `git -C ${shellQuote(workdir)} update-ref -d refs/heads/${shellQuote(branch)} || rm -f -- "$(git -C ${shellQuote(workdir)} rev-parse --absolute-git-dir)/refs/heads/${branch}"`,
+        // `--no-deref` so a broken symref is deleted itself instead of git
+        // following it to some other branch. `update-ref -d` can still refuse
+        // a broken ref; fall back to removing the loose ref file (branch
+        // passed isValidGitRef, so the interpolation inside the double quotes
+        // is inert).
+        `git -C ${shellQuote(workdir)} update-ref --no-deref -d refs/heads/${shellQuote(branch)} || rm -f -- "$(git -C ${shellQuote(workdir)} rev-parse --absolute-git-dir)/refs/heads/${branch}"`,
       );
       if (drop.exitCode !== 0) throw classifyGitFailure(fetch, 'clone-failed');
       const retry = await sh(sandbox, `git -C ${shellQuote(workdir)} checkout -b ${shellQuote(branch)} FETCH_HEAD`, {

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -413,11 +413,14 @@ async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<voi
 /**
  * Reset a pooled workdir that a new session just claimed: the previous
  * session's branch and dirty state must not leak into the new session, so
- * force-checkout the default branch and drop all local modifications. When
- * the claimed VM was reaped and re-provisioned there is no checkout yet and
- * this is a no-op (the clone path handles it). A wedged checkout falls back
- * to wiping the workdir so `materializeRepo` re-clones inside the same VM
- * instead of permanently failing the session.
+ * force-checkout the default branch, drop all local modifications, and delete
+ * every other local branch (a surviving branch would otherwise hand the next
+ * session for the same branch the previous session's stale tip instead of a
+ * fresh fork from the base branch). When the claimed VM was reaped and
+ * re-provisioned there is no checkout yet and this is a no-op (the clone path
+ * handles it). A wedged checkout falls back to wiping the workdir so
+ * `materializeRepo` re-clones inside the same VM instead of permanently
+ * failing the session.
  */
 export async function recycleClaimedWorkdir(
   sandbox: MaterializationSandbox,
@@ -437,10 +440,24 @@ export async function recycleClaimedWorkdir(
     `git -C ${w} checkout -f ${shellQuote(defaultBranch)} && git -C ${w} reset --hard && git -C ${w} clean -fdx`,
     { phase: 'claimed workdir recycle' },
   );
-  if (recycle.exitCode === 0) return;
+  let failure = recycle;
+  if (recycle.exitCode === 0) {
+    // Ref names cannot contain spaces or shell metacharacters (git rejects
+    // them), so word-splitting the for-each-ref output is safe. `update-ref -d`
+    // instead of `branch -D` so deletion never trips over "not fully merged"
+    // checks; broken loose refs are skipped by for-each-ref and handled by the
+    // collision fallback in `checkoutSessionBranch`.
+    const sweep = await sh(
+      sandbox,
+      `set -e; for ref in $(git -C ${w} for-each-ref --format='%(refname)' refs/heads); do [ "$ref" = ${shellQuote(`refs/heads/${defaultBranch}`)} ] || git -C ${w} update-ref -d "$ref"; done`,
+      { phase: 'claimed workdir branch sweep' },
+    );
+    if (sweep.exitCode === 0) return;
+    failure = sweep;
+  }
   const wipe = await sh(sandbox, `rm -rf ${w}`);
   if (wipe.exitCode !== 0) {
-    throw new MaterializeError(`Failed to recycle claimed sandbox workdir: ${recycle.stderr}`, 'clone-failed');
+    throw new MaterializeError(`Failed to recycle claimed sandbox workdir: ${failure.stderr}`, 'clone-failed');
   }
 }
 
@@ -502,11 +519,45 @@ async function checkoutSessionBranchImpl(
       // Same rule as above: uncommitted work in the tree blocks the switch
       // to the new branch. Leave the checkout on its current branch.
       if (isBlockedByLocalWork(fetch)) return;
-      throw classifyGitFailure(fetch, 'clone-failed');
+      if (!isBranchCollision(fetch)) throw classifyGitFailure(fetch, 'clone-failed');
+      // The branch exists even though the show-ref probe missed it: either a
+      // concurrent materialization of this session created it between the
+      // probe and `checkout -b` (adopt it), or a reused sandbox carries a
+      // broken loose ref the probe cannot resolve (replace it and retry —
+      // "already exists" means the fetch half succeeded, so FETCH_HEAD is
+      // set).
+      const adopt = await sh(sandbox, `git -C ${shellQuote(workdir)} checkout ${shellQuote(branch)}`);
+      if (adopt.exitCode === 0 || isBlockedByLocalWork(adopt)) return;
+      const drop = await sh(
+        sandbox,
+        // `update-ref -d` can itself refuse a broken ref; fall back to
+        // removing the loose ref file (branch passed isValidGitRef, so the
+        // interpolation inside the double quotes is inert).
+        `git -C ${shellQuote(workdir)} update-ref -d refs/heads/${shellQuote(branch)} || rm -f -- "$(git -C ${shellQuote(workdir)} rev-parse --absolute-git-dir)/refs/heads/${branch}"`,
+      );
+      if (drop.exitCode !== 0) throw classifyGitFailure(fetch, 'clone-failed');
+      const retry = await sh(sandbox, `git -C ${shellQuote(workdir)} checkout -b ${shellQuote(branch)} FETCH_HEAD`, {
+        timeoutMs: CHECKOUT_COMMAND_TIMEOUT_MS,
+        phase: 'branch checkout retry',
+      });
+      if (retry.exitCode !== 0) {
+        if (isBlockedByLocalWork(retry)) return;
+        throw classifyGitFailure(retry, 'clone-failed');
+      }
     }
   } finally {
     await sh(sandbox, `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(cleanUrl(repoFullName))}`);
   }
+}
+
+/**
+ * True when `git checkout -b` failed only because the branch ref already
+ * exists — the collision Factory hits when a pooled sandbox carries a ref the
+ * show-ref probe could not see (broken loose ref) or a concurrent
+ * materialization created the branch after the probe ran.
+ */
+function isBranchCollision(result: SandboxCommandResult): boolean {
+  return /a branch named .* already exists/i.test(`${result.stderr || ''}\n${result.stdout || ''}`);
 }
 
 /**


### PR DESCRIPTION
Deleting a review/workspace thread keeps its Platform sandbox alive and returns it to the reuse pool, but the recycle only reset the working tree — the deleted session's local branches stayed behind. Restarting a review on the same branch could then pick up the stale branch tip instead of a fresh fork from the base branch, or fail the workspace open entirely when the leftover ref was broken (agent killed mid-git-op):

```
Failed to load messages: Error: git clone failed: From https://github.com/superset-sh/superset
 * branch            main       -> FETCH_HEAD
fatal: a branch named 'factory/pr-21159' already exists
```

Now the recycle sweeps every non-default local branch off a reclaimed sandbox (falling back to the existing wipe-and-reclone path if the sweep fails), and branch checkout recovers from "already exists" collisions the show-ref probe can't see — adopting the branch when a concurrent materialization created it, or dropping the wedged ref and retrying the create from FETCH_HEAD. So restarting a deleted review works immediately instead of only after the old VM idles out and gets reaped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a review is deleted, its workspace can keep old branches. This change removes those branches and repairs checkout problems so later reviews can start cleanly.

## Changes

- Recycle sandboxes by deleting all local branches except the default branch.
- Fall back to wiping and recloning the workdir when branch cleanup fails.
- Recover from “branch already exists” collisions during checkout:
  - Adopt a healthy branch created by another process.
  - Delete broken references and recreate the branch from `FETCH_HEAD`.
  - Report unrecoverable reference-lock failures as `clone-failed`.
- Add tests for branch races, broken references, branch cleanup, and wipe fallback.
- Add a changeset for `@mastra/factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->