### PR TITLE
feat(client): add mobile workflow entrypoints

### DIFF
--- a/.changeset/mobile-workflow-client.md
+++ b/.changeset/mobile-workflow-client.md
@@ -1,0 +1,12 @@
+---
+'@mastra/client-js': minor
+---
+
+Added the `@mastra/client-js/workflows` entrypoint for workflow clients in Expo and React Native applications.
+
+```ts
+import { createWorkflowClient } from '@mastra/client-js/workflows';
+
+const client = createWorkflowClient({ baseUrl: 'https://example.com' });
+const workflow = client.getWorkflow('campaign-workflow');
+```

--- a/.changeset/mobile-workflow-react.md
+++ b/.changeset/mobile-workflow-react.md
@@ -1,0 +1,31 @@
+---
+'@mastra/react': minor
+---
+
+Added the `@mastra/react/workflows` entrypoint for headless workflow lifecycle hooks and components in Expo and React Native applications.
+
+```tsx
+import { MastraWorkflowProvider, useStreamWorkflow } from '@mastra/react/workflows';
+import { Button } from 'react-native';
+
+function App() {
+  return (
+    <MastraWorkflowProvider baseUrl="https://example.com">
+      <WorkflowScreen />
+    </MastraWorkflowProvider>
+  );
+}
+
+function WorkflowScreen() {
+  const { streamWorkflow, streamResult } = useStreamWorkflow({ debugMode: false });
+  const generate = () =>
+    streamWorkflow.mutateAsync({
+      workflowId: 'campaign-workflow',
+      runId: 'run-1',
+      inputData: { image: 'image.png' },
+      requestContext: {},
+    });
+
+  return <Button title={streamResult.status ?? 'Generate'} onPress={generate} />;
+}
+```

--- a/.changeset/workflow-client-react-native.md
+++ b/.changeset/workflow-client-react-native.md
@@ -1,0 +1,6 @@
+---
+'@mastra/client-js': minor
+'@mastra/react': minor
+---
+
+Added workflow-only entrypoints for Expo and React Native applications. Use `@mastra/client-js/workflows` for the native workflow resources, or `@mastra/react/workflows` for the provider, lifecycle hooks, and `WorkflowStepFactory`, without bundling browser-only client surfaces.

--- a/.changeset/workflow-client-react-native.md
+++ b/.changeset/workflow-client-react-native.md
@@ -1,6 +1,0 @@
----
-'@mastra/client-js': minor
-'@mastra/react': minor
----
-
-Added workflow-only entrypoints for Expo and React Native applications. Use `@mastra/client-js/workflows` for the native workflow resources, or `@mastra/react/workflows` for the provider, lifecycle hooks, and `WorkflowStepFactory`, without bundling browser-only client surfaces.

