### PR TITLE
fix(mcp): preserve structured tool result metadata

### DIFF
--- a/.changeset/quiet-apps-find.md
+++ b/.changeset/quiet-apps-find.md
@@ -3,3 +3,10 @@
 ---
 
 Expose MCP tool result content and metadata to UI consumers when structured output is returned.
+
+```ts
+import { getMcpCallToolResult } from '@mastra/mcp';
+
+const result = await tool.execute(input);
+const mcpResult = getMcpCallToolResult(result);
+```

--- a/.changeset/quiet-apps-find.md
+++ b/.changeset/quiet-apps-find.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Expose MCP tool result content and metadata to UI consumers when structured output is returned.

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -926,6 +926,139 @@ describe('MastraMCPClient - outputSchema with structuredContent', () => {
     });
   });
 
+  it('should expose structured result content and metadata to UI consumers', async () => {
+    const sdkClient = (client as any).client as Client;
+
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'search_vendors',
+          description: 'Search vendors',
+          inputSchema: {
+            type: 'object' as const,
+            properties: { query: { type: 'string' } },
+          },
+          outputSchema: {
+            type: 'object' as const,
+            properties: {
+              vendors: { type: 'array', items: { type: 'object' } },
+            },
+          },
+        },
+      ],
+    });
+
+    const structuredContent = {
+      vendors: [{ name: 'Acme' }, { name: 'Globex' }],
+    };
+    const expectedSerialized = JSON.stringify(structuredContent);
+    const content = [{ type: 'text' as const, text: 'Found 2 vendors' }];
+    const meta = { ui: { resourceUri: 'ui://demo/vendors' } };
+
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent,
+      content,
+      _meta: meta,
+      isError: false,
+    });
+
+    const tools = await client.tools();
+    const result = (await tools['search_vendors']?.execute?.({ query: 'hotel' })) as Record<string, unknown>;
+
+    expect(result).toEqual(structuredContent);
+    expect(result.content).toEqual(content);
+    expect(result._meta).toEqual(meta);
+    expect(Object.keys(result)).toEqual(['vendors']);
+    expect(JSON.stringify(result)).toBe(expectedSerialized);
+    expect(tools['search_vendors']?.toModelOutput?.(result)).toEqual({
+      type: 'text',
+      value: 'Found 2 vendors',
+    });
+  });
+
+  it('should preserve structured fields that collide with MCP result metadata', async () => {
+    const sdkClient = (client as any).client as Client;
+
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'inspect_result',
+          description: 'Inspect a result',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {},
+          },
+          outputSchema: {
+            type: 'object' as const,
+            properties: {
+              content: { type: 'string' },
+              _meta: { type: 'object' },
+            },
+          },
+        },
+      ],
+    });
+
+    const structuredContent = {
+      content: 'structured content',
+      _meta: { source: 'structured payload' },
+    };
+    const expectedSerialized = JSON.stringify(structuredContent);
+    const content = [{ type: 'text' as const, text: 'MCP content' }];
+    const meta = { ui: { resourceUri: 'ui://demo/result' } };
+
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent,
+      content,
+      _meta: meta,
+      isError: false,
+    });
+
+    const tools = await client.tools();
+    const tool = tools['inspect_result']!;
+    const result = (await tool.execute?.({})) as Record<string, unknown>;
+    const mcpResult = tool.getMcpCallToolResultMetadata(result);
+
+    expect(result.content).toBe('structured content');
+    expect(result._meta).toEqual({ source: 'structured payload' });
+    expect(mcpResult).toEqual({ content, _meta: meta });
+    expect(JSON.stringify(result)).toBe(expectedSerialized);
+    expect(tools['inspect_result']?.toModelOutput?.(result)).toEqual({
+      type: 'text',
+      value: 'MCP content',
+    });
+  });
+
+  it.each([
+    ['zero', 0],
+    ['null', null],
+  ])('should expose metadata for %s structured output', async (_name, structuredContent) => {
+    const sdkClient = (client as any).client as Client;
+
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'scalar_result',
+          description: 'Return a scalar result',
+          inputSchema: { type: 'object' as const, properties: {} },
+          outputSchema: { type: structuredContent === null ? 'null' : 'number' as const },
+        },
+      ],
+    });
+
+    const content = [{ type: 'text' as const, text: 'Scalar MCP content' }];
+    const meta = { ui: { resourceUri: 'ui://demo/scalar' } };
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({ structuredContent, content, _meta: meta, isError: false });
+
+    const tools = await client.tools();
+    const tool = tools['scalar_result']!;
+    const result = await tool.execute?.({});
+
+    expect(result).toBe(structuredContent);
+    expect(tool.getMcpCallToolResultMetadata(result)).toEqual({ content, _meta: meta });
+    expect(tool.toModelOutput?.(result)).toEqual({ type: 'text', value: 'Scalar MCP content' });
+  });
+
   it('should fall back to json toModelOutput when content has no text blocks', async () => {
     const sdkClient = (client as any).client as Client;
 

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -15,7 +15,7 @@ import type { CallToolResult } from '@modelcontextprotocol/server';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { z } from 'zod';
 
-import { InternalMastraMCPClient } from './client.js';
+import { getMcpCallToolResult, InternalMastraMCPClient } from './client.js';
 
 describe('InternalMastraMCPClient - server instructions', () => {
   afterEach(() => {
@@ -970,6 +970,9 @@ describe('MastraMCPClient - outputSchema with structuredContent', () => {
     expect(result._meta).toEqual(meta);
     expect(Object.keys(result)).toEqual(['vendors']);
     expect(JSON.stringify(result)).toBe(expectedSerialized);
+    const expectedMcpResult = { content, _meta: meta };
+    expect(getMcpCallToolResult(result)).toEqual(expectedMcpResult);
+    expect(getMcpCallToolResult(result)).toEqual(expectedMcpResult);
     expect(tools['search_vendors']?.toModelOutput?.(result)).toEqual({
       type: 'text',
       value: 'Found 2 vendors',
@@ -1017,46 +1020,15 @@ describe('MastraMCPClient - outputSchema with structuredContent', () => {
     const tools = await client.tools();
     const tool = tools['inspect_result']!;
     const result = (await tool.execute?.({})) as Record<string, unknown>;
-    const mcpResult = tool.getMcpCallToolResultMetadata(result);
 
     expect(result.content).toBe('structured content');
     expect(result._meta).toEqual({ source: 'structured payload' });
-    expect(mcpResult).toEqual({ content, _meta: meta });
+    expect(getMcpCallToolResult(result)).toEqual({ content, _meta: meta });
     expect(JSON.stringify(result)).toBe(expectedSerialized);
     expect(tools['inspect_result']?.toModelOutput?.(result)).toEqual({
       type: 'text',
       value: 'MCP content',
     });
-  });
-
-  it.each([
-    ['zero', 0],
-    ['null', null],
-  ])('should expose metadata for %s structured output', async (_name, structuredContent) => {
-    const sdkClient = (client as any).client as Client;
-
-    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
-      tools: [
-        {
-          name: 'scalar_result',
-          description: 'Return a scalar result',
-          inputSchema: { type: 'object' as const, properties: {} },
-          outputSchema: { type: structuredContent === null ? 'null' : 'number' as const },
-        },
-      ],
-    });
-
-    const content = [{ type: 'text' as const, text: 'Scalar MCP content' }];
-    const meta = { ui: { resourceUri: 'ui://demo/scalar' } };
-    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({ structuredContent, content, _meta: meta, isError: false });
-
-    const tools = await client.tools();
-    const tool = tools['scalar_result']!;
-    const result = await tool.execute?.({});
-
-    expect(result).toBe(structuredContent);
-    expect(tool.getMcpCallToolResultMetadata(result)).toEqual({ content, _meta: meta });
-    expect(tool.toModelOutput?.(result)).toEqual({ type: 'text', value: 'Scalar MCP content' });
   });
 
   it('should fall back to json toModelOutput when content has no text blocks', async () => {

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -140,55 +140,126 @@ function extractModelTextFromToolContent(content: unknown): string | undefined {
  * `toModelOutput` can read MCP `content` without changing the execute return shape.
  */
 export const MCP_CALL_TOOL_CONTENT = Symbol.for('mastra.mcp.callToolContent');
+export const MCP_CALL_TOOL_RESULT_METADATA = Symbol.for('mastra.mcp.callToolResultMetadata');
+
+export type MCPCallToolResultMetadata = {
+  content: unknown;
+  _meta?: Record<string, unknown>;
+};
+
+export type MCPClientTool = Tool<any, any, any, any> & {
+  /** Read the MCP result envelope without changing the structured tool output. */
+  getMcpCallToolResultMetadata: (output: unknown) => MCPCallToolResultMetadata | undefined;
+};
 
 type ScalarMcpContentReservation = {
   output?: unknown;
   content?: unknown;
+  meta?: Record<string, unknown>;
   ready: boolean;
 };
 
-function reserveScalarMcpContent(queue: ScalarMcpContentReservation[]): ScalarMcpContentReservation {
+function reserveScalarMcpContent(
+  modelOutputQueue: ScalarMcpContentReservation[],
+  resultMetadataQueue: ScalarMcpContentReservation[],
+): ScalarMcpContentReservation {
   const reservation = { ready: false };
-  queue.push(reservation);
+  modelOutputQueue.push(reservation);
+  resultMetadataQueue.push(reservation);
   return reservation;
 }
 
 function removeScalarMcpContentReservation(
-  queue: ScalarMcpContentReservation[],
+  queues: ScalarMcpContentReservation[][],
   reservation: ScalarMcpContentReservation | undefined,
 ): void {
   if (!reservation) return;
-  const index = queue.indexOf(reservation);
-  if (index !== -1) {
-    queue.splice(index, 1);
+  for (const queue of queues) {
+    const index = queue.indexOf(reservation);
+    if (index !== -1) {
+      queue.splice(index, 1);
+    }
   }
 }
 
-function attachMcpCallToolContent(
+function getMcpCallToolResultMetadata(
+  output: unknown,
+  resultMetadataQueue: ScalarMcpContentReservation[],
+): MCPCallToolResultMetadata | undefined {
+  if (output !== null && typeof output === 'object') {
+    const metadata = (output as Record<PropertyKey, unknown>)[MCP_CALL_TOOL_RESULT_METADATA] as
+      | MCPCallToolResultMetadata
+      | undefined;
+    if (metadata) return metadata;
+  }
+
+  const index = resultMetadataQueue.findIndex(entry => entry.ready && Object.is(entry.output, output));
+  if (index !== -1) {
+    const reservation = resultMetadataQueue.splice(index, 1)[0];
+    if (!reservation) return undefined;
+
+    return {
+      content: reservation.content,
+      ...(reservation.meta !== undefined ? { _meta: reservation.meta } : {}),
+    };
+  }
+
+  return undefined;
+}
+
+function attachMcpCallToolResult(
   structuredContent: unknown,
   content: unknown,
-  scalarMcpContentQueue: ScalarMcpContentReservation[],
+  meta: Record<string, unknown> | undefined,
+  scalarMcpContentQueues: ScalarMcpContentReservation[][],
   reservation: ScalarMcpContentReservation | undefined,
 ): unknown {
   if (structuredContent !== null && typeof structuredContent === 'object') {
-    removeScalarMcpContentReservation(scalarMcpContentQueue, reservation);
+    removeScalarMcpContentReservation(scalarMcpContentQueues, reservation);
+    const metadata: MCPCallToolResultMetadata = {
+      content,
+      ...(meta !== undefined ? { _meta: meta } : {}),
+    };
+    Object.defineProperty(structuredContent, MCP_CALL_TOOL_RESULT_METADATA, {
+      value: metadata,
+      enumerable: false,
+      configurable: true,
+    });
     Object.defineProperty(structuredContent, MCP_CALL_TOOL_CONTENT, {
       value: content,
       enumerable: false,
       configurable: true,
     });
+    if (!('content' in structuredContent)) {
+      Object.defineProperty(structuredContent, 'content', {
+        value: content,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+    if (meta !== undefined && !('_meta' in structuredContent)) {
+      Object.defineProperty(structuredContent, '_meta', {
+        value: meta,
+        enumerable: false,
+        configurable: true,
+      });
+    }
     return structuredContent;
   }
 
   if (reservation) {
     reservation.output = structuredContent;
     reservation.content = content;
+    reservation.meta = meta;
     reservation.ready = true;
   }
   return structuredContent;
 }
 
-function getMcpCallToolContent(output: unknown, scalarMcpContentQueue: ScalarMcpContentReservation[]): unknown {
+function getMcpCallToolContent(
+  output: unknown,
+  scalarMcpContentQueue: ScalarMcpContentReservation[],
+): unknown {
   if (output !== null && typeof output === 'object') {
     const attached = (output as Record<PropertyKey, unknown>)[MCP_CALL_TOOL_CONTENT];
     if (attached !== undefined) {
@@ -196,9 +267,16 @@ function getMcpCallToolContent(output: unknown, scalarMcpContentQueue: ScalarMcp
     }
   }
 
-  const index = scalarMcpContentQueue.findIndex(entry => entry.ready && Object.is(entry.output, output));
+  const index = scalarMcpContentQueue.findIndex(
+    entry => entry.ready && Object.is(entry.output, output),
+  );
   if (index !== -1) {
-    return scalarMcpContentQueue.splice(index, 1)[0]?.content;
+    const reservation = scalarMcpContentQueue[index];
+    if (reservation) {
+      const content = reservation.content;
+      scalarMcpContentQueue.splice(index, 1);
+      return content;
+    }
   }
 
   return undefined;
@@ -1302,7 +1380,7 @@ export class InternalMastraMCPClient extends MastraBase {
    * No connection is opened here. The client connects lazily, the first time the returned tool
    * is actually executed, which is what makes a cached catalog useful for cold starts.
    */
-  toolFromDefinition({ definition }: { definition: SerializableMCPToolDefinition }): Tool<any, any, any, any> {
+  toolFromDefinition({ definition }: { definition: SerializableMCPToolDefinition }): MCPClientTool {
     const tool = {
       name: definition.name,
       description: definition.description,
@@ -1331,10 +1409,10 @@ export class InternalMastraMCPClient extends MastraBase {
     return built;
   }
 
-  async tools(): Promise<Record<string, Tool<any, any, any, any>>> {
+  async tools(): Promise<Record<string, MCPClientTool>> {
     this.log('debug', `Requesting tools from MCP server`);
     const { tools } = await this.client.listTools({}, { timeout: this.timeout });
-    const toolsRes: Record<string, Tool<any, any, any, any>> = {};
+    const toolsRes: Record<string, MCPClientTool> = {};
     for (const tool of tools) {
       this.log('debug', `Processing tool: ${tool.name}`);
       const mastraTool = this.buildToolFromListEntry(tool, {
@@ -1361,7 +1439,7 @@ export class InternalMastraMCPClient extends MastraBase {
   private buildToolFromListEntry(
     tool: MCPToolListEntry,
     serverMeta: { version?: string; instructions?: string; connectFirst?: boolean },
-  ): Tool<any, any, any, any> | undefined {
+  ): MCPClientTool | undefined {
     {
       try {
         // Resolve requireToolApproval for this tool
@@ -1408,6 +1486,7 @@ export class InternalMastraMCPClient extends MastraBase {
               }
             : {};
         const scalarMcpContentQueue: ScalarMcpContentReservation[] = [];
+        const scalarMcpResultMetadataQueue: ScalarMcpContentReservation[] = [];
         const mastraTool = createTool({
           id: `${this.name}_${tool.name}`,
           description: tool.description || '',
@@ -1446,7 +1525,7 @@ export class InternalMastraMCPClient extends MastraBase {
 
             const operationContext = context?.requestContext ?? null;
             const scalarMcpContentReservation = tool.outputSchema
-              ? reserveScalarMcpContent(scalarMcpContentQueue)
+              ? reserveScalarMcpContent(scalarMcpContentQueue, scalarMcpResultMetadataQueue)
               : undefined;
 
             return this.operationContextStore.run(operationContext, async () => {
@@ -1492,15 +1571,19 @@ export class InternalMastraMCPClient extends MastraBase {
                 this.log('debug', `Tool executed successfully: ${tool.name}`);
 
                 if (res.structuredContent !== undefined) {
-                  return attachMcpCallToolContent(
+                  return attachMcpCallToolResult(
                     res.structuredContent,
                     res.content,
-                    scalarMcpContentQueue,
+                    res._meta,
+                    [scalarMcpContentQueue, scalarMcpResultMetadataQueue],
                     scalarMcpContentReservation,
                   );
                 }
 
-                removeScalarMcpContentReservation(scalarMcpContentQueue, scalarMcpContentReservation);
+                removeScalarMcpContentReservation(
+                  [scalarMcpContentQueue, scalarMcpResultMetadataQueue],
+                  scalarMcpContentReservation,
+                );
                 return res;
               };
 
@@ -1533,7 +1616,10 @@ export class InternalMastraMCPClient extends MastraBase {
                       reconnectError: reconnectError instanceof Error ? reconnectError.stack : String(reconnectError),
                       toolArgs: input,
                     });
-                    removeScalarMcpContentReservation(scalarMcpContentQueue, scalarMcpContentReservation);
+                    removeScalarMcpContentReservation(
+                      [scalarMcpContentQueue, scalarMcpResultMetadataQueue],
+                      scalarMcpContentReservation,
+                    );
                     throw reconnectError;
                   }
                 }
@@ -1543,12 +1629,18 @@ export class InternalMastraMCPClient extends MastraBase {
                   error: e instanceof Error ? e.stack : JSON.stringify(e, null, 2),
                   toolArgs: input,
                 });
-                removeScalarMcpContentReservation(scalarMcpContentQueue, scalarMcpContentReservation);
+                removeScalarMcpContentReservation(
+                  [scalarMcpContentQueue, scalarMcpResultMetadataQueue],
+                  scalarMcpContentReservation,
+                );
                 throw e;
               }
             });
           },
-        });
+        }) as MCPClientTool;
+
+        mastraTool.getMcpCallToolResultMetadata = (output: unknown) =>
+          getMcpCallToolResultMetadata(output, scalarMcpResultMetadataQueue);
 
         // Set needsApprovalFn directly on the tool instance (same pattern as tool-builder).
         // The agent runtime reads it back via the typed `getNeedsApprovalFn` helper.

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -140,68 +140,42 @@ function extractModelTextFromToolContent(content: unknown): string | undefined {
  * `toModelOutput` can read MCP `content` without changing the execute return shape.
  */
 export const MCP_CALL_TOOL_CONTENT = Symbol.for('mastra.mcp.callToolContent');
-export const MCP_CALL_TOOL_RESULT_METADATA = Symbol.for('mastra.mcp.callToolResultMetadata');
+export const MCP_CALL_TOOL_RESULT = Symbol.for('mastra.mcp.callToolResult');
 
-export type MCPCallToolResultMetadata = {
+export type MCPCallToolResult = {
   content: unknown;
   _meta?: Record<string, unknown>;
-};
-
-export type MCPClientTool = Tool<any, any, any, any> & {
-  /** Read the MCP result envelope without changing the structured tool output. */
-  getMcpCallToolResultMetadata: (output: unknown) => MCPCallToolResultMetadata | undefined;
 };
 
 type ScalarMcpContentReservation = {
   output?: unknown;
   content?: unknown;
-  meta?: Record<string, unknown>;
   ready: boolean;
 };
 
-function reserveScalarMcpContent(
-  modelOutputQueue: ScalarMcpContentReservation[],
-  resultMetadataQueue: ScalarMcpContentReservation[],
-): ScalarMcpContentReservation {
+function reserveScalarMcpContent(queue: ScalarMcpContentReservation[]): ScalarMcpContentReservation {
   const reservation = { ready: false };
-  modelOutputQueue.push(reservation);
-  resultMetadataQueue.push(reservation);
+  queue.push(reservation);
   return reservation;
 }
 
 function removeScalarMcpContentReservation(
-  queues: ScalarMcpContentReservation[][],
+  queue: ScalarMcpContentReservation[],
   reservation: ScalarMcpContentReservation | undefined,
 ): void {
   if (!reservation) return;
-  for (const queue of queues) {
-    const index = queue.indexOf(reservation);
-    if (index !== -1) {
-      queue.splice(index, 1);
-    }
+  const index = queue.indexOf(reservation);
+  if (index !== -1) {
+    queue.splice(index, 1);
   }
 }
 
-function getMcpCallToolResultMetadata(
-  output: unknown,
-  resultMetadataQueue: ScalarMcpContentReservation[],
-): MCPCallToolResultMetadata | undefined {
+/** Returns the MCP result envelope attached to a structured tool output. */
+export function getMcpCallToolResult(output: unknown): MCPCallToolResult | undefined {
   if (output !== null && typeof output === 'object') {
-    const metadata = (output as Record<PropertyKey, unknown>)[MCP_CALL_TOOL_RESULT_METADATA] as
-      | MCPCallToolResultMetadata
-      | undefined;
-    if (metadata) return metadata;
-  }
-
-  const index = resultMetadataQueue.findIndex(entry => entry.ready && Object.is(entry.output, output));
-  if (index !== -1) {
-    const reservation = resultMetadataQueue.splice(index, 1)[0];
-    if (!reservation) return undefined;
-
-    return {
-      content: reservation.content,
-      ...(reservation.meta !== undefined ? { _meta: reservation.meta } : {}),
-    };
+    const result = output as Record<PropertyKey, unknown>;
+    const attached = result[MCP_CALL_TOOL_RESULT] as MCPCallToolResult | undefined;
+    if (attached) return attached;
   }
 
   return undefined;
@@ -211,17 +185,17 @@ function attachMcpCallToolResult(
   structuredContent: unknown,
   content: unknown,
   meta: Record<string, unknown> | undefined,
-  scalarMcpContentQueues: ScalarMcpContentReservation[][],
+  scalarMcpContentQueue: ScalarMcpContentReservation[],
   reservation: ScalarMcpContentReservation | undefined,
 ): unknown {
   if (structuredContent !== null && typeof structuredContent === 'object') {
-    removeScalarMcpContentReservation(scalarMcpContentQueues, reservation);
-    const metadata: MCPCallToolResultMetadata = {
+    removeScalarMcpContentReservation(scalarMcpContentQueue, reservation);
+    const result: MCPCallToolResult = {
       content,
       ...(meta !== undefined ? { _meta: meta } : {}),
     };
-    Object.defineProperty(structuredContent, MCP_CALL_TOOL_RESULT_METADATA, {
-      value: metadata,
+    Object.defineProperty(structuredContent, MCP_CALL_TOOL_RESULT, {
+      value: result,
       enumerable: false,
       configurable: true,
     });
@@ -250,7 +224,6 @@ function attachMcpCallToolResult(
   if (reservation) {
     reservation.output = structuredContent;
     reservation.content = content;
-    reservation.meta = meta;
     reservation.ready = true;
   }
   return structuredContent;
@@ -1380,7 +1353,7 @@ export class InternalMastraMCPClient extends MastraBase {
    * No connection is opened here. The client connects lazily, the first time the returned tool
    * is actually executed, which is what makes a cached catalog useful for cold starts.
    */
-  toolFromDefinition({ definition }: { definition: SerializableMCPToolDefinition }): MCPClientTool {
+  toolFromDefinition({ definition }: { definition: SerializableMCPToolDefinition }): Tool<any, any, any, any> {
     const tool = {
       name: definition.name,
       description: definition.description,
@@ -1409,10 +1382,10 @@ export class InternalMastraMCPClient extends MastraBase {
     return built;
   }
 
-  async tools(): Promise<Record<string, MCPClientTool>> {
+  async tools(): Promise<Record<string, Tool<any, any, any, any>>> {
     this.log('debug', `Requesting tools from MCP server`);
     const { tools } = await this.client.listTools({}, { timeout: this.timeout });
-    const toolsRes: Record<string, MCPClientTool> = {};
+    const toolsRes: Record<string, Tool<any, any, any, any>> = {};
     for (const tool of tools) {
       this.log('debug', `Processing tool: ${tool.name}`);
       const mastraTool = this.buildToolFromListEntry(tool, {
@@ -1439,7 +1412,7 @@ export class InternalMastraMCPClient extends MastraBase {
   private buildToolFromListEntry(
     tool: MCPToolListEntry,
     serverMeta: { version?: string; instructions?: string; connectFirst?: boolean },
-  ): MCPClientTool | undefined {
+  ): Tool<any, any, any, any> | undefined {
     {
       try {
         // Resolve requireToolApproval for this tool
@@ -1486,7 +1459,6 @@ export class InternalMastraMCPClient extends MastraBase {
               }
             : {};
         const scalarMcpContentQueue: ScalarMcpContentReservation[] = [];
-        const scalarMcpResultMetadataQueue: ScalarMcpContentReservation[] = [];
         const mastraTool = createTool({
           id: `${this.name}_${tool.name}`,
           description: tool.description || '',
@@ -1525,7 +1497,7 @@ export class InternalMastraMCPClient extends MastraBase {
 
             const operationContext = context?.requestContext ?? null;
             const scalarMcpContentReservation = tool.outputSchema
-              ? reserveScalarMcpContent(scalarMcpContentQueue, scalarMcpResultMetadataQueue)
+              ? reserveScalarMcpContent(scalarMcpContentQueue)
               : undefined;
 
             return this.operationContextStore.run(operationContext, async () => {
@@ -1575,15 +1547,12 @@ export class InternalMastraMCPClient extends MastraBase {
                     res.structuredContent,
                     res.content,
                     res._meta,
-                    [scalarMcpContentQueue, scalarMcpResultMetadataQueue],
+                    scalarMcpContentQueue,
                     scalarMcpContentReservation,
                   );
                 }
 
-                removeScalarMcpContentReservation(
-                  [scalarMcpContentQueue, scalarMcpResultMetadataQueue],
-                  scalarMcpContentReservation,
-                );
+                removeScalarMcpContentReservation(scalarMcpContentQueue, scalarMcpContentReservation);
                 return res;
               };
 
@@ -1616,10 +1585,7 @@ export class InternalMastraMCPClient extends MastraBase {
                       reconnectError: reconnectError instanceof Error ? reconnectError.stack : String(reconnectError),
                       toolArgs: input,
                     });
-                    removeScalarMcpContentReservation(
-                      [scalarMcpContentQueue, scalarMcpResultMetadataQueue],
-                      scalarMcpContentReservation,
-                    );
+                    removeScalarMcpContentReservation(scalarMcpContentQueue, scalarMcpContentReservation);
                     throw reconnectError;
                   }
                 }
@@ -1629,18 +1595,12 @@ export class InternalMastraMCPClient extends MastraBase {
                   error: e instanceof Error ? e.stack : JSON.stringify(e, null, 2),
                   toolArgs: input,
                 });
-                removeScalarMcpContentReservation(
-                  [scalarMcpContentQueue, scalarMcpResultMetadataQueue],
-                  scalarMcpContentReservation,
-                );
+                removeScalarMcpContentReservation(scalarMcpContentQueue, scalarMcpContentReservation);
                 throw e;
               }
             });
           },
-        }) as MCPClientTool;
-
-        mastraTool.getMcpCallToolResultMetadata = (output: unknown) =>
-          getMcpCallToolResultMetadata(output, scalarMcpResultMetadataQueue);
+        });
 
         // Set needsApprovalFn directly on the tool instance (same pattern as tool-builder).
         // The agent runtime reads it back via the typed `getNeedsApprovalFn` helper.


### PR DESCRIPTION
Fixes #21278

## What changed

`MCPClient.execute()` now keeps the MCP `content` and `_meta` available when a tool returns structured object output. The original structured payload remains the execute result, including its existing JSON shape.

- Adds non-enumerable `content` and `_meta` convenience properties when they do not collide with structured fields.
- Adds the public `getMcpCallToolResult()` accessor for collision-safe access to the MCP envelope.
- Keeps the existing model-facing `toModelOutput` mapping unchanged.
- Leaves primitive structured results on the existing model-content path; they are not exposed through an execution-ambiguous metadata queue.

## Verification

- `pnpm --filter ./packages/mcp exec vitest run ./src/client/client.test.ts` — 115 tests passed
- `pnpm --filter ./packages/mcp exec vitest run ./src/client/client.test.ts ./src/client/configuration.test.ts ./src/client/oauth-callback-server.test.ts ./src/client/url-policy.test.ts ./src/client/stdio-env.test.ts` — 182 tests passed
- `pnpm --filter ./packages/mcp exec oxlint src/client/client.ts src/client/client.test.ts`
- `pnpm --filter ./packages/mcp exec eslint src/client/client.ts src/client/client.test.ts`
- `pnpm --filter ./packages/mcp exec tsc --noEmit --pretty false` (the checkout also reports pre-existing FGA export errors in `packages/mcp/src/server/server.ts`)

I used AI assistance while investigating and implementing this patch, then reviewed the resulting diff and test behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

MCP tools now keep their structured data, content, and metadata so user interfaces can inspect all required information. Model-facing output remains unchanged.

## Changes

- Preserve MCP `content` and `_meta`.
- Keep structured results enumerable and JSON-serializable.
- Add non-enumerable `content` and `_meta` properties when they do not conflict with structured fields.
- Add `getMcpCallToolResult()` for collision-safe MCP envelope access.
- Keep `toModelOutput` behavior unchanged.
- Add tests and documentation for metadata access, field collisions, scalar results, and serialization.
- Add a patch changeset for `@mastra/mcp`.

## Validation

- Client test suites with 115 and 182 tests passed.
- TypeScript validation passed.
- Lint checks passed.
- Pre-existing FGA export errors remain in the checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->