### PR TITLE
fix(server): hide runtime-only tool schema fields

### DIFF
--- a/.changeset/calm-tools-hide.md
+++ b/.changeset/calm-tools-hide.md
@@ -1,0 +1,5 @@
+---
+"@mastra/server": patch
+---
+
+Fixed serialized tool schemas to hide runtime-only background and suspended-run fields from user input forms.

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -87,6 +87,7 @@ import type { Context } from '../types';
 import { toSlug } from '../utils';
 
 import { handleError } from './error';
+import { stripInjectedToolOverrideFields } from './tool-schema-overrides';
 import {
   sanitizeBody,
   validateBody,
@@ -452,7 +453,7 @@ export async function getSerializedAgentTools(
           resolveLazySchema('inputSchema' in tool ? tool.inputSchema : undefined) as PublicSchema<unknown> | undefined,
         );
         if (inputSchema !== undefined) {
-          inputSchemaForReturn = stringify(inputSchema);
+          inputSchemaForReturn = stringify(stripInjectedToolOverrideFields(inputSchema));
         }
 
         const outputSchema = schemaToJsonSchema(

--- a/packages/server/src/server/handlers/tool-schema-overrides.ts
+++ b/packages/server/src/server/handlers/tool-schema-overrides.ts
@@ -1,0 +1,44 @@
+/**
+ * Core's `CoreToolBuilder` injects runtime-only override fields into tool input
+ * schemas (`_background` for background execution, `suspendedToolRunId` /
+ * `resumeData` for resumable tools). Those fields are meant for the LLM tool-call
+ * protocol, not for humans filling in a tool-execution form, so we strip them
+ * from serialized input schemas returned by the API.
+ *
+ * `suspendedToolRunId` / `resumeData` are only removed when their description
+ * matches the exact injected shape, so a user-authored field with the same name
+ * is preserved.
+ */
+
+const INJECTED_OVERRIDE_DESCRIPTIONS: Record<string, string> = {
+  suspendedToolRunId: 'The runId of the suspended tool',
+  resumeData: 'The resumeData object created from the resumeSchema of suspended tool',
+};
+
+export function stripInjectedToolOverrideFields<T>(jsonSchema: T): T {
+  if (!jsonSchema || typeof jsonSchema !== 'object' || Array.isArray(jsonSchema)) return jsonSchema;
+  const schema = jsonSchema as { properties?: Record<string, unknown>; required?: unknown };
+  if (!schema.properties || typeof schema.properties !== 'object') return jsonSchema;
+
+  const properties = { ...schema.properties };
+  let changed = false;
+
+  if ('_background' in properties) {
+    delete properties._background;
+    changed = true;
+  }
+
+  for (const [key, description] of Object.entries(INJECTED_OVERRIDE_DESCRIPTIONS)) {
+    const prop = properties[key];
+    if (prop && typeof prop === 'object' && (prop as { description?: string }).description === description) {
+      delete properties[key];
+      changed = true;
+    }
+  }
+
+  if (!changed) return jsonSchema;
+
+  const required = Array.isArray(schema.required) ? schema.required.filter(key => key in properties) : schema.required;
+
+  return { ...jsonSchema, properties, ...(required !== undefined ? { required } : {}) };
+}

--- a/packages/server/src/server/handlers/tools.test.ts
+++ b/packages/server/src/server/handlers/tools.test.ts
@@ -4,6 +4,7 @@ import { RequestContext } from '@mastra/core/di';
 import { Mastra } from '@mastra/core/mastra';
 import { createTool } from '@mastra/core/tools';
 import type { ToolAction, VercelTool } from '@mastra/core/tools';
+import { parse } from 'superjson';
 import type { Mock } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HTTPException } from '../http-exception';
@@ -744,6 +745,87 @@ describe('Tools Handlers', () => {
         expect(result).toHaveProperty(mockTool.id);
         expect(result).toHaveProperty('mcp-calculator');
         expect(result['mcp-calculator'].inputSchema).toBeDefined();
+      });
+    });
+  });
+
+  describe('injected override fields stripping', () => {
+    // Simulates a tool whose inputSchema was mutated by CoreToolBuilder's
+    // background/resume override injection.
+    const injectedTool = createTool({
+      id: 'injected-tool',
+      description: 'A tool with injected runtime override fields',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          url: { type: 'string' },
+          _background: { type: 'object' },
+          suspendedToolRunId: { type: ['string', 'null'], description: 'The runId of the suspended tool' },
+          resumeData: { description: 'The resumeData object created from the resumeSchema of suspended tool' },
+        },
+        required: ['url', 'suspendedToolRunId'],
+      } as any,
+      execute: async () => ({ ok: true }),
+    });
+
+    // A tool with a user-authored field that happens to share the injected name
+    // but not the injected description — it must survive serialization.
+    const lookalikeTool = createTool({
+      id: 'lookalike-tool',
+      description: 'A tool with a genuine suspendedToolRunId field',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          suspendedToolRunId: { type: 'string', description: 'A user-defined run id' },
+        },
+        required: ['suspendedToolRunId'],
+      } as any,
+      execute: async () => ({ ok: true }),
+    });
+
+    const getProperties = (serialized: string | undefined) => {
+      expect(serialized).toBeDefined();
+      const schema = parse(serialized!) as { properties?: Record<string, unknown>; required?: string[] };
+      return schema;
+    };
+
+    describe('listToolsHandler', () => {
+      it('strips injected override fields from serialized input schemas', async () => {
+        const mastra = new Mastra({ logger: false });
+        const result = await LIST_TOOLS_ROUTE.handler({
+          ...createTestServerContext({ mastra }),
+          registeredTools: { [injectedTool.id]: injectedTool } as any,
+        });
+        const schema = getProperties(result['injected-tool'].inputSchema);
+        expect(schema.properties).toHaveProperty('url');
+        expect(schema.properties).not.toHaveProperty('_background');
+        expect(schema.properties).not.toHaveProperty('suspendedToolRunId');
+        expect(schema.properties).not.toHaveProperty('resumeData');
+        expect(schema.required).toEqual(['url']);
+      });
+
+      it('preserves user-authored fields that share injected names but not descriptions', async () => {
+        const mastra = new Mastra({ logger: false });
+        const result = await LIST_TOOLS_ROUTE.handler({
+          ...createTestServerContext({ mastra }),
+          registeredTools: { [lookalikeTool.id]: lookalikeTool } as any,
+        });
+        const schema = getProperties(result['lookalike-tool'].inputSchema);
+        expect(schema.properties).toHaveProperty('suspendedToolRunId');
+        expect(schema.required).toEqual(['suspendedToolRunId']);
+      });
+    });
+
+    describe('getSerializedAgentTools', () => {
+      it('strips injected override fields from serialized agent tool input schemas', async () => {
+        const result = await getSerializedAgentTools({
+          [injectedTool.id]: injectedTool as any,
+        });
+        const schema = getProperties(result['injected-tool'].inputSchema);
+        expect(schema.properties).toHaveProperty('url');
+        expect(schema.properties).not.toHaveProperty('_background');
+        expect(schema.properties).not.toHaveProperty('suspendedToolRunId');
+        expect(schema.properties).not.toHaveProperty('resumeData');
       });
     });
   });

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -18,6 +18,7 @@ import { createRoute } from '../server-adapter/routes/route-builder';
 
 import { getAgentFromSystem } from './agents';
 import { handleError } from './error';
