### PR TITLE
fix(core): couple get_process_output's blocking wait to the run abortSignal

### DIFF
--- a/.changeset/process-wait-abort-signal.md
+++ b/.changeset/process-wait-abort-signal.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Couple the blocking wait in get_process_output to the run's abortSignal: ProcessHandle.wait() now accepts abortSignal and kills the process on abort (the same convention the process manager applies at spawn time), and the workspace tool forwards context.abortSignal, so aborting a run no longer leaves the tool blocking on a background process.

--- a/.changeset/process-wait-abort-signal.md
+++ b/.changeset/process-wait-abort-signal.md
@@ -3,3 +3,13 @@
 ---
 
 Couple the blocking wait in get_process_output to the run's abortSignal: ProcessHandle.wait() now accepts abortSignal and kills the process on abort (the same convention the process manager applies at spawn time), and the workspace tool forwards context.abortSignal, so aborting a run no longer leaves the tool blocking on a background process.
+
+```ts
+const controller = new AbortController();
+
+const result = await handle.wait({
+  abortSignal: controller.signal,
+});
+
+// controller.abort() kills the process and wait() resolves with its exit result
+```

--- a/packages/core/src/workspace/sandbox/process-manager/process-handle.test.ts
+++ b/packages/core/src/workspace/sandbox/process-manager/process-handle.test.ts
@@ -268,3 +268,58 @@ describe('ProcessHandle output retention', () => {
     expect(chunks.join('')).toBe('hello world');
   });
 });
