### PR TITLE
feat(core): fire onOutput for client-executed tool results

### DIFF
--- a/.changeset/happy-eggs-invite.md
+++ b/.changeset/happy-eggs-invite.md
@@ -1,0 +1,25 @@
+---
+'@mastra/core': minor
+---
+
+Client-executed tools (tools without a server-side `execute`) now fire their `onOutput` lifecycle hook when the browser returns the tool result on a follow-up request. Previously `onOutput` only fired after a server-side `execute`, so client tools never reported their output.
+
+```ts
+const agent = new Agent({
+  // ...
+  tools: {
+    browserTool: createTool({
+      id: 'browserTool',
+      description: 'Runs in the browser',
+      inputSchema: z.object({ query: z.string() }),
+      // No execute — the client runs the tool. This hook now fires when
+      // the client sends the result back.
+      onOutput: async ({ toolCallId, output }) => {
+        console.log('client tool resolved', toolCallId, output);
+      },
+    }),
+  },
+});
+```
+
+The hook fires for trailing tool results that match a raw tool call from the preceding assistant message, so the follow-up request must include both (as `@mastra/client-js` does automatically). This works with standard, legacy, and durable agents, including requests with a same-name serialized `clientTools` entry. The callback receives `{ toolCallId, toolName, output, abortSignal }`. Because the input is client-provided, treat the output as untrusted data. Delivery is at least once, and the hook does not fire when an input processor rejects the request. Keep hooks idempotent.

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -302,7 +302,7 @@ The first `execute` parameter is the validated value from `inputSchema`. Destruc
     name: 'onOutput',
     type: 'function',
     description:
-      "Optional callback invoked after a server-executed tool returns output or after a client-executed tool result arrives on a follow-up request. For client-executed results, `TSchemaOut` is a static type only: the server doesn't validate the result against `outputSchema`, so treat the output as untrusted. Signature: `({ output, toolName, ...options }: { output: TSchemaOut; toolName: string } & Omit<ToolCallOptions, 'messages'>) => void | PromiseLike<void>`.",
+      "Optional callback invoked after a server-executed tool returns output or after a successful client-executed tool result arrives on a follow-up request. Error results don't invoke the hook. For client-executed results, `TSchemaOut` is a static type only: the server doesn't validate the result against `outputSchema`, so treat the output as untrusted. Signature: `({ output, toolName, ...options }: { output: TSchemaOut; toolName: string } & Omit<ToolCallOptions, 'messages'>) => void | PromiseLike<void>`.",
     isOptional: true,
   },
 ]}
@@ -667,7 +667,7 @@ export const tool = createTool({
 
 #### `onOutput`
 
-Called after a server-executed tool returns output or after a client-executed tool result arrives on a follow-up request. Use it to log results, trigger follow-up actions, or collect analytics.
+Called after a server-executed tool returns output or after a successful client-executed tool result arrives on a follow-up request. Use it to log results or trigger follow-up actions.
 
 ```typescript
 export const tool = createTool({
@@ -686,9 +686,9 @@ export const tool = createTool({
 })
 ```
 
-Client-executed tools don't define an `execute` function. The browser runs the tool and sends the result on a follow-up request. `onOutput` then runs on the server.
+Client-executed tools don't define an `execute` function. The browser runs the tool and sends the result on a follow-up request. `onOutput` then runs on the server. Only a correlated successful result invokes the hook: error results, such as the AI SDK `error-text` and `error-json` output types, don't invoke `onOutput`.
 
-For client-executed results, the follow-up request must include both the assistant tool call and the tool result, which `@mastra/client-js` sends automatically. A request that carries only the tool result does not fire the hook. In this case the callback receives `{ toolCallId, toolName, output, abortSignal }` only.
+For client-executed results, the follow-up request must include both the assistant tool call and the tool result, which `@mastra/client-js` sends automatically. A request that carries only the tool result doesn't fire the hook. In this case the callback receives `{ toolCallId, toolName, output, abortSignal }` only.
 
 Delivery is at least once, so a retried request runs the hook again. Keep the hook idempotent and treat client output as untrusted data: the server doesn't validate the result against `outputSchema`, so the `output` type is a static type only.
 
@@ -702,7 +702,7 @@ For a typical streaming tool call on a server-executed tool, the hooks are invok
 1. Tool's **execute** function runs
 1. **onOutput**: Tool has completed successfully
 
-For a client-executed tool, steps 1-3 run while the model streams the tool call, the client runs the tool instead of a server-side `execute`, and `onOutput` runs on the follow-up request that carries the result.
+For a client-executed tool, steps 1-3 run while the model streams the tool call, the client runs the tool instead of a server-side `execute`, and `onOutput` runs on the follow-up request that carries a successful result.
 
 ### Hook parameters
 

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -302,7 +302,7 @@ The first `execute` parameter is the validated value from `inputSchema`. Destruc
     name: 'onOutput',
     type: 'function',
     description:
-      "Optional callback invoked after the tool has successfully executed and returned output. Signature: `({ output, toolName, ...options }: { output: TSchemaOut; toolName: string } & Omit<ToolCallOptions, 'messages'>) => void | PromiseLike<void>`.",
+      "Optional callback invoked after a server-executed tool returns output or after a client-executed tool result arrives on a follow-up request. Signature: `({ output, toolName, ...options }: { output: TSchemaOut; toolName: string } & Omit<ToolCallOptions, 'messages'>) => void | PromiseLike<void>`.",
     isOptional: true,
   },
 ]}
