### PR TITLE
fix(core): preserve actionable API errors

### DIFF
--- a/.changeset/small-ravens-rest.md
+++ b/.changeset/small-ravens-rest.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed schedule errors to preserve actionable HTTP statuses and retained structured agent errors after model fallback exhaustion.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -1618,7 +1618,7 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     });
   });
 
-  it('preserves structured errors when all fallback models fail', async () => {
+  it('preserves a structured error when fallback execution is exhausted', async () => {
     // Mirrors the observational-memory case: an input processor throws a
     // structured USER error before the model is ever called. The fallback loop
     // must rethrow the original MastraError (with details.status) instead of

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -5,6 +5,7 @@ import type { Mock } from 'vitest';
 import { z } from 'zod/v4';
 import { MODEL_TOKENS } from '../../../../../../docs/src/plugins/remark-model-tokens/models';
 import { MessageList } from '../../../agent/message-list';
+import { ErrorCategory, ErrorDomain, MastraError } from '../../../error';
 import { SpanType } from '../../../observability';
 import { StreamErrorRetryProcessor } from '../../../processors';
 import { ProviderHistoryCompat } from '../../../processors/provider-history-compat';
@@ -1615,6 +1616,87 @@ describe('createLLMExecutionStep gateway provider tools', () => {
       stepResult: { reason: 'tripwire', isContinued: false },
       output: { text: '' },
     });
+  });
+
+  it('preserves structured errors when all fallback models fail', async () => {
+    // Mirrors the observational-memory case: an input processor throws a
+    // structured USER error before the model is ever called. The fallback loop
+    // must rethrow the original MastraError (with details.status) instead of
+    // wrapping it in a plain "Exhausted all fallback models" Error.
+    const structuredError = new MastraError({
+      id: 'TEST_USER_INPUT_ERROR',
+      domain: ErrorDomain.AGENT,
+      category: ErrorCategory.USER,
+      details: { status: 400 },
+      text: 'Invalid agent input',
+    });
+    const doStream = vi.fn(async () => ({
+      stream: convertArrayToReadableStream([
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: testUsage,
+        },
+      ]),
+      request: {},
+      response: { headers: undefined },
+      warnings: [],
+    }));
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream,
+          } as any,
+        },
+      ],
+      inputProcessors: [
+        {
+          id: 'structured-error-processor',
+          processLLMRequest: vi.fn(async () => {
+            throw structuredError;
+          }),
+        },
+      ],
+      tools: {},
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+        threadId: 'thread-123',
+        resourceId: 'resource-456',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<{}>);
+
+    await expect(llmExecutionStep.execute(createExecuteParams(createIterationInput()))).rejects.toMatchObject({
+      id: 'TEST_USER_INPUT_ERROR',
+      category: ErrorCategory.USER,
+      details: { status: 400 },
+    });
+    expect(doStream).not.toHaveBeenCalled();
   });
 
   it('preserves fallback model index when processAPIError requests a retry', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -1691,11 +1691,7 @@ describe('createLLMExecutionStep gateway provider tools', () => {
       } as any,
     } as unknown as OuterLLMRun<{}>);
 
-    await expect(llmExecutionStep.execute(createExecuteParams(createIterationInput()))).rejects.toMatchObject({
-      id: 'TEST_USER_INPUT_ERROR',
-      category: ErrorCategory.USER,
-      details: { status: 400 },
-    });
+    await expect(llmExecutionStep.execute(createExecuteParams(createIterationInput()))).rejects.toBe(structuredError);
     expect(doStream).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1094,10 +1094,9 @@ function executeStreamWithFallbackModels<T>(
       }
     }
     if (typeof finalResult === 'undefined') {
-      const lastErrMsg = lastError instanceof Error ? lastError.message : String(lastError);
-      const errorMessage = `Exhausted all fallback models. Last error: ${lastErrMsg}`;
-      logger?.error(errorMessage);
-      throw new Error(errorMessage, { cause: lastError });
+      const fatalError = lastError ?? new Error('Exhausted all fallback models without receiving a result.');
+      logger?.error('Exhausted all fallback models.', fatalError);
+      throw fatalError;
     }
     return finalResult;
   };

