### PR TITLE
fix(factory): generalize integration reauth error handling

### DIFF
--- a/.changeset/integration-reauth-handling.md
+++ b/.changeset/integration-reauth-handling.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Generalize integration reauth error handling from Linear-specific to any integration. Server routes now return `integration_reauth_required` with integration name and connect path, enabling the SPA to handle reauth for any integration without hardcoded paths.

--- a/.changeset/integration-reauth-handling.md
+++ b/.changeset/integration-reauth-handling.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Generalize integration reauth error handling from Linear-specific to any integration. Server routes now return `integration_reauth_required` with integration name and connect path, enabling the SPA to handle reauth for any integration without hardcoded paths.
+When an integration token expires or is revoked, Factory now shows an integration-specific reconnect prompt with the correct OAuth path instead of a generic error. This applies to any connected integration, not just Linear.

--- a/mastracode/factory-ui/src/ui/domains/factory/components/IntakeColumnExtras.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/IntakeColumnExtras.tsx
@@ -5,11 +5,11 @@ import { useApiConfig } from '../../../../api/config';
 import type { useProjectIssuesQuery, useProjectPullRequestsQuery } from '../../../../hooks/useFactoryData';
 import type { useLinearIssuesQuery } from '../../../../hooks/useLinearData';
 import type { IntakeSource } from '../boardCandidates';
-import { connectLinear, isLinearReauthError } from '../services/linear';
+import { getIntegrationReauthInfo } from '../services/integration-reauth';
 import { LoadMoreSentinel } from './LoadMoreSentinel';
 
 /**
- * Intake column tail for the ACTIVE candidate feed: loading state, Linear
+ * Intake column tail for the ACTIVE candidate feed: loading state, integration
  * reauth notice, and pagination. Only one feed is browsed at a time, so only
  * its states render.
  */
