### PR TITLE
fix(pg): add default index on mastra_workflow_snapshot for listWorkflowRuns

### DIFF
--- a/.changeset/pg-workflows-default-index.md
+++ b/.changeset/pg-workflows-default-index.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Studio's workflow runs list stays fast as workflow history grows. `@mastra/pg` now creates a default index on `mastra_workflow_snapshot(workflow_name, "createdAt" DESC)` so listing recent runs no longer scans and re-sorts the whole snapshot table on every poll.

--- a/.changeset/pg-workflows-default-index.md
+++ b/.changeset/pg-workflows-default-index.md
@@ -2,4 +2,4 @@
 '@mastra/pg': patch
 ---
 
-Studio's workflow runs list stays fast as workflow history grows. `@mastra/pg` now creates a default index on `mastra_workflow_snapshot(workflow_name, "createdAt" DESC)` so listing recent runs no longer scans and re-sorts the whole snapshot table on every poll.
+Improved workflow run list performance in `@mastra/pg` when filtering by workflow name. The default index avoids sorting the ordered result query for workflows with large run histories. Paginated requests still use a separate count query.

--- a/docs/src/content/en/integrations/databases/postgresql.mdx
+++ b/docs/src/content/en/integrations/databases/postgresql.mdx
@@ -468,8 +468,9 @@ PostgreSQL storage creates composite indexes during initialization for common qu
 - `mastra_ai_spans_name_startedat_idx`: (name, startedAt DESC)
 - `mastra_ai_spans_scope_startedat_idx`: (scope, startedAt DESC)
 - `mastra_scores_trace_id_span_id_created_at_idx`: (traceId, spanId, createdAt DESC)
+- `mastra_workflow_snapshot_name_createdat_idx`: (workflow\_name, createdAt DESC)
 
-These indexes improve performance for filtered queries with sorting, including `dateRange` filters on message queries.
+These indexes improve performance for filtered queries with sorting, including `dateRange` filters on message queries and Studio's workflow runs-list.
 
 ### Configuring Indexes
 

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -19,8 +19,9 @@ import type {
   RetentionTablesDescriptor,
   TableRetentionPolicy,
 } from '@mastra/core/storage';
+import { parseSqlIdentifier } from '@mastra/core/utils';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
-import { PgDB, resolvePgConfig, generateTableSQL } from '../../db';
+import { PgDB, resolvePgConfig, generateTableSQL, generateIndexSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { runPrune, resolveTargets } from '../../retention';
 
@@ -108,12 +109,24 @@ export class WorkflowsPG extends WorkflowsStorage {
     };
   }
 
+  static getDefaultIndexDefs(schemaPrefix: string): CreateIndexOptions[] {
+    return [
+      {
+        name: `${schemaPrefix}mastra_workflow_snapshot_name_createdat_idx`,
+        table: TABLE_WORKFLOW_SNAPSHOT,
+        columns: ['workflow_name', 'createdAt DESC'],
+      },
+    ];
+  }
+
   /**
    * Returns all DDL statements for this domain: table with unique constraint.
    * Used by exportSchemas to produce a complete, reproducible schema export.
    */
   static getExportDDL(schemaName?: string): string[] {
     const statements: string[] = [];
+    const parsedSchema = schemaName ? parseSqlIdentifier(schemaName, 'schema name') : '';
+    const schemaPrefix = parsedSchema && parsedSchema !== 'public' ? `${parsedSchema}_` : '';
 
     // Table (includes the UNIQUE constraint on workflow_name, run_id via generateTableSQL)
     statements.push(
@@ -125,26 +138,33 @@ export class WorkflowsPG extends WorkflowsStorage {
       }),
     );
 