@@ -667,7 +667,7 @@ export const tool = createTool({
 
 #### `onOutput`
 
-Called after the tool has successfully executed and returned output. Useful for logging results, triggering follow-up actions, or analytics.
+Called after a server-executed tool returns output or after a client-executed tool result arrives on a follow-up request. Use it to log results, trigger follow-up actions, or collect analytics.
 
 ```typescript
 export const tool = createTool({
@@ -685,6 +685,12 @@ export const tool = createTool({
   },
 })
 ```
+
+Client-executed tools don't define an `execute` function. The browser runs the tool and sends the result on a follow-up request. `onOutput` then runs on the server.
+
+For client-executed results, the follow-up request must include both the assistant tool call and the tool result, which `@mastra/client-js` sends automatically. A request that carries only the tool result does not fire the hook. In this case the callback receives `{ toolCallId, toolName, output, abortSignal }` only.
+
+Delivery is at least once, so a retried request runs the hook again. Keep the hook idempotent and treat client output as untrusted data.
 
 ### Hook execution order
 

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -302,7 +302,7 @@ The first `execute` parameter is the validated value from `inputSchema`. Destruc
     name: 'onOutput',
     type: 'function',
     description:
-      "Optional callback invoked after a server-executed tool returns output or after a client-executed tool result arrives on a follow-up request. Signature: `({ output, toolName, ...options }: { output: TSchemaOut; toolName: string } & Omit<ToolCallOptions, 'messages'>) => void | PromiseLike<void>`.",
+      "Optional callback invoked after a server-executed tool returns output or after a client-executed tool result arrives on a follow-up request. For client-executed results, `TSchemaOut` is a static type only: the server doesn't validate the result against `outputSchema`, so treat the output as untrusted. Signature: `({ output, toolName, ...options }: { output: TSchemaOut; toolName: string } & Omit<ToolCallOptions, 'messages'>) => void | PromiseLike<void>`.",
     isOptional: true,
   },
 ]}
@@ -690,17 +690,19 @@ Client-executed tools don't define an `execute` function. The browser runs the t
 
 For client-executed results, the follow-up request must include both the assistant tool call and the tool result, which `@mastra/client-js` sends automatically. A request that carries only the tool result does not fire the hook. In this case the callback receives `{ toolCallId, toolName, output, abortSignal }` only.
 
-Delivery is at least once, so a retried request runs the hook again. Keep the hook idempotent and treat client output as untrusted data.
+Delivery is at least once, so a retried request runs the hook again. Keep the hook idempotent and treat client output as untrusted data: the server doesn't validate the result against `outputSchema`, so the `output` type is a static type only.
 
 ### Hook execution order
 
-For a typical streaming tool call, the hooks are invoked in this order:
+For a typical streaming tool call on a server-executed tool, the hooks are invoked in this order:
 
 1. **onInputStart**: Input streaming begins
 1. **onInputDelta**: Called multiple times as chunks arrive
 1. **onInputAvailable**: Complete input is parsed and validated
 1. Tool's **execute** function runs
 1. **onOutput**: Tool has completed successfully
+
+For a client-executed tool, steps 1-3 run while the model streams the tool call, the client runs the tool instead of a server-side `execute`, and `onOutput` runs on the follow-up request that carries the result.
 
 ### Hook parameters
 

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -48,6 +48,7 @@ import type {
 } from './types';
 
 import { resolveThreadIdFromArgs } from './utils';
+import { fireClientToolOutputHooks } from './workflows/prepare-stream/client-tool-output-hooks';
 
 /**
  * Interface for accessing Agent methods needed by the legacy handler.
@@ -320,6 +321,14 @@ export class AgentLegacyHandler {
           hooks,
         });
 
+        // The legacy path has no abort signal to forward to the hook.
+        const fireClientHooks = () =>
+          fireClientToolOutputHooks({
+            messages,
+            tools: convertedTools,
+            logger: this.capabilities.logger,
+          });
+
         let messageList = new MessageList({
           threadId,
           resourceId,
@@ -366,6 +375,9 @@ export class AgentLegacyHandler {
                 tripwire: inputStepResult.tripwire,
               };
             }
+          }
+          if (!tripwire) {
+            await fireClientHooks();
           }
           return {
             messageObjects: tripwire ? [] : messageList.get.all.prompt(),
@@ -473,6 +485,10 @@ export class AgentLegacyHandler {
               threadExists: !!existingThread,
             };
           }
+        }
+
+        if (!tripwire) {
+          await fireClientHooks();
         }
 
         // Messages are already processed by __runInputProcessors and __runProcessInputStep above

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6025,6 +6025,20 @@ export class Agent<
       model,
     });
 
+    // Preserve `onOutput` from server-declared execute-less tools when the
+    // serialized client copy overwrites them below. Normal server-executed
+    // tools never hand hooks to client-controlled input. Copy instead of
+    // mutating so a future cache inside listClientTools cannot leak hooks
+    // across requests.
+    const serverDeclaredTools = { ...assignedTools, ...toolsetTools };
+    for (const [name, clientSideTool] of Object.entries(clientSideTools)) {
+      const serverTool = serverDeclaredTools[name];
+      if (!serverTool || serverTool.execute) continue;
+      if (!clientSideTool.onOutput && typeof serverTool.onOutput === 'function') {
+        clientSideTools[name] = { ...clientSideTool, onOutput: serverTool.onOutput };
+      }
+    }
+
     const agentTools = await this.listAgentTools({
       runId,
       resourceId,

--- a/packages/core/src/agent/durable/__tests__/durable-agent-client-tool-callbacks.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-client-tool-callbacks.test.ts
@@ -1,9 +1,8 @@
 /**
- * DurableAgent client-tool onInputStart / onInputDelta callback tests.
+ * DurableAgent client-tool lifecycle callback tests.
  *
- * Verifies that tool-level onInputStart and onInputDelta callbacks are
- * invoked during durable streaming when the LLM streams tool-call input
- * (Bug 10 parity fix).
+ * Covers streamed input callbacks and server-side `onOutput` handling for
+ * client-executed tool results.
  */
 
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
@@ -13,6 +12,7 @@ import { z } from 'zod';
 import { EventEmitterPubSub } from '../../../events/event-emitter';
 import { Mastra } from '../../../mastra';
 import { InMemoryStore } from '../../../storage';
