### PR TITLE
feat(playground-ui): anchor chat turns to the top of the scroller

### DIFF
--- a/.changeset/fair-pianos-run.md
+++ b/.changeset/fair-pianos-run.md
@@ -1,0 +1,5 @@
+---
+'mastra': minor
+---
+
+Improved chat transcript scrolling so new prompts settle near the top while replies grow below without shifting the reading position.

--- a/.changeset/nice-ravens-greet.md
+++ b/.changeset/nice-ravens-greet.md
@@ -2,16 +2,18 @@
 '@mastra/playground-ui': minor
 ---
 
-Chat transcripts now lift each new turn toward the top of the viewport instead of following the bottom of the stream. Send a message and it climbs clear of the composer while the reply fills the room below it, so you read an answer from its first line rather than watching it slide past. Scrolling up no longer fights you, and the jump-to-latest button brings you back.
+Added anchored turn positioning to `MessageScroller`. Newly added rows marked with `scrollAnchor` move toward the top of the viewport, while `defaultScrollPosition="last-anchor"` opens saved transcripts at their latest turn.
 
-The room a turn climbs into is plain CSS: the scroller viewport is a size container, and a chat surface gives its last turn a minimum height in `cqh`. Nothing measures or resizes anything while a reply streams, so the composer stays perfectly still. The room also stays once the reply finishes — taking it away would shift what you are reading — and simply moves to the next turn when you send again.
-
-`MessageScroller` reads the turns from the rows you already mark with `scrollAnchor`. Open a saved thread on its last turn and reserve room under it with:
+Streaming replies can now grow beneath the current prompt without shifting the reading position. Completed replies retain that space until the next anchored turn arrives.
 
 ```tsx
 <MessageScrollerProvider defaultScrollPosition="last-anchor">
-```
-
-```tsx
-<div className={isLiveTurn ? 'min-h-[50cqh]' : undefined}>{turnRows}</div>
+  <MessageScrollerViewport>
+    <MessageScrollerContent>
+      <MessageScrollerItem messageId="turn-1" scrollAnchor>
+        <p>How do I deploy this workflow?</p>
+      </MessageScrollerItem>
+    </MessageScrollerContent>
+  </MessageScrollerViewport>
+</MessageScrollerProvider>
 ```

--- a/.changeset/nice-ravens-greet.md
+++ b/.changeset/nice-ravens-greet.md
@@ -4,14 +4,14 @@
 
 Chat transcripts now lift each new turn toward the top of the viewport instead of following the bottom of the stream. Send a message and it climbs clear of the composer while the reply fills the room below it, so you read an answer from its first line rather than watching it slide past. Scrolling up no longer fights you, and the jump-to-latest button brings you back.
 
-The room a turn climbs into is plain CSS: the scroller viewport is a size container, and a chat surface gives its live turn a minimum height in `cqh`. Nothing measures or resizes anything while a reply streams, so the composer stays perfectly still.
+The room a turn climbs into is plain CSS: the scroller viewport is a size container, and a chat surface gives its last turn a minimum height in `cqh`. Nothing measures or resizes anything while a reply streams, so the composer stays perfectly still. The room also stays once the reply finishes — taking it away would shift what you are reading — and simply moves to the next turn when you send again.
 
-`MessageScroller` reads the turns from the rows you already mark with `scrollAnchor`. Open a saved thread on its last turn and reserve room under the turn being answered with:
+`MessageScroller` reads the turns from the rows you already mark with `scrollAnchor`. Open a saved thread on its last turn and reserve room under it with:
 
 ```tsx
 <MessageScrollerProvider defaultScrollPosition="last-anchor">
 ```
 
 ```tsx
-<div className={isLiveTurn && awaitingReply ? 'min-h-[50cqh]' : undefined}>{turnRows}</div>
+<div className={isLiveTurn ? 'min-h-[50cqh]' : undefined}>{turnRows}</div>
 ```

--- a/.changeset/nice-ravens-greet.md
+++ b/.changeset/nice-ravens-greet.md
@@ -1,0 +1,17 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Chat transcripts now lift each new turn toward the top of the viewport instead of following the bottom of the stream. Send a message and it climbs clear of the composer while the reply fills the room below it, so you read an answer from its first line rather than watching it slide past. Scrolling up no longer fights you, and the jump-to-latest button brings you back.
+
+The room a turn climbs into is plain CSS: the scroller viewport is a size container, and a chat surface gives its live turn a minimum height in `cqh`. Nothing measures or resizes anything while a reply streams, so the composer stays perfectly still.
+
+`MessageScroller` reads the turns from the rows you already mark with `scrollAnchor`. Open a saved thread on its last turn and reserve room under the turn being answered with:
+
+```tsx
+<MessageScrollerProvider defaultScrollPosition="last-anchor">
+```
+
+```tsx
+<div className={isLiveTurn && awaitingReply ? 'min-h-[50cqh]' : undefined}>{turnRows}</div>
+```

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -6,6 +6,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/pla
 import { Input } from '@mastra/playground-ui/components/Input';
 import { MessageScrollerItem } from '@mastra/playground-ui/components/MessageScroller';
 import { Notice } from '@mastra/playground-ui/components/Notice';
