### PR TITLE
fix(core): remap tool-result media for ModelRouter v6 path

### DIFF
--- a/.changeset/tender-tips-brake.md
+++ b/.changeset/tender-tips-brake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed ModelRouter-resolved AI SDK v6 providers dropping multimodal tool results. When a tool returned an image or file as a media content part, the router path previously forwarded the legacy `media` shape instead of converting it to `image-data`/`file-data`, so providers could drop or reject those parts. (#21183)

--- a/.changeset/tender-tips-brake.md
+++ b/.changeset/tender-tips-brake.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed ModelRouter-resolved AI SDK v6 providers dropping multimodal tool results. When a tool returned an image or file as a media content part, the router path previously forwarded the legacy `media` shape instead of converting it to `image-data`/`file-data`, so providers could drop or reject those parts. (#21183)
+Fixed routed models so tool results can include images and files. (#21183)

--- a/packages/core/src/llm/model/aisdk/v6/model.test.ts
+++ b/packages/core/src/llm/model/aisdk/v6/model.test.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3 } from '@ai-sdk/provider-v6';
+import type { LanguageModelV3, LanguageModelV3CallOptions } from '@ai-sdk/provider-v6';
 import { describe, expect, it, vi } from 'vitest';
 import { AISDKV6LanguageModel } from './model';
 
@@ -8,8 +8,17 @@ function createMockV3Model() {
     provider: 'openai',
     modelId: 'test-v3-model',
     supportedUrls: {},
-    doGenerate: vi.fn(),
-    doStream: vi.fn(),
+    doGenerate: vi.fn(async () => ({
+      content: [],
+      finishReason: 'stop',
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      warnings: [],
+      request: {},
+      response: { id: 'test', modelId: 'test-v3-model' },
+    })),
+    doStream: vi.fn(async () => ({
+      stream: new ReadableStream(),
+    })),
   } as unknown as LanguageModelV3;
 }
 
@@ -33,6 +42,144 @@ describe('AISDKV6LanguageModel', () => {
       expect(serialized).not.toContain('supportedUrls');
       expect(serialized).not.toContain('doGenerate');
       expect(serialized).not.toContain('doStream');
+    });
+  });
+
+  describe('tool remapping', () => {
+    it('remaps provider-defined tools to provider for V3 in doStream', async () => {
+      const model = createMockV3Model();
+      const wrapped = new AISDKV6LanguageModel(model);
+
+      const options = {
+        prompt: [],
+        tools: [{ type: 'provider-defined', id: 'openai.web_search', name: 'web_search', args: {} }],
+      } as unknown as LanguageModelV3CallOptions;
+
+      await wrapped.doStream(options);
+
+      const passed = (model.doStream as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(passed.tools[0].type).toBe('provider');
+    });
+
+    it('leaves function tools untouched', async () => {
+      const model = createMockV3Model();
+      const wrapped = new AISDKV6LanguageModel(model);
+
+      const options = {
+        prompt: [],
+        tools: [{ type: 'function', name: 'getWeather', inputSchema: {} }],
+      } as unknown as LanguageModelV3CallOptions;
+
+      await wrapped.doStream(options);
+
+      const passed = (model.doStream as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(passed.tools[0].type).toBe('function');
+    });
+  });
+
+  describe('tool-result media remapping', () => {
+    it('remaps a v2 tool-result media image part to image-data', async () => {
+      const model = createMockV3Model();
+      const wrapped = new AISDKV6LanguageModel(model);
+
+      const options = {
+        prompt: [
+          {
+            role: 'assistant',
+            content: [{ type: 'tool-call', toolCallId: 'call_1', toolName: 'read_image', input: {} }],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_1',
+                toolName: 'read_image',
+                output: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'image result' },
+                    { type: 'media', data: 'iVBORw0KGgo=', mediaType: 'image/png' },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      } as unknown as LanguageModelV3CallOptions;
+
+      await wrapped.doStream(options);
+
+      const passed = (model.doStream as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      const toolMsg = passed.prompt.find((m: { role: string }) => m.role === 'tool');
+      const value = toolMsg.content[0].output.value;
+
+      expect(value).toEqual([
+        { type: 'text', text: 'image result' },
+        { type: 'image-data', data: 'iVBORw0KGgo=', mediaType: 'image/png' },
+      ]);
+    });
+
+    it('remaps a v2 tool-result media non-image part to file-data', async () => {
+      const model = createMockV3Model();
+      const wrapped = new AISDKV6LanguageModel(model);
+
+      const options = {
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_1',
+                toolName: 'read_pdf',
+                output: {
+                  type: 'content',
+                  value: [{ type: 'media', data: 'JVBERi0=', mediaType: 'application/pdf' }],
+                },
+              },
+            ],
+          },
+        ],
+      } as unknown as LanguageModelV3CallOptions;
+
+      await wrapped.doGenerate(options);
+
+      const passed = (model.doGenerate as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      const value = passed.prompt[0].content[0].output.value;
+
+      expect(value).toEqual([{ type: 'file-data', data: 'JVBERi0=', mediaType: 'application/pdf' }]);
+    });
+
+    it('leaves already-converted image-data parts untouched', async () => {
+      const model = createMockV3Model();
+      const wrapped = new AISDKV6LanguageModel(model);
+
+      const options = {
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_1',
+                toolName: 'read_image',
+                output: {
+                  type: 'content',
+                  value: [{ type: 'image-data', data: 'iVBORw0KGgo=', mediaType: 'image/png' }],
+                },
+              },
+            ],
+          },
+        ],
+      } as unknown as LanguageModelV3CallOptions;
+
+      await wrapped.doStream(options);
+
+      const passed = (model.doStream as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      const value = passed.prompt[0].content[0].output.value;
+
+      expect(value).toEqual([{ type: 'image-data', data: 'iVBORw0KGgo=', mediaType: 'image/png' }]);
     });
   });
 });

