### PR TITLE
fix(storage): keep dynamic workflow owners immutable

### DIFF
--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -1,0 +1,11 @@
+---
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/mssql': patch
+'@mastra/mysql': patch
+'@mastra/pg': patch
+---
+
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -8,4 +8,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior. Concurrent registrations on one Mastra instance are serialized so a rejected registration can't roll back the successful live workflow.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -8,4 +8,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior. Concurrent registrations on one Mastra instance are serialized so a rejected registration can't roll back the successful live workflow.
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.

--- a/.changeset/warm-pianos-push.md
+++ b/.changeset/warm-pianos-push.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': minor
+---
+
+Added trusted author metadata for dynamic workflow registration.
+
+```ts
+await mastra.addDynamicWorkflow(definition, { authorId: verifiedUserId });
+```
+
+The author is persisted with the definition and remains outside untrusted workflow JSON. This metadata does not enforce access control.
+
+See [#21444](https://github.com/mastra-ai/mastra/issues/21444) for the remaining tenant-isolation design.

--- a/.changeset/wise-owls-queue.md
+++ b/.changeset/wise-owls-queue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Serialize dynamic workflow registrations on each Mastra instance so a rejected registration cannot roll back a workflow that another registration successfully replaced.

--- a/.changeset/wise-owls-queue.md
+++ b/.changeset/wise-owls-queue.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Serialize dynamic workflow registrations on each Mastra instance so a rejected registration cannot roll back a workflow that another registration successfully replaced.
+Serialize dynamic workflow registrations with overlapping workflow ids so a rejected registration cannot roll back a workflow that another registration successfully replaced. Unrelated ids no longer wait behind network storage I/O. Callers may cancel or bound queue admission; a rejected waiter never starts a storage mutation.

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -156,7 +156,7 @@ await mastra.addDynamicWorkflow(untrustedDefinition, {
 })
 ```
 
-Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -146,6 +146,18 @@ Stored definitions use the `workflowDefinitions` storage domain. On startup, Mas
 
 Without a storage adapter that supports this domain, `addDynamicWorkflow()` still registers the workflow in memory, but the definition is lost when the process restarts. See the [storage reference](/reference/storage/overview) for adapter support.
 
+### Record a verified author
+
+Pass trusted author metadata as the second argument. Keep it outside the workflow definition when the definition comes from a user, agent, or external system.
+
+```typescript
+await mastra.addDynamicWorkflow(untrustedDefinition, {
+  authorId: authenticatedUser.id,
+})
+```
+
+Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+
 ## Related
 
 - [Dynamic workflow definition](/reference/workflows/dynamic-workflow-definition)

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -20,29 +20,34 @@ See [Dynamic workflows](/docs/workflows/dynamic-workflows) for a complete setup 
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflow({
-  id: 'greeting-workflow',
-  description: 'Returns a greeting for the supplied name',
-  inputSchema: {
-    type: 'object',
-    properties: { name: { type: 'string' } },
-    required: ['name'],
-  },
-  outputSchema: {
-    type: 'object',
-    properties: { message: { type: 'string' } },
-    required: ['message'],
-  },
-  graph: [
-    {
-      type: 'mapping',
-      id: 'create-greeting',
-      mapConfig: JSON.stringify({
-        message: { template: 'Hello, ${initData.name}!' },
-      }),
+await mastra.addDynamicWorkflow(
+  {
+    id: 'greeting-workflow',
+    description: 'Returns a greeting for the supplied name',
+    inputSchema: {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
     },
-  ],
-})
+    outputSchema: {
+      type: 'object',
+      properties: { message: { type: 'string' } },
+      required: ['message'],
+    },
+    graph: [
+      {
+        type: 'mapping',
+        id: 'create-greeting',
+        mapConfig: JSON.stringify({
+          message: { template: 'Hello, ${initData.name}!' },
+        }),
+      },
+    ],
+  },
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 
 const run = await mastra.getWorkflow('greeting-workflow').createRun()
 const result = await run.start({ inputData: { name: 'Ada' } })
@@ -58,6 +63,13 @@ const result = await run.start({ inputData: { name: 'Ada' } })
     description:
       'The workflow definition: id, optional description and metadata, JSON Schema input/output schemas, optional state and request-context schemas, and the step graph.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata supplied by the host. Use `authorId` for a verified author identity that must not come from the workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -69,6 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
+- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -81,7 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
-- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored on the definition in the same write and becomes immutable. When replacing an existing definition, omitting `options.authorId` retains its stored author, while using a different author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -22,10 +22,15 @@ The whole bundle is validated up front. Members are then registered in dependenc
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflows([
-  helperDefinition, // nested by the root — order in the array doesn't matter
-  rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
-])
+await mastra.addDynamicWorkflows(
+  [
+    helperDefinition, // nested by the root — order in the array doesn't matter
+    rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
+  ],
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 ```
 
 ## Parameters
@@ -38,6 +43,13 @@ await mastra.addDynamicWorkflows([
     description:
       'The workflow definitions to add. Nested-workflow references may resolve against the live registries or against other members of the same bundle.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata applied to every definition in the bundle. Use `authorId` for a verified author identity that must not come from a workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -48,6 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
+- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -60,7 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
-- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored with every bundle member and becomes immutable. When replacing existing members, omitting `options.authorId` retains each member's stored author, while a member whose ID belongs to another author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -390,6 +390,80 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect(() => mastra.getWorkflow('loser-only')).toThrow();
   });
 
+  it('does not let a hung write block unrelated ids and times out an overlapping waiter before mutation', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-keyed-registration-queue' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const realUpsert = store.upsert.bind(store);
+
+    let releaseHungWrite!: () => void;
+    const hungWrite = new Promise<void>(resolve => {
+      releaseHungWrite = resolve;
+    });
+    let markHungWriteEntered!: () => void;
+    const hungWriteEntered = new Promise<void>(resolve => {
+      markHungWriteEntered = resolve;
+    });
+    const mutatedDescriptions: string[] = [];
+    store.upsert = (async definition => {
+      if (definition.id === 'blocked' && definition.description === 'first') {
+        markHungWriteEntered();
+        await hungWrite;
+      }
+      mutatedDescriptions.push(definition.description ?? '');
+      return realUpsert(definition);
+    }) as typeof store.upsert;
+
+    const first = mastra.addDynamicWorkflow(
+      { ...helperDefinition('blocked', 'email1'), description: 'first' },
+      { authorId: 'owner' },
+    );
+    await hungWriteEntered;
+
+    await expect(
+      mastra.addDynamicWorkflow(
+        { ...helperDefinition('unrelated', 'email1'), description: 'unrelated' },
+        { authorId: 'owner' },
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      mastra.addDynamicWorkflow(
+        { ...helperDefinition('blocked', 'email2'), description: 'timed-out' },
+        { authorId: 'owner', waitTimeoutMs: 1 },
+      ),
+    ).rejects.toThrow(/Timed out waiting/);
+    const controller = new AbortController();
+    controller.abort(new Error('caller cancelled'));
+    await expect(
+      mastra.addDynamicWorkflow(
+        { ...helperDefinition('blocked', 'email2'), description: 'cancelled' },
+        { authorId: 'owner', signal: controller.signal },
+      ),
+    ).rejects.toThrow(/caller cancelled/);
+    expect(mutatedDescriptions).not.toContain('timed-out');
+    expect(mutatedDescriptions).not.toContain('cancelled');
+    expect(mastra.getWorkflow('blocked').description).toBe('first');
+
+    let laterSettled = false;
+    const later = mastra
+      .addDynamicWorkflow({ ...helperDefinition('blocked', 'email2'), description: 'later' }, { authorId: 'owner' })
+      .finally(() => {
+        laterSettled = true;
+      });
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+    expect(laterSettled).toBe(false);
+
+    releaseHungWrite();
+    await first;
+    await later;
+    expect(await store.get('blocked')).toMatchObject({ description: 'later', authorId: 'owner' });
+    expect(await store.get('unrelated')).toMatchObject({ description: 'unrelated', authorId: 'owner' });
+    expect(mutatedDescriptions).not.toContain('timed-out');
+    expect(mutatedDescriptions).not.toContain('cancelled');
+    expect(mutatedDescriptions).toContain('later');
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import { InMemoryStore } from '../storage';
+import { InMemoryStore, WorkflowDefinitionOwnershipConflictError } from '../storage';
 import { createTool } from '../tools';
 import { Mastra } from './index';
 
@@ -296,6 +296,26 @@ describe('Mastra.addDynamicWorkflows', () => {
     const definition = await store.get('lookup-first-customer');
 
     expect(definition?.authorId).toBe('verified-author');
+  });
+
+  it('rejects a different trusted author and restores the previous registration', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-conflict' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+      authorId: 'verified-author',
+    });
+    const original = mastra.getWorkflow('lookup-first-customer');
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email2'), {
+        authorId: 'other-author',
+      }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(mastra.getWorkflow('lookup-first-customer')).toBe(original);
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    expect((await store.get('lookup-first-customer'))?.authorId).toBe('verified-author');
   });
 
   it('is a no-op for an empty bundle', async () => {

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -318,6 +318,62 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect((await store.get('lookup-first-customer'))?.authorId).toBe('verified-author');
   });
 
