### PR TITLE
fix(factory): preserve page when switching factories

### DIFF
--- a/.changeset/grumpy-peaches-push.md
+++ b/.changeset/grumpy-peaches-push.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory switching to keep the current section and open Overview instead of carrying session links into another Factory.

--- a/.changeset/strict-badgers-kiss.md
+++ b/.changeset/strict-badgers-kiss.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/factory': patch
+'mastra': patch
 ---
 
 Fixed Factory switching to keep the current section and open Overview instead of carrying session links into another Factory.

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/FactorySwitcher.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/FactorySwitcher.tsx
@@ -4,13 +4,14 @@ import { useMainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { Check, ChevronsUpDown, Factory as FactoryIcon, Plus } from 'lucide-react';
-import { useNavigate, useParams } from 'react-router';
+import { useLocation, useNavigate, useParams } from 'react-router';
 import { useFactoriesQuery, useFactoryQuery } from '../../../../hooks/useFactories';
-import { factoryHomePath } from '../services/factoryPaths';
+import { factorySwitchPath } from '../services/factoryPaths';
 
 /** Inline factory selection with a single Create Factory action. */
 export function FactorySwitcher() {
   const { factoryId } = useParams<{ factoryId: string }>();
+  const location = useLocation();
   const factoriesQuery = useFactoriesQuery();
   const activeFactoryQuery = useFactoryQuery(factoryId);
   const factories = factoriesQuery.data ?? [];
@@ -45,7 +46,7 @@ export function FactorySwitcher() {
           <DropdownMenu.Item
             key={factory.id}
             onSelect={() => {
-              void navigate(factoryHomePath(factory));
+              void navigate(factorySwitchPath(factory, location));
             }}
           >
             <FactoryIcon />

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/FactorySwitcherNavigation.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/FactorySwitcherNavigation.msw.test.tsx
@@ -1,0 +1,92 @@
+import { MainSidebarProvider } from '@mastra/playground-ui/components/MainSidebar';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../e2e/ui/msw-server';
+import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
+import { FactorySwitcher } from '../FactorySwitcher';
+import { factorySwitcherProjects } from './fixtures/factorySwitcher';
+
+beforeEach(() => {
+  server.use(
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () => HttpResponse.json({ projects: factorySwitcherProjects })),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/:factoryProjectId/source-control-connections`, () =>
+      HttpResponse.json({ connections: [] }),
+    ),
+  );
+});
+
+function renderFactorySwitcher(initialEntry: string) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/factories/:factoryId/*',
+        element: (
+          <MainSidebarProvider storageKey="factory-switcher-navigation" mobileBreakpoint={768}>
+            <FactorySwitcher />
+          </MainSidebarProvider>
+        ),
+      },
+    ],
+    { initialEntries: [initialEntry] },
+  );
+  renderWithProviders(<RouterProvider router={router} />);
+  return {
+    currentLocation: () => {
+      const { pathname, search, hash } = router.state.location;
+      return `${pathname}${search}${hash}`;
+    },
+  };
+}
+
+async function switchToNextFactory() {
+  const user = userEvent.setup();
+  await user.click(await screen.findByRole('button', { name: 'Select factory' }));
+  await user.click(await screen.findByRole('menuitem', { name: 'Next Factory' }));
+}
+
+describe('Factory switch navigation', () => {
+  describe('when switching from a factory board tab', () => {
+    it.each([
+      {
+        tab: 'work',
+        initialEntry: '/factories/factory-current/work?status=ready#done',
+        expectedLocation: '/factories/factory-next/work?status=ready#done',
+      },
+      {
+        tab: 'review',
+        initialEntry: '/factories/factory-current/review?status=open#queue',
+        expectedLocation: '/factories/factory-next/review?status=open#queue',
+      },
+    ])('keeps the $tab location', async ({ initialEntry, expectedLocation }) => {
+      const { currentLocation } = renderFactorySwitcher(initialEntry);
+
+      await switchToNextFactory();
+
+      expect(currentLocation()).toBe(expectedLocation);
+    });
+  });
+
+  describe('when switching from a factory-scoped session', () => {
+    it.each([
+      {
+        session: 'review',
+        initialEntry:
+          '/factories/factory-current/workspaces/review-session/threads/review-thread?resourceId=review#messages',
+      },
+      {
+        session: 'user',
+        initialEntry: '/factories/factory-current/user/threads/user-thread?resourceId=user#messages',
+      },
+    ])('opens the destination overview from a $session session', async ({ initialEntry }) => {
+      const { currentLocation } = renderFactorySwitcher(initialEntry);
+
+      await switchToNextFactory();
+
+      expect(currentLocation()).toBe('/factories/factory-next/overview');
+    });
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/FactorySwitcherNavigation.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/FactorySwitcherNavigation.msw.test.tsx
@@ -53,15 +53,16 @@ describe('Factory switch navigation', () => {
     it.each([
       {
         tab: 'work',
-        initialEntry: '/factories/factory-current/work?status=ready#done',
-        expectedLocation: '/factories/factory-next/work?status=ready#done',
+        initialEntry: '/factories/factory-current/work?teammate=factory%3Auser-a&relevance=worked&label=bug#done',
+        expectedLocation: '/factories/factory-next/work#done',
       },
       {
         tab: 'review',
-        initialEntry: '/factories/factory-current/review?status=open#queue',
-        expectedLocation: '/factories/factory-next/review?status=open#queue',
+        initialEntry:
+          '/factories/factory-current/review?teammate=github%3Aoctocat&relevance=review-requested&label=needs-review#queue',
+        expectedLocation: '/factories/factory-next/review#queue',
       },
-    ])('keeps the $tab location', async ({ initialEntry, expectedLocation }) => {
+    ])('keeps the $tab location without the previous Factory filters', async ({ initialEntry, expectedLocation }) => {
       const { currentLocation } = renderFactorySwitcher(initialEntry);
 
       await switchToNextFactory();

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/fixtures/factorySwitcher.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/fixtures/factorySwitcher.ts
@@ -1,0 +1,6 @@
+import type { FactoryProjectPayload } from '../../../services/github';
+
+export const factorySwitcherProjects = [
+  { id: 'factory-current', name: 'Current Factory' },
+  { id: 'factory-next', name: 'Next Factory' },
+] satisfies FactoryProjectPayload[];

--- a/mastracode/factory-ui/src/ui/domains/workspaces/services/factoryPaths.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/services/factoryPaths.ts
@@ -1,6 +1,21 @@
 import type { FactoryProject } from './github';
 
+const PRESERVED_FACTORY_ROUTE =
+  /^(?:\/(?:work|review|overview|metrics|rules|audit|new)|\/settings(?:\/[^/]+){0,2})\/?$/;
+
 /** Landing path for a server-backed factory project. */
 export function factoryHomePath(factory: FactoryProject): string {
   return `/factories/${factory.id}`;
+}
+
+export function factorySwitchPath(
+  factory: FactoryProject,
+  location: { pathname: string; search: string; hash: string },
+): string {
+  const homePath = factoryHomePath(factory);
+  const factoryRouteSuffix = /^\/factories\/[^/]+(\/.*)?$/.exec(location.pathname)?.[1] ?? '';
+
+  if (factoryRouteSuffix && !PRESERVED_FACTORY_ROUTE.test(factoryRouteSuffix)) return `${homePath}/overview`;
+
+  return `${homePath}${factoryRouteSuffix}${location.search}${location.hash}`;
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/services/factoryPaths.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/services/factoryPaths.ts
@@ -8,14 +8,11 @@ export function factoryHomePath(factory: FactoryProject): string {
   return `/factories/${factory.id}`;
 }
 
-export function factorySwitchPath(
-  factory: FactoryProject,
-  location: { pathname: string; search: string; hash: string },
-): string {
+export function factorySwitchPath(factory: FactoryProject, location: { pathname: string; hash: string }): string {
   const homePath = factoryHomePath(factory);
   const factoryRouteSuffix = /^\/factories\/[^/]+(\/.*)?$/.exec(location.pathname)?.[1] ?? '';
 
   if (factoryRouteSuffix && !PRESERVED_FACTORY_ROUTE.test(factoryRouteSuffix)) return `${homePath}/overview`;
 
-  return `${homePath}${factoryRouteSuffix}${location.search}${location.hash}`;
+  return `${homePath}${factoryRouteSuffix}${location.hash}`;
 }


### PR DESCRIPTION
Switching Factories from the Work or Review board used to reset the user to the new Factory's default page. It now keeps the current Factory section and hash while replacing only the Factory ID. Factory-specific teammate, relevance, and label filters are cleared so the destination board does not appear falsely empty.

Session URLs are scoped to their original Factory, so switching from a work, review, or user session opens the destination Factory's Overview instead of carrying an invalid session ID. The focused MSW navigation test covers both board tabs and scoped session routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you switch factories, the app now keeps you on the same page when possible. It also avoids carrying session links to a factory where they are not valid.

## Changes

- Preserve the current factory section, query, and hash during factory switching.
- Clear filters when switching factories.
- Redirect unsupported routes and session routes to the destination factory’s Overview.
- Add `factorySwitchPath` for route-preserving navigation.
- Update `FactorySwitcher` to use the current location during navigation.
- Add MSW tests for board tabs, hashes, filters, and scoped session routes.
- Add typed factory project fixtures.
- Add a patch changeset for `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->