### PR TITLE
feat(core): persist trusted dynamic workflow author

### DIFF
--- a/.changeset/warm-pianos-push.md
+++ b/.changeset/warm-pianos-push.md
@@ -10,4 +10,6 @@ await mastra.addDynamicWorkflow(definition, { authorId: verifiedUserId });
 
 The author is persisted with the definition and remains outside untrusted workflow JSON. This metadata does not enforce access control.
 
+Replacing a definition without `options.authorId` retains its stored author. Bundle replacements retain each existing member's stored author.
+
 See [#21444](https://github.com/mastra-ai/mastra/issues/21444) for the remaining tenant-isolation design.

--- a/.changeset/warm-pianos-push.md
+++ b/.changeset/warm-pianos-push.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': minor
+---
+
+Added trusted author metadata for dynamic workflow registration.
+
+```ts
+await mastra.addDynamicWorkflow(definition, { authorId: verifiedUserId });
+```
+
+The author is persisted with the definition and remains outside untrusted workflow JSON. This metadata does not enforce access control.
+
+See [#21444](https://github.com/mastra-ai/mastra/issues/21444) for the remaining tenant-isolation design.

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -156,7 +156,7 @@ await mastra.addDynamicWorkflow(untrustedDefinition, {
 })
 ```
 
-Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+Mastra stores `authorId` with the definition in the same write. When replacing an existing definition, omitting `authorId` retains its stored author. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -146,6 +146,18 @@ Stored definitions use the `workflowDefinitions` storage domain. On startup, Mas
 
 Without a storage adapter that supports this domain, `addDynamicWorkflow()` still registers the workflow in memory, but the definition is lost when the process restarts. See the [storage reference](/reference/storage/overview) for adapter support.
 
+### Record a verified author
+
+Pass trusted author metadata as the second argument. Keep it outside the workflow definition when the definition comes from a user, agent, or external system.
+
+```typescript
+await mastra.addDynamicWorkflow(untrustedDefinition, {
+  authorId: authenticatedUser.id,
+})
+```
+
+Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+
 ## Related
 
 - [Dynamic workflow definition](/reference/workflows/dynamic-workflow-definition)

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -81,7 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
-- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored on the definition in the same write. When replacing an existing definition, omitting `options.authorId` retains its stored author. This metadata records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -20,29 +20,34 @@ See [Dynamic workflows](/docs/workflows/dynamic-workflows) for a complete setup 
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflow({
-  id: 'greeting-workflow',
-  description: 'Returns a greeting for the supplied name',
-  inputSchema: {
-    type: 'object',
-    properties: { name: { type: 'string' } },
-    required: ['name'],
-  },
-  outputSchema: {
-    type: 'object',
-    properties: { message: { type: 'string' } },
-    required: ['message'],
-  },
-  graph: [
-    {
-      type: 'mapping',
-      id: 'create-greeting',
-      mapConfig: JSON.stringify({
-        message: { template: 'Hello, ${initData.name}!' },
-      }),
+await mastra.addDynamicWorkflow(
+  {
+    id: 'greeting-workflow',
+    description: 'Returns a greeting for the supplied name',
+    inputSchema: {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
     },
-  ],
-})
+    outputSchema: {
+      type: 'object',
+      properties: { message: { type: 'string' } },
+      required: ['message'],
+    },
+    graph: [
+      {
+        type: 'mapping',
+        id: 'create-greeting',
+        mapConfig: JSON.stringify({
+          message: { template: 'Hello, ${initData.name}!' },
+        }),
+      },
+    ],
+  },
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 
 const run = await mastra.getWorkflow('greeting-workflow').createRun()
 const result = await run.start({ inputData: { name: 'Ada' } })
@@ -58,6 +63,13 @@ const result = await run.start({ inputData: { name: 'Ada' } })
     description:
       'The workflow definition: id, optional description and metadata, JSON Schema input/output schemas, optional state and request-context schemas, and the step graph.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata supplied by the host. Use `authorId` for a verified author identity that must not come from the workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -69,6 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
+- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -22,10 +22,15 @@ The whole bundle is validated up front. Members are then registered in dependenc
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflows([
-  helperDefinition, // nested by the root — order in the array doesn't matter
-  rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
-])
+await mastra.addDynamicWorkflows(
+  [
+    helperDefinition, // nested by the root — order in the array doesn't matter
+    rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
+  ],
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 ```
 
 ## Parameters
@@ -38,6 +43,13 @@ await mastra.addDynamicWorkflows([
     description:
       'The workflow definitions to add. Nested-workflow references may resolve against the live registries or against other members of the same bundle.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata applied to every definition in the bundle. Use `authorId` for a verified author identity that must not come from a workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -48,6 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
+- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -60,7 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
-- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored with every bundle member. When replacing existing members, omitting `options.authorId` retains each member's stored author. This metadata records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -262,6 +262,42 @@ describe('Mastra.addDynamicWorkflows', () => {
     ]);
   });
 
