### PR TITLE
feat(server): scope dynamic workflow management by owner

### DIFF
--- a/.changeset/calm-workflows-scope.md
+++ b/.changeset/calm-workflows-scope.md
@@ -1,0 +1,9 @@
+---
+'@mastra/server': minor
+---
+
+Added server-derived ownership for dynamic workflow list, get, and upsert routes.
+
+Authenticated callers only list, get, and upsert definitions owned by the author in their request context. Callers with `stored-workflows:admin` can inspect definitions across authors and update an owned definition without transferring it. Legacy definitions without an author remain hidden from regular callers and read-only for admins.
+
+Deletion, execution, and nested workflow references aren't owner-scoped by this change.

--- a/.changeset/calm-workflows-scope.md
+++ b/.changeset/calm-workflows-scope.md
@@ -7,3 +7,13 @@ Added server-derived ownership for dynamic workflow list, get, and upsert routes
 Authenticated callers only list, get, and upsert definitions owned by the author in their request context. Callers with `stored-workflows:admin` can inspect definitions across authors and update an owned definition without transferring it. Legacy definitions without an author remain hidden from regular callers and read-only for admins.
 
 Deletion, execution, and nested workflow references aren't owner-scoped by this change.
+
+Previously, management routes could accept a caller-selected author. Hosts should now map verified identity into the request context and omit author ownership from request bodies:
+
+```ts
+authConfig: {
+  mapUserToResourceId: user => user.id,
+}
+```
+
+The built-in list, get, and upsert routes derive ownership from that server-populated resource ID. Cross-author administration requires `stored-workflows:admin`.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -1,0 +1,11 @@
+---
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/mssql': patch
+'@mastra/mysql': patch
+'@mastra/pg': patch
+---
+
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -8,4 +8,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior. Concurrent registrations on one Mastra instance are serialized so a rejected registration can't roll back the successful live workflow.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -8,4 +8,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior. Concurrent registrations on one Mastra instance are serialized so a rejected registration can't roll back the successful live workflow.
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.

