### PR TITLE
fix(factory): keep injected issues in intake

### DIFF
--- a/.changeset/polite-showers-argue.md
+++ b/.changeset/polite-showers-argue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed injected GitHub and Linear issues so they stay in Intake until triage is explicitly started.

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
@@ -32,7 +32,7 @@ const issueWorkItem = {
   },
   parentWorkItemId: null,
   title: 'Fix login bug',
-  stages: ['triage'],
+  stages: ['intake'],
   stageHistory: [],
   sessions: {},
   metadata: { number: 7 },
@@ -51,6 +51,7 @@ const linearWorkItem = {
     url: 'https://linear.app/acme/issue/ENG-42/fix-intake-sync',
   },
   title: 'ENG-42: Fix intake sync',
+  stages: ['triage'],
   metadata: { identifier: 'ENG-42' },
 };
 
@@ -144,8 +145,9 @@ describe('Board card click starts the default run', () => {
 
     await waitFor(() => expect(startRequests).toHaveLength(1));
     expect(startRequests[0]).toMatchObject({
+      destinationStage: 'triage',
       invocation: { type: 'skill', skillName: 'factory-triage' },
-      workItem: { id: 'item-1', role: 'plan' },
+      workItem: { id: 'item-1', role: 'triage' },
     });
   });
 
