### PR TITLE
feat(memory): add continuationHints to observational memory

### DIFF
--- a/.changeset/lucky-donkeys-listen.md
+++ b/.changeset/lucky-donkeys-listen.md
@@ -25,11 +25,8 @@ const memory = new Memory({
 });
 ```
 
-Also fixes two prompt bugs this exposed: the Observer and Reflector prompts named
-`<current-task>` and `<suggested-response>` in their closing guidance, nesting instruction, and
-multi-thread examples unconditionally, even when the output format had already omitted them;
-and `buildObserverOutputFormat` treated an empty extractor list as "legacy caller, describe
-both sections", which would have silently re-enabled the sections it was asked to drop.
+Disabling a section removes it fully: the Observer and Reflector no longer describe or
+reference it, and a previously stored hint stops being injected into the agent's context once
+both observation and reflection disable it.
 
-Defaults are unchanged — `buildObserverSystemPrompt()` and `buildReflectorSystemPrompt()` with
-no arguments produce byte-identical prompts.
+Defaults are unchanged — existing configurations keep both sections enabled.

--- a/.changeset/lucky-donkeys-listen.md
+++ b/.changeset/lucky-donkeys-listen.md
@@ -1,0 +1,35 @@
+---
+'@mastra/memory': minor
+---
+
+Added `continuationHints` to observational memory configuration, so an agent that drives its
+own control flow can stop memory from proposing what it says next.
+
+`<current-task>` and `<suggested-response>` were always requested and there was no way to turn
+them off. A `<suggested-response>` is injected into the agent's context and the continuation
+reminder tells the agent to follow it, which makes memory a second controller competing with
+the agent's own. Pass `false` to disable both sections, or an object to disable them
+individually — keeping `<current-task>` while dropping `<suggested-response>` is the common
+case.
+
+```ts
+import { Memory } from '@mastra/memory';
+
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      observation: { continuationHints: { suggestedResponse: false } },
+      reflection: { continuationHints: false },
+    },
+  },
+});
+```
+
+Also fixes two prompt bugs this exposed: the Observer and Reflector prompts named
+`<current-task>` and `<suggested-response>` in their closing guidance, nesting instruction, and
+multi-thread examples unconditionally, even when the output format had already omitted them;
+and `buildObserverOutputFormat` treated an empty extractor list as "legacy caller, describe
+both sections", which would have silently re-enabled the sections it was asked to drop.
+
+Defaults are unchanged — `buildObserverSystemPrompt()` and `buildReflectorSystemPrompt()` with
+no arguments produce byte-identical prompts.

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -138,7 +138,7 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             name: 'continuationHints',
             type: 'boolean | { currentTask?: boolean; suggestedResponse?: boolean }',
             description:
-              'Which continuation-hint sections the Observer emits. Pass `false` to disable both, or an object to disable them individually. Agents that drive their own control flow generally want `{ suggestedResponse: false }` so memory does not compete for what the agent says next.',
+              'Which continuation-hint sections the Observer emits. Pass `false` to disable both, or an object to disable them individually. Agents that drive their own control flow generally want `{ suggestedResponse: false }` so memory does not compete for what the agent says next. A previously stored hint stops being injected into context once both observation and reflection disable its section.',
             isOptional: true,
             defaultValue: 'true',
           },
@@ -312,7 +312,7 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             name: 'continuationHints',
             type: 'boolean | { currentTask?: boolean; suggestedResponse?: boolean }',
             description:
-              'Which continuation-hint sections the Reflector emits. Pass `false` to disable both, or an object to disable them individually.',
+              'Which continuation-hint sections the Reflector emits. Pass `false` to disable both, or an object to disable them individually. A previously stored hint stops being injected into context once both observation and reflection disable its section.',
             isOptional: true,
             defaultValue: 'true',
           },

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -135,6 +135,14 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             isOptional: true,
           },
           {
+            name: 'continuationHints',
+            type: 'boolean | { currentTask?: boolean; suggestedResponse?: boolean }',
+            description:
+              'Which continuation-hint sections the Observer emits. Pass `false` to disable both, or an object to disable them individually. Agents that drive their own control flow generally want `{ suggestedResponse: false }` so memory does not compete for what the agent says next.',
+            isOptional: true,
+            defaultValue: 'true',
+          },
+          {
             name: 'threadTitle',
             type: 'boolean',
             description:
@@ -299,6 +307,14 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             description:
               "Custom instruction appended to the Reflector's system prompt. Use this to customize how the Reflector consolidates observations, such as prioritizing certain types of information.",
             isOptional: true,
+          },
+          {
+            name: 'continuationHints',
+            type: 'boolean | { currentTask?: boolean; suggestedResponse?: boolean }',
+            description:
+              'Which continuation-hint sections the Reflector emits. Pass `false` to disable both, or an object to disable them individually.',
+            isOptional: true,
+            defaultValue: 'true',
           },
           {
             name: 'extract',

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
@@ -20,7 +20,7 @@ import { BufferingCoordinator } from '../buffering-coordinator';
 import { Extractor } from '../extractor';
 import { ModelByInputTokens } from '../model-by-input-tokens';
 import { ObservationalMemory } from '../observational-memory';
-import type { ObserveHooks } from '../types';
+import type { ContinuationHintsConfig, ObserveHooks } from '../types';
 
 // =============================================================================
 // Helpers
@@ -155,6 +155,8 @@ function createOM(
     reflectorModel?: any;
     observationExtract?: Extractor<any>[];
     reflectionExtract?: Extractor<any>[];
+    observationContinuationHints?: ContinuationHintsConfig;
+    reflectionContinuationHints?: ContinuationHintsConfig;
     activateAfterIdle?: number | string;
     hooks?: ObserveHooks;
   },
@@ -169,11 +171,13 @@ function createOM(
       messageTokens: opts?.messageTokens ?? 100,
       bufferTokens: opts?.bufferTokens ?? false,
       extract: opts?.observationExtract,
+      continuationHints: opts?.observationContinuationHints,
     },
     reflection: {
       model: opts?.reflectorModel ?? createMockReflectorModel(),
       observationTokens: opts?.observationTokens ?? 50_000,
       extract: opts?.reflectionExtract,
+      continuationHints: opts?.reflectionContinuationHints,
     },
   });
 }
@@ -1730,6 +1734,61 @@ describe('buildContextSystemMessage()', () => {
     });
 
     expect(result).toBeTruthy();
+  });
+
+  describe('continuation hints injection', () => {
+    // Observe to create the record, then overwrite thread metadata to simulate hints
+    // persisted by an earlier configuration — the injection decision must depend only
+    // on the current config, not on what some previous config stored.
+    const seedPersistedHints = async () => {
+      await storage.saveMessages({ messages: createBulkMessages(10, threadId) });
+      await om.observe({ threadId });
+      await storage.saveThread({
+        thread: {
+          id: threadId,
+          resourceId: 'ctx-resource',
+          title: 'Context thread',
+          metadata: setThreadOMMetadata(
+            {},
+            { currentTask: 'Ship the report', suggestedResponse: 'Ask about the deadline' },
+          ),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+    };
+
+    it('injects persisted hints by default', async () => {
+      await seedPersistedHints();
+
+      const result = await om.buildContextSystemMessage({ threadId });
+
+      expect(result).toContain('<current-task>\nShip the report\n</current-task>');
+      expect(result).toContain('<suggested-response>\nAsk about the deadline\n</suggested-response>');
+    });
+
+    it('does not inject persisted hints once both pipelines disable them', async () => {
+      om = createOM(storage, { observationContinuationHints: false, reflectionContinuationHints: false });
+      await seedPersistedHints();
+
+      const result = await om.buildContextSystemMessage({ threadId });
+
+      expect(result).toBeTruthy();
+      expect(result).not.toContain('<current-task>');
+      expect(result).not.toContain('<suggested-response>');
+    });
+
+    it('keeps injecting a hint while the other pipeline still produces it', async () => {
+      om = createOM(storage, { observationContinuationHints: { suggestedResponse: false } });
+      await seedPersistedHints();
+
+      const result = await om.buildContextSystemMessage({ threadId });
+
+      // Reflection still registers the suggested-response extractor, so the persisted
+      // value keeps flowing until reflection disables it too.
+      expect(result).toContain('<suggested-response>\nAsk about the deadline\n</suggested-response>');
+      expect(result).toContain('<current-task>\nShip the report\n</current-task>');
+    });
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/built-in-extractors.ts
+++ b/packages/memory/src/processors/observational-memory/built-in-extractors.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { Extractor, validateExtractorList } from './extractor';
-import type { ObservationConfig, ReflectionConfig, ResolvedObservationConfig } from './types';
+import type { ContinuationHintsConfig, ObservationConfig, ReflectionConfig, ResolvedObservationConfig } from './types';
 
 const currentTaskInstructions = `State the current task(s) explicitly. Can be single or multiple:
 - Primary: What the agent is currently working on