+import { createTool } from '../../../tools';
 import { Agent } from '../../agent';
 import { createDurableAgent } from '../create-durable-agent';
 
@@ -193,5 +193,119 @@ describe('DurableAgent client-tool callbacks (Bug 10)', () => {
         }),
       );
     }
+  });
+
+  it('invokes onOutput for a client-executed tool result arriving on a follow-up request', async () => {
+    const onOutputSpy = vi.fn();
+
+    // Second (text-only) response shape is enough: the incoming request already
+    // carries the tool result, so no tool call is needed on this run.
+    const model = createStreamingToolInputModel('client-tool', ['{}']);
+
+    const baseAgent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a test agent',
+      model,
+      tools: {
+        // Execute-less: the tool runs on the client; the server only observes.
+        'client-tool': createTool({
+          id: 'client-tool',
+          description: 'A client-side tool',
+          inputSchema: z.object({ query: z.string().optional() }),
+          onOutput: onOutputSpy,
+        }),
+      },
+    });
+
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+    _mastra = new Mastra({
+      agents: { 'test-agent': durableAgent },
+      storage: new InMemoryStore(),
+    });
+
+    // Follow-up request shape from @mastra/client-js: previous assistant
+    // tool-call + the client-produced tool result.
+    const { output } = await durableAgent.stream(
+      [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool-call', toolCallId: 'tc-client-1', toolName: 'client-tool', args: {} }],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'tool-result', toolCallId: 'tc-client-1', toolName: 'client-tool', result: { ok: true } }],
+        },
+      ] satisfies Parameters<typeof durableAgent.stream>[0],
+      { maxSteps: 2 },
+    );
+
+    await output.consumeStream();
+
+    expect(onOutputSpy).toHaveBeenCalledTimes(1);
+    expect(onOutputSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCallId: 'tc-client-1',
+        toolName: 'client-tool',
+        output: { ok: true },
+      }),
+    );
+  });
+
+  it('does not invoke onOutput when an input processor tripwires the request', async () => {
+    const onOutputSpy = vi.fn();
+
+    const model = createStreamingToolInputModel('client-tool', ['{}']);
+
+    const baseAgent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a test agent',
+      model,
+      tools: {
+        'client-tool': createTool({
+          id: 'client-tool',
+          description: 'A client-side tool',
+          inputSchema: z.object({ query: z.string().optional() }),
+          onOutput: onOutputSpy,
+        }),
+      },
+      inputProcessors: [
+        {
+          id: 'block-everything',
+          name: 'block-everything',
+          processInput: async ({ abort, messages }) => {
+            abort('blocked by policy');
+            return messages;
+          },
+        },
+      ],
+    });
+
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+    _mastra = new Mastra({
+      agents: { 'test-agent': durableAgent },
+      storage: new InMemoryStore(),
+    });
+
+    const { output } = await durableAgent.stream(
+      [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool-call', toolCallId: 'tc-client-1', toolName: 'client-tool', args: {} }],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'tool-result', toolCallId: 'tc-client-1', toolName: 'client-tool', result: { ok: true } }],
+        },
+      ] satisfies Parameters<typeof durableAgent.stream>[0],
+      { maxSteps: 2 },
+    );
+
+    await output.consumeStream();
+
+    expect(onOutputSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/agent/durable/preparation.ts
+++ b/packages/core/src/agent/durable/preparation.ts
@@ -30,6 +30,7 @@ import type {
   ToolsetsInput,
   ToolsInput,
 } from '../types';
+import { fireClientToolOutputHooks } from '../workflows/prepare-stream/client-tool-output-hooks';
 import type { DurableAgenticWorkflowInput, RunRegistryEntry, SerializableStructuredOutput } from './types';
 import { createWorkflowInput } from './utils/serialize-state';
 import { generateDurableThreadTitle } from './workflows/finalize-run';
@@ -495,6 +496,17 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
   const model = await typedAgent.getModel({ requestContext });
   if (!model) {
     throw new Error('Agent model not available');
+  }
+
+  // Client-executed results fire only after processors accept the request and
+  // the required runtime model has resolved.
+  if (!tripwireData) {
+    await fireClientToolOutputHooks({
+      messages,
+      tools,
+      abortSignal: execOptions?.abortSignal,
+      logger,
+    });
   }
 
   const modelList = await typedAgent.getModelList(requestContext);

--- a/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.test.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.test.ts
@@ -358,19 +358,73 @@ describe('fireClientToolOutputHooks', () => {
     expect(logger.error).toHaveBeenCalled();
   });
 
-  it('no-ops when no registered tool is an execute-less onOutput tool', async () => {
+  it('does not fire onOutput for AI SDK v5 error-text outputs', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+
+    const messages = [
+      toolCallMessage('call-1'),
+      {
+        role: 'tool' as const,
+        content: [
+          {
+            type: 'tool-result' as const,
+            toolCallId: 'call-1',
+            toolName: 'browserTool',
+            output: { type: 'error-text' as const, value: 'client failed' },
+          },
+        ],
+      },
+    ];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(onOutput).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onOutput for AI SDK v5 error-json outputs', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+
+    const messages = [
+      toolCallMessage('call-1'),
+      {
+        role: 'tool' as const,
+        content: [
+          {
+            type: 'tool-result' as const,
+            toolCallId: 'call-1',
+            toolName: 'browserTool',
+            output: { type: 'error-json' as const, value: { code: 'E_FAIL' } },
+          },
+        ],
+      },
+    ];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(onOutput).not.toHaveBeenCalled();
+  });
+
+  it('no-ops without reading messages when no registered tool is an execute-less onOutput tool', async () => {
     const tools = await buildAgentTools({
       serverTools: {
         plain: createTool({ id: 'plain', description: 'no hooks', inputSchema: z.object({}) }),
       },
     });
 
-    const messageList = new MessageList();
-    const getInput = vi.spyOn(messageList.get, 'input', 'get');
+    // The messages input must not even be read when the tool precheck fails.
+    let read = false;
+    const messages = new Proxy([toolCallMessage('call-1', 'plain'), toolResultMessage('call-1', 'x', 'plain')], {
+      get(target, prop, receiver) {
+        read = true;
+        return Reflect.get(target, prop, receiver);
+      },
+    });
 
-    await fireClientToolOutputHooks({ messages: messageList.get.input.db(), tools });
+    await fireClientToolOutputHooks({ messages, tools });
 
-    expect(getInput).not.toHaveBeenCalled();
+    expect(read).toBe(false);
   });
 });
 

