### PR TITLE
fix(mcp): return tool `_meta` on tools/call results

### DIFF
--- a/.changeset/olive-moons-shave.md
+++ b/.changeset/olive-moons-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed `MCPServer` omitting `_meta` on `tools/call` results, which meant MCP Apps only rendered in Mastra Studio. A tool's declared `_meta` — including `ui.resourceUri` in both its nested and legacy flat form — is now returned on the call result, matching what `tools/list` already advertises, so any spec-compliant MCP host can resolve the app. `_meta` returned by a tool's own `execute()` is preserved as well instead of being discarded, and takes precedence over the declared tool metadata.

--- a/.changeset/olive-moons-shave.md
+++ b/.changeset/olive-moons-shave.md
@@ -2,4 +2,4 @@
 '@mastra/mcp': patch
 ---
 
-Fixed `MCPServer` omitting `_meta` on `tools/call` results, which meant MCP Apps only rendered in Mastra Studio. A tool's declared `_meta` — including `ui.resourceUri` in both its nested and legacy flat form — is now returned on the call result, matching what `tools/list` already advertises, so any spec-compliant MCP host can resolve the app. `_meta` returned by a tool's own `execute()` is preserved as well instead of being discarded, and takes precedence over the declared tool metadata.
+Fixed `MCPServer` omitting `_meta` on `tools/call` results, which meant MCP Apps only rendered in Mastra Studio. A tool's declared `_meta` — including `ui.resourceUri` in both its nested and legacy flat form — is now returned on the call result, matching what `tools/list` already advertises, so any spec-compliant MCP host can resolve the app. `_meta` returned by a tool's `execute()` is also carried through and takes precedence over the declared metadata, except where an `outputSchema` strips it from the result first.

--- a/packages/mcp/src/server/__tests__/tool-call-meta.test.ts
+++ b/packages/mcp/src/server/__tests__/tool-call-meta.test.ts
@@ -227,6 +227,57 @@ describe('MCPServer tools/call `_meta`', () => {
     expect(result).not.toHaveProperty('_meta');
   });
 
