### PR TITLE
feat(core): expose channel signal metadata

### DIFF
--- a/.changeset/new-ants-chew.md
+++ b/.changeset/new-ants-chew.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Expose per-message signal metadata to channel handlers so structured context follows both wake and active delivery paths.

--- a/.changeset/new-ants-chew.md
+++ b/.changeset/new-ants-chew.md
@@ -1,5 +1,14 @@
 ---
-'@mastra/core': patch
+'@mastra/core': minor
 ---
 
-Expose per-message signal metadata to channel handlers so structured context follows both wake and active delivery paths.
+Added per-message Signal metadata to Channel handlers. Use `ctx.signalMetadata` to attach serializable, non-sensitive context that follows both idle and active message delivery:
+
+```typescript
+handlers: {
+  onDirectMessage: async (thread, message, defaultHandler, ctx) => {
+    ctx.signalMetadata.attachmentIds = ['file-1']
+    await defaultHandler(thread, message)
+  },
+}
+```

--- a/docs/src/content/en/docs/capabilities/channels.mdx
+++ b/docs/src/content/en/docs/capabilities/channels.mdx
@@ -175,6 +175,39 @@ In group conversations, Mastra prefixes each message with the sender's name and 
 [Bob (@U456DEF)]: I have a question too.
 ```
 
+## Per-message Signal metadata
+
+Use `signalMetadata` in a custom Channel handler to attach structured context to one inbound message. The metadata follows the message when it starts an idle run or joins an active run.
+
+The following example attaches registered file IDs before calling the default handler:
+
+```typescript title="src/mastra/agents/your-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { createSlackAdapter } from '@chat-adapter/slack'
+
+export const yourAgent = new Agent({
+  id: 'your-agent',
+  name: 'Your Agent',
+  instructions: 'You are a helpful assistant.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  channels: {
+    adapters: {
+      slack: createSlackAdapter(),
+    },
+    handlers: {
+      onDirectMessage: async (thread, message, defaultHandler, ctx) => {
+        ctx.signalMetadata.attachmentIds = ['file-1']
+        await defaultHandler(thread, message)
+      },
+    },
+  },
+})
+```
+
+Add only JSON-serializable, non-sensitive values. Signal metadata may be stored in memory or sent through a shared publish-subscribe transport. It isn't added to the model prompt.
+
+Use `requestContext` for run-scoped configuration, such as credentials for a message that starts a run. Use `signalMetadata` for context that must stay attached to one message, including messages delivered to an active run.
+
 ## Multimodal content
 
 Models like Gemini can process images, video, and audio natively. Combine `inlineMedia` and `inlineLinks` to let users share rich content with your agent across platforms:

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -2861,6 +2861,7 @@ describe('Agent signals', () => {
     });
     let streamCount = 0;
     const prompts: any[][] = [];
+    const handledSignalMetadata: unknown[] = [];
     const model = new MockLanguageModelV2({
       doStream: async ({ prompt }) => {
         streamCount += 1;
@@ -2895,7 +2896,24 @@ describe('Agent signals', () => {
         };
       },
     });
-    const agent = new Agent({ id: 'active-message-agent', name: 'Active Message Agent', instructions: 'Test', model });
+    const agent = new Agent({
+      id: 'active-message-agent',
+      name: 'Active Message Agent',
+      instructions: 'Test',
+      model,
+      inputProcessors: [
+        {
+          id: 'capture-active-message-metadata',
+          processInputStep: ({ messageList }) => {
+            for (const message of messageList.get.input.db()) {
+              if (message.role !== 'signal') continue;
+              const signal = message.content.metadata?.signal as Record<string, unknown> | undefined;
+              if (signal?.metadata !== undefined) handledSignalMetadata.push(signal.metadata);
+            }
+          },
+        },
+      ],
+    });
     const subscription = await agent.subscribeToThread({
       threadId: 'active-message-thread',
       resourceId: 'active-message-user',
@@ -2905,16 +2923,23 @@ describe('Agent signals', () => {
       memory: { thread: 'active-message-thread', resource: 'active-message-user' },
     });
     await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
-    const result = agent.sendMessage('Hello while active', {
-      resourceId: 'active-message-user',
-      threadId: 'active-message-thread',
-    });
+    const result = agent.sendMessage(
+      {
+        contents: 'Hello while active',
+        metadata: { channel: { attachmentId: 'file-1' } },
+      },
+      {
+        resourceId: 'active-message-user',
+        threadId: 'active-message-thread',
+      },
+    );
 
     await expect(result.accepted).resolves.toMatchObject({ action: 'deliver', runId: stream.runId });
     releaseFirst();
     await expect(stream.text).resolves.toBe('first responsemessage response');
     expect(streamCount).toBe(2);
     expect(JSON.stringify(prompts[1])).toContain('Hello while active');
+    expect(handledSignalMetadata).toContainEqual({ channel: { attachmentId: 'file-1' } });
 
     subscription.unsubscribe();
   });
@@ -4413,13 +4438,22 @@ describe('Agent signals', () => {
 
     const result = senderRuntime.sendSignal(
       sender,
-      { type: 'user-message', contents: 'remote follow-up' },
+      {
+        type: 'user-message',
+        contents: 'remote follow-up',
+        metadata: { channel: { attachmentId: 'file-remote' } },
+      },
       { resourceId: 'remote-resource', threadId: 'remote-thread' },
       pubsub,
     );
 
     await expect(result.accepted).resolves.toMatchObject({ action: 'deliver' });
-    await waitForCondition(() => ownerRuntime.drainPendingSignals('remote-run-1', pubsub).length === 1);
+    let deliveredSignals: ReturnType<typeof ownerRuntime.drainPendingSignals> = [];
+    await waitForCondition(() => {
+      deliveredSignals = ownerRuntime.drainPendingSignals('remote-run-1', pubsub);
+      return deliveredSignals.length === 1;
+    });
+    expect(deliveredSignals[0]?.metadata).toEqual({ channel: { attachmentId: 'file-remote' } });
 
     finishRun();
     await waitForRemoteRun;

--- a/packages/core/src/channels/__tests__/agent-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-channels.test.ts
@@ -1079,10 +1079,14 @@ describe('AgentChannels', () => {
       await registeredDMWrapper!(chatThread, message);
 
       expect(onDirectMessage).toHaveBeenCalledTimes(1);
-      // 4th arg is the handler context carrying the resolved Mastra instance
-      // and the request context for the run this message will start.
+      // 4th arg is the per-message handler context carrying the resolved
+      // Mastra instance plus run-level and Signal-level context.
       const ctx = onDirectMessage.mock.calls[0]![3];
-      expect(ctx).toEqual({ mastra: mockMastra, requestContext: expect.any(RequestContext) });
+      expect(ctx).toEqual({
+        mastra: mockMastra,
+        requestContext: expect.any(RequestContext),
+        signalMetadata: {},
+      });
 
       spy.mockRestore();
     });
@@ -1149,7 +1153,41 @@ describe('AgentChannels', () => {
       spy.mockRestore();
     });
 
-    it('does not leak one message request context into the next', async () => {
+    it('carries handler signal metadata through an active delivery', async () => {
+      const chatMod = await getChatModule();
+      let registeredDMWrapper: ((thread: any, message: any) => unknown) | undefined;
+      const spy = vi.spyOn(chatMod.Chat.prototype as any, 'onDirectMessage').mockImplementation((handler: any) => {
+        registeredDMWrapper = handler;
+      });
+
+      const onDirectMessage = vi.fn(async (thread: any, msg: any, defaultHandler: any, ctx: any) => {
+        ctx.signalMetadata.attachments = [{ id: 'file-1', mediaType: 'application/pdf' }];
+        await defaultHandler(thread, msg);
+      });
+
+      const channels = new AgentChannels({
+        adapters: { discord: createMockAdapter('discord') },
+        handlers: { onDirectMessage },
+      });
+      channels.__setAgent(mockAgent);
+      await channels.initialize(makeMastra());
+
+      const chatThread = makeChatThread({ adapter: channels.adapters.discord });
+      await registeredDMWrapper!(chatThread, message);
+
+      expect(mockAgent.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: {
+            attachments: [{ id: 'file-1', mediaType: 'application/pdf' }],
+          },
+        }),
+        expect.anything(),
+      );
+
+      spy.mockRestore();
+    });
+
+    it('does not leak one message handler context into the next', async () => {
       const chatMod = await getChatModule();
       let registeredDMWrapper: ((thread: any, message: any) => unknown) | undefined;
       const spy = vi.spyOn(chatMod.Chat.prototype as any, 'onDirectMessage').mockImplementation((handler: any) => {
@@ -1157,11 +1195,14 @@ describe('AgentChannels', () => {
       });
 
       const seen: (unknown | undefined)[] = [];
+      const seenSignalMetadata: (unknown | undefined)[] = [];
       const onDirectMessage = vi.fn(async (_thread: any, _msg: any, _defaultHandler: any, ctx: any) => {
         // Record what this message's context already carried on arrival, then
         // write a marker that must not survive into the next message.
         seen.push(ctx.requestContext.get('leak-marker'));
         ctx.requestContext.set('leak-marker', 'from-first-message');
+        seenSignalMetadata.push(ctx.signalMetadata['leak-marker']);
+        ctx.signalMetadata['leak-marker'] = 'from-first-message';
       });
 
       const channels = new AgentChannels({
@@ -1181,10 +1222,18 @@ describe('AgentChannels', () => {
       expect(seen[0]).toBeUndefined();
       // The second message must start clean — a shared context would carry the marker.
       expect(seen[1]).toBeUndefined();
+      expect(seenSignalMetadata).toEqual([undefined, undefined]);
 
-      const first = onDirectMessage.mock.calls[0]![3] as { requestContext: RequestContext };
-      const second = onDirectMessage.mock.calls[1]![3] as { requestContext: RequestContext };
+      const first = onDirectMessage.mock.calls[0]![3] as {
+        requestContext: RequestContext;
+        signalMetadata: Record<string, unknown>;
+      };
+      const second = onDirectMessage.mock.calls[1]![3] as {
+        requestContext: RequestContext;
+        signalMetadata: Record<string, unknown>;
+      };
       expect(first.requestContext).not.toBe(second.requestContext);
+      expect(first.signalMetadata).not.toBe(second.signalMetadata);
 
       spy.mockRestore();
     });

--- a/packages/core/src/channels/__tests__/agent-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-channels.test.ts
@@ -1153,7 +1153,7 @@ describe('AgentChannels', () => {
       spy.mockRestore();
     });
 
-    it('carries handler signal metadata through an active delivery', async () => {
+    it('forwards handler signal metadata to sendMessage', async () => {
       const chatMod = await getChatModule();
       let registeredDMWrapper: ((thread: any, message: any) => unknown) | undefined;
       const spy = vi.spyOn(chatMod.Chat.prototype as any, 'onDirectMessage').mockImplementation((handler: any) => {

--- a/packages/core/src/channels/__tests__/agent-controller-channels-tenant-context.test.ts
+++ b/packages/core/src/channels/__tests__/agent-controller-channels-tenant-context.test.ts
@@ -124,6 +124,7 @@ describe('AgentControllerChannels tenant context', () => {
     // host resolves the sender itself and writes the tenant before deferring.
     const onDirectMessage: ChannelHandler = async (thread, message, defaultHandler, ctx) => {
       ctx.requestContext.set('user', { id: 'tenant-user-9', organizationId: 'org-9' });
+      ctx.signalMetadata.attachments = [{ id: 'file-1', mediaType: 'application/pdf' }];
       await defaultHandler(thread, message);
     };
 
@@ -131,15 +132,17 @@ describe('AgentControllerChannels tenant context', () => {
     const chatThread = createSlackChatThread(adapter, 'C-1:t-1');
 
     let signalUser: unknown;
+    let signalMetadata: unknown;
     let createSessionUser: unknown;
     const createSession = controller.createSession.bind(controller);
     vi.spyOn(controller, 'createSession').mockImplementation(async (opts: any) => {
       createSessionUser = opts?.requestContext?.get('user');
       const session = await createSession(opts);
       const sendSignal = session.sendSignal.bind(session);
-      vi.spyOn(session, 'sendSignal').mockImplementation((signalArgs: any) => {
-        signalUser = signalArgs.requestContext?.get('user');
-        return sendSignal(signalArgs);
+      vi.spyOn(session, 'sendSignal').mockImplementation((signalArgs: any, signalOptions: any) => {
+        signalUser = signalOptions?.requestContext?.get('user');
+        signalMetadata = signalArgs.metadata;
+        return sendSignal(signalArgs, signalOptions);
       });
       return session;
     });
@@ -150,6 +153,9 @@ describe('AgentControllerChannels tenant context', () => {
     // The tenant reached the run's requestContext as `user` — the single seam
     // `resolveCredentialStore` reads to load the sender's model credentials.
     expect(signalUser).toEqual({ id: 'tenant-user-9', organizationId: 'org-9' });
+    expect(signalMetadata).toEqual({
+      attachments: [{ id: 'file-1', mediaType: 'application/pdf' }],
+    });
 
     // Session creation saw the same stamped context: a dynamic workspace factory
     // resolves once at creation time, and it must see the tenant or a

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -256,6 +256,7 @@ export class AgentChannels {
   protected async dispatchInboundMessage(args: {
     signalContents: AgentSignalContents;
     attributes: Record<string, string | undefined>;
+    signalMetadata: Record<string, unknown>;
     providerOptions: MastraProviderMetadata;
     requestContext: RequestContext;
     /** The mapped Mastra thread for the chat thread this message arrived on. */
@@ -264,12 +265,21 @@ export class AgentChannels {
     /** Set when the adapter can't render approval buttons, to avoid runs parking forever. */
     autoResumeSuspendedTools: true | undefined;
   }): Promise<void> {
-    const { signalContents, attributes, providerOptions, requestContext, memory, autoResumeSuspendedTools } = args;
+    const {
+      signalContents,
+      attributes,
+      signalMetadata,
+      providerOptions,
+      requestContext,
+      memory,
+      autoResumeSuspendedTools,
+    } = args;
 
     const result = this.agent.sendMessage(
       {
         contents: signalContents,
         attributes,
+        ...(Object.keys(signalMetadata).length > 0 ? { metadata: signalMetadata } : {}),
         providerOptions,
       },
       {
@@ -422,12 +432,13 @@ export class AgentChannels {
       // shared instance would leak that tenant into the next message's run.
       const beginMessage = () => {
         const requestContext = new RequestContext();
+        const signalMetadata: Record<string, unknown> = {};
         const defaultHandler = (chatThread: Thread, message: Message) =>
-          this.handleChatMessage(chatThread, message, mastra, requestContext);
+          this.handleChatMessage(chatThread, message, mastra, requestContext, signalMetadata);
         // Context handed to custom handlers so they can reach the resolved Mastra
         // instance without being injected with an external accessor, and
         // contribute to the request context the run will dispatch with.
-        const handlerContext: ChannelHandlerContext = { mastra, requestContext };
+        const handlerContext: ChannelHandlerContext = { mastra, requestContext, signalMetadata };
         return { defaultHandler, handlerContext };
       };
 
@@ -1010,9 +1021,10 @@ export class AgentChannels {
     message: Message,
     mastra: Mastra,
     requestContext: RequestContext,
+    signalMetadata: Record<string, unknown>,
   ): Promise<void> {
     try {
-      await this.processChatMessage(chatThread, message, mastra, requestContext);
+      await this.processChatMessage(chatThread, message, mastra, requestContext, signalMetadata);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       // A refused request is not a malfunction: the host decided this sender
@@ -1049,6 +1061,7 @@ export class AgentChannels {
     message: Message,
     mastra: Mastra,
     requestContext: RequestContext,
+    signalMetadata: Record<string, unknown> = {},
   ): Promise<void> {
     const platform = chatThread.adapter.name;
 
@@ -1276,6 +1289,7 @@ export class AgentChannels {
     await this.dispatchInboundMessage({
       signalContents,
       attributes,
+      signalMetadata,
       providerOptions,
       requestContext,
       thread: mastraThread,

--- a/packages/core/src/channels/agent-controller-channels.ts
+++ b/packages/core/src/channels/agent-controller-channels.ts
@@ -260,13 +260,22 @@ export class AgentControllerChannels extends AgentChannels {
   protected override async dispatchInboundMessage(args: {
     signalContents: AgentSignalContents;
     attributes: Record<string, string | undefined>;
+    signalMetadata: Record<string, unknown>;
     providerOptions: MastraProviderMetadata;
     requestContext: RequestContext;
     thread: StorageThreadType;
     memory: { thread: string; resource: string };
     autoResumeSuspendedTools: true | undefined;
   }): Promise<void> {
-    const { signalContents, attributes, providerOptions, requestContext, thread, autoResumeSuspendedTools } = args;
+    const {
+      signalContents,
+      attributes,
+      signalMetadata,
+      providerOptions,
+      requestContext,
+      thread,
+      autoResumeSuspendedTools,
+    } = args;
 
     // The tenant, when there is one, is already stamped on `requestContext` by
     // the channel handler that accepted this message — a host that maps
@@ -288,13 +297,17 @@ export class AgentControllerChannels extends AgentChannels {
       this.autoApproveResourceIds.delete(sessionResourceId);
     }
 
-    const result = session.sendSignal({
-      content: signalContents,
-      ifActive: { attributes },
-      ifIdle: { attributes },
-      requestContext,
-      providerOptions,
-    });
+    const result = session.sendSignal(
+      {
+        type: 'user',
+        tagName: 'user',
+        contents: signalContents,
+        attributes,
+        ...(Object.keys(signalMetadata).length > 0 ? { metadata: signalMetadata } : {}),
+        providerOptions,
+      },
+      { requestContext },
+    );
     await result.accepted;
   }
 

--- a/packages/core/src/channels/types.ts
+++ b/packages/core/src/channels/types.ts
@@ -348,7 +348,7 @@ export interface ChannelHandlerContext {
    * through PubSub. Unlike run-level request context, it follows the message
    * through both idle `wake` and active `deliver` paths.
    */
-  signalMetadata: Record<string, unknown>;
+  readonly signalMetadata: Record<string, unknown>;
 }
 
 /**

--- a/packages/core/src/channels/types.ts
+++ b/packages/core/src/channels/types.ts
@@ -331,15 +331,24 @@ export interface ChannelHandlerContext {
   /** The Mastra instance that owns the channels, resolved from the bound agent or controller. */
   mastra?: Mastra;
   /**
-   * The request context for the run this message will start, constructed fresh
-   * per message.
+   * The request context used when this message starts a run, constructed fresh
+   * per message. A message delivered to an already-active run does not replace
+   * that run's request context.
    *
    * A handler may write to it before calling `defaultHandler` — for example to
    * stamp the tenant a channel sender maps to, so the run resolves that user's
    * credentials. Core adds the channel and render-context entries afterward and
-   * dispatches with this same instance.
+   * uses this same instance when the Signal wakes an idle run.
    */
   requestContext: RequestContext;
+  /**
+   * Metadata attached to this message's Agent Signal, constructed fresh per
+   * message. A handler may add JSON-serializable, non-sensitive values before
+   * calling `defaultHandler`. Signal metadata may be persisted and published
+   * through PubSub. Unlike run-level request context, it follows the message
+   * through both idle `wake` and active `deliver` paths.
+   */
+  signalMetadata: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Description

Expose a fresh, message-scoped `signalMetadata` record on each `ChannelHandlerContext` and forward non-empty values through the existing Agent Signal `metadata` field.

This gives Channel integrations a supported place for JSON-serializable, non-sensitive transport context such as registered attachment references or quoted-message metadata:

- regular Agent Channels forward metadata through `agent.sendMessage()`
- Agent Controller Channels preserve the same metadata through `session.sendSignal()`
- metadata follows both idle `wake` and active `deliver` paths, including PubSub delivery
- each inbound message receives an isolated metadata record
- messages without metadata preserve the existing Agent input shape

`requestContext` remains run-scoped and is still used only when a message wakes an idle run. Signal metadata remains message-scoped, does not replace the active run's request context, and does not change Signal scheduling or concurrency semantics.

The public Channels documentation now describes the lifecycle and security boundaries. A minor changeset is included because this adds a backward-compatible public API.

## Validation

- `corepack pnpm --filter @mastra/core exec vitest run src/channels/__tests__/agent-channels.test.ts src/channels/__tests__/agent-controller-channels-tenant-context.test.ts src/agent/__tests__/agent-signals.test.ts src/agent-controller/signal-messages.test.ts` - 4 files passed, 199 tests passed, 3 skipped, 0 type errors
- `corepack pnpm --filter @mastra/core check`
- `corepack pnpm --filter @mastra/core lint`
- `corepack pnpm exec oxfmt --check ...` for all changed code and changeset files
- `corepack pnpm --dir docs exec oxfmt-mdx --check src/content/en/docs/capabilities/channels.mdx`
- `corepack pnpm --dir docs validate:frontmatter` - 609 files passed
- `corepack pnpm --dir docs validate:sidebar-new-tags`
- `corepack pnpm exec changeset status`

## Related issue(s)

Closes #21327

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Channel handlers can now attach extra information to each message. That information follows the message to the correct agent run without changing the run’s existing context or prompt.

## What changed

- Added `ChannelHandlerContext.signalMetadata`.
- Forwarded non-empty metadata through `AgentMessageInput.metadata`.
- Supported metadata for:
  - Regular Agent Channels via `agent.sendMessage()`.
  - Agent Controller Channels via `session.sendSignal()`.
  - Idle `wake` and active `deliver` flows.
  - Same-process and PubSub delivery.
- Isolated metadata between inbound messages.
- Preserved existing input shapes when messages have no metadata.
- Kept `requestContext` run-scoped and unchanged.
- Preserved Signal scheduling and concurrency behavior.
- Added documentation, tests, and a minor changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->