### PR TITLE
fix(core): report one suspended leaf for nested workflows

### DIFF
--- a/.changeset/odd-rings-post.md
+++ b/.changeset/odd-rings-post.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed nested workflow suspend reporting so getWorkflowRunById exposes a single suspended leaf step instead of duplicating the parent container, and cleared stale suspendPayload/suspendedAt after a step re-enters or completes.
+
+Closes #21229

--- a/.changeset/odd-rings-post.md
+++ b/.changeset/odd-rings-post.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed getWorkflowRunById so nested workflows report the correct single suspended leaf step. Obsolete suspension details are removed after the step resumes or completes. (#21229)
+Fixed getWorkflowRunById and getWorkflowRunSteps so nested workflows report the correct single suspended leaf step. Obsolete suspension details are removed after the step resumes or completes. (#21229)

--- a/.changeset/odd-rings-post.md
+++ b/.changeset/odd-rings-post.md
@@ -2,6 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed nested workflow suspend reporting so getWorkflowRunById exposes a single suspended leaf step instead of duplicating the parent container, and cleared stale suspendPayload/suspendedAt after a step re-enters or completes.
-
-Closes #21229
+Fixed getWorkflowRunById so nested workflows report the correct single suspended leaf step. Obsolete suspension details are removed after the step resumes or completes. (#21229)

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -19,6 +19,7 @@ import type { SingleStepEntry, StepFlowEntry, StepResult } from '../types';
 import {
   validateStepInput,
   createDeprecationProxy,
+  omitPriorCompletionFields,
   runCountDeprecationMessage,
   validateStepSuspendData,
 } from '../utils';
@@ -104,7 +105,7 @@ export class StepExecutor extends MastraBase {
       resumedAt?: number;
       [key: string]: any;
     } = {
-      ...stepResults[stepId],
+      ...omitPriorCompletionFields((stepResults[stepId] ?? {}) as Record<string, unknown>),
       startedAt,
       payload: (typeof params.foreachIdx === 'number' ? params.input : inputData) ?? {},
     };
@@ -275,10 +276,11 @@ export class StepExecutor extends MastraBase {
       // Use stateUpdate if setState was called, otherwise use original state
       const finalState = stateUpdate ?? params.state;
 
+      const baseStepInfo = omitPriorCompletionFields(stepInfo);
       let finalResult: StepResult<any, any, any, any> & { __state?: Record<string, any> };
       if (suspended) {
         finalResult = {
-          ...stepInfo,
+          ...baseStepInfo,
           status: 'suspended',
           suspendedAt: endedAt,
           ...(stepOutput ? { suspendOutput: stepOutput } : {}),
@@ -290,7 +292,7 @@ export class StepExecutor extends MastraBase {
         }
       } else if (bailed) {
         finalResult = {
-          ...stepInfo,
+          ...baseStepInfo,
           // @ts-expect-error - bailed status not in type
           status: 'bailed',
           endedAt,
@@ -299,13 +301,13 @@ export class StepExecutor extends MastraBase {
         };
       } else if (nestedWflowStepPaused) {
         finalResult = {
-          ...stepInfo,
+          ...baseStepInfo,
           status: 'paused',
           __state: finalState,
         };
       } else {
         finalResult = {
-          ...stepInfo,
+          ...baseStepInfo,
           status: 'success',
           endedAt,
           output: stepOutput,
@@ -344,7 +346,7 @@ export class StepExecutor extends MastraBase {
       this.logger?.error(`Error executing step ${stepId}: ` + errorInstance?.stack);
 
       return {
-        ...stepInfo,
+        ...omitPriorCompletionFields(stepInfo),
         status: 'failed',
         endedAt,
         error: errorInstance,

--- a/packages/core/src/workflows/handlers/control-flow.ts
+++ b/packages/core/src/workflows/handlers/control-flow.ts
@@ -929,7 +929,8 @@ export async function executeForeach(
   const resumeTime = resume?.steps[0] === stepId ? Date.now() : undefined;
 
   const stepInfo = {
-    ...stepResults[stepId],
+    // Same as executeStep: strip prior completion/suspend fields on re-entry.
+    ...omitPriorCompletionFields((stepResults[stepId] ?? {}) as Record<string, unknown>),
     ...(resume?.steps[0] === stepId ? { resumePayload: resume?.resumePayload } : { payload: prevOutput }),
     ...(startTime ? { startedAt: startTime } : {}),
     ...(resumeTime ? { resumedAt: resumeTime } : {}),

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -158,7 +158,9 @@ export async function executeStep(
   const resumeTime = resumeDataToUse ? Date.now() : undefined;
 
   const stepInfo = {
-    ...stepResults[step.id],
+    // Drop prior completion/suspend fields so they cannot linger across re-entry
+    // (e.g. suspendPayload/suspendedAt after resume, or startedAt > suspendedAt on loops).
+    ...omitPriorCompletionFields((stepResults[step.id] ?? {}) as Record<string, unknown>),
     ...(resumeDataToUse ? { resumePayload: resumeDataToUse } : { payload: inputData }),
     ...(startTime ? { startedAt: startTime } : {}),
     ...(resumeTime ? { resumedAt: resumeTime } : {}),
@@ -263,7 +265,10 @@ export async function executeStep(
         }
       }
 
-      const stepResult = { ...stepInfo, ...workflowResult } as StepResult<any, any, any, any>;
+      const stepResult = {
+        ...omitPriorCompletionFields(stepInfo),
+        ...workflowResult,
+      } as StepResult<any, any, any, any>;
       return {
         result: stepResult,
         stepResults: { [step.id]: stepResult },
@@ -517,9 +522,8 @@ export async function executeStep(
       await emitStepResultEvents({
         stepId: step.id,
         stepCallId,
-        // The persisted step result keeps the full prior-result spread (see
-        // `stepResult` below); the emitted event must not re-publish the
-        // previous completion's state blobs alongside the fresh execResults.
+        // Emit uses the same omit+merge as the persisted stepResult below so
+        // watch events and snapshots agree on cleared prior completion fields.
         execResults: { ...omitPriorCompletionFields(stepInfo), ...execResults } as StepResult<any, any, any, any>,
         pubsub,
         runId,
@@ -540,7 +544,10 @@ export async function executeStep(
     });
   }
 
-  const stepResult = { ...stepInfo, ...execResults } as StepResult<any, any, any, any>;
+  const stepResult = {
+    ...omitPriorCompletionFields(stepInfo),
+    ...execResults,
+  } as StepResult<any, any, any, any>;
 
   return {
     result: stepResult,

--- a/packages/core/src/workflows/nested-suspend-steps.test.ts
+++ b/packages/core/src/workflows/nested-suspend-steps.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage/mock';
+import { createWorkflow } from './create';
+import { createStep } from './workflow';
+
+/**
+ * Regression for #21229: one nested (sub-workflow) suspend must appear as a
+ * single suspended leaf in getWorkflowRunById().steps, and suspend-scoped
+ * fields must not linger after resume completes.
+ */
+describe('nested suspend steps — issue #21229', () => {
+  const state = z.object({ round: z.number(), done: z.boolean() });
+
+  const inner = createStep({
+    id: 'inner-step',
+    inputSchema: state,
+    outputSchema: state,
+    suspendSchema: z.object({ question: z.string() }),
+    resumeSchema: z.object({ answer: z.string() }),
+    execute: async ({ inputData, resumeData, suspend }) => {
+      if (resumeData) {
+        return { round: inputData.round + 1, done: true };
+      }
+      if (inputData.round > 0) {
+        return { round: inputData.round, done: true };
+      }
+      return await suspend({ question: 'pick one' });
+    },
+  });
+
+  const nested = createWorkflow({
+    id: 'inner-loop',
+    inputSchema: state,
+    outputSchema: state,
+  })
+    .then(inner)
+    .commit();
+
+  const after = createStep({
+    id: 'after-step',
+    inputSchema: state,
+    outputSchema: state,
+    execute: async ({ inputData }) => inputData,
+  });
+
+  const parent = createWorkflow({
+    id: 'parent-wf',
+    inputSchema: state,
+    outputSchema: state,
+  })
+    .then(nested)
+    .then(after)
+    .commit();
+
+  function suspendedStepIds(steps: Record<string, { status?: string } | undefined> | undefined) {
+    return Object.entries(steps ?? {})
+      .filter(([key, value]) => key !== 'input' && value?.status === 'suspended')
+      .map(([key]) => key);
+  }
+
+  it('reports exactly one suspended leaf for a nested sub-workflow suspend', async () => {
+    const storage = new MockStore();
+    new Mastra({
+      logger: false,
+      storage,
+      workflows: { parent },
+    });
+
+    const run = await parent.createRun();
+    const startResult = await run.start({ inputData: { round: 0, done: false } });
+    expect(startResult.status).toBe('suspended');
+
+    const suspended = await parent.getWorkflowRunById(run.runId);
+    expect(Object.keys(suspended?.suspendedPaths ?? {})).toHaveLength(1);
+    expect(suspendedStepIds(suspended?.steps)).toEqual(['inner-loop.inner-step']);
+    expect(suspended?.steps?.['inner-loop']?.status).not.toBe('suspended');
+    expect(suspended?.steps?.['inner-loop']).toBeDefined();
+    expect(suspended?.steps?.['inner-loop.inner-step']?.status).toBe('suspended');
+  });
+
+  it('clears suspendPayload after resume completes successfully', async () => {
+    const storage = new MockStore();
+    new Mastra({
+      logger: false,
+      storage,
+      workflows: { parent },
+    });
+
+    const run = await parent.createRun();
+    await run.start({ inputData: { round: 0, done: false } });
+
+    const rootStep = Object.keys((await parent.getWorkflowRunById(run.runId))?.suspendedPaths ?? {})[0];
+    expect(rootStep).toBeDefined();
+
+    const resumeResult = await run.resume({
+      step: [rootStep!, 'inner-step'],
+      resumeData: { answer: 'a' },
+    });
+    expect(resumeResult.status).toBe('success');
+
+    const completed = await parent.getWorkflowRunById(run.runId);
+    expect(suspendedStepIds(completed?.steps)).toEqual([]);
+
+    for (const [key, step] of Object.entries(completed?.steps ?? {})) {
+      if (key === 'input' || !step || typeof step !== 'object') continue;
+      expect(step, key).not.toHaveProperty('suspendPayload');
+      expect((step as { suspendedAt?: number }).suspendedAt).toBeUndefined();
+    }
+  });
+});

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -3037,6 +3037,18 @@ export class Workflow<
             {} as Record<string, StepResult<any, any, any, any>>,
           );
           finalSteps = { ...finalSteps, ...updatedNestedSteps };
+
+          // Nested suspend is recorded on both the container and the flattened leaf.
+          // Demote the container in the public steps map so clients (e.g. Studio)
+          // that treat every status==='suspended' entry as a resume target only
+          // see the leaf. Keep the container entry for hierarchy; leave suspendedPaths alone.
+          const parentStep = finalSteps[step];
+          if (parentStep?.status === 'suspended') {
+            const hasSuspendedChild = Object.values(updatedNestedSteps).some(child => child?.status === 'suspended');
+            if (hasSuspendedChild) {
+              finalSteps[step] = { ...parentStep, status: 'running' };
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Fixes #21229: \`getWorkflowRunById\` / \`getWorkflowRunSteps\` exposed both a nested workflow container and its flattened leaf as \`suspended\`, so Studio could show two resume forms for one suspend.
- Demotes the parent container to \`running\` in the projected steps map when a nested child is suspended (\`suspendedPaths\` unchanged).
- Clears stale \`suspendPayload\` / \`suspendedAt\` (and other completion fields) when a step re-enters or completes via \`omitPriorCompletionFields\`.

## Test plan
- [x] \`nested-suspend-steps.test.ts\`, \`branch-map-bug.test.ts\`, \`nested-resume-label.test.ts\`
- [x] \`watch-event-payload.test.ts\`, \`foreach-suspend-payload.test.ts\`
- [ ] CodeRabbit review addressed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a nested workflow pauses, the system now shows only the step that needs input. It also removes old pause and completion details when the step resumes or finishes.

## Changes

- Updated `getWorkflowRunById` and `getWorkflowRunSteps` to report one suspended leaf step.
- Marked the nested workflow container as `running` when a child step is suspended.
- Cleared stale completion and suspension fields during step re-entry, completion, and result updates.
- Applied the cleanup to standard steps, nested workflows, and `foreach` steps.
- Added regression tests for nested suspension, resume labels, branch maps, watch events, and `foreach` suspend payloads.
- Added a changeset for the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->