### PR TITLE
fix(playground-ui): keep code colors while a streamed fence grows

### DIFF
--- a/.changeset/lucky-donkeys-repeat.md
+++ b/.changeset/lucky-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed code blocks flickering between colored and plain text while an agent streams a fenced snippet. Syntax highlighting runs one frame behind the text, and every delta used to throw the previous colors away before the new ones arrived. The settled part of the snippet now keeps its colors and only the characters that just landed wait, uncolored, for the next highlighting pass.

--- a/.changeset/lucky-donkeys-repeat.md
+++ b/.changeset/lucky-donkeys-repeat.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed code blocks flickering between colored and plain text while an agent streams a fenced snippet. Syntax highlighting runs one frame behind the text, and every delta used to throw the previous colors away before the new ones arrived. The settled part of the snippet now keeps its colors and only the characters that just landed wait, uncolored, for the next highlighting pass.
+Fixed code blocks flickering between colored and plain text while an agent streams a fenced snippet. The part already highlighted now keeps its colors, and only the characters that just landed show uncolored until highlighting catches up.

--- a/packages/playground-ui/src/ds/components/Code/code.test.tsx
+++ b/packages/playground-ui/src/ds/components/Code/code.test.tsx
@@ -24,6 +24,16 @@ function lineTokens(code: string) {
   return code.split('\n').map(line => [{ content: line }]);
 }
 
+/** Highlighting that only lands when the test says so, like a pass trailing the streamed text. */
+function deferredHighlight() {
+  const pending: Array<() => void> = [];
+  vi.mocked(highlight).mockImplementation(
+    code => new Promise(resolve => pending.push(() => resolve(lineTokens(code)))),
+  );
+
+  return () => act(async () => pending.shift()?.());
+}
+
 beforeEach(() => {
   vi.mocked(highlight).mockImplementation(singleToken);
 });
@@ -61,13 +71,10 @@ describe('Code', () => {
   });
 
   it('keeps the settled colors and the full text while a streamed tail is still highlighting', async () => {
-    const pending: Array<() => void> = [];
-    vi.mocked(highlight).mockImplementation(
-      code => new Promise(resolve => pending.push(() => resolve(lineTokens(code)))),
-    );
+    const settle = deferredHighlight();
 
     const { container, rerender } = render(<Code code="const a" lang="typescript" />);
-    await act(async () => pending.shift()?.());
+    await settle();
 
     rerender(<Code code="const a = 1" lang="typescript" />);
 
@@ -78,18 +85,30 @@ describe('Code', () => {
   });
 
   it('falls back to plain text when the code is rewritten rather than appended to', async () => {
-    const pending: Array<() => void> = [];
-    vi.mocked(highlight).mockImplementation(
-      code => new Promise(resolve => pending.push(() => resolve(lineTokens(code)))),
-    );
+    const settle = deferredHighlight();
 
-    const { rerender } = render(<Code code="const a" lang="typescript" />);
-    await act(async () => pending.shift()?.());
+    const { container, rerender } = render(<Code code="const a" lang="typescript" />);
+    await settle();
 
     rerender(<Code code="let b" lang="typescript" />);
 
-    const pre = screen.getByText('let b');
+    const pre = container.querySelector('pre');
 
-    expect(pre.querySelector('.shiki-token')).toBeNull();
+    expect(pre?.querySelector('.shiki-token')).toBeNull();
+    expect(pre?.textContent).toBe('let b');
+  });
+
+  it('drops the colors when the language changes under unchanged code', async () => {
+    const settle = deferredHighlight();
+
+    const { container, rerender } = render(<Code code="const a" lang="typescript" />);
+    await settle();
+
+    rerender(<Code code="const a" lang="python" />);
+
+    const pre = container.querySelector('pre');
+
+    expect(pre?.querySelector('.shiki-token')).toBeNull();
+    expect(pre?.textContent).toBe('const a');
   });
 });

