### PR TITLE
feat(code-sdk): authorize dynamic workflow saves

### DIFF
--- a/.changeset/gentle-workflows-authorize.md
+++ b/.changeset/gentle-workflows-authorize.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': minor
+---
+
+Add a `createSaveWorkflowTool` factory with an optional deny-only authorization hook that receives the native request context and a detached workflow definition.

--- a/.changeset/gentle-workflows-authorize.md
+++ b/.changeset/gentle-workflows-authorize.md
@@ -3,3 +3,17 @@
 ---
 
 Add a `createSaveWorkflowTool` factory with an optional deny-only authorization hook that receives the native request context and a detached workflow definition.
+
+```ts
+import { createSaveWorkflowTool } from '@mastra/code-sdk';
+
+const saveWorkflowTool = createSaveWorkflowTool({
+  authorize: ({ requestContext }) => {
+    if (requestContext.get('role') !== 'workflow-author') {
+      throw new Error('Workflow save denied');
+    }
+  },
+});
+```
+
+Throwing from `authorize` rejects the save before Mastra validates, persists, or registers the workflow.

--- a/mastracode/sdk/src/tools/workflows/__tests__/save-workflow.predicate.test.ts
+++ b/mastracode/sdk/src/tools/workflows/__tests__/save-workflow.predicate.test.ts
@@ -8,8 +8,9 @@
  * 2. `execute` — must call `mastra.addDynamicWorkflow` with the normalized
  *    canonical shape, so the SDK and Core schemas agree end-to-end.
  */
+import { RequestContext } from '@mastra/core/request-context';
 import { describe, it, expect, vi } from 'vitest';
-import { saveWorkflowTool } from '../save-workflow.js';
+import { createSaveWorkflowTool, saveWorkflowTool } from '../save-workflow.js';
 
 function invoke(input: unknown, mastra: unknown) {
   // Call the raw execute; callers of the tool are responsible for schema
@@ -135,5 +136,57 @@ describe('save-workflow — execute', () => {
       const mastra = { addDynamicWorkflow } as unknown;
       await expect(invoke(loopGraphWithPredicate, mastra)).rejects.toThrow(/unresolved reference to tool "inc-tool"/);
     });
+  });
+
+  describe('when mastra.addDynamicWorkflow rejects (storage failure)', () => {
+    it('propagates the underlying error unchanged', async () => {
+      const addDynamicWorkflow = vi.fn().mockRejectedValue(new Error('workflow storage unavailable'));
+      const mastra = { addDynamicWorkflow } as unknown;
+      await expect(invoke(loopGraphWithPredicate, mastra)).rejects.toThrow(/workflow storage unavailable/);
+    });
+  });
+});
+
+describe('createSaveWorkflowTool — authorization', () => {
+  it('passes the native request context and a detached definition to the policy', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('tenantId', 'tenant-1');
+    const addDynamicWorkflow = vi.fn().mockResolvedValue(undefined);
+    let receivedRequestContext: RequestContext | undefined;
+    let receivedDefinition: unknown;
+    const authorize = vi.fn(({ definition, requestContext: context }) => {
+      receivedRequestContext = context;
+      receivedDefinition = structuredClone(definition);
+      (definition as { id: string }).id = 'attempted-rewrite';
+    });
+    const tool = createSaveWorkflowTool({ authorize });
+
+    const result = await (tool as any).execute(loopGraphWithPredicate, {
+      mastra: { addDynamicWorkflow },
+      requestContext,
+    });
+
+    expect(result).toEqual({ ok: true, id: 'wf-loop' });
+    expect(authorize).toHaveBeenCalledTimes(1);
+    expect(receivedRequestContext).toBe(requestContext);
+    expect(receivedDefinition).toStrictEqual(loopGraphWithPredicate);
+    expect(addDynamicWorkflow).toHaveBeenCalledWith(loopGraphWithPredicate);
+  });
+
+  it('does not call Mastra when the policy denies by throwing', async () => {
+    const addDynamicWorkflow = vi.fn().mockResolvedValue(undefined);
+    const tool = createSaveWorkflowTool({
+      authorize: async () => {
+        throw new Error('workflow save not authorized');
+      },
+    });
+
+    await expect(
+      (tool as any).execute(loopGraphWithPredicate, {
+        mastra: { addDynamicWorkflow },
+        requestContext: new RequestContext(),
+      }),
+    ).rejects.toThrow(/workflow save not authorized/);
+    expect(addDynamicWorkflow).not.toHaveBeenCalled();
   });
 });

