### PR TITLE
fix(factory-ui): stop the factories error notice collapsing to one character per line

### DIFF
--- a/.changeset/factory-error-notice-width.md
+++ b/.changeset/factory-error-notice-width.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the Factory error screen rendering its message as a single column of letters down the page when the factories list fails to load. The notice now shows as a centered card with a readable line length.

--- a/mastracode/factory-ui/src/ui/domains/workspaces/__tests__/FactoryLayout.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/__tests__/FactoryLayout.msw.test.tsx
@@ -1,0 +1,33 @@
+import { screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../e2e/ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../../e2e/ui/render';
+import { FactoryLayout } from '../components/FactoryLayout';
+
+function renderFactoryRoute() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/factories/factory-1']}>
+      <Routes>
+        <Route path="/" element={<div>landing</div>} />
+        <Route path="/factories/:factoryId" element={<FactoryLayout />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('FactoryLayout', () => {
+  it('shows the error notice instead of bouncing to the landing route when the factories query fails', async () => {
+    server.use(http.get(`${TEST_BASE_URL}/web/factory/projects`, () => new HttpResponse(null, { status: 500 })));
+
+    const { container } = renderFactoryRoute();
+
+    const message = await screen.findByText(/Could not load factories/);
+    expect(screen.queryByText('landing')).not.toBeInTheDocument();
+
+    // Notice is a CSS container, so a content-sized parent collapses it to one character per line.
+    expect(container.querySelector('.w-full.max-w-md')).toContainElement(message);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/FactoryLayout.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/FactoryLayout.tsx
@@ -18,7 +18,9 @@ export function FactoryLayout() {
   if (isError) {
     return (
       <div className="bg-surface1 grid h-dvh w-full place-items-center px-4">
-        <Notice variant="destructive">Could not load factories. Check the server connection and reload.</Notice>
+        <Notice variant="destructive" className="w-full max-w-md">
+          Could not load factories. Check the server connection and reload.
+        </Notice>
       </div>
     );
   }


### PR DESCRIPTION
When the factories query fails, the error notice rendered as a single column of letters running down the whole page instead of a card. Now it shows as a normal centered notice with a readable line length.

The cause is that Notice declares `@container` (`container-type: inline-size`), which means its own inline size can't be derived from its content — its intrinsic contribution is zero. The error screen wrapped it in a grid with `place-items-center`, and `justify-items: center` sizes the item with fit-content, so the card resolved to roughly the width of its icon and every character wrapped onto its own line. I gave it a definite width instead (`w-full max-w-md`), which resolves against the grid track and never asks for the contained intrinsic size.

Worth knowing for anyone else placing a Notice: any shrink-to-fit context (grid centering, flex row, inline-block, `w-fit`) collapses it the same way. This call site was the only one in factory-ui. Diagnosed from the CSS rather than in the browser, since the failure needs the factories request to be down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When factories fail to load, the error message now appears in a readable, centered card instead of a narrow column.

## Changes

- Updated the factory-load error `Notice` in `FactoryLayout.tsx` with `w-full max-w-md`.
- Preserved the destructive styling and existing error message.
- Added test coverage for the failed factories request and notice layout.
- Added a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->