--- a/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.test.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.test.ts
@@ -1,0 +1,481 @@
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { createTool } from '../../../tools';
+import type { CoreTool } from '../../../tools/types';
+import { Agent } from '../../agent';
+import { MessageList } from '../../message-list';
+import type { ToolsInput } from '../../types';
+import { fireClientToolOutputHooks } from './client-tool-output-hooks';
+
+/**
+ * Builds tools through the real production pipeline (`Agent#getToolsForExecution`
+ * → `convertTools` → `makeCoreTool`) instead of hand-crafting CoreTool shapes,
+ * so these tests exercise exactly what map-results-step receives at runtime.
+ */
+async function buildAgentTools({
+  serverTools,
+  clientTools,
+  toolsets,
+}: {
+  serverTools: ToolsInput;
+  // Serialized over-the-wire shape: functions stripped, schemas as JSON schema.
+  // This intentionally does not satisfy ToolsInput; the server receives it as-is.
+  clientTools?: Record<string, unknown>;
+  toolsets?: Record<string, ToolsInput>;
+}): Promise<Record<string, CoreTool>> {
+  const agent = new Agent({
+    id: 'test-agent',
+    name: 'test-agent',
+    instructions: 'test agent',
+    model: new MockLanguageModelV2({}) as unknown as LanguageModelV2,
+    tools: serverTools,
+  });
+  return agent.getToolsForExecution({ clientTools: clientTools as ToolsInput | undefined, toolsets });
+}
+
+type OnOutputOptions = { toolCallId: string; toolName: string; output: unknown; abortSignal?: AbortSignal };
+
+function browserToolWith(onOutput: (options: OnOutputOptions) => void | Promise<void>) {
+  return createTool({
+    id: 'browserTool',
+    description: 'runs in the browser',
+    inputSchema: z.object({ q: z.string().optional() }),
+    onOutput,
+  });
+}
+
+function toolCallMessage(toolCallId: string, toolName = 'browserTool') {
+  return {
+    role: 'assistant' as const,
+    content: [{ type: 'tool-call' as const, toolCallId, toolName, args: {} }],
+  };
+}
+
+function toolResultMessage(toolCallId: string, result: unknown, toolName = 'browserTool') {
+  return {
+    role: 'tool' as const,
+    content: [{ type: 'tool-result' as const, toolCallId, toolName, result }],
+  };
+}
+
+describe('fireClientToolOutputHooks', () => {
+  it('fires onOutput for a trailing correlated client tool result', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+
+    // Server-defined execute-less tool must come out of conversion without execute
+    // but with the hook intact — otherwise the runtime path can never fire.
+    expect(tools.browserTool!.execute).toBeUndefined();
+    expect(typeof tools.browserTool!.onOutput).toBe('function');
+
+    const messages = [toolCallMessage('call-1'), toolResultMessage('call-1', { ok: true })];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(onOutput).toHaveBeenCalledTimes(1);
+    expect(onOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCallId: 'call-1',
+        toolName: 'browserTool',
+        output: { ok: true },
+      }),
+    );
+  });
+
+  it('does not unwrap a client result that merely contains a `value` key', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+
+    const messages = [toolCallMessage('call-1'), toolResultMessage('call-1', { value: 72, unit: 'F' })];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(onOutput).toHaveBeenCalledWith(expect.objectContaining({ output: { value: 72, unit: 'F' } }));
+  });
+
+  it('unwraps the AI SDK v5 `{ type, value }` output wrapper', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+
+    const messages = [
+      toolCallMessage('call-1'),
+      {
+        role: 'tool' as const,
+        content: [
+          {
+            type: 'tool-result' as const,
+            toolCallId: 'call-1',
+            toolName: 'browserTool',
+            output: { type: 'json' as const, value: { ok: true } },
+          },
+        ],
+      },
+    ];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(onOutput).toHaveBeenCalledWith(expect.objectContaining({ output: { ok: true } }));
+  });
+
+  it('preserves the server-defined onOutput when a serialized client tool of the same name is sent', async () => {
+    const onOutput = vi.fn();
+    // Simulate the HTTP round trip: @mastra/client-js serializes clientTools to
+    // JSON, so functions (execute, hooks) are stripped and schemas arrive as
+    // JSON schema.
+    const serializedClientTools = JSON.parse(
+      JSON.stringify({
+        browserTool: {
+          description: 'runs in the browser',
+          inputSchema: { type: 'object', properties: { q: { type: 'string' } } },
+        },
+      }),
+    );
+
+    const tools = await buildAgentTools({
+      serverTools: { browserTool: browserToolWith(onOutput) },
+      clientTools: serializedClientTools,
+    });
+
+    // The client entry overwrites the server tool in convertTools; the server
+    // lifecycle hook must survive the merge.
+    expect(tools.browserTool!.execute).toBeUndefined();
+    expect(typeof tools.browserTool!.onOutput).toBe('function');
+
+    const messages = [toolCallMessage('call-1'), toolResultMessage('call-1', 'client says hi')];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(onOutput).toHaveBeenCalledTimes(1);
+    expect(onOutput).toHaveBeenCalledWith(expect.objectContaining({ toolCallId: 'call-1', output: 'client says hi' }));
+  });
+
+  it('preserves onOutput from an execute-less toolset tool shadowed by its serialized client copy', async () => {
+    const onOutput = vi.fn();
+    const serializedClientTools = {
+      browserTool: {
+        description: 'runs in the browser',
+        inputSchema: { type: 'object', properties: { q: { type: 'string' } } },
+      },
+    };
+    const tools = await buildAgentTools({
+      serverTools: {},
+      toolsets: { browser: { browserTool: browserToolWith(onOutput) } },
+      clientTools: serializedClientTools,
+    });
+
+    expect(tools.browserTool!.execute).toBeUndefined();
+    expect(tools.browserTool!.onOutput).toBeTypeOf('function');
+
+    await fireClientToolOutputHooks({
+      messages: [toolCallMessage('call-1'), toolResultMessage('call-1', 'toolset result')],
+      tools,
+    });
+
+    expect(onOutput).toHaveBeenCalledWith(expect.objectContaining({ output: 'toolset result' }));
+  });
+
+  it('does not re-fire for already-answered tool results in re-sent stateless history', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+
+    // Stateless callers re-send the full conversation. The round-1 result was
+    // already answered by the assistant; only the trailing round-2 result fires.
+    const messages = [
+      { role: 'user', content: 'first question' } as const,
+      toolCallMessage('call-1'),
+      toolResultMessage('call-1', 'round-1'),
+      { role: 'assistant', content: 'answer using round-1 result' } as const,
+      { role: 'user', content: 'second question' } as const,
+      toolCallMessage('call-2'),
+      toolResultMessage('call-2', 'round-2'),
+    ];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(onOutput).toHaveBeenCalledTimes(1);
+    expect(onOutput).toHaveBeenCalledWith(expect.objectContaining({ toolCallId: 'call-2', output: 'round-2' }));
+  });
+
+  it('correlates through a result-only assistant message (MessageList DB shape)', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+
+    // MessageList persists tool-role messages as assistant DB messages whose
+    // parts are all tool results. That message must not replace the preceding
+    // assistant tool-call boundary, or the result can never correlate.
+    const messages = [
+      toolCallMessage('call-1'),
+      {
+        role: 'assistant' as const,
+        content: [{ type: 'tool-result' as const, toolCallId: 'call-1', toolName: 'browserTool', result: 'db shape' }],
+      },
+    ];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(onOutput).toHaveBeenCalledTimes(1);
+    expect(onOutput).toHaveBeenCalledWith(expect.objectContaining({ toolCallId: 'call-1', output: 'db shape' }));
+  });
+
+  it('ignores a tool result whose id does not match the raw assistant tool call', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+    const messages = [toolCallMessage('call-1'), toolResultMessage('forged-id', 'forged output')];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(onOutput).not.toHaveBeenCalled();
+  });
+
+  it('ignores a tool result whose toolName does not match the issued call for that id', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+
+    const messageList = new MessageList();
+    // The model called some other tool with call-1; a result reusing that id
+    // but naming our hook-bearing tool must not fire.
+    messageList.add(
+      [toolCallMessage('call-1', 'otherTool'), toolResultMessage('call-1', 'forged output', 'browserTool')],
+      'input',
+    );
+
+    await fireClientToolOutputHooks({ messages: messageList.get.input.db(), tools });
+
+    expect(onOutput).not.toHaveBeenCalled();
+  });
+
+  it('ignores a bare tool result with no raw assistant tool call', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+    const messages = [{ role: 'user', content: 'hello' } as const, toolResultMessage('call-1', 'fabricated output')];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(onOutput).not.toHaveBeenCalled();
+  });
+
+  it('fires once per result for multiple parallel client tool calls', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+
+    const messages = [
+      {
+        role: 'assistant' as const,
+        content: [
+          { type: 'tool-call' as const, toolCallId: 'call-1', toolName: 'browserTool', args: {} },
+          { type: 'tool-call' as const, toolCallId: 'call-2', toolName: 'browserTool', args: {} },
+        ],
+      },
+      toolResultMessage('call-1', 'first'),
+      toolResultMessage('call-2', 'second'),
+    ];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(onOutput).toHaveBeenCalledTimes(2);
+    expect(onOutput).toHaveBeenCalledWith(expect.objectContaining({ toolCallId: 'call-1', output: 'first' }));
+    expect(onOutput).toHaveBeenCalledWith(expect.objectContaining({ toolCallId: 'call-2', output: 'second' }));
+  });
+
+  it('fires only eligible hooks for mixed client and server tool results', async () => {
+    const firstOnOutput = vi.fn();
+    const secondOnOutput = vi.fn();
+    const serverOnOutput = vi.fn();
+    const tools = await buildAgentTools({
+      serverTools: {
+        browserTool: browserToolWith(firstOnOutput),
+        secondBrowserTool: createTool({
+          id: 'secondBrowserTool',
+          description: 'another browser tool',
+          inputSchema: z.object({}),
+          onOutput: secondOnOutput,
+        }),
+        serverTool: createTool({
+          id: 'serverTool',
+          description: 'runs on the server',
+          inputSchema: z.object({}),
+          execute: async () => 'server',
+          onOutput: serverOnOutput,
+        }),
+      },
+    });
+    const messages = [
+      {
+        role: 'assistant' as const,
+        content: [
+          { type: 'tool-call' as const, toolCallId: 'call-1', toolName: 'browserTool', args: {} },
+          { type: 'tool-call' as const, toolCallId: 'call-2', toolName: 'secondBrowserTool', args: {} },
+          { type: 'tool-call' as const, toolCallId: 'call-3', toolName: 'serverTool', args: {} },
+        ],
+      },
+      toolResultMessage('call-1', 'first'),
+      toolResultMessage('call-2', 'second', 'secondBrowserTool'),
+      toolResultMessage('call-3', 'server', 'serverTool'),
+    ];
+
+    await fireClientToolOutputHooks({ messages, tools });
+
+    expect(firstOnOutput).toHaveBeenCalledWith(expect.objectContaining({ output: 'first' }));
+    expect(secondOnOutput).toHaveBeenCalledWith(expect.objectContaining({ output: 'second' }));
+    expect(serverOnOutput).not.toHaveBeenCalled();
+  });
+
+  it('skips tools that have a server-side execute (tool-call-step owns their onOutput)', async () => {
+    const onOutput = vi.fn();
+    const tools = await buildAgentTools({
+      serverTools: {
+        serverTool: createTool({
+          id: 'serverTool',
+          description: 'runs on the server',
+          inputSchema: z.object({}),
+          execute: async () => 'x',
+          onOutput,
+        }),
+      },
+    });
+
+    const messageList = new MessageList();
+    messageList.add([toolCallMessage('call-1', 'serverTool'), toolResultMessage('call-1', 'x', 'serverTool')], 'input');
+
+    await fireClientToolOutputHooks({ messages: messageList.get.input.db(), tools });
+
+    expect(onOutput).not.toHaveBeenCalled();
+  });
+
+  it('swallows onOutput errors so the run is not broken', async () => {
+    const onOutput = vi.fn().mockRejectedValue(new Error('boom'));
+    const logger = { error: vi.fn() };
+    const tools = await buildAgentTools({ serverTools: { browserTool: browserToolWith(onOutput) } });
+
+    const messages = [toolCallMessage('call-1'), toolResultMessage('call-1', 'x')];
+
+    await expect(fireClientToolOutputHooks({ messages, tools, logger })).resolves.toBeUndefined();
+
+    expect(onOutput).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('no-ops when no registered tool is an execute-less onOutput tool', async () => {
+    const tools = await buildAgentTools({
+      serverTools: {
+        plain: createTool({ id: 'plain', description: 'no hooks', inputSchema: z.object({}) }),
+      },
+    });
+
+    const messageList = new MessageList();
+    const getInput = vi.spyOn(messageList.get, 'input', 'get');
+
+    await fireClientToolOutputHooks({ messages: messageList.get.input.db(), tools });
+
+    expect(getInput).not.toHaveBeenCalled();
+  });
+});
+
+describe('client tool onOutput through agent.generate (production path)', () => {
+  function textModel() {
+    return new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        content: [{ type: 'text' as const, text: 'ok' }],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'ok' },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
+    }) as unknown as LanguageModelV2;
+  }
+
+  const followUpMessages = [toolCallMessage('call-1'), toolResultMessage('call-1', { ok: true })] satisfies Parameters<
+    Agent['generate']
+  >[0];
+
+  it('fires onOutput when a follow-up request carrying a client tool result runs end-to-end', async () => {
+    const onOutput = vi.fn();
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'test agent',
+      model: textModel(),
+      tools: { browserTool: browserToolWith(onOutput) },
+    });
+
+    const serializedClientTools = {
+      browserTool: {
+        description: 'runs in the browser',
+        inputSchema: { type: 'object', properties: { q: { type: 'string' } } },
+      },
+    };
+    const result = await agent.generate(followUpMessages, { clientTools: serializedClientTools as ToolsInput });
+
+    expect(result.tripwire).toBeUndefined();
+    expect(onOutput).toHaveBeenCalledTimes(1);
+    expect(onOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ toolCallId: 'call-1', toolName: 'browserTool', output: { ok: true } }),
+    );
+  });
+
+  it('fires onOutput through generateLegacy', async () => {
+    const onOutput = vi.fn();
+    const agent = new Agent({
+      id: 'legacy-test-agent',
+      name: 'legacy-test-agent',
+      instructions: 'test agent',
+      model: new MockLanguageModelV1({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { promptTokens: 1, completionTokens: 1 },
+          text: 'ok',
+        }),
+      }),
+      tools: { browserTool: browserToolWith(onOutput) },
+    });
+
+    await agent.generateLegacy(followUpMessages);
+
+    expect(onOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ toolCallId: 'call-1', toolName: 'browserTool', output: { ok: true } }),
+    );
+  });
+
+  it('does not fire onOutput when an input processor tripwires the request', async () => {
+    const onOutput = vi.fn();
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'test agent',
+      model: textModel(),
+      tools: { browserTool: browserToolWith(onOutput) },
+      inputProcessors: [
+        {
+          id: 'block-everything',
+          name: 'block-everything',
+          processInput: async ({ abort, messages }) => {
+            abort('blocked by policy');
+            return messages;
+          },
+        },
+      ],
+    });
+
+    const result = await agent.generate(followUpMessages);
+
+    expect(result.tripwire).toBeDefined();
+    expect(result.tripwire?.reason).toBe('blocked by policy');
+    expect(onOutput).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.ts
@@ -43,14 +43,15 @@ function getToolResult(part: unknown): ToolResult | undefined {
     // AI SDK v5 wraps tool output as `{ type: 'json' | 'text' | ..., value }`.
     // Only unwrap that exact wrapper shape; a client result that merely happens
     // to contain a `value` key must pass through untouched.
-    const output =
+    const isV5Wrapper =
       typeof value === 'object' &&
       value !== null &&
       'type' in value &&
       'value' in value &&
-      Object.keys(value).length === 2
-        ? (value as Record<string, unknown>).value
-        : value;
+      Object.keys(value).length === 2;
+    // `onOutput` is a success-only hook: skip v5 error result variants.
+    if (isV5Wrapper && (value.type === 'error-text' || value.type === 'error-json')) return;
+    const output = isV5Wrapper ? (value as Record<string, unknown>).value : value;
     return { toolCallId: record.toolCallId, toolName: record.toolName, output };
   }
 
