### PR TITLE
fix(factory-ui): tell a retried failure from a dead run in the transcript

### DIFF
--- a/.changeset/few-humans-fetch.md
+++ b/.changeset/few-humans-fetch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Added the retry fields the agent controller already emits (`retryable`, `retryDelay`, `retryAttempt`, `maxRetries`) to the `error` event type, so clients can tell a failure the controller is retrying from one that ended the run.

--- a/.changeset/yummy-lights-go.md
+++ b/.changeset/yummy-lights-go.md
@@ -1,0 +1,6 @@
+---
+'@mastra/client-js': patch
+'@mastra/factory': patch
+---
+
+Fixed transient provider failures looking like a dead run in the chat. A 503 the agent is already retrying now shows as one live line under the turn — `Service Unavailable · retrying 2/10` — that disappears as soon as output resumes, instead of stacking a red panel per attempt. A failure that really ends the run stays in the transcript, but as a compact inline row rather than a full-width notice.

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -161,7 +161,16 @@ export type KnownAgentControllerEvent =
   | { type: 'workspace_status_changed'; status: string }
   // Notices.
   | { type: 'info'; message: string }
-  | { type: 'error'; error: { message?: string } | string; errorType?: string };
+  | {
+      type: 'error';
+      error: { message?: string } | string;
+      errorType?: string;
+      /** Set when the controller scheduled an automatic retry: the run is still alive. */
+      retryable?: boolean;
+      retryDelay?: number;
+      retryAttempt?: number;
+      maxRetries?: number;
+    };
 
 /** Any other agent controller event the SDK doesn't model explicitly. */
 export interface OtherAgentControllerEvent {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ActivityLine.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ActivityLine.tsx
@@ -4,7 +4,7 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 
 import { useChatTranscript } from '../context/useChatTranscript';
 import { isTerminalInvocationState } from '../services/transcript';
-import type { TimelineEntry } from '../services/transcript';
+import type { RetrySnapshot, TimelineEntry } from '../services/transcript';
 import { isTranscriptToolVisible } from './ToolFactory';
 
 /**
@@ -53,17 +53,36 @@ function awaitingFirstOutput(entries: TimelineEntry[]): boolean {
 }
 
 /**
- * Covers the silence between sending and the run's first visible output. Everything after that
- * says its own state: a running tool sweeps its label, text arrives as it streams, and the
- * composer ring carries the rest.
+ * Covers the silence between sending and the run's first visible output, and the silence of a
+ * retry wait. Everything after that says its own state: a running tool sweeps its label, text
+ * arrives as it streams, and the composer ring carries the rest.
  */
 export function ActivityLine() {
   const { busy, transcript } = useChatTranscript();
-  if (!busy || !awaitingFirstOutput(transcript.entries)) return null;
+  if (!busy) return null;
+  // A stream that drops mid-wait never sends the event that would retire the
+  // line, so `busy` — reconciled against the session state — is what ends it.
+  if (transcript.retry) return <RetryLine retry={transcript.retry} />;
+  if (!awaitingFirstOutput(transcript.entries)) return null;
 
   return (
     <Txt as="p" variant="ui-sm" aria-hidden className="text-icon3 px-1.5 py-1">
       <Shimmer>Thinking</Shimmer>
+    </Txt>
+  );
+}
+
+/**
+ * A failure the controller is retrying on its own. It reads as work in progress, because it is:
+ * the sweep says the run is alive, the attempt count says how long it can keep trying, and the
+ * whole line disappears the moment output resumes.
+ */
+function RetryLine({ retry }: { retry: RetrySnapshot }) {
+  const progress = retry.attempt && retry.maxRetries ? ` ${retry.attempt}/${retry.maxRetries}` : '';
+
+  return (
+    <Txt as="p" variant="ui-sm" role="status" aria-live="polite" className="text-icon3 px-1.5 py-1">
+      <Shimmer>{`${retry.text} · retrying${progress}`}</Shimmer>
     </Txt>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ErrorRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ErrorRow.tsx
@@ -1,0 +1,22 @@
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { OctagonAlert } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+/**
+ * A run that died, in the row rhythm the rest of the transcript uses. It carries
+ * the weight of a line, not of a panel: the failure is one moment of the
+ * conversation, and everything around it stays readable.
+ */
+export function ErrorRow({ children }: { children: ReactNode }) {
+  return (
+    <p role="alert" className="text-notice-destructive-fg flex w-full min-w-0 items-start gap-2 px-1.5 py-1">
+      <span aria-hidden className="flex h-[1lh] shrink-0 items-center">
+        <OctagonAlert size={13} />
+      </span>
+      {/* wrap-anywhere — provider errors carry URLs and tokens with no break opportunity */}
+      <Txt as="span" variant="ui-sm" className="min-w-0 wrap-anywhere">
+        {children}
+      </Txt>
+    </p>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -15,6 +15,7 @@ import { Bell, CircleDot, ExternalLink, Info, Layers, Slack } from 'lucide-react
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
+import { ErrorRow } from './ErrorRow';
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 import { useChatSessionContext } from '../context/useChatSessionContext';
 import { useChatTranscript } from '../context/useChatTranscript';
@@ -559,6 +560,8 @@ export function TranscriptEntries({
         );
       case 'notice':
         return <NoticeCard entry={entry} />;
+      case 'error':
+        return <ErrorRow>{entry.text}</ErrorRow>;
       case 'approval':
         return <ApprovalCard prompt={entry} isSubmitting={isSubmitting} onApprove={onApprove} />;
       case 'notification':
@@ -1084,8 +1087,10 @@ function statusMetadata(entry: MessageEntry): StatusMetadata | undefined {
 }
 
 function StatusMetadataCard({ status }: { status: StatusMetadata }) {
+  if (status.level === 'error') return <ErrorRow>{status.text}</ErrorRow>;
+
   return (
-    <Notice className="my-2" variant={status.level === 'error' ? 'destructive' : 'info'}>
+    <Notice className="my-2" variant="info">
       {status.text}
     </Notice>
   );
@@ -1093,7 +1098,7 @@ function StatusMetadataCard({ status }: { status: StatusMetadata }) {
 
 function NoticeCard({ entry }: { entry: NoticeEntry }) {
   return (
-    <Notice className="my-2" variant={entry.level === 'error' ? 'destructive' : 'info'}>
+    <Notice className="my-2" variant="info">
       <div className="prose">
         <Markdown>{entry.text}</Markdown>
       </div>

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -810,9 +810,9 @@ describe('transcript reducer mergeWindow', () => {
 describe('transcript reducer error notices', () => {
   function errorNoticeText(event: Record<string, unknown>): string {
     const state = transcriptReducer(initialTranscript, { type: 'event', event: { type: 'error', ...event } });
-    const notice = state.entries.find(entry => entry.kind === 'notice');
-    if (!notice || notice.kind !== 'notice') throw new Error('expected a notice entry');
-    return notice.text;
+    const entry = state.entries.find(entry => entry.kind === 'error');
+    if (!entry || entry.kind !== 'error') throw new Error('expected an error entry');
+    return entry.text;
   }
 
   it('renders a string error payload verbatim', () => {
@@ -831,6 +831,55 @@ describe('transcript reducer error notices', () => {
 
   it('falls back to a generic hint when the payload is empty', () => {
     expect(errorNoticeText({ error: {} })).toBe('Run failed with an unknown error. Check the server logs for details.');
+  });
+});
+
+describe('a failure the controller is retrying', () => {
+  const attempt = (retryAttempt: number) => ({
+    type: 'event' as const,
+    event: {
+      type: 'error' as const,
+      error: { message: 'Service Unavailable' },
+      retryable: true,
+      retryDelay: 1000,
+      retryAttempt,
+      maxRetries: 10,
+    },
+  });
+
+  it('stays out of the transcript and reports the attempt instead', () => {
+    const state = transcriptReducer(initialTranscript, attempt(1));
+
+    expect(state.entries).toHaveLength(0);
+    expect(state.retry).toEqual({ text: 'Service Unavailable', attempt: 1, maxRetries: 10 });
+  });
+
+  it('replaces the previous attempt rather than stacking', () => {
+    const state = [attempt(1), attempt(2), attempt(3)].reduce(transcriptReducer, initialTranscript);
+
+    expect(state.entries).toHaveLength(0);
+    expect(state.retry?.attempt).toBe(3);
+  });
+
+  it('is retired as soon as the run produces output again', () => {
+    const retrying = transcriptReducer(initialTranscript, attempt(1));
+    const resumed = transcriptReducer(retrying, {
+      type: 'event',
+      event: { type: 'message_update', message: dbMessage('a1', 'assistant', [{ type: 'text', text: 'Back' }]) },
+    });
+
+    expect(resumed.retry).toBeUndefined();
+  });
+
+  it('becomes a transcript entry once the controller gives up', () => {
+    const retrying = transcriptReducer(initialTranscript, attempt(10));
+    const failed = transcriptReducer(retrying, {
+      type: 'event',
+      event: { type: 'error', error: { message: 'Service Unavailable' } },
+    });
+
+    expect(failed.retry).toBeUndefined();
+    expect(failed.entries).toMatchObject([{ kind: 'error', text: 'Service Unavailable' }]);
   });
 });
 

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -1,4 +1,9 @@
-import type { AgentControllerEvent, AgentControllerTaskSnapshot, AgentControllerOMProgress } from '@mastra/client-js';
+import type {
+  AgentControllerEvent,
+  AgentControllerTaskSnapshot,
+  AgentControllerOMProgress,
+  KnownAgentControllerEvent,
+} from '@mastra/client-js';
 import { isKnownAgentControllerEvent } from '@mastra/client-js';
 import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent-controller';
 
@@ -50,7 +55,17 @@ export interface MessageEntry {
 export interface NoticeEntry {
   kind: 'notice';
   id: string;
-  level: 'info' | 'error';
+  text: string;
+}
+
+/**
+ * A run that died. Only failures the controller could not recover from land
+ * here — a failure it is retrying is live state (`TranscriptState.retry`), not
+ * a fact of the conversation.
+ */
+export interface ErrorEntry {
+  kind: 'error';
+  id: string;
   text: string;
 }
 
@@ -111,6 +126,7 @@ export type PromptEntry = ApprovalPrompt | SuspensionPrompt;
 export type TimelineEntry =
   | MessageEntry
   | NoticeEntry
+  | ErrorEntry
   | PromptEntry
   | NotificationEntry
   | NotificationSummaryEntry
@@ -127,6 +143,13 @@ export interface UsageSnapshot {
 
 /** OM (observational memory) status. */
 export type OMPhase = 'idle' | 'observing' | 'reflecting' | 'buffering';
+
+/** The failure behind an automatic retry, as reported by the `error` event that scheduled it. */
+export interface RetrySnapshot {
+  text: string;
+  attempt?: number;
+  maxRetries?: number;
+}
 
 /** Goal evaluation snapshot from goal_evaluation events. */
 export interface GoalSnapshot {
@@ -163,6 +186,12 @@ export interface TranscriptState {
   workspaceReady?: boolean;
   /** Latest goal evaluation. */
   goal?: GoalSnapshot;
+  /**
+   * The failure the controller is currently retrying. Live state, not history:
+   * it is replaced by each further attempt and retired the moment the stream
+   * produces anything again.
+   */
+  retry?: RetrySnapshot;
   /** Current tokens/sec throughput (0 when idle). */
   tokensPerSec: number;
   /**
@@ -258,7 +287,7 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
     case 'clearPending':
       return { ...state, pending: false };
     case 'localNotice':
-      return pushNotice(state, action.level, action.text);
+      return action.level === 'error' ? pushError(state, action.text) : pushNotice(state, action.text);
     case 'resolvePrompt':
       return { ...state, entries: state.entries.filter(e => !('id' in e) || e.id !== action.id) };
     case 'event':
@@ -268,8 +297,9 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
   }
 }
 
-function applyEvent(state: TranscriptState, event: AgentControllerEvent): TranscriptState {
-  if (!isKnownAgentControllerEvent(event)) return state;
+function applyEvent(previous: TranscriptState, event: AgentControllerEvent): TranscriptState {
+  if (!isKnownAgentControllerEvent(event)) return previous;
+  const state = previous.retry && streamResumed(event) ? { ...previous, retry: undefined } : previous;
   switch (event.type) {
     case 'agent_start':
       // Reset the rate at the start of a new turn (not at the end) so the last
@@ -513,12 +543,36 @@ function applyEvent(state: TranscriptState, event: AgentControllerEvent): Transc
 
     // Notices.
     case 'info':
-      return pushNotice(state, 'info', event.message);
-    case 'error':
-      return pushNotice(state, 'error', describeErrorEvent(event));
+      return pushNotice(state, event.message);
+    case 'error': {
+      // A retryable error means the controller already scheduled another
+      // attempt, so it says how the live run is doing — not that it failed.
+      const text = describeErrorEvent(event);
+      if (event.retryable) {
+        return { ...state, retry: { text, attempt: event.retryAttempt, maxRetries: event.maxRetries } };
+      }
+      return pushError({ ...state, retry: undefined }, text);
+    }
 
     default:
       return state;
+  }
+}
+
+/** Anything the run emits once it is producing again, which retires the retry line. */
+function streamResumed(event: KnownAgentControllerEvent): boolean {
+  switch (event.type) {
+    case 'agent_start':
+    case 'agent_end':
+    case 'message_start':
+    case 'message_update':
+    case 'message_end':
+    case 'tool_input_start':
+    case 'tool_start':
+    case 'tool_end':
+      return true;
+    default:
+      return false;
   }
 }
 
@@ -1061,9 +1115,12 @@ function pushPrompt(state: TranscriptState, prompt: PromptEntry): TranscriptStat
   return { ...state, entries: [...state.entries, prompt] };
 }
 
-function pushNotice(state: TranscriptState, level: 'info' | 'error', text: string): TranscriptState {
-  return {
-    ...state,
-    entries: [...state.entries, { kind: 'notice', id: `notice-${Date.now()}-${noticeSeq++}`, level, text }],
-  };
+function pushNotice(state: TranscriptState, text: string): TranscriptState {
+  const id = `notice-${Date.now()}-${noticeSeq++}`;
+  return { ...state, entries: [...state.entries, { kind: 'notice', id, text }] };
+}
+
+function pushError(state: TranscriptState, text: string): TranscriptState {
+  const id = `error-${Date.now()}-${noticeSeq++}`;
+  return { ...state, entries: [...state.entries, { kind: 'error', id, text }] };
 }

--- a/mastracode/factory-ui/src/ui/pages/NewPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/NewPage.tsx
@@ -86,8 +86,8 @@ function NewPageContent({
   const { transcript } = useChatTranscript();
   const location = useLocation();
   const routeErrorNotice = readRouteErrorNotice(location.state);
-  const noticeEntries = transcript.entries.filter(entry => entry.kind === 'notice');
-  const hasNotices = Boolean(routeErrorNotice) || noticeEntries.length > 0;
+  const statusEntries = transcript.entries.filter(entry => entry.kind === 'notice' || entry.kind === 'error');
+  const hasNotices = Boolean(routeErrorNotice) || statusEntries.length > 0;
 
   return (
     <div className="grid min-h-0 flex-1 place-items-center overflow-y-auto px-4 py-10 md:px-6">
@@ -101,7 +101,7 @@ function NewPageContent({
         {hasNotices && (
           <div className="flex w-full flex-col gap-4">
             {routeErrorNotice && <Notice variant="destructive">{routeErrorNotice}</Notice>}
-            <TranscriptEntries entries={noticeEntries} onApprove={() => undefined} onRespond={() => undefined} />
+            <TranscriptEntries entries={statusEntries} onApprove={() => undefined} onRespond={() => undefined} />
           </div>
         )}
       </div>


### PR DESCRIPTION
Today a transient provider hiccup reads exactly like a dead run. The agent controller already retries `ECONNRESET`, 500, 502 and 503 on its own — up to ten attempts with backoff — and it tells us so on the `error` event via `retryable`, `retryAttempt` and `maxRetries`. The web transcript ignored all of that and appended a full-width destructive notice per attempt, so a 503 the run recovered from shouted louder than the answer, ten times over, and stayed there for the rest of the conversation.

I split the two states by lifetime, because they are not the same kind of fact. A failure the controller is retrying is live state of the run in flight, so it no longer creates an entry at all: it feeds one sweeping line under the current turn — `Service Unavailable · retrying 2/10` — that each further attempt replaces and that disappears the moment output resumes. A failure that actually ended the run is a moment of the conversation, so it stays in the transcript, but as a compact inline row in the same rhythm as every other row rather than a panel. `Notice` keeps its job for failures outside the stream, like a workspace that could not be prepared. The attempt counter is there because it turns "it's broken" into "it's working, and here is how long it can keep trying"; I deliberately left out a ticking countdown, which is a re-rendering timer that says nothing the sweep doesn't already say.

The retry fields had to be added to `KnownAgentControllerEvent` in `@mastra/client-js` first — core has emitted them for a while but the client type had drifted, so the front literally could not see them. One thing I chose not to do: no Retry button on the terminal row. Re-sending the prompt after an agent already ran five tools is not a retry, it's a second run over changed state, and a button that does that silently is worse than the composer sitting right below. If we want one it should be conditional on the run having produced nothing, which is its own change.

I have not reproduced a real 503 against a live provider, so the retry line is covered by reducer tests rather than by a screenshot.
