### PR TITLE
fix(core): skip locked threads when opening a second terminal

### DIFF
--- a/.changeset/famous-dogs-cough.md
+++ b/.changeset/famous-dogs-cough.md
@@ -2,4 +2,4 @@
 '@mastra/code-sdk': patch
 ---
 
-Fixed thread locks so simultaneous local processes cannot claim the same thread. Lock files are created exclusively and carry a generation so stale locks are superseded instead of deleted. (#21243)
+Fixed thread locking so concurrent local processes cannot open the same thread. (#21243)

--- a/.changeset/famous-dogs-cough.md
+++ b/.changeset/famous-dogs-cough.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed thread locks so simultaneous local processes cannot claim the same thread. Lock files are created exclusively and carry a generation so stale locks are superseded instead of deleted. (#21243)

--- a/.changeset/sunny-heads-run.md
+++ b/.changeset/sunny-heads-run.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed automatic thread selection so a second process can use another thread when the newest one is locked. (#21243)

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -360,7 +360,6 @@ vi.mock('../utils/storage-factory.js', () => ({
 
 vi.mock('../utils/thread-lock.js', () => ({
   acquireThreadLock: vi.fn(),
-  tryAcquireThreadLock: vi.fn(() => true),
   releaseThreadLock: vi.fn(),
 }));
 
@@ -772,32 +771,6 @@ describe('createMastraCode', () => {
     await expect(createMastraCode({ crossProcessPubSub: true })).rejects.toThrow(
       'crossProcessPubSub requires a pubsub instance',
     );
-  });
-
-  it('keeps thread locks enabled for configured PubSub unless cross-process mode is explicit', async () => {
-    const pubsub = {} as any;
-    const { createMastraCode } = await import('../index.js');
-
-    await createMastraCode({ pubsub, unixSocketPubSub: true });
-
-    const agentControllerConfig = controllerConstructorMock.mock.calls.at(-1)?.[0] as
-      | { pubsub?: unknown; threadLock?: unknown }
-      | undefined;
-    expect(agentControllerConfig?.pubsub).toBe(pubsub);
-    expect(agentControllerConfig?.threadLock).toBeDefined();
-  });
-
-  it('skips thread locks for configured PubSub when cross-process mode is explicit', async () => {
-    const pubsub = {} as any;
-    const { createMastraCode } = await import('../index.js');
-
-    await createMastraCode({ pubsub, crossProcessPubSub: true });
-
-    const agentControllerConfig = controllerConstructorMock.mock.calls.at(-1)?.[0] as
-      | { pubsub?: unknown; threadLock?: unknown }
-      | undefined;
-    expect(agentControllerConfig?.pubsub).toBe(pubsub);
-    expect(agentControllerConfig?.threadLock).toBeUndefined();
   });
 
   it('restores the current thread caveman observation setting at startup', async () => {

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -360,6 +360,7 @@ vi.mock('../utils/storage-factory.js', () => ({
 
 vi.mock('../utils/thread-lock.js', () => ({
   acquireThreadLock: vi.fn(),
+  tryAcquireThreadLock: vi.fn(() => true),
   releaseThreadLock: vi.fn(),
 }));
 

--- a/mastracode/sdk/src/index.test.ts
+++ b/mastracode/sdk/src/index.test.ts
@@ -373,9 +373,13 @@ describe('createMastraCode thread lock wiring', () => {
 
     await createMastraCode({ pubsub: pubsub as never, unixSocketPubSub: true });
 
-    const agentControllerConfig = controllerConstructorConfigs.at(-1);
+    const agentControllerConfig = controllerConstructorConfigs.at(-1) as
+      | { pubsub?: unknown; threadLock?: { tryAcquire?: (threadId: string) => boolean } }
+      | undefined;
     expect(agentControllerConfig?.pubsub).toBe(pubsub);
     expect(agentControllerConfig?.threadLock).toBeDefined();
+    expect(agentControllerConfig?.threadLock?.tryAcquire).toEqual(expect.any(Function));
+    expect(agentControllerConfig?.threadLock?.tryAcquire?.('thread-id')).toBe(true);
   });
 
   it('skips thread locks for configured PubSub when cross-process mode is explicit', async () => {

--- a/mastracode/sdk/src/index.test.ts
+++ b/mastracode/sdk/src/index.test.ts
@@ -197,6 +197,7 @@ vi.mock('./utils/storage-factory.js', () => ({
 
 vi.mock('./utils/thread-lock.js', () => ({
   acquireThreadLock: vi.fn(),
+  tryAcquireThreadLock: vi.fn(() => true),
   releaseThreadLock: vi.fn(),
 }));
 

--- a/mastracode/sdk/src/index.test.ts
+++ b/mastracode/sdk/src/index.test.ts
@@ -8,6 +8,9 @@ const createSessionCalls = vi.hoisted<Array<{ id?: string; ownerId?: string; res
 // which settings.json values were seeded into session state.
 const controllerInitialStates = vi.hoisted<Array<Record<string, unknown>>>(() => []);
 
+// Captures full AgentController constructor configs for thread-lock wiring tests.
+const controllerConstructorConfigs = vi.hoisted<Array<Record<string, unknown>>>(() => []);
+
 vi.mock('@mastra/core/llm', () => ({
   MastraModelGateway: class {},
   GatewayRegistry: {
@@ -30,7 +33,10 @@ vi.mock('@mastra/core/agent-controller', () => ({
       resourceId?: string;
       initialState?: Record<string, unknown>;
       intervalHandlers?: Array<{ immediate?: boolean; handler: () => unknown }>;
+      pubsub?: unknown;
+      threadLock?: unknown;
     }) {
+      controllerConstructorConfigs.push(config as Record<string, unknown>);
       controllerInitialStates.push(config.initialState ?? {});
       for (const interval of config.intervalHandlers ?? []) {
         if (interval.immediate !== false) void interval.handler();
@@ -353,6 +359,34 @@ describe('settings.json OM seeding', () => {
       vi.mocked(resolveOmRoleModel).mockReturnValue('');
       vi.mocked(loadSettings).mockReturnValue(baseSettings);
     }
+  });
+});
+
+describe('createMastraCode thread lock wiring', () => {
+  beforeEach(() => {
+    controllerConstructorConfigs.length = 0;
+  });
+
+  it('keeps thread locks enabled for configured PubSub unless cross-process mode is explicit', async () => {
+    const pubsub = {} as Record<string, never>;
+    const { createMastraCode } = await import('./index.js');
+
+    await createMastraCode({ pubsub: pubsub as never, unixSocketPubSub: true });
+
+    const agentControllerConfig = controllerConstructorConfigs.at(-1);
+    expect(agentControllerConfig?.pubsub).toBe(pubsub);
+    expect(agentControllerConfig?.threadLock).toBeDefined();
+  });
+
+  it('skips thread locks for configured PubSub when cross-process mode is explicit', async () => {
+    const pubsub = {} as Record<string, never>;
+    const { createMastraCode } = await import('./index.js');
+
+    await createMastraCode({ pubsub: pubsub as never, crossProcessPubSub: true });
+
+    const agentControllerConfig = controllerConstructorConfigs.at(-1);
+    expect(agentControllerConfig?.pubsub).toBe(pubsub);
+    expect(agentControllerConfig?.threadLock).toBeUndefined();
   });
 });
 

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -111,7 +111,7 @@ import { createStorage, createVectorStore } from './utils/storage-factory.js';
 import type { StorageResult } from './utils/storage-factory.js';
 import { createStorageMaintenance, DEFAULT_RETENTION, resolveLocalDbFiles } from './utils/storage-maintenance.js';
 import type { StorageMaintenance } from './utils/storage-maintenance.js';
-import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
+import { acquireThreadLock, releaseThreadLock, tryAcquireThreadLock } from './utils/thread-lock.js';
 import { registerWorkflowBuilderPrimitives } from './workflows/register-primitives.js';
 
 const CODE_AGENT_ID = 'code-agent';
@@ -1144,6 +1144,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
       ? undefined
       : {
           acquire: acquireThreadLock,
+          tryAcquire: tryAcquireThreadLock,
           release: releaseThreadLock,
         },
   });

--- a/mastracode/sdk/src/utils/thread-lock.test.ts
+++ b/mastracode/sdk/src/utils/thread-lock.test.ts
@@ -1,0 +1,161 @@
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { acquireThreadLock, getThreadLockOwner, ThreadLockError, tryAcquireThreadLock } from './thread-lock.js';
+
+const DEAD_PID = 2_147_483_647;
+
+const interleave = vi.hoisted(() => ({
+  onExclusiveCreate: undefined as (() => void) | undefined,
+  onUnlink: undefined as (() => void) | undefined,
+}));
+
+function fireOnce(key: 'onExclusiveCreate' | 'onUnlink'): void {
+  const hook = interleave[key];
+  if (!hook) return;
+  interleave[key] = undefined;
+  hook();
+}
+
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    openSync: (...args: Parameters<typeof actual.openSync>) => {
+      if (args[1] === 'wx') fireOnce('onExclusiveCreate');
+      return actual.openSync(...args);
+    },
+    unlinkSync: (...args: Parameters<typeof actual.unlinkSync>) => {
+      fireOnce('onUnlink');
+      return actual.unlinkSync(...args);
+    },
+  };
+});
+
+describe('thread locks', () => {
+  let appDataDir: string;
+
+  beforeEach(() => {
+    appDataDir = mkdtempSync(join(tmpdir(), 'mastracode-thread-lock-'));
+    vi.stubEnv('MASTRA_APP_DATA_DIR', appDataDir);
+  });
+
+  afterEach(() => {
+    interleave.onExclusiveCreate = undefined;
+    interleave.onUnlink = undefined;
+    vi.unstubAllEnvs();
+    rmSync(appDataDir, { recursive: true, force: true });
+  });
+
+  function locksDir(): string {
+    const dir = join(appDataDir, 'locks');
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  function writeOwner(threadId: string, pid: number, generation = 1): string {
+    const lockPath = join(locksDir(), `${threadId}.${generation}.lock`);
+    writeFileSync(lockPath, String(pid));
+    return lockPath;
+  }
+
+  function writeLegacyOwner(threadId: string, pid: number): string {
+    const lockPath = join(locksDir(), `${threadId}.lock`);
+    writeFileSync(lockPath, String(pid));
+    return lockPath;
+  }
+
+  function lockFiles(threadId: string): string[] {
+    return readdirSync(locksDir())
+      .filter(file => file.startsWith(`${threadId}.`) && file.endsWith('.lock'))
+      .sort();
+  }
+
+  function currentOwner(threadId: string): string | undefined {
+    const files = lockFiles(threadId);
+    const newest = files
+      .map(file => ({ file, generation: Number(file.slice(threadId.length + 1, -'.lock'.length) || 0) }))
+      .sort((a, b) => b.generation - a.generation)[0];
+    return newest ? readFileSync(join(locksDir(), newest.file), 'utf-8') : undefined;
+  }
+
+  /** Runs `fn` as if this process had another PID, so races can be driven in-process. */
+  function asPid<T>(pid: number, fn: () => T): T {
+    const descriptor = Object.getOwnPropertyDescriptor(process, 'pid')!;
+    Object.defineProperty(process, 'pid', { ...descriptor, value: pid });
+    try {
+      return fn();
+    } finally {
+      Object.defineProperty(process, 'pid', descriptor);
+    }
+  }
+
+  function tryAcquire(threadId: string, pid?: number): boolean {
+    const attempt = () => tryAcquireThreadLock(threadId);
+    return pid === undefined ? attempt() : asPid(pid, attempt);
+  }
+
+  it('reports contention without replacing a live process lock', () => {
+    const lockPath = writeOwner('thread-live', process.ppid);
+
+    expect(tryAcquireThreadLock('thread-live')).toBe(false);
+    expect(() => acquireThreadLock('thread-live')).toThrow(ThreadLockError);
+    expect(getThreadLockOwner('thread-live')).toBe(process.ppid);
+    expect(readFileSync(lockPath, 'utf-8')).toBe(String(process.ppid));
+  });
+
+  it('does not delete stale locks while checking their owner', () => {
+    const lockPath = writeOwner('thread-stale-query', DEAD_PID);
+
+    expect(getThreadLockOwner('thread-stale-query')).toBeNull();
+    expect(readFileSync(lockPath, 'utf-8')).toBe(String(DEAD_PID));
+  });
+
+  it('supersedes a lock owned by a dead process', () => {
+    writeOwner('thread-stale', DEAD_PID);
+
+    expect(tryAcquireThreadLock('thread-stale')).toBe(true);
+    expect(currentOwner('thread-stale')).toBe(String(process.pid));
+    expect(lockFiles('thread-stale')).toEqual(['thread-stale.2.lock']);
+  });
+
+  it('honours a lock file written before generations existed', () => {
+    const lockPath = writeLegacyOwner('thread-legacy', process.ppid);
+
+    expect(tryAcquireThreadLock('thread-legacy')).toBe(false);
+    expect(readFileSync(lockPath, 'utf-8')).toBe(String(process.ppid));
+
+    writeFileSync(lockPath, String(DEAD_PID));
+    expect(tryAcquireThreadLock('thread-legacy')).toBe(true);
+    expect(lockFiles('thread-legacy')).toEqual(['thread-legacy.1.lock']);
+  });
+
+  // Two processes reclaiming the same stale lock must not both end up owning it.
+  const raceCases = [
+    { seed: 'generation', hook: 'onExclusiveCreate' },
+    { seed: 'generation', hook: 'onUnlink' },
+    { seed: 'legacy', hook: 'onExclusiveCreate' },
+    { seed: 'legacy', hook: 'onUnlink' },
+  ] as const;
+
+  it.each(raceCases)(
+    'grants a $seed stale lock to a single process when a competitor interleaves at $hook',
+    ({ seed, hook }) => {
+      const otherPid = process.ppid;
+      if (seed === 'legacy') writeLegacyOwner('thread-race', DEAD_PID);
+      else writeOwner('thread-race', DEAD_PID);
+
+      let otherAcquired = false;
+      interleave[hook] = () => {
+        otherAcquired = tryAcquire('thread-race', otherPid);
+      };
+
+      const selfAcquired = tryAcquire('thread-race');
+
+      expect([selfAcquired, otherAcquired].filter(Boolean)).toHaveLength(1);
+      expect(currentOwner('thread-race')).toBe(String(selfAcquired ? process.pid : otherPid));
+    },
+  );
+});

--- a/mastracode/sdk/src/utils/thread-lock.ts
+++ b/mastracode/sdk/src/utils/thread-lock.ts
@@ -1,13 +1,21 @@
 /**
  * Thread lock — ensures only one process writes to a thread at a time.
  *
- * Uses filesystem lock files: <appDataDir>/locks/<threadId>.lock
- * Each lock file contains the PID of the owning process.
- * Stale locks (from crashed processes) are detected and reclaimed.
+ * Lock files live at <appDataDir>/locks/<threadId>.<generation>.lock and contain
+ * the owning PID. The owner is the highest generation present, and claiming is an
+ * exclusive create one generation above it, so a stale lock is superseded rather
+ * than deleted: no process ever removes a file a live process may have created.
+ * Invariant this relies on — a lock file is only removed by its own owner or by a
+ * claimant that already holds a higher generation.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { getAppDataDir } from './project.js';
+
+const LOCK_SUFFIX = '.lock';
+const FIRST_GENERATION = 1;
+// pre-generation lock file written by older mastracode versions
+const LEGACY_GENERATION = 0;
 
 export class ThreadLockError extends Error {
   constructor(
@@ -27,10 +35,33 @@ function getLocksDir(): string {
   return dir;
 }
 
-function getLockPath(threadId: string): string {
-  // Sanitize thread ID for filesystem safety
-  const safeId = threadId.replace(/[^a-zA-Z0-9_-]/g, '_');
-  return path.join(getLocksDir(), `${safeId}.lock`);
+function getSafeThreadId(threadId: string): string {
+  return threadId.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+function parseGeneration(fileName: string, safeThreadId: string): number | undefined {
+  if (!fileName.startsWith(`${safeThreadId}.`) || !fileName.endsWith(LOCK_SUFFIX)) return undefined;
+  const generation = fileName.slice(safeThreadId.length + 1, -LOCK_SUFFIX.length);
+  if (generation === '') return LEGACY_GENERATION;
+  return /^\d+$/.test(generation) ? Number(generation) : undefined;
+}
+
+type LockFile = { generation: number; filePath: string };
+
+/** Newest generation first. */
+function listLockFiles(threadId: string): { locksDir: string; safeThreadId: string; files: LockFile[] } {
+  const locksDir = getLocksDir();
+  const safeThreadId = getSafeThreadId(threadId);
+  const files: LockFile[] = [];
+
+  for (const fileName of fs.readdirSync(locksDir)) {
+    const generation = parseGeneration(fileName, safeThreadId);
+    if (generation === undefined) continue;
+    files.push({ generation, filePath: path.join(locksDir, fileName) });
+  }
+
+  files.sort((a, b) => b.generation - a.generation);
+  return { locksDir, safeThreadId, files };
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -42,51 +73,116 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+function getErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return undefined;
+  return typeof error.code === 'string' ? error.code : undefined;
+}
+
+/** Throws on read failures other than a lock file that vanished. */
+function readOwnerPid(filePath: string): number | undefined {
+  const ownerPid = parseInt(fs.readFileSync(filePath, 'utf-8').trim(), 10);
+  return isNaN(ownerPid) ? undefined : ownerPid;
+}
+
+function readOwnerPidIfPresent(filePath: string): number | undefined {
+  try {
+    return readOwnerPid(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+function findLiveOwner(files: LockFile[], myPid: number): number | undefined {
+  for (const file of files) {
+    const ownerPid = readOwnerPidIfPresent(file.filePath);
+    if (ownerPid !== undefined && ownerPid !== myPid && isProcessAlive(ownerPid)) return ownerPid;
+  }
+  return undefined;
+}
+
+function removeLockFile(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    // Best-effort — a superseded lock left behind is reclaimed by the next generation
+  }
+}
+
+function writeNewLock(lockPath: string, pid: number): void {
+  const file = fs.openSync(lockPath, 'wx', 0o644);
+  try {
+    fs.writeFileSync(file, String(pid), 'utf-8');
+  } finally {
+    fs.closeSync(file);
+  }
+}
+
 /**
  * Attempt to acquire a lock for the given thread.
  * Throws ThreadLockError if another live process holds the lock.
- * Reclaims stale locks from dead processes.
+ * Supersedes stale locks from dead processes.
  */
 export function acquireThreadLock(threadId: string): void {
-  const lockPath = getLockPath(threadId);
   const myPid = process.pid;
 
-  // Check for existing lock
-  if (fs.existsSync(lockPath)) {
-    try {
-      const content = fs.readFileSync(lockPath, 'utf-8').trim();
-      const ownerPid = parseInt(content, 10);
+  while (true) {
+    const { locksDir, safeThreadId, files } = listLockFiles(threadId);
+    const current = files[0];
+    let ownerPid: number | undefined;
 
-      if (!isNaN(ownerPid) && ownerPid !== myPid && isProcessAlive(ownerPid)) {
-        throw new ThreadLockError(threadId, ownerPid);
+    if (current) {
+      try {
+        ownerPid = readOwnerPid(current.filePath);
+      } catch (error) {
+        if (getErrorCode(error) === 'ENOENT') continue;
+        throw error;
       }
-      // Stale lock (dead process) or our own lock — reclaim it
-    } catch (error) {
-      if (error instanceof ThreadLockError) throw error;
-      // File read error — try to overwrite
+      if (ownerPid === myPid) return;
+      // a dead owner stays dead, so this observation cannot go stale under us
+      if (ownerPid !== undefined && isProcessAlive(ownerPid)) throw new ThreadLockError(threadId, ownerPid);
     }
-  }
 
-  // Write our PID to the lock file
-  fs.writeFileSync(lockPath, String(myPid), { mode: 0o644 });
+    const generation = current ? current.generation + 1 : FIRST_GENERATION;
+    const lockPath = path.join(locksDir, `${safeThreadId}.${generation}${LOCK_SUFFIX}`);
+    try {
+      writeNewLock(lockPath, myPid);
+    } catch (error) {
+      if (getErrorCode(error) === 'EEXIST') continue;
+      throw error;
+    }
+
+    const superseded = listLockFiles(threadId).files.filter(file => file.generation < generation);
+    // a live owner below us means the generation counter was reset behind our snapshot
+    const liveOwner = findLiveOwner(superseded, myPid);
+    if (liveOwner !== undefined) {
+      removeLockFile(lockPath);
+      throw new ThreadLockError(threadId, liveOwner);
+    }
+
+    for (const file of superseded) removeLockFile(file.filePath);
+    return;
+  }
+}
+
+export function tryAcquireThreadLock(threadId: string): boolean {
+  try {
+    acquireThreadLock(threadId);
+    return true;
+  } catch (error) {
+    if (error instanceof ThreadLockError) return false;
+    throw error;
+  }
 }
 
 /**
  * Release the lock for the given thread (only if we own it).
  */
 export function releaseThreadLock(threadId: string): void {
-  const lockPath = getLockPath(threadId);
   const myPid = process.pid;
 
   try {
-    if (!fs.existsSync(lockPath)) return;
-
-    const content = fs.readFileSync(lockPath, 'utf-8').trim();
-    const ownerPid = parseInt(content, 10);
-
-    // Only remove if we own it
-    if (ownerPid === myPid) {
-      fs.unlinkSync(lockPath);
+    for (const file of listLockFiles(threadId).files) {
+      if (readOwnerPidIfPresent(file.filePath) === myPid) removeLockFile(file.filePath);
     }
   } catch {
     // Best-effort cleanup — ignore errors
@@ -98,25 +194,14 @@ export function releaseThreadLock(threadId: string): void {
  * Returns the PID of the owner if locked, null otherwise.
  */
 export function getThreadLockOwner(threadId: string): number | null {
-  const lockPath = getLockPath(threadId);
-
   try {
-    if (!fs.existsSync(lockPath)) return null;
+    const current = listLockFiles(threadId).files[0];
+    if (!current) return null;
 
-    const content = fs.readFileSync(lockPath, 'utf-8').trim();
-    const ownerPid = parseInt(content, 10);
+    const ownerPid = readOwnerPidIfPresent(current.filePath);
+    if (ownerPid === undefined || ownerPid === process.pid) return null;
 
-    if (isNaN(ownerPid)) return null;
-    if (ownerPid === process.pid) return null; // Our own lock
-    if (!isProcessAlive(ownerPid)) {
-      // Stale lock — clean it up
-      try {
-        fs.unlinkSync(lockPath);
-      } catch {}
-      return null;
-    }
-
-    return ownerPid;
+    return isProcessAlive(ownerPid) ? ownerPid : null;
   } catch {
     return null;
   }
@@ -130,19 +215,12 @@ export function releaseAllThreadLocks(): void {
   try {
     const locksDir = getLocksDir();
     const files = fs.readdirSync(locksDir);
-    const myPid = String(process.pid);
+    const myPid = process.pid;
 
     for (const file of files) {
-      if (!file.endsWith('.lock')) continue;
+      if (!file.endsWith(LOCK_SUFFIX)) continue;
       const lockPath = path.join(locksDir, file);
-      try {
-        const content = fs.readFileSync(lockPath, 'utf-8').trim();
-        if (content === myPid) {
-          fs.unlinkSync(lockPath);
-        }
-      } catch {
-        // Best-effort
-      }
+      if (readOwnerPidIfPresent(lockPath) === myPid) removeLockFile(lockPath);
     }
   } catch {
     // Best-effort

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -696,14 +696,29 @@ export class AgentController<TState = {}> {
         return scopeEntries.every(([key, value]) => metadata[key] === value);
       });
 
-      if (candidates.length === 0) {
-        await session.thread.create();
-      } else {
-        const mostRecent = [...candidates].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0]!;
-        await this.config.threadLock?.acquire(mostRecent.id);
-        session.thread.set({ threadId: mostRecent.id });
+      const byRecency = [...candidates].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+      const threadLock = this.config.threadLock;
+      let selectedThread: AgentControllerThread | undefined;
+
+      if (threadLock?.tryAcquire) {
+        for (const candidate of byRecency) {
+          if (await threadLock.tryAcquire(candidate.id)) {
+            selectedThread = candidate;
+            break;
+          }
+        }
+      } else if (byRecency[0]) {
+        // no non-throwing probe available — contention stays fatal, as before tryAcquire existed
+        await threadLock?.acquire(byRecency[0].id);
+        selectedThread = byRecency[0];
+      }
+
+      if (selectedThread) {
+        session.thread.set({ threadId: selectedThread.id });
         await session.thread.loadMetadata();
         await session.thread.ensureCurrentSubscription();
+      } else {
+        await session.thread.create();
       }
     }
 

--- a/packages/core/src/agent-controller/thread-locking.test.ts
+++ b/packages/core/src/agent-controller/thread-locking.test.ts
@@ -183,7 +183,7 @@ describe('AgentController thread locking', () => {
   });
 
   describe('createSession thread selection', () => {
-    function freshController(store: InMemoryStore) {
+    function freshController(store: InMemoryStore, tryAcquire?: (id: string) => boolean | Promise<boolean>) {
       const agent = new Agent({
         name: 'test-agent',
         instructions: 'You are a test agent.',
@@ -194,7 +194,7 @@ describe('AgentController thread locking', () => {
         id: 'test-controller',
         storage: store,
         modes: [{ id: 'default', name: 'Default', default: true, agent }],
-        threadLock: { acquire, release },
+        threadLock: { acquire, tryAcquire, release },
       });
     }
 
@@ -226,6 +226,86 @@ describe('AgentController thread locking', () => {
 
       expect(sessionB.thread.getId()).toBe(existing);
       expect(acquire).toHaveBeenCalledWith(existing);
+    });
+
+    it('resumes the next thread when the most recent thread is locked', async () => {
+      const store = new InMemoryStore();
+      const controllerA = freshController(store);
+      await controllerA.init();
+      const sessionA = await controllerA.createSession({
+        id: 'session-a',
+        ownerId: 'test-owner',
+        resourceId: 'user-1',
+      });
+      const olderThreadId = sessionA.thread.getId();
+      const now = Date.now();
+      vi.useFakeTimers();
+      vi.setSystemTime(now + 1000);
+      const newestThread = await sessionA.thread.create();
+      vi.useRealTimers();
+
+      acquire.mockClear();
+      const tryAcquire = vi.fn((id: string) => id !== newestThread.id);
+      const controllerB = freshController(store, tryAcquire);
+      await controllerB.init();
+      const sessionB = await controllerB.createSession({
+        id: 'session-b',
+        ownerId: 'test-owner',
+        resourceId: 'user-1',
+      });
+
+      expect(tryAcquire).toHaveBeenNthCalledWith(1, newestThread.id);
+      expect(tryAcquire).toHaveBeenNthCalledWith(2, olderThreadId);
+      expect(sessionB.thread.getId()).toBe(olderThreadId);
+    });
+
+    it('creates a new thread when every existing thread is locked', async () => {
+      const store = new InMemoryStore();
+      const controllerA = freshController(store);
+      await controllerA.init();
+      const sessionA = await controllerA.createSession({
+        id: 'session-a',
+        ownerId: 'test-owner',
+        resourceId: 'user-1',
+      });
+      const lockedThreadId = sessionA.thread.getId();
+
+      acquire.mockClear();
+      const tryAcquire = vi.fn(() => false);
+      const controllerB = freshController(store, tryAcquire);
+      await controllerB.init();
+      const sessionB = await controllerB.createSession({
+        id: 'session-b',
+        ownerId: 'test-owner',
+        resourceId: 'user-1',
+      });
+
+      expect(tryAcquire).toHaveBeenCalledWith(lockedThreadId);
+      expect(sessionB.thread.getId()).not.toBe(lockedThreadId);
+      expect(acquire).toHaveBeenCalledWith(sessionB.thread.getId());
+    });
+
+    it('surfaces contention when the lock has no non-throwing probe', async () => {
+      const store = new InMemoryStore();
+      const controllerA = freshController(store);
+      await controllerA.init();
+      const sessionA = await controllerA.createSession({
+        id: 'session-a',
+        ownerId: 'test-owner',
+        resourceId: 'user-1',
+      });
+      const lockedThreadId = sessionA.thread.getId()!;
+
+      acquire.mockClear();
+      acquire.mockImplementation((id: string) => {
+        if (id === lockedThreadId) throw new Error('locked by another process');
+      });
+      const controllerB = freshController(store);
+      await controllerB.init();
+
+      await expect(
+        controllerB.createSession({ id: 'session-b', ownerId: 'test-owner', resourceId: 'user-1' }),
+      ).rejects.toThrow('locked by another process');
     });
 
     it('creates a fresh thread for a different resourceId', async () => {

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -371,6 +371,8 @@ export interface AgentControllerConfig<TState = {}> {
    */
   threadLock?: {
     acquire: (threadId: string) => void | Promise<void>;
+    /** Attempts implicit selection without treating contention as an error. */
+    tryAcquire?: (threadId: string) => boolean | Promise<boolean>;
     release: (threadId: string) => void | Promise<void>;
   };
 


### PR DESCRIPTION
## Summary
- Fixes #21243: MastraCode failed to start a second terminal in the same directory when the newest thread held the file lock.
- \`createSession\` (no explicit thread id) now walks candidates newest→oldest with optional \`tryAcquire\`, creating a new thread if all are locked.
- SDK thread locks use exclusive \`wx\` create + generation-based stale reclaim; wires \`tryAcquire\` into the MastraCode controller.

## Test plan
- [x] \`pnpm --filter ./packages/core exec vitest run src/agent-controller/thread-locking.test.ts\`
- [x] \`pnpm --filter ./mastracode/sdk exec vitest run src/utils/thread-lock.test.ts\`
- [ ] CodeRabbit review addressed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

MastraCode now skips threads that another process is using. If every existing thread is busy, it starts a new one instead of failing.

## Summary

- Added optional non-blocking thread selection through `threadLock.tryAcquire`.
- Updated `createSession` to check threads from newest to oldest.
- Preserved contention errors when `tryAcquire` is unavailable.
- Preserved errors when a user explicitly targets a locked thread.
- Added exclusive lock-file creation with generation-based stale-lock reclamation.
- Added race-safe cleanup and legacy lock-file support.
- Connected `tryAcquireThreadLock` to the MastraCode controller.
- Added tests for contention, stale locks, races, and automatic thread selection.
- Added patch changesets for `@mastra/core` and `@mastra/code-sdk`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->