### PR TITLE
fix: address alpha smoke test findings

### DIFF
--- a/.changeset/crisp-states-ring.md
+++ b/.changeset/crisp-states-ring.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed trace detail status reporting and hid runtime-only tool fields from serialized execution schemas.

--- a/.changeset/deep-mugs-brake.md
+++ b/.changeset/deep-mugs-brake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Updated observability trace response types to include derived span statuses.

--- a/.changeset/khaki-wings-yell.md
+++ b/.changeset/khaki-wings-yell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/stagehand': patch
+---
+
+Fixed browser close tracking so agent-initiated Stagehand shutdowns are reported accurately.

--- a/.changeset/spicy-areas-strive.md
+++ b/.changeset/spicy-areas-strive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed schedule errors to preserve actionable HTTP statuses and retained structured agent errors after model fallback exhaustion.

--- a/.claude/skills/builder-smoke-test/SKILL.md
+++ b/.claude/skills/builder-smoke-test/SKILL.md
@@ -417,7 +417,7 @@ Mobile renders a bottom-bar with the same primary entries.
 
 Use whichever browser tool the harness has wired up (Stagehand, Chrome MCP, etc.). Don't assume a specific provider — discover what's available, then drive the same checklist in `references/ui.md`.
 
-The scaffolded project registers `StagehandBrowser` (matching `examples/agent-builder`). If `BROWSERBASE_*` keys aren't set in the shell, Stagehand falls back to local Playwright; that's fine for smoke. If neither Stagehand nor a local browser is reachable, mark UI as `⏭️ Skipped (no browser provider)`.
+The scaffolded project registers `StagehandBrowser` (matching `examples/agent-builder`). If `BROWSERBASE_*` keys aren't set in the shell, Stagehand launches an installed local Chromium browser such as Google Chrome; no separate Playwright browser install is required. If neither Stagehand nor a local Chromium browser is reachable, mark UI as `⏭️ Skipped (no browser provider)`.
 
 ## Result reporting
 

--- a/.claude/skills/mastra-smoke-test/references/local-setup.md
+++ b/.claude/skills/mastra-smoke-test/references/local-setup.md
@@ -144,11 +144,7 @@ curl http://localhost:4111/hello
 
 When testing browser agents locally, you'll experience "browserception" — your MastraCode browser watching the project's agent browser.
 
-Ensure Playwright browsers are installed:
-
-```bash
-<pm> exec playwright install chromium
-```
+Stagehand launches an installed local Chromium browser, such as Google Chrome. Verify one is available on the machine; no separate Playwright browser install is required.
 
 ## Notes
 

--- a/.claude/skills/mastra-smoke-test/references/tests/scorers.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/scorers.md
@@ -69,8 +69,10 @@ curl -s http://localhost:4111/api/scores/scorers | jq 'keys'
 
 Pass: returns an object keyed by scorer id (`weather-scorer`,
 `translation-quality-scorer`, etc.) for the scorers declared in the
-project. Empty `{}` is only acceptable if the project genuinely declares
-none.
+project. Each value is an entry whose scorer configuration is nested under
+`.scorer.config`, alongside `agentIds`, `agentNames`, `workflowIds`,
+`isRegistered`, and `source`. Empty `{}` is only acceptable if the project
+genuinely declares none.
 
 **2. Get a single scorer's config**
 
@@ -78,9 +80,9 @@ none.
 curl -s http://localhost:4111/api/scores/scorers/<scorerId> | jq '.'
 ```
 
-Pass: returns a non-null object with `config` and the agents/workflows it
-is attached to. `null` means the id is wrong or the scorer is not
-registered.
+Pass: returns a non-null entry with the scorer configuration at
+`.scorer.config` and its associations in `agentIds`, `agentNames`, and
+`workflowIds`. `null` means the id is wrong or the scorer is not registered.
 
 **3. Trigger scoring by running an agent / workflow, then read scores**
 

--- a/.claude/skills/mastra-smoke-test/references/tests/setup.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/setup.md
@@ -182,11 +182,9 @@ export const mastra = new Mastra({
 });
 ```
 
-### 4. Install Playwright
+### 4. Verify a Local Chromium Browser
 
-```bash
-<pm> exec playwright install chromium
-```
+Stagehand launches an installed local Chromium browser, such as Google Chrome. No separate Playwright browser install is required.
 
 ### 5. Runtime requirement: pass thread + resource on every call
 

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -326,7 +326,7 @@ After completing all tests, provide a summary:
 
 **Browser agent fails**
 
