### PR TITLE
docs: correct smoke test browser guidance

### DIFF
--- a/.claude/skills/builder-smoke-test/SKILL.md
+++ b/.claude/skills/builder-smoke-test/SKILL.md
@@ -417,7 +417,7 @@ Mobile renders a bottom-bar with the same primary entries.
 
 Use whichever browser tool the harness has wired up (Stagehand, Chrome MCP, etc.). Don't assume a specific provider — discover what's available, then drive the same checklist in `references/ui.md`.
 
-The scaffolded project registers `StagehandBrowser` (matching `examples/agent-builder`). If `BROWSERBASE_*` keys aren't set in the shell, Stagehand falls back to local Playwright; that's fine for smoke. If neither Stagehand nor a local browser is reachable, mark UI as `⏭️ Skipped (no browser provider)`.
+The scaffolded project registers `StagehandBrowser` (matching `examples/agent-builder`). If `BROWSERBASE_*` keys aren't set in the shell, Stagehand launches an installed local Chromium browser such as Google Chrome; no separate Playwright browser install is required. If neither Stagehand nor a local Chromium browser is reachable, mark UI as `⏭️ Skipped (no browser provider)`.
 
 ## Result reporting
 

--- a/.claude/skills/mastra-smoke-test/references/local-setup.md
+++ b/.claude/skills/mastra-smoke-test/references/local-setup.md
@@ -144,11 +144,7 @@ curl http://localhost:4111/hello
 
 When testing browser agents locally, you'll experience "browserception" — your MastraCode browser watching the project's agent browser.
 
-Ensure Playwright browsers are installed:
-
-```bash
-<pm> exec playwright install chromium
-```
+Stagehand launches an installed local Chromium browser, such as Google Chrome. Verify one is available on the machine; no separate Playwright browser install is required.
 
 ## Notes
 

--- a/.claude/skills/mastra-smoke-test/references/tests/scorers.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/scorers.md
@@ -69,8 +69,10 @@ curl -s http://localhost:4111/api/scores/scorers | jq 'keys'
 
 Pass: returns an object keyed by scorer id (`weather-scorer`,
 `translation-quality-scorer`, etc.) for the scorers declared in the
-project. Empty `{}` is only acceptable if the project genuinely declares
-none.
+project. Each value is an entry whose scorer configuration is nested under
+`.scorer.config`, alongside `agentIds`, `agentNames`, `workflowIds`,
+`isRegistered`, and `source`. Empty `{}` is only acceptable if the project
+genuinely declares none.
 
 **2. Get a single scorer's config**
 
@@ -78,9 +80,9 @@ none.
 curl -s http://localhost:4111/api/scores/scorers/<scorerId> | jq '.'
 ```
 
-Pass: returns a non-null object with `config` and the agents/workflows it
-is attached to. `null` means the id is wrong or the scorer is not
-registered.
+Pass: returns a non-null entry with the scorer configuration at
+`.scorer.config` and its associations in `agentIds`, `agentNames`, and
+`workflowIds`. `null` means the id is wrong or the scorer is not registered.
 
 **3. Trigger scoring by running an agent / workflow, then read scores**
 

--- a/.claude/skills/mastra-smoke-test/references/tests/setup.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/setup.md
@@ -182,11 +182,9 @@ export const mastra = new Mastra({
 });
 ```
 
-### 4. Install Playwright
+### 4. Verify a Local Chromium Browser
 
-```bash
-<pm> exec playwright install chromium
-```
+Stagehand launches an installed local Chromium browser, such as Google Chrome. No separate Playwright browser install is required.
 
 ### 5. Runtime requirement: pass thread + resource on every call
 

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -326,7 +326,7 @@ After completing all tests, provide a summary:
 
 **Browser agent fails**
 
-- Ensure Playwright browsers are installed: `pnpm exec playwright install chromium`
+- Verify a local Chromium browser, such as Google Chrome, is installed and reachable
 - Check that no other browser instance is blocking
 
 ## Studio Routes


### PR DESCRIPTION
PR 5 of 5 split from #21357. This updates internal smoke-test skills to reflect the current Stagehand browser setup and the nested scorer API response shape.

The browser guidance no longer instructs maintainers to install Playwright Chromium for local Stagehand smoke tests, and scorer examples now read metadata from `entry.scorer.config`.

This is documentation-only and intentionally excluded from the product release fixes. The Studio 404 change from the original combined draft was dropped entirely.

Verified with stale-guidance searches and `git diff --check`.