--- a/packages/core/src/schedules/schedules.test.ts
+++ b/packages/core/src/schedules/schedules.test.ts
@@ -122,7 +122,7 @@ describe('mastra.schedules canonical service', () => {
     const { mastra } = makeMastra(['a']);
     await expect(
       mastra.schedules.create({ agentId: 'a', cron: '*/5 * * * *', prompt: 'A', id: '!!!' }),
-    ).rejects.toThrow(/empty after normalization/);
+    ).rejects.toMatchObject({ id: 'SCHEDULES_INVALID_ID', details: { status: 400 } });
   });
 
   it('list with no filter returns schedules across agents', async () => {

--- a/packages/core/src/schedules/schedules.test.ts
+++ b/packages/core/src/schedules/schedules.test.ts
@@ -85,7 +85,37 @@ describe('mastra.schedules canonical service', () => {
 
     await expect(
       mastra.schedules.create({ agentId: 'a', cron: '*/5 * * * *', prompt: 'B', id: 'dupe' }),
-    ).rejects.toThrow(/already exists/);
+    ).rejects.toMatchObject({ id: 'SCHEDULES_ID_EXISTS', details: { status: 409 } });
+  });
+
+  it('carries an HTTP status on user-facing schedule errors', async () => {
+    const { mastra } = makeMastra(['a']);
+
+    // Not-found errors map to 404 so API consumers get a 4xx instead of 500.
+    await expect(mastra.schedules.update('missing', { prompt: 'x' })).rejects.toMatchObject({
+      id: 'SCHEDULES_NOT_FOUND',
+      details: { status: 404 },
+    });
+    await expect(mastra.schedules.pause('missing')).rejects.toMatchObject({
+      id: 'SCHEDULES_NOT_FOUND',
+      details: { status: 404 },
+    });
+    await expect(mastra.schedules.resume('missing')).rejects.toMatchObject({
+      id: 'SCHEDULES_NOT_FOUND',
+      details: { status: 404 },
+    });
+    await expect(mastra.schedules.run('missing')).rejects.toMatchObject({
+      id: 'SCHEDULES_NOT_FOUND',
+      details: { status: 404 },
+    });
+
+    // Validation errors map to 400.
+    await expect(
+      mastra.schedules.create({ agentId: 'a', cron: '*/5 * * * *', prompt: 'A', resourceId: 'u1' }),
+    ).rejects.toMatchObject({ id: 'SCHEDULES_THREADLESS_OPTIONS', details: { status: 400 } });
+    await expect(
+      mastra.schedules.create({ agentId: 'a', cron: '*/5 * * * *', prompt: 'A', threadId: 't1' }),
+    ).rejects.toMatchObject({ id: 'SCHEDULES_MISSING_RESOURCE_ID', details: { status: 400 } });
   });
 
   it('throws when a custom id is empty after normalization', async () => {

--- a/packages/core/src/schedules/schedules.ts
+++ b/packages/core/src/schedules/schedules.ts
@@ -42,6 +42,7 @@ function normalizeScheduleId(rawId: string, prefix: string): string {
       id: 'SCHEDULES_INVALID_ID',
       domain: ErrorDomain.AGENT,
       category: ErrorCategory.USER,
+      details: { status: 400 },
       text: `schedules.create: id "${rawId}" is empty after normalization. Provide an id with at least one alphanumeric character.`,
     });
   }

--- a/packages/core/src/schedules/schedules.ts
+++ b/packages/core/src/schedules/schedules.ts
@@ -275,6 +275,7 @@ export class Schedules {
         id: 'SCHEDULES_MISSING_TARGET_ID',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 400 },
         text: 'schedules.create requires `agentId` or `workflowId`.',
       });
     }
@@ -284,6 +285,7 @@ export class Schedules {
         id: 'SCHEDULES_MISSING_RESOURCE_ID',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 400 },
         text: 'schedules.create requires `resourceId` when `threadId` is set.',
       });
     }
@@ -298,6 +300,7 @@ export class Schedules {
           id: 'SCHEDULES_THREADLESS_OPTIONS',
           domain: ErrorDomain.AGENT,
           category: ErrorCategory.USER,
+          details: { status: 400 },
           text: `schedules.create: ${offenders.join(', ')} require a threadId.`,
         });
       }
@@ -398,6 +401,7 @@ export class Schedules {
         id: 'SCHEDULES_ID_EXISTS',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 409 },
         text: `schedules.create: a schedule with id "${id}" already exists. Use update() to modify it or choose a different id.`,
       });
     }
@@ -441,6 +445,7 @@ export class Schedules {
         id: 'SCHEDULES_NOT_FOUND',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 404 },
         text: `Schedule "${id}" not found.`,
       });
     }
@@ -495,6 +500,7 @@ export class Schedules {
           id: 'SCHEDULES_THREADLESS_OPTIONS',
           domain: ErrorDomain.AGENT,
           category: ErrorCategory.USER,
+          details: { status: 400 },
           text: `schedules.update: ${offenders.join(', ')} require a threadId.`,
         });
       }
@@ -530,6 +536,7 @@ export class Schedules {
         id: 'SCHEDULES_INVALID_WORKFLOW_PATCH',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 400 },
         text: `schedules.update: ${offenders.join(', ')} only apply to agent schedules.`,
       });
     }
@@ -557,6 +564,7 @@ export class Schedules {
         id: 'SCHEDULES_NOT_FOUND',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 404 },
         text: `Schedule "${id}" not found.`,
       });
     }
@@ -573,6 +581,7 @@ export class Schedules {
         id: 'SCHEDULES_NOT_FOUND',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 404 },
         text: `Schedule "${id}" not found.`,
       });
     }
@@ -592,6 +601,7 @@ export class Schedules {
         id: 'SCHEDULES_NOT_FOUND',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
+        details: { status: 404 },
         text: `Schedule "${id}" not found.`,
       });
     }


### PR DESCRIPTION
PR 1 of 5 split from #21357. This keeps structured user errors intact when agent model fallback is exhausted and adds HTTP status metadata to schedule errors, so callers receive the intended 400, 404, or 409 response instead of a generic 500.

Before, the fallback path wrapped the final error and schedule failures omitted status metadata. After, the original structured error is rethrown and schedule errors carry actionable statuses.

Intentionally excludes trace status reporting, tool schema serialization, Stagehand close tracking, Studio routing, and internal smoke documentation.

Verified with the focused core build and 50 schedule/fallback tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If an agent cannot use any backup model, the system now keeps the original useful error details. Schedule errors now return the correct HTTP status instead of appearing as generic server errors.

## Changes

- Rethrow the original error after all agent model fallbacks fail.
- Preserve structured `MastraError` details from input processors.
- Add HTTP statuses to schedule errors:
  - `400` for invalid inputs.
  - `404` for missing schedules.
  - `409` for duplicate schedule IDs.
- Add regression coverage for fallback errors and schedule error metadata.
- Add a patch changeset for `@mastra/core`.

## Verification

- Focused core build.
- 50 schedule and fallback tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->