-- Ensure Playwright browsers are installed: `pnpm exec playwright install chromium`
+- Verify a local Chromium browser, such as Google Chrome, is installed and reachable
 - Check that no other browser instance is blocking
 
 ## Studio Routes

--- a/browser/stagehand/src/__tests__/stagehand-browser.test.ts
+++ b/browser/stagehand/src/__tests__/stagehand-browser.test.ts
@@ -10,6 +10,7 @@ const { mockPage, mockContext, mockStagehand, mockCdpSession, mockStagehandConst
   };
 
   const mockPage = {
+    targetId: 'page-target-123',
     url: vi.fn().mockReturnValue('https://example.com'),
     title: vi.fn().mockResolvedValue('Example Page'),
     goto: vi.fn().mockResolvedValue(undefined),
@@ -29,6 +30,7 @@ const { mockPage, mockContext, mockStagehand, mockCdpSession, mockStagehandConst
     init: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
     context: mockContext,
+    ctx: { conn: mockCdpSession },
     act: vi.fn().mockResolvedValue({
       success: true,
       message: 'Clicked button',
@@ -57,6 +59,7 @@ vi.mock('@browserbasehq/stagehand', () => ({
     init = mockStagehand.init;
     close = mockStagehand.close;
     context = mockStagehand.context;
+    ctx = mockStagehand.ctx;
     act = mockStagehand.act;
     extract = mockStagehand.extract;
     observe = mockStagehand.observe;
@@ -262,6 +265,40 @@ describe('StagehandBrowser', () => {
       await browser.close();
       expect(browser.status).toBe('closed');
       expect(mockStagehand.close).toHaveBeenCalled();
+    });
+
+    it('preserves agent close reason in the last browser state', async () => {
+      await browser.launch();
+      browser.markBrowserCloseReason('agent');
+
+      await browser.close();
+
+      expect(browser.getLastBrowserState()).toEqual(expect.objectContaining({ closeReason: 'agent' }));
+    });
+
+    it('preserves user close reason when the browser disconnects externally', async () => {
+      await browser.launch();
+      const targetDestroyedHandler = mockCdpSession.on.mock.calls.find(
+        ([event]) => event === 'Target.targetDestroyed',
+      )?.[1];
+
+      targetDestroyedHandler?.({ targetId: 'page-target-123' });
+
+      expect(browser.getLastBrowserState()).toEqual(expect.objectContaining({ closeReason: 'user' }));
+    });
+
+    it('does not reuse stale close reasons after relaunch', async () => {
+      await browser.launch();
+      browser.markBrowserCloseReason('agent');
+      await browser.close();
+      await browser.ensureReady();
+      const targetDestroyedHandler = mockCdpSession.on.mock.calls.findLast(
+        ([event]) => event === 'Target.targetDestroyed',
+      )?.[1];
+
+      targetDestroyedHandler?.({ targetId: 'page-target-123' });
+
+      expect(browser.getLastBrowserState()).toEqual(expect.objectContaining({ closeReason: 'user' }));
     });
 
     it('should handle close when not launched', async () => {

--- a/browser/stagehand/src/stagehand-browser.ts
+++ b/browser/stagehand/src/stagehand-browser.ts
@@ -60,6 +60,7 @@ export class StagehandBrowser extends MastraBrowser {
 
   /** Debounce timers per thread for tab change reconnection */
   private tabChangeDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly pendingCloseReasons = new Map<string, 'agent' | 'user' | 'process_restart' | 'error'>();
 
   constructor(config: StagehandBrowserConfig = {}) {
     super(config);
@@ -190,6 +191,7 @@ export class StagehandBrowser extends MastraBrowser {
   }
 
   protected override async doLaunch(): Promise<void> {
+    this.pendingCloseReasons.clear();
     const scope = this.getScope();
 
     // Set up the thread manager's factory function for creating new Stagehand instances
@@ -240,6 +242,7 @@ export class StagehandBrowser extends MastraBrowser {
     const handleDisconnect = () => {
       if (disconnectHandled) return;
       disconnectHandled = true;
+      this.rememberClosedBrowserState(stagehand, 'user', threadId);
       onDisconnect();
     };
 
@@ -306,8 +309,38 @@ export class StagehandBrowser extends MastraBrowser {
   }
 
   override async closeThreadSession(threadId: string): Promise<void> {
+    const stagehand = this.threadManager.getExistingManagerForThread(threadId);
+    if (stagehand) {
+      this.rememberClosedBrowserState(stagehand, 'agent', threadId);
+    }
     await super.closeThreadSession(threadId);
     this.patchExitType();
+  }
+
+  private browserStateKey(threadId?: string): string {
+    return threadId ?? this.getCurrentThread() ?? DEFAULT_THREAD_ID;
+  }
+
+  markBrowserCloseReason(reason: 'agent' | 'user' | 'process_restart' | 'error', threadId?: string): void {
+    this.pendingCloseReasons.set(this.browserStateKey(threadId), reason);
+  }
+
+  private getCloseReason(threadId?: string): 'agent' | 'user' | 'process_restart' | 'error' | undefined {
+    return (
+      this.pendingCloseReasons.get(this.browserStateKey(threadId)) ?? this.pendingCloseReasons.get(DEFAULT_THREAD_ID)
+    );
+  }
+
+  private rememberClosedBrowserState(stagehand: Stagehand, reason: 'agent' | 'user', threadId?: string): void {
+    const state = this.getBrowserStateFromStagehand(stagehand, threadId);
+    if (!state || state.tabs.length === 0) return;
+
+    const closedState: BrowserState = { ...state, closeReason: this.getCloseReason(threadId) ?? reason };
+    if (threadId) {
+      this.threadManager.updateBrowserState(threadId, closedState);
+    } else {
+      this.lastBrowserState = closedState;
+    }
   }
 
   private patchExitType(): void {
@@ -912,10 +945,10 @@ export class StagehandBrowser extends MastraBrowser {
       if (scope === 'thread' && effectiveThreadId) {
         const stagehand = this.threadManager.getExistingManagerForThread(effectiveThreadId);
         if (!stagehand) return null;
-        return this.getBrowserStateFromStagehand(stagehand);
+        return this.getBrowserStateFromStagehand(stagehand, effectiveThreadId);
       }
 
-      return this.getBrowserStateFromStagehand(this.sharedManager);
+      return this.getBrowserStateFromStagehand(this.sharedManager, effectiveThreadId);
     } catch {
       return null;
     }
@@ -928,13 +961,13 @@ export class StagehandBrowser extends MastraBrowser {
   protected getBrowserStateForThread(threadId?: string): BrowserState | null {
     const effectiveThreadId = threadId ?? this.getCurrentThread() ?? DEFAULT_THREAD_ID;
     const stagehand = this.threadManager.getExistingManagerForThread(effectiveThreadId);
-    return this.getBrowserStateFromStagehand(stagehand);
+    return this.getBrowserStateFromStagehand(stagehand, effectiveThreadId);
   }
 
   /**
    * Get browser state from a specific Stagehand instance.
    */
-  private getBrowserStateFromStagehand(stagehand: Stagehand | null): BrowserState | null {
+  private getBrowserStateFromStagehand(stagehand: Stagehand | null, threadId?: string): BrowserState | null {
     if (!stagehand?.context) return null;
 
     try {
@@ -949,9 +982,11 @@ export class StagehandBrowser extends MastraBrowser {
         return { url: page.url() };
       });
 
+      const closeReason = this.getCloseReason(threadId);
       return {
         tabs,
         activeTabIndex: activeIndex,
+        ...(closeReason ? { closeReason } : {}),
       };
     } catch {
       return null;

--- a/browser/stagehand/src/tools/close.ts
+++ b/browser/stagehand/src/tools/close.ts
@@ -15,10 +15,12 @@ export function createCloseTool(browser: StagehandBrowser) {
     execute: async (_input, { agent }) => {
       // For thread scope, close only the thread's session
       const threadId = agent?.threadId;
+      browser.setCurrentThread(threadId);
       if (browser.getScope() !== 'shared') {
         if (!threadId) {
           throw new Error('stagehand_close requires agent.threadId when browser scope is not shared');
         }
+        browser.markBrowserCloseReason('agent', threadId);
         await browser.closeThreadSession(threadId);
         return {
           success: true,
@@ -26,6 +28,7 @@ export function createCloseTool(browser: StagehandBrowser) {
         };
       }
       // For shared scope, close the entire browser
+      browser.markBrowserCloseReason('agent');
       await browser.close();
       return {
         success: true,

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -8585,7 +8585,11 @@ export type GetObservabilityTracesTraceId_PathParams = {
   traceId: string;
 };
 
-export type GetObservabilityTracesTraceId_Response = GetObservabilityTracesTraceIdBranchesSpanId_Response;
+export type GetObservabilityTracesTraceId_Response = {
+  /** Unique trace identifier */
+  traceId: string;
+  spans: Shared_Type_74[];
+};
 
 export type GetObservabilityTracesTraceId_Request = Simplify<
   (GetObservabilityTracesTraceId_PathParams extends never ? {} : { params: GetObservabilityTracesTraceId_PathParams }) &

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -5,6 +5,7 @@ import type { Mock } from 'vitest';
 import { z } from 'zod/v4';
 import { MODEL_TOKENS } from '../../../../../../docs/src/plugins/remark-model-tokens/models';
 import { MessageList } from '../../../agent/message-list';
+import { ErrorCategory, ErrorDomain, MastraError } from '../../../error';
 import { SpanType } from '../../../observability';
 import { StreamErrorRetryProcessor } from '../../../processors';
 import { ProviderHistoryCompat } from '../../../processors/provider-history-compat';
@@ -1615,6 +1616,87 @@ describe('createLLMExecutionStep gateway provider tools', () => {
       stepResult: { reason: 'tripwire', isContinued: false },
       output: { text: '' },
     });
+  });
+
+  it('preserves structured errors when all fallback models fail', async () => {
+    // Mirrors the observational-memory case: an input processor throws a
+    // structured USER error before the model is ever called. The fallback loop
+    // must rethrow the original MastraError (with details.status) instead of
+    // wrapping it in a plain "Exhausted all fallback models" Error.
+    const structuredError = new MastraError({
+      id: 'TEST_USER_INPUT_ERROR',
+      domain: ErrorDomain.AGENT,
+      category: ErrorCategory.USER,
+      details: { status: 400 },
+      text: 'Invalid agent input',
+    });
+    const doStream = vi.fn(async () => ({
+      stream: convertArrayToReadableStream([
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: testUsage,
+        },
+      ]),
+      request: {},
+      response: { headers: undefined },
+      warnings: [],
+    }));
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream,
+          } as any,
+        },
+      ],
+      inputProcessors: [
+        {
+          id: 'structured-error-processor',
+          processLLMRequest: vi.fn(async () => {
+            throw structuredError;
+          }),
+        },
+      ],
+      tools: {},
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+        threadId: 'thread-123',
+        resourceId: 'resource-456',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<{}>);
+
+    await expect(llmExecutionStep.execute(createExecuteParams(createIterationInput()))).rejects.toMatchObject({
+      id: 'TEST_USER_INPUT_ERROR',
+      category: ErrorCategory.USER,
+      details: { status: 400 },
+    });
+    expect(doStream).not.toHaveBeenCalled();
   });
 
   it('preserves fallback model index when processAPIError requests a retry', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1094,10 +1094,9 @@ function executeStreamWithFallbackModels<T>(
       }
     }
     if (typeof finalResult === 'undefined') {
-      const lastErrMsg = lastError instanceof Error ? lastError.message : String(lastError);
-      const errorMessage = `Exhausted all fallback models. Last error: ${lastErrMsg}`;
-      logger?.error(errorMessage);
-      throw new Error(errorMessage, { cause: lastError });
+      const fatalError = lastError ?? new Error('Exhausted all fallback models without receiving a result.');
+      logger?.error('Exhausted all fallback models.', fatalError);
+      throw fatalError;
     }
     return finalResult;
   };

--- a/packages/core/src/schedules/schedules.test.ts
+++ b/packages/core/src/schedules/schedules.test.ts
@@ -85,7 +85,37 @@ describe('mastra.schedules canonical service', () => {
 
     await expect(
       mastra.schedules.create({ agentId: 'a', cron: '*/5 * * * *', prompt: 'B', id: 'dupe' }),
-    ).rejects.toThrow(/already exists/);
+    ).rejects.toMatchObject({ id: 'SCHEDULES_ID_EXISTS', details: { status: 409 } });
+  });
+
+  it('carries an HTTP status on user-facing schedule errors', async () => {
+    const { mastra } = makeMastra(['a']);
+
+    // Not-found errors map to 404 so API consumers get a 4xx instead of 500.
+    await expect(mastra.schedules.update('missing', { prompt: 'x' })).rejects.toMatchObject({
+      id: 'SCHEDULES_NOT_FOUND',
+      details: { status: 404 },
+    });
+    await expect(mastra.schedules.pause('missing')).rejects.toMatchObject({
+      id: 'SCHEDULES_NOT_FOUND',
+      details: { status: 404 },
+    });
+    await expect(mastra.schedules.resume('missing')).rejects.toMatchObject({
+      id: 'SCHEDULES_NOT_FOUND',
+      details: { status: 404 },
+    });
+    await expect(mastra.schedules.run('missing')).rejects.toMatchObject({
+      id: 'SCHEDULES_NOT_FOUND',
+      details: { status: 404 },
+    });
+
+    // Validation errors map to 400.
+    await expect(
+      mastra.schedules.create({ agentId: 'a', cron: '*/5 * * * *', prompt: 'A', resourceId: 'u1' }),
+    ).rejects.toMatchObject({ id: 'SCHEDULES_THREADLESS_OPTIONS', details: { status: 400 } });
+    await expect(
+      mastra.schedules.create({ agentId: 'a', cron: '*/5 * * * *', prompt: 'A', threadId: 't1' }),
+    ).rejects.toMatchObject({ id: 'SCHEDULES_MISSING_RESOURCE_ID', details: { status: 400 } });
   });
 
   it('throws when a custom id is empty after normalization', async () => {

--- a/packages/core/src/schedules/schedules.ts
+++ b/packages/core/src/schedules/schedules.ts
@@ -275,6 +275,7 @@ export class Schedules {
         id: 'SCHEDULES_MISSING_TARGET_ID',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 400 },
         text: 'schedules.create requires `agentId` or `workflowId`.',
       });
     }
@@ -284,6 +285,7 @@ export class Schedules {
         id: 'SCHEDULES_MISSING_RESOURCE_ID',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 400 },
         text: 'schedules.create requires `resourceId` when `threadId` is set.',
       });
     }
@@ -298,6 +300,7 @@ export class Schedules {
           id: 'SCHEDULES_THREADLESS_OPTIONS',
           domain: ErrorDomain.AGENT,
           category: ErrorCategory.USER,
+          details: { status: 400 },
           text: `schedules.create: ${offenders.join(', ')} require a threadId.`,
         });
       }
@@ -398,6 +401,7 @@ export class Schedules {
         id: 'SCHEDULES_ID_EXISTS',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 409 },
         text: `schedules.create: a schedule with id "${id}" already exists. Use update() to modify it or choose a different id.`,
       });
     }
@@ -441,6 +445,7 @@ export class Schedules {
         id: 'SCHEDULES_NOT_FOUND',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 404 },
         text: `Schedule "${id}" not found.`,
       });
     }