+  it('serializes overlapping bundles so a rejected owner cannot roll back the winner', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-concurrent-owner-conflict' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const realUpsert = store.upsert.bind(store);
+
+    let releaseFirstUpsert!: () => void;
+    const firstUpsertEntered = new Promise<void>(resolve => {
+      releaseFirstUpsert = resolve;
+    });
+    let upsertCalls = 0;
+    store.upsert = (async definition => {
+      upsertCalls += 1;
+      if (upsertCalls === 1) {
+        releaseFirstUpsert();
+        // Keep the first bundle inside persistence for one event-loop turn.
+        // Without registration serialization, the overlapping bundle can
+        // replace its registry slots and win storage before this write resumes.
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+      }
+      return realUpsert(definition);
+    }) as typeof store.upsert;
+
+    const winner = mastra.addDynamicWorkflows(
+      [
+        { ...helperDefinition('shared-helper', 'email1'), description: 'winner' },
+        helperDefinition('winner-only', 'email1'),
+      ],
+      { authorId: 'winner-author' },
+    );
+    await firstUpsertEntered;
+
+    const loser = mastra.addDynamicWorkflows(
+      [
+        { ...helperDefinition('shared-helper', 'email2'), description: 'loser' },
+        helperDefinition('loser-only', 'email2'),
+      ],
+      { authorId: 'loser-author' },
+    );
+
+    const [winnerResult, loserResult] = await Promise.allSettled([winner, loser]);
+    expect(winnerResult.status).toBe('fulfilled');
+    expect(loserResult).toMatchObject({
+      status: 'rejected',
+      reason: expect.any(WorkflowDefinitionOwnershipConflictError),
+    });
+
+    expect(await store.get('shared-helper')).toMatchObject({ authorId: 'winner-author', description: 'winner' });
+    expect(await store.get('winner-only')).toMatchObject({ authorId: 'winner-author' });
+    expect(await store.get('loser-only')).toBeNull();
+
+    expect(mastra.getWorkflow('shared-helper').description).toBe('winner');
+    expect(mastra.getWorkflow('winner-only')).toBeDefined();
+    expect(() => mastra.getWorkflow('loser-only')).toThrow();
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -283,6 +283,22 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect(definitions.every(definition => definition.authorId === 'verified-author')).toBe(true);
   });
 
