### PR TITLE
fix(factory): observational memory ignores stored settings in web user sessions

### DIFF
--- a/.changeset/hot-ideas-tap.md
+++ b/.changeset/hot-ideas-tap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed observational memory in Factory web user sessions ignoring the stored memory settings. Sessions created from the web UI now start with the observer and reflector models, thresholds, and attachment preferences saved in your memory settings, instead of falling back to the built-in default model — which failed with a missing API key error when that provider was not configured.

--- a/.changeset/spicy-hands-shake.md
+++ b/.changeset/spicy-hands-shake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added a `blocking` option to `AgentController.onSessionCreated`. Blocking listeners are awaited before `createSession()` resolves, so hosts can seed session state (for example observational-memory settings loaded from storage) before the caller can start a run. Blocking listeners run sequentially in registration order before fire-and-forget listeners are notified. Listener failures remain isolated and logged; default (non-blocking) listeners keep their fire-and-forget behavior.

--- a/.changeset/spicy-hands-shake.md
+++ b/.changeset/spicy-hands-shake.md
@@ -3,3 +3,17 @@
 ---
 
 Added a `blocking` option to `AgentController.onSessionCreated`. Blocking listeners are awaited before `createSession()` resolves, so hosts can seed session state (for example observational-memory settings loaded from storage) before the caller can start a run. Blocking listeners run sequentially in registration order before fire-and-forget listeners are notified. Listener failures remain isolated and logged; default (non-blocking) listeners keep their fire-and-forget behavior.
+
+```ts
+controller.onSessionCreated(
+  async session => {
+    // Runs before createSession() resolves for a newly materialized session.
+    const settings = await loadSettings(session.identity.getResourceId());
+    if (settings) await session.state.set(settings);
+  },
+  { blocking: true },
+);
+
+// Default listeners stay fire-and-forget.
+controller.onSessionCreated(session => audit(session));
+```