@@ -113,7 +114,11 @@ export async function fireClientToolOutputHooks({
       try {
         await tool.onOutput({ ...result, abortSignal });
       } catch (error) {
-        logger?.error('Error calling onOutput', error);
+        logger?.error('Error calling client tool onOutput', {
+          error,
+          toolName: result.toolName,
+          toolCallId: result.toolCallId,
+        });
       }
     }
   }

--- a/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/client-tool-output-hooks.ts
@@ -1,0 +1,120 @@
+import type { IMastraLogger } from '../../../logger';
+import type { CoreTool } from '../../../tools/types';
+import type { MessageListInput } from '../../message-list';
+
+type ToolCall = { toolCallId: string; toolName: string };
+type ToolResult = ToolCall & { output: unknown };
+
+function getMessages(messages: MessageListInput): unknown[] {
+  return Array.isArray(messages) ? messages : [messages];
+}
+
+function getParts(message: unknown): unknown[] {
+  if (!message || typeof message !== 'object') return [];
+  const record = message as Record<string, unknown>;
+  if (Array.isArray(record.content)) return record.content;
+  if (Array.isArray(record.parts)) return record.parts;
+  return [];
+}
+
+function getToolCall(part: unknown): ToolCall | undefined {
+  if (!part || typeof part !== 'object') return;
+  const record = part as Record<string, unknown>;
+  if (record.type === 'tool-call' && typeof record.toolCallId === 'string' && typeof record.toolName === 'string') {
+    return { toolCallId: record.toolCallId, toolName: record.toolName };
+  }
+
+  if (record.type !== 'tool-invocation' || !record.toolInvocation || typeof record.toolInvocation !== 'object') return;
+  const invocation = record.toolInvocation as Record<string, unknown>;
+  if (
+    (invocation.state === 'call' || invocation.state === 'partial-call') &&
+    typeof invocation.toolCallId === 'string' &&
+    typeof invocation.toolName === 'string'
+  ) {
+    return { toolCallId: invocation.toolCallId, toolName: invocation.toolName };
+  }
+}
+
+function getToolResult(part: unknown): ToolResult | undefined {
+  if (!part || typeof part !== 'object') return;
+  const record = part as Record<string, unknown>;
+  if (record.type === 'tool-result' && typeof record.toolCallId === 'string' && typeof record.toolName === 'string') {
+    const value = 'result' in record ? record.result : record.output;
+    // AI SDK v5 wraps tool output as `{ type: 'json' | 'text' | ..., value }`.
+    // Only unwrap that exact wrapper shape; a client result that merely happens
+    // to contain a `value` key must pass through untouched.
+    const output =
+      typeof value === 'object' &&
+      value !== null &&
+      'type' in value &&
+      'value' in value &&
+      Object.keys(value).length === 2
+        ? (value as Record<string, unknown>).value
+        : value;
+    return { toolCallId: record.toolCallId, toolName: record.toolName, output };
+  }
+
+  if (record.type !== 'tool-invocation' || !record.toolInvocation || typeof record.toolInvocation !== 'object') return;
+  const invocation = record.toolInvocation as Record<string, unknown>;
+  if (
+    invocation.state === 'result' &&
+    typeof invocation.toolCallId === 'string' &&
+    typeof invocation.toolName === 'string'
+  ) {
+    return { toolCallId: invocation.toolCallId, toolName: invocation.toolName, output: invocation.result };
+  }
+}
+
+/** Fire `onOutput` for correlated client-executed tool results on a follow-up request. */
+export async function fireClientToolOutputHooks({
+  messages,
+  tools,
+  abortSignal,
+  logger,
+}: {
+  messages: MessageListInput;
+  tools?: Record<string, CoreTool>;
+  abortSignal?: AbortSignal;
+  logger?: Pick<IMastraLogger, 'error'>;
+}): Promise<void> {
+  if (!tools) return;
+  if (!Object.values(tools).some(tool => !tool.execute && typeof tool.onOutput === 'function')) return;
+
+  const inputMessages = getMessages(messages);
+  let lastAssistantIdx = -1;
+  for (let i = 0; i < inputMessages.length; i++) {
+    const message = inputMessages[i];
+    if (!message || typeof message !== 'object' || (message as Record<string, unknown>).role !== 'assistant') continue;
+
+    // MessageList stores tool-role model messages as assistant DB messages. A
+    // result-only DB message is not a new assistant turn and must not replace
+    // the preceding assistant tool-call boundary.
+    const parts = getParts(message);
+    const isResultOnlyMessage = parts.length > 0 && parts.every(part => getToolResult(part));
+    if (!isResultOnlyMessage) lastAssistantIdx = i;
+  }
+  if (lastAssistantIdx === -1) return;
+
+  const issuedCalls = new Map<string, string>();
+  for (const part of getParts(inputMessages[lastAssistantIdx])) {
+    const call = getToolCall(part);
+    if (call) issuedCalls.set(call.toolCallId, call.toolName);
+  }
+  if (issuedCalls.size === 0) return;
+
+  for (let i = lastAssistantIdx + 1; i < inputMessages.length; i++) {
+    for (const part of getParts(inputMessages[i])) {
+      const result = getToolResult(part);
+      if (!result || issuedCalls.get(result.toolCallId) !== result.toolName) continue;
+
+      const tool = tools[result.toolName];
+      if (!tool || tool.execute || typeof tool.onOutput !== 'function') continue;
+
+      try {
+        await tool.onOutput({ ...result, abortSignal });
+      } catch (error) {
+        logger?.error('Error calling onOutput', error);
+      }
+    }
+  }
+}

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -14,6 +14,7 @@ import type { SaveQueueManager } from '../../save-queue';
 import { getModelOutputForTripwire } from '../../trip-wire';
 import type { AgentMethodType } from '../../types';
 import { isSupportedLanguageModel } from '../../utils';
