### PR TITLE
fix(clickhouse): use command for DDL operations

### DIFF
--- a/.changeset/ninety-hands-call.md
+++ b/.changeset/ninety-hands-call.md
@@ -1,0 +1,5 @@
+---
+'@mastra/clickhouse': patch
+---
+
+Fixed ClickHouse schema operations to avoid socket warnings from unread responses.

--- a/stores/clickhouse/src/storage/db/index.test.ts
+++ b/stores/clickhouse/src/storage/db/index.test.ts
@@ -1,0 +1,62 @@
+import type { ClickHouseClient } from '@clickhouse/client';
+import { TABLE_SCHEMAS, TABLE_SPANS } from '@mastra/core/storage';
+import { describe, expect, it, vi } from 'vitest';
+import { ClickhouseDB } from './index';
+
+describe('ClickhouseDB DDL execution', () => {
+  it('uses command for CREATE while keeping replication lookup on query', async () => {
+    const query = vi.fn(async () => ({ json: async () => [] }));
+    const command = vi.fn();
+    const db = new ClickhouseDB({
+      client: { query, command } as unknown as ClickHouseClient,
+      ttl: undefined,
+      replication: { cluster: 'cluster-a' },
+    });
+
+    await db.createTable({ tableName: TABLE_SPANS, schema: TABLE_SCHEMAS[TABLE_SPANS] });
+
+    expect(query).toHaveBeenCalledOnce();
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.stringContaining('FROM system.tables') }),
+    );
+    expect(command).toHaveBeenCalledOnce();
+    expect(command).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.stringContaining('CREATE TABLE IF NOT EXISTS') }),
+    );
+  });
+
+  it('uses query for DESCRIBE and command for ALTER', async () => {
+    const query = vi.fn(async () => ({ json: async () => ({ data: [] }) }));
+    const command = vi.fn();
+    const db = new ClickhouseDB({
+      client: { query, command } as unknown as ClickHouseClient,
+      ttl: undefined,
+    });
+
+    await db.alterTable({
+      tableName: TABLE_SPANS,
+      schema: TABLE_SCHEMAS[TABLE_SPANS],
+      ifNotExists: ['spanId'],
+    });
+
+    expect(query).toHaveBeenCalledOnce();
+    expect(query).toHaveBeenCalledWith({ query: `DESCRIBE TABLE ${TABLE_SPANS}` });
+    expect(command).toHaveBeenCalledOnce();
+    expect(command).toHaveBeenCalledWith(expect.objectContaining({ query: expect.stringContaining('ALTER TABLE') }));
+  });
+
+  it('uses command for DROP', async () => {
+    const query = vi.fn();
+    const command = vi.fn();
+    const db = new ClickhouseDB({
+      client: { query, command } as unknown as ClickHouseClient,
+      ttl: undefined,
+    });
+
+    await db.dropTable({ tableName: TABLE_SPANS });
+
+    expect(query).not.toHaveBeenCalled();
+    expect(command).toHaveBeenCalledOnce();
+    expect(command).toHaveBeenCalledWith({ query: `DROP TABLE IF EXISTS ${TABLE_SPANS}` });
+  });
+});

--- a/stores/clickhouse/src/storage/db/index.ts
+++ b/stores/clickhouse/src/storage/db/index.ts
@@ -573,7 +573,7 @@ export class ClickhouseDB extends MastraBase {
           `;
       }
 
-      await this.client.query({
+      await this.client.command({
         query: applyReplicationToDDL(sql, this.replication),
         clickhouse_settings: {
           // Allows to insert serialized JS Dates (such as '2023-12-06T10:54:48.000Z')
@@ -629,7 +629,7 @@ export class ClickhouseDB extends MastraBase {
           const alterSql =
             `ALTER TABLE ${tableName} ADD COLUMN IF NOT EXISTS "${columnName}" ${sqlType} ${defaultValue}`.trim();
 
-          await this.client.query({
+          await this.client.command({
             query: addOnClusterToDDL(alterSql, this.replication),
           });
           this.logger?.debug?.(`Added column ${columnName} to table ${tableName}`);
@@ -683,7 +683,7 @@ export class ClickhouseDB extends MastraBase {
 
   async dropTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
     try {
-      await this.client.query({
+      await this.client.command({
         query: addOnClusterToDDL(`DROP TABLE IF EXISTS ${tableName}`, this.replication),
       });
     } catch (error: any) {

--- a/stores/clickhouse/src/storage/db/replication.test.ts
+++ b/stores/clickhouse/src/storage/db/replication.test.ts
@@ -170,19 +170,25 @@ ORDER BY id`;
 
   it('checks existing tables before emitting replicated CREATE TABLE DDL', async () => {
     const queries: string[] = [];
+    const commands: string[] = [];
     const client = {
       query: async ({ query }: { query: string }) => {
         queries.push(query);
         return { json: async () => [] };
+      },
+      command: async ({ query }: { query: string }) => {
+        commands.push(query);
       },
     };
     const db = new ClickhouseDB({ client: client as any, ttl: undefined, replication: { cluster: 'cluster-a' } });
 
     await db.createTable({ tableName: TABLE_SPANS, schema: TABLE_SCHEMAS[TABLE_SPANS] });
 
+    expect(queries).toHaveLength(1);
     expect(queries[0]).toContain('FROM system.tables');
-    expect(queries[1]).toContain(`CREATE TABLE IF NOT EXISTS ${TABLE_SPANS} ON CLUSTER 'cluster-a'`);
-    expect(queries[1]).toContain(
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toContain(`CREATE TABLE IF NOT EXISTS ${TABLE_SPANS} ON CLUSTER 'cluster-a'`);
+    expect(commands[0]).toContain(
       "ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}', updatedAt)",
     );
   });


### PR DESCRIPTION
## Description

Execute ClickHouse `CREATE`, `ALTER`, and `DROP` statements through `client.command()` instead of `client.query()`.

These statements do not return result sets, so discarding the `query()` response left sockets undrained and emitted connection warnings. Metadata and schema reads continue to use `query()`.

This change adds mocked regression coverage for all three DDL paths and updates the existing replication test to distinguish metadata queries from schema commands.

## Related issue(s)

Fixes #21339

## Validation

- `pnpm turbo build --filter @mastra/clickhouse` — 15/15 tasks passed
- focused Vitest coverage — 4 tests passed with no type errors
- package Oxlint and ESLint checks passed
- repository formatting check passed

The Docker-backed adapter suite could not be started locally because Docker is unavailable in the current environment; CI can cover that integration path.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue in the description above
- [x] Documentation changes are not applicable to this internal API correction
- [x] I have added tests that prove the fix is effective
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

ClickHouse schema changes now use the correct API for commands that do not return data. This prevents unread responses, socket warnings, and possible connection errors.

## Changes

- Updated `createTable()`, `alterTable()`, and `dropTable()` to use `client.command()`.
- Kept metadata and schema reads on `client.query()`.
- Added regression tests for all three DDL operations.
- Updated replication tests to distinguish metadata queries from schema commands.
- Added a patch changeset for `@mastra/clickhouse`.

## Validation

- Build, focused tests, linting, type checks, and formatting checks passed.
- Docker-backed integration tests were not run because Docker was unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->