+  it('persists one trusted author for every member outside the workflow definitions', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    const untrustedHelper = {
+      ...helperDefinition('lookup-first-customer', 'email1'),
+      authorId: 'forged-author',
+    };
+
+    await mastra.addDynamicWorkflows(
+      [untrustedHelper, helperDefinition('lookup-second-customer', 'email2'), rootDefinition],
+      { authorId: 'verified-author' },
+    );
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const { definitions } = await store.list({ status: 'active' });
+
+    expect(definitions).toHaveLength(3);
+    expect(definitions.every(definition => definition.authorId === 'verified-author')).toBe(true);
+  });
+
+  it('preserves an existing author when a trusted author is omitted on replacement', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-preserved' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+      authorId: 'verified-author',
+    });
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email2'));
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const definition = await store.get('lookup-first-customer');
+
+    expect(definition?.authorId).toBe('verified-author');
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -99,6 +99,21 @@ import { createRunScope } from './run-scope';
 import type { VersionOverrides, VersionSelector } from './types';
 
 /**
+ * Trusted metadata applied while a dynamic workflow is persisted.
+ *
+ * Keep these values outside the JSON workflow definition when that definition
+ * comes from an untrusted authoring surface. This metadata is persisted with
+ * the definition but does not itself enforce authorization.
+ */
+export interface DynamicWorkflowRegistrationOptions {
+  /**
+   * Verified identity responsible for the stored definition. Callers must
+   * authorize this value before registration.
+   */
+  authorId?: string;
+}
+
+/**
  * Creates an error for when a null/undefined value is passed to an add* method.
  * This commonly occurs when config is spread ({ ...config }) and the original
  * object had getters or non-enumerable properties.
@@ -4796,8 +4811,11 @@ export class Mastra<
    * await run.start({ inputData: { location: 'Helsinki' } });
    * ```
    */
-  public async addDynamicWorkflow(def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput): Promise<void> {
-    await this.addDynamicWorkflows([def]);
+  public async addDynamicWorkflow(
+    def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput,
+    options?: DynamicWorkflowRegistrationOptions,
+  ): Promise<void> {
+    await this.addDynamicWorkflows([def], options);
   }
 
   /**
@@ -4832,6 +4850,7 @@ export class Mastra<
    */
   public async addDynamicWorkflows(
     defs: readonly (DynamicWorkflowGraph | WorkflowBuilderDefinitionInput)[],
+    options?: DynamicWorkflowRegistrationOptions,
   ): Promise<void> {
     if (defs.length === 0) return;
 
@@ -4937,6 +4956,7 @@ export class Mastra<
             stateSchema: normalized.stateSchema,
             requestContextSchema: normalized.requestContextSchema,
             graph: normalized.graph,
+            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
           });
         }
       }


### PR DESCRIPTION
## Summary

- add `DynamicWorkflowRegistrationOptions.authorId` to `addDynamicWorkflow()` and `addDynamicWorkflows()`
- keep verified authorship outside untrusted `DynamicWorkflowGraph` input
- persist the trusted author with each workflow definition and preserve an existing author when the option is omitted
- document and test the boundary

## Security boundary

This PR records trusted authorship metadata; it does **not** claim to enforce tenant authorization. It intentionally does not add partial route guards or product-side plumbing. The end-to-end ownership and isolation design is tracked in #21444, including immutable ownership, server-derived access checks for management and every execution/control route, nested-workflow isolation, atomic bundle persistence, legacy migration, and multi-replica registry behavior.

## Tests

- `pnpm build:core`
- `pnpm --filter ./packages/core exec vitest run src/mastra/add-dynamic-workflows-bundle.test.ts src/mastra/add-dynamic-workflow-warnings.test.ts --reporter=dot --bail=1` (24 passed, no type errors)
- `pnpm --filter ./packages/core check`
- `pnpm --dir docs validate:frontmatter` (609 passed)
- `git diff --check`

The broader `pnpm --dir docs validate` currently fails on Windows before validating this content because the sidebar-sort ESM loader receives the drive-letter protocol `c:`; the independent frontmatter validator passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This change lets dynamic workflows store the verified ID of their author. It keeps this trusted information separate from workflow input that users can modify.

## What changed

- Added optional `authorId` support to:
  - `addDynamicWorkflow()`
  - `addDynamicWorkflows()`
- Persisted the supplied `authorId` with each workflow definition.
- Applied one trusted author to every workflow in a bundle.
- Preserved an existing author when replacement registration omits `authorId`.
- Added tests for bundled and replacement workflows.
- Updated API and workflow documentation.
- Added a minor `@mastra/core` changeset.

This metadata does not enforce authorization or ownership. Those controls remain separate work.

## Validation

- Core build and type checks passed.
- Targeted Vitest tests passed.
- `git diff --check` passed.
- Documentation validation fails on Windows because of a sidebar-sort ESM loader error involving the `c:` drive-letter protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->