@@ -495,6 +500,7 @@ export class Schedules {
           id: 'SCHEDULES_THREADLESS_OPTIONS',
           domain: ErrorDomain.AGENT,
           category: ErrorCategory.USER,
+          details: { status: 400 },
           text: `schedules.update: ${offenders.join(', ')} require a threadId.`,
         });
       }
@@ -530,6 +536,7 @@ export class Schedules {
         id: 'SCHEDULES_INVALID_WORKFLOW_PATCH',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 400 },
         text: `schedules.update: ${offenders.join(', ')} only apply to agent schedules.`,
       });
     }
@@ -557,6 +564,7 @@ export class Schedules {
         id: 'SCHEDULES_NOT_FOUND',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 404 },
         text: `Schedule "${id}" not found.`,
       });
     }
@@ -573,6 +581,7 @@ export class Schedules {
         id: 'SCHEDULES_NOT_FOUND',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 404 },
         text: `Schedule "${id}" not found.`,
       });
     }
@@ -592,6 +601,7 @@ export class Schedules {
         id: 'SCHEDULES_NOT_FOUND',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 404 },
         text: `Schedule "${id}" not found.`,
       });
     }

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -67,6 +67,7 @@ import MCPs from './pages/mcps';
 import { McpServerPage } from './pages/mcps/[serverId]';
 import MCPServerToolExecutor from './pages/mcps/tool';
 import Metrics from './pages/metrics';
