### PR TITLE
fix(core): fail closed on ambiguous auto-resume approvals

### DIFF
--- a/.changeset/safe-auto-resume-approval.md
+++ b/.changeset/safe-auto-resume-approval.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Prevent auto-resume from approving tool calls when the user's decision is unclear.

--- a/packages/core/src/loop/shared/auto-resume-system-message.test.ts
+++ b/packages/core/src/loop/shared/auto-resume-system-message.test.ts
@@ -149,6 +149,15 @@ describe('buildAutoResumeSystemMessageSuffix', () => {
     expect(suffix!).not.toContain('parentRunId');
     expect(suffix!).not.toContain('parent-run');
   });
+
+  it('fails closed when an approval decision is ambiguous', () => {
+    const suffix = buildAutoResumeSystemMessageSuffix([{ toolName: 'deleteFile', type: 'approval' }]);
+
+    expect(suffix).toContain("only set 'approved' to true or false when the user's message clearly communicates");
+    expect(suffix).toContain('do not construct resumeData, do not call the tool');
+    expect(suffix).toContain('ask the user to explicitly approve or deny it');
+    expect(suffix).not.toContain('set approved to true and add resumeData: { approved: true }');
+  });
 });
 
 describe('appendSuffixToLeadingSystemMessage', () => {

--- a/packages/core/src/loop/shared/auto-resume-system-message.ts
+++ b/packages/core/src/loop/shared/auto-resume-system-message.ts
@@ -116,7 +116,7 @@ export function buildAutoResumeSystemMessageSuffix(
                       resumeData can not be an empty object nor null/undefined.
                       When you find that and call that tool, add the resumeData to the tool call arguments/input.
                       Also, add the runId of the suspended tool as suspendedToolRunId to the tool call arguments/input.
-                      If the suspendedTool.type is 'approval', resumeData will be an object that contains 'approved' which can either be true or false depending on the user's message. If you can't construct resumeData from the message for approval type, set approved to true and add resumeData: { approved: true } to the tool call arguments/input.
+                      If the suspendedTool.type is 'approval', only set 'approved' to true or false when the user's message clearly communicates that decision. If you cannot determine whether the user approved or denied the action, do not construct resumeData, do not call the tool, and ask the user to explicitly approve or deny it.
 
                       IMPORTANT: If you're able to construct resumeData and get suspendedToolRunId, get the previous arguments/input of the tool call from args in the suspended tool, and spread it in the new arguments/input created, do not add duplicate data. 
                       `;


### PR DESCRIPTION
## Description

`autoResumeSuspendedTools` currently tells the model to use `{ approved: true }` when it cannot determine the user's decision for an approval-gated tool. That makes an ambiguous follow-up fail open.

This updates the shared auto-resume instruction to only set `approved` when the user's message clearly communicates the decision. Otherwise, the model must leave the tool suspended and ask for an explicit approval or denial. Data-shaped suspensions keep their existing behavior.

## Related issue(s)

Fixes #21195

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

Tests:
- Focused unit test: 18 passed
- `pnpm build:core`
- `pnpm exec oxfmt --check packages/core/src/loop/shared/auto-resume-system-message.ts packages/core/src/loop/shared/auto-resume-system-message.test.ts .changeset/safe-auto-resume-approval.md`
- `pnpm exec eslint packages/core/src/loop/shared/auto-resume-system-message.ts packages/core/src/loop/shared/auto-resume-system-message.test.ts`
- `git diff --check`

The full `@mastra/core` typecheck still reports existing shallow-checkout/internal-package baseline errors unrelated to this change.

I used AI assistance during the initial investigation and reviewed the final diff and tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the user gives an unclear answer to an approval request, the system no longer assumes approval. It keeps the tool paused and asks the user to clearly approve or deny the action.

## Changes

- Updated `autoResumeSuspendedTools` instructions to:
  - Resume approval-gated tools only after clear user approval or denial.
  - Keep tools suspended when the user’s decision is unclear.
  - Avoid creating `resumeData` or executing the tool for ambiguous decisions.
  - Preserve existing behavior for data-shaped suspensions.
- Added a unit test for ambiguous approval decisions.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->