### PR TITLE
Normalize OpenAI strict structured-output schemas

### DIFF
--- a/.changeset/big-snakes-fail.md
+++ b/.changeset/big-snakes-fail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed OpenAI strict structured-output schemas with optional fields.

--- a/packages/core/src/stream/aisdk/v5/execute.test.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.test.ts
@@ -129,6 +129,52 @@ describe('execute structured output prompt handling', () => {
     expect(JSON.stringify((capturedPrompt as any[])[3])).toContain('Extract now.');
   });
 
+  it('normalizes OpenAI strict-mode schemas through compatibility layers', async () => {
+    let capturedResponseFormat: any;
+    const model = new MockLanguageModelV2({
+      doStream: async ({ responseFormat }: any) => {
+        capturedResponseFormat = responseFormat;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-openai', modelId: 'gpt-4o', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: '{"name":"Mastra"}' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: testUsage, providerMetadata: undefined },
+          ]),
+          request: { body: '' },
+          response: { headers: {} },
+          warnings: [] as any[],
+        };
+      },
+    });
+    Object.assign(model, { provider: 'openai', modelId: 'gpt-4o' });
+
+    const stream = execute({
+      runId: 'test-run-id-openai-strict',
+      model: model as any,
+      inputMessages,
+      onResult: () => {},
+      methodType: 'stream',
+      structuredOutput: {
+        schema: z.object({ name: z.string().optional() }),
+      },
+    });
+    await readStream(stream);
+
+    expect(capturedResponseFormat).toMatchObject({
+      type: 'json',
+      schema: {
+        additionalProperties: false,
+        required: ['name'],
+        properties: {
+          name: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+        },
+      },
+    });
+  });
+
   it('adds a user message for inline mode when no user message exists', async () => {
     let capturedPrompt: unknown;
     const model = new MockLanguageModelV2({

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -2,7 +2,7 @@ import { injectJsonInstructionIntoMessages } from '@ai-sdk/provider-utils-v5';
 import type { LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
 import { APICallError } from '@internal/ai-sdk-v5';
 import type { IdGenerator, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
-import { prepareJsonSchemaForOpenAIStrictMode } from '@mastra/schema-compat';
+import { OpenAIReasoningSchemaCompatLayer, OpenAISchemaCompatLayer, applyCompatLayer } from '@mastra/schema-compat';
 import type { StructuredOutputOptions } from '../../../agent/types';
 import type { ModelMethodType } from '../../../llm/model/model.loop.types';
 import { modelSupportsStructuredOutput } from '../../../llm/model/provider-registry';
@@ -213,7 +213,14 @@ export function execute<OUTPUT = undefined>({
 
   // For OpenAI strict mode, ensure all properties are required and additionalProperties: false
   if (isOpenAIStrictMode && responseFormat?.schema) {
-    responseFormat.schema = prepareJsonSchemaForOpenAIStrictMode(responseFormat.schema);
+    responseFormat.schema = applyCompatLayer({
+      schema: responseFormat.schema,
+      compatLayers: [
+        new OpenAIReasoningSchemaCompatLayer({ ...model, supportsStructuredOutputs: true }),
+        new OpenAISchemaCompatLayer({ ...model, supportsStructuredOutputs: true }),
+      ],
+      mode: 'jsonSchema',
+    });
   }
 
   const providerOptionsToUse: SharedProviderOptions | undefined = isOpenAIStrictMode


### PR DESCRIPTION
## Summary

- Normalize direct structured-output schemas with the OpenAI compatibility layers before enabling strict JSON Schema mode.
- Represent optional fields as required nullable fields, as required by OpenAI strict mode.
- Add a regression test for the AISDK v5 streaming response-format path.

Fixes #16383.

**Stack:** based on #21293.

## Test plan

```sh
pnpm --filter ./packages/core exec vitest run src/stream/aisdk/v5/execute.test.ts
pnpm --filter ./packages/core check
```
