### PR TITLE
fix(core): support workflow eval gates with threshold scorers

### DIFF
--- a/.changeset/fix-workflow-eval-overloads.md
+++ b/.changeset/fix-workflow-eval-overloads.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workflow eval overloads so threshold scorers and gates can be used together.

--- a/packages/core/src/evals/run/gates-scorer-config-types.test-d.ts
+++ b/packages/core/src/evals/run/gates-scorer-config-types.test-d.ts
@@ -1,9 +1,12 @@
 import { describe, it, expectTypeOf } from 'vitest';
+import { z } from 'zod/v4';
 import type { Agent } from '../../agent';
+import { createStep, createWorkflow } from '../../workflows';
 import type { AnyWorkflow } from '../../workflows/workflow';
+import { createScorer } from '../base';
 import type { MastraScorer } from '../base';
 import { runEvals } from '.';
-import type { AgentScorerConfig, RunEvalsResult, ScorerEntry, WorkflowScorerConfig } from '.';
+import type { AgentScorerConfig, RunEvalsResult, WorkflowScorerConfig } from '.';
 
 /**
  * Regression tests for issues #21136 and #21290: `runEvals` accepts `gates`
@@ -43,16 +46,33 @@ describe('runEvals gates + scorer overloads', () => {
     expectTypeOf(result).resolves.toEqualTypeOf<RunEvalsResult>();
   });
 
-  it('accepts gates together with threshold scorers for a workflow target', () => {
-    const workflow = {} as AnyWorkflow;
-    const gates = [] as MastraScorer<any, any, any, any>[];
-    const scorers = [{ scorer: {} as MastraScorer, threshold: 0.7 }] satisfies ScorerEntry[];
+  it('accepts the issue #21290 workflow repro with gates and a threshold scorer', () => {
+    const inputSchema = z.object({ n: z.number() });
+    const outputSchema = z.object({ doubled: z.number() });
+    const workflow = createWorkflow({ id: 'repro-wf', inputSchema, outputSchema })
+      .then(
+        createStep({
+          id: 'double',
+          inputSchema,
+          outputSchema,
+          execute: async ({ inputData }) => ({ doubled: inputData.n * 2 }),
+        }),
+      )
+      .commit();
+
+    const scorerType = { input: inputSchema, output: outputSchema };
+    const evenGate = createScorer({ id: 'even-gate', description: 'gate', type: scorerType }).generateScore(
+      ({ run }) => (run.output.doubled % 2 === 0 ? 1 : 0),
+    );
+    const ratioScorer = createScorer({ id: 'ratio', description: 'threshold scorer', type: scorerType }).generateScore(
+      ({ run }) => run.output.doubled / 10,
+    );
 
     const result = runEvals({
       target: workflow,
-      data: [{ input: 'run it' }],
-      gates,
-      scorers,
+      data: [{ input: { n: 2 } }, { input: { n: 4 } }],
+      gates: [evenGate],
+      scorers: [{ scorer: ratioScorer, threshold: 0.5 }],
     });
 
     expectTypeOf(result).resolves.toEqualTypeOf<RunEvalsResult>();

--- a/packages/core/src/evals/run/gates-scorer-config-types.test-d.ts
+++ b/packages/core/src/evals/run/gates-scorer-config-types.test-d.ts
@@ -3,17 +3,16 @@ import type { Agent } from '../../agent';
 import type { AnyWorkflow } from '../../workflows/workflow';
 import type { MastraScorer } from '../base';
 import { runEvals } from '.';
-import type { AgentScorerConfig, RunEvalsResult, WorkflowScorerConfig } from '.';
+import type { AgentScorerConfig, RunEvalsResult, ScorerEntry, WorkflowScorerConfig } from '.';
 
 /**
- * Regression tests for issue #21136: `runEvals` accepts `gates` together with a
- * categorized scorer config (`AgentScorerConfig` / `WorkflowScorerConfig`) at
- * runtime, but the TypeScript overloads only declared `gates` alongside a flat
- * `ScorerEntry[]`. Combining `gates` with `scorers: { trajectory: [...] }`
- * therefore failed to compile with TS2769 even though the call works. These are
- * type-level assertions only — no runtime behavior is exercised.
+ * Regression tests for issues #21136 and #21290: `runEvals` accepts `gates`
+ * alongside its scorer configurations at runtime, but the TypeScript overloads
+ * were narrower than the implementation. These type-level assertions cover
+ * both categorized configs and workflow threshold entries — no runtime
+ * behavior is exercised.
  */
-describe('runEvals gates + categorized scorer config overloads (issue #21136)', () => {
+describe('runEvals gates + scorer overloads', () => {
   it('accepts gates together with an AgentScorerConfig (trajectory scorers)', () => {
     const agent = {} as Agent;
     const gates = [] as MastraScorer<any, any, any, any>[];
@@ -33,6 +32,21 @@ describe('runEvals gates + categorized scorer config overloads (issue #21136)', 
     const workflow = {} as AnyWorkflow;
     const gates = [] as MastraScorer<any, any, any, any>[];
     const scorers = {} as WorkflowScorerConfig;
+
+    const result = runEvals({
+      target: workflow,
+      data: [{ input: 'run it' }],
+      gates,
+      scorers,
+    });
+
+    expectTypeOf(result).resolves.toEqualTypeOf<RunEvalsResult>();
+  });
+
+  it('accepts gates together with threshold scorers for a workflow target', () => {
+    const workflow = {} as AnyWorkflow;
+    const gates = [] as MastraScorer<any, any, any, any>[];
+    const scorers = [{ scorer: {} as MastraScorer, threshold: 0.7 }] satisfies ScorerEntry[];
 
     const result = runEvals({
       target: workflow,

--- a/packages/core/src/evals/run/index.ts
+++ b/packages/core/src/evals/run/index.ts
@@ -202,8 +202,10 @@ export function runEvals<TAgent extends Agent>(config: {
 // Workflow with scorers array
 export function runEvals<TWorkflow extends AnyWorkflow>(config: {
   data: RunEvalsDataItem<TWorkflow>[];
-  scorers: MastraScorer<any, any, any, any>[];
+  scorers: ScorerEntry[];
   target: TWorkflow;
+  /** Gates: scorers that must score 1.0 for the run to pass. */
+  gates?: MastraScorer<any, any, any, any>[];
   targetOptions?: WorkflowRunOptions;
   onItemComplete?: (params: {
     item: RunEvalsDataItem<TWorkflow>;


### PR DESCRIPTION
## Description

The workflow flat-array `runEvals` overload was narrower than the runtime-supported configuration. It now accepts threshold-bearing `ScorerEntry` values and optional `gates` for Workflow targets.

This patch only widens the public TypeScript overload and adds a type-level regression case based on the issue's concrete workflow repro.

## Related issue(s)

Fixes #21290

## Type of change

- [x] Bug fix
- [x] Test update

## Verification

- `pnpm exec oxfmt --check packages/core/src/evals/run/index.ts packages/core/src/evals/run/gates-scorer-config-types.test-d.ts`
- `pnpm exec oxlint packages/core/src/evals/run/index.ts packages/core/src/evals/run/gates-scorer-config-types.test-d.ts`
- Focused Vitest typecheck: 5/5 cases passed, including the Workflow gates + threshold repro
- `git diff --check upstream/main...HEAD`

The full `@mastra/core` TypeScript check still reports existing fresh-checkout baseline errors in unrelated workspace/type surfaces. Vercel preview checks require the Mastra team's deployment authorization. The runtime path already handled gates and thresholds; no runtime execution logic changed.
