### PR TITLE
fix(stagehand): preserve browser close reasons

### DIFF
--- a/.changeset/quiet-browsers-close.md
+++ b/.changeset/quiet-browsers-close.md
@@ -1,0 +1,5 @@
+---
+"@mastra/stagehand": patch
+---
+
+Fixed browser close tracking so agent-initiated Stagehand shutdowns are reported accurately.

--- a/browser/stagehand/src/__tests__/stagehand-browser.test.ts
+++ b/browser/stagehand/src/__tests__/stagehand-browser.test.ts
@@ -10,6 +10,7 @@ const { mockPage, mockContext, mockStagehand, mockCdpSession, mockStagehandConst
   };
 
   const mockPage = {
+    targetId: 'page-target-123',
     url: vi.fn().mockReturnValue('https://example.com'),
     title: vi.fn().mockResolvedValue('Example Page'),
     goto: vi.fn().mockResolvedValue(undefined),
@@ -29,6 +30,7 @@ const { mockPage, mockContext, mockStagehand, mockCdpSession, mockStagehandConst
     init: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
     context: mockContext,
+    ctx: { conn: mockCdpSession },
     act: vi.fn().mockResolvedValue({
       success: true,
       message: 'Clicked button',
@@ -57,6 +59,7 @@ vi.mock('@browserbasehq/stagehand', () => ({
     init = mockStagehand.init;
     close = mockStagehand.close;
     context = mockStagehand.context;
+    ctx = mockStagehand.ctx;
     act = mockStagehand.act;
     extract = mockStagehand.extract;
     observe = mockStagehand.observe;
@@ -262,6 +265,40 @@ describe('StagehandBrowser', () => {
       await browser.close();
       expect(browser.status).toBe('closed');
       expect(mockStagehand.close).toHaveBeenCalled();
+    });
+
+    it('preserves agent close reason in the last browser state', async () => {
+      await browser.launch();
+      browser.markBrowserCloseReason('agent');
+
+      await browser.close();
+
+      expect(browser.getLastBrowserState()).toEqual(expect.objectContaining({ closeReason: 'agent' }));
+    });
+
+    it('preserves user close reason when the browser disconnects externally', async () => {
+      await browser.launch();
+      const targetDestroyedHandler = mockCdpSession.on.mock.calls.find(
+        ([event]) => event === 'Target.targetDestroyed',
+      )?.[1];
+
+      targetDestroyedHandler?.({ targetId: 'page-target-123' });
+
+      expect(browser.getLastBrowserState()).toEqual(expect.objectContaining({ closeReason: 'user' }));
+    });
+
+    it('does not reuse stale close reasons after relaunch', async () => {
+      await browser.launch();
+      browser.markBrowserCloseReason('agent');
+      await browser.close();
+      await browser.ensureReady();
+      const targetDestroyedHandler = mockCdpSession.on.mock.calls.findLast(
+        ([event]) => event === 'Target.targetDestroyed',
+      )?.[1];
+
+      targetDestroyedHandler?.({ targetId: 'page-target-123' });
+
+      expect(browser.getLastBrowserState()).toEqual(expect.objectContaining({ closeReason: 'user' }));
     });
 
     it('should handle close when not launched', async () => {

--- a/browser/stagehand/src/stagehand-browser.ts
+++ b/browser/stagehand/src/stagehand-browser.ts
@@ -60,6 +60,7 @@ export class StagehandBrowser extends MastraBrowser {
 
   /** Debounce timers per thread for tab change reconnection */
   private tabChangeDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly pendingCloseReasons = new Map<string, 'agent' | 'user' | 'process_restart' | 'error'>();
 
   constructor(config: StagehandBrowserConfig = {}) {
     super(config);
@@ -190,6 +191,7 @@ export class StagehandBrowser extends MastraBrowser {
   }
 
   protected override async doLaunch(): Promise<void> {
+    this.pendingCloseReasons.clear();
     const scope = this.getScope();
 
     // Set up the thread manager's factory function for creating new Stagehand instances
@@ -240,6 +242,7 @@ export class StagehandBrowser extends MastraBrowser {
     const handleDisconnect = () => {
       if (disconnectHandled) return;
       disconnectHandled = true;
+      this.rememberClosedBrowserState(stagehand, 'user', threadId);
       onDisconnect();
     };
 
@@ -306,8 +309,38 @@ export class StagehandBrowser extends MastraBrowser {
   }
 
   override async closeThreadSession(threadId: string): Promise<void> {
+    const stagehand = this.threadManager.getExistingManagerForThread(threadId);
+    if (stagehand) {
+      this.rememberClosedBrowserState(stagehand, 'agent', threadId);
+    }
     await super.closeThreadSession(threadId);
     this.patchExitType();
+  }
+
+  private browserStateKey(threadId?: string): string {
+    return threadId ?? this.getCurrentThread() ?? DEFAULT_THREAD_ID;
+  }
+
+  markBrowserCloseReason(reason: 'agent' | 'user' | 'process_restart' | 'error', threadId?: string): void {
+    this.pendingCloseReasons.set(this.browserStateKey(threadId), reason);
+  }
+
+  private getCloseReason(threadId?: string): 'agent' | 'user' | 'process_restart' | 'error' | undefined {
+    return (
+      this.pendingCloseReasons.get(this.browserStateKey(threadId)) ?? this.pendingCloseReasons.get(DEFAULT_THREAD_ID)
+    );
+  }
+
+  private rememberClosedBrowserState(stagehand: Stagehand, reason: 'agent' | 'user', threadId?: string): void {
+    const state = this.getBrowserStateFromStagehand(stagehand, threadId);
+    if (!state || state.tabs.length === 0) return;
+
+    const closedState: BrowserState = { ...state, closeReason: this.getCloseReason(threadId) ?? reason };
+    if (threadId) {
+      this.threadManager.updateBrowserState(threadId, closedState);
+    } else {
+      this.lastBrowserState = closedState;
+    }
   }
 
   private patchExitType(): void {
@@ -912,10 +945,10 @@ export class StagehandBrowser extends MastraBrowser {
       if (scope === 'thread' && effectiveThreadId) {
         const stagehand = this.threadManager.getExistingManagerForThread(effectiveThreadId);
         if (!stagehand) return null;
-        return this.getBrowserStateFromStagehand(stagehand);
+        return this.getBrowserStateFromStagehand(stagehand, effectiveThreadId);
       }
 
-      return this.getBrowserStateFromStagehand(this.sharedManager);
+      return this.getBrowserStateFromStagehand(this.sharedManager, effectiveThreadId);
     } catch {
       return null;
     }
@@ -928,13 +961,13 @@ export class StagehandBrowser extends MastraBrowser {
   protected getBrowserStateForThread(threadId?: string): BrowserState | null {
     const effectiveThreadId = threadId ?? this.getCurrentThread() ?? DEFAULT_THREAD_ID;
     const stagehand = this.threadManager.getExistingManagerForThread(effectiveThreadId);
-    return this.getBrowserStateFromStagehand(stagehand);
+    return this.getBrowserStateFromStagehand(stagehand, effectiveThreadId);
   }
 
   /**
    * Get browser state from a specific Stagehand instance.
    */
-  private getBrowserStateFromStagehand(stagehand: Stagehand | null): BrowserState | null {
+  private getBrowserStateFromStagehand(stagehand: Stagehand | null, threadId?: string): BrowserState | null {
     if (!stagehand?.context) return null;
 
     try {
@@ -949,9 +982,11 @@ export class StagehandBrowser extends MastraBrowser {
         return { url: page.url() };
       });
 
+      const closeReason = this.getCloseReason(threadId);
       return {
         tabs,
         activeTabIndex: activeIndex,
+        ...(closeReason ? { closeReason } : {}),
       };
     } catch {
       return null;

--- a/browser/stagehand/src/tools/close.ts
+++ b/browser/stagehand/src/tools/close.ts
@@ -15,10 +15,12 @@ export function createCloseTool(browser: StagehandBrowser) {
     execute: async (_input, { agent }) => {
       // For thread scope, close only the thread's session
       const threadId = agent?.threadId;
+      browser.setCurrentThread(threadId);
       if (browser.getScope() !== 'shared') {
         if (!threadId) {
           throw new Error('stagehand_close requires agent.threadId when browser scope is not shared');
         }
+        browser.markBrowserCloseReason('agent', threadId);
         await browser.closeThreadSession(threadId);
         return {
           success: true,
@@ -26,6 +28,7 @@ export function createCloseTool(browser: StagehandBrowser) {
         };
       }
       // For shared scope, close the entire browser
+      browser.markBrowserCloseReason('agent');
       await browser.close();
       return {
         success: true,


### PR DESCRIPTION
PR 4 of 5 split from #21357. This records whether a Stagehand browser session was closed by the agent or externally, persists the final thread state before shutdown, and clears stale reasons when the browser relaunches.

Before, agent-initiated Stagehand shutdowns could be reported as external closes. After, close messaging can use the recorded agent or user reason accurately.

Intentionally excludes core API errors, trace status reporting, tool schema serialization, Studio routing, and internal smoke documentation.

Verified with all 108 Stagehand tests, lint, and the package build.
