### PR TITLE
Require a model for structured-output processor options

### DIFF
--- a/.changeset/big-snakes-fail.md
+++ b/.changeset/big-snakes-fail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed OpenAI strict structured-output schemas with optional fields.

--- a/.changeset/perky-snails-feel.md
+++ b/.changeset/perky-snails-feel.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': patch
+---
+
+Fixed structured output option typing so processor-only fields require a separate `structuredOutput.model`.
+
+```ts
+await agent.generate('Extract details', {
+  structuredOutput: {
+    model: 'openai/gpt-5-mini',
+    instructions: 'Extract structured details from the prompt',
+    schema: userSchema,
+  },
+});
+```

--- a/packages/core/src/agent/agent-structured-output.test-d.ts
+++ b/packages/core/src/agent/agent-structured-output.test-d.ts
@@ -1,0 +1,154 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { z } from 'zod/v4';
+import type { IMastraLogger } from '../logger';
+import { Agent } from './agent';
+import type { SerializableStructuredOutputOptions, StructuredOutputOptionsBase } from './types';
+
+describe('Agent structured output call-site types', () => {
+  const agent = new Agent({
+    id: 'test-agent',
+    name: 'test-agent',
+    instructions: 'Test instructions',
+    model: 'openai/gpt-5-mini',
+  });
+  const schema = z.object({ name: z.string() });
+  const logger = {} as IMastraLogger;
+
+  describe('agent.generate()', () => {
+    it('allows direct-mode common fields', () => {
+      const response = agent.generate('prompt', {
+        structuredOutput: {
+          schema,
+          jsonPromptInjection: 'auto',
+          errorStrategy: 'fallback',
+          fallbackValue: { name: 'default' },
+        },
+      });
+
+      expectTypeOf(response).resolves.toHaveProperty('object');
+    });
+
+    it('allows processor-mode fields with model', () => {
+      const response = agent.generate('prompt', {
+        structuredOutput: {
+          model: 'openai/gpt-5-mini',
+          instructions: 'Give me a name',
+          useAgent: true,
+          logger,
+          providerOptions: { openai: { reasoningEffort: 'low' } },
+          schema,
+          errorStrategy: 'fallback',
+          fallbackValue: { name: 'default' },
+        },
+      });
+
+      expectTypeOf(response).resolves.toHaveProperty('object');
+    });
+
+    it('rejects processor-mode fields without model', () => {
+      void agent.generate('prompt', {
+        // @ts-expect-error instructions requires model
+        structuredOutput: { instructions: 'Give me a name', schema },
+      });
+      void agent.generate('prompt', {
+        // @ts-expect-error useAgent requires model
+        structuredOutput: { useAgent: true, schema },
+      });
+      void agent.generate('prompt', {
+        // @ts-expect-error logger requires model
+        structuredOutput: { logger, schema },
+      });
+      void agent.generate('prompt', {
+        // @ts-expect-error providerOptions requires model
+        structuredOutput: { providerOptions: { openai: { reasoningEffort: 'low' } }, schema },
+      });
+    });
+
+    it('requires fallbackValue for the fallback error strategy', () => {
+      void agent.generate('prompt', {
+        // @ts-expect-error fallback requires fallbackValue
+        structuredOutput: { schema, errorStrategy: 'fallback' },
+      });
+    });
+  });
+
+  describe('agent.stream()', () => {
+    it('allows direct mode', () => {
+      const response = agent.stream('prompt', {
+        structuredOutput: { schema, jsonPromptInjection: 'inline' },
+      });
+
+      expectTypeOf(response).resolves.toHaveProperty('object');
+    });
+
+    it('allows processor mode', () => {
+      const response = agent.stream('prompt', {
+        structuredOutput: {
+          model: 'openai/gpt-5-mini',
+          instructions: 'Give me a name',
+          schema,
+        },
+      });
+
+      expectTypeOf(response).resolves.toHaveProperty('object');
+    });
+
+    it('rejects processor-mode fields without model', () => {
+      void agent.stream('prompt', {
+        // @ts-expect-error instructions requires model
+        structuredOutput: { instructions: 'Give me a name', schema },
+      });
+      void agent.stream('prompt', {
+        // @ts-expect-error useAgent requires model
+        structuredOutput: { useAgent: true, schema },
+      });
+      void agent.stream('prompt', {
+        // @ts-expect-error logger requires model
+        structuredOutput: { logger, schema },
+      });
+      void agent.stream('prompt', {
+        // @ts-expect-error providerOptions requires model
+        structuredOutput: { providerOptions: { openai: { reasoningEffort: 'low' } }, schema },
+      });
+    });
+  });
+
+  describe('structured output type compatibility', () => {
+    it('preserves the schema-free, permissive public base type', () => {
+      const options: StructuredOutputOptionsBase<{ name: string }> = {
+        instructions: 'Give me a name',
+        useAgent: true,
+        logger,
+        providerOptions: { openai: { reasoningEffort: 'low' } },
+        jsonPromptInjection: 'auto',
+        errorStrategy: 'fallback',
+        fallbackValue: { name: 'default' },
+      };
+
+      expectTypeOf(options.fallbackValue).toEqualTypeOf<{ name: string }>();
+    });
+
+    it('supports direct and processor serializable variants', () => {
+      const direct: SerializableStructuredOutputOptions<{ name: string }> = {
+        schema: { type: 'object' },
+        errorStrategy: 'fallback',
+        fallbackValue: { name: 'default' },
+      };
+      const processor: SerializableStructuredOutputOptions<{ name: string }> = {
+        model: { providerId: 'openai', modelId: 'gpt-5-mini' },
+        schema: { type: 'object' },
+        instructions: 'Give me a name',
+      };
+
+      void direct;
+      void processor;
+
+      // @ts-expect-error processor-only fields require model
+      const invalid: SerializableStructuredOutputOptions<{ name: string }> = {
+        schema: { type: 'object' },
+        instructions: 'Give me a name',
+      };
+      void invalid;
+    });
+  });
+});

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -364,22 +364,7 @@ type FallbackFields<OUTPUT = undefined> =
   | { errorStrategy?: 'strict' | 'warn'; fallbackValue?: never }
   | { errorStrategy: 'fallback'; fallbackValue: OUTPUT };
 