+  it('rejects an authored bundle before live registration when workflow definition storage is unavailable', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-no-definition-store' });
+    const getStore = storage.getStore.bind(storage);
+    storage.getStore = (async domain =>
+      domain === 'workflowDefinitions' ? undefined : getStore(domain)) as typeof storage.getStore;
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+        authorId: 'verified-author',
+      }),
+    ).rejects.toThrow(/workflowDefinitions storage domain is required/);
+
+    expect(() => mastra.getWorkflow('lookup-first-customer')).toThrow();
+  });
+
   it('preserves an existing author when a trusted author is omitted on replacement', async () => {
     const storage = new InMemoryStore({ id: 'bundle-author-preserved' });
     const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -262,6 +262,42 @@ describe('Mastra.addDynamicWorkflows', () => {
     ]);
   });
 
+  it('persists one trusted author for every member outside the workflow definitions', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    const untrustedHelper = {
+      ...helperDefinition('lookup-first-customer', 'email1'),
+      authorId: 'forged-author',
+    };
+
+    await mastra.addDynamicWorkflows(
+      [untrustedHelper, helperDefinition('lookup-second-customer', 'email2'), rootDefinition],
+      { authorId: 'verified-author' },
+    );
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const { definitions } = await store.list({ status: 'active' });
+
+    expect(definitions).toHaveLength(3);
+    expect(definitions.every(definition => definition.authorId === 'verified-author')).toBe(true);
+  });
+
+  it('preserves an existing author when a trusted author is omitted on replacement', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-preserved' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+      authorId: 'verified-author',
+    });
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email2'));
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const definition = await store.get('lookup-first-customer');
+
+    expect(definition?.authorId).toBe('verified-author');
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -4855,6 +4855,9 @@ export class Mastra<
    *   before anything is mutated.
    * - If hydration or persistence fails partway, the in-memory registry is
    *   restored to its prior state.
+   * - Registrations are serialized on this Mastra instance through validation,
+   *   hydration, and persistence so one caller's rollback cannot undo another
+   *   caller's accepted live registration.
    * - Storage writes happen last. A storage-level failure mid-bundle is the
    *   one residual window where rows can be partially written; the registry is
    *   still rolled back, and the orphaned rows are inert until the next boot.
@@ -4901,6 +4904,13 @@ export class Mastra<
           graph: def.graph,
         }),
       }));
+
+      const store = await this.#storage?.getStore('workflowDefinitions');
+      if (options?.authorId !== undefined && !store) {
+        throw new Error(
+          'A workflowDefinitions storage domain is required when registering an authored dynamic workflow.',
+        );
+      }
 
       // Members may nest each other, so the index every member validates against
       // is the live registries plus the bundle itself — not the registry alone.
@@ -4966,7 +4976,6 @@ export class Mastra<
           this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
         }
 
