### PR TITLE
fix(core): preserve provider metadata in generated streams

### DIFF
--- a/.changeset/bright-streams-remember.md
+++ b/.changeset/bright-streams-remember.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed generated streams to preserve provider metadata on text and file events.

--- a/packages/core/src/llm/model/aisdk/generate-to-stream.test.ts
+++ b/packages/core/src/llm/model/aisdk/generate-to-stream.test.ts
@@ -78,4 +78,67 @@ describe('createStreamFromGenerateResult', () => {
     expect(toolCall).toBeDefined();
     expect(toolCall.providerMetadata).toBeUndefined();
   });
+
+  it('should forward providerMetadata on text and file stream events', async () => {
+    const textProviderMetadata = {
+      google: { thoughtSignature: 'sig_text' },
+    };
+    const fileProviderMetadata = {
+      openai: { fileId: 'file_123' },
+    };
+    const result = {
+      warnings: [],
+      content: [
+        {
+          type: 'text',
+          text: 'Hello',
+          providerMetadata: textProviderMetadata,
+        },
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          data: 'file-data',
+          providerMetadata: fileProviderMetadata,
+        },
+      ],
+      finishReason: 'stop',
+      usage: { promptTokens: 5, completionTokens: 3 },
+    };
+
+    const chunks = await collectStream(createStreamFromGenerateResult(result));
+
+    const textStart = chunks.find((c: any) => c.type === 'text-start') as any;
+    const textDelta = chunks.find((c: any) => c.type === 'text-delta') as any;
+    const textEnd = chunks.find((c: any) => c.type === 'text-end') as any;
+    const file = chunks.find((c: any) => c.type === 'file') as any;
+
+    expect(textStart.providerMetadata).toEqual(textProviderMetadata);
+    expect(textDelta.providerMetadata).toEqual(textProviderMetadata);
+    expect(textEnd.providerMetadata).toEqual(textProviderMetadata);
+    expect(file.providerMetadata).toEqual(fileProviderMetadata);
+  });
+
+  it('should handle text and file content without providerMetadata', async () => {
+    const result = {
+      warnings: [],
+      content: [
+        { type: 'text', text: 'Hello' },
+        { type: 'file', mediaType: 'application/pdf', data: 'file-data' },
+      ],
+      finishReason: 'stop',
+      usage: { promptTokens: 5, completionTokens: 3 },
+    };
+
+    const chunks = await collectStream(createStreamFromGenerateResult(result));
+
+    const textStart = chunks.find((c: any) => c.type === 'text-start') as any;
+    const textDelta = chunks.find((c: any) => c.type === 'text-delta') as any;
+    const textEnd = chunks.find((c: any) => c.type === 'text-end') as any;
+    const file = chunks.find((c: any) => c.type === 'file') as any;
+
+    expect(textStart.providerMetadata).toBeUndefined();
+    expect(textDelta.providerMetadata).toBeUndefined();
+    expect(textEnd.providerMetadata).toBeUndefined();
+    expect(file.providerMetadata).toBeUndefined();
+  });
 });

--- a/packages/core/src/llm/model/aisdk/generate-to-stream.ts
+++ b/packages/core/src/llm/model/aisdk/generate-to-stream.ts
@@ -86,10 +86,12 @@ export function createStreamFromGenerateResult(result: {
             type: 'text-delta',
             id,
             delta: text.text,
+            providerMetadata: text.providerMetadata,
           });
           controller.enqueue({
             type: 'text-end',
             id,
+            providerMetadata: text.providerMetadata,
           });
         } else if (message.type === 'reasoning') {
           const id = `reasoning_${randomUUID()}`;
@@ -119,11 +121,13 @@ export function createStreamFromGenerateResult(result: {
             type: 'file';
             mediaType: string;
             data: unknown;
+            providerMetadata?: unknown;
           };
           controller.enqueue({
             type: 'file',
             mediaType: file.mediaType,
             data: file.data,
+            providerMetadata: file.providerMetadata,
           });
         } else if (message.type === 'source') {
           const source = message as {


### PR DESCRIPTION
## Description

Preserves content-part `providerMetadata` when streams are synthesized from `doGenerate()` results.

Previously:

- Text metadata was included on `text-start` but dropped from `text-delta` and `text-end`.
- File metadata was dropped from generated `file` events.

This could discard provider-specific information such as thought signatures and file identifiers.

## Related issue

Fixes #21440 

## Changes

- Forward text `providerMetadata` to:
  - `text-start`
  - `text-delta`
  - `text-end`
- Forward file `providerMetadata` to generated `file` events.
- Add regression coverage for text and file content with metadata.
- Verify content without metadata remains unchanged.
- Add an `@mastra/core` patch changeset.

## Test plan

- [x] Generated text metadata is preserved across all text events.
- [x] Generated file metadata is preserved.
- [x] Content without metadata continues to work.
- [x] All AI SDK model tests pass: 35/35.
- [x] Core TypeScript check passes.
- [x] ESLint and Oxlint pass.
- [x] Formatting and `git diff --check` pass.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR keeps extra information attached to text and files when it converts generated results into streams. It also adds tests to confirm the information is preserved or remains absent when not provided.

## Changes

- Preserve text `providerMetadata` on `text-start`, `text-delta`, and `text-end` events.
- Preserve file `providerMetadata` on generated `file` events.
- Add regression tests for metadata propagation.
- Verify that content without metadata keeps the existing behavior.
- Add an `@mastra/core` patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->