+
+describe('ProcessHandle wait abortSignal', () => {
+  it('kills the process when the signal aborts during a blocking wait', async () => {
+    const handle = new TestProcessHandle();
+    const kill = vi.spyOn(handle, 'kill');
+    const controller = new AbortController();
+
+    const waiting = handle.wait({ abortSignal: controller.signal });
+    expect(kill).not.toHaveBeenCalled();
+
+    controller.abort();
+    expect(kill).toHaveBeenCalledTimes(1);
+
+    // The wait still settles through the normal exit path.
+    handle.finish();
+    const result = await waiting;
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('kills immediately when the signal is already aborted', async () => {
+    const handle = new TestProcessHandle();
+    const kill = vi.spyOn(handle, 'kill');
+    const controller = new AbortController();
+    controller.abort();
+
+    const waiting = handle.wait({ abortSignal: controller.signal });
+    expect(kill).toHaveBeenCalledTimes(1);
+
+    handle.finish();
+    await waiting;
+  });
+
+  it('removes the abort listener once the wait settles', async () => {
+    const handle = new TestProcessHandle();
+    const kill = vi.spyOn(handle, 'kill');
+    const controller = new AbortController();
+
+    const waiting = handle.wait({ abortSignal: controller.signal });
+    handle.finish();
+    await waiting;
+
+    // Aborting after the wait resolved must not kill a process the caller
+    // is no longer waiting on.
+    controller.abort();
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('a wait without a signal is unaffected', async () => {
+    const handle = new TestProcessHandle();
+    const waiting = handle.wait();
+    handle.finish();
+    const result = await waiting;
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/core/src/workspace/sandbox/process-manager/process-handle.test.ts
+++ b/packages/core/src/workspace/sandbox/process-manager/process-handle.test.ts
@@ -24,6 +24,7 @@ class TestProcessHandle extends ProcessHandle {
   async wait(_options?: {
     onStdout?: (data: string) => void;
     onStderr?: (data: string) => void;
+    abortSignal?: AbortSignal;
   }): Promise<CommandResult> {
     return this.waitPromise;
   }

--- a/packages/core/src/workspace/sandbox/process-manager/process-handle.ts
+++ b/packages/core/src/workspace/sandbox/process-manager/process-handle.ts
@@ -196,12 +196,18 @@ export abstract class ProcessHandle {
    * while waiting. The callbacks are automatically removed when `wait()`
    * resolves, so there's no cleanup needed by the caller.
    *
-   * Subclasses implement `wait()` with platform-specific logic — the base
+   * Optionally pass an `abortSignal` to couple the blocking wait to a caller
+   * lifetime: on abort the process is killed (mirroring the spawn-time
+   * `abortSignal` convention in {@link CommandOptions}), which lets the wait
+   * settle with the killed process's result instead of blocking forever.
+   *
+   * Subclasses implement `wait()` with platform-specific logic; the base
    * constructor wraps it to handle the optional streaming callbacks.
    */
   async wait(_options?: {
     onStdout?: (data: string) => void;
     onStderr?: (data: string) => void;
+    abortSignal?: AbortSignal;
   }): Promise<CommandResult> {
     throw new Error(`${this.constructor.name} must implement wait()`);
   }
@@ -228,9 +234,22 @@ export abstract class ProcessHandle {
     // with a wrapper that handles optional streaming callbacks.
     const implWait = this.wait.bind(this);
 
-    this.wait = async (waitOptions?: { onStdout?: (data: string) => void; onStderr?: (data: string) => void }) => {
+    this.wait = async (waitOptions?: {
+      onStdout?: (data: string) => void;
+      onStderr?: (data: string) => void;
+      abortSignal?: AbortSignal;
+    }) => {
       if (waitOptions?.onStdout) this._stdoutListeners.add(waitOptions.onStdout);
       if (waitOptions?.onStderr) this._stderrListeners.add(waitOptions.onStderr);
+      // Abort kills the process (same convention as spawn-time `abortSignal`
+      // in the process manager) so the wait settles via the normal exit path
+      // instead of blocking past the caller's lifetime.
+      const abortSignal = waitOptions?.abortSignal;
+      const onAbort = () => {
+        void this.kill().catch(() => {});
+      };
+      if (abortSignal?.aborted) onAbort();
+      else abortSignal?.addEventListener('abort', onAbort, { once: true });
       try {
         const result = await implWait();
         return {
@@ -241,6 +260,7 @@ export abstract class ProcessHandle {
           stderrDroppedBytes: this.stderrDroppedBytes,
         };
       } finally {
+        abortSignal?.removeEventListener('abort', onAbort);
         if (waitOptions?.onStdout) this._stdoutListeners.delete(waitOptions.onStdout);
         if (waitOptions?.onStderr) this._stderrListeners.delete(waitOptions.onStderr);
       }

--- a/packages/core/src/workspace/tools/get-process-output.ts
+++ b/packages/core/src/workspace/tools/get-process-output.ts
@@ -59,9 +59,14 @@ Use this after starting a background command with execute_command (background: t
         });
       }
 
-      // If wait requested, block until process exits with streaming callbacks
+      // If wait requested, block until process exits with streaming callbacks.
+      // The run's abortSignal is forwarded so aborting the run (e.g. a user
+      // stop) interrupts a blocking wait instead of outliving the turn: the
+      // handle kills the process on abort, mirroring the spawn-time
+      // `abortSignal` convention.
       if (shouldWait && handle.exitCode === undefined) {
         const result = await handle.wait({
+          abortSignal: context?.abortSignal,
           onStdout: context?.writer
             ? async (data: string) => {
                 await context.writer!.custom({


### PR DESCRIPTION
## Description

Aborting a run while `get_process_output(wait: true)` is blocked on a background process left the tool blocking until the process exited on its own. `handle.wait()` had no abort concept and the tool never forwarded `context.abortSignal`, so a stop request could not end the turn.

Two small changes that follow conventions the codebase already has:

1. `ProcessHandle.wait()` accepts an optional `abortSignal`. The base wrapper wires abort to `handle.kill()`, the same convention the process manager applies to spawn-time `abortSignal`, so the wait settles through the normal exit path with the killed process's result. The listener is removed when the wait settles, so an abort after resolution cannot kill a process nobody is waiting on.
2. `get_process_output` forwards `context.abortSignal` into the wait, matching `execute_command`, which already forwards it for foreground commands.

Production context: we have been running exactly this behavior as a local dist patch on a durable-agent deployment since core 1.52. It is what lets a user stop a turn that is blocked on a container process.

Tests: four new cases in `process-handle.test.ts`. Abort mid-wait kills the process and the wait still settles normally; an already aborted signal kills immediately; the abort listener is removed once the wait settles; a wait without a signal is unaffected.

## Related issue(s)

Fixes #21387

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a run stops, `get_process_output(wait: true)` now stops waiting for the process. This lets the run finish normally instead of remaining blocked.

## Changes

- Added optional `abortSignal` support to `ProcessHandle.wait()`.
- Kill the process when the signal is already aborted or aborts during the wait.
- Remove the abort listener after the wait settles.
- Forward `context.abortSignal` from `get_process_output`.
- Added tests for aborts during and before waits, listener cleanup, and waits without signals.
- Added a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->