### PR TITLE
fix(playground-ui): flatten the plain step marker

### DIFF
--- a/.changeset/quiet-steps-marker.md
+++ b/.changeset/quiet-steps-marker.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Flattened the step markers in the `plain` variant of `ProcessStepListItem`. A completed step now shows a green check on its own instead of a filled green disc with a glow behind it, and the pending, running and completed markers finally share the same diameter — the dashed pending circle used to be 28px next to an 11px spinner.

--- a/packages/playground-ui/src/ds/components/Steps/process-step-list-item.test.tsx
+++ b/packages/playground-ui/src/ds/components/Steps/process-step-list-item.test.tsx
@@ -36,4 +36,17 @@ describe('ProcessStepListItem', () => {
     render(<ProcessStepListItem step={step} isActive position={2} variant="plain" />);
     expect(cardOf('Cloning repository')?.classList.contains('bg-surface3')).toBe(false);
   });
+
+  it('drops the filled disc and its glow from a completed marker in the plain variant', () => {
+    const completed: ProcessStep = { ...step, status: 'success', isActive: false };
+
+    render(<ProcessStepListItem step={completed} isActive={false} position={2} />);
+    expect(document.querySelector('.bg-accent1Dark.shadow-glow-accent1')).toBeTruthy();
+
+    cleanup();
+
+    render(<ProcessStepListItem step={completed} isActive={false} position={2} variant="plain" />);
+    expect(document.querySelector('.bg-accent1Dark')).toBeNull();
+    expect(document.querySelector('.shadow-glow-accent1')).toBeNull();
+  });
 });

--- a/packages/playground-ui/src/ds/components/Steps/process-step-list-item.tsx
+++ b/packages/playground-ui/src/ds/components/Steps/process-step-list-item.tsx
@@ -5,6 +5,62 @@ import { cn } from '@/lib/utils';
 
 type ProcessStepListItemVariant = 'default' | 'plain';
 
+/** Same ring geometry and stroke as `<Spinner size="sm" />`, so pending and running read as one shape. */
+function PendingRing() {
+  return (
+    <svg viewBox="0 0 24 24" className="text-neutral2" aria-hidden>
+      <circle
+        cx="12"
+        cy="12"
+        r="8.5"
+        pathLength="48"
+        fill="none"
+        stroke="currentcolor"
+        strokeWidth="2.8"
+        strokeLinecap="round"
+        strokeDasharray="3 3"
+      />
+    </svg>
+  );
+}
+
+function StepStatusMarker({ status, variant }: { status: string; variant: ProcessStepListItemVariant }) {
+  if (variant === 'plain') {
+    return (
+      <span
+        className={cn('flex size-4 items-center justify-center self-center [&>svg]:size-4', transitions.colors, {
+          '[&>svg]:text-positive1': status === 'success',
+          '[&>svg]:text-negative1': status === 'failed',
+        })}
+      >
+        {status === 'pending' ? <PendingRing /> : getStatusIcon(status)}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        'flex size-7 items-center justify-center self-center rounded-full motion-reduce:transition-none',
+        transitions.colors,
+        transitions.transform,
+        transitions.shadow,
+        {
+          '[&>svg]:text-notice-success-fg': status === 'success',
+          '[&>svg]:text-notice-destructive-fg': status === 'failed',
+          'border border-dashed border-neutral2': status === 'pending',
+          '[&>svg]:size-4': status !== 'running',
+          'bg-accent1Dark shadow-glow-accent1': status === 'success',
+          'bg-accent2Dark shadow-glow-accent2': status === 'failed',
+          'scale-110': status === 'success' || status === 'failed',
+        },
+      )}
+    >
+      {getStatusIcon(status)}
+    </span>
+  );
+}
+
 export type ProcessStepListItemProps = {
   /** @deprecated Ignored — the heading comes from `step.title`. */
   stepId?: string;
@@ -51,25 +107,7 @@ export function ProcessStepListItem({ step, isActive, position, variant = 'defau
           )}
         </div>
       </div>
-      <div
-        className={cn(
-          'flex size-7 items-center justify-center self-center rounded-full motion-reduce:transition-none',
-          transitions.colors,
-          transitions.transform,
-          transitions.shadow,
-          {
-            'border border-dashed border-neutral2': step.status === 'pending',
-            '[&>svg]:size-4': step.status !== 'running',
-            '[&>svg]:text-notice-success-fg': step.status === 'success',
-            '[&>svg]:text-notice-destructive-fg': step.status === 'failed',
-            'bg-accent1Dark shadow-glow-accent1': step.status === 'success',
-            'bg-accent2Dark shadow-glow-accent2': step.status === 'failed',
-            'scale-110': step.status === 'success' || step.status === 'failed',
-          },
-        )}
-      >
-        {getStatusIcon(step.status)}
-      </div>
+      <StepStatusMarker status={step.status} variant={variant} />
     </div>
   );
 }


### PR DESCRIPTION
The session prepare checklist in Factory now reads as a quiet list of statuses instead of three markers drawn at three different sizes with a green halo around the finished ones.

Before, a completed step was a filled green disc with a glow behind it, scaled up by 10%, while the step still waiting was a 28px dashed circle and the running one an 11px spinner. Side by side that reads as three unrelated shapes, and the glow gives a routine "sandbox is ready" the weight of a celebration. Now the completed step is a green check on its own, and the pending ring is drawn with the spinner's exact geometry — same radius, same stroke — so pending, running and done all sit at the same diameter.

I kept this scoped to the `plain` variant of `ProcessStepListItem`, the one Factory uses, so the template installation screen in the playground keeps the look it ships with today. One thing that fell out of removing the disc: the check was using `notice-success-fg`, which is the on-success-surface color and is nearly white in dark mode — correct on a green disc, invisible-ish without one. It now uses `positive1`, so the check stays green in both themes.

Screenshots are from the `Navigation/Steps` storybook, `PlainEmbedded` story.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR makes step markers in the plain UI smaller and clearer. Completed steps show a simple green check, while pending steps use a ring that matches the spinner.

## Changes

- Added reusable `PendingRing` and `StepStatusMarker` components.
- Updated the `plain` variant to:
  - Remove the filled disc and glow from completed and failed markers.
  - Show a standalone green check for completed steps.
  - Align the pending ring with the spinner radius and stroke geometry.
  - Use `positive1` for the completion check color.
- Preserved the existing default marker styling and template installation screen appearance.
- Added a test for completed marker classes in the default and `plain` variants.
- Added a patch changeset for `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->