+import { NotFound } from './pages/not-found';
 import PromptBlocks from './pages/prompt-blocks';
 import RequestContext from './pages/request-context';
 import Resources from './pages/resources';
@@ -679,6 +680,11 @@ export const routes: RouteObject[] = [
         handle: { crumbs: [{ id: 'home', label: 'Home' }] },
       },
       { path: '/request-context', element: <RequestContext />, handle: navHandle('/request-context') },
+      {
+        path: '*',
+        element: <NotFound />,
+        handle: { crumbs: [{ id: 'not-found', label: 'Page not found' }] },
+      },
     ],
   },
 ];

--- a/packages/playground/src/pages/not-found/__tests__/not-found-route.test.ts
+++ b/packages/playground/src/pages/not-found/__tests__/not-found-route.test.ts
@@ -1,0 +1,27 @@
+import { createMemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import { routes } from '@/App';
+
+async function navigateTo(entry: string) {
+  const router = createMemoryRouter(routes, { initialEntries: [entry] });
+  await new Promise<void>(resolve => {
+    if (router.state.initialized) return resolve();
+    const unsubscribe = router.subscribe(state => {
+      if (!state.initialized) return;
+      unsubscribe();
+      resolve();
+    });
+  });
+  return router;
+}
+
+describe('not-found route', () => {
+  describe('when an unknown Studio URL is opened', () => {
+    it('serves the catch-all page', async () => {
+      const router = await navigateTo('/missing-page');
+
+      expect(router.state.errors).toBeNull();
+      expect(router.state.matches.at(-1)?.route.path).toBe('*');
+    });
+  });
+});

--- a/packages/playground/src/pages/not-found/index.tsx
+++ b/packages/playground/src/pages/not-found/index.tsx
@@ -1,0 +1,23 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
+import { ArrowLeft, CircleSlashIcon } from 'lucide-react';
+import { Link } from 'react-router';
+
+export function NotFound() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <EmptyState
+        as="h1"
+        iconSlot={<CircleSlashIcon className="text-neutral3 h-8 w-8" />}
+        titleSlot="Page not found"
+        descriptionSlot="The page you requested doesn't exist in this Studio."
+        actionSlot={
+          <Button as={Link} to="/agents" variant="outline" size="sm">
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to Studio
+          </Button>
+        }
+      />
+    </div>
+  );
+}

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -87,6 +87,7 @@ import type { Context } from '../types';
 import { toSlug } from '../utils';
 
 import { handleError } from './error';
