### PR TITLE
fix: stabilize experiment artifacts and transcript reopening

### DIFF
--- a/.changeset/big-signs-build.md
+++ b/.changeset/big-signs-build.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed experiment worker artifacts to exclude generated local database state while preserving reproducible digests and unique build identities.

--- a/.changeset/chatty-boats-kick.md
+++ b/.changeset/chatty-boats-kick.md
@@ -1,0 +1,6 @@
+---
+'create-mastra': patch
+'mastra': patch
+---
+
+Fixed generated projects to approve required pnpm native builds and externalize DuckDB bindings for experiment workers.

--- a/.changeset/social-poets-sniff.md
+++ b/.changeset/social-poets-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed saved chat transcripts to open at the latest turn after asynchronously loaded history finishes layout.

--- a/e2e-tests/experiment-worker/tests/portability-isolation.test.ts
+++ b/e2e-tests/experiment-worker/tests/portability-isolation.test.ts
@@ -94,6 +94,8 @@ beforeAll(async () => {
 
   expect(first.build.buildId).not.toBe(second.build.buildId);
   expect(first.build.createdAt).not.toBe(second.build.createdAt);
+  expect(first.files).toEqual(second.files);
+  expect(first.artifact.contentDigest).toBe(second.artifact.contentDigest);
   expect({
     ...first,
     build: undefined,

--- a/mastracode/tui/src/tui/commands/__tests__/goal.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/goal.test.ts
@@ -637,7 +637,7 @@ describe('handleGoalCommand', () => {
     vi.setSystemTime(new Date('2026-05-15T15:00:00.000Z'));
 
     expect(goalManager.isActive()).toBe(true);
-    expect(goalManager.getGoal()).toMatchObject({ activeDurationMs: 0, activeStartedAt: undefined });
+    expect(goalManager.getGoal()).toMatchObject({ activeDurationMs: 0 });
     expect(sendMessage).not.toHaveBeenCalled();
     vi.useRealTimers();
   });

--- a/packages/cli/src/commands/create/pnpm11-packagemanager.test.ts
+++ b/packages/cli/src/commands/create/pnpm11-packagemanager.test.ts
@@ -55,5 +55,6 @@ describe('pnpm v11 packageManager normalization', () => {
     expect(workspace).toContain('  bufferutil: true');
     expect(workspace).toContain('  protobufjs: true');
     expect(workspace).toContain('  utf-8-validate: true');
+    expect(workspace).not.toContain('onlyBuiltDependencies');
   });
 });

--- a/packages/cli/src/commands/create/pnpm11-packagemanager.test.ts
+++ b/packages/cli/src/commands/create/pnpm11-packagemanager.test.ts
@@ -50,6 +50,10 @@ describe('pnpm v11 packageManager normalization', () => {
   it('writes the complete pnpm 11 workspace and build-policy configuration', async () => {
     const projectPath = await createPnpmProject();
 
-    expect(await fs.readFile(path.join(projectPath, 'pnpm-workspace.yaml'), 'utf8')).toBe(PNPM_WORKSPACE);
+    const workspace = await fs.readFile(path.join(projectPath, 'pnpm-workspace.yaml'), 'utf8');
+    expect(workspace).toBe(PNPM_WORKSPACE);
+    expect(workspace).toContain('  bufferutil: true');
+    expect(workspace).toContain('  protobufjs: true');
+    expect(workspace).toContain('  utf-8-validate: true');
   });
 });

--- a/packages/cli/src/commands/create/provider-adapter.test.ts
+++ b/packages/cli/src/commands/create/provider-adapter.test.ts
@@ -149,6 +149,17 @@ describe('adaptDefaultTemplate', () => {
     expect(result.adaptationFailed).toBe(false);
   });
 
+  it('preserves the DuckDB native external required by experiment workers', async () => {
+    const projectPath = await createFixture();
+
+    const result = await adaptFixture({ projectPath, provider: 'openai', versionTag: 'latest' });
+
+    expect(await fs.readFile(path.join(projectPath, 'src/mastra/index.ts'), 'utf8')).toContain(
+      "externals: ['@duckdb/node-bindings']",
+    );
+    expect(result.adaptationFailed).toBe(false);
+  });
+
   it('preserves template-owned OpenAI models, built-in tools, and unrelated environment variables', async () => {
     const projectPath = await createFixture();
     const agentPath = path.join(projectPath, 'src/mastra/agents/agent.ts');

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -37,11 +37,17 @@ minimumReleaseAgeExclude:
   - mastra
   - "@mastra/*"
 allowBuilds:
+  bufferutil: true
   esbuild: true
+  protobufjs: true
   sharp: true
+  utf-8-validate: true
 onlyBuiltDependencies:
+  - bufferutil
   - esbuild
+  - protobufjs
   - sharp
+  - utf-8-validate
 `;
 
 export interface OwnedStagingDirectory {

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -42,12 +42,6 @@ allowBuilds:
   protobufjs: true
   sharp: true
   utf-8-validate: true
-onlyBuiltDependencies:
-  - bufferutil
-  - esbuild
-  - protobufjs
-  - sharp
-  - utf-8-validate
 `;
 
 export interface OwnedStagingDirectory {

--- a/packages/cli/src/commands/experiment/ExperimentBundler.test.ts
+++ b/packages/cli/src/commands/experiment/ExperimentBundler.test.ts
@@ -29,6 +29,16 @@ describe('ExperimentBundler', () => {
     return directory;
   };
 
+  const writeWorkerManifest = async (directory: string, buildId: string) => {
+    await writeFile(
+      join(directory, 'experiment-worker-manifest.json'),
+      JSON.stringify({
+        build: { buildId },
+        protocol: { versions: ['1'], datasetCanonicalizationVersion: '1' },
+      }),
+    );
+  };
+
   afterEach(async () => {
     vi.clearAllMocks();
     await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { recursive: true, force: true })));
@@ -51,6 +61,20 @@ describe('ExperimentBundler', () => {
     expect(entry).toContain('process.stdout.end(resolve)');
     expect(entry).toContain('setTimeout(resolve, 5_000)');
     expect(entry).toContain('process.exit(exitCode)');
+    expect(entry).toContain("readFile(new URL('./experiment-worker-manifest.json', import.meta.url), 'utf8')");
+    expect(entry).not.toContain(bundler.buildIdentity.buildId);
+  });
+
+  it('keeps worker bundle content stable across build identities', async () => {
+    const { ExperimentBundler } = await import('./ExperimentBundler');
+    const firstBundler = new ExperimentBundler();
+    const secondBundler = new ExperimentBundler();
+
+    const firstEntry = (firstBundler as unknown as { getEntry(): string }).getEntry();
+    const secondEntry = (secondBundler as unknown as { getEntry(): string }).getEntry();
+
+    expect(firstBundler.buildIdentity.buildId).not.toBe(secondBundler.buildIdentity.buildId);
+    expect(firstEntry).toBe(secondEntry);
   });
 
   it('installs explicitly configured externals that static analysis cannot observe', async () => {
@@ -161,6 +185,35 @@ describe('ExperimentBundler', () => {
       contentDigest: expectedContentDigest,
       excludes: ['experiment-worker-manifest.json', 'node_modules'],
     });
+  });
+
+  it('removes local database state before creating the artifact manifest', async () => {
+    const { ExperimentBundler } = await import('./ExperimentBundler');
+    const output = await createTemporaryDirectory('mastra-experiment-worker-');
+    const nestedDirectory = join(output, 'runtime-state');
+    await mkdir(nestedDirectory);
+    await writeFile(join(output, 'index.mjs'), '');
+    await writeFile(join(output, 'package.json'), '{}');
+    const localStorageFiles = [
+      'mastra.db',
+      'mastra.db-shm',
+      'mastra.db-wal',
+      'mastra.duckdb',
+      'mastra.duckdb.wal',
+      'runtime-state/cache.sqlite',
+      'runtime-state/cache.sqlite-wal',
+    ];
+    await Promise.all(localStorageFiles.map(path => writeFile(join(output, path), 'local state')));
+
+    await new ExperimentBundler().writeArtifactManifest(output, '1.2.3');
+
+    const manifest = JSON.parse(await readFile(join(output, 'experiment-worker-manifest.json'), 'utf8'));
+    expect(manifest.files.map((file: { path: string }) => file.path)).toEqual(['index.mjs', 'package.json']);
+    await Promise.all(
+      localStorageFiles.map(path =>
+        expect(readFile(join(output, path), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' }),
+      ),
+    );
   });
 
   it('excludes node_modules from file digests and content digest', async () => {
@@ -300,6 +353,7 @@ describe('ExperimentBundler', () => {
       .replace("import('@mastra/core/datasets')", `import(${JSON.stringify(pathToFileURL(coreModule).href)})`)
       .replace("import('#mastra')", `import(${JSON.stringify(pathToFileURL(mastraModule).href)})`);
     await writeFile(entryFile, entry);
+    await writeWorkerManifest(directory, bundler.buildIdentity.buildId);
 
     const items = [{ id: 'item-1', input: { prompt: 'hello' }, groundTruth: 'world', toolMocks: [] }];
     const canonical = canonicalize(items);
@@ -362,6 +416,7 @@ describe('ExperimentBundler', () => {
       .replace("import('@mastra/core/datasets')", `import(${JSON.stringify(pathToFileURL(coreModule).href)})`)
       .replace("import('#mastra')", `import(${JSON.stringify(pathToFileURL(mastraModule).href)})`);
     await writeFile(entryFile, entry);
+    await writeWorkerManifest(directory, bundler.buildIdentity.buildId);
 
     const experimentId = randomUUID();
     const request = {
@@ -410,6 +465,7 @@ describe('ExperimentBundler', () => {
       .replace("import('@mastra/core/datasets')", `import(${JSON.stringify(pathToFileURL(coreModule).href)})`)
       .replace("import('#mastra')", `import(${JSON.stringify(pathToFileURL(mastraModule).href)})`);
     await writeFile(entryFile, entry);
+    await writeWorkerManifest(directory, bundler.buildIdentity.buildId);
 
     const items: unknown[] = [];
     const digest = createHash('sha256').update(canonicalize(items)).digest('hex');

--- a/packages/cli/src/commands/experiment/ExperimentBundler.ts
+++ b/packages/cli/src/commands/experiment/ExperimentBundler.ts
@@ -86,6 +86,7 @@ export class ExperimentBundler extends Bundler {
   async writeArtifactManifest(outputDirectory: string, cliVersion: string): Promise<void> {
     await Promise.all([
       removePnpmInstallMetadata(outputDirectory),
+      removeLocalStorageArtifacts(outputDirectory),
       rm(join(outputDirectory, this.analyzeOutputDir), { recursive: true, force: true }),
     ]);
     const files = await collectFileDigests(outputDirectory);
@@ -118,6 +119,7 @@ export class ExperimentBundler extends Bundler {
   protected getEntry(): string {
     const runtimePath = resolveRuntimePath();
     return `
+import { readFile } from 'node:fs/promises';
 import { runExperimentWorker } from ${JSON.stringify(runtimePath)};
 
 console.log = (...args) => console.error(...args);
@@ -129,10 +131,17 @@ const [{ runExperiment }, mastraModule] = await Promise.all([
 ]);
 const { mastra } = mastraModule;
 if (!mastra) throw new Error("#mastra does not provide an export named 'mastra'");
+const artifactManifest = JSON.parse(
+  await readFile(new URL('./experiment-worker-manifest.json', import.meta.url), 'utf8'),
+);
 const exitCode = await runExperimentWorker({
   mastra,
   runExperiment,
-  build: ${JSON.stringify(this.buildIdentity)},
+  build: {
+    buildId: artifactManifest.build.buildId,
+    protocolVersion: artifactManifest.protocol.versions[0],
+    datasetCanonicalizationVersion: artifactManifest.protocol.datasetCanonicalizationVersion,
+  },
 });
 await Promise.race([
   new Promise(resolve => process.stdout.end(resolve)),
@@ -153,6 +162,28 @@ export function resolveRuntimePath(
 }
 
 type ArtifactFileDigest = { path: string; sha256: string; type?: 'file' | 'symlink'; target?: string };
+
+const LOCAL_STORAGE_ARTIFACT_PATTERN = /(?:\.db(?:-.+)?|\.duckdb(?:\.wal)?|\.sqlite(?:-.+)?)$/;
+
+export async function removeLocalStorageArtifacts(root: string): Promise<void> {
+  const visit = async (directory: string): Promise<void> => {
+    const entries = await readdir(directory, { withFileTypes: true });
+    await Promise.all(
+      entries.map(async entry => {
+        const entryPath = join(directory, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name !== 'node_modules') await visit(entryPath);
+          return;
+        }
+        if (LOCAL_STORAGE_ARTIFACT_PATTERN.test(entry.name)) {
+          await rm(entryPath, { force: true });
+        }
+      }),
+    );
+  };
+
+  await visit(root);
+}
 
 export async function removePnpmInstallMetadata(root: string): Promise<void> {
   const nodeModules = join(root, 'node_modules');

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
@@ -597,6 +597,36 @@ describe('MessageScroller older history', () => {
 });
 
 describe('MessageScroller turn anchoring', () => {
+  it('opens an asynchronously loaded transcript at its latest turn after layout settles', () => {
+    let layoutReady = false;
+    const scheduledScrolls: FrameRequestCallback[] = [];
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      scheduledScrolls.push(callback);
+      return scheduledScrolls.length;
+    });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      const top = layoutReady && this.dataset.messageId === 'message-1' ? 100 : 0;
+      if (layoutReady && this.dataset.messageId === 'message-2') return createRect({ top: 700 });
+      return createRect({ top });
+    });
+    const { rerender } = render(<TurnHarness messageIds={[]} />);
+
+    const viewport = screen.getByTestId('turn-viewport');
+    const scrollTo = installScrollTo(viewport);
+    setScrollMetrics(viewport, { scrollHeight: 1200, clientHeight: 400, scrollTop: 250 });
+
+    rerender(<TurnHarness messageIds={['message-1', 'message-2']} />);
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    act(() => scheduledScrolls.shift()?.(0));
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    layoutReady = true;
+    act(() => scheduledScrolls.shift()?.(16));
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 950, behavior: 'auto' });
+  });
+
   it('parks a turn that opens below the ones already read at the top of the viewport', () => {
     stubLayout({ 'message-2': 300 });
     const { rerender } = render(<TurnHarness messageIds={['message-1']} />);

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
@@ -205,6 +205,8 @@ export function MessageScrollerProvider({
   const [viewportElement, setViewportElement] = React.useState<HTMLDivElement | null>(null);
   const [contentElement, setContentElement] = React.useState<HTMLDivElement | null>(null);
   const defaultScrollAppliedRef = React.useRef(false);
+  const deferDefaultScrollRef = React.useRef(false);
+  const defaultScrollScheduledRef = React.useRef(false);
   const seenAnchorIdsRef = React.useRef<Set<string> | null>(null);
   seenAnchorIdsRef.current ??= new Set<string>();
   const seenAnchorIds = seenAnchorIdsRef.current;
@@ -519,21 +521,48 @@ export function MessageScrollerProvider({
   }, [itemsVersion, updateScrollable, updateVisibility]);
 
   React.useLayoutEffect(() => {
-    if (defaultScrollAppliedRef.current || !viewportElement || itemsRegistry.size === 0) return;
-
-    const lastAnchorId = getLastAnchorId();
-    let didScroll = false;
-    if (defaultScrollPosition === 'start') {
-      didScroll = scrollToStart({ behavior: 'auto' });
-    } else if (defaultScrollPosition === 'last-anchor') {
-      didScroll = lastAnchorId
-        ? scrollToMessage(lastAnchorId, { align: 'start', behavior: 'auto' })
-        : scrollToEnd({ behavior: 'auto' });
-    } else {
-      didScroll = scrollToEnd({ behavior: 'auto' });
+    if (defaultScrollAppliedRef.current || !viewportElement) return undefined;
+    if (itemsRegistry.size === 0) {
+      deferDefaultScrollRef.current = true;
+      return undefined;
     }
 
-    if (didScroll) defaultScrollAppliedRef.current = true;
+    const applyDefaultScroll = () => {
+      const lastAnchorId = getLastAnchorId();
+      let didScroll = false;
+      if (defaultScrollPosition === 'start') {
+        didScroll = scrollToStart({ behavior: 'auto' });
+      } else if (defaultScrollPosition === 'last-anchor') {
+        didScroll = lastAnchorId
+          ? scrollToMessage(lastAnchorId, { align: 'start', behavior: 'auto' })
+          : scrollToEnd({ behavior: 'auto' });
+      } else {
+        didScroll = scrollToEnd({ behavior: 'auto' });
+      }
+
+      if (!didScroll) return;
+      defaultScrollAppliedRef.current = true;
+      turnAnchoringArmedRef.current = true;
+    };
+
+    if (!deferDefaultScrollRef.current) {
+      applyDefaultScroll();
+      return undefined;
+    }
+    if (defaultScrollScheduledRef.current) return undefined;
+
+    defaultScrollScheduledRef.current = true;
+    let cancelled = false;
+    scheduleScrollSync(() => {
+      scheduleScrollSync(() => {
+        defaultScrollScheduledRef.current = false;
+        if (!cancelled && !defaultScrollAppliedRef.current) applyDefaultScroll();
+      });
+    });
+    return () => {
+      cancelled = true;
+      defaultScrollScheduledRef.current = false;
+    };
   }, [
     defaultScrollPosition,
     getLastAnchorId,

--- a/templates/template-agent-harness/src/mastra/index.ts
+++ b/templates/template-agent-harness/src/mastra/index.ts
@@ -12,6 +12,9 @@ import { agent } from './agents/agent';
 import { startScheduleTool, stopScheduleTool } from './tools/schedule-tools';
 
 export const mastra = new Mastra({
+  bundler: {
+    externals: ['@duckdb/node-bindings'],
+  },
   agents: { agent },
   tools: { startScheduleTool, stopScheduleTool },
   storage: new MastraCompositeStore({


### PR DESCRIPTION
Experiment worker builds could include local database side effects and produce different artifact digests from identical source. This removes generated SQLite, LibSQL, and DuckDB state before manifesting the worker, while keeping each build identity unique by reading it from the excluded artifact manifest at runtime.

Generated pnpm projects now approve the native build dependencies used by the default stack, and the agent harness externalizes DuckDB's native bindings so a fresh project can build an experiment worker without manual config:

```ts
bundler: {
  externals: ['@duckdb/node-bindings'],
}
```

Saved Studio threads also wait for asynchronously loaded transcript layout before applying the last-turn anchor. This keeps the latest prompt at the top when reopening a thread instead of landing midway through history. The stale Mastra Code goal-state assertion is updated to match the current core-owned activity state.

Verified with the full CLI suite (979 tests), focused MessageScroller and goal tests, package builds, two consecutive real experiment-worker builds with identical content digests and no local database files, and a real Studio saved-thread reopen. The full playground-ui suite still has two unrelated failures in `use-traces-light-list.test.tsx` where the light endpoint is called twice instead of once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR keeps experiment worker builds stable by removing temporary database files before packaging. It also makes saved Studio conversations reopen at the latest message after loading finishes.

## Changes

- Removed generated `.db`, `.duckdb`, and `.sqlite` files before creating artifact manifests.
- Loaded unique build identities from `experiment-worker-manifest.json` at runtime.
- Externalized `@duckdb/node-bindings` from the worker bundle.
- Updated generated pnpm projects to use `allowBuilds` for required native dependencies.
- Delayed saved-thread scrolling until transcript layout completes.
- Updated experiment-worker, MessageScroller, CLI, provider-adapter, and goal-state tests.
- Added changesets for `mastra`, `create-mastra`, and `@mastra/playground-ui`.

## Validation

- Confirmed repeated worker builds produce matching manifests and content digests.
- Confirmed worker artifacts contain no local database files.
- Ran the full CLI suite, focused tests, package builds, and saved-thread reopen coverage.
- The playground UI suite still reports two unrelated duplicate light-traces endpoint call failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->