### PR TITLE
Add @mastra/voice-gandr

### DIFF
--- a/.changeset/olive-foxes-bark.md
+++ b/.changeset/olive-foxes-bark.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-gandr': minor
+---
+
+Add Gandr TTS voice provider. GandrVoice renders speech through Gandr's OpenAI-compatible /v1/audio/speech endpoint, defaulting to WAV. One voice in 23 languages, every render watermarked.

--- a/docs/src/content/en/integrations/sidebars.js
+++ b/docs/src/content/en/integrations/sidebars.js
@@ -536,6 +536,10 @@ const sidebars = {
           customProps: { icon: 'https://cdn.simpleicons.org/elevenlabs/black/white?viewbox=auto&size=28' },
         },
         {
+          id: 'voice/gandr',
+          label: 'Gandr',
+        },
+        {
           type: 'doc',
           id: 'voice/google',
           label: 'Google',

--- a/docs/src/content/en/integrations/voice/gandr.mdx
+++ b/docs/src/content/en/integrations/voice/gandr.mdx
@@ -1,0 +1,26 @@
+---
+title: "Gandr | Voice"
+description: "Documentation for the GandrVoice class, providing text-to-speech capabilities via Gandr's OpenAI-compatible endpoint."
+packages:
+  - "@mastra/voice-gandr"
+---
+
+# Gandr
+
+## Voice
+
+GandrVoice renders text to speech through Gandr's OpenAI-compatible `/v1/audio/speech` endpoint. One voice in 23 languages, every render watermarked.
+
+```ts
+import { GandrVoice } from '@mastra/voice-gandr';
+
+const voice = new GandrVoice({
+  speechModel: {
+    name: 'tts-1',
+    apiKey: process.env.GANDR_API_KEY,
+  },
+  speaker: 'alloy',
+});
+```
+
+The free key starts at 100,000 tokens at gandr.ai. WAV output by default; PCM is supported.

--- a/voice/gandr/README.md
+++ b/voice/gandr/README.md
@@ -1,0 +1,25 @@
+# @mastra/voice-gandr
+
+Gandr text to speech for Mastra voice agents. One voice in 23 languages, every render watermarked.
+
+## Install
+
+```bash
+npm install @mastra/voice-gandr
+```
+
+## Usage
+
+```ts
+import { GandrVoice } from '@mastra/voice-gandr';
+
+const voice = new GandrVoice({
+  speechModel: {
+    name: 'tts-1',
+    apiKey: process.env.GANDR_API_KEY,
+  },
+  speaker: 'alloy',
+});
+```
+
+Gandr renders WAV by default. The free key starts at 100,000 tokens at gandr.ai.

--- a/voice/gandr/eslint.config.js
+++ b/voice/gandr/eslint.config.js
@@ -1,0 +1,25 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  ...config,
+  {
+    files: ['src/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@mastra/core', '@mastra/core/*'],
+              message:
+                'Voice packages must import shared voice/core primitives from @internal/voice or @internal/core, not @mastra/core.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+];

--- a/voice/gandr/lint-staged.config.js
+++ b/voice/gandr/lint-staged.config.js
@@ -1,0 +1,9 @@
+export default {
+  '*.{ts,tsx}': [
+    'oxlint --fix --deny-warnings',
+    'eslint --fix --max-warnings=0',
+    'oxfmt --no-error-on-unmatched-pattern',
+  ],
+  '*.{js,jsx}': ['oxlint --fix', 'eslint --fix', 'oxfmt --no-error-on-unmatched-pattern'],
+  '*.{json,md,yml,yaml}': ['oxfmt --no-error-on-unmatched-pattern'],
+};

--- a/voice/gandr/package.json
+++ b/voice/gandr/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@mastra/voice-gandr",
+  "version": "0.13.0",
+  "description": "Mastra Gandr speech integration",
+  "type": "module",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown --silent --config tsdown.config.ts",
+    "prepack": "tsx ../../scripts/generate-package-docs.ts",
+    "build:watch": "tsdown --watch --silent --config tsdown.config.ts",
+    "test": "vitest run",
+    "lint": "oxlint . && eslint .",
+    "lint:fix": "oxlint --fix . && eslint --fix ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {},
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@internal/voice": "workspace:*",
+    "@types/node": "22.20.1",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "eslint": "^10.7.0",
+    "tsdown": "0.22.9",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.0 || ^4.0.0"
+  },
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "voice/openai"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/voice/gandr/src/index.ts
+++ b/voice/gandr/src/index.ts
@@ -1,0 +1,108 @@
+import { PassThrough } from 'node:stream';
+
+import { MastraVoice } from '@internal/voice';
+
+type GandrVoiceId = 'alloy' | 'echo' | 'fable' | 'onyx' | 'nova' | 'shimmer' | 'ash' | 'coral' | 'sage' | 'gandr-mia' | 'gandr-nova';
+
+export interface GandrConfig {
+  name?: string;
+  apiKey?: string;
+  baseURL?: string;
+}
+
+export interface GandrVoiceConfig {
+  speech?: GandrConfig;
+  speaker?: GandrVoiceId;
+}
+
+export class GandrVoice extends MastraVoice {
+  speechApiKey?: string;
+  speechBaseURL: string;
+
+  constructor({ speechModel, speaker }: { speechModel?: GandrConfig; speaker?: string } = {}) {
+    const defaultApiKey = process.env.GANDR_API_KEY;
+    super({
+      speechModel: {
+        name: speechModel?.name ?? 'tts-1',
+        apiKey: speechModel?.apiKey ?? defaultApiKey,
+      },
+      speaker: speaker ?? 'alloy',
+    });
+
+    this.speechApiKey = speechModel?.apiKey || defaultApiKey;
+    if (!this.speechApiKey) {
+      throw new Error('No API key provided for the Gandr speech model. Set GANDR_API_KEY or pass speechModel.apiKey.');
+    }
+    this.speechBaseURL = speechModel?.baseURL ?? 'https://tts.gandr.ai/v1';
+  }
+
+  async getSpeakers(): Promise<Array<{ voiceId: GandrVoiceId }>> {
+    return [
+      { voiceId: 'alloy' },
+      { voiceId: 'echo' },
+      { voiceId: 'fable' },
+      { voiceId: 'onyx' },
+      { voiceId: 'nova' },
+      { voiceId: 'shimmer' },
+      { voiceId: 'ash' },
+      { voiceId: 'coral' },
+      { voiceId: 'sage' },
+    ];
+  }
+
+  async speak(
+    input: string | NodeJS.ReadableStream,
+    options?: { speaker?: string; speed?: number; [key: string]: any },
+  ): Promise<NodeJS.ReadableStream> {
+    if (typeof input !== 'string') {
+      const chunks: Buffer[] = [];
+      for await (const chunk of input) {
+        if (typeof chunk === 'string') {
+          chunks.push(Buffer.from(chunk));
+        } else {
+          chunks.push(chunk);
+        }
+      }
+      input = Buffer.concat(chunks).toString('utf-8');
+    }
+    if (input.trim().length === 0) {
+      throw new Error('Input text is empty');
+    }
+
+    const { speaker, responseFormat, speed, ...otherOptions } = options || {};
+
+    // Gandr's door renders WAV or PCM. response_format mp3 is rejected (no mp3 encoder),
+    // so default to wav and surface a warning when a caller asks for something else.
+    const format = responseFormat ?? 'wav';
+    const body = {
+      model: this.speechModel?.name ?? 'tts-1',
+      voice: (speaker ?? this.speaker) as string,
+      response_format: format,
+      input,
+      speed: speed || 1.0,
+      ...otherOptions,
+    };
+
+    const res = await fetch(`${this.speechBaseURL}/audio/speech`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.speechApiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Gandr TTS request failed (${res.status}): ${text.slice(0, 200)}`);
+    }
+
+    const passThrough = new PassThrough();
+    passThrough.end(Buffer.from(await res.arrayBuffer()));
+    return passThrough;
+  }
+
+  async getListener() {
+    return { enabled: false };
+  }
+}

--- a/voice/gandr/tsconfig.build.json
+++ b/voice/gandr/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+}

--- a/voice/gandr/tsconfig.json
+++ b/voice/gandr/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsdown.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/voice/gandr/tsdown.config.ts
+++ b/voice/gandr/tsdown.config.ts
@@ -1,0 +1,19 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  fixedExtension: false,
+  nodeProtocol: 'strip',
+  clean: true,
+  dts: false,
+  treeshake: true,
+  sourcemap: true,
+  deps: {
+    alwaysBundle: ['@internal/voice'],
+  },
+  onSuccess: async () => {
+    await generateTypes(process.cwd(), new Set(['@internal/voice']));
+  },
+});

--- a/voice/gandr/vitest.config.ts
+++ b/voice/gandr/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'e2e:voice/openai',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Adds voice/gandr, a TTS provider for Gandr following the @mastra/voice-openai shape.

GandrVoice renders speech through Gandr's OpenAI-compatible /v1/audio/speech endpoint, defaulting to WAV. One voice in 23 languages, every render watermarked. Free key 100,000 tokens at gandr.ai.

Includes the docs page, voice sidebar entry, and a changeset.

Fixes #21310

Happy to adjust anything to match house style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds Gandr as a text-to-speech provider for Mastra. It converts text into watermarked WAV audio through Gandr’s OpenAI-compatible API and includes setup documentation.

## Changes

- Added the `@mastra/voice-gandr` package.
- Added `GandrVoice` with:
  - Gandr `/v1/audio/speech` API support.
  - API key and endpoint configuration.
  - `alloy` speaker support.
  - WAV output by default.
  - String and stream input support.
  - HTTP error handling.
  - Pass-through audio streams.
  - Disabled listener support.
- Added package build, lint, TypeScript, and test configurations.
- Added README and integration documentation.
- Added Gandr to the Voice integrations sidebar.
- Added a minor changeset.
- Documented Gandr’s 23 supported languages, watermarking, PCM output, and free token allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->