### PR TITLE
docs(observability): describe span parent fields by provenance, not storage

### DIFF
--- a/.changeset/ripe-bugs-drum.md
+++ b/.changeset/ripe-bugs-drum.md
@@ -2,19 +2,4 @@
 '@mastra/core': minor
 ---
 
-Fixed traces that start under an OpenTelemetry parent span not appearing in Mastra Studio, and kept resumed agent and workflow runs linked to the suspended run's trace.
-
-Tracing now distinguishes a parent Mastra created within the trace from a parent that belongs to an external tracing system (an OpenTelemetry or Datadog span your app already started). Pass an external parent through `tracingOptions.parentSpanId` as before. It correlates your Mastra trace into the external system and no longer hides the trace in Studio:
-
-```ts
-import { trace } from '@opentelemetry/api';
-
-const spanContext = trace.getActiveSpan()?.spanContext();
-
-await agent.generate('Analyze this data', {
-  tracingOptions: {
-    traceId: spanContext?.traceId,
-    parentSpanId: spanContext?.spanId,
-  },
-});
-```
+Fixed traces that start under an external parent span not appearing in Mastra Studio. Resumed agent and workflow runs keep their link to the suspended run's trace.

--- a/.changeset/ripe-bugs-drum.md
+++ b/.changeset/ripe-bugs-drum.md
@@ -1,5 +1,20 @@
 ---
-'@mastra/core': patch
+'@mastra/core': minor
 ---
 
-Fixed traces that start under an OpenTelemetry parent span not appearing in Mastra Studio. Resumed agent and workflow runs keep their link to the suspended run's trace.
+Fixed traces that start under an OpenTelemetry parent span not appearing in Mastra Studio, and kept resumed agent and workflow runs linked to the suspended run's trace.
+
+Tracing now distinguishes a parent Mastra created within the trace from a parent that belongs to an external tracing system (an OpenTelemetry or Datadog span your app already started). Pass an external parent through `tracingOptions.parentSpanId` as before. It correlates your Mastra trace into the external system and no longer hides the trace in Studio:
+
+```ts
+import { trace } from '@opentelemetry/api';
+
+const spanContext = trace.getActiveSpan()?.spanContext();
+
+await agent.generate('Analyze this data', {
+  tracingOptions: {
+    traceId: spanContext?.traceId,
+    parentSpanId: spanContext?.spanId,
+  },
+});
+```

--- a/.changeset/sweet-pots-cough.md
+++ b/.changeset/sweet-pots-cough.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/observability': patch
+'@mastra/observability': minor
 ---
 
-Fix traces created under OpenTelemetry parent spans not appearing in Mastra Studio.
+Fixed traces created under OpenTelemetry parent spans not appearing in Mastra Studio. Spans now carry a separate `externalParentSpanId` for a parent that comes from an external tracing system, so a run started under an ambient OpenTelemetry span is still recorded as a trace root.

--- a/.changeset/sweet-pots-cough.md
+++ b/.changeset/sweet-pots-cough.md
@@ -2,4 +2,4 @@
 '@mastra/observability': minor
 ---
 
-Fixed traces created under OpenTelemetry parent spans not appearing in Mastra Studio. Spans now carry a separate `externalParentSpanId` for a parent that comes from an external tracing system, so a run started under an ambient OpenTelemetry span is still recorded as a trace root.
+Fixed traces that start under an external parent span not appearing in Mastra Studio.

--- a/.changeset/two-words-clean.md
+++ b/.changeset/two-words-clean.md
@@ -3,4 +3,4 @@
 '@mastra/datadog': minor
 ---
 
-The OpenTelemetry and Datadog bridges now report whether a created span's parent is a Mastra span or belongs to the external tracing system. Custom bridges should set the new `SpanIds.externalParentSpanId` field for a parent that comes from the external tracing system, so runs started under an external parent are still recorded as trace roots.
+Bridges now report whether a created span's parent is a Mastra span or an external one, so runs that start under an external parent are recorded as trace roots in Mastra Studio.

--- a/.changeset/two-words-clean.md
+++ b/.changeset/two-words-clean.md
@@ -1,6 +1,6 @@
 ---
-'@mastra/otel-bridge': patch
-'@mastra/datadog': patch
+'@mastra/otel-bridge': minor
+'@mastra/datadog': minor
 ---
 
-The OpenTelemetry and Datadog bridges now report whether a created span's parent is a Mastra span or lives only in the external tracing system. Custom bridges should adopt the new SpanIds.externalParentSpanId field so externally parented runs keep appearing as trace roots in Mastra Studio.
+The OpenTelemetry and Datadog bridges now report whether a created span's parent is a Mastra span or belongs to the external tracing system. Custom bridges should set the new `SpanIds.externalParentSpanId` field for a parent that comes from the external tracing system, so runs started under an external parent are still recorded as trace roots.

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -268,9 +268,9 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       const parentSpanId = parentContext?.toSpanId?.(true) ?? externalParentId;
 
       // Declare which kind of parent was used. A parent resolved from the
