### PR TITLE
fix(core):scope model cache by gateway API key

### DIFF
--- a/.changeset/clear-gateways-rotate.md
+++ b/.changeset/clear-gateways-rotate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed model routing to use rotated gateway API keys.

--- a/packages/core/src/llm/model/router-gateway-auth-cache.test.ts
+++ b/packages/core/src/llm/model/router-gateway-auth-cache.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GatewayLanguageModel, MastraModelGatewayInterface, ProviderConfig } from './gateways/base.js';
+import { ModelRouterLanguageModel } from './router.js';
+
+function createGateway() {
+  return {
+    id: 'test-gateway',
+    name: 'Test Gateway',
+    fetchProviders: vi.fn(async (): Promise<Record<string, ProviderConfig>> => ({})),
+    buildUrl: vi.fn(() => 'https://api.example.com/v1'),
+    getApiKey: vi.fn(async () => 'legacy-key'),
+    resolveAuth: vi.fn(),
+    resolveLanguageModel: vi.fn(
+      ({ providerId, modelId }) =>
+        ({
+          specificationVersion: 'v2',
+          provider: providerId,
+          modelId,
+          supportedUrls: {},
+          doGenerate: vi.fn(),
+          doStream: vi.fn(async () => ({ stream: new ReadableStream() })),
+        }) as GatewayLanguageModel,
+    ),
+  } satisfies MastraModelGatewayInterface;
+}
+
+describe('ModelRouterLanguageModel gateway auth cache', () => {
+  beforeEach(() => {
+    (ModelRouterLanguageModel as unknown as { _clearCachesForTests: () => void })._clearCachesForTests();
+  });
+
+  it('creates a new model when a gateway-resolved API key rotates', async () => {
+    const gateway = createGateway();
+    gateway.resolveAuth
+      .mockReturnValueOnce({ apiKey: 'first-key', source: 'gateway' as const })
+      .mockReturnValueOnce({ apiKey: 'first-key', source: 'gateway' as const })
+      .mockReturnValueOnce({ apiKey: 'rotated-key', source: 'gateway' as const });
+    const router = new ModelRouterLanguageModel('test-gateway/provider/model', [gateway]);
+
+    await router.doStream({} as any);
+    await router.doStream({} as any);
+    await router.doStream({} as any);
+
+    expect(gateway.resolveAuth).toHaveBeenCalledTimes(3);
+    expect(gateway.resolveLanguageModel).toHaveBeenCalledTimes(2);
+    expect(gateway.resolveLanguageModel).toHaveBeenNthCalledWith(1, expect.objectContaining({ apiKey: 'first-key' }));
+    expect(gateway.resolveLanguageModel).toHaveBeenNthCalledWith(2, expect.objectContaining({ apiKey: 'rotated-key' }));
+  });
+});

--- a/packages/core/src/llm/model/router.ts
+++ b/packages/core/src/llm/model/router.ts
@@ -509,6 +509,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
           modelId,
           providerId,
           this.config.url || '',
+          apiKey,
           stableHeaderKey(headers),
           resolvedTransport,
           websocketKey,


### PR DESCRIPTION
## Summary

Fixes model-router caching when a gateway dynamically rotates its API key.

Gateway authentication is resolved for every request, but the effective API key was not included in the model cache identity. This allowed Mastra to reuse a model instance created with an expired or previous credential.

FIXES #21362 

## Changes

- Include the effective API key in the existing SHA-256 model cache key.
- Preserve model reuse when the gateway returns the same API key.
- Create a new model instance when the gateway returns a different API key.
- Keep the raw API key out of the cache map by storing only the resulting SHA-256 digest.
- Add a focused regression test covering gateway credential rotation.
- Add an `@mastra/core` patch changeset.

No public APIs or gateway authentication types were changed.

## Behavior

Before:

```text
Request 1 → first-key   → create and cache model
Request 2 → rotated-key → cache hit → reuse model containing first-key
```

After:

```text
Request 1 → first-key   → create and cache model
Request 2 → first-key   → reuse cached model
Request 3 → rotated-key → create and cache a new model
```

## Test plan

- Added a regression test that:
  - Resolves gateway authentication for every request.
  - Verifies the same API key reuses the cached model.
  - Verifies a rotated API key creates a new model.
  - Verifies both model instances receive the expected API keys.
- Ran the focused Vitest test.
- Ran the `@mastra/core` TypeScript check.
- Ran targeted ESLint and Oxlint checks.
- Ran the formatting check.
- Ran `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a gateway changes its API key, the router now detects the change and creates a model with the new key. It still reuses the existing model when the key remains unchanged.

## Changes

- Added the resolved gateway API key to the model cache identity.
- Stored only the API-key digest in the cache map.
- Added regression tests for key reuse and credential rotation.
- Added an `@mastra/core` patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->