### PR TITLE
fix(core): resolve dynamic models once for assigned tools

### DIFF
--- a/.changeset/quiet-tools-resolve.md
+++ b/.changeset/quiet-tools-resolve.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Resolve dynamic models once when preparing assigned tools.

--- a/packages/core/src/agent/__tests__/tool-handling.test.ts
+++ b/packages/core/src/agent/__tests__/tool-handling.test.ts
@@ -4,7 +4,7 @@ import {
   convertArrayToReadableStream as convertArrayToReadableStreamV3,
   MockLanguageModelV3,
 } from '@internal/ai-v6/test';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { MastraError } from '../../error';
 import { RequestContext } from '../../request-context';
@@ -16,6 +16,50 @@ function toolhandlingTests(version: 'v1' | 'v2' | 'v3' | 'v4') {
   const dummyModel = getSingleDummyResponseModel(version);
 
   describe(`${version} - agent tool handling`, () => {
+    describe('dynamic model resolution', () => {
+      it('resolves the model once for all assigned tools', async () => {
+        const resolveModel = vi.fn(() => dummyModel);
+        const agent = new Agent({
+          id: 'dynamic-model-agent',
+          name: 'dynamic-model-agent',
+          instructions: 'Use the assigned tools.',
+          model: resolveModel,
+          tools: {
+            firstTool: createTool({
+              id: 'first-tool',
+              description: 'First test tool.',
+              inputSchema: z.object({}),
+              execute: async () => 'first',
+            }),
+            secondTool: createTool({
+              id: 'second-tool',
+              description: 'Second test tool.',
+              inputSchema: z.object({}),
+              execute: async () => 'second',
+            }),
+          },
+        });
+
+        await agent.getToolsForExecution({ requestContext: new RequestContext() });
+
+        expect(resolveModel).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not resolve the model when there are no assigned tools', async () => {
+        const resolveModel = vi.fn(() => dummyModel);
+        const agent = new Agent({
+          id: 'dynamic-model-agent-without-tools',
+          name: 'dynamic-model-agent-without-tools',
+          instructions: 'No tools are assigned.',
+          model: resolveModel,
+        });
+
+        await agent.getToolsForExecution({ requestContext: new RequestContext() });
+
+        expect(resolveModel).not.toHaveBeenCalled();
+      });
+    });
+
     it('should handle tool name collisions caused by formatting', async () => {
       // Create two tool names that will collide after truncation to 63 chars
       const base = 'a'.repeat(63);

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4479,6 +4479,7 @@ export class Agent<
     const assignedTools = await this.listTools({ requestContext, resolveWebSearch: false });
 
     const assignedToolEntries = Object.entries(assignedTools || {});
+    const model = activeModel ?? (assignedToolEntries.length > 0 ? await this.getModel({ requestContext }) : undefined);
 
     const assignedCoreToolEntries = await Promise.all(
       assignedToolEntries.map(async ([k, tool]) => {
@@ -4486,7 +4487,6 @@ export class Agent<
           return;
         }
 
-        const model = activeModel ?? (await this.getModel({ requestContext }));
         const toolToConvert = isWebSearchTool(tool)
           ? createWebSearchProviderTool(normalizeWebSearchProvider(model))
           : tool;


### PR DESCRIPTION
## Description

Fixes #21267.

`getToolsForExecution()` was resolving a function-based model once per assigned tool. This patch resolves it once for the assigned-tool conversion batch and reuses the result, while leaving agents with no assigned tools untouched.

## Type of change

- [x] Bug fix
- [x] Test update

## Testing

- `vitest run src/agent/__tests__/tool-handling.test.ts` (47 passed)
- `tsc --noEmit -p packages/core/tsconfig.json`
- `oxfmt --check packages/core/src/agent/agent.ts packages/core/src/agent/__tests__/tool-handling.test.ts`

AI assistance: I used Codex for repository navigation and test scaffolding; the implementation was reviewed against the existing conversion flow and verified with the focused test suite above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When assigned tools need a dynamic model, the agent now finds that model once and reuses it. Agents without assigned tools do not resolve a model unnecessarily.

## Changes

- Resolve function-based models once during assigned-tool conversion.
- Reuse the resolved model for all assigned tools.
- Add tests for single resolution and no resolution without assigned tools.
- Add a patch changeset for `@mastra/core`.

## Validation

- Focused Vitest suite
- TypeScript compilation
- Formatting checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->