+import { stripInjectedToolOverrideFields } from './tool-schema-overrides';
 import {
   sanitizeBody,
   validateBody,
@@ -452,7 +453,7 @@ export async function getSerializedAgentTools(
           resolveLazySchema('inputSchema' in tool ? tool.inputSchema : undefined) as PublicSchema<unknown> | undefined,
         );
         if (inputSchema !== undefined) {
-          inputSchemaForReturn = stringify(inputSchema);
+          inputSchemaForReturn = stringify(stripInjectedToolOverrideFields(inputSchema));
         }
 
         const outputSchema = schemaToJsonSchema(

--- a/packages/server/src/server/handlers/observability.test.ts
+++ b/packages/server/src/server/handlers/observability.test.ts
@@ -170,9 +170,37 @@ describe('Observability Handlers', () => {
         traceId: 'test-trace-123',
       });
 
-      expect(result).toEqual(mockTrace);
+      expect(result).toEqual({
+        traceId: 'test-trace-123',
+        spans: [{ ...createSampleSpan(), status: 'success' }],
+      });
       expect(mockObservabilityStore.getTrace).toHaveBeenCalledWith({ traceId: 'test-trace-123' });
       expect(handleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('should derive span status from error and endedAt', async () => {
+      const mockTrace: TraceRecord = {
+        traceId: 'test-trace-123',
+        spans: [
+          createSampleSpan({ spanId: 'span-success' }),
+          createSampleSpan({ spanId: 'span-error', error: { message: 'boom' } }),
+          createSampleSpan({ spanId: 'span-running', endedAt: null }),
+        ],
+      };
+
+      (mockObservabilityStore.getTrace as ReturnType<typeof vi.fn>).mockResolvedValue(mockTrace);
+
+      const result = (await GET_TRACE_ROUTE.handler({
+        ...createTestServerContext({ mastra: mockMastra }),
+        traceId: 'test-trace-123',
+      })) as { spans: Array<{ spanId: string; status: string }> };
+
+      const statuses = Object.fromEntries(result.spans.map(span => [span.spanId, span.status]));
+      expect(statuses).toEqual({
+        'span-success': 'success',
+        'span-error': 'error',
+        'span-running': 'running',
+      });
     });
 
     it('should throw 404 when trace not found', async () => {

--- a/packages/server/src/server/handlers/observability.ts
+++ b/packages/server/src/server/handlers/observability.ts
@@ -13,6 +13,8 @@ import {
   getSpanArgsSchema,
   getSpanResponseSchema,
   dateRangeSchema,
+  toTraceSpans,
+  traceSpanSchema,
 } from '@mastra/core/storage';
 // `branches*`, `listBranches*`, and `getBranch*` schemas are new in
 // @mastra/core@1.32.0; route them through a shim that tolerates older cores
@@ -274,7 +276,7 @@ export const GET_TRACE_ROUTE: ServerRoute = createRoute({
   path: '/observability/traces/:traceId',
   responseType: 'json',
   pathParamSchema: getTraceArgsSchema,
-  responseSchema: getTraceResponseSchema,
+  responseSchema: getTraceResponseSchema.extend({ spans: z.array(traceSpanSchema) }),
   summary: 'Get AI trace by ID',
   description: 'Returns a complete AI trace with all spans by trace ID',
   tags: ['Observability'],
@@ -288,7 +290,9 @@ export const GET_TRACE_ROUTE: ServerRoute = createRoute({
         throw new HTTPException(404, { message: `Trace with ID '${traceId}' not found` });
       }
 
-      return trace;
+      // Stored SpanRecords carry no status field; derive it from error/endedAt so
+      // trace-detail spans match the status shown in trace list rows.
+      return { ...trace, spans: toTraceSpans(trace.spans) };
     } catch (error) {
       return handleError(error, 'Error getting trace');
     }

--- a/packages/server/src/server/handlers/tool-schema-overrides.ts
+++ b/packages/server/src/server/handlers/tool-schema-overrides.ts
@@ -1,0 +1,44 @@
+/**
+ * Core's `CoreToolBuilder` injects runtime-only override fields into tool input
+ * schemas (`_background` for background execution, `suspendedToolRunId` /
+ * `resumeData` for resumable tools). Those fields are meant for the LLM tool-call
+ * protocol, not for humans filling in a tool-execution form, so we strip them
+ * from serialized input schemas returned by the API.
+ *
+ * `suspendedToolRunId` / `resumeData` are only removed when their description
+ * matches the exact injected shape, so a user-authored field with the same name
+ * is preserved.
+ */
+
+const INJECTED_OVERRIDE_DESCRIPTIONS: Record<string, string> = {
+  suspendedToolRunId: 'The runId of the suspended tool',
+  resumeData: 'The resumeData object created from the resumeSchema of suspended tool',
+};
+
+export function stripInjectedToolOverrideFields<T>(jsonSchema: T): T {
+  if (!jsonSchema || typeof jsonSchema !== 'object' || Array.isArray(jsonSchema)) return jsonSchema;
+  const schema = jsonSchema as { properties?: Record<string, unknown>; required?: unknown };
+  if (!schema.properties || typeof schema.properties !== 'object') return jsonSchema;
+
+  const properties = { ...schema.properties };
+  let changed = false;
+
+  if ('_background' in properties) {
+    delete properties._background;
+    changed = true;
+  }
+
+  for (const [key, description] of Object.entries(INJECTED_OVERRIDE_DESCRIPTIONS)) {
+    const prop = properties[key];
+    if (prop && typeof prop === 'object' && (prop as { description?: string }).description === description) {
+      delete properties[key];
+      changed = true;
+    }
+  }
+
+  if (!changed) return jsonSchema;
+
+  const required = Array.isArray(schema.required) ? schema.required.filter(key => key in properties) : schema.required;
+
+  return { ...jsonSchema, properties, ...(required !== undefined ? { required } : {}) };
+}

--- a/packages/server/src/server/handlers/tools.test.ts
+++ b/packages/server/src/server/handlers/tools.test.ts
@@ -4,6 +4,7 @@ import { RequestContext } from '@mastra/core/di';
 import { Mastra } from '@mastra/core/mastra';
 import { createTool } from '@mastra/core/tools';
 import type { ToolAction, VercelTool } from '@mastra/core/tools';
+import { parse } from 'superjson';
 import type { Mock } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HTTPException } from '../http-exception';
@@ -744,6 +745,87 @@ describe('Tools Handlers', () => {
         expect(result).toHaveProperty(mockTool.id);
         expect(result).toHaveProperty('mcp-calculator');
         expect(result['mcp-calculator'].inputSchema).toBeDefined();
+      });
+    });
+  });
+
+  describe('injected override fields stripping', () => {
+    // Simulates a tool whose inputSchema was mutated by CoreToolBuilder's
+    // background/resume override injection.
+    const injectedTool = createTool({
+      id: 'injected-tool',
+      description: 'A tool with injected runtime override fields',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          url: { type: 'string' },
+          _background: { type: 'object' },
+          suspendedToolRunId: { type: ['string', 'null'], description: 'The runId of the suspended tool' },
+          resumeData: { description: 'The resumeData object created from the resumeSchema of suspended tool' },
+        },
+        required: ['url', 'suspendedToolRunId'],
+      } as any,
+      execute: async () => ({ ok: true }),
+    });
+
+    // A tool with a user-authored field that happens to share the injected name
+    // but not the injected description — it must survive serialization.
+    const lookalikeTool = createTool({
+      id: 'lookalike-tool',
+      description: 'A tool with a genuine suspendedToolRunId field',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          suspendedToolRunId: { type: 'string', description: 'A user-defined run id' },
+        },
+        required: ['suspendedToolRunId'],
+      } as any,
+      execute: async () => ({ ok: true }),
+    });
+
+    const getProperties = (serialized: string | undefined) => {
+      expect(serialized).toBeDefined();
+      const schema = parse(serialized!) as { properties?: Record<string, unknown>; required?: string[] };
+      return schema;
+    };
+
+    describe('listToolsHandler', () => {
+      it('strips injected override fields from serialized input schemas', async () => {
+        const mastra = new Mastra({ logger: false });
+        const result = await LIST_TOOLS_ROUTE.handler({
+          ...createTestServerContext({ mastra }),
+          registeredTools: { [injectedTool.id]: injectedTool } as any,
+        });
+        const schema = getProperties(result['injected-tool'].inputSchema);
+        expect(schema.properties).toHaveProperty('url');
+        expect(schema.properties).not.toHaveProperty('_background');
+        expect(schema.properties).not.toHaveProperty('suspendedToolRunId');
+        expect(schema.properties).not.toHaveProperty('resumeData');
+        expect(schema.required).toEqual(['url']);
+      });
+
+      it('preserves user-authored fields that share injected names but not descriptions', async () => {
+        const mastra = new Mastra({ logger: false });
+        const result = await LIST_TOOLS_ROUTE.handler({
+          ...createTestServerContext({ mastra }),
+          registeredTools: { [lookalikeTool.id]: lookalikeTool } as any,
+        });
+        const schema = getProperties(result['lookalike-tool'].inputSchema);
+        expect(schema.properties).toHaveProperty('suspendedToolRunId');
+        expect(schema.required).toEqual(['suspendedToolRunId']);
+      });
+    });
+
+    describe('getSerializedAgentTools', () => {
+      it('strips injected override fields from serialized agent tool input schemas', async () => {
+        const result = await getSerializedAgentTools({
+          [injectedTool.id]: injectedTool as any,
+        });
+        const schema = getProperties(result['injected-tool'].inputSchema);
+        expect(schema.properties).toHaveProperty('url');
+        expect(schema.properties).not.toHaveProperty('_background');
+        expect(schema.properties).not.toHaveProperty('suspendedToolRunId');
+        expect(schema.properties).not.toHaveProperty('resumeData');
       });
     });
   });

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -18,6 +18,7 @@ import { createRoute } from '../server-adapter/routes/route-builder';
 
 import { getAgentFromSystem } from './agents';
 import { handleError } from './error';
