### PR TITLE
chore: add missing frontmatter to the testing-core-processors skill

### DIFF
--- a/.claude/skills/testing-core-processors/SKILL.md
+++ b/.claude/skills/testing-core-processors/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: testing-core-processors
+description: Use when writing or debugging integration tests for error processors in packages/core/src/processors/. Covers the MockLanguageModelV2 pattern for simulating API errors and verifying retry behavior, plus the build prerequisites for focused vitest runs.
+---
+
 # Testing Core Error Processors
 
 How to write integration tests for error processors in `packages/core/src/processors/`.


### PR DESCRIPTION
`.claude/skills/testing-core-processors/SKILL.md` was the only one of the sixteen skills in the repo with no frontmatter at all, so the loader rejected it outright with `name: Expected string, received undefined` and the skill was silently unavailable. The other fifteen all carry it, the format is required by the Agent Skills specification the docs point at, and `validateSkillMetadata` in core treats both `name` and `description` as required — with `name` having to match the directory name.

I checked whether the absence was deliberate before adding it. The file arrived in a single commit as a side artifact of an unrelated observational-memory PR and was never touched or referenced since, so there was nothing to preserve. Nothing else was affected in the meantime either: the loader uses `Promise.allSettled`, so the rejection stayed isolated to this one skill rather than breaking the other fifteen.

Split out of #21338, where it was riding along with an unrelated factory fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This change adds the information the skill loader needs to recognize the testing skill. It makes the `testing-core-processors` skill available again.

## Changes

- Added YAML frontmatter to `.claude/skills/testing-core-processors/SKILL.md`.
- Defined the skill name as `testing-core-processors`.
- Added a description covering core error processor integration tests, mock language-model errors, retry verification, and focused Vitest prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->