### PR TITLE
fix(core): announce recovered thread runs

### DIFF
--- a/.changeset/itchy-sites-doubt.md
+++ b/.changeset/itchy-sites-doubt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed recovered durable runs so reconnecting thread subscribers receive their remaining output and terminal event.

--- a/.changeset/itchy-sites-doubt.md
+++ b/.changeset/itchy-sites-doubt.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed recovered durable runs so reconnecting thread subscribers receive their remaining output and terminal event.
+Fixed recovered durable runs so only the recovery-lease holder announces and restarts a run, allowing reconnecting thread subscribers to receive its remaining output and terminal event without duplicate recovery races.

--- a/.changeset/itchy-sites-doubt.md
+++ b/.changeset/itchy-sites-doubt.md
@@ -2,4 +2,6 @@
 '@mastra/core': patch
 ---
 
-Fixed recovered durable runs so only the recovery-lease holder announces and restarts a run, allowing reconnecting thread subscribers to receive its remaining output and terminal event without duplicate recovery races.
+Fixed durable run recovery so a reconnecting thread subscriber receives the remaining output and terminal event of a recovered run.
+
+Only one recovery of a run can be active at a time. A second concurrent `durableAgent.recover(runId)` call now fails fast with the error `DURABLE_AGENT_RECOVER_ALREADY_IN_PROGRESS` instead of restarting the run twice.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -4248,41 +4248,44 @@ describe('Agent signals', () => {
     }
   });
 
