### PR TITLE
feat(observability): indexed redaction tokens for SensitiveDataFilter

### DIFF
--- a/.changeset/many-mirrors-train.md
+++ b/.changeset/many-mirrors-train.md
@@ -1,0 +1,13 @@
+---
+'@mastra/observability': minor
+---
+
+Added an `indexed` redaction style to `SensitiveDataFilter`. Instead of collapsing every sensitive value to the same `[REDACTED]` string, each unique value gets a stable token derived from the matched field name, like `[APIKEY_1]`. The same value maps to the same token across all spans of a trace, so redacted traces keep their referential structure (you can tell whether two redacted fields held the same secret or different ones) without exposing the raw values. Token numbering restarts for each trace, so values cannot be linked across traces.
+
+```ts
+new SensitiveDataFilter({
+  redactionStyle: 'indexed',
+});
+```
+
+See [#21313](https://github.com/mastra-ai/mastra/issues/21313)

--- a/.changeset/many-mirrors-train.md
+++ b/.changeset/many-mirrors-train.md
@@ -2,7 +2,7 @@
 '@mastra/observability': minor
 ---
 
-Added an `indexed` redaction style to `SensitiveDataFilter`. Instead of collapsing every sensitive value to the same `[REDACTED]` string, each unique value gets a stable token derived from the matched field name, like `[APIKEY_1]`. The same value maps to the same token across all spans of a trace, so redacted traces keep their referential structure (you can tell whether two redacted fields held the same secret or different ones) without exposing the raw values. Token numbering restarts for each trace, so values cannot be linked across traces.
+Added an `indexed` redaction style to `SensitiveDataFilter`. Instead of collapsing every sensitive value to the same `[REDACTED]` string, each unique value gets a stable token derived from the matched field name, like `[APIKEY_1]`. The same value maps to the same token across the spans of a trace while the trace's mapping is retained, so redacted traces keep their referential structure (you can tell whether two redacted fields held the same secret or different ones) without exposing the raw values. Token numbering restarts for each trace, so values cannot be linked across traces. Mapping state is bounded: the filter keeps state for the 1000 most recently used traces (spans of an evicted trace start a fresh mapping) and tracks up to 1000 unique values per trace (new values beyond the cap fall back to the full redaction token).
 
 ```ts
 new SensitiveDataFilter({

--- a/.changeset/many-mirrors-train.md
+++ b/.changeset/many-mirrors-train.md
@@ -2,7 +2,7 @@
 '@mastra/observability': minor
 ---
 
-Added an `indexed` redaction style to `SensitiveDataFilter`. Instead of collapsing every sensitive value to the same `[REDACTED]` string, each unique value gets a stable token derived from the matched field name, like `[APIKEY_1]`. The same value maps to the same token across the spans of a trace while the trace's mapping is retained, so redacted traces keep their referential structure (you can tell whether two redacted fields held the same secret or different ones) without exposing the raw values. Token numbering restarts for each trace, so values cannot be linked across traces. Mapping state is bounded: the filter keeps state for the 1000 most recently used traces (spans of an evicted trace start a fresh mapping) and tracks up to 1000 unique values per trace (new values beyond the cap fall back to the full redaction token).
+Added an `indexed` redaction style to `SensitiveDataFilter`. Instead of collapsing every sensitive value to the same `[REDACTED]` string, each unique value gets a stable token derived from the first matched field name, like `[APIKEY_1]`. The same value maps to the same token across the spans of a trace while the trace's mapping is retained, so redacted traces keep their referential structure (you can tell whether two redacted fields held the same secret or different ones) without exposing the raw values. Token numbering restarts for each trace, so values cannot be linked across traces. Mapping state is bounded: the filter keeps state for the 1000 most recently used traces (spans of an evicted trace start a fresh mapping) and tracks up to 1000 unique values per trace (new values beyond the cap fall back to the full redaction token).
 
 ```ts
 new SensitiveDataFilter({

--- a/.changeset/many-mirrors-train.md
+++ b/.changeset/many-mirrors-train.md
@@ -2,7 +2,7 @@
 '@mastra/observability': minor
 ---
 
-Added an `indexed` redaction style to `SensitiveDataFilter`. Instead of collapsing every sensitive value to the same `[REDACTED]` string, each unique value gets a stable token derived from the first matched field name, like `[APIKEY_1]`. The same value maps to the same token across the spans of a trace while the trace's mapping is retained, so redacted traces keep their referential structure (you can tell whether two redacted fields held the same secret or different ones) without exposing the raw values. Token numbering restarts for each trace, so values cannot be linked across traces. Mapping state is bounded: the filter keeps state for the 1000 most recently used traces (spans of an evicted trace start a fresh mapping) and tracks up to 1000 unique values per trace (new values beyond the cap fall back to the full redaction token).
+Added an `indexed` redaction style to `SensitiveDataFilter`. Instead of collapsing every sensitive value to the same `[REDACTED]` string, each unique value gets a stable token derived from the first matched field name, like `[APIKEY_1]`.
 
 ```ts
 new SensitiveDataFilter({

--- a/docs/src/content/en/reference/observability/tracing/processors/sensitive-data-filter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/processors/sensitive-data-filter.mdx
@@ -80,8 +80,8 @@ new SensitiveDataFilter(options?: SensitiveDataFilterOptions)
   },
   {
     name: 'redactionStyle',
-    type: "'full' | 'partial'",
-    description: 'Controls whether matched values are fully or partially redacted.',
+    type: "'full' | 'partial' | 'indexed'",
+    description: 'Controls how matched values are redacted.',
     isOptional: true,
     defaultValue: "'full'",
   },
@@ -95,7 +95,7 @@ interface SensitiveDataFilterOptions {
   redactionStyle?: RedactionStyle
 }
 
-type RedactionStyle = 'full' | 'partial'
+type RedactionStyle = 'full' | 'partial' | 'indexed'
 ```
 
 ## Redaction styles
@@ -129,6 +129,30 @@ const filter = new SensitiveDataFilter({
 // After
 { "apiKey": "sk-…789" }
 ```
+
+### Indexed redaction
+
+Indexed redaction replaces each unique value with a stable token derived from the first field name that matched it, for example `[APIKEY_1]`. The same value maps to the same token across the spans of a trace while the trace's mapping is retained, so redacted values stay correlatable without exposing the raw value. Later occurrences under other sensitive fields reuse the first token.
+
+```typescript
+const filter = new SensitiveDataFilter({
+  redactionStyle: 'indexed',
+})
+```
+
+```jsonc prettier:false
+// Before (two spans in the same trace)
+[{ "apiKey": "sk-alice-key" }, { "apiKey": "sk-bob-key" }]
+
+// After
+[{ "apiKey": "[APIKEY_1]" }, { "apiKey": "[APIKEY_2]" }]
+```
+
+The mapping is scoped per trace. Numbering restarts for each trace, so tokens from different traces can't be linked.
+
+State is bounded in two ways. The filter keeps mappings for the 1000 most recently used traces. The least recently used trace is evicted beyond that, and spans arriving for an evicted trace start a fresh mapping, so later values may receive new tokens. Each trace also tracks up to 1000 unique values. Once that cap is reached, already-tracked values keep their tokens and new values are redacted with `redactionToken`.
+
+Non-string values are converted to strings before a token is assigned.
 
 ## Field matching
 
@@ -202,7 +226,7 @@ Returns: `AnySpan`
 
 #### `shutdown()`
 
-Completes processor shutdown. The current processor has no resources or state to clean up.
+Completes processor shutdown and clears the per-trace state used by indexed redaction.
 
 ```typescript
 await filter.shutdown()

--- a/observability/mastra/src/config.test.ts
+++ b/observability/mastra/src/config.test.ts
@@ -198,6 +198,22 @@ describe('Observability Config Validation', () => {
       }).not.toThrow();
     });
 
+    it('should accept indexed redactionStyle', () => {
+      expect(() => {
+        new Observability({
+          configs: {
+            myTracing: {
+              serviceName: 'my-service',
+              exporters: [new TestExporter()],
+            },
+          },
+          sensitiveDataFilter: {
+            redactionStyle: 'indexed',
+          },
+        });
+      }).not.toThrow();
+    });
+
     it('should reject invalid sensitiveDataFilter value', () => {
       try {
         new Observability({

--- a/observability/mastra/src/config.ts
+++ b/observability/mastra/src/config.ts
@@ -291,7 +291,7 @@ const sensitiveDataFilterOptionsSchema = z
   .object({
     sensitiveFields: z.array(z.string()).optional(),
     redactionToken: z.string().optional(),
-    redactionStyle: z.enum(['full', 'partial']).optional(),
+    redactionStyle: z.enum(['full', 'partial', 'indexed']).optional(),
   })
   .strict();
 

--- a/observability/mastra/src/span_processors/sensitive-data-filter.ts
+++ b/observability/mastra/src/span_processors/sensitive-data-filter.ts
@@ -1,6 +1,21 @@
 import type { SpanOutputProcessor, AnySpan } from '@mastra/core/observability';
 
-export type RedactionStyle = 'full' | 'partial';
+export type RedactionStyle = 'full' | 'partial' | 'indexed';
+
+/**
+ * Per-trace state for indexed redaction: maps raw values to their assigned
+ * tokens and tracks the next index per token label.
+ */
+interface IndexedRedactionState {
+  tokensByValue: Map<string, string>;
+  counters: Map<string, number>;
+}
+
+/**
+ * Maximum number of traces to keep indexed-redaction state for.
+ * Spans never signal trace completion, so state is evicted least-recently-used.
+ */
+const MAX_TRACKED_TRACES = 1000;
 
 /**
  * Options for configuring the SensitiveDataFilter.
@@ -25,6 +40,10 @@ export interface SensitiveDataFilterOptions {
    * Style of redaction to use:
    * - "full": always replace with redactionToken.
    * - "partial": show 3 characters from the start and end, redact the middle.
+   * - "indexed": replace each unique value with a stable token derived from the
+   *   matched field name, e.g. `[APIKEY_1]`. The same value maps to the same
+   *   token across all spans of a trace, so redacted values stay correlatable
+   *   without exposing the raw value. Mapping is scoped per trace.
    *
    * Default: "full"
    */
@@ -37,8 +56,10 @@ export interface SensitiveDataFilterOptions {
  * An SpanOutputProcessor that redacts sensitive information from span fields.
  *
  * - Sensitive keys are matched case-insensitively, normalized to remove separators.
- * - Sensitive values are redacted using either full or partial redaction.
+ * - Sensitive values are redacted using full, partial, or indexed redaction.
  * - Partial redaction always keeps 3 chars at the start and end.
+ * - Indexed redaction assigns each unique value a stable `[LABEL_N]` token,
+ *   consistent across all spans of a trace.
  * - JSON strings containing sensitive fields are parsed and redacted.
  * - If filtering a field fails, the field is replaced with:
  *   `{ error: { processor: "sensitive-data-filter" } }`
@@ -48,6 +69,7 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
   private sensitiveFields: string[];
   private redactionToken: string;
   private redactionStyle: RedactionStyle;
+  private traceStates = new Map<string, IndexedRedactionState>();
 
   constructor(options: SensitiveDataFilterOptions = {}) {
     this.sensitiveFields = (
@@ -82,12 +104,34 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
    * @returns A new span with sensitive values redacted
    */
   process(span: AnySpan): AnySpan {
-    span.attributes = this.tryFilter(span.attributes);
-    span.metadata = this.tryFilter(span.metadata);
-    span.input = this.tryFilter(span.input);
-    span.output = this.tryFilter(span.output);
-    span.errorInfo = this.tryFilter(span.errorInfo);
+    const indexedState = this.redactionStyle === 'indexed' ? this.getTraceState(span.traceId) : undefined;
+    span.attributes = this.tryFilter(span.attributes, indexedState);
+    span.metadata = this.tryFilter(span.metadata, indexedState);
+    span.input = this.tryFilter(span.input, indexedState);
+    span.output = this.tryFilter(span.output, indexedState);
+    span.errorInfo = this.tryFilter(span.errorInfo, indexedState);
     return span;
+  }
+
+  /**
+   * Get (or create) the indexed-redaction state for a trace.
+   * Uses the Map's insertion order as an LRU: accessed traces are re-inserted,
+   * and the least recently used trace is evicted once the cap is exceeded.
+   */
+  private getTraceState(traceId: string): IndexedRedactionState {
+    let state = this.traceStates.get(traceId);
+    if (state) {
+      this.traceStates.delete(traceId);
+    } else {
+      state = { tokensByValue: new Map(), counters: new Map() };
+    }
+    this.traceStates.set(traceId, state);
+    while (this.traceStates.size > MAX_TRACKED_TRACES) {
+      const oldest = this.traceStates.keys().next().value;
+      if (oldest === undefined) break;
+      this.traceStates.delete(oldest);
+    }
+    return state;
   }
 
   /**
@@ -95,14 +139,14 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
    * Handles circular references by replacing with a marker.
    * Also attempts to parse and redact JSON strings.
    */
-  private deepFilter(obj: any, seen = new WeakSet()): any {
+  private deepFilter(obj: any, seen = new WeakSet(), indexedState?: IndexedRedactionState): any {
     if (obj === null || typeof obj !== 'object') {
       // Handle string values - check if they contain JSON that needs redacting
       if (typeof obj === 'string') {
         // Quick check - JSON objects/arrays start with { or [
         const trimmed = obj.trim();
         if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-          return this.redactJsonString(obj);
+          return this.redactJsonString(obj, indexedState);
         }
       }
       return obj;
@@ -120,7 +164,7 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
     }
 
     if (Array.isArray(obj)) {
-      return obj.map(item => this.deepFilter(item, seen));
+      return obj.map(item => this.deepFilter(item, seen, indexedState));
     }
 
     const filtered: any = {};
@@ -129,21 +173,21 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
 
       if (this.isSensitive(normKey)) {
         if (obj[key] && typeof obj[key] === 'object') {
-          filtered[key] = this.deepFilter(obj[key], seen);
+          filtered[key] = this.deepFilter(obj[key], seen, indexedState);
         } else {
-          filtered[key] = this.redactValue(obj[key]);
+          filtered[key] = this.redactValue(obj[key], normKey, indexedState);
         }
       } else {
-        filtered[key] = this.deepFilter(obj[key], seen);
+        filtered[key] = this.deepFilter(obj[key], seen, indexedState);
       }
     }
 
     return filtered;
   }
 
-  private tryFilter(value: any): any {
+  private tryFilter(value: any, indexedState?: IndexedRedactionState): any {
     try {
-      return this.deepFilter(value);
+      return this.deepFilter(value, new WeakSet(), indexedState);
     } catch {
       return { error: { processor: this.name } };
     }
@@ -177,14 +221,14 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
    * Attempt to parse a string as JSON and redact sensitive fields within it.
    * If parsing fails or no sensitive data is found, returns the original string.
    */
-  private redactJsonString(str: string): string {
+  private redactJsonString(str: string, indexedState?: IndexedRedactionState): string {
     try {
       // Try to parse as JSON
       const parsed = JSON.parse(str);
 
       // If it's an object, filter it and serialize back
       if (parsed && typeof parsed === 'object') {
-        const filtered = this.deepFilter(parsed, new WeakSet());
+        const filtered = this.deepFilter(parsed, new WeakSet(), indexedState);
         return JSON.stringify(filtered);
       }
 
@@ -200,23 +244,40 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
    * Redact a sensitive value.
    * - Full style: replaces with a fixed token.
    * - Partial style: shows 3 chars at start and end, hides the middle.
+   * - Indexed style: replaces with a stable `[LABEL_N]` token, where the label
+   *   comes from the normalized field name and the same value always maps to
+   *   the same token within a trace.
    *
-   * Non-string values are converted to strings before partial redaction.
+   * Non-string values are converted to strings before partial or indexed redaction.
    */
-  private redactValue(value: any): string {
-    if (this.redactionStyle === 'full') {
-      return this.redactionToken;
+  private redactValue(value: any, normKey: string, indexedState?: IndexedRedactionState): string {
+    if (this.redactionStyle === 'partial') {
+      const str = String(value);
+      const len = str.length;
+      if (len <= 6) {
+        return this.redactionToken; // too short, redact fully
+      }
+      return str.slice(0, 3) + '…' + str.slice(len - 3);
     }
 
-    const str = String(value);
-    const len = str.length;
-    if (len <= 6) {
-      return this.redactionToken; // too short, redact fully
+    if (this.redactionStyle === 'indexed' && indexedState) {
+      const valueKey = String(value);
+      const existing = indexedState.tokensByValue.get(valueKey);
+      if (existing) {
+        return existing;
+      }
+      const label = normKey.toUpperCase();
+      const count = (indexedState.counters.get(label) ?? 0) + 1;
+      indexedState.counters.set(label, count);
+      const token = `[${label}_${count}]`;
+      indexedState.tokensByValue.set(valueKey, token);
+      return token;
     }
-    return str.slice(0, 3) + '…' + str.slice(len - 3);
+
+    return this.redactionToken;
   }
 
   async shutdown(): Promise<void> {
-    // No cleanup needed
+    this.traceStates.clear();
   }
 }

--- a/observability/mastra/src/span_processors/sensitive-data-filter.ts
+++ b/observability/mastra/src/span_processors/sensitive-data-filter.ts
@@ -1,10 +1,13 @@
+import { createHash } from 'node:crypto';
 import type { SpanOutputProcessor, AnySpan } from '@mastra/core/observability';
 
 export type RedactionStyle = 'full' | 'partial' | 'indexed';
 
 /**
- * Per-trace state for indexed redaction: maps raw values to their assigned
- * tokens and tracks the next index per token label.
+ * Per-trace state for indexed redaction: maps SHA-256 digests of values to
+ * their assigned tokens and tracks the next index per token label.
+ * Keying on fixed-length digests keeps state size bounded and avoids
+ * retaining raw sensitive values in memory.
  */
 interface IndexedRedactionState {
   tokensByValue: Map<string, string>;
@@ -271,7 +274,7 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
     }
 
     if (this.redactionStyle === 'indexed' && indexedState) {
-      const valueKey = String(value);
+      const valueKey = createHash('sha256').update(String(value)).digest('hex');
       const existing = indexedState.tokensByValue.get(valueKey);
       if (existing) {
         return existing;

--- a/observability/mastra/src/span_processors/sensitive-data-filter.ts
+++ b/observability/mastra/src/span_processors/sensitive-data-filter.ts
@@ -18,6 +18,13 @@ interface IndexedRedactionState {
 const MAX_TRACKED_TRACES = 1000;
 
 /**
+ * Maximum number of unique values tracked per trace for indexed redaction.
+ * Once reached, new values fall back to the full redaction token while
+ * already-tracked values keep their assigned tokens.
+ */
+const MAX_TRACKED_VALUES_PER_TRACE = 1000;
+
+/**
  * Options for configuring the SensitiveDataFilter.
  */
 export interface SensitiveDataFilterOptions {
@@ -42,8 +49,11 @@ export interface SensitiveDataFilterOptions {
    * - "partial": show 3 characters from the start and end, redact the middle.
    * - "indexed": replace each unique value with a stable token derived from the
    *   matched field name, e.g. `[APIKEY_1]`. The same value maps to the same
-   *   token across all spans of a trace, so redacted values stay correlatable
-   *   without exposing the raw value. Mapping is scoped per trace.
+   *   token across the spans of a trace while the trace's mapping is retained,
+   *   so redacted values stay correlatable without exposing the raw value.
+   *   Mapping is scoped per trace and bounded: state is kept for the 1000 most
+   *   recently used traces, and each trace tracks up to 1000 unique values
+   *   (further new values fall back to the full redaction token).
    *
    * Default: "full"
    */
@@ -265,6 +275,9 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
       const existing = indexedState.tokensByValue.get(valueKey);
       if (existing) {
         return existing;
+      }
+      if (indexedState.tokensByValue.size >= MAX_TRACKED_VALUES_PER_TRACE) {
+        return this.redactionToken;
       }
       const label = normKey.toUpperCase();
       const count = (indexedState.counters.get(label) ?? 0) + 1;

--- a/observability/mastra/src/span_processors/senstive-data-filter.test.ts
+++ b/observability/mastra/src/span_processors/senstive-data-filter.test.ts
@@ -562,20 +562,46 @@ describe('Tracing', () => {
         expect(attributes.backup.ssn).toBe('[SSN_1]');
       });
 
-      it('should evict least recently used trace state once the cap is exceeded', () => {
+      it('should evict the least recently used trace state once the cap is exceeded', () => {
         const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
 
-        processor.process(makeSpan('trace-evicted', { attributes: { apiKey: 'sk-first' } }));
+        processor.process(makeSpan('trace-refreshed', { attributes: { apiKey: 'sk-refreshed-1' } }));
+        processor.process(makeSpan('trace-evicted', { attributes: { apiKey: 'sk-evicted-1' } }));
 
-        // Flood past the 1000-trace cap so 'trace-evicted' is dropped
-        for (let i = 0; i < 1000; i++) {
+        // Fill the cache to exactly the 1000-trace cap
+        for (let i = 0; i < 998; i++) {
           processor.process(makeSpan(`trace-flood-${i}`, { attributes: { apiKey: `sk-flood-${i}` } }));
         }
 
-        const revisited = processor.process(makeSpan('trace-evicted', { attributes: { apiKey: 'sk-second' } }))!;
+        // Refresh the oldest trace so LRU order differs from insertion (FIFO) order
+        processor.process(makeSpan('trace-refreshed', { attributes: { apiKey: 'sk-refreshed-2' } }));
 
-        // Fresh state: a new value starts back at _1 instead of continuing at _2
-        expect((revisited.attributes as any).apiKey).toBe('[APIKEY_1]');
+        // One more distinct trace pushes past the cap, evicting 'trace-evicted'
+        processor.process(makeSpan('trace-extra', { attributes: { apiKey: 'sk-extra' } }));
+
+        // Evicted trace starts a fresh mapping: a new value restarts at _1
+        const evicted = processor.process(makeSpan('trace-evicted', { attributes: { apiKey: 'sk-evicted-2' } }))!;
+        expect((evicted.attributes as any).apiKey).toBe('[APIKEY_1]');
+
+        // Refreshed trace kept its state: a third value continues at _3
+        const refreshed = processor.process(makeSpan('trace-refreshed', { attributes: { apiKey: 'sk-refreshed-3' } }))!;
+        expect((refreshed.attributes as any).apiKey).toBe('[APIKEY_3]');
+      });
+
+      it('should fall back to the full redaction token once the per-trace value cap is reached', () => {
+        const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
+
+        // Fill one trace to exactly the 1000-value cap
+        for (let i = 0; i < 1000; i++) {
+          processor.process(makeSpan('trace-1', { attributes: { apiKey: `sk-${i}` } }));
+        }
+
+        const span = processor.process(makeSpan('trace-1', { attributes: { apiKey: 'sk-overflow', secret: 'sk-0' } }))!;
+
+        // New value beyond the cap falls back to the full token
+        expect((span.attributes as any).apiKey).toBe('[REDACTED]');
+        // Already-tracked values keep their assigned tokens
+        expect((span.attributes as any).secret).toBe('[APIKEY_1]');
       });
     });
 

--- a/observability/mastra/src/span_processors/senstive-data-filter.test.ts
+++ b/observability/mastra/src/span_processors/senstive-data-filter.test.ts
@@ -588,6 +588,29 @@ describe('Tracing', () => {
         expect((refreshed.attributes as any).apiKey).toBe('[APIKEY_3]');
       });
 
+      it('should tokenize oversized values without retaining them in state', () => {
+        const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
+
+        const bigValueA = 'a'.repeat(1024 * 1024);
+        const bigValueB = 'b'.repeat(1024 * 1024);
+
+        const first = processor.process(makeSpan('trace-1', { attributes: { apiKey: bigValueA } }))!;
+        const second = processor.process(
+          makeSpan('trace-1', { attributes: { apiKey: bigValueB, secret: bigValueA } }),
+        )!;
+
+        // Distinct oversized values get distinct tokens; repeats reuse the token
+        expect((first.attributes as any).apiKey).toBe('[APIKEY_1]');
+        expect((second.attributes as any).apiKey).toBe('[APIKEY_2]');
+        expect((second.attributes as any).secret).toBe('[APIKEY_1]');
+
+        // State keys are fixed-length digests, not the raw values
+        const state = (processor as any).traceStates.get('trace-1');
+        for (const key of state.tokensByValue.keys()) {
+          expect(key).toHaveLength(64);
+        }
+      });
+
       it('should fall back to the full redaction token once the per-trace value cap is reached', () => {
         const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
 

--- a/observability/mastra/src/span_processors/senstive-data-filter.test.ts
+++ b/observability/mastra/src/span_processors/senstive-data-filter.test.ts
@@ -446,6 +446,139 @@ describe('Tracing', () => {
       });
     });
 
+    describe('indexed redaction style', () => {
+      const makeSpan = (traceId: string, fields: { attributes?: any; input?: any }) =>
+        ({
+          id: `span-${traceId}`,
+          name: 'test-span',
+          type: SpanType.AGENT_RUN,
+          startTime: new Date(),
+          traceId,
+          trace: { traceId } as any,
+          attributes: fields.attributes ?? {},
+          input: fields.input,
+          observabilityInstance: {} as any,
+          end: () => {},
+          error: () => {},
+          update: () => {},
+          createChildSpan: () => ({}) as any,
+        }) as any;
+
+      it('should assign stable indexed tokens per unique value', () => {
+        const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
+
+        const span = makeSpan('trace-1', {
+          attributes: {
+            apiKey: 'sk-first',
+            config: { apiKey: 'sk-first', backupKey: 'unrelated' },
+            fallback: { api_key: 'sk-second' },
+          },
+        });
+
+        const attributes = processor.process(span)!.attributes as any;
+
+        // Same value gets the same token, distinct values get distinct indexes
+        expect(attributes.apiKey).toBe('[APIKEY_1]');
+        expect(attributes.config.apiKey).toBe('[APIKEY_1]');
+        expect(attributes.fallback.api_key).toBe('[APIKEY_2]');
+
+        // Non-sensitive fields are untouched
+        expect(attributes.config.backupKey).toBe('unrelated');
+      });
+
+      it('should reuse the token when the same value appears under different field names', () => {
+        const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
+
+        const span = makeSpan('trace-1', {
+          attributes: {
+            token: 'shared-secret',
+            authorization: 'shared-secret',
+            password: 'other-secret',
+          },
+        });
+
+        const attributes = processor.process(span)!.attributes as any;
+
+        // First-seen field name determines the label
+        expect(attributes.token).toBe('[TOKEN_1]');
+        expect(attributes.authorization).toBe('[TOKEN_1]');
+        expect(attributes.password).toBe('[PASSWORD_1]');
+      });
+
+      it('should keep tokens consistent across spans of the same trace', () => {
+        const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
+
+        const first = processor.process(makeSpan('trace-1', { attributes: { apiKey: 'sk-first' } }))!;
+        const second = processor.process(
+          makeSpan('trace-1', { attributes: { apiKey: 'sk-first', secret: 'sk-second' } }),
+        )!;
+
+        expect((first.attributes as any).apiKey).toBe('[APIKEY_1]');
+        expect((second.attributes as any).apiKey).toBe('[APIKEY_1]');
+        expect((second.attributes as any).secret).toBe('[SECRET_1]');
+      });
+
+      it('should number tokens independently per trace', () => {
+        const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
+
+        const traceA = processor.process(makeSpan('trace-a', { attributes: { apiKey: 'sk-a' } }))!;
+        const traceB = processor.process(makeSpan('trace-b', { attributes: { apiKey: 'sk-b' } }))!;
+
+        // Different values in different traces both start at _1
+        expect((traceA.attributes as any).apiKey).toBe('[APIKEY_1]');
+        expect((traceB.attributes as any).apiKey).toBe('[APIKEY_1]');
+      });
+
+      it('should redact JSON strings with indexed tokens', () => {
+        const processor = new SensitiveDataFilter({ redactionStyle: 'indexed', sensitiveFields: ['email'] });
+
+        const span = makeSpan('trace-1', {
+          input: {
+            messages: [
+              { role: 'tool', content: JSON.stringify({ email: 'john@email.com', id: '32ddf' }) },
+              { role: 'tool', content: JSON.stringify({ email: 'john@email.com' }) },
+              { role: 'tool', content: JSON.stringify({ email: 'jane@email.com' }) },
+            ],
+          },
+        });
+
+        const input = processor.process(span)!.input as any;
+
+        expect(JSON.parse(input.messages[0].content)).toEqual({ email: '[EMAIL_1]', id: '32ddf' });
+        expect(JSON.parse(input.messages[1].content)).toEqual({ email: '[EMAIL_1]' });
+        expect(JSON.parse(input.messages[2].content)).toEqual({ email: '[EMAIL_2]' });
+      });
+
+      it('should redact non-string values with indexed tokens', () => {
+        const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
+
+        const span = makeSpan('trace-1', {
+          attributes: { ssn: 123456789, backup: { ssn: 123456789 } },
+        });
+
+        const attributes = processor.process(span)!.attributes as any;
+
+        expect(attributes.ssn).toBe('[SSN_1]');
+        expect(attributes.backup.ssn).toBe('[SSN_1]');
+      });
+
+      it('should evict least recently used trace state once the cap is exceeded', () => {
+        const processor = new SensitiveDataFilter({ redactionStyle: 'indexed' });
+
+        processor.process(makeSpan('trace-evicted', { attributes: { apiKey: 'sk-first' } }));
+
+        // Flood past the 1000-trace cap so 'trace-evicted' is dropped
+        for (let i = 0; i < 1000; i++) {
+          processor.process(makeSpan(`trace-flood-${i}`, { attributes: { apiKey: `sk-flood-${i}` } }));
+        }
+
+        const revisited = processor.process(makeSpan('trace-evicted', { attributes: { apiKey: 'sk-second' } }))!;
+
+        // Fresh state: a new value starts back at _1 instead of continuing at _2
+        expect((revisited.attributes as any).apiKey).toBe('[APIKEY_1]');
+      });
+    });
+
     describe('as part of the default config', () => {
       it('should automatically filter sensitive data in default tracing', () => {
         const tracing = new DefaultObservabilityInstance({


### PR DESCRIPTION
## Description

`SensitiveDataFilter`'s `full` redaction collapses every sensitive value to the identical `[REDACTED]` string, so redacted traces lose the relationships between values — you can't tell whether two redacted fields held the same secret, or correlate a value across steps of a trace. This adds an `indexed` redaction style that replaces each unique value with a stable token derived from the matched field name (e.g. `[APIKEY_1]`), so redacted traces keep their referential structure (traces → datasets → evals) without exposing raw values.

- New `redactionStyle: 'indexed'`: the same raw value maps to the same token across all spans of a trace (including values redacted inside JSON-string content); distinct values get distinct indexes per label
- Mapping scope is per trace: numbering restarts each trace so tokens can't be linked across traces; state is LRU-evicted beyond the 1000 most recently seen traces (span processors get no end-of-trace signal) and `shutdown()` clears it
- The auto-applied filter's config schema now accepts `'indexed'` (`observability/mastra/src/config.ts`)
- Verified end-to-end with a real OpenAI agent run whose tool returns per-user secrets: the two users' credentials export as `[APIKEY_1]`/`[APIKEY_2]` consistently across span events, vs. all-identical `[REDACTED]` before
- Incidental hardening: an unrecognized `redactionStyle` now falls back to full redaction instead of partial (which leaked the first/last 3 characters)
- Docs updated (processor doc + API reference) and a minor changeset added

## Related Issue(s)

Fixes #21313

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR replaces sensitive values with consistent labels within each trace. The labels preserve relationships between repeated values without exposing the original data.

## Changes

- Added the `indexed` `SensitiveDataFilter` redaction style.
- Generates field-based tokens such as `[APIKEY_1]`.
- Reuses tokens for identical values across spans and JSON content.
- Fully removes raw values from output.
- Resets mappings for each trace.
- Limits state to 1,000 traces with LRU eviction.
- Limits each trace to 1,000 unique values.
- Falls back to `[REDACTED]` when the per-trace limit is reached.
- Falls back to full redaction for unrecognized styles.
- Clears indexed state during `shutdown()`.
- Updated configuration validation, documentation, tests, and changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->