+import { fireClientToolOutputHooks } from './client-tool-output-hooks';
 import type { PrepareStreamRunScope } from './run-scope';
 import {
   CONVERTED_TOOLS_KEY,
@@ -167,6 +168,18 @@ export function createMapResultsStep<OUTPUT = undefined>({
         throw error;
       }
     }
+
+    // Client-executed tool results arrive as trailing tool-role input messages on
+    // a follow-up request (the browser ran the tool and re-invoked the agent).
+    // The tool already resolved on the client, so fire `onOutput` for matching
+    // execute-less tools. This runs after the tripwire check on purpose: a
+    // request rejected by input processors must not trigger hook side effects.
+    await fireClientToolOutputHooks({
+      messages: options.messages,
+      tools: convertedTools,
+      abortSignal: options.abortSignal,
+      logger: capabilities.logger,
+    });
 
     // Resolve output processors - overrides replace user-configured but auto-derived (memory) are kept
     let effectiveOutputProcessors = capabilities.outputProcessors


### PR DESCRIPTION
## Summary

Tools without a server-side `execute` run on the client (e.g. in the browser via `@mastra/client-js`). Until now their `onOutput` lifecycle hook never fired, because `onOutput` was only invoked inside `tool-call-step` after a server-side `execute`. This PR makes the server fire `onOutput` for execute-less tools when the client sends the tool result back on a follow-up request, so client-executed tools can report their output for logging, follow-up actions, or analytics.

## How it works

- A new `fireClientToolOutputHooks` helper inspects the raw incoming request messages, finds the last real assistant message, and fires `onOutput` only for trailing tool results whose `toolCallId` + `toolName` match a tool call actually issued in that assistant message. Orphan, forged-id, and mismatched-name results are ignored.
- Wired into all three execution paths: standard (`map-results-step`), durable (`preparation`), and legacy (`agent-legacy`). In every path the hook runs **after** the input-processor tripwire check, so a rejected request triggers no side effects.
- A serialized `clientTools` entry with the same name as a server-declared execute-less tool no longer erases the server's `onOutput` — the hook is preserved (copied, not mutated). Server tools **with** `execute` are untouched; `tool-call-step` still owns their hooks.
- Only the exact AI SDK v5 `{ type, value }` output wrapper is unwrapped; client results that merely contain a `value` key pass through unchanged.
- Hook errors are logged and swallowed so the run is never broken.

## Semantics (documented in docs + changeset)

- The follow-up request must carry both the assistant tool call and the tool result (`@mastra/client-js` does this automatically).
- Delivery is at least once — keep hooks idempotent.
- The output is client-provided — treat it as untrusted data.
- The callback receives `{ toolCallId, toolName, output, abortSignal }`.

## Test plan

- 18 unit/integration tests in `client-tool-output-hooks.test.ts`: correlation, forged/orphan results, stateless history replay, parallel calls, mixed client/server tools, toolset shadowing, v5 wrapper unwrapping, error swallowing, plus production-path tests through `agent.generate`, `generateLegacy`, and a tripwire rejection.
- 2 new durable-agent tests: follow-up result fires the hook; tripwired request does not.
- `pnpm --filter ./packages/core check` (typecheck) clean; docs remark lint + format clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a client runs a tool and sends the result back, the server now notifies the tool’s `onOutput` handler. The server verifies that the result matches a recent tool call and ignores invalid or unsafe results.

## Summary

- Added `fireClientToolOutputHooks` to correlate client tool results with preceding assistant tool calls.
- Added support for standard, legacy, and durable execution paths.
- Runs hooks after input-processor tripwire checks.
- Preserves server-declared `onOutput` handlers when client tools use the same name.
- Unwraps only AI SDK v5 `{ type, value }` success wrappers.
- Ignores orphaned, forged, malformed, duplicate, mismatched, `error-text`, and `error-json` results.
- Logs and swallows hook errors.
- Added documentation for client execution, untrusted output, at-least-once delivery, and idempotency.
- Documented that `outputSchema` is not a trust boundary for client-executed results.
- Added tests for correlation, replay, parallel and mixed tools, shadowing, errors, production paths, and tripwire rejection.
- Added a minor `@mastra/core` changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->