### PR TITLE
fix(factory): stop a failed token scrub masking the real push failure

### DIFF
--- a/.changeset/factory-push-scrub-error-masking.md
+++ b/.changeset/factory-push-scrub-error-masking.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed a failed branch push being reported as the wrong error when token cleanup also failed. The cleanup error used to replace the push error entirely, so a push blocked by network egress surfaced as a token-cleanup failure with an unrelated classification. The push failure now keeps the lead and its classification, with the cleanup failure reported alongside.
+Fixed a failed branch push being reported as a token cleanup error. When the push failed and the token cleanup failed too, the cleanup error replaced the push error, so a push blocked by the network was reported with an unrelated error code. The push error is now reported as-is with its own code, and the cleanup error is added to the end of its message.

--- a/.changeset/factory-push-scrub-error-masking.md
+++ b/.changeset/factory-push-scrub-error-masking.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed a failed branch push being reported as the wrong error when token cleanup also failed. The cleanup error used to replace the push error entirely, so a push blocked by network egress surfaced as a token-cleanup failure with an unrelated classification. The push failure now keeps the lead and its classification, with the cleanup failure reported alongside.

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -950,6 +950,24 @@ describe('withInstallToken', () => {
     expect(scrub).not.toContain('tok-secret');
   });
 
