### PR TITLE
fix(core): reject model-authored approvals for consent-gated tools

### DIFF
--- a/.changeset/large-worlds-burn.md
+++ b/.changeset/large-worlds-burn.md
@@ -1,0 +1,44 @@
+---
+'@mastra/core': minor
+---
+
+Fixed an issue where an agent could approve its own suspended tool call and run a consent-gated tool with no human input.
+
+Tools gated by `requireApproval` (on the tool) or `requireToolApproval` (on the agent) could execute without anyone approving them. Three behaviors combined to allow it:
+
+- The `autoResumeSuspendedTools` system prompt told the model to fall back to `approved: true` whenever it could not infer a decision from the user's message.
+- The tool execution step accepted `resumeData` that the model wrote into its own tool call arguments as the approval answer.
+- Answered suspensions were never marked as resumed, so the auto-resume prompt kept re-arming on every later turn in the thread.
+
+An unrelated follow-up message was enough to make the model re-issue the gated tool call with `resumeData: { approved: true }` and execute it.
+
+**What changed**
+
+Approval decisions are now accepted only from the resume APIs (`approveToolCall()`, `declineToolCall()`, `resumeStream()`). Resume data authored by the model never satisfies an approval gate, so an approval-gated tool the model retries on a later turn suspends again and waits. Answered suspensions are now marked as resumed so the auto-resume directive stops re-arming.
+
+**Before**
+
+```typescript
+const stream = await agent.stream('Post this update', { memory });
+// suspends for approval
+
+await agent.stream('hm, what happened?', { memory });
+// tool executed: the model supplied its own resumeData: { approved: true }
+```
+
+**After**
+
+```typescript
+const stream = await agent.stream('Post this update', { memory });
+// suspends for approval
+
+await agent.stream('hm, what happened?', { memory });
+// still suspended, the tool did not run
+
+await agent.approveToolCall({ runId: stream.runId, memory });
+// the tool runs only now
+```
+
+`autoResumeSuspendedTools` is unchanged for tools that call `suspend()` without an approval gate. Those still resume from the user's next message as before.
+
+Fixes #21303

--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -493,6 +493,12 @@ For automatic tool resumption to work:
 
 Both approaches work with the same tool definitions. Automatic resumption triggers only when suspended tools exist in the message history and the user sends a new message on the same thread.
 
+:::note
+
+Automatic resumption never answers an approval. It applies only to tools that call `suspend()`. A tool gated by `requireApproval` or `requireToolApproval` stays suspended until a decision arrives through `approveToolCall()`, `declineToolCall()`, or `resumeStream()`. An agent cannot approve its own tool call, so an approval-gated tool that the model retries on a later turn suspends again and waits for the user.
+
+:::
+
 ## Resuming after a restart
 
 The examples above hold on to `stream.runId` between suspension and approval. That works while the process stays alive, but in production the approval often arrives later, after a page refresh, a server restart, or on a different server instance behind a load balancer.