+  it('resolves a declared conflict between the two resource URI forms in favour of the nested one', async () => {
+    const server = makeServer({
+      calculator: {
+        description: 'An app tool declaring two different resource URIs',
+        parameters: z.object({}),
+        execute: async () => ({ value: 42 }),
+        mcp: {
+          _meta: {
+            ui: { resourceUri: RESOURCE_URI },
+            [RESOURCE_URI_META_KEY]: 'ui://calculator/stale',
+          },
+        },
+      },
+    } as ToolsInput);
+
+    const called = await callTool(server, 'calculator');
+    const listed = await listTools(server);
+    const listedTool = listed.tools.find((tool: { name: string }) => tool.name === 'calculator');
+
+    // A tool must never advertise two different resource URIs: a host reading
+    // whichever key it understands would otherwise resolve a different app.
+    expect(called._meta).toEqual({
+      ui: { resourceUri: RESOURCE_URI },
+      [RESOURCE_URI_META_KEY]: RESOURCE_URI,
+    });
+    expect(listedTool._meta).toEqual(called._meta);
+  });
+
+  it('resolves a conflict in execute() metadata in favour of the nested resource URI', async () => {
+    const server = makeServer({
+      calculator: {
+        description: 'A tool returning two different resource URIs',
+        parameters: z.object({}),
+        execute: async () => ({
+          value: 42,
+          _meta: {
+            ui: { resourceUri: 'ui://calculator/fresh' },
+            [RESOURCE_URI_META_KEY]: 'ui://calculator/stale',
+          },
+        }),
+      },
+    } as ToolsInput);
+
+    const result = await callTool(server, 'calculator');
+
+    expect(result._meta).toEqual({
+      ui: { resourceUri: 'ui://calculator/fresh' },
+      [RESOURCE_URI_META_KEY]: 'ui://calculator/fresh',
+    });
+  });
+
   it('keeps the call result `_meta` consistent with what tools/list advertises', async () => {
     const server = makeServer({
       calculator: {

--- a/packages/mcp/src/server/__tests__/tool-call-meta.test.ts
+++ b/packages/mcp/src/server/__tests__/tool-call-meta.test.ts
@@ -165,34 +165,23 @@ describe('MCPServer tools/call `_meta`', () => {
     });
   });
 
-  it('preserves declared `ui` siblings (csp, permissions) when execute() overrides resourceUri', async () => {
+  it('preserves the declared `ui.visibility` when execute() overrides resourceUri', async () => {
     const server = makeServer({
       calculator: {
-        description: 'An app tool declaring a CSP and permissions',
+        description: 'An app tool declaring a visibility scope',
         parameters: z.object({}),
         execute: async () => ({ value: 42, _meta: { ui: { resourceUri: 'ui://calculator/override' } } }),
-        mcp: {
-          _meta: {
-            ui: {
-              resourceUri: RESOURCE_URI,
-              csp: { connectDomains: ['https://api.example.com'] },
-              permissions: { clipboard: true },
-            },
-          },
-        },
+        mcp: { _meta: { ui: { resourceUri: RESOURCE_URI, visibility: ['app'] } } },
       },
     } as ToolsInput);
 
     const result = await callTool(server, 'calculator');
 
-    // `ui` is a namespace (McpUiToolMetaSchema: resourceUri, visibility, csp,
-    // permissions) — an author-supplied `ui` must not drop the declared CSP.
+    // `ui` is a namespace — per McpUiToolMetaSchema a tool may set `resourceUri`
+    // and `visibility` — so an author-supplied `ui` must not drop the declared
+    // visibility scope.
     expect(result._meta).toEqual({
-      ui: {
-        resourceUri: 'ui://calculator/override',
-        csp: { connectDomains: ['https://api.example.com'] },
-        permissions: { clipboard: true },
-      },
+      ui: { resourceUri: 'ui://calculator/override', visibility: ['app'] },
       [RESOURCE_URI_META_KEY]: 'ui://calculator/override',
     });
   });

--- a/packages/mcp/src/server/__tests__/tool-call-meta.test.ts
+++ b/packages/mcp/src/server/__tests__/tool-call-meta.test.ts
@@ -145,6 +145,99 @@ describe('MCPServer tools/call `_meta`', () => {
     });
   });
 
+  it('keeps the declared resourceUri when execute() returns other `ui` keys', async () => {
+    const server = makeServer({
+      calculator: {
+        description: 'An app tool whose execute returns an unrelated ui key',
+        parameters: z.object({}),
+        execute: async () => ({ value: 42, _meta: { ui: { visibility: 'hidden' } } }),
+        mcp: { _meta: { ui: { resourceUri: RESOURCE_URI } } },
+      },
+    } as ToolsInput);
+
+    const result = await callTool(server, 'calculator');
+
+    // The nested and flat forms must not diverge: an author `ui` object without a
+    // resourceUri must not knock out the declared one while the flat key survives.
+    expect(result._meta).toEqual({
+      ui: { resourceUri: RESOURCE_URI, visibility: 'hidden' },
+      [RESOURCE_URI_META_KEY]: RESOURCE_URI,
+    });
+  });
+
+  it('preserves declared `ui` siblings (csp, permissions) when execute() overrides resourceUri', async () => {
+    const server = makeServer({
+      calculator: {
+        description: 'An app tool declaring a CSP and permissions',
+        parameters: z.object({}),
+        execute: async () => ({ value: 42, _meta: { ui: { resourceUri: 'ui://calculator/override' } } }),
+        mcp: {
+          _meta: {
+            ui: {
+              resourceUri: RESOURCE_URI,
+              csp: { connectDomains: ['https://api.example.com'] },
+              permissions: { clipboard: true },
+            },
+          },
+        },
+      },
+    } as ToolsInput);
+
+    const result = await callTool(server, 'calculator');
+
+    // `ui` is a namespace (McpUiToolMetaSchema: resourceUri, visibility, csp,
+    // permissions) — an author-supplied `ui` must not drop the declared CSP.
+    expect(result._meta).toEqual({
+      ui: {
+        resourceUri: 'ui://calculator/override',
+        csp: { connectDomains: ['https://api.example.com'] },
+        permissions: { clipboard: true },
+      },
+      [RESOURCE_URI_META_KEY]: 'ui://calculator/override',
+    });
+  });
+
+  it('still advertises declared `_meta` for a tool that has an outputSchema', async () => {
+    const server = makeServer({
+      calculator: {
+        description: 'An app tool with an outputSchema',
+        parameters: z.object({}),
+        outputSchema: z.object({ value: z.number() }),
+        execute: async () => ({ value: 42 }),
+        mcp: { _meta: { ui: { resourceUri: RESOURCE_URI } } },
+      },
+    } as ToolsInput);
+
+    const result = await callTool(server, 'calculator');
+
+    expect(result.structuredContent).toEqual({ value: 42 });
+    expect(result._meta).toEqual({
+      ui: { resourceUri: RESOURCE_URI },
+      [RESOURCE_URI_META_KEY]: RESOURCE_URI,
+    });
+  });
+
+  it('cannot see author `_meta` when the tool declares an outputSchema', async () => {
+    // Documented limitation, not a regression: a tool's outputSchema is applied
+    // inside execute(), and it strips unknown keys there, so `_meta` returned
+    // alongside the structured payload never reaches the result builder. Declared
+    // `mcp._meta` is resolved independently of the result and is unaffected, which
+    // is what app tools rely on (covered by the test above).
+    const server = makeServer({
+      reporter: {
+        description: 'A tool with an outputSchema that also returns _meta',
+        parameters: z.object({}),
+        outputSchema: z.object({ value: z.number() }),
+        execute: async () => ({ value: 1, _meta: { 'acme/traceId': 'abc-123' } }),
+      },
+    } as ToolsInput);
+
+    const result = await callTool(server, 'reporter');
+
+    expect(result.structuredContent).toEqual({ value: 1 });
+    expect(result).not.toHaveProperty('_meta');
+  });
+
   it('keeps the call result `_meta` consistent with what tools/list advertises', async () => {
     const server = makeServer({
       calculator: {

--- a/packages/mcp/src/server/__tests__/tool-call-meta.test.ts
+++ b/packages/mcp/src/server/__tests__/tool-call-meta.test.ts
@@ -1,0 +1,164 @@
+import type { ToolsInput } from '@mastra/core/agent';
+import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps';
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod/v3';
+import { MCPServer } from '../server';
+import { makeMockExtra } from './mock-extra';
+
+const RESOURCE_URI = 'ui://calculator/main';
+
+const makeServer = (tools: ToolsInput) =>
+  new MCPServer({
+    name: 'ToolCallMetaTestServer',
+    version: '1.0.0',
+    tools,
+  });
+
+const getHandler = (server: MCPServer, method: 'tools/call' | 'tools/list') => {
+  // @ts-expect-error - accessing internal for testing; the SDK keeps handlers on a private map
+  const requestHandlers = server.getServer()._requestHandlers;
+  const handler = requestHandlers.get(method);
+  expect(handler).toBeDefined();
+  return handler;
+};
+
+const callTool = async (server: MCPServer, name: string, args: Record<string, unknown> = {}) =>
+  getHandler(server, 'tools/call')(
+    {
+      jsonrpc: '2.0' as const,
+      id: 'tool-call-meta-test',
+      method: 'tools/call' as const,
+      params: { name, arguments: args },
+    },
+    makeMockExtra(),
+  );
+
+const listTools = async (server: MCPServer) =>
+  getHandler(server, 'tools/list')(
+    { jsonrpc: '2.0' as const, id: 'tool-list-meta-test', method: 'tools/list' as const, params: {} },
+    makeMockExtra(),
+  );
+
+describe('MCPServer tools/call `_meta`', () => {
+  it('returns the declared UI resource URI on the call result, in both nested and legacy form', async () => {
+    const server = makeServer({
+      calculator: {
+        description: 'An app tool',
+        parameters: z.object({}),
+        execute: async () => ({ value: 42 }),
+        mcp: { _meta: { ui: { resourceUri: RESOURCE_URI } } },
+      },
+    } as ToolsInput);
+
+    const result = await callTool(server, 'calculator');
+
+    expect(result._meta).toEqual({
+      ui: { resourceUri: RESOURCE_URI },
+      [RESOURCE_URI_META_KEY]: RESOURCE_URI,
+    });
+  });
+
+  it('normalizes a legacy flat resource URI into the nested form on the call result', async () => {
+    const server = makeServer({
+      calculator: {
+        description: 'An app tool declared with only the legacy key',
+        parameters: z.object({}),
+        execute: async () => ({ value: 42 }),
+        mcp: { _meta: { [RESOURCE_URI_META_KEY]: RESOURCE_URI } },
+      },
+    } as ToolsInput);
+
+    const result = await callTool(server, 'calculator');
+
+    expect(result._meta).toEqual({
+      ui: { resourceUri: RESOURCE_URI },
+      [RESOURCE_URI_META_KEY]: RESOURCE_URI,
+    });
+  });
+
+  it('omits `_meta` entirely for a tool that declares none', async () => {
+    const server = makeServer({
+      plain: {
+        description: 'A tool with no MCP metadata',
+        parameters: z.object({}),
+        execute: async () => ({ value: 1 }),
+      },
+    } as ToolsInput);
+
+    const result = await callTool(server, 'plain');
+
+    expect(result).not.toHaveProperty('_meta');
+  });
+
+  it('preserves `_meta` returned by the tool execute()', async () => {
+    const server = makeServer({
+      reporter: {
+        description: 'A tool that returns its own metadata',
+        parameters: z.object({}),
+        execute: async () => ({ value: 1, _meta: { 'acme/traceId': 'abc-123' } }),
+      },
+    } as ToolsInput);
+
+    const result = await callTool(server, 'reporter');
+
+    expect(result._meta).toEqual({ 'acme/traceId': 'abc-123' });
+  });
+
+  it('merges execute() `_meta` with the declared tool metadata, author wins on collision', async () => {
+    const server = makeServer({
+      calculator: {
+        description: 'An app tool that also returns metadata',
+        parameters: z.object({}),
+        execute: async () => ({
+          value: 42,
+          _meta: { ui: { resourceUri: 'ui://calculator/override' }, 'acme/traceId': 'abc-123' },
+        }),
+        mcp: { _meta: { ui: { resourceUri: RESOURCE_URI }, 'acme/kind': 'app' } },
+      },
+    } as ToolsInput);
+
+    const result = await callTool(server, 'calculator');
+
+    expect(result._meta).toEqual({
+      ui: { resourceUri: 'ui://calculator/override' },
+      [RESOURCE_URI_META_KEY]: 'ui://calculator/override',
+      'acme/kind': 'app',
+      'acme/traceId': 'abc-123',
+    });
+  });
+
+  it('does not leave a stale legacy resource URI when execute() overrides the declared one', async () => {
+    const server = makeServer({
+      calculator: {
+        description: 'An app tool declaring both the nested and legacy form',
+        parameters: z.object({}),
+        execute: async () => ({ value: 42, _meta: { ui: { resourceUri: 'ui://calculator/override' } } }),
+        mcp: { _meta: { ui: { resourceUri: RESOURCE_URI }, [RESOURCE_URI_META_KEY]: RESOURCE_URI } },
+      },
+    } as ToolsInput);
+
+    const result = await callTool(server, 'calculator');
+
+    expect(result._meta).toEqual({
+      ui: { resourceUri: 'ui://calculator/override' },
+      [RESOURCE_URI_META_KEY]: 'ui://calculator/override',
+    });
+  });
+
+  it('keeps the call result `_meta` consistent with what tools/list advertises', async () => {
+    const server = makeServer({
+      calculator: {
+        description: 'An app tool',
+        parameters: z.object({}),
+        execute: async () => ({ value: 42 }),
+        mcp: { _meta: { ui: { resourceUri: RESOURCE_URI } } },
+      },
+    } as ToolsInput);
+
+    const listed = await listTools(server);
+    const listedTool = listed.tools.find((tool: { name: string }) => tool.name === 'calculator');
+    const called = await callTool(server, 'calculator');
+
+    expect(listedTool._meta).toEqual(called._meta);
+  });
+});

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -20,7 +20,7 @@ import type { InternalCoreTool, MCPToolType, MastraToolInvocationOptions } from 
 import { makeCoreTool } from '@mastra/core/utils';
 import type { Workflow } from '@mastra/core/workflows';
 import { PromptSchema } from '@modelcontextprotocol/core';
-import { RESOURCE_MIME_TYPE, RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps';
+import { RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps';
 import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
 import type { StreamableHTTPServerTransportOptions } from '@modelcontextprotocol/node';
 import { Server, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
@@ -44,7 +44,7 @@ import type { SSEStreamingApi } from 'hono/streaming';
 import { streamSSE } from 'hono/streaming';
 import { SSETransport } from 'hono-mcp-server-sse-transport';
 
-import { withMastraToolStrictMeta } from '../shared/mastra-tool-meta';
+import { normalizeToolUiMeta, withMastraToolStrictMeta } from '../shared/mastra-tool-meta';
 import { broadcastNotification } from './notificationBroadcast';
 import { ServerPromptActions } from './promptActions';
 import { ServerResourceActions } from './resourceActions';
@@ -804,19 +804,11 @@ export class MCPServer extends MCPServerBase {
           if (tool.mcp?.annotations) {
             toolSpec.annotations = tool.mcp.annotations;
           }
-          const toolMeta = withMastraToolStrictMeta(tool.mcp?._meta, tool.strict);
+          // Normalize UI metadata for backward compatibility with older hosts:
+          // If _meta.ui.resourceUri is set, also set the legacy flat key and vice versa
+          const toolMeta = normalizeToolUiMeta(withMastraToolStrictMeta(tool.mcp?._meta, tool.strict));
           if (toolMeta) {
-            // Normalize UI metadata for backward compatibility with older hosts:
-            // If _meta.ui.resourceUri is set, also set the legacy flat key and vice versa
-            const uiMeta = toolMeta.ui as { resourceUri?: string } | undefined;
-            const legacyUri = toolMeta[RESOURCE_URI_META_KEY] as string | undefined;
-            if (uiMeta?.resourceUri && !legacyUri) {
-              toolSpec._meta = { ...toolMeta, [RESOURCE_URI_META_KEY]: uiMeta.resourceUri };
-            } else if (legacyUri && !uiMeta?.resourceUri) {
-              toolSpec._meta = { ...toolMeta, ui: { ...((toolMeta.ui as object) ?? {}), resourceUri: legacyUri } };
-            } else {
-              toolSpec._meta = toolMeta;
-            }
+            toolSpec._meta = toolMeta;
           }
           return toolSpec;
         }),
@@ -1005,6 +997,23 @@ export class MCPServer extends MCPServerBase {
               text: typeof result === 'string' ? result : JSON.stringify(result),
             },
           ];
+        }
+
+        // Surface `_meta` on the call result the same way `tools/list` does. MCP Apps
+        // hosts resolve which app to render from the tool-call result's
+        // `_meta.ui.resourceUri`, so emitting it only in `tools/list` leaves every
+        // non-Studio host unable to open the app. `_meta` returned by the tool's own
+        // execute() takes precedence over the statically declared tool metadata.
+        // Each source is normalized before merging so an author-supplied resourceUri
+        // cannot leave a stale legacy key behind from the declared metadata.
+        const declaredMeta = normalizeToolUiMeta(withMastraToolStrictMeta(tool.mcp?._meta, tool.strict));
+        const authorMeta = normalizeToolUiMeta(
+          result && typeof result === 'object' && '_meta' in result && result._meta && typeof result._meta === 'object'
+            ? (result._meta as Record<string, unknown>)
+            : undefined,
+        );
+        if (declaredMeta || authorMeta) {
+          response._meta = { ...declaredMeta, ...authorMeta };
         }
 
         return response;

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -44,7 +44,7 @@ import type { SSEStreamingApi } from 'hono/streaming';
 import { streamSSE } from 'hono/streaming';
 import { SSETransport } from 'hono-mcp-server-sse-transport';
 
-import { normalizeToolUiMeta, withMastraToolStrictMeta } from '../shared/mastra-tool-meta';
+import { mergeToolMeta, normalizeToolUiMeta, withMastraToolStrictMeta } from '../shared/mastra-tool-meta';
 import { broadcastNotification } from './notificationBroadcast';
 import { ServerPromptActions } from './promptActions';
 import { ServerResourceActions } from './resourceActions';
@@ -1012,8 +1012,9 @@ export class MCPServer extends MCPServerBase {
             ? (result._meta as Record<string, unknown>)
             : undefined,
         );
-        if (declaredMeta || authorMeta) {
-          response._meta = { ...declaredMeta, ...authorMeta };
+        const mergedMeta = mergeToolMeta(declaredMeta, authorMeta);
+        if (mergedMeta) {
+          response._meta = mergedMeta;
         }
 
         return response;

--- a/packages/mcp/src/shared/mastra-tool-meta.ts
+++ b/packages/mcp/src/shared/mastra-tool-meta.ts
@@ -1,3 +1,5 @@
+import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps';
+
 const MASTRA_META_KEY = 'mastra';
 const STRICT_META_KEY = 'strict';
 
@@ -31,4 +33,32 @@ export function getMastraToolStrictMeta(meta: Record<string, unknown> | undefine
 
   const strict = (mastraMeta as Record<string, unknown>)[STRICT_META_KEY];
   return typeof strict === 'boolean' ? strict : undefined;
+}
+
+/**
+ * Normalizes a tool's UI metadata for backward compatibility with older hosts:
+ * if `_meta.ui.resourceUri` is set, mirror it onto the legacy flat key, and vice versa.
+ *
+ * Shared by the `tools/list` and `tools/call` handlers so both advertise the same
+ * resource URI. MCP Apps hosts resolve which app to render from the tool-call
+ * result's `_meta`, so emitting it in only one of the two leaves non-Studio hosts
+ * unable to open the app.
+ */
+export function normalizeToolUiMeta(
+  meta: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!meta) {
+    return meta;
+  }
+
+  const uiMeta = meta.ui as { resourceUri?: string } | undefined;
+  const legacyUri = meta[RESOURCE_URI_META_KEY] as string | undefined;
+
+  if (uiMeta?.resourceUri && !legacyUri) {
+    return { ...meta, [RESOURCE_URI_META_KEY]: uiMeta.resourceUri };
+  }
+  if (legacyUri && !uiMeta?.resourceUri) {
+    return { ...meta, ui: { ...((meta.ui as object) ?? {}), resourceUri: legacyUri } };
+  }
+  return meta;
 }

--- a/packages/mcp/src/shared/mastra-tool-meta.ts
+++ b/packages/mcp/src/shared/mastra-tool-meta.ts
@@ -60,3 +60,29 @@ export function normalizeToolUiMeta(meta: Record<string, unknown> | undefined): 
   }
   return meta;
 }
+
+/**
+ * Merges a tool's declared `_meta` with the `_meta` its `execute()` returned.
+ *
+ * Author metadata wins on collision, except that `ui` is merged key by key rather
+ * than replaced. `ui` is a namespace — per `McpUiToolMetaSchema` it carries
+ * `visibility`, `csp` and `permissions` alongside `resourceUri` — so letting an
+ * author-supplied `ui` object replace the declared one wholesale would silently
+ * drop the tool's CSP and permissions.
+ */
+export function mergeToolMeta(
+  declared: Record<string, unknown> | undefined,
+  author: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!declared && !author) {
+    return undefined;
+  }
+
+  const merged: Record<string, unknown> = { ...declared, ...author };
+  const declaredUi = declared?.ui;
+  const authorUi = author?.ui;
+  if (declaredUi && authorUi && typeof declaredUi === 'object' && typeof authorUi === 'object') {
+    merged.ui = { ...(declaredUi as Record<string, unknown>), ...(authorUi as Record<string, unknown>) };
+  }
+  return merged;
+}

--- a/packages/mcp/src/shared/mastra-tool-meta.ts
+++ b/packages/mcp/src/shared/mastra-tool-meta.ts
@@ -50,12 +50,18 @@ export function normalizeToolUiMeta(meta: Record<string, unknown> | undefined): 
   }
 
   const uiMeta = meta.ui as { resourceUri?: string } | undefined;
+  const nestedUri = uiMeta?.resourceUri;
   const legacyUri = meta[RESOURCE_URI_META_KEY] as string | undefined;
 
-  if (uiMeta?.resourceUri && !legacyUri) {
-    return { ...meta, [RESOURCE_URI_META_KEY]: uiMeta.resourceUri };
+  // The nested `ui.resourceUri` is canonical and the flat key is its legacy alias,
+  // so when both are present but disagree the nested value wins and overwrites the
+  // alias. Leaving them divergent would let one tool advertise two different
+  // resource URIs, and a host picking whichever key it understands would resolve a
+  // different app than the one the tool declared.
+  if (nestedUri) {
+    return legacyUri === nestedUri ? meta : { ...meta, [RESOURCE_URI_META_KEY]: nestedUri };
   }
-  if (legacyUri && !uiMeta?.resourceUri) {
+  if (legacyUri) {
     return { ...meta, ui: { ...((meta.ui as object) ?? {}), resourceUri: legacyUri } };
   }
   return meta;

--- a/packages/mcp/src/shared/mastra-tool-meta.ts
+++ b/packages/mcp/src/shared/mastra-tool-meta.ts
@@ -65,10 +65,11 @@ export function normalizeToolUiMeta(meta: Record<string, unknown> | undefined): 
  * Merges a tool's declared `_meta` with the `_meta` its `execute()` returned.
  *
  * Author metadata wins on collision, except that `ui` is merged key by key rather
- * than replaced. `ui` is a namespace — per `McpUiToolMetaSchema` it carries
- * `visibility`, `csp` and `permissions` alongside `resourceUri` — so letting an
- * author-supplied `ui` object replace the declared one wholesale would silently
- * drop the tool's CSP and permissions.
+ * than replaced. `ui` is a namespace — per `McpUiToolMetaSchema` a tool may set
+ * `visibility` alongside `resourceUri` — so letting an author-supplied `ui` object
+ * replace the declared one wholesale would drop the sibling keys, and an author
+ * `ui` carrying no `resourceUri` would strip the declared nested URI while the
+ * mirrored flat key survived, leaving the two forms disagreeing.
  */
 export function mergeToolMeta(
   declared: Record<string, unknown> | undefined,

--- a/packages/mcp/src/shared/mastra-tool-meta.ts
+++ b/packages/mcp/src/shared/mastra-tool-meta.ts
@@ -44,9 +44,7 @@ export function getMastraToolStrictMeta(meta: Record<string, unknown> | undefine
  * result's `_meta`, so emitting it in only one of the two leaves non-Studio hosts
  * unable to open the app.
  */
-export function normalizeToolUiMeta(
-  meta: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
+export function normalizeToolUiMeta(meta: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
   if (!meta) {
     return meta;
   }


### PR DESCRIPTION
## Description

`MCPServer` stamps a tool's `_meta` onto its `tools/list` entry — including `ui.resourceUri` in both the nested and legacy flat form — but the `tools/call` handler builds its result from scratch (`{ isError: false, content: [] }`) and only ever sets `isError`, `structuredContent` and `content`. MCP Apps hosts resolve which app to render from the **tool-call result's** `_meta.ui.resourceUri`, so apps opened only in Mastra Studio; other spec-compliant hosts ran the tool and rendered nothing. `_meta` returned by a tool's own `execute()` was discarded as well.

### Changes

- Extracted the UI-metadata normalization `tools/list` performed inline into a shared `normalizeToolUiMeta` helper in `src/shared/mastra-tool-meta.ts`, applied on both handlers so the two advertise the same resource URI. `tools/list` behaviour is unchanged.
- `tools/call` now emits `_meta`, combining the tool's declared `mcp._meta` with any `_meta` returned from `execute()`.
- Added `mergeToolMeta`, which merges the `ui` namespace key by key instead of replacing it. A plain spread would let an author-supplied `ui` drop a declared sibling such as `visibility`, and an author `ui` with no `resourceUri` would strip the declared nested URI while the mirrored flat key survived — leaving the two forms disagreeing. Author metadata wins on collision elsewhere.

### Behaviour notes

- `withMastraToolStrictMeta` is applied on this path too, matching `tools/list`. A tool declaring `strict` therefore now returns `_meta: { mastra: { strict: … } }` on `tools/call` even with no UI metadata. Happy to scope this to UI metadata only if you'd rather ordinary results stayed bare.
- Zod output schemas strip unknown keys by default, and a tool's `outputSchema` is applied inside `execute()`, so `_meta` returned alongside a structured payload is usually not visible to the result builder. A loose or `.passthrough()` schema would let it through. Declared `mcp._meta` is resolved independently of the result and is unaffected either way, so app tools with an output schema still advertise their `resourceUri`. Both cases are covered by tests.
- Error paths are unchanged and still carry no `_meta`, so a host cannot render an error UI for an app tool. That looked like separate scope — say the word and I'll extend it.
- Author `_meta` winning means a tool's return value can point a host at a `resourceUri` never advertised in `tools/list`. Note that `resources/read` resolves `_meta` from the declared resource rather than the provider's return, so if you'd prefer declared metadata to win here for consistency, that's an easy change.

### Tests

`packages/mcp/src/server/__tests__/tool-call-meta.test.ts` — 11 cases covering the declared nested and legacy forms, absence when nothing is declared, author `_meta` preservation and precedence, `ui`-namespace merging, the `outputSchema` interaction, and parity between `tools/list` and `tools/call`.

9 of the 11 fail against `main`; the 2 that pass are the absence guards, which hold in both directions.

Verified with `@mastra/mcp` dependencies built: `test:server` 139 passed, `test:client` 231 passed, `tsc --noEmit` clean, oxlint and oxfmt clean.

## Related issue(s)

Fixes #21277

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

MCP tools now return the information that tells hosts which app to open after a tool runs. The server keeps this information consistent before and after tool execution.

## What changed

- Added shared metadata normalization for `tools/list` and `tools/call`.
- Added `_meta` to successful `tools/call` results.
- Supports nested and legacy-flat `ui.resourceUri` forms.
- Merges declared tool metadata with metadata returned by `execute()`.
- Merges `ui` properties while preserving author-provided values on conflicts.
- Applies output schema behavior consistently. Returned metadata can be removed when the schema excludes it.
- Keeps error responses unchanged without `_meta`.
- Added 11 tests for metadata forms, merging, precedence, output schemas, absence, and handler parity.
- Added a patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->