--- a/.changeset/warm-pianos-push.md
+++ b/.changeset/warm-pianos-push.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': minor
+---
+
+Added trusted author metadata for dynamic workflow registration.
+
+```ts
+await mastra.addDynamicWorkflow(definition, { authorId: verifiedUserId });
+```
+
+The author is persisted with the definition and remains outside untrusted workflow JSON. This metadata does not enforce access control.
+
+See [#21444](https://github.com/mastra-ai/mastra/issues/21444) for the remaining tenant-isolation design.

--- a/.changeset/wise-owls-queue.md
+++ b/.changeset/wise-owls-queue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Serialize dynamic workflow registrations on each Mastra instance so a rejected registration cannot roll back a workflow that another registration successfully replaced.

--- a/docs/src/content/en/docs/server/mastra-client.mdx
+++ b/docs/src/content/en/docs/server/mastra-client.mdx
@@ -120,7 +120,9 @@ Durable storage requires a configured storage adapter that supports the `workflo
 
 Stored definitions support declarative agent, tool, mapping, nested workflow, parallel, foreach, sleep, sleep-until, conditional, and loop entries. They can't contain JavaScript closures. Conditional and loop logic must use the declarative predicate format, and referenced agents, tools, and nested workflows must already be registered.
 
-Authenticated servers require `stored-workflows:read` or `stored-workflows:write` for definition operations and `workflows:execute` to run the workflow.
+Authenticated servers derive the author for list, get, and upsert operations from the server-owned request context. Regular callers only list, get, and upsert their own definitions. Callers with `stored-workflows:admin` can inspect every definition and update an owned definition without transferring it. Definitions without ownership metadata are hidden from regular callers and read-only for admins.
+
+These routes require `stored-workflows:read` or `stored-workflows:write`. Deletion and execution aren't owner-scoped yet. The `workflows:execute` permission can run a registered workflow, but it doesn't establish definition ownership.
 
 :::
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -101,9 +101,14 @@ The definition uses JSON Schema because it must survive a JSON round trip. The `
 A definition can come from any source that produces JSON. For example, an API route can accept a definition created by a visual editor and register it directly:
 
 ```typescript
+const authenticatedUser = await authenticate(request)
 const definition = await request.json()
-await mastra.addDynamicWorkflow(definition)
+await mastra.addDynamicWorkflow(definition, {
+  authorId: authenticatedUser.id,
+})
 ```
+
+Derive `authorId` from verified server identity. Never accept it from the submitted workflow definition.
 
 ### Register dependencies first
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -156,7 +156,7 @@ await mastra.addDynamicWorkflow(untrustedDefinition, {
 })
 ```
 
-Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -138,7 +138,9 @@ Applications don't need direct access to the `Mastra` instance to manage dynamic
 - [Client SDK workflows API](/reference/client-js/workflows): Call `upsertDynamicWorkflow()` from a JavaScript or TypeScript client.
 - [Server routes](/reference/server/routes): Send definitions to `POST /api/stored/workflows`.
 
-On authenticated servers, dynamic-workflow management requires the `stored-workflows:read` and `stored-workflows:write` permissions. Running the registered workflow requires `workflows:execute`.
+On authenticated servers, listing, reading, and upserting dynamic workflows derives the author from the server-owned request context. Regular callers can only list, read, and replace their own definitions. Callers with `stored-workflows:admin` can inspect every definition and can replace an owned definition without changing its author. Definitions created before ownership metadata was available are hidden from regular callers and read-only for admins.
+
+These management routes still require `stored-workflows:read` or `stored-workflows:write`. Deletion and execution aren't owner-scoped yet. Running the registered workflow requires `workflows:execute`, but this permission doesn't establish tenant ownership by itself.
 
 ### Persist definitions
 
@@ -156,7 +158,7 @@ await mastra.addDynamicWorkflow(untrustedDefinition, {
 })
 ```
 
-Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. The authenticated server's list, get, and upsert routes enforce this ownership. Direct Core calls, deletion, execution, and nested workflow references still require application-level authorization.
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -146,6 +146,18 @@ Stored definitions use the `workflowDefinitions` storage domain. On startup, Mas
 
 Without a storage adapter that supports this domain, `addDynamicWorkflow()` still registers the workflow in memory, but the definition is lost when the process restarts. See the [storage reference](/reference/storage/overview) for adapter support.
 
+### Record a verified author
+
+Pass trusted author metadata as the second argument. Keep it outside the workflow definition when the definition comes from a user, agent, or external system.
+
+```typescript
+await mastra.addDynamicWorkflow(untrustedDefinition, {
+  authorId: authenticatedUser.id,
+})
+```
+
+Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+
 ## Related
 
 - [Dynamic workflow definition](/reference/workflows/dynamic-workflow-definition)

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -20,29 +20,34 @@ See [Dynamic workflows](/docs/workflows/dynamic-workflows) for a complete setup 
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflow({
-  id: 'greeting-workflow',
-  description: 'Returns a greeting for the supplied name',
-  inputSchema: {
-    type: 'object',
-    properties: { name: { type: 'string' } },
-    required: ['name'],
-  },
-  outputSchema: {
-    type: 'object',
-    properties: { message: { type: 'string' } },
-    required: ['message'],
-  },
-  graph: [
-    {
-      type: 'mapping',
-      id: 'create-greeting',
-      mapConfig: JSON.stringify({
-        message: { template: 'Hello, ${initData.name}!' },
-      }),
+await mastra.addDynamicWorkflow(
+  {
+    id: 'greeting-workflow',
+    description: 'Returns a greeting for the supplied name',
+    inputSchema: {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
     },
-  ],
-})
+    outputSchema: {
+      type: 'object',
+      properties: { message: { type: 'string' } },
+      required: ['message'],
+    },
+    graph: [
+      {
+        type: 'mapping',
+        id: 'create-greeting',
+        mapConfig: JSON.stringify({
+          message: { template: 'Hello, ${initData.name}!' },
+        }),
+      },
+    ],
+  },
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 
 const run = await mastra.getWorkflow('greeting-workflow').createRun()
 const result = await run.start({ inputData: { name: 'Ada' } })
@@ -58,6 +63,13 @@ const result = await run.start({ inputData: { name: 'Ada' } })
     description:
       'The workflow definition: id, optional description and metadata, JSON Schema input/output schemas, optional state and request-context schemas, and the step graph.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata supplied by the host. Use `authorId` for a verified author identity that must not come from the workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -69,6 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
+- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -81,7 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
-- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored on the definition in the same write and becomes immutable. When replacing an existing definition, omitting `options.authorId` retains its stored author, while using a different author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -22,10 +22,15 @@ The whole bundle is validated up front. Members are then registered in dependenc
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflows([
-  helperDefinition, // nested by the root — order in the array doesn't matter
-  rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
-])
+await mastra.addDynamicWorkflows(
+  [
+    helperDefinition, // nested by the root — order in the array doesn't matter
+    rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
+  ],
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 ```
 
 ## Parameters
@@ -38,6 +43,13 @@ await mastra.addDynamicWorkflows([
     description:
       'The workflow definitions to add. Nested-workflow references may resolve against the live registries or against other members of the same bundle.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata applied to every definition in the bundle. Use `authorId` for a verified author identity that must not come from a workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -48,6 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
+- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -60,7 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
-- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored with every bundle member and becomes immutable. When replacing existing members, omitting `options.authorId` retains each member's stored author, while a member whose ID belongs to another author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/docs/src/content/en/reference/server/routes.mdx
+++ b/docs/src/content/en/reference/server/routes.mdx
@@ -208,12 +208,14 @@ Dynamic workflow definitions (beta) are workflows expressed as JSON, persisted t
 
 | Method | Path | Description |
 | - | - | - |
-| `GET` | `/api/stored/workflows` | List dynamic workflow definitions, filterable by `status` and `authorId` |
-| `GET` | `/api/stored/workflows/:dynamicWorkflowId` | Get a dynamic workflow definition by ID |
-| `POST` | `/api/stored/workflows` | Upsert a definition (plus optional helper `dependencies`) and live-register it |
+| `GET` | `/api/stored/workflows` | List the caller's dynamic workflow definitions. Admins can filter by `status` and `authorId` |
+| `GET` | `/api/stored/workflows/:dynamicWorkflowId` | Get a caller-owned dynamic workflow definition. Admins can read any definition |
+| `POST` | `/api/stored/workflows` | Upsert a caller-owned definition (plus optional helper `dependencies`) and live-register it |
 | `DELETE` | `/api/stored/workflows/:dynamicWorkflowId` | Delete a dynamic workflow definition and unregister the live workflow |
 
-On authenticated servers, the read routes require the `stored-workflows:read` permission and the write routes require `stored-workflows:write`. Registered dynamic workflows are executed through the ordinary `/api/workflows/:workflowId` routes above.
+On authenticated servers, the read routes require the `stored-workflows:read` permission and the write routes require `stored-workflows:write`. List, get, and upsert derive the author from the server-owned request context. Regular callers can't select another `authorId`. The `stored-workflows:admin` permission bypasses read scoping and preserves the existing author during updates. Legacy definitions without an author are hidden from regular callers and read-only for admins.
+
+Deletion and execution aren't owner-scoped yet. Registered dynamic workflows are executed through the ordinary `/api/workflows/:workflowId` routes above, which require workflow permissions but don't enforce definition ownership.
 
 ### Create run request body
 

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import { InMemoryStore } from '../storage';
+import { InMemoryStore, WorkflowDefinitionOwnershipConflictError } from '../storage';
 import { createTool } from '../tools';
 import { Mastra } from './index';
 
@@ -296,6 +296,26 @@ describe('Mastra.addDynamicWorkflows', () => {
     const definition = await store.get('lookup-first-customer');
 
     expect(definition?.authorId).toBe('verified-author');
+  });
+
+  it('rejects a different trusted author and restores the previous registration', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-conflict' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+      authorId: 'verified-author',
+    });
+    const original = mastra.getWorkflow('lookup-first-customer');
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email2'), {
+        authorId: 'other-author',
+      }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(mastra.getWorkflow('lookup-first-customer')).toBe(original);
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    expect((await store.get('lookup-first-customer'))?.authorId).toBe('verified-author');
   });
 
   it('is a no-op for an empty bundle', async () => {

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -318,6 +318,62 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect((await store.get('lookup-first-customer'))?.authorId).toBe('verified-author');
   });
 
+  it('serializes overlapping bundles so a rejected owner cannot roll back the winner', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-concurrent-owner-conflict' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const realUpsert = store.upsert.bind(store);
+
+    let releaseFirstUpsert!: () => void;
+    const firstUpsertEntered = new Promise<void>(resolve => {
+      releaseFirstUpsert = resolve;
+    });
+    let upsertCalls = 0;
+    store.upsert = (async definition => {
+      upsertCalls += 1;
+      if (upsertCalls === 1) {
+        releaseFirstUpsert();
+        // Keep the first bundle inside persistence for one event-loop turn.
+        // Without registration serialization, the overlapping bundle can
+        // replace its registry slots and win storage before this write resumes.
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+      }
+      return realUpsert(definition);
+    }) as typeof store.upsert;
+
+    const winner = mastra.addDynamicWorkflows(
+      [
+        { ...helperDefinition('shared-helper', 'email1'), description: 'winner' },
+        helperDefinition('winner-only', 'email1'),
+      ],
+      { authorId: 'winner-author' },
+    );
+    await firstUpsertEntered;
+
+    const loser = mastra.addDynamicWorkflows(
+      [
+        { ...helperDefinition('shared-helper', 'email2'), description: 'loser' },
+        helperDefinition('loser-only', 'email2'),
+      ],
+      { authorId: 'loser-author' },
+    );
+
+    const [winnerResult, loserResult] = await Promise.allSettled([winner, loser]);
+    expect(winnerResult.status).toBe('fulfilled');
+    expect(loserResult).toMatchObject({
+      status: 'rejected',
+      reason: expect.any(WorkflowDefinitionOwnershipConflictError),
+    });
+
+    expect(await store.get('shared-helper')).toMatchObject({ authorId: 'winner-author', description: 'winner' });
+    expect(await store.get('winner-only')).toMatchObject({ authorId: 'winner-author' });
+    expect(await store.get('loser-only')).toBeNull();
+
+    expect(mastra.getWorkflow('shared-helper').description).toBe('winner');
+    expect(mastra.getWorkflow('winner-only')).toBeDefined();
+    expect(() => mastra.getWorkflow('loser-only')).toThrow();
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -283,6 +283,22 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect(definitions.every(definition => definition.authorId === 'verified-author')).toBe(true);
   });
 
+  it('rejects an authored bundle before live registration when workflow definition storage is unavailable', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-no-definition-store' });
+    const getStore = storage.getStore.bind(storage);
+    storage.getStore = (async domain =>
+      domain === 'workflowDefinitions' ? undefined : getStore(domain)) as typeof storage.getStore;
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+        authorId: 'verified-author',
+      }),
+    ).rejects.toThrow(/workflowDefinitions storage domain is required/);
+
+    expect(() => mastra.getWorkflow('lookup-first-customer')).toThrow();
+  });
+
   it('preserves an existing author when a trusted author is omitted on replacement', async () => {
     const storage = new InMemoryStore({ id: 'bundle-author-preserved' });
     const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -262,6 +262,42 @@ describe('Mastra.addDynamicWorkflows', () => {
     ]);
   });
 
+  it('persists one trusted author for every member outside the workflow definitions', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    const untrustedHelper = {
+      ...helperDefinition('lookup-first-customer', 'email1'),
+      authorId: 'forged-author',
+    };
+
+    await mastra.addDynamicWorkflows(
+      [untrustedHelper, helperDefinition('lookup-second-customer', 'email2'), rootDefinition],
+      { authorId: 'verified-author' },
+    );
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const { definitions } = await store.list({ status: 'active' });
+
+    expect(definitions).toHaveLength(3);
+    expect(definitions.every(definition => definition.authorId === 'verified-author')).toBe(true);
+  });
+
+  it('preserves an existing author when a trusted author is omitted on replacement', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-preserved' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+      authorId: 'verified-author',
+    });
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email2'));
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const definition = await store.get('lookup-first-customer');
+
+    expect(definition?.authorId).toBe('verified-author');
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -4855,6 +4855,9 @@ export class Mastra<
    *   before anything is mutated.
    * - If hydration or persistence fails partway, the in-memory registry is
    *   restored to its prior state.
+   * - Registrations are serialized on this Mastra instance through validation,
+   *   hydration, and persistence so one caller's rollback cannot undo another
+   *   caller's accepted live registration.
    * - Storage writes happen last. A storage-level failure mid-bundle is the
    *   one residual window where rows can be partially written; the registry is
    *   still rolled back, and the orphaned rows are inert until the next boot.
@@ -4901,6 +4904,13 @@ export class Mastra<
           graph: def.graph,
         }),
       }));
+
+      const store = await this.#storage?.getStore('workflowDefinitions');
+      if (options?.authorId !== undefined && !store) {
+        throw new Error(
+          'A workflowDefinitions storage domain is required when registering an authored dynamic workflow.',
+        );
+      }
 
       // Members may nest each other, so the index every member validates against
       // is the live registries plus the bundle itself — not the registry alone.
@@ -4966,7 +4976,6 @@ export class Mastra<
           this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
         }
 
-        const store = await this.#storage?.getStore('workflowDefinitions');
         if (store) {
           for (const { normalized } of ordered) {
             await store.upsert({

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -688,6 +688,7 @@ export class Mastra<
   #workflows: TWorkflows;
   #harnesses: Record<string, Harness<any>> = {};
   #hiddenWorkflowKeys = new Set<string>();
+  #dynamicWorkflowRegistrationTail: Promise<void> = Promise.resolve();
   #observability: ObservabilityEntrypoint;
   #observabilityExplicit = false;
   #onScorerHook?: ReturnType<typeof createOnScorerHook>;
@@ -4758,6 +4759,26 @@ export class Mastra<
   }
 
   /**
+   * Runs dynamic workflow registrations one at a time so each rollback owns a
+   * stable registry snapshot. An instance-wide queue also makes overlapping
+   * bundles deadlock-free because callers never acquire per-workflow locks.
+   */
+  async #serializeDynamicWorkflowRegistration<T>(operation: () => Promise<T>): Promise<T> {
+    const prior = this.#dynamicWorkflowRegistrationTail;
+    let release!: () => void;
+    this.#dynamicWorkflowRegistrationTail = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    await prior;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  /**
    * Flattens this instance's registries into the index the dynamic-workflow
    * validation core resolves references and schemas against. Registered keys
    * and canonical ids both count as valid references. Schemas are converted
@@ -4854,116 +4875,118 @@ export class Mastra<
   ): Promise<void> {
     if (defs.length === 0) return;
 
-    const seen = new Set<string>();
-    for (const def of defs) {
-      if (seen.has(def.id)) {
-        throw new Error(
-          `Dynamic workflow bundle contains more than one definition with id "${def.id}". Ids must be unique within a bundle.`,
-        );
-      }
-      seen.add(def.id);
-    }
-
-    // Save-path is strict (boot-time load is lenient — see #loadDynamicWorkflows).
-    // Normalization coerces the wire shape; one validation call per member
-    // covers structure, JSON-Schema keywords, references, and schema-flow.
-    const members = defs.map(def => ({
-      normalized: normalizeWorkflowBuilderDefinition({
-        id: def.id,
-        description: def.description,
-        metadata: def.metadata,
-        inputSchema: def.inputSchema,
-        outputSchema: def.outputSchema,
-        stateSchema: def.stateSchema,
-        requestContextSchema: def.requestContextSchema,
-        graph: def.graph,
-      }),
-    }));
-
-    // Members may nest each other, so the index every member validates against
-    // is the live registries plus the bundle itself — not the registry alone.
-    const index = this.#buildWorkflowRegistryIndex();
-    const bundleIds = new Set(members.map(member => member.normalized.id));
-    for (const { normalized } of members) {
-      (index.workflows ??= {})[normalized.id] = {
-        inputSchema: normalized.inputSchema,
-        outputSchema: normalized.outputSchema,
-      } as WorkflowRegistrySchemas;
-    }
-    for (const { normalized } of members) {
-      assertValidDynamicWorkflow(normalized, index);
-    }
-
-    // Hydration resolves nested workflows through the live registry, so a
-    // member cannot be hydrated before the bundle members it nests.
-    const ordered: typeof members = [];
-    const remaining = new Map(members.map(member => [member.normalized.id, member] as const));
-    const hydrated = new Set<string>();
-    let progress = true;
-    while (remaining.size > 0 && progress) {
-      progress = false;
-      for (const [id, member] of Array.from(remaining)) {
-        const pending = Array.from(collectNestedWorkflowIds(member.normalized.graph)).filter(
-          dependency => dependency !== id && bundleIds.has(dependency) && !hydrated.has(dependency),
-        );
-        if (pending.length > 0) continue;
-        remaining.delete(id);
-        hydrated.add(id);
-        ordered.push(member);
-        progress = true;
-      }
-    }
-    if (remaining.size > 0) {
-      throw new Error(
-        `Dynamic workflow bundle has a circular nested-workflow dependency among: ${Array.from(remaining.keys())
-          .sort()
-          .join(', ')}.`,
-      );
-    }
-
-    // Snapshot the registry slots this bundle will overwrite so a failure
-    // anywhere below leaves the instance exactly as it was found.
-    const registry = this.#workflows as Record<string, AnyWorkflow>;
-    const priorWorkflows = new Map<string, AnyWorkflow | undefined>();
-    const priorHiddenKeys = new Set<string>();
-    for (const { normalized } of ordered) {
-      priorWorkflows.set(normalized.id, registry[normalized.id]);
-      if (this.#hiddenWorkflowKeys.has(normalized.id)) priorHiddenKeys.add(normalized.id);
-    }
-    const restoreRegistry = () => {
-      for (const [id, prior] of priorWorkflows) {
-        if (prior) registry[id] = prior;
-        else delete registry[id];
-        if (priorHiddenKeys.has(id)) this.#hiddenWorkflowKeys.add(id);
-      }
-    };
-
-    try {
-      for (const { normalized } of ordered) {
-        const { workflow } = await rehydrateWorkflow(normalized, this);
-        this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
+    await this.#serializeDynamicWorkflowRegistration(async () => {
+      const seen = new Set<string>();
+      for (const def of defs) {
+        if (seen.has(def.id)) {
+          throw new Error(
+            `Dynamic workflow bundle contains more than one definition with id "${def.id}". Ids must be unique within a bundle.`,
+          );
+        }
+        seen.add(def.id);
       }
 
-      const store = await this.#storage?.getStore('workflowDefinitions');
-      if (store) {
-        for (const { normalized } of ordered) {
-          await store.upsert({
-            id: normalized.id,
-            description: normalized.description,
-            metadata: normalized.metadata,
-            inputSchema: normalized.inputSchema,
-            outputSchema: normalized.outputSchema,
-            stateSchema: normalized.stateSchema,
-            requestContextSchema: normalized.requestContextSchema,
-            graph: normalized.graph,
-            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
-          });
+      // Save-path is strict (boot-time load is lenient — see #loadDynamicWorkflows).
+      // Normalization coerces the wire shape; one validation call per member
+      // covers structure, JSON-Schema keywords, references, and schema-flow.
+      const members = defs.map(def => ({
+        normalized: normalizeWorkflowBuilderDefinition({
+          id: def.id,
+          description: def.description,
+          metadata: def.metadata,
+          inputSchema: def.inputSchema,
+          outputSchema: def.outputSchema,
+          stateSchema: def.stateSchema,
+          requestContextSchema: def.requestContextSchema,
+          graph: def.graph,
+        }),
+      }));
+
+      // Members may nest each other, so the index every member validates against
+      // is the live registries plus the bundle itself — not the registry alone.
+      const index = this.#buildWorkflowRegistryIndex();
+      const bundleIds = new Set(members.map(member => member.normalized.id));
+      for (const { normalized } of members) {
+        (index.workflows ??= {})[normalized.id] = {
+          inputSchema: normalized.inputSchema,
+          outputSchema: normalized.outputSchema,
+        } as WorkflowRegistrySchemas;
+      }
+      for (const { normalized } of members) {
+        assertValidDynamicWorkflow(normalized, index);
+      }
+
+      // Hydration resolves nested workflows through the live registry, so a
+      // member cannot be hydrated before the bundle members it nests.
+      const ordered: typeof members = [];
+      const remaining = new Map(members.map(member => [member.normalized.id, member] as const));
+      const hydrated = new Set<string>();
+      let progress = true;
+      while (remaining.size > 0 && progress) {
+        progress = false;
+        for (const [id, member] of Array.from(remaining)) {
+          const pending = Array.from(collectNestedWorkflowIds(member.normalized.graph)).filter(
+            dependency => dependency !== id && bundleIds.has(dependency) && !hydrated.has(dependency),
+          );
+          if (pending.length > 0) continue;
+          remaining.delete(id);
+          hydrated.add(id);
+          ordered.push(member);
+          progress = true;
         }
       }
-    } catch (error) {
-      restoreRegistry();
-      throw error;
-    }
+      if (remaining.size > 0) {
+        throw new Error(
+          `Dynamic workflow bundle has a circular nested-workflow dependency among: ${Array.from(remaining.keys())
+            .sort()
+            .join(', ')}.`,
+        );
+      }
+
+      // Snapshot the registry slots this bundle will overwrite so a failure
+      // anywhere below leaves the instance exactly as it was found.
+      const registry = this.#workflows as Record<string, AnyWorkflow>;
+      const priorWorkflows = new Map<string, AnyWorkflow | undefined>();
+      const priorHiddenKeys = new Set<string>();
+      for (const { normalized } of ordered) {
+        priorWorkflows.set(normalized.id, registry[normalized.id]);
+        if (this.#hiddenWorkflowKeys.has(normalized.id)) priorHiddenKeys.add(normalized.id);
+      }
+      const restoreRegistry = () => {
+        for (const [id, prior] of priorWorkflows) {
+          if (prior) registry[id] = prior;
+          else delete registry[id];
+          if (priorHiddenKeys.has(id)) this.#hiddenWorkflowKeys.add(id);
+        }
+      };
+
+      try {
+        for (const { normalized } of ordered) {
+          const { workflow } = await rehydrateWorkflow(normalized, this);
+          this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
+        }
+
+        const store = await this.#storage?.getStore('workflowDefinitions');
+        if (store) {
+          for (const { normalized } of ordered) {
+            await store.upsert({
+              id: normalized.id,
+              description: normalized.description,
+              metadata: normalized.metadata,
+              inputSchema: normalized.inputSchema,
+              outputSchema: normalized.outputSchema,
+              stateSchema: normalized.stateSchema,
+              requestContextSchema: normalized.requestContextSchema,
+              graph: normalized.graph,
+              ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
+            });
+          }
+        }
+      } catch (error) {
+        restoreRegistry();
+        throw error;
+      }
+    });
   }
 
   /**

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -99,6 +99,21 @@ import { createRunScope } from './run-scope';
 import type { VersionOverrides, VersionSelector } from './types';
 
 /**
+ * Trusted metadata applied while a dynamic workflow is persisted.
+ *
+ * Keep these values outside the JSON workflow definition when that definition
+ * comes from an untrusted authoring surface. This metadata is persisted with
+ * the definition but does not itself enforce authorization.
+ */
+export interface DynamicWorkflowRegistrationOptions {
+  /**
+   * Verified identity responsible for the stored definition. Callers must
+   * authorize this value before registration.
+   */
+  authorId?: string;
+}
+
+/**
  * Creates an error for when a null/undefined value is passed to an add* method.
  * This commonly occurs when config is spread ({ ...config }) and the original
  * object had getters or non-enumerable properties.
@@ -4796,8 +4811,11 @@ export class Mastra<
    * await run.start({ inputData: { location: 'Helsinki' } });
    * ```
    */
-  public async addDynamicWorkflow(def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput): Promise<void> {
-    await this.addDynamicWorkflows([def]);
+  public async addDynamicWorkflow(
+    def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput,
+    options?: DynamicWorkflowRegistrationOptions,
+  ): Promise<void> {
+    await this.addDynamicWorkflows([def], options);
   }
 
   /**
@@ -4832,6 +4850,7 @@ export class Mastra<
    */
   public async addDynamicWorkflows(
     defs: readonly (DynamicWorkflowGraph | WorkflowBuilderDefinitionInput)[],
+    options?: DynamicWorkflowRegistrationOptions,
   ): Promise<void> {
     if (defs.length === 0) return;
 
@@ -4937,6 +4956,7 @@ export class Mastra<
             stateSchema: normalized.stateSchema,
             requestContextSchema: normalized.requestContextSchema,
             graph: normalized.graph,
+            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
           });
         }
       }

--- a/packages/core/src/storage/domains/workflow-definitions/base.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/base.ts
@@ -42,6 +42,8 @@ export interface WorkflowDefinition {
 
   /** Provenance — distinguishes user-stored from code-registered workflows. */
   source: 'storage';
+
+  /** Immutable owner assigned when the definition is created. */
   authorId?: string;
 
   createdAt: Date;
@@ -58,6 +60,8 @@ export interface CreateWorkflowDefinitionInput {
   stateSchema?: unknown;
   requestContextSchema?: unknown;
   graph: ValidatableStepFlowEntry[];
+
+  /** Immutable owner to assign when the definition is created. */
   authorId?: string;
 }
 
@@ -72,6 +76,8 @@ export interface UpdateWorkflowDefinitionInput {
   requestContextSchema?: unknown;
   graph?: ValidatableStepFlowEntry[];
   status?: 'active' | 'archived';
+
+  /** Expected immutable owner. A different owner produces a conflict. */
   authorId?: string;
 }
 
@@ -86,10 +92,42 @@ export interface ListWorkflowDefinitionsOutput {
 }
 
 /**
+ * Thrown when an upsert attempts to claim a workflow definition that already
+ * belongs to a different author. The message intentionally does not disclose
+ * the existing author.
+ */
+export class WorkflowDefinitionOwnershipConflictError extends Error {
+  readonly workflowId: string;
+
+  constructor(workflowId: string) {
+    super(`Workflow definition "${workflowId}" conflicts with an existing definition.`);
+    this.name = 'WorkflowDefinitionOwnershipConflictError';
+    this.workflowId = workflowId;
+  }
+}
+
+/**
+ * Treat an explicitly supplied author as both creation ownership and the
+ * expected owner on update. Omitting authorId preserves legacy/unscoped
+ * behavior; supplying it can never create or transfer ownership after a row
+ * already exists.
+ */
+export function assertWorkflowDefinitionAuthor(
+  existing: Pick<WorkflowDefinition, 'id' | 'authorId'>,
+  input: Pick<UpdateWorkflowDefinitionInput, 'authorId'>,
+): void {
+  if (input.authorId !== undefined && existing.authorId !== input.authorId) {
+    throw new WorkflowDefinitionOwnershipConflictError(existing.id);
+  }
+}
+
+/**
  * Abstract storage domain for persisted workflow definitions.
  *
  * Versioning is intentionally out of scope for v1 — `upsert` overwrites in
- * place. A future revision can layer the {@link VersionedStorageDomain}
+ * place. Ownership is the exception: an explicitly supplied `authorId` is an
+ * immutable compare condition, so concurrent creators cannot take over the
+ * winning row. A future revision can layer the {@link VersionedStorageDomain}
  * pattern on top without breaking the rehydration path.
  */
 export abstract class WorkflowDefinitionsStorage extends StorageDomain {

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.test.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { InMemoryDB } from '../inmemory-db';
+import { WorkflowDefinitionOwnershipConflictError } from './base';
 import { InMemoryWorkflowDefinitionsStorage } from './inmemory';
 
 const graph = [{ type: 'tool', id: 'echo-tool', toolId: 'echo-tool' }] as any;
@@ -36,14 +37,24 @@ describe('InMemoryWorkflowDefinitionsStorage', () => {
   });
 
   describe('update', () => {
-    it('updates authorId on an existing definition', async () => {
+    it('keeps authorId immutable on an existing definition', async () => {
       await storage.upsert({ ...baseInput(), authorId: 'author-1' });
-      const updated = await storage.upsert({ id: 'wf-1', authorId: 'author-2' });
-      expect(updated.authorId).toBe('author-2');
+      await expect(storage.upsert({ id: 'wf-1', authorId: 'author-2' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
       const fetched = await storage.get('wf-1');
-      expect(fetched?.authorId).toBe('author-2');
+      expect(fetched?.authorId).toBe('author-1');
       // Unspecified columns survive the partial upsert.
       expect(fetched?.graph).toEqual(graph);
+    });
+
+    it('does not disclose the existing author in ownership conflicts', async () => {
+      await storage.upsert({ ...baseInput(), authorId: 'private-owner' });
+
+      const error = await storage.upsert({ id: 'wf-1', authorId: 'other-owner' }).catch(cause => cause);
+
+      expect(error).toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+      expect(error.message).not.toContain('private-owner');
     });
   });
 });

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
@@ -6,7 +6,7 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from './base';
-import { WorkflowDefinitionsStorage } from './base';
+import { assertWorkflowDefinitionAuthor, WorkflowDefinitionsStorage } from './base';
 
 export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStorage {
   private db: InMemoryDB;
@@ -25,6 +25,7 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
     const existing = this.db.workflowDefinitions.get(input.id);
 
     if (existing) {
+      assertWorkflowDefinitionAuthor(existing, input);
       const merged: WorkflowDefinition = {
         ...existing,
         ...('description' in input && input.description !== undefined && { description: input.description }),
@@ -36,7 +37,6 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
           input.requestContextSchema !== undefined && { requestContextSchema: input.requestContextSchema }),
         ...('graph' in input && input.graph !== undefined && { graph: input.graph }),
         ...('status' in input && input.status !== undefined && { status: input.status }),
-        ...('authorId' in input && input.authorId !== undefined && { authorId: input.authorId }),
         updatedAt: now,
       };
       this.db.workflowDefinitions.set(input.id, merged);

--- a/packages/server/src/server/handlers/dynamic-workflows.test.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.test.ts
@@ -7,6 +7,7 @@ import { createTool } from '@mastra/core/tools';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_USER_PERMISSIONS_KEY } from '../constants';
 import { HTTPException } from '../http-exception';
 import { upsertDynamicWorkflowBodySchema } from '../schemas/dynamic-workflows';
 import type { ServerContext } from '../server-adapter';
@@ -83,10 +84,15 @@ function buildMastra() {
   return mastra;
 }
 
-function ctx(mastra: MastraType): ServerContext {
+function ctx(mastra: MastraType, options: { authorId?: string | null; admin?: boolean } = {}): ServerContext {
+  const requestContext = new RequestContext();
+  const authorId = options.authorId === undefined ? 'test-user' : options.authorId;
+  if (authorId) requestContext.set(MASTRA_RESOURCE_ID_KEY, authorId);
+  if (options.admin) requestContext.set(MASTRA_USER_PERMISSIONS_KEY, ['stored-workflows:admin']);
+
   return {
     mastra,
-    requestContext: new RequestContext(),
+    requestContext,
     abortSignal: new AbortController().signal,
   };
 }
@@ -106,6 +112,18 @@ const baseSchemas = {
   inputSchema: objectWith({ value: stringSchema }, ['value']),
   outputSchema: objectWith({ value: stringSchema }, ['value']),
 };
+
+function workflowDefinition(id: string, description?: string) {
+  return {
+    id,
+    description,
+    metadata: undefined,
+    stateSchema: undefined,
+    requestContextSchema: undefined,
+    ...baseSchemas,
+    graph: toolOnlyGraph(),
+  };
+}
 
 // =============================================================================
 // Tests
@@ -186,6 +204,222 @@ describe('Dynamic Workflows handlers', () => {
       });
       expect(row.id).toBe('wf-get');
       expect(row.status).toBe('active');
+    });
+  });
+
+  describe('trusted author scoping', () => {
+    it('scopes ordinary lists to the caller and reserves cross-author filters for admins', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        ...workflowDefinition('wf-a'),
+      });
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-b'),
+      });
+
+      const userAList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(userAList.workflows.map(workflow => workflow.id)).toEqual(['wf-a']);
+
+      const userAExplicitList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        status: undefined,
+        authorId: 'user-a',
+      });
+      expect(userAExplicitList.workflows.map(workflow => workflow.id)).toEqual(['wf-a']);
+
+      await expect(
+        LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          status: undefined,
+          authorId: 'user-b',
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+
+      const adminList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(adminList.workflows.map(workflow => workflow.id).sort()).toEqual(['wf-a', 'wf-b']);
+
+      const adminFiltered = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        status: undefined,
+        authorId: 'user-b',
+      });
+      expect(adminFiltered.workflows.map(workflow => workflow.id)).toEqual(['wf-b']);
+    });
+
+    it('returns the same 404 for missing and cross-owner reads while allowing an admin read', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-private'),
+      });
+
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          dynamicWorkflowId: 'wf-private',
+        }),
+      ).rejects.toMatchObject({ status: 404, message: 'Not found' });
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          dynamicWorkflowId: 'missing',
+        }),
+      ).rejects.toMatchObject({ status: 404, message: 'Not found' });
+
+      const adminRead = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        dynamicWorkflowId: 'wf-private',
+      });
+      expect(adminRead.authorId).toBe('user-b');
+    });
+
+    it('requires a stable caller for list, get, and upsert', async () => {
+      await expect(
+        LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+          ...ctx(mastra, { authorId: null }),
+          status: undefined,
+          authorId: undefined,
+        }),
+      ).rejects.toMatchObject({ status: 401 });
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: null }),
+          dynamicWorkflowId: 'missing',
+        }),
+      ).rejects.toMatchObject({ status: 401 });
+      await expect(
+        UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: null }),
+          ...workflowDefinition('wf-missing-caller'),
+        }),
+      ).rejects.toMatchObject({ status: 401 });
+    });
+
+    it('derives the owner from RequestContext and strips a forged body author', async () => {
+      const parsed = upsertDynamicWorkflowBodySchema.parse({
+        ...workflowDefinition('wf-forged'),
+        authorId: 'user-b',
+      });
+      expect(parsed).not.toHaveProperty('authorId');
+
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        ...parsed,
+      });
+
+      const row = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        dynamicWorkflowId: 'wf-forged',
+      });
+      expect(row.authorId).toBe('user-a');
+    });
+
+    it('rejects a cross-owner update with a non-disclosing conflict', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-owned', 'original'),
+      });
+
+      await expect(
+        UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          ...workflowDefinition('wf-owned', 'takeover'),
+        }),
+      ).rejects.toMatchObject({
+        status: 409,
+        message: 'Dynamic workflow conflicts with an existing definition',
+      });
+
+      const row = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        dynamicWorkflowId: 'wf-owned',
+      });
+      expect(row).toMatchObject({ authorId: 'user-b', description: 'original' });
+    });
+
+    it('lets an admin update an owned bundle without transferring its owner', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-owned', 'original'),
+      });
+
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        ...workflowDefinition('wf-owned', 'admin edit'),
+        dependencies: [workflowDefinition('wf-helper')],
+      });
+
+      const store = (await mastra.getStorage()!.getStore('workflowDefinitions'))!;
+      await expect(store.get('wf-owned')).resolves.toMatchObject({ authorId: 'user-b', description: 'admin edit' });
+      await expect(store.get('wf-helper')).resolves.toMatchObject({ authorId: 'user-b' });
+    });
+
+    it("doesn't let an existing helper choose the owner of a new admin-created root", async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-helper', 'original'),
+      });
+
+      await expect(
+        UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'admin', admin: true }),
+          ...workflowDefinition('wf-new-root'),
+          dependencies: [workflowDefinition('wf-helper', 'admin edit')],
+        }),
+      ).rejects.toMatchObject({
+        status: 409,
+        message: 'Dynamic workflow conflicts with an existing definition',
+      });
+
+      const store = (await mastra.getStorage()!.getStore('workflowDefinitions'))!;
+      await expect(store.get('wf-new-root')).resolves.toBeNull();
+      await expect(store.get('wf-helper')).resolves.toMatchObject({ authorId: 'user-b', description: 'original' });
+    });
+
+    it('keeps legacy unowned definitions hidden from users and read-only for admins', async () => {
+      await mastra.addDynamicWorkflow(workflowDefinition('wf-legacy'));
+
+      const userList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(userList.workflows).toEqual([]);
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          dynamicWorkflowId: 'wf-legacy',
+        }),
+      ).rejects.toMatchObject({ status: 404, message: 'Not found' });
+
+      const adminRead = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        dynamicWorkflowId: 'wf-legacy',
+      });
+      expect(adminRead.authorId).toBeUndefined();
+      const adminList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(adminList.workflows.map(workflow => workflow.id)).toEqual(['wf-legacy']);
+
+      for (const caller of [{ authorId: 'user-a' }, { authorId: 'admin', admin: true }]) {
+        await expect(
+          UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+            ...ctx(mastra, caller),
+            ...workflowDefinition('wf-legacy', 'claimed'),
+          }),
+        ).rejects.toMatchObject({ status: 409 });
+      }
     });
   });
 

