### PR TITLE
fix(core): notify session-deleted listeners when teardown cleanup fails

### DIFF
--- a/.changeset/chatty-lions-learn.md
+++ b/.changeset/chatty-lions-learn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed session-deleted listeners missing their notification when a session teardown failed while releasing its thread lock. The controller deregisters the session either way, so `onSessionDeleted` now always fires and listeners no longer hold on to a dead session.

--- a/packages/core/src/agent-controller/__tests__/agent-controller-session-deleted.test.ts
+++ b/packages/core/src/agent-controller/__tests__/agent-controller-session-deleted.test.ts
@@ -221,4 +221,25 @@ describe('AgentController.deleteSession', () => {
     const fresh = await controller.createSession({ resourceId: 'resource-2' });
     expect(fresh).not.toBe(session);
   });
+
+  it('notifies listeners even when releasing the thread lock fails', async () => {
+    const controller = createController(new InMemoryStore(), {
+      acquire: vi.fn(),
+      release: vi.fn().mockRejectedValue(new Error('lock release failed')),
+    });
+    await controller.init();
+    const session = await controller.createSession({ resourceId: 'resource-1' });
+    const deleted = vi.fn();
+    controller.onSessionDeleted(deleted);
+
+    await expect(controller.deleteSession({ resourceId: 'resource-1' })).rejects.toThrow('lock release failed');
+
+    // The failed teardown still deregistered the session, so listeners
+    // mirroring the registry must hear about it — otherwise they hold the
+    // dead session forever.
+    expect(deleted).toHaveBeenCalledWith(session);
+    await expect(controller.getSessionByResource('resource-1')).resolves.toBeUndefined();
+    const fresh = await controller.createSession({ resourceId: 'resource-1' });
+    expect(fresh).not.toBe(session);
+  });
 });

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -300,7 +300,11 @@ export class AgentController<TState = {}> {
     }
   }
 
-  /** Subscribe to process-local notifications after live sessions are torn down. */
+  /**
+   * Subscribe to process-local notifications after live sessions are torn
+   * down. Fires even when teardown cleanup fails — the session is
+   * deregistered either way.
+   */
   onSessionDeleted(listener: AgentControllerSessionDeletedListener<TState>): () => void {
     this.#sessionDeletedListeners.push(listener);
     return () => {
@@ -745,9 +749,11 @@ export class AgentController<TState = {}> {
       try {
         await session.thread.clearAndReleaseLock();
       } finally {
+        // Notify inside the finally: even when lock release fails the session
+        // is deregistered for good, and listeners mirror the registry.
         await this.#dropSessionFromRegistry(registryKey, session);
+        this.#notifySessionDeleted(session);
       }
-      this.#notifySessionDeleted(session);
     })();
     // Waiters only need to know when teardown finished, not why it failed.
     // Without this, a clearAndReleaseLock rejection would propagate to every


### PR DESCRIPTION
`deleteSession` fired its session-deleted notification after the teardown `try/finally`, so when releasing the thread lock rejected, the `finally` still dropped the session from the registry but listeners never heard about it. That rejection is one the controller already expects — the tolerant promise around the deletion exists precisely to shield concurrent `createSession` callers from it — and after the failure the session is gone for good: a retry returns `false` and a new `createSession` builds a fresh one, so no later event ever corrects a listener that missed the notification. Any listener mirroring the registry (the Factory Overview's running-sessions read in #21333 is the first production consumer of `onSessionDeleted`) would hold a dead session forever.

I moved the notification inside the `finally`, right after the registry drop, so listeners are told exactly when membership changes, success or failure — mirroring the created side, which only notifies once the session actually lands in the registry. Listener errors were already isolated in the notify helper, so nothing can mask the original failure, and `deleteSession` still rejects with it. The new test goes red on the old code (a rejecting lock release skipped the notification) and green now; the full agent-controller suite, `tsc` and lint pass on `@mastra/core`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a session is deleted, its listeners now receive the update even if cleanup fails. The session is also removed so a new session can start.

## Changes

- Moved session-deleted notifications into the teardown `finally` block.
- Preserved deletion error propagation.
- Kept listener errors isolated.
- Added a regression test for thread-lock release failures.
- Added a patch changeset for `@mastra/core`.
- Updated `onSessionDeleted` documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->