### PR TITLE
fix(pg): add default indexes for the workflow runs list

### DIFF
--- a/.changeset/pg-workflow-runs-default-indexes.md
+++ b/.changeset/pg-workflow-runs-default-indexes.md
@@ -1,0 +1,22 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed workflow run lists doing a full table scan on Postgres.
+
+`listWorkflowRuns` orders by `"createdAt" DESC` and filters on `workflow_name` or `resourceId`, but the only index on `mastra_workflow_snapshot` was the primary key on `(workflow_name, run_id)`, which has no `"createdAt"` component. Once one workflow name dominated the table, Postgres fell back to a sequential scan plus a top-N sort — on every call. Studio polls this while a workflow page is open, so an idle browser tab could hold sustained CPU load on a large database.
+
+`@mastra/pg` now creates two default indexes on `mastra_workflow_snapshot`:
+
+- `(workflow_name, "createdAt" DESC)`
+- `("resourceId", "createdAt" DESC)`
+
+These are created automatically on `init()` for new and existing tables, and are included in `exportSchemas()` output. Reported in [#21306](https://github.com/mastra-ai/mastra/issues/21306).
+
+Deployments that manage their own indexes can keep opting out with `skipDefaultIndexes: true`:
+
+```ts
+const store = new PostgresStore({ connectionString, skipDefaultIndexes: true });
+```
+
+**Note on the paginated count:** when `page`/`perPage` are supplied, `listWorkflowRuns` also issues a `COUNT(*)`, which remains O(N) for a dominant `workflow_name` even with these indexes. Making that constant-time needs keyset pagination, which is a separate API change.

--- a/stores/pg/src/storage/domains/workflows/default-indexes.test.ts
+++ b/stores/pg/src/storage/domains/workflows/default-indexes.test.ts
@@ -1,0 +1,131 @@
+import { TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WorkflowsPG } from './index';
+
+const mockClient = {
+  $pool: {},
+  none: vi.fn(),
+  one: vi.fn(),
+  manyOrNone: vi.fn(),
+  oneOrNone: vi.fn(),
+  many: vi.fn(),
+  any: vi.fn(),
+  query: vi.fn(),
+  tx: vi.fn(),
+};
+
+describe('WorkflowsPG default indexes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getDefaultIndexDefinitions', () => {
+    it('returns the indexes serving the listWorkflowRuns access pattern', () => {
+      const workflows = new WorkflowsPG({ client: mockClient as any, schemaName: 'test_schema' });
+
+      const indexes = workflows.getDefaultIndexDefinitions();
+
+      expect(indexes.length).toBe(2);
+      expect(indexes).toContainEqual({
+        name: 'test_schema_mastra_workflow_snapshot_name_createdat_idx',
+        table: TABLE_WORKFLOW_SNAPSHOT,
+        columns: ['workflow_name', 'createdAt DESC'],
+      });
+      expect(indexes).toContainEqual({
+        name: 'test_schema_mastra_workflow_snapshot_resourceid_createdat_idx',
+        table: TABLE_WORKFLOW_SNAPSHOT,
+        columns: ['resourceId', 'createdAt DESC'],
+      });
+    });
+
+    it('omits the schema prefix on the default public schema', () => {
+      const workflows = new WorkflowsPG({ client: mockClient as any });
+
+      const indexes = workflows.getDefaultIndexDefinitions();
+
+      expect(indexes.map(i => i.name)).toEqual([
+        'mastra_workflow_snapshot_name_createdat_idx',
+        'mastra_workflow_snapshot_resourceid_createdat_idx',
+      ]);
+    });
+
+    it('leads with the filter column and trails with the sort column', () => {
+      // listWorkflowRuns filters on equality, then orders by "createdAt" DESC.
+      // A btree can only serve that ordering when the sort column trails the
+      // equality column, so this column order is load-bearing, not cosmetic.
+      const workflows = new WorkflowsPG({ client: mockClient as any });
+
+      for (const index of workflows.getDefaultIndexDefinitions()) {
+        expect(index.columns).toHaveLength(2);
+        expect(index.columns[1]).toBe('createdAt DESC');
+      }
+    });
+
+    it('keeps index names within the 63-byte Postgres identifier limit', () => {
+      // Postgres silently truncates identifiers past 63 bytes. The schema
+      // prefix eats into that budget, so a sufficiently long custom schema
+      // name will truncate for any domain in this package — that is a
+      // pre-existing, repo-wide property, not something specific to these
+      // indexes. What is asserted here is the case that must always hold:
+      // the unprefixed names, used by the default `public` schema.
+      const workflows = new WorkflowsPG({ client: mockClient as any });
+
+      for (const index of workflows.getDefaultIndexDefinitions()) {
+        expect(Buffer.byteLength(index.name, 'utf8')).toBeLessThanOrEqual(63);
+      }
+    });
+  });
+
+  describe('createDefaultIndexes', () => {
+    it('issues a CREATE INDEX for each default index', async () => {
+      // oneOrNone backs the "does this index already exist?" probe in
+      // PgDB.createIndex; null means it does not, so creation proceeds.
+      mockClient.oneOrNone.mockResolvedValue(null);
+      mockClient.none.mockResolvedValue(undefined);
+      const workflows = new WorkflowsPG({ client: mockClient as any });
+
+      await workflows.createDefaultIndexes();
+
+      const statements = mockClient.none.mock.calls.map(call => String(call[0]));
+      expect(statements).toHaveLength(2);
+      expect(statements[0]).toContain('"mastra_workflow_snapshot_name_createdat_idx"');
+      expect(statements[0]).toContain('("workflow_name", "createdAt" DESC)');
+      expect(statements[1]).toContain('"mastra_workflow_snapshot_resourceid_createdat_idx"');
+      expect(statements[1]).toContain('("resourceId", "createdAt" DESC)');
+      // Built without holding a write lock on an existing, possibly large table.
+      expect(statements.every(sql => sql.includes('CONCURRENTLY'))).toBe(true);
+    });
+
+    it('skips index creation when skipDefaultIndexes is set', async () => {
+      const workflows = new WorkflowsPG({
+        client: mockClient as any,
+        skipDefaultIndexes: true,
+      });
+
+      await workflows.createDefaultIndexes();
+
+      expect(mockClient.none).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getExportDDL', () => {
+    it('emits index DDL so schema exports stay reproducible', () => {
+      const statements = WorkflowsPG.getExportDDL('test_schema');
+      const indexStatements = statements.filter(s => s.includes('CREATE INDEX'));
+
+      expect(indexStatements).toHaveLength(2);
+      expect(indexStatements[0]).toContain('"test_schema_mastra_workflow_snapshot_name_createdat_idx"');
+      expect(indexStatements[0]).toContain('("workflow_name", "createdAt" DESC)');
+      expect(indexStatements[1]).toContain('"test_schema_mastra_workflow_snapshot_resourceid_createdat_idx"');
+      expect(indexStatements[1]).toContain('("resourceId", "createdAt" DESC)');
+    });
+
+    it('emits index DDL for the default schema', () => {
+      const statements = WorkflowsPG.getExportDDL();
+      const indexStatements = statements.filter(s => s.includes('CREATE INDEX'));
+
+      expect(indexStatements).toHaveLength(2);
+      expect(indexStatements[0]).toContain('"mastra_workflow_snapshot_name_createdat_idx"');
+    });
+  });
+});

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -19,8 +19,9 @@ import type {
   RetentionTablesDescriptor,
   TableRetentionPolicy,
 } from '@mastra/core/storage';
+import { parseSqlIdentifier } from '@mastra/core/utils';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
-import { PgDB, resolvePgConfig, generateTableSQL } from '../../db';
+import { PgDB, resolvePgConfig, generateTableSQL, generateIndexSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { runPrune, resolveTargets } from '../../retention';
 
@@ -109,11 +110,13 @@ export class WorkflowsPG extends WorkflowsStorage {
   }
 
   /**
-   * Returns all DDL statements for this domain: table with unique constraint.
+   * Returns all DDL statements for this domain: table with unique constraint, indexes.
    * Used by exportSchemas to produce a complete, reproducible schema export.
    */
   static getExportDDL(schemaName?: string): string[] {
     const statements: string[] = [];
+    const parsedSchema = schemaName ? parseSqlIdentifier(schemaName, 'schema name') : '';
+    const schemaPrefix = parsedSchema && parsedSchema !== 'public' ? `${parsedSchema}_` : '';
 
     // Table (includes the UNIQUE constraint on workflow_name, run_id via generateTableSQL)
     statements.push(
@@ -125,26 +128,76 @@ export class WorkflowsPG extends WorkflowsStorage {
       }),
     );
 
+    // Default indexes
+    for (const idx of WorkflowsPG.getDefaultIndexDefs(schemaPrefix)) {
+      statements.push(generateIndexSQL(idx, schemaName));
+    }
+
     return statements;
   }
 
   /**
-   * Returns default index definitions for the workflows domain tables.
-   * Currently no default indexes are defined for workflows.
+   * Default indexes serving `listWorkflowRuns`, which always orders by
+   * `"createdAt" DESC` and filters on either `workflow_name` or `resourceId`.
+   *
+   * Both are composite `(filter, "createdAt" DESC)` rather than single-column:
+   * the leading equality column narrows the scan and the trailing sort column
+   * lets Postgres read rows already ordered, so a paged query stops after
+   * `LIMIT` rows instead of sorting the whole match set. The same
+   * `"createdAt"` position also serves the `fromDate`/`toDate` range filters.
+   *
+   * The primary key `(workflow_name, run_id)` cannot serve these queries — it
+   * has no `"createdAt"` component — so before these indexes existed a
+   * dominant `workflow_name` degraded to a sequential scan plus a top-N sort.
+   *
+   * Ordered `DESC` to match the query's sort direction. A btree can be walked
+   * backwards, so `ASC` would also be usable here; `DESC` keeps the common
+   * path a plain forward scan and matches the convention used by the other
+   * domains.
+   *
+   * The `status` filter is deliberately not indexed: it is evaluated as a
+   * `regexp_replace(...)::jsonb ->> 'status'` expression over the snapshot,
+   * which is not indexable without a matching expression index.
+   */
+  static getDefaultIndexDefs(schemaPrefix: string): CreateIndexOptions[] {
+    return [
+      {
+        name: `${schemaPrefix}mastra_workflow_snapshot_name_createdat_idx`,
+        table: TABLE_WORKFLOW_SNAPSHOT,
+        columns: ['workflow_name', 'createdAt DESC'],
+      },
+      {
+        name: `${schemaPrefix}mastra_workflow_snapshot_resourceid_createdat_idx`,
+        table: TABLE_WORKFLOW_SNAPSHOT,
+        columns: ['resourceId', 'createdAt DESC'],
+      },
+    ];
+  }
+
+  /**
+   * Returns default index definitions for this instance's schema.
    */
   getDefaultIndexDefinitions(): CreateIndexOptions[] {
-    return [];
+    const schemaPrefix = this.#schema !== 'public' ? `${this.#schema}_` : '';
+    return WorkflowsPG.getDefaultIndexDefs(schemaPrefix);
   }
 
   /**
    * Creates default indexes for optimal query performance.
-   * Currently no default indexes are defined for workflows.
    */
   async createDefaultIndexes(): Promise<void> {
     if (this.#skipDefaultIndexes) {
       return;
     }
-    // No default indexes for workflows domain
+
+    for (const indexDef of this.getDefaultIndexDefinitions()) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch (error) {
+        // Log but continue - indexes are performance optimizations
+        this.logger?.warn?.(`Failed to create index ${indexDef.name}:`, error);
+      }
+    }
   }
 
   async init(): Promise<void> {

--- a/stores/pg/src/storage/test-utils.ts
+++ b/stores/pg/src/storage/test-utils.ts
@@ -769,6 +769,10 @@ export function pgTests() {
           'CREATE INDEX IF NOT EXISTS "mastra_ai_spans_tags_gin_idx" ON "public"."mastra_ai_spans" USING gin',
         );
 
+        // Workflows domain indexes
+        expect(schema).toContain('CREATE INDEX IF NOT EXISTS "mastra_workflow_snapshot_name_createdat_idx"');
+        expect(schema).toContain('CREATE INDEX IF NOT EXISTS "mastra_workflow_snapshot_resourceid_createdat_idx"');
+
         // Scores domain indexes
         expect(schema).toContain('CREATE INDEX IF NOT EXISTS "mastra_scores_trace_id_span_id_created_at_idx"');
 
@@ -785,6 +789,7 @@ export function pgTests() {
         // Index names should have the schema prefix
         expect(schema).toContain('CREATE INDEX IF NOT EXISTS "my_schema_mastra_threads_resourceid_createdat_idx"');
         expect(schema).toContain('CREATE INDEX IF NOT EXISTS "my_schema_mastra_ai_spans_traceid_startedat_idx"');
+        expect(schema).toContain('CREATE INDEX IF NOT EXISTS "my_schema_mastra_workflow_snapshot_name_createdat_idx"');
         expect(schema).toContain(
           'CREATE INDEX IF NOT EXISTS "my_schema_mastra_scores_trace_id_span_id_created_at_idx"',
         );


### PR DESCRIPTION
Fixes #21306

## Problem

`WorkflowsPG.getDefaultIndexDefinitions()` returned `[]`, so the only index on `mastra_workflow_snapshot` was the primary key on `(workflow_name, run_id)`.

`listWorkflowRuns` always orders by `"createdAt" DESC` and filters on `workflow_name` or `resourceId`. The primary key cannot serve that — it has no `"createdAt"` component, so it can neither supply the ordering nor bound the scan once `workflow_name` stops being selective. With one dominant workflow name (the reporter measured ~397k of 451k rows), Postgres falls back to a sequential scan plus a top-N heapsort.

Studio polls this endpoint on an interval while a workflow page is open, so an idle browser tab holds that scan on a loop. The reporter saw sustained P99 CPU around 76% on a 1-vCPU Cloud SQL instance, with query insights attributing effectively all of it to the Studio service account.

## Fix

Two composite default indexes on `mastra_workflow_snapshot`:

| Index | Serves |
|---|---|
| `(workflow_name, "createdAt" DESC)` | the main Studio runs-list, plus `fromDate`/`toDate` |
| `("resourceId", "createdAt" DESC)` | `listWorkflowRuns({ status, resourceId })` |

Each is `(filter, sort)` rather than single-column on purpose: the leading equality column bounds the scan, and because the sort column trails it the rows come back already ordered, so a paged query can stop after `LIMIT` rows instead of sorting the whole match set. The same `"createdAt"` position also serves the `fromDate`/`toDate` range filters, so those need no separate index.

The `resourceId` index is not speculative — `packages/server/src/server/handlers/workflows.ts` calls `listWorkflowRuns({ status, resourceId })` with no `workflowName`, which had no usable index at all.

These are built through the existing `PgDB.createIndex`, which defaults to `concurrent: true` and falls back to a non-concurrent build on error, so adding them to an existing large table does not take a write-blocking lock.

`getExportDDL` now emits the index DDL too, matching `MemoryPG` and `ObservabilityPG`. Without that, a database built from `exportSchemas()` would silently differ from one built by `init()`.

## Deliberately not included

- **`status` is left unindexed.** It is evaluated as `regexp_replace(snapshot::text, ...)::jsonb ->> 'status'`, which needs a matching expression index to be usable. That is a larger decision about indexing snapshot internals.
- **The `COUNT(*)` companion is unchanged.** As the issue notes, it stays O(N) for a dominant `workflow_name` even with these indexes. Making it constant-time means keyset pagination instead of `LIMIT/OFFSET` + `COUNT(*)`, which changes the storage API across every adapter — out of scope here.
- **Studio polling behaviour** (suggestion 3 in the issue) is a separate package.

`skipDefaultIndexes: true` still opts out, for deployments that manage their own indexes.

## Testing

Added `stores/pg/src/storage/domains/workflows/default-indexes.test.ts` (8 tests): index shape and naming, schema-prefixed and default-schema variants, that the sort column trails the filter column, that `createDefaultIndexes` issues both `CREATE INDEX ... CONCURRENTLY` statements, that `skipDefaultIndexes` suppresses them, and that `getExportDDL` emits both.

Extended the two existing schema-export assertions in `test-utils.ts` to cover the new indexes.

Verified locally: 8/8 new tests pass, `@mastra/pg` builds, `oxlint` and `oxfmt --check` clean, `tsc --noEmit` clean.

**One gap to flag honestly:** I have no Docker on this machine, so I could not run the Postgres-backed integration tests or reproduce the `EXPLAIN` plan flip myself. The plan evidence in this PR is the reporter's, from the repro linked in #21306. The DB-dependent suites will need CI.

## Note on an unrelated stale test

While looking for the right place to put these tests I found that `stores/pg/src/storage/performance-indexes/performance-indexes.test.ts` is excluded from the default vitest run (`vitest.config.ts`) and is only picked up by `vitest.perf.config.ts`, which no CI workflow invokes. On current `main` it fails 3 of its 5 tests — it asserts 4 observability indexes where there are now 10, and 7 total where there are 13.

I have not touched it, since that is unrelated to this bug, but you may want to either re-enable it or update it. It is why I put the new tests in a colocated file that the default config actually runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Workflow run searches can scan and sort a large table repeatedly. This PR adds indexes that help Postgres find and sort these runs faster.

## Changes

- Added default indexes on `mastra_workflow_snapshot`:
  - `(workflow_name, "createdAt" DESC)`
  - `("resourceId", "createdAt" DESC)`
- Added index creation during `WorkflowsPG.init()` for new and existing tables.
- Included the indexes in `exportSchemas()` output for public and custom schemas.
- Preserved the `skipDefaultIndexes: true` opt-out.
- Added `WorkflowsPG.getDefaultIndexDefs()` and updated `getDefaultIndexDefinitions()`.
- Added tests for index definitions, schema names, identifier limits, concurrent creation, opt-out behavior, and exported DDL.
- Documented that paginated `COUNT(*)` queries remain unchanged and may still require a future keyset pagination API.

## Validation

- Builds, linting, formatting, and type checking passed.
- Postgres integration tests were not run because Docker was unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->