### PR TITLE
fix: fix incorrect GCS bucket name validation

### DIFF
--- a/.changeset/wide-rice-make.md
+++ b/.changeset/wide-rice-make.md
@@ -1,0 +1,7 @@
+---
+'@mastra/daytona': patch
+'@mastra/e2b': patch
+'@mastra/blaxel': patch
+---
+
+Fixed GCS mounts to accept bucket names containing underscores.

--- a/workspaces/blaxel/src/sandbox/mounts/gcs.ts
+++ b/workspaces/blaxel/src/sandbox/mounts/gcs.ts
@@ -4,7 +4,7 @@ import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
 import { shellQuote } from '../../utils/shell-quote';
 
-import { LOG_PREFIX, validateBucketName, runCommand, detectPackageManager } from './types';
+import { LOG_PREFIX, validateGCSBucketName, runCommand, detectPackageManager } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -28,7 +28,7 @@ export async function mountGCS(mountPath: string, config: BlaxelGCSMountConfig, 
   const { sandbox, logger } = ctx;
 
   // Validate inputs before interpolating into shell commands
-  validateBucketName(config.bucket);
+  validateGCSBucketName(config.bucket);
 
   const quotedMountPath = shellQuote(mountPath);
 

--- a/workspaces/blaxel/src/sandbox/mounts/s3.ts
+++ b/workspaces/blaxel/src/sandbox/mounts/s3.ts
@@ -5,7 +5,7 @@ import type { FilesystemMountConfig } from '@mastra/core/workspace';
 import { shellQuote } from '../../utils/shell-quote';
 import {
   LOG_PREFIX,
-  validateBucketName,
+  validateS3BucketName,
   validateEndpoint,
   validatePrefix,
   runCommand,
@@ -49,7 +49,7 @@ export async function mountS3(mountPath: string, config: BlaxelS3MountConfig, ct
   const { sandbox, logger } = ctx;
 
   // Validate inputs before interpolating into shell commands
-  validateBucketName(config.bucket);
+  validateS3BucketName(config.bucket);
   if (config.endpoint) {
     validateEndpoint(config.endpoint);
   }

--- a/workspaces/blaxel/src/sandbox/mounts/types.test.ts
+++ b/workspaces/blaxel/src/sandbox/mounts/types.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateGCSBucketName, validateS3BucketName } from './types';
+
+describe('bucket name validation', () => {
+  it('allows underscores in GCS bucket names', () => {
+    expect(() => validateGCSBucketName('my_gcs_bucket')).not.toThrow();
+  });
+
+  it('rejects underscores in S3 bucket names', () => {
+    expect(() => validateS3BucketName('my_s3_bucket')).toThrow('Invalid S3 bucket name');
+  });
+});

--- a/workspaces/blaxel/src/sandbox/mounts/types.ts
+++ b/workspaces/blaxel/src/sandbox/mounts/types.ts
@@ -27,16 +27,21 @@ export interface MountContext {
   };
 }
 
-/**
- * Validate a bucket name before interpolating into shell commands.
- * Covers S3, GCS, and S3-compatible (R2, MinIO) naming rules.
- */
-const SAFE_BUCKET_NAME = /^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$/;
+const SAFE_S3_BUCKET_NAME = /^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$/;
+const SAFE_GCS_BUCKET_NAME = /^[a-z0-9][a-z0-9._-]{1,61}[a-z0-9]$/;
 
-export function validateBucketName(bucket: string): void {
-  if (!SAFE_BUCKET_NAME.test(bucket)) {
+export function validateS3BucketName(bucket: string): void {
+  if (!SAFE_S3_BUCKET_NAME.test(bucket)) {
     throw new Error(
-      `Invalid bucket name: "${bucket}". Bucket names must be 3-63 characters, lowercase alphanumeric, hyphens, or dots.`,
+      `Invalid S3 bucket name: "${bucket}". Bucket names must be 3-63 characters, lowercase alphanumeric, hyphens, or dots.`,
+    );
+  }
+}
+
+export function validateGCSBucketName(bucket: string): void {
+  if (!SAFE_GCS_BUCKET_NAME.test(bucket)) {
+    throw new Error(
+      `Invalid GCS bucket name: "${bucket}". Bucket names must be 3-63 characters, lowercase alphanumeric, hyphens, underscores, or dots.`,
     );
   }
 }

--- a/workspaces/daytona/src/sandbox/mounts/gcs.ts
+++ b/workspaces/daytona/src/sandbox/mounts/gcs.ts
@@ -3,7 +3,7 @@ import { createHash } from 'node:crypto';
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
 import { shellQuote } from '../../utils/shell-quote';
-import { LOG_PREFIX, validateBucketName, validatePrefix } from './types';
+import { LOG_PREFIX, validateGCSBucketName, validatePrefix } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -31,7 +31,7 @@ export interface DaytonaGCSMountConfig extends FilesystemMountConfig {
 export async function mountGCS(mountPath: string, config: DaytonaGCSMountConfig, ctx: MountContext): Promise<void> {
   const { run, writeFile, logger } = ctx;
 
-  validateBucketName(config.bucket);
+  validateGCSBucketName(config.bucket);
 
   const quotedMountPath = shellQuote(mountPath);
 

--- a/workspaces/daytona/src/sandbox/mounts/s3.ts
+++ b/workspaces/daytona/src/sandbox/mounts/s3.ts
@@ -3,7 +3,7 @@ import { createHash } from 'node:crypto';
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
 import { shellQuote } from '../../utils/shell-quote';
-import { LOG_PREFIX, validateBucketName, validateEndpoint, validatePrefix } from './types';
+import { LOG_PREFIX, validateEndpoint, validatePrefix, validateS3BucketName } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -41,7 +41,7 @@ export interface DaytonaS3MountConfig extends FilesystemMountConfig {
 export async function mountS3(mountPath: string, config: DaytonaS3MountConfig, ctx: MountContext): Promise<void> {
   const { run, writeFile, logger } = ctx;
 
-  validateBucketName(config.bucket);
+  validateS3BucketName(config.bucket);
   if (config.endpoint) {
     validateEndpoint(config.endpoint);
   }

--- a/workspaces/daytona/src/sandbox/mounts/types.test.ts
+++ b/workspaces/daytona/src/sandbox/mounts/types.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateGCSBucketName, validateS3BucketName } from './types';
+
+describe('bucket name validation', () => {
+  it('allows underscores in GCS bucket names', () => {
+    expect(() => validateGCSBucketName('my_gcs_bucket')).not.toThrow();
+  });
+
+  it('rejects underscores in S3 bucket names', () => {
+    expect(() => validateS3BucketName('my_s3_bucket')).toThrow('Invalid S3 bucket name');
+  });
+});

--- a/workspaces/daytona/src/sandbox/mounts/types.ts
+++ b/workspaces/daytona/src/sandbox/mounts/types.ts
@@ -30,16 +30,21 @@ export interface MountContext {
   };
 }
 
-/**
- * Validate a bucket name before interpolating into shell commands.
- * Covers S3, GCS, and S3-compatible (R2, MinIO) naming rules.
- */
-const SAFE_BUCKET_NAME = /^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$/;
+const SAFE_S3_BUCKET_NAME = /^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$/;
+const SAFE_GCS_BUCKET_NAME = /^[a-z0-9][a-z0-9._-]{1,61}[a-z0-9]$/;
 
-export function validateBucketName(bucket: string): void {
-  if (!SAFE_BUCKET_NAME.test(bucket)) {
+export function validateS3BucketName(bucket: string): void {
+  if (!SAFE_S3_BUCKET_NAME.test(bucket)) {
     throw new Error(
-      `Invalid bucket name: "${bucket}". Bucket names must be 3-63 characters, lowercase alphanumeric, hyphens, or dots.`,
+      `Invalid S3 bucket name: "${bucket}". Bucket names must be 3-63 characters, lowercase alphanumeric, hyphens, or dots.`,
+    );
+  }
+}
+
+export function validateGCSBucketName(bucket: string): void {
+  if (!SAFE_GCS_BUCKET_NAME.test(bucket)) {
+    throw new Error(
+      `Invalid GCS bucket name: "${bucket}". Bucket names must be 3-63 characters, lowercase alphanumeric, hyphens, underscores, or dots.`,
     );
   }
 }

--- a/workspaces/e2b/src/sandbox/mounts/gcs.ts
+++ b/workspaces/e2b/src/sandbox/mounts/gcs.ts
@@ -3,7 +3,7 @@ import { createHash } from 'node:crypto';
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
 import { shellQuote } from '../../utils/shell-quote';
-import { LOG_PREFIX, validateBucketName, validatePrefix } from './types';
+import { LOG_PREFIX, validateGCSBucketName, validatePrefix } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -37,7 +37,7 @@ export async function mountGCS(mountPath: string, config: E2BGCSMountConfig, ctx
   const { sandbox, logger } = ctx;
 
   // Validate inputs before interpolating into shell commands
-  validateBucketName(config.bucket);
+  validateGCSBucketName(config.bucket);
 
   // Install gcsfuse if not present
   const checkResult = await sandbox.commands.run('which gcsfuse || echo "not found"');

--- a/workspaces/e2b/src/sandbox/mounts/s3.ts
+++ b/workspaces/e2b/src/sandbox/mounts/s3.ts
@@ -3,7 +3,7 @@ import { createHash } from 'node:crypto';
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
 import { shellQuote } from '../../utils/shell-quote';
-import { LOG_PREFIX, validateBucketName, validateEndpoint, validatePrefix, validateRegion } from './types';
+import { LOG_PREFIX, validateEndpoint, validatePrefix, validateRegion, validateS3BucketName } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -42,7 +42,7 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
   const { sandbox, logger } = ctx;
 
   // Validate inputs before interpolating into shell commands
-  validateBucketName(config.bucket);
+  validateS3BucketName(config.bucket);
   validateRegion(config.region);
   if (config.endpoint) {
     validateEndpoint(config.endpoint);

--- a/workspaces/e2b/src/sandbox/mounts/types.test.ts
+++ b/workspaces/e2b/src/sandbox/mounts/types.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateGCSBucketName, validateS3BucketName } from './types';
+
+describe('bucket name validation', () => {
+  it('allows underscores in GCS bucket names', () => {
+    expect(() => validateGCSBucketName('my_gcs_bucket')).not.toThrow();
+  });
+
+  it('rejects underscores in S3 bucket names', () => {
+    expect(() => validateS3BucketName('my_s3_bucket')).toThrow('Invalid S3 bucket name');
+  });
+});

--- a/workspaces/e2b/src/sandbox/mounts/types.ts
+++ b/workspaces/e2b/src/sandbox/mounts/types.ts
@@ -36,16 +36,21 @@ export interface MountOperationResult {
   error?: string;
 }
 
-/**
- * Validate a bucket name before interpolating into shell commands.
- * Covers S3, GCS, and S3-compatible (R2, MinIO) naming rules.
- */
-const SAFE_BUCKET_NAME = /^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$/;
+const SAFE_S3_BUCKET_NAME = /^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$/;
+const SAFE_GCS_BUCKET_NAME = /^[a-z0-9][a-z0-9._-]{1,61}[a-z0-9]$/;
 
-export function validateBucketName(bucket: string): void {
-  if (!SAFE_BUCKET_NAME.test(bucket)) {
+export function validateS3BucketName(bucket: string): void {
+  if (!SAFE_S3_BUCKET_NAME.test(bucket)) {
     throw new Error(
-      `Invalid bucket name: "${bucket}". Bucket names must be 3-63 characters, lowercase alphanumeric, hyphens, or dots.`,
+      `Invalid S3 bucket name: "${bucket}". Bucket names must be 3-63 characters, lowercase alphanumeric, hyphens, or dots.`,
+    );
+  }
+}
+
+export function validateGCSBucketName(bucket: string): void {
+  if (!SAFE_GCS_BUCKET_NAME.test(bucket)) {
+    throw new Error(
+      `Invalid GCS bucket name: "${bucket}". Bucket names must be 3-63 characters, lowercase alphanumeric, hyphens, underscores, or dots.`,
     );
   }
 }


### PR DESCRIPTION
## Description

GCS bucket names can contain underscores, but the validation regex used in Mastra disallowed them. This meant that GCS buckets with underscores in the name weren't usable through Mastra, despite existing.

## Related issue(s)

Closes #21392

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