+    for (const idx of WorkflowsPG.getDefaultIndexDefs(schemaPrefix)) {
+      statements.push(generateIndexSQL(idx, schemaName));
+    }
+
     return statements;
   }
 
   /**
    * Returns default index definitions for the workflows domain tables.
-   * Currently no default indexes are defined for workflows.
    */
   getDefaultIndexDefinitions(): CreateIndexOptions[] {
-    return [];
+    const schemaPrefix = this.#schema !== 'public' ? `${this.#schema}_` : '';
+    return WorkflowsPG.getDefaultIndexDefs(schemaPrefix);
   }
 
   /**
    * Creates default indexes for optimal query performance.
-   * Currently no default indexes are defined for workflows.
    */
   async createDefaultIndexes(): Promise<void> {
-    if (this.#skipDefaultIndexes) {
-      return;
+    if (this.#skipDefaultIndexes) return;
+    for (const indexDef of this.getDefaultIndexDefinitions()) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create index ${indexDef.name}:`, error);
+      }
     }
-    // No default indexes for workflows domain
   }
 
   async init(): Promise<void> {

--- a/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
+++ b/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MemoryPG } from '../domains/memory';
 import { ObservabilityPG } from '../domains/observability';
 import { ScoresPG } from '../domains/scores';
+import { WorkflowsPG } from '../domains/workflows';
 
 // Mock DbClient
 const mockClient = {
@@ -107,6 +108,38 @@ describe('PostgresStore Domain Performance Indexes', () => {
         name: 'test_schema_mastra_ai_spans_spantype_startedat_idx',
         table: 'mastra_ai_spans',
         columns: ['spanType', 'startedAt DESC'],
+      });
+    });
+  });
+
+  describe('WorkflowsPG.getDefaultIndexDefinitions', () => {
+    it('should return a composite index for workflow_snapshot on (workflow_name, "createdAt" DESC)', () => {
+      const workflows = new WorkflowsPG({
+        client: mockClient as any,
+        schemaName: 'test_schema',
+      });
+
+      const indexes = workflows.getDefaultIndexDefinitions();
+
+      expect(indexes.length).toBe(1);
+      expect(indexes).toContainEqual({
+        name: 'test_schema_mastra_workflow_snapshot_name_createdat_idx',
+        table: 'mastra_workflow_snapshot',
+        columns: ['workflow_name', 'createdAt DESC'],
+      });
+    });
+
+    it('should work with default schema (public)', () => {
+      const workflows = new WorkflowsPG({
+        client: mockClient as any,
+      });
+
+      const indexes = workflows.getDefaultIndexDefinitions();
+
+      expect(indexes).toContainEqual({
+        name: 'mastra_workflow_snapshot_name_createdat_idx',
+        table: 'mastra_workflow_snapshot',
+        columns: ['workflow_name', 'createdAt DESC'],
       });
     });
   });

--- a/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
+++ b/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
@@ -144,8 +144,8 @@ describe('PostgresStore Domain Performance Indexes', () => {
     });
   });
 
-  describe('Total index count across all domains', () => {
-    it('should define 7 indexes total (2 memory + 1 scores + 4 observability)', () => {
+  describe('Total index count across tested domains', () => {
+    it('should define 13 indexes total (2 memory + 1 scores + 10 observability)', () => {
       const memory = new MemoryPG({ client: mockClient as any });
       const scores = new ScoresPG({ client: mockClient as any });
       const observability = new ObservabilityPG({ client: mockClient as any });
@@ -155,7 +155,7 @@ describe('PostgresStore Domain Performance Indexes', () => {
         scores.getDefaultIndexDefinitions().length +
         observability.getDefaultIndexDefinitions().length;
 
-      expect(totalIndexes).toBe(7);
+      expect(totalIndexes).toBe(13);
     });
   });
 });

--- a/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
+++ b/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
@@ -73,7 +73,7 @@ describe('PostgresStore Domain Performance Indexes', () => {
       expect(indexes.length).toBe(1);
       expect(indexes).toContainEqual({
         name: 'test_schema_mastra_scores_trace_id_span_id_created_at_idx',
-        table: 'mastra_scores',
+        table: 'mastra_scorers',
         columns: ['traceId', 'spanId', 'createdAt DESC'],
       });
     });

--- a/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
+++ b/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
@@ -88,7 +88,7 @@ describe('PostgresStore Domain Performance Indexes', () => {
 
       const indexes = observability.getDefaultIndexDefinitions();
 
-      expect(indexes.length).toBe(4);
+      expect(indexes.length).toBe(10);
       expect(indexes).toContainEqual({
         name: 'test_schema_mastra_ai_spans_traceid_startedat_idx',
         table: 'mastra_ai_spans',


### PR DESCRIPTION
## Description

Studio's workflow runs list previously performed a **top-N heapsort** on every poll because `WorkflowsPG` declared no default index for the `WHERE workflow_name = $1 ORDER BY "createdAt" DESC LIMIT $2` access pattern.

The existing `UNIQUE (workflow_name, run_id)` constraint already produced an index-only scan for the `WHERE workflow_name = $1` predicate — so filtering was cheap — but nothing supported the `ORDER BY "createdAt" DESC`, and Postgres had to sort the entire filtered result set on every request.

This PR adds a default composite index on `mastra_workflow_snapshot(workflow_name, "createdAt" DESC)` so the ordered result set can be walked directly, eliminating the sort.

## Root cause

`WorkflowsPG.getDefaultIndexDefinitions()` returned `[]`, so `IndexManager` created no index for this domain. Every call to `listWorkflowRuns({ workflowName, perPage, page, … })` — including the per-workflow Studio runs-list route in `packages/server/src/server/handlers/workflows.ts` — issued:

```sql
SELECT * FROM mastra_workflow_snapshot
WHERE workflow_name = $1 [AND …]
ORDER BY "createdAt" DESC
LIMIT $2 OFFSET $3
```

which reduced to Bitmap Heap Scan on the UNIQUE constraint + top-N heapsort.

## Fix

Follow the pattern used by the 15+ sibling domains (`MemoryPG`, `ScoresPG`, `ObservabilityPG`, `ChannelsPG`, …):

- Add `static getDefaultIndexDefs(schemaPrefix)` on `WorkflowsPG` returning the composite index definition.
- Wire the instance `getDefaultIndexDefinitions()` to forward to the static method.
- Include the index DDL in `getExportDDL()` so `exportSchemas()` emits a matching `CREATE INDEX`.
- `IndexManager` picks the index up on next `init()` — no migration is required for existing deployments; `CREATE INDEX IF NOT EXISTS` runs at startup.

## Performance impact — realistic multi-workflow shape

Benchmarked with 50,000 rows spread across 51 `workflow_name` values (2,500 rows for the "hot" workflow, 47,500 across 50 others), Postgres 16, `VACUUM ANALYZE` between runs. See `EXPLAIN (ANALYZE, BUFFERS)` output in the repro at [petrchiriboga/mastra-pg-workflow-runs-fullscan-repro](https://github.com/petrchiriboga/mastra-pg-workflow-runs-fullscan-repro).

### List query (fires on every poll)

| | Plan | Buffers | Execution time |
|---|---|---|---|
| Before | Bitmap Heap Scan on UNIQUE(workflow_name, run_id) + top-N heapsort | 117 | 0.369 ms |
| After | Index Scan on new index (no sort) | 3 | **0.045 ms** |

**~8× faster; sort eliminated; buffer reads reduced ~39×.**

### COUNT(*) query (fires on every paginated poll)

| | Plan | Buffers | Execution time |
|---|---|---|---|
| Before | Index Only Scan on UNIQUE(workflow_name, run_id) | 19 | 0.186 ms |
| After | Index Only Scan on new index | 5 | 0.177 ms |

The `COUNT(*)` was **already** cheap — the UNIQUE constraint on `(workflow_name, run_id)` covered the predicate. The new index becomes the preferred index-only scan target but the win here is marginal.

**Where the real fix lands: eliminating the top-N heapsort on the list query.**

### Where this index does NOT help

- `listWorkflowRuns` calls with no `workflow_name` filter (e.g. the `workflowsStore.listWorkflowRuns({ status, resourceId })` calls in the top-level runs-list handler): still full-scan.
- `status` filter: uses a computed `regexp_replace(...)::jsonb ->> 'status'` expression, which cannot use a plain btree index.

Both are separate concerns worth tracking in a follow-up.

## Related issue(s)

Fixes #21306.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds an index that helps PostgreSQL find workflow runs in the correct order. It makes filtered workflow-run lists faster and avoids unnecessary sorting.

## Changes

- Added the default `mastra_workflow_snapshot_name_createdat_idx` index on `(workflow_name, "createdAt" DESC)`.
- Created the index during `WorkflowsPG` initialization through `IndexManager`.
- Added matching `CREATE INDEX` statements to `exportSchemas()`.
- Added schema-prefix support for index names and identifiers.
- Respected `skipDefaultIndexes` and logged index creation failures.
- Added tests for public and custom schema configurations.
- Corrected ScoresPG and ObservabilityPG index assertions.
- Updated PostgreSQL integration documentation.
- Added a patch changeset for `@mastra/pg`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
