### PR TITLE
fix(core): allow file-based agents to disable the default workspace

### DIFF
--- a/.changeset/shy-toys-change.md
+++ b/.changeset/shy-toys-change.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed file-based agents so setting `workspace` to `undefined` disables the default workspace and its automatic file and shell tools.

--- a/docs/src/content/en/reference/file-based-agents/workspace.mdx
+++ b/docs/src/content/en/reference/file-based-agents/workspace.mdx
@@ -26,6 +26,21 @@ Without `workspace.ts`, a file-based agent gets a default [`Workspace`](/referen
 
 This gives the agent file tools and shell tools automatically. The default workspace is per agent; subagents get nested workspace directories under their parent agent's workspace path.
 
+## Disable the default workspace
+
+Set `workspace` to `undefined` in `config.ts` to create the agent without a workspace:
+
+```typescript title="src/mastra/agents/weather/config.ts"
+import { agentConfig } from '@mastra/core/agent'
+
+export default agentConfig({
+  model: '__GATEWAY_OPENAI_MODEL__',
+  workspace: undefined,
+})
+```
+
+The agent doesn't receive the automatic file and shell tools when you disable the workspace.
+
 ## Quickstart
 
 For the default workspace, don't add a file. Start with an agent directory like this:
@@ -82,4 +97,4 @@ The files are copied into the bundled workspace path, where workspace file tools
 
 ## Precedence with config
 
-`config.workspace` wins over `workspace.ts`; otherwise the default file-based workspace is used. See [`config.ts` precedence](/reference/file-based-agents/config#precedence) for the full merge table.
+`config.workspace` wins over `workspace.ts`, including when you set it to `undefined`. Otherwise, Mastra uses the default file-based workspace. See [`config.ts` precedence](/reference/file-based-agents/config#precedence) for the full merge table.

--- a/packages/core/src/agent/fs-routing/index.test.ts
+++ b/packages/core/src/agent/fs-routing/index.test.ts
@@ -525,6 +525,18 @@ describe('assembleAgentFromFsEntry', () => {
       expect(workspace).toBeUndefined();
     });
 
+    it('does not attach the default workspace when config sets workspace to undefined', async () => {
+      const agent = assembleAgentFromFsEntry({
+        name: 'weather',
+        config: { model: 'openai/gpt-4o', workspace: undefined },
+        instructionsMd: 'hi',
+        defaultWorkspaceBasePath: '/tmp/mastra-fs/weather',
+      });
+
+      const workspace = await agent.getWorkspace({ requestContext: new RequestContext() });
+      expect(workspace).toBeUndefined();
+    });
+
     it('uses workspace.ts over the default workspace', async () => {
       const custom = new Workspace({
         name: 'custom-ws',

--- a/packages/core/src/agent/fs-routing/index.ts
+++ b/packages/core/src/agent/fs-routing/index.ts
@@ -325,7 +325,7 @@ function assembleAtDepth(entry: FsAgentEntry, depth: number, options?: { onWarn?
 
   const mergedTools = mergeTools(name, tools, config.tools, onWarn);
   const mergedSkills = mergeSkills(name, skills, config.skills, onWarn);
-  const mergedWorkspace = mergeWorkspace(name, workspace, config.workspace, defaultWorkspaceBasePath, onWarn);
+  const mergedWorkspace = mergeWorkspace(name, workspace, config, defaultWorkspaceBasePath, onWarn);
   const mergedMemory = mergeMemory(name, memory, config.memory, onWarn);
   const mergedAgents = mergeSubAgents(name, subagents, config.agents, mergedTools, depth, options);
   const mergedInputProcessors = mergeProcessors(name, 'input', inputProcessors, config.inputProcessors, onWarn);
@@ -684,7 +684,8 @@ function mergeSubAgents(
  * Resolve the workspace for a file-based agent.
  *
  * Precedence (explicit > convention > default):
- * - `config.workspace` (from `config.ts`) wins over everything.
+ * - A `config.workspace` key (from `config.ts`) wins over everything. An
+ *   explicit `workspace: undefined` disables the workspace.
  * - `workspace.ts`'s default export wins over the convention default.
  * - Otherwise, when `defaultWorkspaceBasePath` is provided, a default
  *   `Workspace` (contained `LocalFilesystem` + `LocalSandbox`) is created so
@@ -694,15 +695,15 @@ function mergeSubAgents(
 function mergeWorkspace(
   name: string,
   fsWorkspace: AnyWorkspace | undefined,
-  configWorkspace: FsAgentConfig['workspace'],
+  config: Pick<FsAgentConfig, 'workspace'>,
   defaultWorkspaceBasePath: string | undefined,
   onWarn: (message: string) => void,
 ): FsAgentConfig['workspace'] | undefined {
-  if (configWorkspace !== undefined) {
+  if (Object.hasOwn(config, 'workspace')) {
     if (fsWorkspace !== undefined) {
       onWarn(`Agent "${name}": workspace defined in both config.ts and workspace.ts; config.workspace wins.`);
     }
-    return configWorkspace;
+    return config.workspace;
   }
 
   if (fsWorkspace !== undefined) {


### PR DESCRIPTION
## Description

File-based agents get a default workspace when they do not define one. The merge logic treated a missing `workspace` setting and `workspace: undefined` as the same case, so an explicit `undefined` still created the default workspace.

The merge now checks whether the config contains the `workspace` key. A missing key keeps the default workspace. Setting `workspace: undefined` creates the agent without a workspace or the automatic file and shell tools.

This includes a regression test, documentation, and a patch changeset.

## Validation

- File-based agent tests: 71 passed
- Full core test suite: 13,707 passed
- Core build, typecheck, and lint passed
- Documentation checks passed
- Verified in Mastra Studio and through the API

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding documentation changes
- [x] I have added tests that prove the fix works
- [ ] I have addressed all Coderabbit comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

An agent can now opt out of the automatic workspace by setting `workspace: undefined`. Agents without a `workspace` setting continue to use the default workspace and its automatic file and shell tools.

## Changes

- Updated workspace merging to detect an explicitly configured `workspace: undefined`.
- Disabled convention-based and default workspaces when `workspace` is explicitly present.
- Added regression coverage for this behavior.
- Documented the configuration and its effect on automatic file and shell tools.
- Added a patch changeset for `@mastra/core`.

## Validation

- File-based agent tests passed.
- Core tests, build, typecheck, lint, and documentation checks passed.
- Verified behavior in Mastra Studio and through the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->