+import { startsUserTurn } from '@mastra/playground-ui/components/ThreadRail';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { MessageFactory } from '@mastra/react/ui';
@@ -490,9 +491,9 @@ function SignalRow({ kind, label, message }: { kind: string; label: string; mess
 // Transcript
 // ---------------------------------------------------------------------------
 
-export function Transcript() {
+export function Transcript({ tail }: { tail?: ReactNode }) {
   const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
-  const { transcript, resolvePrompt } = useChatTranscript();
+  const { busy, transcript, resolvePrompt } = useChatTranscript();
   const hookArgs = {
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
@@ -515,23 +516,31 @@ export function Transcript() {
   return (
     <TranscriptEntries
       entries={transcript.entries}
+      awaitingReply={busy}
       isSubmitting={approveMutation.isPending || respondMutation.isPending}
       onApprove={onApprove}
       onRespond={onRespond}
+      tail={tail}
     />
   );
 }
 
 export function TranscriptEntries({
   entries,
+  awaitingReply = false,
   isSubmitting = false,
   onApprove,
   onRespond,
+  tail,
 }: {
   entries: TimelineEntry[];
+  /** A reply is on its way, so the live turn is worth room it has not filled yet. */
+  awaitingReply?: boolean;
   isSubmitting?: boolean;
   onApprove: (toolCallId: string, approved: boolean, promptId: string) => void;
   onRespond: (toolCallId: string, resumeData: string | string[] | PlanResume, promptId: string) => void;
+  /** Rendered inside the live turn (the activity line), so the reserved room stays under it. */
+  tail?: ReactNode;
 }) {
   const suspensions = new Map(
     entries.flatMap(entry => (entry.kind === 'suspension' ? [[entry.toolCallId, entry] as const] : [])),
@@ -571,25 +580,43 @@ export function TranscriptEntries({
     }
   };
 
+  const turnGroups: { key: string; entries: TimelineEntry[] }[] = [];
+  for (const entry of entries) {
+    const opensTurn = entry.kind === 'message' && startsUserTurn(entry.message);
+    if (opensTurn || turnGroups.length === 0) turnGroups.push({ key: entry.id, entries: [] });
+    turnGroups.at(-1)?.entries.push(entry);
+  }
+
   return (
     <>
-      {entries.map(entry => {
-        const rendered = renderEntry(entry);
-        if (!rendered) return null;
-
+      {turnGroups.map((group, index) => {
+        const isLiveTurn = index === turnGroups.length - 1;
         return (
-          <MessageScrollerItem
-            key={entry.id}
-            messageId={entry.id}
-            scrollAnchor={entry.kind === 'message' && entry.message.role === 'user'}
-            // Estimated off-screen heights would make the prepend anchor restore
-            // the wrong offset — measure the real thing.
-            className="[content-visibility:visible]"
-          >
-            {rendered}
-          </MessageScrollerItem>
+          // The room a fresh turn scrolls up into is this min-height: pure layout,
+          // filled by the streaming reply, gone with the flag — nothing measures it.
+          <div key={group.key} className={cn('flex flex-col', awaitingReply && isLiveTurn && 'min-h-[50cqh]')}>
+            {group.entries.map(entry => {
+              const rendered = renderEntry(entry);
+              if (!rendered) return null;
+
+              return (
+                <MessageScrollerItem
+                  key={entry.id}
+                  messageId={entry.id}
+                  scrollAnchor={entry.kind === 'message' && startsUserTurn(entry.message)}
+                  // Estimated off-screen heights would make the prepend anchor restore
+                  // the wrong offset — measure the real thing.
+                  className="[content-visibility:visible]"
+                >
+                  {rendered}
+                </MessageScrollerItem>
+              );
+            })}
+            {isLiveTurn && tail}
+          </div>
         );
       })}
+      {turnGroups.length === 0 && tail}
     </>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -493,7 +493,7 @@ function SignalRow({ kind, label, message }: { kind: string; label: string; mess
 
 export function Transcript({ tail }: { tail?: ReactNode }) {
   const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
-  const { busy, transcript, resolvePrompt } = useChatTranscript();
+  const { transcript, resolvePrompt } = useChatTranscript();
   const hookArgs = {
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
@@ -516,7 +516,6 @@ export function Transcript({ tail }: { tail?: ReactNode }) {
   return (
     <TranscriptEntries
       entries={transcript.entries}
-      awaitingReply={busy}
       isSubmitting={approveMutation.isPending || respondMutation.isPending}
       onApprove={onApprove}
       onRespond={onRespond}
@@ -527,15 +526,12 @@ export function Transcript({ tail }: { tail?: ReactNode }) {
 
 export function TranscriptEntries({
   entries,
-  awaitingReply = false,
   isSubmitting = false,
   onApprove,
   onRespond,
   tail,
 }: {
   entries: TimelineEntry[];
-  /** A reply is on its way, so the live turn is worth room it has not filled yet. */
-  awaitingReply?: boolean;
   isSubmitting?: boolean;
   onApprove: (toolCallId: string, approved: boolean, promptId: string) => void;
   onRespond: (toolCallId: string, resumeData: string | string[] | PlanResume, promptId: string) => void;
@@ -580,10 +576,10 @@ export function TranscriptEntries({
     }
   };
 
-  const turnGroups: { key: string; entries: TimelineEntry[] }[] = [];
+  const turnGroups: { key: string; entries: TimelineEntry[]; opensTurn: boolean }[] = [];
   for (const entry of entries) {
     const opensTurn = entry.kind === 'message' && startsUserTurn(entry.message);
-    if (opensTurn || turnGroups.length === 0) turnGroups.push({ key: entry.id, entries: [] });
+    if (opensTurn || turnGroups.length === 0) turnGroups.push({ key: entry.id, entries: [], opensTurn });
     turnGroups.at(-1)?.entries.push(entry);
   }
 
@@ -593,8 +589,9 @@ export function TranscriptEntries({
         const isLiveTurn = index === turnGroups.length - 1;
         return (
           // The room a fresh turn scrolls up into is this min-height: pure layout,
-          // filled by the streaming reply, gone with the flag — nothing measures it.
-          <div key={group.key} className={cn('flex flex-col', awaitingReply && isLiveTurn && 'min-h-[50cqh]')}>
+          // filled by the streaming reply. It stays after the run — collapsing it
+          // would shift the reader — and moves to the next turn with the anchor scroll.
+          <div key={group.key} className={cn('flex flex-col', isLiveTurn && group.opensTurn && 'min-h-[50cqh]')}>
             {group.entries.map(entry => {
               const rendered = renderEntry(entry);
               if (!rendered) return null;

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
@@ -25,11 +25,10 @@ const entries = [
 ];
 
 describe('TranscriptEntries turn groups', () => {
-  it('reserves room under the live turn only while a reply is coming', () => {
+  it('keeps the reserved room on the live turn and hands it to the next turn', () => {
     const { rerender } = renderWithProviders(
       <TranscriptEntries
         entries={entries}
-        awaitingReply
         onApprove={() => {}}
         onRespond={() => {}}
         tail={<div data-testid="tail" />}
@@ -44,24 +43,35 @@ describe('TranscriptEntries turn groups', () => {
 
     rerender(
       <TranscriptEntries
-        entries={entries}
+        entries={[
+          ...entries,
+          textEntry('assistant-2', 'assistant', 'second answer'),
+          textEntry('user-3', 'user', 'third question'),
+        ]}
         onApprove={() => {}}
         onRespond={() => {}}
         tail={<div data-testid="tail" />}
       />,
     );
-    expect(screen.getByTestId('tail').parentElement).not.toHaveClass('min-h-[50cqh]');
+    expect(screen.getByTestId('tail').parentElement).toHaveClass('min-h-[50cqh]');
+    expect(screen.getByText('second question').closest('.min-h-\\[50cqh\\]')).toBeNull();
+  });
+
+  it('gives no room to a group no user turn opens', () => {
+    renderWithProviders(
+      <TranscriptEntries
+        entries={[textEntry('assistant-only', 'assistant', 'orphan answer')]}
+        onApprove={() => {}}
+        onRespond={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('orphan answer').closest('.min-h-\\[50cqh\\]')).toBeNull();
   });
 
   it('still shows the tail while the transcript is empty', () => {
     renderWithProviders(
-      <TranscriptEntries
-        entries={[]}
-        awaitingReply
-        onApprove={() => {}}
-        onRespond={() => {}}
-        tail={<div data-testid="tail" />}
-      />,
+      <TranscriptEntries entries={[]} onApprove={() => {}} onRespond={() => {}} tail={<div data-testid="tail" />} />,
     );
 
     expect(screen.getByTestId('tail')).toBeInTheDocument();

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
@@ -1,0 +1,69 @@
+import type { MastraDBMessage } from '@mastra/core/agent-controller';
+import { screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithProviders } from '../../../../../../e2e/ui/render';
+import type { TimelineEntry } from '../../services/transcript';
+import { TranscriptEntries } from '../Transcript';
+
+const CREATED_AT = new Date('2026-07-15T10:00:00.000Z');
+
+function textEntry(id: string, role: 'user' | 'assistant', text: string): TimelineEntry {
+  const message: MastraDBMessage = {
+    id,
+    role,
+    createdAt: CREATED_AT,
+    content: { format: 2, parts: [{ type: 'text', text }] },
+  };
+  return { kind: 'message', id, message };
+}
+
+const entries = [
+  textEntry('user-1', 'user', 'first question'),
+  textEntry('assistant-1', 'assistant', 'first answer'),
+  textEntry('user-2', 'user', 'second question'),
+];
+
+describe('TranscriptEntries turn groups', () => {
+  it('reserves room under the live turn only while a reply is coming', () => {
+    const { rerender } = renderWithProviders(
+      <TranscriptEntries
+        entries={entries}
+        awaitingReply
+        onApprove={() => {}}
+        onRespond={() => {}}
+        tail={<div data-testid="tail" />}
+      />,
+    );
+
+    const liveGroup = screen.getByTestId('tail').parentElement;
+    expect(liveGroup).toHaveClass('min-h-[50cqh]');
+    expect(liveGroup).toBeInstanceOf(HTMLElement);
+    if (liveGroup) expect(within(liveGroup).getByText('second question')).toBeInTheDocument();
+    expect(screen.getByText('first question').closest('.min-h-\\[50cqh\\]')).toBeNull();
+
+    rerender(
+      <TranscriptEntries
+        entries={entries}
+        onApprove={() => {}}
+        onRespond={() => {}}
+        tail={<div data-testid="tail" />}
+      />,
+    );
+    expect(screen.getByTestId('tail').parentElement).not.toHaveClass('min-h-[50cqh]');
+  });
+
+  it('still shows the tail while the transcript is empty', () => {
+    renderWithProviders(
+      <TranscriptEntries
+        entries={[]}
+        awaitingReply
+        onApprove={() => {}}
+        onRespond={() => {}}
+        tail={<div data-testid="tail" />}
+      />,
+    );
+
+    expect(screen.getByTestId('tail')).toBeInTheDocument();
+  });
+});

--- a/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
@@ -136,7 +136,7 @@ function ThreadShell({
     <ChatShell
       className={threadShellClass}
       scroller={{
-        autoScroll: true,
+        defaultScrollPosition: 'last-anchor',
         preserveScrollOnPrepend: true,
         onReachStart: canLoadMore ? loadMore.load : undefined,
       }}
@@ -153,8 +153,7 @@ function ThreadTranscript() {
     <>
       <TranscriptHistoryLoader />
       {transcript.entries.length === 0 && <EmptyThreadState />}
-      <Transcript />
-      <ActivityLine />
+      <Transcript tail={<ActivityLine />} />
     </>
   );
 }

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
@@ -428,6 +428,32 @@ const HistoryRailHarness = ({ messageIds }: { messageIds: string[] }) => (
   </MessageScrollerProvider>
 );
 
+const TurnHarness = ({ messageIds, replyIds = [] }: { messageIds: string[]; replyIds?: string[] }) => (
+  <MessageScrollerProvider defaultScrollPosition="last-anchor">
+    <MessageScrollerViewport data-testid="turn-viewport">
+      <MessageScrollerContent>
+        {messageIds.map(messageId => (
+          <MessageScrollerItem key={messageId} messageId={messageId} scrollAnchor>
+            <div>{messageId}</div>
+          </MessageScrollerItem>
+        ))}
+        {replyIds.map(replyId => (
+          <MessageScrollerItem key={replyId} messageId={replyId}>
+            <div>{replyId}</div>
+          </MessageScrollerItem>
+        ))}
+      </MessageScrollerContent>
+    </MessageScrollerViewport>
+  </MessageScrollerProvider>
+);
+
+const stubLayout = (tops: Record<string, number>) => {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+    const top = this.dataset.messageId ? tops[this.dataset.messageId] : undefined;
+    return createRect({ top: top ?? 0 });
+  });
+};
+
 const contentResizeObserver = () => {
   const content = document.querySelector<HTMLElement>('[data-slot="message-scroller-content"]');
   if (!content) throw new Error('No scroller content');
@@ -555,6 +581,34 @@ describe('MessageScroller older history', () => {
     rerender(<HistoryHarness messageIds={['message-1', 'message-2', 'message-3']} onReachStart={onReachStart} />);
 
     expect(viewport.scrollTop).toBe(600);
+  });
+});
+
+describe('MessageScroller turn anchoring', () => {
+  it('parks a turn that opens below the ones already read at the top of the viewport', () => {
+    stubLayout({ 'message-2': 300 });
+    const { rerender } = render(<TurnHarness messageIds={['message-1']} />);
+
+    const viewport = screen.getByTestId('turn-viewport');
+    const scrollTo = installScrollTo(viewport);
+    setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 0 });
+
+    rerender(<TurnHarness messageIds={['message-1', 'message-2']} />);
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 300, behavior: 'smooth' });
+  });
+
+  it('stays put while the reply streams in below the turn', () => {
+    stubLayout({ 'message-1': 300 });
+    const { rerender } = render(<TurnHarness messageIds={['message-1']} />);
+
+    const viewport = screen.getByTestId('turn-viewport');
+    setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 300 });
+    const scrollTo = installScrollTo(viewport);
+
+    rerender(<TurnHarness messageIds={['message-1']} replyIds={['reply-1']} />);
+
+    expect(scrollTo).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
@@ -447,6 +447,18 @@ const TurnHarness = ({ messageIds, replyIds = [] }: { messageIds: string[]; repl
   </MessageScrollerProvider>
 );
 
+const ReconciledTurnHarness = ({ messageId }: { messageId: string }) => (
+  <MessageScrollerProvider defaultScrollPosition="last-anchor">
+    <MessageScrollerViewport data-testid="reconciled-turn-viewport">
+      <MessageScrollerContent>
+        <MessageScrollerItem key="stable-turn" messageId={messageId} scrollAnchor>
+          <div>{messageId}</div>
+        </MessageScrollerItem>
+      </MessageScrollerContent>
+    </MessageScrollerViewport>
+  </MessageScrollerProvider>
+);
+
 const stubLayout = (tops: Record<string, number>) => {
   vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
     const top = this.dataset.messageId ? tops[this.dataset.messageId] : undefined;
@@ -596,6 +608,19 @@ describe('MessageScroller turn anchoring', () => {
     rerender(<TurnHarness messageIds={['message-1', 'message-2']} />);
 
     expect(scrollTo).toHaveBeenLastCalledWith({ top: 300, behavior: 'smooth' });
+  });
+
+  it('does not re-anchor a turn when reconciliation replaces its message id', () => {
+    stubLayout({ 'client-message': 300, 'server-message': 300 });
+    const { rerender } = render(<ReconciledTurnHarness messageId="client-message" />);
+
+    const viewport = screen.getByTestId('reconciled-turn-viewport');
+    setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 300 });
+    const scrollTo = installScrollTo(viewport);
+
+    rerender(<ReconciledTurnHarness messageId="server-message" />);
+
+    expect(scrollTo).not.toHaveBeenCalled();
   });
 
   it('stays put while the reply streams in below the turn', () => {

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
@@ -205,6 +205,10 @@ export function MessageScrollerProvider({
   const [viewportElement, setViewportElement] = React.useState<HTMLDivElement | null>(null);
   const [contentElement, setContentElement] = React.useState<HTMLDivElement | null>(null);
   const defaultScrollAppliedRef = React.useRef(false);
+  const seenAnchorIdsRef = React.useRef<Set<string> | null>(null);
+  seenAnchorIdsRef.current ??= new Set<string>();
+  const seenAnchorIds = seenAnchorIdsRef.current;
+  const turnAnchoringArmedRef = React.useRef(false);
   const [scrollable, setScrollable] = React.useState<MessageScrollerScrollable>(DEFAULT_SCROLLABLE);
   const [visibility, setVisibility] = React.useState<MessageScrollerVisibility>(DEFAULT_VISIBILITY);
   const atEndRef = React.useRef(true);
@@ -258,11 +262,23 @@ export function MessageScrollerProvider({
     });
   }, [publishScrollable, scrollEdgeThreshold, viewportElement]);
 
-  const updateVisibility = React.useCallback(() => {
-    // Registration is mount order, not document order, once history is prepended.
+  // Registration is mount order, not document order, once history is prepended.
+  const getOrderedItems = React.useCallback(() => {
     orderedItemsRef.current ??= orderItemsByDocumentPosition(Array.from(itemsRegistry.entries()));
-    const items = orderedItemsRef.current;
-    const fallbackAnchorId = items.filter(([, item]) => item.scrollAnchor).at(-1)?.[0] ?? items.at(-1)?.[0];
+    return orderedItemsRef.current;
+  }, [itemsRegistry]);
+
+  const getLastAnchorId = React.useCallback(
+    () =>
+      getOrderedItems()
+        .filter(([, item]) => item.scrollAnchor)
+        .at(-1)?.[0],
+    [getOrderedItems],
+  );
+
+  const updateVisibility = React.useCallback(() => {
+    const items = getOrderedItems();
+    const fallbackAnchorId = getLastAnchorId() ?? items.at(-1)?.[0];
 
     if (items.length === 0) {
       publishVisibility(DEFAULT_VISIBILITY);
@@ -306,7 +322,15 @@ export function MessageScrollerProvider({
       visibleMessageIds:
         orderedVisibleMessageIds.length > 0 ? orderedVisibleMessageIds : fallbackAnchorId ? [fallbackAnchorId] : [],
     });
-  }, [intersectingMessageIds, itemsRegistry, publishVisibility, scrollMargin, scrollPreviousItemPeek, viewportElement]);
+  }, [
+    getLastAnchorId,
+    getOrderedItems,
+    intersectingMessageIds,
+    publishVisibility,
+    scrollMargin,
+    scrollPreviousItemPeek,
+    viewportElement,
+  ]);
 
   const syncAfterScroll = React.useCallback(() => {
     updateScrollable();
@@ -493,13 +517,11 @@ export function MessageScrollerProvider({
   React.useLayoutEffect(() => {
     if (defaultScrollAppliedRef.current || !viewportElement || itemsRegistry.size === 0) return;
 
+    const lastAnchorId = getLastAnchorId();
     let didScroll = false;
     if (defaultScrollPosition === 'start') {
       didScroll = scrollToStart({ behavior: 'auto' });
     } else if (defaultScrollPosition === 'last-anchor') {
-      const lastAnchorId = Array.from(itemsRegistry.entries())
-        .filter(([, item]) => item.scrollAnchor)
-        .at(-1)?.[0];
       didScroll = lastAnchorId
         ? scrollToMessage(lastAnchorId, { align: 'start', behavior: 'auto' })
         : scrollToEnd({ behavior: 'auto' });
@@ -510,6 +532,7 @@ export function MessageScrollerProvider({
     if (didScroll) defaultScrollAppliedRef.current = true;
   }, [
     defaultScrollPosition,
+    getLastAnchorId,
     itemsRegistry,
     itemsVersion,
     scrollToEnd,
@@ -517,6 +540,24 @@ export function MessageScrollerProvider({
     scrollToStart,
     viewportElement,
   ]);
+
+  // Park an arriving turn at the top and let the reply fill the room underneath.
+  // Prepended history and removed rows move the last anchor too, hence the ids
+  // already seen rather than a plain comparison against the previous one.
+  React.useLayoutEffect(() => {
+    const lastAnchorId = getLastAnchorId();
+    const newTurnId =
+      turnAnchoringArmedRef.current && lastAnchorId && !seenAnchorIds.has(lastAnchorId) ? lastAnchorId : undefined;
+
+    for (const [messageId, item] of getOrderedItems()) {
+      if (item.scrollAnchor) seenAnchorIds.add(messageId);
+    }
+    // Armed once the opening position lands: what was there at mount is history.
+    turnAnchoringArmedRef.current = defaultScrollAppliedRef.current;
+
+    if (!newTurnId) return;
+    scrollToMessage(newTurnId, { align: 'start', behavior: 'smooth' });
+  }, [getLastAnchorId, getOrderedItems, itemsVersion, scrollToMessage, seenAnchorIds]);
 
   // Older items land above the reader and shove their position down. A prepend is
   // told from an append by the first item's id, then undone by offsetting
@@ -617,7 +658,9 @@ export const MessageScrollerViewport = React.forwardRef<HTMLDivElement, MessageS
         tabIndex={tabIndex ?? 0}
         data-slot="message-scroller-viewport"
         className={cn(
-          'size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent',
+          // Size container so consumers can size the room under a live turn in cqh.
+          '[container-type:size] size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain',
+          'data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent',
           className,
         )}
         onScroll={event => {

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
@@ -208,6 +208,10 @@ export function MessageScrollerProvider({
   const seenAnchorIdsRef = React.useRef<Set<string> | null>(null);
   seenAnchorIdsRef.current ??= new Set<string>();
   const seenAnchorIds = seenAnchorIdsRef.current;
+  // Message ID reconciliation keeps the row element while replacing its ID.
+  const seenAnchorElementsRef = React.useRef<WeakSet<HTMLElement> | null>(null);
+  seenAnchorElementsRef.current ??= new WeakSet<HTMLElement>();
+  const seenAnchorElements = seenAnchorElementsRef.current;
   const turnAnchoringArmedRef = React.useRef(false);
   const [scrollable, setScrollable] = React.useState<MessageScrollerScrollable>(DEFAULT_SCROLLABLE);
   const [visibility, setVisibility] = React.useState<MessageScrollerVisibility>(DEFAULT_VISIBILITY);
@@ -541,23 +545,34 @@ export function MessageScrollerProvider({
     viewportElement,
   ]);
 
-  // Park an arriving turn at the top and let the reply fill the room underneath.
-  // Prepended history and removed rows move the last anchor too, hence the ids
-  // already seen rather than a plain comparison against the previous one.
   React.useLayoutEffect(() => {
     const lastAnchorId = getLastAnchorId();
-    const newTurnId =
-      turnAnchoringArmedRef.current && lastAnchorId && !seenAnchorIds.has(lastAnchorId) ? lastAnchorId : undefined;
+    const lastAnchor = lastAnchorId ? itemsRegistry.get(lastAnchorId) : undefined;
+    const shouldAnchorNewTurn =
+      turnAnchoringArmedRef.current &&
+      lastAnchorId !== undefined &&
+      lastAnchor !== undefined &&
+      !seenAnchorIds.has(lastAnchorId) &&
+      !seenAnchorElements.has(lastAnchor.element);
 
     for (const [messageId, item] of getOrderedItems()) {
-      if (item.scrollAnchor) seenAnchorIds.add(messageId);
+      if (!item.scrollAnchor) continue;
+      seenAnchorIds.add(messageId);
+      seenAnchorElements.add(item.element);
     }
-    // Armed once the opening position lands: what was there at mount is history.
     turnAnchoringArmedRef.current = defaultScrollAppliedRef.current;
 
-    if (!newTurnId) return;
-    scrollToMessage(newTurnId, { align: 'start', behavior: 'smooth' });
-  }, [getLastAnchorId, getOrderedItems, itemsVersion, scrollToMessage, seenAnchorIds]);
+    if (!shouldAnchorNewTurn || !lastAnchorId) return;
+    scrollToMessage(lastAnchorId, { align: 'start', behavior: 'smooth' });
+  }, [
+    getLastAnchorId,
+    getOrderedItems,
+    itemsRegistry,
+    itemsVersion,
+    scrollToMessage,
+    seenAnchorElements,
+    seenAnchorIds,
+  ]);
 
   // Older items land above the reader and shove their position down. A prepend is
   // told from an append by the first item's id, then undone by offsetting

--- a/packages/playground-ui/src/ds/components/ThreadRail/thread-rail-turns.ts
+++ b/packages/playground-ui/src/ds/components/ThreadRail/thread-rail-turns.ts
@@ -92,7 +92,8 @@ const getSignalType = (message: MastraDBMessage): string | undefined => {
   return typeof metadataType === 'string' ? metadataType : message.type;
 };
 
-const isDisplayableUserMessage = (message: MastraDBMessage): boolean => {
+/** What opens a turn: a rail stop, and the row the scroller parks at the top. */
+export const startsUserTurn = (message: MastraDBMessage): boolean => {
   if (message.role === 'user') return true;
   if (message.role !== 'signal') return false;
 
@@ -104,7 +105,7 @@ const getNextAssistantReply = (messages: MastraDBMessage[], startIndex: number):
   for (let index = startIndex + 1; index < messages.length; index += 1) {
     const message = messages[index];
     if (!message) continue;
-    if (isDisplayableUserMessage(message)) return undefined;
+    if (startsUserTurn(message)) return undefined;
     if (message.role !== 'assistant') continue;
 
     const reply = normalizeSummary(getTextFromParts(message), '');
@@ -116,7 +117,7 @@ const getNextAssistantReply = (messages: MastraDBMessage[], startIndex: number):
 
 export const buildThreadRailTurns = (messages: MastraDBMessage[]): ThreadRailTurn[] =>
   messages.flatMap((message, index) => {
-    if (!isDisplayableUserMessage(message)) return [];
+    if (!startsUserTurn(message)) return [];
 
     const files = getFileLabels(message);
     const visibleFiles = files.slice(0, FILE_PREVIEW_LIMIT);

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -21,7 +21,7 @@ import {
 import { PendingIndicator } from '@mastra/playground-ui/components/PendingIndicator';
 import { buildThreadRailTurns, getClientMessageKey, ThreadRail } from '@mastra/playground-ui/components/ThreadRail';
 import type { ThreadRailTurn } from '@mastra/playground-ui/components/ThreadRail';
-import { useAutoscroll } from '@mastra/playground-ui/hooks/use-autoscroll';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { MessageFactoryPart } from '@mastra/react';
 import { useSpeechRecognition } from '@mastra/react';
 import { ArrowUp, Mic } from 'lucide-react';
@@ -129,9 +129,7 @@ export const Thread = ({
   runOptionsSlot,
   refreshThreadList,
 }: ThreadProps) => {
-  const areaRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
-  useAutoscroll(areaRef, { enabled: true });
 
   const messages = useChatMessages();
   const { isRunning } = useChatRunning();
@@ -147,17 +145,26 @@ export const Thread = ({
   const delayedPending = useDelayedFlag(showPending, SKELETON_DELAY_MS);
   const threadRailTurns = useMemo(() => buildThreadRailTurns(messages), [messages]);
   const threadRailAnchorIds = useMemo(() => new Set(threadRailTurns.map(turn => turn.messageId)), [threadRailTurns]);
+  // Keyed by the opening message's client key: `data-user-message` reconciliation
+  // swaps `message.id` to the server signal id, and a changing key would remount
+  // the whole turn.
+  const turnGroups = useMemo(() => {
+    const groups: { key: string; messages: MastraDBMessage[] }[] = [];
+    for (const message of messages) {
+      if (threadRailAnchorIds.has(message.id) || groups.length === 0) {
+        groups.push({ key: getClientMessageKey(message), messages: [] });
+      }
+      groups.at(-1)?.messages.push(message);
+    }
+    return groups;
+  }, [messages, threadRailAnchorIds]);
 
   return (
     <ComposerAttachmentsProvider>
-      <MessageScrollerProvider>
+      <MessageScrollerProvider defaultScrollPosition="last-anchor">
         <div className="group/thread grid h-full grid-rows-[1fr_auto] overflow-y-auto" data-testid="thread-wrapper">
           <MessageScroller>
-            <MessageScrollerViewport
-              ref={areaRef}
-              className="h-full overflow-y-scroll"
-              style={{ overflowAnchor: 'none' }}
-            >
+            <MessageScrollerViewport className="h-full overflow-y-scroll" style={{ overflowAnchor: 'none' }}>
               {isEmpty ? (
                 <ThreadWelcome agentName={agentName} suggestedPrompts={suggestedPrompts} />
               ) : (
@@ -170,31 +177,34 @@ export const Thread = ({
                   >
                     <BracketOverlay containerRef={messagesContainerRef} />
                     <MessageScrollerContent className="flex flex-col gap-6 py-6">
-                      {messages.map(message => {
-                        // Prefer the optimistic `clientMessageId` as the React key so the
-                        // user row keeps a stable identity when `data-user-message`
-                        // reconciliation swaps `message.id` to the server signal id. A
-                        // changing key would unmount/remount the row and shift the
-                        // trailing pending indicator. Falls back to `message.id` for
-                        // messages without a correlation key (assistant, reloaded).
-                        const messageKey = getClientMessageKey(message);
+                      {turnGroups.map((group, index) => {
+                        const isLiveTurn = index === turnGroups.length - 1;
                         return (
-                          <MessageScrollerItem
-                            key={messageKey}
-                            messageId={message.id}
-                            scrollAnchor={threadRailAnchorIds.has(message.id)}
+                          // The room a fresh turn scrolls up into is this min-height: pure
+                          // layout, filled by the streaming reply, gone with the run.
+                          <div
+                            key={group.key}
+                            className={cn('flex flex-col gap-6', isRunning && isLiveTurn && 'min-h-[50cqh]')}
                           >
-                            <MessageRow
-                              message={message}
-                              hasModelList={hasModelList}
-                              isSpeaking={isSpeaking}
-                              onReadAloud={readAloud}
-                              onStopSpeaking={stopSpeaking}
-                            />
-                          </MessageScrollerItem>
+                            {group.messages.map(message => (
+                              <MessageScrollerItem
+                                key={getClientMessageKey(message)}
+                                messageId={message.id}
+                                scrollAnchor={threadRailAnchorIds.has(message.id)}
+                              >
+                                <MessageRow
+                                  message={message}
+                                  hasModelList={hasModelList}
+                                  isSpeaking={isSpeaking}
+                                  onReadAloud={readAloud}
+                                  onStopSpeaking={stopSpeaking}
+                                />
+                              </MessageScrollerItem>
+                            ))}
+                            {isLiveTurn && delayedPending && <PendingIndicator />}
+                          </div>
                         );
                       })}
-                      {delayedPending && <PendingIndicator />}
                     </MessageScrollerContent>
 
                     {!isRunning && <SaveFullConversationAction />}

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -148,16 +148,17 @@ export const Thread = ({
   // Keyed by the opening message's client key: `data-user-message` reconciliation
   // swaps `message.id` to the server signal id, and a changing key would remount
   // the whole turn.
-  const turnGroups = useMemo(() => {
-    const groups: { key: string; messages: MastraDBMessage[] }[] = [];
-    for (const message of messages) {
-      if (threadRailAnchorIds.has(message.id) || groups.length === 0) {
-        groups.push({ key: getClientMessageKey(message), messages: [] });
-      }
-      groups.at(-1)?.messages.push(message);
+  const turnGroups: { key: string; messages: MastraDBMessage[]; opensTurn: boolean }[] = [];
+  for (const message of messages) {
+    if (threadRailAnchorIds.has(message.id) || turnGroups.length === 0) {
+      turnGroups.push({
+        key: getClientMessageKey(message),
+        messages: [],
+        opensTurn: threadRailAnchorIds.has(message.id),
+      });
     }
-    return groups;
-  }, [messages, threadRailAnchorIds]);
+    turnGroups.at(-1)?.messages.push(message);
+  }
 
   return (
     <ComposerAttachmentsProvider>
@@ -181,10 +182,12 @@ export const Thread = ({
                         const isLiveTurn = index === turnGroups.length - 1;
                         return (
                           // The room a fresh turn scrolls up into is this min-height: pure
-                          // layout, filled by the streaming reply, gone with the run.
+                          // layout, filled by the streaming reply. It stays after the run —
+                          // collapsing it would shift the reader — and moves to the next
+                          // turn with the anchor scroll.
                           <div
                             key={group.key}
-                            className={cn('flex flex-col gap-6', isRunning && isLiveTurn && 'min-h-[50cqh]')}
+                            className={cn('flex flex-col gap-6', isLiveTurn && group.opensTurn && 'min-h-[50cqh]')}
                           >
                             {group.messages.map(message => (
                               <MessageScrollerItem


### PR DESCRIPTION
Chat transcripts used to follow the bottom of the stream, so an arriving answer slid past while you read it. Now sending a message parks it near the top of the viewport and the reply fills the room underneath, shadcn-style: you read an answer from its first line, scrolling up never fights you, and the jump-to-latest button brings you back. Saved threads open on their last turn instead of the raw end.

The room a fresh turn scrolls up into is plain CSS. The scroller viewport is a size container and each chat surface wraps its turns in groups, giving the live one a min-height in cqh while a reply is on its way. An earlier JS spacer version measured and wrote pixel heights and made the composer jitter by a pixel during streaming; the min-height resolves in the same layout pass as the growing reply, so nothing moves and the space collapses on its own when the run ends.

I also fixed a split source of truth while wiring this: the factory transcript recomputed what counts as a user turn and missed user-typed signals the thread rail already showed. Both transcripts and the rail now share one startsUserTurn predicate. Verified with unit tests on the scroller and turn grouping plus a visual pass in the factory app; the landing height is one number (50cqh) if we want to tune it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a user sends a chat message, the playground keeps it near the top of the screen so the reply can grow below it. Users can jump to the latest message, and saved threads reopen at their last turn.

## What changed

- Replaced the JavaScript spacer with a CSS-based layout using `min-height: 50cqh`.
- Kept the active turn’s space stable while a reply streams and after it finishes.
- Added `last-anchor` positioning for saved threads.
- Added jump-to-latest and stable turn-anchor handling.
- Added shared `startsUserTurn` logic for transcripts and the thread rail.
- Grouped transcript entries by user turns.
- Added a `tail` prop to `Transcript` for live activity content.
- Added changesets for the chat scrolling behavior.

## Testing

- Added transcript tests for active-turn spacing, rerender behavior, assistant-only groups, and empty transcripts.
- Added scroller tests for turn anchoring, streaming replies, and message reconciliation.
- Performed visual verification in the factory app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->