### PR TITLE
fix(core): stop requestContextSchema from closing the request context map

### DIFF
--- a/.changeset/request-context-open-map-typing.md
+++ b/.changeset/request-context-open-map-typing.md
@@ -1,0 +1,21 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `requestContextSchema` rejecting runtime-only keys that the runtime accepts.
+
+Declaring a `requestContextSchema` narrowed `RequestContext`'s `get`/`set`/`has`/`delete` to `keyof Values`, which modelled a closed record. The runtime is an open `Map`: schema validation checks the declared keys and passes everything else through, and Mastra's own middleware writes reserved keys (`mastra__resourceId`, `mastra__threadId`, `mastra__versions`, `mastra__authToken`) into contexts that never declared them.
+
+So the intended pattern — declare the human-facing flags in the schema, pass infrastructure payloads as runtime-only keys — only compiled with casts:
+
+```ts
+// Before
+const value = requestContext.get(RUNTIME_KEY as never) as MyPayload | undefined;
+
+// After
+const value = requestContext.get(RUNTIME_KEY); // unknown, narrow it yourself
+```
+
+Declared keys are unchanged: they keep exact value types on `get` and are still enforced on `set`. Undeclared keys are now accepted and typed `unknown` rather than rejected. `RequestContextKey` and `RequestContextValue` are exported from `@mastra/core/request-context` for code that needs to name them.
+
+Reported in [#21286](https://github.com/mastra-ai/mastra/issues/21286). This is the first of the two problems in that issue; generic `Agent` assignability with a declared `requestContextSchema` is unchanged and still tracked there.

--- a/e2e-tests/type-check/template/core/request-context.test-d.ts
+++ b/e2e-tests/type-check/template/core/request-context.test-d.ts
@@ -32,8 +32,10 @@ describe('RequestContext', () => {
       // @ts-expect-error - wrong value type for 'count'
       ctx.set('count', 'not-a-number');
 
-      // @ts-expect-error - unknown key
+      // Undeclared keys are accepted: the runtime map is open and Mastra's own
+      // middleware writes reserved keys into schema'd contexts (#21286).
       ctx.set('unknown', 'value');
+      expectTypeOf(ctx.get('unknown')).toEqualTypeOf<unknown>();
     });
 
     it('should return typed keys', () => {

--- a/packages/_internal-core/src/request-context/index.ts
+++ b/packages/_internal-core/src/request-context/index.ts
@@ -190,6 +190,32 @@ function isPlainObjectOrArray(value: unknown): boolean {
 let _probeBudgetActive = false;
 let _probeBudgetRemaining = 0;
 
+/**
+ * Keys the accessors accept.
+ *
+ * A declared `Values` record narrows autocomplete to its own keys, but does not
+ * close the map: the runtime registry is a plain `Map` that accepts any string,
+ * schema validation only validates the declared keys and passes everything else
+ * through, and Mastra's own middleware writes reserved keys
+ * (`mastra__resourceId`, `mastra__threadId`, `mastra__versions`,
+ * `mastra__authToken`) into contexts that never declared them. Typing the key
+ * as `keyof Values` alone therefore rejected keys the runtime accepts, which
+ * forced callers into `get(KEY as never)` casts.
+ *
+ * The `string & {}` arm is what keeps both properties at once: it accepts any
+ * string while still letting TypeScript infer literal types for the declared
+ * keys, so `Values[K]` inference survives.
+ */
+export type RequestContextKey<Values> = Values extends Record<string, any> ? keyof Values | (string & {}) : string;
+
+/**
+ * Value type for a given key: declared keys keep their exact type from
+ * `Values`, undeclared keys are `unknown` — mirroring a runtime that stores
+ * them but knows nothing about their shape.
+ */
+export type RequestContextValue<Values, K> =
+  Values extends Record<string, any> ? (K extends keyof Values ? Values[K] : unknown) : unknown;
+
 export class RequestContext<Values extends Record<string, any> | unknown = unknown> {
   private registry = new Map<string, unknown>();
 
@@ -206,12 +232,10 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
   }
 
   /**
-   * set a value with strict typing if `Values` is a Record and the key exists in it.
+   * Set a value. Declared keys are strictly typed against `Values`; undeclared
+   * keys are accepted and typed `unknown`, matching the open runtime map.
    */
-  public set<K extends (Values extends Record<string, any> ? keyof Values : string)>(
-    key: K,
-    value: Values extends Record<string, any> ? (K extends keyof Values ? Values[K] : never) : unknown,
-  ): void {
+  public set<K extends RequestContextKey<Values>>(key: K, value: RequestContextValue<Values, K>): void {
     // The type assertion `key as string` is safe because K always extends string ultimately.
     this.registry.set(key as string, value);
   }
@@ -219,25 +243,22 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
   /**
    * Get a value with its type
    */
-  public get<
-    K extends (Values extends Record<string, any> ? keyof Values : string),
-    R = Values extends Record<string, any> ? (K extends keyof Values ? Values[K] : never) : unknown,
-  >(key: K): R {
+  public get<K extends RequestContextKey<Values>, R = RequestContextValue<Values, K>>(key: K): R {
     return this.registry.get(key as string) as R;
   }
 
   /**
    * Check if a key exists in the container
    */
-  public has<K extends (Values extends Record<string, any> ? keyof Values : string)>(key: K): boolean {
-    return this.registry.has(key);
+  public has<K extends RequestContextKey<Values>>(key: K): boolean {
+    return this.registry.has(key as string);
   }
 
   /**
    * Delete a value by key
    */
-  public delete<K extends (Values extends Record<string, any> ? keyof Values : string)>(key: K): boolean {
-    return this.registry.delete(key);
+  public delete<K extends RequestContextKey<Values>>(key: K): boolean {
+    return this.registry.delete(key as string);
   }
 
   /**

--- a/packages/core/src/agent/agent-types.test-d.ts
+++ b/packages/core/src/agent/agent-types.test-d.ts
@@ -172,9 +172,10 @@ describe('Agent Type Tests', () => {
           const documentId = requestContext.get('documentId');
           expectTypeOf(documentId).toEqualTypeOf<string>();
 
-          // Verify unknown keys are rejected
-          // @ts-expect-error - key does not exist in the request context schema
-          requestContext.get('nonexistentKey');
+          // Undeclared keys are accepted — the runtime map is open, and Mastra's
+          // own middleware writes reserved keys into schema'd contexts (#21286).
+          // They carry no declared type, so they surface as `unknown`.
+          expectTypeOf(requestContext.get('nonexistentKey')).toEqualTypeOf<unknown>();
 
           return [];
         },

--- a/packages/core/src/request-context/index.test.ts
+++ b/packages/core/src/request-context/index.test.ts
@@ -571,4 +571,36 @@ describe('RequestContext', () => {
       expect(ctx.serializeForSpan()).toEqual({});
     });
   });
+
+  describe('open map with a declared Values type (#21286)', () => {
+    type Declared = { tenantTier?: 'free' | 'pro' };
+
+    it('should store and return undeclared keys on a typed context', () => {
+      // The type parameter narrows autocomplete; it must not narrow the
+      // registry. This guards the runtime contract the typing was corrected
+      // to match — a future change that closes the map would break callers
+      // relying on runtime-only keys.
+      const ctx = new RequestContext<Declared>();
+
+      ctx.set('tenantTier', 'pro');
+      ctx.set('session.cache', { hits: 0 });
+
+      expect(ctx.get('tenantTier')).toBe('pro');
+      expect(ctx.get('session.cache')).toEqual({ hits: 0 });
+      expect(ctx.has('session.cache')).toBe(true);
+      expect([...ctx.keys()]).toEqual(['tenantTier', 'session.cache']);
+      expect(ctx.size()).toBe(2);
+      expect(ctx.delete('session.cache')).toBe(true);
+      expect(ctx.has('session.cache')).toBe(false);
+    });
+
+    it('should pass reserved middleware keys through a declared schema', () => {
+      // Mastra injects these regardless of any declared schema.
+      const ctx = new RequestContext<Declared>();
+
+      ctx.set(MASTRA_AUTH_TOKEN_KEY, 'token-1');
+
+      expect(ctx.get(MASTRA_AUTH_TOKEN_KEY)).toBe('token-1');
+    });
+  });
 });

--- a/packages/core/src/request-context/index.ts
+++ b/packages/core/src/request-context/index.ts
@@ -6,4 +6,9 @@ export {
   RequestContext,
   mergeVersionOverrides,
 } from '@internal/core/request-context';
-export type { VersionOverrides, VersionSelector } from '@internal/core/request-context';
+export type {
+  RequestContextKey,
+  RequestContextValue,
+  VersionOverrides,
+  VersionSelector,
+} from '@internal/core/request-context';

--- a/packages/core/src/request-context/request-context.test-d.ts
+++ b/packages/core/src/request-context/request-context.test-d.ts
@@ -112,6 +112,54 @@ describe('RequestContext Type Tests', () => {
     });
   });
 
+  describe('Issue #21286: a declared schema narrows autocomplete without closing the map', () => {
+    type MyContext = {
+      tenantTier?: 'free' | 'pro';
+      verbose?: boolean;
+    };
+
+    const RUNTIME_KEY = 'session.cache';
+
+    it('should accept undeclared keys without a cast', () => {
+      const context = new RequestContext<MyContext>();
+
+      // The runtime stores these; before #21286 each of these lines was a
+      // TS2345 and callers had to write `get(KEY as never)`.
+      context.set(RUNTIME_KEY, { hits: 0 });
+      context.set('mastra__resourceId', 'resource-1');
+      context.has(RUNTIME_KEY);
+      context.delete(RUNTIME_KEY);
+    });
+
+    it('should type undeclared keys as unknown, not never', () => {
+      const context = new RequestContext<MyContext>();
+
+      const value = context.get(RUNTIME_KEY);
+      expectTypeOf(value).toEqualTypeOf<unknown>();
+
+      // `unknown` is the honest type: the caller narrows it themselves.
+      expectTypeOf<{ hits: number }>().toMatchTypeOf<unknown>();
+    });
+
+    it('should keep declared keys strictly typed', () => {
+      const context = new RequestContext<MyContext>();
+
+      // Declared keys must not have been widened to unknown by the fix.
+      expectTypeOf(context.get('tenantTier')).toEqualTypeOf<'free' | 'pro' | undefined>();
+      expectTypeOf(context.get('verbose')).toEqualTypeOf<boolean | undefined>();
+
+      // And their value types are still enforced on set().
+      expectTypeOf<number>().not.toMatchTypeOf<Parameters<typeof context.set<'verbose'>>[1]>();
+    });
+
+    it('should still honour an explicit return-type override on get()', () => {
+      const context = new RequestContext<MyContext>();
+
+      const value = context.get<typeof RUNTIME_KEY, { hits: number }>(RUNTIME_KEY);
+      expectTypeOf(value).toEqualTypeOf<{ hits: number }>();
+    });
+  });
+
   describe('Untyped RequestContext should allow any key', () => {
     it('should return unknown for untyped context', () => {
       const context = new RequestContext();

--- a/packages/core/src/tools/request-context-schema-types.test-d.ts
+++ b/packages/core/src/tools/request-context-schema-types.test-d.ts
@@ -31,9 +31,9 @@ describe('requestContextSchema type inference', () => {
         const all = context.requestContext.all;
         expectTypeOf(all).toEqualTypeOf<{ userId: string; apiKey: string }>();
 
-        // Verify unknown keys are rejected
-        // @ts-expect-error - key does not exist in the request context schema
-        context.requestContext.get('nonexistentKey');
+        // Undeclared keys are accepted — the runtime map is open (#21286) — and
+        // surface as `unknown` since the schema says nothing about their shape.
+        expectTypeOf(context.requestContext.get('nonexistentKey')).toEqualTypeOf<unknown>();
 
         return { success: true };
       },
@@ -129,8 +129,8 @@ describe('requestContextSchema type inference', () => {
         const all = context.requestContext.all;
         expectTypeOf(all).toEqualTypeOf<{ userId: string; apiKey: string }>();
 
-        // @ts-expect-error - key does not exist in the request context schema
-        context.requestContext.get('nonexistentKey');
+        // Undeclared keys are accepted and typed `unknown` (#21286).
+        expectTypeOf(context.requestContext.get('nonexistentKey')).toEqualTypeOf<unknown>();
 
         return { success: true };
       },


### PR DESCRIPTION
Fixes #21286

> **Note on the issue link:** this PR resolves the *first* of the two problems in #21286 (the closed-map typing). The second — generic `Agent` assignability under a declared `requestContextSchema` — is not addressed here, so #21286 should probably stay open, or be split, rather than being auto-closed by this merge. I have used `Fixes` only because the triage bot requires a linking keyword and closed the PR without one.

## Problem

`RequestContext`'s `get`/`set`/`has`/`delete` narrowed their key parameter to `keyof Values` whenever a `Values` record was declared:

```ts
public set<K extends (Values extends Record<string, any> ? keyof Values : string)>(
  key: K,
  value: Values extends Record<string, any> ? (K extends keyof Values ? Values[K] : never) : unknown,
): void
```

That models a closed record. The runtime is an open `Map` — schema validation validates the declared keys and passes everything else through untouched, and Mastra's own middleware writes reserved keys (`mastra__resourceId`, `mastra__threadId`, `mastra__versions`, `mastra__authToken`) into contexts that never declared them.

So the types rejected keys the implementation accepts, and the intended pattern — declare the human-facing flags in the schema so they surface in Studio's Variables panel, pass infrastructure payloads as runtime-only keys — compiled only with casts:

```ts
const value = requestContext.get(RUNTIME_KEY as never) as MyPayload | undefined;
```

Note the value type for an undeclared key was `never`, so `set` on one was unsatisfiable — there was no cast-free way to write the key either.

## Fix

The key parameter becomes `keyof Values | (string & {})`. The `string & {}` arm accepts any string while still letting TypeScript infer literal types for declared keys, so `Values[K]` inference survives. The value type resolves to `Values[K]` for declared keys and `unknown` for everything else.

```ts
export type RequestContextKey<Values> =
  Values extends Record<string, any> ? keyof Values | (string & {}) : string;

export type RequestContextValue<Values, K> =
  Values extends Record<string, any> ? (K extends keyof Values ? Values[K] : unknown) : unknown;
```

`unknown` rather than `any` is deliberate: the schema genuinely says nothing about these keys, so the caller should have to narrow.

Both types are exported from `@mastra/core/request-context` — they already appear in the public signatures, so naming them lets people write generic wrappers over a context. Happy to drop that export if you'd rather keep the surface smaller.

**What is unchanged:** declared keys keep exact `get` types and are still enforced on `set`. The `R` type parameter on `get` is kept, so existing explicit overrides still work.

## The part that needs your call

Three existing type assertions encoded the closed-map behaviour and now fail as unused `@ts-expect-error` directives, so this PR updates them:

- `packages/core/src/agent/agent-types.test-d.ts:176`
- `packages/core/src/tools/request-context-schema-types.test-d.ts:35` and `:132`
- plus `e2e-tests/type-check/template/core/request-context.test-d.ts:35`

Each was `// @ts-expect-error - key does not exist in the request context schema` followed by `requestContext.get('nonexistentKey')`. They now assert the key is accepted and typed `unknown`.

I want to flag this rather than bury it: **the closed typing was deliberate and tested, not an oversight.** I changed those assertions because #21286 and your own triage comment both conclude the closed model contradicts the runtime. If you actually want the map closed, the fix belongs on the runtime side instead and this PR is the wrong direction — tell me and I'll redo it.

The neighbouring assertions that check *value* types on declared keys still error correctly and were left alone, which is the evidence that declared-key strictness survived.

## Not addressed

The second problem in #21286 — an agent with a `requestContextSchema` no longer being assignable to the default `Agent` — is untouched. That is a variance question on `TRequestContext`, which threads through 16 files of public generic surface in `core`, and it deserves its own PR and its own maintainer decision. This PR is the self-contained half.

Also left alone: `keys()`, `values()`, `entries()` and `forEach()` still describe only declared keys, which has the same soundness gap. Changing them would alter inference that existing type tests assert deliberately (`keys()` returning `IterableIterator<keyof MyContext>`), so it seemed like a call for you rather than something to slip into this PR.

## Testing

- 4 new type tests in `request-context.test-d.ts`: undeclared keys accepted without a cast, typed `unknown` not `never`, declared keys still strictly typed, explicit `get` return-type override still honoured.
- 2 new runtime tests in `index.test.ts` guarding the open-map contract the typing was corrected to match — including reserved middleware keys passing through a declared schema.
- Full `packages/core` typecheck suite: **no type errors**, 13703 tests passing.
- `@internal/core` and `@mastra/core` both build; the emitted `.d.ts` carries the new signatures.
- `oxlint` and `oxfmt --check` clean.

The only failures in the full run were 3 hook timeouts in `evented-workflow.test.ts`; that file passes 293/293 in isolation both with and without this change, so it is parallel-run contention rather than a regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

`RequestContext` can now store extra keys that are not listed in its schema. Known keys keep their exact types, while extra keys use `unknown` so they remain safe to use.

## Changes

- Added open-map typing for `RequestContext`.
- Updated `get`, `set`, `has`, and `delete` to accept declared and undeclared string keys.
- Preserved inferred types and `set` validation for declared keys.
- Added and re-exported `RequestContextKey` and `RequestContextValue`.
- Added type tests for undeclared keys and `unknown` values.
- Added runtime tests for undeclared keys and reserved middleware keys.
- Added a changeset documenting the API change.

## Scope

- `keys()`, `values()`, `entries()`, and `forEach()` typing is unchanged.
- Agent assignability with a declared `requestContextSchema` remains out of scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->