-export type StructuredOutputOptionsBase<OUTPUT = {}> = {
-  /** Model to use for the internal structuring agent. If not provided, falls back to the agent's model */
-  model?: MastraModelConfig;
-  /**
-   * Custom instructions for the structuring agent.
-   * If not provided, will generate instructions based on the schema.
-   */
-  instructions?: string;
-
-  /**
-   * When true and `model` is also provided, reuse the parent agent for the separate
-   * structuring pass. If a thread is available, Mastra attaches read-only memory so
-   * the structuring model has full conversation context.
-   */
-  useAgent?: boolean;
-
+type StructuredOutputCommonFields<OUTPUT = {}> = {
   /**
    * Whether to use prompt injection instead of native response format to coerce the LLM to respond with JSON text.
    * true and 'system' inject JSON instructions into the leading system message.
@@ -388,12 +373,22 @@ export type StructuredOutputOptionsBase<OUTPUT = {}> = {
    * false or omitted uses the provider's native response format.
    */
   jsonPromptInjection?: boolean | 'system' | 'inline' | 'auto';
+} & FallbackFields<OUTPUT>;
 
+type StructuredOutputProcessorFields = {
   /**
-   * Optional logger instance for structured logging
+   * Custom instructions for the structuring agent.
+   * If not provided, will generate instructions based on the schema.
    */
+  instructions?: string;
+  /**
+   * When true and `model` is also provided, reuse the parent agent for the separate
+   * structuring pass. If a thread is available, Mastra attaches read-only memory so
+   * the structuring model has full conversation context.
+   */
+  useAgent?: boolean;
+  /** Optional logger instance for structured logging */
   logger?: IMastraLogger;
-
   /**
    * Provider-specific options passed to the internal structuring agent.
    * Use this to control model behavior like reasoning effort for thinking models.
@@ -406,19 +401,42 @@ export type StructuredOutputOptionsBase<OUTPUT = {}> = {
    * ```
    */
   providerOptions?: ProviderOptions;
-} & FallbackFields<OUTPUT>;
+};
 