-      // Mastra span chain exists in Mastra storage; an active dd-trace scope
+      // Mastra span chain is part of the Mastra trace; an active dd-trace scope
       // span is a Mastra span only if this bridge created it, otherwise it
-      // lives solely in Datadog (e.g. APM auto-instrumentation).
+      // belongs to Datadog (e.g. APM auto-instrumentation).
       const parentIsMastraSpan =
         parentSpanId !== undefined && (parentSource !== 'active-scope' || this.ddSpanMap.has(parentSpanId));
 

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -229,7 +229,7 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     // Extract traceId and parent ids from tracingOptions for root spans (no parent)
     // These allow nested workflows to join the parent workflow's trace.
     // tracingOptions.parentSpanId is the public external-correlation channel,
-    // so it feeds externalParentSpanId — never the stored parent.
+    // so it feeds externalParentSpanId — not Mastra's own parent link.
     const traceId = !options.parent ? (options.traceId ?? tracingOptions?.traceId) : options.traceId;
     const parentSpanId = options.parentSpanId;
     const externalParentSpanId = !options.parent

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -149,9 +149,9 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
   public entityId?: string;
   /** Entity name that created the span */
   public entityName?: string;
-  /** Parent span ID — always a Mastra span present in storage (e.g. the suspended span a resumed run links to) */
+  /** Parent span within this Mastra trace: a span Mastra created (the span-tree parent, or a prior Mastra span such as the suspended run a resume links back to) */
   protected parentSpanId?: string;
-  /** Parent span ID outside Mastra storage (ambient OTel / bridge parent); never used as the stored parent */
+  /** Parent from an external tracing system (ambient OTel / dd-trace span) that Mastra did not create; carried for external correlation, not part of Mastra's own parent/child linkage */
   protected externalParentSpanId?: string;
   /** Deep clean options for serialization */
   protected deepCleanOptions: DeepCleanOptions;
