### PR TITLE
docs: clarify feature request PR eligibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Also ensure that the PR description clearly describes the problem and solution.
 ### Do you intend to add a new feature or change an existing one?
 
 - Open a [feature request](https://github.com/mastra-ai/mastra/issues/new?template=feature_request.yml) and wait for feedback from the Mastra maintainers
-- Assuming you get positive feedback, raise a pull request against your fork/branch to track the development of the feature and discuss the implementation.
+- A Pull Request can only be opened for feature requests when there is no "status: needs triage" or "status: needs approval" label. If an Issue still has those labels, the PR will automatically be closed.
 
 ### Want to improve documentation?
 


### PR DESCRIPTION
Clarifies that contributors should wait for the feature-request triage and approval labels to be cleared before opening an implementation PR. This makes the feature contribution workflow explicit.

Validation: Checking formatting...

All matched files use the correct format.
Finished in 94ms on 1 files using 28 threads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Contributors must wait for maintainers to review and approve a feature request before opening an implementation pull request. This prevents pull requests from opening too early and being closed automatically.

## Changes

- Updated `CONTRIBUTING.md` to require cleared `status: needs triage` and `status: needs approval` labels before contributors open a pull request.
- Removed the previous guidance to open a pull request after positive feedback.
- Formatting validation passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->