### PR TITLE
fix(core): prevent duplicate concurrent workflow resumes

### DIFF
--- a/.changeset/quiet-runs-claim.md
+++ b/.changeset/quiet-runs-claim.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/pg': patch
+---
+
+Prevent concurrent workflow resumes from executing the same suspended run more than once when using in-memory or PostgreSQL workflow storage.

--- a/packages/core/src/storage/domains/workflows/base.ts
+++ b/packages/core/src/storage/domains/workflows/base.ts
@@ -1,5 +1,12 @@
 import type { StepResult, WorkflowRunState } from '../../../workflows';
-import type { UpdateWorkflowStateOptions, WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '../../types';
+import type {
+  ClaimWorkflowResumeOptions,
+  ClaimWorkflowResumeResult,
+  UpdateWorkflowStateOptions,
+  WorkflowRun,
+  WorkflowRuns,
+  StorageListWorkflowRunsInput,
+} from '../../types';
 import { StorageDomain } from '../base';
 
 export abstract class WorkflowsStorage extends StorageDomain {
@@ -11,6 +18,14 @@ export abstract class WorkflowsStorage extends StorageDomain {
   }
 
   abstract supportsConcurrentUpdates(): boolean;
+
+  /**
+   * Atomically claims a suspended run for resumption when the storage supports it.
+   * Stores that cannot provide a compare-and-set operation return `supported: false`.
+   */
+  async claimWorkflowResume(_: ClaimWorkflowResumeOptions): Promise<ClaimWorkflowResumeResult> {
+    return { supported: false, claimed: false };
+  }
 
   abstract updateWorkflowResults({
     workflowName,

--- a/packages/core/src/storage/domains/workflows/inmemory-persist.test.ts
+++ b/packages/core/src/storage/domains/workflows/inmemory-persist.test.ts
@@ -41,4 +41,24 @@ describe('WorkflowsInMemory persistWorkflowSnapshot', () => {
     expect(new Date(second!.createdAt).getTime()).toBe(createdAtBefore);
     expect(new Date(second!.updatedAt).getTime()).toBeGreaterThan(createdAtBefore);
   });
+
+  it('claims a suspended run only once', async () => {
+    const store = new InMemoryStore();
+    const workflows = (await store.getStore('workflows'))!;
+    const workflowName = 'wf';
+    const runId = 'run-claim';
+    const snapshot = makeSnapshot(runId, 'suspended');
+
+    await workflows.persistWorkflowSnapshot({ workflowName, runId, snapshot });
+
+    const [first, second] = await Promise.all([
+      workflows.claimWorkflowResume({ workflowName, runId, expectedTimestamp: snapshot.timestamp }),
+      workflows.claimWorkflowResume({ workflowName, runId, expectedTimestamp: snapshot.timestamp }),
+    ]);
+
+    expect([first.claimed, second.claimed].filter(Boolean)).toHaveLength(1);
+    expect(first.supported).toBe(true);
+    expect(second.supported).toBe(true);
+    expect((await workflows.loadWorkflowSnapshot({ workflowName, runId }))?.status).toBe('running');
+  });
 });

--- a/packages/core/src/storage/domains/workflows/inmemory.ts
+++ b/packages/core/src/storage/domains/workflows/inmemory.ts
@@ -1,6 +1,8 @@
 import type { StepResult, WorkflowRunState } from '../../../workflows';
 import { normalizePerPage } from '../../base';
 import type {
+  ClaimWorkflowResumeOptions,
+  ClaimWorkflowResumeResult,
   StorageWorkflowRun,
   WorkflowRun,
   WorkflowRuns,
@@ -177,6 +179,31 @@ export class WorkflowsInMemory extends WorkflowsStorage {
 
   supportsConcurrentUpdates(): boolean {
     return true;
+  }
+
+  async claimWorkflowResume({
+    workflowName,
+    runId,
+    expectedTimestamp,
+  }: ClaimWorkflowResumeOptions): Promise<ClaimWorkflowResumeResult> {
+    const key = this.getWorkflowKey(workflowName, runId);
+    const run = this.db.workflows.get(key);
+
+    if (!run) {
+      return { supported: true, claimed: false };
+    }
+
+    const snapshot = typeof run.snapshot === 'string' ? JSON.parse(run.snapshot) : run.snapshot;
+    if (!snapshot || snapshot.status !== 'suspended' || snapshot.timestamp !== expectedTimestamp) {
+      return { supported: true, claimed: false };
+    }
+
+    this.db.workflows.set(key, {
+      ...run,
+      snapshot: { ...snapshot, status: 'running' },
+    });
+
+    return { supported: true, claimed: true };
   }
 
   async dangerouslyClearAll(): Promise<void> {

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -33,6 +33,17 @@ export interface WorkflowRuns {
   total: number;
 }
 
+export interface ClaimWorkflowResumeOptions {
+  workflowName: string;
+  runId: string;
+  expectedTimestamp: number;
+}
+
+export interface ClaimWorkflowResumeResult {
+  supported: boolean;
+  claimed: boolean;
+}
+
 export interface StorageWorkflowRun {
   workflow_name: string;
   run_id: string;

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -2398,6 +2398,10 @@ export class EventedRun<
 
     const resumeDataToUse = await this._validateResumeData(params.resumeData, suspendedStep);
 
+    if (!this.mastra?.pubsub) {
+      throw new Error('Mastra instance with pubsub is required for workflow execution');
+    }
+
     const resumeClaim = await workflowsStore.claimWorkflowResume({
       workflowName: this.workflowId,
       runId: this.runId,
@@ -2406,10 +2410,6 @@ export class EventedRun<
 
     if (resumeClaim.supported && !resumeClaim.claimed) {
       throw new Error('This workflow run is already being resumed or has changed since it was loaded');
-    }
-
-    if (!this.mastra?.pubsub) {
-      throw new Error('Mastra instance with pubsub is required for workflow execution');
     }
 
     this.setupAbortHandler();

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -2398,6 +2398,16 @@ export class EventedRun<
 
     const resumeDataToUse = await this._validateResumeData(params.resumeData, suspendedStep);
 
+    const resumeClaim = await workflowsStore.claimWorkflowResume({
+      workflowName: this.workflowId,
+      runId: this.runId,
+      expectedTimestamp: snapshot.timestamp,
+    });
+
+    if (resumeClaim.supported && !resumeClaim.claimed) {
+      throw new Error('This workflow run is already being resumed or has changed since it was loaded');
+    }
+
     if (!this.mastra?.pubsub) {
       throw new Error('Mastra instance with pubsub is required for workflow execution');
     }

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1353,6 +1353,7 @@ describe('concurrent stream close', () => {
   }
 
   it('closes both outputs when two resumeStream calls race for the same run', async () => {
+    let finalStepExecutions = 0;
     const suspending = createStep({
       id: 'suspending-step',
       inputSchema: z.object({}),
@@ -1366,7 +1367,10 @@ describe('concurrent stream close', () => {
       id: 'final-step',
       inputSchema: z.object({ result: z.string() }),
       outputSchema: z.object({ result: z.string() }),
-      execute: async () => ({ result: 'done' }),
+      execute: async () => {
+        finalStepExecutions += 1;
+        return { result: 'done' };
+      },
     });
 
     const workflow = createWorkflow({
@@ -1399,8 +1403,8 @@ describe('concurrent stream close', () => {
 
     expect(firstDrain.closed).toBe(true);
     expect(secondDrain.closed).toBe(true);
-    expect(firstDrain.types).toContain('workflow-finish');
-    expect(secondDrain.types).toContain('workflow-finish');
+    expect([firstDrain, secondDrain].filter(drain => drain.types.includes('workflow-finish'))).toHaveLength(1);
+    expect(finalStepExecutions).toBe(1);
   });
 
   it('closes both outputs when two timeTravelStream calls race for the same run', async () => {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -4327,6 +4327,16 @@ export class Run<
 
     const resumeDataToUse = await this._validateResumeData(params.resumeData, suspendedStep);
 
+    const resumeClaim = await workflowsStore?.claimWorkflowResume({
+      workflowName: this.workflowId,
+      runId: this.runId,
+      expectedTimestamp: snapshot.timestamp,
+    });
+
+    if (resumeClaim?.supported && !resumeClaim.claimed) {
+      throw new Error('This workflow run is already being resumed or has changed since it was loaded');
+    }
+
     let requestContextInput;
     if (params.retryCount && params.retryCount > 0 && params.requestContext) {
       requestContextInput = (params.requestContext as RequestContext).get('__mastraWorflowInputData');

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -8,6 +8,8 @@ import {
   createStorageErrorId,
 } from '@mastra/core/storage';
 import type {
+  ClaimWorkflowResumeOptions,
+  ClaimWorkflowResumeResult,
   UpdateWorkflowStateOptions,
   StorageListWorkflowRunsInput,
   WorkflowRun,
@@ -87,6 +89,52 @@ export class WorkflowsPG extends WorkflowsStorage {
 
   supportsConcurrentUpdates(): boolean {
     return true;
+  }
+
+  async claimWorkflowResume({
+    workflowName,
+    runId,
+    expectedTimestamp,
+  }: ClaimWorkflowResumeOptions): Promise<ClaimWorkflowResumeResult> {
+    try {
+      return await this.#db.client.tx(async t => {
+        const tableName = getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: getSchemaName(this.#schema) });
+        const result = await t.oneOrNone<{ snapshot: WorkflowRunState | string }>(
+          `SELECT snapshot FROM ${tableName} WHERE workflow_name = $1 AND run_id = $2 FOR UPDATE`,
+          [workflowName, runId],
+        );
+
+        if (!result) {
+          return { supported: true, claimed: false };
+        }
+
+        const snapshot = typeof result.snapshot === 'string' ? JSON.parse(result.snapshot) : result.snapshot;
+        if (!snapshot || snapshot.status !== 'suspended' || snapshot.timestamp !== expectedTimestamp) {
+          return { supported: true, claimed: false };
+        }
+
+        const updatedSnapshot = { ...snapshot, status: 'running' as const };
+        const now = new Date();
+        await t.none(
+          `UPDATE ${tableName}
+           SET snapshot = $1, "updatedAt" = $2, "updatedAtZ" = $3
+           WHERE workflow_name = $4 AND run_id = $5`,
+          [sanitizeJsonForPg(JSON.stringify(updatedSnapshot)), now, now, workflowName, runId],
+        );
+
+        return { supported: true, claimed: true };
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'CLAIM_WORKFLOW_RESUME', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { workflowName, runId },
+        },
+        error,
+      );
+    }
   }
 
   private parseWorkflowRun(row: Record<string, any>): WorkflowRun {


### PR DESCRIPTION
## Summary

- add an optional storage-backed atomic resume claim for workflow snapshots
- claim suspended runs with a timestamp compare-and-set before execution
- implement the claim for in-memory and PostgreSQL workflow storage
- cover the claim and concurrent resume behavior with regression tests

Fixes #20443

## Verification

- `git diff --check`
- `pnpm exec oxfmt --check` on changed files

The full core test/typecheck run was blocked in the sparse checkout by pre-existing missing internal workspace build artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

A workflow now gives only one caller permission to resume it. This prevents duplicate workflow steps and external side effects.

## Changes

- Added storage types and APIs for atomic workflow resume claims.
- Added in-memory claim support with timestamp validation.
- Added PostgreSQL claim support with transactional row locking.
- Updated workflow resume paths to claim suspended runs before execution.
- Added conflict errors when another caller already claimed or changed a run.
- Added regression tests for concurrent claims and single execution.
- Added a changeset for `@mastra/core` and `@mastra/pg` patch releases.

## Verification

- Passed `git diff --check`.
- Passed formatting checks on changed files.
- Full core tests and type checks were blocked by missing internal workspace build artifacts in the sparse checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->