@@ -320,7 +320,7 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
   }
 
   /**
-   * External (non-Mastra-storage) parent id to export alongside
+   * External (foreign tracing-system) parent id to export alongside
    * {@link getParentSpanId}. When every Mastra ancestor is dropped from
    * export, the span is exported at the root's position, so the root's
    * external parent must travel with it.

--- a/observability/otel-bridge/src/bridge.ts
+++ b/observability/otel-bridge/src/bridge.ts
@@ -231,8 +231,8 @@ export class OtelBridge extends BaseExporter implements ObservabilityBridge {
         parentSpanContext && isSpanContextValid(parentSpanContext) ? parentSpanContext.spanId : undefined;
 
       // Declare which kind of parent was used: a span this bridge created for
-      // a Mastra span exists in Mastra storage, while anything else in the
-      // ambient OTEL context lives only in the external tracing system.
+      // a Mastra span is part of the Mastra trace, while anything else in the
+      // ambient OTEL context belongs to the external tracing system.
       const parentIsMastraSpan = parentSpanId !== undefined && this.otelSpanMap.has(parentSpanId);
 
       this.logger.debug(

--- a/observability/otel-exporter/src/span-converter.ts
+++ b/observability/otel-exporter/src/span-converter.ts
@@ -132,7 +132,7 @@ export class SpanConverter {
       isRemote: false,
     };
 
-    // External parents (ambient OTel spans outside Mastra storage) are real
+    // External parents (ambient OTel spans Mastra did not create) are real
     // spans in the OTel namespace this exporter targets, so keep them as the
     // OTel-side parent when no Mastra parent exists.
     const exportedParentSpanId = span.parentSpanId ?? span.externalParentSpanId;

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -992,9 +992,9 @@ export interface AIModelGenerationSpan extends Span<SpanType.MODEL_GENERATION> {
  * - RecordedSpan: span data loaded from storage with annotation methods
  */
 export interface SpanData<TType extends SpanType> extends BaseSpan<TType> {
-  /** Parent span id reference — always a Mastra span present in storage (undefined for root spans) */
+  /** Parent span id reference — a span Mastra created within this trace (undefined for root spans) */
   parentSpanId?: string;
-  /** Parent span id outside Mastra storage (ambient OTel / bridge parent); never used as the stored parent */
+  /** Parent from an external tracing system (ambient OTel / dd-trace) that Mastra did not create; carried for external correlation, not Mastra's own parentage */
   externalParentSpanId?: string;
   /** `TRUE` if the span is the root span of a trace */
   isRootSpan: boolean;
@@ -1244,15 +1244,15 @@ export interface CreateSpanOptions<TType extends SpanType> extends CreateBaseOpt
   spanId?: string;
   /**
    * Parent span ID to use for this span (1-16 hexadecimal characters).
-   * Must reference a Mastra span present in storage (a rebuilt span's parent,
+   * Must reference a Mastra span within this trace (a rebuilt span's parent,
    * or the suspended span a resumed run links back to).
    * Only used for root spans without a parent.
    */
   parentSpanId?: string;
   /**
-   * Parent span ID outside Mastra storage (1-16 hexadecimal characters), such
-   * as an ambient OpenTelemetry span. Exported for external tracing systems;
-   * never persisted as the stored parent.
+   * Parent span ID from an external tracing system (1-16 hexadecimal characters),
+   * such as an ambient OpenTelemetry span Mastra did not create. Exported to
+   * external tracing exporters for correlation; not part of Mastra's own parentage.
    * Only used for root spans without a parent.
    */
   externalParentSpanId?: string;
@@ -1348,8 +1348,8 @@ export interface GetOrCreateSpanOptions<TType extends SpanType> {
   requestContext?: RequestContext;
   mastra?: Mastra;
   /**
-   * Span id of the suspended span a resumed run links back to. The id is in
-   * Mastra storage, so it becomes the new root span's stored parent.
+   * Span id of the suspended span a resumed run links back to. It is a Mastra
+   * span within the trace, so it becomes the new root span's parent.
    */
   resumedFromSpanId?: string;
 }
@@ -1457,11 +1457,11 @@ export interface TracingOptions {
 export interface SpanIds {
   traceId: string;
   spanId: string;
-  /** Parent that is a Mastra span (present in Mastra storage). */
+  /** Parent that is a Mastra span (one this bridge created within the trace). */
   parentSpanId?: string;
   /**
-   * Parent that lives only in the external tracing system (e.g. an ambient
-   * OpenTelemetry or dd-trace span). Not present in Mastra storage.
+   * Parent that belongs to the external tracing system (e.g. an ambient
+   * OpenTelemetry or dd-trace span) that Mastra did not create.
    * Bridges set exactly one of `parentSpanId` / `externalParentSpanId`.
    */
   externalParentSpanId?: string;

--- a/packages/core/src/observability/utils.ts
+++ b/packages/core/src/observability/utils.ts
@@ -137,10 +137,10 @@ export function getOrCreateSpan<T extends SpanType>(options: GetOrCreateSpanOpti
     requestContext,
     tracingOptions,
     traceId: tracingOptions?.traceId,
-    // A resumed run's parent is the suspended span, which is in Mastra storage.
+    // A resumed run's parent is the suspended span, a Mastra span in the trace.
     parentSpanId: resumedFromSpanId,
     // tracingOptions.parentSpanId is the public external-correlation channel;
-    // the id lives in the caller's tracing system, not in Mastra storage.
+    // the id belongs to the caller's tracing system, not Mastra's own parentage.
     externalParentSpanId: tracingOptions?.parentSpanId,
     customSamplerOptions: {
       requestContext,

--- a/packages/core/src/storage/domains/observability/record-builders.ts
+++ b/packages/core/src/storage/domains/observability/record-builders.ts
@@ -168,6 +168,9 @@ export function buildCreateSpanRecord(span: AnyExportedSpan): CreateSpanRecord {
   return {
     traceId: span.traceId,
     spanId: span.id,
+    // Mastra storage detects trace roots by a null parentSpanId, so only a Mastra
+    // parent belongs here. A span's externalParentSpanId is intentionally not
+    // persisted, so a run started under an external parent stays a trace root.
     parentSpanId: span.parentSpanId ?? null,
     name: span.name,
 


### PR DESCRIPTION
## Description

Doc/comment-only follow-up stacked on top of #20499 (base: `knowing-tree`). No logic changes.

That PR documents `parentSpanId` / `externalParentSpanId` in terms of **Mastra storage** ("always a Mastra span present in storage", "outside Mastra storage", "never the stored parent"). That framing is both over-applied and inaccurate: Mastra tracing runs without any storage backend (external exporters only), and in that case `parentSpanId` still means something — it's the parent span Mastra created within the trace. The real distinction between the two fields is **provenance** (did Mastra create this parent, or does it belong to an external tracing system), not storage residency. Storage is just one consumer, and only when configured.

This PR:

- Rewords the field docs and comments on `SpanData`, `CreateSpanOptions`, `SpanIds`, `GetOrCreateSpanOptions`, `BaseSpan`, both bridges, and the core/instance call sites to describe the fields by provenance rather than storage.
- Moves the one legitimately storage-specific detail — Mastra storage detects trace roots by a null `parentSpanId` — to the single place it applies, `buildCreateSpanRecord`, instead of stamping it onto every field description.
- Bumps the changesets from `patch` to `minor`, since the change adds public API surface (`externalParentSpanId` on `TracingOptions` / `CreateSpanOptions` / `SpanData` / `SpanIds`), and adds a public-usage example to the `@mastra/core` changelog entry.

## Related issue(s)

N/A — follow-up to #20499.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0139T4Ry7o5FGM2aSBNPAQb9)_