+import { stripInjectedToolOverrideFields } from './tool-schema-overrides';
 import { validateBody } from './utils';
 
 /**
@@ -41,10 +42,10 @@ function schemaToJsonSchema(schema: PublicSchema<unknown> | undefined) {
   return standardSchemaToJSONSchema(toStandardSchema(schema), { target: 'draft-2020-12' });
 }
 
-function serializeSchema(schema: unknown): string | undefined {
+function serializeSchema(schema: unknown, options?: { stripInjectedOverrides?: boolean }): string | undefined {
   const jsonSchema = schemaToJsonSchema(resolveLazySchema(schema) as PublicSchema<unknown> | undefined);
   if (jsonSchema === undefined) return undefined;
-  return stringify(jsonSchema);
+  return stringify(options?.stripInjectedOverrides ? stripInjectedToolOverrideFields(jsonSchema) : jsonSchema);
 }
 
 /**
@@ -100,7 +101,7 @@ function serializeTool(tool: any): any {
 
   return {
     ...tool,
-    inputSchema: serializeSchema(tool.inputSchema),
+    inputSchema: serializeSchema(tool.inputSchema, { stripInjectedOverrides: true }),
     outputSchema: serializeSchema(tool.outputSchema),
     requestContextSchema: serializeSchema(tool.requestContextSchema),
   };


### PR DESCRIPTION
PR 3 of 5 split from #21357. This removes runtime-only background and resume fields from tool input schemas serialized for Studio and API consumers, while preserving user-authored fields that only share the same names.

Before, generated forms exposed internal fields such as `_background`, `suspendedToolRunId`, and `resumeData`. After, only fields recognized as framework-injected are stripped and required entries are kept consistent.

Intentionally excludes core API errors, trace status reporting, Stagehand close tracking, Studio routing, and internal smoke documentation.

Verified with the server build, focused tool and agent handler tests, and the core-import compatibility check.