--- a/packages/playground-ui/src/ds/components/Code/code.test.tsx
+++ b/packages/playground-ui/src/ds/components/Code/code.test.tsx
@@ -1,25 +1,36 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { highlight } from '../CodeEditor/highlight';
 import { Code } from './code';
 
-vi.mock('../CodeEditor/highlight', () => ({
-  highlight: vi.fn(async () => [
-    [
-      {
-        content: 'const',
-        htmlStyle: {
-          '--shiki-light': '#24292f',
-          '--shiki-dark': '#c9d1d9',
-        },
+const singleToken = vi.hoisted(() => async () => [
+  [
+    {
+      content: 'const',
+      htmlStyle: {
+        '--shiki-light': '#24292f',
+        '--shiki-dark': '#c9d1d9',
       },
-    ],
-  ]),
-}));
+    },
+  ],
+]);
+
+vi.mock('../CodeEditor/highlight', () => ({ highlight: vi.fn() }));
+
+/** One token per line, so the rendered tokens spell out exactly the code they came from. */
+function lineTokens(code: string) {
+  return code.split('\n').map(line => [{ content: line }]);
+}
+
+beforeEach(() => {
+  vi.mocked(highlight).mockImplementation(singleToken);
+});
 
 afterEach(() => {
   cleanup();
+  vi.mocked(highlight).mockReset();
 });
 
 describe('Code', () => {
@@ -47,5 +58,38 @@ describe('Code', () => {
     render(<Code code="x" className="custom-class" />);
 
     expect(screen.getByText('x').classList.contains('custom-class')).toBe(true);
+  });
+
+  it('keeps the settled colors and the full text while a streamed tail is still highlighting', async () => {
+    const pending: Array<() => void> = [];
+    vi.mocked(highlight).mockImplementation(
+      code => new Promise(resolve => pending.push(() => resolve(lineTokens(code)))),
+    );
+
+    const { container, rerender } = render(<Code code="const a" lang="typescript" />);
+    await act(async () => pending.shift()?.());
+
+    rerender(<Code code="const a = 1" lang="typescript" />);
+
+    const pre = container.querySelector('pre');
+
+    expect(pre?.querySelector('.shiki-token')?.textContent).toBe('const a');
+    expect(pre?.textContent).toBe('const a = 1');
+  });
+
+  it('falls back to plain text when the code is rewritten rather than appended to', async () => {
+    const pending: Array<() => void> = [];
+    vi.mocked(highlight).mockImplementation(
+      code => new Promise(resolve => pending.push(() => resolve(lineTokens(code)))),
+    );
+
+    const { rerender } = render(<Code code="const a" lang="typescript" />);
+    await act(async () => pending.shift()?.());
+
+    rerender(<Code code="let b" lang="typescript" />);
+
+    const pre = screen.getByText('let b');
+
+    expect(pre.querySelector('.shiki-token')).toBeNull();
   });
 });

--- a/packages/playground-ui/src/ds/components/Code/code.tsx
+++ b/packages/playground-ui/src/ds/components/Code/code.tsx
@@ -16,6 +16,18 @@ function tokenStyle(token: ThemedToken): React.CSSProperties | undefined {
   return token.color ? { color: token.color } : undefined;
 }
 
+interface Highlighted {
+  code: string;
+  lang: string;
+  tokens: ThemedToken[][];
+}
+
+/** Colors from an earlier pass still hold when the new code only appends to the old. */
+function usableHighlight(highlighted: Highlighted | null, code: string, lang?: string): Highlighted | null {
+  if (!highlighted || highlighted.lang !== lang) return null;
+  return code.startsWith(highlighted.code) ? highlighted : null;
+}
+
 /**
  * Low-level shiki token renderer shared by `CodeBlock` and `MarkdownRenderer`.
  * Dual-theme colors stay as `--shiki-light` / `--shiki-dark` CSS variables on
@@ -23,39 +35,46 @@ function tokenStyle(token: ThemedToken): React.CSSProperties | undefined {
  * the `.dark` root class, so theme switching is pure CSS — no ThemeProvider
  * required. Renders plain text while highlighting is pending or when the
  * language is missing/unknown.
+ *
+ * A streaming fence re-renders on every delta while highlighting stays a frame
+ * behind. Dropping the previous tokens each time would strobe the whole block
+ * between colored and plain, so the settled prefix keeps its colors and only
+ * the newly arrived tail waits, uncolored, for the next pass.
  */
 export const Code = React.memo(function Code({ code, lang, ...props }: CodeProps) {
-  const [tokens, setTokens] = React.useState<ThemedToken[][] | null>(null);
+  const [highlighted, setHighlighted] = React.useState<Highlighted | null>(null);
 
   React.useEffect(() => {
-    setTokens(null);
-    if (!lang) return;
+    if (!lang) {
+      setHighlighted(null);
+      return;
+    }
 
     let cancelled = false;
 
     void highlight(code, lang)
-      .then(result => {
-        if (!cancelled) setTokens(result);
+      .then(tokens => {
+        if (!cancelled && tokens?.length) setHighlighted({ code, lang, tokens });
       })
-      .catch(() => {
-        if (!cancelled) setTokens(null);
-      });
+      .catch(() => {});
 
     return () => {
       cancelled = true;
     };
   }, [code, lang]);
 
-  if (!tokens?.length) {
+  const usable = usableHighlight(highlighted, code, lang);
+  if (!usable) {
     return <pre {...props}>{code}</pre>;
   }
 
+  const tail = code.slice(usable.code.length);
   let codeOffset = 0;
 
   return (
     <pre {...props}>
       <code>
-        {tokens.map((line, lineIndex) => {
+        {usable.tokens.map((line, lineIndex) => {
           const lineOffset = codeOffset;
           let tokenOffset = lineOffset;
           const tokenSpans = line.map(token => {
@@ -74,10 +93,11 @@ export const Code = React.memo(function Code({ code, lang, ...props }: CodeProps
           return (
             <React.Fragment key={lineOffset}>
               <span>{tokenSpans}</span>
-              {lineIndex !== tokens.length - 1 && '\n'}
+              {lineIndex !== usable.tokens.length - 1 && '\n'}
             </React.Fragment>
           );
         })}
+        {tail}
       </code>
     </pre>
   );


### PR DESCRIPTION
A code block written by the agent no longer strobes between colored and plain while it streams.

Before, a fenced code block being streamed flickered on every delta: the shared shiki renderer cleared its tokens as soon as the code string changed, so between that clear and the async re-highlight the whole block fell back to plain text. At a few deltas per second that reads as a strobe. Now the colors from the previous pass hold while the next pass runs, and the characters that arrived since are appended as plain text at the end, so the block grows instead of blinking.

The keep-or-drop decision is a prefix check: colors are reused only when the new code starts with the code they were computed from and the language is unchanged. A rewrite rather than an append drops back to plain text instead of painting stale colors onto shifted text. Clearing on every change was deliberate in the original — it is what guaranteed colors could never lag behind the text — so I kept that guarantee and narrowed it to the case that actually needs it.

The test pins both halves at once: the settled prefix keeps its token spans, and the full text including the not-yet-highlighted tail is on screen. It fails against the old implementation.

First of three stacked PRs on streaming render. The next two are perf/markdown-renderer-memo and feat/markdown-stream-word-fade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The playground no longer makes streaming code blocks flash between colored and plain text. It keeps existing highlighting and shows new text as plain until highlighting finishes.

## Changes

- Reuse highlighted tokens when code is appended in the same language.
- Discard old tokens when code is rewritten or the language changes.
- Keep usable tokens when highlighting fails.
- Add tests for appended text, rewritten code, and language changes.
- Add a patch changeset for `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->