### PR TITLE
fix(core): ship .d.ts for @mastra/core/test-utils/llm-mock

### DIFF
--- a/.changeset/wise-pears-raise.md
+++ b/.changeset/wise-pears-raise.md
@@ -1,0 +1,21 @@
+---
+'@mastra/core': patch
+---
+
+Fixed missing TypeScript declarations for the `@mastra/core/test-utils/llm-mock` entrypoint. `MastraLanguageModelV2Mock`, `createMockModel`, and `simulateReadableStream` are now fully typed when imported in consumer projects — no need for a local ambient `declare module` shim.
+
+```ts
+import { MastraLanguageModelV2Mock } from '@mastra/core/test-utils/llm-mock';
+
+const mockModel = new MastraLanguageModelV2Mock({
+  doGenerate: async () => ({
+    content: [{ type: 'text', text: 'stubbed response' }],
+    finishReason: 'stop',
+    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    warnings: [],
+  }),
+});
+
+// Spy arrays are typed as LanguageModelV2CallOptions[]
+mockModel.doGenerateCalls;
+```

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -12,6 +12,6 @@
     "src/**/*.mock.ts",
     "**/__tests__/**/*",
     "**/*.test-d.ts",
-    "src/**/test-utils/**/*"
+    "src/*/**/test-utils/**/*"
   ]
 }


### PR DESCRIPTION
## Summary

The published entrypoint `@mastra/core/test-utils/llm-mock` shipped `.js` and `.cjs` bundles but no `.d.ts`, so consumers importing `MastraLanguageModelV2Mock`, `createMockModel`, or `simulateReadableStream` had to write a local ambient `declare module '@mastra/core/test-utils/llm-mock';` shim (typed as `any`) to satisfy TypeScript.

## Root cause

`packages/core/tsconfig.build.json` excluded `src/**/test-utils/**/*` from the type-emission tsc pass. That glob matched the top-level `src/test-utils/` directory where `llm-mock.ts` lives, so tsc skipped it entirely. The runtime bundler (tsdown) ignores that exclude, which is why the `.js` / `.cjs` artifacts were fine but the declarations went missing.

## Fix

Narrow the exclude to `src/*/**/test-utils/**/*`. The added `*/` requires at least one intermediate directory before `test-utils`, so:

- `src/test-utils/llm-mock.ts` — **included** in type build (its declarations now emit)
- `src/loop/test-utils/**` and other internal test-utility folders — **still excluded**

## Verification

- Rebuilt `@mastra/core`; `dist/test-utils/llm-mock.d.ts` now exists (1.4 KB) with real type definitions for all three exports.
- Consumer typecheck against the freshly built dist resolves to real types (not `any`) and correctly flags intentional misuse with `Type 'LanguageModelV2CallOptions[]' is not assignable to type 'string'`.
- `pnpm typecheck` on `packages/core` still passes.

## After merge

Consumers can drop any local `declare module '@mastra/core/test-utils/llm-mock';` shim and just import directly:

\`\`\`ts
import {
  MastraLanguageModelV2Mock,
  createMockModel,
} from '@mastra/core/test-utils/llm-mock';
\`\`\`

Changeset included: `@mastra/core` patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR adds missing TypeScript instructions for the `@mastra/core/test-utils/llm-mock` tools. This lets users import these tools without adding their own type workaround.

## Changes

- Includes `src/test-utils/llm-mock.ts` in declaration generation.
- Continues to exclude nested internal test-utility directories.
- Adds `dist/test-utils/llm-mock.d.ts` with types for:
  - `MastraLanguageModelV2Mock`
  - `createMockModel`
  - `simulateReadableStream`
  - Mock call arrays
- Adds an `@mastra/core` patch changeset.
- Package typechecking passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->