@@ -158,7 +160,7 @@ describe('Board card click starts the default run', () => {
 
     await waitFor(() => expect(startRequests).toHaveLength(1));
     expect(startRequests[0]).toMatchObject({
-      destinationStage: 'planning',
+      destinationStage: 'triage',
       invocation: {
         type: 'skill',
         skillName: 'factory-triage',
@@ -167,7 +169,7 @@ describe('Board card click starts the default run', () => {
             `Start by fetching the issue's full details (description and comments) with the linear_get_issue tool.`,
         ),
       },
-      workItem: { id: 'linear-item-1', role: 'plan' },
+      workItem: { id: 'linear-item-1', role: 'triage' },
     });
   });
 
@@ -193,8 +195,9 @@ describe('Board card click starts the default run', () => {
 
     await waitFor(() => expect(startRequests).toHaveLength(1));
     expect(startRequests[0]).toMatchObject({
+      destinationStage: 'triage',
       invocation: { type: 'skill', skillName: 'factory-triage' },
-      workItem: { role: 'plan' },
+      workItem: { role: 'triage' },
     });
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/factory/boardRunSpecs.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardRunSpecs.ts
@@ -12,7 +12,7 @@ export const RUN_PHASE_LABELS: Record<FactoryRunPhase, string> = {
 /**
  * One agent run a card or candidate can start, and the lane it lands the card
  * in. Cards offer several: e.g. an issue can be investigated (understand it →
- * Planning) or built right away (implement it → Building). All of an item's
+ * Triage) or built right away (implement it → Building). All of an item's
  * runs share one branch/worktree, so a later run continues the same
  * conversation as a follow-up.
  */
@@ -46,14 +46,14 @@ export function guidedPrompt(base: string, instructions: string): string {
   return `${base}\n\nGuidance for this run: ${instructions}`;
 }
 
-/** Investigate (understand → Planning) + Build (implement → Building) runs for an issue. */
+/** Investigate (understand → Triage) + Build (implement → Building) runs for an issue. */
 export function issueRunActions(ref: string, extra?: { context?: string }): RunAction[] {
   const context = extra?.context ? `\n\n${extra.context}` : '';
   return [
     {
       label: 'Investigate',
-      role: 'plan',
-      stage: 'planning',
+      role: 'triage',
+      stage: 'triage',
       invocation: {
         type: 'skill',
         skillName: 'factory-triage',
@@ -102,7 +102,7 @@ export const LINEAR_FETCH_HINT = `Start by fetching the issue's full details (de
 
 /**
  * The runs a persisted card can start, derived from its source + metadata.
- * Issues can be investigated (→ Planning) or built (→ Building); PRs get a
+ * Issues can be investigated (→ Triage) or built (→ Building); PRs get a
  * review run. Manual cards (or cards missing the needed metadata) can't
  * start runs.
  */

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { builtInFactoryRules, defaultFactoryRules } from '../../rules/defaults.js';
 import { FactoryDecisionDispatcher } from '../../rules/dispatcher.js';
-import { FactoryStartCoordinator } from '../../rules/start-coordinator.js';
 import { FactoryTransitionService } from '../../rules/transition-service.js';
 import { createFactoryStorageForTests } from '../../storage/test-utils.js';
 import type { GithubIntegration } from './integration.js';
@@ -391,28 +390,9 @@ describe('GithubRules', () => {
     expect(decision?.decision).toMatchObject({ type: 'upsertLinkedWorkItem', stage: 'intake' });
   });
 
-  it('moves a trusted issue through Intake to Triage with one investigation and rematerializes it after deletion', async () => {
-    const { github, sourceControl, integrationStorage, workItems, projects, project, projectRepository } =
-      await setup('write');
-    const rules = defaultFactoryRules({
-      version: 'test-web-policy',
-      overrides: {
-        work: {
-          intake: {
-            issue: {
-              onEnter: context => ({
-                type: 'invokeSkill',
-                idempotencyKey: `${context.ingress.id}:factory-triage`,
-                role: 'triage',
-                skillName: 'factory-triage',
-                arguments: context.item.url ? `GitHub issue (${context.item.url})` : context.item.title,
-              }),
-            },
-          },
-        },
-      },
-    });
-    const transitionService = new FactoryTransitionService({ storage: workItems, rules });
+  it('materializes a trusted issue in Intake without starting triage and rematerializes it after deletion', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    const rules = builtInFactoryRules();
     const service = new GithubRules({
       github,
       sourceControl,
@@ -421,143 +401,40 @@ describe('GithubRules', () => {
       storage: workItems,
       rules,
     });
-    const deliveredSignals: Array<{ id: string; contents: string; threadId: string; user: unknown }> = [];
-    const sessions = new Map<string, ReturnType<typeof makeSession>>();
-
-    function makeSession(key: string, initialThreadId?: string) {
-      let threadId: string | undefined = initialThreadId;
-      const agentEndListeners = new Set<(event: { type: string }) => void>();
-      const session = {
-        thread: {
-          list: vi.fn(async () => []),
-          create: vi.fn(async () => {
-            threadId = 'thread-issue-42';
-            return { id: threadId };
-          }),
-          switch: vi.fn(async ({ threadId: next }: { threadId: string }) => {
-            threadId = next;
-          }),
-          setSetting: vi.fn(async () => {}),
-          rename: vi.fn(async () => {}),
-          requireId: vi.fn(() => {
-            if (!threadId) throw new Error('Thread was not persisted before binding creation.');
-            return threadId;
-          }),
-          listActiveMessages: vi.fn(async () => deliveredSignals.map(({ id }) => ({ id }))),
-        },
-        getWorkspace: () => ({
-          skills: {
-            maybeRefresh: vi.fn(async () => {}),
-            get: vi.fn(async (name: string) => ({ name, instructions: 'Investigate the issue.' })),
-          },
-        }),
-        sendSignal: vi.fn(
-          (input: { id: string; contents: string }, options: { requestContext: { get(key: string): unknown } }) => {
-            if (!threadId) throw new Error('Signal delivered before thread persistence.');
-            deliveredSignals.push({ ...input, threadId, user: options.requestContext.get('user') });
-            for (const listener of agentEndListeners) {
-              listener({ type: 'agent_end' });
-            }
-            return { accepted: Promise.resolve({ accepted: true, action: 'wake' }) };
-          },
-        ),
-        subscribe: vi.fn((listener: (event: { type: string }) => void) => {
-          agentEndListeners.add(listener);
-          return () => agentEndListeners.delete(listener);
-        }),
-        state: { set: vi.fn(async () => {}) },
-        sendMessage: vi.fn(async () => {}),
-        sendNotificationSignal: vi.fn(async () => ({ persisted: Promise.resolve(), accepted: Promise.resolve() })),
-      };
-      sessions.set(key, session);
-      return session;
-    }
-
-    const controller = {
-      createSession: vi.fn(async ({ id, threadId }: { id: string; threadId: string }) => makeSession(id, threadId)),
-      getSessionByResource: vi.fn(async (resourceId: string) => sessions.get(resourceId)),
-    };
-    await sourceControl.sessions.create({
-      sessionId: 'session-issue-42',
-      projectRepositoryId: projectRepository.id,
-      orgId: 'org-1',
-      userId: 'user-1',
-      branch: 'factory/issue-42',
-      baseBranch: 'main',
-    });
-    const coordinator = new FactoryStartCoordinator(controller as never, workItems, transitionService, sourceControl);
-    const primeCredentials = vi.fn(async () => {});
     const dispatcher = new FactoryDecisionDispatcher({
-      controller: controller as never,
-      transitionService,
+      controller: {} as never,
+      transitionService: new FactoryTransitionService({ storage: workItems, rules }),
       storage: workItems,
       isAutoRunEnabled: async () => true,
       ownerId: 'worker-1',
-      primeCredentials,
-      prepareBinding: async ({ record, item, role }) => {
-        await coordinator.prepare({
-          orgId: record.orgId,
-          userId: 'user-1',
-          factoryProjectId: record.factoryProjectId,
-          sessionId: 'session-issue-42',
-          threadTitle: `Issue: ${item.title}`,
-          kickoffKey: record.idempotencyKey,
-          destinationStage: 'triage',
-          workItem: { id: item.id, role, input: item },
-        });
-      },
     });
 
     await service.ingest(issueOpened('delivery-full-flow'));
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
-    await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
 
     const [item] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
     expect(item).toMatchObject({
       externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:42' },
-      stages: ['triage'],
-      sessions: {
-        triage: {
-          sessionId: 'session-issue-42',
-          branch: 'factory/issue-42',
-          threadId: 'session-issue-42',
-        },
-      },
+      stages: ['intake'],
+      sessions: {},
     });
-    expect(primeCredentials).toHaveBeenCalledWith({ orgId: 'org-1', userId: 'user-1' });
-    expect(deliveredSignals).toEqual([
-      expect.objectContaining({
-        threadId: 'session-issue-42',
-        contents: expect.stringContaining('<skill name="factory-triage">'),
-        user: { workosId: 'user-1', organizationId: 'org-1' },
-      }),
+    expect(await workItems.listRunBindings('org-1', project.id, item!.id)).toEqual([]);
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toMatchObject([
+      { status: 'succeeded', decision: { type: 'upsertLinkedWorkItem', stage: 'intake' } },
     ]);
-    const deferredDecisions = await workItems.listDeferredDecisions('org-1', project.id);
-    expect(deferredDecisions).toHaveLength(2);
-    expect(deferredDecisions.map(decision => decision.status)).toEqual(['succeeded', 'succeeded']);
-    expect(
-      deferredDecisions.filter(
-        decision => decision.decision.type === 'invokeSkill' && decision.decision.skillName === 'factory-triage',
-      ),
-    ).toHaveLength(1);
 
     await workItems.delete({ orgId: 'org-1', id: item!.id });
     await expect(service.ingest(issueOpened('delivery-full-flow'))).resolves.toEqual({ status: 'replayed' });
-    expect((await workItems.listDeferredDecisions('org-1', project.id)).map(decision => decision.status)).toEqual([
-      'retry',
-      'succeeded',
-    ]);
-
-    await dispatcher.runOnce(new Date('2030-01-01T00:00:02Z'));
-    await dispatcher.runOnce(new Date('2030-01-01T00:00:03Z'));
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
 
     const [rematerialized] = await workItems.list({ orgId: 'org-1', factoryProjectId: project.id });
     expect(rematerialized).toMatchObject({
       externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:42' },
-      stages: ['triage'],
+      stages: ['intake'],
+      sessions: {},
     });
     expect(rematerialized?.id).not.toBe(item?.id);
-    expect(deliveredSignals).toHaveLength(2);
+    expect(await workItems.listRunBindings('org-1', project.id, rematerialized!.id)).toEqual([]);
   });
 
   it('prefers canonical board identities over legacy GitHub rows during ingress', async () => {

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -149,7 +149,7 @@ describe('defaultFactoryRules', () => {
     expect(rules.work.triage?.linearIssue?.onEnter).toBeTypeOf('function');
   });
 
-  it('materializes observed Linear issues directly in Triage', async () => {
+  it('materializes observed Linear issues in Intake', async () => {
     const rule = defaultFactoryRules({ version: 'deployment-7' }).linear.issueObserved?.onEvent;
 
     expect(await rule?.(linearContext())).toMatchObject({
@@ -157,7 +157,7 @@ describe('defaultFactoryRules', () => {
       source: 'linear-issue',
       sourceKey: 'linear:ENG-42',
       title: 'ENG-42: Fix intake sync',
-      stage: 'triage',
+      stage: 'intake',
       metadata: { linearIssueId: 'issue-1', identifier: 'ENG-42' },
     });
   });
@@ -301,22 +301,38 @@ describe('defaultFactoryRules', () => {
     },
   );
 
-  it('does not duplicate investigation when a new GitHub issue is materialized into Triage', async () => {
+  it('does not duplicate investigation when a start coordinator moves a GitHub issue into Triage', async () => {
     const rule = defaultFactoryRules({ version: 'deployment-7' }).work.triage?.issue?.onEnter;
     const context = {
-      ...stageContext({ type: 'github', login: 'author', trusted: true, factoryAuthored: false }, 'work'),
-      cause: 'linked_item_materialized',
+      ...stageContext({ type: 'human', id: 'user-1' }, 'work'),
+      cause: 'run_start',
       stage: 'triage',
       fromStage: 'intake',
       toStage: 'triage',
     } as FactoryStageRuleContext;
 
     expect(await rule?.(context)).toBeUndefined();
-    expect(await rule?.({ ...context, fromStage: 'planning' })).toMatchObject({
-      type: 'invokeSkill',
-      role: 'triage',
-      skillName: 'factory-triage',
-    });
+  });
+
+  it('does not duplicate investigation when a start coordinator moves a Linear issue into Triage', async () => {
+    const rule = defaultFactoryRules({ version: 'deployment-7' }).work.triage?.linearIssue?.onEnter;
+    const context = {
+      ...stageContext({ type: 'human', id: 'user-1' }, 'work'),
+      cause: 'run_start',
+      item: {
+        ...item,
+        source: 'linear-issue',
+        sourceKey: 'linear:ENG-42',
+        title: 'ENG-42: Fix intake sync',
+        url: 'https://linear.app/acme/issue/ENG-42',
+      },
+      source: 'linearIssue',
+      stage: 'triage',
+      fromStage: 'intake',
+      toStage: 'triage',
+    } as FactoryStageRuleContext;
+
+    expect(await rule?.(context)).toBeUndefined();
   });
 
   it('starts investigation when a board drag or reconciliation moves an issue into Triage', async () => {
@@ -580,48 +596,51 @@ describe('defaultFactoryRules', () => {
     });
   });
 
-  it.each(['issueOpened', 'pullRequestOpened'] as const)(
-    'advances trusted %s authors and leaves untrusted authors in Intake',
-    async event => {
-      const rules = defaultFactoryRules({ version: 'deployment-7' });
-      const trustedStage = event === 'issueOpened' ? 'triage' : 'review';
-      const trusted = githubContext(event);
-      const untrusted = {
-        ...githubContext(event),
-        actor: { type: 'github', login: 'reader', trusted: false, factoryAuthored: false } as const,
-      };
-      const factoryAuthored = {
-        ...githubContext(event),
-        actor: { type: 'github', login: 'factory-bot', trusted: false, factoryAuthored: true } as const,
-      };
-
-      expect(await rules.github[event]?.onEvent?.(trusted)).toMatchObject({
-        type: 'upsertLinkedWorkItem',
-        stage: trustedStage,
-      });
-      expect(await rules.github[event]?.onEvent?.(untrusted)).toMatchObject({
-        type: 'upsertLinkedWorkItem',
-        stage: 'intake',
-      });
-      expect(await rules.github[event]?.onEvent?.(factoryAuthored)).toMatchObject({
-        type: 'upsertLinkedWorkItem',
-        stage: 'intake',
-      });
+  it.each([
+    githubContext('issueOpened'),
+    {
+      ...githubContext('issueOpened'),
+      actor: { type: 'github', login: 'reader', trusted: false, factoryAuthored: false } as const,
     },
-  );
-
-  it.each(['issueOpened', 'pullRequestOpened'] as const)(
-    'keeps trusted %s items created before the Factory in Intake',
-    async event => {
-      const rules = defaultFactoryRules({ version: 'deployment-7' });
-      const olderContext = githubContext(event, '2026-05-01T00:00:00Z');
-
-      expect(await rules.github[event]?.onEvent?.(olderContext)).toMatchObject({
-        type: 'upsertLinkedWorkItem',
-        stage: 'intake',
-      });
+    {
+      ...githubContext('issueOpened'),
+      actor: { type: 'github', login: 'factory-bot', trusted: false, factoryAuthored: true } as const,
     },
-  );
+    githubContext('issueOpened', '2026-05-01T00:00:00Z'),
+  ])('keeps injected GitHub issues in Intake regardless of trust or creation time', async context => {
+    const rule = defaultFactoryRules({ version: 'deployment-7' }).github.issueOpened?.onEvent;
+
+    expect(await rule?.(context)).toMatchObject({
+      type: 'upsertLinkedWorkItem',
+      stage: 'intake',
+    });
+  });
+
+  it('advances trusted pull-request authors and leaves untrusted authors in Intake', async () => {
+    const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestOpened?.onEvent;
+    const trusted = githubContext('pullRequestOpened');
+    const untrusted = {
+      ...githubContext('pullRequestOpened'),
+      actor: { type: 'github', login: 'reader', trusted: false, factoryAuthored: false } as const,
+    };
+    const factoryAuthored = {
+      ...githubContext('pullRequestOpened'),
+      actor: { type: 'github', login: 'factory-bot', trusted: false, factoryAuthored: true } as const,
+    };
+
+    expect(await rule?.(trusted)).toMatchObject({ type: 'upsertLinkedWorkItem', stage: 'review' });
+    expect(await rule?.(untrusted)).toMatchObject({ type: 'upsertLinkedWorkItem', stage: 'intake' });
+    expect(await rule?.(factoryAuthored)).toMatchObject({ type: 'upsertLinkedWorkItem', stage: 'intake' });
+  });
+
+  it('keeps trusted pull requests created before the Factory in Intake', async () => {
+    const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestOpened?.onEvent;
+
+    expect(await rule?.(githubContext('pullRequestOpened', '2026-05-01T00:00:00Z'))).toMatchObject({
+      type: 'upsertLinkedWorkItem',
+      stage: 'intake',
+    });
+  });
 
   it('uses the same issue and pull-request identities as board Intake', async () => {
     const rules = defaultFactoryRules({ version: 'deployment-7' });

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -38,7 +38,10 @@ function invokeIssueInvestigation(context: FactoryStageRuleContext) {
 }
 
 function investigateTriagedIssue(context: FactoryStageRuleContext) {
-  if (context.cause === 'linked_item_materialized' && context.fromStage === 'intake' && context.toStage === 'triage') {
+  if (
+    context.cause === 'run_start' ||
+    (context.cause === 'linked_item_materialized' && context.fromStage === 'intake' && context.toStage === 'triage')
+  ) {
     return;
   }
   return invokeIssueInvestigation(context);
@@ -70,6 +73,7 @@ function retriageGithubIssue(context: FactoryGithubRuleContext) {
 }
 
 function investigateTriagedLinearIssue(context: FactoryStageRuleContext) {
+  if (context.cause === 'run_start') return;
   const identifier = context.item.sourceKey?.startsWith('linear:')
     ? context.item.sourceKey.slice('linear:'.length)
     : context.item.title;
@@ -160,10 +164,7 @@ function issueOpened(context: FactoryGithubRuleContext) {
     sourceKey: `github-issue:${context.issue.number}`,
     title: context.issue.title,
     url: context.issue.url,
-    stage:
-      trustedGithubActor(context) && createdAfterFactory(context.issue.createdAt, context.factory.createdAt)
-        ? 'triage'
-        : 'intake',
+    stage: 'intake',
     metadata: {
       githubRepositoryId: context.repository.id,
       githubIssueNumber: context.issue.number,
@@ -321,7 +322,7 @@ function linearIssueObserved(context: FactoryLinearRuleContext) {
     sourceKey: `linear:${context.issue.identifier}`,
     title: `${context.issue.identifier}: ${context.issue.title}`,
     url: context.issue.url,
-    stage: 'triage',
+    stage: 'intake',
     metadata: {
       linearIssueId: context.issue.id,
       identifier: context.issue.identifier,


### PR DESCRIPTION
New GitHub and Linear issues now remain in Intake until someone explicitly starts triage. Clicking Investigate starts the triage session and uses the governed transition into Triage, while trusted pull requests still go directly to Review.

Before: injected issues advanced to Triage automatically. After: they stay in Intake until triage begins.

Verified with the focused Factory rules and GitHub integration tests, the board start-request MSW test, and Factory/Factory UI typechecks. The full Factory UI MSW suite still has two unrelated existing failures in SlackConnectionPage and UserSessionDraftHandoff.