@@ -56,16 +56,42 @@ export function createThreadTitleExtractor(): Extractor<string> {
   );
 }
 
+export interface ResolvedContinuationHints {
+  currentTask: boolean;
+  suggestedResponse: boolean;
+}
+
+/**
+ * Normalize the user-facing `continuationHints` config into explicit per-section flags.
+ * Both sections stay enabled unless the caller opts out, so omitting the config is a no-op.
+ */
+export function resolveContinuationHints(config: ContinuationHintsConfig | undefined): ResolvedContinuationHints {
+  if (config === undefined || config === true) {
+    return { currentTask: true, suggestedResponse: true };
+  }
+  if (config === false) {
+    return { currentTask: false, suggestedResponse: false };
+  }
+  return {
+    currentTask: config.currentTask ?? true,
+    suggestedResponse: config.suggestedResponse ?? true,
+  };
+}
+
 interface ComposeExtractorOptions {
-  includeContinuationHints?: boolean;
+  continuationHints?: ContinuationHintsConfig;
   includeThreadTitle?: boolean;
   userExtractors?: readonly Extractor<any>[];
 }
 
 export function composeExtractors(options: ComposeExtractorOptions): Extractor<any>[] {
+  const continuationHints = resolveContinuationHints(options.continuationHints);
   const extractors: Extractor<any>[] = [];
-  if (options.includeContinuationHints) {
-    extractors.push(createCurrentTaskExtractor(), createSuggestedResponseExtractor());
+  if (continuationHints.currentTask) {
+    extractors.push(createCurrentTaskExtractor());
+  }
+  if (continuationHints.suggestedResponse) {
+    extractors.push(createSuggestedResponseExtractor());
   }
   if (options.includeThreadTitle) {
     extractors.push(createThreadTitleExtractor());
@@ -75,18 +101,20 @@ export function composeExtractors(options: ComposeExtractorOptions): Extractor<a
 }
 
 export function composeObservationExtractors(
-  config: Pick<ResolvedObservationConfig, 'threadTitle'> & Pick<ObservationConfig, 'extract'>,
+  config: Pick<ResolvedObservationConfig, 'threadTitle'> & Pick<ObservationConfig, 'extract' | 'continuationHints'>,
 ): Extractor[] {
   return composeExtractors({
-    includeContinuationHints: true,
+    continuationHints: config.continuationHints,
     includeThreadTitle: config.threadTitle,
     userExtractors: config.extract,
   });
 }
 
-export function composeReflectionExtractors(config: Pick<ReflectionConfig, 'extract'>): Extractor[] {
+export function composeReflectionExtractors(
+  config: Pick<ReflectionConfig, 'extract' | 'continuationHints'>,
+): Extractor[] {
   return composeExtractors({
-    includeContinuationHints: true,
+    continuationHints: config.continuationHints,
     userExtractors: config.extract,
   });
 }

--- a/packages/memory/src/processors/observational-memory/continuation-hints.test.ts
+++ b/packages/memory/src/processors/observational-memory/continuation-hints.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  composeObservationExtractors,
+  composeReflectionExtractors,
+  resolveContinuationHints,
+} from './built-in-extractors';
+import { Extractor } from './extractor';
+import { buildObserverSystemPrompt } from './observer-agent';
+import { buildReflectorSystemPrompt } from './reflector-agent';
+
+describe('resolveContinuationHints', () => {
+  it('enables both sections by default', () => {
+    expect(resolveContinuationHints(undefined)).toEqual({ currentTask: true, suggestedResponse: true });
+    expect(resolveContinuationHints(true)).toEqual({ currentTask: true, suggestedResponse: true });
+  });
+
+  it('disables both sections when false', () => {
+    expect(resolveContinuationHints(false)).toEqual({ currentTask: false, suggestedResponse: false });
+  });
+
+  it('supports disabling sections individually', () => {
+    expect(resolveContinuationHints({ suggestedResponse: false })).toEqual({
+      currentTask: true,
+      suggestedResponse: false,
+    });
+    expect(resolveContinuationHints({ currentTask: false })).toEqual({
+      currentTask: false,
+      suggestedResponse: true,
+    });
+  });
+});
+
+describe('continuationHints extractor composition', () => {
+  const user = new Extractor({ name: 'Preference', instructions: 'Extract preference.' });
+
+  it('registers both continuation extractors by default', () => {
+    expect(composeObservationExtractors({ threadTitle: false, extract: [user] }).map(e => e.slug)).toEqual([
+      'current-task',
+      'suggested-response',
+      'preference',
+    ]);
+  });
+
+  it('omits both continuation extractors when disabled', () => {
+    expect(
+      composeObservationExtractors({ threadTitle: false, extract: [user], continuationHints: false }).map(e => e.slug),
+    ).toEqual(['preference']);
+  });
+
+  it('omits only the suggested-response extractor when disabled individually', () => {
+    expect(
+      composeObservationExtractors({
+        threadTitle: true,
+        extract: [user],
+        continuationHints: { suggestedResponse: false },
+      }).map(e => e.slug),
+    ).toEqual(['current-task', 'thread-title', 'preference']);
+  });
+
+  it('applies continuation hints to reflection extractors too', () => {
+    expect(
+      composeReflectionExtractors({ extract: [user], continuationHints: { suggestedResponse: false } }).map(
+        e => e.slug,
+      ),
+    ).toEqual(['current-task', 'preference']);
+  });
+});
+
+describe('prompts only reference continuation sections they define', () => {
+  it('drops suggested-response guidance from the observer prompt when disabled', () => {
+    const extractors = composeObservationExtractors({
+      threadTitle: false,
+      continuationHints: { suggestedResponse: false },
+    });
+    const prompt = buildObserverSystemPrompt(false, undefined, false, extractors);
+
+    expect(prompt).not.toContain('<suggested-response>');
+    expect(prompt).toContain('<current-task>');
+  });
+
+  it('drops all continuation guidance from the observer prompt when both are disabled', () => {
+    const extractors = composeObservationExtractors({ threadTitle: false, continuationHints: false });
+    const prompt = buildObserverSystemPrompt(false, undefined, false, extractors);
+
+    expect(prompt).not.toContain('<suggested-response>');
+    expect(prompt).not.toContain('<current-task>');
+    expect(prompt).toContain('User messages are extremely important.');
+  });
+
+  it('drops suggested-response guidance from the reflector prompt when disabled', () => {
+    const extractors = composeReflectionExtractors({ continuationHints: { suggestedResponse: false } });
+    const prompt = buildReflectorSystemPrompt(undefined, extractors);
+
+    expect(prompt).not.toContain('<suggested-response>');
+    expect(prompt).toContain('<current-task>');
+  });
+
+  it('still describes both sections on the legacy path with no extractors', () => {
+    const prompt = buildObserverSystemPrompt();
+
+    expect(prompt).toContain('<current-task>');
+    expect(prompt).toContain('<suggested-response>');
+  });
+});
+
+describe('multi-thread prompt follows the active continuation sections', () => {
+  const multiThreadPrompt = (
+    continuationHints: Parameters<typeof composeObservationExtractors>[0]['continuationHints'],
+  ) =>
+    buildObserverSystemPrompt(
+      true,
+      undefined,
+      false,
+      composeObservationExtractors({ threadTitle: false, continuationHints }),
+    );
+
+  it('nests and demonstrates both sections by default', () => {
+    const prompt = multiThreadPrompt(undefined);
+
+    expect(prompt).toContain(
+      "Each thread's observations, current-task, and suggested-response should be nested inside",
+    );
+    expect(prompt).toContain('<current-task>');
+    expect(prompt).toContain('<suggested-response>');
+  });
+
+  it('omits suggested-response from the nesting instruction and examples when disabled', () => {
+    const prompt = multiThreadPrompt({ suggestedResponse: false });
+
+    expect(prompt).toContain("Each thread's observations and current-task should be nested inside");
+    expect(prompt).toContain('<current-task>');
+    expect(prompt).not.toContain('<suggested-response>');
+  });
+
+  it('omits current-task from the nesting instruction and examples when disabled', () => {
+    const prompt = multiThreadPrompt({ currentTask: false });
+
+    expect(prompt).toContain("Each thread's observations and suggested-response should be nested inside");
+    expect(prompt).toContain('<suggested-response>');
+    expect(prompt).not.toContain('<current-task>');
+  });
+
+  it('drops both sections entirely when continuation hints are disabled', () => {
+    const prompt = multiThreadPrompt(false);
+
+    expect(prompt).toContain("Each thread's observations should be nested inside");
+    expect(prompt).not.toContain('<current-task>');
+    expect(prompt).not.toContain('<suggested-response>');
+    // The thread scaffolding itself must survive so multi-thread output stays parseable.
+    expect(prompt).toContain('<thread id="thread_id_1">');
+    expect(prompt).toContain('=== MULTI-THREAD INPUT ===');
+  });
+
+  it('still lists thread-title alongside the enabled sections', () => {
+    const prompt = buildObserverSystemPrompt(
+      true,
+      undefined,
+      true,
+      composeObservationExtractors({ threadTitle: true, continuationHints: { suggestedResponse: false } }),
+    );
+
+    expect(prompt).toContain("Each thread's observations, current-task, and thread-title should be nested inside");
+    expect(prompt).toContain('<thread-title>');
+    expect(prompt).not.toContain('<suggested-response>');
+  });
+
+  it('leaves the default multi-thread prompt unchanged on the legacy path', () => {
+    expect(buildObserverSystemPrompt(true, undefined, false, undefined)).toContain(
+      "Each thread's observations, current-task, and suggested-response should be nested inside",
+    );
+  });
+
+  // Pins the exact default example so the section-driven template can't silently drift
+  // from the shape the multi-thread parser expects.
+  it('renders the default per-thread example verbatim', () => {
+    expect(buildObserverSystemPrompt(true, undefined, true, undefined)).toContain(
+      `<observations>
+<thread id="thread_id_1">
+Date: Dec 4, 2025
+* 🔴 (14:30) User prefers direct answers
+* 🔴 (14:31) Working on feature X
+
+<current-task>
+What the agent is currently working on in this thread
+</current-task>
+
+<suggested-response>
+Hint for the agent's next message in this thread
+</suggested-response>
+<thread-title>Feature X implementation</thread-title>
+</thread>
+
+<thread id="thread_id_2">
+Date: Dec 5, 2025
+* 🔴 (09:15) User asked about deployment
+
+<current-task>
+Current task for this thread
+</current-task>
+
+<suggested-response>
+Suggested response for this thread
+</suggested-response>
+<thread-title>Deployment setup</thread-title>
+</thread>
+</observations>`,
+    );
+  });
+});

--- a/packages/memory/src/processors/observational-memory/index.ts
+++ b/packages/memory/src/processors/observational-memory/index.ts
@@ -53,6 +53,7 @@ export type {
   ObserveTrigger,
   ObservationConfig,
   ReflectionConfig,
+  ContinuationHintsConfig,
   ObserverResult,
   ReflectorResult,
   // Observation marker config

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -1719,8 +1719,7 @@ export class ObservationalMemory {
   ): { threadId: string; resourceId?: string } | null {
     // First try RequestContext (set by Memory)
     const memoryContext = requestContext?.get('MastraMemory') as
-      | { thread?: { id: string }; resourceId?: string }
-      | undefined;
+      { thread?: { id: string }; resourceId?: string } | undefined;
 
     if (memoryContext?.thread?.id) {
       return {
@@ -2597,11 +2596,18 @@ ${formattedMessages}
       return undefined;
     }
 
-    // Read thread metadata for continuation hints
+    // Read thread metadata for continuation hints. A persisted hint is only injected while a
+    // pipeline can still produce it — once observation and reflection both disable a section,
+    // a stale value stored by an earlier configuration must not keep steering the actor.
     const thread = await this.storage.getThreadById({ threadId });
     const omMetadata = getThreadOMMetadata(thread?.metadata);
-    const currentTask = omMetadata?.currentTask;
-    const suggestedResponse = omMetadata?.suggestedResponse;
+    const activeExtractors = [...this.observationConfig.extractors, ...this.reflectionConfig.extractors];
+    const currentTask = activeExtractors.some(extractor => extractor.slug === 'current-task')
+      ? omMetadata?.currentTask
+      : undefined;
+    const suggestedResponse = activeExtractors.some(extractor => extractor.slug === 'suggested-response')
+      ? omMetadata?.suggestedResponse
+      : undefined;
     const currentDate = opts.currentDate ?? new Date();
 
     return this.formatObservationsForContext(

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -543,6 +543,7 @@ export class ObservationalMemory {
       extractors: composeObservationExtractors({
         threadTitle: config.observation?.threadTitle ?? false,
         extract: config.observation?.extract,
+        continuationHints: config.observation?.continuationHints,
       }),
     };
 
@@ -575,7 +576,10 @@ export class ObservationalMemory {
             config.reflection?.observationTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.reflection.observationTokens,
           ),
       instruction: config.reflection?.instruction,
-      extractors: composeReflectionExtractors({ extract: config.reflection?.extract }),
+      extractors: composeReflectionExtractors({
+        extract: config.reflection?.extract,
+        continuationHints: config.reflection?.continuationHints,
+      }),
     };
 
     this.tokenCounter = new TokenCounter({

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -303,8 +303,9 @@ export const OBSERVER_OUTPUT_FORMAT_BASE = buildObserverOutputFormat();
  * Build the Observer's output format.
  *
  * `extractors` distinguishes two cases that both look empty:
- * - `undefined` — the caller is on the legacy path and never opted into extractors, so the
- *   built-in continuation sections are described inline.
+ * - `undefined` — the no-arg call behind the exported defaults (OBSERVER_OUTPUT_FORMAT_BASE,
+ *   OBSERVER_SYSTEM_PROMPT, REFLECTOR_SYSTEM_PROMPT), which keep describing both built-in
+ *   sections with their historical text. Runtime callers always pass the composed list.
  * - `[]` — the caller composed extractors and every section was disabled, so no continuation
  *   sections are described at all.
  */
@@ -382,7 +383,7 @@ export const OBSERVER_GUIDELINES = `- Be specific enough for the assistant to ac
  * @param instruction - Optional custom instructions to append to the prompt
  * @param includeThreadTitle - Whether the Observer should also produce a thread title
  * @param extractors - Active extractors, used to decide which sections the prompt describes.
- *   Omit entirely for the legacy path; pass `[]` to describe no continuation sections at all.
+ *   Omitted only by the exported no-arg defaults; pass `[]` to describe no continuation sections at all.
  */
 export function buildObserverSystemPrompt(
   multiThread: boolean = false,
@@ -392,8 +393,8 @@ export function buildObserverSystemPrompt(
 ): string {
   const outputFormat = buildObserverOutputFormat(extractors);
   const customInstructions = instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : '';
-  // `undefined` extractors = legacy caller that never opted into extractors; both built-in
-  // continuation sections stay enabled on that path.
+  // Runtime callers always pass the composed extractor list; `undefined` only occurs through
+  // the exported no-arg defaults (e.g. OBSERVER_SYSTEM_PROMPT), which keep both built-in sections.
   const currentTaskEnabled =
     extractors === undefined || extractors.some(extractor => extractor.slug === 'current-task');
   const suggestedResponseEnabled =

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -299,10 +299,19 @@ Prefer concrete resolved outcomes over abstract workflow status so the assistant
  */
 export const OBSERVER_OUTPUT_FORMAT_BASE = buildObserverOutputFormat();
 
-export function buildObserverOutputFormat(extractors: readonly Extractor<any>[] = []): string {
-  const extractorSections = buildExtractorOutputSections(extractors);
+/**
+ * Build the Observer's output format.
+ *
+ * `extractors` distinguishes two cases that both look empty:
+ * - `undefined` — the caller is on the legacy path and never opted into extractors, so the
+ *   built-in continuation sections are described inline.
+ * - `[]` — the caller composed extractors and every section was disabled, so no continuation
+ *   sections are described at all.
+ */
+export function buildObserverOutputFormat(extractors?: readonly Extractor<any>[]): string {
+  const extractorSections = buildExtractorOutputSections(extractors ?? []);
   const legacyContinuationSections =
-    extractors.length === 0
+    extractors === undefined
       ? `
 <current-task>
 State the current task(s) explicitly:
@@ -367,21 +376,68 @@ export const OBSERVER_GUIDELINES = `- Be specific enough for the assistant to ac
 - Observe WHAT the agent did and WHAT it means
 - If the user provides detailed messages or code snippets, observe all important details`;
 
+const CURRENT_TASK_SENTENCE =
+  'If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority.';
+const SUGGESTED_RESPONSE_SENTENCE =
+  'If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.';
+
+/**
+ * Undefined extractors mean the caller is on the legacy path, where
+ * `buildObserverOutputFormat` still describes both continuation sections.
+ */
+function hasContinuationSection(extractors: readonly Extractor<any>[] | undefined, slug: string): boolean {
+  return extractors === undefined || extractors.some(extractor => extractor.slug === slug);
+}
+
+/** Render section names as a readable English list: "a", "a and b", "a, b, and c". */
+function formatSectionList(sections: readonly string[]): string {
+  if (sections.length <= 1) return sections[0] ?? '';
+  if (sections.length === 2) return `${sections[0]} and ${sections[1]}`;
+  return `${sections.slice(0, -1).join(', ')}, and ${sections[sections.length - 1]}`;
+}
+
+/**
+ * Build the closing guidance about continuation sections, naming only the sections the
+ * prompt actually defines. Without this the prompt can reference `<current-task>` or
+ * `<suggested-response>` tags that the output format has already omitted.
+ */
+export function buildContinuationGuidance(
+  extractors: readonly Extractor<any>[] | undefined,
+  { includeSuggestedResponse }: { includeSuggestedResponse: boolean },
+): string {
+  const sentences = ['User messages are extremely important.'];
+  if (hasContinuationSection(extractors, 'current-task')) {
+    sentences.push(CURRENT_TASK_SENTENCE);
+  }
+  if (includeSuggestedResponse && hasContinuationSection(extractors, 'suggested-response')) {
+    sentences.push(SUGGESTED_RESPONSE_SENTENCE);
+  }
+  return sentences.join(' ');
+}
+
 /**
  * Build the complete observer system prompt.
  * @param multiThread - Whether this is for multi-thread batched observation (default: false)
  * @param instruction - Optional custom instructions to append to the prompt
+ * @param includeThreadTitle - Whether the Observer should also produce a thread title
+ * @param extractors - Active extractors, used to decide which sections the prompt describes.
+ *   Omit entirely for the legacy path; pass `[]` to describe no continuation sections at all.
  */
 export function buildObserverSystemPrompt(
   multiThread: boolean = false,
   instruction?: string,
   includeThreadTitle: boolean = false,
-  extractors: readonly Extractor<any>[] = [],
+  extractors?: readonly Extractor<any>[],
 ): string {
   const outputFormat = buildObserverOutputFormat(extractors);
-  const multiThreadTitleInstruction = includeThreadTitle
-    ? ` Each thread's observations, current-task, suggested-response, and thread-title should be nested inside a <thread id="..."> block within <observations>.`
-    : ` Each thread's observations, current-task, and suggested-response should be nested inside a <thread id="..."> block within <observations>.`;
+  const customInstructions = instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : '';
+  const multiThreadSections = [
+    'observations',
+    ...(hasContinuationSection(extractors, 'current-task') ? ['current-task'] : []),
+    ...(hasContinuationSection(extractors, 'suggested-response') ? ['suggested-response'] : []),
+    ...(includeThreadTitle ? ['thread-title'] : []),
+  ];
+  const multiThreadTitleInstruction = ` Each thread's ${formatSectionList(multiThreadSections)} should be nested inside a <thread id="..."> block within <observations>.`;
   const multiThreadTitleExample = includeThreadTitle
     ? `
 <thread-title>Feature X implementation</thread-title>`
@@ -390,6 +446,19 @@ export function buildObserverSystemPrompt(
     ? `
 <thread-title>Deployment setup</thread-title>`
     : '';
+  // Only demonstrate the continuation sections the prompt actually asks for, otherwise the
+  // example contradicts the instructions whenever a section is disabled.
+  const buildThreadExample = (currentTask: string, suggestedResponse: string, titleExample: string): string => {
+    const sections = [
+      ...(hasContinuationSection(extractors, 'current-task')
+        ? [`\n\n<current-task>\n${currentTask}\n</current-task>`]
+        : []),
+      ...(hasContinuationSection(extractors, 'suggested-response')
+        ? [`\n\n<suggested-response>\n${suggestedResponse}\n</suggested-response>`]
+        : []),
+    ];
+    return `${sections.join('')}${titleExample}`;
+  };
 
   if (multiThread) {
     return `You are the memory consciousness of an AI assistant. Your observations will be the ONLY information the assistant has about past interactions with this user.
@@ -417,28 +486,20 @@ For multi-thread output, wrap each thread's observations like this:
 <thread id="thread_id_1">
 Date: Dec 4, 2025
 * 🔴 (14:30) User prefers direct answers
-* 🔴 (14:31) Working on feature X
-
-<current-task>
-What the agent is currently working on in this thread
-</current-task>
-
-<suggested-response>
-Hint for the agent's next message in this thread
-</suggested-response>${multiThreadTitleExample}
+* 🔴 (14:31) Working on feature X${buildThreadExample(
+      'What the agent is currently working on in this thread',
+      "Hint for the agent's next message in this thread",
+      multiThreadTitleExample,
+    )}
 </thread>
 
 <thread id="thread_id_2">
 Date: Dec 5, 2025
-* 🔴 (09:15) User asked about deployment
-
-<current-task>
-Current task for this thread
-</current-task>
-
-<suggested-response>
-Suggested response for this thread
-</suggested-response>${multiThreadSecondTitleExample}
+* 🔴 (09:15) User asked about deployment${buildThreadExample(
+      'Current task for this thread',
+      'Suggested response for this thread',
+      multiThreadSecondTitleExample,
+    )}
 </thread>
 </observations>
 
@@ -448,7 +509,7 @@ ${OBSERVER_GUIDELINES}
 
 Remember: These observations are the assistant's ONLY memory. Make them count.
 
-User messages are extremely important. If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority.${instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : ''}`;
+${buildContinuationGuidance(extractors, { includeSuggestedResponse: false })}${customInstructions}`;
   }
 
   return `You are the memory consciousness of an AI assistant. Your observations will be the ONLY information the assistant has about past interactions with this user.
@@ -475,7 +536,7 @@ Simply output your observations without any thread-related markup.
 
 Remember: These observations are the assistant's ONLY memory. Make them count.
 
-User messages are extremely important. If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority. If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.${instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : ''}`;
+${buildContinuationGuidance(extractors, { includeSuggestedResponse: true })}${customInstructions}`;
 }
 
 /**

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -389,13 +389,6 @@ function hasContinuationSection(extractors: readonly Extractor<any>[] | undefine
   return extractors === undefined || extractors.some(extractor => extractor.slug === slug);
 }
 
-/** Render section names as a readable English list: "a", "a and b", "a, b, and c". */
-function formatSectionList(sections: readonly string[]): string {
-  if (sections.length <= 1) return sections[0] ?? '';
-  if (sections.length === 2) return `${sections[0]} and ${sections[1]}`;
-  return `${sections.slice(0, -1).join(', ')}, and ${sections[sections.length - 1]}`;
-}
-
 /**
  * Build the closing guidance about continuation sections, naming only the sections the
  * prompt actually defines. Without this the prompt can reference `<current-task>` or
@@ -431,13 +424,23 @@ export function buildObserverSystemPrompt(
 ): string {
   const outputFormat = buildObserverOutputFormat(extractors);
   const customInstructions = instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : '';
+  // `undefined` extractors = legacy caller that never opted into extractors; both built-in
+  // continuation sections stay enabled on that path.
+  const currentTaskEnabled = extractors === undefined || extractors.some(extractor => extractor.slug === 'current-task');
+  const suggestedResponseEnabled =
+    extractors === undefined || extractors.some(extractor => extractor.slug === 'suggested-response');
   const multiThreadSections = [
     'observations',
-    ...(hasContinuationSection(extractors, 'current-task') ? ['current-task'] : []),
-    ...(hasContinuationSection(extractors, 'suggested-response') ? ['suggested-response'] : []),
+    ...(currentTaskEnabled ? ['current-task'] : []),
+    ...(suggestedResponseEnabled ? ['suggested-response'] : []),
     ...(includeThreadTitle ? ['thread-title'] : []),
   ];
-  const multiThreadTitleInstruction = ` Each thread's ${formatSectionList(multiThreadSections)} should be nested inside a <thread id="..."> block within <observations>.`;
+  // Grammatical list for any combination: "a", "a and b", "a, b, and c".
+  const multiThreadSectionList =
+    multiThreadSections.length <= 2
+      ? multiThreadSections.join(' and ')
+      : `${multiThreadSections.slice(0, -1).join(', ')}, and ${multiThreadSections[multiThreadSections.length - 1]}`;
+  const multiThreadTitleInstruction = ` Each thread's ${multiThreadSectionList} should be nested inside a <thread id="..."> block within <observations>.`;
   const multiThreadTitleExample = includeThreadTitle
     ? `
 <thread-title>Feature X implementation</thread-title>`
@@ -446,20 +449,6 @@ export function buildObserverSystemPrompt(
     ? `
 <thread-title>Deployment setup</thread-title>`
     : '';
-  // Only demonstrate the continuation sections the prompt actually asks for, otherwise the
-  // example contradicts the instructions whenever a section is disabled.
-  const buildThreadExample = (currentTask: string, suggestedResponse: string, titleExample: string): string => {
-    const sections = [
-      ...(hasContinuationSection(extractors, 'current-task')
-        ? [`\n\n<current-task>\n${currentTask}\n</current-task>`]
-        : []),
-      ...(hasContinuationSection(extractors, 'suggested-response')
-        ? [`\n\n<suggested-response>\n${suggestedResponse}\n</suggested-response>`]
-        : []),
-    ];
-    return `${sections.join('')}${titleExample}`;
-  };
-
   if (multiThread) {
     return `You are the memory consciousness of an AI assistant. Your observations will be the ONLY information the assistant has about past interactions with this user.
 
@@ -486,20 +475,44 @@ For multi-thread output, wrap each thread's observations like this:
 <thread id="thread_id_1">
 Date: Dec 4, 2025
 * 🔴 (14:30) User prefers direct answers
-* 🔴 (14:31) Working on feature X${buildThreadExample(
-      'What the agent is currently working on in this thread',
-      "Hint for the agent's next message in this thread",
-      multiThreadTitleExample,
-    )}
+* 🔴 (14:31) Working on feature X${
+      currentTaskEnabled
+        ? `
+
+<current-task>
+What the agent is currently working on in this thread
+</current-task>`
+        : ''
+    }${
+      suggestedResponseEnabled
+        ? `
+
+<suggested-response>
+Hint for the agent's next message in this thread
+</suggested-response>`
+        : ''
+    }${multiThreadTitleExample}
 </thread>
 
 <thread id="thread_id_2">
 Date: Dec 5, 2025
-* 🔴 (09:15) User asked about deployment${buildThreadExample(
-      'Current task for this thread',
-      'Suggested response for this thread',
-      multiThreadSecondTitleExample,
-    )}
+* 🔴 (09:15) User asked about deployment${
+      currentTaskEnabled
+        ? `
+
+<current-task>
+Current task for this thread
+</current-task>`
+        : ''
+    }${
+      suggestedResponseEnabled
+        ? `
+
+<suggested-response>
+Suggested response for this thread
+</suggested-response>`
+        : ''
+    }${multiThreadSecondTitleExample}
 </thread>
 </observations>
 

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -376,38 +376,6 @@ export const OBSERVER_GUIDELINES = `- Be specific enough for the assistant to ac
 - Observe WHAT the agent did and WHAT it means
 - If the user provides detailed messages or code snippets, observe all important details`;
 
-const CURRENT_TASK_SENTENCE =
-  'If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority.';
-const SUGGESTED_RESPONSE_SENTENCE =
-  'If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.';
-
-/**
- * Undefined extractors mean the caller is on the legacy path, where
- * `buildObserverOutputFormat` still describes both continuation sections.
- */
-function hasContinuationSection(extractors: readonly Extractor<any>[] | undefined, slug: string): boolean {
-  return extractors === undefined || extractors.some(extractor => extractor.slug === slug);
-}
-
-/**
- * Build the closing guidance about continuation sections, naming only the sections the
- * prompt actually defines. Without this the prompt can reference `<current-task>` or
- * `<suggested-response>` tags that the output format has already omitted.
- */
-export function buildContinuationGuidance(
-  extractors: readonly Extractor<any>[] | undefined,
-  { includeSuggestedResponse }: { includeSuggestedResponse: boolean },
-): string {
-  const sentences = ['User messages are extremely important.'];
-  if (hasContinuationSection(extractors, 'current-task')) {
-    sentences.push(CURRENT_TASK_SENTENCE);
-  }
-  if (includeSuggestedResponse && hasContinuationSection(extractors, 'suggested-response')) {
-    sentences.push(SUGGESTED_RESPONSE_SENTENCE);
-  }
-  return sentences.join(' ');
-}
-
 /**
  * Build the complete observer system prompt.
  * @param multiThread - Whether this is for multi-thread batched observation (default: false)
@@ -426,7 +394,8 @@ export function buildObserverSystemPrompt(
   const customInstructions = instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : '';
   // `undefined` extractors = legacy caller that never opted into extractors; both built-in
   // continuation sections stay enabled on that path.
-  const currentTaskEnabled = extractors === undefined || extractors.some(extractor => extractor.slug === 'current-task');
+  const currentTaskEnabled =
+    extractors === undefined || extractors.some(extractor => extractor.slug === 'current-task');
   const suggestedResponseEnabled =
     extractors === undefined || extractors.some(extractor => extractor.slug === 'suggested-response');
   const multiThreadSections = [
@@ -522,7 +491,11 @@ ${OBSERVER_GUIDELINES}
 
 Remember: These observations are the assistant's ONLY memory. Make them count.
 
-${buildContinuationGuidance(extractors, { includeSuggestedResponse: false })}${customInstructions}`;
+User messages are extremely important.${
+      currentTaskEnabled
+        ? ' If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority.'
+        : ''
+    }${customInstructions}`;
   }
 
   return `You are the memory consciousness of an AI assistant. Your observations will be the ONLY information the assistant has about past interactions with this user.
@@ -549,7 +522,15 @@ Simply output your observations without any thread-related markup.
 
 Remember: These observations are the assistant's ONLY memory. Make them count.
 
-${buildContinuationGuidance(extractors, { includeSuggestedResponse: true })}${customInstructions}`;
+User messages are extremely important.${
+    currentTaskEnabled
+      ? ' If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority.'
+      : ''
+  }${
+    suggestedResponseEnabled
+      ? ' If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.'
+      : ''
+  }${customInstructions}`;
 }
 
 /**

--- a/packages/memory/src/processors/observational-memory/reflector-agent.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-agent.ts
@@ -41,8 +41,8 @@ export interface ReflectorResult extends BaseReflectorResult {
 export function buildReflectorSystemPrompt(instruction?: string, extractors?: readonly Extractor<any>[]): string {
   const outputFormat = buildObserverOutputFormat(extractors);
   const customInstructions = instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : '';
-  // `undefined` extractors = legacy caller that never opted into extractors; both built-in
-  // continuation sections stay enabled on that path.
+  // Runtime callers always pass the composed extractor list; `undefined` only occurs through
+  // the exported no-arg default (REFLECTOR_SYSTEM_PROMPT), which keeps both built-in sections.
   const currentTaskEnabled =
     extractors === undefined || extractors.some(extractor => extractor.slug === 'current-task');
   const suggestedResponseEnabled =

--- a/packages/memory/src/processors/observational-memory/reflector-agent.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-agent.ts
@@ -10,7 +10,6 @@ import { reconcileObservationGroupsFromReflection, stripObservationGroups } from
 import {
   OBSERVER_EXTRACTION_INSTRUCTIONS,
   OBSERVER_GUIDELINES,
-  buildContinuationGuidance,
   buildObserverOutputFormat,
   sanitizeObservationLines,
   detectDegenerateRepetition,
@@ -39,12 +38,15 @@ export interface ReflectorResult extends BaseReflectorResult {
  * @param instruction - Optional custom instructions to append to the prompt
  * @param extractors - Active extractors, used to decide which sections the prompt describes
  */
-export function buildReflectorSystemPrompt(
-  instruction?: string,
-  extractors?: readonly Extractor<any>[],
-): string {
+export function buildReflectorSystemPrompt(instruction?: string, extractors?: readonly Extractor<any>[]): string {
   const outputFormat = buildObserverOutputFormat(extractors);
   const customInstructions = instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : '';
+  // `undefined` extractors = legacy caller that never opted into extractors; both built-in
+  // continuation sections stay enabled on that path.
+  const currentTaskEnabled =
+    extractors === undefined || extractors.some(extractor => extractor.slug === 'current-task');
+  const suggestedResponseEnabled =
+    extractors === undefined || extractors.some(extractor => extractor.slug === 'suggested-response');
   return `You are the memory consciousness of an AI assistant. Your memory observation reflections will be the ONLY information the assistant has about past interactions with this user.
 
 The following instructions were given to another part of your psyche (the observer) to create memories.
@@ -121,7 +123,15 @@ Date: Dec 4, 2025
 
 ${outputFormat}
 
-${buildContinuationGuidance(extractors, { includeSuggestedResponse: true })}${customInstructions}`;
+User messages are extremely important.${
+    currentTaskEnabled
+      ? ' If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority.'
+      : ''
+  }${
+    suggestedResponseEnabled
+      ? ' If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.'
+      : ''
+  }${customInstructions}`;
 }
 
 /**

--- a/packages/memory/src/processors/observational-memory/reflector-agent.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-agent.ts
@@ -10,6 +10,7 @@ import { reconcileObservationGroupsFromReflection, stripObservationGroups } from
 import {
   OBSERVER_EXTRACTION_INSTRUCTIONS,
   OBSERVER_GUIDELINES,
+  buildContinuationGuidance,
   buildObserverOutputFormat,
   sanitizeObservationLines,
   detectDegenerateRepetition,
@@ -36,9 +37,14 @@ export interface ReflectorResult extends BaseReflectorResult {
  * - Preserving ALL important information (reflections become the ENTIRE memory)
  *
  * @param instruction - Optional custom instructions to append to the prompt
+ * @param extractors - Active extractors, used to decide which sections the prompt describes
  */
-export function buildReflectorSystemPrompt(instruction?: string, extractors: readonly Extractor<any>[] = []): string {
+export function buildReflectorSystemPrompt(
+  instruction?: string,
+  extractors?: readonly Extractor<any>[],
+): string {
   const outputFormat = buildObserverOutputFormat(extractors);
+  const customInstructions = instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : '';
   return `You are the memory consciousness of an AI assistant. Your memory observation reflections will be the ONLY information the assistant has about past interactions with this user.
 
 The following instructions were given to another part of your psyche (the observer) to create memories.
@@ -115,7 +121,7 @@ Date: Dec 4, 2025
 
 ${outputFormat}
 
-User messages are extremely important. If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority. If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.${instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : ''}`;
+${buildContinuationGuidance(extractors, { includeSuggestedResponse: true })}${customInstructions}`;
 }
 
 /**

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -61,6 +61,24 @@ export type ResolvedActivationTTL = number | 'auto';
  */
 export type ObservationalMemoryModel = Exclude<AgentConfig['model'], undefined> | ModelByInputTokens;
 
+/**
+ * Controls which continuation-hint sections OM asks the Observer and Reflector to emit.
+ *
+ * Pass `false` to disable both, or an object to disable them individually. Agents that
+ * drive their own control flow generally want `suggestedResponse: false` so memory does
+ * not compete with the agent for what to say next.
+ *
+ * @default true
+ */
+export type ContinuationHintsConfig =
+  | boolean
+  | {
+      /** Emit the `<current-task>` section. @default true */
+      currentTask?: boolean;
+      /** Emit the `<suggested-response>` section. @default true */
+      suggestedResponse?: boolean;
+    };
+
 export interface ObservationConfig {
   /**
    * Model for the Observer agent.
@@ -198,6 +216,14 @@ export interface ObservationConfig {
   instruction?: string;
 
   /**
+   * Which continuation-hint sections the Observer should emit.
+   * Set `{ suggestedResponse: false }` when the agent owns its own control flow.
+   *
+   * @default true
+   */
+  continuationHints?: ContinuationHintsConfig;
+
+  /**
    * Manage working memory through Observational Memory extraction.
    * When enabled alongside `workingMemory.enabled`, Memory supplies defaults that
    * disable main-agent working memory management and add the WorkingMemoryExtractor.
@@ -333,6 +359,14 @@ export interface ReflectionConfig {
    * Use this to customize reflection behavior for specific use cases.
    */
   instruction?: string;
+
+  /**
+   * Which continuation-hint sections the Reflector should emit.
+   * Set `{ suggestedResponse: false }` when the agent owns its own control flow.
+   *
+   * @default true
+   */
+  continuationHints?: ContinuationHintsConfig;
 
   /**
    * Additional values to extract from reflector output. Built-in OM fields are registered automatically.


### PR DESCRIPTION
> **Stacked on #20665.** Base is `fix/om-optimizer-preserves-markdown-links`; review that one first. This PR's own diff is the last commit. Retarget to `main` once #20665 merges.
>
> **Split out of #20666** at @TylerBarnes's request. #20666 bundled two options with separate motivations; it is now `instructionMode` only, and is a **sibling** of this PR rather than a parent — both branch from #20665, so either can merge first and neither blocks the other. They touch adjacent lines in `observer-agent.ts` and `reflector-agent.ts`, so whichever lands second needs a rebase; I will handle it. This is the smaller and less contentious half.

## Description

`<current-task>` and `<suggested-response>` are always requested and there is no way to turn them off. `composeExtractors` already had an `includeContinuationHints` option, but both call sites hardcoded `true` and nothing ever passed `false`.

The problem is not the token cost. A `<suggested-response>` is written to thread metadata, injected into the actor's context on every step that has observations, and accompanied by a continuation reminder that says *"If a suggested response is provided, follow it naturally."* For an agent whose next action is determined by its own state machine, that is a second controller giving instructions in the same context — at best noise, at worst it overrides the real one.

```ts
observation: { continuationHints: { suggestedResponse: false } }   // keep current-task, drop suggested-response
reflection:  { continuationHints: false }                          // drop both
```

The granular object form matters: wanting `<current-task>` but not `<suggested-response>` is the common case, and a plain boolean would force all-or-nothing.

## Why not just disable hints internally when buffering is enabled

This was the suggested alternative — have OM turn continuation hints off in buffering mode and emit them only during synchronous observation/reflection. It does not cover the case, for three reasons, and the third one makes it worse than a stable opt-out.

**1. The async-buffer path already skips them.** `AsyncBufferTurn.observe` passes `skipContinuationHints: true` today. So "off during buffering" is largely current behaviour — the hints an adopter actually sees come from the non-buffered observation cycles, which the change would not touch.

**2. Production is not the only injection point.** `buildContextSystemMessages` reads `currentTask` and `suggestedResponse` from **thread metadata**, not from the extractor, and injects them on every step where the record has observations. A `<suggested-response>` written once persists and keeps being injected until something overwrites it. Suppressing production on some paths does not clear a value that is already stored — it just stops refreshing it, which leaves a stale hint in context indefinitely.

**3. It makes the behaviour mode-dependent in exactly the wrong direction.** Synchronous observation is what happens once a thread crosses its unobserved-token threshold — i.e. on long, high-volume conversations. So "hints only when sync" means an agent runs without a competing controller early on and acquires one deep into the session, changing character mid-conversation. That is harder to reason about than either always-on or always-off. Whether memory proposes the agent's next turn is a property of the agent's architecture, not of how much has been observed so far.

The underlying point: `skipContinuationHints` is an internal signal about *which cycle is running*. Whether the sections should exist at all is a property of the *agent*. Those are different axes, and inferring one from the other is what produces the mode-dependence in (3). This PR adds the second axis and leaves the first alone.

## Two correctness fixes this required

**Prompts referenced sections they no longer defined.** `buildObserverOutputFormat` correctly swaps the legacy continuation blocks for extractor sections, but the closing sentence of the observer and reflector prompts, the multi-thread nesting instruction, and the per-thread examples all named `<current-task>` and `<suggested-response>` unconditionally. That was harmless only because both built-ins were always registered. It becomes a live bug the moment either is disabled, so all three are now derived from the active extractors.

**Empty extractors were ambiguous.** `buildObserverOutputFormat` used `extractors.length === 0` to mean "legacy caller, describe both sections inline". Once continuation hints can be disabled, `[]` also legitimately means "describe no sections". Disabling both would have silently fallen back to the legacy prompt and re-enabled them. `undefined` now means legacy and `[]` means explicitly-none. My own test caught this, which is why the case is covered below.

## Known gap — now fixed in this PR

Point 2 above originally applied to this PR too: disabling `suggestedResponse` stopped new hints being written, but a value already in thread metadata was never cleared, so an existing thread kept having its last stored hint injected. CodeRabbit flagged it, so the fix is now included: `buildContextSystemMessages` injects a persisted hint only while its extractor is still registered in either the observation or reflection pipeline. A hint one pipeline still produces keeps flowing; once both disable a section, stale stored values stop reaching the actor. Covered by three new tests (default injection, both pipelines disabled, one pipeline still enabled).

## Related issue(s)

None — filing directly. Glad to open tracking issues if preferred.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Backwards compatibility

`continuationHints` defaults to current behaviour. `buildObserverSystemPrompt()` and `buildReflectorSystemPrompt()` with no arguments produce byte-identical prompts — asserted in the tests.

## Testing

New `continuation-hints.test.ts`, 18 cases:

- `resolveContinuationHints` for `undefined` / `true` / `false` / partial objects
- extractor composition for both, neither, and each individually, on observation and reflection
- observer and reflector prompts omit `<suggested-response>` guidance when disabled, omit both when both are disabled, and still describe both on the legacy path
- multi-thread nesting instruction and per-thread examples follow the active sections, including thread-title interaction
- the default multi-thread per-thread example is pinned verbatim, so the section-driven template cannot drift from the shape the parser expects

```
pnpm exec vitest run src/processors/observational-memory
  Test Files  34 passed (34)
       Tests  1057 passed | 1 todo (1058)

pnpm exec tsc --noEmit -p tsconfig.json   # no new errors (10 pre-existing on the base branch, unrelated: setThreadOMMetadata title)
pnpm --filter ./packages/memory lint   # clean (oxlint + eslint), exit 0
```

Reference docs updated for the new option on `observation` and `reflection`.

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets users control which follow-up hints observational memory includes. Users can keep both hints, disable both, or enable only the hints they need.

## Changes

- Added `continuationHints` to observation and reflection settings.
- Added independent controls for `currentTask` and `suggestedResponse`.
- Updated observer and reflector prompts to include guidance only for enabled extractors.
- Preserved legacy prompts when extractors are omitted.
- Preserved explicit empty extractor lists without restoring legacy sections.
- Updated multi-thread instructions and examples for active extractors.
- Exported `ContinuationHintsConfig` and added `resolveContinuationHints`.
- Added documentation and a changeset.
- Added 18 tests for configuration, extractor composition, prompt output, multi-thread behavior, and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