+import { stripInjectedToolOverrideFields } from './tool-schema-overrides';
 import { validateBody } from './utils';
 
 /**
@@ -41,10 +42,10 @@ function schemaToJsonSchema(schema: PublicSchema<unknown> | undefined) {
   return standardSchemaToJSONSchema(toStandardSchema(schema), { target: 'draft-2020-12' });
 }
 
-function serializeSchema(schema: unknown): string | undefined {
+function serializeSchema(schema: unknown, options?: { stripInjectedOverrides?: boolean }): string | undefined {
   const jsonSchema = schemaToJsonSchema(resolveLazySchema(schema) as PublicSchema<unknown> | undefined);
   if (jsonSchema === undefined) return undefined;
-  return stringify(jsonSchema);
+  return stringify(options?.stripInjectedOverrides ? stripInjectedToolOverrideFields(jsonSchema) : jsonSchema);
 }
 
 /**
@@ -100,7 +101,7 @@ function serializeTool(tool: any): any {
 
   return {
     ...tool,
-    inputSchema: serializeSchema(tool.inputSchema),
+    inputSchema: serializeSchema(tool.inputSchema, { stripInjectedOverrides: true }),
     outputSchema: serializeSchema(tool.outputSchema),
     requestContextSchema: serializeSchema(tool.requestContextSchema),
   };


### PR DESCRIPTION
The latest alpha smoke test surfaced a handful of mismatches across runtime errors, browser state, API serialization, and Studio behavior. This PR fixes the findings that were reproducible in the current source.

Structured user errors now survive agent model fallback exhaustion, and schedule validation/not-found/conflict errors expose their intended HTTP statuses. Trace detail responses derive the same span status shown in trace lists, while serialized tool input schemas no longer expose runtime-only background and resume fields.

Stagehand now records whether a browser was closed by the agent or externally, so later context does not misreport an intentional close. Studio also renders a catch-all page for unknown routes instead of leaving the frame empty.

The smoke-test guidance now reflects Stagehand's current local Chrome setup and the nested scorer API response shape.

Validation included focused core and server handler tests, the full Stagehand and Playground test suites, package builds/typechecks/lint, server permission/core-import checks, route-type generation, and route metadata coverage.
