### PR TITLE
fix(server): scope memory API to a resource for authenticated callers

### DIFF
--- a/.changeset/quiet-moons-refuse.md
+++ b/.changeset/quiet-moons-refuse.md
@@ -1,0 +1,9 @@
+---
+'@mastra/server': patch
+---
+
+Fixed the memory API returning other users' threads when server auth is configured without `mapUserToResourceId`. Previously an authenticated request that resolved to no resource ID listed, read and mutated every resource's threads instead of just its own. Those requests are now rejected with a 403.
+
+Servers with no auth provider (local development and Studio) are unaffected, and callers holding a `memory:*` or `memory:admin` permission can still enumerate across resources.
+
+Resolves https://github.com/mastra-ai/mastra/issues/18911

--- a/.changeset/quiet-moons-refuse.md
+++ b/.changeset/quiet-moons-refuse.md
@@ -2,8 +2,35 @@
 '@mastra/server': patch
 ---
 
-Fixed the memory API returning other users' threads when server auth is configured without `mapUserToResourceId`. Previously an authenticated request that resolved to no resource ID listed, read and mutated every resource's threads instead of just its own. Those requests are now rejected with a 403.
+Fixed the memory API returning other users' threads when server auth is configured without `mapUserToResourceId`. An authenticated request that resolved to no resource ID previously listed, read and mutated every resource's threads; it is now rejected with a 403.
 