--- a/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
+++ b/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
@@ -404,6 +404,31 @@ const session = await controller.getSessionByResource('project-42', 'editor-wind
 
 Returns: `Promise<Session<TState> | undefined>`
 
+#### `onSessionCreated(listener, options?)`
+
+Subscribe to process-local notifications after `createSession()` materializes a new live session. Listener errors are isolated and don't prevent other listeners from running. Call the returned function to unsubscribe.
+
+By default listeners are fire-and-forget. Pass `{ blocking: true }` to make `createSession()` await the listener before resolving the new session, so the host can prepare session state before the caller can start a run. Blocking listeners run sequentially in registration order, before fire-and-forget listeners are notified. A blocking listener must not call `createSession()` for the same `(resourceId, scope)` pair — that call would await its own hydration and deadlock.
+
+```typescript
+const unsubscribe = controller.onSessionCreated(
+  async session => {
+    const settings = await loadSettings(session.identity.getResourceId())
+    if (settings) await session.state.set(settings)
+  },
+  { blocking: true },
+)
+
+// Default listeners stay fire-and-forget.
+controller.onSessionCreated(session => {
+  console.log(`Created ${session.identity.getResourceId()}`)
+})
+```
+
+Listeners run once per newly materialized session, not for cached sessions returned by later `createSession()` calls. They run only in the current process and aren't persisted events.
+
+Returns: `() => void`
+
 #### `onSessionDeleted(listener)`
 
 Subscribe to process-local notifications after `deleteSession()` tears down a live session. Listener errors are isolated and don't prevent other listeners from running. Call the returned function to unsubscribe.

--- a/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
+++ b/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
@@ -408,7 +408,7 @@ Returns: `Promise<Session<TState> | undefined>`
 
 Subscribe to process-local notifications after `createSession()` materializes a new live session. Listener errors are isolated and don't prevent other listeners from running. Call the returned function to unsubscribe.
 
-By default listeners are fire-and-forget. Pass `{ blocking: true }` to make `createSession()` await the listener before resolving the new session, so the host can prepare session state before the caller can start a run. Blocking listeners run sequentially in registration order, before fire-and-forget listeners are notified. A blocking listener must not call `createSession()` for the same `(resourceId, scope)` pair — that call would await its own hydration and deadlock.
+By default listeners are fire-and-forget. Pass `{ blocking: true }` to make `createSession()` await the listener before resolving the new session, so the host can prepare session state before the caller can start a run. Blocking listeners run sequentially in registration order, before fire-and-forget listeners are notified. A blocking listener must not call `createSession()` for the same `(resourceId, scope)` pair. That call would await its own hydration and deadlock.
 
 ```typescript
 const unsubscribe = controller.onSessionCreated(

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -16,6 +16,9 @@ import type * as surfaceModule from './routes/surface.js';
 import type * as tenantCredentialsModule from './routes/tenant-credentials.js';
 import { defaultFactoryRules, DEFAULT_FACTORY_RULE_VERSION } from './rules/defaults.js';
 import type * as dispatcherModule from './rules/dispatcher.js';
+import type { MemorySettingsStorage } from './storage/domains/memory-settings/base.js';
+import type { FactoryProjectsStorage } from './storage/domains/projects/base.js';
+import type { SourceControlStorage } from './storage/domains/source-control/base.js';
 import type { WorkItemsStorage } from './storage/domains/work-items/base.js';
 import { getFactoryWorkspace } from './workspace.js';
 /** A real in-memory FactoryStorage with init spied for boot-order assertions. */
@@ -185,6 +188,75 @@ describe('MastraFactory.prepare', () => {
     // The overlapping call must not double-run one-time adapter init.
     expect(auth.init).toHaveBeenCalledOnce();
     expect(prepareMock).toHaveBeenCalledOnce();
+  });
+
+  it('registers a blocking session-created listener that seeds stored OM settings', async () => {
+    const storage = fakeStorage();
+    const factory = new MastraFactory({ storage });
+    await factory.prepare();
+
+    const blockingCall = controllerMock.onSessionCreated.mock.calls.find(
+      call => (call[1] as { blocking?: boolean } | undefined)?.blocking === true,
+    );
+    expect(blockingCall).toBeDefined();
+
+    // Seed the owner's web session row and stored memory settings through the
+    // same storage domains the factory registered.
+    await storage.init();
+    const sourceControl = storage.getDomain<SourceControlStorage>('source-control').forIntegration('github');
+    const project = await storage
+      .getDomain<FactoryProjectsStorage>('projects')
+      .create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Mastra' } });
+    const installation = await sourceControl.installations.upsert({
+      orgId: 'org-1',
+      connectedByUserId: 'user-1',
+      externalId: '123',
+    });
+    const repository = await sourceControl.repositories.upsert({
+      orgId: 'org-1',
+      input: { installationId: installation.id, externalId: '456', slug: 'mastra-ai/mastra', defaultBranch: 'main' },
+    });
+    const connection = await sourceControl.connections.create({
+      orgId: 'org-1',
+      factoryProjectId: project.id,
+      installationId: installation.id,
+      createdByUserId: 'user-1',
+    });
+    const projectRepository = await sourceControl.projectRepositories.link({
+      orgId: 'org-1',
+      connectionId: connection.id,
+      repositoryId: repository.id,
+      createdByUserId: 'user-1',
+      sandboxProvider: 'local',
+      sandboxWorkdir: '/sandbox/mastra',
+    });
+    await sourceControl.sessions.create({
+      sessionId: 'session-1',
+      projectRepositoryId: projectRepository.id,
+      orgId: 'org-1',
+      userId: 'user-1',
+      branch: 'user/session-1',
+      baseBranch: 'main',
+    });
+    await storage.getDomain<MemorySettingsStorage>('memory-settings').patch({
+      orgId: 'org-1',
+      userId: 'user-1',
+      patch: { observerModelId: 'anthropic/claude-haiku-4-5', reflectorModelId: 'anthropic/claude-haiku-4-5' },
+    });
+
+    const session = {
+      identity: { getResourceId: () => 'session-1' },
+      om: {
+        observer: { modelId: () => undefined, switchModel: vi.fn().mockResolvedValue(undefined) },
+        reflector: { modelId: () => undefined, switchModel: vi.fn().mockResolvedValue(undefined) },
+      },
+      state: { get: () => ({}), set: vi.fn().mockResolvedValue(undefined) },
+    };
+
+    await (blockingCall![0] as (session: unknown) => Promise<void>)(session);
+
+    expect(session.om.observer.switchModel).toHaveBeenCalledWith({ modelId: 'anthropic/claude-haiku-4-5' });
+    expect(session.om.reflector.switchModel).toHaveBeenCalledWith({ modelId: 'anthropic/claude-haiku-4-5' });
   });
 
   it('constructs an enabled sandbox fleet from the configured machine', async () => {

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -67,6 +67,7 @@ import { observeSessionCheckpoint } from './session/checkpoint-capture.js';
 import { observeSessionFilesystem } from './session/filesystem-capture.js';
 import { observeSessionFirstExec } from './session/first-exec-capture.js';
 import { observeSessionFirstMessage } from './session/first-message-capture.js';
+import { hydrateSessionMemorySettings } from './session/memory-settings-hydration.js';
 import { createSpaStaticMiddleware, resolveUiDistDir } from './spa-static.js';
 import { createStateSigner } from './state-signing.js';
 import { observeAgentGitAction } from './storage/domains/audit/agent-audit.js';
@@ -820,6 +821,19 @@ export class MastraFactory {
         sourceControl: sourceControlStorage.forIntegration('github'),
       });
     });
+
+    // Blocking: `createSession` awaits this seed, so when hydration succeeds
+    // a session's first run starts with the owner's stored OM settings.
+    // Best-effort — failures are logged inside the helper, never thrown, and
+    // the session then falls back to its persisted/default OM configuration.
+    prepared.base.controller.onSessionCreated(
+      session =>
+        hydrateSessionMemorySettings(session, {
+          sourceControl: sourceControlStorage.forIntegration('github'),
+          memorySettings: memorySettingsStorage,
+        }),
+      { blocking: true },
+    );
 
     this.#prepared = prepared;
     this.#factoryProcessor = factoryProcessor;

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -15,6 +15,11 @@ import type { ApiRoute } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 
 import type { Context } from 'hono';
+import {
+  applyStoredMemorySettings,
+  DEFAULT_OBSERVATION_THRESHOLD,
+  DEFAULT_REFLECTION_THRESHOLD,
+} from '../session/memory-settings-hydration.js';
 import type {
   CredentialRecord,
   LoginSessionKind,
@@ -488,10 +493,6 @@ async function applyPackToSession({
 // user in the Factory app database. Requests with an active session also apply
 // changes immediately to that session's state and thread settings.
 
-/** Default thresholds mirror the TUI `/om` fallbacks. */
-const DEFAULT_OBSERVATION_THRESHOLD = 30_000;
-const DEFAULT_REFLECTION_THRESHOLD = 40_000;
-
 /** Read the current OM config from a session. */
 export interface OMConfigInfo {
   observerModelId: string;
@@ -600,38 +601,6 @@ async function persistMemorySettings(
   fillIfUnset?: MemorySettingsFillIfUnset,
 ): Promise<void> {
   await context.storage.patch({ orgId: context.orgId, userId: context.userId, patch, fillIfUnset });
-}
-
-/**
- * Apply the stored memory-settings row onto the session, so the DB — not
- * whatever happens to sit in persisted session state (e.g. a stale boot-time
- * seed from before memory settings moved to the DB) — is what the web surface
- * reads and what the session's OM actually runs with. The row is authoritative:
- * knobs without a stored value reset to the built-in defaults.
- */
-async function hydrateSessionMemorySettings(session: OMSession, record: MemorySettingsRecord | null): Promise<void> {
-  for (const role of ['observer', 'reflector'] as const) {
-    const stored = role === 'observer' ? record?.observerModelId : record?.reflectorModelId;
-    const target = stored ?? DEFAULT_OM_MODEL_ID;
-    if (session.om[role].modelId() !== target) {
-      await session.om[role].switchModel({ modelId: target });
-    }
-  }
-  const state = session.state.get() ?? {};
-  const updates: OMStateWrites = {};
-  const observationThreshold = record?.observationThreshold ?? DEFAULT_OBSERVATION_THRESHOLD;
-  if (state.observationThreshold !== observationThreshold) {
-    updates.observationThreshold = observationThreshold;
-  }
-  const reflectionThreshold = record?.reflectionThreshold ?? DEFAULT_REFLECTION_THRESHOLD;
-  if (state.reflectionThreshold !== reflectionThreshold) {
-    updates.reflectionThreshold = reflectionThreshold;
-  }
-  const observeAttachments = record?.observeAttachments ?? 'auto';
-  if ((state.observeAttachments ?? 'auto') !== observeAttachments) {
-    updates.observeAttachments = observeAttachments;
-  }
-  if (Object.keys(updates).length > 0) await session.state.set(updates);
 }
 
 /** Dependencies injected into {@link ConfigRoutes}. */
@@ -1240,7 +1209,7 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
             // stored config instead of failing.
             const session = await controller.getSessionByResource?.(resourceId, scope);
             if (!session) return c.json({ config: readStoredOMConfig(record) });
-            await hydrateSessionMemorySettings(session, record);
+            await applyStoredMemorySettings(session, record);
             return c.json({ config: readOMConfig(session) });
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);

--- a/mastracode/factory/src/session/factory-session.test.ts
+++ b/mastracode/factory/src/session/factory-session.test.ts
@@ -46,10 +46,10 @@ function createSessionDouble() {
   const calls: string[] = [];
   const session = {
     om: {
-      observer: { switchModel: vi.fn(async () => void calls.push('observer')) },
-      reflector: { switchModel: vi.fn(async () => void calls.push('reflector')) },
+      observer: { modelId: () => undefined, switchModel: vi.fn(async () => void calls.push('observer')) },
+      reflector: { modelId: () => undefined, switchModel: vi.fn(async () => void calls.push('reflector')) },
     },
-    state: { set: vi.fn(async () => void calls.push('state')) },
+    state: { get: () => ({}), set: vi.fn(async () => void calls.push('state')) },
     model: { switch: vi.fn(async () => void calls.push('model')) },
   };
   return { session: session as unknown as FactorySessionHandle, double: session, calls };

--- a/mastracode/factory/src/session/factory-session.ts
+++ b/mastracode/factory/src/session/factory-session.ts
@@ -3,9 +3,10 @@ import { randomUUID } from 'node:crypto';
 import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentController } from '@mastra/core/agent-controller';
 
-import type { MemorySettingsRecord, MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
+import { applyStoredMemorySettings } from './memory-settings-hydration.js';
 
 type FactorySession = Awaited<ReturnType<AgentController<MastraCodeState>['createSession']>>;
 
@@ -195,18 +196,6 @@ export async function ensureFactorySourceSession(
   };
 }
 
-async function applyMemorySettings(session: FactorySession, record: MemorySettingsRecord | null): Promise<void> {
-  if (record?.observerModelId) await session.om.observer.switchModel({ modelId: record.observerModelId });
-  if (record?.reflectorModelId) await session.om.reflector.switchModel({ modelId: record.reflectorModelId });
-
-  const state = {
-    ...(record?.observationThreshold != null ? { observationThreshold: record.observationThreshold } : {}),
-    ...(record?.reflectionThreshold != null ? { reflectionThreshold: record.reflectionThreshold } : {}),
-    ...(record?.observeAttachments != null ? { observeAttachments: record.observeAttachments } : {}),
-  };
-  if (Object.keys(state).length > 0) await session.state.set(state);
-}
-
 export interface HydrateFactorySessionArgs {
   orgId: string;
   userId: string;
@@ -228,7 +217,7 @@ export async function hydrateFactorySession(session: FactorySession, args: Hydra
   if (args.memorySettings) {
     try {
       const record = await args.memorySettings.get({ orgId: args.orgId, userId: args.userId });
-      await applyMemorySettings(session, record);
+      await applyStoredMemorySettings(session, record);
     } catch (error) {
       console.warn('[Factory Start] Failed to apply observational-memory settings', {
         error: error instanceof Error ? error.message : String(error),

--- a/mastracode/factory/src/session/memory-settings-hydration.test.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.test.ts
@@ -1,0 +1,237 @@
+import { DEFAULT_OM_MODEL_ID } from '@mastra/code-sdk/constants';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MemorySettingsRecord } from '../storage/domains/memory-settings/base.js';
+import type { SourceControlSession } from '../storage/domains/source-control/base.js';
+import {
+  applyStoredMemorySettings,
+  DEFAULT_OBSERVATION_THRESHOLD,
+  DEFAULT_REFLECTION_THRESHOLD,
+  hydrateSessionMemorySettings,
+  type MemorySettingsHydrationDependencies,
+  type MemorySettingsHydrationSession,
+} from './memory-settings-hydration.js';
+
+function createSession(state: Record<string, unknown> = {}, modelIds: { observer?: string; reflector?: string } = {}) {
+  const session: MemorySettingsHydrationSession = {
+    identity: { getResourceId: () => 'session-1' },
+    om: {
+      observer: { modelId: () => modelIds.observer, switchModel: vi.fn().mockResolvedValue(undefined) },
+      reflector: { modelId: () => modelIds.reflector, switchModel: vi.fn().mockResolvedValue(undefined) },
+    },
+    state: {
+      get: () => state,
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+  return session;
+}
+
+function sourceControlRow(): SourceControlSession {
+  return {
+    id: 'row-1',
+    sessionId: 'session-1',
+    projectRepositoryId: 'repo-1',
+    orgId: 'org-1',
+    userId: 'user-1',
+    branch: 'user/session-1',
+    title: null,
+    baseBranch: 'main',
+    sandboxId: null,
+    sandboxWorkdir: null,
+    materializedAt: null,
+    firstMessageAt: null,
+    firstMeaningfulExecAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function memorySettingsRow(overrides: Partial<MemorySettingsRecord> = {}): MemorySettingsRecord {
+  return {
+    orgId: 'org-1',
+    userId: 'user-1',
+    observerModelId: 'anthropic/claude-haiku-4-5',
+    reflectorModelId: 'anthropic/claude-haiku-4-5',
+    observationThreshold: null,
+    reflectionThreshold: null,
+    observeAttachments: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function createDependencies({
+  row = sourceControlRow(),
+  settings = memorySettingsRow(),
+}: {
+  row?: SourceControlSession | null;
+  settings?: MemorySettingsRecord | null;
+} = {}): MemorySettingsHydrationDependencies {
+  return {
+    sourceControl: { sessions: { getBySessionId: vi.fn().mockResolvedValue(row) } },
+    memorySettings: { get: vi.fn().mockResolvedValue(settings) },
+  };
+}
+
+describe('applyStoredMemorySettings', () => {
+  it('resets knobs without a stored value to the built-in defaults', async () => {
+    // A record whose model fields are null must not preserve stale session
+    // values — the row is authoritative, matching the settings routes.
+    const session = createSession(
+      { observationThreshold: 12_000, reflectionThreshold: 21_000, observeAttachments: false },
+      { observer: 'openai/gpt-5-mini', reflector: 'openai/gpt-5-mini' },
+    );
+
+    await applyStoredMemorySettings(session, memorySettingsRow({ observerModelId: null, reflectorModelId: null }));
+
+    expect(session.om.observer.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: DEFAULT_OM_MODEL_ID });
+    expect(session.om.reflector.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: DEFAULT_OM_MODEL_ID });
+    expect(session.state.set).toHaveBeenCalledExactlyOnceWith({
+      observationThreshold: DEFAULT_OBSERVATION_THRESHOLD,
+      reflectionThreshold: DEFAULT_REFLECTION_THRESHOLD,
+      observeAttachments: 'auto',
+    });
+  });
+
+  it('applies a partial row: stored knobs win, the rest reset to defaults', async () => {
+    const session = createSession({}, { observer: 'openai/gpt-5-mini', reflector: 'anthropic/claude-haiku-4-5' });
+
+    await applyStoredMemorySettings(
+      session,
+      memorySettingsRow({
+        observerModelId: 'anthropic/claude-haiku-4-5',
+        reflectorModelId: null,
+        observationThreshold: 12_000,
+      }),
+    );
+
+    expect(session.om.observer.switchModel).toHaveBeenCalledExactlyOnceWith({
+      modelId: 'anthropic/claude-haiku-4-5',
+    });
+    expect(session.om.reflector.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: DEFAULT_OM_MODEL_ID });
+    expect(session.state.set).toHaveBeenCalledExactlyOnceWith({
+      observationThreshold: 12_000,
+      reflectionThreshold: DEFAULT_REFLECTION_THRESHOLD,
+    });
+  });
+
+  it('skips model switches and state writes that are already in effect', async () => {
+    const session = createSession(
+      {
+        observationThreshold: DEFAULT_OBSERVATION_THRESHOLD,
+        reflectionThreshold: DEFAULT_REFLECTION_THRESHOLD,
+      },
+      { observer: DEFAULT_OM_MODEL_ID, reflector: DEFAULT_OM_MODEL_ID },
+    );
+
+    await applyStoredMemorySettings(session, null);
+
+    expect(session.om.observer.switchModel).not.toHaveBeenCalled();
+    expect(session.om.reflector.switchModel).not.toHaveBeenCalled();
+    expect(session.state.set).not.toHaveBeenCalled();
+  });
+});
+
+describe('hydrateSessionMemorySettings', () => {
+  it('applies the stored OM models keyed by the session row tenant', async () => {
+    const session = createSession();
+    const dependencies = createDependencies();
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(dependencies.sourceControl.sessions.getBySessionId).toHaveBeenCalledExactlyOnceWith('session-1');
+    expect(dependencies.memorySettings.get).toHaveBeenCalledExactlyOnceWith({ orgId: 'org-1', userId: 'user-1' });
+    expect(session.om.observer.switchModel).toHaveBeenCalledExactlyOnceWith({
+      modelId: 'anthropic/claude-haiku-4-5',
+    });
+    expect(session.om.reflector.switchModel).toHaveBeenCalledExactlyOnceWith({
+      modelId: 'anthropic/claude-haiku-4-5',
+    });
+  });
+
+  it('applies stored thresholds and attachment preferences to session state', async () => {
+    const session = createSession();
+    const dependencies = createDependencies({
+      settings: memorySettingsRow({ observationThreshold: 12_000, observeAttachments: false }),
+    });
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.state.set).toHaveBeenCalledExactlyOnceWith({
+      observationThreshold: 12_000,
+      reflectionThreshold: DEFAULT_REFLECTION_THRESHOLD,
+      observeAttachments: false,
+    });
+  });
+
+  it('resets stale session state when the stored row has null knobs', async () => {
+    const session = createSession(
+      { observationThreshold: 99_000 },
+      { observer: 'google/gemini-3.5-flash', reflector: 'google/gemini-3.5-flash' },
+    );
+    const dependencies = createDependencies();
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.state.set).toHaveBeenCalledExactlyOnceWith({
+      observationThreshold: DEFAULT_OBSERVATION_THRESHOLD,
+      reflectionThreshold: DEFAULT_REFLECTION_THRESHOLD,
+    });
+  });
+
+  it('skips factory-run sessions, which hydrate through the start coordinator', async () => {
+    const session = createSession({ factoryProjectId: 'project-1' });
+    const dependencies = createDependencies();
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(dependencies.sourceControl.sessions.getBySessionId).not.toHaveBeenCalled();
+    expect(session.om.observer.switchModel).not.toHaveBeenCalled();
+  });
+
+  it('skips sessions without a source-control row', async () => {
+    const session = createSession();
+    const dependencies = createDependencies({ row: null });
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(dependencies.memorySettings.get).not.toHaveBeenCalled();
+    expect(session.om.observer.switchModel).not.toHaveBeenCalled();
+  });
+
+  it('resets to defaults when the owner has no stored settings row', async () => {
+    // A missing row must behave like the settings routes: stale persisted
+    // session values reset to the built-in defaults instead of surviving.
+    const session = createSession(
+      { observationThreshold: 99_000 },
+      { observer: 'openai/gpt-5-mini', reflector: 'openai/gpt-5-mini' },
+    );
+    const dependencies = createDependencies({ settings: null });
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.om.observer.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: DEFAULT_OM_MODEL_ID });
+    expect(session.om.reflector.switchModel).toHaveBeenCalledExactlyOnceWith({ modelId: DEFAULT_OM_MODEL_ID });
+    expect(session.state.set).toHaveBeenCalledExactlyOnceWith({
+      observationThreshold: DEFAULT_OBSERVATION_THRESHOLD,
+      reflectionThreshold: DEFAULT_REFLECTION_THRESHOLD,
+    });
+  });
+
+  it('warns instead of throwing when a lookup fails', async () => {
+    const session = createSession();
+    const dependencies = createDependencies();
+    dependencies.memorySettings.get = vi.fn().mockRejectedValue(new Error('db down'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(hydrateSessionMemorySettings(session, dependencies)).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith(
+      '[Factory memory-settings hydration] Unable to apply stored memory settings.',
+      expect.any(Error),
+    );
+    warn.mockRestore();
+  });
+});

--- a/mastracode/factory/src/session/memory-settings-hydration.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.ts
@@ -1,0 +1,111 @@
+import { DEFAULT_OM_MODEL_ID } from '@mastra/code-sdk/constants';
+
+import type { MemorySettingsRecord, MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
+
+/** Default thresholds mirror the TUI `/om` fallbacks. */
+export const DEFAULT_OBSERVATION_THRESHOLD = 30_000;
+export const DEFAULT_REFLECTION_THRESHOLD = 40_000;
+
+/** One observational-memory role's read/switch surface. */
+interface OMRoleSlice {
+  modelId: () => string | undefined;
+  switchModel: (args: { modelId: string }) => Promise<unknown>;
+}
+
+/**
+ * Session-state fields memory-settings hydration writes. The index signatures
+ * mirror `MastraCodeState` so the concrete `Session.state.set(Partial<MastraCodeState>)`
+ * stays assignable to this minimal surface (contravariant parameter check).
+ */
+interface OMStateWrites {
+  [key: string]: unknown;
+  [key: `subagentModelId_${string}`]: string | undefined;
+  observationThreshold?: number;
+  reflectionThreshold?: number;
+  observeAttachments?: 'auto' | boolean;
+}
+
+/** The slice of a session needed to apply stored observational-memory settings. */
+export interface OMConfigurableSession {
+  om: { observer: OMRoleSlice; reflector: OMRoleSlice };
+  state: {
+    get: () => Record<string, unknown> | undefined;
+    set: (updates: OMStateWrites) => Promise<void> | void;
+  };
+}
+
+/**
+ * Apply a stored memory-settings row onto a session, so the DB — not whatever
+ * happens to sit in persisted session state (e.g. a stale boot-time seed from
+ * before memory settings moved to the DB) — is what the web surface reads and
+ * what the session's OM actually runs with. The row is authoritative: knobs
+ * without a stored value reset to the built-in defaults. This is the single
+ * application path shared by the settings routes, coordinator hydration, and
+ * the web session boot seed.
+ */
+export async function applyStoredMemorySettings(
+  session: OMConfigurableSession,
+  record: MemorySettingsRecord | null,
+): Promise<void> {
+  for (const role of ['observer', 'reflector'] as const) {
+    const stored = role === 'observer' ? record?.observerModelId : record?.reflectorModelId;
+    const target = stored ?? DEFAULT_OM_MODEL_ID;
+    if (session.om[role].modelId() !== target) {
+      await session.om[role].switchModel({ modelId: target });
+    }
+  }
+  const state = session.state.get() ?? {};
+  const updates: OMStateWrites = {};
+  const observationThreshold = record?.observationThreshold ?? DEFAULT_OBSERVATION_THRESHOLD;
+  if (state.observationThreshold !== observationThreshold) {
+    updates.observationThreshold = observationThreshold;
+  }
+  const reflectionThreshold = record?.reflectionThreshold ?? DEFAULT_REFLECTION_THRESHOLD;
+  if (state.reflectionThreshold !== reflectionThreshold) {
+    updates.reflectionThreshold = reflectionThreshold;
+  }
+  const observeAttachments = record?.observeAttachments ?? 'auto';
+  if ((state.observeAttachments ?? 'auto') !== observeAttachments) {
+    updates.observeAttachments = observeAttachments;
+  }
+  if (Object.keys(updates).length > 0) await session.state.set(updates);
+}
+
+export interface MemorySettingsHydrationSession extends OMConfigurableSession {
+  readonly identity: { getResourceId(): string };
+}
+
+export interface MemorySettingsHydrationDependencies {
+  /** GitHub-integration source-control rows — the only creator of web user sessions today. */
+  sourceControl: {
+    sessions: Pick<SourceControlStorageHandle['sessions'], 'getBySessionId'>;
+  };
+  memorySettings: Pick<MemorySettingsStorage, 'get'>;
+}
+
+/**
+ * Seed a freshly created controller session's observational-memory settings
+ * from the owner's stored `memory-settings` row. Registered as a blocking
+ * session-created listener so the seed lands before the caller can start a run.
+ *
+ * Sessions tagged `factoryProjectId` (work/review runs, created with that tag)
+ * hydrate through the start coordinator; sessions without a GitHub
+ * source-control row (e.g. chat-only channel sessions) hydrate through
+ * `hydrateFactorySession` with their own resolved tenant. Both are skipped
+ * here. Best-effort: failures are logged, never thrown.
+ */
+export async function hydrateSessionMemorySettings(
+  session: MemorySettingsHydrationSession,
+  { sourceControl, memorySettings }: MemorySettingsHydrationDependencies,
+): Promise<void> {
+  if (session.state.get()?.factoryProjectId) return;
+  try {
+    const record = await sourceControl.sessions.getBySessionId(session.identity.getResourceId());
+    if (!record) return;
+    const settings = await memorySettings.get({ orgId: record.orgId, userId: record.userId });
+    await applyStoredMemorySettings(session, settings);
+  } catch (error) {
+    console.warn('[Factory memory-settings hydration] Unable to apply stored memory settings.', error);
+  }
+}

--- a/packages/core/src/agent-controller/__tests__/agent-controller-session-created.test.ts
+++ b/packages/core/src/agent-controller/__tests__/agent-controller-session-created.test.ts
@@ -106,6 +106,129 @@ describe('AgentController.onSessionCreated', () => {
     error.mockRestore();
   });
 
+  it('awaits blocking listeners before createSession resolves, without blocking on fire-and-forget ones', async () => {
+    const { controller } = createController(new InMemoryStore());
+    await controller.init();
+    let releaseBlocking: (() => void) | undefined;
+    let blockingSettled = false;
+    controller.onSessionCreated(
+      () =>
+        new Promise<void>(resolve => {
+          releaseBlocking = () => {
+            blockingSettled = true;
+            resolve();
+          };
+        }),
+      { blocking: true },
+    );
+    // A never-resolving fire-and-forget listener must not delay creation.
+    controller.onSessionCreated(() => new Promise<void>(() => {}));
+
+    let created = false;
+    const creation = controller.createSession({ resourceId: 'resource-1' }).then(session => {
+      created = true;
+      return session;
+    });
+    await vi.waitFor(() => expect(releaseBlocking).toBeDefined());
+    expect(created).toBe(false);
+
+    releaseBlocking?.();
+    await creation;
+    expect(blockingSettled).toBe(true);
+    expect(created).toBe(true);
+  });
+
+  it('runs blocking listeners sequentially in registration order before fire-and-forget ones', async () => {
+    const { controller } = createController(new InMemoryStore());
+    await controller.init();
+    const order: string[] = [];
+    controller.onSessionCreated(() => {
+      order.push('plain');
+    });
+    controller.onSessionCreated(
+      async () => {
+        order.push('blocking-1:start');
+        await Promise.resolve();
+        order.push('blocking-1:end');
+      },
+      { blocking: true },
+    );
+    controller.onSessionCreated(
+      async () => {
+        order.push('blocking-2');
+      },
+      { blocking: true },
+    );
+
+    await controller.createSession({ resourceId: 'resource-1' });
+
+    expect(order).toEqual(['blocking-1:start', 'blocking-1:end', 'blocking-2', 'plain']);
+  });
+
+  it('makes concurrent get-or-create callers await the same blocking initialization', async () => {
+    const { controller } = createController(new InMemoryStore());
+    await controller.init();
+    let release: (() => void) | undefined;
+    controller.onSessionCreated(
+      () =>
+        new Promise<void>(resolve => {
+          release = resolve;
+        }),
+      { blocking: true },
+    );
+
+    let settledCount = 0;
+    const creations = [
+      controller.createSession({ resourceId: 'resource-1' }),
+      controller.createSession({ resourceId: 'resource-1' }),
+      controller.createSession({ resourceId: 'resource-1' }),
+    ].map(promise =>
+      promise.then(session => {
+        settledCount += 1;
+        return session;
+      }),
+    );
+    await vi.waitFor(() => expect(release).toBeDefined());
+    expect(settledCount).toBe(0);
+
+    release?.();
+    const [first, second, third] = await Promise.all(creations);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+    expect(settledCount).toBe(3);
+  });
+
+  it('removes only one registration when the same listener is registered twice', async () => {
+    const { controller } = createController(new InMemoryStore());
+    await controller.init();
+    const listener = vi.fn();
+    controller.onSessionCreated(listener);
+    const unsubscribeSecond = controller.onSessionCreated(listener);
+    unsubscribeSecond();
+
+    await controller.createSession({ resourceId: 'resource-1' });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('isolates blocking listener failures instead of failing createSession', async () => {
+    const { controller } = createController(new InMemoryStore());
+    await controller.init();
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    controller.onSessionCreated(
+      async () => {
+        throw new Error('blocking failure');
+      },
+      { blocking: true },
+    );
+
+    const session = await controller.createSession({ resourceId: 'resource-1' });
+
+    expect(session).toBeDefined();
+    expect(error).toHaveBeenCalledWith('Error in session-created listener:', expect.any(Error));
+    error.mockRestore();
+  });
+
   it('awaits before-agent-end listeners before exposing the terminal event', async () => {
     const { controller } = createController(new InMemoryStore());
     await controller.init();

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -39,6 +39,7 @@ import type {
   AgentControllerRequestContext,
   AgentControllerRequestStateUpdater,
   AgentControllerSessionCreatedListener,
+  AgentControllerSessionCreatedOptions,
   AgentControllerSessionDeletedListener,
   AgentControllerThread,
   ModelAuthStatus,
@@ -197,7 +198,10 @@ export class AgentController<TState = {}> {
    * that session's model/mode/state instead of an arbitrary one.
    */
   readonly #sessionsByResource = new Map<string, Promise<Session<TState>>>();
-  readonly #sessionCreatedListeners: AgentControllerSessionCreatedListener<TState>[] = [];
+  readonly #sessionCreatedListeners: Array<{
+    listener: AgentControllerSessionCreatedListener<TState>;
+    blocking: boolean;
+  }> = [];
   readonly #sessionDeletedListeners: AgentControllerSessionDeletedListener<TState>[] = [];
   /**
    * In-progress deletions keyed by registry key, so {@link createSession} can
@@ -276,19 +280,45 @@ export class AgentController<TState = {}> {
   /**
    * Subscribe to process-local notifications for newly materialized sessions.
    * Cached `createSession()` calls do not notify listeners again.
+   *
+   * Async listeners are fire-and-forget by default. Pass `blocking: true` to
+   * make `createSession()` await the listener before resolving — for setup that
+   * must land before the caller can start a run (e.g. seeding session state
+   * from storage). Blocking listeners run sequentially in registration order,
+   * before fire-and-forget listeners are notified. Failures are isolated and
+   * logged, never thrown — session creation stays best-effort with respect to
+   * listener setup. A blocking listener must not call `createSession()` for
+   * the same `(resourceId, scope)` it is initializing: that lookup awaits the
+   * in-flight creation that is awaiting the listener, which deadlocks.
    */
-  onSessionCreated(listener: AgentControllerSessionCreatedListener<TState>): () => void {
-    this.#sessionCreatedListeners.push(listener);
+  onSessionCreated(
+    listener: AgentControllerSessionCreatedListener<TState>,
+    options?: AgentControllerSessionCreatedOptions,
+  ): () => void {
+    const entry = { listener, blocking: options?.blocking === true };
+    this.#sessionCreatedListeners.push(entry);
     return () => {
-      const index = this.#sessionCreatedListeners.indexOf(listener);
+      const index = this.#sessionCreatedListeners.indexOf(entry);
       if (index !== -1) {
         this.#sessionCreatedListeners.splice(index, 1);
       }
     };
   }
 
-  #notifySessionCreated(session: Session<TState>): void {
-    for (const listener of [...this.#sessionCreatedListeners]) {
+  async #notifySessionCreated(session: Session<TState>): Promise<void> {
+    const entries = [...this.#sessionCreatedListeners];
+    // Blocking listeners complete sequentially, in registration order, before
+    // fire-and-forget listeners can observe the session.
+    for (const { listener, blocking } of entries) {
+      if (!blocking) continue;
+      try {
+        await listener(session);
+      } catch (error) {
+        console.error('Error in session-created listener:', error);
+      }
+    }
+    for (const { listener, blocking } of entries) {
+      if (blocking) continue;
       try {
         const result = listener(session);
         if (result && typeof result === 'object' && 'catch' in result) {
@@ -706,7 +736,7 @@ export class AgentController<TState = {}> {
       }
     }
 
-    this.#notifySessionCreated(session);
+    await this.#notifySessionCreated(session);
     return session;
   }
 

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -225,6 +225,18 @@ export type BuiltinToolId =
 /** Process-local listener notified after AgentController materializes a live session. */
 export type AgentControllerSessionCreatedListener<TState = {}> = (session: Session<TState>) => void | Promise<void>;
 
+/** Options for {@link AgentController.onSessionCreated}. */
+export interface AgentControllerSessionCreatedOptions {
+  /**
+   * Make `createSession()` await this listener before resolving a newly
+   * materialized session. Blocking listeners run sequentially in registration
+   * order, before fire-and-forget listeners are notified. Failures are
+   * isolated and logged, never thrown. Keep the work short — it holds up every
+   * caller awaiting that session's creation.
+   */
+  blocking?: boolean;
+}
+
 /** Process-local listener notified after AgentController tears down a live session. */
 export type AgentControllerSessionDeletedListener<TState = {}> = (session: Session<TState>) => void | Promise<void>;
 


### PR DESCRIPTION
Web user sessions in the Factory never loaded the owner's memory settings from the database. Observational memory always booted with the built-in default model (`google/gemini-3.5-flash`), so if that provider wasn't configured, OM buffering failed with a missing API key error — even when the user had picked a different observer/reflector model in Settings → Memory.

The Factory now registers a session-created hook that seeds the stored observer/reflector models, thresholds, and attachment preference before the session's first run. To make that reliable, `AgentController.onSessionCreated` gains an opt-in blocking mode:

```ts
controller.onSessionCreated(
  session => hydrateSessionMemorySettings(session, deps),
  { blocking: true },
);
```

Blocking listeners are awaited before `createSession()` resolves, run sequentially in registration order before fire-and-forget listeners, and stay best-effort — failures are logged, never thrown. Default listeners keep their fire-and-forget behavior.

Along the way, the three separate memory-settings application paths (settings routes, coordinator hydration, and the new web session seed) were consolidated into one canonical `applyStoredMemorySettings`, which treats the stored row as authoritative: knobs without a stored value reset to defaults instead of preserving stale session state.

Covered by unit tests for the hydration helper, an integration test that verifies the real Factory registration against seeded storage, and core tests for blocking listener ordering, concurrent callers, and failure isolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Factory sessions now load saved memory settings before the first run. Session creation continues if settings loading fails.

## Changes

- Added shared memory-settings hydration for Factory sessions.
- Applied stored observer and reflector models, thresholds, and attachment preferences.
- Reset unset settings to defaults.
- Added the `blocking` option to `AgentController.onSessionCreated`.
- Ran blocking listeners sequentially before fire-and-forget listeners.
- Awaited blocking listeners before `createSession()` resolves.
- Logged listener and hydration failures without stopping session creation.
- Added tests for hydration, listener ordering, concurrent callers, failure isolation, and Factory integration.
- Added documentation for `onSessionCreated` and blocking behavior.
- Added patch changesets for `@mastra/factory` and `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->