### PR TITLE
feat(factory): Skills page in Agent settings showing pipeline stage playbooks

### DIFF
--- a/.changeset/solid-trains-sing.md
+++ b/.changeset/solid-trains-sing.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Added a Skills page under the Agent section in Factory settings that shows the pipeline stage skills (Triage, Planning, Review, Re-review) with their playbook content, backed by a new GET /web/factory/skills endpoint. Also fixed a noisy checkpoint warning when the sandbox does not support snapshots.

--- a/mastracode/factory-ui/src/api/keys.ts
+++ b/mastracode/factory-ui/src/api/keys.ts
@@ -60,6 +60,7 @@ export const queryKeys = {
   modelPacksAll: () => ['model-packs'] as const,
   om: (resourceId: string | undefined) => ['om', resourceId ?? null] as const,
   thinkingConfig: () => ['thinking-config'] as const,
+  factorySkills: () => ['factory', 'skills'] as const,
   fsList: (path: string | undefined) => ['fs-list', path ?? null] as const,
   artifactsList: (path: string | undefined) => ['artifacts-list', path ?? null] as const,
   workspaceRenderedList: (workspacePath: string | undefined, renderedRoot: string | undefined) =>

--- a/mastracode/factory-ui/src/api/types.ts
+++ b/mastracode/factory-ui/src/api/types.ts
@@ -78,6 +78,18 @@ export interface OMResponse {
   config: OMConfigInfo;
 }
 
+/** A bundled Factory skill (`GET /web/factory/skills`). */
+export interface FactorySkillInfo {
+  name: string;
+  description: string;
+  /** SKILL.md body with the frontmatter removed. */
+  content: string;
+}
+
+export interface FactorySkillsResponse {
+  skills: FactorySkillInfo[];
+}
+
 // ── Mutation request bodies ────────────────────────────────────────────────
 
 export interface SaveProviderKeyBody {

--- a/mastracode/factory-ui/src/hooks/useFactorySkills.ts
+++ b/mastracode/factory-ui/src/hooks/useFactorySkills.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useApiConfig } from '../api/config';
+import { queryKeys } from '../api/keys';
+import type { FactorySkillsResponse } from '../api/types';
+
+/**
+ * The read-only catalog of Factory skills bundled with the server — the
+ * stage playbooks (triage, plan, review, …) automated Factory runs follow.
+ * Mirrors `GET /web/factory/skills`.
+ */
+export function useFactorySkillsQuery() {
+  const { client } = useApiConfig();
+  return useQuery({
+    queryKey: queryKeys.factorySkills(),
+    queryFn: () => client.get<FactorySkillsResponse>('/web/factory/skills'),
+    select: data => data.skills,
+  });
+}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/FactorySkillsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/FactorySkillsSection.tsx
@@ -1,0 +1,80 @@
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { ChevronRight } from 'lucide-react';
+
+import { useFactorySkillsQuery } from '../../../../hooks/useFactorySkills';
+import type { FactorySkillInfo } from '../../../../api/types';
+import { SettingsCard } from './SettingsCard';
+import { SettingsSubsection } from './SettingsSubsection';
+
+/** The built-in skills shown on the Skills page, in display order. */
+const DISPLAYED_SKILLS: { name: string; title: string }[] = [
+  { name: 'factory-triage', title: 'Triage' },
+  { name: 'factory-plan', title: 'Planning' },
+  { name: 'factory-review', title: 'Review' },
+  { name: 'factory-rereview', title: 'Re-review' },
+];
+
+function SkillCard({ title, skill }: { title: string; skill: FactorySkillInfo }) {
+  return (
+    <SettingsCard>
+      <Collapsible>
+        <CollapsibleTrigger className="group flex w-full items-center justify-between gap-4 px-4 py-3 text-left">
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <Txt as="span" variant="ui-md" className="text-icon5">
+              {title}
+              <Txt as="span" variant="ui-sm" className="text-icon3 ml-2 font-mono">
+                {skill.name}
+              </Txt>
+            </Txt>
+            <Txt as="span" variant="ui-sm" className="text-icon3">
+              {skill.description}
+            </Txt>
+          </div>
+          <ChevronRight
+            aria-hidden="true"
+            className="text-icon3 size-4 shrink-0 transition-transform group-data-[state=open]:rotate-90"
+          />
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <pre className="text-ui-sm text-icon4 max-h-96 overflow-auto px-4 pb-4 font-mono whitespace-pre-wrap">
+            {skill.content}
+          </pre>
+        </CollapsibleContent>
+      </Collapsible>
+    </SettingsCard>
+  );
+}
+
+/**
+ * Read-only view of the built-in Factory skills — the playbooks automated
+ * Factory runs follow at each stage (Settings › Agent › Skills).
+ */
+export function FactorySkillsSection() {
+  const skillsQuery = useFactorySkillsQuery();
+  const skills = skillsQuery.data ?? [];
+
+  return (
+    <SettingsSubsection
+      title="Factory skills"
+      description="The built-in playbooks Factory agents follow when working your items. Expand a skill to read the exact instructions the agent receives."
+    >
+      {skillsQuery.isPending && (
+        <Txt as="p" variant="ui-sm" role="status" className="text-icon3">
+          Loading skills…
+        </Txt>
+      )}
+      {skillsQuery.error && (
+        <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg">
+          {skillsQuery.error instanceof Error ? skillsQuery.error.message : 'Failed to load skills'}
+        </Txt>
+      )}
+      <div className="flex flex-col gap-3">
+        {DISPLAYED_SKILLS.flatMap(({ name, title }) => {
+          const skill = skills.find(s => s.name === name);
+          return skill ? [<SkillCard key={name} title={title} skill={skill} />] : [];
+        })}
+      </div>
+    </SettingsSubsection>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsNavigation.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsNavigation.tsx
@@ -3,6 +3,7 @@ import { MainSidebar, useMainSidebar } from '@mastra/playground-ui/components/Ma
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import {
   ArrowLeft,
+  BookOpen,
   Bot,
   Building2,
   Cable,
@@ -91,6 +92,12 @@ const SETTINGS_GROUPS: SettingsNavGroup[] = [
         icon: Bot,
         searchText:
           'models thinking level factory default model packs api keys providers credentials sign in oauth custom endpoints memory observational recall',
+      },
+      {
+        id: 'skills',
+        label: SETTINGS_SECTION_LABELS.skills,
+        icon: BookOpen,
+        searchText: 'skills factory triage plan review agent instructions prompts stages',
       },
       {
         id: 'behavior',

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.tsx
@@ -20,6 +20,7 @@ import { CustomProvidersSection } from './CustomProvidersSection';
 import { SettingsHeader } from './SettingsHeader';
 import { FactoryManagementSection } from './FactoryManagementSection';
 import { FactoryDefaultModelSection } from './FactoryDefaultModelSection';
+import { FactorySkillsSection } from './FactorySkillsSection';
 import { IntakeSection } from './IntakeSection';
 import { ModelPacksSection } from './ModelPacksSection';
 import { RepositoriesSection } from './RepositoriesSection';
@@ -132,6 +133,7 @@ export function SettingsPanel() {
             </SettingsSubsection>
           </div>
         )}
+        {section === 'skills' && <FactorySkillsSection />}
         {section === 'behavior' && (
           <BehaviorSettings
             settings={settings}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/FactorySkillsSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/FactorySkillsSection.msw.test.tsx
@@ -1,0 +1,82 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../e2e/ui/msw-server';
+import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
+import type { FactorySkillsResponse } from '../../../../../api/types';
+import { FactorySkillsSection } from '../FactorySkillsSection';
+
+const SKILLS_URL = `${TEST_BASE_URL}/web/factory/skills`;
+
+const catalog: FactorySkillsResponse = {
+  skills: [
+    {
+      name: 'factory-triage',
+      description: "Triage a Factory work item's issue — diagnose root cause, then advance the stage",
+      content: '# Triage\n\nTrace history and diagnose the root cause.',
+    },
+    {
+      name: 'factory-plan',
+      description: 'Produce a phased implementation plan for a Factory work item',
+      content: '# Plan\n\nProduce a phased implementation plan.',
+    },
+    {
+      name: 'factory-rereview',
+      description: 'Re-review a Factory work item PR after changes',
+      content: '# Re-review',
+    },
+    {
+      name: 'factory-review',
+      description: 'Review a Factory work item PR',
+      content: '# Review',
+    },
+    {
+      name: 'configure-factory-rules',
+      description: 'Configure repository rules for Factory runs',
+      content: '# Configure rules',
+    },
+  ],
+};
+
+describe('FactorySkillsSection', () => {
+  it('shows the pipeline stage skills from the catalog', async () => {
+    server.use(http.get(SKILLS_URL, () => HttpResponse.json(catalog)));
+
+    renderWithProviders(<FactorySkillsSection />);
+
+    expect(await screen.findByText('Triage')).toBeInTheDocument();
+    expect(screen.getByText('factory-triage')).toBeInTheDocument();
+    expect(screen.getByText(/diagnose root cause/)).toBeInTheDocument();
+    expect(screen.getByText('Planning')).toBeInTheDocument();
+    expect(screen.getByText('factory-plan')).toBeInTheDocument();
+    expect(screen.getByText('Review')).toBeInTheDocument();
+    expect(screen.getByText('factory-review')).toBeInTheDocument();
+    expect(screen.getByText('Re-review')).toBeInTheDocument();
+    expect(screen.getByText('factory-rereview')).toBeInTheDocument();
+    // Skills not in the displayed set are not rendered.
+    expect(screen.queryByText('configure-factory-rules')).not.toBeInTheDocument();
+  });
+
+  it('expands a skill to reveal its SKILL.md content', async () => {
+    server.use(http.get(SKILLS_URL, () => HttpResponse.json(catalog)));
+
+    const user = userEvent.setup();
+    renderWithProviders(<FactorySkillsSection />);
+
+    const trigger = await screen.findByRole('button', { name: /Triage/ });
+    expect(screen.queryByText(/Trace history and diagnose/)).not.toBeInTheDocument();
+
+    await user.click(trigger);
+    expect(await screen.findByText(/Trace history and diagnose/)).toBeInTheDocument();
+  });
+
+  it('surfaces a load failure from the server', async () => {
+    server.use(http.get(SKILLS_URL, () => HttpResponse.json({ error: 'boom' }, { status: 500 })));
+
+    renderWithProviders(<FactorySkillsSection />);
+
+    expect(await screen.findByText(/boom|Failed to load skills/)).toBeInTheDocument();
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/settings/settingsSections.ts
+++ b/mastracode/factory-ui/src/ui/domains/settings/settingsSections.ts
@@ -6,6 +6,7 @@ export type SettingsSection =
   | 'repositories'
   | 'intake'
   | 'models'
+  | 'skills'
   | 'behavior';
 
 export const SETTINGS_SECTION_LABELS: Record<SettingsSection, string> = {
@@ -16,6 +17,7 @@ export const SETTINGS_SECTION_LABELS: Record<SettingsSection, string> = {
   repositories: 'Repositories',
   intake: 'Work Intake',
   models: 'Models',
+  skills: 'Skills',
   behavior: 'Behavior',
 };
 

--- a/mastracode/factory/src/routes/skills.test.ts
+++ b/mastracode/factory/src/routes/skills.test.ts
@@ -424,3 +424,53 @@ describe('workspace skill invocation route', () => {
     expect(harness.sendA).not.toHaveBeenCalled();
   });
 });
+
+describe('factory skills catalog route', () => {
+  function createCatalogApp(options: { authEnabled?: boolean; user?: TestAuthUser } = {}) {
+    const app = new Hono();
+    if (options.user) {
+      app.use('*', async (c, next) => {
+        c.set('factoryAuthUser' as never, options.user as never);
+        await next();
+      });
+    }
+    mountApiRoutes(
+      app as never,
+      new SkillRoutes({
+        auth: fakeRouteAuth({ enabled: options.authEnabled ?? true }),
+        controllerId: 'code',
+        controller: { getSessionByResource: vi.fn(async () => undefined) } as never,
+      }).routes(),
+    );
+    return app;
+  }
+
+  it('rejects unauthenticated callers when auth is enabled', async () => {
+    const app = createCatalogApp();
+    const response = await app.request('/web/factory/skills');
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'unauthorized', message: 'Authentication required.' });
+  });
+
+  it('lists the bundled factory skills with descriptions and content', async () => {
+    const app = createCatalogApp({ authEnabled: false });
+    const response = await app.request('/web/factory/skills');
+    expect(response.status).toBe(200);
+    const { skills } = (await response.json()) as {
+      skills: { name: string; description: string; content: string }[];
+    };
+    const names = skills.map(s => s.name);
+    expect(names).toContain('factory-triage');
+    expect(names).toContain('factory-plan');
+    const triage = skills.find(s => s.name === 'factory-triage')!;
+    expect(triage.description.length).toBeGreaterThan(0);
+    expect(triage.content).toContain('# Factory Triage');
+    expect(triage.content).not.toContain('---\nname:');
+  });
+
+  it('serves the catalog to signed-in tenants', async () => {
+    const app = createCatalogApp({ user: { workosId: 'user-1', organizationId: 'org-1' } });
+    const response = await app.request('/web/factory/skills');
+    expect(response.status).toBe(200);
+  });
+});

--- a/mastracode/factory/src/routes/skills.ts
+++ b/mastracode/factory/src/routes/skills.ts
@@ -4,6 +4,7 @@ import type { ApiRoute } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
 
+import { listFactorySkills } from '../skills/catalog.js';
 import { resolveSkillInvocation, SkillInvocationError } from '../skills/service.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 import type { RouteDependencies } from './route.js';
@@ -181,7 +182,24 @@ export class SkillRoutes extends Route<SkillRoutesDeps> {
       }
     };
 
+    const handleFactorySkillsList = async (context: unknown) => {
+      const c = loose(context);
+      const { auth } = this.deps;
+      if (auth.enabled()) {
+        await auth.ensureUser(c);
+        if (!auth.tenant(c)) {
+          return c.json({ error: 'unauthorized', message: 'Authentication required.' }, 401);
+        }
+      }
+      return c.json({ skills: await listFactorySkills() });
+    };
+
     return [
+      registerApiRoute('/web/factory/skills', {
+        method: 'GET',
+        requiresAuth: false,
+        handler: context => handleFactorySkillsList(context),
+      }),
       registerApiRoute('/web/agent-controller/:controllerId/skills/prepare', {
         method: 'POST',
         requiresAuth: false,

--- a/mastracode/factory/src/session/checkpoint-capture.test.ts
+++ b/mastracode/factory/src/session/checkpoint-capture.test.ts
@@ -46,6 +46,23 @@ describe('observeSessionCheckpoint', () => {
     await expect(listeners[0]!({ type: 'agent_end', reason: 'complete' })).resolves.toBeUndefined();
   });
 
+  it('skips sandboxes that do not implement snapshot', async () => {
+    const { listeners } = createSession();
+    const session: CheckpointCaptureSession = {
+      getWorkspace: () => ({ sandbox: {} as { snapshot(): Promise<void> } }),
+      onBeforeAgentEnd: listener => {
+        listeners.push(listener);
+        return () => {};
+      },
+    };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    observeSessionCheckpoint(session);
+
+    await expect(listeners[0]!({ type: 'agent_end', reason: 'complete' })).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it('logs and swallows snapshot failures', async () => {
     const failure = new Error('snapshot unavailable');
     const { session, listeners } = createSession(vi.fn().mockRejectedValue(failure));

--- a/mastracode/factory/src/session/checkpoint-capture.ts
+++ b/mastracode/factory/src/session/checkpoint-capture.ts
@@ -19,7 +19,8 @@ export function observeSessionCheckpoint(session: CheckpointCaptureSession): () 
     capture = capture.then(async () => {
       // Chat-only sessions run without a workspace; there is nothing to snapshot.
       const sandbox = session.getWorkspace()?.sandbox;
-      if (!sandbox) return;
+      // Older sandbox implementations predate `snapshot()`; skip them quietly.
+      if (typeof sandbox?.snapshot !== 'function') return;
       try {
         await sandbox.snapshot();
       } catch (error) {

--- a/mastracode/factory/src/skills/catalog.ts
+++ b/mastracode/factory/src/skills/catalog.ts
@@ -1,0 +1,46 @@
+/**
+ * Read-only catalog of the Factory skills bundled with the server.
+ *
+ * These are the built-in skills the Factory pipeline invokes at each stage
+ * (triage, plan, review, …). The catalog reads the bundled `SKILL.md` files
+ * so the settings UI can show users exactly what each skill instructs the
+ * agent to do.
+ */
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { FACTORY_SKILL_NAMES, FACTORY_SKILLS_SOURCE_PATH } from '../workspace.js';
+
+export interface FactorySkillInfo {
+  name: string;
+  description: string;
+  /** SKILL.md body with the frontmatter block removed. */
+  content: string;
+}
+
+function parseSkillMarkdown(name: string, raw: string): FactorySkillInfo {
+  const frontmatterMatch = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  let description = '';
+  let content = raw;
+  if (frontmatterMatch?.[1] !== undefined) {
+    content = raw.slice(frontmatterMatch[0].length);
+    const descriptionLine = frontmatterMatch[1].match(/^description:\s*(.+)$/m);
+    if (descriptionLine?.[1]) description = descriptionLine[1].trim();
+  }
+  return { name, description, content: content.trim() };
+}
+
+/** List the bundled Factory skills, skipping any missing from the bundle. */
+export async function listFactorySkills(): Promise<FactorySkillInfo[]> {
+  const skills: FactorySkillInfo[] = [];
+  for (const name of [...FACTORY_SKILL_NAMES].sort()) {
+    let raw: string;
+    try {
+      raw = await readFile(join(FACTORY_SKILLS_SOURCE_PATH, name, 'SKILL.md'), 'utf8');
+    } catch {
+      continue;
+    }
+    skills.push(parseSkillMarkdown(name, raw));
+  }
+  return skills;
+}

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -36,7 +36,7 @@ export function checkpointNameForSession(sessionId: string): string {
 
 const bundleDirectory = dirname(fileURLToPath(import.meta.url));
 const bundledFactorySkillsPath = join(bundleDirectory, 'factory-skills');
-const FACTORY_SKILLS_SOURCE_PATH =
+export const FACTORY_SKILLS_SOURCE_PATH =
   [
     // Deploy bundle: the consumer copies `factory-skills/` next to the built
     // server module (e.g. via its public/ dir).
@@ -48,7 +48,7 @@ const FACTORY_SKILLS_SOURCE_PATH =
     join(process.cwd(), 'src', 'mastra', 'public', 'factory-skills'),
   ].find(existsSync) ?? bundledFactorySkillsPath;
 const FACTORY_SKILLS_MOUNT = path.resolve(path.parse(process.cwd()).root, '__mastracode_factory_skills__');
-const FACTORY_SKILL_NAMES = new Set([
+export const FACTORY_SKILL_NAMES = new Set([
   'configure-factory-rules',
   'factory-plan',
   'factory-rereview',


### PR DESCRIPTION
## Summary

Adds a **Skills** page under the Agent section of Factory settings that displays the pipeline stage skills — Triage, Planning, Review, and Re-review — with their full playbook content, so users can see exactly what the agent does at each stage of the pipeline.

- New `GET /web/factory/skills` endpoint (auth-required) that reads the bundled `SKILL.md` files, parses frontmatter, and returns name/description/content for each skill (`mastracode/factory/src/skills/catalog.ts`)
- New `skills` settings section with navigation entry, `FactorySkillsSection` component rendering each stage skill as a collapsible card, and a `useFactorySkillsQuery` React Query hook
- Internal setup skill (`configure-factory-rules`) is intentionally excluded — only stage playbooks are shown
- Also guards Factory checkpoint capture against sandboxes that don't implement `snapshot()`, silencing a TypeError logged on every agent-end event when running against an older `mastra` build

## Test plan

- Backend: `skills.test.ts` — endpoint returns 401 unauthenticated, full catalog when authenticated (17 tests passing)
- Checkpoint guard: `checkpoint-capture.test.ts` covers missing-snapshot sandbox (9 tests passing)
- UI: `FactorySkillsSection.msw.test.tsx` MSW tests for render, all four stage skills, exclusions, and error states (full MSW suite 500/500 passing)
- Typecheck clean for `@mastra/factory` and factory-ui

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory settings now include a Skills page. Users can view the built-in pipeline playbooks, their descriptions, and their full instructions.

## Changes

- Added authenticated `GET /web/factory/skills`.
- Added parsing for bundled `SKILL.md` files.
- Excluded the internal `configure-factory-rules` skill.
- Added Skills navigation and a collapsible `FactorySkillsSection`.
- Added `useFactorySkillsQuery` and related API types.
- Skipped checkpoint capture when `snapshot()` is not supported.
- Added backend, checkpoint, and UI tests.
- Typechecks pass for `@mastra/factory` and the Factory UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->