--- a/packages/server/src/server/handlers/dynamic-workflows.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.ts
@@ -1,4 +1,5 @@
 import type { Mastra } from '@mastra/core/mastra';
+import { WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 
 import { HTTPException } from '../http-exception';
 import {
@@ -12,13 +13,42 @@ import {
 } from '../schemas/dynamic-workflows';
 import { createRoute } from '../server-adapter/routes/route-builder';
 
+import { getCallerAuthorId, hasAdminBypass } from './authorship';
 import { handleError } from './error';
+
+const DYNAMIC_WORKFLOW_RESOURCE = 'stored-workflows';
+
+type DynamicWorkflowPrincipal = {
+  authorId: string;
+  isAdmin: boolean;
+};
+
+function getDynamicWorkflowPrincipal(
+  requestContext: Parameters<typeof getCallerAuthorId>[0],
+): DynamicWorkflowPrincipal {
+  const authorId = getCallerAuthorId(requestContext);
+  if (!authorId) {
+    throw new HTTPException(401, { message: 'Authentication required' });
+  }
+
+  return {
+    authorId,
+    isAdmin: hasAdminBypass(requestContext, DYNAMIC_WORKFLOW_RESOURCE),
+  };
+}
+
+function throwDynamicWorkflowNotFound(): never {
+  throw new HTTPException(404, { message: 'Not found' });
+}
+
+function throwDynamicWorkflowConflict(): never {
+  throw new HTTPException(409, { message: 'Dynamic workflow conflicts with an existing definition' });
+}
 
 /**
  * GET /stored/workflows — list stored static workflow definitions.
  *
- * Mirrors `LIST_STORED_AGENTS_ROUTE` but without favorites/visibility/authorship
- * scoping (which the workflow-definitions domain doesn't carry in v1).
+ * Non-admin callers are scoped to the author derived from RequestContext.
  */
 export const LIST_DYNAMIC_WORKFLOWS_ROUTE = createRoute({
   method: 'GET',
@@ -27,19 +57,28 @@ export const LIST_DYNAMIC_WORKFLOWS_ROUTE = createRoute({
   queryParamSchema: listDynamicWorkflowsQuerySchema,
   responseSchema: listDynamicWorkflowsResponseSchema,
   summary: 'List dynamic workflow definitions',
-  description: 'Returns workflow definitions persisted to storage. Filterable by status and authorId.',
+  description:
+    'Returns workflow definitions persisted to storage. Non-admin callers only receive their own definitions.',
   tags: ['Dynamic Workflows'],
   requiresAuth: true,
   requiresPermission: 'stored-workflows:read',
-  handler: async ({ mastra, status, authorId }) => {
+  handler: async ({ mastra, requestContext, status, authorId }) => {
     try {
+      const principal = getDynamicWorkflowPrincipal(requestContext);
+      if (!principal.isAdmin && authorId !== undefined && authorId !== principal.authorId) {
+        throw new HTTPException(400, { message: 'authorId can only select the authenticated caller' });
+      }
+
       const storage = mastra.getStorage();
       if (!storage) throw new HTTPException(500, { message: 'Storage is not configured' });
 
       const store = await storage.getStore('workflowDefinitions');
       if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
 
-      const result = await store.list({ status: status ?? 'active', authorId });
+      const result = await store.list({
+        status: status ?? 'active',
+        authorId: principal.isAdmin ? authorId : principal.authorId,
+      });
       return { workflows: result.definitions, total: result.total };
     } catch (error) {
       return handleError(error, 'Error listing dynamic workflows');
@@ -61,8 +100,9 @@ export const GET_DYNAMIC_WORKFLOW_ROUTE = createRoute({
   tags: ['Dynamic Workflows'],
   requiresAuth: true,
   requiresPermission: 'stored-workflows:read',
-  handler: async ({ mastra, dynamicWorkflowId }) => {
+  handler: async ({ mastra, requestContext, dynamicWorkflowId }) => {
     try {
+      const principal = getDynamicWorkflowPrincipal(requestContext);
       const storage = mastra.getStorage();
       if (!storage) throw new HTTPException(500, { message: 'Storage is not configured' });
 
@@ -70,7 +110,9 @@ export const GET_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
 
       const def = await store.get(dynamicWorkflowId);
-      if (!def) throw new HTTPException(404, { message: `Dynamic workflow "${dynamicWorkflowId}" not found` });
+      if (!def || (!principal.isAdmin && (!def.authorId || def.authorId !== principal.authorId))) {
+        throwDynamicWorkflowNotFound();
+      }
       return def;
     } catch (error) {
       return handleError(error, 'Error getting dynamic workflow');
@@ -101,6 +143,7 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
   requiresPermission: 'stored-workflows:write',
   handler: async ({
     mastra,
+    requestContext,
     id,
     description,
     metadata,
@@ -112,6 +155,13 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
     dependencies,
   }) => {
     try {
+      const principal = getDynamicWorkflowPrincipal(requestContext);
+      const storage = mastra.getStorage();
+      if (!storage) throw new HTTPException(500, { message: 'Storage is not configured' });
+
+      const store = await storage.getStore('workflowDefinitions');
+      if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
+
       // Pick the body fields explicitly — handler args also carry server
       // context (requestContext, abortSignal, ...) which must not leak into
       // the stored definition.
@@ -121,6 +171,35 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       // its helpers behind as orphans. Order within the bundle is derived
       // from the graphs, not from the order the client sent them in.
       const bundle = [...(dependencies ?? []), def];
+
+      // Ownership is supplied by the server, outside the untrusted graph.
+      // Existing rows are read only to choose the expected immutable owner;
+      // storage enforces that owner again in the write predicate so a
+      // concurrent delete/recreate can't turn this check into a takeover.
+      const existing = await Promise.all(bundle.map(member => store.get(member.id)));
+      if (existing.some(member => member && !member.authorId)) {
+        // Legacy rows have no trusted owner to preserve. Administrators may
+        // inspect them through GET/list, but mutation stays quarantined until
+        // an explicit migration assigns an owner.
+        throwDynamicWorkflowConflict();
+      }
+
+      const existingOwners = new Set(existing.flatMap(member => (member?.authorId ? [member.authorId] : [])));
+      let registrationAuthorId = principal.authorId;
+      if (principal.isAdmin) {
+        if (existingOwners.size > 1) throwDynamicWorkflowConflict();
+        const existingRoot = existing.at(-1);
+        if (!existingRoot && existingOwners.size > 0) {
+          // An existing helper must not choose the owner of a new root. Admins
+          // may extend an owned root with new helpers, but creating a new root
+          // that references someone else's helper requires a separate,
+          // explicit ownership design.
+          throwDynamicWorkflowConflict();
+        }
+        registrationAuthorId = existingRoot?.authorId ?? principal.authorId;
+      } else if (existingOwners.size > 1 || (existingOwners.size === 1 && !existingOwners.has(principal.authorId))) {
+        throwDynamicWorkflowConflict();
+      }
       // The wire schema is deliberately looser than the core authoring type:
       // it admits `mapping` entries as children of parallel/conditional/loop,
       // which `WorkflowBuilderExecutableInnerEntry` excludes. That is not
@@ -138,13 +217,18 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       // rehydration, so nothing reaches the engine unvalidated; the cast
       // documents this boundary. Narrowing the schema to delete the cast
       // would trade a repairable issue for a generic 400.
-      await mastra.addDynamicWorkflows(bundle as Parameters<Mastra['addDynamicWorkflows']>[0]);
+      await mastra.addDynamicWorkflows(bundle as Parameters<Mastra['addDynamicWorkflows']>[0], {
+        authorId: registrationAuthorId,
+      });
       return {
         ok: true as const,
         id: def.id,
         ...(dependencies?.length ? { dependencyIds: dependencies.map(dependency => dependency.id) } : {}),
       };
     } catch (error) {
+      if (error instanceof WorkflowDefinitionOwnershipConflictError) {
+        throwDynamicWorkflowConflict();
+      }
       return handleError(error, 'Error upserting dynamic workflow');
     }
   },

--- a/stores/_test-utils/src/domains/workflow-definitions/index.ts
+++ b/stores/_test-utils/src/domains/workflow-definitions/index.ts
@@ -1,3 +1,4 @@
+import { WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 import type { MastraStorage, WorkflowDefinitionsStorage } from '@mastra/core/storage';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
@@ -68,12 +69,30 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
       expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime());
     });
 
-    it('updates authorId on existing rows', async () => {
+    it('rejects ownership transfer on existing rows', async () => {
       await store.upsert({ ...baseInput('wf-1'), authorId: 'author-1' });
-      const updated = await store.upsert({ id: 'wf-1', authorId: 'author-2' });
-      expect(updated.authorId).toBe('author-2');
+      await expect(store.upsert({ id: 'wf-1', authorId: 'author-2' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
       const fetched = await store.get('wf-1');
-      expect(fetched?.authorId).toBe('author-2');
+      expect(fetched?.authorId).toBe('author-1');
+    });
+
+    it('allows the existing owner to update an owned row', async () => {
+      await store.upsert({ ...baseInput('wf-1'), authorId: 'author-1' });
+      const updated = await store.upsert({ id: 'wf-1', authorId: 'author-1', description: 'renamed' });
+
+      expect(updated).toMatchObject({ authorId: 'author-1', description: 'renamed' });
+    });
+
+    it('does not let an author claim a legacy unowned row', async () => {
+      await store.upsert(baseInput('wf-1'));
+
+      await expect(store.upsert({ id: 'wf-1', authorId: 'author-1' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
+      const stored = await store.get('wf-1');
+      expect(stored?.authorId).toBeUndefined();
     });
 
     it('preserves unspecified columns across a partial upsert', async () => {
@@ -105,6 +124,20 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
       }
       const all = await store.list();
       expect(all.total).toBe(1);
+    });
+
+    it('lets exactly one author win concurrent creation of the same id', async () => {
+      const results = await Promise.allSettled([
+        store.upsert({ ...baseInput('wf-owner-race'), authorId: 'author-1' }),
+        store.upsert({ ...baseInput('wf-owner-race'), authorId: 'author-2' }),
+      ]);
+
+      expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+      const rejected = results.find(result => result.status === 'rejected');
+      expect(rejected).toMatchObject({ reason: expect.any(WorkflowDefinitionOwnershipConflictError) });
+
+      const stored = await store.get('wf-owner-race');
+      expect(['author-1', 'author-2']).toContain(stored?.authorId);
     });
 
     it('rejects creation when required fields are explicitly undefined', async () => {

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
@@ -8,7 +8,7 @@
  *  - the domain is reachable through the LibSQLStore composite
  */
 import { createClient } from '@libsql/client';
-import { TABLE_WORKFLOW_DEFINITIONS } from '@mastra/core/storage';
+import { TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 import type { SerializedStepFlowEntry } from '@mastra/core/workflows';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -81,7 +81,7 @@ describe('WorkflowDefinitionsLibSQL', () => {
     expect(updated.graph).toEqual(graph);
   });
 
-  it('updates authorId on an existing row and keeps createdAt stable', async () => {
+  it('rejects an authorId change and keeps the original row stable', async () => {
     const wd = (await store.getStore('workflowDefinitions'))!;
 
     const created = await wd.upsert({
@@ -93,14 +93,53 @@ describe('WorkflowDefinitionsLibSQL', () => {
     });
     expect(created.authorId).toBe('author-1');
 
-    await new Promise(r => setTimeout(r, 5));
-    const updated = await wd.upsert({ id: 'wf-author', authorId: 'author-2' });
-    expect(updated.authorId).toBe('author-2');
-    expect(updated.createdAt.getTime()).toBe(created.createdAt.getTime());
-    expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime());
+    await expect(wd.upsert({ id: 'wf-author', authorId: 'author-2' })).rejects.toBeInstanceOf(
+      WorkflowDefinitionOwnershipConflictError,
+    );
 
     const fetched = await wd.get('wf-author');
-    expect(fetched?.authorId).toBe('author-2');
+    expect(fetched?.authorId).toBe('author-1');
+    expect(fetched?.createdAt.getTime()).toBe(created.createdAt.getTime());
+    expect(fetched?.updatedAt.getTime()).toBe(created.updatedAt.getTime());
+  });
+
+  it('does not update a different owner after a delete-and-recreate race', async () => {
+    const wd = (await store.getStore('workflowDefinitions'))!;
+    await wd.upsert({
+      id: 'wf-recreated',
+      description: 'original owner',
+      inputSchema,
+      outputSchema,
+      graph,
+      authorId: 'author-1',
+    });
+
+    const originalGet = wd.get.bind(wd);
+    const getSpy = vi.spyOn(wd, 'get');
+    let reads = 0;
+    getSpy.mockImplementation(async id => {
+      const current = await originalGet(id);
+      reads += 1;
+      if (reads === 2) {
+        getSpy.mockRestore();
+        await wd.delete(id);
+        await wd.upsert({
+          id,
+          description: 'new owner',
+          inputSchema,
+          outputSchema,
+          graph,
+          authorId: 'author-2',
+        });
+      }
+      return current;
+    });
+
+    await expect(
+      wd.upsert({ id: 'wf-recreated', description: 'stale update', authorId: 'author-1' }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(await wd.get('wf-recreated')).toMatchObject({ authorId: 'author-2', description: 'new owner' });
   });
 
   it('round-trips JSON columns intact', async () => {

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.ts
@@ -6,7 +6,12 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from '@mastra/core/storage';
-import { TABLE_SCHEMAS, TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_SCHEMAS,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';
@@ -131,6 +136,10 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     // Update — only patch fields present in the input
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
@@ -142,11 +151,11 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,8 @@
-import { TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import type {
   CreateWorkflowDefinitionInput,
   ListWorkflowDefinitionsInput,
@@ -141,6 +145,9 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
     now: Date,
   ): Promise<WorkflowDefinition> {
     const collection = await this.getCollection(TABLE_WORKFLOW_DEFINITIONS);
+    const existing = await collection.findOne<Record<string, any>>({ id: input.id });
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(docToDefinition(existing), input);
 
     const update: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) update.description = input.description;
@@ -152,12 +159,13 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
       update.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) update.graph = input.graph;
     if ('status' in input && input.status !== undefined) update.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) update.authorId = input.authorId;
-
-    await collection.updateOne({ id: input.id }, { $set: update });
+    const filter = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await collection.updateOne(filter, { $set: update });
     const updated = await collection.findOne<Record<string, any>>({ id: input.id });
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
-    return docToDefinition(updated);
+    const definition = docToDefinition(updated);
+    assertWorkflowDefinitionAuthor(definition, input);
+    return definition;
   }
 
   async get(id: string): Promise<WorkflowDefinition | null> {

--- a/stores/mssql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mssql/src/storage/domains/workflow-definitions/index.ts
@@ -1,6 +1,7 @@
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -177,6 +178,10 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -187,11 +192,11 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/mysql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mysql/src/storage/domains/workflow-definitions/index.ts
@@ -1,6 +1,7 @@
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -123,6 +124,10 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -133,11 +138,11 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/pg/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/pg/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,9 @@
-import { TABLE_SCHEMAS, TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_SCHEMAS,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import type {
   CreateIndexOptions,
   CreateWorkflowDefinitionInput,
@@ -165,6 +170,10 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -175,11 +184,11 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/spanner/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/spanner/src/storage/domains/workflow-definitions/index.ts
@@ -2,6 +2,7 @@ import type { Database } from '@google-cloud/spanner';
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -143,6 +144,10 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -153,11 +158,11 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 


### PR DESCRIPTION
## What changed

- derive dynamic workflow owners from the authenticated server request context for list, get, and upsert
- prevent ordinary callers from selecting another author and return non-disclosing cross-owner read/update errors
- let `stored-workflows:admin` inspect all definitions while preserving an existing root owner's immutable authorship during updates
- quarantine legacy unowned definitions from mutation and prevent an existing helper from assigning ownership to a new admin-created root
- document the exact boundary and add a server changeset

## Stack

This draft is stacked on #21448, which supplies immutable workflow-definition ownership and owner-conditional storage writes. Review the final commit (`7424844518`) as this PR's management-route slice until the dependency merges.

## Verification

- `pnpm --filter ./packages/server exec vitest run src/server/handlers/dynamic-workflows.test.ts` (43 passed)
- `pnpm --filter ./packages/server exec tsc --noEmit`
- `pnpm --filter ./packages/server lint`
- `pnpm --filter ./packages/server build:lib`
- `pnpm build:server` (18/18 tasks)
- docs frontmatter validation (609 passed)
- targeted Remark checks for all three changed docs
- `git diff --check`

## Deliberate limits

This does **not** owner-scope delete, workflow execution/control, nested workflow references, or direct Core calls. It does not complete tenant isolation or SEC-01. Legacy rows remain admin-readable but mutation-quarantined until an explicit ownership migration exists.

The repository's `check:core-imports` script also has a pre-existing Windows `spawnSync('npm', ...)` failure where `stderr` is undefined; the server build, package build, typecheck, lint, and focused tests above pass independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Dynamic workflows now belong to the person who creates them. Users can access only their own workflows, while admins can inspect all workflows without changing their ownership.

## Changes

- Added trusted `authorId` support to dynamic workflow registration.
- Made workflow ownership immutable across replacements.
- Scoped server list, get, and upsert operations by the authenticated request author.
- Added admin access for cross-owner reads and updates without ownership transfer.
- Protected legacy unowned definitions:
  - Regular users cannot access them.
  - Admins can read them but cannot mutate them.
- Added non-disclosing authorization errors and `409` responses for ownership conflicts.
- Serialized concurrent workflow registrations to prevent stale registry state.
- Added ownership validation across all supported storage adapters.
- Added tests for authorization, ownership conflicts, concurrent registration, and delete/recreate races.
- Updated server, workflow, and Core API documentation.
- Added release changesets for Core, server, and storage packages.

## Out of Scope

Owner-scoped deletion, workflow execution and control, nested workflow references, direct Core authorization, and full tenant isolation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->