### PR TITLE
fix(langfuse): send scores to the exporter's configured environment

### DIFF
--- a/.changeset/modern-falcons-tease.md
+++ b/.changeset/modern-falcons-tease.md
@@ -1,0 +1,5 @@
+---
+'@mastra/langfuse': patch
+---
+
+Fixed Langfuse scores being ingested into the wrong environment. Scores submitted through the exporter's score pipeline (including `observability.addScore` and the deprecated `addScoreToTrace`) now carry the exporter's configured `environment`, matching the traces they belong to. Previously, with `new LangfuseExporter({ environment: 'production' })`, spans landed in `production` but their scores landed in the `default` environment, so environment-scoped views like the session list's Scores column and score analytics showed nothing. Fixes [#21315](https://github.com/mastra-ai/mastra/issues/21315)

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -714,6 +714,31 @@ describe('LangfuseExporter', () => {
       expect(mockScoreCreate).toHaveBeenCalledWith(expect.objectContaining({ name: 'accuracy' }));
     });
 
+    it('includes the configured environment on the score', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test', environment: 'production' });
+
+      await exporter.onScoreEvent({ type: 'score', score: { ...baseScore } } as any);
+
+      expect(mockScoreCreate).toHaveBeenCalledWith(expect.objectContaining({ environment: 'production' }));
+    });
+
+    it('falls back to LANGFUSE_TRACING_ENVIRONMENT when no environment is configured', async () => {
+      process.env.LANGFUSE_TRACING_ENVIRONMENT = 'staging';
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+
+      await exporter.onScoreEvent({ type: 'score', score: { ...baseScore } } as any);
+
+      expect(mockScoreCreate).toHaveBeenCalledWith(expect.objectContaining({ environment: 'staging' }));
+    });
+
+    it('omits environment when none is configured', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+
+      await exporter.onScoreEvent({ type: 'score', score: { ...baseScore } } as any);
+
+      expect(mockScoreCreate.mock.calls[0][0]).not.toHaveProperty('environment');
+    });
+
     it('omits the call when traceId is missing', async () => {
       exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
 

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -170,6 +170,7 @@ export class LangfuseExporter extends BaseExporter {
         value,
         ...(comment ? { comment } : {}),
         ...(metadata ? { metadata } : {}),
+        ...(this.#environment ? { environment: this.#environment } : {}),
         dataType: 'NUMERIC' as const,
       });
     } catch (error) {


### PR DESCRIPTION
## Description

`LangfuseExporter` applies its configured `environment` to every span but never to scores: `submitScore` builds the `score.create()` payload without it, and `@langfuse/client` only falls back to the `LANGFUSE_TRACING_ENVIRONMENT` env var. So with `new LangfuseExporter({ environment: 'production' })`, traces land in `production` while their scores land in `default`, and environment-scoped views (the session list's Scores column, score analytics, dashboards filtered by environment) show nothing.

- Pass the exporter's already-computed `#environment` (config value with `LANGFUSE_TRACING_ENVIRONMENT` fallback) in the `score.create()` payload; `LangfuseClientParams` has no environment field, so per-score is the only place to set it
- Omit the field when no environment is configured, preserving `@langfuse/client`'s own env-var fallback at ingestion time
- Covers both score paths (`onScoreEvent` and the deprecated `addScoreToTrace`), which share `submitScore`
- Added colocated tests for the configured value, the env-var fallback, and the unset case; the two positive tests fail without the fix
- A/B verified against Langfuse Cloud (US): on published `@mastra/langfuse@1.4.8` the ingested score reports `environment: "default"` despite a configured environment; with this fix the same script reports the configured environment
- The issue's other two asks (session-targeted scores, non-numeric `dataType`) need `@mastra/core` scoring-model changes and are intentionally out of scope

## Related Issue(s)

Fixes #21315

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR