### PR TITLE
perf(core): stop persisting the stepResult.request echo in agent-loop snapshots

### DIFF
--- a/.changeset/prune-step-result-request.md
+++ b/.changeset/prune-step-result-request.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Stop persisting the raw provider request echo in agent-loop snapshots: pruneAgentLoopSnapshot now drops stepResult.request (the full serialized prompt plus tool schemas, duplicated on both sides of every step result and rewritten at every step boundary; measured at 24% of all persisted snapshot bytes in production). Nothing reads it back and resume rebuilds requests from messageListState. All routing members of stepResult are preserved.

--- a/.changeset/prune-step-result-request.md
+++ b/.changeset/prune-step-result-request.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Stop persisting the raw provider request echo in agent-loop snapshots: pruneAgentLoopSnapshot now drops stepResult.request (the full serialized prompt plus tool schemas, duplicated on both sides of every step result and rewritten at every step boundary; measured at 24% of all persisted snapshot bytes in production). Nothing reads it back and resume rebuilds requests from messageListState. All routing members of stepResult are preserved.
+Reduced persisted agent-loop snapshot size by no longer storing duplicated provider request data (measured at 24% of all persisted snapshot bytes in production). Resume behavior and step routing data are unchanged.

--- a/packages/core/src/loop/workflows/prune-snapshot.test.ts
+++ b/packages/core/src/loop/workflows/prune-snapshot.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit coverage for the `stepResult.request` strip in the agent-loop snapshot
+ * pruner. The engine echoes the raw provider request (full serialized prompt
+ * plus the entire tool JSON schema) into `stepResult.request` on both sides of
+ * every step result, and the snapshot is re-persisted at every step boundary,
+ * so the echo dominates persisted bytes on long conversations. Nothing reads
+ * it back; resume rebuilds requests from `messageListState`.
+ */
+import { describe, expect, it } from 'vitest';
+import type { WorkflowRunState } from '../../workflows/types';
+import { pruneAgentLoopSnapshot } from './prune-snapshot';
+
+function requestEcho() {
+  return {
+    body: {
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'x'.repeat(2000) }] }],
+      tools: [{ type: 'function', function: { name: 'big', parameters: { blob: 'y'.repeat(2000) } } }],
+    },
+  };
+}
+
+function stepResult() {
+  return {
+    reason: 'tool-calls',
+    isContinued: true,
+    messageId: 'msg-1',
+    warnings: [],
+    totalUsage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    request: requestEcho(),
+  };
+}
+
+function snapshotWith(steps: Record<string, Record<string, unknown>>): WorkflowRunState {
+  return { context: { input: { some: 'input' }, ...steps } } as unknown as WorkflowRunState;
+}
+
+/** Deep-scans a structure for surviving `stepResult.request` occurrences. */
+function countRequestEchoes(value: unknown): number {
+  if (Array.isArray(value)) return value.reduce<number>((n, v) => n + countRequestEchoes(v), 0);
+  if (value === null || typeof value !== 'object') return 0;
+  const record = value as Record<string, unknown>;
+  let n = 0;
+  const sr = record.stepResult;
+  if (sr !== null && typeof sr === 'object' && 'request' in (sr as object)) n += 1;
+  for (const v of Object.values(record)) n += countRequestEchoes(v);
+  return n;
+}
+
+describe('pruneAgentLoopSnapshot stepResult.request strip', () => {
+  it('strips the request echo from a terminal step on both payload and output', () => {
+    const pruned = pruneAgentLoopSnapshot({
+      snapshot: snapshotWith({
+        'durable-llm-execution': {
+          status: 'success',
+          payload: { stepResult: stepResult() },
+          output: { stepResult: stepResult() },
+        },
+      }),
+    });
+
+    const step = (pruned.context as Record<string, any>)['durable-llm-execution'];
+    expect(step.payload.stepResult).not.toHaveProperty('request');
+    expect(step.output.stepResult).not.toHaveProperty('request');
+  });
+
+  it('strips non-terminal steps too, since the snapshot persists at every step boundary', () => {
+    const pruned = pruneAgentLoopSnapshot({
+      snapshot: snapshotWith({
+        'durable-tool-call': {
+          status: 'running',
+          payload: { stepResult: stepResult() },
+          output: { stepResult: stepResult() },
+        },
+      }),
+    });
+
+    expect(countRequestEchoes((pruned.context as Record<string, any>)['durable-tool-call'])).toBe(0);
+  });
+
+  it('preserves every routing field of stepResult', () => {
+    const pruned = pruneAgentLoopSnapshot({
+      snapshot: snapshotWith({
+        step: { status: 'success', output: { stepResult: stepResult() } },
+      }),
+    });
+
+    const kept = (pruned.context as Record<string, any>).step.output.stepResult;
+    expect(kept.reason).toBe('tool-calls');
+    expect(kept.isContinued).toBe(true);
+    expect(kept.messageId).toBe('msg-1');
+    expect(kept.totalUsage).toEqual({ inputTokens: 10, outputTokens: 20, totalTokens: 30 });
+    expect(kept.warnings).toEqual([]);
+  });
+
+  it('passes step results without a stepResult through unchanged', () => {
+    const pruned = pruneAgentLoopSnapshot({
+      snapshot: snapshotWith({
+        'collect-tool-results': { status: 'success', output: { toolResults: [{ result: 'ok' }] } },
+      }),
+    });
+
+    expect((pruned.context as Record<string, any>)['collect-tool-results']).toMatchObject({
+      output: { toolResults: [{ result: 'ok' }] },
+    });
+  });
+
+  it('leaves no echo anywhere in a mixed snapshot', () => {
+    const build = () =>
+      snapshotWith({
+        a: { status: 'success', payload: { stepResult: stepResult() }, output: { stepResult: stepResult() } },
+        b: { status: 'running', payload: { stepResult: stepResult() }, output: { stepResult: stepResult() } },
+        c: { status: 'success', output: { stepResult: stepResult() } },
+      });
+
+    // Self-check: the unpruned snapshot really carries 5 echoes, so the zero
+    // below cannot pass vacuously.
+    expect(countRequestEchoes(build())).toBe(5);
+    expect(countRequestEchoes(pruneAgentLoopSnapshot({ snapshot: build() }))).toBe(0);
+  });
+
+  it('is copy-on-write and does not mutate the caller snapshot', () => {
+    const original = snapshotWith({
+      step: { status: 'success', output: { stepResult: stepResult() } },
+    });
+    pruneAgentLoopSnapshot({ snapshot: original });
+
+    expect(countRequestEchoes(original)).toBe(1);
+  });
+});

--- a/packages/core/src/loop/workflows/prune-snapshot.ts
+++ b/packages/core/src/loop/workflows/prune-snapshot.ts
@@ -130,11 +130,33 @@ function stripTerminalOutputFields<T>(value: T): T {
   return pruned as T;
 }
 
+/**
+ * Drops `stepResult.request`: the raw provider request the engine echoes back
+ * into the iteration state, carrying the full serialized prompt and the entire
+ * tool JSON schema on BOTH sides of every step result, rewritten at every step
+ * boundary. Nothing reads it back (there are zero `stepResult.request` reads
+ * in the codebase) and resume rebuilds the next request from
+ * `messageListState`, never from this echo. The sibling `metadata.request` is
+ * already deleted unconditionally for exactly this reason; `stepResult` itself
+ * stays because core documents it as a preserved routing field, but `request`
+ * is the one member of it that carries no routing. Measured over 300 real
+ * production snapshots it was 86.7 MB of 360.7 MB persisted, 24% of
+ * everything written.
+ */
+function stripStepResultRequest<T>(value: T): T {
+  if (!isPlainObject(value) || !isPlainObject(value.stepResult)) return value;
+  if (!('request' in value.stepResult)) return value;
+  const { request: _request, ...stepResult } = value.stepResult;
+  return { ...value, stepResult } as T;
+}
+
 /** Applies the pruning rules to a single serialized step result. */
 function pruneStepResult(result: Record<string, any>): Record<string, any> {
   if (!isPlainObject(result) || typeof result.status !== 'string') return result;
 
   const pruned: Record<string, any> = { ...result };
+  pruned.payload = stripStepResultRequest(pruned.payload);
+  if ('output' in pruned) pruned.output = stripStepResultRequest(pruned.output);
   pruned.payload = stripHeavyIterationFields(pruned.payload);
   if ('prevOutput' in pruned) pruned.prevOutput = stripHeavyIterationFields(pruned.prevOutput);
 


### PR DESCRIPTION
## Description

`pruneAgentLoopSnapshot` now drops `stepResult.request` from step payloads and outputs, terminal and non-terminal alike. This is the raw provider request the engine echoes back into the iteration state: the full serialized prompt plus the entire tool JSON schema, stored on both sides of every step result and rewritten at every step boundary.

Measured on a production durable-agent deployment over 300 real snapshots: 86.7 MB of 360.7 MB persisted, 24% of everything written, the single largest item left after the existing pruning rules.

Why it is safe:

- There are zero `stepResult.request` reads in the codebase; resume rebuilds the next model request from `messageListState`, never from this echo.
- The pruner already deletes the sibling `metadata.request` / `metadata.response` unconditionally for the same reason.
- `stepResult` itself is a documented preserved routing field, so every routing member (`reason`, `isContinued`, `messageId`, `warnings`, `totalUsage`) stays; only `request` goes.
- Adjacent to but not covered by #21002, which dedupes `output.steps[].request` and leaves the `stepResult.request` copies whole.
- We have been running exactly this strip as a local dist patch in production since core 1.52, currently on 1.58.0, with the suspend/resume/HITL surface fully exercised.

Tests: new `prune-snapshot.test.ts` with six cases covering terminal both sides, non-terminal, routing fields preserved literally, no-stepResult passthrough, a mixed-snapshot deep scan that first self-checks the unpruned count so the zero cannot pass vacuously, and copy-on-write. The existing snapshot suites (`agent-loop-snapshot-size`, `suspended-snapshot-request-dedupe`, `serialization-invariants`) stay green.

## Related issue(s)

Fixes #21389

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR removes duplicate request data from saved agent snapshots. It reduces storage use while keeping all data needed to resume an agent loop.

## Changes

- Remove `stepResult.request` from terminal and non-terminal snapshot steps.
- Preserve all routing fields in `stepResult`.
- Apply copy-on-write pruning without changing the original snapshot.
- Add tests for pruning, mixed snapshots, missing step results, routing fields, passthrough behavior, and immutability.
- Add a changeset documenting the update.

## Impact

`stepResult.request` contains the serialized prompt and tool schema. Resume does not use this field because requests are rebuilt from `messageListState`. Removing it eliminates redundant persisted data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->