### PR TITLE
perf(playground-ui): memoize the markdown renderer

### DIFF
--- a/.changeset/olive-hoops-tickle.md
+++ b/.changeset/olive-hoops-tickle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved chat responsiveness on long conversations. `MarkdownRenderer` is memoized, so a streaming reply no longer re-parses the markdown of every message already on screen on each chunk it receives — only the message actually being written is re-parsed.

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.memo.test.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.memo.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MarkdownRenderer } from './markdown-renderer';
+
+const parsed = vi.hoisted(() => [] as string[]);
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => {
+    parsed.push(children);
+    return <div>{children}</div>;
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  parsed.length = 0;
+});
+
+/** A settled message next to something that re-renders on every streamed delta. */
+function Transcript({ settled }: { settled: string }) {
+  const [tick, setTick] = useState(0);
+
+  return (
+    <>
+      <button onClick={() => setTick(tick + 1)}>tick {tick}</button>
+      <MarkdownRenderer>{settled}</MarkdownRenderer>
+    </>
+  );
+}
+
+describe('MarkdownRenderer memoization', () => {
+  it('does not re-parse a message whose text has not changed', () => {
+    const { getByRole } = render(<Transcript settled="already **done**" />);
+
+    fireEvent.click(getByRole('button'));
+    fireEvent.click(getByRole('button'));
+
+    expect(parsed).toEqual(['already **done**']);
+  });
+});

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { MouseEvent, MouseEventHandler, ReactNode } from 'react';
 import Markdown from 'react-markdown';
 import type { Components, ExtraProps } from 'react-markdown';
@@ -20,8 +21,16 @@ export interface MarkdownRendererProps {
  * Renders a markdown string. Agent output can carry attacker-influenced text
  * (file contents, tool output, web pages): react-markdown escapes raw HTML and
  * drops dangerous link schemes, so nothing here reaches the DOM as markup.
+ *
+ * Memoized because react-markdown re-parses on every render and a streaming
+ * reply re-renders its whole transcript on every delta: without this, each
+ * chunk re-parses every settled message on the page as well as the live one.
  */
-export function MarkdownRenderer({ children, className, externalLinkTarget = 'tab' }: MarkdownRendererProps) {
+export const MarkdownRenderer = memo(function MarkdownRenderer({
+  children,
+  className,
+  externalLinkTarget = 'tab',
+}: MarkdownRendererProps) {
   return (
     <Markdown
       remarkPlugins={[remarkGfm]}
@@ -31,7 +40,7 @@ export function MarkdownRenderer({ children, className, externalLinkTarget = 'ta
       {decodeEscapedNewlines(children)}
     </Markdown>
   );
-}
+});
 
 // Agent networks emit their text with literal `\n`. Only unescape when the text
 // has no real newline, otherwise a `"a\nb"` inside a code fence gets shredded.


### PR DESCRIPTION
A long transcript no longer re-parses every settled message each time a chunk of the live reply arrives.

react-markdown parses its input on every render, and a streaming reply re-renders the whole transcript on every delta. So a conversation with forty settled messages re-parsed all forty, plus the one being written, for each chunk — work that grows with the length of the conversation and is thrown away unchanged every single time.

MarkdownRenderer is now memoized. Its props are a string and two optional flags, so the default shallow compare is exactly right and settled messages stop re-parsing entirely. That is one line of real change; the rest of the diff is a test that counts parses through a mocked react-markdown and sees three instead of one without the memo.

This does not touch the message being written — that one legitimately re-parses on every chunk and stays quadratic in its own length. I looked at splitting it into memoized blocks and decided against it for now: only one message streams at a time, so the memo above is most of the win, and block splitting is only worth its complexity if measurement shows a single long reply still janks.

Second of three stacked PRs. Based on fix/markdown-code-highlight-flicker; review that one first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Playground now remembers rendered messages that have not changed. This prevents settled messages from being processed again while a live message continues to update.

## Changes

- Wrapped `MarkdownRenderer` with React `memo`.
- Added a Vitest test that verifies unchanged markdown is parsed only once.
- Added a patch release changeset for `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->