--- a/packages/core/src/agent/__tests__/tool-approval.test.ts
+++ b/packages/core/src/agent/__tests__/tool-approval.test.ts
@@ -27,7 +27,7 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
 
   describe('tool approval and suspension', () => {
     describe.skipIf(version === 'v1')('requireToolApproval (mock-based)', () => {
-      it('should call findUserTool with requireToolApproval on tool and resume via stream when autoResumeSuspendedTools is true', async () => {
+      it('does not execute an approval-gated tool when the model self-approves, and executes once approved out-of-band', async () => {
         const findUserTool = createTool({
           id: 'Find user tool',
           description: 'This is a test tool that returns the name and email',
@@ -145,6 +145,8 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
             resourceId: memory.resource,
           });
 
+          mockFindUser.mockClear();
+
           const stream = await agentOne.stream('Find the user with name - Dero Israel', { memory });
           let toolName = '';
           for await (const _chunk of stream.fullStream) {
@@ -158,7 +160,17 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
           expect((await agentOne.getObjective({ threadId: memory.thread }))?.activeDurationMs).toBe(durationAtApproval);
 
           if (toolName) {
-            const resumeStream = await agentOne.stream('Approve', {
+            const selfApproveStream = await agentOne.stream('Approve', {
+              memory,
+            });
+            for await (const _chunk of selfApproveStream.fullStream) {
+            }
+
+            expect(mockFindUser).not.toHaveBeenCalled();
+
+            const resumeStream = await agentOne.approveToolCall({
+              runId: selfApproveStream.runId,
+              toolCallId: 'call-2',
               memory,
             });
             for await (const _chunk of resumeStream.fullStream) {
@@ -298,16 +310,12 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
               stream: convertArrayToReadableStream([
                 { type: 'stream-start', warnings: [] },
                 { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
-                {
-                  type: 'tool-call',
-                  toolCallId: 'call-2',
-                  toolName: 'findUserTool',
-                  input: '{"name":"Dero Israel", "resumeData": { "approved": true }}',
-                  providerExecuted: false,
-                },
+                { type: 'text-start', id: 'text-1' },
+                { type: 'text-delta', id: 'text-1', delta: 'User name is Dero Israel' },
+                { type: 'text-end', id: 'text-1' },
                 {
                   type: 'finish',
-                  finishReason: 'tool-calls',
+                  finishReason: 'stop',
                   usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
                 },
               ]),
@@ -353,7 +361,12 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
         expect(mockFindUser).not.toHaveBeenCalled();
 
         // Resume call: re-supplies the same function policy. Approval is granted, tool executes.
-        const resumeStream = await agent.stream('Approve', { memory, requireToolApproval });
+        const resumeStream = await agent.approveToolCall({
+          runId: suspendStream.runId,
+          toolCallId: 'call-1',
+          memory,
+          requireToolApproval,
+        });
         for await (const _chunk of resumeStream.fullStream) {
           // drain
         }

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -608,6 +608,15 @@ export function createDurableToolCallStep() {
             ? (lastAssistantMessage.content.metadata as Record<string, any>)
             : undefined;
         if (!meta?.[metadataKey]) return;
+        lastAssistantMessage.content.parts = lastAssistantMessage.content.parts?.map(part => {
+          if (part.type === 'data-tool-call-suspended' || part.type === 'data-tool-call-approval') {
+            const data = part.data as any;
+            if (data?.toolCallId === toolCallId || data?.toolName === toolName) {
+              return { ...part, data: { ...data, resumed: true } };
+            }
+          }
+          return part;
+        });
         // Resolve key: exact toolCallId, then by entry toolCallId, then by toolName
         const entries = meta[metadataKey] as Record<string, any>;
         const key = entries[toolCallId]
@@ -627,7 +636,7 @@ export function createDurableToolCallStep() {
         await doFlush();
       };
 
-      if (requiresApproval && !resumeData) {
+      if (requiresApproval && !workflowResumeData) {
         const resumeSchema = JSON.stringify({
           type: 'object',
           properties: {
@@ -690,15 +699,15 @@ export function createDurableToolCallStep() {
       // would be misinterpreted as an approval response.
       if (
         requiresApproval &&
-        resumeData &&
-        typeof resumeData === 'object' &&
-        resumeData !== null &&
-        'approved' in resumeData
+        workflowResumeData &&
+        typeof workflowResumeData === 'object' &&
+        workflowResumeData !== null &&
+        'approved' in workflowResumeData
       ) {
         // Remove approval metadata since we're resuming (either approved or declined)
         await removeToolMetadata('approval');
 
-        if (!(resumeData as { approved: boolean }).approved) {
+        if (!(workflowResumeData as { approved: boolean }).approved) {
           // Return the approval decision (not a `result` string) so it persists as
           // `state: 'output-denied'` with `approval`. The denial reason carries the
           // existing string so downstream consumers/UI keep the same message.
@@ -707,7 +716,7 @@ export function createDurableToolCallStep() {
           const approval = {
             id: toolCallId,
             approved: false as const,
-            reason: resolveDeclineReason(resumeData),
+            reason: resolveDeclineReason(workflowResumeData),
           };
           if (pubsub) {
             try {
@@ -751,10 +760,10 @@ export function createDurableToolCallStep() {
       // approval decision so it round-trips through persistence as `approval: { approved: true }`.
       const approvalGrant =
         requiresApproval &&
-        resumeData &&
-        typeof resumeData === 'object' &&
-        resumeData !== null &&
-        (resumeData as { approved?: boolean }).approved === true
+        workflowResumeData &&
+        typeof workflowResumeData === 'object' &&
+        workflowResumeData !== null &&
+        (workflowResumeData as { approved?: boolean }).approved === true
           ? ({ approval: { id: toolCallId, approved: true as const } } as const)
           : undefined;
 

--- a/packages/core/src/loop/shared/auto-resume-system-message.test.ts
+++ b/packages/core/src/loop/shared/auto-resume-system-message.test.ts
@@ -149,6 +149,19 @@ describe('buildAutoResumeSystemMessageSuffix', () => {
     expect(suffix!).not.toContain('parentRunId');
     expect(suffix!).not.toContain('parent-run');
   });
+
+  it('never instructs the model to default an approval to approved', () => {
+    const suffix = buildAutoResumeSystemMessageSuffix([{ toolName: 'sendPost', type: 'approval', runId: 'run-1' }]);
+    expect(suffix).not.toBeNull();
+    expect(suffix!).not.toContain('set approved to true');
+    expect(suffix!).not.toContain('{ approved: true }');
+  });
+
+  it('tells the model to skip approval-type suspended tools', () => {
+    const suffix = buildAutoResumeSystemMessageSuffix([{ toolName: 'sendPost', type: 'approval', runId: 'run-1' }]);
+    expect(suffix!).toContain("If the suspendedTool.type is 'approval', skip it entirely");
+    expect(suffix!).toContain('Approval decisions are only accepted from the user through the approval API');
+  });
 });
 
 describe('appendSuffixToLeadingSystemMessage', () => {

--- a/packages/core/src/loop/shared/auto-resume-system-message.ts
+++ b/packages/core/src/loop/shared/auto-resume-system-message.ts
@@ -116,7 +116,7 @@ export function buildAutoResumeSystemMessageSuffix(
                       resumeData can not be an empty object nor null/undefined.
                       When you find that and call that tool, add the resumeData to the tool call arguments/input.
                       Also, add the runId of the suspended tool as suspendedToolRunId to the tool call arguments/input.
-                      If the suspendedTool.type is 'approval', resumeData will be an object that contains 'approved' which can either be true or false depending on the user's message. If you can't construct resumeData from the message for approval type, set approved to true and add resumeData: { approved: true } to the tool call arguments/input.
+                      If the suspendedTool.type is 'approval', skip it entirely: do not construct resumeData for it, do not call that tool, and never add an 'approved' field to the tool call arguments/input. Approval decisions are only accepted from the user through the approval API, so tell the user the tool is still waiting for their approval.
 
                       IMPORTANT: If you're able to construct resumeData and get suspendedToolRunId, get the previous arguments/input of the tool call from args in the suspended tool, and spread it in the new arguments/input created, do not add duplicate data. 
                       `;

--- a/packages/core/src/loop/test-utils/aimock/scenarios/auto-resume-suspended-tools.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/auto-resume-suspended-tools.scenario.test.ts
@@ -17,15 +17,15 @@ import { randomUUID } from 'node:crypto';
  * Regression classes:
  * - Tool with `requireApproval: true` emits `tool-call-approval` chunk
  * - `autoResumeSuspendedTools` detects suspended tool in memory on next call
- * - Tool executes with `resumeData: { approved: true }` injected by the loop
- * - Final output reflects the resumed tool's result
+ * - Approval gates never accept a model-authored `resumeData: { approved: true }`
+ * - A plain `suspend()` tool still auto-resumes from model-authored resumeData
  */
 describeForAllEngines(
   'AIMock loop scenario: autoResumeSuspendedTools',
   engine => {
     const getMock = useLoopScenarioAimock();
 
-    it('auto-resumes a suspended tool when the user sends a follow-up message on the same thread', async () => {
+    it('does not let the model approve its own suspended approval-gated tool call', async () => {
       let toolExecuted = false;
       let toolInputName = '';
 
@@ -87,10 +87,7 @@ describeForAllEngines(
       // Tool should NOT have executed yet (suspended before execution)
       expect(toolExecuted).toBe(false);
 
-      // Second call: user sends follow-up on same thread.
-      // With autoResumeSuspendedTools, the loop detects the suspended tool
-      // and modifies the system prompt to instruct the model about it.
-      const { output, requests: secondCallRequests } = await runLoopScenario({
+      const { chunks: secondCallChunks, requests: secondCallRequests } = await runLoopScenario({
         engine,
         llm: getMock(),
         sharedAgent: shared,
@@ -99,8 +96,6 @@ describeForAllEngines(
         threadId,
         resourceId,
         fixtures: llm => {
-          // Turn 1 of second call: model re-calls the tool with resumeData
-          // (responding to the auto-resume instruction in the system prompt)
           llm.on(
             { endpoint: 'chat', hasToolResult: false },
             {
@@ -113,30 +108,93 @@ describeForAllEngines(
               ],
             },
           );
-          // Turn 2 of second call: after tool executes, model gets result and returns text
-          llm.on(
-            { endpoint: 'chat', toolCallId: 'call-2', hasToolResult: true },
-            {
-              content: 'User found: Dero Israel (dero.israel@test.com)',
-            },
-          );
         },
+        collectChunks: true,
       });
 
-      // Assert: system prompt was modified to mention suspended tools
       // AIMock captures ALL requests across calls; the second call's first request is at index 1
       // (index 0 is from the first call which had no suspended tools yet)
       const secondCallFirstRequest = secondCallRequests[1];
       const systemMessage = secondCallFirstRequest?.body?.messages?.find((m: any) => m.role === 'system');
       expect(systemMessage?.content).toContain('suspended tools');
 
-      // Assert: tool was executed during the auto-resume
-      expect(toolExecuted).toBe(true);
-      expect(toolInputName).toBe('Dero Israel');
+      expect(toolExecuted).toBe(false);
+      expect(toolInputName).toBe('');
+      expect(secondCallChunks!.filter(c => c.type === 'tool-call-approval').length).toBeGreaterThan(0);
+    });
 
-      // Assert: final output mentions the user
-      const text = await output.text;
-      expect(text.length).toBeGreaterThan(0);
+    it('auto-resumes a plain suspension that is not gated by approval', async () => {
+      let resumedCity = '';
+
+      const weatherTool = createTool({
+        id: 'weather',
+        description: 'Fetches weather for a city',
+        inputSchema: z.object({ city: z.string().optional() }),
+        suspendSchema: z.object({ message: z.string() }),
+        resumeSchema: z.object({ city: z.string() }),
+        execute: async (_input, context) => {
+          const resumeData = context?.agent?.resumeData as { city?: string } | undefined;
+          if (!resumeData?.city) {
+            await context?.agent?.suspend?.({ message: 'Which city?' });
+            return { weather: 'unknown' };
+          }
+          resumedCity = resumeData.city;
+          return { weather: `${resumeData.city}: sunny` };
+        },
+      });
+
+      const sharedMemory = new MockMemory();
+      const shared = await createSharedAgent(getMock(), {
+        tools: { weatherTool },
+        memory: sharedMemory,
+        defaultOptions: {
+          autoResumeSuspendedTools: true,
+        },
+        engine,
+      });
+
+      const threadId = randomUUID();
+      const resourceId = randomUUID();
+
+      const { chunks } = await runLoopScenario({
+        engine,
+        llm: getMock(),
+        sharedAgent: shared,
+        prompt: 'What is the weather?',
+        memory: sharedMemory,
+        threadId,
+        resourceId,
+        fixtures: llm => {
+          llm.onMessage(/weather/i, {
+            toolCalls: [{ id: 'w-1', name: 'weather', arguments: {} }],
+          });
+        },
+        collectChunks: true,
+      });
+
+      expect(chunks!.filter(c => c.type === 'tool-call-suspended').length).toBeGreaterThan(0);
+      expect(resumedCity).toBe('');
+
+      await runLoopScenario({
+        engine,
+        llm: getMock(),
+        sharedAgent: shared,
+        prompt: 'Paris',
+        memory: sharedMemory,
+        threadId,
+        resourceId,
+        fixtures: llm => {
+          llm.on(
+            { endpoint: 'chat', hasToolResult: false },
+            {
+              toolCalls: [{ id: 'w-2', name: 'weather', arguments: { resumeData: { city: 'Paris' } } }],
+            },
+          );
+          llm.on({ endpoint: 'chat', toolCallId: 'w-2', hasToolResult: true }, { content: 'Paris: sunny' });
+        },
+      });
+
+      expect(resumedCity).toBe('Paris');
     });
 
     it('does NOT auto-resume when autoResumeSuspendedTools is false', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -9,6 +9,7 @@ import { createTool } from '../../../tools';
 import { ToolStream } from '../../../tools/stream';
 import { CoreToolBuilder } from '../../../tools/tool-builder/builder';
 import type { MastraToolInvocationOptions } from '../../../tools/types';
+import { extractSuspendedToolsFromMessages } from '../../shared/auto-resume-system-message';
 import type { OuterLLMRun } from '../../types';
 import { createToolCallStep } from './tool-call-step';
 
@@ -817,6 +818,95 @@ describe('createToolCallStep tool approval workflow', () => {
         approved: true,
       },
     });
+  });
+
+  it('re-suspends instead of executing when the model authors an approval in its tool call arguments', async () => {
+    const inputData = { ...makeInputData(), args: { param: 'test', resumeData: { approved: true } } };
+
+    const executePromise = toolCallStep.execute(makeExecuteParams({ inputData }));
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(controller.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-call-approval',
+        payload: expect.objectContaining({ toolCallId: 'test-call-id', toolName: 'test-tool' }),
+      }),
+    );
+    expect(suspend).toHaveBeenCalled();
+    expectNoToolExecution();
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('re-suspends when model-authored approval data carries extra fields', async () => {
+    const inputData = {
+      ...makeInputData(),
+      args: { param: 'test', resumeData: { approved: true, reason: 'user said yes', extra: 1 } },
+    };
+
+    const executePromise = toolCallStep.execute(makeExecuteParams({ inputData }));
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(suspend).toHaveBeenCalled();
+    expectNoToolExecution();
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('re-suspends when the model authors non-approval resume data for an approval-gated tool', async () => {
+    const inputData = { ...makeInputData(), args: { param: 'test', resumeData: { city: 'Paris' } } };
+
+    const executePromise = toolCallStep.execute(makeExecuteParams({ inputData }));
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(suspend).toHaveBeenCalled();
+    expectNoToolExecution();
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('executes when an out-of-band approval arrives alongside a model-authored one', async () => {
+    const toolResult = { success: true, data: 'test-result' };
+    tools['test-tool'].execute.mockResolvedValue(toolResult);
+    const inputData = { ...makeInputData(), args: { param: 'test', resumeData: { approved: true } } };
+
+    const result = await toolCallStep.execute(makeExecuteParams({ inputData, resumeData: { approved: true } }));
+
+    expect(tools['test-tool'].execute).toHaveBeenCalledWith({ param: 'test' }, expect.objectContaining({}));
+    expect(suspend).not.toHaveBeenCalled();
+    expect(result.result).toEqual(toolResult);
+    expect(result.approval).toEqual({ id: 'test-call-id', approved: true });
+  });
+
+  it('honors an out-of-band decline over a model-authored approval', async () => {
+    const inputData = { ...makeInputData(), args: { param: 'test', resumeData: { approved: true } } };
+
+    const result = await toolCallStep.execute(makeExecuteParams({ inputData, resumeData: { approved: false } }));
+
+    expect(result.approval).toEqual({
+      id: 'test-call-id',
+      approved: false,
+      reason: 'Tool call was not approved by the user',
+    });
+    expectNoToolExecution();
+  });
+
+  it('still forwards model-authored resume data to a tool that does not require approval', async () => {
+    const execute = vi.fn().mockResolvedValue('resumed');
+    const ungatedStep = createToolCallStep({
+      tools: { 'test-tool': { execute } } as unknown as ToolSet,
+      messageList,
+      controller,
+      runId: 'test-run',
+      streamState,
+    });
+    const inputData = { ...makeInputData(), args: { param: 'test', resumeData: { city: 'Paris' } } };
+
+    const result = await ungatedStep.execute(makeExecuteParams({ inputData }));
+
+    expect(execute).toHaveBeenCalledWith({ param: 'test' }, expect.objectContaining({ resumeData: { city: 'Paris' } }));
+    expect(suspend).not.toHaveBeenCalled();
+    expect(result.result).toBe('resumed');
   });
 });
 
@@ -1723,5 +1813,84 @@ describe('createToolCallStep malformed JSON args (issue #9815)', () => {
     // Should return a descriptive error
     expect(result.error).toBeDefined();
     expect(result.error.message).toMatch(/invalid|malformed|json|args|arguments/i);
+  });
+});
+
+describe('createToolCallStep resumed suspension marker', () => {
+  const makeAssistantMessage = (toolCallId: string) => ({
+    id: 'assistant-1',
+    role: 'assistant' as const,
+    createdAt: new Date(0),
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+    content: {
+      format: 3 as const,
+      metadata: {
+        pendingToolApprovals: {
+          [toolCallId]: { toolCallId, toolName: 'test-tool', type: 'approval', runId: 'test-run' },
+        },
+      },
+      parts: [
+        {
+          type: 'tool-invocation' as const,
+          toolInvocation: { state: 'call' as const, toolCallId, toolName: 'test-tool', args: { param: 'test' } },
+        },
+        {
+          type: 'data-tool-call-approval' as const,
+          data: { toolCallId, toolName: 'test-tool', type: 'approval', runId: 'test-run' },
+        },
+      ],
+      content: '',
+    },
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('stamps resumed on the approval part so the auto-resume directive stops re-arming', async () => {
+    const toolCallId = 'test-call-id';
+    const assistantMessage = makeAssistantMessage(toolCallId);
+    const flushMessages = vi.fn();
+    const messageList = {
+      get: {
+        input: { aiV5: { model: () => [] } },
+        response: { db: () => [] },
+        all: { db: () => [assistantMessage] },
+      },
+      updateMessageMetadataByToolCallId: vi.fn(() => true),
+    } as unknown as MessageList;
+
+    expect(extractSuspendedToolsFromMessages([assistantMessage as any])).toHaveLength(1);
+
+    const execute = vi.fn().mockResolvedValue('ok');
+    const step = createToolCallStep({
+      tools: { 'test-tool': { execute, requireApproval: true } } as unknown as ToolSet,
+      messageList,
+      controller: { enqueue: vi.fn() },
+      requireToolApproval: true,
+      runId: 'test-run',
+      streamState: { serialize: vi.fn().mockReturnValue('serialized-state') },
+      _internal: { saveQueueManager: { flushMessages }, threadId: 'thread-1' },
+    } as unknown as OuterLLMRun);
+
+    await step.execute(
+      makeBaseExecuteParams(vi.fn(), {
+        writer: new ToolStream({ prefix: 'tool', callId: toolCallId, name: 'test-tool', runId: 'test-run' }),
+        inputData: { toolCallId, toolName: 'test-tool', args: { param: 'test' } },
+        resumeData: { approved: true },
+      }),
+    );
+
+    expect(execute).toHaveBeenCalled();
+    expect(flushMessages).toHaveBeenCalled();
+
+    const approvalPart = assistantMessage.content.parts.find(part => part.type === 'data-tool-call-approval') as {
+      data: { resumed?: boolean };
+    };
+    expect(approvalPart.data.resumed).toBe(true);
+    expect(assistantMessage.content.metadata.pendingToolApprovals).toBeUndefined();
+    expect(extractSuspendedToolsFromMessages([assistantMessage as any])).toEqual([]);
   });
 });

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -337,26 +337,25 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           }
 
           if (suspendedTools && typeof suspendedTools === 'object') {
+            lastAssistantMessage.content.parts = lastAssistantMessage.content.parts?.map(part => {
+              if (part.type === 'data-tool-call-suspended' || part.type === 'data-tool-call-approval') {
+                if (partMatches(part.data)) {
+                  return {
+                    ...part,
+                    data: {
+                      ...(part.data as any),
+                      resumed: true,
+                    },
+                  };
+                }
+              }
+              return part;
+            });
             if (metadata) {
               const entryKey = resolveEntryKey(suspendedTools);
               if (entryKey) {
                 delete suspendedTools[entryKey];
               }
-            } else {
-              lastAssistantMessage.content.parts = lastAssistantMessage.content.parts?.map(part => {
-                if (part.type === 'data-tool-call-suspended' || part.type === 'data-tool-call-approval') {
-                  if (partMatches(part.data)) {
-                    return {
-                      ...part,
-                      data: {
-                        ...(part.data as any),
-                        resumed: true,
-                      },
-                    };
-                  }
-                }
-                return part;
-              });
             }
 
             // If no more pending suspensions, remove the whole object
@@ -552,7 +551,9 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           !isDelegatedApproval,
         );
         const isApprovalResume =
-          resumeData != null && typeof resumeData === 'object' && 'approved' in (resumeData as Record<string, unknown>);
+          workflowResumeData != null &&
+          typeof workflowResumeData === 'object' &&
+          'approved' in (workflowResumeData as Record<string, unknown>);
         // Gate the resume branch on either a live policy or a prior outer approval suspend.
         // Without this, `declineToolCall` falls through to `execute` when the policy was
         // lost (#20470). Do not key only on `approved` in resumeData — generic tool
@@ -576,7 +577,8 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         );
 
         if (approvalGated) {
-          if (!resumeData) {
+          const approvalDecision = workflowResumeData as { approved?: boolean } | undefined;
+          if (!approvalDecision) {
             await stopGoalActivity({
               agentId,
               runId,
@@ -633,7 +635,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
             // Remove approval metadata since we're resuming (either approved or declined)
             await removeToolMetadata({ toolCallId: inputData.toolCallId, toolName: inputData.toolName }, 'approval');
 
-            if (!resumeData.approved) {
+            if (!approvalDecision.approved) {
               // Return the approval decision (not a `result` string) so it persists as
               // `state: 'output-denied'` with `approval`. The denial reason carries the
               // caller-supplied reason when one was provided, otherwise the default string
@@ -642,7 +644,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                 approval: {
                   id: inputData.toolCallId,
                   approved: false,
-                  reason: resolveDeclineReason(resumeData),
+                  reason: resolveDeclineReason(approvalDecision),
                 },
                 ...inputData,
               };
@@ -654,7 +656,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         // approval decision so it round-trips through persistence as `approval: { approved: true }`.
         // Use `approvalGated` (not only the live policy) so approve-after-policy-loss still tags.
         const approvalGrant =
-          approvalGated && resumeData && (resumeData as { approved?: boolean }).approved === true
+          approvalGated && workflowResumeData && (workflowResumeData as { approved?: boolean }).approved === true
             ? ({ approval: { id: inputData.toolCallId, approved: true as const } } as const)
             : undefined;
 


### PR DESCRIPTION
## Description

An agent could approve its own suspended tool call and execute a consent-gated action with no human input. Three behaviors combined:

- The auto-resume system message told the model to fall back to `approved: true` whenever it could not infer a decision from the user's message.
- Both tool-call steps accepted `resumeData` written by the model into its own tool-call arguments as the approval answer.
- Answered suspensions were never stamped `resumed`, so the auto-resume directive re-armed on every later turn in the thread.

Approval decisions are now read only from the out-of-band workflow resume data that `approveToolCall()`, `declineToolCall()`, and `resumeStream()` supply. Resume data authored by the model never satisfies an approval gate, so a gated tool the model retries suspends again instead of running. Both engines now stamp `resumed` on the matching part whenever a suspension is answered, not only when metadata is absent.

Applied to both `loop/workflows/agentic-execution/tool-call-step.ts` and `agent/durable/workflows/steps/tool-call.ts`. The Inngest engine reuses `createDurableToolCallStep()`, so it is covered by the durable change.

**Behavior change:** `autoResumeSuspendedTools` no longer auto-answers approvals. It is unchanged for tools that call `suspend()` without an approval gate the documented conversational resume flow still works, with a new test asserting so on both engines.

**Tests:** approval gates reject model-authored `resumeData` (including when it carries extra fields alongside `approved`); an out-of-band decline wins over a model-authored approval; approval still executes via the resume API; non-approval tools still receive model-authored resume data; `resumed` is stamped so `extractSuspendedToolsFromMessages` returns `[]` once answered. 72 tests across the four changed test files, plus the full durable suite (64 files / 548 tests).

Note: two existing tests encoded the vulnerable behavior (a mock model emitting `resumeData: { approved: true }` with the suite asserting the tool *executed*) and were rewritten to resume through the approval API instead.

## Related issue(s)

Fixes #21303

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A tool can no longer approve itself using data written by the model. Approval must come from an explicit approval API or resume action, and answered approval requests are no longer shown as pending.

## Changes

- Restrict approval decisions to out-of-band data from `approveToolCall()`, `declineToolCall()`, or `resumeStream()`.
- Reject model-authored `resumeData` and `suspendedToolRunId` as approval signals.
- Keep approval-gated tools suspended until a valid approval or decline is received.
- Mark answered suspension parts as `resumed` in loop and durable tool-call steps.
- Preserve automatic resume behavior for non-approval suspensions.
- Update documentation and add coverage for self-approval prevention, explicit decisions, resume behavior, and resumed-state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->