### PR TITLE
fix(workflows): persist normalized dynamic definitions

### DIFF
--- a/.changeset/bright-flies-invent.md
+++ b/.changeset/bright-flies-invent.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed workflow command errors to preserve message-like failure details.

--- a/.changeset/bright-flies-invent.md
+++ b/.changeset/bright-flies-invent.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Fixed workflow command errors to preserve message-like failure details.
+Fixed `/workflows` command errors so the message from a failure is shown, whether the failure is a string or an object with a message, instead of `[object Object]`.

--- a/.changeset/brown-pugs-drum.md
+++ b/.changeset/brown-pugs-drum.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed dynamic workflow registration to hydrate and persist normalized definitions.
+Fixed dynamic workflows so object-form mapping configs keep working. Passing `mapConfig` as an object to `addDynamicWorkflow` previously failed at run time with `"[object Object]" is not valid JSON`; it now stays intact when the workflow is registered, saved, and loaded.

--- a/.changeset/brown-pugs-drum.md
+++ b/.changeset/brown-pugs-drum.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed dynamic workflow registration to hydrate and persist normalized definitions.

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -54,7 +54,7 @@ const result = await run.start({ inputData: { name: 'Ada' } })
   content={[
   {
     name: 'def',
-    type: 'DynamicWorkflowGraph',
+    type: 'DynamicWorkflowGraph | WorkflowBuilderDefinitionInput',
     description:
       'The workflow definition: id, optional description and metadata, JSON Schema input/output schemas, optional state and request-context schemas, and the step graph.',
   },

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -34,7 +34,7 @@ await mastra.addDynamicWorkflows([
   content={[
   {
     name: 'defs',
-    type: 'readonly DynamicWorkflowGraph[]',
+    type: 'readonly (DynamicWorkflowGraph | WorkflowBuilderDefinitionInput)[]',
     description:
       'The workflow definitions to add. Nested-workflow references may resolve against the live registries or against other members of the same bundle.',
   },

--- a/docs/src/content/en/reference/workflows/dynamic-workflow-definition.mdx
+++ b/docs/src/content/en/reference/workflows/dynamic-workflow-definition.mdx
@@ -141,7 +141,7 @@ Tool entries accept the same optional `description` and `options` fields as agen
 
 A `mapping` entry reshapes data. Its `mapConfig` is a JSON string that encodes an object. Each key becomes a key in the step output, and each descriptor defines one source.
 
-When you call [`Mastra.addDynamicWorkflow()`](/reference/core/addDynamicWorkflow) directly, `mapConfig` also accepts the object itself. It is encoded to a JSON string before the definition is registered and stored, so the persisted row is the same either way. A stored definition always carries the JSON string form.
+When you call [`Mastra.addDynamicWorkflow()`](/reference/core/addDynamicWorkflow) directly, `mapConfig` also accepts the object itself. Mastra encodes it to a JSON string before registering and storing the definition, so the persisted row is the same either way. A stored definition always carries the JSON string form.
 
 | Descriptor | Description |
 | - | - |

--- a/docs/src/content/en/reference/workflows/dynamic-workflow-definition.mdx
+++ b/docs/src/content/en/reference/workflows/dynamic-workflow-definition.mdx
@@ -141,6 +141,8 @@ Tool entries accept the same optional `description` and `options` fields as agen
 
 A `mapping` entry reshapes data. Its `mapConfig` is a JSON string that encodes an object. Each key becomes a key in the step output, and each descriptor defines one source.
 
+When you call [`Mastra.addDynamicWorkflow()`](/reference/core/addDynamicWorkflow) directly, `mapConfig` also accepts the object itself. It is encoded to a JSON string before the definition is registered and stored, so the persisted row is the same either way. A stored definition always carries the JSON string form.
+
 | Descriptor | Description |
 | - | - |
 | `{ "value": ... }` | A constant JSON value |

--- a/mastracode/tui/e2e/tui/workflows-command.ts
+++ b/mastracode/tui/e2e/tui/workflows-command.ts
@@ -52,8 +52,7 @@ export const workflowsCommandScenario: McE2eScenario = {
     await runtime.waitForScreenText(/e2e-greeting \(active\).*Create a greeting for a name/i, terminal);
 
     terminal.submit('/workflows show e2e-greeting');
-    await runtime.waitForScreenText(/"id": "e2e-greeting"/i, terminal);
-    await runtime.waitForScreenText(/format-greeting/i, terminal);
+    await runtime.waitForScreenText(/format-greeting.*mapping/is, terminal);
 
     terminal.submit('/workflows run e2e-greeting {"name":"Ada  Lovelace"}');
     await runtime.waitForScreenText(/Running "e2e-greeting"/i, terminal);

--- a/mastracode/tui/e2e/tui/workflows-command.ts
+++ b/mastracode/tui/e2e/tui/workflows-command.ts
@@ -58,6 +58,9 @@ export const workflowsCommandScenario: McE2eScenario = {
     await runtime.waitForScreenText(/Running "e2e-greeting"/i, terminal);
     await runtime.waitForScreenText(/Hello, Ada  Lovelace!/i, terminal);
 
+    terminal.submit('/workflows run e2e-greeting {"name":}');
+    await runtime.waitForScreenText(/Invalid JSON input:/i, terminal);
+
     terminal.submit('/workflows delete e2e-greeting');
     await runtime.waitForScreenText(/Deleted workflow "e2e-greeting"\./i, terminal);
 

--- a/mastracode/tui/e2e/tui/workflows-command.ts
+++ b/mastracode/tui/e2e/tui/workflows-command.ts
@@ -52,7 +52,12 @@ export const workflowsCommandScenario: McE2eScenario = {
     await runtime.waitForScreenText(/e2e-greeting \(active\).*Create a greeting for a name/i, terminal);
 
     terminal.submit('/workflows show e2e-greeting');
-    await runtime.waitForScreenText(/format-greeting.*mapping/is, terminal);
+    // The JSON dump prints `"id": "e2e-greeting"` first, so it scrolls out of
+    // the viewport before the graph renders. Assert against the diagram header
+    // instead, which renders `<id>  (<status>)` with two spaces — `list` uses
+    // one, so this stays a single match and proves `show` rendered the
+    // requested workflow rather than just some workflow.
+    await runtime.waitForScreenText(/e2e-greeting {2}\(active\)[\s\S]*?format-greeting[\s\S]*?mapping/i, terminal);
 
     terminal.submit('/workflows run e2e-greeting {"name":"Ada  Lovelace"}');
     await runtime.waitForScreenText(/Running "e2e-greeting"/i, terminal);

--- a/mastracode/tui/e2e/tui/workflows-command.ts
+++ b/mastracode/tui/e2e/tui/workflows-command.ts
@@ -64,7 +64,8 @@ export const workflowsCommandScenario: McE2eScenario = {
     await runtime.waitForScreenText(/Hello, Ada  Lovelace!/i, terminal);
 
     terminal.submit('/workflows run e2e-greeting {"name":}');
-    await runtime.waitForScreenText(/Invalid JSON input:/i, terminal);
+    // `\s*\S` asserts a message was actually interpolated rather than `undefined`.
+    await runtime.waitForScreenText(/Invalid JSON input:\s*\S/i, terminal);
 
     terminal.submit('/workflows delete e2e-greeting');
     await runtime.waitForScreenText(/Deleted workflow "e2e-greeting"\./i, terminal);

--- a/mastracode/tui/src/tui/commands/__tests__/workflows.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/workflows.test.ts
@@ -60,10 +60,13 @@ describe('handleWorkflowsCommand', () => {
     expect(ctx.showError).not.toHaveBeenCalled();
   });
 
-  it('preserves non-Error workflow command failures', async () => {
+  it.each([
+    ['a string', 'connection lost'],
+    ['an object with a message', { message: 'connection lost' }],
+  ])('preserves non-Error workflow command failures from %s', async (_source, failure) => {
     const ctx = createCtx();
     ctx.controller.getMastra.mockReturnValue({});
-    mocks.runWorkflow.mockRejectedValue('connection lost');
+    mocks.runWorkflow.mockRejectedValue(failure);
 
     await handleWorkflowsCommand(ctx, ['run', 'greeting'], 'run greeting {}');
 

--- a/mastracode/tui/src/tui/commands/workflows.ts
+++ b/mastracode/tui/src/tui/commands/workflows.ts
@@ -282,6 +282,14 @@ function renderWorkflowDefinition(def: StoredWorkflowRow): string {
   return lines.join('\n');
 }
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string') {
+    return error.message;
+  }
+  return String(error);
+}
+
 function help(ctx: SlashCommandContext): void {
   ctx.showInfo(
     [
@@ -359,7 +367,7 @@ export async function handleWorkflowsCommand(
         try {
           inputData = JSON.parse(rawInput);
         } catch (e) {
-          ctx.showError(`Invalid JSON input: ${(e as Error).message}`);
+          ctx.showError(`Invalid JSON input: ${getErrorMessage(e)}`);
           return;
         }
         // Pass a session-derived request context so any `code-agent` agent steps
@@ -420,7 +428,6 @@ export async function handleWorkflowsCommand(
         ctx.showError(`Unknown /workflows subcommand: "${sub}". Try /workflows help.`);
     }
   } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    ctx.showError(`Workflow command failed: ${message}`);
+    ctx.showError(`Workflow command failed: ${getErrorMessage(e)}`);
   }
 }

--- a/packages/core/src/mastra/add-dynamic-workflow-warnings.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflow-warnings.test.ts
@@ -62,6 +62,39 @@ describe('Mastra.addDynamicWorkflow — save path is strict on unsupported schem
     expect(mastra.getWorkflow('clean-wf')).toBeDefined();
   });
 
+  it('hydrates and persists the normalized definition', async () => {
+    const storage = new InMemoryStore({ id: 'normalized-definition' });
+    const mastra = new Mastra({ logger: false, storage });
+
+    await expect(
+      mastra.addDynamicWorkflow({
+        id: 'normalized-wf',
+        metadata: { owner: 'mastracode' },
+        inputSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] },
+        outputSchema: { type: 'object', properties: { message: { type: 'string' } }, required: ['message'] },
+        graph: [
+          {
+            type: 'mapping',
+            id: 'format-greeting',
+            mapConfig: { message: { template: 'Hello, ${initData.name}!' } },
+          },
+        ],
+      } as any),
+    ).resolves.toBeUndefined();
+
+    expect(mastra.getWorkflow('normalized-wf')).toBeDefined();
+    const store = await storage.getStore('workflowDefinitions');
+    const row = await store!.get('normalized-wf');
+    expect(row?.metadata).toEqual({ owner: 'mastracode' });
+    expect(row?.graph).toEqual([
+      {
+        type: 'mapping',
+        id: 'format-greeting',
+        mapConfig: JSON.stringify({ message: { template: 'Hello, ${initData.name}!' } }),
+      },
+    ]);
+  });
+
   it('ignores runtime request context values outside the persisted workflow definition', async () => {
     const storage = new InMemoryStore({ id: 'runtime-request-context' });
     const mastra = new Mastra({

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -74,6 +74,7 @@ import { OrchestrationWorker, SchedulerWorker, BackgroundTaskWorker } from '../w
 import type { MastraWorker, WorkerDeps } from '../worker';
 import type { AnyWorkflow, Workflow } from '../workflows';
 import { normalizeWorkflowBuilderDefinition } from '../workflows/builder';
+import type { WorkflowBuilderDefinitionInput } from '../workflows/builder';
 import type { DynamicWorkflowGraph, WorkflowRegistryIndex, WorkflowRegistrySchemas } from '../workflows/dynamic';
 import {
   assertValidDynamicWorkflow,
@@ -4795,7 +4796,7 @@ export class Mastra<
    * await run.start({ inputData: { location: 'Helsinki' } });
    * ```
    */
-  public async addDynamicWorkflow(def: DynamicWorkflowGraph): Promise<void> {
+  public async addDynamicWorkflow(def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput): Promise<void> {
     await this.addDynamicWorkflows([def]);
   }
 
@@ -4829,7 +4830,9 @@ export class Mastra<
    * ]);
    * ```
    */
-  public async addDynamicWorkflows(defs: readonly DynamicWorkflowGraph[]): Promise<void> {
+  public async addDynamicWorkflows(
+    defs: readonly (DynamicWorkflowGraph | WorkflowBuilderDefinitionInput)[],
+  ): Promise<void> {
     if (defs.length === 0) return;
 
     const seen = new Set<string>();
@@ -4846,10 +4849,10 @@ export class Mastra<
     // Normalization coerces the wire shape; one validation call per member
     // covers structure, JSON-Schema keywords, references, and schema-flow.
     const members = defs.map(def => ({
-      def,
       normalized: normalizeWorkflowBuilderDefinition({
         id: def.id,
         description: def.description,
+        metadata: def.metadata,
         inputSchema: def.inputSchema,
         outputSchema: def.outputSchema,
         stateSchema: def.stateSchema,
@@ -4861,7 +4864,7 @@ export class Mastra<
     // Members may nest each other, so the index every member validates against
     // is the live registries plus the bundle itself — not the registry alone.
     const index = this.#buildWorkflowRegistryIndex();
-    const bundleIds = new Set(members.map(member => member.def.id));
+    const bundleIds = new Set(members.map(member => member.normalized.id));
     for (const { normalized } of members) {
       (index.workflows ??= {})[normalized.id] = {
         inputSchema: normalized.inputSchema,
@@ -4875,13 +4878,13 @@ export class Mastra<
     // Hydration resolves nested workflows through the live registry, so a
     // member cannot be hydrated before the bundle members it nests.
     const ordered: typeof members = [];
-    const remaining = new Map(members.map(member => [member.def.id, member] as const));
+    const remaining = new Map(members.map(member => [member.normalized.id, member] as const));
     const hydrated = new Set<string>();
     let progress = true;
     while (remaining.size > 0 && progress) {
       progress = false;
       for (const [id, member] of Array.from(remaining)) {
-        const pending = Array.from(collectNestedWorkflowIds(member.def.graph)).filter(
+        const pending = Array.from(collectNestedWorkflowIds(member.normalized.graph)).filter(
           dependency => dependency !== id && bundleIds.has(dependency) && !hydrated.has(dependency),
         );
         if (pending.length > 0) continue;
@@ -4904,9 +4907,9 @@ export class Mastra<
     const registry = this.#workflows as Record<string, AnyWorkflow>;
     const priorWorkflows = new Map<string, AnyWorkflow | undefined>();
     const priorHiddenKeys = new Set<string>();
-    for (const { def } of ordered) {
-      priorWorkflows.set(def.id, registry[def.id]);
-      if (this.#hiddenWorkflowKeys.has(def.id)) priorHiddenKeys.add(def.id);
+    for (const { normalized } of ordered) {
+      priorWorkflows.set(normalized.id, registry[normalized.id]);
+      if (this.#hiddenWorkflowKeys.has(normalized.id)) priorHiddenKeys.add(normalized.id);
     }
     const restoreRegistry = () => {
       for (const [id, prior] of priorWorkflows) {
@@ -4917,23 +4920,23 @@ export class Mastra<
     };
 
     try {
-      for (const { def } of ordered) {
-        const { workflow } = await rehydrateWorkflow(def, this);
-        this.#replaceDynamicWorkflow(workflow as AnyWorkflow, def.id);
+      for (const { normalized } of ordered) {
+        const { workflow } = await rehydrateWorkflow(normalized, this);
+        this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
       }
 
       const store = await this.#storage?.getStore('workflowDefinitions');
       if (store) {
-        for (const { def } of ordered) {
+        for (const { normalized } of ordered) {
           await store.upsert({
-            id: def.id,
-            description: def.description,
-            metadata: def.metadata,
-            inputSchema: def.inputSchema,
-            outputSchema: def.outputSchema,
-            stateSchema: def.stateSchema,
-            requestContextSchema: def.requestContextSchema,
-            graph: def.graph,
+            id: normalized.id,
+            description: normalized.description,
+            metadata: normalized.metadata,
+            inputSchema: normalized.inputSchema,
+            outputSchema: normalized.outputSchema,
+            stateSchema: normalized.stateSchema,
+            requestContextSchema: normalized.requestContextSchema,
+            graph: normalized.graph,
           });
         }
       }

--- a/packages/core/src/storage/domains/workflow-definitions/base.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/base.ts
@@ -22,9 +22,18 @@ export interface WorkflowDefinition {
   requestContextSchema?: unknown;
 
   /**
-   * The workflow graph in its JSON-safe form. Same shape the engine already
-   * emits via `serializedStepGraph` — but with full mapping configs preserved
-   * (no truncation) and all step/agent/tool references stored as ids.
+   * The workflow graph in its JSON-safe form: close to what the engine emits
+   * via `serializedStepGraph`, but with full mapping configs preserved (no
+   * truncation) and all step/agent/tool references stored as ids.
+   *
+   * Typed as `ValidatableStepFlowEntry` rather than `SerializedStepFlowEntry`
+   * because a persisted row is deliberately not the runtime shape: dates are
+   * ISO strings, and the `serializedConditions`/`serializedCondition` debug
+   * labels are absent because rehydration derives them from the stored
+   * predicates instead of persisting them.
+   *
+   * Rows are written already normalized (see `normalizeWorkflowBuilderDefinition`),
+   * so mapping configs arrive here as JSON strings.
    */
   graph: ValidatableStepFlowEntry[];
 

--- a/packages/core/src/storage/domains/workflow-definitions/base.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/base.ts
@@ -1,4 +1,4 @@
-import type { SerializedStepFlowEntry } from '../../../workflows/types';
+import type { ValidatableStepFlowEntry } from '../../../workflows/dynamic/validate/types';
 import { StorageDomain } from '../base';
 
 /**
@@ -26,7 +26,7 @@ export interface WorkflowDefinition {
    * emits via `serializedStepGraph` — but with full mapping configs preserved
    * (no truncation) and all step/agent/tool references stored as ids.
    */
-  graph: SerializedStepFlowEntry[];
+  graph: ValidatableStepFlowEntry[];
 
   /** Lifecycle status. Only 'active' definitions are loaded at startWorkers(). */
   status: 'active' | 'archived';
@@ -48,7 +48,7 @@ export interface CreateWorkflowDefinitionInput {
   outputSchema: unknown;
   stateSchema?: unknown;
   requestContextSchema?: unknown;
-  graph: SerializedStepFlowEntry[];
+  graph: ValidatableStepFlowEntry[];
   authorId?: string;
 }
 
@@ -61,7 +61,7 @@ export interface UpdateWorkflowDefinitionInput {
   outputSchema?: unknown;
   stateSchema?: unknown;
   requestContextSchema?: unknown;
-  graph?: SerializedStepFlowEntry[];
+  graph?: ValidatableStepFlowEntry[];
   status?: 'active' | 'archived';
   authorId?: string;
 }

--- a/packages/core/src/workflows/builder/authoring-schema.ts
+++ b/packages/core/src/workflows/builder/authoring-schema.ts
@@ -392,6 +392,7 @@ export const deleteStoredWorkflowResponseSchema = z.object({
   message: z.string(),
 });
 
+export type WorkflowBuilderDefinitionInput = z.input<typeof workflowBuilderDefinitionInputSchema>;
 export type StoredWorkflowDefinition = z.infer<typeof storedWorkflowDefinitionSchema>;
 export type ListStoredWorkflowsResponse = z.infer<typeof listStoredWorkflowsResponseSchema>;
 export type UpsertStoredWorkflowResponse = z.infer<typeof upsertStoredWorkflowResponseSchema>;

--- a/packages/core/src/workflows/dynamic/graph.ts
+++ b/packages/core/src/workflows/dynamic/graph.ts
@@ -5,7 +5,7 @@
  * function, so recursion into container entries lives in exactly one place
  * and is exhaustiveness-checked against `SerializedStepFlowEntry`.
  */
-import type { SerializedSingleStepEntry, SerializedStepFlowEntry } from '../types';
+import type { SerializedSingleStepEntry } from '../types';
 import type { ValidatableStepFlowEntry } from './validate/types';
 
 /**
@@ -17,7 +17,7 @@ import type { ValidatableStepFlowEntry } from './validate/types';
  * `sleep`/`sleepUntil` entries carry no references or schemas and are skipped.
  */
 export function forEachSingleStepEntry(
-  entries: readonly SerializedStepFlowEntry[],
+  entries: readonly ValidatableStepFlowEntry[],
   visit: (entry: SerializedSingleStepEntry) => void,
 ): void {
   for (const entry of entries) {
@@ -52,7 +52,7 @@ export function forEachSingleStepEntry(
  * Collect the ids of every nested workflow referenced by a stored graph.
  * Used by boot-time loading to hydrate stored definitions in dependency order.
  */
-export function collectNestedWorkflowIds(graph: readonly SerializedStepFlowEntry[]): Set<string> {
+export function collectNestedWorkflowIds(graph: readonly ValidatableStepFlowEntry[]): Set<string> {
   const out = new Set<string>();
   forEachSingleStepEntry(graph, entry => {
     if (entry.type === 'workflow') out.add(entry.workflowId);

--- a/packages/core/src/workflows/dynamic/graph.ts
+++ b/packages/core/src/workflows/dynamic/graph.ts
@@ -3,7 +3,8 @@
  * needs "all the leaf entries in this graph" (schema validation, reference
  * validation, nested-workflow dependency collection) goes through this one
  * function, so recursion into container entries lives in exactly one place
- * and is exhaustiveness-checked against `SerializedStepFlowEntry`.
+ * and is exhaustiveness-checked against `ValidatableStepFlowEntry`, which
+ * covers both persisted rows and wire-shaped authoring submissions.
  */
 import type { SerializedSingleStepEntry } from '../types';
 import type { ValidatableStepFlowEntry } from './validate/types';

--- a/packages/core/src/workflows/dynamic/rehydrate.ts
+++ b/packages/core/src/workflows/dynamic/rehydrate.ts
@@ -17,7 +17,10 @@ import type { JsonSchema, JsonSchemaToZodOptions } from './json-schema-to-zod';
 import { parseMapConfig } from './mapping-config';
 import type { ValidatableStepFlowEntry } from './validate/types';
 
-/** JSON shape persisted to WorkflowDefinitionsStorage. */
+/**
+ * JSON shape persisted to WorkflowDefinitionsStorage, and the same shape
+ * `addDynamicWorkflows` hydrates from before it writes the row.
+ */
 export interface DynamicWorkflowGraph {
   id: string;
   description?: string;

--- a/packages/core/src/workflows/dynamic/rehydrate.ts
+++ b/packages/core/src/workflows/dynamic/rehydrate.ts
@@ -9,18 +9,13 @@ import { cloneWorkflow, createWorkflow } from '../create';
 import { derivePredicateLabel } from '../predicate';
 import type { Step } from '../step';
 import { createStepFromAgent, createStepFromTool } from '../step-factories';
-import type {
-  SerializedSingleStepEntry,
-  SerializedStepFlowEntry,
-  SerializedStepOptions,
-  SingleStepEntry,
-  StepFlowEntry,
-} from '../types';
+import type { SerializedSingleStepEntry, SerializedStepOptions, SingleStepEntry, StepFlowEntry } from '../types';
 import { getSingleStepEntryId } from '../utils';
 import { mapVariable, predicateToCondition } from '../workflow';
 import { jsonSchemaToZod } from './json-schema-to-zod';
 import type { JsonSchema, JsonSchemaToZodOptions } from './json-schema-to-zod';
 import { parseMapConfig } from './mapping-config';
+import type { ValidatableStepFlowEntry } from './validate/types';
 
 /** JSON shape persisted to WorkflowDefinitionsStorage. */
 export interface DynamicWorkflowGraph {
@@ -31,7 +26,7 @@ export interface DynamicWorkflowGraph {
   outputSchema: JsonSchema;
   stateSchema?: JsonSchema;
   requestContextSchema?: JsonSchema;
-  graph: SerializedStepFlowEntry[];
+  graph: ValidatableStepFlowEntry[];
 }
 
 /**
@@ -82,7 +77,7 @@ export async function rehydrateWorkflow(
 
 function applyGraphEntry(
   wf: any,
-  entry: SerializedStepFlowEntry,
+  entry: ValidatableStepFlowEntry,
   mastra: Mastra,
   schemaOpts?: JsonSchemaToZodOptions,
 ): void {

--- a/packages/server/src/server/handlers/dynamic-workflows.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.ts
@@ -121,15 +121,23 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       // its helpers behind as orphans. Order within the bundle is derived
       // from the graphs, not from the order the client sent them in.
       const bundle = [...(dependencies ?? []), def];
-      // The Zod schema output is structurally compatible with
-      // DynamicWorkflowGraph but TS can't prove every arm:
-      //   - sleepUntil.date is an ISO string on the wire, Date on the
-      //     runtime type; the rehydrator parses it via `new Date(...)`.
-      //   - conditional/loop's `serializedConditions`/`serializedCondition`
-      //     debug labels are emitted by the fluent builder at rehydration
-      //     time; clients don't send them.
+      // The wire schema is deliberately looser than the core authoring type:
+      // it admits `mapping` entries as children of parallel/conditional/loop,
+      // which `WorkflowBuilderExecutableInnerEntry` excludes. That is not
+      // drift. Letting those through means a misplaced mapping surfaces from
+      // the validation domain as a structured `invalid-map-placement` issue —
+      // pointed at the offending path and carrying a machine-applicable
+      // `remove-workflow-step` repair action that Studio's draft UI consumes —
+      // instead of dying at the boundary as an opaque discriminated-union
+      // error. `foreach` is excluded from this on purpose: core rejects a
+      // foreach mapping body with an unstructured throw during rehydration,
+      // so there is no repairable issue to preserve and the wire schema is
+      // the better place to catch it.
+      //
       // `addDynamicWorkflows` runs a full registry pre-flight before
-      // rehydration; the cast documents this boundary.
+      // rehydration, so nothing reaches the engine unvalidated; the cast
+      // documents this boundary. Narrowing the schema to delete the cast
+      // would trade a repairable issue for a generic 400.
       await mastra.addDynamicWorkflows(bundle as Parameters<Mastra['addDynamicWorkflows']>[0]);
       return {
         ok: true as const,


### PR DESCRIPTION
Dynamic workflow registration validated normalized definitions but then hydrated and persisted the original wire input. An object-form mapping configuration could therefore reach rehydration as `"[object Object]"` and fail at runtime.

Before:

```ts
const normalized = normalizeWorkflowBuilderDefinition(def);
await rehydrateWorkflow(def, mastra);
```

After:

```ts
const normalized = normalizeWorkflowBuilderDefinition(def);
await rehydrateWorkflow(normalized, mastra);
```

This uses normalized definitions consistently for dependency discovery, hydration, live registration, and persistence.

It also changes the graph type on the workflow definitions storage interface, which deserves an explicit note because a patch-level change touching an interface that storage adapters implement looks alarming. That field was typed `SerializedStepFlowEntry[]`, but a real persisted row has never satisfied that type: rows store ISO date strings rather than `Date`, and they deliberately omit the `serializedConditions` and `serializedCondition` debug labels because rehydration derives those from the stored predicates instead. The type has been wrong since dynamic workflows were introduced, and the runtime already accepted the looser shape. Widening it to `ValidatableStepFlowEntry` describes what is actually stored. No adapter behavior changes.

The follow-up also preserves string `message` properties from non-`Error` workflow command failures, and reference documentation now records that these registration APIs accept the authoring input form.

Verified with the focused Core, SDK, and TUI workflow suites, Core and TUI typechecks, the Mastra Code build, docs validation, and the `/workflows` terminal E2E scenario.

One scope note on that scenario: its invalid-JSON step exercises the JSON parse failure path, where the thrown value is a real `SyntaxError` and the old and new formatting behave identically. It is there as lifecycle coverage of the rendered error output, not as coverage of the non-`Error` formatting change. The unit test covering string and message-bearing object failures is what verifies that.