-  it('ends a remote wait on a terminal event before the lease deadline', async () => {
-    const pubsub = new ControlledLeasePubSub();
-    const runtime = new AgentThreadStreamRuntime();
-    const key = 'terminal-wait-resource\u0000terminal-wait-thread';
-    const topic = `agent.thread-stream.${encodeURIComponent(key)}`;
-    const runId = 'terminal-wait-run';
-    pubsub.owners.set(key, runId);
-    const subscription = await runtime.subscribeToThread(
-      { id: 'terminal-wait-owner' } as Agent<any, any, any, any>,
-      { resourceId: 'terminal-wait-resource', threadId: 'terminal-wait-thread' },
-      pubsub,
-    );
-    await pubsub.publish(topic, {
-      type: 'run-registered',
-      runId,
-      data: { type: 'run-registered', runId, streamId: 'terminal-wait-stream', streamSeq: 1 },
-    });
-    await pubsub.flush();
-    await waitForCondition(() => subscription.activeRunId() === runId);
+  it.each(['run-completed', 'run-discarded'] as const)(
+    'ends a remote wait on %s before the lease deadline',
+    async terminalType => {
+      const pubsub = new ControlledLeasePubSub();
+      const runtime = new AgentThreadStreamRuntime();
+      const key = 'terminal-wait-resource\u0000terminal-wait-thread';
+      const topic = `agent.thread-stream.${encodeURIComponent(key)}`;
+      const runId = 'terminal-wait-run';
+      pubsub.owners.set(key, runId);
+      const subscription = await runtime.subscribeToThread(
+        { id: 'terminal-wait-owner' } as Agent<any, any, any, any>,
+        { resourceId: 'terminal-wait-resource', threadId: 'terminal-wait-thread' },
+        pubsub,
+      );
+      await pubsub.publish(topic, {
+        type: 'run-registered',
+        runId,
+        data: { type: 'run-registered', runId, streamId: 'terminal-wait-stream', streamSeq: 1 },
+      });
+      await pubsub.flush();
+      await waitForCondition(() => subscription.activeRunId() === runId);
 
-    const wait = runtime.waitForCrossAgentThreadRun(
-      { id: 'terminal-wait-other' } as Agent<any, any, any, any>,
-      { memory: { resource: 'terminal-wait-resource', thread: 'terminal-wait-thread' } },
-      pubsub,
-    );
-    await pubsub.publish(topic, {
-      type: 'run-completed',
-      runId,
-      data: { type: 'run-completed', runId, streamId: 'terminal-wait-stream' },
-    });
-    await pubsub.flush();
-    await expect(wait).resolves.toBeUndefined();
-    expect(pubsub.unsubscribeCount).toBeGreaterThanOrEqual(1);
-    subscription.unsubscribe();
-  });
+      const wait = runtime.waitForCrossAgentThreadRun(
+        { id: 'terminal-wait-other' } as Agent<any, any, any, any>,
+        { memory: { resource: 'terminal-wait-resource', thread: 'terminal-wait-thread' } },
+        pubsub,
+      );
+      await pubsub.publish(topic, {
+        type: terminalType,
+        runId,
+        data: { type: terminalType, runId, streamId: 'terminal-wait-stream' },
+      });
+      await pubsub.flush();
+      await expect(wait).resolves.toBeUndefined();
+      expect(pubsub.unsubscribeCount).toBeGreaterThanOrEqual(1);
+      subscription.unsubscribe();
+    },
+  );
 
   it('routes remote abort requests to only the live lease owner', async () => {
     const pubsub = new ControlledLeasePubSub();

--- a/packages/core/src/agent/__tests__/agent-thread-lease.test.ts
+++ b/packages/core/src/agent/__tests__/agent-thread-lease.test.ts
@@ -40,11 +40,18 @@ async function waitForCondition(predicate: () => boolean, timeoutMs = 2_000) {
  */
 class ControlledLeasePubSub extends PubSub implements LeaseProvider {
   owners = new Map<string, string>();
+  denyAcquire = false;
+  failAcquire = false;
+  failPublish = false;
+  failPublishAfterDelivery = false;
+  publishedTypes: string[] = [];
   #subscribers = new Map<string, Set<EventCallback>>();
   #pending = new Set<Promise<void>>();
   #index = 0;
 
   async publish(topic: string, event: any): Promise<void> {
+    if (this.failPublish) throw new Error('publish failed');
+    this.publishedTypes.push(event.type);
     const envelope = { ...event, id: `event-${this.#index}`, createdAt: new Date(), index: this.#index++ };
     const subscribers = [...(this.#subscribers.get(topic) ?? [])];
     const pending = new Promise<void>(resolve => {
@@ -55,6 +62,11 @@ class ControlledLeasePubSub extends PubSub implements LeaseProvider {
     });
     this.#pending.add(pending);
     void pending.finally(() => this.#pending.delete(pending));
+    await pending;
+    if (this.failPublishAfterDelivery) {
+      this.failPublishAfterDelivery = false;
+      throw new Error('publish acknowledgement failed');
+    }
   }
 
   async subscribe(topic: string, cb: EventCallback): Promise<void> {
@@ -72,8 +84,9 @@ class ControlledLeasePubSub extends PubSub implements LeaseProvider {
   }
 
   async acquireLease(key: string, owner: string): Promise<{ acquired: boolean; owner?: string }> {
+    if (this.failAcquire) throw new Error('acquire failed');
     const current = this.owners.get(key);
-    if (current && current !== owner) return { acquired: false, owner: current };
+    if (this.denyAcquire || (current && current !== owner)) return { acquired: false, owner: current };
     this.owners.set(key, owner);
     return { acquired: true, owner };
   }
@@ -146,5 +159,137 @@ describe('registerRun thread lease', () => {
     // Release is fire-and-forget inside the completion watcher's finally —
     // poll rather than asserting immediately.
     await waitForCondition(() => pubsub.owners.get(key) === undefined);
+  });
+
+  it('fails strict registration closed without installing a ghost record', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new ControlledLeasePubSub();
+    const agent = { id: 'strict-conflict-agent' } as Agent<any, any, any, any>;
+    const threadId = 'strict-conflict-thread';
+    const resourceId = 'strict-conflict-resource';
+    const key = [resourceId, threadId].join(AGENT_THREAD_KEY_SEPARATOR);
+    pubsub.owners.set(key, 'other-run');
+
+    const register = () =>
+      runtime.registerRun(
+        agent,
+        {
+          runId: 'strict-conflict-run',
+          status: 'running',
+          fullStream: new ReadableStream(),
+          _waitUntilFinished: () => new Promise<void>(() => {}),
+        } as any,
+        { memory: { thread: threadId, resource: resourceId } } as any,
+        pubsub,
+        { strict: true },
+      )!;
+
+    await expect(register()).rejects.toThrow('thread lease is held');
+    expect(runtime.getThreadState({ threadId, resourceId }, pubsub)).toBe('idle');
+    expect(pubsub.publishedTypes).not.toContain('run-registered');
+
+    pubsub.owners.delete(key);
+    pubsub.failAcquire = true;
+    await expect(register()).rejects.toThrow('acquire failed');
+    expect(runtime.getThreadState({ threadId, resourceId }, pubsub)).toBe('idle');
+  });
+
+  it('strict rollback removes only its registration and permits a new run', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new ControlledLeasePubSub();
+    const agent = { id: 'strict-rollback-agent' } as Agent<any, any, any, any>;
+    const threadId = 'strict-rollback-thread';
+    const resourceId = 'strict-rollback-resource';
+    const key = [resourceId, threadId].join(AGENT_THREAD_KEY_SEPARATOR);
+    const neverFinishes = () => new Promise<void>(() => {});
+    const register = (runId: string) =>
+      runtime.registerRun(
+        agent,
+        { runId, status: 'running', fullStream: new ReadableStream(), _waitUntilFinished: neverFinishes } as any,
+        { memory: { thread: threadId, resource: resourceId } } as any,
+        pubsub,
+        { strict: true },
+      )!;
+
+    const first = await register('strict-rollback-run-1');
+    expect(runtime.getThreadState({ threadId, resourceId }, pubsub)).toBe('active');
+    await first.rollback();
+    expect(runtime.getThreadState({ threadId, resourceId }, pubsub)).toBe('idle');
+    expect(pubsub.owners.get(key)).toBeUndefined();
+
+    const second = await register('strict-rollback-run-2');
+    expect(pubsub.owners.get(key)).toBe('strict-rollback-run-2');
+    expect(runtime.getThreadState({ threadId, resourceId }, pubsub)).toBe('active');
+    await second.rollback({ releaseLease: false });
+    expect(runtime.getThreadState({ threadId, resourceId }, pubsub)).toBe('idle');
+    expect(pubsub.owners.get(key)).toBe('strict-rollback-run-2');
+    await pubsub.releaseLease(key, 'strict-rollback-run-2');
+  });
+
+  it('rolls strict registration back and releases its lease when publishing fails', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new ControlledLeasePubSub();
+    const agent = { id: 'strict-publish-agent' } as Agent<any, any, any, any>;
+    const threadId = 'strict-publish-thread';
+    const resourceId = 'strict-publish-resource';
+    const key = [resourceId, threadId].join(AGENT_THREAD_KEY_SEPARATOR);
+    let streamPulled = false;
+    pubsub.failPublish = true;
+
+    const registered = runtime.registerRun(
+      agent,
+      {
+        runId: 'strict-publish-run',
+        status: 'running',
+        fullStream: {
+          getReader() {
+            streamPulled = true;
+            throw new Error('strict publish failure must not start the stream');
+          },
+        },
+        _waitUntilFinished: () => new Promise<void>(() => {}),
+      } as any,
+      { memory: { thread: threadId, resource: resourceId } } as any,
+      pubsub,
+      { strict: true },
+    )!;
+
+    await expect(registered).rejects.toThrow('publish failed');
+    expect(runtime.getThreadState({ threadId, resourceId }, pubsub)).toBe('idle');
+    expect(pubsub.owners.get(key)).toBeUndefined();
+    expect(streamPulled).toBe(false);
+  });
+
+  it('discards a delivered registration when its publish acknowledgement fails', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const observer = new AgentThreadStreamRuntime();
+    const pubsub = new ControlledLeasePubSub();
+    const agent = { id: 'strict-ack-agent' } as Agent<any, any, any, any>;
+    const threadId = 'strict-ack-thread';
+    const resourceId = 'strict-ack-resource';
+    const subscription = await observer.subscribeToThread(agent, { threadId, resourceId }, pubsub);
+    pubsub.failPublishAfterDelivery = true;
+
+    try {
+      await expect(
+        runtime.registerRun(
+          agent,
+          {
+            runId: 'strict-ack-run',
+            status: 'running',
+            fullStream: new ReadableStream(),
+            _waitUntilFinished: () => new Promise<void>(() => {}),
+          } as any,
+          { memory: { thread: threadId, resource: resourceId } } as any,
+          pubsub,
+          { strict: true },
+        )!,
+      ).rejects.toThrow('publish acknowledgement failed');
+      await pubsub.flush();
+      expect(observer.getThreadState({ threadId, resourceId }, pubsub)).toBe('idle');
+      expect(pubsub.publishedTypes).toEqual(['run-registered', 'run-discarded']);
+    } finally {
+      subscription.unsubscribe();
+    }
   });
 });

--- a/packages/core/src/agent/__tests__/agent-thread-lease.test.ts
+++ b/packages/core/src/agent/__tests__/agent-thread-lease.test.ts
@@ -286,7 +286,7 @@ describe('registerRun thread lease', () => {
         )!,
       ).rejects.toThrow('publish acknowledgement failed');
       await pubsub.flush();
-      expect(observer.getThreadState({ threadId, resourceId }, pubsub)).toBe('idle');
+      await waitForCondition(() => observer.getThreadState({ threadId, resourceId }, pubsub) === 'idle');
       expect(pubsub.publishedTypes).toEqual(['run-registered', 'run-discarded']);
     } finally {
       subscription.unsubscribe();

--- a/packages/core/src/agent/durable/__tests__/recover-active-runs.test.ts
+++ b/packages/core/src/agent/durable/__tests__/recover-active-runs.test.ts
@@ -129,8 +129,8 @@ describe('DurableAgent.recoverActiveRuns', () => {
   });
 
   it('restarts every discovered running run for this agent', async () => {
-    await seed(store, makeSnapshot('run-1', 'running', { agentId: 'agent-A', threadId: 't', resourceId: 'r' }), 'r');
-    await seed(store, makeSnapshot('run-2', 'running', { agentId: 'agent-A', threadId: 't', resourceId: 'r' }), 'r');
+    await seed(store, makeSnapshot('run-1', 'running', { agentId: 'agent-A', threadId: 't-1', resourceId: 'r' }), 'r');
+    await seed(store, makeSnapshot('run-2', 'running', { agentId: 'agent-A', threadId: 't-2', resourceId: 'r' }), 'r');
     const { restartedRunIds } = stubWorkflow(agent);
 
     const { recovered, succeeded, failed } = await agent.recoverActiveRuns();
@@ -231,7 +231,7 @@ describe('DurableAgent.recoverActiveRuns', () => {
       store,
       makeSnapshot('run-good-1', 'running', {
         agentId: 'agent-A',
-        threadId: 't',
+        threadId: 't-good-1',
         resourceId: 'r',
       }),
       'r',
@@ -240,7 +240,7 @@ describe('DurableAgent.recoverActiveRuns', () => {
       store,
       makeSnapshot('run-bad', 'running', {
         agentId: 'agent-A',
-        threadId: 't',
+        threadId: 't-bad',
         resourceId: 'r',
       }),
       'r',
@@ -249,7 +249,7 @@ describe('DurableAgent.recoverActiveRuns', () => {
       store,
       makeSnapshot('run-good-2', 'running', {
         agentId: 'agent-A',
-        threadId: 't',
+        threadId: 't-good-2',
         resourceId: 'r',
       }),
       'r',

--- a/packages/core/src/agent/durable/__tests__/recover-run.test.ts
+++ b/packages/core/src/agent/durable/__tests__/recover-run.test.ts
@@ -304,6 +304,7 @@ describe('DurableAgent.recover(runId)', () => {
     const conflictStore = new InMemoryStore();
     const conflictPubsub = new EventEmitterPubSub();
     const { agent: conflictAgent } = createDurableWithStore('agent-thread-conflict', conflictStore, conflictPubsub);
+    const publish = vi.spyOn(conflictPubsub, 'publish');
     await seed(conflictStore, runId, 'running', 'agent-thread-conflict');
     const workflow = stubWorkflow(conflictAgent, 'success');
     const threadKey = ['r', 't'].join('\u0000');
@@ -315,6 +316,11 @@ describe('DurableAgent.recover(runId)', () => {
       expect(globalRunRegistry.get(runId)).toBeUndefined();
       expect(conflictAgent.runRegistry.get(runId)).toBeUndefined();
       expect(agentThreadStreamRuntime.getThreadState({ threadId: 't', resourceId: 'r' }, conflictPubsub)).toBe('idle');
+      expect(
+        publish.mock.calls.filter(
+          ([topic, event]) => topic === AGENT_STREAM_TOPIC(runId) && event.type === AgentStreamEventTypes.ERROR,
+        ),
+      ).toHaveLength(0);
       await expect(conflictPubsub.acquireLease(threadKey, 'probe-run', 30_000)).resolves.toMatchObject({
         acquired: false,
         owner: 'other-run',

--- a/packages/core/src/agent/durable/__tests__/recover-run.test.ts
+++ b/packages/core/src/agent/durable/__tests__/recover-run.test.ts
@@ -22,7 +22,7 @@ import { InMemoryStore } from '../../../storage';
 import type { WorkflowRunState, WorkflowRunStatus } from '../../../workflows/types';
 import { Agent } from '../../agent';
 import { agentThreadStreamRuntime } from '../../thread-stream-runtime';
-import { DurableStepIds } from '../constants';
+import { AGENT_STREAM_TOPIC, DurableStepIds } from '../constants';
 import { createDurableAgent } from '../create-durable-agent';
 import type { DurableAgent } from '../durable-agent';
 import { globalRunRegistry } from '../run-registry';
@@ -435,5 +435,30 @@ describe('DurableAgent.recover(runId)', () => {
     cleanup();
 
     expect(seenError?.message).toBe('workflow blew up');
+  });
+
+  it('reports a subscription setup failure via the pubsub error stream', async () => {
+    const runId = 'run-ready-fail';
+    const failingStore = new InMemoryStore();
+    const failingPubsub = new EventEmitterPubSub();
+    const actualSubscribeFromOffset = failingPubsub.subscribeFromOffset.bind(failingPubsub);
+    vi.spyOn(failingPubsub, 'subscribeFromOffset').mockImplementation((topic, offset, callback) => {
+      if (topic === AGENT_STREAM_TOPIC(runId)) {
+        return Promise.reject(new Error('pubsub subscription failed'));
+      }
+      return actualSubscribeFromOffset(topic, offset, callback);
+    });
+    const { agent: failingAgent } = createDurableWithStore('agent-ready-fail', failingStore, failingPubsub);
+    await seed(failingStore, runId, 'running', 'agent-ready-fail');
+    const workflow = stubWorkflow(failingAgent, 'success');
+    const emitError = vi.spyOn(failingAgent as any, 'emitError').mockResolvedValue(undefined);
+
+    const recovered = await failingAgent.recover(runId);
+    const workflowExecution = globalRunRegistry.get(runId)?.workflowExecution;
+
+    await expect(workflowExecution).rejects.toThrow('pubsub subscription failed');
+    expect(emitError).toHaveBeenCalledWith(runId, expect.objectContaining({ message: 'pubsub subscription failed' }));
+    expect(workflow.createRun).not.toHaveBeenCalled();
+    recovered.cleanup();
   });
 });

--- a/packages/core/src/agent/durable/__tests__/recover-run.test.ts
+++ b/packages/core/src/agent/durable/__tests__/recover-run.test.ts
@@ -14,7 +14,7 @@
 
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventEmitterPubSub } from '../../../events/event-emitter';
 import type { PubSub } from '../../../events/pubsub';
 import { Mastra } from '../../../mastra';
@@ -138,6 +138,10 @@ describe('DurableAgent.recover(runId)', () => {
 
   beforeEach(() => {
     ({ agent, store } = createDurableWithStore('agent-A'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('rehydrates the run registry with memory + messageList so terminal steps can flush', async () => {
@@ -295,6 +299,31 @@ describe('DurableAgent.recover(runId)', () => {
     }
   });
 
+  it('fails closed without a ghost registration when another run owns the thread lease', async () => {
+    const runId = 'run-thread-lease-conflict';
+    const conflictStore = new InMemoryStore();
+    const conflictPubsub = new EventEmitterPubSub();
+    const { agent: conflictAgent } = createDurableWithStore('agent-thread-conflict', conflictStore, conflictPubsub);
+    await seed(conflictStore, runId, 'running', 'agent-thread-conflict');
+    const workflow = stubWorkflow(conflictAgent, 'success');
+    const threadKey = ['r', 't'].join('\u0000');
+    await conflictPubsub.acquireLease(threadKey, 'other-run', 30_000);
+
+    try {
+      await expect(conflictAgent.recover(runId)).rejects.toThrow('thread lease is held by other-run');
+      expect(workflow.createRun).not.toHaveBeenCalled();
+      expect(globalRunRegistry.get(runId)).toBeUndefined();
+      expect(conflictAgent.runRegistry.get(runId)).toBeUndefined();
+      expect(agentThreadStreamRuntime.getThreadState({ threadId: 't', resourceId: 'r' }, conflictPubsub)).toBe('idle');
+      await expect(conflictPubsub.acquireLease(threadKey, 'probe-run', 30_000)).resolves.toMatchObject({
+        acquired: false,
+        owner: 'other-run',
+      });
+    } finally {
+      await conflictPubsub.releaseLease(threadKey, 'other-run');
+    }
+  });
+
   it('does not let an older cleanup remove a newer recovery of the same run', async () => {
     const runId = 'run-cleanup-generation';
     await seed(store, runId, 'running', 'agent-A');
@@ -315,6 +344,7 @@ describe('DurableAgent.recover(runId)', () => {
 
     firstRecovery.cleanup();
     expect(globalRunRegistry.get(runId)).toBe(secondEntry);
+    expect(agent.runRegistry.get(runId)).toBe(secondEntry);
 
     await secondEntry?.workflowExecution;
     expect(firstRestart).toHaveBeenCalledTimes(1);
@@ -374,7 +404,6 @@ describe('DurableAgent.recover(runId)', () => {
       releaseRestart();
       await globalRunRegistry.get(runId)?.workflowExecution?.catch(() => {});
       recovery?.cleanup();
-      vi.useRealTimers();
     }
   });
 
@@ -433,7 +462,67 @@ describe('DurableAgent.recover(runId)', () => {
       releaseRegistration();
       await recovery.catch(() => {});
       registerRun.mockRestore();
-      vi.useRealTimers();
+    }
+  });
+
+  it('settles recovery promptly when lease loss abort is ignored by restart', async () => {
+    vi.useFakeTimers();
+    const runId = 'run-lease-loss-race';
+    const raceStore = new InMemoryStore();
+    const racePubsub = new EventEmitterPubSub();
+    const actualRenewLease = racePubsub.renewLease.bind(racePubsub);
+    vi.spyOn(racePubsub, 'renewLease').mockImplementation(async (key, owner, ttlMs) => {
+      if (key.startsWith('mastra:durable-agent-recovery:')) return false;
+      return actualRenewLease(key, owner, ttlMs);
+    });
+    const { agent: raceAgent } = createDurableWithStore('agent-lease-race', raceStore, racePubsub);
+    await seed(raceStore, runId, 'running', 'agent-lease-race');
+    let markRestartStarted!: () => void;
+    const restartStarted = new Promise<void>(resolve => {
+      markRestartStarted = resolve;
+    });
+    let releaseRestart!: () => void;
+    const restartGate = new Promise<void>(resolve => {
+      releaseRestart = resolve;
+    });
+    let resolveLatePublish!: (error: unknown) => void;
+    const latePublish = new Promise<unknown>(resolve => {
+      resolveLatePublish = resolve;
+    });
+    let workflowPubsub: PubSub | undefined;
+    const restart = vi.fn(async () => {
+      markRestartStarted();
+      await restartGate;
+      try {
+        await workflowPubsub!.publish('late-recovery-output', { type: 'late-output', runId, data: {} } as any);
+        resolveLatePublish(undefined);
+      } catch (error) {
+        resolveLatePublish(error);
+      }
+      return { status: 'suspended' as const };
+    });
+    vi.spyOn(raceAgent, 'getWorkflow').mockReturnValue({
+      createRun: vi.fn(async ({ pubsub }: { pubsub: PubSub }) => {
+        workflowPubsub = pubsub;
+        return { restart, runId };
+      }),
+    } as any);
+
+    let recovered: Awaited<ReturnType<typeof raceAgent.recover>> | undefined;
+    try {
+      recovered = await raceAgent.recover(runId);
+      const workflowExecution = globalRunRegistry.get(runId)?.workflowExecution;
+      await restartStarted;
+      await vi.advanceTimersByTimeAsync(RECOVERY_LEASE_RENEW_INTERVAL_MS_FOR_TEST);
+
+      await expect(workflowExecution).rejects.toMatchObject({ id: 'DURABLE_AGENT_RECOVER_LEASE_LOST' });
+      expect(globalRunRegistry.get(runId)).toBeUndefined();
+      expect(agentThreadStreamRuntime.getThreadState({ threadId: 't', resourceId: 'r' }, racePubsub)).toBe('idle');
+      releaseRestart();
+      await expect(latePublish).resolves.toMatchObject({ id: 'DURABLE_AGENT_RECOVER_LEASE_LOST' });
+    } finally {
+      releaseRestart();
+      recovered?.cleanup();
     }
   });
 
@@ -590,7 +679,35 @@ describe('DurableAgent.recover(runId)', () => {
     recovered.cleanup();
   });
 
-  it('reports a subscription setup failure via the pubsub error stream', async () => {
+  it('rolls back thread registration when terminal error publication fails', async () => {
+    const runId = 'run-terminal-publish-fail';
+    const failedStore = new InMemoryStore();
+    const failedPubsub = new EventEmitterPubSub();
+    const actualPublish = failedPubsub.publish.bind(failedPubsub);
+    vi.spyOn(failedPubsub, 'publish').mockImplementation(async (topic, event, options) => {
+      if (topic === AGENT_STREAM_TOPIC(runId) && event.type === AgentStreamEventTypes.ERROR) {
+        throw new Error('terminal error publication failed');
+      }
+      return actualPublish(topic, event, options);
+    });
+    const { agent: failedAgent } = createDurableWithStore('agent-terminal-publish-fail', failedStore, failedPubsub);
+    await seed(failedStore, runId, 'running', 'agent-terminal-publish-fail');
+    const restart = vi.fn(async () => ({ status: 'failed' as const, error: { message: 'workflow failed' } }));
+    vi.spyOn(failedAgent, 'getWorkflow').mockReturnValue({
+      createRun: vi.fn(async () => ({ restart, runId })),
+      deleteWorkflowRunById: vi.fn(async () => {}),
+    } as any);
+
+    const recovered = await failedAgent.recover(runId);
+    await expect(globalRunRegistry.get(runId)?.workflowExecution).rejects.toThrow('workflow failed');
+
+    expect(globalRunRegistry.get(runId)).toBeUndefined();
+    expect(failedAgent.runRegistry.get(runId)).toBeUndefined();
+    expect(agentThreadStreamRuntime.getThreadState({ threadId: 't', resourceId: 'r' }, failedPubsub)).toBe('idle');
+    recovered.cleanup();
+  });
+
+  it('rejects and rolls back when the recovered stream subscription fails', async () => {
     const runId = 'run-ready-fail';
     const failingStore = new InMemoryStore();
     const failingPubsub = new EventEmitterPubSub();
@@ -606,16 +723,14 @@ describe('DurableAgent.recover(runId)', () => {
     const workflow = stubWorkflow(failingAgent, 'success');
     const publish = vi.spyOn(failingPubsub, 'publish');
 
-    const recovered = await failingAgent.recover(runId);
-    const workflowExecution = globalRunRegistry.get(runId)?.workflowExecution;
-
-    await expect(workflowExecution).rejects.toThrow('pubsub subscription failed');
+    await expect(failingAgent.recover(runId)).rejects.toThrow('pubsub subscription failed');
     const errorEvents = publish.mock.calls.filter(
       ([topic, event]) => topic === AGENT_STREAM_TOPIC(runId) && event.type === AgentStreamEventTypes.ERROR,
     );
     expect(errorEvents).toHaveLength(1);
     expect((errorEvents[0]?.[1] as any).data.error.message).toBe('pubsub subscription failed');
     expect(workflow.createRun).not.toHaveBeenCalled();
-    recovered.cleanup();
+    expect(globalRunRegistry.get(runId)).toBeUndefined();
+    expect(failingAgent.runRegistry.get(runId)).toBeUndefined();
   });
 });

--- a/packages/core/src/agent/durable/__tests__/recover-run.test.ts
+++ b/packages/core/src/agent/durable/__tests__/recover-run.test.ts
@@ -22,7 +22,7 @@ import { InMemoryStore } from '../../../storage';
 import type { WorkflowRunState, WorkflowRunStatus } from '../../../workflows/types';
 import { Agent } from '../../agent';
 import { agentThreadStreamRuntime } from '../../thread-stream-runtime';
-import { AGENT_STREAM_TOPIC, DurableStepIds } from '../constants';
+import { AGENT_STREAM_TOPIC, AgentStreamEventTypes, DurableStepIds } from '../constants';
 import { createDurableAgent } from '../create-durable-agent';
 import type { DurableAgent } from '../durable-agent';
 import { globalRunRegistry } from '../run-registry';
@@ -159,6 +159,32 @@ describe('DurableAgent.recover(runId)', () => {
     cleanup();
   });
 
+  it('re-reads the authoritative snapshot after acquiring recovery ownership', async () => {
+    const runId = 'run-fresh-snapshot';
+    await seed(store, runId, 'running', 'agent-A');
+    const workflows = (await store.getStore('workflows'))!;
+    const getWorkflowRunById = workflows.getWorkflowRunById.bind(workflows);
+    let loopSnapshotReads = 0;
+    vi.spyOn(workflows, 'getWorkflowRunById').mockImplementation(async args => {
+      const persisted = await getWorkflowRunById(args);
+      if (args.workflowName !== DurableStepIds.AGENTIC_LOOP || !persisted || ++loopSnapshotReads !== 2) {
+        return persisted;
+      }
+      const claimedSnapshot = makeSnapshot(runId, 'running', 'agent-A');
+      (claimedSnapshot.context.input as any).requestContextEntries = { userId: 'u-2' };
+      return { ...persisted, snapshot: claimedSnapshot };
+    });
+    stubWorkflow(agent, 'success');
+
+    const recovered = await agent.recover(runId);
+    const entry = globalRunRegistry.get(runId);
+
+    expect(loopSnapshotReads).toBe(2);
+    expect(entry?.requestContext?.get?.('userId')).toBe('u-2');
+    await entry?.workflowExecution;
+    recovered.cleanup();
+  });
+
   it('re-subscribes to the pubsub topic and returns a live fullStream', async () => {
     await seed(store, 'run-stream', 'running', 'agent-A');
     stubWorkflow(agent, 'success');
@@ -269,6 +295,33 @@ describe('DurableAgent.recover(runId)', () => {
     }
   });
 
+  it('does not let an older cleanup remove a newer recovery of the same run', async () => {
+    const runId = 'run-cleanup-generation';
+    await seed(store, runId, 'running', 'agent-A');
+    const firstRestart = vi.fn(async () => ({ status: 'suspended' as const }));
+    const secondRestart = vi.fn(async () => ({ status: 'suspended' as const }));
+    const createRun = vi
+      .fn()
+      .mockResolvedValueOnce({ restart: firstRestart, runId })
+      .mockResolvedValueOnce({ restart: secondRestart, runId });
+    vi.spyOn(agent, 'getWorkflow').mockReturnValue({ createRun } as any);
+
+    const firstRecovery = await agent.recover(runId);
+    await globalRunRegistry.get(runId)?.workflowExecution;
+
+    const secondRecovery = await agent.recover(runId);
+    const secondEntry = globalRunRegistry.get(runId);
+    expect(secondEntry).toBeDefined();
+
+    firstRecovery.cleanup();
+    expect(globalRunRegistry.get(runId)).toBe(secondEntry);
+
+    await secondEntry?.workflowExecution;
+    expect(firstRestart).toHaveBeenCalledTimes(1);
+    expect(secondRestart).toHaveBeenCalledTimes(1);
+    secondRecovery.cleanup();
+  });
+
   it('retries a transient recovery-lease renewal error without aborting the run', async () => {
     vi.useFakeTimers();
     const runId = 'run-renewal-retry';
@@ -323,6 +376,81 @@ describe('DurableAgent.recover(runId)', () => {
       recovery?.cleanup();
       vi.useRealTimers();
     }
+  });
+
+  it('rolls back before restart when the recovery lease is definitively lost', async () => {
+    vi.useFakeTimers();
+    const runId = 'run-renewal-lost';
+    const lossStore = new InMemoryStore();
+    const lossPubsub = new EventEmitterPubSub();
+    const actualRenewLease = lossPubsub.renewLease.bind(lossPubsub);
+    const renewLease = vi.spyOn(lossPubsub, 'renewLease').mockImplementation(async (key, owner, ttlMs) => {
+      if (key.startsWith('mastra:durable-agent-recovery:')) return false;
+      return actualRenewLease(key, owner, ttlMs);
+    });
+    const releaseLease = vi.spyOn(lossPubsub, 'releaseLease');
+    const publish = vi.spyOn(lossPubsub, 'publish');
+    const { agent: lossAgent } = createDurableWithStore('agent-renewal-lost', lossStore, lossPubsub);
+    await seed(lossStore, runId, 'running', 'agent-renewal-lost');
+    const workflow = stubWorkflow(lossAgent, 'success');
+
+    let markRegistrationStarted!: () => void;
+    const registrationStarted = new Promise<void>(resolve => {
+      markRegistrationStarted = resolve;
+    });
+    let releaseRegistration!: () => void;
+    const registrationGate = new Promise<void>(resolve => {
+      releaseRegistration = resolve;
+    });
+    const registerRun = vi.spyOn(agentThreadStreamRuntime, 'registerRun').mockImplementation(async () => {
+      markRegistrationStarted();
+      await registrationGate;
+    });
+    const recovery = lossAgent.recover(runId);
+
+    try {
+      await registrationStarted;
+      await vi.advanceTimersByTimeAsync(RECOVERY_LEASE_RENEW_INTERVAL_MS_FOR_TEST);
+
+      expect(globalRunRegistry.get(runId)?.abortController?.signal.aborted).toBe(true);
+      releaseRegistration();
+      await expect(recovery).rejects.toMatchObject({ id: 'DURABLE_AGENT_RECOVER_LEASE_LOST' });
+
+      expect(workflow.createRun).not.toHaveBeenCalled();
+      expect(releaseLease.mock.calls.filter(([key]) => key.startsWith('mastra:durable-agent-recovery:'))).toHaveLength(
+        1,
+      );
+      expect(
+        publish.mock.calls.filter(
+          ([topic, event]) => topic === AGENT_STREAM_TOPIC(runId) && event.type === AgentStreamEventTypes.ERROR,
+        ),
+      ).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(RECOVERY_LEASE_RENEW_INTERVAL_MS_FOR_TEST * 2);
+      expect(renewLease.mock.calls.filter(([key]) => key.startsWith('mastra:durable-agent-recovery:'))).toHaveLength(1);
+      expect(workflow.createRun).not.toHaveBeenCalled();
+    } finally {
+      releaseRegistration();
+      await recovery.catch(() => {});
+      registerRun.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('releases recovery ownership when workflow construction throws synchronously', async () => {
+    const runId = 'run-workflow-construction-fail';
+    const failureStore = new InMemoryStore();
+    const failurePubsub = new EventEmitterPubSub();
+    const releaseLease = vi.spyOn(failurePubsub, 'releaseLease');
+    const { agent: failureAgent } = createDurableWithStore('agent-workflow-fail', failureStore, failurePubsub);
+    await seed(failureStore, runId, 'running', 'agent-workflow-fail');
+    vi.spyOn(failureAgent, 'getWorkflow').mockImplementation(() => {
+      throw new Error('workflow construction failed');
+    });
+
+    await expect(failureAgent.recover(runId)).rejects.toThrow('workflow construction failed');
+    expect(releaseLease.mock.calls.filter(([key]) => key.startsWith('mastra:durable-agent-recovery:'))).toHaveLength(1);
+    expect(globalRunRegistry.get(runId)).toBeUndefined();
   });
 
   it('deletes both AGENTIC_LOOP and AGENTIC_EXECUTION snapshot rows on success', async () => {
@@ -437,6 +565,31 @@ describe('DurableAgent.recover(runId)', () => {
     expect(seenError?.message).toBe('workflow blew up');
   });
 
+  it('publishes a failed workflow result exactly once', async () => {
+    const runId = 'run-failed-result';
+    const failedStore = new InMemoryStore();
+    const failedPubsub = new EventEmitterPubSub();
+    const publish = vi.spyOn(failedPubsub, 'publish');
+    const { agent: failedAgent } = createDurableWithStore('agent-failed-result', failedStore, failedPubsub);
+    await seed(failedStore, runId, 'running', 'agent-failed-result');
+    const restart = vi.fn(async () => ({ status: 'failed' as const, error: { message: 'terminal failure' } }));
+    const createRun = vi.fn(async () => ({ restart, runId }));
+    vi.spyOn(failedAgent, 'getWorkflow').mockReturnValue({
+      createRun,
+      deleteWorkflowRunById: vi.fn(async () => {}),
+    } as any);
+
+    const recovered = await failedAgent.recover(runId);
+    await expect(globalRunRegistry.get(runId)?.workflowExecution).rejects.toThrow('terminal failure');
+
+    const errorEvents = publish.mock.calls.filter(
+      ([topic, event]) => topic === AGENT_STREAM_TOPIC(runId) && event.type === AgentStreamEventTypes.ERROR,
+    );
+    expect(errorEvents).toHaveLength(1);
+    expect((errorEvents[0]?.[1] as any).data.error.message).toBe('terminal failure');
+    recovered.cleanup();
+  });
+
   it('reports a subscription setup failure via the pubsub error stream', async () => {
     const runId = 'run-ready-fail';
     const failingStore = new InMemoryStore();
@@ -451,13 +604,17 @@ describe('DurableAgent.recover(runId)', () => {
     const { agent: failingAgent } = createDurableWithStore('agent-ready-fail', failingStore, failingPubsub);
     await seed(failingStore, runId, 'running', 'agent-ready-fail');
     const workflow = stubWorkflow(failingAgent, 'success');
-    const emitError = vi.spyOn(failingAgent as any, 'emitError').mockResolvedValue(undefined);
+    const publish = vi.spyOn(failingPubsub, 'publish');
 
     const recovered = await failingAgent.recover(runId);
     const workflowExecution = globalRunRegistry.get(runId)?.workflowExecution;
 
     await expect(workflowExecution).rejects.toThrow('pubsub subscription failed');
-    expect(emitError).toHaveBeenCalledWith(runId, expect.objectContaining({ message: 'pubsub subscription failed' }));
+    const errorEvents = publish.mock.calls.filter(
+      ([topic, event]) => topic === AGENT_STREAM_TOPIC(runId) && event.type === AgentStreamEventTypes.ERROR,
+    );
+    expect(errorEvents).toHaveLength(1);
+    expect((errorEvents[0]?.[1] as any).data.error.message).toBe('pubsub subscription failed');
     expect(workflow.createRun).not.toHaveBeenCalled();
     recovered.cleanup();
   });

--- a/packages/core/src/agent/durable/__tests__/recover-run.test.ts
+++ b/packages/core/src/agent/durable/__tests__/recover-run.test.ts
@@ -15,10 +15,13 @@
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import type { PubSub } from '../../../events/pubsub';
 import { Mastra } from '../../../mastra';
 import { InMemoryStore } from '../../../storage';
 import type { WorkflowRunState, WorkflowRunStatus } from '../../../workflows/types';
 import { Agent } from '../../agent';
+import { agentThreadStreamRuntime } from '../../thread-stream-runtime';
 import { DurableStepIds } from '../constants';
 import { createDurableAgent } from '../create-durable-agent';
 import type { DurableAgent } from '../durable-agent';
@@ -63,18 +66,18 @@ function makeMockModel(): LanguageModelV2 {
   }) as unknown as LanguageModelV2;
 }
 
-function createDurableWithStore(agentId: string) {
+function createDurableWithStore(agentId: string, store = new InMemoryStore(), pubsub?: PubSub) {
   const baseAgent = new Agent({
     id: agentId,
     name: agentId,
     instructions: 'x',
     model: makeMockModel(),
   });
-  const store = new InMemoryStore();
-  const agent = createDurableAgent({ agent: baseAgent });
+  const agent = createDurableAgent({ agent: baseAgent, pubsub, ...(pubsub ? { cache: false } : {}) });
   void new Mastra({
     agents: { [agentId]: agent as any },
     storage: store,
+    ...(pubsub ? { pubsub } : {}),
   });
   return { agent, store };
 }
@@ -206,6 +209,51 @@ describe('DurableAgent.recover(runId)', () => {
     await globalRunRegistry.get(runId)?.workflowExecution;
     recovered.cleanup();
     subscription.unsubscribe();
+  });
+
+  it('allows only the recovery-lease holder to register and restart a run', async () => {
+    const runId = 'run-concurrent-recovery';
+    const sharedStore = new InMemoryStore();
+    const sharedPubsub = new EventEmitterPubSub();
+    const { agent: firstAgent } = createDurableWithStore('agent-race', sharedStore, sharedPubsub);
+    const { agent: secondAgent } = createDurableWithStore('agent-race', sharedStore, sharedPubsub);
+    await seed(sharedStore, runId, 'running', 'agent-race');
+
+    let markRestartStarted!: () => void;
+    const restartStarted = new Promise<void>(resolve => {
+      markRestartStarted = resolve;
+    });
+    let releaseRestart!: () => void;
+    const restartGate = new Promise<void>(resolve => {
+      releaseRestart = resolve;
+    });
+    const firstRestart = vi.fn(async () => {
+      markRestartStarted();
+      await restartGate;
+      return { status: 'suspended' as const };
+    });
+    const firstCreateRun = vi.fn(async () => ({ restart: firstRestart, runId }));
+    vi.spyOn(firstAgent, 'getWorkflow').mockReturnValue({ createRun: firstCreateRun } as any);
+    const secondWorkflow = stubWorkflow(secondAgent, 'success');
+    const registerRun = vi.spyOn(agentThreadStreamRuntime, 'registerRun');
+    let firstRecovery: Awaited<ReturnType<typeof firstAgent.recover>> | undefined;
+
+    try {
+      firstRecovery = await firstAgent.recover(runId);
+      await restartStarted;
+
+      await expect(secondAgent.recover(runId)).rejects.toMatchObject({
+        id: 'DURABLE_AGENT_RECOVER_ALREADY_IN_PROGRESS',
+      });
+      expect(registerRun).toHaveBeenCalledTimes(1);
+      expect(firstCreateRun).toHaveBeenCalledTimes(1);
+      expect(secondWorkflow.createRun).not.toHaveBeenCalled();
+    } finally {
+      releaseRestart();
+      await globalRunRegistry.get(runId)?.workflowExecution?.catch(() => {});
+      firstRecovery?.cleanup();
+      registerRun.mockRestore();
+    }
   });
 
   it('deletes both AGENTIC_LOOP and AGENTIC_EXECUTION snapshot rows on success', async () => {

--- a/packages/core/src/agent/durable/__tests__/recover-run.test.ts
+++ b/packages/core/src/agent/durable/__tests__/recover-run.test.ts
@@ -23,6 +23,7 @@ import { DurableStepIds } from '../constants';
 import { createDurableAgent } from '../create-durable-agent';
 import type { DurableAgent } from '../durable-agent';
 import { globalRunRegistry } from '../run-registry';
+import { emitChunkEvent, emitFinishEvent } from '../stream-adapter';
 
 function makeSnapshot(runId: string, status: WorkflowRunStatus, agentId: string): WorkflowRunState {
   return {
@@ -113,6 +114,19 @@ async function readSnapshot(store: InMemoryStore, workflowName: string, runId: s
   return workflows.getWorkflowRunById({ runId, workflowName });
 }
 
+async function readThreadRun(stream: AsyncIterable<any>) {
+  let runId: string | undefined;
+  let text = '';
+  for await (const part of stream) {
+    runId ??= part.runId;
+    if (part.type === 'text-delta') text += part.payload.text;
+    if (part.type === 'finish' || part.type === 'error' || part.type === 'abort') {
+      return { runId, text, terminal: part.type };
+    }
+  }
+  throw new Error('Thread subscription ended without a terminal event');
+}
+
 describe('DurableAgent.recover(runId)', () => {
   let agent: DurableAgent;
   let store: InMemoryStore;
@@ -156,6 +170,42 @@ describe('DurableAgent.recover(runId)', () => {
     // stream terminates immediately.
     await globalRunRegistry.get('run-stream')?.workflowExecution;
     result.cleanup();
+  });
+
+  it('announces a recovered run to a fresh thread subscriber before replaying output', async () => {
+    const runId = 'run-thread-reconnect';
+    await seed(store, runId, 'running', 'agent-A');
+
+    const restart = vi.fn(async () => {
+      await emitChunkEvent(agent.pubsub, runId, {
+        type: 'text-delta',
+        runId,
+        from: 'AGENT',
+        payload: { text: 'recovered output' },
+      } as any);
+      await emitFinishEvent(agent.pubsub, runId, {
+        output: { text: 'recovered output', steps: [] },
+        stepResult: { reason: 'stop' },
+      } as any);
+      return { status: 'success' as const };
+    });
+    const createRun = vi.fn(async () => ({ restart, runId }));
+    const deleteWorkflowRunById = vi.fn(async () => {});
+    vi.spyOn(agent, 'getWorkflow').mockReturnValue({ createRun, restart, deleteWorkflowRunById } as any);
+
+    const subscription = await agent.subscribeToThread({ threadId: 't', resourceId: 'r' });
+    const threadRun = readThreadRun(subscription.stream);
+    const recovered = await agent.recover(runId);
+
+    await expect(threadRun).resolves.toEqual({
+      runId,
+      text: 'recovered output',
+      terminal: 'finish',
+    });
+
+    await globalRunRegistry.get(runId)?.workflowExecution;
+    recovered.cleanup();
+    subscription.unsubscribe();
   });
 
   it('deletes both AGENTIC_LOOP and AGENTIC_EXECUTION snapshot rows on success', async () => {

--- a/packages/core/src/agent/durable/__tests__/recover-run.test.ts
+++ b/packages/core/src/agent/durable/__tests__/recover-run.test.ts
@@ -28,6 +28,8 @@ import type { DurableAgent } from '../durable-agent';
 import { globalRunRegistry } from '../run-registry';
 import { emitChunkEvent, emitFinishEvent } from '../stream-adapter';
 
+const RECOVERY_LEASE_RENEW_INTERVAL_MS_FOR_TEST = 10_000;
+
 function makeSnapshot(runId: string, status: WorkflowRunStatus, agentId: string): WorkflowRunState {
   return {
     runId,
@@ -248,11 +250,78 @@ describe('DurableAgent.recover(runId)', () => {
       expect(registerRun).toHaveBeenCalledTimes(1);
       expect(firstCreateRun).toHaveBeenCalledTimes(1);
       expect(secondWorkflow.createRun).not.toHaveBeenCalled();
+
+      releaseRestart();
+      await globalRunRegistry.get(runId)?.workflowExecution;
+      firstRecovery.cleanup();
+      firstRecovery = undefined;
+
+      const secondRecovery = await secondAgent.recover(runId);
+      await globalRunRegistry.get(runId)?.workflowExecution;
+      expect(secondWorkflow.createRun).toHaveBeenCalledTimes(1);
+      expect(registerRun).toHaveBeenCalledTimes(2);
+      secondRecovery.cleanup();
     } finally {
       releaseRestart();
       await globalRunRegistry.get(runId)?.workflowExecution?.catch(() => {});
       firstRecovery?.cleanup();
       registerRun.mockRestore();
+    }
+  });
+
+  it('retries a transient recovery-lease renewal error without aborting the run', async () => {
+    vi.useFakeTimers();
+    const runId = 'run-renewal-retry';
+    const retryStore = new InMemoryStore();
+    const retryPubsub = new EventEmitterPubSub();
+    const actualRenewLease = retryPubsub.renewLease.bind(retryPubsub);
+    let rejectFirstRecoveryRenewal = true;
+    const renewLease = vi.spyOn(retryPubsub, 'renewLease').mockImplementation(async (key, owner, ttlMs) => {
+      if (key.startsWith('mastra:durable-agent-recovery:') && rejectFirstRecoveryRenewal) {
+        rejectFirstRecoveryRenewal = false;
+        throw new Error('temporary lease backend error');
+      }
+      return actualRenewLease(key, owner, ttlMs);
+    });
+    const recoveryRenewalCalls = () =>
+      renewLease.mock.calls.filter(([key]) => key.startsWith('mastra:durable-agent-recovery:'));
+    const { agent: retryAgent } = createDurableWithStore('agent-renewal', retryStore, retryPubsub);
+    await seed(retryStore, runId, 'running', 'agent-renewal');
+
+    let markRestartStarted!: () => void;
+    const restartStarted = new Promise<void>(resolve => {
+      markRestartStarted = resolve;
+    });
+    let releaseRestart!: () => void;
+    const restartGate = new Promise<void>(resolve => {
+      releaseRestart = resolve;
+    });
+    const restart = vi.fn(async () => {
+      markRestartStarted();
+      await restartGate;
+      return { status: 'suspended' as const };
+    });
+    vi.spyOn(retryAgent, 'getWorkflow').mockReturnValue({
+      createRun: vi.fn(async () => ({ restart, runId })),
+    } as any);
+    let recovery: Awaited<ReturnType<typeof retryAgent.recover>> | undefined;
+
+    try {
+      recovery = await retryAgent.recover(runId);
+      await restartStarted;
+
+      await vi.advanceTimersByTimeAsync(RECOVERY_LEASE_RENEW_INTERVAL_MS_FOR_TEST);
+      expect(recoveryRenewalCalls()).toHaveLength(1);
+      expect(globalRunRegistry.get(runId)?.abortController?.signal.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(RECOVERY_LEASE_RENEW_INTERVAL_MS_FOR_TEST);
+      expect(recoveryRenewalCalls()).toHaveLength(2);
+      expect(globalRunRegistry.get(runId)?.abortController?.signal.aborted).toBe(false);
+    } finally {
+      releaseRestart();
+      await globalRunRegistry.get(runId)?.workflowExecution?.catch(() => {});
+      recovery?.cleanup();
+      vi.useRealTimers();
     }
   });
 

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -2009,7 +2009,29 @@ export class DurableAgent<
       messageList,
     });
 
-    // 10. Re-drive the workflow from the persisted snapshot in the background
+    // 10. Register the recovered run before restarting its workflow. A client
+    //     reconnecting with only the thread target must learn which run now
+    //     owns the thread before recovered chunks can be published.
+    const recoverStreamOptions: AgentExecutionOptions<TOutput> = {
+      runId,
+      requestContext,
+      ...(threadId
+        ? {
+            memory: {
+              thread: threadId,
+              ...(resourceId ? { resource: resourceId } : {}),
+            },
+          }
+        : {}),
+    } as AgentExecutionOptions<TOutput>;
+    await agentThreadStreamRuntime.registerRun(
+      this as unknown as Agent<any, any, any, any>,
+      output,
+      recoverStreamOptions,
+      this.getPubSub(),
+    );
+
+    // 11. Re-drive the workflow from the persisted snapshot in the background
     //     and delete snapshot rows on non-suspended terminals (same contract
     //     as start()/resume()). Errors are also broadcast via `emitError` so
     //     observers on the pubsub topic see the failure. Callers who await

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -9,6 +9,7 @@ import type { Mastra } from '../../mastra';
 import { createObservabilityContext, getOrCreateSpan, SpanType, EntityType } from '../../observability';
 import { RequestContext } from '../../request-context';
 import type { DeclaredAgentSchedule } from '../../schedules/define';
+import type { WorkflowsStorage } from '../../storage';
 import type { FullOutput, MastraModelOutput } from '../../stream/base/output';
 import type { ChunkType, MastraOnFinishCallback, MastraStreamTransformOptions } from '../../stream/types';
 import { ChunkFrom } from '../../stream/types';
@@ -21,6 +22,7 @@ import { MessageList } from '../message-list';
 import type { MessageListInput } from '../message-list';
 import { SaveQueueManager } from '../save-queue';
 import { agentThreadStreamRuntime } from '../thread-stream-runtime';
+import type { AgentThreadRunRegistration } from '../thread-stream-runtime';
 import type { ToolsInput } from '../types';
 
 import { publishAbortRequest } from './abort-transport';
@@ -43,10 +45,12 @@ const CLOSE_ON_SUSPEND = Symbol('mastra.durable.closeOnSuspend');
 const RESOLVED_EXECUTION_OPTIONS = Symbol('mastra.durable.resolvedExecutionOptions');
 const RECOVERY_LEASE_TTL_MS = 30_000;
 const RECOVERY_LEASE_RENEW_INTERVAL_MS = 10_000;
+const localRecoveryClaims = new Map<string, string>();
 
 interface RecoveryLease {
   assertOwned(): void;
   getLossError(): MastraError | undefined;
+  waitForLoss(): Promise<MastraError>;
   release(): Promise<void>;
 }
 
@@ -58,6 +62,8 @@ interface RehydratedRecoveryState {
   recoverAgentSpan: any;
   registryEntry: any;
 }
+
+type RecoveryRaceResult<T> = { kind: 'result'; value: T } | { kind: 'lease-lost'; error: MastraError };
 
 /**
  * Options for DurableAgent.stream()
@@ -552,11 +558,24 @@ export class DurableAgent<
     const key = `mastra:durable-agent-recovery:v1:${JSON.stringify([this.id, runId])}`;
     const owner = crypto.randomUUID();
 
+    const localOwner = localRecoveryClaims.get(key);
+    if (localOwner) {
+      throw new MastraError({
+        id: 'DURABLE_AGENT_RECOVER_ALREADY_IN_PROGRESS',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text: `DurableAgent "${this.name}" recover(${runId}): another process is already recovering this run.`,
+        details: { agentName: this.name, runId },
+      });
+    }
+    localRecoveryClaims.set(key, owner);
+
     const leaseAcquireStartedAt = Date.now();
     let acquired: Awaited<ReturnType<LeaseProvider['acquireLease']>>;
     try {
       acquired = await provider.acquireLease(key, owner, RECOVERY_LEASE_TTL_MS);
     } catch (cause) {
+      if (localRecoveryClaims.get(key) === owner) localRecoveryClaims.delete(key);
       throw new MastraError(
         {
           id: 'DURABLE_AGENT_RECOVER_LEASE_ACQUIRE_FAILED',
@@ -570,6 +589,7 @@ export class DurableAgent<
     }
 
     if (!acquired.acquired) {
+      if (localRecoveryClaims.get(key) === owner) localRecoveryClaims.delete(key);
       throw new MastraError({
         id: 'DURABLE_AGENT_RECOVER_ALREADY_IN_PROGRESS',
         domain: ErrorDomain.AGENT,
@@ -583,6 +603,10 @@ export class DurableAgent<
     let renewalInFlight = false;
     let leaseExpiresAt = leaseAcquireStartedAt + RECOVERY_LEASE_TTL_MS;
     let lossError: MastraError | undefined;
+    let resolveLoss!: (error: MastraError) => void;
+    const loss = new Promise<MastraError>(resolve => {
+      resolveLoss = resolve;
+    });
     const stopOnLeaseLoss = (cause?: unknown) => {
       if (released || lossError) return;
       lossError = new MastraError(
@@ -598,6 +622,7 @@ export class DurableAgent<
       if (!abortController.signal.aborted) {
         abortController.abort(lossError);
       }
+      resolveLoss(lossError);
       this.#mastra?.getLogger?.()?.error?.(lossError.message);
     };
     const renewalTimer = setInterval(() => {
@@ -635,9 +660,13 @@ export class DurableAgent<
 
     return {
       assertOwned: () => {
+        if (!lossError && Date.now() >= leaseExpiresAt) {
+          stopOnLeaseLoss();
+        }
         if (lossError) throw lossError;
       },
       getLossError: () => lossError,
+      waitForLoss: () => loss,
       release: async () => {
         if (released) return;
         released = true;
@@ -648,9 +677,59 @@ export class DurableAgent<
           this.#mastra
             ?.getLogger?.()
             ?.warn?.(`[DurableAgent] recover(${runId}) failed to release recovery lease: ${error}`);
+        } finally {
+          if (localRecoveryClaims.get(key) === owner) localRecoveryClaims.delete(key);
         }
       },
     };
+  }
+
+  async #loadRecoverableWorkflowInput(
+    workflowsStore: WorkflowsStorage,
+    runId: string,
+  ): Promise<DurableAgenticWorkflowInput> {
+    const persisted = await workflowsStore.getWorkflowRunById({
+      runId,
+      workflowName: DurableStepIds.AGENTIC_LOOP,
+    });
+    if (!persisted) {
+      throw new MastraError({
+        id: 'DURABLE_AGENT_RECOVER_SNAPSHOT_NOT_FOUND',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text:
+          `DurableAgent "${this.name}" recover(${runId}): no persisted workflow snapshot found. ` +
+          `The run may have already completed or been cleaned up.`,
+        details: { agentName: this.name, runId },
+      });
+    }
+
+    const snapshot =
+      typeof persisted.snapshot === 'string'
+        ? (JSON.parse(persisted.snapshot) as WorkflowRunState)
+        : persisted.snapshot;
+    const workflowInput = snapshot?.context?.input as DurableAgenticWorkflowInput | undefined;
+    if (!workflowInput || workflowInput.__workflowKind !== 'durable-agent') {
+      throw new MastraError({
+        id: 'DURABLE_AGENT_RECOVER_INVALID_SNAPSHOT',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.SYSTEM,
+        text: `DurableAgent "${this.name}" recover(${runId}): persisted snapshot does not contain a durable-agent workflow input.`,
+        details: { agentName: this.name, runId },
+      });
+    }
+
+    if (workflowInput.agentId !== this.id) {
+      throw new MastraError({
+        id: 'DURABLE_AGENT_RECOVER_AGENT_MISMATCH',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text: `DurableAgent "${this.name}" recover(${runId}): persisted run belongs to agent "${workflowInput.agentId}", not "${this.id}".`,
+        details: { agentName: this.name, runId, ownerAgentId: workflowInput.agentId },
+      });
+    }
+
+    return workflowInput;
   }
 
   /**
@@ -679,8 +758,12 @@ export class DurableAgent<
     options?: DurableAgentRecoverOptions<TOutput>;
     scheduleAutoCleanup: () => void;
     recoveryLease: RecoveryLease;
-  }): Promise<DurableStreamAdapterResult<TOutput>> {
+  }): Promise<{
+    stream: DurableStreamAdapterResult<TOutput>;
+    threadRegistration?: AgentThreadRunRegistration;
+  }> {
     let streamCleanup: (() => void) | undefined;
+    let threadRegistration: AgentThreadRunRegistration | undefined;
     try {
       recoveryLease.assertOwned();
       registryEntry.messageList = messageList;
@@ -717,6 +800,8 @@ export class DurableAgent<
         messageList,
       });
       streamCleanup = stream.cleanup;
+      await this.#raceRecoveryLease(stream.ready, recoveryLease);
+      recoveryLease.assertOwned();
 
       const recoverStreamOptions: AgentExecutionOptions<TOutput> = {
         runId,
@@ -731,15 +816,26 @@ export class DurableAgent<
           : {}),
       } as AgentExecutionOptions<TOutput>;
       recoveryLease.assertOwned();
-      await agentThreadStreamRuntime.registerRun(
+      threadRegistration = await agentThreadStreamRuntime.registerRun(
         this as unknown as Agent<any, any, any, any>,
         stream.output,
         recoverStreamOptions,
         this.getPubSub(),
+        {
+          strict: true,
+          validate: () => recoveryLease.assertOwned(),
+        },
       );
       recoveryLease.assertOwned();
-      return stream;
+      return { stream, threadRegistration };
     } catch (error) {
+      try {
+        await threadRegistration?.rollback({ releaseLease: !recoveryLease.getLossError() });
+      } catch (rollbackError) {
+        this.#mastra
+          ?.getLogger?.()
+          ?.warn?.(`[DurableAgent] recover(${runId}) failed to roll back thread registration: ${rollbackError}`);
+      }
       streamCleanup?.();
       if (this.#runRegistry.get(runId) === registryEntry) {
         this.#runRegistry.cleanup(runId);
@@ -747,24 +843,53 @@ export class DurableAgent<
       if (globalRunRegistry.get(runId) === registryEntry) {
         globalRunRegistry.delete(runId);
       }
+      await this.#reportRecoveryFailure(runId, recoveryLease.getLossError() ?? error);
       await recoveryLease.release();
       throw error;
     }
   }
 
-  async #reportRecoveryFailure(runId: string, error: unknown): Promise<void> {
+  async #reportRecoveryFailure(runId: string, error: unknown): Promise<boolean> {
     const normalizedError = error instanceof Error ? error : new Error(String(error));
     if (normalizedError instanceof MastraError && normalizedError.id === 'DURABLE_AGENT_RECOVER_LEASE_LOST') {
-      return;
+      return false;
     }
 
     try {
       await this.emitError(runId, normalizedError);
+      return true;
     } catch (reportingError) {
       this.#mastra
         ?.getLogger?.()
         ?.warn?.(`[DurableAgent] recover(${runId}) failed to publish terminal error: ${reportingError}`);
+      return false;
     }
+  }
+
+  async #raceRecoveryLease<T>(operation: Promise<T>, recoveryLease: RecoveryLease): Promise<T> {
+    const outcome = await Promise.race<RecoveryRaceResult<T>>([
+      operation.then(value => ({ kind: 'result', value })),
+      recoveryLease.waitForLoss().then(error => ({ kind: 'lease-lost', error })),
+    ]);
+    if (outcome.kind === 'lease-lost') throw outcome.error;
+    return outcome.value;
+  }
+
+  #createRecoveryFencedPubSub(recoveryLease: RecoveryLease): PubSub {
+    const pubsub = this.pubsub;
+    const publish: PubSub['publish'] = async (topic, event, options) => {
+      recoveryLease.assertOwned();
+      await pubsub.publish(topic, event, options);
+      recoveryLease.assertOwned();
+    };
+
+    return new Proxy(pubsub, {
+      get(target, property) {
+        if (property === 'publish') return publish;
+        const value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
   }
 
   async #rehydrateRecoveryState({
@@ -2130,52 +2255,9 @@ export class DurableAgent<
       });
     }
 
-    // 1. Load the persisted snapshot for the durable agentic loop workflow.
-    const persisted = await workflowsStore.getWorkflowRunById({
-      runId,
-      workflowName: DurableStepIds.AGENTIC_LOOP,
-    });
-    if (!persisted) {
-      throw new MastraError({
-        id: 'DURABLE_AGENT_RECOVER_SNAPSHOT_NOT_FOUND',
-        domain: ErrorDomain.AGENT,
-        category: ErrorCategory.USER,
-        text:
-          `DurableAgent "${this.name}" recover(${runId}): no persisted workflow snapshot found. ` +
-          `The run may have already completed or been cleaned up.`,
-        details: { agentName: this.name, runId },
-      });
-    }
-
-    const snapshot =
-      typeof persisted.snapshot === 'string'
-        ? (JSON.parse(persisted.snapshot) as WorkflowRunState)
-        : persisted.snapshot;
-
-    let workflowInput = snapshot?.context?.input as DurableAgenticWorkflowInput | undefined;
-    if (!workflowInput || workflowInput.__workflowKind !== 'durable-agent') {
-      throw new MastraError({
-        id: 'DURABLE_AGENT_RECOVER_INVALID_SNAPSHOT',
-        domain: ErrorDomain.AGENT,
-        category: ErrorCategory.SYSTEM,
-        text: `DurableAgent "${this.name}" recover(${runId}): persisted snapshot does not contain a durable-agent workflow input.`,
-        details: { agentName: this.name, runId },
-      });
-    }
-
-    // All durable agents share the same workflow name (`durable-agentic-loop`),
-    // so a caller with runId in hand could otherwise recover another agent's
-    // run. Refuse to rehydrate a snapshot whose agentId doesn't match this
-    // instance — the caller must reach the owning agent to recover the run.
-    if (workflowInput.agentId !== this.id) {
-      throw new MastraError({
-        id: 'DURABLE_AGENT_RECOVER_AGENT_MISMATCH',
-        domain: ErrorDomain.AGENT,
-        category: ErrorCategory.USER,
-        text: `DurableAgent "${this.name}" recover(${runId}): persisted run belongs to agent "${workflowInput.agentId}", not "${this.id}".`,
-        details: { agentName: this.name, runId, ownerAgentId: workflowInput.agentId },
-      });
-    }
+    // 1. Validate the persisted durable-agent input before claiming ownership
+    //    so obvious caller errors fail fast.
+    let workflowInput = await this.#loadRecoverableWorkflowInput(workflowsStore, runId);
 
     // 2. Claim recovery ownership before resolving any live dependencies so a
     //    concurrent caller cannot finish first and leave this attempt using a
@@ -2199,45 +2281,7 @@ export class DurableAgent<
       // The lease RPC itself may have waited while an earlier owner completed.
       // Re-read after acquisition and recover from that authoritative snapshot,
       // never from the pre-claim copy.
-      const claimedPersisted = await workflowsStore.getWorkflowRunById({
-        runId,
-        workflowName: DurableStepIds.AGENTIC_LOOP,
-      });
-      if (!claimedPersisted) {
-        throw new MastraError({
-          id: 'DURABLE_AGENT_RECOVER_SNAPSHOT_NOT_FOUND',
-          domain: ErrorDomain.AGENT,
-          category: ErrorCategory.USER,
-          text:
-            `DurableAgent "${this.name}" recover(${runId}): no persisted workflow snapshot found. ` +
-            `The run may have already completed or been cleaned up.`,
-          details: { agentName: this.name, runId },
-        });
-      }
-      const claimedSnapshot =
-        typeof claimedPersisted.snapshot === 'string'
-          ? (JSON.parse(claimedPersisted.snapshot) as WorkflowRunState)
-          : claimedPersisted.snapshot;
-      const claimedWorkflowInput = claimedSnapshot?.context?.input as DurableAgenticWorkflowInput | undefined;
-      if (!claimedWorkflowInput || claimedWorkflowInput.__workflowKind !== 'durable-agent') {
-        throw new MastraError({
-          id: 'DURABLE_AGENT_RECOVER_INVALID_SNAPSHOT',
-          domain: ErrorDomain.AGENT,
-          category: ErrorCategory.SYSTEM,
-          text: `DurableAgent "${this.name}" recover(${runId}): persisted snapshot does not contain a durable-agent workflow input.`,
-          details: { agentName: this.name, runId },
-        });
-      }
-      if (claimedWorkflowInput.agentId !== this.id) {
-        throw new MastraError({
-          id: 'DURABLE_AGENT_RECOVER_AGENT_MISMATCH',
-          domain: ErrorDomain.AGENT,
-          category: ErrorCategory.USER,
-          text: `DurableAgent "${this.name}" recover(${runId}): persisted run belongs to agent "${claimedWorkflowInput.agentId}", not "${this.id}".`,
-          details: { agentName: this.name, runId, ownerAgentId: claimedWorkflowInput.agentId },
-        });
-      }
-      workflowInput = claimedWorkflowInput;
+      workflowInput = await this.#loadRecoverableWorkflowInput(workflowsStore, runId);
       recoveryLease.assertOwned();
       recoveryState = await this.#rehydrateRecoveryState({
         runId,
@@ -2284,11 +2328,7 @@ export class DurableAgent<
 
     // 4. Register the reconstructed state and recovered stream only after
     //    claiming exclusive recovery ownership.
-    const {
-      output,
-      cleanup: streamCleanup,
-      ready,
-    } = await this.#setupRecoveredStream({
+    const { stream, threadRegistration } = await this.#setupRecoveredStream({
       runId,
       workflowInput,
       requestContext,
@@ -2300,6 +2340,8 @@ export class DurableAgent<
       scheduleAutoCleanup,
       recoveryLease,
     });
+    const { output, cleanup: streamCleanup, ready } = stream;
+    const recoveryPubsub = this.#createRecoveryFencedPubSub(recoveryLease);
 
     // 5. Re-drive the workflow from the persisted snapshot in the background
     //     and delete snapshot rows on non-suspended terminals (same contract
@@ -2307,21 +2349,25 @@ export class DurableAgent<
     //     observers on the pubsub topic see the failure. Callers who await
     //     the returned `workflowExecution` (e.g. `recoverActiveRuns()`) see
     //     the raw rejection so they can classify the run as failed.
-    const workflowExecution = ready
+    const workflowExecution = this.#raceRecoveryLease(ready, recoveryLease)
       .then(async () => {
         recoveryLease.assertOwned();
-        const run = await workflow.createRun({ runId, pubsub: this.pubsub });
+        const run = await this.#raceRecoveryLease(workflow.createRun({ runId, pubsub: recoveryPubsub }), recoveryLease);
         recoveryLease.assertOwned();
-        const result = await run.restart({
-          requestContext,
-          ...createObservabilityContext({ currentSpan: recoverAgentSpan }),
-        } as any);
+        const result = await this.#raceRecoveryLease(
+          run.restart({
+            requestContext,
+            ...createObservabilityContext({ currentSpan: recoverAgentSpan }),
+          } as any),
+          recoveryLease,
+        );
         recoveryLease.assertOwned();
         // Snapshot cleanup runs for every non-suspended terminal (success or
         // failed) so storage stays bounded — mirrors the start()/resume()
         // contract.
         if (result?.status && result.status !== 'suspended') {
           await this.deleteRunSnapshots(runId);
+          recoveryLease.assertOwned();
         }
         if (result?.status === 'failed') {
           throw new Error((result as any).error?.message || 'Workflow recover failed');
@@ -2330,11 +2376,17 @@ export class DurableAgent<
       .catch(async error => {
         const leaseLossError = recoveryLease.getLossError();
         if (leaseLossError) {
+          await threadRegistration?.rollback({ releaseLease: false });
           streamCleanup();
           cleanupOwnedRegistryState();
         }
         const recoveryError = leaseLossError ?? error;
-        await this.#reportRecoveryFailure(runId, recoveryError);
+        const reported = await this.#reportRecoveryFailure(runId, recoveryError);
+        if (!reported && !leaseLossError) {
+          await threadRegistration?.rollback();
+          streamCleanup();
+          cleanupOwnedRegistryState();
+        }
         throw recoveryError;
       })
       .finally(() => recoveryLease.release());

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -29,6 +29,7 @@ import { runDurableStreamUntilIdle, runResumeDurableStreamUntilIdle } from './du
 import { prepareForDurableExecution } from './preparation';
 import { endRunSpansWithError, ExtendedRunRegistry, globalRunRegistry } from './run-registry';
 import { createDurableAgentStream, emitChunkEvent, emitErrorEvent } from './stream-adapter';
+import type { DurableAgentStreamResult as DurableStreamAdapterResult } from './stream-adapter';
 import type { AgentStepFinishEventData, AgentSuspendedEventData, DurableAgenticWorkflowInput } from './types';
 import { createDurableAgenticWorkflow } from './workflows';
 
@@ -564,6 +565,7 @@ export class DurableAgent<
 
     let released = false;
     let renewalInFlight = false;
+    let leaseExpiresAt = Date.now() + RECOVERY_LEASE_TTL_MS;
     const stopOnLeaseLoss = (cause?: unknown) => {
       if (released || abortController.signal.aborted) return;
       const error = new MastraError(
@@ -580,14 +582,31 @@ export class DurableAgent<
       this.#mastra?.getLogger?.()?.error?.(error.message);
     };
     const renewalTimer = setInterval(() => {
-      if (released || renewalInFlight) return;
+      if (released) return;
+      if (Date.now() >= leaseExpiresAt) {
+        stopOnLeaseLoss();
+        return;
+      }
+      if (renewalInFlight) return;
       renewalInFlight = true;
       void provider
         .renewLease(key, owner, RECOVERY_LEASE_TTL_MS)
         .then(renewed => {
-          if (!renewed) stopOnLeaseLoss();
+          if (renewed) {
+            leaseExpiresAt = Date.now() + RECOVERY_LEASE_TTL_MS;
+            return;
+          }
+          stopOnLeaseLoss();
         })
-        .catch(stopOnLeaseLoss)
+        .catch(cause => {
+          if (Date.now() >= leaseExpiresAt) {
+            stopOnLeaseLoss(cause);
+            return;
+          }
+          this.#mastra
+            ?.getLogger?.()
+            ?.warn?.(`[DurableAgent] recover(${runId}) lease renewal failed, retrying: ${cause}`);
+        })
         .finally(() => {
           renewalInFlight = false;
         });
@@ -606,6 +625,96 @@ export class DurableAgent<
           ?.warn?.(`[DurableAgent] recover(${runId}) failed to release recovery lease: ${error}`);
       }
     };
+  }
+
+  /**
+   * Rebuild and register the stream for a claimed recovery attempt. Rolls back
+   * every partial registration and releases the claim if setup fails.
+   */
+  async #setupRecoveredStream({
+    runId,
+    workflowInput,
+    requestContext,
+    threadId,
+    resourceId,
+    messageList,
+    registryEntry,
+    options,
+    scheduleAutoCleanup,
+    releaseRecoveryLease,
+  }: {
+    runId: string;
+    workflowInput: DurableAgenticWorkflowInput;
+    requestContext: RequestContext;
+    threadId?: string;
+    resourceId?: string;
+    messageList: MessageList;
+    registryEntry: any;
+    options?: DurableAgentRecoverOptions<TOutput>;
+    scheduleAutoCleanup: () => void;
+    releaseRecoveryLease: () => Promise<void>;
+  }): Promise<DurableStreamAdapterResult<TOutput>> {
+    let streamCleanup: (() => void) | undefined;
+    try {
+      this.#runRegistry.registerWithMessageList(runId, registryEntry, messageList, { threadId, resourceId });
+      globalRunRegistry.set(runId, { ...registryEntry, messageList });
+
+      // Persistent backends may retain chunks from the pre-crash segment.
+      const recoverOffset = await this.#getPubsubOffset(runId);
+      const stream = createDurableAgentStream<TOutput>({
+        pubsub: this.pubsub,
+        runId,
+        messageId: workflowInput.messageId ?? crypto.randomUUID(),
+        model: {
+          modelId: workflowInput.modelConfig?.modelId,
+          provider: workflowInput.modelConfig?.provider,
+          version: 'v3',
+        },
+        threadId,
+        resourceId,
+        offset: recoverOffset,
+        onChunk: options?.onChunk,
+        experimentalTransform: options?.experimentalTransform,
+        onStepFinish: options?.onStepFinish,
+        onFinish: options?.onFinish,
+        onStreamFinished: scheduleAutoCleanup,
+        onError: async error => {
+          await options?.onError?.(error);
+          scheduleAutoCleanup();
+        },
+        onSuspended: options?.onSuspended,
+        // Keep recovered runs observable if they suspend again so a later
+        // resume or recovery can pick them up.
+        messageList,
+      });
+      streamCleanup = stream.cleanup;
+
+      const recoverStreamOptions: AgentExecutionOptions<TOutput> = {
+        runId,
+        requestContext,
+        ...(threadId
+          ? {
+              memory: {
+                thread: threadId,
+                ...(resourceId ? { resource: resourceId } : {}),
+              },
+            }
+          : {}),
+      } as AgentExecutionOptions<TOutput>;
+      await agentThreadStreamRuntime.registerRun(
+        this as unknown as Agent<any, any, any, any>,
+        stream.output,
+        recoverStreamOptions,
+        this.getPubSub(),
+      );
+      return stream;
+    } catch (error) {
+      streamCleanup?.();
+      this.#runRegistry.cleanup(runId);
+      globalRunRegistry.delete(runId);
+      await releaseRecoveryLease();
+      throw error;
+    }
   }
 
   /**
@@ -2060,82 +2169,24 @@ export class DurableAgent<
       }, this.#cleanupTimeoutMs);
     };
 
-    // 8. Build and register the recovered stream only after claiming exclusive
-    //    recovery ownership. Any setup failure releases the claim and removes
-    //    partial local state so a later recovery attempt can retry safely.
-    let setupStreamCleanup: (() => void) | undefined;
+    // 8. Register the reconstructed state and recovered stream only after
+    //    claiming exclusive recovery ownership.
     const {
       output,
       cleanup: streamCleanup,
       ready,
-    } = await (async () => {
-      try {
-        this.#runRegistry.registerWithMessageList(runId, registryEntry, messageList, { threadId, resourceId });
-        globalRunRegistry.set(runId, { ...registryEntry, messageList });
-
-        // Skip pubsub events broadcast before recovery started. Persistent
-        // backends may retain chunks from the pre-crash segment.
-        const recoverOffset = await this.#getPubsubOffset(runId);
-        const stream = createDurableAgentStream<TOutput>({
-          pubsub: this.pubsub,
-          runId,
-          messageId: workflowInput.messageId ?? crypto.randomUUID(),
-          model: {
-            modelId: workflowInput.modelConfig?.modelId,
-            provider: workflowInput.modelConfig?.provider,
-            version: 'v3',
-          },
-          threadId,
-          resourceId,
-          offset: recoverOffset,
-          onChunk: options?.onChunk,
-          experimentalTransform: options?.experimentalTransform,
-          onStepFinish: options?.onStepFinish,
-          onFinish: options?.onFinish,
-          onStreamFinished: scheduleAutoCleanup,
-          onError: async error => {
-            await options?.onError?.(error);
-            scheduleAutoCleanup();
-          },
-          onSuspended: options?.onSuspended,
-          // Recovered runs use the default `closeOnSuspend: false` — a run that
-          // suspends again should stay observable so a later resume/recover can
-          // pick it up. Callers wanting to close on suspend can call `cleanup()`
-          // from `onSuspended`.
-          messageList,
-        });
-        setupStreamCleanup = stream.cleanup;
-
-        // 10. Register the recovered run before restarting its workflow. A client
-        //     reconnecting with only the thread target must learn which run now
-        //     owns the thread before recovered chunks can be published.
-        const recoverStreamOptions: AgentExecutionOptions<TOutput> = {
-          runId,
-          requestContext,
-          ...(threadId
-            ? {
-                memory: {
-                  thread: threadId,
-                  ...(resourceId ? { resource: resourceId } : {}),
-                },
-              }
-            : {}),
-        } as AgentExecutionOptions<TOutput>;
-        await agentThreadStreamRuntime.registerRun(
-          this as unknown as Agent<any, any, any, any>,
-          stream.output,
-          recoverStreamOptions,
-          this.getPubSub(),
-        );
-        return stream;
-      } catch (error) {
-        setupStreamCleanup?.();
-        this.#runRegistry.cleanup(runId);
-        globalRunRegistry.delete(runId);
-        await releaseRecoveryLease();
-        throw error;
-      }
-    })();
+    } = await this.#setupRecoveredStream({
+      runId,
+      workflowInput,
+      requestContext,
+      threadId,
+      resourceId,
+      messageList,
+      registryEntry,
+      options,
+      scheduleAutoCleanup,
+      releaseRecoveryLease,
+    });
 
     // 9. Re-drive the workflow from the persisted snapshot in the background
     //     and delete snapshot rows on non-suspended terminals (same contract
@@ -2144,29 +2195,31 @@ export class DurableAgent<
     //     the returned `workflowExecution` (e.g. `recoverActiveRuns()`) see
     //     the raw rejection so they can classify the run as failed.
     const workflow = this.getWorkflow();
-    const workflowExecution = ready.then(async () => {
-      try {
-        const run = await workflow.createRun({ runId, pubsub: this.pubsub });
-        const result = await run.restart({
-          requestContext,
-          ...createObservabilityContext({ currentSpan: recoverAgentSpan }),
-        } as any);
-        // Snapshot cleanup runs for every non-suspended terminal (success or
-        // failed) so storage stays bounded — mirrors the start()/resume()
-        // contract.
-        if (result?.status && result.status !== 'suspended') {
-          await this.deleteRunSnapshots(runId);
-        }
-        if (result?.status === 'failed') {
-          const error = new Error((result as any).error?.message || 'Workflow recover failed');
-          void this.emitError(runId, error);
+    const workflowExecution = ready
+      .then(async () => {
+        try {
+          const run = await workflow.createRun({ runId, pubsub: this.pubsub });
+          const result = await run.restart({
+            requestContext,
+            ...createObservabilityContext({ currentSpan: recoverAgentSpan }),
+          } as any);
+          // Snapshot cleanup runs for every non-suspended terminal (success or
+          // failed) so storage stays bounded — mirrors the start()/resume()
+          // contract.
+          if (result?.status && result.status !== 'suspended') {
+            await this.deleteRunSnapshots(runId);
+          }
+          if (result?.status === 'failed') {
+            const error = new Error((result as any).error?.message || 'Workflow recover failed');
+            void this.emitError(runId, error);
+            throw error;
+          }
+        } catch (error) {
+          void this.emitError(runId, error as Error);
           throw error;
         }
-      } catch (error) {
-        void this.emitError(runId, error as Error);
-        throw error;
-      }
-    });
+      })
+      .finally(releaseRecoveryLease);
     const trackedRecoverEntry = globalRunRegistry.get(runId);
     if (trackedRecoverEntry) {
       trackedRecoverEntry.workflowExecution = workflowExecution;
@@ -2176,7 +2229,6 @@ export class DurableAgent<
     // workflow promise). Errors are already surfaced through `emitError` /
     // the stream's `onError` callback.
     workflowExecution.catch(() => {});
-    void workflowExecution.finally(releaseRecoveryLease).catch(() => {});
 
     const cleanup = () => {
       if (autoCleanupTimer) {

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -44,6 +44,21 @@ const RESOLVED_EXECUTION_OPTIONS = Symbol('mastra.durable.resolvedExecutionOptio
 const RECOVERY_LEASE_TTL_MS = 30_000;
 const RECOVERY_LEASE_RENEW_INTERVAL_MS = 10_000;
 
+interface RecoveryLease {
+  assertOwned(): void;
+  getLossError(): MastraError | undefined;
+  release(): Promise<void>;
+}
+
+interface RehydratedRecoveryState {
+  requestContext: RequestContext;
+  threadId?: string;
+  resourceId?: string;
+  messageList: MessageList;
+  recoverAgentSpan: any;
+  registryEntry: any;
+}
+
 /**
  * Options for DurableAgent.stream()
  */
@@ -525,7 +540,7 @@ export class DurableAgent<
    * its owner is the logical runId, so two processes recovering the same run
    * are indistinguishable to an idempotent lease backend.
    */
-  async #acquireRecoveryLease(runId: string, abortController: AbortController): Promise<() => Promise<void>> {
+  async #acquireRecoveryLease(runId: string, abortController: AbortController): Promise<RecoveryLease> {
     const pubsub = this.pubsub;
     const unwrap = (pubsub as { getLeaseProvider?: () => LeaseProvider | undefined }).getLeaseProvider;
     const provider =
@@ -537,6 +552,7 @@ export class DurableAgent<
     const key = `mastra:durable-agent-recovery:v1:${JSON.stringify([this.id, runId])}`;
     const owner = crypto.randomUUID();
 
+    const leaseAcquireStartedAt = Date.now();
     let acquired: Awaited<ReturnType<LeaseProvider['acquireLease']>>;
     try {
       acquired = await provider.acquireLease(key, owner, RECOVERY_LEASE_TTL_MS);
@@ -565,10 +581,11 @@ export class DurableAgent<
 
     let released = false;
     let renewalInFlight = false;
-    let leaseExpiresAt = Date.now() + RECOVERY_LEASE_TTL_MS;
+    let leaseExpiresAt = leaseAcquireStartedAt + RECOVERY_LEASE_TTL_MS;
+    let lossError: MastraError | undefined;
     const stopOnLeaseLoss = (cause?: unknown) => {
-      if (released || abortController.signal.aborted) return;
-      const error = new MastraError(
+      if (released || lossError) return;
+      lossError = new MastraError(
         {
           id: 'DURABLE_AGENT_RECOVER_LEASE_LOST',
           domain: ErrorDomain.AGENT,
@@ -578,8 +595,10 @@ export class DurableAgent<
         },
         cause,
       );
-      abortController.abort(error);
-      this.#mastra?.getLogger?.()?.error?.(error.message);
+      if (!abortController.signal.aborted) {
+        abortController.abort(lossError);
+      }
+      this.#mastra?.getLogger?.()?.error?.(lossError.message);
     };
     const renewalTimer = setInterval(() => {
       if (released) return;
@@ -589,11 +608,12 @@ export class DurableAgent<
       }
       if (renewalInFlight) return;
       renewalInFlight = true;
+      const renewalStartedAt = Date.now();
       void provider
         .renewLease(key, owner, RECOVERY_LEASE_TTL_MS)
         .then(renewed => {
           if (renewed) {
-            leaseExpiresAt = Date.now() + RECOVERY_LEASE_TTL_MS;
+            leaseExpiresAt = renewalStartedAt + RECOVERY_LEASE_TTL_MS;
             return;
           }
           stopOnLeaseLoss();
@@ -613,17 +633,23 @@ export class DurableAgent<
     }, RECOVERY_LEASE_RENEW_INTERVAL_MS);
     renewalTimer.unref?.();
 
-    return async () => {
-      if (released) return;
-      released = true;
-      clearInterval(renewalTimer);
-      try {
-        await provider.releaseLease(key, owner);
-      } catch (error) {
-        this.#mastra
-          ?.getLogger?.()
-          ?.warn?.(`[DurableAgent] recover(${runId}) failed to release recovery lease: ${error}`);
-      }
+    return {
+      assertOwned: () => {
+        if (lossError) throw lossError;
+      },
+      getLossError: () => lossError,
+      release: async () => {
+        if (released) return;
+        released = true;
+        clearInterval(renewalTimer);
+        try {
+          await provider.releaseLease(key, owner);
+        } catch (error) {
+          this.#mastra
+            ?.getLogger?.()
+            ?.warn?.(`[DurableAgent] recover(${runId}) failed to release recovery lease: ${error}`);
+        }
+      },
     };
   }
 
@@ -641,7 +667,7 @@ export class DurableAgent<
     registryEntry,
     options,
     scheduleAutoCleanup,
-    releaseRecoveryLease,
+    recoveryLease,
   }: {
     runId: string;
     workflowInput: DurableAgenticWorkflowInput;
@@ -652,15 +678,18 @@ export class DurableAgent<
     registryEntry: any;
     options?: DurableAgentRecoverOptions<TOutput>;
     scheduleAutoCleanup: () => void;
-    releaseRecoveryLease: () => Promise<void>;
+    recoveryLease: RecoveryLease;
   }): Promise<DurableStreamAdapterResult<TOutput>> {
     let streamCleanup: (() => void) | undefined;
     try {
+      recoveryLease.assertOwned();
+      registryEntry.messageList = messageList;
       this.#runRegistry.registerWithMessageList(runId, registryEntry, messageList, { threadId, resourceId });
-      globalRunRegistry.set(runId, { ...registryEntry, messageList });
+      globalRunRegistry.set(runId, registryEntry);
 
       // Persistent backends may retain chunks from the pre-crash segment.
       const recoverOffset = await this.#getPubsubOffset(runId);
+      recoveryLease.assertOwned();
       const stream = createDurableAgentStream<TOutput>({
         pubsub: this.pubsub,
         runId,
@@ -701,20 +730,164 @@ export class DurableAgent<
             }
           : {}),
       } as AgentExecutionOptions<TOutput>;
+      recoveryLease.assertOwned();
       await agentThreadStreamRuntime.registerRun(
         this as unknown as Agent<any, any, any, any>,
         stream.output,
         recoverStreamOptions,
         this.getPubSub(),
       );
+      recoveryLease.assertOwned();
       return stream;
     } catch (error) {
       streamCleanup?.();
-      this.#runRegistry.cleanup(runId);
-      globalRunRegistry.delete(runId);
-      await releaseRecoveryLease();
+      if (this.#runRegistry.get(runId) === registryEntry) {
+        this.#runRegistry.cleanup(runId);
+      }
+      if (globalRunRegistry.get(runId) === registryEntry) {
+        globalRunRegistry.delete(runId);
+      }
+      await recoveryLease.release();
       throw error;
     }
+  }
+
+  async #reportRecoveryFailure(runId: string, error: unknown): Promise<void> {
+    const normalizedError = error instanceof Error ? error : new Error(String(error));
+    if (normalizedError instanceof MastraError && normalizedError.id === 'DURABLE_AGENT_RECOVER_LEASE_LOST') {
+      return;
+    }
+
+    try {
+      await this.emitError(runId, normalizedError);
+    } catch (reportingError) {
+      this.#mastra
+        ?.getLogger?.()
+        ?.warn?.(`[DurableAgent] recover(${runId}) failed to publish terminal error: ${reportingError}`);
+    }
+  }
+
+  async #rehydrateRecoveryState({
+    runId,
+    workflowInput,
+    abortController,
+    recoveryLease,
+  }: {
+    runId: string;
+    workflowInput: DurableAgenticWorkflowInput;
+    abortController: AbortController;
+    recoveryLease: RecoveryLease;
+  }): Promise<RehydratedRecoveryState> {
+    const requestContext: RequestContext = workflowInput.requestContextEntries
+      ? new RequestContext(Object.entries(workflowInput.requestContextEntries) as Iterable<readonly [string, unknown]>)
+      : new RequestContext();
+
+    const messageListMemoryInfo = (
+      workflowInput.messageListState as { memoryInfo?: { threadId?: string; resourceId?: string } } | undefined
+    )?.memoryInfo;
+    const threadId = workflowInput.state?.threadId ?? messageListMemoryInfo?.threadId;
+    const resourceId = workflowInput.state?.resourceId ?? messageListMemoryInfo?.resourceId;
+    const messageList = new MessageList({ threadId, resourceId });
+    try {
+      messageList.deserialize(workflowInput.messageListState);
+    } catch (error) {
+      this.#mastra?.getLogger?.()?.warn?.(`[DurableAgent] recover(${runId}) messageList deserialize skipped: ${error}`);
+    }
+
+    const wrapped = this.#wrappedAgent as Agent<string, any, TOutput>;
+    let model;
+    try {
+      model = await wrapped.getModel({ requestContext });
+    } catch (error) {
+      this.#mastra?.getLogger?.()?.warn?.(`[DurableAgent] Failed to resolve model during recover(${runId}): ${error}`);
+    }
+    recoveryLease.assertOwned();
+
+    let memory;
+    try {
+      memory = await wrapped.getMemory({ requestContext });
+    } catch (error) {
+      this.#mastra?.getLogger?.()?.warn?.(`[DurableAgent] Failed to resolve memory during recover(${runId}): ${error}`);
+    }
+    recoveryLease.assertOwned();
+
+    const saveQueueManager = memory
+      ? new SaveQueueManager({ logger: this.#mastra?.getLogger?.() as any, memory })
+      : undefined;
+    const backgroundTasksConfig = this.getBackgroundTasksConfig?.();
+    const backgroundTaskManager = this.#mastra?.backgroundTaskManager;
+
+    let inputProcessors: any[] = [];
+    let llmRequestInputProcessors: any[] = [];
+    let outputProcessors: any[] = [];
+    let errorProcessors: any[] = [];
+    try {
+      inputProcessors = (await (wrapped as any).listInputProcessors?.(requestContext)) ?? [];
+      llmRequestInputProcessors = (await (wrapped as any).__listLLMRequestProcessors?.(requestContext)) ?? [];
+      outputProcessors = (await (wrapped as any).listOutputProcessors?.(requestContext)) ?? [];
+      errorProcessors = (await (wrapped as any).listErrorProcessors?.(requestContext)) ?? [];
+    } catch (error) {
+      this.#mastra?.getLogger?.()?.warn?.(`[DurableAgent] recover(${runId}) processor resolution failed: ${error}`);
+    }
+    recoveryLease.assertOwned();
+
+    const processorStates = new Map<string, any>();
+    const origAgentSpanData = workflowInput.agentSpanData as { traceId?: string; id?: string } | undefined;
+    let recoverAgentSpan: any;
+    if (this.#mastra?.observability) {
+      try {
+        const rawConfig =
+          typeof (wrapped as any).toRawConfig === 'function' ? (wrapped as any).toRawConfig() : undefined;
+        const resolvedVersionId = rawConfig?.resolvedVersionId as string | undefined;
+        const agentTracingPolicy =
+          typeof wrapped.getTracingPolicy === 'function' ? wrapped.getTracingPolicy() : undefined;
+        recoverAgentSpan = getOrCreateSpan({
+          type: SpanType.AGENT_RUN,
+          name: `agent run: '${wrapped.id}' (recovered)`,
+          entityType: EntityType.AGENT,
+          entityId: wrapped.id,
+          entityName: wrapped.name,
+          metadata: {
+            runId,
+            recovered: true,
+            ...(origAgentSpanData?.id ? { recoveredFromSpanId: origAgentSpanData.id } : {}),
+            ...(resolvedVersionId ? { entityVersionId: resolvedVersionId } : {}),
+          },
+          tracingPolicy: agentTracingPolicy,
+          tracingOptions: origAgentSpanData?.traceId ? { traceId: origAgentSpanData.traceId } : undefined,
+          requestContext,
+          mastra: this.#mastra,
+        });
+      } catch (error) {
+        this.#mastra?.getLogger?.()?.warn?.(`[DurableAgent] Failed to open recover span: ${error}`);
+      }
+    }
+    recoveryLease.assertOwned();
+
+    return {
+      requestContext,
+      threadId,
+      resourceId,
+      messageList,
+      recoverAgentSpan,
+      registryEntry: {
+        model,
+        memory,
+        saveQueueManager,
+        requestContext,
+        agentSpan: recoverAgentSpan,
+        abortController,
+        abortSignal: abortController.signal,
+        backgroundTaskManager,
+        backgroundTasksConfig,
+        inputProcessors,
+        llmRequestInputProcessors,
+        outputProcessors,
+        errorProcessors,
+        processorStates,
+        cleanup: () => {},
+      },
+    };
   }
 
   /**
@@ -1979,7 +2152,7 @@ export class DurableAgent<
         ? (JSON.parse(persisted.snapshot) as WorkflowRunState)
         : persisted.snapshot;
 
-    const workflowInput = snapshot?.context?.input as DurableAgenticWorkflowInput | undefined;
+    let workflowInput = snapshot?.context?.input as DurableAgenticWorkflowInput | undefined;
     if (!workflowInput || workflowInput.__workflowKind !== 'durable-agent') {
       throw new MastraError({
         id: 'DURABLE_AGENT_RECOVER_INVALID_SNAPSHOT',
@@ -2004,85 +2177,9 @@ export class DurableAgent<
       });
     }
 
-    // 2. Rebuild the RequestContext from the persisted JSON-safe snapshot.
-    const requestContext: RequestContext = workflowInput.requestContextEntries
-      ? new RequestContext(Object.entries(workflowInput.requestContextEntries) as Iterable<readonly [string, unknown]>)
-      : new RequestContext();
-
-    // 3. Rebuild MessageList from the persisted state. threadId/resourceId
-    //    come from the workflow input's `state` block when present; older
-    //    snapshots may only have them under `messageListState.memoryInfo`.
-    const messageListMemoryInfo = (
-      workflowInput.messageListState as { memoryInfo?: { threadId?: string; resourceId?: string } } | undefined
-    )?.memoryInfo;
-    const threadId = workflowInput.state?.threadId ?? messageListMemoryInfo?.threadId;
-    const resourceId = workflowInput.state?.resourceId ?? messageListMemoryInfo?.resourceId;
-    const messageList = new MessageList({ threadId, resourceId });
-    try {
-      messageList.deserialize(workflowInput.messageListState);
-    } catch (err) {
-      // Fresh (never-executed) snapshots may have a minimal `messageListState`;
-      // fall back to an empty MessageList so recovery still proceeds. The
-      // workflow steps rebuild the real MessageList from serialized input.
-      this.#mastra?.getLogger?.()?.warn?.(`[DurableAgent] recover(${runId}) messageList deserialize skipped: ${err}`);
-    }
-
-    // 4. Resolve model/memory from the live agent. Tools are rebuilt by the
-    //    durable step from `toolsMetadata`, so we only need the live agent's
-    //    memory here to enable message persistence at the terminal step.
-    const wrapped = this.#wrappedAgent as Agent<string, any, TOutput>;
-    let model;
-    try {
-      model = await wrapped.getModel({ requestContext });
-    } catch (err) {
-      const logger = this.#mastra?.getLogger?.();
-      logger?.warn?.(`[DurableAgent] Failed to resolve model during recover(${runId}): ${err}`);
-    }
-    let memory;
-    try {
-      memory = await wrapped.getMemory({ requestContext });
-    } catch (err) {
-      const logger = this.#mastra?.getLogger?.();
-      logger?.warn?.(`[DurableAgent] Failed to resolve memory during recover(${runId}): ${err}`);
-    }
-    const saveQueueManager = memory
-      ? new SaveQueueManager({ logger: this.#mastra?.getLogger?.() as any, memory })
-      : undefined;
-
-    // Re-wire background-task state so the recovered segment can wait for
-    // pre-crash tasks (via `bg-task-check`), dispatch new background tool
-    // calls (via `tool-call`), and inject the background-task system prompt
-    // (via `llm-execution`). The manager is storage-backed, so in-flight
-    // tasks spawned before the crash are still discoverable via
-    // `bgManager.listTasks(...)`.
-    const backgroundTasksConfig = this.getBackgroundTasksConfig?.();
-    const backgroundTaskManager = this.#mastra?.backgroundTaskManager;
-
-    // Re-resolve processors from the live agent config. `llm-execution` reads
-    // `inputProcessors` / `llmRequestInputProcessors` / `outputProcessors` from
-    // the global registry, and the terminal `.map(...)` reads `outputProcessors`
-    // + `errorProcessors` — without these, the recovered segment would run
-    // with no processors even if the agent has some configured.
-    let inputProcessors: any[] = [];
-    let llmRequestInputProcessors: any[] = [];
-    let outputProcessors: any[] = [];
-    let errorProcessors: any[] = [];
-    try {
-      inputProcessors = (await (wrapped as any).listInputProcessors?.(requestContext)) ?? [];
-      llmRequestInputProcessors = (await (wrapped as any).__listLLMRequestProcessors?.(requestContext)) ?? [];
-      outputProcessors = (await (wrapped as any).listOutputProcessors?.(requestContext)) ?? [];
-      errorProcessors = (await (wrapped as any).listErrorProcessors?.(requestContext)) ?? [];
-    } catch (err) {
-      this.#mastra?.getLogger?.()?.warn?.(`[DurableAgent] recover(${runId}) processor resolution failed: ${err}`);
-    }
-    // Fresh empty processorStates for the recovered segment — the pre-crash
-    // segment's in-memory processor state is gone, but the terminal state
-    // (memory writes, message list) lives on the persisted snapshot.
-    const processorStates = new Map<string, any>();
-
-    // 5. Re-open an AGENT_RUN span for the recovered segment. Follow the same
-    //    pattern as resume(): reuse the original traceId when possible so the
-    //    recovered run stays linked to the original agent trace.
+    // 2. Claim recovery ownership before resolving any live dependencies so a
+    //    concurrent caller cannot finish first and leave this attempt using a
+    //    stale snapshot.
     const abortController = new AbortController();
     if (options?.abortSignal) {
       if (options.abortSignal.aborted) {
@@ -2095,81 +2192,97 @@ export class DurableAgent<
         );
       }
     }
-    const releaseRecoveryLease = await this.#acquireRecoveryLease(runId, abortController);
+    const recoveryLease = await this.#acquireRecoveryLease(runId, abortController);
 
-    const origAgentSpanData = workflowInput.agentSpanData as { traceId?: string; id?: string } | undefined;
-    let recoverAgentSpan: any;
-    if (this.#mastra?.observability) {
-      try {
-        const rawConfig =
-          typeof (wrapped as any).toRawConfig === 'function' ? (wrapped as any).toRawConfig() : undefined;
-        const resolvedVersionId = rawConfig?.resolvedVersionId as string | undefined;
-        const agentTracingPolicy =
-          typeof wrapped.getTracingPolicy === 'function' ? wrapped.getTracingPolicy() : undefined;
-        recoverAgentSpan = getOrCreateSpan({
-          type: SpanType.AGENT_RUN,
-          name: `agent run: '${wrapped.id}' (recovered)`,
-          entityType: EntityType.AGENT,
-          entityId: wrapped.id,
-          entityName: wrapped.name,
-          metadata: {
-            runId,
-            recovered: true,
-            ...(origAgentSpanData?.id ? { recoveredFromSpanId: origAgentSpanData.id } : {}),
-            ...(resolvedVersionId ? { entityVersionId: resolvedVersionId } : {}),
-          },
-          tracingPolicy: agentTracingPolicy,
-          tracingOptions: origAgentSpanData?.traceId ? { traceId: origAgentSpanData.traceId } : undefined,
-          requestContext,
-          mastra: this.#mastra,
+    let recoveryState: RehydratedRecoveryState;
+    try {
+      // The lease RPC itself may have waited while an earlier owner completed.
+      // Re-read after acquisition and recover from that authoritative snapshot,
+      // never from the pre-claim copy.
+      const claimedPersisted = await workflowsStore.getWorkflowRunById({
+        runId,
+        workflowName: DurableStepIds.AGENTIC_LOOP,
+      });
+      if (!claimedPersisted) {
+        throw new MastraError({
+          id: 'DURABLE_AGENT_RECOVER_SNAPSHOT_NOT_FOUND',
+          domain: ErrorDomain.AGENT,
+          category: ErrorCategory.USER,
+          text:
+            `DurableAgent "${this.name}" recover(${runId}): no persisted workflow snapshot found. ` +
+            `The run may have already completed or been cleaned up.`,
+          details: { agentName: this.name, runId },
         });
-      } catch (err) {
-        // Span bookkeeping must never block recovery.
-        this.#mastra?.getLogger?.()?.warn?.(`[DurableAgent] Failed to open recover span: ${err}`);
       }
+      const claimedSnapshot =
+        typeof claimedPersisted.snapshot === 'string'
+          ? (JSON.parse(claimedPersisted.snapshot) as WorkflowRunState)
+          : claimedPersisted.snapshot;
+      const claimedWorkflowInput = claimedSnapshot?.context?.input as DurableAgenticWorkflowInput | undefined;
+      if (!claimedWorkflowInput || claimedWorkflowInput.__workflowKind !== 'durable-agent') {
+        throw new MastraError({
+          id: 'DURABLE_AGENT_RECOVER_INVALID_SNAPSHOT',
+          domain: ErrorDomain.AGENT,
+          category: ErrorCategory.SYSTEM,
+          text: `DurableAgent "${this.name}" recover(${runId}): persisted snapshot does not contain a durable-agent workflow input.`,
+          details: { agentName: this.name, runId },
+        });
+      }
+      if (claimedWorkflowInput.agentId !== this.id) {
+        throw new MastraError({
+          id: 'DURABLE_AGENT_RECOVER_AGENT_MISMATCH',
+          domain: ErrorDomain.AGENT,
+          category: ErrorCategory.USER,
+          text: `DurableAgent "${this.name}" recover(${runId}): persisted run belongs to agent "${claimedWorkflowInput.agentId}", not "${this.id}".`,
+          details: { agentName: this.name, runId, ownerAgentId: claimedWorkflowInput.agentId },
+        });
+      }
+      workflowInput = claimedWorkflowInput;
+      recoveryLease.assertOwned();
+      recoveryState = await this.#rehydrateRecoveryState({
+        runId,
+        workflowInput,
+        abortController,
+        recoveryLease,
+      });
+    } catch (error) {
+      await recoveryLease.release();
+      throw error;
     }
+    const { requestContext, threadId, resourceId, messageList, recoverAgentSpan, registryEntry } = recoveryState;
 
-    // 6. Assemble a minimal RunRegistryEntry. Fields that the durable steps
-    //    would normally populate on the fly (tools, workspace, processor
-    //    states, etc.) are left undefined — the workflow's own
-    //    `resolveRuntimeDependencies` will fall back to the persisted step
-    //    input to reconstruct them, so we only need the fields that the
-    //    terminal `.map(...)` step and stream adapter read from the registry:
-    //    saveQueueManager + memory + agentSpan + abortController.
-    const registryEntry: any = {
-      model,
-      memory,
-      saveQueueManager,
-      requestContext,
-      agentSpan: recoverAgentSpan,
-      abortController,
-      abortSignal: abortController.signal,
-      backgroundTaskManager,
-      backgroundTasksConfig,
-      inputProcessors,
-      llmRequestInputProcessors,
-      outputProcessors,
-      errorProcessors,
-      processorStates,
-      cleanup: () => {},
-    };
-
-    // 7. Cleanup plumbing (mirrors stream()/resume()).
+    // 3. Cleanup plumbing (mirrors stream()/resume()).
     let cleanedUp = false;
     let autoCleanupTimer: ReturnType<typeof setTimeout> | null = null;
+    const cleanupOwnedRegistryState = () => {
+      if (this.#runRegistry.get(runId) === registryEntry) {
+        this.#runRegistry.cleanup(runId);
+      }
+      if (globalRunRegistry.get(runId) === registryEntry) {
+        globalRunRegistry.delete(runId);
+        this.#clearPubsubTopic(runId);
+      }
+      cleanedUp = true;
+    };
     const scheduleAutoCleanup = () => {
       if (autoCleanupTimer || cleanedUp || this.#cleanupTimeoutMs === 0) return;
       autoCleanupTimer = setTimeout(() => {
         if (!cleanedUp) {
-          this.#runRegistry.cleanup(runId);
-          globalRunRegistry.delete(runId);
-          this.#clearPubsubTopic(runId);
-          cleanedUp = true;
+          cleanupOwnedRegistryState();
         }
       }, this.#cleanupTimeoutMs);
     };
 
-    // 8. Register the reconstructed state and recovered stream only after
+    let workflow: ReturnType<DurableAgent<TAgentId, TTools, TOutput>['getWorkflow']>;
+    try {
+      workflow = this.getWorkflow();
+      recoveryLease.assertOwned();
+    } catch (error) {
+      await recoveryLease.release();
+      throw error;
+    }
+
+    // 4. Register the reconstructed state and recovered stream only after
     //    claiming exclusive recovery ownership.
     const {
       output,
@@ -2185,45 +2298,46 @@ export class DurableAgent<
       registryEntry,
       options,
       scheduleAutoCleanup,
-      releaseRecoveryLease,
+      recoveryLease,
     });
 
-    // 9. Re-drive the workflow from the persisted snapshot in the background
+    // 5. Re-drive the workflow from the persisted snapshot in the background
     //     and delete snapshot rows on non-suspended terminals (same contract
     //     as start()/resume()). Errors are also broadcast via `emitError` so
     //     observers on the pubsub topic see the failure. Callers who await
     //     the returned `workflowExecution` (e.g. `recoverActiveRuns()`) see
     //     the raw rejection so they can classify the run as failed.
-    const workflow = this.getWorkflow();
-    const readyForRestart = ready.catch(error => {
-      void this.emitError(runId, error as Error);
-      throw error;
-    });
-    const workflowExecution = readyForRestart
+    const workflowExecution = ready
       .then(async () => {
-        try {
-          const run = await workflow.createRun({ runId, pubsub: this.pubsub });
-          const result = await run.restart({
-            requestContext,
-            ...createObservabilityContext({ currentSpan: recoverAgentSpan }),
-          } as any);
-          // Snapshot cleanup runs for every non-suspended terminal (success or
-          // failed) so storage stays bounded — mirrors the start()/resume()
-          // contract.
-          if (result?.status && result.status !== 'suspended') {
-            await this.deleteRunSnapshots(runId);
-          }
-          if (result?.status === 'failed') {
-            const error = new Error((result as any).error?.message || 'Workflow recover failed');
-            void this.emitError(runId, error);
-            throw error;
-          }
-        } catch (error) {
-          void this.emitError(runId, error as Error);
-          throw error;
+        recoveryLease.assertOwned();
+        const run = await workflow.createRun({ runId, pubsub: this.pubsub });
+        recoveryLease.assertOwned();
+        const result = await run.restart({
+          requestContext,
+          ...createObservabilityContext({ currentSpan: recoverAgentSpan }),
+        } as any);
+        recoveryLease.assertOwned();
+        // Snapshot cleanup runs for every non-suspended terminal (success or
+        // failed) so storage stays bounded — mirrors the start()/resume()
+        // contract.
+        if (result?.status && result.status !== 'suspended') {
+          await this.deleteRunSnapshots(runId);
+        }
+        if (result?.status === 'failed') {
+          throw new Error((result as any).error?.message || 'Workflow recover failed');
         }
       })
-      .finally(releaseRecoveryLease);
+      .catch(async error => {
+        const leaseLossError = recoveryLease.getLossError();
+        if (leaseLossError) {
+          streamCleanup();
+          cleanupOwnedRegistryState();
+        }
+        const recoveryError = leaseLossError ?? error;
+        await this.#reportRecoveryFailure(runId, recoveryError);
+        throw recoveryError;
+      })
+      .finally(() => recoveryLease.release());
     const trackedRecoverEntry = globalRunRegistry.get(runId);
     if (trackedRecoverEntry) {
       trackedRecoverEntry.workflowExecution = workflowExecution;
@@ -2241,10 +2355,7 @@ export class DurableAgent<
       }
       if (!cleanedUp) {
         streamCleanup();
-        this.#runRegistry.cleanup(runId);
-        globalRunRegistry.delete(runId);
-        this.#clearPubsubTopic(runId);
-        cleanedUp = true;
+        cleanupOwnedRegistryState();
       }
     };
 

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -3,7 +3,8 @@ import { InMemoryServerCache } from '../../cache/inmemory';
 import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import { CachingPubSub } from '../../events/caching-pubsub';
 import { EventEmitterPubSub } from '../../events/event-emitter';
-import type { PubSub } from '../../events/pubsub';
+import { isLeaseProvider, NoopLeaseProvider } from '../../events/pubsub';
+import type { LeaseProvider, PubSub } from '../../events/pubsub';
 import type { Mastra } from '../../mastra';
 import { createObservabilityContext, getOrCreateSpan, SpanType, EntityType } from '../../observability';
 import { RequestContext } from '../../request-context';
@@ -39,6 +40,8 @@ import { createDurableAgenticWorkflow } from './workflows';
  */
 const CLOSE_ON_SUSPEND = Symbol('mastra.durable.closeOnSuspend');
 const RESOLVED_EXECUTION_OPTIONS = Symbol('mastra.durable.resolvedExecutionOptions');
+const RECOVERY_LEASE_TTL_MS = 30_000;
+const RECOVERY_LEASE_RENEW_INTERVAL_MS = 10_000;
 
 /**
  * Options for DurableAgent.stream()
@@ -513,6 +516,96 @@ export class DurableAgent<
   get pubsub(): PubSub {
     this.#ensurePubsubInitialized();
     return this.#cachingPubsub!;
+  }
+
+  /**
+   * Claim exclusive ownership of a recovery attempt before exposing the run
+   * through the thread stream. The thread lease cannot provide this guarantee:
+   * its owner is the logical runId, so two processes recovering the same run
+   * are indistinguishable to an idempotent lease backend.
+   */
+  async #acquireRecoveryLease(runId: string, abortController: AbortController): Promise<() => Promise<void>> {
+    const pubsub = this.pubsub;
+    const unwrap = (pubsub as { getLeaseProvider?: () => LeaseProvider | undefined }).getLeaseProvider;
+    const provider =
+      typeof unwrap === 'function'
+        ? (unwrap.call(pubsub) ?? NoopLeaseProvider)
+        : isLeaseProvider(pubsub)
+          ? pubsub
+          : NoopLeaseProvider;
+    const key = `mastra:durable-agent-recovery:v1:${JSON.stringify([this.id, runId])}`;
+    const owner = crypto.randomUUID();
+
+    let acquired: Awaited<ReturnType<LeaseProvider['acquireLease']>>;
+    try {
+      acquired = await provider.acquireLease(key, owner, RECOVERY_LEASE_TTL_MS);
+    } catch (cause) {
+      throw new MastraError(
+        {
+          id: 'DURABLE_AGENT_RECOVER_LEASE_ACQUIRE_FAILED',
+          domain: ErrorDomain.AGENT,
+          category: ErrorCategory.SYSTEM,
+          text: `DurableAgent "${this.name}" recover(${runId}): failed to acquire the recovery lease.`,
+          details: { agentName: this.name, runId },
+        },
+        cause,
+      );
+    }
+
+    if (!acquired.acquired) {
+      throw new MastraError({
+        id: 'DURABLE_AGENT_RECOVER_ALREADY_IN_PROGRESS',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text: `DurableAgent "${this.name}" recover(${runId}): another process is already recovering this run.`,
+        details: { agentName: this.name, runId },
+      });
+    }
+
+    let released = false;
+    let renewalInFlight = false;
+    const stopOnLeaseLoss = (cause?: unknown) => {
+      if (released || abortController.signal.aborted) return;
+      const error = new MastraError(
+        {
+          id: 'DURABLE_AGENT_RECOVER_LEASE_LOST',
+          domain: ErrorDomain.AGENT,
+          category: ErrorCategory.SYSTEM,
+          text: `DurableAgent "${this.name}" recover(${runId}): recovery lease was lost while the run was active.`,
+          details: { agentName: this.name, runId },
+        },
+        cause,
+      );
+      abortController.abort(error);
+      this.#mastra?.getLogger?.()?.error?.(error.message);
+    };
+    const renewalTimer = setInterval(() => {
+      if (released || renewalInFlight) return;
+      renewalInFlight = true;
+      void provider
+        .renewLease(key, owner, RECOVERY_LEASE_TTL_MS)
+        .then(renewed => {
+          if (!renewed) stopOnLeaseLoss();
+        })
+        .catch(stopOnLeaseLoss)
+        .finally(() => {
+          renewalInFlight = false;
+        });
+    }, RECOVERY_LEASE_RENEW_INTERVAL_MS);
+    renewalTimer.unref?.();
+
+    return async () => {
+      if (released) return;
+      released = true;
+      clearInterval(renewalTimer);
+      try {
+        await provider.releaseLease(key, owner);
+      } catch (error) {
+        this.#mastra
+          ?.getLogger?.()
+          ?.warn?.(`[DurableAgent] recover(${runId}) failed to release recovery lease: ${error}`);
+      }
+    };
   }
 
   /**
@@ -1893,6 +1986,7 @@ export class DurableAgent<
         );
       }
     }
+    const releaseRecoveryLease = await this.#acquireRecoveryLease(runId, abortController);
 
     const origAgentSpanData = workflowInput.agentSpanData as { traceId?: string; id?: string } | undefined;
     let recoverAgentSpan: any;
@@ -1951,12 +2045,7 @@ export class DurableAgent<
       cleanup: () => {},
     };
 
-    // 7. Register the reconstructed state in both the per-instance and global
-    //    registries so the workflow steps + terminal memory flush can find it.
-    this.#runRegistry.registerWithMessageList(runId, registryEntry, messageList, { threadId, resourceId });
-    globalRunRegistry.set(runId, { ...registryEntry, messageList });
-
-    // 8. Cleanup plumbing (mirrors stream()/resume()).
+    // 7. Cleanup plumbing (mirrors stream()/resume()).
     let cleanedUp = false;
     let autoCleanupTimer: ReturnType<typeof setTimeout> | null = null;
     const scheduleAutoCleanup = () => {
@@ -1971,67 +2060,84 @@ export class DurableAgent<
       }, this.#cleanupTimeoutMs);
     };
 
-    // 9. Skip any pubsub events broadcast before recovery started. Persistent
-    //    pubsub backends may retain chunks from the pre-crash segment; the
-    //    caller only wants events from the recovered segment forward.
-    const recoverOffset = await this.#getPubsubOffset(runId);
-
+    // 8. Build and register the recovered stream only after claiming exclusive
+    //    recovery ownership. Any setup failure releases the claim and removes
+    //    partial local state so a later recovery attempt can retry safely.
+    let setupStreamCleanup: (() => void) | undefined;
     const {
       output,
       cleanup: streamCleanup,
       ready,
-    } = createDurableAgentStream<TOutput>({
-      pubsub: this.pubsub,
-      runId,
-      messageId: workflowInput.messageId ?? crypto.randomUUID(),
-      model: {
-        modelId: workflowInput.modelConfig?.modelId,
-        provider: workflowInput.modelConfig?.provider,
-        version: 'v3',
-      },
-      threadId,
-      resourceId,
-      offset: recoverOffset,
-      onChunk: options?.onChunk,
-      experimentalTransform: options?.experimentalTransform,
-      onStepFinish: options?.onStepFinish,
-      onFinish: options?.onFinish,
-      onStreamFinished: scheduleAutoCleanup,
-      onError: async error => {
-        await options?.onError?.(error);
-        scheduleAutoCleanup();
-      },
-      onSuspended: options?.onSuspended,
-      // Recovered runs use the default `closeOnSuspend: false` — a run that
-      // suspends again should stay observable so a later resume/recover can
-      // pick it up. Callers wanting to close on suspend can call `cleanup()`
-      // from `onSuspended`.
-      messageList,
-    });
+    } = await (async () => {
+      try {
+        this.#runRegistry.registerWithMessageList(runId, registryEntry, messageList, { threadId, resourceId });
+        globalRunRegistry.set(runId, { ...registryEntry, messageList });
 
-    // 10. Register the recovered run before restarting its workflow. A client
-    //     reconnecting with only the thread target must learn which run now
-    //     owns the thread before recovered chunks can be published.
-    const recoverStreamOptions: AgentExecutionOptions<TOutput> = {
-      runId,
-      requestContext,
-      ...(threadId
-        ? {
-            memory: {
-              thread: threadId,
-              ...(resourceId ? { resource: resourceId } : {}),
-            },
-          }
-        : {}),
-    } as AgentExecutionOptions<TOutput>;
-    await agentThreadStreamRuntime.registerRun(
-      this as unknown as Agent<any, any, any, any>,
-      output,
-      recoverStreamOptions,
-      this.getPubSub(),
-    );
+        // Skip pubsub events broadcast before recovery started. Persistent
+        // backends may retain chunks from the pre-crash segment.
+        const recoverOffset = await this.#getPubsubOffset(runId);
+        const stream = createDurableAgentStream<TOutput>({
+          pubsub: this.pubsub,
+          runId,
+          messageId: workflowInput.messageId ?? crypto.randomUUID(),
+          model: {
+            modelId: workflowInput.modelConfig?.modelId,
+            provider: workflowInput.modelConfig?.provider,
+            version: 'v3',
+          },
+          threadId,
+          resourceId,
+          offset: recoverOffset,
+          onChunk: options?.onChunk,
+          experimentalTransform: options?.experimentalTransform,
+          onStepFinish: options?.onStepFinish,
+          onFinish: options?.onFinish,
+          onStreamFinished: scheduleAutoCleanup,
+          onError: async error => {
+            await options?.onError?.(error);
+            scheduleAutoCleanup();
+          },
+          onSuspended: options?.onSuspended,
+          // Recovered runs use the default `closeOnSuspend: false` — a run that
+          // suspends again should stay observable so a later resume/recover can
+          // pick it up. Callers wanting to close on suspend can call `cleanup()`
+          // from `onSuspended`.
+          messageList,
+        });
+        setupStreamCleanup = stream.cleanup;
 
-    // 11. Re-drive the workflow from the persisted snapshot in the background
+        // 10. Register the recovered run before restarting its workflow. A client
+        //     reconnecting with only the thread target must learn which run now
+        //     owns the thread before recovered chunks can be published.
+        const recoverStreamOptions: AgentExecutionOptions<TOutput> = {
+          runId,
+          requestContext,
+          ...(threadId
+            ? {
+                memory: {
+                  thread: threadId,
+                  ...(resourceId ? { resource: resourceId } : {}),
+                },
+              }
+            : {}),
+        } as AgentExecutionOptions<TOutput>;
+        await agentThreadStreamRuntime.registerRun(
+          this as unknown as Agent<any, any, any, any>,
+          stream.output,
+          recoverStreamOptions,
+          this.getPubSub(),
+        );
+        return stream;
+      } catch (error) {
+        setupStreamCleanup?.();
+        this.#runRegistry.cleanup(runId);
+        globalRunRegistry.delete(runId);
+        await releaseRecoveryLease();
+        throw error;
+      }
+    })();
+
+    // 9. Re-drive the workflow from the persisted snapshot in the background
     //     and delete snapshot rows on non-suspended terminals (same contract
     //     as start()/resume()). Errors are also broadcast via `emitError` so
     //     observers on the pubsub topic see the failure. Callers who await
@@ -2070,6 +2176,7 @@ export class DurableAgent<
     // workflow promise). Errors are already surfaced through `emitError` /
     // the stream's `onError` callback.
     workflowExecution.catch(() => {});
+    void workflowExecution.finally(releaseRecoveryLease).catch(() => {});
 
     const cleanup = () => {
       if (autoCleanupTimer) {

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -2195,7 +2195,11 @@ export class DurableAgent<
     //     the returned `workflowExecution` (e.g. `recoverActiveRuns()`) see
     //     the raw rejection so they can classify the run as failed.
     const workflow = this.getWorkflow();
-    const workflowExecution = ready
+    const readyForRestart = ready.catch(error => {
+      void this.emitError(runId, error as Error);
+      throw error;
+    });
+    const workflowExecution = readyForRestart
       .then(async () => {
         try {
           const run = await workflow.createRun({ runId, pubsub: this.pubsub });

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -21,7 +21,7 @@ import { beginGoalActivity, stopGoalActivity } from '../goal';
 import { MessageList } from '../message-list';
 import type { MessageListInput } from '../message-list';
 import { SaveQueueManager } from '../save-queue';
-import { agentThreadStreamRuntime } from '../thread-stream-runtime';
+import { AgentThreadLeaseConflictError, agentThreadStreamRuntime } from '../thread-stream-runtime';
 import type { AgentThreadRunRegistration } from '../thread-stream-runtime';
 import type { ToolsInput } from '../types';
 
@@ -851,7 +851,10 @@ export class DurableAgent<
 
   async #reportRecoveryFailure(runId: string, error: unknown): Promise<boolean> {
     const normalizedError = error instanceof Error ? error : new Error(String(error));
-    if (normalizedError instanceof MastraError && normalizedError.id === 'DURABLE_AGENT_RECOVER_LEASE_LOST') {
+    if (
+      (normalizedError instanceof MastraError && normalizedError.id === 'DURABLE_AGENT_RECOVER_LEASE_LOST') ||
+      normalizedError instanceof AgentThreadLeaseConflictError
+    ) {
       return false;
     }
 

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -202,6 +202,24 @@ type AgentThreadRuntimeState = {
 
 export type AgentThreadState = 'active' | 'idle';
 
+export type AgentThreadStrictRegistrationOptions = {
+  strict: true;
+  /**
+   * Revalidates ownership held outside this runtime (for example, a durable
+   * recovery lease). A validation failure rolls back local registration but
+   * deliberately leaves the same-run thread lease intact for the new owner.
+   */
+  validate?: () => void | Promise<void>;
+};
+
+export type AgentThreadRunRegistration = {
+  /**
+   * Remove this exact registration. Callers that lost an external ownership
+   * claim can preserve the same-run thread lease for its successor.
+   */
+  rollback(options?: { releaseLease?: boolean }): Promise<void>;
+};
+
 type SerializableAgentSignal = AgentSignal & Pick<CreatedAgentSignal, 'id' | 'createdAt'>;
 
 type AgentThreadStreamRuntimeEvent =
@@ -209,6 +227,7 @@ type AgentThreadStreamRuntimeEvent =
   | { type: 'stream-part'; runId: string; streamId: string; part: unknown; sourceId: string }
   | { type: 'run-completed'; runId: string; streamId?: string; persisted?: boolean }
   | { type: 'run-suspended'; runId: string; streamId?: string }
+  | { type: 'run-discarded'; runId: string; streamId: string }
   | { type: 'run-abort-requested'; runId: string; streamId: string }
   | { type: 'run-aborted'; runId: string; streamId?: string }
   | { type: 'run-failed'; runId: string; streamId?: string; error: string }
@@ -584,7 +603,9 @@ export class AgentThreadStreamRuntime {
     const waiters = new Set<() => void>();
     let started = false;
     let done = false;
+    let cancelled = false;
     let error: unknown;
+    let cancelSource: (() => Promise<void>) | undefined;
     // Resolves once the broadcast pump has drained the source stream AND every
     // stream-part publish has completed. Terminal events (`run-completed` /
     // `run-suspended`) must wait on this: publishing the terminal event while
@@ -639,13 +660,17 @@ export class AgentThreadStreamRuntime {
       started = true;
       void (async () => {
         try {
+          if (cancelled) return;
           const source = output.fullStream as ReadableStream<unknown> | undefined;
           if (!source) return;
 
           if (typeof source.getReader === 'function') {
             const reader = source.getReader();
+            cancelSource = async () => {
+              await reader.cancel().catch(() => {});
+            };
             try {
-              while (true) {
+              while (!cancelled) {
                 const { value: part, done: streamDone } = await reader.read();
                 if (streamDone) break;
                 await emitPart(part);
@@ -654,8 +679,31 @@ export class AgentThreadStreamRuntime {
               reader.releaseLock();
             }
           } else {
-            for await (const part of source as any) {
-              await emitPart(part);
+            const iterable = source as AsyncIterable<unknown> | Iterable<unknown>;
+            const iterator =
+              Symbol.asyncIterator in Object(iterable)
+                ? (iterable as AsyncIterable<unknown>)[Symbol.asyncIterator]()
+                : (iterable as Iterable<unknown>)[Symbol.iterator]();
+            let iteratorClosed = false;
+            const closeIterator = async () => {
+              if (iteratorClosed) return;
+              iteratorClosed = true;
+              await iterator.return?.();
+            };
+            cancelSource = async () => {
+              await closeIterator().catch(() => {});
+            };
+            try {
+              while (!cancelled) {
+                const { value: part, done: streamDone } = await iterator.next();
+                if (streamDone) {
+                  iteratorClosed = true;
+                  break;
+                }
+                await emitPart(part);
+              }
+            } finally {
+              if (!iteratorClosed) await closeIterator();
             }
           }
         } catch (caught) {
@@ -666,6 +714,21 @@ export class AgentThreadStreamRuntime {
           wake();
         }
       })();
+    };
+
+    const cancel = async () => {
+      if (cancelled) return;
+      cancelled = true;
+      if (!started) {
+        done = true;
+        resolveBroadcastFinished();
+        wake();
+        return;
+      }
+      await cancelSource?.();
+      // The pump can already be awaiting an in-flight publish. Do not let the
+      // rollback return until that work has drained and no later part can land.
+      await broadcastFinished;
     };
 
     const createStream = () => {
@@ -709,7 +772,13 @@ export class AgentThreadStreamRuntime {
       });
     };
 
-    return { output, createSubscriberStream: createStream, startBroadcast: start, broadcastFinished };
+    return {
+      output,
+      createSubscriberStream: createStream,
+      startBroadcast: start,
+      cancelBroadcast: cancel,
+      broadcastFinished,
+    };
   }
 
   #getThreadTarget(options?: { memory?: AgentExecutionOptions<any>['memory']; requestContext?: RequestContext }) {
@@ -1099,10 +1168,28 @@ export class AgentThreadStreamRuntime {
     agent: Agent<any, any, any, any>,
     output: MastraModelOutput<OUTPUT>,
     streamOptions: AgentExecutionOptions<OUTPUT>,
+    pubsub: PubSub | undefined,
+    registrationOptions: AgentThreadStrictRegistrationOptions,
+  ): Promise<AgentThreadRunRegistration> | undefined;
+  registerRun<OUTPUT>(
+    agent: Agent<any, any, any, any>,
+    output: MastraModelOutput<OUTPUT>,
+    streamOptions: AgentExecutionOptions<OUTPUT>,
     pubsub?: PubSub,
-  ): Promise<void> | undefined {
+  ): Promise<void> | undefined;
+  registerRun<OUTPUT>(
+    agent: Agent<any, any, any, any>,
+    output: MastraModelOutput<OUTPUT>,
+    streamOptions: AgentExecutionOptions<OUTPUT>,
+    pubsub?: PubSub,
+    registrationOptions?: AgentThreadStrictRegistrationOptions,
+  ): Promise<void | AgentThreadRunRegistration> | undefined {
     const { threadId, resourceId } = this.#getThreadTarget(streamOptions);
     if (!threadId) return;
+
+    if (registrationOptions?.strict) {
+      return this.#registerRunStrict(agent, output, streamOptions, pubsub, threadId, resourceId, registrationOptions);
+    }
 
     const state = this.#getState(pubsub);
     this.#sweepStaleSuspendedRecords(state, pubsub);
@@ -1181,12 +1268,158 @@ export class AgentThreadStreamRuntime {
     return registered;
   }
 
+  async #registerRunStrict<OUTPUT>(
+    agent: Agent<any, any, any, any>,
+    output: MastraModelOutput<OUTPUT>,
+    streamOptions: AgentExecutionOptions<OUTPUT>,
+    pubsub: PubSub | undefined,
+    threadId: string,
+    resourceId: string | undefined,
+    registrationOptions: AgentThreadStrictRegistrationOptions,
+  ): Promise<AgentThreadRunRegistration> {
+    await registrationOptions.validate?.();
+
+    const state = this.#getState(pubsub);
+    const key = this.#threadKey(resourceId, threadId);
+    const activeRunId = state.activeThreadRunIds.get(key);
+    const activeRecord = activeRunId ? state.threadRunsById.get(activeRunId) : undefined;
+    if (activeRecord && activeRecord.runId !== output.runId && this.#isThreadBlockingRun(state, activeRecord)) {
+      throw new Error(`Cannot register run ${output.runId}: thread is already active with run ${activeRunId}`);
+    }
+    const resolvedPubSub = this.#getPubSub(pubsub);
+    const leaseProvider = this.#getLeaseProvider(resolvedPubSub);
+    const lease = await leaseProvider.acquireLease(key, output.runId, AGENT_THREAD_LEASE_TTL_MS);
+    if (!lease.acquired) {
+      throw new Error(`Cannot register run ${output.runId}: thread lease is held by ${lease.owner ?? 'another owner'}`);
+    }
+
+    // A failed external-ownership validation means another recovery attempt may
+    // already own this same runId. Do not release its indistinguishable thread
+    // lease; its TTL or the successor registration will take over renewal.
+    await registrationOptions.validate?.();
+
+    this.#startLeaseRenewal(resolvedPubSub, key, output.runId);
+    const { streamId, streamSeq } = this.#nextStreamIdentity(state, output.runId);
+    const {
+      output: outputForSubscribers,
+      createSubscriberStream,
+      startBroadcast,
+      cancelBroadcast,
+      broadcastFinished,
+    } = this.#withBroadcastStream(output, pubsub, key, streamId);
+    const record: AgentThreadRunRecord<OUTPUT> = {
+      agent,
+      output: outputForSubscribers,
+      runId: output.runId,
+      streamId,
+      streamSeq,
+      lifecycle: 'running',
+      threadId,
+      resourceId,
+      streamOptions: streamOptions as AgentThreadRunRecord<OUTPUT>['streamOptions'],
+      createSubscriberStream,
+      suspensions: state.suspensionMetadataByRunId.get(output.runId),
+      broadcastFinished,
+    };
+
+    let rolledBack = false;
+    let registrationPublished = false;
+    let completionWatcherDisabled = false;
+    const rollback = async ({ releaseLease = true }: { releaseLease?: boolean } = {}) => {
+      if (rolledBack) return;
+      rolledBack = true;
+      completionWatcherDisabled = true;
+      await cancelBroadcast();
+
+      const ownsCurrentRecord = state.threadRunsById.get(record.runId) === record;
+      if (state.threadRunsByStreamId.get(record.streamId) === record) {
+        state.threadRunsByStreamId.delete(record.streamId);
+      }
+      state.watchedThreadStreamIds.delete(record.streamId);
+      if (ownsCurrentRecord) {
+        state.threadRunsById.delete(record.runId);
+        if (state.threadKeysByRunId.get(record.runId) === key) {
+          state.threadKeysByRunId.delete(record.runId);
+        }
+      }
+      if (
+        state.activeThreadRunIds.get(key) === record.runId &&
+        state.activeThreadStreamIds.get(key) === record.streamId
+      ) {
+        state.activeThreadRunIds.delete(key);
+        state.activeThreadStreamIds.delete(key);
+      }
+
+      // Renewal is keyed by runId, so only the current record may stop or
+      // release it; an older rollback must not disturb a newer registration.
+      if (ownsCurrentRecord) {
+        this.#stopLeaseRenewal(resolvedPubSub, record.runId);
+        if (releaseLease) {
+          await leaseProvider.releaseLease(key, record.runId).catch(() => {});
+        }
+      }
+      if (registrationPublished) await discardPublishedRegistration().catch(() => {});
+    };
+
+    const discardPublishedRegistration = async () => {
+      await this.#publishAndWait(pubsub, key, {
+        type: 'run-discarded',
+        runId: record.runId,
+        streamId: record.streamId,
+      });
+    };
+
+    state.threadRunsById.set(output.runId, record);
+    state.threadRunsByStreamId.set(streamId, record);
+    state.threadKeysByRunId.set(output.runId, key);
+    state.activeThreadRunIds.set(key, output.runId);
+    state.activeThreadStreamIds.set(key, streamId);
+
+    try {
+      await this.#publishAndWait(pubsub, key, {
+        type: 'run-registered',
+        runId: output.runId,
+        streamId,
+        streamSeq,
+        sourceId: this.#getSourceId(),
+      });
+      registrationPublished = true;
+      await registrationOptions.validate?.();
+    } catch (error) {
+      if (!rolledBack) {
+        let releaseLease = true;
+        try {
+          await registrationOptions.validate?.();
+        } catch {
+          releaseLease = false;
+        }
+        await rollback({ releaseLease });
+        // A durable backend may accept/deliver the registration and still fail
+        // its acknowledgement. `rollback` compensates every confirmed publish;
+        // an ambiguous acknowledgement also gets an idempotent discard here.
+        if (!registrationPublished) await discardPublishedRegistration().catch(() => {});
+      }
+      throw error;
+    }
+
+    const resumedToolCallId = (streamOptions as AgentExecutionOptions<OUTPUT> & { toolCallId?: string }).toolCallId;
+    if (resumedToolCallId) {
+      this.#clearSuspendedToolCall(state, output.runId, resumedToolCallId);
+    } else {
+      this.#clearSuspendedRun(state, output.runId);
+    }
+    this.#watchThreadRunCompletion(state, pubsub, key, record, undefined, () => completionWatcherDisabled);
+    startBroadcast();
+    return { rollback };
+  }
+
   #watchThreadRunCompletion(
     state: AgentThreadRuntimeState,
     pubsub: PubSub | undefined,
     key: string,
     record: AgentThreadRunRecord<any>,
     registered?: Promise<unknown>,
+    isDisabled?: () => boolean,
   ) {
     if (state.watchedThreadStreamIds.has(record.streamId)) return;
     state.watchedThreadStreamIds.add(record.streamId);
@@ -1200,6 +1433,7 @@ export class AgentThreadStreamRuntime {
     const finished = record.output._waitUntilFinished();
     void Promise.allSettled(registered ? [finished, registered] : [finished]).then(() => {
       state.watchedThreadStreamIds.delete(record.streamId);
+      if (isDisabled?.()) return;
       this.#cleanupPreparedRun(state, record.runId);
 
       if (record.output.status === 'suspended' && this.#isSuspendedRun(state, record.runId)) {
@@ -1244,6 +1478,7 @@ export class AgentThreadStreamRuntime {
       // suspended), so the broadcast pump is guaranteed to settle. Local state
       // cleanup above stays immediate.
       void Promise.resolve(record.broadcastFinished).then(() => {
+        if (isDisabled?.()) return;
         this.#publish(pubsub, key, {
           type: 'run-completed',
           runId: record.runId,
@@ -1849,6 +2084,7 @@ export class AgentThreadStreamRuntime {
     const deferredRunsByStreamId = new Map<string, AgentThreadRunRecord<any>>();
     let currentReader: ReadableStreamDefaultReader<any> | null = null;
     let activeReaderRunId: string | null = null;
+    let activeReaderStreamId: string | null = null;
     let currentRunRequestContext: RequestContext | undefined;
     let cancelledByAbort = false;
 
@@ -2027,6 +2263,30 @@ export class AgentThreadStreamRuntime {
         wake();
         return;
       }
+      if (data.type === 'run-discarded') {
+        clearActiveIfCurrent(data.runId, data.streamId);
+        localStreamIds.delete(data.streamId);
+        replayedStreamIds.delete(data.streamId);
+        for (let index = pendingRuns.length - 1; index >= 0; index--) {
+          if (pendingRuns[index]?.streamId === data.streamId) pendingRuns.splice(index, 1);
+        }
+        discardDeferredRun(data.streamId);
+        const remoteRun = remoteRuns.get(data.streamId);
+        if (remoteRun) {
+          remoteRun.done = true;
+          while (remoteRun.waiters.length) remoteRun.waiters.shift()?.();
+          while (remoteRun.finishWaiters.length) remoteRun.finishWaiters.shift()?.();
+          remoteRuns.delete(data.streamId);
+        }
+        seenStreamIds.delete(data.streamId);
+        if (activeReaderRunId === data.runId && activeReaderStreamId === data.streamId && currentReader) {
+          try {
+            void currentReader.cancel();
+          } catch {}
+        }
+        wake();
+        return;
+      }
       if (data.type === 'run-completed' || data.type === 'run-aborted' || data.type === 'run-suspended') {
         const eventStreamId = data.streamId ?? data.runId;
         const deferredRecord = deferredRunsByStreamId.get(eventStreamId);
@@ -2140,6 +2400,7 @@ export class AgentThreadStreamRuntime {
             const reader = subscriberStream.getReader();
             currentReader = reader as ReadableStreamDefaultReader<any>;
             activeReaderRunId = run.runId;
+            activeReaderStreamId = run.streamId;
             currentRunRequestContext = run.streamOptions.requestContext;
             let readerReleased = false;
             try {
@@ -2187,6 +2448,7 @@ export class AgentThreadStreamRuntime {
             } finally {
               currentReader = null;
               activeReaderRunId = null;
+              activeReaderStreamId = null;
               currentRunRequestContext = undefined;
               if (!readerReleased) {
                 reader.releaseLock();

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -60,6 +60,17 @@ const AGENT_THREAD_LEASE_RENEW_INTERVAL_MS = readPositiveIntEnv(
  */
 const AGENT_SUSPENDED_RUN_TTL_MS = readPositiveIntEnv('MASTRA_SUSPENDED_RUN_TTL_MS', 30 * 60 * 1000);
 
+export const AGENT_THREAD_LEASE_CONFLICT_CODE = 'AGENT_THREAD_LEASE_CONFLICT';
+
+export class AgentThreadLeaseConflictError extends Error {
+  readonly code = AGENT_THREAD_LEASE_CONFLICT_CODE;
+
+  constructor(runId: string, owner: string) {
+    super(`Cannot register run ${runId}: thread lease is held by ${owner}`);
+    this.name = 'AgentThreadLeaseConflictError';
+  }
+}
+
 export let defaultAgentThreadPubSub: PubSub = new EventEmitterPubSub();
 
 /**
@@ -1280,6 +1291,7 @@ export class AgentThreadStreamRuntime {
     await registrationOptions.validate?.();
 
     const state = this.#getState(pubsub);
+    this.#sweepStaleSuspendedRecords(state, pubsub);
     const key = this.#threadKey(resourceId, threadId);
     const activeRunId = state.activeThreadRunIds.get(key);
     const activeRecord = activeRunId ? state.threadRunsById.get(activeRunId) : undefined;
@@ -1290,7 +1302,7 @@ export class AgentThreadStreamRuntime {
     const leaseProvider = this.#getLeaseProvider(resolvedPubSub);
     const lease = await leaseProvider.acquireLease(key, output.runId, AGENT_THREAD_LEASE_TTL_MS);
     if (!lease.acquired) {
-      throw new Error(`Cannot register run ${output.runId}: thread lease is held by ${lease.owner ?? 'another owner'}`);
+      throw new AgentThreadLeaseConflictError(output.runId, lease.owner ?? 'another owner');
     }
 
     // A failed external-ownership validation means another recovery attempt may
@@ -1938,7 +1950,10 @@ export class AgentThreadStreamRuntime {
     const onEvent: EventCallback = async (event, ack) => {
       const data = event.data as AgentThreadStreamRuntimeEvent | undefined;
       const isTerminal =
-        (data?.type === 'run-completed' || data?.type === 'run-aborted' || data?.type === 'run-failed') &&
+        (data?.type === 'run-completed' ||
+          data?.type === 'run-aborted' ||
+          data?.type === 'run-failed' ||
+          data?.type === 'run-discarded') &&
         data.runId === runId;
       // Acknowledge every delivered event, not just the terminal one — this is a
       // private fan-out subscription, so anything left unacked stays pending on


### PR DESCRIPTION
## Description

Registers recovered durable runs with the thread-stream runtime before restarting their workflow, so a fresh `subscribeToThread({ resourceId, threadId })` client can discover the run, receive its remaining output, and observe termination.

Recovery now claims uniquely owned, renewable ownership before rehydration, re-reads the authoritative snapshot after the claim, checks ownership across asynchronous setup and restart boundaries, and rolls back only its own stream and registry state if ownership is lost. Terminal failures are published exactly once and awaited before ownership is released.

## Related issue(s)

Fixes #21343

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all CodeRabbit comments on this PR

## Validation

- `pnpm --filter @mastra/core test:unit src/agent/__tests__/agent-thread-lease.test.ts src/agent/durable/__tests__/recover-run.test.ts src/agent/durable/__tests__/recover-active-runs.test.ts src/agent/__tests__/agent-signals.test.ts` — 143 passed, 3 skipped
- `eslint` on all five changed files — passed
- `prettier --check` on all five changed files — passed
- `pnpm --filter @mastra/core check` (`tsc --noEmit`) — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a workflow restarts, new subscribers can find it and receive its remaining output and final status. The system restores the saved thread only after it obtains control of the run.

## What changed

- Acquire an exclusive, renewable recovery lease before recovery starts.
- Re-read and validate the persisted snapshot after lease acquisition.
- Strictly register the recovered run before restarting the workflow.
- Allow fresh `subscribeToThread({ resourceId, threadId })` clients to receive remaining output and terminal events without the run ID.
- Abort recovery when lease ownership is lost.
- Roll back only state owned by the failed recovery attempt.
- Release the lease after recovery settles or fails.
- Prevent concurrent recovery with `DURABLE_AGENT_RECOVER_ALREADY_IN_PROGRESS`.
- Publish terminal failures exactly once before releasing ownership.
- Handle registration, publication, acknowledgement, and subscription failures.
- Add cancellation and rollback support to the thread-stream runtime.
- Add regression tests for reconnects, concurrent recovery, stale snapshots, lease loss, cleanup, setup failures, rollback, and duplicate error events.
- Add a patch changeset for `@mastra/core`.

## Validation

- 142 tests passed.
- 3 tests skipped.
- ESLint passed.
- Prettier passed.
- TypeScript compilation passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->