### PR TITLE
fix(editor): preserve version resolution semantics

### DIFF
--- a/.changeset/calm-prompts-resolve.md
+++ b/.changeset/calm-prompts-resolve.md
@@ -1,0 +1,5 @@
+---
+'@mastra/editor': patch
+---
+
+Fixed version-specific reads across editor namespaces and prevented prompt draft updates from changing cached published reads.

--- a/.changeset/calm-prompts-resolve.md
+++ b/.changeset/calm-prompts-resolve.md
@@ -2,4 +2,4 @@
 '@mastra/editor': patch
 ---
 
-Fixed version-specific reads across editor namespaces and prevented prompt draft updates from changing cached published reads.
+After updating a prompt, default reads return the published version, while draft reads and reads for an explicit version return the requested version.

--- a/packages/editor/src/namespaces/base.ts
+++ b/packages/editor/src/namespaces/base.ts
@@ -5,6 +5,30 @@ import type { MastraEditor } from '../index';
 
 export type { GetByIdOptions };
 
+type VersionResolutionOptions =
+  | { status?: GetByIdOptions['status']; versionId?: never }
+  | { versionId: string; status?: never };
+
+/** Resolve editor version-number requests before delegating to versioned storage. */
+export async function getVersionedEntityById<TResolved>(
+  id: string,
+  options: GetByIdOptions | undefined,
+  getByIdResolved: (id: string, options?: VersionResolutionOptions) => Promise<TResolved | null>,
+  getVersionByNumber: (id: string, versionNumber: number) => Promise<{ id: string } | null>,
+): Promise<TResolved | null> {
+  if (options?.versionNumber !== undefined) {
+    const version = await getVersionByNumber(id, options.versionNumber);
+    if (!version) return null;
+    return getByIdResolved(id, { versionId: version.id });
+  }
+
+  if (options?.versionId) {
+    return getByIdResolved(id, { versionId: options.versionId });
+  }
+
+  return getByIdResolved(id, options?.status ? { status: options.status } : undefined);
+}
+
 /**
  * Adapter interface that bridges entity-specific storage method names
  * to a generic CRUD interface. Each CrudEditorNamespace subclass implements

--- a/packages/editor/src/namespaces/mcp-server.ts
+++ b/packages/editor/src/namespaces/mcp-server.ts
@@ -12,7 +12,7 @@ import type {
   StorageToolConfig,
 } from '@mastra/core/storage';
 
-import { CrudEditorNamespace } from './base';
+import { CrudEditorNamespace, getVersionedEntityById } from './base';
 import type { StorageAdapter } from './base';
 
 export class EditorMCPServerNamespace extends CrudEditorNamespace<
@@ -150,7 +150,8 @@ export class EditorMCPServerNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ mcpServer: input }),
-      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
+      getByIdResolved: (id, options) =>
+        getVersionedEntityById(id, options, store.getByIdResolved.bind(store), store.getVersionByNumber.bind(store)),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),

--- a/packages/editor/src/namespaces/mcp-server.ts
+++ b/packages/editor/src/namespaces/mcp-server.ts
@@ -150,7 +150,7 @@ export class EditorMCPServerNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ mcpServer: input }),
-      getByIdResolved: id => store.getByIdResolved(id),
+      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),

--- a/packages/editor/src/namespaces/mcp.ts
+++ b/packages/editor/src/namespaces/mcp.ts
@@ -40,7 +40,7 @@ export class EditorMCPNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ mcpClient: input }),
-      getByIdResolved: id => store.getByIdResolved(id),
+      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),

--- a/packages/editor/src/namespaces/mcp.ts
+++ b/packages/editor/src/namespaces/mcp.ts
@@ -8,7 +8,7 @@ import type {
   StorageMCPServerConfig,
 } from '@mastra/core/storage';
 
-import { CrudEditorNamespace } from './base';
+import { CrudEditorNamespace, getVersionedEntityById } from './base';
 import type { StorageAdapter } from './base';
 
 export class EditorMCPNamespace extends CrudEditorNamespace<
@@ -40,7 +40,8 @@ export class EditorMCPNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ mcpClient: input }),
-      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
+      getByIdResolved: (id, options) =>
+        getVersionedEntityById(id, options, store.getByIdResolved.bind(store), store.getVersionByNumber.bind(store)),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),

--- a/packages/editor/src/namespaces/prompt.test.ts
+++ b/packages/editor/src/namespaces/prompt.test.ts
@@ -102,5 +102,8 @@ describe('EditorPromptNamespace', () => {
     const versionTwo = versions.versions.find(version => version.versionNumber === 2)!;
     const explicitVersion = await freshPrompt.getById('pinned-block', { versionId: versionTwo.id });
     expect(explicitVersion!.content).toBe('Draft content');
+
+    const numberedVersion = await freshPrompt.getById('pinned-block', { versionNumber: 2 });
+    expect(numberedVersion!.content).toBe('Draft content');
   });
 });

--- a/packages/editor/src/namespaces/prompt.test.ts
+++ b/packages/editor/src/namespaces/prompt.test.ts
@@ -71,4 +71,36 @@ describe('EditorPromptNamespace', () => {
     expect(versions.versions[0]!.changedFields).toEqual(['name', 'content', 'rules', 'requestContextSchema']);
     expect(updated.activeVersionId).toBeUndefined();
   });
+
+  it('keeps default reads pinned while exposing draft and specific versions', async () => {
+    const storage = new InMemoryStore();
+    const prompt = createPromptNamespace(storage);
+
+    await prompt.create({
+      id: 'pinned-block',
+      name: 'Pinned Block',
+      content: 'Published content',
+    });
+    const promptStore = await storage.getStore('promptBlocks');
+    const initialVersions = await promptStore!.listVersions({ blockId: 'pinned-block' });
+    const versionOne = initialVersions.versions.find(version => version.versionNumber === 1)!;
+    await promptStore!.update({ id: 'pinned-block', activeVersionId: versionOne.id, status: 'published' });
+
+    const updated = await prompt.update({ id: 'pinned-block', content: 'Draft content' });
+    expect(updated.content).toBe('Draft content');
+
+    const warmDefault = await prompt.getById('pinned-block');
+    const freshPrompt = createPromptNamespace(storage);
+    const coldDefault = await freshPrompt.getById('pinned-block');
+    expect(warmDefault!.content).toBe('Published content');
+    expect(coldDefault!.content).toBe('Published content');
+
+    const draft = await freshPrompt.getById('pinned-block', { status: 'draft' });
+    expect(draft!.content).toBe('Draft content');
+
+    const versions = await promptStore!.listVersions({ blockId: 'pinned-block' });
+    const versionTwo = versions.versions.find(version => version.versionNumber === 2)!;
+    const explicitVersion = await freshPrompt.getById('pinned-block', { versionId: versionTwo.id });
+    expect(explicitVersion!.content).toBe('Draft content');
+  });
 });

--- a/packages/editor/src/namespaces/prompt.ts
+++ b/packages/editor/src/namespaces/prompt.ts
@@ -173,7 +173,7 @@ export class EditorPromptNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ promptBlock: input }),
-      getByIdResolved: id => store.getByIdResolved(id),
+      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),
@@ -211,7 +211,6 @@ export class EditorPromptNamespace extends CrudEditorNamespace<
       throw new Error(`Failed to resolve entity ${input.id} after update`);
     }
 
-    this._cache.set(input.id, resolved);
     return resolved;
   }
 

--- a/packages/editor/src/namespaces/prompt.ts
+++ b/packages/editor/src/namespaces/prompt.ts
@@ -12,7 +12,7 @@ import type {
 } from '@mastra/core/storage';
 
 import { resolveInstructionBlocks } from '../instruction-builder';
-import { CrudEditorNamespace } from './base';
+import { CrudEditorNamespace, getVersionedEntityById } from './base';
 import type { StorageAdapter } from './base';
 
 const PROMPT_BLOCK_SNAPSHOT_CONFIG_FIELDS = [
@@ -173,7 +173,8 @@ export class EditorPromptNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ promptBlock: input }),
-      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
+      getByIdResolved: (id, options) =>
+        getVersionedEntityById(id, options, store.getByIdResolved.bind(store), store.getVersionByNumber.bind(store)),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),

--- a/packages/editor/src/namespaces/scorer.ts
+++ b/packages/editor/src/namespaces/scorer.ts
@@ -9,7 +9,7 @@ import type {
   StorageListScorerDefinitionsResolvedOutput,
 } from '@mastra/core/storage';
 
-import { CrudEditorNamespace } from './base';
+import { CrudEditorNamespace, getVersionedEntityById } from './base';
 import type { StorageAdapter } from './base';
 
 export class EditorScorerNamespace extends CrudEditorNamespace<
@@ -56,7 +56,8 @@ export class EditorScorerNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ scorerDefinition: input }),
-      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
+      getByIdResolved: (id, options) =>
+        getVersionedEntityById(id, options, store.getByIdResolved.bind(store), store.getVersionByNumber.bind(store)),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),

--- a/packages/editor/src/namespaces/scorer.ts
+++ b/packages/editor/src/namespaces/scorer.ts
@@ -56,7 +56,7 @@ export class EditorScorerNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ scorerDefinition: input }),
-      getByIdResolved: id => store.getByIdResolved(id),
+      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),

--- a/packages/editor/src/namespaces/skill.ts
+++ b/packages/editor/src/namespaces/skill.ts
@@ -9,7 +9,7 @@ import type {
 import type { SkillSource } from '@mastra/core/workspace';
 import { publishSkillFromSource } from '@mastra/core/workspace';
 
-import { CrudEditorNamespace } from './base';
+import { CrudEditorNamespace, getVersionedEntityById } from './base';
 import type { StorageAdapter } from './base';
 
 export class EditorSkillNamespace extends CrudEditorNamespace<
@@ -41,7 +41,8 @@ export class EditorSkillNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ skill: input }),
-      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
+      getByIdResolved: (id, options) =>
+        getVersionedEntityById(id, options, store.getByIdResolved.bind(store), store.getVersionByNumber.bind(store)),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),

--- a/packages/editor/src/namespaces/skill.ts
+++ b/packages/editor/src/namespaces/skill.ts
@@ -41,7 +41,7 @@ export class EditorSkillNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ skill: input }),
-      getByIdResolved: id => store.getByIdResolved(id),
+      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),

--- a/packages/editor/src/namespaces/workspace.ts
+++ b/packages/editor/src/namespaces/workspace.ts
@@ -274,7 +274,7 @@ export class EditorWorkspaceNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ workspace: input }),
-      getByIdResolved: id => store.getByIdResolved(id),
+      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),

--- a/packages/editor/src/namespaces/workspace.ts
+++ b/packages/editor/src/namespaces/workspace.ts
@@ -13,7 +13,7 @@ import type {
   StorageSandboxConfig,
 } from '@mastra/core/storage';
 
-import { CrudEditorNamespace } from './base';
+import { CrudEditorNamespace, getVersionedEntityById } from './base';
 import type { StorageAdapter } from './base';
 
 export class EditorWorkspaceNamespace extends CrudEditorNamespace<
@@ -274,7 +274,8 @@ export class EditorWorkspaceNamespace extends CrudEditorNamespace<
 
     return {
       create: input => store.create({ workspace: input }),
-      getByIdResolved: (id, options) => store.getByIdResolved(id, options),
+      getByIdResolved: (id, options) =>
+        getVersionedEntityById(id, options, store.getByIdResolved.bind(store), store.getVersionByNumber.bind(store)),
       update: input => store.update(input),
       delete: id => store.delete(id),
       list: args => store.list(args),


### PR DESCRIPTION
﻿## What does this PR do?

Fixes editor version resolution in two related places:

- forwards `GetByIdOptions` from the prompt, MCP client, MCP server, scorer, skill, and workspace namespace adapters to their versioned storage domains;
- prevents `prompt.update()` from caching its draft-resolved return value under the default published-read cache key.

The update call still returns the newly created draft. A following default read now resolves the published version consistently, whether the namespace cache is warm or cold.

Fixes #21360.

## How was it tested?

- `pnpm --filter @mastra/editor exec vitest run src/namespaces/prompt.test.ts` (2 passed)
- `oxfmt --check` on all 8 changed files
- broader editor run reached 159 passing tests; 14 suites could not collect in the filtered snapshot because `@mastra/libsql` / `@mastra/mcp` build outputs were not installed, plus an unrelated Windows `gray-matter` patched-package load error.

The added regression test pins prompt v1, creates draft v2, and verifies:
- warm and cold default reads both remain on v1;
- explicit draft and version-ID reads return v2.

## Scope

Agent auto-activation semantics from #21354 are intentionally unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Editor reads now return the correct version of an item. Updates no longer make draft content appear as the default published content.

## Changes

- Forward `GetByIdOptions` through prompt, MCP, MCP server, scorer, skill, and workspace namespace adapters.
- Add shared version-aware resolution with `getVersionedEntityById`.
- Prevent `prompt.update()` from caching draft content under the default published-read key.
- Preserve explicit draft, `versionId`, and version-number reads.
- Add regression coverage for warm and cold prompt namespace caches.
- Add a patch changeset for `@mastra/editor`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->