-        const store = await this.#storage?.getStore('workflowDefinitions');
         if (store) {
           for (const { normalized } of ordered) {
             await store.upsert({

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -688,6 +688,7 @@ export class Mastra<
   #workflows: TWorkflows;
   #harnesses: Record<string, Harness<any>> = {};
   #hiddenWorkflowKeys = new Set<string>();
+  #dynamicWorkflowRegistrationTail: Promise<void> = Promise.resolve();
   #observability: ObservabilityEntrypoint;
   #observabilityExplicit = false;
   #onScorerHook?: ReturnType<typeof createOnScorerHook>;
@@ -4758,6 +4759,26 @@ export class Mastra<
   }
 
   /**
+   * Runs dynamic workflow registrations one at a time so each rollback owns a
+   * stable registry snapshot. An instance-wide queue also makes overlapping
+   * bundles deadlock-free because callers never acquire per-workflow locks.
+   */
+  async #serializeDynamicWorkflowRegistration<T>(operation: () => Promise<T>): Promise<T> {
+    const prior = this.#dynamicWorkflowRegistrationTail;
+    let release!: () => void;
+    this.#dynamicWorkflowRegistrationTail = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    await prior;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  /**
    * Flattens this instance's registries into the index the dynamic-workflow
    * validation core resolves references and schemas against. Registered keys
    * and canonical ids both count as valid references. Schemas are converted
@@ -4854,116 +4875,118 @@ export class Mastra<
   ): Promise<void> {
     if (defs.length === 0) return;
 
-    const seen = new Set<string>();
-    for (const def of defs) {
-      if (seen.has(def.id)) {
-        throw new Error(
-          `Dynamic workflow bundle contains more than one definition with id "${def.id}". Ids must be unique within a bundle.`,
-        );
-      }
-      seen.add(def.id);
-    }
-
-    // Save-path is strict (boot-time load is lenient — see #loadDynamicWorkflows).
-    // Normalization coerces the wire shape; one validation call per member
-    // covers structure, JSON-Schema keywords, references, and schema-flow.
-    const members = defs.map(def => ({
-      normalized: normalizeWorkflowBuilderDefinition({
-        id: def.id,
-        description: def.description,
-        metadata: def.metadata,
-        inputSchema: def.inputSchema,
-        outputSchema: def.outputSchema,
-        stateSchema: def.stateSchema,
-        requestContextSchema: def.requestContextSchema,
-        graph: def.graph,
-      }),
-    }));
-
-    // Members may nest each other, so the index every member validates against
-    // is the live registries plus the bundle itself — not the registry alone.
-    const index = this.#buildWorkflowRegistryIndex();
-    const bundleIds = new Set(members.map(member => member.normalized.id));
-    for (const { normalized } of members) {
-      (index.workflows ??= {})[normalized.id] = {
-        inputSchema: normalized.inputSchema,
-        outputSchema: normalized.outputSchema,
-      } as WorkflowRegistrySchemas;
-    }
-    for (const { normalized } of members) {
-      assertValidDynamicWorkflow(normalized, index);
-    }
-
-    // Hydration resolves nested workflows through the live registry, so a
-    // member cannot be hydrated before the bundle members it nests.
-    const ordered: typeof members = [];
-    const remaining = new Map(members.map(member => [member.normalized.id, member] as const));
-    const hydrated = new Set<string>();
-    let progress = true;
-    while (remaining.size > 0 && progress) {
-      progress = false;
-      for (const [id, member] of Array.from(remaining)) {
-        const pending = Array.from(collectNestedWorkflowIds(member.normalized.graph)).filter(
-          dependency => dependency !== id && bundleIds.has(dependency) && !hydrated.has(dependency),
-        );
-        if (pending.length > 0) continue;
-        remaining.delete(id);
-        hydrated.add(id);
-        ordered.push(member);
-        progress = true;
-      }
-    }
-    if (remaining.size > 0) {
-      throw new Error(
-        `Dynamic workflow bundle has a circular nested-workflow dependency among: ${Array.from(remaining.keys())
-          .sort()
-          .join(', ')}.`,
-      );
-    }
-
-    // Snapshot the registry slots this bundle will overwrite so a failure
-    // anywhere below leaves the instance exactly as it was found.
-    const registry = this.#workflows as Record<string, AnyWorkflow>;
-    const priorWorkflows = new Map<string, AnyWorkflow | undefined>();
-    const priorHiddenKeys = new Set<string>();
-    for (const { normalized } of ordered) {
-      priorWorkflows.set(normalized.id, registry[normalized.id]);
-      if (this.#hiddenWorkflowKeys.has(normalized.id)) priorHiddenKeys.add(normalized.id);
-    }
-    const restoreRegistry = () => {
-      for (const [id, prior] of priorWorkflows) {
-        if (prior) registry[id] = prior;
-        else delete registry[id];
-        if (priorHiddenKeys.has(id)) this.#hiddenWorkflowKeys.add(id);
-      }
-    };
-
-    try {
-      for (const { normalized } of ordered) {
-        const { workflow } = await rehydrateWorkflow(normalized, this);
-        this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
+    await this.#serializeDynamicWorkflowRegistration(async () => {
+      const seen = new Set<string>();
+      for (const def of defs) {
+        if (seen.has(def.id)) {
+          throw new Error(
+            `Dynamic workflow bundle contains more than one definition with id "${def.id}". Ids must be unique within a bundle.`,
+          );
+        }
+        seen.add(def.id);
       }
 
-      const store = await this.#storage?.getStore('workflowDefinitions');
-      if (store) {
-        for (const { normalized } of ordered) {
-          await store.upsert({
-            id: normalized.id,
-            description: normalized.description,
-            metadata: normalized.metadata,
-            inputSchema: normalized.inputSchema,
-            outputSchema: normalized.outputSchema,
-            stateSchema: normalized.stateSchema,
-            requestContextSchema: normalized.requestContextSchema,
-            graph: normalized.graph,
-            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
-          });
+      // Save-path is strict (boot-time load is lenient — see #loadDynamicWorkflows).
+      // Normalization coerces the wire shape; one validation call per member
+      // covers structure, JSON-Schema keywords, references, and schema-flow.
+      const members = defs.map(def => ({
+        normalized: normalizeWorkflowBuilderDefinition({
+          id: def.id,
+          description: def.description,
+          metadata: def.metadata,
+          inputSchema: def.inputSchema,
+          outputSchema: def.outputSchema,
+          stateSchema: def.stateSchema,
+          requestContextSchema: def.requestContextSchema,
+          graph: def.graph,
+        }),
+      }));
+
+      // Members may nest each other, so the index every member validates against
+      // is the live registries plus the bundle itself — not the registry alone.
+      const index = this.#buildWorkflowRegistryIndex();
+      const bundleIds = new Set(members.map(member => member.normalized.id));
+      for (const { normalized } of members) {
+        (index.workflows ??= {})[normalized.id] = {
+          inputSchema: normalized.inputSchema,
+          outputSchema: normalized.outputSchema,
+        } as WorkflowRegistrySchemas;
+      }
+      for (const { normalized } of members) {
+        assertValidDynamicWorkflow(normalized, index);
+      }
+
+      // Hydration resolves nested workflows through the live registry, so a
+      // member cannot be hydrated before the bundle members it nests.
+      const ordered: typeof members = [];
+      const remaining = new Map(members.map(member => [member.normalized.id, member] as const));
+      const hydrated = new Set<string>();
+      let progress = true;
+      while (remaining.size > 0 && progress) {
+        progress = false;
+        for (const [id, member] of Array.from(remaining)) {
+          const pending = Array.from(collectNestedWorkflowIds(member.normalized.graph)).filter(
+            dependency => dependency !== id && bundleIds.has(dependency) && !hydrated.has(dependency),
+          );
+          if (pending.length > 0) continue;
+          remaining.delete(id);
+          hydrated.add(id);
+          ordered.push(member);
+          progress = true;
         }
       }
-    } catch (error) {
-      restoreRegistry();
-      throw error;
-    }
+      if (remaining.size > 0) {
+        throw new Error(
+          `Dynamic workflow bundle has a circular nested-workflow dependency among: ${Array.from(remaining.keys())
+            .sort()
+            .join(', ')}.`,
+        );
+      }
+
+      // Snapshot the registry slots this bundle will overwrite so a failure
+      // anywhere below leaves the instance exactly as it was found.
+      const registry = this.#workflows as Record<string, AnyWorkflow>;
+      const priorWorkflows = new Map<string, AnyWorkflow | undefined>();
+      const priorHiddenKeys = new Set<string>();
+      for (const { normalized } of ordered) {
+        priorWorkflows.set(normalized.id, registry[normalized.id]);
+        if (this.#hiddenWorkflowKeys.has(normalized.id)) priorHiddenKeys.add(normalized.id);
+      }
+      const restoreRegistry = () => {
+        for (const [id, prior] of priorWorkflows) {
+          if (prior) registry[id] = prior;
+          else delete registry[id];
+          if (priorHiddenKeys.has(id)) this.#hiddenWorkflowKeys.add(id);
+        }
+      };
+
+      try {
+        for (const { normalized } of ordered) {
+          const { workflow } = await rehydrateWorkflow(normalized, this);
+          this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
+        }
+
+        const store = await this.#storage?.getStore('workflowDefinitions');
+        if (store) {
+          for (const { normalized } of ordered) {
+            await store.upsert({
+              id: normalized.id,
+              description: normalized.description,
+              metadata: normalized.metadata,
+              inputSchema: normalized.inputSchema,
+              outputSchema: normalized.outputSchema,
+              stateSchema: normalized.stateSchema,
+              requestContextSchema: normalized.requestContextSchema,
+              graph: normalized.graph,
+              ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
+            });
+          }
+        }
+      } catch (error) {
+        restoreRegistry();
+        throw error;
+      }
+    });
   }
 
   /**

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -111,6 +111,10 @@ export interface DynamicWorkflowRegistrationOptions {
    * authorize this value before registration.
    */
   authorId?: string;
+  /** Maximum time to wait for an overlapping registration already using the same workflow id(s). */
+  waitTimeoutMs?: number;
+  /** Cancels only while waiting to enter registration; admitted storage mutations are always awaited. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -688,7 +692,7 @@ export class Mastra<
   #workflows: TWorkflows;
   #harnesses: Record<string, Harness<any>> = {};
   #hiddenWorkflowKeys = new Set<string>();
-  #dynamicWorkflowRegistrationTail: Promise<void> = Promise.resolve();
+  #dynamicWorkflowRegistrationTails = new Map<string, Promise<void>>();
   #observability: ObservabilityEntrypoint;
   #observabilityExplicit = false;
   #onScorerHook?: ReturnType<typeof createOnScorerHook>;
@@ -4759,22 +4763,76 @@ export class Mastra<
   }
 
   /**
-   * Runs dynamic workflow registrations one at a time so each rollback owns a
-   * stable registry snapshot. An instance-wide queue also makes overlapping
-   * bundles deadlock-free because callers never acquire per-workflow locks.
+   * Serializes only registrations with overlapping ids. All ids are reserved
+   * synchronously before waiting, so bundles cannot deadlock. Cancellation and
+   * timeout apply to queue admission only: a rejected waiter never starts a
+   * storage mutation, while an admitted mutation remains awaited to completion.
    */
-  async #serializeDynamicWorkflowRegistration<T>(operation: () => Promise<T>): Promise<T> {
-    const prior = this.#dynamicWorkflowRegistrationTail;
+  async #serializeDynamicWorkflowRegistration<T>(
+    ids: readonly string[],
+    options: DynamicWorkflowRegistrationOptions | undefined,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    if (options?.signal?.aborted) {
+      throw options.signal.reason ?? new Error('Dynamic workflow registration aborted.');
+    }
+    if (
+      options?.waitTimeoutMs !== undefined &&
+      (!Number.isFinite(options.waitTimeoutMs) || options.waitTimeoutMs < 0)
+    ) {
+      throw new Error('Dynamic workflow registration waitTimeoutMs must be a finite non-negative number.');
+    }
+    const uniqueIds = Array.from(new Set(ids)).sort();
+    const priors = uniqueIds.map(id => this.#dynamicWorkflowRegistrationTails.get(id) ?? Promise.resolve());
+    const admission = Promise.all(priors).then(() => undefined);
     let release!: () => void;
-    this.#dynamicWorkflowRegistrationTail = new Promise<void>(resolve => {
+    const slot = new Promise<void>(resolve => {
       release = resolve;
     });
+    for (const id of uniqueIds) this.#dynamicWorkflowRegistrationTails.set(id, slot);
+    void slot.then(() => {
+      for (const id of uniqueIds) {
+        if (this.#dynamicWorkflowRegistrationTails.get(id) === slot) this.#dynamicWorkflowRegistrationTails.delete(id);
+      }
+    });
 
-    await prior;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const waitWarning = setTimeout(() => {
+      this.#logger?.warn?.(`Dynamic workflow registration is waiting for ids: ${uniqueIds.join(', ')}.`);
+    }, 5_000);
+    let removeAbortListener: (() => void) | undefined;
+    let admitted = false;
     try {
+      const blockers: Promise<void>[] = [admission];
+      if (options?.signal) {
+        blockers.push(
+          new Promise<void>((_, reject) => {
+            const rejectAbort = () =>
+              reject(options.signal?.reason ?? new Error('Dynamic workflow registration aborted.'));
+            options.signal!.addEventListener('abort', rejectAbort, { once: true });
+            removeAbortListener = () => options.signal!.removeEventListener('abort', rejectAbort);
+          }),
+        );
+      }
+      if (options?.waitTimeoutMs !== undefined) {
+        blockers.push(
+          new Promise<void>((_, reject) => {
+            timeout = setTimeout(
+              () => reject(new Error(`Timed out waiting to register dynamic workflow ids: ${uniqueIds.join(', ')}.`)),
+              options.waitTimeoutMs,
+            );
+          }),
+        );
+      }
+      await Promise.race(blockers);
+      admitted = true;
       return await operation();
     } finally {
-      release();
+      if (timeout) clearTimeout(timeout);
+      clearTimeout(waitWarning);
+      removeAbortListener?.();
+      if (admitted) release();
+      else void admission.then(release, release);
     }
   }
 
@@ -4855,9 +4913,11 @@ export class Mastra<
    *   before anything is mutated.
    * - If hydration or persistence fails partway, the in-memory registry is
    *   restored to its prior state.
-   * - Registrations are serialized on this Mastra instance through validation,
+   * - Registrations with overlapping ids are serialized through validation,
    *   hydration, and persistence so one caller's rollback cannot undo another
-   *   caller's accepted live registration.
+   *   caller's accepted live registration. Unrelated ids proceed independently.
+   * - `waitTimeoutMs` and `signal` apply before admission. A rejected waiter
+   *   performs no registry or storage mutation; admitted writes are fully awaited.
    * - Storage writes happen last. A storage-level failure mid-bundle is the
    *   one residual window where rows can be partially written; the registry is
    *   still rolled back, and the orphaned rows are inert until the next boot.
@@ -4878,7 +4938,12 @@ export class Mastra<
   ): Promise<void> {
     if (defs.length === 0) return;
 
-    await this.#serializeDynamicWorkflowRegistration(async () => {
+    const serializeRegistration = this.#serializeDynamicWorkflowRegistration.bind(
+      this,
+      defs.map(def => def.id),
+      options,
+    );
+    await serializeRegistration(async () => {
       const seen = new Set<string>();
       for (const def of defs) {
         if (seen.has(def.id)) {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -99,6 +99,21 @@ import { createRunScope } from './run-scope';
 import type { VersionOverrides, VersionSelector } from './types';
 
 /**
+ * Trusted metadata applied while a dynamic workflow is persisted.
+ *
+ * Keep these values outside the JSON workflow definition when that definition
+ * comes from an untrusted authoring surface. This metadata is persisted with
+ * the definition but does not itself enforce authorization.
+ */
+export interface DynamicWorkflowRegistrationOptions {
+  /**
+   * Verified identity responsible for the stored definition. Callers must
+   * authorize this value before registration.
+   */
+  authorId?: string;
+}
+
+/**
  * Creates an error for when a null/undefined value is passed to an add* method.
  * This commonly occurs when config is spread ({ ...config }) and the original
  * object had getters or non-enumerable properties.
@@ -4796,8 +4811,11 @@ export class Mastra<
    * await run.start({ inputData: { location: 'Helsinki' } });
    * ```
    */
-  public async addDynamicWorkflow(def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput): Promise<void> {
-    await this.addDynamicWorkflows([def]);
+  public async addDynamicWorkflow(
+    def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput,
+    options?: DynamicWorkflowRegistrationOptions,
+  ): Promise<void> {
+    await this.addDynamicWorkflows([def], options);
   }
 
   /**
@@ -4832,6 +4850,7 @@ export class Mastra<
    */
   public async addDynamicWorkflows(
     defs: readonly (DynamicWorkflowGraph | WorkflowBuilderDefinitionInput)[],
+    options?: DynamicWorkflowRegistrationOptions,
   ): Promise<void> {
     if (defs.length === 0) return;
 
@@ -4937,6 +4956,7 @@ export class Mastra<
             stateSchema: normalized.stateSchema,
             requestContextSchema: normalized.requestContextSchema,
             graph: normalized.graph,
+            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
           });
         }
       }

--- a/packages/core/src/storage/domains/workflow-definitions/base.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/base.ts
@@ -42,6 +42,8 @@ export interface WorkflowDefinition {
 
   /** Provenance — distinguishes user-stored from code-registered workflows. */
   source: 'storage';
+
+  /** Immutable owner assigned when the definition is created. */
   authorId?: string;
 
   createdAt: Date;
@@ -58,6 +60,8 @@ export interface CreateWorkflowDefinitionInput {
   stateSchema?: unknown;
   requestContextSchema?: unknown;
   graph: ValidatableStepFlowEntry[];
+
+  /** Immutable owner to assign when the definition is created. */
   authorId?: string;
 }
 
@@ -72,6 +76,8 @@ export interface UpdateWorkflowDefinitionInput {
   requestContextSchema?: unknown;
   graph?: ValidatableStepFlowEntry[];
   status?: 'active' | 'archived';
+
+  /** Expected immutable owner. A different owner produces a conflict. */
   authorId?: string;
 }
 
@@ -86,10 +92,42 @@ export interface ListWorkflowDefinitionsOutput {
 }
 
 /**
+ * Thrown when an upsert attempts to claim a workflow definition that already
+ * belongs to a different author. The message intentionally does not disclose
+ * the existing author.
+ */
+export class WorkflowDefinitionOwnershipConflictError extends Error {
+  readonly workflowId: string;
+
+  constructor(workflowId: string) {
+    super(`Workflow definition "${workflowId}" conflicts with an existing definition.`);
+    this.name = 'WorkflowDefinitionOwnershipConflictError';
+    this.workflowId = workflowId;
+  }
+}
+
+/**
+ * Treat an explicitly supplied author as both creation ownership and the
+ * expected owner on update. Omitting authorId preserves legacy/unscoped
+ * behavior; supplying it can never create or transfer ownership after a row
+ * already exists.
+ */
+export function assertWorkflowDefinitionAuthor(
+  existing: Pick<WorkflowDefinition, 'id' | 'authorId'>,
+  input: Pick<UpdateWorkflowDefinitionInput, 'authorId'>,
+): void {
+  if (input.authorId !== undefined && existing.authorId !== input.authorId) {
+    throw new WorkflowDefinitionOwnershipConflictError(existing.id);
+  }
+}
+
+/**
  * Abstract storage domain for persisted workflow definitions.
  *
  * Versioning is intentionally out of scope for v1 — `upsert` overwrites in
- * place. A future revision can layer the {@link VersionedStorageDomain}
+ * place. Ownership is the exception: an explicitly supplied `authorId` is an
+ * immutable compare condition, so concurrent creators cannot take over the
+ * winning row. A future revision can layer the {@link VersionedStorageDomain}
  * pattern on top without breaking the rehydration path.
  */
 export abstract class WorkflowDefinitionsStorage extends StorageDomain {

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.test.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { InMemoryDB } from '../inmemory-db';
+import { WorkflowDefinitionOwnershipConflictError } from './base';
 import { InMemoryWorkflowDefinitionsStorage } from './inmemory';
 
 const graph = [{ type: 'tool', id: 'echo-tool', toolId: 'echo-tool' }] as any;
@@ -36,14 +37,24 @@ describe('InMemoryWorkflowDefinitionsStorage', () => {
   });
 
   describe('update', () => {
-    it('updates authorId on an existing definition', async () => {
+    it('keeps authorId immutable on an existing definition', async () => {
       await storage.upsert({ ...baseInput(), authorId: 'author-1' });
-      const updated = await storage.upsert({ id: 'wf-1', authorId: 'author-2' });
-      expect(updated.authorId).toBe('author-2');
+      await expect(storage.upsert({ id: 'wf-1', authorId: 'author-2' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
       const fetched = await storage.get('wf-1');
-      expect(fetched?.authorId).toBe('author-2');
+      expect(fetched?.authorId).toBe('author-1');
       // Unspecified columns survive the partial upsert.
       expect(fetched?.graph).toEqual(graph);
+    });
+
+    it('does not disclose the existing author in ownership conflicts', async () => {
+      await storage.upsert({ ...baseInput(), authorId: 'private-owner' });
+
+      const error = await storage.upsert({ id: 'wf-1', authorId: 'other-owner' }).catch(cause => cause);
+
+      expect(error).toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+      expect(error.message).not.toContain('private-owner');
     });
   });
 });

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
@@ -6,7 +6,7 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from './base';
-import { WorkflowDefinitionsStorage } from './base';
+import { assertWorkflowDefinitionAuthor, WorkflowDefinitionsStorage } from './base';
 
 export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStorage {
   private db: InMemoryDB;
@@ -25,6 +25,7 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
     const existing = this.db.workflowDefinitions.get(input.id);
 
     if (existing) {
+      assertWorkflowDefinitionAuthor(existing, input);
       const merged: WorkflowDefinition = {
         ...existing,
         ...('description' in input && input.description !== undefined && { description: input.description }),
@@ -36,7 +37,6 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
           input.requestContextSchema !== undefined && { requestContextSchema: input.requestContextSchema }),
         ...('graph' in input && input.graph !== undefined && { graph: input.graph }),
         ...('status' in input && input.status !== undefined && { status: input.status }),
-        ...('authorId' in input && input.authorId !== undefined && { authorId: input.authorId }),
         updatedAt: now,
       };
       this.db.workflowDefinitions.set(input.id, merged);

--- a/stores/_test-utils/src/domains/workflow-definitions/index.ts
+++ b/stores/_test-utils/src/domains/workflow-definitions/index.ts
@@ -1,3 +1,4 @@
+import { WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 import type { MastraStorage, WorkflowDefinitionsStorage } from '@mastra/core/storage';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
@@ -68,12 +69,30 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
       expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime());
     });
 
-    it('updates authorId on existing rows', async () => {
+    it('rejects ownership transfer on existing rows', async () => {
       await store.upsert({ ...baseInput('wf-1'), authorId: 'author-1' });
-      const updated = await store.upsert({ id: 'wf-1', authorId: 'author-2' });
-      expect(updated.authorId).toBe('author-2');
+      await expect(store.upsert({ id: 'wf-1', authorId: 'author-2' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
       const fetched = await store.get('wf-1');
-      expect(fetched?.authorId).toBe('author-2');
+      expect(fetched?.authorId).toBe('author-1');
+    });
+
+    it('allows the existing owner to update an owned row', async () => {
+      await store.upsert({ ...baseInput('wf-1'), authorId: 'author-1' });
+      const updated = await store.upsert({ id: 'wf-1', authorId: 'author-1', description: 'renamed' });
+
+      expect(updated).toMatchObject({ authorId: 'author-1', description: 'renamed' });
+    });
+
+    it('does not let an author claim a legacy unowned row', async () => {
+      await store.upsert(baseInput('wf-1'));
+
+      await expect(store.upsert({ id: 'wf-1', authorId: 'author-1' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
+      const stored = await store.get('wf-1');
+      expect(stored?.authorId).toBeUndefined();
     });
 
     it('preserves unspecified columns across a partial upsert', async () => {
@@ -105,6 +124,20 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
       }
       const all = await store.list();
       expect(all.total).toBe(1);
+    });
+
+    it('lets exactly one author win concurrent creation of the same id', async () => {
+      const results = await Promise.allSettled([
+        store.upsert({ ...baseInput('wf-owner-race'), authorId: 'author-1' }),
+        store.upsert({ ...baseInput('wf-owner-race'), authorId: 'author-2' }),
+      ]);
+
+      expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+      const rejected = results.find(result => result.status === 'rejected');
+      expect(rejected).toMatchObject({ reason: expect.any(WorkflowDefinitionOwnershipConflictError) });
+
+      const stored = await store.get('wf-owner-race');
+      expect(['author-1', 'author-2']).toContain(stored?.authorId);
     });
 
     it('rejects creation when required fields are explicitly undefined', async () => {

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
@@ -8,7 +8,7 @@
  *  - the domain is reachable through the LibSQLStore composite
  */
 import { createClient } from '@libsql/client';
-import { TABLE_WORKFLOW_DEFINITIONS } from '@mastra/core/storage';
+import { TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 import type { SerializedStepFlowEntry } from '@mastra/core/workflows';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -81,7 +81,7 @@ describe('WorkflowDefinitionsLibSQL', () => {
     expect(updated.graph).toEqual(graph);
   });
 
-  it('updates authorId on an existing row and keeps createdAt stable', async () => {
+  it('rejects an authorId change and keeps the original row stable', async () => {
     const wd = (await store.getStore('workflowDefinitions'))!;
 
     const created = await wd.upsert({
@@ -93,14 +93,53 @@ describe('WorkflowDefinitionsLibSQL', () => {
     });
     expect(created.authorId).toBe('author-1');
 
-    await new Promise(r => setTimeout(r, 5));
-    const updated = await wd.upsert({ id: 'wf-author', authorId: 'author-2' });
-    expect(updated.authorId).toBe('author-2');
-    expect(updated.createdAt.getTime()).toBe(created.createdAt.getTime());
-    expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime());
+    await expect(wd.upsert({ id: 'wf-author', authorId: 'author-2' })).rejects.toBeInstanceOf(
+      WorkflowDefinitionOwnershipConflictError,
+    );
 
     const fetched = await wd.get('wf-author');
-    expect(fetched?.authorId).toBe('author-2');
+    expect(fetched?.authorId).toBe('author-1');
+    expect(fetched?.createdAt.getTime()).toBe(created.createdAt.getTime());
+    expect(fetched?.updatedAt.getTime()).toBe(created.updatedAt.getTime());
+  });
+
+  it('does not update a different owner after a delete-and-recreate race', async () => {
+    const wd = (await store.getStore('workflowDefinitions'))!;
+    await wd.upsert({
+      id: 'wf-recreated',
+      description: 'original owner',
+      inputSchema,
+      outputSchema,
+      graph,
+      authorId: 'author-1',
+    });
+
+    const originalGet = wd.get.bind(wd);
+    const getSpy = vi.spyOn(wd, 'get');
+    let reads = 0;
+    getSpy.mockImplementation(async id => {
+      const current = await originalGet(id);
+      reads += 1;
+      if (reads === 2) {
+        getSpy.mockRestore();
+        await wd.delete(id);
+        await wd.upsert({
+          id,
+          description: 'new owner',
+          inputSchema,
+          outputSchema,
+          graph,
+          authorId: 'author-2',
+        });
+      }
+      return current;
+    });
+
+    await expect(
+      wd.upsert({ id: 'wf-recreated', description: 'stale update', authorId: 'author-1' }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(await wd.get('wf-recreated')).toMatchObject({ authorId: 'author-2', description: 'new owner' });
   });
 
   it('round-trips JSON columns intact', async () => {

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.ts
@@ -6,7 +6,12 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from '@mastra/core/storage';
-import { TABLE_SCHEMAS, TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_SCHEMAS,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';
@@ -131,6 +136,10 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     // Update — only patch fields present in the input
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
@@ -142,11 +151,11 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,8 @@
-import { TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import type {
   CreateWorkflowDefinitionInput,
   ListWorkflowDefinitionsInput,
@@ -141,6 +145,9 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
     now: Date,
   ): Promise<WorkflowDefinition> {
     const collection = await this.getCollection(TABLE_WORKFLOW_DEFINITIONS);
+    const existing = await collection.findOne<Record<string, any>>({ id: input.id });
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(docToDefinition(existing), input);
 
     const update: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) update.description = input.description;
@@ -152,12 +159,13 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
       update.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) update.graph = input.graph;
     if ('status' in input && input.status !== undefined) update.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) update.authorId = input.authorId;
-
-    await collection.updateOne({ id: input.id }, { $set: update });
+    const filter = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await collection.updateOne(filter, { $set: update });
     const updated = await collection.findOne<Record<string, any>>({ id: input.id });
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
-    return docToDefinition(updated);
+    const definition = docToDefinition(updated);
+    assertWorkflowDefinitionAuthor(definition, input);
+    return definition;
   }
 
   async get(id: string): Promise<WorkflowDefinition | null> {

--- a/stores/mssql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mssql/src/storage/domains/workflow-definitions/index.ts
@@ -1,6 +1,7 @@
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -177,6 +178,10 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -187,11 +192,11 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/mysql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mysql/src/storage/domains/workflow-definitions/index.ts
@@ -1,6 +1,7 @@
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -123,6 +124,10 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -133,11 +138,11 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/pg/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/pg/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,9 @@
-import { TABLE_SCHEMAS, TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_SCHEMAS,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import type {
   CreateIndexOptions,
   CreateWorkflowDefinitionInput,
@@ -165,6 +170,10 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -175,11 +184,11 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/spanner/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/spanner/src/storage/domains/workflow-definitions/index.ts
@@ -2,6 +2,7 @@ import type { Database } from '@google-cloud/spanner';
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -143,6 +144,10 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -153,11 +158,11 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 


### PR DESCRIPTION
## Summary

- Make an explicitly supplied dynamic-workflow author an immutable storage precondition.
- Use owner-qualified update predicates and a post-write ownership assertion so a stale owner cannot mutate a definition deleted and recreated by another owner.
- Let exactly one author win concurrent creation through the existing primary-key insert, returning a non-disclosing `WorkflowDefinitionOwnershipConflictError` to the loser.
- Apply the contract to Core in-memory storage and every current persistent workflow-definition adapter: LibSQL, PostgreSQL, MySQL, MongoDB, MSSQL, and Spanner.
- Add shared adapter conformance, a deterministic delete/recreate race test, native registration rollback coverage, docs, and changesets.

## Stack and scope

This draft is stacked on #21445 and advances RFC #21444. Review commit `57f0e950c9`; the preceding commit is the current #21445 implementation and will be rebased away after that PR lands.

This is a storage invariant, not complete tenant authorization. It does not yet scope list/get/delete/run routes or nested workflow references. Calls that omit `authorId` retain the existing legacy/unscoped update behavior; trusted management routes must always supply the server-derived author in the later route-scoping slice.

## Verification

- Core focused workflow-definition and registration suites: 17/17 passed, including type checking.
- Core `check`: passed.
- LibSQL workflow-definition suite: 10/10 passed, including the deterministic delete/recreate race.
- LibSQL shared workflow-definition conformance: 14/14 passed.
- `build:lib` and package lint passed for LibSQL, PostgreSQL, MySQL, MongoDB, MSSQL, and Spanner.
- Core package lint passed.
- Targeted MDX formatting passed; docs frontmatter validation passed for 609 files.
- Changeset status recognizes all six persistent stores at patch and Core through the stacked minor changeset.

Full docs validation remains non-actionable on Windows current-main because its ESM loader rejects absolute `C:` paths and the sidebar validator then reports hundreds of false missing entries; targeted changed-doc checks are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR prevents one person from replacing another person as the owner of a dynamic workflow. It checks ownership during updates and concurrent creation, while keeping existing behavior when no author is provided.

## What changed

- Added trusted `authorId` options to `addDynamicWorkflow()` and `addDynamicWorkflows()`.
- Persisted author metadata separately from workflow JSON.
- Added immutable ownership checks and `WorkflowDefinitionOwnershipConflictError`.
- Added owner-qualified update predicates and post-write ownership checks across all supported storage adapters.
- Preserved legacy unscoped updates when `authorId` is omitted.
- Added protections for delete/recreate races and concurrent workflow creation.
- Serialized dynamic workflow registrations to prevent failed registrations from restoring stale registry state.
- Added rollback, ownership, conformance, race-condition, and non-disclosure tests.
- Updated API documentation and changesets.
- Clarified that `authorId` metadata does not provide tenant authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->