-Servers with no auth provider (local development and Studio) are unaffected, and callers holding a `memory:*` or `memory:admin` permission can still enumerate across resources.
+**Before** — auth is configured, but nothing maps the user to a resource, so `GET /api/memory/threads` returned every resource's threads:
+
+```typescript
+export const mastra = new Mastra({
+  server: {
+    auth: {
+      authenticateToken: async token => verifyToken(token),
+    },
+  },
+});
+```
+
+**After** — derive the resource ID from the authenticated user, and each caller sees only their own threads:
+
+```typescript
+export const mastra = new Mastra({
+  server: {
+    auth: {
+      authenticateToken: async token => verifyToken(token),
+      mapUserToResourceId: user => user.id,
+    },
+  },
+});
+```
+
+Callers can instead pass an explicit `resourceId` on the routes that accept one, such as `GET /api/memory/threads?resourceId=user-123`.
+
+Servers with no auth provider (local development and Studio) are unaffected, an FGA provider still authorizes each thread individually, and callers holding a `memory:*` or `memory:admin` permission can still enumerate across resources.
 
 Resolves https://github.com/mastra-ai/mastra/issues/18911

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -258,6 +258,8 @@ auth: {
 
 When the resource ID is derived this way, clients can omit `memory.resource` from agent generate and stream request bodies, the server-derived value is used instead (and always takes precedence over any client-provided value). If a request uses memory and neither the body nor the request context provides a resource ID, the server responds with a 400 error.
 
+Deriving the resource ID is what scopes the memory API to a single user. When auth is configured without `mapUserToResourceId` and the client sends no `resourceId`, the server cannot tell whose data a request is for, so the memory routes reject it with a 403 instead of falling back to every resource's threads. Servers with no auth provider, and callers holding a `memory:*` or `memory:admin` permission, are unaffected.
+
 You can also set these keys manually in middleware:
 
 ```typescript

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -5,6 +5,7 @@ import { MockMemory } from '@mastra/core/memory';
 import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY, RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MASTRA_USER_PERMISSIONS_KEY } from '../constants';
 import { HTTPException } from '../http-exception';
 import {
   GET_MEMORY_STATUS_ROUTE,
@@ -348,6 +349,58 @@ describe('Memory Handlers', () => {
         perPage: 10,
         orderBy: undefined,
       });
+    });
+
+    it('should not enumerate other resources when an authenticated caller has no resource scope', async () => {
+      const mastra = new Mastra({
+        logger: false,
+        agents: { 'test-agent': mockAgent },
+      });
+
+      await mockMemory.createThread({ resourceId: 'resource-1' });
+      await mockMemory.createThread({ resourceId: 'resource-2' });
+
+      // Auth ran (a user is on the context) but mapUserToResourceId is not
+      // configured, so MASTRA_RESOURCE_ID_KEY is never set and the caller
+      // supplies no resourceId of its own.
+      const ctx = createTestContextWithReservedKeys({ mastra });
+      ctx.requestContext.set('user', { id: 'user-1' });
+
+      await expect(
+        LIST_THREADS_ROUTE.handler({
+          ...ctx,
+          agentId: 'test-agent',
+          page: 0,
+          perPage: 10,
+          resourceId: undefined,
+          metadata: undefined,
+        }),
+      ).rejects.toMatchObject({ status: 403 });
+    });
+
+    it('should still enumerate across resources for an admin caller', async () => {
+      const mastra = new Mastra({
+        logger: false,
+        agents: { 'test-agent': mockAgent },
+      });
+
+      await mockMemory.createThread({ resourceId: 'resource-1' });
+      await mockMemory.createThread({ resourceId: 'resource-2' });
+
+      const ctx = createTestContextWithReservedKeys({ mastra });
+      ctx.requestContext.set('user', { id: 'admin-1' });
+      ctx.requestContext.set(MASTRA_USER_PERMISSIONS_KEY, ['memory:*']);
+
+      const result = await LIST_THREADS_ROUTE.handler({
+        ...ctx,
+        agentId: 'test-agent',
+        page: 0,
+        perPage: 10,
+        resourceId: undefined,
+        metadata: undefined,
+      });
+
+      expect(result.total).toEqual(2);
     });
 
     it('should return paginated threads with default parameters', async () => {

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -61,7 +61,13 @@ import {
   toLocalMessage,
   toLocalOMRecord,
 } from './gateway-memory-client';
-import { validateBody, getEffectiveResourceId, getEffectiveThreadId, enforceThreadAccess } from './utils';
+import {
+  validateBody,
+  getEffectiveResourceId,
+  getEffectiveThreadId,
+  enforceThreadAccess,
+  requireResourceScope,
+} from './utils';
 
 interface MemoryContext extends Context {
   agentId?: string;
@@ -837,6 +843,9 @@ export const LIST_THREADS_ROUTE = createRoute({
     try {
       // Use effective resourceId (context key takes precedence over client-provided value)
       const effectiveResourceId = getEffectiveResourceId(requestContext, resourceId);
+      // An unscoped list returns every resource's threads, so an authenticated
+      // caller must resolve to a resource before reaching storage.
+      requireResourceScope({ mastra, requestContext, effectiveResourceId });
 
       // Gateway proxy: list threads from gateway API
       const agent = await getAgentFromContext({ mastra, agentId, requestContext });

--- a/packages/server/src/server/handlers/utils.ts
+++ b/packages/server/src/server/handlers/utils.ts
@@ -1,3 +1,4 @@
+import type { Mastra } from '@mastra/core';
 import type { MastraFGAPermissionInput } from '@mastra/core/auth/ee';
 import type { RequestContext } from '@mastra/core/di';
 import { MastraMemory } from '@mastra/core/memory';
@@ -124,7 +125,7 @@ export function requireResourceScope({
   effectiveResourceId,
   resource = 'memory',
 }: {
-  mastra?: any;
+  mastra?: Mastra;
   requestContext?: RequestContext;
   effectiveResourceId?: string;
   resource?: string;

--- a/packages/server/src/server/handlers/utils.ts
+++ b/packages/server/src/server/handlers/utils.ts
@@ -1,9 +1,10 @@
 import type { MastraFGAPermissionInput } from '@mastra/core/auth/ee';
 import type { RequestContext } from '@mastra/core/di';
 import { MastraMemory } from '@mastra/core/memory';
-import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../constants';
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY, MASTRA_USER_KEY } from '../constants';
 import { MastraFGAPermissions } from '../fga-permissions';
 import { HTTPException } from '../http-exception';
+import { hasAdminBypass } from './authorship';
 
 // Validation helper
 export function validateBody(body: Record<string, unknown>) {
@@ -97,6 +98,51 @@ export function requireEffectiveResourceId(
 }
 
 /**
+ * True when an auth provider ran and accepted the caller. `coreAuthMiddleware`
+ * writes both `MASTRA_USER_KEY` and the legacy `user` key, so either is enough.
+ */
+export function hasAuthenticatedUser(requestContext: RequestContext | undefined): boolean {
+  const user = requestContext?.get(MASTRA_USER_KEY) ?? requestContext?.get('user');
+  return !!user && typeof user === 'object';
+}
+
+/**
+ * Fails closed when an authenticated caller cannot be scoped to a resource.
+ *
+ * `getEffectiveResourceId` returns undefined when auth is configured without
+ * `mapUserToResourceId` and the caller passes no `resourceId`. Handlers that
+ * read that as "no filter" widen access to every resource, so any authenticated
+ * user can list, read or mutate another user's threads — in auth-only mode
+ * (no RBAC) the route layer has already granted full access by then.
+ *
+ * With no auth provider (local dev, Studio) there is no identity to scope to,
+ * so behaviour is unchanged.
+ */
+export function requireResourceScope({
+  mastra,
+  requestContext,
+  effectiveResourceId,
+  resource = 'memory',
+}: {
+  mastra?: any;
+  requestContext?: RequestContext;
+  effectiveResourceId?: string;
+  resource?: string;
+}): void {
+  if (effectiveResourceId) return;
+  if (!hasAuthenticatedUser(requestContext)) return;
+  // A configured FGA provider authorizes every thread individually, so an
+  // unscoped request is still checked record by record.
+  if (mastra?.getServer?.()?.fga) return;
+  if (requestContext && hasAdminBypass(requestContext, resource)) return;
+
+  throw new HTTPException(403, {
+    message:
+      'Access denied: request could not be scoped to a resource. Configure server auth with mapUserToResourceId, or pass an explicit resourceId.',
+  });
+}
+
+/**
  * Gets the effective threadId, preferring the reserved key from requestContext
  * over client-provided values for security.
  */
@@ -141,6 +187,7 @@ export async function enforceThreadAccess({
   effectiveResourceId?: string;
   permission?: MastraFGAPermissionInput;
 }): Promise<void> {
+  requireResourceScope({ mastra, requestContext, effectiveResourceId });
   await validateThreadOwnership(thread, effectiveResourceId);
 
   const fgaProvider = mastra?.getServer?.()?.fga;

--- a/packages/server/src/server/handlers/utils.ts
+++ b/packages/server/src/server/handlers/utils.ts
@@ -181,7 +181,7 @@ export async function enforceThreadAccess({
   effectiveResourceId,
   permission = MastraFGAPermissions.MEMORY_READ,
 }: {
-  mastra: any;
+  mastra: Mastra;
   requestContext?: RequestContext;
   threadId: string;
   thread?: { resourceId?: string | null } | null;


### PR DESCRIPTION
Fixes #18911

## Problem

`GET /api/memory/threads` returns every resource's threads when server auth is configured without `mapUserToResourceId`.

`getEffectiveResourceId` reads `MASTRA_RESOURCE_ID_KEY` and falls back to the client's `resourceId`. Without `mapUserToResourceId` that key is never set, so a request that also omits `resourceId` resolves to `undefined`. `LIST_THREADS_ROUTE` builds its filter only when a resource id is present, so storage is queried unfiltered.

The same gap is wider than the listing. `validateThreadOwnership` short-circuits on a falsy `effectiveResourceId`, so the thread read/update/delete/clone routes that go through `enforceThreadAccess` lose their ownership check as well. In auth-only mode (no RBAC) the route layer has already granted access by then, so any authenticated caller can read and mutate another user's threads.

## Fix

`requireResourceScope` rejects with 403 when a request carries an authenticated user but no resolvable resource id. It is applied in `LIST_THREADS_ROUTE` and in `enforceThreadAccess`, which covers the thread-scoped routes.

Deliberately unchanged:

- **No auth provider** (local dev, Studio) — there is no identity to scope to, so the unscoped listing still works.
- **FGA configured** — `filterAccessibleThreads` / `checkThreadFGA` already authorize each thread individually. Guarding earlier broke three existing FGA tests, which is what surfaced this.
- **`memory:*` / `memory:admin`** — admin enumeration still works, via the existing `hasAdminBypass`.

`SEARCH_MEMORY_ROUTE` already required a resource id through `validateBody`, so it needed no change.

## Tests

Two tests in `memory.test.ts`: an authenticated caller with no resource scope is rejected, and an admin caller still enumerates.

Against unfixed code the first fails by returning both resources' threads rather than throwing:

```
FAIL src/server/handlers/memory.test.ts > listThreadsHandler >
  should not enumerate other resources when an authenticated caller has no resource scope

AssertionError: promise resolved "{ …(5) }" instead of rejecting

- Expected
+ Received

- Error {
-   "message": "rejected promise",
+ {
+   "hasMore": false,
+   "page": 0,
+   "perPage": 10,
+   "threads": [
+     { "id": "…0002", "resourceId": "resource-2", … },
+     { "id": "…0001", "resourceId": "resource-1", … },
+   ],
+   "total": 2,
  }

 ❯ src/server/handlers/memory.test.ts:378:7
```

`@mastra/server` suite, unchanged aside from the two added tests:

| | Test Files | Tests |
|---|---|---|
| before | 15 failed \| 58 passed (73) | 5 failed \| 1783 passed \| 3 skipped \| 1 todo (1792) |
| after | 15 failed \| 58 passed (73) | 5 failed \| 1785 passed \| 3 skipped \| 1 todo (1794) |

The 15 pre-existing file failures are unrelated (agent-builder, voice, mcp, workflows) and identical in both runs. `tsc --noEmit` reports the same 443 errors before and after.

The 403 is a behaviour change for deployments currently relying on the unscoped listing, so it is described in the changeset and in `request-context.mdx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a logged-in user has no known resource ID, the server now blocks memory-thread access instead of showing threads from all users. Administrators can still view threads across resources.

## Changes

- Added `requireResourceScope` to return HTTP 403 for authenticated requests without a resolved resource ID.
- Applied the guard to thread listing and `enforceThreadAccess`, covering thread read, update, delete, and clone routes.
- Preserved unscoped behavior when no authentication provider is configured.
- Preserved FGA authorization and administrator bypass behavior.
- Added tests for rejected unscoped access and administrator enumeration.
- Documented the behavior and `mapUserToResourceId` configuration in the changeset and request-context documentation.
- Typed `mastra` parameters as `Mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->