-export type StructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<OUTPUT> & {
+type StructuredOutputDirectFields = {
+  model?: never;
+  instructions?: never;
+  useAgent?: never;
+  logger?: never;
+  providerOptions?: never;
+};
+
+/**
+ * Base structured-output options retained for backwards compatibility.
+ *
+ * Use a schema-bearing structured-output type for execution options so processor-only fields require `model`.
+ */
+export type StructuredOutputOptionsBase<OUTPUT = {}> = StructuredOutputCommonFields<OUTPUT> & {
+  /** Model to use for the internal structuring agent. If not provided, falls back to the agent's model */
+  model?: MastraModelConfig;
+} & StructuredOutputProcessorFields;
+
+type StructuredOutputOptionsWithModel<MODEL, OUTPUT = {}> = StructuredOutputCommonFields<OUTPUT> &
+  (({ model: MODEL } & StructuredOutputProcessorFields) | StructuredOutputDirectFields);
+
+export type StructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsWithModel<MastraModelConfig, OUTPUT> & {
   /** Zod schema to validate the output against */
   schema: StandardSchemaWithJSON<OUTPUT>;
 };
 
-export type PublicStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<OUTPUT> & {
+export type PublicStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsWithModel<MastraModelConfig, OUTPUT> & {
   schema: PublicSchema<OUTPUT>;
 };
 
-export type SerializableStructuredOutputOptions<OUTPUT = {}> = Omit<StructuredOutputOptionsBase<OUTPUT>, 'model'> & {
-  model?: ModelRouterModelId | OpenAICompatibleConfig;
+export type SerializableStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsWithModel<
+  ModelRouterModelId | OpenAICompatibleConfig,
+  OUTPUT
+> & {
   /** JSON Schema to validate the output against */
   schema: JSONSchema7;
 };

--- a/packages/core/src/stream/aisdk/v5/execute.test.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.test.ts
@@ -129,6 +129,52 @@ describe('execute structured output prompt handling', () => {
     expect(JSON.stringify((capturedPrompt as any[])[3])).toContain('Extract now.');
   });
 
+  it('normalizes OpenAI strict-mode schemas through compatibility layers', async () => {
+    let capturedResponseFormat: any;
+    const model = new MockLanguageModelV2({
+      doStream: async ({ responseFormat }: any) => {
+        capturedResponseFormat = responseFormat;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-openai', modelId: 'gpt-4o', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: '{"name":"Mastra"}' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: testUsage, providerMetadata: undefined },
+          ]),
+          request: { body: '' },
+          response: { headers: {} },
+          warnings: [] as any[],
+        };
+      },
+    });
+    Object.assign(model, { provider: 'openai', modelId: 'gpt-4o' });
+
+    const stream = execute({
+      runId: 'test-run-id-openai-strict',
+      model: model as any,
+      inputMessages,
+      onResult: () => {},
+      methodType: 'stream',
+      structuredOutput: {
+        schema: z.object({ name: z.string().optional() }),
+      },
+    });
+    await readStream(stream);
+
+    expect(capturedResponseFormat).toMatchObject({
+      type: 'json',
+      schema: {
+        additionalProperties: false,
+        required: ['name'],
+        properties: {
+          name: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+        },
+      },
+    });
+  });
+
   it('adds a user message for inline mode when no user message exists', async () => {
     let capturedPrompt: unknown;
     const model = new MockLanguageModelV2({

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -2,7 +2,7 @@ import { injectJsonInstructionIntoMessages } from '@ai-sdk/provider-utils-v5';
 import type { LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
 import { APICallError } from '@internal/ai-sdk-v5';
 import type { IdGenerator, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
-import { prepareJsonSchemaForOpenAIStrictMode } from '@mastra/schema-compat';
+import { OpenAIReasoningSchemaCompatLayer, OpenAISchemaCompatLayer, applyCompatLayer } from '@mastra/schema-compat';
 import type { StructuredOutputOptions } from '../../../agent/types';
 import type { ModelMethodType } from '../../../llm/model/model.loop.types';
 import { modelSupportsStructuredOutput } from '../../../llm/model/provider-registry';
@@ -213,7 +213,14 @@ export function execute<OUTPUT = undefined>({
 
   // For OpenAI strict mode, ensure all properties are required and additionalProperties: false
   if (isOpenAIStrictMode && responseFormat?.schema) {
-    responseFormat.schema = prepareJsonSchemaForOpenAIStrictMode(responseFormat.schema);
+    responseFormat.schema = applyCompatLayer({
+      schema: responseFormat.schema,
+      compatLayers: [
+        new OpenAIReasoningSchemaCompatLayer({ ...model, supportsStructuredOutputs: true }),
+        new OpenAISchemaCompatLayer({ ...model, supportsStructuredOutputs: true }),
+      ],
+      mode: 'jsonSchema',
+    });
   }
 
   const providerOptionsToUse: SharedProviderOptions | undefined = isOpenAIStrictMode

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -1,7 +1,7 @@
 import { TransformStream } from 'node:stream/web';
 import { isDeepEqualData, parsePartialJson } from '@internal/ai-sdk-v5';
 import { isZodType } from '@mastra/schema-compat';
-import type { StructuredOutputOptions } from '../../agent/types';
+import type { PublicStructuredOutputOptions } from '../../agent/types';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import type { IMastraLogger } from '../../logger';
 import type { ZodType, PublicSchema, StandardSchemaWithJSON } from '../../schema';
@@ -12,9 +12,7 @@ import type { ChunkType } from '../types';
 import { getTransformedSchema } from './schema';
 import type { ZodLikePartialSchema } from './schema';
 
-type StreamTransformerStructuredOutput<OUTPUT> = Omit<StructuredOutputOptions<OUTPUT>, 'schema'> & {
-  schema: PublicSchema<OUTPUT>;
-};
+type StreamTransformerStructuredOutput<OUTPUT> = PublicStructuredOutputOptions<OUTPUT>;
 
 /**
  * Escapes unescaped newlines, carriage returns, and tabs within JSON string values.


### PR DESCRIPTION
## Summary

- Reject processor-only `structuredOutput` options unless `structuredOutput.model` is provided.
- Keep the existing permissive `StructuredOutputOptionsBase` public type source-compatible.
- Preserve direct-mode and fallback-option correlations through stream transformer types.

Fixes #14552.

**Stack:** based on #21294.

## Test plan

```sh
pnpm --filter ./packages/core exec vitest --project typecheck:packages/core --run src/agent/agent-structured-output.test-d.ts
pnpm --filter ./packages/core exec vitest run src/stream/base/output-format-handlers.test.ts src/processors/processors/structured-output.test.ts src/agent/__tests__/structured-output.test.ts
pnpm --filter ./packages/core check
pnpm build:core
```