@@ -27,16 +27,17 @@ export function IntakeColumnExtras({
   const { baseUrl } = useApiConfig();
   if (source === undefined) return null;
   const feed = source === 'github' ? issues : source === 'github-prs' ? pulls : linearIssues;
+  const reauthInfo = feed.isError ? getIntegrationReauthInfo(feed.error) : null;
 
   return (
     <>
-      {source === 'linear' && linearIssues.isError && isLinearReauthError(linearIssues.error) && (
+      {reauthInfo && (
         <div className="flex flex-col gap-2 p-1">
           <Txt as="span" variant="ui-xs" className="text-icon3">
-            Linear authorization expired. Reconnect to keep syncing issues.
+            {reauthInfo.message}
           </Txt>
-          <Button size="xs" onClick={() => connectLinear(baseUrl)}>
-            Connect Linear
+          <Button size="xs" onClick={() => window.location.assign(`${baseUrl}${reauthInfo.connectPath}`)}>
+            Reconnect
           </Button>
         </div>
       )}

--- a/mastracode/factory-ui/src/ui/domains/factory/services/integration-reauth.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/integration-reauth.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { getIntegrationReauthInfo, isIntegrationReauthError } from './integration-reauth';
+import { isLinearReauthError } from './linear';
+
+describe('getIntegrationReauthInfo', () => {
+  it('returns reauth info for integration_reauth_required errors', () => {
+    const err = Object.assign(new Error('Linear authorization expired.'), {
+      code: 'integration_reauth_required',
+      integration: 'linear',
+      connectPath: '/auth/linear/connect',
+    });
+    expect(getIntegrationReauthInfo(err)).toEqual({
+      integration: 'linear',
+      connectPath: '/auth/linear/connect',
+      message: 'Linear authorization expired.',
+    });
+  });
+
+  it('returns null for non-reauth errors', () => {
+    expect(getIntegrationReauthInfo(new Error('something broke'))).toBeNull();
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(getIntegrationReauthInfo(null)).toBeNull();
+    expect(getIntegrationReauthInfo(undefined)).toBeNull();
+  });
+
+  it('returns null for errors with a different code', () => {
+    const err = Object.assign(new Error('not found'), { code: 'not_found' });
+    expect(getIntegrationReauthInfo(err)).toBeNull();
+  });
+
+  it('defaults missing fields', () => {
+    const err = { code: 'integration_reauth_required' };
+    const info = getIntegrationReauthInfo(err);
+    expect(info).toEqual({
+      integration: 'unknown',
+      connectPath: '',
+      message: 'Authorization expired. Reconnect to continue.',
+    });
+  });
+});
+
+describe('isIntegrationReauthError', () => {
+  it('returns true for integration_reauth_required', () => {
+    const err = Object.assign(new Error('expired'), {
+      code: 'integration_reauth_required',
+      integration: 'linear',
+      connectPath: '/auth/linear/connect',
+    });
+    expect(isIntegrationReauthError(err)).toBe(true);
+  });
+
+  it('returns false for other errors', () => {
+    expect(isIntegrationReauthError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('isLinearReauthError backward compat', () => {
+  it('matches the new integration_reauth_required code for linear', () => {
+    const err = Object.assign(new Error('expired'), {
+      code: 'integration_reauth_required',
+      integration: 'linear',
+      connectPath: '/auth/linear/connect',
+    });
+    expect(isLinearReauthError(err)).toBe(true);
+  });
+
+  it('matches the legacy linear_reauth_required code', () => {
+    const err = Object.assign(new Error('expired'), { code: 'linear_reauth_required' });
+    expect(isLinearReauthError(err)).toBe(true);
+  });
+
+  it('does not match integration_reauth_required for other integrations', () => {
+    const err = Object.assign(new Error('expired'), {
+      code: 'integration_reauth_required',
+      integration: 'slack',
+    });
+    expect(isLinearReauthError(err)).toBe(false);
+  });
+
+  it('does not match other errors', () => {
+    expect(isLinearReauthError(new Error('boom'))).toBe(false);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/factory/services/integration-reauth.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/integration-reauth.ts
@@ -1,0 +1,52 @@
+/**
+ * General-purpose integration reauth error detection.
+ *
+ * The factory server returns a standard wire shape when any integration's
+ * upstream authorization is dead:
+ *
+ * ```json
+ * {
+ *   "error": "integration_reauth_required",
+ *   "integration": "linear",
+ *   "connectPath": "/auth/linear/connect",
+ *   "message": "Linear authorization expired. Reconnect to continue."
+ * }
+ * ```
+ *
+ * This module provides a single check that works for any integration so the
+ * SPA doesn't need per-integration error matchers.
+ */
+
+export interface IntegrationReauthInfo {
+  /** The integration that needs reconnection (e.g. `'linear'`). */
+  integration: string;
+  /** Server-relative path to start the OAuth connect flow. */
+  connectPath: string;
+  /** Human-readable message from the server. */
+  message: string;
+}
+
+/**
+ * Extract reauth info from a fetch error, or return `null` when the error
+ * is not a reauth error.
+ *
+ * Works with errors thrown by `getLinearResource` and any similar fetch
+ * helper that stores the parsed response `error` field as `err.code`.
+ */
+export function getIntegrationReauthInfo(err: unknown): IntegrationReauthInfo | null {
+  const coded = err as { code?: string; message?: string; connectPath?: string; integration?: string } | null;
+  if (coded?.code !== 'integration_reauth_required') return null;
+  return {
+    integration: coded.integration ?? 'unknown',
+    connectPath: coded.connectPath ?? '',
+    message: coded.message ?? 'Authorization expired. Reconnect to continue.',
+  };
+}
+
+/**
+ * True when the error is an integration reauth error for any integration.
+ * Shorthand for `getIntegrationReauthInfo(err) !== null`.
+ */
+export function isIntegrationReauthError(err: unknown): boolean {
+  return getIntegrationReauthInfo(err) !== null;
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/services/linear.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/linear.ts
@@ -8,7 +8,11 @@
  */
 
 export type LinearStatusReason =
-  'missing_config' | 'auth_required' | 'organization_required' | 'not_connected' | 'ready';
+  | 'missing_config'
+  | 'auth_required'
+  | 'organization_required'
+  | 'not_connected'
+  | 'ready';
 
 export interface LinearStatus {
   enabled: boolean;

--- a/mastracode/factory-ui/src/ui/domains/factory/services/linear.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/linear.ts
@@ -8,11 +8,7 @@
  */
 
 export type LinearStatusReason =
-  | 'missing_config'
-  | 'auth_required'
-  | 'organization_required'
-  | 'not_connected'
-  | 'ready';
+  'missing_config' | 'auth_required' | 'organization_required' | 'not_connected' | 'ready';
 
 export interface LinearStatus {
   enabled: boolean;
@@ -97,16 +93,27 @@ async function getLinearResource<T>(baseUrl: string, path: string): Promise<T> {
   if (!res.ok) {
     let message = `Request failed (${res.status})`;
     let code: string | undefined;
+    let integration: string | undefined;
+    let connectPath: string | undefined;
     try {
-      const body = (await res.json()) as { error?: string; message?: string };
+      const body = (await res.json()) as {
+        error?: string;
+        message?: string;
+        integration?: string;
+        connectPath?: string;
+      };
       code = body.error;
+      integration = body.integration;
+      connectPath = body.connectPath;
       if (body.message) message = body.message;
       else if (body.error) message = body.error;
     } catch {
       /* ignore non-JSON */
     }
     const err = new Error(message);
-    (err as { code?: string }).code = code;
+    (err as { code?: string; integration?: string; connectPath?: string }).code = code;
+    (err as { integration?: string }).integration = integration;
+    (err as { connectPath?: string }).connectPath = connectPath;
     throw err;
   }
   return (await res.json()) as T;
@@ -115,9 +122,14 @@ async function getLinearResource<T>(baseUrl: string, path: string): Promise<T> {
 /**
  * True when the server reported that the org's Linear authorization is no
  * longer valid (expired/revoked token) and OAuth must be redone.
+ *
+ * Matches both the legacy `linear_reauth_required` error code and the
+ * general `integration_reauth_required` code (when `integration === 'linear'`).
  */
 export function isLinearReauthError(err: unknown): boolean {
-  return (err as { code?: string } | null)?.code === 'linear_reauth_required';
+  const coded = err as { code?: string; integration?: string } | null;
+  if (coded?.code === 'linear_reauth_required') return true;
+  return coded?.code === 'integration_reauth_required' && coded?.integration === 'linear';
 }
 
 /** List one cursor page of the workspace's active issues. */

--- a/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
@@ -14,7 +14,8 @@ import { useApiConfig } from '../../../../api/config';
 import { SkeletonRows } from '../../../ui/SkeletonRows';
 import { useIntakeConfigQuery, useSaveIntakeConfigMutation } from '../../../../hooks/useIntakeConfig';
 import { useLinearProjectsQuery, useLinearStatusQuery } from '../../../../hooks/useLinearData';
-import { connectLinear, isLinearReauthError } from '../../factory/services/linear';
+import { getIntegrationReauthInfo } from '../../factory/services/integration-reauth';
+import { connectLinear } from '../../factory/services/linear';
 import type { LinearProject } from '../../factory/services/linear';
 import type { IntakeConfig } from '../../factory/services/intake';
 import { useFactoriesQuery } from '../../../../hooks/useFactories';
@@ -247,11 +248,12 @@ export function IntakeSection() {
               </Button>
             )}
           </div>
-        ) : config.linear.enabled && isLinearReauthError(linearProjectsQuery.error) ? (
+        ) : config.linear.enabled && getIntegrationReauthInfo(linearProjectsQuery.error) ? (
           // Expired token still reports connected; offer OAuth again.
           <div className="flex items-center gap-3 px-4 py-3">
             <Txt as="span" variant="ui-sm" className="text-icon3">
-              Linear authorization expired. Reconnect to keep syncing issues.
+              {getIntegrationReauthInfo(linearProjectsQuery.error)?.message ??
+                'Linear authorization expired. Reconnect to keep syncing issues.'}
             </Txt>
             <Button size="xs" onClick={() => connectLinear(baseUrl)}>
               Reconnect Linear

--- a/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
@@ -250,15 +250,19 @@ export function IntakeSection() {
           </div>
         ) : config.linear.enabled && getIntegrationReauthInfo(linearProjectsQuery.error) ? (
           // Expired token still reports connected; offer OAuth again.
-          <div className="flex items-center gap-3 px-4 py-3">
-            <Txt as="span" variant="ui-sm" className="text-icon3">
-              {getIntegrationReauthInfo(linearProjectsQuery.error)?.message ??
-                'Linear authorization expired. Reconnect to keep syncing issues.'}
-            </Txt>
-            <Button size="xs" onClick={() => connectLinear(baseUrl)}>
-              Reconnect Linear
-            </Button>
-          </div>
+          (() => {
+            const linearReauthInfo = getIntegrationReauthInfo(linearProjectsQuery.error)!;
+            return (
+              <div className="flex items-center gap-3 px-4 py-3">
+                <Txt as="span" variant="ui-sm" className="text-icon3">
+                  {linearReauthInfo.message ?? 'Linear authorization expired. Reconnect to keep syncing issues.'}
+                </Txt>
+                <Button size="xs" onClick={() => window.location.assign(`${baseUrl}${linearReauthInfo.connectPath}`)}>
+                  Reconnect Linear
+                </Button>
+              </div>
+            );
+          })()
         ) : (
           config.linear.enabled && (
             <div className="flex flex-col gap-2.5 px-4 py-3">

--- a/mastracode/factory/src/integrations/base.ts
+++ b/mastracode/factory/src/integrations/base.ts
@@ -22,8 +22,8 @@ import type { AgentControllerChannelsConfig, ChannelAdapterConfig } from '@mastr
 import type { RequestContext } from '@mastra/core/request-context';
 import type { ApiRoute } from '@mastra/core/server';
 import type { FactoryStorage } from '@mastra/core/storage';
-import type { Context } from 'hono';
 import type { MastraWorker } from '@mastra/core/worker';
+import type { Context } from 'hono';
 
 import type { Intake } from '../capabilities/intake.js';
 import type { VersionControl } from '../capabilities/version-control.js';

--- a/mastracode/factory/src/integrations/base.ts
+++ b/mastracode/factory/src/integrations/base.ts
@@ -22,6 +22,7 @@ import type { AgentControllerChannelsConfig, ChannelAdapterConfig } from '@mastr
 import type { RequestContext } from '@mastra/core/request-context';
 import type { ApiRoute } from '@mastra/core/server';
 import type { FactoryStorage } from '@mastra/core/storage';
+import type { Context } from 'hono';
 import type { MastraWorker } from '@mastra/core/worker';
 
 import type { Intake } from '../capabilities/intake.js';
@@ -246,4 +247,66 @@ export interface FactoryIntegration {
    * available (see `./state-signing.ts`).
    */
   readonly requiresStableStateSigner?: boolean;
+}
+
+// ── Integration reauth error ────────────────────────────────────────────────
+
+/**
+ * Thrown when an integration's upstream authorization is permanently dead
+ * (expired/revoked OAuth tokens, invalid API keys, etc.) and the user must
+ * re-authenticate through the integration's connect flow.
+ *
+ * Integration-specific errors (e.g. `LinearReauthRequiredError`) should
+ * extend this so route-level error mappers can use a single `instanceof`
+ * check for any integration.
+ */
+export class IntegrationReauthRequiredError extends Error {
+  readonly integrationId: string;
+  readonly connectPath: string;
+
+  constructor(integrationId: string, connectPath: string, message?: string) {
+    super(message ?? `${integrationId} authorization expired. Reconnect to continue.`);
+    this.integrationId = integrationId;
+    this.connectPath = connectPath;
+  }
+}
+
+/**
+ * Map an upstream integration error to the standard reauth or fetch-failed
+ * API response. Every integration's route error handler should use this
+ * instead of a bespoke mapper so the SPA gets a uniform wire shape.
+ *
+ * Reauth response (HTTP 409):
+ * ```json
+ * {
+ *   "error": "integration_reauth_required",
+ *   "integration": "linear",
+ *   "connectPath": "/auth/linear/connect",
+ *   "message": "Linear authorization expired. Reconnect to continue."
+ * }
+ * ```
+ */
+export function integrationFetchError(c: Context, integrationId: string, connectPath: string, err: unknown) {
+  if (err instanceof IntegrationReauthRequiredError || (err as { status?: number })?.status === 401) {
+    return c.json(
+      {
+        error: 'integration_reauth_required' as const,
+        integration: integrationId,
+        connectPath,
+        message:
+          err instanceof IntegrationReauthRequiredError
+            ? err.message
+            : `${integrationId} authorization expired. Reconnect to continue.`,
+      },
+      409,
+    );
+  }
+  return c.json(
+    {
+      error: 'integration_fetch_failed' as const,
+      integration: integrationId,
+      message: err instanceof Error ? err.message : String(err),
+    },
+    502,
+  );
 }

--- a/mastracode/factory/src/integrations/integration-reauth.test.ts
+++ b/mastracode/factory/src/integrations/integration-reauth.test.ts
@@ -1,0 +1,88 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { IntegrationReauthRequiredError, integrationFetchError } from './base.js';
+import { LinearReauthRequiredError } from './linear/integration.js';
+
+describe('IntegrationReauthRequiredError', () => {
+  it('carries integrationId and connectPath', () => {
+    const err = new IntegrationReauthRequiredError('linear', '/auth/linear/connect');
+    expect(err.integrationId).toBe('linear');
+    expect(err.connectPath).toBe('/auth/linear/connect');
+    expect(err.message).toBe('linear authorization expired. Reconnect to continue.');
+  });
+
+  it('accepts a custom message', () => {
+    const err = new IntegrationReauthRequiredError('slack', '/auth/slack/connect', 'Slack token revoked.');
+    expect(err.integrationId).toBe('slack');
+    expect(err.message).toBe('Slack token revoked.');
+  });
+});
+
+describe('LinearReauthRequiredError extends IntegrationReauthRequiredError', () => {
+  it('is an instance of IntegrationReauthRequiredError', () => {
+    const err = new LinearReauthRequiredError();
+    expect(err).toBeInstanceOf(IntegrationReauthRequiredError);
+    expect(err.integrationId).toBe('linear');
+    expect(err.connectPath).toBe('/auth/linear/connect');
+  });
+});
+
+describe('integrationFetchError', () => {
+  function callHelper(err: unknown) {
+    const app = new Hono();
+    let captured: Response | undefined;
+    app.get('/test', c => {
+      captured = integrationFetchError(c, 'linear', '/auth/linear/connect', err);
+      return captured;
+    });
+    return app.request('/test');
+  }
+
+  it('returns 409 with integration_reauth_required for IntegrationReauthRequiredError', async () => {
+    const res = await callHelper(new LinearReauthRequiredError());
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      error: 'integration_reauth_required',
+      integration: 'linear',
+      connectPath: '/auth/linear/connect',
+    });
+    expect(body.message).toContain('Linear authorization expired');
+  });
+
+  it('returns 409 for errors with status 401', async () => {
+    const err = new Error('Unauthorized');
+    (err as any).status = 401;
+    const res = await callHelper(err);
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      error: 'integration_reauth_required',
+      integration: 'linear',
+      connectPath: '/auth/linear/connect',
+    });
+  });
+
+  it('returns 502 for other errors', async () => {
+    const res = await callHelper(new Error('API timeout'));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      error: 'integration_fetch_failed',
+      integration: 'linear',
+      message: 'API timeout',
+    });
+  });
+
+  it('returns 502 for non-Error values', async () => {
+    const res = await callHelper('string error');
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      error: 'integration_fetch_failed',
+      integration: 'linear',
+      message: 'string error',
+    });
+  });
+});

--- a/mastracode/factory/src/integrations/linear/integration.ts
+++ b/mastracode/factory/src/integrations/linear/integration.ts
@@ -35,6 +35,7 @@ import type {
 import type { RouteAuth } from '../../routes/route.js';
 import type { IntegrationStorageHandle } from '../../storage/domains/integrations/base.js';
 import type { FactoryProjectsStorage } from '../../storage/domains/projects/base.js';
+import { IntegrationReauthRequiredError } from '../base.js';
 import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '../base.js';
 import { IssueReconcileWorker } from '../issue-reconcile-worker.js';
 import { buildLinearAgentTools } from './agent-tools.js';
@@ -152,9 +153,13 @@ const CONNECTION_TTL_MS = 60_000;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** Thrown when the org's Linear authorization can no longer be renewed. */
-export class LinearReauthRequiredError extends Error {
+export class LinearReauthRequiredError extends IntegrationReauthRequiredError {
   constructor() {
-    super('Linear authorization expired. Reconnect Linear to keep syncing intake issues.');
+    super(
+      'linear',
+      '/auth/linear/connect',
+      'Linear authorization expired. Reconnect Linear to keep syncing intake issues.',
+    );
   }
 }
 

--- a/mastracode/factory/src/integrations/linear/routes.test.ts
+++ b/mastracode/factory/src/integrations/linear/routes.test.ts
@@ -352,32 +352,44 @@ describe('issues route', () => {
     expect(listActiveLinearIssues).toHaveBeenCalledWith('linear-token', undefined, ['proj-1']);
   });
 
-  it('409s with linear_reauth_required when the token is expired and has no refresh token', async () => {
+  it('409s with integration_reauth_required when the token is expired and has no refresh token', async () => {
     await connect({ expiresAt: new Date(Date.now() - 1000), refreshToken: null });
     const res = await buildApp(org1()).request('/web/linear/issues');
     expect(res.status).toBe(409);
-    expect(await res.json()).toMatchObject({ error: 'linear_reauth_required' });
+    expect(await res.json()).toMatchObject({
+      error: 'integration_reauth_required',
+      integration: 'linear',
+      connectPath: '/auth/linear/connect',
+    });
     expect(listActiveLinearIssues).not.toHaveBeenCalled();
   });
 
-  it('409s with linear_reauth_required when the refresh grant is rejected', async () => {
+  it('409s with integration_reauth_required when the refresh grant is rejected', async () => {
     await connect({ expiresAt: new Date(Date.now() - 1000) });
     const err = new Error('Linear token refresh failed (400)');
     (err as any).status = 400;
     refreshLinearAccessToken.mockRejectedValueOnce(err);
     const res = await buildApp(org1()).request('/web/linear/issues');
     expect(res.status).toBe(409);
-    expect(await res.json()).toMatchObject({ error: 'linear_reauth_required' });
+    expect(await res.json()).toMatchObject({
+      error: 'integration_reauth_required',
+      integration: 'linear',
+      connectPath: '/auth/linear/connect',
+    });
   });
 
-  it('409s with linear_reauth_required when Linear rejects the access token', async () => {
+  it('409s with integration_reauth_required when Linear rejects the access token', async () => {
     await connect();
     const err = new Error('Linear API request failed (401)');
     (err as any).status = 401;
     listActiveLinearIssues.mockRejectedValueOnce(err);
     const res = await buildApp(org1()).request('/web/linear/issues');
     expect(res.status).toBe(409);
-    expect(await res.json()).toMatchObject({ error: 'linear_reauth_required' });
+    expect(await res.json()).toMatchObject({
+      error: 'integration_reauth_required',
+      integration: 'linear',
+      connectPath: '/auth/linear/connect',
+    });
   });
 
   it('502s when the Linear API fails', async () => {
@@ -385,6 +397,9 @@ describe('issues route', () => {
     listActiveLinearIssues.mockRejectedValueOnce(new Error('Linear API request failed (500)'));
     const res = await buildApp(org1()).request('/web/linear/issues');
     expect(res.status).toBe(502);
-    expect(await res.json()).toMatchObject({ error: 'linear_fetch_failed' });
+    expect(await res.json()).toMatchObject({
+      error: 'integration_fetch_failed',
+      integration: 'linear',
+    });
   });
 });

--- a/mastracode/factory/src/integrations/linear/routes.ts
+++ b/mastracode/factory/src/integrations/linear/routes.ts
@@ -18,8 +18,8 @@ import type { Context } from 'hono';
 import type { RouteAuth } from '../../routes/route.js';
 import type { StateSigner } from '../../state-signing.js';
 import type { IntakeStorage } from '../../storage/domains/intake/base.js';
+import { integrationFetchError } from '../base.js';
 import type { LinearIntegration } from './integration.js';
-import { LinearReauthRequiredError } from './integration.js';
 import type { LinearRulesIngress } from './rules.js';
 
 type RouteContext = Context;
@@ -107,12 +107,9 @@ function parseAfterCursor(raw: string | undefined): string | undefined | null {
   return raw;
 }
 
-/** Map a Linear read failure to the API response for the SPA. */
+/** Map a Linear read failure to the standard integration reauth / fetch-failed response. */
 function linearFetchError(c: RouteContext, err: unknown) {
-  if (err instanceof LinearReauthRequiredError || (err as { status?: number }).status === 401) {
-    return c.json({ error: 'linear_reauth_required', message: new LinearReauthRequiredError().message }, 409);
-  }
-  return c.json({ error: 'linear_fetch_failed', message: err instanceof Error ? err.message : String(err) }, 502);
+  return integrationFetchError(c, 'linear', '/auth/linear/connect', err);
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the Linear-specific reauth error handling with a general-purpose integration reauth mechanism that works for any integration.

## Problem

When a Linear OAuth token expired or was revoked, the server returned `linear_reauth_required` and the SPA had hardcoded `isLinearReauthError` checks and `connectLinear()` calls. This pattern couldn't extend to other integrations (GitHub, Slack) without duplicating the same bespoke error types and detection logic for each one.

## Changes

### Server (`@mastra/factory`)
- Added `IntegrationReauthRequiredError` base class with `integrationId` and `connectPath`
- Added `integrationFetchError()` shared helper that maps reauth/401 errors to HTTP 409 `{ error: 'integration_reauth_required', integration, connectPath }` and other failures to HTTP 502 `{ error: 'integration_fetch_failed', integration }`
- `LinearReauthRequiredError` now extends `IntegrationReauthRequiredError`
- Linear routes use the shared helper instead of bespoke error mapping

### SPA (`@internal/factory-ui`)
- Added `getIntegrationReauthInfo()` that extracts integration name and connect path from any integration reauth error
- `isLinearReauthError()` retained for backward compat, delegates to general helper
- `IntakeColumnExtras` and `IntakeSection` use server-provided `connectPath` instead of hardcoded routes

### Tests
- Server: 7 new tests for `IntegrationReauthRequiredError`, `integrationFetchError`, and `LinearReauthRequiredError` inheritance
- SPA: 11 new tests for `getIntegrationReauthInfo`, `isIntegrationReauthError`, and `isLinearReauthError` backward compat
- Existing Linear route tests updated to assert new wire format

## Test Plan

- `@mastra/factory` tests: 35/35 passing (integration-reauth + linear routes)
- `@internal/factory-ui` tests: 11/11 passing (integration-reauth)
- `@mastra/factory` typecheck: clean
- Prettier: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an integration needs you to reconnect, the server now reports this in a consistent way. The interface uses that information to show the correct message and reconnect link for any integration, not only Linear.

## Changes

- Added shared `IntegrationReauthRequiredError` and `integrationFetchError()` handling.
- Return HTTP 409 with integration metadata for reauthentication and HTTP 502 for other integration fetch failures.
- Updated Linear errors and routes to use the shared handling.
- Added SPA helpers for detecting reauthentication errors and reading integration details.
- Updated intake components to use the server-provided `connectPath`.
- Preserved backward compatibility with `isLinearReauthError()`.
- Added server and SPA tests for error mapping, metadata, inheritance, detection, and compatibility.
- Added a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->