--- a/mastracode/sdk/src/tools/workflows/save-workflow.ts
+++ b/mastracode/sdk/src/tools/workflows/save-workflow.ts
@@ -8,8 +8,13 @@
  * `submit-workflow-draft` and lives in `@mastra/core/workflows/builder`.
  */
 import type { Mastra } from '@mastra/core/mastra';
+import type { RequestContext } from '@mastra/core/request-context';
 import { createTool } from '@mastra/core/tools';
-import { normalizeWorkflowBuilderDefinition, workflowBuilderDefinitionSchema } from '@mastra/core/workflows/builder';
+import {
+  normalizeWorkflowBuilderDefinition,
+  workflowBuilderDefinitionSchema,
+  type WorkflowBuilderDefinition,
+} from '@mastra/core/workflows/builder';
 import { z } from 'zod';
 
 export { WORKFLOW_BUILDER_MAPPING_CONFIG_DESCRIPTION as MAPPING_CONFIG_DESCRIPTION } from '@mastra/core/workflows/builder';
@@ -19,26 +24,59 @@ export const workflowDefinitionInputSchema = z.preprocess(
   workflowBuilderDefinitionSchema,
 );
 
-export const saveWorkflowTool = createTool({
-  id: 'save-workflow',
-  description:
-    'Persist a Dynamic Workflow definition and live-register it on the running Mastra instance. Supports all ten persisted graph families: agent, tool, mapping, nested workflow, parallel, foreach, sleep, sleepUntil, conditional, and loop. Conditional and loop entries require declarative predicates; JS closures cannot round-trip through storage. After this returns, the workflow is immediately runnable. Call it exactly once with the complete definition; there is no incremental save API.',
-  inputSchema: workflowDefinitionInputSchema,
-  outputSchema: z.object({
-    ok: z.literal(true),
-    id: z.string(),
-  }),
-  execute: async (def, { mastra }) => {
-    if (!mastra) throw new Error('save-workflow requires a Mastra context.');
-    const m = mastra as Mastra;
-    const normalizedDefinition = normalizeWorkflowBuilderDefinition(def);
+export interface SaveWorkflowAuthorizationContext {
+  /**
+   * A detached copy of the complete definition. Mutating it cannot change the
+   * definition passed to `Mastra.addDynamicWorkflow()`.
+   */
+  definition: Readonly<WorkflowBuilderDefinition>;
+  requestContext: RequestContext;
+}
 
-    // `mastra.addDynamicWorkflow` performs registry pre-flight — a mis-classified
-    // agentId/toolId or unregistered id throws before rehydration with an
-    // actionable message listing every offender. It also rejects JSON Schemas
-    // that use keywords the storage-side converter can't rehydrate
-    // (oneOf/anyOf/allOf/not/$ref/patternProperties/discriminator).
-    await m.addDynamicWorkflow(normalizedDefinition as Parameters<Mastra['addDynamicWorkflow']>[0]);
-    return { ok: true as const, id: normalizedDefinition.id };
-  },
-});
+export interface CreateSaveWorkflowToolOptions {
+  /**
+   * Optional deny-only policy hook. Throw to reject the save. Return normally
+   * to allow it. The callback cannot replace or rewrite the saved definition.
+   */
+  authorize?: (context: SaveWorkflowAuthorizationContext) => void | Promise<void>;
+}
+
+/**
+ * Creates the native Dynamic Workflow save tool with an optional host policy.
+ * Validation, persistence, registration, and rollback remain owned by
+ * `Mastra.addDynamicWorkflow()`.
+ */
+export function createSaveWorkflowTool(options: CreateSaveWorkflowToolOptions = {}) {
+  return createTool({
+    id: 'save-workflow',
+    description:
+      'Persist a Dynamic Workflow definition and live-register it on the running Mastra instance. Supports all ten persisted graph families: agent, tool, mapping, nested workflow, parallel, foreach, sleep, sleepUntil, conditional, and loop. Conditional and loop entries require declarative predicates; JS closures cannot round-trip through storage. After this returns, the workflow is immediately runnable. Call it exactly once with the complete definition; there is no incremental save API.',
+    inputSchema: workflowDefinitionInputSchema,
+    outputSchema: z.object({
+      ok: z.literal(true),
+      id: z.string(),
+    }),
+    execute: async (def, { mastra, requestContext }) => {
+      if (!mastra) throw new Error('save-workflow requires a Mastra context.');
+      const m = mastra as Mastra;
+      const normalizedDefinition = normalizeWorkflowBuilderDefinition(def);
+
+      if (options.authorize) {
+        // Normalize again to give policy code a detached JSON-safe value. The
+        // callback can inspect or reject, but cannot mutate the accepted input.
+        const authorizationDefinition = normalizeWorkflowBuilderDefinition(normalizedDefinition);
+        await options.authorize({ definition: authorizationDefinition, requestContext });
+      }
+
+      // `mastra.addDynamicWorkflow` performs registry pre-flight — a mis-classified
+      // agentId/toolId or unregistered id throws before rehydration with an
+      // actionable message listing every offender. It also rejects JSON Schemas
+      // that use keywords the storage-side converter can't rehydrate
+      // (oneOf/anyOf/allOf/not/$ref/patternProperties/discriminator).
+      await m.addDynamicWorkflow(normalizedDefinition as Parameters<Mastra['addDynamicWorkflow']>[0]);
+      return { ok: true as const, id: normalizedDefinition.id };
+    },
+  });
+}
+
+export const saveWorkflowTool = createSaveWorkflowTool();