--- a/packages/core/src/llm/model/aisdk/v6/model.ts
+++ b/packages/core/src/llm/model/aisdk/v6/model.ts
@@ -1,4 +1,6 @@
+import type { LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
 import type { LanguageModelV3, LanguageModelV3CallOptions } from '@ai-sdk/provider-v6';
+import { aiV5PromptToAIV6Prompt } from '../../../../agent/message-list/conversion/to-prompt';
 import type { MastraLanguageModelV3 } from '../../shared.types';
 import { createStreamFromGenerateResult } from '../generate-to-stream';
 
@@ -26,6 +28,28 @@ function remapToolsToV3(options: LanguageModelV3CallOptions): LanguageModelV3Cal
     ...options,
     tools: remappedTools as typeof options.tools,
   };
+}
+
+/**
+ * Convert v2 tool-result `media` parts to v3 `image-data`/`file-data`.
+ *
+ * The agentic loop picks the prompt converter from `model.specificationVersion`,
+ * but `ModelRouterLanguageModel` always reports `'v2'`. Router-wrapped native v3
+ * providers therefore receive the plain v5 prompt; remap at this adapter boundary
+ * using the same conversion the direct-model path already applies.
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/21183
+ */
+function remapToolResultMediaPartsToV3(options: LanguageModelV3CallOptions): LanguageModelV3CallOptions {
+  const remappedPrompt = aiV5PromptToAIV6Prompt(options.prompt as LanguageModelV2Prompt);
+  return {
+    ...options,
+    prompt: remappedPrompt as typeof options.prompt,
+  };
+}
+
+function remapCallOptionsToV3(options: LanguageModelV3CallOptions): LanguageModelV3CallOptions {
+  return remapToolsToV3(remapToolResultMediaPartsToV3(options));
 }
 
 /**
@@ -66,7 +90,7 @@ export class AISDKV6LanguageModel implements MastraLanguageModelV3 {
   }
 
   async doGenerate(options: LanguageModelV3CallOptions) {
-    const result = await this.#model.doGenerate(remapToolsToV3(options));
+    const result = await this.#model.doGenerate(remapCallOptionsToV3(options));
 
     return {
       ...result,
@@ -77,7 +101,7 @@ export class AISDKV6LanguageModel implements MastraLanguageModelV3 {
   }
 
   async doStream(options: LanguageModelV3CallOptions) {
-    return await this.#model.doStream(remapToolsToV3(options));
+    return await this.#model.doStream(remapCallOptionsToV3(options));
   }
 
   /**

--- a/packages/core/src/llm/model/router-v3-tool-result-media.test.ts
+++ b/packages/core/src/llm/model/router-v3-tool-result-media.test.ts
@@ -1,0 +1,172 @@
+import type { LanguageModelV3 } from '@ai-sdk/provider-v6';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MastraModelGateway } from './gateways/base';
+import type { ProviderConfig, GatewayLanguageModel } from './gateways/base';
+import { ModelRouterLanguageModel } from './router';
+
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/21183
+ *
+ * ModelRouterLanguageModel hardcodes specificationVersion='v2', so the v6
+ * prompt-conversion path (aiV5PromptToAIV6Prompt) never runs when the
+ * resolved provider is a V3 model. The router then wraps that V3 model in
+ * AISDKV6LanguageModel; without an adapter-side remap, a v2 tool-result
+ * media part reaches the V3 provider unchanged and cannot survive provider
+ * serialization (v3 has no `media` content-part type).
+ *
+ * This test exercises the full router dispatch path (not just the adapter
+ * directly) to confirm the fix covers the actual entry point agents use.
+ */
+
+function createMockV3Model(): LanguageModelV3 {
+  return {
+    specificationVersion: 'v3',
+    provider: 'openai',
+    modelId: 'gpt-test',
+    supportedUrls: {},
+    doGenerate: vi.fn().mockResolvedValue({
+      content: [],
+      finishReason: 'stop',
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      warnings: [],
+      request: {},
+      response: { id: 'test', modelId: 'gpt-test' },
+    }),
+    doStream: vi.fn().mockResolvedValue({
+      stream: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    }),
+  } as unknown as LanguageModelV3;
+}
+
+class V3Gateway extends MastraModelGateway {
+  readonly id = 'v3-gateway';
+  readonly name = 'V3 Gateway';
+
+  private mockModel: LanguageModelV3;
+
+  constructor(mockModel: LanguageModelV3) {
+    super();
+    this.mockModel = mockModel;
+  }
+
+  async fetchProviders(): Promise<Record<string, ProviderConfig>> {
+    return {
+      openai: {
+        name: 'OpenAI',
+        models: ['gpt-test'],
+        apiKeyEnvVar: 'OPENAI_API_KEY',
+        gateway: 'v3-gateway',
+      },
+    };
+  }
+
+  buildUrl(): string {
+    return 'https://api.openai.com';
+  }
+
+  async getApiKey(): Promise<string> {
+    return 'test-api-key';
+  }
+
+  async resolveLanguageModel(): Promise<GatewayLanguageModel> {
+    return this.mockModel;
+  }
+}
+
+describe('ModelRouterLanguageModel with V3 gateway and tool-result media (#21183)', () => {
+  let mockV3Model: LanguageModelV3;
+  let gateway: V3Gateway;
+
+  beforeEach(() => {
+    (ModelRouterLanguageModel as any)._clearCachesForTests();
+    mockV3Model = createMockV3Model();
+    gateway = new V3Gateway(mockV3Model);
+  });
+
+  it('remaps a v2 tool-result media part to image-data when routed to a V3 provider via doStream', async () => {
+    const router = new ModelRouterLanguageModel({ id: 'v3-gateway/openai/gpt-test' as `${string}/${string}` }, [
+      gateway,
+    ]);
+
+    await router.doStream({
+      inputFormat: 'messages',
+      prompt: [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool-call', toolCallId: 'call_1', toolName: 'read_image', input: {} }],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_1',
+              toolName: 'read_image',
+              output: {
+                type: 'content',
+                value: [
+                  { type: 'text', text: 'image result' },
+                  { type: 'media', data: 'iVBORw0KGgo=', mediaType: 'image/png' },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    const doStreamCall = (mockV3Model.doStream as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(doStreamCall).toBeDefined();
+
+    const passedOptions = doStreamCall[0];
+    const toolMsg = passedOptions.prompt.find((m: any) => m.role === 'tool');
+    const value = toolMsg.content[0].output.value;
+
+    expect(value).toEqual([
+      { type: 'text', text: 'image result' },
+      {
+        type: 'image-data',
+        data: 'iVBORw0KGgo=',
+        mediaType: 'image/png',
+      },
+    ]);
+  });
+
+  it('remaps a v2 tool-result media part to file-data for non-image media via doGenerate', async () => {
+    const router = new ModelRouterLanguageModel({ id: 'v3-gateway/openai/gpt-test' as `${string}/${string}` }, [
+      gateway,
+    ]);
+
+    await router.doGenerate({
+      inputFormat: 'messages',
+      prompt: [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_1',
+              toolName: 'read_pdf',
+              output: {
+                type: 'content',
+                value: [{ type: 'media', data: 'JVBERi0=', mediaType: 'application/pdf' }],
+              },
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    const doGenerateCall = (mockV3Model.doGenerate as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(doGenerateCall).toBeDefined();
+
+    const passedOptions = doGenerateCall[0];
+    const value = passedOptions.prompt[0].content[0].output.value;
+
+    expect(value).toEqual([{ type: 'file-data', data: 'JVBERi0=', mediaType: 'application/pdf' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #21183: ModelRouter always reports `specificationVersion: 'v2'`, so router-resolved AI SDK v6 providers received legacy tool-result `media` parts instead of `image-data`/`file-data`.
- Remaps tool-result media at the `AISDKV6LanguageModel` adapter boundary via `aiV5PromptToAIV6Prompt` (same conversion the direct-model path already uses).
- Adds adapter unit tests and a router-path regression test.

## Test plan
- [x] `pnpm --filter ./packages/core exec vitest run src/llm/model/aisdk/v6/model.test.ts src/llm/model/router-v3-tool-result-media.test.ts`
- [ ] CodeRabbit review addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a routed model returns an image or file from a tool, ModelRouter now sends it in the format that v6 providers expect. This prevents images and files from being misread.

## Changes

- Updated `AISDKV6LanguageModel` to convert tool-result `media` parts to:
  - `image-data` for images.
  - `file-data` for other files.
- Preserved existing handling for null entries, non-string data, invalid arrays, and already-converted parts.
- Applied the conversion in both `doGenerate` and `doStream`.
- Added adapter tests for media conversion, tool remapping, and existing converted parts.
- Added a ModelRouter regression test for routed v6 providers.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->