### PR TITLE
fix(memory): fall through to sync observation when blockAfter is exceeded post-activation

### DIFF
--- a/.changeset/yellow-clocks-tell.md
+++ b/.changeset/yellow-clocks-tell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed to force synchronous observation when pending tokens exceed the configured threshold after activation, matching the documented behavior

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -435,11 +435,34 @@ export class ObservationStep {
           reflectionHooks: om.composeHooks(undefined, { threadId, resourceId, trigger: 'turn-sync' }),
         });
 
-        return {
-          succeeded: true,
-          record: activation.record,
-          activatedMessageIds: activation.activatedMessageIds,
-        };
+        // blockAfter safety net: when pending tokens exceed blockAfter but activation
+        // doesn't bring them back below it, fall through to synchronous observation.
+        const blockAfter = om.getObservationConfig().blockAfter;
+        if (blockAfter) {
+          const postStatus = await om.getStatus({
+            threadId,
+            resourceId,
+            messages: observableMessages,
+          });
+          if (postStatus.pendingTokens >= blockAfter) {
+            omDebug(
+              `[OM:runThresholdObs] blockAfter exceeded post-activation (${postStatus.pendingTokens} >= ${blockAfter}), falling through to sync observation`,
+            );
+            // fall through to sync observation below
+          } else {
+            return {
+              succeeded: true,
+              record: activation.record,
+              activatedMessageIds: activation.activatedMessageIds,
+            };
+          }
+        } else {
+          return {
+            succeeded: true,
+            record: activation.record,
+            activatedMessageIds: activation.activatedMessageIds,
+          };
+        }
       }
     }
 


### PR DESCRIPTION
## What

`observation.blockAfter` was documented as forcing synchronous observation when pending tokens exceeded the threshold, but the implementation only used it to widen the activation ratio — it never triggered a sync observe call when buffered chunks were present.

## Fix

After buffered chunk activation succeeds in `runThresholdObservation()`, check whether `blockAfter` is configured and whether post-activation pending tokens still exceed it. If they do, fall through to synchronous observation instead of returning early.

This matches the pattern already used for reflection's `blockAfter` in `reflector-runner.ts`.

**Before:** activation succeeds → always returns early, regardless of `blockAfter`

**After:** activation succeeds → if `blockAfter` is set and post-activation pending tokens >= `blockAfter`, fall through to sync observation

---

Fixes #19768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the system still has too many unprocessed tokens after activating buffered data, it now processes them immediately. This ensures `observation.blockAfter` works as documented.

## Changes

- Updated `runThresholdObservation()` in `@mastra/memory`.
- Added a post-activation check for `observation.blockAfter`.
- Falls back to synchronous observation when pending tokens meet or exceed the threshold.
- Preserves the existing activation result when the threshold is not exceeded.
- Added a patch changeset for `@mastra/memory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->