### PR DESCRIPTION
## Summary

- add `createSaveWorkflowTool` with an optional authorization callback
- pass the native `RequestContext` and a detached normalized workflow definition to the callback
- keep authorization deny-only: returning allows the save, while throwing rejects it
- preserve the existing `saveWorkflowTool` export and behavior
- continue delegating validation, persistence, live registration, and rollback to `Mastra.addDynamicWorkflow`

## Why

Hosts may need to authorize a dynamic workflow definition against request-scoped identity before it is persisted. Providing this seam in the native save tool avoids wrappers that duplicate workflow validation or storage behavior. The detached definition prevents authorization code from rewriting the definition that Mastra accepts.

## Test plan

- `pnpm --filter @mastra/code-sdk test -- src/tools/workflows/__tests__/save-workflow.predicate.test.ts`
- `pnpm --filter @mastra/code-sdk check`
- `pnpm exec oxfmt --check mastracode/sdk/src/tools/workflows/save-workflow.ts mastracode/sdk/src/tools/workflows/__tests__/save-workflow.predicate.test.ts .changeset/gentle-workflows-authorize.md`
- targeted Oxlint and ESLint for the changed TypeScript files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets applications check permission before saving a workflow. Existing workflow-saving behavior stays unchanged unless the new authorization callback denies the save.

## Changes

- Added `createSaveWorkflowTool` with an optional asynchronous authorization callback.
- Passed native `RequestContext` and a detached, normalized workflow definition to the callback.
- Kept authorization deny-only: the save proceeds unless the callback throws.
- Preserved the existing `saveWorkflowTool` export and behavior.
- Continued to delegate validation, persistence, registration, and rollback to `Mastra.addDynamicWorkflow`.
- Added tests for authorization context, definition isolation, denial, and storage errors.
- Added a minor-release changeset for `@mastra/code-sdk`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->