### PR TITLE
feat(factory): split issue and pull request reconciliation

### DIFF
--- a/.changeset/ten-gifts-shop.md
+++ b/.changeset/ten-gifts-shop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Added independent GitHub issue and pull request reconciliation controls for Factory, with legacy reconciliation settings preserved as fallbacks. Added Linear issue reconciliation aliases and automatically move linked work cards to Done or Canceled when upstream issues close.

--- a/.changeset/ten-gifts-shop.md
+++ b/.changeset/ten-gifts-shop.md
@@ -3,3 +3,9 @@
 ---
 
 Added independent GitHub issue and pull request reconciliation controls for Factory, with legacy reconciliation settings preserved as fallbacks. Added Linear issue reconciliation aliases and automatically move linked work cards to Done or Canceled when upstream issues close.
+
+For example, run GitHub issue reconciliation every minute while leaving pull-request reconciliation at its existing cadence:
+
+```sh
+MASTRACODE_GITHUB_ISSUE_RECONCILE_INTERVAL_MS=60000
+```

--- a/mastracode/factory/src/integrations/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/github/integration.test.ts
@@ -1,5 +1,5 @@
 import { createPrivateKey, generateKeyPairSync } from 'node:crypto';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 
 import { fakeRouteAuth } from '../../routes/test-utils.js';
 import { SandboxFleet } from '../../sandbox/fleet.js';