+  it('rethrows the error fn threw when the scrub also fails', async () => {
+    const sandbox = new FakeSandbox(script =>
+      script.includes('remote set-url origin') && !script.includes('x-access-token')
+        ? { exitCode: 255, stdout: '', stderr: 'error: could not lock config file .git/config' }
+        : OK,
+    );
+    const primary = new WorktreeError('git worktree add failed', 'worktree-failed');
+
+    const err = await withInstallToken(sandbox, '/workspace/hello', 'octocat/hello', 'tok-secret', async () => {
+      throw primary;
+    }).catch(e => e);
+
+    // Routes map WorktreeError and MaterializeError to different responses.
+    expect(err).toBe(primary);
+    expect(err.code).toBe('worktree-failed');
+    expect(err.message).toMatch(/git worktree add failed.*Failed to scrub installation token/s);
+  });
+
   it('rejects a malformed repo full name before touching the remote', async () => {
     const sandbox = new FakeSandbox();
     const err = await withInstallToken(sandbox, '/workspace/hello', 'evil; whoami', 'tok', async () => undefined).catch(

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -997,6 +997,22 @@ describe('pushBranch', () => {
     expect(scrub).not.toContain('tok-secret');
   });
 
+  it('keeps the push failure and its classification when the scrub also fails', async () => {
+    const sandbox = new FakeSandbox(script => {
+      if (script.includes('push -u origin')) {
+        return { exitCode: 128, stdout: '', stderr: 'fatal: unable to access: Could not resolve host: github.com' };
+      }
+      if (script.includes('remote set-url origin') && !script.includes('x-access-token')) {
+        return { exitCode: 255, stdout: '', stderr: 'error: could not lock config file .git/config' };
+      }
+      return OK;
+    });
+    const err = await pushBranch(sandbox, '/workspace/hello', 'feat/x', 'tok-secret', 'octocat/hello').catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('egress-blocked');
+    expect(err.message).toMatch(/could not reach github\.com.*Failed to scrub installation token/s);
+  });
+
   it('classifies an egress failure during push', async () => {
     const sandbox = new FakeSandbox(script =>
       script.includes('push -u origin')

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -585,9 +585,10 @@ async function scrubRemote(
 }
 
 /**
- * Scrub after `primary` already failed and return the error to throw: the
- * primary keeps the lead and its classification, a failed scrub is appended
- * to it instead of masking it.
+ * Scrub after `primary` already failed and return the error to throw. A failed
+ * scrub is appended to `primary` rather than replacing it, so the caller gets
+ * the error it would have had without the scrub — same class, same `code` —
+ * carrying the leaked-token warning in its message.
  */
 async function scrubbedFailure(
   sandbox: MaterializationSandbox,
@@ -599,15 +600,15 @@ async function scrubbedFailure(
 ): Promise<unknown> {
   try {
     await scrubRemote(sandbox, workdir, repoFullName, tokenInRemote);
+    return primary;
   } catch (scrubError) {
-    const primaryMessage = primary instanceof Error ? primary.message : String(primary);
     const scrubMessage = scrubError instanceof Error ? scrubError.message : String(scrubError);
-    return new MaterializeError(
-      `${primaryMessage} — additionally: ${scrubMessage}`,
-      primary instanceof MaterializeError ? primary.code : fallback,
-    );
+    if (!(primary instanceof Error)) {
+      return new MaterializeError(`${String(primary)} — additionally: ${scrubMessage}`, fallback);
+    }
+    primary.message = `${primary.message} — additionally: ${scrubMessage}`;
+    return primary;
   }
-  return primary;
 }
 
 /**
@@ -736,9 +737,9 @@ export async function configureGitIdentity(
  *
  * Once the tokenized URL is installed a failed scrub may leave the token
  * persisted, so it is always surfaced: on its own after a successful `fn`,
- * appended after `fn`'s own failure otherwise — the primary failure keeps the
- * lead and its classification. Only a failed set-url (the token never reached
- * the remote) downgrades the scrub to best-effort.
+ * appended to `fn`'s own error otherwise — `fn`'s error is never replaced.
+ * Only a failed set-url (the token never reached the remote) downgrades the
+ * scrub to best-effort.
  */
 export async function withInstallToken<T>(
   sandbox: MaterializationSandbox,

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -406,17 +406,7 @@ async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<voi
     // config. The scrub must never hide the actionable failure, but once the
     // token reached the remote its own failure can't stay silent either:
     // report both, primary cause and classification first.
-    try {
-      await scrubRemote(sandbox, workdir, repo, tokenInRemote);
-    } catch (scrubError) {
-      const primaryMessage = primary instanceof Error ? primary.message : String(primary);
-      const scrubMessage = scrubError instanceof Error ? scrubError.message : String(scrubError);
-      throw new MaterializeError(
-        `${primaryMessage} — additionally: ${scrubMessage}`,
-        primary instanceof MaterializeError ? primary.code : 'pull-failed',
-      );
-    }
-    throw primary;
+    throw await scrubbedFailure(sandbox, workdir, repo, tokenInRemote, primary, 'pull-failed');
   }
 
   // 3b. Success — the token is in the remote and the workdir has a `.git`, so
@@ -595,6 +585,32 @@ async function scrubRemote(
 }
 
 /**
+ * Scrub after `primary` already failed and return the error to throw: the
+ * primary keeps the lead and its classification, a failed scrub is appended
+ * to it instead of masking it.
+ */
+async function scrubbedFailure(
+  sandbox: MaterializationSandbox,
+  workdir: string,
+  repoFullName: string,
+  tokenInRemote: boolean,
+  primary: unknown,
+  fallback: MaterializeError['code'],
+): Promise<unknown> {
+  try {
+    await scrubRemote(sandbox, workdir, repoFullName, tokenInRemote);
+  } catch (scrubError) {
+    const primaryMessage = primary instanceof Error ? primary.message : String(primary);
+    const scrubMessage = scrubError instanceof Error ? scrubError.message : String(scrubError);
+    return new MaterializeError(
+      `${primaryMessage} — additionally: ${scrubMessage}`,
+      primary instanceof MaterializeError ? primary.code : fallback,
+    );
+  }
+  return primary;
+}
+
+/**
  * True when a failed `git pull --ff-only` on re-open just means the current
  * branch can't be fast-forwarded — not that anything is broken. The shared
  * workdir is routinely left on a session's working branch, which may have
@@ -649,8 +665,8 @@ function classifyGitFailure(
 //
 // These helpers let the sandbox author and push commits safely. The install
 // token is short-lived, minted per-operation server-side, injected only into
-// the temporary remote URL inside the sandbox, and always scrubbed in a
-// `finally` so it never persists in `.git/config`.
+// the temporary remote URL inside the sandbox, and always scrubbed afterwards
+// so it never persists in `.git/config`.
 // ---------------------------------------------------------------------------
 
 /**
@@ -714,13 +730,15 @@ export async function configureGitIdentity(
 
 /**
  * Temporarily rewrite `origin` to a tokenized URL, run `fn` (e.g. a push), and
- * **always** scrub the remote back to the tokenless URL in a `finally`. The
- * token therefore only ever lives in the remote URL for the duration of the
+ * **always** scrub the remote back to the tokenless URL afterwards. The token
+ * therefore only ever lives in the remote URL for the duration of the
  * operation and is never left in the VM's git config.
  *
- * Once the tokenized URL is installed the scrub must succeed — a leaked token
- * is a hard error that outranks even `fn`'s own failure. Only a failed
- * set-url (the token never reached the remote) downgrades it to best-effort.
+ * Once the tokenized URL is installed a failed scrub may leave the token
+ * persisted, so it is always surfaced: on its own after a successful `fn`,
+ * appended after `fn`'s own failure otherwise — the primary failure keeps the
+ * lead and its classification. Only a failed set-url (the token never reached
+ * the remote) downgrades the scrub to best-effort.
  */
 export async function withInstallToken<T>(
   sandbox: MaterializationSandbox,
@@ -743,14 +761,16 @@ export async function withInstallToken<T>(
     throw new MaterializeError(`Failed to set git remote: ${setUrl.stderr.trim()}`, 'push-failed');
   }
 
+  let result: T;
   try {
-    return await fn();
-  } finally {
-    // Always restore the tokenless remote. The workdir has a `.git` (we just
-    // rewrote its remote) so a scrub failure means the token may still persist
-    // — surface it.
-    await scrubRemote(sandbox, workdir, repoFullName, true);
+    result = await fn();
+  } catch (primary) {
+    throw await scrubbedFailure(sandbox, workdir, repoFullName, true, primary, 'push-failed');
   }
+  // Restore the tokenless remote. The workdir has a `.git` (we just rewrote
+  // its remote) so a scrub failure means the token may still persist — surface it.
+  await scrubRemote(sandbox, workdir, repoFullName, true);
+  return result;
 }
 
 /**


### PR DESCRIPTION
A push that failed for a real reason could be reported as a token-cleanup failure instead, with the wrong error classification. `withInstallToken` scrubbed the tokenized remote in a `finally`, so when the push failed and the scrub failed too, the scrub error replaced the push error entirely — and it carried code `pull-failed` in a push flow, so anything switching on the classification got the wrong case: a push blocked by egress never surfaced as `egress-blocked`.

Stacked on #21338, which introduced the primary-first combine for materialize; this applies the same rule to the push flow and dedupes both call sites into one `scrubbedFailure` helper. The push failure keeps the lead and its classification, the failed scrub is appended after it, and a scrub failure after a successful push still surfaces on its own — security behaviour is unchanged, only which error wins when both fail.

The regression test reproduces a DNS-blocked push plus a locked git config: on the base branch it fails with `expected 'pull-failed' to be 'egress-blocked'`, which is exactly the bug. Tests (90), tsc, eslint and prettier all pass on the factory package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a push and its cleanup both fail, the push error remains visible and the cleanup error is added after it. When the push succeeds but cleanup fails, the cleanup error is reported.

## Changes

- Preserved the original push error and classification when token scrubbing fails.
- Added the shared `scrubbedFailure` helper.
- Added regression tests for `withInstallToken` and `pushBranch`.
- Added a patch changeset for `@mastra/factory`.
- Factory tests, TypeScript checks, ESLint, and Prettier pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->