### PR TITLE
feat(factory): classify issue effort and impact

### DIFF
--- a/.changeset/long-rocks-try.md
+++ b/.changeset/long-rocks-try.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved Factory issue investigations with effort and impact labels.

--- a/mastracode/factory/factory-skills/factory-triage/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-triage/SKILL.md
@@ -114,7 +114,7 @@ Find the existing marker-owned comment deterministically; never use `gh issue co
 export FACTORY_COMMENT_AUTHOR=$(gh api user --jq .login)
 COMMENT_ID=$(gh api --paginate "repos/$OWNER/$REPO/issues/$ISSUE/comments" \
   --jq '.[] | select(.user.login == env.FACTORY_COMMENT_AUTHOR and (.body | contains("<!-- mastra-factory-triage -->"))) | .id' | sort -n | head -n1)
-if [ -n "$COMMENT_ID" ]; thenhttps://github.com/mastra-ai/mastra/pull/21401/conflict?name=mastracode%252Ffactory%252Fsrc%252Fworkspace.test.ts&ancestor_oid=1c57f730bbd4d58a0f273485c2d24f2cac7c7c24&base_oid=6a2eb941a15ded90730b761e9d8ba1fb42010eb4&head_oid=2362f011ec3a13de8d7eb976ae043d8fe1f8d877
+if [ -n "$COMMENT_ID" ]; then
   gh api --method PATCH "repos/$OWNER/$REPO/issues/comments/$COMMENT_ID" -f body="$COMMENT_BODY"
 else
   gh api --method POST "repos/$OWNER/$REPO/issues/$ISSUE/comments" -f body="$COMMENT_BODY"

--- a/mastracode/factory/factory-skills/factory-triage/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-triage/SKILL.md
@@ -49,6 +49,8 @@ For each contributing area, build real understanding:
 
 Form the verdict. First, is the issue what it appears to be — genuine bug, configuration/user error, documentation gap, working-as-designed, or an XY problem? Then, what's causing it? Ground the causal chain in the code and history you traced.
 
+Choose one **effort** and one **impact** level independently from the completed investigation. Effort estimates the implementation scope; impact estimates the user or business consequence. Never derive either mechanically from severity.
+
 When multiple explanations remain plausible, pick the one the evidence best supports, record the ranking and why as an assumption, and list what would discriminate between them. Do not present candidates and wait — decide and move.
 
 ## Output contract
@@ -61,6 +63,8 @@ Write one concise **handoff** for whoever plans the fix. It must begin with the 
 **Type:** <bug|feature request|docs|question/support|maintenance|duplicate|resolved|invalid|spam|out-of-scope|other> — <one-sentence classification>
 **Route:** <Plan fix|Await approval|Ask author for info|Close as duplicate/resolved/invalid/spam/out-of-scope|Answer provided / close|No transition / refresh|Other>
 **Severity:** <🔴 critical|🟠 high|🟡 medium|🟢 low> — <short reason>
+**Effort:** <low|medium|high> — <short implementation-scope reason>
+**Impact:** <low|medium|high> — <short user/business-consequence reason>
 **Confidence:** <high|medium|low> — <short reason>
 **Next step:** <concise maintainer-facing next action>
 
@@ -84,7 +88,19 @@ Severity guide:
 - 🟡 medium — actionable bug/docs gap/behavior confusion with limited scope.
 - 🟢 low — minor issue, support question, duplicate, invalid, spam, or unclear report.
 
-Recompute the complete header and handoff on every refresh. `Route` describes the outcome of this completed investigation: use `Plan fix` for actionable issues advancing to Planning, `Await approval` for a feature or other maintainer decision, and `No transition / refresh` when Planning-or-later work is refreshed.
+Effort guide:
+
+- low — localized, well-understood work in one subsystem with straightforward tests.
+- medium — several files or interacting paths, or meaningful investigation, migration, or regression coverage.
+- high — architectural or cross-package work, broad tests, substantial uncertainty, or compatibility risk.
+
+Impact guide:
+
+- low — narrow audience or edge case with a viable workaround.
+- medium — a normal workflow is degraded or a meaningful user group is affected.
+- high — a core workflow is blocked, a widespread regression exists, or there is data, security, or correctness risk without a practical workaround.
+
+Recompute the complete header and handoff, including independent effort and impact estimates, on every refresh. `Route` describes the outcome of this completed investigation: use `Plan fix` for actionable issues advancing to Planning, `Await approval` for a feature or other maintainer decision, and `No transition / refresh` when Planning-or-later work is refreshed.
 
 ## Phase 5: GitHub Handoff & Transition
 
@@ -105,13 +121,15 @@ fi
 
 Set `COMMENT_BODY` to the marker followed by the structured handoff. Update the oldest marked comment authored by the current GitHub identity when duplicates exist; do not add another comment merely because a newer Factory comment exists. If a human deleted the marked comment, create it again.
 
-After a GitHub comment is posted or updated, reconcile the triage labels before the terminal transition:
+After a GitHub comment is posted or updated, reconcile the labels before the terminal transition:
 
 - Add `status: auto-triaged` for every GitHub issue: `gh issue edit "$ISSUE" --add-label "status: auto-triaged"`.
 - Remove `status: needs triage` when it appears in the labels fetched in Phase 1: `gh issue edit "$ISSUE" --remove-label "status: needs triage"`.
 - Add `status: needs approval` when `Route: Await approval`, or when the recommended next action needs maintainer approval or prep before someone should investigate, implement, close, or reject: `gh issue edit "$ISSUE" --add-label "status: needs approval"`.
+- Add the selected `effort:<level>` and `impact:<level>` labels from the handoff.
+- Remove only conflicting alternatives from these explicit labels: `effort:low`, `effort:medium`, `effort:high`, `impact:low`, `impact:medium`, and `impact:high`. On every initial run and refresh, keep exactly the selected effort label and exactly the selected impact label.
 
-Apply only these label mutations. Do not remove `status: needs approval` merely because a later refresh has a different route. For Linear issues, use the same structured handoff without attempting GitHub publication or label mutations.
+Apply only these label mutations. Do not remove `status: needs approval` merely because a later refresh has a different route. Do not add, remove, or derive any `trio-*` labels; leave all type, area, ownership, and unrelated labels untouched. For Linear issues, use the same structured handoff without attempting GitHub publication or label mutations.
 
 Post the same handoff as your final conversation message. Take the current stage and `expectedRevision` from the `factory-phase` signal.
 

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -299,6 +299,8 @@ describe('getFactoryWorkspace', () => {
     const typeIndex = triage.indexOf('**Type:**');
     const routeIndex = triage.indexOf('**Route:**');
     const severityIndex = triage.indexOf('**Severity:**');
+    const effortIndex = triage.indexOf('**Effort:**');
+    const impactIndex = triage.indexOf('**Impact:**');
     const confidenceIndex = triage.indexOf('**Confidence:**');
     const nextStepIndex = triage.indexOf('**Next step:**');
     const understandingIndex = triage.indexOf('### Understanding');
@@ -309,23 +311,38 @@ describe('getFactoryWorkspace', () => {
     expect(typeIndex).toBeGreaterThan(markerIndex);
     expect(routeIndex).toBeGreaterThan(typeIndex);
     expect(severityIndex).toBeGreaterThan(routeIndex);
-    expect(confidenceIndex).toBeGreaterThan(severityIndex);
+    expect(effortIndex).toBeGreaterThan(severityIndex);
+    expect(impactIndex).toBeGreaterThan(effortIndex);
+    expect(confidenceIndex).toBeGreaterThan(impactIndex);
     expect(nextStepIndex).toBeGreaterThan(confidenceIndex);
     expect(understandingIndex).toBeGreaterThan(nextStepIndex);
     expect(assumptionsIndex).toBeGreaterThan(understandingIndex);
     expect(questionsIndex).toBeGreaterThan(assumptionsIndex);
     expect(triage).toContain('Severity guide:');
+    expect(triage).toContain('Effort guide:');
+    expect(triage).toContain('Impact guide:');
+    expect(triage).toContain(
+      'Effort estimates the implementation scope; impact estimates the user or business consequence.',
+    );
+    expect(triage).toContain('including independent effort and impact estimates, on every refresh');
     expect(triage).toContain('Plan fix');
     expect(triage).toContain('Await approval');
     expect(triage).toContain('No transition / refresh');
     expect(triage).toContain('Keep the issue in its current initial stage until manually moved to planning.');
     const labelReconciliationIndex = triage.indexOf(
-      'After a GitHub comment is posted or updated, reconcile the triage labels',
+      'After a GitHub comment is posted or updated, reconcile the labels',
     );
     expect(labelReconciliationIndex).toBeGreaterThan(questionsIndex);
     expect(triage).toContain('gh issue edit "$ISSUE" --add-label "status: auto-triaged"');
     expect(triage).toContain('gh issue edit "$ISSUE" --remove-label "status: needs triage"');
     expect(triage).toContain('gh issue edit "$ISSUE" --add-label "status: needs approval"');
+    for (const label of ['effort:low', 'effort:medium', 'effort:high', 'impact:low', 'impact:medium', 'impact:high']) {
+      expect(triage).toContain(label);
+    }
+    expect(triage).toContain('Add the selected `effort:<level>` and `impact:<level>` labels from the handoff.');
+    expect(triage).toContain('Remove only conflicting alternatives from these explicit labels');
+    expect(triage).toContain('On every initial run and refresh, keep exactly the selected effort label');
+    expect(triage).toContain('Do not add, remove, or derive any `trio-*` labels');
     expect(triage).toContain('Apply only these label mutations.');
     expect(triage).toContain(
       'For Linear issues, use the same structured handoff without attempting GitHub publication or label mutations.',


### PR DESCRIPTION
Factory triage now records independent effort and impact estimates in its handoff and reconciles the matching GitHub labels on every refresh. It preserves `trio-*` and unrelated labels, and Linear triage remains comment-only.

After: a medium-effort, high-impact issue receives `effort:medium` and `impact:high`; stale alternatives are removed on later refreshes.

Tests: `pnpm --filter @mastra/factory exec vitest run src/workspace.test.ts --reporter=dot --bail=1`, `pnpm --filter @mastra/factory check`, and `pnpm --filter @mastra/factory lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory now estimates how much work an issue needs and how much it matters. It records these estimates in handoffs and keeps the matching GitHub labels up to date without changing unrelated labels.

## Changes

- Added independent `effort` and `impact` classifications to Factory triage.
- Added rating definitions and refresh requirements for both classifications.
- Added GitHub label reconciliation for `effort:<level>` and `impact:<level>`.
- Removed stale alternative effort and impact labels during refresh.
- Preserved `trio-*` and unrelated GitHub labels.
- Kept Linear triage comment-only.
- Added tests for field order, rating guidance, refresh behavior, and label reconciliation.
- Added a patch changeset for `@mastra/factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->