--- a/client-sdks/client-js/package.json
+++ b/client-sdks/client-js/package.json
@@ -21,6 +21,24 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./workflows": {
+      "react-native": {
+        "types": "./dist/workflows/index.d.ts",
+        "default": "./dist/workflows/index.js"
+      },
+      "browser": {
+        "types": "./dist/workflows/index.d.ts",
+        "default": "./dist/workflows/index.js"
+      },
+      "import": {
+        "types": "./dist/workflows/index.d.ts",
+        "default": "./dist/workflows/index.js"
+      },
+      "require": {
+        "types": "./dist/workflows/index.d.ts",
+        "default": "./dist/workflows/index.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "repository": {

--- a/client-sdks/client-js/src/workflows/index.test.ts
+++ b/client-sdks/client-js/src/workflows/index.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWorkflowClient, MastraWorkflowClient, Run, Workflow } from './index';
+
+describe('workflow-only client', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('creates the native workflow and run resources without the root client barrel', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ runId: 'run-1' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const client = createWorkflowClient({
+      baseUrl: 'https://mastra.example',
+      fetch: fetchMock,
+      retries: 0,
+    });
+    const workflow = client.getWorkflow('campaign');
+    const run = await workflow.createRun();
+
+    expect(client).toBeInstanceOf(MastraWorkflowClient);
+    expect(workflow).toBeInstanceOf(Workflow);
+    expect(run).toBeInstanceOf(Run);
+    expect(run.runId).toBe('run-1');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://mastra.example/api/workflows/campaign/create-run?',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('passes a platform fetch implementation through to the native stream lifecycle', async () => {
+    const body = Workflow.createRecordStream([{ type: 'workflow-start', payload: {}, runId: 'run-1' }]);
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ runId: 'run-1' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(body, { status: 200 }));
+
+    const client = new MastraWorkflowClient({
+      baseUrl: 'https://mastra.example',
+      fetch: fetchMock,
+      retries: 0,
+    });
+    const workflow = client.getWorkflow('campaign');
+    const run = await workflow.createRun();
+    const stream = await run.stream({ inputData: { image: 'data:image/png;base64,AA==' } });
+
+    await expect(stream.getReader().read()).resolves.toMatchObject({
+      done: false,
+      value: { type: 'workflow-start', runId: 'run-1' },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client-sdks/client-js/src/workflows/index.ts
+++ b/client-sdks/client-js/src/workflows/index.ts
@@ -1,0 +1,38 @@
+import { Workflow } from '../resources/workflow';
+import type { ClientOptions } from '../types';
+
+/**
+ * Workflow-only Mastra client for browser, Expo, and React Native applications.
+ *
+ * This entrypoint intentionally excludes agent, A2A, observability, and other
+ * client resources so Metro can bundle the native workflow lifecycle without
+ * traversing the full Client SDK barrel.
+ */
+export class MastraWorkflowClient {
+  readonly options: ClientOptions;
+
+  constructor(options: ClientOptions) {
+    this.options = options;
+  }
+
+  getWorkflow(workflowId: string): Workflow {
+    return new Workflow(this.options, workflowId);
+  }
+}
+
+export function createWorkflowClient(options: ClientOptions): MastraWorkflowClient {
+  return new MastraWorkflowClient(options);
+}
+
+export { Workflow } from '../resources/workflow';
+export { Run } from '../resources/run';
+export type { ClientOptions } from '../types';
+export type {
+  GetWorkflowResponse,
+  GetWorkflowRunByIdResponse,
+  ListWorkflowRunsParams,
+  ListWorkflowRunsResponse,
+  StreamVNextChunkType,
+  TimeTravelParams,
+  WorkflowRunResult,
+} from '../types';

--- a/client-sdks/client-js/tsdown.config.ts
+++ b/client-sdks/client-js/tsdown.config.ts
@@ -2,7 +2,7 @@ import { generateTypes } from '@internal/types-builder';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/workflows/index.ts'],
   format: ['esm', 'cjs'],
   fixedExtension: false,
   nodeProtocol: 'strip',

--- a/client-sdks/react/package.json
+++ b/client-sdks/react/package.json
@@ -36,6 +36,24 @@
         "default": "./dist/ui/index.cjs"
       }
     },
+    "./workflows": {
+      "react-native": {
+        "types": "./dist/workflows/index.d.ts",
+        "default": "./dist/workflows/index.js"
+      },
+      "browser": {
+        "types": "./dist/workflows/index.d.ts",
+        "default": "./dist/workflows/index.js"
+      },
+      "import": {
+        "types": "./dist/workflows/index.d.ts",
+        "default": "./dist/workflows/index.js"
+      },
+      "require": {
+        "types": "./dist/workflows/index.d.ts",
+        "default": "./dist/workflows/index.cjs"
+      }
+    },
     "./styles.css": "./dist/react.css"
   },
   "scripts": {
@@ -68,6 +86,11 @@
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",
     "zod": "^3.25.0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react-dom": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/client-sdks/react/src/lib/mastra-db/accumulator.ts
+++ b/client-sdks/react/src/lib/mastra-db/accumulator.ts
@@ -7,8 +7,9 @@ import type {
   MastraToolInvocationPart,
 } from '@mastra/core/agent/message-list';
 import type { AgentChunkType, ChunkType, NetworkChunkType } from '@mastra/core/stream';
-import type { WorkflowStreamResult, StepResult } from '@mastra/core/workflows';
+import type { WorkflowStreamResult } from '@mastra/core/workflows';
 import { uint8ArrayToBase64, encodeFilePartDataForStorage } from '../../agent/signal-data';
+import { mapWorkflowStreamChunkToWatchResult } from '../../workflows/workflow-stream-reducer';
 import { formatCompletionFeedback, formatStreamCompletionFeedback } from './formatCompletionFeedback';
 import { CLIENT_MESSAGE_ID_KEY } from './types';
 import type {
@@ -35,13 +36,6 @@ import type {
 // in this file is a deliberate storage-boundary cast for one of the above
 // extensions, not an accident. Downstream consumers (`toAISdkV5Messages`,
 // playground `to-assistant-ui-message`) read the V5 fields directly.
-
-type StreamChunk = {
-  type: string;
-  payload: any;
-  runId: string;
-  from: 'AGENT' | 'WORKFLOW';
-};
 
 const cloneMetadata = (metadata: MastraDBMessageMetadata | undefined): MastraDBMessageMetadata =>
   metadata ? { ...metadata } : {};
@@ -227,99 +221,6 @@ const mergeBgTaskMetadata = (
   };
   if (args.resetRunningCount) merged.runningBackgroundTasksCount = undefined;
   return merged;
-};
-
-/**
- * Workflow chunk accumulation. Mirrors
- * `mapWorkflowStreamChunkToWatchResult` from the previous accumulator.
- */
-export const mapWorkflowStreamChunkToWatchResult = (
-  prev: WorkflowStreamResult<any, any, any, any>,
-  chunk: StreamChunk,
-): WorkflowStreamResult<any, any, any, any> => {
-  if (chunk.type === 'workflow-start') {
-    return {
-      input: prev?.input,
-      status: 'running',
-      steps: prev?.steps || {},
-    };
-  }
-
-  if (chunk.type === 'workflow-canceled') {
-    return { ...prev, status: 'canceled' };
-  }
-
-  if (chunk.type === 'workflow-finish') {
-    const finalStatus = chunk.payload.workflowStatus;
-    const prevSteps = prev?.steps ?? {};
-    const lastStep = Object.values(prevSteps).pop();
-    return {
-      ...prev,
-      status: chunk.payload.workflowStatus,
-      ...(finalStatus === 'success' && lastStep?.status === 'success'
-        ? { result: lastStep?.output }
-        : finalStatus === 'failed' && lastStep?.status === 'failed'
-          ? { error: lastStep?.error }
-          : finalStatus === 'tripwire' && chunk.payload.tripwire
-            ? { tripwire: chunk.payload.tripwire }
-            : {}),
-    };
-  }
-
-  const { stepCallId: _stepCallId, stepName: _stepName, ...newPayload } = chunk.payload ?? {};
-  const newSteps = {
-    ...prev?.steps,
-    [chunk.payload.id]: {
-      ...prev?.steps?.[chunk.payload.id],
-      ...newPayload,
-    },
-  };
-
-  if (chunk.type === 'workflow-step-start') return { ...prev, steps: newSteps };
-
-  if (chunk.type === 'workflow-step-suspended') {
-    const suspendedStepIds = Object.entries(newSteps as Record<string, StepResult<any, any, any, any>>).flatMap(
-      ([stepId, stepResult]) => {
-        if (stepResult?.status === 'suspended') {
-          const nestedPath = stepResult?.suspendPayload?.__workflow_meta?.path;
-          return nestedPath ? [[stepId, ...nestedPath]] : [[stepId]];
-        }
-        return [];
-      },
-    );
-    return {
-      ...prev,
-      status: 'suspended',
-      steps: newSteps,
-      suspendPayload: chunk.payload.suspendPayload,
-      suspended: suspendedStepIds as any,
-    };
-  }
-
-  if (chunk.type === 'workflow-step-waiting') return { ...prev, status: 'waiting', steps: newSteps };
-
-  if (chunk.type === 'workflow-step-progress') {
-    return {
-      ...prev,
-      steps: {
-        ...prev?.steps,
-        [chunk.payload.id]: {
-          ...prev?.steps?.[chunk.payload.id],
-          foreachProgress: {
-            completedCount: chunk.payload.completedCount,
-            totalCount: chunk.payload.totalCount,
-            currentIndex: chunk.payload.currentIndex,
-            iterationStatus: chunk.payload.iterationStatus,
-            iterationOutput: chunk.payload.iterationOutput,
-          },
-        },
-      },
-    };
-  }
-
-  if (chunk.type === 'workflow-step-result') return { ...prev, steps: newSteps };
-
-  return prev;
 };
 
 const signalContentsToUserMessages = (contents: unknown, metadata: MastraDBMessageMetadata): MastraDBMessage[] => {

--- a/client-sdks/react/src/lib/mastra-db/index.ts
+++ b/client-sdks/react/src/lib/mastra-db/index.ts
@@ -1,9 +1,5 @@
-export {
-  accumulateChunk,
-  accumulateNetworkChunk,
-  finishStreamingAssistantMessage,
-  mapWorkflowStreamChunkToWatchResult,
-} from './accumulator';
+export { accumulateChunk, accumulateNetworkChunk, finishStreamingAssistantMessage } from './accumulator';
+export { mapWorkflowStreamChunkToWatchResult } from '../../workflows/workflow-stream-reducer';
 export type { AccumulateChunkArgs, AccumulateNetworkChunkArgs } from './accumulator';
 export { fromCoreUserMessageToMastraDBMessage, fromCoreUserMessagesToMastraDBMessage } from './fromCoreUserMessage';
 export { CLIENT_MESSAGE_ID_KEY } from './types';

--- a/client-sdks/react/src/mastra-client-context.tsx
+++ b/client-sdks/react/src/mastra-client-context.tsx
@@ -1,6 +1,7 @@
 import { MastraClient } from '@mastra/client-js';
 import type { ReactNode } from 'react';
 import { createContext, useContext, useMemo } from 'react';
+import { WorkflowClientContextProvider } from './workflows/workflow-client-context';
 
 export type MastraClientContextType = MastraClient;
 
@@ -42,7 +43,11 @@ export const MastraClientProvider = ({
     [baseUrl, headers, apiPrefix, credentials, customFetch],
   );
 
-  return <MastraClientContext.Provider value={client}>{children}</MastraClientContext.Provider>;
+  return (
+    <MastraClientContext.Provider value={client}>
+      <WorkflowClientContextProvider client={client}>{children}</WorkflowClientContextProvider>
+    </MastraClientContext.Provider>
+  );
 };
 
 export const useMastraClient = () => useContext(MastraClientContext);

--- a/client-sdks/react/src/workflows/hooks.test.tsx
+++ b/client-sdks/react/src/workflows/hooks.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useCancelWorkflowRun, useCreateWorkflowRun } from './hooks';
+import { WorkflowClientContextProvider, type WorkflowClientContextType } from './workflow-client-context';
+
+describe('workflow lifecycle hooks', () => {
+  it('creates and cancels runs through the native Run resource', async () => {
+    const cancel = vi.fn(async () => ({ message: 'Workflow run canceled' }));
+    const createRun = vi.fn(async ({ runId }: { runId?: string } = {}) =>
+      runId ? { runId, cancel } : { runId: 'run-1', cancel },
+    );
+    const getWorkflow = vi.fn(() => ({ createRun }));
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(WorkflowClientContextProvider, {
+        client: { getWorkflow } as unknown as WorkflowClientContextType,
+        children,
+      });
+
+    const createHook = renderHook(() => useCreateWorkflowRun(), { wrapper });
+    await act(() => createHook.result.current.mutateAsync({ workflowId: 'campaign' }));
+
+    expect(createHook.result.current.data).toEqual({ runId: 'run-1' });
+    expect(getWorkflow).toHaveBeenCalledWith('campaign');
+
+    const cancelHook = renderHook(() => useCancelWorkflowRun(), { wrapper });
+    await act(() => cancelHook.result.current.mutateAsync({ workflowId: 'campaign', runId: 'run-1' }));
+
+    expect(createRun).toHaveBeenLastCalledWith({ runId: 'run-1' });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cancelHook.result.current.data).toEqual({ message: 'Workflow run canceled' });
+  });
+});

--- a/client-sdks/react/src/workflows/hooks.ts
+++ b/client-sdks/react/src/workflows/hooks.ts
@@ -1,11 +1,11 @@
 import { useMutation } from '../lib/use-mutation';
-import { useMastraClient } from '../mastra-client-context';
 import type {
   CreateWorkflowRunParams,
   CreateWorkflowRunResult,
   CancelWorkflowRunParams,
   CancelWorkflowRunResult,
 } from './types';
+import { useWorkflowClient } from './workflow-client-context';
 
 export { useStreamWorkflow } from './use-stream-workflow';
 
@@ -24,7 +24,7 @@ export { useStreamWorkflow } from './use-stream-workflow';
  * ```
  */
 export function useCreateWorkflowRun() {
-  const client = useMastraClient();
+  const client = useWorkflowClient();
 
   return useMutation<CreateWorkflowRunResult, Error, CreateWorkflowRunParams>(async ({ workflowId, prevRunId }) => {
     try {
@@ -54,13 +54,13 @@ export function useCreateWorkflowRun() {
  * ```
  */
 export function useCancelWorkflowRun() {
-  const client = useMastraClient();
+  const client = useWorkflowClient();
 
   return useMutation<CancelWorkflowRunResult, Error, CancelWorkflowRunParams>(async ({ workflowId, runId }) => {
     try {
       const workflow = client.getWorkflow(workflowId);
       const run = await workflow.createRun({ runId });
-      return run.cancelRun();
+      return run.cancel();
     } catch (error) {
       console.error('Error canceling workflow run:', error);
       throw error;

--- a/client-sdks/react/src/workflows/index.ts
+++ b/client-sdks/react/src/workflows/index.ts
@@ -1,3 +1,4 @@
 export * from './hooks';
 export * from './types';
 export * from './WorkflowStepFactory';
+export * from './workflow-client-context';

--- a/client-sdks/react/src/workflows/types.ts
+++ b/client-sdks/react/src/workflows/types.ts
@@ -1,4 +1,4 @@
-import type { TimeTravelParams } from '@mastra/client-js';
+import type { TimeTravelParams } from '@mastra/client-js/workflows';
 import type { TracingOptions } from '@mastra/core/observability';
 import type { WorkflowStreamResult as CoreWorkflowStreamResult } from '@mastra/core/workflows';
 /**

--- a/client-sdks/react/src/workflows/use-stream-workflow.ts
+++ b/client-sdks/react/src/workflows/use-stream-workflow.ts
@@ -1,8 +1,6 @@
-import type { StreamVNextChunkType } from '@mastra/client-js';
+import type { StreamVNextChunkType } from '@mastra/client-js/workflows';
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { mapWorkflowStreamChunkToWatchResult } from '../lib/mastra-db';
 import { useMutation } from '../lib/use-mutation';
-import { useMastraClient } from '../mastra-client-context';
 import type {
   UseStreamWorkflowParams,
   WorkflowStreamResult,
@@ -11,6 +9,8 @@ import type {
   ResumeWorkflowStreamParams,
   TimeTravelWorkflowStreamParams,
 } from './types';
+import { useWorkflowClient } from './workflow-client-context';
+import { mapWorkflowStreamChunkToWatchResult } from './workflow-stream-reducer';
 
 /**
  * Hook for streaming workflow execution with support for observing, resuming, and time-travel.
@@ -41,7 +41,7 @@ import type {
  * ```
  */
 export function useStreamWorkflow({ debugMode, tracingOptions, onError }: UseStreamWorkflowParams) {
-  const client = useMastraClient();
+  const client = useWorkflowClient();
   const [streamResult, setStreamResult] = useState<WorkflowStreamResult>({} as WorkflowStreamResult);
   const [isStreaming, setIsStreaming] = useState(false);
   const readerRef = useRef<ReadableStreamDefaultReader<StreamVNextChunkType> | null>(null);

--- a/client-sdks/react/src/workflows/workflow-client-context.test.tsx
+++ b/client-sdks/react/src/workflows/workflow-client-context.test.tsx
@@ -1,0 +1,48 @@
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createdOptions: Array<Record<string, unknown>> = [];
+const workflowClient = { getWorkflow: vi.fn() };
+
+vi.mock('@mastra/client-js/workflows', () => ({
+  createWorkflowClient: (options: Record<string, unknown>) => {
+    createdOptions.push(options);
+    return workflowClient;
+  },
+}));
+
+const { MastraWorkflowProvider, useWorkflowClient } = await import('./workflow-client-context');
+
+describe('MastraWorkflowProvider', () => {
+  beforeEach(() => {
+    createdOptions.length = 0;
+  });
+
+  it('creates the workflow-only client with a platform fetch implementation', () => {
+    const platformFetch = vi.fn<typeof fetch>();
+    let capturedClient: unknown;
+
+    function Inspector() {
+      capturedClient = useWorkflowClient();
+      return null;
+    }
+
+    renderToString(
+      createElement(MastraWorkflowProvider, {
+        baseUrl: 'https://mastra.example',
+        customFetch: platformFetch,
+        children: createElement(Inspector),
+      }),
+    );
+
+    expect(capturedClient).toBe(workflowClient);
+    expect(createdOptions).toEqual([
+      expect.objectContaining({
+        baseUrl: 'https://mastra.example',
+        credentials: 'include',
+        fetch: platformFetch,
+      }),
+    ]);
+  });
+});

--- a/client-sdks/react/src/workflows/workflow-client-context.tsx
+++ b/client-sdks/react/src/workflows/workflow-client-context.tsx
@@ -1,0 +1,67 @@
+import { createWorkflowClient, type ClientOptions, type MastraWorkflowClient } from '@mastra/client-js/workflows';
+import type { ReactNode } from 'react';
+import { createContext, useContext, useMemo } from 'react';
+
+export type WorkflowClientContextType = Pick<MastraWorkflowClient, 'getWorkflow'>;
+
+export interface MastraWorkflowProviderProps {
+  children: ReactNode;
+  baseUrl: string;
+  headers?: ClientOptions['headers'];
+  apiPrefix?: ClientOptions['apiPrefix'];
+  credentials?: ClientOptions['credentials'];
+  customFetch?: ClientOptions['fetch'];
+  retries?: ClientOptions['retries'];
+  backoffMs?: ClientOptions['backoffMs'];
+  maxBackoffMs?: ClientOptions['maxBackoffMs'];
+  abortSignal?: ClientOptions['abortSignal'];
+}
+
+const WorkflowClientContext = createContext<WorkflowClientContextType | null>(null);
+
+export const WorkflowClientContextProvider = ({
+  client,
+  children,
+}: {
+  client: WorkflowClientContextType;
+  children: ReactNode;
+}) => <WorkflowClientContext.Provider value={client}>{children}</WorkflowClientContext.Provider>;
+
+export const MastraWorkflowProvider = ({
+  children,
+  baseUrl,
+  headers,
+  apiPrefix,
+  credentials = 'include',
+  customFetch,
+  retries,
+  backoffMs,
+  maxBackoffMs,
+  abortSignal,
+}: MastraWorkflowProviderProps) => {
+  const client = useMemo(
+    () =>
+      createWorkflowClient({
+        baseUrl,
+        headers,
+        apiPrefix,
+        credentials,
+        fetch: customFetch,
+        retries,
+        backoffMs,
+        maxBackoffMs,
+        abortSignal,
+      }),
+    [abortSignal, apiPrefix, backoffMs, baseUrl, credentials, customFetch, headers, maxBackoffMs, retries],
+  );
+
+  return <WorkflowClientContextProvider client={client}>{children}</WorkflowClientContextProvider>;
+};
+
+export const useWorkflowClient = (): WorkflowClientContextType => {
+  const client = useContext(WorkflowClientContext);
+  if (!client) {
+    throw new Error('useWorkflowClient must be used within MastraWorkflowProvider or MastraReactProvider');
+  }
+  return client;
+};

--- a/client-sdks/react/src/workflows/workflow-stream-reducer.test.ts
+++ b/client-sdks/react/src/workflows/workflow-stream-reducer.test.ts
@@ -18,12 +18,43 @@ describe('mapWorkflowStreamChunkToWatchResult', () => {
       status: 'success',
       output: { images: ['one.png', 'two.png'] },
     });
-    const finished = reduce(stepFinished, 'workflow-finish', { workflowStatus: 'success' });
+    const finished = reduce(stepFinished, 'workflow-finish', {
+      workflowStatus: 'success',
+      finalWorkflowResult: { images: ['one.png', 'two.png'] },
+    });
 
     expect(finished).toMatchObject({
       status: 'success',
       result: { images: ['one.png', 'two.png'] },
       steps: { generate: { status: 'success' } },
+    });
+  });
+
+  it.each([
+    ['is still running', undefined],
+    ['completes later', { id: 'step-b', status: 'success', output: { value: 'done' } }],
+  ])('preserves the failing parallel step error when a later step %s', (_scenario, laterStepResult) => {
+    const error = new Error('step A failed');
+    const stepAStarted = reduce({ status: 'running', steps: {} }, 'workflow-step-start', {
+      id: 'step-a',
+      status: 'running',
+    });
+    const stepBStarted = reduce(stepAStarted, 'workflow-step-start', { id: 'step-b', status: 'running' });
+    const stepAFailed = reduce(stepBStarted, 'workflow-step-result', {
+      id: 'step-a',
+      status: 'failed',
+      error,
+    });
+    const beforeFinish = laterStepResult ? reduce(stepAFailed, 'workflow-step-result', laterStepResult) : stepAFailed;
+    const finished = reduce(beforeFinish, 'workflow-finish', { workflowStatus: 'failed', metadata: {} });
+
+    expect(finished).toMatchObject({
+      status: 'failed',
+      error,
+      steps: {
+        'step-a': { status: 'failed', error },
+        'step-b': { status: laterStepResult ? 'success' : 'running' },
+      },
     });
   });
 

--- a/client-sdks/react/src/workflows/workflow-stream-reducer.test.ts
+++ b/client-sdks/react/src/workflows/workflow-stream-reducer.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { mapWorkflowStreamChunkToWatchResult } from './workflow-stream-reducer';
+
+const reduce = (previous: any, type: string, payload: Record<string, unknown> = {}) =>
+  mapWorkflowStreamChunkToWatchResult(previous, {
+    type,
+    payload,
+    runId: 'run-1',
+    from: 'WORKFLOW',
+  });
+
+describe('mapWorkflowStreamChunkToWatchResult', () => {
+  it('projects native lifecycle chunks into a successful run result', () => {
+    const running = reduce({ input: { image: 'image.png' }, steps: {} }, 'workflow-start');
+    const stepStarted = reduce(running, 'workflow-step-start', { id: 'generate', status: 'running' });
+    const stepFinished = reduce(stepStarted, 'workflow-step-result', {
+      id: 'generate',
+      status: 'success',
+      output: { images: ['one.png', 'two.png'] },
+    });
+    const finished = reduce(stepFinished, 'workflow-finish', { workflowStatus: 'success' });
+
+    expect(finished).toMatchObject({
+      status: 'success',
+      result: { images: ['one.png', 'two.png'] },
+      steps: { generate: { status: 'success' } },
+    });
+  });
+
+  it('preserves nested suspended paths from native chunks', () => {
+    const suspended = reduce({ status: 'running', steps: {} }, 'workflow-step-suspended', {
+      id: 'approval',
+      status: 'suspended',
+      suspendPayload: {
+        reason: 'approval',
+        __workflow_meta: { path: ['nested', 'approval'] },
+      },
+    });
+
+    expect(suspended).toMatchObject({
+      status: 'suspended',
+      suspended: [['approval', 'nested', 'approval']],
+      suspendPayload: { reason: 'approval' },
+    });
+  });
+
+  it.each([
+    ['workflow-canceled', 'canceled'],
+    ['workflow-step-waiting', 'waiting'],
+  ])('maps %s to %s', (type, status) => {
+    expect(reduce({ status: 'running', steps: {} }, type, { id: 'step-1' })).toMatchObject({ status });
+  });
+});

--- a/client-sdks/react/src/workflows/workflow-stream-reducer.ts
+++ b/client-sdks/react/src/workflows/workflow-stream-reducer.ts
@@ -1,0 +1,92 @@
+import type { StreamVNextChunkType } from '@mastra/client-js/workflows';
+import type { StepResult, WorkflowStreamResult } from '@mastra/core/workflows';
+
+/** Reduces a native workflow stream chunk into Mastra's public run result. */
+export const mapWorkflowStreamChunkToWatchResult = (
+  prev: WorkflowStreamResult<any, any, any, any>,
+  chunk: StreamVNextChunkType,
+): WorkflowStreamResult<any, any, any, any> => {
+  if (chunk.type === 'workflow-start') {
+    return {
+      input: prev?.input,
+      status: 'running',
+      steps: prev?.steps || {},
+    };
+  }
+
+  if (chunk.type === 'workflow-canceled') {
+    return { ...prev, status: 'canceled' };
+  }
+
+  if (chunk.type === 'workflow-finish') {
+    const finalStatus = chunk.payload.workflowStatus;
+    const prevSteps = prev?.steps ?? {};
+    const lastStep = Object.values(prevSteps).pop();
+    return {
+      ...prev,
+      status: chunk.payload.workflowStatus,
+      ...(finalStatus === 'success' && lastStep?.status === 'success'
+        ? { result: lastStep?.output }
+        : finalStatus === 'failed' && lastStep?.status === 'failed'
+          ? { error: lastStep?.error }
+          : finalStatus === 'tripwire' && chunk.payload.tripwire
+            ? { tripwire: chunk.payload.tripwire }
+            : {}),
+    };
+  }
+
+  const { stepCallId: _stepCallId, stepName: _stepName, ...newPayload } = chunk.payload ?? {};
+  const newSteps = {
+    ...prev?.steps,
+    [chunk.payload.id]: {
+      ...prev?.steps?.[chunk.payload.id],
+      ...newPayload,
+    },
+  };
+
+  if (chunk.type === 'workflow-step-start') return { ...prev, steps: newSteps };
+
+  if (chunk.type === 'workflow-step-suspended') {
+    const suspendedStepIds = Object.entries(newSteps as Record<string, StepResult<any, any, any, any>>).flatMap(
+      ([stepId, stepResult]) => {
+        if (stepResult?.status === 'suspended') {
+          const nestedPath = stepResult?.suspendPayload?.__workflow_meta?.path;
+          return nestedPath ? [[stepId, ...nestedPath]] : [[stepId]];
+        }
+        return [];
+      },
+    );
+    return {
+      ...prev,
+      status: 'suspended',
+      steps: newSteps,
+      suspendPayload: chunk.payload.suspendPayload,
+      suspended: suspendedStepIds as any,
+    };
+  }
+
+  if (chunk.type === 'workflow-step-waiting') return { ...prev, status: 'waiting', steps: newSteps };
+
+  if (chunk.type === 'workflow-step-progress') {
+    return {
+      ...prev,
+      steps: {
+        ...prev?.steps,
+        [chunk.payload.id]: {
+          ...prev?.steps?.[chunk.payload.id],
+          foreachProgress: {
+            completedCount: chunk.payload.completedCount,
+            totalCount: chunk.payload.totalCount,
+            currentIndex: chunk.payload.currentIndex,
+            iterationStatus: chunk.payload.iterationStatus,
+            iterationOutput: chunk.payload.iterationOutput,
+          },
+        },
+      },
+    };
+  }
+
+  if (chunk.type === 'workflow-step-result') return { ...prev, steps: newSteps };
+
+  return prev;
+};

--- a/client-sdks/react/src/workflows/workflow-stream-reducer.ts
+++ b/client-sdks/react/src/workflows/workflow-stream-reducer.ts
@@ -21,14 +21,16 @@ export const mapWorkflowStreamChunkToWatchResult = (
   if (chunk.type === 'workflow-finish') {
     const finalStatus = chunk.payload.workflowStatus;
     const prevSteps = prev?.steps ?? {};
-    const lastStep = Object.values(prevSteps).pop();
+    const failedStep = Object.values(prevSteps).find(step => step?.status === 'failed');
+    const failureError =
+      chunk.payload.metadata?.error ?? (failedStep?.status === 'failed' ? failedStep.error : undefined);
     return {
       ...prev,
       status: chunk.payload.workflowStatus,
-      ...(finalStatus === 'success' && lastStep?.status === 'success'
-        ? { result: lastStep?.output }
-        : finalStatus === 'failed' && lastStep?.status === 'failed'
-          ? { error: lastStep?.error }
+      ...(finalStatus === 'success'
+        ? { result: chunk.payload.finalWorkflowResult }
+        : finalStatus === 'failed' && failureError
+          ? { error: failureError }
           : finalStatus === 'tripwire' && chunk.payload.tripwire
             ? { tripwire: chunk.payload.tripwire }
             : {}),

--- a/client-sdks/react/tsdown.config.ts
+++ b/client-sdks/react/tsdown.config.ts
@@ -37,7 +37,7 @@ async function rewritePathAliases(rootDir: string) {
 }
 
 export default defineConfig(options => ({
-  entry: ['src/index.ts', 'src/ui/index.ts'],
+  entry: ['src/index.ts', 'src/ui/index.ts', 'src/workflows/index.ts'],
   format: ['esm', 'cjs'],
   fixedExtension: false,
   nodeProtocol: 'strip',

--- a/docs/src/content/en/reference/client-js/workflows.mdx
+++ b/docs/src/content/en/reference/client-js/workflows.mdx
@@ -3,11 +3,51 @@ title: "Reference: Workflows API | Client SDK"
 description: Learn how to interact with and execute automated workflows in Mastra using the client-js SDK.
 packages:
   - "@mastra/client-js"
+  - "@mastra/react"
 ---
 
 # Workflows API
 
 The Workflows API provides methods to interact with and execute automated workflows in Mastra.
+
+## Expo and React Native
+
+Mobile applications can import the workflow-only client entrypoint and provide the platform's fetch implementation:
+
+```typescript
+import { fetch as expoFetch } from 'expo/fetch'
+import { createWorkflowClient } from '@mastra/client-js/workflows'
+
+const workflowClient = createWorkflowClient({
+  baseUrl: 'https://api.example.com',
+  fetch: expoFetch,
+})
+
+const workflow = workflowClient.getWorkflow('city-workflow')
+const run = await workflow.createRun()
+const stream = await run.stream({ inputData: { city: 'New York' } })
+```
+
+React Native applications can use the headless workflow provider and hooks. This entrypoint does not include web UI components:
+
+```tsx
+import { fetch as expoFetch } from 'expo/fetch'
+import { MastraWorkflowProvider, useCreateWorkflowRun } from '@mastra/react/workflows'
+
+export function App() {
+  return (
+    <MastraWorkflowProvider baseUrl="https://api.example.com" customFetch={expoFetch}>
+      <WorkflowScreen />
+    </MastraWorkflowProvider>
+  )
+}
+
+function WorkflowScreen() {
+  const createRun = useCreateWorkflowRun()
+  // Render your application UI and call createRun.mutateAsync when needed.
+  return null
+}
+```
 
 ## Getting all workflows
 


### PR DESCRIPTION
## Summary

- add a workflow-only `@mastra/client-js/workflows` entrypoint backed by the existing `Workflow` and `Run` resources
- add a headless `@mastra/react/workflows` entrypoint with the existing lifecycle hooks, stream projection, and `WorkflowStepFactory`
- add `MastraWorkflowProvider` so Expo can supply `expo/fetch` without importing the web-oriented React SDK root
- preserve `MastraReactProvider` compatibility and switch cancellation to the public native `Run.cancel()` method
- document Expo/React Native usage and make the unused `react-dom` peer optional

## Why

The published root entrypoints are not Metro-safe. In an Expo 57 / React Native 0.86 Android fixture using `@mastra/client-js@1.39.0`, `@mastra/react@1.4.2`, and `@mastra/core@1.58.0`, Metro traversed the React root into `AIV5Adapter`, browser voice/UI code, and Core's vendored AI bundle, then failed after 1,131 modules on a dynamic `import(id)` expression.

These subpaths keep Mastra's existing workflow resources and lifecycle projection authoritative. They do not add a second protocol, event decoder, run store, or retry lifecycle.

Related to #7140.

## Verification

- `@mastra/client-js`: 2 focused workflow resource/stream tests pass
- `@mastra/react`: 20 provider/hook/reducer/root-provider tests pass
- existing React accumulator regression suite: 124 tests pass
- ESLint and `git diff --check` pass for the touched surface
- focused ESM/CJS builds and declarations for both new entrypoints pass
- Expo 57 / React Native 0.86 Android Hermes export succeeds through the packed packages: 589 modules, 1.5 MB bundle
- runtime bundle scan contains no `AIV5Adapter`, browser speech/audio, Radix, React DOM, or dynamic `import(id)` path

Full monorepo declaration generation in the sparse verification clone still reports unrelated current-main route-type errors under client observability and existing React agent/UI sources; the new entrypoint declarations themselves generate successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds workflow tools that work in Expo and React Native. It avoids browser-only code while keeping existing workflow behavior and adds documentation and tests.

## Changes

- Added `@mastra/client-js/workflows` for native-safe workflow and run resources.
- Added `@mastra/react/workflows` with:
  - `MastraWorkflowProvider`
  - `useWorkflowClient`
  - Workflow lifecycle hooks
  - Stream state projection
  - `WorkflowStepFactory`
- Added platform fetch support, including `expo/fetch`.
- Updated `MastraReactProvider` for workflow client context compatibility.
- Switched workflow cancellation to the public `Run.cancel()` method.
- Centralized workflow stream reduction and added coverage for lifecycle, suspension, waiting, cancellation, failures, and results.
- Added optional `react-dom` peer dependency support.
- Added Expo and React Native documentation.
- Added a changeset for minor releases of `@mastra/client-js` and `@mastra/react`.

## Verification

- Added focused client and React tests.
- Added accumulator regression tests.
- Verified linting, builds, declarations, and package diffs.
- Verified an Expo 57 and React Native 0.86 Android Hermes export with packed packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->