### PR TITLE
fix(cli): layer default dotenv files

### DIFF
--- a/.changeset/layered-env-files.md
+++ b/.changeset/layered-env-files.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'mastra': patch
+---
+
+Layer default dotenv files from base to environment-specific overrides and preserve inherited shell environment variables in `mastra dev`.

--- a/packages/cli/src/commands/build/BuildBundler.test.ts
+++ b/packages/cli/src/commands/build/BuildBundler.test.ts
@@ -17,6 +17,7 @@ vi.mock('fs-extra', () => ({
 vi.mock('@mastra/deployer/build', () => {
   class MockFileService {
     getFirstExistingFile = vi.fn().mockReturnValue('.env');
+    getExistingFiles = vi.fn((files: string[]) => files);
   }
 
   return {
@@ -70,6 +71,14 @@ describe('BuildBundler', () => {
 
       const entry = (bundler as any).getEntry();
       expect(entry).toContain('studio: false');
+    });
+  });
+
+  describe('getEnvFiles', () => {
+    it('layers default dotenv files from base to production override', async () => {
+      const { BuildBundler } = await import('./BuildBundler');
+
+      await expect(new BuildBundler().getEnvFiles()).resolves.toEqual(['.env', '.env.local', '.env.production']);
     });
   });
 

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -38,18 +38,7 @@ export class BuildBundler extends Bundler {
       return Promise.resolve([]);
     }
 
-    const possibleFiles = ['.env.production', '.env.local', '.env'];
-
-    try {
-      const fileService = new FileService();
-      const envFile = fileService.getFirstExistingFile(possibleFiles);
-
-      return Promise.resolve([envFile]);
-    } catch {
-      // ignore
-    }
-
-    return Promise.resolve([]);
+    return Promise.resolve(new FileService().getExistingFiles(['.env', '.env.local', '.env.production']));
   }
 
   async prepare(outputDirectory: string): Promise<void> {

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -60,8 +60,17 @@ vi.mock('@mastra/deployer/build', () => {
     getWatcherInputOptions: vi.fn().mockResolvedValue({ plugins: [] }),
     prepareFsAgentsEntry: vi.fn(),
     writeFsAgentsEntry: vi.fn(),
+    FileService: class {
+      getExistingFiles = vi.fn((files: string[]) => files);
+    },
   };
 });
+
+vi.mock('@mastra/deployer', () => ({
+  FileService: class {
+    getExistingFiles = vi.fn((files: string[]) => files);
+  },
+}));
 
 vi.mock('fs-extra', () => {
   return {
@@ -157,6 +166,20 @@ describe('DevBundler', () => {
         const { rm } = await import('node:fs/promises');
         await rm(tmpDir, { recursive: true, force: true });
       }
+    });
+  });
+
+  describe('getEnvFiles', () => {
+    it('layers default dotenv files from base to development override', async () => {
+      const bundler = new DevBundler();
+
+      await expect(bundler.getEnvFiles()).resolves.toEqual(['.env', '.env.local', '.env.development']);
+    });
+
+    it('uses only an explicit env file', async () => {
+      const bundler = new DevBundler('.env.custom');
+
+      await expect(bundler.getEnvFiles()).resolves.toEqual(['.env.custom']);
     });
   });
 

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -55,21 +55,13 @@ export class DevBundler extends Bundler {
       return Promise.resolve([]);
     }
 
-    const possibleFiles = ['.env.development', '.env.local', '.env'];
+    const possibleFiles = ['.env', '.env.local', '.env.development'];
     if (this.customEnvFile) {
-      possibleFiles.unshift(this.customEnvFile);
+      const customEnvFiles = new FileService().getExistingFiles([this.customEnvFile]);
+      if (customEnvFiles.length > 0) return Promise.resolve(customEnvFiles);
     }
 
-    try {
-      const fileService = new FileService();
-      const envFile = fileService.getFirstExistingFile(possibleFiles);
-
-      return Promise.resolve([envFile]);
-    } catch {
-      // ignore
-    }
-
-    return Promise.resolve([]);
+    return Promise.resolve(new FileService().getExistingFiles(possibleFiles));
   }
 
   async prepare(outputDirectory: string): Promise<void> {

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -26,12 +26,14 @@ import { resolveFactoryUIDevDist } from '../build/factory-ui-build.js';
 
 import { acquireDevLock, releaseDevLock, updateDevLock } from './dev-lock';
 import { DevBundler } from './DevBundler';
+import { createEnvironmentState } from './env-state.js';
 
 let currentServerProcess: ChildProcess | undefined;
 let isRestarting = false;
 let serverStartTime: number | undefined;
 let requestContextPresetsJson: string | undefined;
 const ON_ERROR_MAX_RESTARTS = 3;
+const environmentState = createEnvironmentState();
 
 function waitForProcessExit(child: ChildProcess, timeoutMs = 2000): Promise<void> {
   if (child.exitCode !== null) {
@@ -155,8 +157,8 @@ const startServer = async (
     currentServerProcess = execa(process.execPath, commands, {
       cwd: publicDir,
       env: {
+        ...environmentState.getChildEnvironment(env),
         NODE_ENV: 'production',
-        ...Object.fromEntries(env),
         MASTRA_DEV: 'true',
         PORT: port.toString(),
         MASTRA_PACKAGES_FILE: packagesFilePath,
@@ -403,10 +405,7 @@ async function rebundleAndRestart(
       env.set('MASTRA_REQUEST_CONTEXT_PRESETS', requestContextPresetsJson);
     }
 
-    // spread env into process.env
-    for (const [key, value] of env.entries()) {
-      process.env[key] = value;
-    }
+    environmentState.sync(env);
 
     await startServer(
       join(dotMastraPath, 'output'),
@@ -479,12 +478,7 @@ export async function dev({
   // Clear any prior presets to avoid cross-run leakage
   requestContextPresetsJson = undefined;
   loadedEnv.delete('MASTRA_REQUEST_CONTEXT_PRESETS');
-  delete process.env.MASTRA_REQUEST_CONTEXT_PRESETS;
-
-  // spread loadedEnv into process.env
-  for (const [key, value] of loadedEnv.entries()) {
-    process.env[key] = value;
-  }
+  environmentState.allowLoadedOverride('MASTRA_REQUEST_CONTEXT_PRESETS');
 
   // Load and validate request context presets if provided
   if (requestContextPresets) {
@@ -497,6 +491,8 @@ export async function dev({
       process.exit(1);
     }
   }
+
+  environmentState.sync(loadedEnv);
 
   const serverOptions = userEntryFile ? await getServerOptions(userEntryFile, join(dotMastraPath, 'output')) : null;
   let portToUse = serverOptions?.port ?? process.env.PORT;

--- a/packages/cli/src/commands/dev/env-state.test.ts
+++ b/packages/cli/src/commands/dev/env-state.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { createEnvironmentState } from './env-state';
+
+describe('createEnvironmentState', () => {
+  it('preserves inherited values while applying loaded dotenv values to the CLI and server', () => {
+    const environment = { FROM_SHELL: 'shell', PATH: 'path' };
+    const state = createEnvironmentState(environment);
+    const loadedEnv = new Map([
+      ['FROM_SHELL', 'dotenv'],
+      ['FROM_ENV', 'dotenv'],
+    ]);
+
+    state.sync(loadedEnv);
+
+    expect(environment).toEqual({ FROM_SHELL: 'shell', PATH: 'path', FROM_ENV: 'dotenv' });
+    expect(state.getChildEnvironment(loadedEnv)).toMatchObject({
+      FROM_SHELL: 'shell',
+      PATH: 'path',
+      FROM_ENV: 'dotenv',
+    });
+  });
+
+  it('refreshes dotenv-owned keys without deleting inherited values', () => {
+    const environment = { FROM_SHELL: 'shell' };
+    const state = createEnvironmentState(environment);
+    state.sync(new Map([['FROM_ENV', 'first'], ['REMOVED', 'value']]));
+    state.sync(new Map([['FROM_ENV', 'second']]));
+
+    expect(environment).toEqual({ FROM_SHELL: 'shell', FROM_ENV: 'second' });
+  });
+
+  it('allows CLI-generated values to replace inherited values intentionally', () => {
+    const environment = { MASTRA_REQUEST_CONTEXT_PRESETS: 'stale' };
+    const state = createEnvironmentState(environment);
+    state.allowLoadedOverride('MASTRA_REQUEST_CONTEXT_PRESETS');
+    state.sync(new Map([['MASTRA_REQUEST_CONTEXT_PRESETS', 'fresh']]));
+
+    expect(environment).toEqual({ MASTRA_REQUEST_CONTEXT_PRESETS: 'fresh' });
+  });
+});

--- a/packages/cli/src/commands/dev/env-state.ts
+++ b/packages/cli/src/commands/dev/env-state.ts
@@ -1,0 +1,31 @@
+export function createEnvironmentState(environment: NodeJS.ProcessEnv = process.env) {
+  const inheritedKeys = new Set(Object.keys(environment));
+  let loadedKeys = new Set<string>();
+
+  return {
+    allowLoadedOverride(key: string) {
+      inheritedKeys.delete(key);
+      delete environment[key];
+    },
+
+    sync(loadedEnv: Map<string, string>) {
+      for (const key of loadedKeys) {
+        if (!loadedEnv.has(key)) delete environment[key];
+      }
+
+      loadedKeys = new Set();
+      for (const [key, value] of loadedEnv) {
+        if (inheritedKeys.has(key)) continue;
+        environment[key] = value;
+        loadedKeys.add(key);
+      }
+    },
+
+    getChildEnvironment(loadedEnv: Map<string, string>): NodeJS.ProcessEnv {
+      return {
+        ...environment,
+        ...Object.fromEntries([...loadedEnv].filter(([key]) => !inheritedKeys.has(key))),
+      };
+    },
+  };
+}

--- a/packages/cli/src/commands/experiment/ExperimentBundler.test.ts
+++ b/packages/cli/src/commands/experiment/ExperimentBundler.test.ts
@@ -17,6 +17,9 @@ vi.mock('@mastra/deployer/build', () => ({
     getFirstExistingFile() {
       return '.env';
     }
+    getExistingFiles(files: string[]) {
+      return files;
+    }
   },
 }));
 vi.mock('../utils.js', () => ({ shouldSkipDotenvLoading: vi.fn().mockReturnValue(false) }));
@@ -42,6 +45,12 @@ describe('ExperimentBundler', () => {
   afterEach(async () => {
     vi.clearAllMocks();
     await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { recursive: true, force: true })));
+  });
+
+  it('layers default dotenv files from base to production override', async () => {
+    const { ExperimentBundler } = await import('./ExperimentBundler');
+
+    await expect(new ExperimentBundler().getEnvFiles()).resolves.toEqual(['.env', '.env.local', '.env.production']);
   });
 
   it('generates an isolated NDJSON experiment worker entry', async () => {

--- a/packages/cli/src/commands/experiment/ExperimentBundler.ts
+++ b/packages/cli/src/commands/experiment/ExperimentBundler.ts
@@ -46,11 +46,7 @@ export class ExperimentBundler extends Bundler {
 
   getEnvFiles(): Promise<string[]> {
     if (shouldSkipDotenvLoading()) return Promise.resolve([]);
-    try {
-      return Promise.resolve([new FileService().getFirstExistingFile(['.env.production', '.env.local', '.env'])]);
-    } catch {
-      return Promise.resolve([]);
-    }
+    return Promise.resolve(new FileService().getExistingFiles(['.env', '.env.local', '.env.production']));
   }
 
   protected async getUserBundlerOptions(

--- a/packages/cli/src/commands/migrate/MigrateBundler.test.ts
+++ b/packages/cli/src/commands/migrate/MigrateBundler.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('@mastra/deployer/build', () => ({
   FileService: vi.fn().mockImplementation(() => ({
     getFirstExistingFile: vi.fn().mockImplementation((files: string[]) => files[0]),
+    getExistingFiles: vi.fn().mockImplementation((files: string[]) => files),
   })),
 }));
 
@@ -129,18 +130,18 @@ describe('MigrateBundler', () => {
   });
 
   describe('getEnvFiles', () => {
-    it('should return env files when no custom env file specified', async () => {
+    it('layers default dotenv files from base to development override', async () => {
       const bundler = new MigrateBundler();
       const envFiles = await bundler.getEnvFiles();
 
-      expect(Array.isArray(envFiles)).toBe(true);
+      expect(envFiles).toEqual(['.env', '.env.local', '.env.development']);
     });
 
-    it('should accept custom env file', async () => {
-      const bundler = new MigrateBundler('.env.production');
+    it('uses only an explicit env file', async () => {
+      const bundler = new MigrateBundler('.env.custom');
       const envFiles = await bundler.getEnvFiles();
 
-      expect(Array.isArray(envFiles)).toBe(true);
+      expect(envFiles).toEqual(['.env.custom']);
     });
 
     it('should return empty array when MASTRA_SKIP_DOTENV is set to "true"', async () => {

--- a/packages/cli/src/commands/migrate/MigrateBundler.ts
+++ b/packages/cli/src/commands/migrate/MigrateBundler.ts
@@ -17,21 +17,13 @@ export class MigrateBundler extends BuildBundler {
       return Promise.resolve([]);
     }
 
-    const possibleFiles = ['.env.development', '.env.local', '.env'];
+    const possibleFiles = ['.env', '.env.local', '.env.development'];
     if (this.customEnvFile) {
-      possibleFiles.unshift(this.customEnvFile);
+      const customEnvFiles = new FileService().getExistingFiles([this.customEnvFile]);
+      if (customEnvFiles.length > 0) return Promise.resolve(customEnvFiles);
     }
 
-    try {
-      const fileService = new FileService();
-      const envFile = fileService.getFirstExistingFile(possibleFiles);
-
-      return Promise.resolve([envFile]);
-    } catch {
-      // ignore
-    }
-
-    return Promise.resolve([]);
+    return Promise.resolve(new FileService().getExistingFiles(possibleFiles));
   }
 
   async bundle(

--- a/packages/cli/src/commands/worker/WorkerBundler.test.ts
+++ b/packages/cli/src/commands/worker/WorkerBundler.test.ts
@@ -14,6 +14,7 @@ vi.mock('fs-extra', () => ({
 vi.mock('@mastra/deployer/build', () => {
   class MockFileService {
     getFirstExistingFile = vi.fn().mockReturnValue('.env');
+    getExistingFiles = vi.fn((files: string[]) => files);
   }
 
   return {
@@ -58,6 +59,12 @@ describe('WorkerBundler', () => {
       // role is determined at runtime via MASTRA_WORKERS, not baked into the bundle
       expect(entry).not.toMatch(/startWorkers\(['"`]/);
     });
+  });
+
+  it('layers default dotenv files from base to production override', async () => {
+    const { WorkerBundler } = await import('./WorkerBundler');
+
+    await expect(new WorkerBundler().getEnvFiles()).resolves.toEqual(['.env', '.env.local', '.env.production']);
   });
 
   describe('output directory', () => {

--- a/packages/cli/src/commands/worker/WorkerBundler.ts
+++ b/packages/cli/src/commands/worker/WorkerBundler.ts
@@ -16,17 +16,7 @@ export class WorkerBundler extends Bundler {
       return Promise.resolve([]);
     }
 
-    const possibleFiles = ['.env.production', '.env.local', '.env'];
-
-    try {
-      const fileService = new FileService();
-      const envFile = fileService.getFirstExistingFile(possibleFiles);
-      return Promise.resolve([envFile]);
-    } catch {
-      // ignore
-    }
-
-    return Promise.resolve([]);
+    return Promise.resolve(new FileService().getExistingFiles(['.env', '.env.local', '.env.production']));
   }
 
   async bundle(

--- a/packages/core/src/bundler/index.test.ts
+++ b/packages/core/src/bundler/index.test.ts
@@ -1,0 +1,54 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { MastraBundler } from './index';
+
+const directories: string[] = [];
+
+class TestBundler extends MastraBundler {
+  constructor(private readonly envFiles: string[]) {
+    super({ name: 'Test' });
+  }
+
+  getEnvFiles(): Promise<string[]> {
+    return Promise.resolve(this.envFiles);
+  }
+
+  getAllToolPaths(): (string | string[])[] {
+    return [];
+  }
+
+  async bundle(): Promise<void> {}
+
+  async prepare(): Promise<void> {}
+
+  async writePackageJson(): Promise<void> {}
+
+  async lint(): Promise<void> {}
+}
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map(directory => rm(directory, { recursive: true, force: true })));
+});
+
+describe('MastraBundler.loadEnvVars', () => {
+  it('layers dotenv files in order so later files override earlier values', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'mastra-bundler-env-'));
+    directories.push(directory);
+    const base = join(directory, '.env');
+    const local = join(directory, '.env.local');
+    await Promise.all([
+      writeFile(base, 'BASE_ONLY=base\nSHARED=base\n', 'utf8'),
+      writeFile(local, 'LOCAL_ONLY=local\nSHARED=local\n', 'utf8'),
+    ]);
+
+    await expect(new TestBundler([base, local]).loadEnvVars()).resolves.toEqual(
+      new Map([
+        ['BASE_ONLY', 'base'],
+        ['SHARED', 'local'],
+        ['LOCAL_ONLY', 'local'],
+      ]),
+    );
+  });
+});

--- a/packages/deployer/src/deploy/base.ts
+++ b/packages/deployer/src/deploy/base.ts
@@ -14,16 +14,7 @@ export abstract class Deployer extends Bundler implements IDeployer {
   }
 
   getEnvFiles(): Promise<string[]> {
-    const possibleFiles = ['.env.production', '.env.local', '.env'];
-
-    try {
-      const fileService = new FileService();
-      const envFile = fileService.getFirstExistingFile(possibleFiles);
-
-      return Promise.resolve([envFile]);
-    } catch {}
-
-    return Promise.resolve([]);
+    return Promise.resolve(new FileService().getExistingFiles(['.env', '.env.local', '.env.production']));
   }
 
   abstract deploy(outputDirectory: string): Promise<void>;

--- a/packages/deployer/src/services/fs.test.ts
+++ b/packages/deployer/src/services/fs.test.ts
@@ -1,0 +1,24 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { FileService } from './fs';
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map(directory => rm(directory, { recursive: true, force: true })));
+});
+
+describe('FileService.getExistingFiles', () => {
+  it('returns every existing file in the supplied precedence order', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'mastra-files-'));
+    directories.push(directory);
+    const base = join(directory, '.env');
+    const local = join(directory, '.env.local');
+    const missing = join(directory, '.env.production');
+    await Promise.all([writeFile(base, ''), writeFile(local, '')]);
+
+    expect(new FileService().getExistingFiles([base, missing, local])).toEqual([base, local]);
+  });
+});

--- a/packages/deployer/src/services/fs.ts
+++ b/packages/deployer/src/services/fs.ts
@@ -50,6 +50,15 @@ export class FileService {
   }
 
   /**
+   * Returns every existing file from the provided array in the same order.
+   * Callers supply files from the lowest to highest precedence so later dotenv
+   * files override earlier values when the bundler loads them.
+   */
+  public getExistingFiles(files: string[]): string[] {
+    return files.filter(file => fs.existsSync(file));
+  }
+
+  /**
    * Returns the first existing file from the provided array, or undefined if none exist
    * @param files array of file paths to check
    * @returns the first existing file path or undefined


### PR DESCRIPTION
## Description

Layers the default dotenv files rather than selecting one file, and preserves shell/CI values when `mastra dev` loads or reloads dotenv values.

- Development and migration commands load `.env`, `.env.local`, then `.env.development`.
- Build, worker, experiment, and deployer commands load `.env`, `.env.local`, then `.env.production`.
- Existing explicit `--env` behavior stays single-file; an absent explicit file falls back to default discovery as before.
- `mastra dev` snapshots inherited environment keys, applies only dotenv-owned values, and refreshes those values on rebundle without replacing shell values. The generated request-context preset remains an intentional CLI override.

## Related issue(s)

Fixes #21429

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Verification

- `git diff --check` passes.
- The targeted tests cover default discovery order, explicit-env selection, dotenv merge precedence, inherited shell precedence, and dotenv hot reload.
- Test execution is currently blocked locally by a corrupted pnpm store link for `eslint`: a frozen install failed with `ENOENT` for the cached package manifest. A forced repair attempted to download the full monorepo's optional cross-platform binaries and exceeded ten minutes before Vitest became available. CI should run the focused suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The CLI now combines dotenv files in a fixed order, so specific settings can override shared settings. It also keeps shell and CI variables safe during `mastra dev` reloads.

## Changes

- Layer default dotenv files in base-to-override order:
  - Development and migration: `.env`, `.env.local`, `.env.development`
  - Build, worker, experiment, and deployer: `.env`, `.env.local`, `.env.production`
- Preserve explicit `--env` single-file behavior.
- Preserve `MASTRA_SKIP_DOTENV` opt-out behavior.
- Preserve inherited shell and CI variables during `mastra dev`.
- Refresh dotenv-owned variables during hot reload.
- Retain CLI-generated request-context presets as overrides.
- Add `FileService.getExistingFiles` to return existing files in the requested order.
- Add tests for file discovery, precedence, explicit environment files, inherited variables, stale-variable removal, and hot reload.
- Add a patch changeset for `mastra` and `@mastra/deployer`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->