@@ -601,9 +601,10 @@ describe('GithubIntegration merge reconciler', () => {
 });
 
 describe('GithubIntegration workers', () => {
-  it('registers a single reconcile worker that folds PR and issue sweeps', () => {
-    const github = new GithubIntegration(validConfig());
-    const context = {
+  const originalEnv = { ...process.env };
+
+  function context() {
+    return {
       controller: {},
       storage: {
         generic: {},
@@ -616,7 +617,33 @@ describe('GithubIntegration workers', () => {
       },
       rules: { config: {}, workItems: {} },
     } as any;
+  }
 
-    expect(github.workers(context).map(worker => worker.name)).toEqual(['github-pull-request-reconcile']);
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('registers a single reconcile worker that folds PR and issue sweeps', () => {
+    const github = new GithubIntegration(validConfig());
+    expect(github.workers(context()).map(worker => worker.name)).toEqual(['github-pull-request-reconcile']);
+  });
+
+  it('allows issue reconciliation when legacy reconciliation is disabled', () => {
+    process.env.MASTRACODE_GITHUB_RECONCILE_ENABLED = 'false';
+    process.env.MASTRACODE_GITHUB_ISSUE_RECONCILE_ENABLED = 'true';
+    const github = new GithubIntegration(validConfig());
+
+    expect(github.workers(context()).map(worker => worker.name)).toEqual(['github-pull-request-reconcile']);
+  });
+
+  it('does not register a worker when both child reconcilers are disabled', () => {
+    process.env.MASTRACODE_GITHUB_PR_RECONCILE_ENABLED = 'false';
+    process.env.MASTRACODE_GITHUB_ISSUE_RECONCILE_ENABLED = 'false';
+    const github = new GithubIntegration(validConfig());
+
+    expect(github.workers(context())).toEqual([]);
   });
 });

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -50,6 +50,7 @@ import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '.
 import { attachGithubIssueReconciler } from './issue-reconciler.js';
 import { runGithubIssueTriage } from './issue-triage.js';
 import { GithubReconcileWorker } from './reconcile-worker.js';
+import { reconcileInterval, reconciliationEnabled } from './reconciliation-config.js';
 import { buildGithubRoutes } from './routes.js';
 import { attachGithubReconciler, attachGithubRules } from './rules.js';
 import type { ReconcileIssueState, ReconcilePullRequestState } from './rules.js';
@@ -1123,24 +1124,36 @@ export class GithubIntegration implements FactoryIntegration {
   }
 
   /**
-   * Merge-state safety net. Webhooks are the only other writer of merge state,
-   * and a self-hosted deployment GitHub cannot reach (private network, local
-   * dev) never receives one — without this sweep its PR cards stay open
-   * forever. Disable with `MASTRACODE_GITHUB_RECONCILE_ENABLED=false`.
+   * Pull-request and issue sweeps share a worker and lease, but can be enabled
+   * and paced independently. The legacy combined controls remain the fallback.
    */
   workers(ctx: IntegrationContext): MastraWorker[] {
-    if (process.env.MASTRACODE_GITHUB_RECONCILE_ENABLED?.trim().toLowerCase() === 'false') return [];
-    const reconcile = attachGithubReconciler(this, ctx, input => this.fetchPullRequestState(input));
-    if (!reconcile) return [];
-    const issues = attachGithubIssueReconciler(this, ctx, input => this.fetchIssueState(input));
-    const intervalMs = Number(process.env.MASTRACODE_GITHUB_RECONCILE_INTERVAL_MS);
-    const interval = Number.isSafeInteger(intervalMs) && intervalMs > 0 ? { intervalMs } : {};
+    const pullRequestEnabled = reconciliationEnabled(
+      process.env.MASTRACODE_GITHUB_PR_RECONCILE_ENABLED,
+      process.env.MASTRACODE_GITHUB_RECONCILE_ENABLED,
+    );
+    const issueEnabled = reconciliationEnabled(
+      process.env.MASTRACODE_GITHUB_ISSUE_RECONCILE_ENABLED,
+      process.env.MASTRACODE_GITHUB_RECONCILE_ENABLED,
+    );
+    if (!pullRequestEnabled && !issueEnabled) return [];
+
+    const reconcile = pullRequestEnabled
+      ? attachGithubReconciler(this, ctx, input => this.fetchPullRequestState(input))
+      : undefined;
+    const issues = issueEnabled ? attachGithubIssueReconciler(this, ctx, input => this.fetchIssueState(input)) : undefined;
+    if (!reconcile && !issues) return [];
+
+    const legacyInterval = reconcileInterval(process.env.MASTRACODE_GITHUB_RECONCILE_INTERVAL_MS);
+    const intervalMs = reconcileInterval(process.env.MASTRACODE_GITHUB_PR_RECONCILE_INTERVAL_MS) ?? legacyInterval;
+    const issueIntervalMs = reconcileInterval(process.env.MASTRACODE_GITHUB_ISSUE_RECONCILE_INTERVAL_MS) ?? legacyInterval;
     return [
       new GithubReconcileWorker({
-        reconcile,
+        ...(reconcile ? { reconcile } : {}),
         ...(issues ? { reconcileIssues: issues } : {}),
         sourceControl: ctx.storage.sourceControl,
-        ...interval,
+        ...(intervalMs ? { intervalMs } : {}),
+        ...(issueIntervalMs ? { issueIntervalMs } : {}),
       }),
     ];
   }

--- a/mastracode/factory/src/integrations/github/issue-reconciler.ts
+++ b/mastracode/factory/src/integrations/github/issue-reconciler.ts
@@ -95,9 +95,9 @@ export function createGithubIssueReconciler(
               githubRepositoryId: repository.id,
               githubIssueNumber: issueNumber,
               state: 'open' as const,
-              author: state.author,
-              assignees: state.assignees ?? [],
-              labels: state.labels ?? [],
+              ...(state.author === undefined ? {} : { author: state.author }),
+              ...(state.assignees === undefined ? {} : { assignees: state.assignees }),
+              ...(state.labels === undefined ? {} : { labels: state.labels }),
             };
 
             for (const item of items) {
@@ -106,9 +106,9 @@ export function createGithubIssueReconciler(
                 current.githubRepositoryId !== desiredMetadata.githubRepositoryId ||
                 current.githubIssueNumber !== desiredMetadata.githubIssueNumber ||
                 current.state !== desiredMetadata.state ||
-                current.author !== desiredMetadata.author ||
-                !sameStrings(current.assignees as string[] | undefined, desiredMetadata.assignees) ||
-                !sameStrings(current.labels as string[] | undefined, desiredMetadata.labels);
+                (state.author !== undefined && current.author !== state.author) ||
+                (state.assignees !== undefined && !sameStrings(current.assignees, state.assignees)) ||
+                (state.labels !== undefined && !sameStrings(current.labels, state.labels));
 
               if (!metadataChanged) continue;
 

--- a/mastracode/factory/src/integrations/github/reconcile-worker.test.ts
+++ b/mastracode/factory/src/integrations/github/reconcile-worker.test.ts
@@ -1,16 +1,16 @@
 import type { WorkerDeps } from '@mastra/core/worker';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { IssueReconcileSummary } from '../issue-reconciler.js';
+import type { GithubIssueReconcileSummary } from './issue-reconciler.js';
 import { GithubReconcileWorker } from './reconcile-worker.js';
 import type { GithubReconcileRepositorySource } from './reconcile-worker.js';
 import type { ReconcileRepository, ReconcileSweepSummary } from './rules.js';
 
-const EMPTY_ISSUE_SUMMARY: IssueReconcileSummary = {
-  projects: 0,
+const EMPTY_ISSUE_SUMMARY: GithubIssueReconcileSummary = {
+  repositories: 0,
   checked: 0,
   updated: 0,
-  missing: 0,
+  closed: 0,
   failed: 0,
   errors: [],
 };
@@ -20,8 +20,6 @@ const EMPTY_SUMMARY: ReconcileSweepSummary = {
   checked: 1,
   merged: 0,
   closed: 0,
-  issuesChecked: 0,
-  issuesClosed: 0,
   failed: 0,
   errors: [],
 };
@@ -153,6 +151,46 @@ describe('GithubReconcileWorker', () => {
     expect(worker.isRunning).toBe(false);
   });
 
+  it('runs issue reconciliation without a pull-request reconciler', async () => {
+    const reconcileIssues = vi.fn(async () => EMPTY_ISSUE_SUMMARY);
+    const worker = new GithubReconcileWorker({
+      reconcileIssues,
+      sourceControl: repositorySource(),
+      issueIntervalMs: 60_000,
+    });
+    await worker.init(workerDeps());
+
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await worker.stop();
+
+    expect(reconcileIssues).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs pull-request and issue reconciliation on independent cadences', async () => {
+    const reconcile = vi.fn(async () => EMPTY_SUMMARY);
+    const reconcileIssues = vi.fn(async () => EMPTY_ISSUE_SUMMARY);
+    const worker = new GithubReconcileWorker({
+      reconcile,
+      reconcileIssues,
+      sourceControl: repositorySource(),
+      intervalMs: 60_000,
+      issueIntervalMs: 20_000,
+    });
+    await worker.init(workerDeps());
+
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(20_000);
+    await vi.advanceTimersByTimeAsync(20_000);
+    await vi.advanceTimersByTimeAsync(20_000);
+    await worker.stop();
+
+    expect(reconcile).toHaveBeenCalledTimes(2);
+    expect(reconcileIssues).toHaveBeenCalledTimes(4);
+  });
+
   it('folds the issue reconcile into the same tick and passes the same targets', async () => {
     const reconcile = vi.fn(async () => EMPTY_SUMMARY);
     const reconcileIssues = vi.fn(async () => EMPTY_ISSUE_SUMMARY);
@@ -172,8 +210,7 @@ describe('GithubReconcileWorker', () => {
     expect(reconcile).toHaveBeenCalledTimes(1);
     expect(reconcileIssues).toHaveBeenCalledTimes(1);
     const targets = reconcile.mock.calls[0]![0];
-    const scope = reconcileIssues.mock.calls[0]![0];
-    expect(scope.scopes).toBe(targets);
+    expect(reconcileIssues.mock.calls[0]![0]).toBe(targets);
     // Same lease covers both writers of card state.
     expect(releaseLease).toHaveBeenCalledTimes(1);
   });

--- a/mastracode/factory/src/integrations/github/reconcile-worker.ts
+++ b/mastracode/factory/src/integrations/github/reconcile-worker.ts
@@ -32,48 +32,56 @@ export interface GithubReconcileRepositorySource {
 }
 
 export interface GithubReconcileWorkerConfig {
-  reconcile: GithubPullRequestReconciler;
-  /**
-   * Optional issue-metadata sweep. When provided, the worker folds it into the
-   * same tick as the PR reconciler, sharing the lease and the same
-   * `ReconcileRepository` target discovery. Mirrors how webhook-driven ingress
-   * flows both issues and PRs through one path.
-   */
+  reconcile?: GithubPullRequestReconciler;
   reconcileIssues?: GithubIssueReconciler;
   sourceControl: GithubReconcileRepositorySource;
   intervalMs?: number;
+  issueIntervalMs?: number;
+  now?: () => number;
 }
 
 /**
- * Periodic merge-state sweep for the self-hosted GitHub integration: webhooks
- * are the only other writer of merge state, and a deployment GitHub cannot
- * reach never receives one, so cards would stay open forever.
+ * Periodic GitHub state sweeps for the self-hosted integration. Pull requests
+ * drive review cards and issues drive work cards, but both share discovery and
+ * a lease so replicas never sweep the same configured repositories together.
  */
 export class GithubReconcileWorker extends MastraWorker {
   readonly name = 'github-pull-request-reconcile';
 
-  readonly #reconcile: GithubPullRequestReconciler;
+  readonly #reconcile: GithubPullRequestReconciler | undefined;
   readonly #reconcileIssues: GithubIssueReconciler | undefined;
   readonly #sourceControl: GithubReconcileRepositorySource;
   readonly #intervalMs: number;
+  readonly #issueIntervalMs: number;
   readonly #leaseTtlMs: number;
   readonly #leaseOwner = randomUUID();
+  readonly #now: () => number;
 
   #running = false;
   #timer: ReturnType<typeof setTimeout> | undefined;
   #inFlight: Promise<void> | undefined;
   #leaseProvider: LeaseProvider = NoopLeaseProvider;
+  #nextPullRequestReconcileAt = 0;
+  #nextIssueReconcileAt = 0;
 
   constructor(config: GithubReconcileWorkerConfig) {
     super();
+    if (!config.reconcile && !config.reconcileIssues) {
+      throw new Error('GitHub reconcile worker requires a pull request or issue reconciler.');
+    }
     this.#reconcile = config.reconcile;
     this.#reconcileIssues = config.reconcileIssues;
     this.#sourceControl = config.sourceControl;
     this.#intervalMs = config.intervalMs ?? DEFAULT_GITHUB_RECONCILE_INTERVAL_MS;
+    this.#issueIntervalMs = config.issueIntervalMs ?? this.#intervalMs;
     if (!Number.isFinite(this.#intervalMs) || this.#intervalMs <= 0) {
       throw new Error('GitHub pull request reconcile interval must be a positive number.');
     }
-    this.#leaseTtlMs = Math.max(MIN_LEASE_TTL_MS, this.#intervalMs * 3);
+    if (!Number.isFinite(this.#issueIntervalMs) || this.#issueIntervalMs <= 0) {
+      throw new Error('GitHub issue reconcile interval must be a positive number.');
+    }
+    this.#leaseTtlMs = Math.max(MIN_LEASE_TTL_MS, Math.min(this.#intervalMs, this.#issueIntervalMs) * 3);
+    this.#now = config.now ?? Date.now;
   }
 
   async init(deps: WorkerDeps): Promise<void> {
@@ -85,7 +93,10 @@ export class GithubReconcileWorker extends MastraWorker {
     if (this.#running) return;
     if (!this.deps) throw new Error('GithubReconcileWorker: call init() before start()');
     this.#running = true;
-    this.deps.logger.info('GitHub pull request reconcile worker started', { intervalMs: this.#intervalMs });
+    this.deps.logger.info('GitHub reconcile worker started', {
+      pullRequestIntervalMs: this.#reconcile ? this.#intervalMs : undefined,
+      issueIntervalMs: this.#reconcileIssues ? this.#issueIntervalMs : undefined,
+    });
     // Sweep on boot: a restart is exactly when webhooks were most likely missed.
     this.#schedule(0);
   }
@@ -108,14 +119,30 @@ export class GithubReconcileWorker extends MastraWorker {
       this.#timer = undefined;
       const run = this.#tick().finally(() => {
         this.#inFlight = undefined;
-        this.#schedule(this.#intervalMs);
+        this.#schedule(this.#nextDelay());
       });
       this.#inFlight = run;
     }, delayMs);
     this.#timer.unref?.();
   }
 
+  #nextDelay(): number {
+    const now = this.#now();
+    const due = [
+      this.#reconcile ? this.#nextPullRequestReconcileAt : undefined,
+      this.#reconcileIssues ? this.#nextIssueReconcileAt : undefined,
+    ].filter((at): at is number => at !== undefined);
+    return Math.max(0, Math.min(...due) - now);
+  }
+
   async #tick(): Promise<void> {
+    const now = this.#now();
+    const reconcilePullRequests = Boolean(this.#reconcile && now >= this.#nextPullRequestReconcileAt);
+    const reconcileIssues = Boolean(this.#reconcileIssues && now >= this.#nextIssueReconcileAt);
+    if (!reconcilePullRequests && !reconcileIssues) return;
+    if (reconcilePullRequests) this.#nextPullRequestReconcileAt = now + this.#intervalMs;
+    if (reconcileIssues) this.#nextIssueReconcileAt = now + this.#issueIntervalMs;
+
     // Replicas share one sweep: the ingress dedupes duplicate writes, but the
     // reads still burn the installation's rate limit.
     const lease = await this.#leaseProvider
@@ -123,14 +150,7 @@ export class GithubReconcileWorker extends MastraWorker {
       .catch(() => ({ acquired: false }));
     if (!lease.acquired) return;
 
-    // Track whether this owner still holds the lease. A `renewLease` result
-    // of `false` (or a renewal error) means another replica has taken the
-    // lease. Once that happens the folded issue sweep must not run — it
-    // would race the new owner's writes.
     let hasLease = true;
-    // Folding the issue sweep into the same tick extends how long we hold the
-    // lease. Renew periodically so a replica can't grab the expired lease and
-    // start an overlapping sweep partway through this one.
     const renewalTimer = setInterval(
       () => {
         void this.#leaseProvider
@@ -157,51 +177,48 @@ export class GithubReconcileWorker extends MastraWorker {
     try {
       const targets = await this.#targets();
       if (targets.length === 0) return;
-      const startedAt = Date.now();
-      const { errors, ...counts } = await this.#reconcile(targets);
-      const context = { ...counts, candidateRepositories: targets.length, durationMs: Date.now() - startedAt };
-      if (counts.failed > 0) {
-        this.deps?.logger.warn('GitHub pull request reconcile sweep completed with failures', { ...context, errors });
-      } else if (counts.merged > 0 || counts.closed > 0) {
-        this.deps?.logger.info('GitHub pull request reconcile replayed missed merges/closes', context);
-      } else {
-        this.deps?.logger.debug('GitHub pull request reconcile sweep completed', context);
-      }
-      // Fold the issue-metadata sweep into the same tick so a single lease
-      // covers both writers of card state for these repositories. Skip it
-      // if the lease was lost during the PR sweep — running would race a
-      // replica that already re-acquired the lease.
-      if (this.#reconcileIssues && hasLease) {
-        const issueStartedAt = Date.now();
+
+      if (reconcilePullRequests && this.#reconcile) {
+        const startedAt = Date.now();
         try {
-          const { errors: issueErrors, ...issueCounts } = await this.#reconcileIssues(targets);
-          const issueContext = {
-            ...issueCounts,
-            candidateRepositories: targets.length,
-            durationMs: Date.now() - issueStartedAt,
-          };
-          if (issueCounts.failed > 0) {
-            this.deps?.logger.warn('GitHub issue reconcile sweep completed with failures', {
-              ...issueContext,
-              errors: issueErrors,
-            });
-          } else if (issueCounts.updated > 0) {
-            this.deps?.logger.info('GitHub issue reconcile patched stale metadata', issueContext);
+          const { errors, ...counts } = await this.#reconcile(targets);
+          const context = { ...counts, candidateRepositories: targets.length, durationMs: Date.now() - startedAt };
+          if (counts.failed > 0) {
+            this.deps?.logger.warn('GitHub pull request reconcile sweep completed with failures', { ...context, errors });
+          } else if (counts.merged > 0 || counts.closed > 0) {
+            this.deps?.logger.info('GitHub pull request reconcile replayed missed merges/closes', context);
           } else {
-            this.deps?.logger.debug('GitHub issue reconcile sweep completed', issueContext);
+            this.deps?.logger.debug('GitHub pull request reconcile sweep completed', context);
           }
-        } catch (issueError) {
-          this.deps?.logger.warn('GitHub issue reconcile sweep failed', {
-            error: issueError instanceof Error ? issueError.message : String(issueError),
+        } catch (error) {
+          this.deps?.logger.warn('GitHub pull request reconcile sweep failed', {
+            error: error instanceof Error ? error.message : String(error),
           });
         }
-      } else if (this.#reconcileIssues && !hasLease) {
+      }
+
+      if (reconcileIssues && this.#reconcileIssues && hasLease) {
+        const startedAt = Date.now();
+        try {
+          const { errors, ...counts } = await this.#reconcileIssues(targets);
+          const context = { ...counts, candidateRepositories: targets.length, durationMs: Date.now() - startedAt };
+          if (counts.failed > 0) {
+            this.deps?.logger.warn('GitHub issue reconcile sweep completed with failures', { ...context, errors });
+          } else if (counts.closed > 0) {
+            this.deps?.logger.info('GitHub issue reconcile replayed closed work items', context);
+          } else if (counts.updated > 0) {
+            this.deps?.logger.info('GitHub issue reconcile patched stale metadata', context);
+          } else {
+            this.deps?.logger.debug('GitHub issue reconcile sweep completed', context);
+          }
+        } catch (error) {
+          this.deps?.logger.warn('GitHub issue reconcile sweep failed', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      } else if (reconcileIssues && this.#reconcileIssues && !hasLease) {
         this.deps?.logger.debug('GitHub issue reconcile skipped: lease lost during pull-request sweep');
       }
-    } catch (error) {
-      this.deps?.logger.warn('GitHub pull request reconcile sweep failed', {
-        error: error instanceof Error ? error.message : String(error),
-      });
     } finally {
       clearInterval(renewalTimer);
       if (hasLease) {

--- a/mastracode/factory/src/integrations/github/reconciliation-config.ts
+++ b/mastracode/factory/src/integrations/github/reconciliation-config.ts
@@ -1,10 +1,11 @@
+import { optionalPositiveInteger } from '../reconciliation-config.js';
+
 export function reconciliationEnabled(child: string | undefined, legacy: string | undefined): boolean {
   return parseOptionalBoolean(child) ?? parseOptionalBoolean(legacy) ?? true;
 }
 
 export function reconcileInterval(value: string | undefined): number | undefined {
-  const intervalMs = Number(value);
-  return Number.isSafeInteger(intervalMs) && intervalMs > 0 ? intervalMs : undefined;
+  return optionalPositiveInteger(value);
 }
 
 function parseOptionalBoolean(value: string | undefined): boolean | undefined {

--- a/mastracode/factory/src/integrations/github/reconciliation-config.ts
+++ b/mastracode/factory/src/integrations/github/reconciliation-config.ts
@@ -1,0 +1,19 @@
+export function reconciliationEnabled(child: string | undefined, legacy: string | undefined): boolean {
+  return parseOptionalBoolean(child) ?? parseOptionalBoolean(legacy) ?? true;
+}
+
+export function reconcileInterval(value: string | undefined): number | undefined {
+  const intervalMs = Number(value);
+  return Number.isSafeInteger(intervalMs) && intervalMs > 0 ? intervalMs : undefined;
+}
+
+function parseOptionalBoolean(value: string | undefined): boolean | undefined {
+  switch (value?.trim().toLowerCase()) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    default:
+      return undefined;
+  }
+}

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -1574,6 +1574,26 @@ describe('issues route', () => {
     });
   });
 
+  it('keeps GitHub triage labels unchanged when triage fails', async () => {
+    seedMaterializedProject();
+    const runIssueTriage = vi.fn(async () => {
+      throw new Error('triage failed');
+    });
+    const res = await buildApp({ workosId: 'u1' }, { runIssueTriage }).request('/web/github/projects/p1/issues/5/triage', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Keep labels retryable',
+        url: 'https://github.com/octo/hello/issues/5',
+        labels: ['status: needs triage'],
+      }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(addIssueLabels).not.toHaveBeenCalled();
+    expect(removeIssueLabel).not.toHaveBeenCalled();
+  });
+
   it('normalises labels through the shared wrapper and resolves the default model', async () => {
     seedMaterializedProject();
     const runIssueTriage = vi.fn(async () => ({ threadId: 'thread-triage' }));

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -462,6 +462,13 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
         if (!input.resourceId || !input.projectPath) {
           throw new Error('GitHub issue triage requires an explicit Factory project repository');
         }
+        const labels = input.labels.filter(label => label !== 'status: needs triage');
+        const result = await runIssueTriage({
+          ...input,
+          defaultModelId:
+            input.defaultModelId ?? (await resolveFactoryDefaultModelId(options.projects, input.resourceId)),
+          labels: labels.includes('status: auto-triaged') ? labels : [...labels, 'status: auto-triaged'],
+        });
         await github.addIssueLabels(input.installationId, input.repository, input.issueNumber, [
           'status: auto-triaged',
         ]);
@@ -473,13 +480,7 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
             'status: needs triage',
           );
         }
-        const labels = input.labels.filter(label => label !== 'status: needs triage');
-        return runIssueTriage({
-          ...input,
-          defaultModelId:
-            input.defaultModelId ?? (await resolveFactoryDefaultModelId(options.projects, input.resourceId)),
-          labels: labels.includes('status: auto-triaged') ? labels : [...labels, 'status: auto-triaged'],
-        });
+        return result;
       }
     : undefined;
 

--- a/mastracode/factory/src/integrations/issue-reconciler.test.ts
+++ b/mastracode/factory/src/integrations/issue-reconciler.test.ts
@@ -1,64 +1,27 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { Intake, IntakeIssueDetail } from '../capabilities/intake.js';
-import type { FactoryProject } from '../storage/domains/projects/base.js';
-import type { WorkItemRow, WorkItemsStorage } from '../storage/domains/work-items/base.js';
-import type { IntegrationContext } from './base.js';
-import type { GithubIntegration } from './github/integration.js';
-import { attachGithubIssueReconciler } from './github/issue-reconciler.js';
+import { builtInFactoryRules } from '../rules/defaults.js';
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import { createGithubIssueReconciler } from './github/issue-reconciler.js';
+import type { ReconcileIssueState } from './github/rules.js';
 import type { LinearIntegration } from './linear/integration.js';
 import { attachLinearIssueReconciler } from './linear/issue-reconciler.js';
 
-const project: FactoryProject = {
-  id: 'project-1',
-  orgId: 'org-1',
-  createdBy: 'user-1',
-  name: 'Factory',
-  description: null,
-  defaultModelId: null,
-  slackWorkItemsEnabled: false,
-  createdAt: new Date('2026-08-01T00:00:00Z'),
-  updatedAt: new Date('2026-08-01T00:00:00Z'),
-};
-
-function item(integrationId: 'github' | 'linear', metadata: Record<string, unknown>): WorkItemRow {
-  return {
-    id: `${integrationId}-item`,
-    orgId: project.orgId,
-    factoryProjectId: project.id,
-    externalSource: {
-      integrationId,
-      type: 'issue',
-      externalId: integrationId === 'github' ? 'github-issue:42' : 'linear:ENG-42',
-      url: `https://example.com/${integrationId}/42`,
-    },
-    parentWorkItemId: null,
-    title: 'Issue',
-    stages: ['backlog'],
-    stageHistory: [],
-    sessions: {},
-    metadata,
-    revision: 1,
-    createdBy: 'factory-rule-dispatcher',
-    createdAt: new Date('2026-08-01T00:00:00Z'),
-    updatedAt: new Date('2026-08-01T00:00:00Z'),
-  };
-}
-
 function issue(overrides: Partial<IntakeIssueDetail> = {}): IntakeIssueDetail {
   return {
-    id: '42',
-    identifier: '#42',
+    id: 'linear-uuid',
+    identifier: 'ENG-42',
     title: 'Issue',
-    url: 'https://example.com/issues/42',
-    author: 'octocat',
-    state: 'open',
-    stateType: 'open',
-    priority: null,
-    assignee: 'hubot',
-    assignees: ['hubot', 'monalisa'],
-    source: 'acme/app',
-    labels: [],
+    url: 'https://linear.app/acme/issue/ENG-42',
+    author: 'Linear Ada',
+    state: 'In Progress',
+    stateType: 'started',
+    priority: 'High',
+    assignee: 'Linear Grace',
+    assignees: ['Linear Grace'],
+    source: 'ENG',
+    labels: ['triage'],
     commentCount: 0,
     createdAt: '2026-08-01T00:00:00Z',
     updatedAt: '2026-08-02T00:00:00Z',
@@ -68,211 +31,194 @@ function issue(overrides: Partial<IntakeIssueDetail> = {}): IntakeIssueDetail {
   };
 }
 
-function context(workItem: WorkItemRow, intake: Intake) {
-  const update = vi.fn(async () => workItem);
-  return {
-    context: {
-      storage: { projects: { listAll: vi.fn(async () => [project]) } },
-      rules: {
-        workItems: {
-          list: vi.fn(async () => [workItem]),
-          update,
-        } as unknown as WorkItemsStorage,
+const repository = { id: 10, fullName: 'acme/repo', installationId: 7 };
+
+async function githubSetup(input: {
+  stages?: string[];
+  metadata?: Record<string, unknown>;
+  externalId?: string;
+  url?: string;
+} = {}) {
+  const seeded = await createFactoryStorageForTests();
+  const project = await seeded.projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Factory' } });
+  const sourceControl = seeded.sourceControl.forIntegration('github');
+  const installation = await sourceControl.installations.upsert({
+    orgId: project.orgId,
+    connectedByUserId: project.createdBy,
+    externalId: String(repository.installationId),
+  });
+  const storedRepository = await sourceControl.repositories.upsert({
+    orgId: project.orgId,
+    input: { installationId: installation.id, externalId: String(repository.id), slug: repository.fullName, defaultBranch: 'main' },
+  });
+  const connection = await sourceControl.connections.create({
+    orgId: project.orgId,
+    factoryProjectId: project.id,
+    installationId: installation.id,
+    createdByUserId: project.createdBy,
+  });
+  await sourceControl.projectRepositories.link({
+    orgId: project.orgId,
+    connectionId: connection.id,
+    repositoryId: storedRepository.id,
+    createdByUserId: project.createdBy,
+    sandboxProvider: 'local',
+    sandboxWorkdir: '/workspace',
+  });
+  const workItem = (
+    await seeded.workItems.upsert({
+      orgId: project.orgId,
+      userId: project.createdBy,
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue',
+          externalId: input.externalId ?? 'github-issue:42',
+          url: input.url ?? 'https://github.com/acme/repo/issues/42',
+        },
+        title: 'Issue 42',
+        stages: input.stages ?? ['planning'],
+        sessions: {},
+        metadata: { githubRepositoryId: repository.id, githubIssueNumber: 42, ...(input.metadata ?? {}) },
       },
-    } as unknown as IntegrationContext,
-    intake,
-    update,
+    })
+  ).item;
+  const reconciler = createGithubIssueReconciler(
+    {
+      github: { getRepositoryCollaboratorPermission: vi.fn() },
+      sourceControl,
+      integrationStorage: seeded.integrations.forIntegration('github'),
+      projects: seeded.projects,
+      storage: seeded.workItems,
+      rules: builtInFactoryRules(),
+    },
+    vi.fn(),
+  );
+  return { ...seeded, project, sourceControl, workItem, reconciler };
+}
+
+function githubState(overrides: Partial<ReconcileIssueState> = {}): ReconcileIssueState {
+  return {
+    title: 'Issue 42',
+    url: 'https://github.com/acme/repo/issues/42',
+    state: 'open',
+    author: 'octocat',
+    assignees: ['hubot', 'monalisa'],
+    labels: ['bug'],
+    ...overrides,
   };
 }
 
 describe('issue reconcilers', () => {
-  // TODO: Update GitHub tests for new fetchIssue-based reconciler
-  it.skip('skips GitHub issue cards for repositories outside the caller-supplied scope', async () => {
-    const inScope = item('github', { githubRepositoryId: 101, githubIssueNumber: 1 });
-    const outOfScope = { ...item('github', { githubRepositoryId: 202, githubIssueNumber: 2 }), id: 'other' };
-    const intake = {
-      resolveIntakeDispatch: vi.fn(async () => ({
-        connection: { type: 'github-app' as const, installationId: 7 },
-        sourceId: 'acme/app',
-        issueId: '1',
-      })),
-      getIssue: vi.fn(async () => issue()),
-    } as unknown as Intake;
-    const update = vi.fn();
-    const ctx = {
-      storage: { projects: { listAll: vi.fn(async () => [project]) } },
-      rules: {
-        workItems: {
-          list: vi.fn(async () => [inScope, outOfScope]),
-          update,
-        },
+  it('reconciles only scoped GitHub issue cards and refreshes metadata', async () => {
+    const setup = await githubSetup({ metadata: { assignees: ['old'] } });
+    const fetchIssue = vi.fn().mockResolvedValue(githubState());
+    const reconcile = createGithubIssueReconciler(
+      {
+        github: { getRepositoryCollaboratorPermission: vi.fn() },
+        sourceControl: setup.sourceControl,
+        integrationStorage: setup.integrations.forIntegration('github'),
+        projects: setup.projects,
+        storage: setup.workItems,
+        rules: builtInFactoryRules(),
       },
-    } as unknown as IntegrationContext;
-    // New reconciler requires fetchIssue callback
-    const reconcile = attachGithubIssueReconciler({ intake } as any, ctx, vi.fn());
-    const targets = [{ id: 101, fullName: 'acme/app', installationId: 7 }];
-
-    // Only the in-scope item is checked; the 202 item is filtered before dispatch.
-    await expect(reconcile?.(targets)).resolves.toMatchObject({ checked: 1 });
-    expect(intake.resolveIntakeDispatch).toHaveBeenCalledTimes(1);
-  });
-
-  it.skip('reconciles GitHub issue author, state, assignees, and labels', async () => {
-    const workItem = item('github', { githubRepositoryId: 101, githubIssueNumber: 42, assignees: ['old'] });
-    const intake = {
-      resolveIntakeDispatch: vi.fn(async () => ({
-        connection: { type: 'github-app' as const, installationId: 7 },
-        sourceId: 'acme/app',
-        issueId: 'github-issue:42',
-      })),
-      getIssue: vi.fn(async () => issue({ labels: ['bug', 'p1'] })),
-    } as unknown as Intake;
-    const test = context(workItem, intake);
-    // New reconciler requires fetchIssue callback
-    const reconcile = attachGithubIssueReconciler({ intake } as any, test.context, vi.fn());
-    const targets = [{ id: 101, fullName: 'acme/app', installationId: 7 }];
-
-    await expect(reconcile?.(targets)).resolves.toMatchObject({ projects: 1, checked: 1, updated: 1, failed: 0 });
-    expect(intake.resolveIntakeDispatch).toHaveBeenCalledWith({
-      orgId: 'org-1',
-      externalSource: { type: 'issue', externalId: '101:42' },
-    });
-    expect(intake.getIssue).toHaveBeenCalledWith(expect.objectContaining({ issueId: '42' }));
-    expect(test.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        patch: {
-          metadata: expect.objectContaining({
-            githubRepositoryId: 101,
-            githubIssueNumber: 42,
-            state: 'open',
-            author: 'octocat',
-            assignees: ['hubot', 'monalisa'],
-            labels: ['bug', 'p1'],
-          }),
-        },
-      }),
+      fetchIssue,
     );
+
+    await expect(reconcile([repository])).resolves.toMatchObject({ repositories: 1, checked: 1, updated: 1, failed: 0 });
+    expect(fetchIssue).toHaveBeenCalledWith({ installationId: 7, repository: 'acme/repo', number: 42 });
+    const [updated] = await setup.workItems.list({ orgId: 'org-1', factoryProjectId: setup.project.id });
+    expect(updated?.metadata).toMatchObject({ author: 'octocat', assignees: ['hubot', 'monalisa'], labels: ['bug'] });
   });
 
-  it('uses the persisted Linear issue UUID and refreshes teammate metadata', async () => {
-    const workItem = item('linear', { linearIssueId: 'linear-uuid', identifier: 'ENG-42' });
-    const intake = {
-      resolveIntakeDispatch: vi.fn(async () => ({
-        connection: { type: 'oauth' as const, accessToken: 'token' },
-        issueId: 'linear:ENG-42',
-      })),
-      getIssue: vi.fn(async () =>
-        issue({
-          id: 'linear-uuid',
-          identifier: 'ENG-42',
-          author: 'Linear Ada',
-          state: 'In Progress',
-          stateType: 'started',
-          priority: 'High',
-          assignee: 'Linear Grace',
-          assignees: undefined,
-          source: 'ENG',
-          labels: ['triage', 'ux'],
-        }),
-      ),
-    } as unknown as Intake;
-    const test = context(workItem, intake);
-    const reconcile = attachLinearIssueReconciler({ intake } as Pick<LinearIntegration, 'intake'>, test.context);
-
-    await expect(reconcile?.()).resolves.toMatchObject({ projects: 1, checked: 1, updated: 1, failed: 0 });
-    expect(intake.getIssue).toHaveBeenCalledWith(expect.objectContaining({ issueId: 'linear-uuid' }));
-    expect(test.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        patch: {
-          metadata: expect.objectContaining({
-            linearIssueId: 'linear-uuid',
-            identifier: 'ENG-42',
-            linearState: 'In Progress',
-            linearStateType: 'started',
-            linearPriority: 'High',
-            linearAssignee: 'Linear Grace',
-            linearCreator: 'Linear Ada',
-            linearTeam: 'ENG',
-            assignee: 'Linear Grace',
-            creator: 'Linear Ada',
-            author: 'Linear Ada',
-            labels: ['triage', 'ux'],
-          }),
-        },
-      }),
-    );
-  });
-
-  it.skip('does not clobber stored metadata when the live issue omits a field', async () => {
-    // Regression: when the live issue returns `author: undefined` we must
-    // preserve whatever was already stored on the work item rather than
-    // spreading `undefined` on top and erasing prior audit data.
-    const workItem = item('github', {
-      githubRepositoryId: 101,
-      githubIssueNumber: 42,
-      author: 'octocat',
-      assignees: ['monalisa'],
-    });
-    const intake = {
-      resolveIntakeDispatch: vi.fn(async () => ({
-        connection: { type: 'github-app' as const, installationId: 7 },
-        sourceId: 'acme/app',
-        issueId: '42',
-      })),
-      // Author disappears (e.g. deleted user); assignees change.
-      getIssue: vi.fn(async () => issue({ author: undefined as unknown as string, assignees: ['newbie'] })),
-    } as unknown as Intake;
-    const test = context(workItem, intake);
-    // New reconciler requires fetchIssue callback
-    const reconcile = attachGithubIssueReconciler({ intake } as any, test.context, vi.fn());
-    const targets = [{ id: 101, fullName: 'acme/app', installationId: 7 }];
-
-    await expect(reconcile?.(targets)).resolves.toMatchObject({ updated: 1 });
-    const patchCall = (test.update.mock.calls as unknown[][])[0]![0] as { patch: { metadata: Record<string, unknown> } };
-    // author was undefined in the desired patch and must not appear as such.
-    expect(patchCall.patch.metadata).not.toHaveProperty('author', undefined);
-    expect(patchCall.patch.metadata.author).toBe('octocat');
-    expect(patchCall.patch.metadata.assignees).toEqual(['newbie']);
-  });
-
-  it.skip('does not write already reconciled metadata and isolates fetch failures', async () => {
-    const current = item('github', {
-      githubRepositoryId: 101,
-      githubIssueNumber: 42,
-      state: 'open',
-      author: 'octocat',
-      assignees: ['monalisa', 'hubot'],
-    });
-    const failed = {
-      ...item('github', { githubRepositoryId: 101, githubIssueNumber: 43 }),
-      id: 'failed-item',
-    };
-    const intake = {
-      resolveIntakeDispatch: vi.fn(async () => ({
-        connection: { type: 'github-app' as const, installationId: 7 },
-        sourceId: 'acme/app',
-        issueId: '42',
-      })),
-      getIssue: vi.fn(async ({ issueId }: { issueId: string }) => {
-        if (issueId === '43') throw new Error('provider unavailable');
-        return issue();
-      }),
-    } as unknown as Intake;
-    const update = vi.fn();
-    const ctx = {
-      storage: { projects: { listAll: vi.fn(async () => [project]) } },
-      rules: {
-        workItems: {
-          list: vi.fn(async () => [current, failed]),
-          update,
-        },
+  it('replays a stable GitHub close through rules ingress without a direct metadata write', async () => {
+    const setup = await githubSetup();
+    const update = vi.spyOn(setup.workItems, 'update');
+    const reconcile = createGithubIssueReconciler(
+      {
+        github: { getRepositoryCollaboratorPermission: vi.fn() },
+        sourceControl: setup.sourceControl,
+        integrationStorage: setup.integrations.forIntegration('github'),
+        projects: setup.projects,
+        storage: setup.workItems,
+        rules: builtInFactoryRules(),
       },
-    } as unknown as IntegrationContext;
-    // New reconciler requires fetchIssue callback
-    const reconcile = attachGithubIssueReconciler({ intake } as any, ctx, vi.fn());
-    const targets = [{ id: 101, fullName: 'acme/app', installationId: 7 }];
+      vi.fn().mockResolvedValue(githubState({ state: 'closed', stateReason: 'not_planned' })),
+    );
 
-    await expect(reconcile?.(targets)).resolves.toMatchObject({ checked: 2, updated: 0, failed: 1 });
+    await expect(reconcile([repository])).resolves.toMatchObject({ checked: 1, closed: 1, updated: 0 });
+    await expect(reconcile([repository])).resolves.toMatchObject({ checked: 1, closed: 1, updated: 0 });
     expect(update).not.toHaveBeenCalled();
+    const decisions = await setup.workItems.listDeferredDecisions('org-1', setup.project.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toMatchObject({ type: 'transition', stage: 'canceled' });
+  });
+
+  it('skips terminal and unrelated GitHub cards, preserves undefined provider metadata, and isolates failures', async () => {
+    const terminal = await githubSetup({ stages: ['done'] });
+    const terminalFetch = vi.fn();
+    const terminalReconcile = createGithubIssueReconciler(
+      {
+        github: { getRepositoryCollaboratorPermission: vi.fn() },
+        sourceControl: terminal.sourceControl,
+        integrationStorage: terminal.integrations.forIntegration('github'),
+        projects: terminal.projects,
+        storage: terminal.workItems,
+        rules: builtInFactoryRules(),
+      },
+      terminalFetch,
+    );
+    await expect(terminalReconcile([repository])).resolves.toMatchObject({ checked: 0 });
+    expect(terminalFetch).not.toHaveBeenCalled();
+
+    const setup = await githubSetup({ metadata: { author: 'stored author', labels: ['stored'] } });
+    const reconcile = createGithubIssueReconciler(
+      {
+        github: { getRepositoryCollaboratorPermission: vi.fn() },
+        sourceControl: setup.sourceControl,
+        integrationStorage: setup.integrations.forIntegration('github'),
+        projects: setup.projects,
+        storage: setup.workItems,
+        rules: builtInFactoryRules(),
+      },
+      vi.fn().mockResolvedValue(githubState({ author: undefined, labels: undefined, assignees: ['new'] })),
+    );
+    await expect(reconcile([repository])).resolves.toMatchObject({ updated: 1, failed: 0 });
+    const [updated] = await setup.workItems.list({ orgId: 'org-1', factoryProjectId: setup.project.id });
+    expect(updated?.metadata).toMatchObject({ author: 'stored author', labels: ['stored'], assignees: ['new'] });
+  });
+
+  it('replays completed and canceled Linear issues through rules ingress', async () => {
+    const seeded = await createFactoryStorageForTests();
+    const project = await seeded.projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Factory' } });
+    await seeded.workItems.upsert({
+      orgId: project.orgId,
+      userId: project.createdBy,
+      factoryProjectId: project.id,
+      input: {
+        externalSource: { integrationId: 'linear', type: 'issue', externalId: 'linear:ENG-42', url: 'https://linear.app/acme/issue/ENG-42' },
+        title: 'ENG-42: Issue',
+        stages: ['planning'],
+        sessions: {},
+        metadata: { linearIssueId: 'linear-uuid' },
+      },
+    });
+    const intake = {
+      resolveIntakeDispatch: vi.fn().mockResolvedValue({ connection: { type: 'oauth', accessToken: 'token' }, issueId: 'linear-uuid' }),
+      getIssue: vi.fn().mockResolvedValue(issue({ state: 'Canceled', stateType: 'canceled' })),
+    } as unknown as Intake;
+    const reconcile = attachLinearIssueReconciler(
+      { intake } as Pick<LinearIntegration, 'intake'>,
+      {
+        storage: { projects: seeded.projects },
+        rules: { config: builtInFactoryRules(), workItems: seeded.workItems },
+      } as never,
+    );
+
+    await expect(reconcile?.()).resolves.toMatchObject({ checked: 1, closed: 1, updated: 0 });
+    const decisions = await seeded.workItems.listDeferredDecisions('org-1', project.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toMatchObject({ type: 'transition', stage: 'canceled' });
   });
 });

--- a/mastracode/factory/src/integrations/issue-reconciler.test.ts
+++ b/mastracode/factory/src/integrations/issue-reconciler.test.ts
@@ -4,7 +4,7 @@ import type { Intake, IntakeIssueDetail } from '../capabilities/intake.js';
 import { builtInFactoryRules } from '../rules/defaults.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import { createGithubIssueReconciler } from './github/issue-reconciler.js';
-import type { ReconcileIssueState } from './github/rules.js';
+import type { GithubIssueFetcher, ReconcileIssueState } from './github/rules.js';
 import type { LinearIntegration } from './linear/integration.js';
 import { attachLinearIssueReconciler } from './linear/issue-reconciler.js';
 
@@ -38,6 +38,7 @@ async function githubSetup(input: {
   metadata?: Record<string, unknown>;
   externalId?: string;
   url?: string;
+  fetchIssue?: GithubIssueFetcher;
 } = {}) {
   const seeded = await createFactoryStorageForTests();
   const project = await seeded.projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Factory' } });
@@ -93,7 +94,7 @@ async function githubSetup(input: {
       storage: seeded.workItems,
       rules: builtInFactoryRules(),
     },
-    vi.fn(),
+    input.fetchIssue ?? vi.fn(),
   );
   return { ...seeded, project, sourceControl, workItem, reconciler };
 }
@@ -112,84 +113,45 @@ function githubState(overrides: Partial<ReconcileIssueState> = {}): ReconcileIss
 
 describe('issue reconcilers', () => {
   it('reconciles only scoped GitHub issue cards and refreshes metadata', async () => {
-    const setup = await githubSetup({ metadata: { assignees: ['old'] } });
     const fetchIssue = vi.fn().mockResolvedValue(githubState());
-    const reconcile = createGithubIssueReconciler(
-      {
-        github: { getRepositoryCollaboratorPermission: vi.fn() },
-        sourceControl: setup.sourceControl,
-        integrationStorage: setup.integrations.forIntegration('github'),
-        projects: setup.projects,
-        storage: setup.workItems,
-        rules: builtInFactoryRules(),
-      },
-      fetchIssue,
-    );
+    const setup = await githubSetup({ metadata: { assignees: ['old'] }, fetchIssue });
 
-    await expect(reconcile([repository])).resolves.toMatchObject({ repositories: 1, checked: 1, updated: 1, failed: 0 });
+    await expect(setup.reconciler([repository])).resolves.toMatchObject({ repositories: 1, checked: 1, updated: 1, failed: 0 });
     expect(fetchIssue).toHaveBeenCalledWith({ installationId: 7, repository: 'acme/repo', number: 42 });
     const [updated] = await setup.workItems.list({ orgId: 'org-1', factoryProjectId: setup.project.id });
     expect(updated?.metadata).toMatchObject({ author: 'octocat', assignees: ['hubot', 'monalisa'], labels: ['bug'] });
   });
 
   it('replays a stable GitHub close through rules ingress without a direct metadata write', async () => {
-    const setup = await githubSetup();
+    const setup = await githubSetup({
+      fetchIssue: vi.fn().mockResolvedValue(githubState({ state: 'closed', stateReason: 'not_planned' })),
+    });
     const update = vi.spyOn(setup.workItems, 'update');
-    const reconcile = createGithubIssueReconciler(
-      {
-        github: { getRepositoryCollaboratorPermission: vi.fn() },
-        sourceControl: setup.sourceControl,
-        integrationStorage: setup.integrations.forIntegration('github'),
-        projects: setup.projects,
-        storage: setup.workItems,
-        rules: builtInFactoryRules(),
-      },
-      vi.fn().mockResolvedValue(githubState({ state: 'closed', stateReason: 'not_planned' })),
-    );
 
-    await expect(reconcile([repository])).resolves.toMatchObject({ checked: 1, closed: 1, updated: 0 });
-    await expect(reconcile([repository])).resolves.toMatchObject({ checked: 1, closed: 1, updated: 0 });
+    await expect(setup.reconciler([repository])).resolves.toMatchObject({ checked: 1, closed: 1, updated: 0 });
+    await expect(setup.reconciler([repository])).resolves.toMatchObject({ checked: 1, closed: 1, updated: 0 });
     expect(update).not.toHaveBeenCalled();
     const decisions = await setup.workItems.listDeferredDecisions('org-1', setup.project.id);
     expect(decisions).toHaveLength(1);
     expect(decisions[0]?.decision).toMatchObject({ type: 'transition', stage: 'canceled' });
   });
 
-  it('skips terminal and unrelated GitHub cards, preserves undefined provider metadata, and isolates failures', async () => {
-    const terminal = await githubSetup({ stages: ['done'] });
+  it('skips terminal GitHub cards and preserves undefined provider metadata', async () => {
     const terminalFetch = vi.fn();
-    const terminalReconcile = createGithubIssueReconciler(
-      {
-        github: { getRepositoryCollaboratorPermission: vi.fn() },
-        sourceControl: terminal.sourceControl,
-        integrationStorage: terminal.integrations.forIntegration('github'),
-        projects: terminal.projects,
-        storage: terminal.workItems,
-        rules: builtInFactoryRules(),
-      },
-      terminalFetch,
-    );
-    await expect(terminalReconcile([repository])).resolves.toMatchObject({ checked: 0 });
+    const terminal = await githubSetup({ stages: ['done'], fetchIssue: terminalFetch });
+    await expect(terminal.reconciler([repository])).resolves.toMatchObject({ checked: 0 });
     expect(terminalFetch).not.toHaveBeenCalled();
 
-    const setup = await githubSetup({ metadata: { author: 'stored author', labels: ['stored'] } });
-    const reconcile = createGithubIssueReconciler(
-      {
-        github: { getRepositoryCollaboratorPermission: vi.fn() },
-        sourceControl: setup.sourceControl,
-        integrationStorage: setup.integrations.forIntegration('github'),
-        projects: setup.projects,
-        storage: setup.workItems,
-        rules: builtInFactoryRules(),
-      },
-      vi.fn().mockResolvedValue(githubState({ author: undefined, labels: undefined, assignees: ['new'] })),
-    );
-    await expect(reconcile([repository])).resolves.toMatchObject({ updated: 1, failed: 0 });
+    const setup = await githubSetup({
+      metadata: { author: 'stored author', labels: ['stored'] },
+      fetchIssue: vi.fn().mockResolvedValue(githubState({ author: undefined, labels: undefined, assignees: ['new'] })),
+    });
+    await expect(setup.reconciler([repository])).resolves.toMatchObject({ updated: 1, failed: 0 });
     const [updated] = await setup.workItems.list({ orgId: 'org-1', factoryProjectId: setup.project.id });
     expect(updated?.metadata).toMatchObject({ author: 'stored author', labels: ['stored'], assignees: ['new'] });
   });
 
-  it('replays completed and canceled Linear issues through rules ingress', async () => {
+  it('replays canceled Linear issues through rules ingress', async () => {
     const seeded = await createFactoryStorageForTests();
     const project = await seeded.projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Factory' } });
     await seeded.workItems.upsert({

--- a/mastracode/factory/src/integrations/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/linear/integration.test.ts
@@ -263,21 +263,41 @@ describe('LinearIntegration capability surface', () => {
 });
 
 describe('LinearIntegration workers', () => {
+  const context = {
+    controller: {},
+    storage: {
+      generic: {},
+      sourceControl: {},
+      projects: { listAll: async () => [] },
+      intake: {},
+    },
+    rules: { config: {}, workItems: {} },
+  };
+
   it('registers a standalone issue reconciler worker', () => {
     const linear = integration() as unknown as {
       workers(ctx: unknown): Array<{ name: string }>;
     };
-    const context = {
-      controller: {},
-      storage: {
-        generic: {},
-        sourceControl: {},
-        projects: { listAll: async () => [] },
-        intake: {},
-      },
-      rules: { config: {}, workItems: {} },
+
+    expect(linear.workers(context).map(worker => worker.name)).toEqual(['linear-issue-reconcile']);
+  });
+
+  it('uses the issue reconcile switch before the legacy switch', () => {
+    vi.stubEnv('MASTRACODE_LINEAR_RECONCILE_ENABLED', 'false');
+    vi.stubEnv('MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED', 'true');
+    const linear = integration() as unknown as {
+      workers(ctx: unknown): Array<{ name: string }>;
     };
 
     expect(linear.workers(context).map(worker => worker.name)).toEqual(['linear-issue-reconcile']);
+  });
+
+  it('does not register when issue reconciliation is disabled', () => {
+    vi.stubEnv('MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED', 'false');
+    const linear = integration() as unknown as {
+      workers(ctx: unknown): Array<{ name: string }>;
+    };
+
+    expect(linear.workers(context)).toEqual([]);
   });
 });

--- a/mastracode/factory/src/integrations/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/linear/integration.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('../issue-reconcile-worker.js', () => ({
+  IssueReconcileWorker: class {
+    readonly name = 'linear-issue-reconcile';
+
+    constructor(readonly config: unknown) {}
+  },
+}));
+
 import { LinearIntegration } from './integration.js';
 import type { LinearIssue, LinearIssueDetail } from './integration.js';
 
@@ -27,6 +35,7 @@ const issue: LinearIssue = {
 const connection = { type: 'oauth' as const, accessToken: 'linear-token' };
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
 });
 
@@ -290,6 +299,37 @@ describe('LinearIntegration workers', () => {
     };
 
     expect(linear.workers(context).map(worker => worker.name)).toEqual(['linear-issue-reconcile']);
+  });
+
+  it('uses the issue reconcile interval before the legacy interval and falls back when invalid', () => {
+    vi.stubEnv('MASTRACODE_LINEAR_RECONCILE_INTERVAL_MS', '120000');
+    vi.stubEnv('MASTRACODE_LINEAR_ISSUE_RECONCILE_INTERVAL_MS', '60000');
+    const linear = integration() as unknown as {
+      workers(ctx: unknown): Array<{ config: { intervalMs?: number } }>;
+    };
+
+    expect(linear.workers(context)[0]?.config).toMatchObject({ intervalMs: 60000 });
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubEnv('MASTRACODE_LINEAR_ISSUE_RECONCILE_INTERVAL_MS', 'invalid');
+    expect(linear.workers(context)[0]?.config).toMatchObject({ intervalMs: 120000 });
+    expect(warn).toHaveBeenCalledWith(
+      '[Linear reconciliation] MASTRACODE_LINEAR_ISSUE_RECONCILE_INTERVAL_MS must be a positive integer; received "invalid".',
+    );
+  });
+
+  it('falls back from an invalid issue reconcile switch and warns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubEnv('MASTRACODE_LINEAR_RECONCILE_ENABLED', 'false');
+    vi.stubEnv('MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED', 'yes');
+    const linear = integration() as unknown as {
+      workers(ctx: unknown): Array<{ name: string }>;
+    };
+
+    expect(linear.workers(context)).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      '[Linear reconciliation] MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED must be true or false; received "yes".',
+    );
   });
 
   it('does not register when issue reconciliation is disabled', () => {

--- a/mastracode/factory/src/integrations/linear/integration.ts
+++ b/mastracode/factory/src/integrations/linear/integration.ts
@@ -39,6 +39,7 @@ import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '.
 import { IssueReconcileWorker } from '../issue-reconcile-worker.js';
 import { buildLinearAgentTools } from './agent-tools.js';
 import { attachLinearIssueReconciler } from './issue-reconciler.js';
+import { linearIssueReconciliationEnabled, linearIssueReconciliationInterval } from './reconciliation-config.js';
 import { buildLinearRoutes } from './routes.js';
 import { attachLinearRules } from './rules.js';
 import type { LinearConnectionRow, LinearStorageHandle, UpsertLinearConnectionInput } from './storage.js';
@@ -972,15 +973,15 @@ export class LinearIntegration implements FactoryIntegration {
   // ── FactoryIntegration surface ───────────────────────────────────────────
 
   workers(ctx: IntegrationContext): MastraWorker[] {
-    if (process.env.MASTRACODE_LINEAR_RECONCILE_ENABLED?.trim().toLowerCase() === 'false') return [];
+    if (!linearIssueReconciliationEnabled()) return [];
     const reconcile = attachLinearIssueReconciler(this, ctx);
     if (!reconcile) return [];
-    const intervalMs = Number(process.env.MASTRACODE_LINEAR_RECONCILE_INTERVAL_MS);
+    const intervalMs = linearIssueReconciliationInterval();
     return [
       new IssueReconcileWorker({
         integrationId: this.id,
         reconcile,
-        ...(Number.isSafeInteger(intervalMs) && intervalMs > 0 ? { intervalMs } : {}),
+        ...(intervalMs ? { intervalMs } : {}),
       }),
     ];
   }

--- a/mastracode/factory/src/integrations/linear/reconciliation-config.ts
+++ b/mastracode/factory/src/integrations/linear/reconciliation-config.ts
@@ -1,0 +1,30 @@
+function reconciliationEnabled(childValue: string | undefined, legacyValue: string | undefined): boolean {
+  return parseBoolean(childValue) ?? parseBoolean(legacyValue) ?? true;
+}
+
+function optionalPositiveInterval(value: string | undefined): number | undefined {
+  const parsed = Number(value?.trim());
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized === 'true') return true;
+  if (normalized === 'false') return false;
+  return undefined;
+}
+
+export function linearIssueReconciliationEnabled(): boolean {
+  return reconciliationEnabled(
+    process.env.MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED,
+    process.env.MASTRACODE_LINEAR_RECONCILE_ENABLED,
+  );
+}
+
+export function linearIssueReconciliationInterval(): number | undefined {
+  return (
+    optionalPositiveInterval(process.env.MASTRACODE_LINEAR_ISSUE_RECONCILE_INTERVAL_MS) ??
+    optionalPositiveInterval(process.env.MASTRACODE_LINEAR_RECONCILE_INTERVAL_MS)
+  );
+}

--- a/mastracode/factory/src/integrations/linear/reconciliation-config.ts
+++ b/mastracode/factory/src/integrations/linear/reconciliation-config.ts
@@ -1,30 +1,46 @@
-function reconciliationEnabled(childValue: string | undefined, legacyValue: string | undefined): boolean {
-  return parseBoolean(childValue) ?? parseBoolean(legacyValue) ?? true;
+import { optionalPositiveInteger } from '../reconciliation-config.js';
+
+function reconciliationEnabled(
+  childName: string,
+  childValue: string | undefined,
+  legacyName: string,
+  legacyValue: string | undefined,
+): boolean {
+  return parseBoolean(childName, childValue) ?? parseBoolean(legacyName, legacyValue) ?? true;
 }
 
-function optionalPositiveInterval(value: string | undefined): number | undefined {
-  const parsed = Number(value?.trim());
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+function optionalPositiveInterval(name: string, value: string | undefined): number | undefined {
+  const interval = optionalPositiveInteger(value);
+  if (value?.trim() && interval === undefined) {
+    console.warn(`[Linear reconciliation] ${name} must be a positive integer; received ${JSON.stringify(value)}.`);
+  }
+  return interval;
 }
 
-function parseBoolean(value: string | undefined): boolean | undefined {
+function parseBoolean(name: string, value: string | undefined): boolean | undefined {
   const normalized = value?.trim().toLowerCase();
   if (!normalized) return undefined;
   if (normalized === 'true') return true;
   if (normalized === 'false') return false;
+  console.warn(`[Linear reconciliation] ${name} must be true or false; received ${JSON.stringify(value)}.`);
   return undefined;
 }
 
 export function linearIssueReconciliationEnabled(): boolean {
   return reconciliationEnabled(
+    'MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED',
     process.env.MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED,
+    'MASTRACODE_LINEAR_RECONCILE_ENABLED',
     process.env.MASTRACODE_LINEAR_RECONCILE_ENABLED,
   );
 }
 
 export function linearIssueReconciliationInterval(): number | undefined {
   return (
-    optionalPositiveInterval(process.env.MASTRACODE_LINEAR_ISSUE_RECONCILE_INTERVAL_MS) ??
-    optionalPositiveInterval(process.env.MASTRACODE_LINEAR_RECONCILE_INTERVAL_MS)
+    optionalPositiveInterval(
+      'MASTRACODE_LINEAR_ISSUE_RECONCILE_INTERVAL_MS',
+      process.env.MASTRACODE_LINEAR_ISSUE_RECONCILE_INTERVAL_MS,
+    ) ??
+    optionalPositiveInterval('MASTRACODE_LINEAR_RECONCILE_INTERVAL_MS', process.env.MASTRACODE_LINEAR_RECONCILE_INTERVAL_MS)
   );
 }

--- a/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
@@ -2,6 +2,7 @@ import type { LeaseProvider } from '@mastra/core/events';
 import type { WorkerDeps } from '@mastra/core/worker';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { GithubIssueReconciler } from '../../github/issue-reconciler.js';
 import type { GithubPullRequestReconciler } from '../../github/rules.js';
 import type { dispatchGithubWebhook } from '../../github/webhook.js';
 import { PlatformApiClient } from '../api-client.js';
@@ -68,7 +69,10 @@ function createWorker(input: {
   dispatch?: typeof dispatchGithubWebhook;
   ingestFactoryEvent?: (event: Parameters<typeof dispatchGithubWebhook>[0]) => Promise<unknown>;
   reconcileFactoryState?: GithubPullRequestReconciler;
+  reconcileIssuesFactoryState?: GithubIssueReconciler;
   reconcileIntervalMs?: number;
+  pullRequestReconcileIntervalMs?: number;
+  issueReconcileIntervalMs?: number;
   pollEventsEnabled?: boolean;
 }) {
   return new PlatformGithubEventWorker({
@@ -78,7 +82,10 @@ function createWorker(input: {
     storage: input.storage,
     ingestFactoryEvent: input.ingestFactoryEvent,
     reconcileFactoryState: input.reconcileFactoryState,
+    reconcileIssuesFactoryState: input.reconcileIssuesFactoryState,
     reconcileIntervalMs: input.reconcileIntervalMs,
+    pullRequestReconcileIntervalMs: input.pullRequestReconcileIntervalMs,
+    issueReconcileIntervalMs: input.issueReconcileIntervalMs,
     pollEventsEnabled: input.pollEventsEnabled,
     intervalMs: input.intervalMs ?? 1_000,
     now: input.now,
@@ -560,6 +567,97 @@ describe('PlatformGithubEventWorker', () => {
     expect(reconcileFactoryState).toHaveBeenCalledTimes(3);
 
     await worker.stop();
+  });
+
+  it('runs issue reconciliation without a pull-request reconciler', async () => {
+    const settings = createSettingsStorage();
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/installations')) {
+        return json({ installations: [{ installationId: 7, usable: true, suspendedAt: null }] });
+      }
+      if (url.pathname.endsWith('/installations/7/repositories')) {
+        return json({ repositories: [{ id: 101, fullName: 'acme/repo' }] });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const reconcileIssuesFactoryState = vi.fn<GithubIssueReconciler>(async () => ({
+      repositories: 1,
+      checked: 1,
+      updated: 0,
+      closed: 0,
+      failed: 0,
+      errors: [],
+    }));
+    const worker = createWorker({
+      fetchImpl,
+      storage: settings.storage,
+      now: () => 1_000_000,
+      reconcileIssuesFactoryState,
+      pollEventsEnabled: false,
+    });
+
+    await worker.init(createDeps());
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await worker.stop();
+
+    expect(reconcileIssuesFactoryState).toHaveBeenCalledWith([{ id: 101, fullName: 'acme/repo', installationId: 7 }]);
+  });
+
+  it('runs pull-request and issue reconciliation on independent cadences', async () => {
+    const settings = createSettingsStorage();
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/installations')) {
+        return json({ installations: [{ installationId: 7, usable: true, suspendedAt: null }] });
+      }
+      if (url.pathname.endsWith('/installations/7/repositories')) {
+        return json({ repositories: [{ id: 101, fullName: 'acme/repo' }] });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    let clock = 1_000_000;
+    const reconcileFactoryState = vi.fn<GithubPullRequestReconciler>(async () => ({
+      repositories: 1,
+      checked: 1,
+      merged: 0,
+      closed: 0,
+      failed: 0,
+      errors: [],
+    }));
+    const reconcileIssuesFactoryState = vi.fn<GithubIssueReconciler>(async () => ({
+      repositories: 1,
+      checked: 1,
+      updated: 0,
+      closed: 0,
+      failed: 0,
+      errors: [],
+    }));
+    const worker = createWorker({
+      fetchImpl,
+      storage: settings.storage,
+      now: () => clock,
+      reconcileFactoryState,
+      reconcileIssuesFactoryState,
+      pullRequestReconcileIntervalMs: 5_000,
+      issueReconcileIntervalMs: 2_000,
+      pollEventsEnabled: false,
+    });
+
+    await worker.init(createDeps());
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+    clock += 2_000;
+    await vi.advanceTimersByTimeAsync(2_000);
+    clock += 2_000;
+    await vi.advanceTimersByTimeAsync(2_000);
+    clock += 2_000;
+    await vi.advanceTimersByTimeAsync(2_000);
+    await worker.stop();
+
+    expect(reconcileFactoryState).toHaveBeenCalledTimes(2);
+    expect(reconcileIssuesFactoryState).toHaveBeenCalledTimes(4);
   });
 
   it('reconciles without tailing events when event polling is disabled', async () => {

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -74,16 +74,14 @@ export interface PlatformGithubEventWorkerConfig {
   storage: PlatformGithubEventStorage;
   ingestFactoryEvent?: (event: ParsedGithubWebhook) => Promise<unknown>;
   reconcileFactoryState?: GithubPullRequestReconciler;
-  /**
-   * Optional issue-metadata reconciler. When set, folded into the same
-   * reconcile tick as `reconcileFactoryState` so a single lease covers both
-   * writers of card state for the currently discovered repositories.
-   */
   reconcileIssuesFactoryState?: GithubIssueReconciler;
-  /** When false the worker skips event tailing and only runs the reconcile sweep. */
+  /** When false the worker skips event tailing and only runs enabled reconciliation sweeps. */
   pollEventsEnabled?: boolean;
   intervalMs?: number;
+  /** Legacy shared reconciliation cadence. */
   reconcileIntervalMs?: number;
+  pullRequestReconcileIntervalMs?: number;
+  issueReconcileIntervalMs?: number;
   now?: () => number;
   dispatch?: typeof dispatchGithubWebhook;
 }
@@ -99,7 +97,8 @@ export class PlatformGithubEventWorker extends MastraWorker {
   readonly #reconcileFactoryState: GithubPullRequestReconciler | undefined;
   readonly #reconcileIssuesFactoryState: GithubIssueReconciler | undefined;
   readonly #pollEventsEnabled: boolean;
-  readonly #reconcileIntervalMs: number;
+  readonly #pullRequestReconcileIntervalMs: number;
+  readonly #issueReconcileIntervalMs: number;
   readonly #intervalMs: number;
   readonly #now: () => number;
   readonly #dispatch: typeof dispatchGithubWebhook;
@@ -113,7 +112,8 @@ export class PlatformGithubEventWorker extends MastraWorker {
   #leaseTtlMs: number;
   #hasLease = false;
   #startedAt = 0;
-  #lastReconcileAt = 0;
+  #lastPullRequestReconcileAt = 0;
+  #lastIssueReconcileAt = 0;
   #settings: PlatformGithubEventWorkerSettings = { version: 1, repositories: {} };
 
   constructor(config: PlatformGithubEventWorkerConfig) {
@@ -126,12 +126,23 @@ export class PlatformGithubEventWorker extends MastraWorker {
     this.#reconcileFactoryState = config.reconcileFactoryState;
     this.#reconcileIssuesFactoryState = config.reconcileIssuesFactoryState;
     this.#pollEventsEnabled = config.pollEventsEnabled ?? true;
-    this.#reconcileIntervalMs = config.reconcileIntervalMs ?? DEFAULT_RECONCILE_INTERVAL_MS;
+    const legacyReconcileIntervalMs = config.reconcileIntervalMs ?? DEFAULT_RECONCILE_INTERVAL_MS;
+    this.#pullRequestReconcileIntervalMs = config.pullRequestReconcileIntervalMs ?? legacyReconcileIntervalMs;
+    this.#issueReconcileIntervalMs = config.issueReconcileIntervalMs ?? legacyReconcileIntervalMs;
     this.#intervalMs = config.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     if (!Number.isFinite(this.#intervalMs) || this.#intervalMs <= 0) {
       throw new Error('Platform GitHub event polling interval must be a positive number.');
     }
-    this.#leaseTtlMs = Math.max(MIN_LEASE_TTL_MS, this.#intervalMs * 3);
+    if (!Number.isFinite(this.#pullRequestReconcileIntervalMs) || this.#pullRequestReconcileIntervalMs <= 0) {
+      throw new Error('Platform GitHub pull request reconcile interval must be a positive number.');
+    }
+    if (!Number.isFinite(this.#issueReconcileIntervalMs) || this.#issueReconcileIntervalMs <= 0) {
+      throw new Error('Platform GitHub issue reconcile interval must be a positive number.');
+    }
+    this.#leaseTtlMs = Math.max(
+      MIN_LEASE_TTL_MS,
+      Math.min(this.#intervalMs, this.#pullRequestReconcileIntervalMs, this.#issueReconcileIntervalMs) * 3,
+    );
     this.#now = config.now ?? Date.now;
     this.#dispatch = config.dispatch ?? dispatchGithubWebhook;
   }
@@ -241,9 +252,7 @@ export class PlatformGithubEventWorker extends MastraWorker {
 
   async #poll(): Promise<number> {
     const repositories = await this.#discoverRepositories();
-    // Reconcile-only mode has no event tail to keep fresh, so tick on the
-    // slower reconcile cadence instead of the polling interval.
-    let retryInMs = this.#pollEventsEnabled ? this.#intervalMs : this.#reconcileIntervalMs;
+    let retryInMs = this.#pollEventsEnabled ? this.#intervalMs : this.#reconcileCadence();
 
     if (this.#pollEventsEnabled) {
       for (const repository of repositories) {
@@ -264,83 +273,85 @@ export class PlatformGithubEventWorker extends MastraWorker {
     }
 
     await this.#maybeReconcile(repositories);
-
     return retryInMs;
   }
 
-  /**
-   * State-based safety net: event tailing can miss merges (cursor gaps,
-   * downtime, terminally failed decisions), so on a slower cadence we compare
-   * still-open PR cards against actual GitHub state and replay missed merges
-   * through the normal ingress, which dedupes against the event path.
-   */
+  #reconcileCadence(): number {
+    const cadences = [
+      this.#reconcileFactoryState ? this.#pullRequestReconcileIntervalMs : undefined,
+      this.#reconcileIssuesFactoryState ? this.#issueReconcileIntervalMs : undefined,
+    ].filter((interval): interval is number => interval !== undefined);
+    return cadences.length > 0 ? Math.min(...cadences) : this.#intervalMs;
+  }
+
   async #maybeReconcile(repositories: Repository[]): Promise<void> {
-    if (!this.#reconcileFactoryState || !this.#running || !this.#hasLease) return;
+    if (!this.#running || !this.#hasLease) return;
     const now = this.#now();
-    if (now - this.#lastReconcileAt < this.#reconcileIntervalMs) return;
-    // Advance the clock before sweeping so a persistently failing sweep stays
-    // on cadence instead of retrying every poll tick.
-    this.#lastReconcileAt = now;
+    const reconcilePullRequests = Boolean(
+      this.#reconcileFactoryState && now - this.#lastPullRequestReconcileAt >= this.#pullRequestReconcileIntervalMs,
+    );
+    const reconcileIssues = Boolean(
+      this.#reconcileIssuesFactoryState && now - this.#lastIssueReconcileAt >= this.#issueReconcileIntervalMs,
+    );
+    if (!reconcilePullRequests && !reconcileIssues) return;
+    if (reconcilePullRequests) this.#lastPullRequestReconcileAt = now;
+    if (reconcileIssues) this.#lastIssueReconcileAt = now;
+
     const targets: ReconcileRepository[] = repositories.flatMap(repository =>
       repository.fullName
         ? [{ id: repository.id, fullName: repository.fullName, installationId: repository.installationId }]
         : [],
     );
     if (targets.length === 0) {
-      this.deps?.logger.debug('Platform GitHub pull request reconcile skipped: no named repositories');
+      this.deps?.logger.debug('Platform GitHub reconciliation skipped: no named repositories');
       return;
     }
-    this.deps?.logger.debug('Platform GitHub pull request reconcile sweep starting', {
-      candidateRepositories: targets.length,
-    });
-    const startedAt = Date.now();
-    try {
-      // `counts.repositories` is the factory-configured subset actually swept;
-      // `candidateRepositories` is everything the installations exposed.
-      const { errors, ...counts } = await this.#reconcileFactoryState(targets);
-      const context = { ...counts, candidateRepositories: targets.length, durationMs: Date.now() - startedAt };
-      if (counts.failed > 0) {
-        this.deps?.logger.warn('Platform GitHub pull request reconcile sweep completed with failures', {
-          ...context,
-          errors,
+
+    if (reconcilePullRequests && this.#reconcileFactoryState) {
+      const startedAt = Date.now();
+      try {
+        const { errors, ...counts } = await this.#reconcileFactoryState(targets);
+        const context = { ...counts, candidateRepositories: targets.length, durationMs: Date.now() - startedAt };
+        if (counts.failed > 0) {
+          this.deps?.logger.warn('Platform GitHub pull request reconcile sweep completed with failures', {
+            ...context,
+            errors,
+          });
+        } else if (counts.merged > 0 || counts.closed > 0) {
+          this.deps?.logger.info('Platform GitHub pull request reconcile replayed missed merges/closes', context);
+        } else {
+          this.deps?.logger.info('Platform GitHub pull request reconcile sweep completed', context);
+        }
+      } catch (error) {
+        this.deps?.logger.error('Platform GitHub pull request reconcile failed', {
+          repositories: targets.length,
+          durationMs: Date.now() - startedAt,
+          error: error instanceof Error ? error.message : String(error),
         });
-      } else if (counts.merged > 0 || counts.closed > 0) {
-        this.deps?.logger.info('Platform GitHub pull request reconcile replayed missed merges/closes', context);
-      } else {
-        this.deps?.logger.info('Platform GitHub pull request reconcile sweep completed', context);
       }
-    } catch (error) {
-      this.deps?.logger.error('Platform GitHub pull request reconcile failed', {
-        repositories: targets.length,
-        durationMs: Date.now() - startedAt,
-        error: error instanceof Error ? error.message : String(error),
-      });
     }
 
-    // Same tick as the PR reconciler: repository set already discovered, lease
-    // already held, cadence already gated. Issues have no closed-webhook replay
-    // so this only patches drifted metadata (state/author/assignees/labels).
-    if (!this.#reconcileIssuesFactoryState) return;
-    const issueStartedAt = Date.now();
-    try {
-      const { errors, ...counts } = await this.#reconcileIssuesFactoryState(targets);
-      const context = { ...counts, candidateRepositories: targets.length, durationMs: Date.now() - issueStartedAt };
-      if (counts.failed > 0) {
-        this.deps?.logger.warn('Platform GitHub issue reconcile sweep completed with failures', {
-          ...context,
-          errors,
+    if (reconcileIssues && this.#reconcileIssuesFactoryState && this.#hasLease) {
+      const startedAt = Date.now();
+      try {
+        const { errors, ...counts } = await this.#reconcileIssuesFactoryState(targets);
+        const context = { ...counts, candidateRepositories: targets.length, durationMs: Date.now() - startedAt };
+        if (counts.failed > 0) {
+          this.deps?.logger.warn('Platform GitHub issue reconcile sweep completed with failures', { ...context, errors });
+        } else if (counts.closed > 0) {
+          this.deps?.logger.info('Platform GitHub issue reconcile replayed closed work items', context);
+        } else if (counts.updated > 0) {
+          this.deps?.logger.info('Platform GitHub issue reconcile patched stale metadata', context);
+        } else {
+          this.deps?.logger.debug('Platform GitHub issue reconcile sweep completed', context);
+        }
+      } catch (error) {
+        this.deps?.logger.error('Platform GitHub issue reconcile failed', {
+          repositories: targets.length,
+          durationMs: Date.now() - startedAt,
+          error: error instanceof Error ? error.message : String(error),
         });
-      } else if (counts.updated > 0) {
-        this.deps?.logger.info('Platform GitHub issue reconcile patched stale metadata', context);
-      } else {
-        this.deps?.logger.debug('Platform GitHub issue reconcile sweep completed', context);
       }
-    } catch (error) {
-      this.deps?.logger.error('Platform GitHub issue reconcile failed', {
-        repositories: targets.length,
-        durationMs: Date.now() - issueStartedAt,
-        error: error instanceof Error ? error.message : String(error),
-      });
     }
   }
 

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -750,7 +750,10 @@ describe('PlatformGithubIntegration', () => {
       mode: 'platform',
       endpointHost: 'platform.example.com',
       polling: { enabled: true },
-      reconcile: { enabled: true },
+      reconcile: {
+        pullRequests: { enabled: true },
+        issues: { enabled: true },
+      },
     });
     expect(JSON.stringify(integration.diagnostics())).not.toContain(config.accessToken);
   });
@@ -1099,11 +1102,14 @@ describe('PlatformGithubIntegration', () => {
       mode: 'platform',
       endpointHost: 'platform.example.com',
       polling: { enabled: false, intervalMs: 9_000 },
-      reconcile: { enabled: false },
+      reconcile: {
+        pullRequests: { enabled: false },
+        issues: { enabled: false },
+      },
     });
   });
 
-  it('keeps the reconcile worker alive when polling is disabled but reconcile stays enabled', () => {
+  it('keeps the reconciliation worker alive when polling is disabled', () => {
     vi.stubEnv('MASTRA_PLATFORM_GITHUB_POLLING_ENABLED', 'false');
     const integration = createIntegration();
 
@@ -1111,7 +1117,26 @@ describe('PlatformGithubIntegration', () => {
     expect(workers).toHaveLength(1);
     expect(integration.diagnostics()).toMatchObject({
       polling: { enabled: false },
-      reconcile: { enabled: true },
+      reconcile: {
+        pullRequests: { enabled: true },
+        issues: { enabled: true },
+      },
+    });
+  });
+
+  it('allows issue reconciliation to override a disabled legacy reconcile switch', () => {
+    vi.stubEnv('MASTRA_PLATFORM_GITHUB_POLLING_ENABLED', 'false');
+    vi.stubEnv('MASTRA_PLATFORM_GITHUB_RECONCILE_ENABLED', 'false');
+    vi.stubEnv('MASTRACODE_PLATFORM_GITHUB_ISSUE_RECONCILE_ENABLED', 'true');
+    const integration = createIntegration();
+
+    const workers = integration.workers({ controller: {}, storage: { generic: {} } } as unknown as IntegrationContext);
+    expect(workers).toHaveLength(1);
+    expect(integration.diagnostics()).toMatchObject({
+      reconcile: {
+        pullRequests: { enabled: false },
+        issues: { enabled: true },
+      },
     });
   });
 

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -48,6 +48,7 @@ import type { GithubIntegration, GithubRepositoryPermission, RepoSummary } from 
 import { attachGithubIssueReconciler } from '../../github/issue-reconciler.js';
 import type { GithubIssueTriageInput, GithubIssueTriageResult } from '../../github/issue-triage.js';
 import { runGithubIssueTriage } from '../../github/issue-triage.js';
+import { reconcileInterval, reconciliationEnabled } from '../../github/reconciliation-config.js';
 import { buildGithubRoutes } from '../../github/routes.js';
 import { attachGithubReconciler, attachGithubRules } from '../../github/rules.js';
 import type { ReconcileIssueState, ReconcilePullRequestState } from '../../github/rules.js';
@@ -195,7 +196,10 @@ export class PlatformGithubIntegration implements FactoryIntegration {
   readonly #slug: string | undefined;
   readonly #pollingEnabled: boolean;
   readonly #pollingIntervalMs: number | undefined;
-  readonly #reconcileEnabled: boolean;
+  readonly #pullRequestReconcileEnabled: boolean;
+  readonly #issueReconcileEnabled: boolean;
+  readonly #pullRequestReconcileIntervalMs: number | undefined;
+  readonly #issueReconcileIntervalMs: number | undefined;
   #storage: SourceControlStorageHandle | undefined;
   #integrationStorage: GithubSubscriptionStorage | undefined;
   /** installationId → cached repository listing (TTL-bounded). */
@@ -461,7 +465,20 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     this.#slug = options.slug;
     this.#pollingEnabled = process.env.MASTRA_PLATFORM_GITHUB_POLLING_ENABLED?.trim().toLowerCase() !== 'false';
     this.#pollingIntervalMs = optionalPositiveIntegerEnv('MASTRA_PLATFORM_GITHUB_POLLING_INTERVAL_MS');
-    this.#reconcileEnabled = process.env.MASTRA_PLATFORM_GITHUB_RECONCILE_ENABLED?.trim().toLowerCase() !== 'false';
+    const legacyReconcileEnabled = process.env.MASTRA_PLATFORM_GITHUB_RECONCILE_ENABLED;
+    this.#pullRequestReconcileEnabled = reconciliationEnabled(
+      process.env.MASTRACODE_PLATFORM_GITHUB_PR_RECONCILE_ENABLED,
+      legacyReconcileEnabled,
+    );
+    this.#issueReconcileEnabled = reconciliationEnabled(
+      process.env.MASTRACODE_PLATFORM_GITHUB_ISSUE_RECONCILE_ENABLED,
+      legacyReconcileEnabled,
+    );
+    const legacyReconcileIntervalMs = reconcileInterval(process.env.MASTRACODE_PLATFORM_GITHUB_RECONCILE_INTERVAL_MS);
+    this.#pullRequestReconcileIntervalMs =
+      reconcileInterval(process.env.MASTRACODE_PLATFORM_GITHUB_PR_RECONCILE_INTERVAL_MS) ?? legacyReconcileIntervalMs;
+    this.#issueReconcileIntervalMs =
+      reconcileInterval(process.env.MASTRACODE_PLATFORM_GITHUB_ISSUE_RECONCILE_INTERVAL_MS) ?? legacyReconcileIntervalMs;
     this.#runIssueTriage = options.runIssueTriage;
   }
 
@@ -513,7 +530,8 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       endpointHost: this.#endpointHost,
       pollingEnabled: this.#pollingEnabled,
       pollingIntervalMs: this.#pollingIntervalMs,
-      reconcileEnabled: this.#reconcileEnabled,
+      pullRequestReconcileEnabled: this.#pullRequestReconcileEnabled,
+      issueReconcileEnabled: this.#issueReconcileEnabled,
     });
   }
 
@@ -696,7 +714,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
   }
 
   workers(ctx: IntegrationContext): MastraWorker[] {
-    if (!this.#pollingEnabled && !this.#reconcileEnabled) return [];
+    if (!this.#pollingEnabled && !this.#pullRequestReconcileEnabled && !this.#issueReconcileEnabled) return [];
     if (!ctx.controller) {
       throw new Error('Platform GitHub event polling requires the mounted Mastra Code controller.');
     }
@@ -707,14 +725,16 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         github: this,
         storage: ctx.storage.generic as unknown as PlatformGithubEventStorage,
         ingestFactoryEvent: attachGithubRules(this, ctx),
-        reconcileFactoryState: this.#reconcileEnabled
+        reconcileFactoryState: this.#pullRequestReconcileEnabled
           ? attachGithubReconciler(this, ctx, input => this.fetchPullRequestState(input))
           : undefined,
-        reconcileIssuesFactoryState: this.#reconcileEnabled
+        reconcileIssuesFactoryState: this.#issueReconcileEnabled
           ? attachGithubIssueReconciler(this, ctx, input => this.fetchIssueState(input))
           : undefined,
         pollEventsEnabled: this.#pollingEnabled,
         intervalMs: this.#pollingIntervalMs,
+        pullRequestReconcileIntervalMs: this.#pullRequestReconcileIntervalMs,
+        issueReconcileIntervalMs: this.#issueReconcileIntervalMs,
       }),
     ];
   }
@@ -853,7 +873,18 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         enabled: this.#pollingEnabled,
         ...(this.#pollingIntervalMs === undefined ? {} : { intervalMs: this.#pollingIntervalMs }),
       },
-      reconcile: { enabled: this.#reconcileEnabled },
+      reconcile: {
+        pullRequests: {
+          enabled: this.#pullRequestReconcileEnabled,
+          ...(this.#pullRequestReconcileIntervalMs === undefined
+            ? {}
+            : { intervalMs: this.#pullRequestReconcileIntervalMs }),
+        },
+        issues: {
+          enabled: this.#issueReconcileEnabled,
+          ...(this.#issueReconcileIntervalMs === undefined ? {} : { intervalMs: this.#issueReconcileIntervalMs }),
+        },
+      },
     };
   }
 

--- a/mastracode/factory/src/integrations/platform/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.test.ts
@@ -561,21 +561,52 @@ describe('PlatformLinearIntegration', () => {
     expect(() => new PlatformLinearIntegration()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
   });
 
+  const workerContext = {
+    controller: {},
+    storage: {
+      generic: {},
+      sourceControl: {},
+      projects: { listAll: async () => [] },
+      intake: {},
+    },
+    rules: { config: {}, workItems: {} },
+  };
+
   it('registers a single platform-linear-events worker with issue reconciliation folded in', () => {
     const integration = new PlatformLinearIntegration() as unknown as {
       workers(ctx: unknown): Array<{ name: string }>;
     };
-    const context = {
-      controller: {},
-      storage: {
-        generic: {},
-        sourceControl: {},
-        projects: { listAll: async () => [] },
-        intake: {},
-      },
-      rules: { config: {}, workItems: {} },
+
+    expect(integration.workers(workerContext).map(worker => worker.name)).toEqual(['platform-linear-events']);
+  });
+
+  it('keeps event polling active when issue reconciliation is disabled', () => {
+    vi.stubEnv('MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED', 'false');
+    const integration = new PlatformLinearIntegration() as unknown as {
+      workers(ctx: unknown): Array<{ name: string }>;
     };
 
-    expect(integration.workers(context).map(worker => worker.name)).toEqual(['platform-linear-events']);
+    expect(integration.workers(workerContext).map(worker => worker.name)).toEqual(['platform-linear-events']);
+  });
+
+  it('registers only issue reconciliation when event polling is disabled', () => {
+    vi.stubEnv('MASTRACODE_PLATFORM_LINEAR_POLLING_ENABLED', 'false');
+    vi.stubEnv('MASTRACODE_LINEAR_RECONCILE_ENABLED', 'false');
+    vi.stubEnv('MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED', 'true');
+    const integration = new PlatformLinearIntegration() as unknown as {
+      workers(ctx: unknown): Array<{ name: string }>;
+    };
+
+    expect(integration.workers(workerContext).map(worker => worker.name)).toEqual(['platform-linear-events']);
+  });
+
+  it('does not register when polling and issue reconciliation are disabled', () => {
+    vi.stubEnv('MASTRACODE_PLATFORM_LINEAR_POLLING_ENABLED', 'false');
+    vi.stubEnv('MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED', 'false');
+    const integration = new PlatformLinearIntegration() as unknown as {
+      workers(ctx: unknown): Array<{ name: string }>;
+    };
+
+    expect(integration.workers(workerContext)).toEqual([]);
   });
 });

--- a/mastracode/factory/src/integrations/platform/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.test.ts
@@ -6,6 +6,15 @@ import { defaultFactoryRules } from '../../../rules/defaults.js';
 import type { IntegrationContext } from '../../base.js';
 
 import { createPlatformStorageForTests } from '../test-utils.js';
+
+vi.mock('./event-worker.js', () => ({
+  PlatformLinearEventWorker: class {
+    readonly name = 'platform-linear-events';
+
+    constructor(readonly config: unknown) {}
+  },
+}));
+
 import { PlatformLinearIntegration } from './integration.js';
 
 const config = {
@@ -574,19 +583,26 @@ describe('PlatformLinearIntegration', () => {
 
   it('registers a single platform-linear-events worker with issue reconciliation folded in', () => {
     const integration = new PlatformLinearIntegration() as unknown as {
-      workers(ctx: unknown): Array<{ name: string }>;
+      workers(ctx: unknown): Array<{ name: string; config: { pollEventsEnabled: boolean; reconcileFactoryState?: unknown } }>;
     };
 
-    expect(integration.workers(workerContext).map(worker => worker.name)).toEqual(['platform-linear-events']);
+    expect(integration.workers(workerContext)).toEqual([
+      expect.objectContaining({
+        name: 'platform-linear-events',
+        config: expect.objectContaining({ pollEventsEnabled: true, reconcileFactoryState: expect.any(Function) }),
+      }),
+    ]);
   });
 
   it('keeps event polling active when issue reconciliation is disabled', () => {
     vi.stubEnv('MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED', 'false');
     const integration = new PlatformLinearIntegration() as unknown as {
-      workers(ctx: unknown): Array<{ name: string }>;
+      workers(ctx: unknown): Array<{ config: { pollEventsEnabled: boolean; reconcileFactoryState?: unknown } }>;
     };
 
-    expect(integration.workers(workerContext).map(worker => worker.name)).toEqual(['platform-linear-events']);
+    const config = integration.workers(workerContext)[0]?.config;
+    expect(config?.pollEventsEnabled).toBe(true);
+    expect(config).not.toHaveProperty('reconcileFactoryState');
   });
 
   it('registers only issue reconciliation when event polling is disabled', () => {
@@ -594,10 +610,13 @@ describe('PlatformLinearIntegration', () => {
     vi.stubEnv('MASTRACODE_LINEAR_RECONCILE_ENABLED', 'false');
     vi.stubEnv('MASTRACODE_LINEAR_ISSUE_RECONCILE_ENABLED', 'true');
     const integration = new PlatformLinearIntegration() as unknown as {
-      workers(ctx: unknown): Array<{ name: string }>;
+      workers(ctx: unknown): Array<{ config: { pollEventsEnabled: boolean; reconcileFactoryState?: unknown } }>;
     };
 
-    expect(integration.workers(workerContext).map(worker => worker.name)).toEqual(['platform-linear-events']);
+    expect(integration.workers(workerContext)[0]?.config).toMatchObject({
+      pollEventsEnabled: false,
+      reconcileFactoryState: expect.any(Function),
+    });
   });
 
   it('does not register when polling and issue reconciliation are disabled', () => {

--- a/mastracode/factory/src/integrations/platform/linear/integration.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.ts
@@ -12,6 +12,7 @@ import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '.
 import { buildLinearAgentTools } from '../../linear/agent-tools.js';
 import type { LinearConnectionCheck, LinearIntegration } from '../../linear/integration.js';
 import { attachLinearIssueReconciler } from '../../linear/issue-reconciler.js';
+import { linearIssueReconciliationEnabled, linearIssueReconciliationInterval } from '../../linear/reconciliation-config.js';
 import { buildLinearRoutes } from '../../linear/routes.js';
 import { attachLinearRules } from '../../linear/rules.js';
 import type { LinearConnectionData, LinearConnectionRow, LinearStorageHandle } from '../../linear/storage.js';
@@ -362,7 +363,7 @@ export class PlatformLinearIntegration implements FactoryIntegration {
 
   workers(ctx: IntegrationContext): MastraWorker[] {
     const pollingEnabled = process.env.MASTRACODE_PLATFORM_LINEAR_POLLING_ENABLED?.trim().toLowerCase() !== 'false';
-    const reconcileEnabled = process.env.MASTRACODE_LINEAR_RECONCILE_ENABLED?.trim().toLowerCase() !== 'false';
+    const reconcileEnabled = linearIssueReconciliationEnabled();
     if (!pollingEnabled && !reconcileEnabled) return [];
 
     const ingest = attachLinearRules(ctx);
@@ -372,7 +373,7 @@ export class PlatformLinearIntegration implements FactoryIntegration {
     if (!ingest && !reconcile) return [];
 
     const pollIntervalMs = optionalPositiveIntegerEnv('MASTRACODE_PLATFORM_LINEAR_POLLING_INTERVAL_MS');
-    const reconcileIntervalMs = optionalPositiveIntegerEnv('MASTRACODE_LINEAR_RECONCILE_INTERVAL_MS');
+    const reconcileIntervalMs = linearIssueReconciliationInterval();
 
     return [
       new PlatformLinearEventWorker({

--- a/mastracode/factory/src/integrations/reconciliation-config.ts
+++ b/mastracode/factory/src/integrations/reconciliation-config.ts
@@ -1,0 +1,4 @@
+export function optionalPositiveInteger(value: string | undefined): number | undefined {
+  const parsed = Number(value?.trim());
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -180,6 +180,83 @@ describe('defaultFactoryRules', () => {
     ).toBeUndefined();
   });
 
+  it('transitions linked GitHub issue cards deterministically on closure', async () => {
+    const rule = defaultFactoryRules({ version: 'deployment-7' }).github.issueClosed?.onEvent;
+    const github = githubContext('issueClosed');
+    const done = await rule?.({
+      ...github,
+      item: { ...item, stages: ['planning'] },
+      board: 'work',
+      itemRevision: 4,
+    });
+    const canceled = await rule?.({
+      ...github,
+      ingress: { type: 'github', id: 'delivery-not-planned' },
+      item: { ...item, stages: ['planning'] },
+      board: 'work',
+      itemRevision: 4,
+      issue: {
+        number: 42,
+        title: 'Issue 42',
+        url: 'https://github.test/acme/repo/issues/42',
+        createdAt: '2026-07-01T00:00:00Z',
+        stateReason: 'not_planned',
+      },
+    });
+
+    expect(done).toMatchObject({
+      type: 'transition',
+      board: 'work',
+      stage: 'done',
+      idempotencyKey: 'delivery-1:issue-closed',
+      message: { text: 'GitHub issue #42 was closed; this Work card was moved to Done.' },
+    });
+    expect(canceled).toMatchObject({
+      type: 'transition',
+      stage: 'canceled',
+      idempotencyKey: 'delivery-not-planned:issue-closed',
+      message: { text: 'GitHub issue #42 was closed (not_planned); this Work card was moved to Canceled.' },
+    });
+  });
+
+  it('only closes non-terminal linked work-board issue cards', async () => {
+    const githubRule = defaultFactoryRules({ version: 'deployment-7' }).github.issueClosed?.onEvent;
+    const linearRule = defaultFactoryRules({ version: 'deployment-7' }).linear.issueClosed?.onEvent;
+    const github = githubContext('issueClosed');
+    const linear = linearContext();
+
+    expect(
+      githubRule?.({ ...github, item: { ...item, source: 'github-pr' }, board: 'review', itemRevision: 1 }),
+    ).toBeUndefined();
+    expect(
+      githubRule?.({ ...github, item: { ...item, stages: ['done'] }, board: 'work', itemRevision: 1 }),
+    ).toBeUndefined();
+    expect(
+      linearRule?.({
+        ...linear,
+        event: 'issueClosed',
+        item: { ...item, source: 'linear-issue', stages: ['planning'] },
+        board: 'work',
+        itemRevision: 1,
+        issue: { ...linear.issue, stateType: 'completed' },
+      }),
+    ).toMatchObject({
+      type: 'transition',
+      stage: 'done',
+      idempotencyKey: 'linear:issue-1:2026-07-02T00:00:00Z:issue-closed',
+    });
+    expect(
+      linearRule?.({
+        ...linear,
+        event: 'issueClosed',
+        item: { ...item, source: 'linear-issue', stages: ['canceled'] },
+        board: 'work',
+        itemRevision: 1,
+        issue: { ...linear.issue, stateType: 'canceled' },
+      }),
+    ).toBeUndefined();
+  });
+
   it('starts Linear investigation when a human moves an issue into Triage', async () => {
     const rule = defaultFactoryRules({ version: 'deployment-7' }).work.triage?.linearIssue?.onEnter;
     const context = {


### PR DESCRIPTION
Factory can now reconcile GitHub work-item issues and review pull requests independently, while continuing to honor the existing shared reconciliation settings as fallbacks.\n\nNew controls include  and , with equivalent Platform GitHub settings and Linear issue aliases. A closed upstream issue now replays through the normal rules path so a linked Work card moves to Done or Canceled without duplicate history.\n\n\n\nValidated with focused reconciliation tests, typecheck, lint, build, and the distribution import smoke test. The full Factory suite still has three unrelated pre-existing failures in automation metrics and work-item locking tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets GitHub issue and pull request syncing run separately. It also moves linked work cards when upstream issues close and standardizes Factory triage labels.

## Changes

- Split GitHub reconciliation into independent issue and pull request workers.
- Add separate enablement flags and intervals with legacy setting fallbacks.
- Add equivalent reconciliation controls for Platform GitHub and Linear.
- Validate reconciliation intervals and calculate lease times from the shortest active interval.
- Replay closed GitHub and Linear issues through normal rules to transition linked Work cards to `Done` or `Canceled`.
- Preserve existing issue metadata when GitHub values are unavailable.
- Standardize triage labels:
  - `status: auto-triaged`
  - `status: needs approval`
- Update Factory triage automation, board filtering, intake guidance, documentation, and tests.

## Validation

- Focused reconciliation tests passed.
- Typecheck, lint, build, and distribution import smoke test passed.
- The full Factory suite still has three unrelated pre-existing failures in automation metrics and work-item locking tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->